### PR TITLE
feat: support any network type in eth api builder

### DIFF
--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -5,7 +5,6 @@ use crate::{EthEngineTypes, EthEvmConfig};
 use alloy_eips::{eip7840::BlobParams, merge::EPOCH_SLOTS};
 use alloy_network::Ethereum;
 use alloy_rpc_types_engine::ExecutionData;
-use alloy_rpc_types_eth::TransactionRequest;
 use reth_chainspec::{ChainSpec, EthChainSpec, EthereumHardforks, Hardforks};
 use reth_engine_local::LocalPayloadAttributesBuilder;
 use reth_engine_primitives::EngineTypes;
@@ -153,14 +152,13 @@ where
         Types: NodeTypes<ChainSpec: EthereumHardforks>,
         Evm: ConfigureEvm<NextBlockEnvCtx: BuildPendingEnv<HeaderTy<N::Types>>>,
     >,
-    NetworkT: RpcTypes,
+    NetworkT: RpcTypes<TransactionRequest: SignableTxRequest<TxTy<N::Types>>>,
     EthRpcConverterFor<N, NetworkT>: RpcConvert<
         Primitives = PrimitivesTy<N::Types>,
         TxEnv = TxEnvFor<N::Evm>,
         Error = EthApiError,
         Network = NetworkT,
     >,
-    TransactionRequest: SignableTxRequest<TxTy<N::Types>>,
     EthApiError: FromEvmError<N::Evm>,
 {
     type EthApi = EthApiFor<N, NetworkT>;

--- a/crates/rpc/rpc-eth-types/src/receipt.rs
+++ b/crates/rpc/rpc-eth-types/src/receipt.rs
@@ -1,5 +1,6 @@
 //! RPC receipt response builder, extends a layer one receipt with layer two data.
 
+use crate::EthApiError;
 use alloy_consensus::{ReceiptEnvelope, Transaction, TxReceipt};
 use alloy_eips::eip7840::BlobParams;
 use alloy_primitives::{Address, TxKind};
@@ -9,8 +10,6 @@ use reth_ethereum_primitives::Receipt;
 use reth_primitives_traits::NodePrimitives;
 use reth_rpc_convert::transaction::{ConvertReceiptInput, ReceiptConverter};
 use std::{borrow::Cow, sync::Arc};
-
-use crate::EthApiError;
 
 /// Builds an [`TransactionReceipt`] obtaining the inner receipt envelope from the given closure.
 pub fn build_receipt<N, E>(
@@ -88,8 +87,8 @@ where
     N: NodePrimitives<Receipt = Receipt>,
     ChainSpec: EthChainSpec + 'static,
 {
-    type Error = EthApiError;
     type RpcReceipt = TransactionReceipt;
+    type Error = EthApiError;
 
     fn convert_receipts(
         &self,

--- a/crates/rpc/rpc/src/eth/builder.rs
+++ b/crates/rpc/rpc/src/eth/builder.rs
@@ -57,6 +57,47 @@ where
     }
 }
 
+impl<N: RpcNodeCore, Rpc, NextEnv> EthApiBuilder<N, Rpc, NextEnv> {
+    /// Converts the RPC converter type of this builder
+    pub fn map_converter<F, R>(self, f: F) -> EthApiBuilder<N, R, NextEnv>
+    where
+        F: FnOnce(Rpc) -> R,
+    {
+        let Self {
+            components,
+            rpc_converter,
+            gas_cap,
+            max_simulate_blocks,
+            eth_proof_window,
+            fee_history_cache_config,
+            proof_permits,
+            eth_state_cache_config,
+            eth_cache,
+            gas_oracle_config,
+            gas_oracle,
+            blocking_task_pool,
+            task_spawner,
+            next_env,
+        } = self;
+        EthApiBuilder {
+            components,
+            rpc_converter: f(rpc_converter),
+            gas_cap,
+            max_simulate_blocks,
+            eth_proof_window,
+            fee_history_cache_config,
+            proof_permits,
+            eth_state_cache_config,
+            eth_cache,
+            gas_oracle_config,
+            gas_oracle,
+            blocking_task_pool,
+            task_spawner,
+            next_env,
+        }
+    }
+}
+
 impl<N, ChainSpec> EthApiBuilder<N, RpcConverter<Ethereum, N::Evm, EthReceiptConverter<ChainSpec>>>
 where
     N: RpcNodeCore<Provider: ChainSpecProvider<ChainSpec = ChainSpec>>,

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -34,17 +34,18 @@ use tokio::sync::{broadcast, Mutex};
 const DEFAULT_BROADCAST_CAPACITY: usize = 2000;
 
 /// Helper type alias for [`RpcConverter`] with components from the given [`FullNodeComponents`].
-pub type EthRpcConverterFor<N> = RpcConverter<
-    Ethereum,
+pub type EthRpcConverterFor<N, NetworkT = Ethereum> = RpcConverter<
+    NetworkT,
     <N as FullNodeComponents>::Evm,
     EthReceiptConverter<<<N as FullNodeTypes>::Provider as ChainSpecProvider>::ChainSpec>,
 >;
 
 /// Helper type alias for [`EthApi`] with components from the given [`FullNodeComponents`].
-pub type EthApiFor<N> = EthApi<N, EthRpcConverterFor<N>>;
+pub type EthApiFor<N, NetworkT = Ethereum> = EthApi<N, EthRpcConverterFor<N, NetworkT>>;
 
 /// Helper type alias for [`EthApi`] with components from the given [`FullNodeComponents`].
-pub type EthApiBuilderFor<N> = EthApiBuilder<N, EthRpcConverterFor<N>>;
+pub type EthApiBuilderFor<N, NetworkT = Ethereum> =
+    EthApiBuilder<N, EthRpcConverterFor<N, NetworkT>>;
 
 /// `Eth` API implementation.
 ///


### PR DESCRIPTION
relaxes the `alloy::Ethereum` type default, this way a different nework type 

ref https://github.com/paradigmxyz/reth/pull/17616