### PR TITLE
chore: remove duplicate deps

### DIFF
--- a/bin/reth-bench/Cargo.toml
+++ b/bin/reth-bench/Cargo.toml
@@ -65,7 +65,6 @@ humantime.workspace = true
 csv.workspace = true
 
 [dev-dependencies]
-reth-tracing.workspace = true
 
 [features]
 default = ["jemalloc"]

--- a/crates/chain-state/Cargo.toml
+++ b/crates/chain-state/Cargo.toml
@@ -53,7 +53,6 @@ reth-primitives-traits = { workspace = true, features = ["test-utils"] }
 reth-testing-utils.workspace = true
 alloy-signer.workspace = true
 alloy-signer-local.workspace = true
-alloy-consensus.workspace = true
 rand.workspace = true
 
 [features]

--- a/crates/chainspec/Cargo.toml
+++ b/crates/chainspec/Cargo.toml
@@ -35,7 +35,6 @@ derive_more.workspace = true
 alloy-trie = { workspace = true, features = ["arbitrary"] }
 alloy-eips = { workspace = true, features = ["arbitrary"] }
 alloy-rlp = { workspace = true, features = ["arrayvec"] }
-alloy-genesis.workspace = true
 
 [features]
 default = ["std"]

--- a/crates/consensus/common/Cargo.toml
+++ b/crates/consensus/common/Cargo.toml
@@ -23,7 +23,6 @@ alloy-eips.workspace = true
 [dev-dependencies]
 alloy-primitives = { workspace = true, features = ["rand"] }
 reth-ethereum-primitives.workspace = true
-alloy-consensus.workspace = true
 rand.workspace = true
 
 [features]

--- a/crates/engine/service/Cargo.toml
+++ b/crates/engine/service/Cargo.toml
@@ -39,7 +39,6 @@ reth-ethereum-consensus.workspace = true
 reth-ethereum-engine-primitives.workspace = true
 reth-evm-ethereum.workspace = true
 reth-exex-types.workspace = true
-reth-chainspec.workspace = true
 reth-primitives-traits.workspace = true
 reth-node-ethereum.workspace = true
 

--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -82,18 +82,15 @@ reth-evm = { workspace = true, features = ["test-utils"] }
 reth-exex-types.workspace = true
 reth-network-p2p = { workspace = true, features = ["test-utils"] }
 reth-prune-types.workspace = true
-reth-prune.workspace = true
 reth-rpc-convert.workspace = true
 reth-stages = { workspace = true, features = ["test-utils"] }
 reth-static-file.workspace = true
 reth-testing-utils.workspace = true
 reth-tracing.workspace = true
-reth-trie-db.workspace = true
 reth-node-ethereum.workspace = true
 reth-e2e-test-utils.workspace = true
 
 # alloy
-alloy-rlp.workspace = true
 revm-state.workspace = true
 
 assert_matches.workspace = true

--- a/crates/era-downloader/Cargo.toml
+++ b/crates/era-downloader/Cargo.toml
@@ -35,8 +35,6 @@ sha2.workspace = true
 sha2.features = ["std"]
 
 [dev-dependencies]
-tokio.workspace = true
-tokio.features = ["fs", "io-util", "macros"]
 tempfile.workspace = true
 test-case.workspace = true
 futures.workspace = true

--- a/crates/era-utils/Cargo.toml
+++ b/crates/era-utils/Cargo.toml
@@ -28,8 +28,7 @@ reth-storage-api.workspace = true
 reth-primitives-traits.workspace = true
 
 # async
-tokio.workspace = true
-tokio.features = ["fs", "io-util"]
+tokio = { workspace = true, features = ["fs", "io-util",  "macros", "rt-multi-thread"] }
 futures-util.workspace = true
 
 # errors
@@ -43,8 +42,6 @@ reth-provider.features = ["test-utils"]
 reth-db-common.workspace = true
 
 # async
-tokio.workspace = true
-tokio.features = ["fs", "io-util", "macros", "rt-multi-thread"]
 tokio-util.workspace = true
 futures.workspace = true
 bytes.workspace = true

--- a/crates/era-utils/Cargo.toml
+++ b/crates/era-utils/Cargo.toml
@@ -28,7 +28,7 @@ reth-storage-api.workspace = true
 reth-primitives-traits.workspace = true
 
 # async
-tokio = { workspace = true, features = ["fs", "io-util",  "macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["fs", "io-util", "macros", "rt-multi-thread"] }
 futures-util.workspace = true
 
 # errors

--- a/crates/ethereum/cli/Cargo.toml
+++ b/crates/ethereum/cli/Cargo.toml
@@ -33,9 +33,6 @@ eyre.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-# reth
-reth-cli-commands.workspace = true
-
 # fs
 tempfile.workspace = true
 

--- a/crates/ethereum/evm/Cargo.toml
+++ b/crates/ethereum/evm/Cargo.toml
@@ -33,7 +33,6 @@ derive_more = { workspace = true, optional = true }
 [dev-dependencies]
 reth-testing-utils.workspace = true
 reth-evm = { workspace = true, features = ["test-utils"] }
-reth-execution-types.workspace = true
 secp256k1.workspace = true
 alloy-genesis.workspace = true
 

--- a/crates/ethereum/node/Cargo.toml
+++ b/crates/ethereum/node/Cargo.toml
@@ -54,25 +54,19 @@ revm = { workspace = true, features = ["secp256k1", "blst", "c-kzg"] }
 eyre.workspace = true
 
 [dev-dependencies]
-reth-chainspec.workspace = true
 reth-db.workspace = true
 reth-exex.workspace = true
 reth-node-core.workspace = true
-reth-payload-primitives.workspace = true
 reth-e2e-test-utils.workspace = true
-reth-rpc-eth-api.workspace = true
 reth-tasks.workspace = true
 
 alloy-primitives.workspace = true
 alloy-provider.workspace = true
 alloy-genesis.workspace = true
 alloy-signer.workspace = true
-alloy-eips.workspace = true
 alloy-sol-types.workspace = true
 alloy-contract.workspace = true
 alloy-rpc-types-beacon = { workspace = true, features = ["ssz"] }
-alloy-rpc-types-engine.workspace = true
-alloy-rpc-types-eth.workspace = true
 alloy-consensus.workspace = true
 
 futures.workspace = true

--- a/crates/evm/evm/Cargo.toml
+++ b/crates/evm/evm/Cargo.toml
@@ -36,7 +36,6 @@ metrics = { workspace = true, optional = true }
 [dev-dependencies]
 reth-ethereum-primitives.workspace = true
 reth-ethereum-forks.workspace = true
-alloy-consensus.workspace = true
 metrics-util = { workspace = true, features = ["debugging"] }
 
 [features]

--- a/crates/exex/exex/Cargo.toml
+++ b/crates/exex/exex/Cargo.toml
@@ -54,13 +54,11 @@ tracing.workspace = true
 [dev-dependencies]
 reth-db-common.workspace = true
 reth-evm-ethereum.workspace = true
-reth-node-api.workspace = true
 reth-primitives-traits = { workspace = true, features = ["test-utils"] }
 reth-provider = { workspace = true, features = ["test-utils"] }
 reth-testing-utils.workspace = true
 
 alloy-genesis.workspace = true
-alloy-consensus.workspace = true
 
 rand.workspace = true
 secp256k1.workspace = true

--- a/crates/net/downloaders/Cargo.toml
+++ b/crates/net/downloaders/Cargo.toml
@@ -66,10 +66,7 @@ reth-tracing.workspace = true
 
 assert_matches.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
-alloy-rlp.workspace = true
-itertools.workspace = true
 rand.workspace = true
-
 tempfile.workspace = true
 
 [features]

--- a/crates/net/eth-wire/Cargo.toml
+++ b/crates/net/eth-wire/Cargo.toml
@@ -51,7 +51,6 @@ reth-tracing.workspace = true
 alloy-consensus.workspace = true
 test-fuzz.workspace = true
 tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
-tokio-util = { workspace = true, features = ["io", "codec"] }
 rand.workspace = true
 secp256k1 = { workspace = true, features = ["global-context", "std", "recovery"] }
 rand_08.workspace = true

--- a/crates/net/network/Cargo.toml
+++ b/crates/net/network/Cargo.toml
@@ -89,7 +89,6 @@ reth-tracing.workspace = true
 reth-transaction-pool = { workspace = true, features = ["test-utils"] }
 
 # alloy deps for testing against nodes
-alloy-consensus.workspace = true
 alloy-genesis.workspace = true
 
 # misc

--- a/crates/optimism/chainspec/Cargo.toml
+++ b/crates/optimism/chainspec/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 
 [dependencies]
 # reth
-reth-chainspec.workspace = true
+reth-chainspec = { workspace = true, features = ["test-utils"] }
 reth-ethereum-forks.workspace = true
 reth-primitives-traits.workspace = true
 reth-network-peers.workspace = true
@@ -45,11 +45,6 @@ derive_more.workspace = true
 paste = { workspace = true, optional = true }
 thiserror = { workspace = true, optional = true }
 op-alloy-consensus.workspace = true
-
-[dev-dependencies]
-reth-chainspec = { workspace = true, features = ["test-utils"] }
-alloy-genesis.workspace = true
-op-alloy-rpc-types.workspace = true
 
 [features]
 default = ["std"]

--- a/crates/optimism/chainspec/Cargo.toml
+++ b/crates/optimism/chainspec/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 
 [dependencies]
 # reth
-reth-chainspec = { workspace = true, features = ["test-utils"] }
+reth-chainspec.workspace = true
 reth-ethereum-forks.workspace = true
 reth-primitives-traits.workspace = true
 reth-network-peers.workspace = true
@@ -45,6 +45,9 @@ derive_more.workspace = true
 paste = { workspace = true, optional = true }
 thiserror = { workspace = true, optional = true }
 op-alloy-consensus.workspace = true
+
+[dev-dependencies]
+reth-chainspec = { workspace = true, features = ["test-utils"] }
 
 [features]
 default = ["std"]

--- a/crates/optimism/cli/Cargo.toml
+++ b/crates/optimism/cli/Cargo.toml
@@ -68,8 +68,6 @@ op-alloy-consensus.workspace = true
 [dev-dependencies]
 tempfile.workspace = true
 reth-stages = { workspace = true, features = ["test-utils"] }
-reth-db-common.workspace = true
-reth-cli-commands.workspace = true
 
 [build-dependencies]
 reth-optimism-chainspec = { workspace = true, features = ["std", "superchain-configs"] }

--- a/crates/optimism/consensus/Cargo.toml
+++ b/crates/optimism/consensus/Cargo.toml
@@ -43,12 +43,10 @@ reth-provider = { workspace = true, features = ["test-utils"] }
 reth-db-common.workspace = true
 reth-revm.workspace = true
 reth-trie.workspace = true
-reth-optimism-chainspec.workspace = true
 reth-optimism-node.workspace = true
 reth-db-api = { workspace = true, features = ["op"] }
 
 alloy-chains.workspace = true
-alloy-primitives.workspace = true
 
 op-alloy-consensus.workspace = true
 

--- a/crates/optimism/evm/Cargo.toml
+++ b/crates/optimism/evm/Cargo.toml
@@ -45,7 +45,6 @@ thiserror.workspace = true
 reth-evm = { workspace = true, features = ["test-utils"] }
 reth-revm = { workspace = true, features = ["test-utils"] }
 alloy-genesis.workspace = true
-alloy-consensus.workspace = true
 reth-optimism-primitives = { workspace = true, features = ["arbitrary"] }
 
 [features]

--- a/crates/optimism/node/Cargo.toml
+++ b/crates/optimism/node/Cargo.toml
@@ -81,9 +81,7 @@ reth-payload-validator.workspace = true
 reth-revm = { workspace = true, features = ["std"] }
 
 alloy-primitives.workspace = true
-op-alloy-consensus.workspace = true
 alloy-network.workspace = true
-alloy-consensus.workspace = true
 futures.workspace = true
 alloy-eips.workspace = true
 

--- a/crates/optimism/node/Cargo.toml
+++ b/crates/optimism/node/Cargo.toml
@@ -72,7 +72,6 @@ serde_json = { workspace = true, optional = true }
 [dev-dependencies]
 reth-optimism-node = { workspace = true, features = ["test-utils"] }
 reth-db = { workspace = true, features = ["op"] }
-reth-node-core.workspace = true
 reth-node-builder = { workspace = true, features = ["test-utils"] }
 reth-provider = { workspace = true, features = ["test-utils"] }
 reth-tasks.workspace = true
@@ -80,7 +79,6 @@ reth-payload-util.workspace = true
 reth-payload-validator.workspace = true
 reth-revm = { workspace = true, features = ["std"] }
 
-alloy-primitives.workspace = true
 alloy-network.workspace = true
 futures.workspace = true
 alloy-eips.workspace = true

--- a/crates/optimism/storage/Cargo.toml
+++ b/crates/optimism/storage/Cargo.toml
@@ -26,7 +26,6 @@ alloy-consensus.workspace = true
 
 [dev-dependencies]
 reth-codecs = { workspace = true, features = ["test-utils"] }
-reth-db-api.workspace = true
 reth-prune-types.workspace = true
 reth-stages-types.workspace = true
 

--- a/crates/payload/builder/Cargo.toml
+++ b/crates/payload/builder/Cargo.toml
@@ -38,7 +38,6 @@ tracing.workspace = true
 
 [dev-dependencies]
 alloy-primitives.workspace = true
-alloy-consensus.workspace = true
 
 tokio = { workspace = true, features = ["sync", "rt"] }
 

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -27,7 +27,6 @@ revm.workspace = true
 [dev-dependencies]
 reth-trie.workspace = true
 reth-ethereum-forks.workspace = true
-alloy-primitives.workspace = true
 alloy-consensus.workspace = true
 
 [features]

--- a/crates/rpc/rpc-builder/Cargo.toml
+++ b/crates/rpc/rpc-builder/Cargo.toml
@@ -53,7 +53,6 @@ alloy-network.workspace = true
 
 [dev-dependencies]
 reth-ethereum-primitives.workspace = true
-reth-network-api.workspace = true
 reth-network-peers.workspace = true
 reth-evm-ethereum.workspace = true
 reth-ethereum-engine-primitives.workspace = true
@@ -74,6 +73,5 @@ alloy-rpc-types-trace.workspace = true
 alloy-eips.workspace = true
 alloy-rpc-types-engine.workspace = true
 
-tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
 serde_json.workspace = true
 clap = { workspace = true, features = ["derive"] }

--- a/crates/rpc/rpc-builder/Cargo.toml
+++ b/crates/rpc/rpc-builder/Cargo.toml
@@ -52,9 +52,7 @@ alloy-provider = { workspace = true, features = ["ws", "ipc"] }
 alloy-network.workspace = true
 
 [dev-dependencies]
-reth-primitives-traits.workspace = true
 reth-ethereum-primitives.workspace = true
-reth-chainspec.workspace = true
 reth-network-api.workspace = true
 reth-network-peers.workspace = true
 reth-evm-ethereum.workspace = true

--- a/crates/rpc/rpc-engine-api/Cargo.toml
+++ b/crates/rpc/rpc-engine-api/Cargo.toml
@@ -50,7 +50,6 @@ parking_lot.workspace = true
 reth-ethereum-engine-primitives.workspace = true
 reth-provider = { workspace = true, features = ["test-utils"] }
 reth-ethereum-primitives.workspace = true
-reth-primitives-traits.workspace = true
 reth-payload-builder = { workspace = true, features = ["test-utils"] }
 reth-testing-utils.workspace = true
 alloy-rlp.workspace = true

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -315,11 +315,13 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> {
 
                 // prepare transactions, we do everything upfront to reduce time spent with open
                 // state
-                let max_transactions =
-                    highest_index.map_or(block.body().transaction_count(), |highest| {
+                let max_transactions = highest_index.map_or_else(
+                    || block.body().transaction_count(),
+                    |highest| {
                         // we need + 1 because the index is 0-based
                         highest as usize + 1
-                    });
+                    },
+                );
 
                 let mut idx = 0;
 

--- a/crates/rpc/rpc-testing-util/Cargo.toml
+++ b/crates/rpc/rpc-testing-util/Cargo.toml
@@ -36,4 +36,3 @@ similar-asserts.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "rt"] }
 reth-rpc-eth-api.workspace = true
 jsonrpsee-http-client.workspace = true
-alloy-rpc-types-trace.workspace = true

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -93,7 +93,6 @@ itertools.workspace = true
 
 [dev-dependencies]
 reth-ethereum-primitives.workspace = true
-reth-evm-ethereum.workspace = true
 reth-testing-utils.workspace = true
 reth-transaction-pool = { workspace = true, features = ["test-utils"] }
 reth-provider = { workspace = true, features = ["test-utils"] }
@@ -101,7 +100,6 @@ reth-db-api.workspace = true
 
 rand.workspace = true
 
-jsonrpsee-types.workspace = true
 jsonrpsee = { workspace = true, features = ["client"] }
 
 [features]

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -99,7 +99,6 @@ reth-transaction-pool = { workspace = true, features = ["test-utils"] }
 reth-provider = { workspace = true, features = ["test-utils"] }
 reth-db-api.workspace = true
 
-alloy-consensus.workspace = true
 rand.workspace = true
 
 jsonrpsee-types.workspace = true

--- a/crates/stages/stages/Cargo.toml
+++ b/crates/stages/stages/Cargo.toml
@@ -76,7 +76,6 @@ reth-execution-errors.workspace = true
 reth-consensus = { workspace = true, features = ["test-utils"] }
 reth-network-p2p = { workspace = true, features = ["test-utils"] }
 reth-downloaders.workspace = true
-reth-revm.workspace = true
 reth-static-file.workspace = true
 reth-stages-api = { workspace = true, features = ["test-utils"] }
 reth-testing-utils.workspace = true
@@ -87,7 +86,7 @@ reth-tracing.workspace = true
 
 alloy-primitives = { workspace = true, features = ["getrandom", "rand"] }
 alloy-rlp.workspace = true
-itertools.workspace = true
+
 tokio = { workspace = true, features = ["rt", "sync", "macros"] }
 assert_matches.workspace = true
 rand.workspace = true

--- a/crates/storage/db-common/Cargo.toml
+++ b/crates/storage/db-common/Cargo.toml
@@ -43,7 +43,6 @@ tracing.workspace = true
 [dev-dependencies]
 reth-db = { workspace = true, features = ["mdbx"] }
 reth-provider = { workspace = true, features = ["test-utils"] }
-alloy-consensus.workspace = true
 
 [lints]
 workspace = true

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -74,11 +74,10 @@ reth-ethereum-primitives.workspace = true
 
 revm-database-interface.workspace = true
 revm-state.workspace = true
-parking_lot.workspace = true
+
 tempfile.workspace = true
 assert_matches.workspace = true
 rand.workspace = true
-eyre.workspace = true
 
 tokio = { workspace = true, features = ["sync", "macros", "rt-multi-thread"] }
 

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -81,7 +81,6 @@ rand.workspace = true
 eyre.workspace = true
 
 tokio = { workspace = true, features = ["sync", "macros", "rt-multi-thread"] }
-alloy-consensus.workspace = true
 
 [features]
 test-utils = [

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -799,21 +799,24 @@ impl alloy_consensus::Transaction for MockTransaction {
     }
 
     fn effective_gas_price(&self, base_fee: Option<u64>) -> u128 {
-        base_fee.map_or(self.max_fee_per_gas(), |base_fee| {
-            // if the tip is greater than the max priority fee per gas, set it to the max
-            // priority fee per gas + base fee
-            let tip = self.max_fee_per_gas().saturating_sub(base_fee as u128);
-            if let Some(max_tip) = self.max_priority_fee_per_gas() {
-                if tip > max_tip {
-                    max_tip + base_fee as u128
+        base_fee.map_or_else(
+            || self.max_fee_per_gas(),
+            |base_fee| {
+                // if the tip is greater than the max priority fee per gas, set it to the max
+                // priority fee per gas + base fee
+                let tip = self.max_fee_per_gas().saturating_sub(base_fee as u128);
+                if let Some(max_tip) = self.max_priority_fee_per_gas() {
+                    if tip > max_tip {
+                        max_tip + base_fee as u128
+                    } else {
+                        // otherwise return the max fee per gas
+                        self.max_fee_per_gas()
+                    }
                 } else {
-                    // otherwise return the max fee per gas
                     self.max_fee_per_gas()
                 }
-            } else {
-                self.max_fee_per_gas()
-            }
-        })
+            },
+        )
     }
 
     fn is_dynamic_fee(&self) -> bool {

--- a/crates/trie/parallel/Cargo.toml
+++ b/crates/trie/parallel/Cargo.toml
@@ -48,7 +48,6 @@ reth-trie = { workspace = true, features = ["test-utils"] }
 
 # misc
 rand.workspace = true
-rayon.workspace = true
 criterion.workspace = true
 proptest.workspace = true
 proptest-arbitrary-interop.workspace = true

--- a/testing/testing-utils/Cargo.toml
+++ b/testing/testing-utils/Cargo.toml
@@ -23,7 +23,3 @@ alloy-eips.workspace = true
 rand.workspace = true
 secp256k1 = { workspace = true, features = ["rand"] }
 rand_08.workspace = true
-
-[dev-dependencies]
-alloy-eips.workspace = true
-reth-primitives-traits.workspace = true


### PR DESCRIPTION
Remove duplicate deps between `dep` and `dev-dep` (I checked if it was possible to keep only in dev-dep) after running subcommand `zepter lint duplicate-deps`. 

Didn't add the `zepter` check to ci yet as it may be premature.