### PR TITLE
chore: make clippy happy

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -315,11 +315,13 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> {
 
                 // prepare transactions, we do everything upfront to reduce time spent with open
                 // state
-                let max_transactions =
-                    highest_index.map_or(block.body().transaction_count(), |highest| {
+                let max_transactions = highest_index.map_or_else(
+                    || block.body().transaction_count(),
+                    |highest| {
                         // we need + 1 because the index is 0-based
                         highest as usize + 1
-                    });
+                    },
+                );
 
                 let mut idx = 0;
 

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -799,21 +799,24 @@ impl alloy_consensus::Transaction for MockTransaction {
     }
 
     fn effective_gas_price(&self, base_fee: Option<u64>) -> u128 {
-        base_fee.map_or(self.max_fee_per_gas(), |base_fee| {
-            // if the tip is greater than the max priority fee per gas, set it to the max
-            // priority fee per gas + base fee
-            let tip = self.max_fee_per_gas().saturating_sub(base_fee as u128);
-            if let Some(max_tip) = self.max_priority_fee_per_gas() {
-                if tip > max_tip {
-                    max_tip + base_fee as u128
+        base_fee.map_or_else(
+            || self.max_fee_per_gas(),
+            |base_fee| {
+                // if the tip is greater than the max priority fee per gas, set it to the max
+                // priority fee per gas + base fee
+                let tip = self.max_fee_per_gas().saturating_sub(base_fee as u128);
+                if let Some(max_tip) = self.max_priority_fee_per_gas() {
+                    if tip > max_tip {
+                        max_tip + base_fee as u128
+                    } else {
+                        // otherwise return the max fee per gas
+                        self.max_fee_per_gas()
+                    }
                 } else {
-                    // otherwise return the max fee per gas
                     self.max_fee_per_gas()
                 }
-            } else {
-                self.max_fee_per_gas()
-            }
-        })
+            },
+        )
     }
 
     fn is_dynamic_fee(&self) -> bool {


### PR DESCRIPTION
fixes these clippy warnings with latest clippy:
```
warning: function call inside of `map_or`
   --> crates/transaction-pool/src/test_utils/mock.rs:802:18
    |
802 |           base_fee.map_or(self.max_fee_per_gas(), |base_fee| {
    |  __________________^
803 | |             // if the tip is greater than the max priority fee per gas, set it to the max
804 | |             // priority fee per gas + base fee
805 | |             let tip = self.max_fee_per_gas().saturating_sub(base_fee as u128);
...   |
816 | |         })
    | |__________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#or_fun_call
    = note: requested on the command line with `-W clippy::or-fun-call`
```
and
```
   --> crates/rpc/rpc-eth-api/src/helpers/trace.rs:319:35
    |
319 |                       highest_index.map_or(block.body().transaction_count(), |highest| {
    |  ___________________________________^
320 | |                         // we need + 1 because the index is 0-based
321 | |                         highest as usize + 1
322 | |                     });
    | |______________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#or_fun_call
    = note: requested on the command line with `-W clippy::or-fun-call`
```