### PR TITLE
fix: correct comment for is_latest_invalid method

### DIFF
--- a/crates/engine/local/src/miner.rs
+++ b/crates/engine/local/src/miner.rs
@@ -69,7 +69,7 @@ impl Future for MiningMode {
     }
 }
 
-/// Local miner advancing the chain/
+/// Local miner advancing the chain
 #[derive(Debug)]
 pub struct LocalMiner<T: PayloadTypes, B> {
     /// The payload attribute builder for the engine

--- a/crates/engine/primitives/src/forkchoice.rs
+++ b/crates/engine/primitives/src/forkchoice.rs
@@ -56,7 +56,7 @@ impl ForkchoiceStateTracker {
         self.latest_status().is_some_and(|s| s.is_syncing())
     }
 
-    /// Returns whether the latest received FCU is syncing: [`ForkchoiceStatus::Invalid`]
+    /// Returns whether the latest received FCU is invalid: [`ForkchoiceStatus::Invalid`]
     pub fn is_latest_invalid(&self) -> bool {
         self.latest_status().is_some_and(|s| s.is_invalid())
     }


### PR DESCRIPTION
Fix incorrect comment in ForkchoiceStateTracker::is_latest_invalid method

The comment incorrectly stated "is syncing" when the method actually checks
if the latest received FCU is invalid. The comment now correctly matches
the method name and implementation which checks ForkchoiceStatus::Invalid.

Also corrected a typo in the end of sentence, i think you meant to put . but accidentally put /