### PR TITLE
chore: era-downloader: Remove debug print statements

### DIFF
--- a/crates/era-downloader/src/client.rs
+++ b/crates/era-downloader/src/client.rs
@@ -128,8 +128,7 @@ impl<Http: HttpClient + Clone> EraClient<Http> {
                 if let Some(name) = entry.file_name().to_str() {
                     if let Some(number) = self.file_name_to_number(name) {
                         if number < index || number >= last {
-                            eprintln!("Deleting kokot {}", entry.path().display());
-                            eprintln!("{number} < {index} || {number} > {last}");
+                            // Remove outdated files that are outside the requested range
                             reth_fs_util::remove_file(entry.path())?;
                         }
                     }


### PR DESCRIPTION
**Remove inappropriate debug output** in `reth-era-downloader`
   - Remove debug print statements that shouldn't be in production code
   - Replace with appropriate code comment