### PR TITLE
Split blob helpers into BlobPoolExt (fixes #294)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3249,6 +3249,7 @@ dependencies = [
  "futures-util",
  "reqwest",
  "reth-ethereum",
+ "reth-transaction-pool",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -3341,6 +3342,7 @@ dependencies = [
  "reth-ethereum-payload-builder",
  "reth-payload-builder",
  "reth-tracing",
+ "reth-transaction-pool",
  "reth-trie-db",
  "serde",
  "thiserror 2.0.12",
@@ -3436,6 +3438,7 @@ dependencies = [
  "reth-ethereum",
  "reth-ethereum-payload-builder",
  "reth-payload-builder",
+ "reth-transaction-pool",
  "tracing",
 ]
 

--- a/crates/ethereum/node/Cargo.toml
+++ b/crates/ethereum/node/Cargo.toml
@@ -81,12 +81,13 @@ serde_json.workspace = true
 rand.workspace = true
 
 [features]
-default = []
+default = ["blob"]
 asm-keccak = [
     "alloy-primitives/asm-keccak",
     "reth-node-core/asm-keccak",
     "revm/asm-keccak",
 ]
+blob = ["reth-transaction-pool/blob"]
 js-tracer = ["reth-node-builder/js-tracer"]
 test-utils = [
     "reth-node-builder/test-utils",

--- a/crates/ethereum/node/src/payload.rs
+++ b/crates/ethereum/node/src/payload.rs
@@ -11,7 +11,7 @@ use reth_node_api::{FullNodeTypes, NodeTypes, PrimitivesTy, TxTy};
 use reth_node_builder::{
     components::PayloadBuilderBuilder, BuilderContext, PayloadBuilderConfig, PayloadTypes,
 };
-use reth_transaction_pool::{PoolTransaction, TransactionPool};
+use reth_transaction_pool::{BlobPoolExt, PoolTransaction, TransactionPool};
 
 /// A basic ethereum payload service.
 #[derive(Clone, Default, Debug)]
@@ -23,6 +23,7 @@ where
     Types: NodeTypes<ChainSpec: EthereumHardforks, Primitives = EthPrimitives>,
     Node: FullNodeTypes<Types = Types>,
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
+        + BlobPoolExt
         + Unpin
         + 'static,
     Evm: ConfigureEvm<

--- a/crates/ethereum/payload/Cargo.toml
+++ b/crates/ethereum/payload/Cargo.toml
@@ -39,3 +39,7 @@ alloy-primitives.workspace = true
 
 # misc
 tracing.workspace = true
+
+[features]
+default = ["blob"]
+blob = ["reth-transaction-pool/blob"]

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -31,7 +31,7 @@ use reth_revm::{database::StateProviderDatabase, db::State};
 use reth_storage_api::StateProviderFactory;
 use reth_transaction_pool::{
     error::{Eip4844PoolTransactionError, InvalidPoolTransactionError},
-    BestTransactions, BestTransactionsAttributes, PoolTransaction, TransactionPool,
+    BestTransactions, BestTransactionsAttributes, BlobPoolExt, PoolTransaction, TransactionPool,
     ValidPoolTransaction,
 };
 use revm::context_interface::Block as _;
@@ -78,7 +78,8 @@ impl<Pool, Client, EvmConfig> PayloadBuilder for EthereumPayloadBuilder<Pool, Cl
 where
     EvmConfig: ConfigureEvm<Primitives = EthPrimitives, NextBlockEnvCtx = NextBlockEnvAttributes>,
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec: EthereumHardforks> + Clone,
-    Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>,
+    Pool:
+        TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>> + BlobPoolExt,
 {
     type Attributes = EthPayloadBuilderAttributes;
     type BuiltPayload = EthBuiltPayload;
@@ -144,7 +145,8 @@ pub fn default_ethereum_payload<EvmConfig, Client, Pool, F>(
 where
     EvmConfig: ConfigureEvm<Primitives = EthPrimitives, NextBlockEnvCtx = NextBlockEnvAttributes>,
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec: EthereumHardforks>,
-    Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>,
+    Pool:
+        TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>> + BlobPoolExt,
     F: FnOnce(BestTransactionsAttributes) -> BestTransactionsIter<Pool>,
 {
     let BuildArguments { mut cached_reads, config, cancel, best_payload } = args;

--- a/crates/node/builder/Cargo.toml
+++ b/crates/node/builder/Cargo.toml
@@ -87,7 +87,8 @@ tracing.workspace = true
 tempfile.workspace = true
 
 [features]
-default = []
+default = ["blob"]
+blob = ["reth-transaction-pool/blob"]
 js-tracer = ["reth-rpc/js-tracer"]
 test-utils = [
     "dep:reth-db",

--- a/crates/node/builder/src/components/pool.rs
+++ b/crates/node/builder/src/components/pool.rs
@@ -4,8 +4,8 @@ use alloy_primitives::Address;
 use reth_chain_state::CanonStateSubscriptions;
 use reth_node_api::TxTy;
 use reth_transaction_pool::{
-    blobstore::DiskFileBlobStore, CoinbaseTipOrdering, PoolConfig, PoolTransaction, SubPoolLimit,
-    TransactionPool, TransactionValidationTaskExecutor, TransactionValidator,
+    blobstore::DiskFileBlobStore, BlobPoolExt, CoinbaseTipOrdering, PoolConfig, PoolTransaction,
+    SubPoolLimit, TransactionPool, TransactionValidationTaskExecutor, TransactionValidator,
 };
 use std::{collections::HashSet, future::Future};
 
@@ -231,7 +231,7 @@ fn spawn_pool_maintenance_task<Node, Pool>(
 ) -> eyre::Result<()>
 where
     Node: FullNodeTypes,
-    Pool: reth_transaction_pool::TransactionPoolExt + Clone + 'static,
+    Pool: reth_transaction_pool::TransactionPoolExt + BlobPoolExt + Clone + 'static,
     Pool::Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>,
 {
     let chain_events = ctx.provider().canonical_state_stream();
@@ -263,7 +263,7 @@ fn spawn_maintenance_tasks<Node, Pool>(
 ) -> eyre::Result<()>
 where
     Node: FullNodeTypes,
-    Pool: reth_transaction_pool::TransactionPoolExt + Clone + 'static,
+    Pool: reth_transaction_pool::TransactionPoolExt + BlobPoolExt + Clone + 'static,
     Pool::Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>,
 {
     spawn_local_backup_task(ctx, pool.clone())?;

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -31,6 +31,7 @@ use reth_rpc_engine_api::{capabilities::EngineCapabilities, EngineApi};
 use reth_rpc_eth_types::{cache::cache_new_blocks_task, EthConfig, EthStateCache};
 use reth_tokio_util::EventSender;
 use reth_tracing::tracing::{debug, info};
+use reth_transaction_pool::BlobPoolExt;
 use std::{
     fmt::{self, Debug},
     future::Future,
@@ -1086,6 +1087,7 @@ where
             Payload: PayloadTypes<ExecutionData = ExecutionData> + EngineTypes,
         >,
     >,
+    N::Pool: BlobPoolExt,
     EV: EngineValidatorBuilder<N>,
 {
     type EngineApi = EngineApi<

--- a/crates/optimism/node/Cargo.toml
+++ b/crates/optimism/node/Cargo.toml
@@ -88,13 +88,14 @@ futures.workspace = true
 alloy-eips.workspace = true
 
 [features]
-default = ["reth-codec"]
+default = ["blob", "reth-codec"]
 asm-keccak = [
     "alloy-primitives/asm-keccak",
     "reth-optimism-node/asm-keccak",
     "reth-node-core/asm-keccak",
     "revm/asm-keccak",
 ]
+blob = ["reth-transaction-pool/blob"]
 js-tracer = ["reth-node-builder/js-tracer"]
 test-utils = [
     "reth-tasks",

--- a/crates/optimism/node/src/rpc.rs
+++ b/crates/optimism/node/src/rpc.rs
@@ -28,6 +28,7 @@ where
         >,
     >,
     EV: EngineValidatorBuilder<N>,
+    <N as FullNodeComponents>::Pool: reth_transaction_pool::BlobPoolExt,
 {
     type EngineApi = OpEngineApi<
         N::Provider,
@@ -37,7 +38,12 @@ where
         <N::Types as NodeTypes>::ChainSpec,
     >;
 
-    async fn build_engine_api(self, ctx: &AddOnsContext<'_, N>) -> eyre::Result<Self::EngineApi> {
+    async fn build_engine_api(self, ctx: &AddOnsContext<'_, N>) -> eyre::Result<Self::EngineApi>
+    where
+        N: FullNodeComponents,
+        EV: EngineValidatorBuilder<N>,
+        <N as FullNodeComponents>::Pool: reth_transaction_pool::BlobPoolExt,
+    {
         let Self { engine_validator_builder } = self;
 
         let engine_validator = engine_validator_builder.build(ctx).await?;

--- a/crates/optimism/rpc/Cargo.toml
+++ b/crates/optimism/rpc/Cargo.toml
@@ -82,6 +82,8 @@ metrics.workspace = true
 reth-optimism-chainspec.workspace = true
 
 [features]
+default = ["blob"]
+blob = ["reth-transaction-pool/blob"]
 client = [
     "jsonrpsee/client",
     "jsonrpsee/async-client",

--- a/crates/optimism/rpc/src/engine.rs
+++ b/crates/optimism/rpc/src/engine.rs
@@ -19,7 +19,7 @@ use reth_node_api::EngineTypes;
 use reth_rpc_api::IntoEngineApiRpcModule;
 use reth_rpc_engine_api::EngineApi;
 use reth_storage_api::{BlockReader, HeaderProvider, StateProviderFactory};
-use reth_transaction_pool::TransactionPool;
+use reth_transaction_pool::{BlobPoolExt, TransactionPool};
 use tracing::{debug, info, trace};
 
 /// The list of all supported Engine capabilities available over the engine endpoint.
@@ -269,7 +269,7 @@ impl<Provider, EngineT, Pool, Validator, ChainSpec> OpEngineApiServer<EngineT>
 where
     Provider: HeaderProvider + BlockReader + StateProviderFactory + 'static,
     EngineT: EngineTypes<ExecutionData = OpExecutionData>,
-    Pool: TransactionPool + 'static,
+    Pool: TransactionPool + BlobPoolExt + 'static,
     Validator: EngineValidator<EngineT>,
     ChainSpec: EthereumHardforks + Send + Sync + 'static,
 {

--- a/crates/rpc/rpc-engine-api/Cargo.toml
+++ b/crates/rpc/rpc-engine-api/Cargo.toml
@@ -57,3 +57,7 @@ alloy-rlp.workspace = true
 reth-node-ethereum.workspace = true
 
 assert_matches.workspace = true
+
+[features]
+default = ["blob"]
+blob = ["reth-transaction-pool/blob"]

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -29,7 +29,7 @@ use reth_primitives_traits::{Block, BlockBody};
 use reth_rpc_api::{EngineApiServer, IntoEngineApiRpcModule};
 use reth_storage_api::{BlockReader, HeaderProvider, StateProviderFactory};
 use reth_tasks::TaskSpawner;
-use reth_transaction_pool::TransactionPool;
+use reth_transaction_pool::{BlobPoolExt, TransactionPool};
 use std::{sync::Arc, time::Instant};
 use tokio::sync::oneshot;
 use tracing::{debug, trace, warn};
@@ -76,7 +76,7 @@ impl<Provider, PayloadT, Pool, Validator, ChainSpec>
 where
     Provider: HeaderProvider + BlockReader + StateProviderFactory + 'static,
     PayloadT: PayloadTypes,
-    Pool: TransactionPool + 'static,
+    Pool: TransactionPool + BlobPoolExt + 'static,
     Validator: EngineValidator<PayloadT>,
     ChainSpec: EthereumHardforks + Send + Sync + 'static,
 {
@@ -293,7 +293,7 @@ impl<Provider, EngineT, Pool, Validator, ChainSpec>
 where
     Provider: HeaderProvider + BlockReader + StateProviderFactory + 'static,
     EngineT: EngineTypes,
-    Pool: TransactionPool + 'static,
+    Pool: TransactionPool + BlobPoolExt + 'static,
     Validator: EngineValidator<EngineT>,
     ChainSpec: EthereumHardforks + Send + Sync + 'static,
 {
@@ -848,7 +848,7 @@ impl<Provider, EngineT, Pool, Validator, ChainSpec> EngineApiServer<EngineT>
 where
     Provider: HeaderProvider + BlockReader + StateProviderFactory + 'static,
     EngineT: EngineTypes<ExecutionData = ExecutionData>,
-    Pool: TransactionPool + 'static,
+    Pool: TransactionPool + BlobPoolExt + 'static,
     Validator: EngineValidator<EngineT>,
     ChainSpec: EthereumHardforks + Send + Sync + 'static,
 {

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -73,6 +73,8 @@ serde_json.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 [features]
+default = ["serde", "blob"]
+blob = []
 serde = [
     "dep:serde",
     "reth-execution-types/serde",

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -4,9 +4,13 @@ use crate::{
     blobstore::{BlobStoreCanonTracker, BlobStoreUpdates},
     error::PoolError,
     metrics::MaintainPoolMetrics,
-    traits::{CanonicalStateUpdate, EthPoolTransaction, TransactionPool, TransactionPoolExt},
     BlockInfo, PoolTransaction, PoolUpdateKind,
 };
+
+use crate::traits::{
+    BlobPoolExt, CanonicalStateUpdate, EthPoolTransaction, TransactionPool, TransactionPoolExt,
+};
+
 use alloy_consensus::{BlockHeader, Typed2718};
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::{Address, BlockHash, BlockNumber};
@@ -105,7 +109,9 @@ where
         + ChainSpecProvider<ChainSpec: EthChainSpec<Header = N::BlockHeader>>
         + Clone
         + 'static,
-    P: TransactionPoolExt<Transaction: PoolTransaction<Consensus = N::SignedTx>> + 'static,
+    P: TransactionPoolExt<Transaction: PoolTransaction<Consensus = N::SignedTx>>
+        + BlobPoolExt
+        + 'static,
     St: Stream<Item = CanonStateNotification<N>> + Send + Unpin + 'static,
     Tasks: TaskSpawner + 'static,
 {
@@ -131,7 +137,9 @@ pub async fn maintain_transaction_pool<N, Client, P, St, Tasks>(
         + ChainSpecProvider<ChainSpec: EthChainSpec<Header = N::BlockHeader>>
         + Clone
         + 'static,
-    P: TransactionPoolExt<Transaction: PoolTransaction<Consensus = N::SignedTx>> + 'static,
+    P: TransactionPoolExt<Transaction: PoolTransaction<Consensus = N::SignedTx>>
+        + BlobPoolExt
+        + 'static,
     St: Stream<Item = CanonStateNotification<N>> + Send + Unpin + 'static,
     Tasks: TaskSpawner + 'static,
 {

--- a/crates/transaction-pool/src/noop.rs
+++ b/crates/transaction-pool/src/noop.rs
@@ -117,10 +117,6 @@ impl<T: EthPoolTransaction> TransactionPool for NoopTransactionPool<T> {
         mpsc::channel(1).1
     }
 
-    fn blob_transaction_sidecars_listener(&self) -> Receiver<NewBlobSidecar> {
-        mpsc::channel(1).1
-    }
-
     fn new_transactions_listener_for(
         &self,
         _kind: TransactionListenerKind,
@@ -303,44 +299,6 @@ impl<T: EthPoolTransaction> TransactionPool for NoopTransactionPool<T> {
     fn unique_senders(&self) -> HashSet<Address> {
         Default::default()
     }
-
-    fn get_blob(
-        &self,
-        _tx_hash: TxHash,
-    ) -> Result<Option<Arc<BlobTransactionSidecarVariant>>, BlobStoreError> {
-        Ok(None)
-    }
-
-    fn get_all_blobs(
-        &self,
-        _tx_hashes: Vec<TxHash>,
-    ) -> Result<Vec<(TxHash, Arc<BlobTransactionSidecarVariant>)>, BlobStoreError> {
-        Ok(vec![])
-    }
-
-    fn get_all_blobs_exact(
-        &self,
-        tx_hashes: Vec<TxHash>,
-    ) -> Result<Vec<Arc<BlobTransactionSidecarVariant>>, BlobStoreError> {
-        if tx_hashes.is_empty() {
-            return Ok(vec![])
-        }
-        Err(BlobStoreError::MissingSidecar(tx_hashes[0]))
-    }
-
-    fn get_blobs_for_versioned_hashes_v1(
-        &self,
-        versioned_hashes: &[B256],
-    ) -> Result<Vec<Option<BlobAndProofV1>>, BlobStoreError> {
-        Ok(vec![None; versioned_hashes.len()])
-    }
-
-    fn get_blobs_for_versioned_hashes_v2(
-        &self,
-        _versioned_hashes: &[B256],
-    ) -> Result<Option<Vec<BlobAndProofV2>>, BlobStoreError> {
-        Ok(None)
-    }
 }
 
 /// A [`TransactionValidator`] that does nothing.
@@ -418,4 +376,54 @@ impl<T: EthPoolTransaction> NoopInsertError<T> {
     pub fn into_inner(self) -> T {
         self.tx
     }
+}
+
+impl<T: EthPoolTransaction> crate::traits::BlobPoolExt for NoopTransactionPool<T> {
+    fn blob_transaction_sidecars_listener(&self) -> Receiver<NewBlobSidecar> {
+        mpsc::channel(1).1
+    }
+
+    fn get_blob(
+        &self,
+        _tx_hash: TxHash,
+    ) -> Result<Option<Arc<BlobTransactionSidecarVariant>>, BlobStoreError> {
+        Ok(None)
+    }
+
+    fn get_all_blobs(
+        &self,
+        _tx_hashes: Vec<TxHash>,
+    ) -> Result<Vec<(TxHash, Arc<BlobTransactionSidecarVariant>)>, BlobStoreError> {
+        Ok(vec![])
+    }
+
+    fn get_all_blobs_exact(
+        &self,
+        tx_hashes: Vec<TxHash>,
+    ) -> Result<Vec<Arc<BlobTransactionSidecarVariant>>, BlobStoreError> {
+        if tx_hashes.is_empty() {
+            return Ok(vec![])
+        }
+        Err(BlobStoreError::MissingSidecar(tx_hashes[0]))
+    }
+
+    fn get_blobs_for_versioned_hashes_v1(
+        &self,
+        versioned_hashes: &[B256],
+    ) -> Result<Vec<Option<BlobAndProofV1>>, BlobStoreError> {
+        Ok(vec![None; versioned_hashes.len()])
+    }
+
+    fn get_blobs_for_versioned_hashes_v2(
+        &self,
+        _versioned_hashes: &[B256],
+    ) -> Result<Option<Vec<BlobAndProofV2>>, BlobStoreError> {
+        Ok(None)
+    }
+
+    fn delete_blob(&self, _tx: B256) {}
+
+    fn delete_blobs(&self, _txs: Vec<B256>) {}
+
+    fn cleanup_blobs(&self) {}
 }

--- a/crates/transaction-pool/src/traits/blob.rs
+++ b/crates/transaction-pool/src/traits/blob.rs
@@ -1,0 +1,62 @@
+use super::*;
+
+/// Blob‑specific extension for `TransactionPool`
+#[cfg(feature = "blob")]
+use crate::traits::NewBlobSidecar;
+use alloy_eips::{
+    eip4844::{BlobAndProofV1, BlobAndProofV2},
+    eip7594::BlobTransactionSidecarVariant,
+};
+
+/// Extra API that is available **only** when the `blob` feature is enabled.
+///
+/// It exposes everything a caller needs to inspect, fetch or delete
+/// EIP‑4844 blob sidecars that live in the pool’s `BlobStore`.
+///
+/// All methods are **read‑only** except `delete_*` and `cleanup_blobs`, which
+/// are maintenance helpers.
+#[auto_impl::auto_impl(&, Arc)]
+pub trait BlobPoolExt: TransactionPool {
+    /// Subscribe to notifications whenever a new blob sidecar is stored.
+    fn blob_transaction_sidecars_listener(&self) -> Receiver<NewBlobSidecar>;
+
+    /// Return the sidecar for `tx_hash` (if it exists in the store).
+    fn get_blob(
+        &self,
+        tx_hash: TxHash,
+    ) -> Result<Option<Arc<BlobTransactionSidecarVariant>>, BlobStoreError>;
+
+    /// Fetch sidecars for several hashes; missing ones are simply skipped.
+    fn get_all_blobs(
+        &self,
+        tx_hashes: Vec<TxHash>,
+    ) -> Result<Vec<(TxHash, Arc<BlobTransactionSidecarVariant>)>, BlobStoreError>;
+
+    /// Same as [`get_all_blobs`] but requires *all* blobs to be present.
+    fn get_all_blobs_exact(
+        &self,
+        tx_hashes: Vec<TxHash>,
+    ) -> Result<Vec<Arc<BlobTransactionSidecarVariant>>, BlobStoreError>;
+
+    /// Convenience helper for Engine‑API: return proofs **v1** for the
+    /// requested versioned hashes, preserving order and gaps.
+    fn get_blobs_for_versioned_hashes_v1(
+        &self,
+        versioned_hashes: &[B256],
+    ) -> Result<Vec<Option<BlobAndProofV1>>, BlobStoreError>;
+
+    /// Same, but uses the stricter **v2** semantics (all‑or‑none).
+    fn get_blobs_for_versioned_hashes_v2(
+        &self,
+        versioned_hashes: &[B256],
+    ) -> Result<Option<Vec<BlobAndProofV2>>, BlobStoreError>;
+
+    /// Remove a single blob sidecar from the store.
+    fn delete_blob(&self, tx: B256);
+
+    /// Remove several sidecars at once.
+    fn delete_blobs(&self, txs: Vec<B256>);
+
+    /// Opportunistic GC: drop orphaned sidecars that no pool tx references.
+    fn cleanup_blobs(&self);
+}

--- a/crates/transaction-pool/tests/it/listeners.rs
+++ b/crates/transaction-pool/tests/it/listeners.rs
@@ -2,7 +2,7 @@ use assert_matches::assert_matches;
 use reth_transaction_pool::{
     noop::MockTransactionValidator,
     test_utils::{MockTransactionFactory, TestPoolBuilder},
-    FullTransactionEvent, PoolTransaction, TransactionEvent, TransactionListenerKind,
+    BlobPoolExt, FullTransactionEvent, PoolTransaction, TransactionEvent, TransactionListenerKind,
     TransactionOrigin, TransactionPool,
 };
 use std::{future::poll_fn, task::Poll};

--- a/examples/beacon-api-sidecar-fetcher/Cargo.toml
+++ b/examples/beacon-api-sidecar-fetcher/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 
 [dependencies]
 reth-ethereum = { workspace = true, features = ["node", "pool", "cli"] }
+reth-transaction-pool.workspace = true
 
 alloy-rpc-types-beacon.workspace = true
 alloy-primitives.workspace = true
@@ -20,3 +21,7 @@ reqwest.workspace = true
 serde_json.workspace = true
 serde.workspace = true
 thiserror.workspace = true
+
+[features]
+default = ["blob"]
+blob = ["reth-transaction-pool/blob"]

--- a/examples/beacon-api-sidecar-fetcher/src/mined_sidecar.rs
+++ b/examples/beacon-api-sidecar-fetcher/src/mined_sidecar.rs
@@ -12,6 +12,7 @@ use reth_ethereum::{
     provider::CanonStateNotification,
     PooledTransactionVariant,
 };
+use reth_transaction_pool::BlobPoolExt;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::VecDeque,
@@ -96,7 +97,7 @@ pub struct MinedSidecarStream<St, P> {
 impl<St, P> MinedSidecarStream<St, P>
 where
     St: Stream<Item = CanonStateNotification> + Send + Unpin + 'static,
-    P: TransactionPoolExt + Unpin + 'static,
+    P: TransactionPoolExt + BlobPoolExt + Unpin + 'static,
 {
     fn process_block(&mut self, block: &RecoveredBlock<reth_ethereum::Block>) {
         let txs: Vec<_> = block
@@ -157,7 +158,7 @@ where
 impl<St, P> Stream for MinedSidecarStream<St, P>
 where
     St: Stream<Item = CanonStateNotification> + Send + Unpin + 'static,
-    P: TransactionPoolExt + Unpin + 'static,
+    P: TransactionPoolExt + BlobPoolExt + Unpin + 'static,
 {
     type Item = Result<BlobTransactionEvent, SideCarError>;
 

--- a/examples/custom-engine-types/Cargo.toml
+++ b/examples/custom-engine-types/Cargo.toml
@@ -12,6 +12,7 @@ reth-ethereum-payload-builder.workspace = true
 reth-ethereum = { workspace = true, features = ["test-utils", "node", "node-api", "pool"] }
 reth-engine-tree.workspace = true
 reth-tracing.workspace = true
+reth-transaction-pool.workspace = true
 reth-trie-db.workspace = true
 alloy-genesis.workspace = true
 alloy-rpc-types = { workspace = true, features = ["engine"] }

--- a/examples/custom-engine-types/src/main.rs
+++ b/examples/custom-engine-types/src/main.rs
@@ -61,6 +61,7 @@ use reth_ethereum::{
 use reth_ethereum_payload_builder::{EthereumBuilderConfig, EthereumExecutionPayloadValidator};
 use reth_payload_builder::{EthBuiltPayload, EthPayloadBuilderAttributes, PayloadBuilderError};
 use reth_tracing::{RethTracer, Tracer};
+use reth_transaction_pool::BlobPoolExt;
 use reth_trie_db::MerklePatriciaTrie;
 use serde::{Deserialize, Serialize};
 use std::{convert::Infallible, sync::Arc};
@@ -335,6 +336,7 @@ where
         >,
     >,
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>
+        + BlobPoolExt
         + Unpin
         + 'static,
 {
@@ -368,7 +370,8 @@ pub struct CustomPayloadBuilder<Pool, Client> {
 impl<Pool, Client> PayloadBuilder for CustomPayloadBuilder<Pool, Client>
 where
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec = ChainSpec> + Clone,
-    Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>,
+    Pool:
+        TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>> + BlobPoolExt,
 {
     type Attributes = CustomPayloadBuilderAttributes;
     type BuiltPayload = EthBuiltPayload;

--- a/examples/custom-payload-builder/Cargo.toml
+++ b/examples/custom-payload-builder/Cargo.toml
@@ -10,6 +10,7 @@ reth-basic-payload-builder.workspace = true
 reth-payload-builder.workspace = true
 reth-ethereum = { workspace = true, features = ["node", "pool", "cli"] }
 reth-ethereum-payload-builder.workspace = true
+reth-transaction-pool.workspace = true
 
 alloy-eips.workspace = true
 

--- a/examples/custom-payload-builder/src/main.rs
+++ b/examples/custom-payload-builder/src/main.rs
@@ -47,6 +47,7 @@ where
         >,
     >,
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>
+        + reth_transaction_pool::BlobPoolExt
         + Unpin
         + 'static,
 {


### PR DESCRIPTION
### Motivation

L2s like RISE and OP do not need EIP-4844 blob transaction helpers. Currently, the core `TransactionPool` trait requires every consumer to implement these blob-related methods, even when they are unused. That forces downstream crates to depend on `alloy-eips` and `blobstore`, increasing compile time and dependency size.

This change splits those methods into a new trait `BlobPoolExt` behind the optional `"blob"` feature. This allows downstream projects to disable the feature cleanly via `default-features = false`.

---

### What changed

- Introduced new trait: `BlobPoolExt`, gated behind `#[cfg(feature = "blob")]`
- Moved 9 blob-specific helpers (e.g. `get_blob`, `delete_blobs`, etc.) out of `TransactionPool`
- Implemented `BlobPoolExt` for `Pool<V, T, S>` and `NoopTransactionPool`
- Updated tests, examples, and integration points
- CI passes with and without `--no-default-features`