### PR TITLE
fix: critical error handling in ExEx launcher

### DIFF
--- a/crates/node/builder/src/launch/exex.rs
+++ b/crates/node/builder/src/launch/exex.rs
@@ -10,7 +10,7 @@ use reth_exex::{
 };
 use reth_node_api::{FullNodeComponents, NodeTypes, PrimitivesTy};
 use reth_provider::CanonStateSubscriptions;
-use reth_tracing::tracing::{debug, info, error};
+use reth_tracing::tracing::{debug, error, info};
 use std::{fmt, fmt::Debug};
 use tracing::Instrument;
 

--- a/crates/node/builder/src/launch/exex.rs
+++ b/crates/node/builder/src/launch/exex.rs
@@ -10,7 +10,7 @@ use reth_exex::{
 };
 use reth_node_api::{FullNodeComponents, NodeTypes, PrimitivesTy};
 use reth_provider::CanonStateSubscriptions;
-use reth_tracing::tracing::{debug, info};
+use reth_tracing::tracing::{debug, info, error};
 use std::{fmt, fmt::Debug};
 use tracing::Instrument;
 
@@ -90,7 +90,13 @@ impl<Node: FullNodeComponents + Clone> ExExLauncher<Node> {
                 let span = reth_tracing::tracing::info_span!("exex", id);
 
                 // init the exex
-                let exex = exex.launch(context).instrument(span.clone()).await.unwrap();
+                let exex = match exex.launch(context).instrument(span.clone()).await {
+                    Ok(exex) => exex,
+                    Err(err) => {
+                        error!(target: "reth::cli", id, "Failed to launch ExEx: {err}");
+                        return;
+                    }
+                };
 
                 // spawn it as a crit task
                 executor.spawn_critical(
@@ -120,7 +126,9 @@ impl<Node: FullNodeComponents + Clone> ExExLauncher<Node> {
         );
         let exex_manager_handle = exex_manager.handle();
         components.task_executor().spawn_critical("exex manager", async move {
-            exex_manager.await.expect("exex manager crashed");
+            if let Err(err) = exex_manager.await {
+                error!(target: "reth::cli", "ExEx manager crashed: {err}");
+            }
         });
 
         // send notifications from the blockchain tree to exex manager
@@ -130,10 +138,13 @@ impl<Node: FullNodeComponents + Clone> ExExLauncher<Node> {
             "exex manager blockchain tree notifications",
             async move {
                 while let Ok(notification) = canon_state_notifications.recv().await {
-                    handle
+                    if let Err(err) = handle
                         .send_async(ExExNotificationSource::BlockchainTree, notification.into())
                         .await
-                        .expect("blockchain tree notification could not be sent to exex manager");
+                        {
+                        error!(target: "reth::cli", "Failed to send blockchain tree notification to exex manager: {err}");
+                        break;
+                    }
                 }
             },
         );

--- a/crates/node/builder/src/launch/exex.rs
+++ b/crates/node/builder/src/launch/exex.rs
@@ -90,7 +90,7 @@ impl<Node: FullNodeComponents + Clone> ExExLauncher<Node> {
                 let span = reth_tracing::tracing::info_span!("exex", id);
 
                 // init the exex
-                let exex = exex.launch(context).instrument(span.clone()).await.unwrap();
+                let exex = exex.launch(context).instrument(span.clone()).await?;
 
                 // spawn it as a crit task
                 executor.spawn_critical(
@@ -104,6 +104,8 @@ impl<Node: FullNodeComponents + Clone> ExExLauncher<Node> {
                     }
                     .instrument(span),
                 );
+
+                Ok::<(), eyre::Error>(())
             });
         }
 

--- a/crates/node/builder/src/launch/exex.rs
+++ b/crates/node/builder/src/launch/exex.rs
@@ -109,7 +109,7 @@ impl<Node: FullNodeComponents + Clone> ExExLauncher<Node> {
             });
         }
 
-        future::join_all(exexes).await;
+        future::try_join_all(exexes).await?;
 
         // spawn exex manager
         debug!(target: "reth::cli", "spawning exex manager");


### PR DESCRIPTION


## Description

Replace unsafe `unwrap()` and `expect()` calls with proper error handling in the ExEx launcher to prevent node panics and enable graceful error recovery.

### Changes

- **Line 92**: Replace `unwrap()` with proper error handling for ExEx launch failures
- **Line 123**: Replace `expect()` with graceful error handling for ExEx manager crashes  
- **Line 136**: Replace `expect()` with proper error handling for blockchain tree notifications
- **Add**: Import `error` macro for proper error logging

### Impact

- **Before**: Any ExEx launch error caused complete node panic
- **After**: Errors are logged and handled gracefully, allowing node to continue operation
- **Improves**: Production stability and debugging capabilities

