### PR TITLE
fix: correct incomplete ping timeout error message

### DIFF
--- a/crates/net/eth-wire/src/errors/p2p.rs
+++ b/crates/net/eth-wire/src/errors/p2p.rs
@@ -48,7 +48,7 @@ pub enum P2PStreamError {
     PingerError(#[from] PingerError),
 
     /// Ping timeout error.
-    #[error("ping timed out with")]
+    #[error("ping timed out")]
     PingTimeout,
 
     /// Error parsing shared capabilities.


### PR DESCRIPTION
The `PingTimeout` error message currently says "ping timed out with" which is clearly incomplete and grammatically incorrect. After testing the actual error output, I confirmed that nothing follows the "with" - it's just an unfinished sentence that would confuse users.