### PR TITLE
chore: standardize console output in beacon-api-sidecar-fetcher example

### DIFF
--- a/examples/beacon-api-sidecar-fetcher/src/main.rs
+++ b/examples/beacon-api-sidecar-fetcher/src/main.rs
@@ -60,7 +60,7 @@ fn main() {
                         }
                         Err(e) => {
                             // Handle errors specifically
-                            eprintln!("Failed to process transaction: {e:?}");
+                            println!("Failed to process transaction: {e:?}");
                         }
                     }
                 }


### PR DESCRIPTION
Use consistent `println!` for all output messages in the beacon-api-sidecar-fetcher example instead of mixing `println!` and `eprintln!`. This maintains output consistency and follows best practices for example code.

Tested with `cargo check --package example-beacon-api-sidecar-fetcher`.