### PR TITLE
feat: add pending block mode configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10126,6 +10126,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-sol-types",
+ "clap",
  "derive_more",
  "futures",
  "itertools 0.14.0",

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -969,6 +969,7 @@ impl<'a, N: FullNodeComponents<Types: NodeTypes<ChainSpec: EthereumHardforks>>> 
             .fee_history_cache_config(self.config.fee_history_cache)
             .proof_permits(self.config.proof_permits)
             .gas_oracle_config(self.config.gas_oracle)
+            .pending_block_mode(self.config.pending_block_mode)
     }
 }
 

--- a/crates/node/core/src/args/rpc_server.rs
+++ b/crates/node/core/src/args/rpc_server.rs
@@ -15,6 +15,7 @@ use clap::{
 };
 use rand::Rng;
 use reth_cli_util::parse_ether_value;
+use reth_rpc_eth_types::PendingBlockMode;
 use reth_rpc_server_types::{constants, RethRpcModule, RpcModuleSelection};
 
 use crate::args::{
@@ -231,6 +232,15 @@ pub struct RpcServerArgs {
     /// Gas price oracle configuration.
     #[command(flatten)]
     pub gas_price_oracle: GasPriceOracleArgs,
+
+    /// Pending block building mode.
+    ///
+    /// Determines how pending blocks are built for RPC requests:
+    /// - full: Build pending blocks with all transactions from the mempool (default)
+    /// - empty: Build pending blocks without any transactions
+    /// - none: Don't build pending blocks, return None for pending requests
+    #[arg(long = "rpc.pending-block", value_name = "MODE", default_value = "full")]
+    pub pending_block: PendingBlockMode,
 }
 
 impl RpcServerArgs {
@@ -367,6 +377,7 @@ impl Default for RpcServerArgs {
             rpc_state_cache: RpcStateCacheArgs::default(),
             rpc_proof_permits: constants::DEFAULT_PROOF_PERMITS,
             builder_disallow: Default::default(),
+            pending_block: PendingBlockMode::default(),
         }
     }
 }

--- a/crates/rpc/rpc-builder/src/config.rs
+++ b/crates/rpc/rpc-builder/src/config.rs
@@ -103,6 +103,7 @@ impl RethRpcServerConfig for RpcServerArgs {
             .state_cache(self.state_cache_config())
             .gpo_config(self.gas_price_oracle_config())
             .proof_permits(self.rpc_proof_permits)
+            .pending_block_mode(self.pending_block)
     }
 
     fn flashbots_config(&self) -> ValidationApiConfig {

--- a/crates/rpc/rpc-eth-types/Cargo.toml
+++ b/crates/rpc/rpc-eth-types/Cargo.toml
@@ -59,6 +59,7 @@ schnellru.workspace = true
 rand.workspace = true
 tracing.workspace = true
 itertools.workspace = true
+clap = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/crates/rpc/rpc-eth-types/src/builder/config.rs
+++ b/crates/rpc/rpc-eth-types/src/builder/config.rs
@@ -3,7 +3,8 @@
 use std::time::Duration;
 
 use crate::{
-    EthStateCacheConfig, FeeHistoryCacheConfig, GasPriceOracleConfig, RPC_DEFAULT_GAS_CAP,
+    EthStateCacheConfig, FeeHistoryCacheConfig, GasPriceOracleConfig, PendingBlockMode,
+    RPC_DEFAULT_GAS_CAP,
 };
 use reth_rpc_server_types::constants::{
     default_max_tracing_requests, DEFAULT_ETH_PROOF_WINDOW, DEFAULT_MAX_BLOCKS_PER_FILTER,
@@ -45,6 +46,8 @@ pub struct EthConfig {
     pub fee_history_cache: FeeHistoryCacheConfig,
     /// The maximum number of getproof calls that can be executed concurrently.
     pub proof_permits: usize,
+    /// Pending block building mode.
+    pub pending_block_mode: PendingBlockMode,
 }
 
 impl EthConfig {
@@ -72,6 +75,7 @@ impl Default for EthConfig {
             stale_filter_ttl: DEFAULT_STALE_FILTER_TTL,
             fee_history_cache: FeeHistoryCacheConfig::default(),
             proof_permits: DEFAULT_PROOF_PERMITS,
+            pending_block_mode: PendingBlockMode::default(),
         }
     }
 }
@@ -134,6 +138,12 @@ impl EthConfig {
     /// Configures the number of getproof requests
     pub const fn proof_permits(mut self, permits: usize) -> Self {
         self.proof_permits = permits;
+        self
+    }
+
+    /// Configures the pending block mode
+    pub const fn pending_block_mode(mut self, mode: PendingBlockMode) -> Self {
+        self.pending_block_mode = mode;
         self
     }
 }

--- a/crates/rpc/rpc-eth-types/src/lib.rs
+++ b/crates/rpc/rpc-eth-types/src/lib.rs
@@ -32,5 +32,5 @@ pub use gas_oracle::{
     GasCap, GasPriceOracle, GasPriceOracleConfig, GasPriceOracleResult, RPC_DEFAULT_GAS_CAP,
 };
 pub use id_provider::EthSubscriptionIdProvider;
-pub use pending_block::{PendingBlock, PendingBlockEnv, PendingBlockEnvOrigin};
+pub use pending_block::{PendingBlock, PendingBlockEnv, PendingBlockEnvOrigin, PendingBlockMode};
 pub use transaction::TransactionSource;

--- a/crates/rpc/rpc/src/eth/builder.rs
+++ b/crates/rpc/rpc/src/eth/builder.rs
@@ -12,7 +12,7 @@ use reth_rpc_eth_api::{
 use reth_rpc_eth_types::{
     fee_history::fee_history_cache_new_blocks_task, receipt::EthReceiptConverter, EthStateCache,
     EthStateCacheConfig, FeeHistoryCache, FeeHistoryCacheConfig, GasCap, GasPriceOracle,
-    GasPriceOracleConfig,
+    GasPriceOracleConfig, PendingBlockMode,
 };
 use reth_rpc_server_types::constants::{
     DEFAULT_ETH_PROOF_WINDOW, DEFAULT_MAX_SIMULATE_BLOCKS, DEFAULT_PROOF_PERMITS,
@@ -40,6 +40,7 @@ pub struct EthApiBuilder<N: RpcNodeCore, Rpc, NextEnv = ()> {
     blocking_task_pool: Option<BlockingTaskPool>,
     task_spawner: Box<dyn TaskSpawner + 'static>,
     next_env: NextEnv,
+    pending_block_mode: PendingBlockMode,
 }
 
 impl<Provider, Pool, Network, EvmConfig, ChainSpec>
@@ -78,6 +79,7 @@ impl<N: RpcNodeCore, Rpc, NextEnv> EthApiBuilder<N, Rpc, NextEnv> {
             blocking_task_pool,
             task_spawner,
             next_env,
+            pending_block_mode,
         } = self;
         EthApiBuilder {
             components,
@@ -94,6 +96,7 @@ impl<N: RpcNodeCore, Rpc, NextEnv> EthApiBuilder<N, Rpc, NextEnv> {
             blocking_task_pool,
             task_spawner,
             next_env,
+            pending_block_mode,
         }
     }
 }
@@ -121,6 +124,7 @@ where
             gas_oracle_config: Default::default(),
             eth_state_cache_config: Default::default(),
             next_env: Default::default(),
+            pending_block_mode: Default::default(),
         }
     }
 }
@@ -155,6 +159,7 @@ where
             task_spawner,
             gas_oracle_config,
             next_env,
+            pending_block_mode,
         } = self;
         EthApiBuilder {
             components,
@@ -171,6 +176,7 @@ where
             task_spawner,
             gas_oracle_config,
             next_env,
+            pending_block_mode,
         }
     }
 
@@ -194,6 +200,7 @@ where
             task_spawner,
             gas_oracle_config,
             next_env: _,
+            pending_block_mode,
         } = self;
         EthApiBuilder {
             components,
@@ -210,6 +217,7 @@ where
             task_spawner,
             gas_oracle_config,
             next_env,
+            pending_block_mode,
         }
     }
 
@@ -281,6 +289,12 @@ where
         self
     }
 
+    /// Sets the pending block mode.
+    pub const fn pending_block_mode(mut self, pending_block_mode: PendingBlockMode) -> Self {
+        self.pending_block_mode = pending_block_mode;
+        self
+    }
+
     /// Builds the [`EthApiInner`] instance.
     ///
     /// If not configured, this will spawn the cache backend: [`EthStateCache::spawn`].
@@ -309,6 +323,7 @@ where
             proof_permits,
             task_spawner,
             next_env,
+            pending_block_mode,
         } = self;
 
         let provider = components.provider().clone();
@@ -345,6 +360,7 @@ where
             proof_permits,
             rpc_converter,
             next_env,
+            pending_block_mode,
         )
     }
 

--- a/crates/rpc/rpc/src/eth/helpers/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/pending_block.rs
@@ -6,7 +6,7 @@ use reth_rpc_eth_api::{
     helpers::{pending_block::PendingEnvBuilder, LoadPendingBlock},
     FromEvmError, RpcNodeCore,
 };
-use reth_rpc_eth_types::{EthApiError, PendingBlock};
+use reth_rpc_eth_types::{EthApiError, PendingBlock, PendingBlockMode};
 
 impl<N, Rpc> LoadPendingBlock for EthApi<N, Rpc>
 where
@@ -22,5 +22,10 @@ where
     #[inline]
     fn pending_env_builder(&self) -> &dyn PendingEnvBuilder<Self::Evm> {
         self.inner.pending_env_builder()
+    }
+
+    #[inline]
+    fn pending_block_mode(&self) -> PendingBlockMode {
+        self.inner.pending_block_mode()
     }
 }


### PR DESCRIPTION
## Summary
- Add `PendingBlockMode` configuration to RPC server arguments
- Propagate pending block mode through the RPC builder chain
- Fix missing field in `EthApiBuilder` struct initialization

This PR adds the ability to configure how pending blocks are built for RPC requests with three modes:
- `full`: Build pending blocks with all transactions from the mempool (default)
- `empty`: Build pending blocks without any transactions  
- `none`: Don't build pending blocks, return None for pending requests

## Test plan
- [ ] Verify RPC server starts with default pending block mode
- [ ] Test setting different pending block modes via CLI args
- [ ] Ensure pending block requests behave according to the configured mode

🤖 Generated with [Claude Code](https://claude.ai/code)