### PR TITLE
fix: typos in sidebar navigation

### DIFF
--- a/crates/optimism/consensus/src/lib.rs
+++ b/crates/optimism/consensus/src/lib.rs
@@ -137,7 +137,7 @@ where
 {
     fn validate_header(&self, header: &SealedHeader<H>) -> Result<(), ConsensusError> {
         let header = header.header();
-        // with OP-stack Bedrock activation number determines when TTD (eth Merge) has been reached.
+        // with OP Stack Bedrock activation number determines when TTD (eth Merge) has been reached.
         debug_assert!(
             self.chain_spec.is_bedrock_active_at_block(header.number()),
             "manually import OVM blocks"

--- a/crates/optimism/rpc/src/engine.rs
+++ b/crates/optimism/rpc/src/engine.rs
@@ -221,7 +221,7 @@ pub trait OpEngineApi<Engine: EngineTypes> {
     ) -> RpcResult<ExecutionPayloadBodiesV1>;
 
     /// Signals superchain information to the Engine.
-    /// Returns the latest supported OP-Stack protocol version of the execution engine.
+    /// Returns the latest supported OP Stack protocol version of the execution engine.
     /// See also <https://specs.optimism.io/protocol/exec-engine.html#engine_signalsuperchainv1>
     #[method(name = "engine_signalSuperchainV1")]
     async fn signal_superchain_v1(&self, _signal: SuperchainSignal) -> RpcResult<ProtocolVersion>;

--- a/docs/vocs/docs/pages/index.mdx
+++ b/docs/vocs/docs/pages/index.mdx
@@ -4,7 +4,7 @@ content:
 layout: landing
 showLogo: false
 title: Reth
-description: Secure, performant and modular node implementation that supports both Ethereum and OP-Stack chains.
+description: Secure, performant and modular node implementation that supports both Ethereum and OP Stack chains.
 ---
 
 import { HomePage, Sponsors } from "vocs/components";

--- a/docs/vocs/sidebar.ts
+++ b/docs/vocs/sidebar.ts
@@ -77,7 +77,7 @@ export const sidebar: SidebarItem[] = [
                                 // ]
                             },
                             {
-                                text: "OP-stack",
+                                text: "OP Stack",
                                 link: "/run/opstack",
                                 // items: [
                                 //     {


### PR DESCRIPTION
Corrected `OP-stack` → `OP Stack`