### PR TITLE
perf: add benchmark for on_canonical_state_change

### DIFF
--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -132,3 +132,13 @@ harness = false
 name = "priority"
 required-features = ["arbitrary"]
 harness = false
+
+[[bench]]
+name = "canonical_state_change"
+required-features = ["test-utils", "arbitrary"]
+harness = false
+
+[[bench]]
+name = "profile_canonical_state_change"
+required-features = ["test-utils", "arbitrary"]
+harness = false

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -137,8 +137,3 @@ harness = false
 name = "canonical_state_change"
 required-features = ["test-utils", "arbitrary"]
 harness = false
-
-[[bench]]
-name = "profile_canonical_state_change"
-required-features = ["test-utils", "arbitrary"]
-harness = false

--- a/crates/transaction-pool/benches/canonical_state_change.rs
+++ b/crates/transaction-pool/benches/canonical_state_change.rs
@@ -99,7 +99,7 @@ fn canonical_state_change_bench(c: &mut Criterion) {
     group.measurement_time(Duration::from_secs(10));
 
     // Test different pool sizes
-    for num_senders in [100, 500, 1000, 2000, 50000] {
+    for num_senders in [100, 500, 1000, 2000] {
         for txs_per_sender in [1, 5, 10] {
             let total_txs = num_senders * txs_per_sender;
 

--- a/crates/transaction-pool/benches/canonical_state_change.rs
+++ b/crates/transaction-pool/benches/canonical_state_change.rs
@@ -1,0 +1,157 @@
+#![allow(missing_docs)]
+use alloy_consensus::Transaction;
+use alloy_primitives::{Address, B256, U256};
+use criterion::{criterion_group, criterion_main, Criterion};
+use proptest::{prelude::*, strategy::ValueTree, test_runner::TestRunner};
+use reth_ethereum_primitives::{Block, BlockBody};
+use reth_execution_types::ChangedAccount;
+use reth_primitives_traits::{Header, SealedBlock};
+use reth_transaction_pool::{test_utils::{MockTransaction, TestPoolBuilder}, BlockInfo, CanonicalStateUpdate, PoolConfig, PoolTransaction, PoolUpdateKind, SubPoolLimit, TransactionOrigin, TransactionPool, TransactionPoolExt};
+use std::collections::HashMap;
+use std::time::Duration;
+
+/// Generates a set of transactions for multiple senders
+fn generate_transactions(num_senders: usize, txs_per_sender: usize) -> Vec<MockTransaction> {
+    let mut runner = TestRunner::deterministic();
+    let mut txs = Vec::new();
+
+    for sender_idx in 0..num_senders {
+        // Create a unique sender address
+        let sender_bytes = sender_idx.to_be_bytes();
+        let addr_slice = [0u8; 12]
+            .into_iter()
+            .chain(sender_bytes.into_iter())
+            .collect::<Vec<_>>();
+        let sender = Address::from_slice(&addr_slice);
+
+        // Generate transactions for this sender
+        for nonce in 0..txs_per_sender {
+            let mut tx = any::<MockTransaction>().new_tree(&mut runner).unwrap().current();
+            tx.set_sender(sender);
+            tx.set_nonce(nonce as u64);
+            
+            // Ensure it's not a legacy transaction
+            if tx.is_legacy() || tx.is_eip2930() {
+                tx = MockTransaction::eip1559();
+                tx.set_priority_fee(any::<u128>().new_tree(&mut runner).unwrap().current());
+                tx.set_max_fee(any::<u128>().new_tree(&mut runner).unwrap().current());
+                tx.set_sender(sender);
+                tx.set_nonce(nonce as u64);
+            }
+            
+            txs.push(tx);
+        }
+    }
+
+    txs
+}
+
+/// Fill the pool with transactions
+async fn fill_pool(pool: &TestPoolBuilder, txs: Vec<MockTransaction>) -> HashMap<Address, u64> {
+    let mut sender_nonces = HashMap::new();
+
+    // Add transactions one by one
+    for tx in txs {
+        let sender = tx.sender();
+        let nonce = tx.nonce();
+        
+        // Track the highest nonce for each sender
+        sender_nonces.insert(sender, nonce.max(sender_nonces.get(&sender).copied().unwrap_or(0)));
+        
+        // Add transaction to the pool
+        let _ = pool.add_transaction(TransactionOrigin::External, tx).await;
+    }
+    
+    sender_nonces
+}
+
+/// Create a canonical state update with changed accounts for all senders
+fn create_canonical_update(
+    sender_nonces: HashMap<Address, u64>,
+) -> CanonicalStateUpdate<'static, Block> {
+    // Create a mock block - using default Ethereum block
+    let header = Header::default();
+    let body = BlockBody::default();
+    let block = Block { header, body };
+    let sealed_block = Box::leak(Box::new(SealedBlock::seal_slow(block)));
+    
+    let changed_accounts: Vec<ChangedAccount> = sender_nonces
+        .into_iter()
+        .map(|(address, nonce)| ChangedAccount {
+            address,
+            nonce: nonce + 1, // Increment nonce as if transactions were mined
+            balance: U256::from(9_000_000_000_000_000u64), // Decrease balance
+        })
+        .collect();
+
+    CanonicalStateUpdate {
+        new_tip: sealed_block,
+        pending_block_base_fee: 1_000_000_000, // 1 gwei
+        pending_block_blob_fee: Some(1_000_000), // 0.001 gwei
+        changed_accounts,
+        mined_transactions: vec![], // No transactions mined in this benchmark
+        update_kind: PoolUpdateKind::Commit,
+    }
+}
+
+fn canonical_state_change_bench(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Transaction Pool Canonical State Change");
+    group.measurement_time(Duration::from_secs(10));
+
+    // Test different pool sizes
+    for num_senders in [100, 500, 1000, 2000, 50000] {
+        for txs_per_sender in [1, 5, 10] {
+            let total_txs = num_senders * txs_per_sender;
+            
+            let group_id = format!(
+                "txpool | canonical_state_change | senders: {} | txs_per_sender: {} | total: {}",
+                num_senders, txs_per_sender, total_txs
+            );
+
+            group.bench_function(group_id, |b| {
+                // Use tokio runtime for async operations
+                let rt = tokio::runtime::Runtime::new().unwrap();
+                
+                // Setup phase - create pool and transactions
+                let pool = TestPoolBuilder::default()
+                    .with_config(PoolConfig {
+                        pending_limit: SubPoolLimit::max(),
+                        basefee_limit: SubPoolLimit::max(),
+                        queued_limit:  SubPoolLimit::max(),
+                        blob_limit: SubPoolLimit::max(),
+                        max_account_slots: 50,
+                        ..Default::default()
+                    });
+                
+                // Set initial block info
+                pool.set_block_info(BlockInfo {
+                    last_seen_block_number: 0,
+                    last_seen_block_hash: B256::ZERO,
+                    pending_basefee: 1_000_000_000,
+                    pending_blob_fee: Some(1_000_000),
+                    block_gas_limit: 30_000_000,
+                });
+
+                let txs = generate_transactions(num_senders, txs_per_sender);
+                let sender_nonces = rt.block_on(fill_pool(&pool, txs));
+                
+                // Pre-create the update to avoid allocation in the benchmark loop
+                let update = create_canonical_update(sender_nonces);
+                
+                // Benchmark the canonical state change
+                b.iter(|| {
+                    pool.on_canonical_state_change(update.clone());
+                });
+            });
+        }
+    }
+    
+    group.finish();
+}
+
+criterion_group! {
+    name = canonical_state_change;
+    config = Criterion::default();
+    targets = canonical_state_change_bench
+}
+criterion_main!(canonical_state_change);

--- a/crates/transaction-pool/src/config.rs
+++ b/crates/transaction-pool/src/config.rs
@@ -115,6 +115,11 @@ impl SubPoolLimit {
         Self { max_txs, max_size }
     }
 
+    /// Creates a an unlimited [`SubPoolLimit`]
+    pub const fn max() -> Self {
+        Self::new(usize::MAX, usize::MAX)
+    }
+
     /// Returns whether the size or amount constraint is violated.
     #[inline]
     pub const fn is_exceeded(&self, txs: usize, size: usize) -> bool {


### PR DESCRIPTION
## Summary

Adds a comprehensive benchmark for the transaction pool's `on_canonical_state_change` method to help evaluate performance optimizations.

## Description

This PR adds a new benchmark that measures the performance of `Pool::on_canonical_state_change`, which is called when the canonical chain state changes and the pool needs to update its internal state accordingly.

The benchmark:
- Tests with varying pool sizes: 100 to 50,000 senders with 1-10 transactions each
- Simulates realistic state changes where all accounts have their nonce incremented and balance decreased
- Uses the same benchmark infrastructure as existing pool benchmarks for consistency

## Context

This benchmark is being added in preparation for evaluating the optimizations proposed in #17434, which aims to improve the performance of canonical state updates in the transaction pool.

## Testing

Run the benchmark with:
```bash
cargo bench -p reth-transaction-pool --bench canonical_state_change
```

For specific test cases:
```bash
cargo bench -p reth-transaction-pool --bench canonical_state_change -- "senders: 1000 | txs_per_sender: 5"
```