### PR TITLE
perf(txpool): rm unused best bijection

### DIFF
--- a/crates/transaction-pool/src/pool/parked.rs
+++ b/crates/transaction-pool/src/pool/parked.rs
@@ -16,9 +16,6 @@ use std::{
 /// basefee, ancestor transactions, balance) that eventually move the transaction into the pending
 /// pool.
 ///
-/// This pool is a bijection: at all times each set (`best`, `by_id`) contains the same
-/// transactions.
-///
 /// Note: This type is generic over [`ParkedPool`] which enforces that the underlying transaction
 /// type is [`ValidPoolTransaction`] wrapped in an [Arc].
 #[derive(Debug, Clone)]
@@ -29,10 +26,6 @@ pub struct ParkedPool<T: ParkedOrd> {
     submission_id: u64,
     /// _All_ Transactions that are currently inside the pool grouped by their identifier.
     by_id: BTreeMap<TransactionId, ParkedPoolTransaction<T>>,
-    /// All transactions sorted by their order function.
-    ///
-    /// The higher, the better.
-    best: BTreeSet<ParkedPoolTransaction<T>>,
     /// Keeps track of last submission id for each sender.
     ///
     /// This are sorted in reverse order, so the last (highest) submission id is first, and the
@@ -71,8 +64,7 @@ impl<T: ParkedOrd> ParkedPool<T> {
         self.add_sender_count(tx.sender_id(), submission_id);
         let transaction = ParkedPoolTransaction { submission_id, transaction: tx.into() };
 
-        self.by_id.insert(id, transaction.clone());
-        self.best.insert(transaction);
+        self.by_id.insert(id, transaction);
     }
 
     /// Increments the count of transactions for the given sender and updates the tracked submission
@@ -142,7 +134,6 @@ impl<T: ParkedOrd> ParkedPool<T> {
     ) -> Option<Arc<ValidPoolTransaction<T::Transaction>>> {
         // remove from queues
         let tx = self.by_id.remove(id)?;
-        self.best.remove(&tx);
         self.remove_sender_count(tx.transaction.sender_id());
 
         // keep track of size
@@ -254,11 +245,9 @@ impl<T: ParkedOrd> ParkedPool<T> {
         self.by_id.get(id)
     }
 
-    /// Asserts that the bijection between `by_id` and `best` is valid.
+    /// Asserts that all subpool invariants
     #[cfg(any(test, feature = "test-utils"))]
     pub(crate) fn assert_invariants(&self) {
-        assert_eq!(self.by_id.len(), self.best.len(), "by_id.len() != best.len()");
-
         assert_eq!(
             self.last_sender_submission.len(),
             self.sender_transaction_count.len(),
@@ -327,7 +316,6 @@ impl<T: ParkedOrd> Default for ParkedPool<T> {
         Self {
             submission_id: 0,
             by_id: Default::default(),
-            best: Default::default(),
             last_sender_submission: Default::default(),
             sender_transaction_count: Default::default(),
             size_of: Default::default(),
@@ -1050,51 +1038,5 @@ mod tests {
         let removed = pool.remove_transaction(&tx_id);
         assert!(removed.is_some());
         assert!(!pool.contains(&tx_id));
-    }
-
-    #[test]
-    fn test_parkpool_ord() {
-        let mut f = MockTransactionFactory::default();
-        let mut pool = ParkedPool::<QueuedOrd<_>>::default();
-
-        let tx1 = MockTransaction::eip1559().with_max_fee(100);
-        let tx1_v = f.validated_arc(tx1.clone());
-
-        let tx2 = MockTransaction::eip1559().with_max_fee(101);
-        let tx2_v = f.validated_arc(tx2.clone());
-
-        let tx3 = MockTransaction::eip1559().with_max_fee(101);
-        let tx3_v = f.validated_arc(tx3.clone());
-
-        let tx4 = MockTransaction::eip1559().with_max_fee(101);
-        let mut tx4_v = f.validated(tx4.clone());
-        tx4_v.timestamp = tx3_v.timestamp;
-
-        let ord_1 = QueuedOrd(tx1_v.clone());
-        let ord_2 = QueuedOrd(tx2_v.clone());
-        let ord_3 = QueuedOrd(tx3_v.clone());
-        assert!(ord_1 < ord_2);
-        // lower timestamp is better
-        assert!(ord_2 > ord_3);
-        assert!(ord_1 < ord_3);
-
-        pool.add_transaction(tx1_v);
-        pool.add_transaction(tx2_v);
-        pool.add_transaction(tx3_v);
-        pool.add_transaction(Arc::new(tx4_v));
-
-        // from worst to best
-        let mut iter = pool.best.iter();
-        let tx = iter.next().unwrap();
-        assert_eq!(tx.transaction.transaction, tx1);
-
-        let tx = iter.next().unwrap();
-        assert_eq!(tx.transaction.transaction, tx4);
-
-        let tx = iter.next().unwrap();
-        assert_eq!(tx.transaction.transaction, tx3);
-
-        let tx = iter.next().unwrap();
-        assert_eq!(tx.transaction.transaction, tx2);
     }
 }


### PR DESCRIPTION
this isnt actually used anymore because eviction changed a bunch and is now based on

https://github.com/paradigmxyz/reth/blob/aa5ac389cc66aacfeafb41ec929300b1d8c5f28c/crates/transaction-pool/src/pool/parked.rs#L34-L36

hence there's no reason to track this, and updating this map is fairly expensive


ref #4520 #6366