### PR TITLE
perf: remove redundant metrics update

### DIFF
--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -864,8 +864,6 @@ impl<T: TransactionOrdering> TxPool<T> {
             }
         }
 
-        self.update_size_metrics();
-
         outcome
     }
 
@@ -1582,7 +1580,6 @@ impl<T: PoolTransaction> AllTransactions<T> {
         self.remove_auths(&internal);
         // decrement the counter for the sender.
         self.tx_decr(tx.sender_id());
-        self.update_size_metrics();
         Some((tx, internal.subpool))
     }
 
@@ -1647,8 +1644,6 @@ impl<T: PoolTransaction> AllTransactions<T> {
             self.by_hash.remove(internal.transaction.hash()).map(|tx| (tx, internal.subpool));
 
         self.remove_auths(&internal);
-
-        self.update_size_metrics();
 
         result
     }


### PR DESCRIPTION
when we process updates this was called multiple times internally.

this only keeps the top level call after processing all updates