### PR TITLE
refactor: stream transactions while executing payload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7980,7 +7980,6 @@ dependencies = [
  "derive_more",
  "eyre",
  "futures",
- "itertools 0.14.0",
  "metrics",
  "mini-moka",
  "parking_lot",

--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -57,12 +57,12 @@ metrics.workspace = true
 reth-metrics = { workspace = true, features = ["common"] }
 
 # misc
+crossbeam-channel.workspace = true
 schnellru.workspace = true
 rayon.workspace = true
 tracing.workspace = true
 derive_more.workspace = true
 parking_lot.workspace = true
-itertools.workspace = true
 
 # optional deps for test-utils
 reth-prune-types = { workspace = true, optional = true }
@@ -97,7 +97,6 @@ assert_matches.workspace = true
 criterion.workspace = true
 eyre.workspace = true
 serde_json.workspace = true
-crossbeam-channel.workspace = true
 proptest.workspace = true
 rand.workspace = true
 rand_08.workspace = true

--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -57,7 +57,6 @@ metrics.workspace = true
 reth-metrics = { workspace = true, features = ["common"] }
 
 # misc
-crossbeam-channel.workspace = true
 schnellru.workspace = true
 rayon.workspace = true
 tracing.workspace = true
@@ -97,6 +96,7 @@ assert_matches.workspace = true
 criterion.workspace = true
 eyre.workspace = true
 serde_json.workspace = true
+crossbeam-channel.workspace = true
 proptest.workspace = true
 rand.workspace = true
 rand_08.workspace = true

--- a/crates/engine/tree/benches/state_root_task.rs
+++ b/crates/engine/tree/benches/state_root_task.rs
@@ -15,9 +15,10 @@ use reth_engine_tree::tree::{
     executor::WorkloadExecutor, precompile_cache::PrecompileCacheMap, PayloadProcessor,
     StateProviderBuilder, TreeConfig,
 };
+use reth_ethereum_primitives::TransactionSigned;
 use reth_evm::OnStateHook;
 use reth_evm_ethereum::EthEvmConfig;
-use reth_primitives_traits::{Account as RethAccount, StorageEntry};
+use reth_primitives_traits::{Account as RethAccount, Recovered, StorageEntry};
 use reth_provider::{
     providers::{BlockchainProvider, ConsistentDbView},
     test_utils::{create_test_provider_factory_with_chain_spec, MockNodeTypesWithDB},
@@ -233,7 +234,7 @@ fn bench_state_root(c: &mut Criterion) {
                         black_box({
                             let mut handle = payload_processor.spawn(
                                 Default::default(),
-                                Default::default(),
+                                core::iter::empty::<Recovered<TransactionSigned>>(),
                                 StateProviderBuilder::new(provider.clone(), genesis_hash, None),
                                 ConsistentDbView::new_with_latest_tip(provider).unwrap(),
                                 TrieInput::default(),

--- a/crates/engine/tree/benches/state_root_task.rs
+++ b/crates/engine/tree/benches/state_root_task.rs
@@ -234,7 +234,9 @@ fn bench_state_root(c: &mut Criterion) {
                         black_box({
                             let mut handle = payload_processor.spawn(
                                 Default::default(),
-                                core::iter::empty::<Recovered<TransactionSigned>>(),
+                                core::iter::empty::<
+                                    Result<Recovered<TransactionSigned>, core::convert::Infallible>,
+                                >(),
                                 StateProviderBuilder::new(provider.clone(), genesis_hash, None),
                                 ConsistentDbView::new_with_latest_tip(provider).unwrap(),
                                 TrieInput::default(),

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -113,7 +113,6 @@ where
             }
 
             // drop handle and wait for all tasks to finish and drop theirs
-            // todo: do we even need this? tasks are spawned anyway and will see all transactions
             drop(done_tx);
             drop(handles);
             while done_rx.recv().is_ok() {}

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -115,6 +115,7 @@ where
             // drop handle and wait for all tasks to finish and drop theirs
             // todo: do we even need this? tasks are spawned anyway and will see all transactions
             drop(done_tx);
+            drop(handles);
             while done_rx.recv().is_ok() {}
 
             let _ = actions_tx

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -115,7 +115,7 @@ where
             // drop handle and wait for all tasks to finish and drop theirs
             // todo: do we even need this? tasks are spawned anyway and will see all transactions
             drop(done_tx);
-            while let Ok(()) = done_rx.recv() {}
+            while done_rx.recv().is_ok() {}
 
             let _ = actions_tx
                 .send(PrewarmTaskEvent::FinishedTxExecution { executed_transactions: executing });

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -6,24 +6,21 @@ use crate::tree::{
         executor::WorkloadExecutor, multiproof::MultiProofMessage, ExecutionCache,
     },
     precompile_cache::{CachedPrecompile, PrecompileCacheMap},
-    StateProviderBuilder,
+    ExecutableTxReceiver, ExecutionEnv, StateProviderBuilder,
 };
-use alloy_consensus::transaction::Recovered;
-use alloy_evm::Database;
+use alloy_evm::{Database, RecoveredTx};
 use alloy_primitives::{keccak256, map::B256Set, B256};
-use itertools::Itertools;
 use metrics::{Gauge, Histogram};
-use reth_evm::{ConfigureEvm, Evm, EvmFor, SpecFor};
+use reth_evm::{execute::OwnedExecutableTxFor, ConfigureEvm, Evm, EvmFor, SpecFor};
 use reth_metrics::Metrics;
-use reth_primitives_traits::{header::SealedHeaderFor, NodePrimitives, SignedTransaction};
+use reth_primitives_traits::{NodePrimitives, SignedTransaction};
 use reth_provider::{BlockReader, StateCommitmentProvider, StateProviderFactory, StateReader};
 use reth_revm::{database::StateProviderDatabase, db::BundleState, state::EvmState};
 use reth_trie::MultiProofTargets;
 use std::{
-    collections::VecDeque,
     sync::{
         atomic::{AtomicBool, Ordering},
-        mpsc::{channel, Receiver, Sender},
+        mpsc::{self, channel, Receiver, Sender},
         Arc,
     },
     time::Instant,
@@ -43,8 +40,6 @@ where
     executor: WorkloadExecutor,
     /// Shared execution cache.
     execution_cache: ExecutionCache,
-    /// Transactions pending execution.
-    pending: VecDeque<Recovered<N::SignedTx>>,
     /// Context provided to execution tasks
     ctx: PrewarmContext<N, P, Evm>,
     /// How many transactions should be executed in parallel
@@ -53,10 +48,6 @@ where
     to_multi_proof: Option<Sender<MultiProofMessage>>,
     /// Receiver for events produced by tx execution
     actions_rx: Receiver<PrewarmTaskEvent>,
-    /// Sender the transactions use to send their result back
-    actions_tx: Sender<PrewarmTaskEvent>,
-    /// Total prewarming tasks spawned
-    prewarm_outcomes_left: usize,
 }
 
 impl<N, P, Evm> PrewarmCacheTask<N, P, Evm>
@@ -71,41 +62,54 @@ where
         execution_cache: ExecutionCache,
         ctx: PrewarmContext<N, P, Evm>,
         to_multi_proof: Option<Sender<MultiProofMessage>>,
-        pending: VecDeque<Recovered<N::SignedTx>>,
-    ) -> Self {
+    ) -> (Self, Sender<PrewarmTaskEvent>) {
         let (actions_tx, actions_rx) = channel();
-        Self {
-            executor,
-            execution_cache,
-            pending,
-            ctx,
-            max_concurrency: 64,
-            to_multi_proof,
-            actions_rx,
+        (
+            Self {
+                executor,
+                execution_cache,
+                ctx,
+                max_concurrency: 64,
+                to_multi_proof,
+                actions_rx,
+            },
             actions_tx,
-            prewarm_outcomes_left: 0,
-        }
-    }
-
-    /// Returns the sender that can communicate with this task.
-    pub(super) fn actions_tx(&self) -> Sender<PrewarmTaskEvent> {
-        self.actions_tx.clone()
+        )
     }
 
     /// Spawns all pending transactions as blocking tasks by first chunking them.
-    fn spawn_all(&mut self) {
-        let chunk_size = (self.pending.len() / self.max_concurrency).max(1);
+    fn spawn_all(
+        &self,
+        mut pending: ExecutableTxReceiver<impl OwnedExecutableTxFor<Evm>>,
+        actions_tx: Sender<PrewarmTaskEvent>,
+    ) {
+        let executor = self.executor.clone();
+        let ctx = self.ctx.clone();
+        let max_concurrency = self.max_concurrency;
 
-        for chunk in &self.pending.drain(..).chunks(chunk_size) {
-            let sender = self.actions_tx.clone();
-            let ctx = self.ctx.clone();
-            let pending_chunk = chunk.collect::<Vec<_>>();
+        self.executor.spawn_blocking(move || {
+            let mut handles = Vec::new();
+            let mut executing = 0;
+            while let Ok(executable) = pending.recv() {
+                let task_idx = executing % max_concurrency;
 
-            self.prewarm_outcomes_left += pending_chunk.len();
-            self.executor.spawn_blocking(move || {
-                ctx.transact_batch(&pending_chunk, sender);
-            });
-        }
+                if handles.len() <= task_idx {
+                    let (tx, rx) = mpsc::channel();
+                    let sender = actions_tx.clone();
+                    let ctx = ctx.clone();
+
+                    executor.spawn_blocking(move || {
+                        ctx.transact_batch(rx, sender);
+                    });
+
+                    handles.push(tx);
+                }
+
+                let _ = handles[task_idx].send(executable);
+
+                executing += 1;
+            }
+        });
     }
 
     /// If configured and the tx returned proof targets, emit the targets the transaction produced
@@ -119,7 +123,7 @@ where
     fn save_cache(self, state: BundleState) {
         let start = Instant::now();
         let cache = SavedCache::new(
-            self.ctx.header.hash(),
+            self.ctx.env.hash,
             self.ctx.cache.clone(),
             self.ctx.cache_metrics.clone(),
         );
@@ -136,30 +140,22 @@ where
         self.ctx.metrics.cache_saving_duration.set(start.elapsed().as_secs_f64());
     }
 
-    /// Removes the `actions_tx` currently stored in the struct, replacing it with a new one that
-    /// does not point to any active receiver.
-    ///
-    /// This is used to drop the `actions_tx` after all tasks have been spawned, and should not be
-    /// used in any context other than the `run` method.
-    fn drop_actions_tx(&mut self) {
-        self.actions_tx = channel().0;
-    }
-
     /// Executes the task.
     ///
     /// This will execute the transactions until all transactions have been processed or the task
     /// was cancelled.
-    pub(super) fn run(mut self) {
-        self.ctx.metrics.transactions.set(self.pending.len() as f64);
-        self.ctx.metrics.transactions_histogram.record(self.pending.len() as f64);
+    pub(super) fn run(
+        self,
+        pending: ExecutableTxReceiver<impl OwnedExecutableTxFor<Evm>>,
+        actions_tx: Sender<PrewarmTaskEvent>,
+    ) {
+        self.ctx.metrics.transactions.set(pending.len() as f64);
+        self.ctx.metrics.transactions_histogram.record(pending.len() as f64);
+
+        let mut num_txs = pending.len();
 
         // spawn execution tasks.
-        self.spawn_all();
-
-        // drop the actions sender after we've spawned all execution tasks. This is so that the
-        // following loop can terminate even if one of the prewarm tasks ends in an error (i.e.,
-        // does not return an Outcome) or panics.
-        self.drop_actions_tx();
+        self.spawn_all(pending, actions_tx);
 
         let mut final_block_output = None;
         while let Ok(event) = self.actions_rx.recv() {
@@ -173,9 +169,9 @@ where
                     self.send_multi_proof_targets(proof_targets);
 
                     // decrement the number of tasks left
-                    self.prewarm_outcomes_left -= 1;
+                    num_txs -= 1;
 
-                    if self.prewarm_outcomes_left == 0 && final_block_output.is_some() {
+                    if num_txs == 0 && final_block_output.is_some() {
                         // all tasks are done, and we have the block output, we can exit
                         break
                     }
@@ -183,7 +179,7 @@ where
                 PrewarmTaskEvent::Terminate { block_output } => {
                     final_block_output = Some(block_output);
 
-                    if self.prewarm_outcomes_left == 0 {
+                    if num_txs == 0 {
                         // all tasks are done, we can exit, which will save caches and exit
                         break
                     }
@@ -205,7 +201,7 @@ where
     N: NodePrimitives,
     Evm: ConfigureEvm<Primitives = N>,
 {
-    pub(super) header: SealedHeaderFor<N>,
+    pub(super) env: ExecutionEnv<Evm>,
     pub(super) evm_config: Evm,
     pub(super) cache: ProviderCaches,
     pub(super) cache_metrics: CachedStateMetrics,
@@ -226,11 +222,9 @@ where
 {
     /// Splits this context into an evm, an evm config, metrics, and the atomic bool for terminating
     /// execution.
-    fn evm_for_ctx(
-        self,
-    ) -> Option<(EvmFor<Evm, impl Database>, Evm, PrewarmMetrics, Arc<AtomicBool>)> {
+    fn evm_for_ctx(self) -> Option<(EvmFor<Evm, impl Database>, PrewarmMetrics, Arc<AtomicBool>)> {
         let Self {
-            header,
+            env,
             evm_config,
             cache: caches,
             cache_metrics,
@@ -259,7 +253,7 @@ where
 
         let state_provider = StateProviderDatabase::new(state_provider);
 
-        let mut evm_env = evm_config.evm_env(&header);
+        let mut evm_env = env.evm_env;
 
         // we must disable the nonce check so that we can execute the transaction even if the nonce
         // doesn't match what's on chain.
@@ -280,7 +274,7 @@ where
             });
         }
 
-        Some((evm, evm_config, metrics, terminate_execution))
+        Some((evm, metrics, terminate_execution))
     }
 
     /// Transacts the vec of transactions and returns the state outcome.
@@ -290,12 +284,14 @@ where
     ///
     /// Note: Since here are no ordering guarantees this won't the state the txs produce when
     /// executed sequentially.
-    fn transact_batch(self, txs: &[Recovered<N::SignedTx>], sender: Sender<PrewarmTaskEvent>) {
-        let Some((mut evm, evm_config, metrics, terminate_execution)) = self.evm_for_ctx() else {
-            return
-        };
+    fn transact_batch(
+        self,
+        txs: mpsc::Receiver<impl OwnedExecutableTxFor<Evm>>,
+        sender: Sender<PrewarmTaskEvent>,
+    ) {
+        let Some((mut evm, metrics, terminate_execution)) = self.evm_for_ctx() else { return };
 
-        for tx in txs {
+        while let Ok(tx) = txs.recv() {
             // If the task was cancelled, stop execution, send an empty result to notify the task,
             // and exit.
             if terminate_execution.load(Ordering::Relaxed) {
@@ -304,16 +300,15 @@ where
             }
 
             // create the tx env
-            let tx_env = evm_config.tx_env(tx);
             let start = Instant::now();
-            let res = match evm.transact(tx_env) {
+            let res = match evm.transact(tx.as_executable()) {
                 Ok(res) => res,
                 Err(err) => {
                     trace!(
                         target: "engine::tree",
                         %err,
-                        tx_hash=%tx.tx_hash(),
-                        sender=%tx.signer(),
+                        tx_hash=%tx.as_executable().tx().tx_hash(),
+                        sender=%tx.as_executable().signer(),
                         "Error when executing prewarm transaction",
                     );
                     return

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -9,10 +9,11 @@ use crate::tree::{
     persistence_state::CurrentPersistenceAction,
     precompile_cache::{CachedPrecompile, CachedPrecompileMetrics, PrecompileCacheMap},
     sparse_trie::StateRootComputeOutcome,
-    ConsistentDbView, EngineApiMetrics, EngineApiTreeState, PayloadHandle, PersistenceState,
-    PersistingKind, StateProviderBuilder, StateProviderDatabase, TreeConfig,
+    ConsistentDbView, EngineApiMetrics, EngineApiTreeState, ExecutionEnv, PayloadHandle,
+    PersistenceState, PersistingKind, StateProviderBuilder, StateProviderDatabase, TreeConfig,
 };
-use alloy_evm::{block::BlockExecutor, Evm};
+use alloy_eips::NumHash;
+use alloy_evm::Evm;
 use alloy_primitives::B256;
 use reth_chain_state::{
     CanonicalInMemoryState, ExecutedBlock, ExecutedBlockWithTrieUpdates, ExecutedTrieUpdates,
@@ -20,7 +21,7 @@ use reth_chain_state::{
 use reth_consensus::{ConsensusError, FullConsensus};
 use reth_engine_primitives::{InvalidBlockHook, PayloadValidator};
 use reth_errors::ProviderResult;
-use reth_evm::{ConfigureEvm, SpecFor};
+use reth_evm::{block::BlockExecutor, execute::OwnedExecutableTxFor, ConfigureEvm, SpecFor};
 use reth_payload_primitives::{
     BuiltPayload, InvalidPayloadAttributesError, NewPayloadError, PayloadTypes,
 };
@@ -232,26 +233,23 @@ where
             };
         }
 
+        let parent_hash = block.parent_hash();
         let block_num_hash = block.num_hash();
 
-        trace!(target: "engine::tree", block=?block_num_hash, "Validating block consensus");
-        // validate block consensus rules
-        ensure_ok!(self.validate_block_inner(&block));
-
-        trace!(target: "engine::tree", block=?block_num_hash, parent=?block.parent_hash(), "Fetching block state provider");
+        trace!(target: "engine::tree", block=?block_num_hash, parent=?parent_hash, "Fetching block state provider");
         let Some(provider_builder) =
-            ensure_ok!(self.state_provider_builder(block.parent_hash(), ctx.state()))
+            ensure_ok!(self.state_provider_builder(parent_hash, ctx.state()))
         else {
             // this is pre-validated in the tree
             return Err((
-                InsertBlockErrorKind::Provider(ProviderError::HeaderNotFound(
-                    block.parent_hash().into(),
-                )),
+                InsertBlockErrorKind::Provider(ProviderError::HeaderNotFound(parent_hash.into())),
                 block,
             ))
         };
 
-        // now validate against the parent
+        let state_provider = ensure_ok!(provider_builder.build());
+
+        // fetch parent block
         let Some(parent_block) =
             ensure_ok!(self.sealed_header_by_hash(block.parent_hash(), ctx.state()))
         else {
@@ -263,14 +261,26 @@ where
             ))
         };
 
-        if let Err(e) =
-            self.consensus.validate_header_against_parent(block.sealed_header(), &parent_block)
+        // todo: move to a separate task
         {
-            warn!(target: "engine::tree", ?block, "Failed to validate header {} against parent: {e}", block.hash());
-            return Err((e.into(), block))
+            trace!(target: "engine::tree", block=?block_num_hash, "Validating block consensus");
+            // validate block consensus rules
+            ensure_ok!(self.validate_block_inner(&block));
+
+            // now validate against the parent
+            if let Err(e) =
+                self.consensus.validate_header_against_parent(block.sealed_header(), &parent_block)
+            {
+                warn!(target: "engine::tree", ?block, "Failed to validate header {} against parent: {e}", block.hash());
+                return Err((e.into(), block))
+            }
         }
 
-        let state_provider = ensure_ok!(provider_builder.build());
+        let env = ExecutionEnv {
+            evm_env: self.evm_config.evm_env(block.header()),
+            hash: block.hash(),
+            parent_hash: block.parent_hash(),
+        };
 
         // We only run the parallel state root if we are not currently persisting any blocks or
         // persisting blocks that are all ancestors of the one we are executing.
@@ -310,8 +320,7 @@ where
         );
 
         // use prewarming background task
-        let header = block.clone_sealed_header();
-        let txs = block.clone_transactions_recovered().collect();
+        let txs = block.clone_transactions_recovered().collect::<Vec<_>>().into_iter();
         let mut handle = if use_state_root_task {
             // use background tasks for state root calc
             let consistent_view =
@@ -322,7 +331,7 @@ where
             let res = self.compute_trie_input(
                 persisting_kind,
                 ensure_ok!(consistent_view.provider_ro()),
-                block.header().parent_hash(),
+                parent_hash,
                 ctx.state(),
             );
             let trie_input = match res {
@@ -340,7 +349,7 @@ where
             // proof.
             if trie_input.prefix_sets.is_empty() {
                 self.payload_processor.spawn(
-                    header,
+                    env.clone(),
                     txs,
                     provider_builder,
                     consistent_view,
@@ -350,10 +359,10 @@ where
             } else {
                 debug!(target: "engine::tree", block=?block_num_hash, "Disabling state root task due to non-empty prefix sets");
                 use_state_root_task = false;
-                self.payload_processor.spawn_cache_exclusive(header, txs, provider_builder)
+                self.payload_processor.spawn_cache_exclusive(env.clone(), txs, provider_builder)
             }
         } else {
-            self.payload_processor.spawn_cache_exclusive(header, txs, provider_builder)
+            self.payload_processor.spawn_cache_exclusive(env.clone(), txs, provider_builder)
         };
 
         // Use cached state provider before executing, used in execution after prewarming threads
@@ -367,13 +376,11 @@ where
         let (output, execution_finish) = if self.config.state_provider_metrics() {
             let state_provider = InstrumentedStateProvider::from_state_provider(&state_provider);
             let (output, execution_finish) =
-                ensure_ok!(self.execute_block(&state_provider, &block, &handle));
+                ensure_ok!(self.execute_block(&state_provider, env, &block, &mut handle));
             state_provider.record_total_latency();
             (output, execution_finish)
         } else {
-            let (output, execution_finish) =
-                ensure_ok!(self.execute_block(&state_provider, &block, &handle));
-            (output, execution_finish)
+            ensure_ok!(self.execute_block(&state_provider, env, &block, &mut handle))
         };
 
         // after executing the block we can stop executing transactions
@@ -549,16 +556,21 @@ where
     fn execute_block<S: StateProvider>(
         &mut self,
         state_provider: S,
+        env: ExecutionEnv<Evm>,
         block: &RecoveredBlock<N::Block>,
-        handle: &PayloadHandle,
+        handle: &mut PayloadHandle<impl OwnedExecutableTxFor<Evm>>,
     ) -> Result<(BlockExecutionOutput<N::Receipt>, Instant), InsertBlockErrorKind> {
-        debug!(target: "engine::tree", block=?block.num_hash(), "Executing block");
+        let num_hash = NumHash::new(env.evm_env.block_env.number.to(), env.hash);
+        debug!(target: "engine::tree", block=?num_hash, "Executing block");
         let mut db = State::builder()
             .with_database(StateProviderDatabase::new(&state_provider))
             .with_bundle_update()
             .without_state_clear()
             .build();
-        let mut executor = self.evm_config.executor_for_block(&mut db, block);
+
+        let evm = self.evm_config.evm_with_env(&mut db, env.evm_env.clone());
+        let ctx = self.evm_config.context_for_block(block.sealed_block());
+        let mut executor = self.evm_config.create_executor(evm, ctx);
 
         if !self.config.precompile_cache_disabled() {
             executor.evm_mut().precompiles_mut().map_precompiles(|address, precompile| {
@@ -570,21 +582,22 @@ where
                 CachedPrecompile::wrap(
                     precompile,
                     self.precompile_cache_map.cache_for_address(*address),
-                    *self.evm_config.evm_env(block.header()).spec_id(),
+                    *env.evm_env.spec_id(),
                     Some(metrics),
                 )
             });
         }
 
         let execution_start = Instant::now();
+        let state_hook = Box::new(handle.state_hook());
         let output = self.metrics.executor.execute_metered(
             executor,
-            block,
-            Box::new(handle.state_hook()),
+            handle.iter_transactions(),
+            state_hook,
         )?;
         let execution_finish = Instant::now();
         let execution_time = execution_finish.duration_since(execution_start);
-        debug!(target: "engine::tree", elapsed = ?execution_time, number=?block.number(), "Executed block");
+        debug!(target: "engine::tree", elapsed = ?execution_time, number=?num_hash.number, "Executed block");
         Ok((output, execution_finish))
     }
 

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -566,14 +566,14 @@ impl<T, Evm: ConfigureEvm> OwnedExecutableTxFor<Evm> for T where
 
 /// A helper trait marking a 'static type that can be converted into an [`ExecutableTx`] for block
 /// executor.
-pub trait OwnedExecutableTx<TxEnv, Tx>: Send + 'static {
+pub trait OwnedExecutableTx<TxEnv, Tx>: Clone + Send + 'static {
     /// Converts the type into an [`ExecutableTx`] for block executor.
     fn as_executable(&self) -> impl IntoTxEnv<TxEnv> + RecoveredTx<Tx> + Copy;
 }
 
 impl<T, TxEnv, Tx> OwnedExecutableTx<TxEnv, Tx> for T
 where
-    T: Send + 'static,
+    T: Clone + Send + 'static,
     for<'a> &'a T: IntoTxEnv<TxEnv> + RecoveredTx<Tx> + Copy,
 {
     fn as_executable(&self) -> impl IntoTxEnv<TxEnv> + RecoveredTx<Tx> + Copy {

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -552,18 +552,6 @@ where
     }
 }
 
-/// A helper trait alias to mark a type that can be used as [`reth_evm::block::ExecutableTx`] for
-/// any block executor produced by [`ConfigureEvm`].
-pub trait ExecutableTxFor<Evm: ConfigureEvm>:
-    IntoTxEnv<TxEnvFor<Evm>> + RecoveredTx<TxTy<Evm::Primitives>> + Copy
-{
-}
-
-impl<T, Evm: ConfigureEvm> ExecutableTxFor<Evm> for T where
-    T: IntoTxEnv<TxEnvFor<Evm>> + RecoveredTx<TxTy<Evm::Primitives>> + Copy
-{
-}
-
 /// A helper trait marking a 'static type that can be converted into an [`ExecutableTx`] for block
 /// executor.
 pub trait OwnedExecutableTxFor<Evm: ConfigureEvm>:

--- a/crates/evm/evm/src/lib.rs
+++ b/crates/evm/evm/src/lib.rs
@@ -191,9 +191,10 @@ pub trait ConfigureEvm: Clone + Debug + Send + Sync + Unpin {
     type NextBlockEnvCtx: Debug + Clone;
 
     /// Configured [`BlockExecutorFactory`], contains [`EvmFactory`] internally.
-    type BlockExecutorFactory: BlockExecutorFactory<
+    type BlockExecutorFactory: for<'a> BlockExecutorFactory<
         Transaction = TxTy<Self::Primitives>,
         Receipt = ReceiptTy<Self::Primitives>,
+        ExecutionCtx<'a>: Debug + Send,
         EvmFactory: EvmFactory<
             Tx: TransactionEnv
                     + FromRecoveredTx<TxTy<Self::Primitives>>

--- a/crates/evm/evm/src/metrics.rs
+++ b/crates/evm/evm/src/metrics.rs
@@ -2,7 +2,7 @@
 //!
 //! Block processing related to syncing should take care to update the metrics by using either
 //! [`ExecutorMetrics::execute_metered`] or [`ExecutorMetrics::metered_one`].
-use crate::{Database, OnStateHook};
+use crate::{execute::OwnedExecutableTx, Database, OnStateHook};
 use alloy_consensus::BlockHeader;
 use alloy_evm::{
     block::{BlockExecutor, StateChangeSource},
@@ -13,7 +13,7 @@ use metrics::{Counter, Gauge, Histogram};
 use reth_execution_errors::BlockExecutionError;
 use reth_execution_types::BlockExecutionOutput;
 use reth_metrics::Metrics;
-use reth_primitives_traits::{Block, BlockBody, RecoveredBlock};
+use reth_primitives_traits::RecoveredBlock;
 use revm::{
     database::{states::bundle_state::BundleRetention, State},
     state::EvmState,
@@ -75,20 +75,19 @@ pub struct ExecutorMetrics {
 }
 
 impl ExecutorMetrics {
-    fn metered<F, R, B>(&self, block: &RecoveredBlock<B>, f: F) -> R
+    fn metered<F, R>(&self, f: F) -> R
     where
-        F: FnOnce() -> R,
-        B: reth_primitives_traits::Block,
+        F: FnOnce() -> (u64, R),
     {
         // Execute the block and record the elapsed time.
         let execute_start = Instant::now();
-        let output = f();
+        let (gas_used, output) = f();
         let execution_duration = execute_start.elapsed().as_secs_f64();
 
         // Update gas metrics.
-        self.gas_processed_total.increment(block.header().gas_used());
-        self.gas_per_second.set(block.header().gas_used() as f64 / execution_duration);
-        self.gas_used_histogram.record(block.header().gas_used() as f64);
+        self.gas_processed_total.increment(gas_used);
+        self.gas_per_second.set(gas_used as f64 / execution_duration);
+        self.gas_used_histogram.record(gas_used as f64);
         self.execution_histogram.record(execution_duration);
         self.execution_duration.set(execution_duration);
 
@@ -105,7 +104,7 @@ impl ExecutorMetrics {
     pub fn execute_metered<E, DB>(
         &self,
         executor: E,
-        input: &RecoveredBlock<impl Block<Body: BlockBody<Transaction = E::Transaction>>>,
+        transactions: impl Iterator<Item = impl OwnedExecutableTx<<E::Evm as Evm>::Tx, E::Transaction>>,
         state_hook: Box<dyn OnStateHook>,
     ) -> Result<BlockExecutionOutput<E::Receipt>, BlockExecutionError>
     where
@@ -119,13 +118,19 @@ impl ExecutorMetrics {
 
         let mut executor = executor.with_state_hook(Some(Box::new(wrapper)));
 
-        // Use metered to execute and track timing/gas metrics
-        let (mut db, result) = self.metered(input, || {
+        let f = || {
             executor.apply_pre_execution_changes()?;
-            for tx in input.transactions_recovered() {
-                executor.execute_transaction(tx)?;
+            for tx in transactions {
+                executor.execute_transaction(tx.as_executable())?;
             }
             executor.finish().map(|(evm, result)| (evm.into_db(), result))
+        };
+
+        // Use metered to execute and track timing/gas metrics
+        let (mut db, result) = self.metered(|| {
+            let res = f();
+            let gas_used = res.as_ref().map(|r| r.1.gas_used).unwrap_or(0);
+            (gas_used, res)
         })?;
 
         // merge transactions into bundle state
@@ -151,7 +156,7 @@ impl ExecutorMetrics {
         F: FnOnce(&RecoveredBlock<B>) -> R,
         B: reth_primitives_traits::Block,
     {
-        self.metered(input, || f(input))
+        self.metered(|| (input.header().gas_used(), f(input)))
     }
 }
 
@@ -295,7 +300,13 @@ mod tests {
             state
         };
         let executor = MockExecutor::new(state);
-        let _result = metrics.execute_metered::<_, EmptyDB>(executor, &input, state_hook).unwrap();
+        let _result = metrics
+            .execute_metered::<_, EmptyDB>(
+                executor,
+                input.clone_transactions_recovered(),
+                state_hook,
+            )
+            .unwrap();
 
         let snapshot = snapshotter.snapshot().into_vec();
 
@@ -327,7 +338,13 @@ mod tests {
         let state = EvmState::default();
 
         let executor = MockExecutor::new(state);
-        let _result = metrics.execute_metered::<_, EmptyDB>(executor, &input, state_hook).unwrap();
+        let _result = metrics
+            .execute_metered::<_, EmptyDB>(
+                executor,
+                input.clone_transactions_recovered(),
+                state_hook,
+            )
+            .unwrap();
 
         let actual_output = rx.try_recv().unwrap();
         assert_eq!(actual_output, expected_output);


### PR DESCRIPTION
Preparation for https://github.com/paradigmxyz/reth/issues/17291

Changes main execution code-paths to not depend on the block and instead take `EvmEnv` directly and take transactions as an iterator of `OwnedExecutableTx`.

`OwnedExecutableTx` is a new trait intoroduced as a helper to bound `'static` types that can be passed to block executors.