### PR TITLE
fix: RPC: feeHistoryEntry should return 0.0 when blob_params.max_blob_count is zero

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/fee.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/fee.rs
@@ -10,8 +10,8 @@ use futures::Future;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_primitives_traits::BlockBody;
 use reth_rpc_eth_types::{
-    fee_history::calculate_reward_percentiles_for_block, EthApiError, FeeHistoryCache,
-    FeeHistoryEntry, GasPriceOracle, RpcInvalidTransactionError,
+    fee_history::calculate_reward_percentiles_for_block, utils::checked_blob_gas_used_ratio,
+    EthApiError, FeeHistoryCache, FeeHistoryEntry, GasPriceOracle, RpcInvalidTransactionError,
 };
 use reth_storage_api::{BlockIdReader, BlockReaderIdExt, HeaderProvider, ProviderHeader};
 use tracing::debug;
@@ -186,8 +186,10 @@ pub trait EthFees:
 
                     base_fee_per_blob_gas.push(header.blob_fee(blob_params).unwrap_or_default());
                     blob_gas_used_ratio.push(
-                        header.blob_gas_used().unwrap_or_default() as f64
-                            / blob_params.max_blob_gas_per_block() as f64,
+                        checked_blob_gas_used_ratio(
+                            header.blob_gas_used().unwrap_or_default(),
+                            blob_params.max_blob_gas_per_block(),
+                        )
                     );
 
                     // Percentiles were specified, so we need to collect reward percentile info

--- a/crates/rpc/rpc-eth-types/Cargo.toml
+++ b/crates/rpc/rpc-eth-types/Cargo.toml
@@ -62,6 +62,7 @@ itertools.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true
+reth-chain-state = { workspace = true, features = ["test-utils"]}
 
 [features]
 js-tracer = ["revm-inspectors/js-tracer"]

--- a/crates/rpc/rpc-eth-types/Cargo.toml
+++ b/crates/rpc/rpc-eth-types/Cargo.toml
@@ -62,7 +62,6 @@ itertools.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true
-reth-chain-state = { workspace = true, features = ["test-utils"]}
 
 [features]
 js-tracer = ["revm-inspectors/js-tracer"]

--- a/crates/rpc/rpc-eth-types/src/fee_history.rs
+++ b/crates/rpc/rpc-eth-types/src/fee_history.rs
@@ -412,35 +412,3 @@ where
         })
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use alloy_eips::eip7840::BlobParams;
-    use alloy_primitives::B256;
-    use reth_chain_state::{test_utils::TestBlockBuilder, EthPrimitives};
-
-    #[test]
-    fn test_fee_history_entries_when_max_blob_count_is_zero() {
-        // Arrange
-
-        let blob_params = BlobParams {
-            target_blob_count: 0,
-            max_blob_count: 0,
-            update_fraction: 1,
-            min_blob_fee: 0,
-            max_blobs_per_tx: 0,
-        };
-
-        let mut test_block_builder: TestBlockBuilder<EthPrimitives> = TestBlockBuilder::default();
-
-        // The block will be generated with no blob gas used
-        let block = test_block_builder.generate_random_block(1u64, B256::ZERO);
-
-        // Act
-        let fee_history_enty =
-            super::FeeHistoryEntry::new(&block.sealed_block(), Some(blob_params.clone()));
-
-        // Assert
-        assert_eq!(fee_history_enty.blob_gas_used_ratio, 0.0);
-    }
-}

--- a/crates/rpc/rpc-eth-types/src/fee_history.rs
+++ b/crates/rpc/rpc-eth-types/src/fee_history.rs
@@ -409,3 +409,35 @@ where
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use alloy_eips::eip7840::BlobParams;
+    use alloy_primitives::B256;
+    use reth_chain_state::{test_utils::TestBlockBuilder, EthPrimitives};
+
+    #[test]
+    fn test_fee_history_entries_when_max_blob_count_is_zero() {
+        // Arrange
+
+        let blob_params = BlobParams {
+            target_blob_count: 0,
+            max_blob_count: 0,
+            update_fraction: 1,
+            min_blob_fee: 0,
+            max_blobs_per_tx: 0,
+        };
+
+        let mut test_block_builder: TestBlockBuilder<EthPrimitives> = TestBlockBuilder::default();
+
+        // The block will be generated with no blob gas used
+        let block = test_block_builder.generate_random_block(1u64, B256::ZERO);
+
+        // Act
+        let fee_history_enty =
+            super::FeeHistoryEntry::new(&block.sealed_block(), Some(blob_params.clone()));
+
+        // Assert
+        assert_eq!(fee_history_enty.blob_gas_used_ratio, 0.0);
+    }
+}

--- a/crates/rpc/rpc-eth-types/src/fee_history.rs
+++ b/crates/rpc/rpc-eth-types/src/fee_history.rs
@@ -110,7 +110,7 @@ where
         if entries.is_empty() {
             self.inner.upper_bound.store(0, SeqCst);
             self.inner.lower_bound.store(0, SeqCst);
-            return;
+            return
         }
 
         let upper_bound = *entries.last_entry().expect("Contains at least one entry").key();
@@ -149,7 +149,7 @@ where
     ) -> Option<Vec<FeeHistoryEntry<H>>> {
         if end_block < start_block {
             // invalid range, return None
-            return None;
+            return None
         }
         let lower_bound = self.lower_bound();
         let upper_bound = self.upper_bound();

--- a/crates/rpc/rpc-eth-types/src/fee_history.rs
+++ b/crates/rpc/rpc-eth-types/src/fee_history.rs
@@ -22,6 +22,8 @@ use reth_storage_api::BlockReaderIdExt;
 use serde::{Deserialize, Serialize};
 use tracing::trace;
 
+use crate::utils::checked_blob_gas_used_ratio;
+
 use super::{EthApiError, EthStateCache};
 
 /// Contains cached fee history entries for blocks.
@@ -376,18 +378,13 @@ where
             base_fee_per_blob_gas: header
                 .excess_blob_gas()
                 .and_then(|excess_blob_gas| Some(blob_params?.calc_blob_fee(excess_blob_gas))),
-            blob_gas_used_ratio: if block.body().blob_gas_used() == 0 {
-                // Prevent returning NaN when blob_params is defined with a max_blob_gas_per_block
-                // equal to zero.
-                0.0
-            } else {
-                block.body().blob_gas_used() as f64 /
-                    blob_params
-                        .as_ref()
-                        .map(|params| params.max_blob_gas_per_block())
-                        .unwrap_or(alloy_eips::eip4844::MAX_DATA_GAS_PER_BLOCK_DENCUN)
-                        as f64
-            },
+            blob_gas_used_ratio: checked_blob_gas_used_ratio(
+                block.body().blob_gas_used(),
+                blob_params
+                    .as_ref()
+                    .map(|params| params.max_blob_gas_per_block())
+                    .unwrap_or(alloy_eips::eip4844::MAX_DATA_GAS_PER_BLOCK_DENCUN),
+            ),
             rewards: Vec::new(),
             blob_params,
         }

--- a/crates/rpc/rpc-eth-types/src/fee_history.rs
+++ b/crates/rpc/rpc-eth-types/src/fee_history.rs
@@ -325,7 +325,7 @@ where
         // Empty blocks should return in a zero row
         if transactions.is_empty() {
             rewards_in_block.push(0);
-            continue;
+            continue
         }
 
         let threshold = (gas_used as f64 * percentile / 100.) as u64;

--- a/crates/rpc/rpc-eth-types/src/fee_history.rs
+++ b/crates/rpc/rpc-eth-types/src/fee_history.rs
@@ -161,7 +161,7 @@ where
                 .collect::<Vec<_>>();
 
             if result.is_empty() {
-                return None;
+                return None
             }
 
             Some(result)

--- a/crates/rpc/rpc-eth-types/src/utils.rs
+++ b/crates/rpc/rpc-eth-types/src/utils.rs
@@ -58,6 +58,19 @@ where
     Ok(num)
 }
 
+/// Calculates the blob gas used ratio for a block, accounting for the case where
+/// max_blob_gas_per_block is zero.
+///
+/// Returns `0.0` if `blob_gas_used` is `0`, otherwise returns the ratio
+/// `blob_gas_used/max_blob_gas_per_block`.
+pub fn checked_blob_gas_used_ratio(blob_gas_used: u64, max_blob_gas_per_block: u64) -> f64 {
+    if blob_gas_used == 0 {
+        0.0
+    } else {
+        blob_gas_used as f64 / max_blob_gas_per_block as f64
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/rpc/rpc-eth-types/src/utils.rs
+++ b/crates/rpc/rpc-eth-types/src/utils.rs
@@ -97,4 +97,16 @@ mod tests {
             binary_search(1, 10, |mid| Box::pin(async move { Ok(mid >= 11) })).await;
         assert_eq!(num, Ok(10));
     }
+
+    #[test]
+    fn test_checked_blob_gas_used_ratio() {
+        // No blob gas used, max blob gas per block is 0
+        assert_eq!(checked_blob_gas_used_ratio(0, 0), 0.0);
+        // Blob gas used is zero, max blob gas per block is non-zero
+        assert_eq!(checked_blob_gas_used_ratio(0, 100), 0.0);
+        // Blob gas used is non-zero, max blob gas per block is non-zero
+        assert_eq!(checked_blob_gas_used_ratio(50, 100), 0.5);
+        // Blob gas used is non-zero and equal to max blob gas per block
+        assert_eq!(checked_blob_gas_used_ratio(100, 100), 1.0);
+    }
 }

--- a/crates/rpc/rpc-eth-types/src/utils.rs
+++ b/crates/rpc/rpc-eth-types/src/utils.rs
@@ -59,7 +59,7 @@ where
 }
 
 /// Calculates the blob gas used ratio for a block, accounting for the case where
-/// max_blob_gas_per_block is zero.
+/// `max_blob_gas_per_block` is zero.
 ///
 /// Returns `0.0` if `blob_gas_used` is `0`, otherwise returns the ratio
 /// `blob_gas_used/max_blob_gas_per_block`.


### PR DESCRIPTION
The documentation of `FeeHistoryEntry` specifies that the `blob_gas_used_ratio` should be `0.0` when there are no blobs in a block. 

https://github.com/paradigmxyz/reth/blob/c45b1cd314f69281115fab3ac736d1584f65e089/crates/rpc/rpc-eth-types/src/fee_history.rs#L352-L354

However, some custom EVM chain disable blobs by specifying a value of `0` for `max_blob_count` in the genesis file's `blobSchedules`. In this case, calling the `eth_feeHistory` method will return a list of `feeHistoryEntry` whose `blob_gas_used_ratio` is `NaN`, serialized to `null`. 

For those chains, this has the impact of having foundry script deployments failing with the following error: 

```
Error: Failed to get EIP-1559 fees
``` 

This PR fixes the impementation of `FeeHistoryEntry` so that when `blob_params.max_blob_count` is `0`, then `blob_gas_used_ratio` is set to `0.0` rather than `NaN`, as per the `FeeHistoryEntry` documentation.

A unit test `fee_history::tests::test_fee_history_entries_when_max_blob_count_is_zero` is provided to validate the fix. 
