### PR TITLE
fix: reorder trait bounds in static_file transactions

### DIFF
--- a/crates/prune/prune/src/segments/static_file/transactions.rs
+++ b/crates/prune/prune/src/segments/static_file/transactions.rs
@@ -29,10 +29,10 @@ impl<N> Transactions<N> {
 
 impl<Provider> Segment<Provider> for Transactions<Provider::Primitives>
 where
-    Provider: DBProvider<Tx: DbTxMut>
+    Provider: StaticFileProviderFactory<Primitives: NodePrimitives<SignedTx: Value>>
+        + DBProvider<Tx: DbTxMut>
         + TransactionsProvider
-        + BlockReader
-        + StaticFileProviderFactory<Primitives: NodePrimitives<SignedTx: Value>>,
+        + BlockReader,
 {
     fn segment(&self) -> PruneSegment {
         PruneSegment::Transactions


### PR DESCRIPTION
Put StaticFileProviderFactory first in trait bounds for consistency
with headers.rs and receipts.rs modules.