### PR TITLE
fix: typos in trie error comment and system requirements docs

### DIFF
--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -598,7 +598,7 @@ where
     pub fn root(self) -> Result<B256, StorageRootError> {
         match self.calculate(false)? {
             StorageRootProgress::Complete(root, _, _) => Ok(root),
-            StorageRootProgress::Progress(..) => unreachable!(), // update retenion is disabled
+            StorageRootProgress::Progress(..) => unreachable!(), // update retention is disabled
         }
     }
 

--- a/docs/vocs/docs/pages/run/system-requirements.mdx
+++ b/docs/vocs/docs/pages/run/system-requirements.mdx
@@ -77,7 +77,7 @@ Once you're synced to the tip you will need a reliable connection, especially if
 
 ### Build your own
 
--   Storage: Consult the [Great and less great SSDs for Ethereum nodes](https://gist.github.com/yorickdowne/f3a3e79a573bf35767cd002cc977b038) gist. The Seagate Firecuda 530 and WD Black SN850(X) are popular TLC NVMEe options. Ensure proper cooling via heatsinks or active fans.
+-   Storage: Consult the [Great and less great SSDs for Ethereum nodes](https://gist.github.com/yorickdowne/f3a3e79a573bf35767cd002cc977b038) gist. The Seagate Firecuda 530 and WD Black SN850(X) are popular TLC NVMe options. Ensure proper cooling via heatsinks or active fans.
 -   CPU: AMD Ryzen 5000/7000/9000 series, AMD EPYC 4004/4005 or Intel Core i5/i7 (11th gen or newer) with at least 6 cores. The AMD Ryzen 9000 series and the AMD EPYC 4005 series offer good value.
 -   Memory: 32GB DDR4 or DDR5 (ECC if your motherboard & CPU supports it).
 


### PR DESCRIPTION
In trie.rs: corrected typo in comment from retenion → retention.
In system-requirements.mdx: fixed typo NVMEe → NVMe in SSD description.