### PR TITLE
feat(rpc): add configurable pending block behaviour

### DIFF
--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -1090,6 +1090,7 @@ impl<'a, N: FullNodeComponents<Types: NodeTypes<ChainSpec: EthereumHardforks>>> 
             .proof_permits(self.config.proof_permits)
             .gas_oracle_config(self.config.gas_oracle)
             .max_batch_size(self.config.max_batch_size)
+            .pending_block_kind(self.config.pending_block_kind)
     }
 }
 

--- a/crates/node/core/src/args/rpc_server.rs
+++ b/crates/node/core/src/args/rpc_server.rs
@@ -15,6 +15,7 @@ use clap::{
 };
 use rand::Rng;
 use reth_cli_util::parse_ether_value;
+use reth_rpc_eth_types::builder::config::PendingBlockKind;
 use reth_rpc_server_types::{constants, RethRpcModule, RpcModuleSelection};
 
 use crate::args::{
@@ -219,6 +220,13 @@ pub struct RpcServerArgs {
     #[arg(long = "rpc.proof-permits", alias = "rpc-proof-permits", value_name = "COUNT", default_value_t = constants::DEFAULT_PROOF_PERMITS)]
     pub rpc_proof_permits: usize,
 
+    /// Configures the pending block behavior for RPC responses.
+    ///
+    /// Options: full (include all transactions), empty (header only), none (disable pending
+    /// blocks).
+    #[arg(long = "rpc.pending-block", default_value = "full", value_name = "KIND")]
+    pub rpc_pending_block: PendingBlockKind,
+
     /// Path to file containing disallowed addresses, json-encoded list of strings. Block
     /// validation API will reject blocks containing transactions from these addresses.
     #[arg(long = "builder.disallow", value_name = "PATH", value_parser = reth_cli_util::parsers::read_json_from_file::<HashSet<Address>>)]
@@ -363,6 +371,7 @@ impl Default for RpcServerArgs {
             rpc_tx_fee_cap: constants::DEFAULT_TX_FEE_CAP_WEI,
             rpc_max_simulate_blocks: constants::DEFAULT_MAX_SIMULATE_BLOCKS,
             rpc_eth_proof_window: constants::DEFAULT_ETH_PROOF_WINDOW,
+            rpc_pending_block: PendingBlockKind::Full,
             gas_price_oracle: GasPriceOracleArgs::default(),
             rpc_state_cache: RpcStateCacheArgs::default(),
             rpc_proof_permits: constants::DEFAULT_PROOF_PERMITS,

--- a/crates/optimism/rpc/src/eth/pending_block.rs
+++ b/crates/optimism/rpc/src/eth/pending_block.rs
@@ -9,7 +9,7 @@ use reth_rpc_eth_api::{
     helpers::{pending_block::PendingEnvBuilder, LoadPendingBlock},
     FromEvmError, RpcConvert, RpcNodeCore,
 };
-use reth_rpc_eth_types::{EthApiError, PendingBlock};
+use reth_rpc_eth_types::{builder::config::PendingBlockKind, EthApiError, PendingBlock};
 use reth_storage_api::{
     BlockReader, BlockReaderIdExt, ProviderBlock, ProviderReceipt, ReceiptProvider,
 };
@@ -28,6 +28,11 @@ where
     #[inline]
     fn pending_env_builder(&self) -> &dyn PendingEnvBuilder<Self::Evm> {
         self.inner.eth_api.pending_env_builder()
+    }
+
+    #[inline]
+    fn pending_block_kind(&self) -> PendingBlockKind {
+        self.inner.eth_api.pending_block_kind()
     }
 
     /// Returns the locally built pending block

--- a/crates/rpc/rpc-builder/src/config.rs
+++ b/crates/rpc/rpc-builder/src/config.rs
@@ -103,6 +103,7 @@ impl RethRpcServerConfig for RpcServerArgs {
             .state_cache(self.state_cache_config())
             .gpo_config(self.gas_price_oracle_config())
             .proof_permits(self.rpc_proof_permits)
+            .pending_block_kind(self.rpc_pending_block)
     }
 
     fn flashbots_config(&self) -> ValidationApiConfig {

--- a/crates/rpc/rpc-eth-types/src/builder/config.rs
+++ b/crates/rpc/rpc-eth-types/src/builder/config.rs
@@ -15,6 +15,47 @@ use serde::{Deserialize, Serialize};
 /// Default value for stale filter ttl
 pub const DEFAULT_STALE_FILTER_TTL: Duration = Duration::from_secs(5 * 60);
 
+/// Config for the locally built pending block
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum PendingBlockKind {
+    /// Return a pending block with header only, no transactions included
+    Empty,
+    /// Return null/no pending block
+    None,
+    /// Return a pending block with all transactions from the mempool (default behavior)
+    #[default]
+    Full,
+}
+
+impl std::str::FromStr for PendingBlockKind {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "empty" => Ok(Self::Empty),
+            "none" => Ok(Self::None),
+            "full" => Ok(Self::Full),
+            _ => Err(format!(
+                "Invalid pending block kind: {}. Valid options are: empty, none, full",
+                s
+            )),
+        }
+    }
+}
+
+impl PendingBlockKind {
+    /// Returns true if the pending block kind is `None`
+    pub const fn is_none(&self) -> bool {
+        matches!(self, Self::None)
+    }
+
+    /// Returns true if the pending block kind is `Empty`
+    pub const fn is_empty(&self) -> bool {
+        matches!(self, Self::Empty)
+    }
+}
+
 /// Additional config values for the eth namespace.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
 pub struct EthConfig {
@@ -47,6 +88,8 @@ pub struct EthConfig {
     pub proof_permits: usize,
     /// Maximum batch size for transaction pool insertions.
     pub max_batch_size: usize,
+    /// Controls how pending blocks are built when requested via RPC methods
+    pub pending_block_kind: PendingBlockKind,
 }
 
 impl EthConfig {
@@ -75,6 +118,7 @@ impl Default for EthConfig {
             fee_history_cache: FeeHistoryCacheConfig::default(),
             proof_permits: DEFAULT_PROOF_PERMITS,
             max_batch_size: 1,
+            pending_block_kind: PendingBlockKind::Full,
         }
     }
 }
@@ -143,6 +187,12 @@ impl EthConfig {
     /// Configures the maximum batch size for transaction pool insertions
     pub const fn max_batch_size(mut self, max_batch_size: usize) -> Self {
         self.max_batch_size = max_batch_size;
+        self
+    }
+
+    /// Configures the pending block config
+    pub const fn pending_block_kind(mut self, pending_block_kind: PendingBlockKind) -> Self {
+        self.pending_block_kind = pending_block_kind;
         self
     }
 }

--- a/crates/rpc/rpc/src/eth/builder.rs
+++ b/crates/rpc/rpc/src/eth/builder.rs
@@ -10,9 +10,9 @@ use reth_rpc_eth_api::{
     helpers::pending_block::PendingEnvBuilder, node::RpcNodeCoreAdapter, RpcNodeCore,
 };
 use reth_rpc_eth_types::{
-    fee_history::fee_history_cache_new_blocks_task, receipt::EthReceiptConverter, EthStateCache,
-    EthStateCacheConfig, FeeHistoryCache, FeeHistoryCacheConfig, GasCap, GasPriceOracle,
-    GasPriceOracleConfig,
+    builder::config::PendingBlockKind, fee_history::fee_history_cache_new_blocks_task,
+    receipt::EthReceiptConverter, EthStateCache, EthStateCacheConfig, FeeHistoryCache,
+    FeeHistoryCacheConfig, GasCap, GasPriceOracle, GasPriceOracleConfig,
 };
 use reth_rpc_server_types::constants::{
     DEFAULT_ETH_PROOF_WINDOW, DEFAULT_MAX_SIMULATE_BLOCKS, DEFAULT_PROOF_PERMITS,
@@ -41,6 +41,7 @@ pub struct EthApiBuilder<N: RpcNodeCore, Rpc, NextEnv = ()> {
     task_spawner: Box<dyn TaskSpawner + 'static>,
     next_env: NextEnv,
     max_batch_size: usize,
+    pending_block_kind: PendingBlockKind,
 }
 
 impl<Provider, Pool, Network, EvmConfig, ChainSpec>
@@ -80,6 +81,7 @@ impl<N: RpcNodeCore, Rpc, NextEnv> EthApiBuilder<N, Rpc, NextEnv> {
             task_spawner,
             next_env,
             max_batch_size,
+            pending_block_kind,
         } = self;
         EthApiBuilder {
             components,
@@ -97,6 +99,7 @@ impl<N: RpcNodeCore, Rpc, NextEnv> EthApiBuilder<N, Rpc, NextEnv> {
             task_spawner,
             next_env,
             max_batch_size,
+            pending_block_kind,
         }
     }
 }
@@ -125,6 +128,7 @@ where
             eth_state_cache_config: Default::default(),
             next_env: Default::default(),
             max_batch_size: 1,
+            pending_block_kind: PendingBlockKind::Full,
         }
     }
 }
@@ -160,6 +164,7 @@ where
             gas_oracle_config,
             next_env,
             max_batch_size,
+            pending_block_kind,
         } = self;
         EthApiBuilder {
             components,
@@ -177,6 +182,7 @@ where
             gas_oracle_config,
             next_env,
             max_batch_size,
+            pending_block_kind,
         }
     }
 
@@ -201,6 +207,7 @@ where
             gas_oracle_config,
             next_env: _,
             max_batch_size,
+            pending_block_kind,
         } = self;
         EthApiBuilder {
             components,
@@ -218,6 +225,7 @@ where
             gas_oracle_config,
             next_env,
             max_batch_size,
+            pending_block_kind,
         }
     }
 
@@ -295,6 +303,12 @@ where
         self
     }
 
+    /// Sets the pending block kind
+    pub const fn pending_block_kind(mut self, pending_block_kind: PendingBlockKind) -> Self {
+        self.pending_block_kind = pending_block_kind;
+        self
+    }
+
     /// Builds the [`EthApiInner`] instance.
     ///
     /// If not configured, this will spawn the cache backend: [`EthStateCache::spawn`].
@@ -324,6 +338,7 @@ where
             task_spawner,
             next_env,
             max_batch_size,
+            pending_block_kind,
         } = self;
 
         let provider = components.provider().clone();
@@ -361,6 +376,7 @@ where
             rpc_converter,
             next_env,
             max_batch_size,
+            pending_block_kind,
         )
     }
 

--- a/crates/rpc/rpc/src/eth/helpers/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/pending_block.rs
@@ -6,7 +6,7 @@ use reth_rpc_eth_api::{
     helpers::{pending_block::PendingEnvBuilder, LoadPendingBlock},
     FromEvmError, RpcNodeCore,
 };
-use reth_rpc_eth_types::{EthApiError, PendingBlock};
+use reth_rpc_eth_types::{builder::config::PendingBlockKind, EthApiError, PendingBlock};
 
 impl<N, Rpc> LoadPendingBlock for EthApi<N, Rpc>
 where
@@ -22,5 +22,10 @@ where
     #[inline]
     fn pending_env_builder(&self) -> &dyn PendingEnvBuilder<Self::Evm> {
         self.inner.pending_env_builder()
+    }
+
+    #[inline]
+    fn pending_block_kind(&self) -> PendingBlockKind {
+        self.inner.pending_block_kind()
     }
 }

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -400,6 +400,13 @@ RPC:
 
           [default: 25]
 
+      --rpc.pending-block <KIND>
+          Configures the pending block behavior for RPC responses.
+
+          Options: full (include all transactions), empty (header only), none (disable pending blocks).
+
+          [default: full]
+
       --builder.disallow <PATH>
           Path to file containing disallowed addresses, json-encoded list of strings. Block validation API will reject blocks containing transactions from these addresses
 


### PR DESCRIPTION
This PR solves the issue addressed [here](https://github.com/paradigmxyz/reth/issues/17535#issue-3248984072), where RPC was always building entire blocks with all transactions.

**Changes**
Add `--rpc.pending-block` CLI option to control pending block construction:
  - `empty`: Return block header only, no transactions
  - `none`: Return null/no pending block
  - `full`: Include all transactions from mempool (default)

Closes #17535 

Let me know if any changes are required! Thanks!