### PR TITLE
fix(GPO): calculate `max_tx_gas_used` corner case

### DIFF
--- a/crates/rpc/rpc-eth-types/src/gas_oracle.rs
+++ b/crates/rpc/rpc-eth-types/src/gas_oracle.rs
@@ -306,27 +306,18 @@ where
             .await?
             .ok_or(EthApiError::ReceiptsNotFound(BlockId::latest()))?;
 
-        let max_tx_gas_used = match receipts.len() {
-            // If no receipts, return the default suggestion
-            0 => return Ok(suggestion),
-            // If only one receipt, use its cumulative gas (which equals the gas used by that
-            // transaction)
-            1 => receipts[0].cumulative_gas_used(),
-            // If multiple receipts, calculate individual transaction gas usage
-            _ => receipts
-                // get the gas used by each transaction in the block, by subtracting the
-                // cumulative gas used of the previous transaction from the cumulative gas used of
-                // the current transaction. This is because there is no gas_used()
-                // method on the Receipt trait.
-                .windows(2)
-                .map(|window| {
-                    let prev = window[0].cumulative_gas_used();
-                    let curr = window[1].cumulative_gas_used();
-                    curr - prev
-                })
-                .max()
-                .expect("len >= 2 guarantees at least one window"),
-        };
+        let mut max_tx_gas_used = 0u64;
+        let mut last_cumulative_gas = 0;
+        for receipt in receipts.as_ref() {
+            let cumulative_gas = receipt.cumulative_gas_used();
+            // get the gas used by each transaction in the block, by subtracting the
+            // cumulative gas used of the previous transaction from the cumulative gas used of
+            // the current transaction. This is because there is no gas_used()
+            // method on the Receipt trait.
+            let gas_used = cumulative_gas - last_cumulative_gas;
+            max_tx_gas_used = max_tx_gas_used.max(gas_used);
+            last_cumulative_gas = cumulative_gas;
+        }
 
         // if the block is at capacity, the suggestion must be increased
         if header.gas_used() + max_tx_gas_used > header.gas_limit() {

--- a/crates/rpc/rpc-eth-types/src/gas_oracle.rs
+++ b/crates/rpc/rpc-eth-types/src/gas_oracle.rs
@@ -300,24 +300,32 @@ where
         // find the maximum gas used by any of the transactions in the block to use as the
         // capacity margin for the block, if no receipts are found return the
         // suggested_min_priority_fee
-        let Some(max_tx_gas_used) = self
+        let receipts = self
             .cache
             .get_receipts(header.hash())
             .await?
-            .ok_or(EthApiError::ReceiptsNotFound(BlockId::latest()))?
-            // get the gas used by each transaction in the block, by subtracting the
-            // cumulative gas used of the previous transaction from the cumulative gas used of the
-            // current transaction. This is because there is no gas_used() method on the Receipt
-            // trait.
-            .windows(2)
-            .map(|window| {
-                let prev = window[0].cumulative_gas_used();
-                let curr = window[1].cumulative_gas_used();
-                curr - prev
-            })
-            .max()
-        else {
-            return Ok(suggestion);
+            .ok_or(EthApiError::ReceiptsNotFound(BlockId::latest()))?;
+
+        let max_tx_gas_used = match receipts.len() {
+            // If no receipts, return the default suggestion
+            0 => return Ok(suggestion),
+            // If only one receipt, use its cumulative gas (which equals the gas used by that
+            // transaction)
+            1 => receipts[0].cumulative_gas_used(),
+            // If multiple receipts, calculate individual transaction gas usage
+            _ => receipts
+                // get the gas used by each transaction in the block, by subtracting the
+                // cumulative gas used of the previous transaction from the cumulative gas used of
+                // the current transaction. This is because there is no gas_used()
+                // method on the Receipt trait.
+                .windows(2)
+                .map(|window| {
+                    let prev = window[0].cumulative_gas_used();
+                    let curr = window[1].cumulative_gas_used();
+                    curr - prev
+                })
+                .max()
+                .expect("len >= 2 guarantees at least one window"),
         };
 
         // if the block is at capacity, the suggestion must be increased


### PR DESCRIPTION
This PR fix a corner case in function `op_suggest_tip_cap` of gas price oracle. I think there are basically three issues:
1. When the receipts length is 1, we considered `max_tx_gas_used` as `None`, but it should be `receipts[0].cumulative_gas_used()`.
2. When the receipts length is larger than 1, this always fail to return the gas used for the first receipt. if we have [receipt_one, receipt_two], this would return `receipt_two.cumulative_gas_used - receipt_one.cumulative_gas_used`. so it miss `receipt_one.cumulative_gas_used`.
3. When the receipts length is 0, we better still update the `inner.last_price` cache.

In this case if the `gas_used` of this single transaction block is large enough, we won't suggest an underpriced gas tip.