### PR TITLE
feat(txpool): Re‑implement blob trait - 1st PR

### DIFF
--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -73,6 +73,8 @@ serde_json.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 [features]
+blob = []
+default = ["blob"]
 serde = [
     "dep:serde",
     "reth-execution-types/serde",

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -1824,3 +1824,9 @@ mod tests {
         assert!(size_limit_2mb.exceeds(3 * 1024 * 1024));
     }
 }
+
+#[cfg(feature = "blob")]
+mod blob;
+
+#[cfg(feature = "blob")]
+pub use blob::BlobPoolExt;

--- a/crates/transaction-pool/src/traits/blob.rs
+++ b/crates/transaction-pool/src/traits/blob.rs
@@ -1,0 +1,9 @@
+//! crates/transaction-pool/src/traits/blob.rs
+
+use super::TransactionPool;
+
+/// Marker trait for pools that expose **blob‑transaction** helpers.
+///
+/// *Empty in PR 1 – methods are added in the follow‑up patch.*
+#[auto_impl::auto_impl(&, Arc)]
+pub trait BlobPoolExt: TransactionPool {}


### PR DESCRIPTION
Updated new PR for below PR.
Add feature‑gated blob flag and empty BlobPoolExt trait (step 1/3 for #294) #17666

Updated for reviewer @mattsse 's feedback - "I dont think this is worth doing, because you could just impl these as noops"
Just implemented as noops.