### PR TITLE
fix(txpool): also emit promoted pending tx on pool drift

### DIFF
--- a/crates/transaction-pool/src/pool/events.rs
+++ b/crates/transaction-pool/src/pool/events.rs
@@ -93,6 +93,14 @@ pub struct NewTransactionEvent<T: PoolTransaction> {
     pub transaction: Arc<ValidPoolTransaction<T>>,
 }
 
+impl<T: PoolTransaction>  NewTransactionEvent<T> {
+
+    /// Creates a new event for a pending transaction.
+    pub const fn pending(transaction: Arc<ValidPoolTransaction<T>>) -> Self {
+        Self { subpool: SubPool::Pending, transaction }
+    }
+}
+
 impl<T: PoolTransaction> Clone for NewTransactionEvent<T> {
     fn clone(&self) -> Self {
         Self { subpool: self.subpool, transaction: self.transaction.clone() }

--- a/crates/transaction-pool/src/pool/events.rs
+++ b/crates/transaction-pool/src/pool/events.rs
@@ -93,8 +93,7 @@ pub struct NewTransactionEvent<T: PoolTransaction> {
     pub transaction: Arc<ValidPoolTransaction<T>>,
 }
 
-impl<T: PoolTransaction>  NewTransactionEvent<T> {
-
+impl<T: PoolTransaction> NewTransactionEvent<T> {
     /// Creates a new event for a pending transaction.
     pub const fn pending(transaction: Arc<ValidPoolTransaction<T>>) -> Self {
         Self { subpool: SubPool::Pending, transaction }

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -440,9 +440,7 @@ where
                     if listener.kind.is_propagate_only() && !tx.propagate {
                         None
                     } else {
-                        Some(NewTransactionEvent::pending(
-                            tx.clone(),
-                        ))
+                        Some(NewTransactionEvent::pending(tx.clone()))
                     }
                 });
                 listener.send_all(promoted_txs)

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -414,6 +414,8 @@ where
     /// Performs account updates on the pool.
     ///
     /// This will either promote or discard transactions based on the new account state.
+    ///
+    /// This should be invoked when the pool drifted and accounts are updated manually
     pub fn update_accounts(&self, accounts: Vec<ChangedAccount>) {
         let changed_senders = self.changed_senders(accounts.into_iter());
         let UpdateOutcome { promoted, discarded } =
@@ -430,6 +432,20 @@ where
                     }
                 });
                 listener.send_all(promoted_hashes)
+            });
+
+            // in this case we should also emit promoted transactions in full
+            self.transaction_listener.lock().retain_mut(|listener| {
+                let promoted_txs = promoted.iter().filter_map(|tx| {
+                    if listener.kind.is_propagate_only() && !tx.propagate {
+                        None
+                    } else {
+                        Some(NewTransactionEvent::pending(
+                            tx.clone(),
+                        ))
+                    }
+                });
+                listener.send_all(promoted_txs)
             });
         }
 


### PR DESCRIPTION
this function is invoked when the pool drifted, e.g. synced initially, then all accounts are updated which can promote transactions to pending.

we should also emit the pending txs here because it is expected that the pending subscription receives all new pending txs (e.g. eth_subscribe)