### PR TITLE
test: add ordering test

### DIFF
--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -3777,4 +3777,65 @@ mod tests {
 
         assert_eq!(pool.pending_pool.independent().len(), 1);
     }
+
+    #[test]
+    fn test_insertion_disorder() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+
+        let sender = address!("1234567890123456789012345678901234567890");
+        let tx0 = f.validated_arc(
+            MockTransaction::legacy().with_sender(sender).with_nonce(0).with_gas_price(10),
+        );
+        let tx1 = f.validated_arc(
+            MockTransaction::eip1559()
+                .with_sender(sender)
+                .with_nonce(1)
+                .with_gas_limit(1000)
+                .with_gas_price(10),
+        );
+        let tx2 = f.validated_arc(
+            MockTransaction::legacy().with_sender(sender).with_nonce(2).with_gas_price(10),
+        );
+        let tx3 = f.validated_arc(
+            MockTransaction::legacy().with_sender(sender).with_nonce(3).with_gas_price(10),
+        );
+
+
+        // tx0 should be put in the pending subpool
+        pool.add_transaction((*tx0).clone(), U256::from(1000), 0, None).unwrap();
+        let mut best = pool.best_transactions();
+        let t0 = best.next().expect("tx0 should be put in the pending subpool");
+        assert_eq!(t0.id(), tx0.id());
+        // tx1 should be put in the queued subpool due to insufficient sender balance
+        pool.add_transaction((*tx1).clone(), U256::from(1000), 0, None).unwrap();
+        let mut best = pool.best_transactions();
+        let t0 = best.next().expect("tx0 should be put in the pending subpool");
+        assert_eq!(t0.id(), tx0.id());
+        assert!(best.next().is_none());
+
+        // tx2 should be put in the pending subpool, and tx1 should be promoted to pending
+        pool.add_transaction((*tx2).clone(), U256::MAX, 0, None).unwrap();
+
+        let mut best = pool.best_transactions();
+
+        let t0 = best.next().expect("tx0 should be put in the pending subpool");
+        let t1 = best.next().expect("tx1 should be put in the pending subpool");
+        let t2 = best.next().expect("tx2 should be put in the pending subpool");
+        assert_eq!(t0.id(), tx0.id());
+        assert_eq!(t1.id(), tx1.id());
+        assert_eq!(t2.id(), tx2.id());
+
+        // tx3 should be put in the pending subpool,
+        pool.add_transaction((*tx3).clone(), U256::MAX, 0, None).unwrap();
+        let mut best = pool.best_transactions();
+        let t0 = best.next().expect("tx0 should be put in the pending subpool");
+        let t1 = best.next().expect("tx1 should be put in the pending subpool");
+        let t2 = best.next().expect("tx2 should be put in the pending subpool");
+        let t3 = best.next().expect("tx3 should be put in the pending subpool");
+        assert_eq!(t0.id(), tx0.id());
+        assert_eq!(t1.id(), tx1.id());
+        assert_eq!(t2.id(), tx2.id());
+        assert_eq!(t3.id(), tx3.id());
+    }
 }

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -3801,7 +3801,6 @@ mod tests {
             MockTransaction::legacy().with_sender(sender).with_nonce(3).with_gas_price(10),
         );
 
-
         // tx0 should be put in the pending subpool
         pool.add_transaction((*tx0).clone(), U256::from(1000), 0, None).unwrap();
         let mut best = pool.best_transactions();


### PR DESCRIPTION
Add test case from #17702

that shows it working as expected

mind taking a look at this @Troublor

how ever there's indeed an edge case with the best iterator if it uses live updates

because they would indeed get emitted out of order

https://github.com/paradigmxyz/reth/pull/17702/files#diff-97cdb3ee79c1b6a6ed646d9a1fde69a761dfede859dffcb542e874be0da81ab2R3863-R3866

here I believe 
https://github.com/paradigmxyz/reth/blob/abab9ff0a2a54538c8c2e7ca08bc589783d1c784/crates/transaction-pool/src/pool/pending.rs#L313-L316