### PR TITLE
fix: feature-gate std-only methods in sparse trie

### DIFF
--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -843,12 +843,14 @@ impl<S: SparseTrieInterface + Default> StorageTries<S> {
 
     /// Takes the storage trie for the account from the internal `HashMap`, creating it if it
     /// doesn't already exist.
+    #[cfg(feature = "std")]
     fn take_or_create_trie(&mut self, account: &B256) -> SparseTrie<S> {
         self.tries.remove(account).unwrap_or_else(|| self.cleared_tries.pop().unwrap_or_default())
     }
 
     /// Takes the revealed paths set from the account from the internal `HashMap`, creating one if
     /// it doesn't exist.
+    #[cfg(feature = "std")]
     fn take_or_create_revealed_paths(&mut self, account: &B256) -> HashSet<Nibbles> {
         self.revealed_paths
             .remove(account)


### PR DESCRIPTION
these methods are only used inside a `#[cfg(feature = "std")]` block, but the methods themselves weren't feature-gated. with `cargo hack check --workspace` we were getting:
```
warning: methods `take_or_create_trie` and 
  `take_or_create_revealed_paths` are never used
     --> crates/trie/sparse/src/state.rs:846:8
      |
  806 | impl<S: SparseTrieInterface + Default> StorageTries<S> {
      | ------------------------------------------------------ methods in this implementation
  ...
  846 |     fn take_or_create_trie(&mut self, account: &B256) -> SparseTrie<S> {
      |        ^^^^^^^^^^^^^^^^^^^
  ...
  852 |     fn take_or_create_revealed_paths(&mut self, account: &B256) -> HashSet<Nibbles> {
      |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      |
      = note: `#[warn(dead_code)]` on by default

  warning: `reth-trie-sparse` (lib) generated 1 warning
```