### PR TITLE
chore: fix clippy warnings

### DIFF
--- a/crates/transaction-pool/benches/canonical_state_change.rs
+++ b/crates/transaction-pool/benches/canonical_state_change.rs
@@ -75,8 +75,7 @@ fn canonical_state_change_bench(c: &mut Criterion) {
             let total_txs = num_senders * txs_per_sender;
 
             let group_id = format!(
-                "txpool | canonical_state_change | senders: {} | txs_per_sender: {} | total: {}",
-                num_senders, txs_per_sender, total_txs
+                "txpool | canonical_state_change | senders: {num_senders} | txs_per_sender: {txs_per_sender} | total: {total_txs}",
             );
 
             // Create the update

--- a/examples/full-contract-state/src/main.rs
+++ b/examples/full-contract-state/src/main.rs
@@ -86,7 +86,7 @@ fn main() -> eyre::Result<()> {
         println!("Code hash: {:?}", state.account.bytecode_hash);
         println!("Storage slots: {}", state.storage.len());
         for (key, value) in &state.storage {
-            println!("\t{}: {}", key, value);
+            println!("\t{key}: {value}");
         }
     }
 


### PR DESCRIPTION
fix 2 clippy warnings