### PR TITLE
docs(discv4): fix incomplete comment in resolve_external_ip_interval

### DIFF
--- a/crates/net/discv4/src/config.rs
+++ b/crates/net/discv4/src/config.rs
@@ -96,7 +96,7 @@ impl Discv4Config {
         self
     }
 
-    /// Returns the corresponding [`ResolveNatInterval`], if a [`NatResolver`] and an interval was
+    /// Returns the corresponding [`ResolveNatInterval`], if a [`NatResolver`] and an interval was configured
     /// configured
     pub fn resolve_external_ip_interval(&self) -> Option<ResolveNatInterval> {
         let resolver = self.external_ip_resolver?;


### PR DESCRIPTION
Complete the documentation comment by adding the missing "configured" word 
at the end of the sentence.