### PR TITLE
test(generators): add topics_count parameter to random_receipt

### DIFF
--- a/crates/prune/prune/src/segments/receipts.rs
+++ b/crates/prune/prune/src/segments/receipts.rs
@@ -115,8 +115,10 @@ mod tests {
         for block in &blocks {
             receipts.reserve_exact(block.transaction_count());
             for transaction in &block.body().transactions {
-                receipts
-                    .push((receipts.len() as u64, random_receipt(&mut rng, transaction, Some(0))));
+                receipts.push((
+                    receipts.len() as u64,
+                    random_receipt(&mut rng, transaction, Some(0), None),
+                ));
             }
         }
         let receipts_len = receipts.len();

--- a/crates/prune/prune/src/segments/user/receipts_by_logs.rs
+++ b/crates/prune/prune/src/segments/user/receipts_by_logs.rs
@@ -274,7 +274,7 @@ mod tests {
         for block in &blocks {
             receipts.reserve_exact(block.body().size());
             for (txi, transaction) in block.body().transactions.iter().enumerate() {
-                let mut receipt = random_receipt(&mut rng, transaction, Some(1));
+                let mut receipt = random_receipt(&mut rng, transaction, Some(1), None);
                 receipt.logs.push(random_log(
                     &mut rng,
                     (txi == (block.transaction_count() - 1)).then_some(deposit_contract_addr),

--- a/crates/stages/stages/src/stages/mod.rs
+++ b/crates/stages/stages/src/stages/mod.rs
@@ -280,7 +280,7 @@ mod tests {
         for block in &blocks {
             let mut block_receipts = Vec::with_capacity(block.transaction_count());
             for transaction in &block.body().transactions {
-                block_receipts.push((tx_num, random_receipt(&mut rng, transaction, Some(0))));
+                block_receipts.push((tx_num, random_receipt(&mut rng, transaction, Some(0), None)));
                 tx_num += 1;
             }
             receipts.push((block.number, block_receipts));

--- a/crates/static-file/static-file/src/static_file_producer.rs
+++ b/crates/static-file/static-file/src/static_file_producer.rs
@@ -304,8 +304,10 @@ mod tests {
         let mut receipts = Vec::new();
         for block in &blocks {
             for transaction in &block.body().transactions {
-                receipts
-                    .push((receipts.len() as u64, random_receipt(&mut rng, transaction, Some(0))));
+                receipts.push((
+                    receipts.len() as u64,
+                    random_receipt(&mut rng, transaction, Some(0), None),
+                ));
             }
         }
         db.insert_receipts(receipts).expect("insert receipts");

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -858,7 +858,7 @@ mod tests {
             .iter()
             .chain(in_memory_blocks.iter())
             .map(|block| block.body().transactions.iter())
-            .map(|tx| tx.map(|tx| random_receipt(rng, tx, Some(2))).collect())
+            .map(|tx| tx.map(|tx| random_receipt(rng, tx, Some(2), None)).collect())
             .collect();
 
         let factory = create_test_provider_factory_with_chain_spec(chain_spec);

--- a/testing/testing-utils/src/generators.rs
+++ b/testing/testing-utils/src/generators.rs
@@ -453,6 +453,7 @@ pub fn random_receipt<R: Rng>(
     rng: &mut R,
     transaction: &TransactionSigned,
     logs_count: Option<u8>,
+    topics_count: Option<u8>,
 ) -> Receipt {
     let success = rng.random::<bool>();
     let logs_count = logs_count.unwrap_or_else(|| rng.random::<u8>());
@@ -462,7 +463,7 @@ pub fn random_receipt<R: Rng>(
         success,
         cumulative_gas_used: rng.random_range(0..=transaction.gas_limit()),
         logs: if success {
-            (0..logs_count).map(|_| random_log(rng, None, None)).collect()
+            (0..logs_count).map(|_| random_log(rng, None, topics_count)).collect()
         } else {
             vec![]
         },


### PR DESCRIPTION
Adds a `topics_count` parameter to the `random_receipt` test utility function to allow control over the number of topics generated in receipt logs during testing.

This is passed through to the existing `random_log` function which already supports configurable topic counts.