### PR TITLE
fix: enforce propagate on getpooledtx

### DIFF
--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -341,7 +341,7 @@ where
         }
     }
 
-    /// Returns pooled transactions for the given transaction hashe sthat are allowed to be propagated.
+    /// Returns pooled transactions for the given transaction hashes that are allowed to be propagated.
     pub fn get_pooled_transaction_elements(
         &self,
         tx_hashes: Vec<TxHash>,

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -341,7 +341,7 @@ where
         }
     }
 
-    /// Returns pooled transactions for the given transaction hashes.
+    /// Returns pooled transactions for the given transaction hashe sthat are allowed to be propagated.
     pub fn get_pooled_transaction_elements(
         &self,
         tx_hashes: Vec<TxHash>,
@@ -350,7 +350,7 @@ where
     where
         <V as TransactionValidator>::Transaction: EthPoolTransaction,
     {
-        let transactions = self.get_all(tx_hashes);
+        let transactions = self.get_all_propagatable(tx_hashes);
         let mut elements = Vec::with_capacity(transactions.len());
         let mut size = 0;
         for transaction in transactions {
@@ -952,6 +952,17 @@ where
         }
         self.get_pool_data().get_all(txs).collect()
     }
+
+    /// Returns all the transactions belonging to the hashes that are propagatable.
+    ///
+    /// If no transaction exists, it is skipped.
+    fn get_all_propagatable(&self, txs: Vec<TxHash>) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        if txs.is_empty() {
+            return Vec::new()
+        }
+        self.get_pool_data().get_all(txs).filter(|tx|tx.propagate).collect()
+    }
+
 
     /// Notify about propagated transactions.
     pub fn on_propagated(&self, txs: PropagatedTransactions) {

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -341,7 +341,8 @@ where
         }
     }
 
-    /// Returns pooled transactions for the given transaction hashes that are allowed to be propagated.
+    /// Returns pooled transactions for the given transaction hashes that are allowed to be
+    /// propagated.
     pub fn get_pooled_transaction_elements(
         &self,
         tx_hashes: Vec<TxHash>,
@@ -956,13 +957,15 @@ where
     /// Returns all the transactions belonging to the hashes that are propagatable.
     ///
     /// If no transaction exists, it is skipped.
-    fn get_all_propagatable(&self, txs: Vec<TxHash>) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+    fn get_all_propagatable(
+        &self,
+        txs: Vec<TxHash>,
+    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
         if txs.is_empty() {
             return Vec::new()
         }
-        self.get_pool_data().get_all(txs).filter(|tx|tx.propagate).collect()
+        self.get_pool_data().get_all(txs).filter(|tx| tx.propagate).collect()
     }
-
 
     /// Notify about propagated transactions.
     pub fn on_propagated(&self, txs: PropagatedTransactions) {


### PR DESCRIPTION
the assumption here was that because this is pull based the remote must already know the hash.

but we've documented that this fn respects propagate setting so we should filter them here