### PR TITLE
fix incomplete and duplicated comments in downloader and history modules

### DIFF
--- a/crates/stages/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/stages/src/stages/index_storage_history.rs
@@ -375,8 +375,6 @@ mod tests {
         almost_full_list.pop();
         let table = cast(db.table::<tables::StoragesHistory>().unwrap());
         assert_eq!(table, BTreeMap::from([(shard(u64::MAX), almost_full_list)]));
-
-        // verify initial state
     }
 
     #[tokio::test]

--- a/crates/stages/stages/src/stages/s3/downloader/worker.rs
+++ b/crates/stages/stages/src/stages/s3/downloader/worker.rs
@@ -13,7 +13,7 @@ use tracing::debug;
 pub(crate) enum WorkerResponse {
     /// Worker has been spawned and awaiting work.
     Ready { worker_id: u64, tx: UnboundedSender<WorkerRequest> },
-    /// Worker has downloaded
+    /// Worker has downloaded a chunk of data
     DownloadedChunk { worker_id: u64, chunk_index: usize, written_bytes: usize },
     /// Worker has encountered an error.
     Err { worker_id: u64, error: DownloaderError },


### PR DESCRIPTION
1. Completes the incomplete comment for `WorkerResponse::DownloadedChunk` in `worker.rs` by changing "Worker has downloaded" to "Worker has downloaded a chunk of data"

2. Removes a duplicated "// verify initial state" comment in `index_storage_history.rs` that appeared at the end of a test function where it was redundant
