### PR TITLE
chore: add flag to disable txpool gossip

### DIFF
--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -161,6 +161,13 @@ pub struct NetworkArgs {
     /// The policy determines which peers transactions are gossiped to.
     #[arg(long = "tx-propagation-policy", default_value_t = TransactionPropagationKind::All)]
     pub tx_propagation_policy: TransactionPropagationKind,
+
+    /// Disable transaction pool gossip
+    ///
+    /// Disables gossiping of transactions in the mempool to peers. This can be omitted for
+    /// personal nodes, though providers should always opt to enable this flag.
+    #[arg(long = "disable-tx-gossip")]
+    pub disable_tx_gossip: bool,
 }
 
 impl NetworkArgs {
@@ -272,6 +279,7 @@ impl NetworkArgs {
                 // set discovery port based on instance number
                 self.discovery.port,
             ))
+            .disable_tx_gossip(self.disable_tx_gossip)
     }
 
     /// If `no_persist_peers` is false then this returns the path to the persistent peers file path.
@@ -342,7 +350,8 @@ impl Default for NetworkArgs {
             max_seen_tx_history: DEFAULT_MAX_COUNT_TRANSACTIONS_SEEN_BY_PEER,
             max_capacity_cache_txns_pending_fetch: DEFAULT_MAX_CAPACITY_CACHE_PENDING_FETCH,
             net_if: None,
-            tx_propagation_policy: TransactionPropagationKind::default()
+            tx_propagation_policy: TransactionPropagationKind::default(),
+            disable_tx_gossip: false,
         }
     }
 }
@@ -615,6 +624,12 @@ mod tests {
 
             assert_eq!(args.dns_retries, retries);
         }
+    }
+
+    #[test]
+    fn parse_disable_tx_gossip_args() {
+        let args = CommandParser::<NetworkArgs>::parse_from(["reth", "--disable-tx-gossip"]).args;
+        assert!(args.disable_tx_gossip);
     }
 
     #[test]

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -233,6 +233,11 @@ Networking:
 
           [default: All]
 
+      --disable-tx-gossip
+          Disable transaction pool gossip
+
+          Disables gossiping of transactions in the mempool to peers. This can be omitted for personal nodes, though providers should always opt to enable this flag.
+
 RPC:
       --http
           Enable the HTTP-RPC server

--- a/docs/vocs/docs/pages/cli/reth/p2p/body.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/body.mdx
@@ -191,6 +191,11 @@ Networking:
 
           [default: All]
 
+      --disable-tx-gossip
+          Disable transaction pool gossip
+
+          Disables gossiping of transactions in the mempool to peers. This can be omitted for personal nodes, though providers should always opt to enable this flag.
+
 Datadir:
       --datadir <DATA_DIR>
           The path to the data dir for all reth files and subdirectories.

--- a/docs/vocs/docs/pages/cli/reth/p2p/header.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/header.mdx
@@ -191,6 +191,11 @@ Networking:
 
           [default: All]
 
+      --disable-tx-gossip
+          Disable transaction pool gossip
+
+          Disables gossiping of transactions in the mempool to peers. This can be omitted for personal nodes, though providers should always opt to enable this flag.
+
 Datadir:
       --datadir <DATA_DIR>
           The path to the data dir for all reth files and subdirectories.

--- a/docs/vocs/docs/pages/cli/reth/stage/run.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/run.mdx
@@ -287,6 +287,11 @@ Networking:
 
           [default: All]
 
+      --disable-tx-gossip
+          Disable transaction pool gossip
+
+          Disables gossiping of transactions in the mempool to peers. This can be omitted for personal nodes, though providers should always opt to enable this flag.
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout


### PR DESCRIPTION
add a flag `disable_txpool_gossip` which behaves similarly to the same flag in op-cli: https://github.com/paradigmxyz/reth/blob/d5f59070bb0be1cf9bba94e01b895fede1ae7078/crates/optimism/node/src/args.rs#L16-L18

Resolves https://github.com/paradigmxyz/reth/issues/17725