### PR TITLE
fix: typo in file deletion error message

### DIFF
--- a/crates/era-downloader/src/client.rs
+++ b/crates/era-downloader/src/client.rs
@@ -128,7 +128,7 @@ impl<Http: HttpClient + Clone> EraClient<Http> {
                 if let Some(name) = entry.file_name().to_str() {
                     if let Some(number) = self.file_name_to_number(name) {
                         if number < index || number >= last {
-                            eprintln!("Deleting kokot {}", entry.path().display());
+                            eprintln!("Deleting file {}", entry.path().display());
                             eprintln!("{number} < {index} || {number} > {last}");
                             reth_fs_util::remove_file(entry.path())?;
                         }


### PR DESCRIPTION
Replace "kokot" with "file" in the error message when deleting
outdated ERA files outside the working range.

This fixes a typo that was present in the debug output message
in the delete_outside_range method of EraClient.