### PR TITLE
fix: execution-apis eth_syncing should return false

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7834,6 +7834,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-network-api",
+ "reth-network-p2p",
  "reth-network-peers",
  "reth-node-api",
  "reth-node-builder",

--- a/crates/e2e-test-utils/Cargo.toml
+++ b/crates/e2e-test-utils/Cargo.toml
@@ -15,6 +15,7 @@ reth-chainspec.workspace = true
 reth-tracing.workspace = true
 reth-db = { workspace = true, features = ["test-utils"] }
 reth-network-api.workspace = true
+reth-network-p2p.workspace = true
 reth-rpc-layer.workspace = true
 reth-rpc-server-types.workspace = true
 reth-rpc-builder.workspace = true

--- a/crates/e2e-test-utils/src/testsuite/setup.rs
+++ b/crates/e2e-test-utils/src/testsuite/setup.rs
@@ -11,6 +11,7 @@ use eyre::{eyre, Result};
 use reth_chainspec::ChainSpec;
 use reth_engine_local::LocalPayloadAttributesBuilder;
 use reth_ethereum_primitives::Block;
+use reth_network_p2p::sync::{NetworkSyncUpdater, SyncState};
 use reth_node_api::{EngineTypes, NodeTypes, PayloadTypes, TreeConfig};
 use reth_node_core::primitives::RecoveredBlock;
 use reth_payload_builder::EthPayloadBuilderAttributes;
@@ -352,6 +353,15 @@ where
             "Environment initialized with {} nodes, starting from block {} (hash: {})",
             self.network.node_count, initial_block_info.number, initial_block_info.hash
         );
+
+        // In test environments, explicitly set sync state to Idle after initialization
+        // This ensures that eth_syncing returns false as expected by tests
+        if let Some(import_result) = &self.import_result_holder {
+            for (idx, node_ctx) in import_result.nodes.iter().enumerate() {
+                debug!("Setting sync state to Idle for node {}", idx);
+                node_ctx.inner.network.update_sync_state(SyncState::Idle);
+            }
+        }
 
         Ok(())
     }

--- a/crates/rpc/rpc-e2e-tests/testdata/rpc-compat/eth_syncing/eth_syncing.io
+++ b/crates/rpc/rpc-e2e-tests/testdata/rpc-compat/eth_syncing/eth_syncing.io
@@ -1,0 +1,3 @@
+// checks client syncing status
+>> {"jsonrpc":"2.0","id":1,"method":"eth_syncing"}
+<< {"jsonrpc":"2.0","id":1,"result":false}

--- a/crates/rpc/rpc-e2e-tests/tests/e2e-testsuite/main.rs
+++ b/crates/rpc/rpc-e2e-tests/tests/e2e-testsuite/main.rs
@@ -13,14 +13,14 @@ use reth_rpc_e2e_tests::rpc_compat::{InitializeFromExecutionApis, RunRpcCompatTe
 use std::{path::PathBuf, sync::Arc};
 use tracing::info;
 
-/// Test `eth_getLogs` RPC method compatibility with execution-apis test data
+/// Test repo-local RPC method compatibility with execution-apis test data
 ///
 /// This test:
 /// 1. Initializes a node with chain data from testdata (chain.rlp)
 /// 2. Applies the forkchoice state from headfcu.json
-/// 3. Runs all `eth_getLogs` test cases from the execution-apis test suite
+/// 3. Runs tests cases in the local repository, some of which are execution-api tests
 #[tokio::test(flavor = "multi_thread")]
-async fn test_eth_get_logs_compat() -> Result<()> {
+async fn test_local_rpc_tests_compat() -> Result<()> {
     reth_tracing::init_test_tracing();
 
     // Use local test data
@@ -69,7 +69,7 @@ async fn test_eth_get_logs_compat() -> Result<()> {
         )
         .with_action(MakeCanonical::new())
         .with_action(RunRpcCompatTests::new(
-            vec!["eth_getLogs".to_string()],
+            vec!["eth_getLogs".to_string(), "eth_syncing".to_string()],
             test_data_path.to_string_lossy(),
         ));
 


### PR DESCRIPTION
e2e test setup does not update the syncing state of the test node. This causes eth_syncing to falsely report the node is still syncing (the default state of all nodes).

Added canonical eth_syncing.io test and updated name of test_eth_get_logs_compat to test_local_rpc_tests_compat so it reflects reality.