### PR TITLE
refactor: Minor cleanups and improvements in ef-tests suite

### DIFF
--- a/testing/ef-tests/src/case.rs
+++ b/testing/ef-tests/src/case.rs
@@ -33,7 +33,7 @@ pub struct Cases<T> {
 }
 
 impl<T: Case> Cases<T> {
-    /// Run the contained test cases.
+    /// Runs all test cases and returns a vector of `CaseResult`.
     pub fn run(&self) -> Vec<CaseResult> {
         self.test_cases
             .par_iter()

--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -381,7 +381,7 @@ pub fn should_skip(path: &Path) -> bool {
     let name = path.file_name().unwrap().to_str().unwrap();
     matches!(
         name,
-        // funky test with `bigint 0x00` value in json :) not possible to happen on mainnet and require
+        // funky test with `bigint 0x00` value in json, not possible to happen on mainnet and require
         // custom json parser. https://github.com/ethereum/tests/issues/971
         | "ValueOverflow.json"
         | "ValueOverflowParis.json"

--- a/testing/ef-tests/src/models.rs
+++ b/testing/ef-tests/src/models.rs
@@ -81,7 +81,7 @@ pub struct Header {
     pub excess_blob_gas: Option<U256>,
     /// Parent beacon block root.
     pub parent_beacon_block_root: Option<B256>,
-    /// Requests root.
+    /// Root hash of the requests trie.
     pub requests_hash: Option<B256>,
     /// Target blobs per block.
     pub target_blobs_per_block: Option<U256>,

--- a/testing/ef-tests/tests/tests.rs
+++ b/testing/ef-tests/tests/tests.rs
@@ -83,7 +83,7 @@ macro_rules! blockchain_test {
         #[test]
         fn $test_name() {
             reth_tracing::init_test_tracing();
-            BlockchainTests::new(format!("{}", stringify!($dir))).run();
+            BlockchainTests::new(stringify!($dir).to_string()).run();
         }
     };
 }


### PR DESCRIPTION
1.  testing/ef-tests/tests/tests.rs:
    -   Replaced an unnecessary `format!("{}", ...)` call with a more direct and efficient `.to_string()` in the `blockchain_test!` macro.

2.  testing/ef-tests/src/case.rs:
    -   Improved the documentation for `Cases::run` to explicitly state what the function returns, enhancing clarity for future developers.

3.  testing/ef-tests/src/models.rs:
    -   Clarified the documentation for the `requests_hash` field in the `Header` struct, specifying that it represents the root of the requests trie.

4.  testing/ef-tests/src/cases/blockchain_test.rs:
    -   Removed an unprofessional smiley face `:)` from a code comment in the `should_skip` function.
