### PR TITLE
fix: add missing semicolon in wallet generation loop

### DIFF
--- a/crates/e2e-test-utils/src/wallet.rs
+++ b/crates/e2e-test-utils/src/wallet.rs
@@ -43,7 +43,7 @@ impl Wallet {
             let builder =
                 builder.clone().derivation_path(format!("{derivation_path}{idx}")).unwrap();
             let wallet = builder.build().unwrap().with_chain_id(Some(self.chain_id));
-            wallets.push(wallet)
+            wallets.push(wallet);
         }
         wallets
     }


### PR DESCRIPTION
Fixed missing semicolon in wallets.push(wallet) statement inside Wallet::derive_wallets implementation.