### PR TITLE
feat: expose new_with_database_path_and_tables on provider factory

### DIFF
--- a/crates/storage/db/src/lib.rs
+++ b/crates/storage/db/src/lib.rs
@@ -32,7 +32,9 @@ pub use reth_storage_errors::db::{DatabaseError, DatabaseWriteOperation};
 pub use utils::is_database_empty;
 
 #[cfg(feature = "mdbx")]
-pub use mdbx::{create_db, init_db, open_db, open_db_read_only, DatabaseEnv, DatabaseEnvKind};
+pub use mdbx::{
+    create_db, init_db, init_db_for, open_db, open_db_read_only, DatabaseEnv, DatabaseEnvKind,
+};
 
 pub use models::ClientVersion;
 pub use reth_db_api::*;

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -144,9 +144,9 @@ impl<N: NodeTypesWithDB<DB = Arc<DatabaseEnv>>> ProviderFactory<N> {
     /// you may encounter unexpected behavior.
     ///
     /// E.g. If the [`TableSet`] does not define the [`Headers`] table
-    /// identically to its specification in [`reth_db::tables`], then attempting
-    /// to access [`HeaderProvider`] methods may fail or produce incorrect
-    /// results.
+    /// identically to its specification in [`mod@reth_db::tables`], then
+    /// attempting to access [`HeaderProvider`] methods may fail or produce
+    /// incorrect results.
     ///
     /// [`Headers`]: reth_db::tables::Headers
     pub fn new_with_database_path_and_tables<P: AsRef<Path>, Ts: TableSet>(


### PR DESCRIPTION
small API change to re-export `init_db_for` and adds `ProviderFactory::new_with_database_path_and_tables`

This is a **partial solution** to allowing custom table sets at the implementor's risk, and includes a warning that improper use may result in failure or unintended behavior. See slack for more discussion
