### PR TITLE
chore: example: correct package names in example run commands

### DIFF
--- a/examples/bsc-p2p/src/main.rs
+++ b/examples/bsc-p2p/src/main.rs
@@ -3,7 +3,7 @@
 //! Run with
 //!
 //! ```sh
-//! cargo run -p bsc-p2p
+//! cargo run -p example-bsc-p2p
 //! ```
 //!
 //! This launches a regular reth node overriding the engine api payload builder with our custom.

--- a/examples/custom-payload-builder/src/main.rs
+++ b/examples/custom-payload-builder/src/main.rs
@@ -4,7 +4,7 @@
 //! Run with
 //!
 //! ```sh
-//! cargo run -p custom-payload-builder -- node
+//! cargo run -p example-custom-payload-builder -- node
 //! ```
 //!
 //! This launches a regular reth node overriding the engine api payload builder with our custom.

--- a/examples/manual-p2p/src/main.rs
+++ b/examples/manual-p2p/src/main.rs
@@ -3,7 +3,7 @@
 //! Run with
 //!
 //! ```sh
-//! cargo run -p manual-p2p
+//! cargo run -p example-manual-p2p
 //! ```
 
 #![warn(unused_crate_dependencies)]

--- a/examples/node-custom-rpc/src/main.rs
+++ b/examples/node-custom-rpc/src/main.rs
@@ -3,7 +3,7 @@
 //! Run with
 //!
 //! ```sh
-//! cargo run -p node-custom-rpc -- node --http --ws --enable-ext
+//! cargo run -p example-node-custom-rpc -- node --http --ws --enable-ext
 //! ```
 //!
 //! This installs an additional RPC method `txpoolExt_transactionCount` that can be queried via [cast](https://github.com/foundry-rs/foundry)

--- a/examples/node-event-hooks/src/main.rs
+++ b/examples/node-event-hooks/src/main.rs
@@ -4,7 +4,7 @@
 //! Run with
 //!
 //! ```sh
-//! cargo run -p node-event-hooks -- node
+//! cargo run -p example-node-event-hooks -- node
 //! ```
 //!
 //! This launches a regular reth node and also print:

--- a/examples/polygon-p2p/src/main.rs
+++ b/examples/polygon-p2p/src/main.rs
@@ -3,7 +3,7 @@
 //! Run with
 //!
 //! ```sh
-//! cargo run -p polygon-p2p
+//! cargo run -p example-polygon-p2p
 //! ```
 //!
 //! This launches a regular reth node overriding the engine api payload builder with our custom.

--- a/examples/rpc-db/src/main.rs
+++ b/examples/rpc-db/src/main.rs
@@ -3,7 +3,7 @@
 //! Run with
 //!
 //! ```sh
-//! cargo run -p rpc-db
+//! cargo run -p example-rpc-db
 //! ```
 //!
 //! This installs an additional RPC method `myrpcExt_customMethod` that can be queried via [cast](https://github.com/foundry-rs/foundry)


### PR DESCRIPTION
Hey! I was trying to run some of the examples and kept getting "package not found" errors. Turns out the cargo run commands in the doc comments were using the wrong package names.

For example, running:
```sh
cargo run -p node-custom-rpc -- node --http --ws --enable-ext
```

Would fail with:
`error: package ID specification node-custom-rpc did not match any packages`

But the actual package name in Cargo.toml is `example-node-custom-rpc`. Same issue with several other examples.