### PR TITLE
refactor: migrate RPC hooks from build-time storage to launch-time parameters

### DIFF
--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -173,8 +173,8 @@ where
 /// Add-ons w.r.t. l1 ethereum.
 #[derive(Debug)]
 pub struct EthereumAddOns<
-    N: FullNodeComponents,
-    EthB: EthApiBuilder<N>,
+    N,
+    EthB,
     PVB,
     EB = BasicEngineApiBuilder<PVB>,
     EVB = BasicEngineValidatorBuilder<PVB>,
@@ -183,29 +183,14 @@ pub struct EthereumAddOns<
     inner: RpcAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>,
 }
 
-impl<N, EthB, PVB, EB, EVB, RpcMiddleware> EthereumAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>
-where
-    N: FullNodeComponents,
-    EthB: EthApiBuilder<N>,
-{
+impl<N, EthB, PVB, EB, EVB, RpcMiddleware> EthereumAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware> {
     /// Creates a new instance from the inner `RpcAddOns`.
     pub const fn new(inner: RpcAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>) -> Self {
         Self { inner }
     }
 }
 
-impl<N> Default for EthereumAddOns<N, EthereumEthApiBuilder, EthereumEngineValidatorBuilder>
-where
-    N: FullNodeComponents<
-        Types: NodeTypes<
-            ChainSpec: EthereumHardforks + Clone + 'static,
-            Payload: EngineTypes<ExecutionData = ExecutionData>
-                         + PayloadTypes<PayloadAttributes = EthPayloadAttributes>,
-            Primitives = EthPrimitives,
-        >,
-    >,
-    EthereumEthApiBuilder: EthApiBuilder<N>,
-{
+impl<N> Default for EthereumAddOns<N, EthereumEthApiBuilder, EthereumEngineValidatorBuilder> {
     fn default() -> Self {
         Self::new(RpcAddOns::new(
             EthereumEthApiBuilder::default(),
@@ -217,11 +202,7 @@ where
     }
 }
 
-impl<N, EthB, PVB, EB, EVB, RpcMiddleware> EthereumAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>
-where
-    N: FullNodeComponents,
-    EthB: EthApiBuilder<N>,
-{
+impl<N, EthB, PVB, EB, EVB, RpcMiddleware> EthereumAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware> {
     /// Replace the engine API builder.
     pub fn with_engine_api<T>(
         self,
@@ -235,7 +216,7 @@ where
     }
 
     /// Replace the payload validator builder.
-    pub fn with_payload_validator<V, T>(
+    pub fn with_payload_validator<T>(
         self,
         payload_validator_builder: T,
     ) -> EthereumAddOns<N, EthB, T, EB, EVB, RpcMiddleware> {
@@ -329,10 +310,6 @@ where
     EvmFactoryFor<N::Evm>: EvmFactory<Tx = TxEnv>,
 {
     type EthApi = EthB::EthApi;
-
-    fn hooks_mut(&mut self) -> &mut reth_node_builder::rpc::RpcHooks<N, Self::EthApi> {
-        self.inner.hooks_mut()
-    }
 }
 
 impl<N, EthB, PVB, EB, EVB> EngineValidatorAddOn<N> for EthereumAddOns<N, EthB, PVB, EB, EVB>

--- a/crates/node/builder/src/hooks.rs
+++ b/crates/node/builder/src/hooks.rs
@@ -1,8 +1,35 @@
 use std::fmt;
 
 use reth_node_api::{FullNodeComponents, NodeAddOns};
+use reth_rpc::eth::EthApiTypes;
 
-use crate::node::FullNode;
+use crate::{
+    node::FullNode,
+    rpc::{ExtendRpcModules, OnRpcStarted},
+};
+
+/// Container for RPC-specific hooks.
+pub struct RpcHooks<Node: FullNodeComponents, EthApi: EthApiTypes> {
+    /// Hook to run once the RPC server is started.
+    pub on_rpc_started: Option<Box<dyn OnRpcStarted<Node, EthApi>>>,
+    /// Hook to run to configure the RPC modules.
+    pub extend_rpc_modules: Option<Box<dyn ExtendRpcModules<Node, EthApi>>>,
+}
+
+impl<Node: FullNodeComponents, EthApi: EthApiTypes> fmt::Debug for RpcHooks<Node, EthApi> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RpcHooks")
+            .field("on_rpc_started", &self.on_rpc_started.is_some())
+            .field("extend_rpc_modules", &self.extend_rpc_modules.is_some())
+            .finish()
+    }
+}
+
+impl<Node: FullNodeComponents, EthApi: EthApiTypes> Default for RpcHooks<Node, EthApi> {
+    fn default() -> Self {
+        Self { on_rpc_started: None, extend_rpc_modules: None }
+    }
+}
 
 /// Container for all the configurable hook functions.
 pub struct NodeHooks<Node: FullNodeComponents, AddOns: NodeAddOns<Node>> {

--- a/examples/node-event-hooks/src/main.rs
+++ b/examples/node-event-hooks/src/main.rs
@@ -24,12 +24,12 @@ fn main() {
                     println!("Node started");
                     Ok(())
                 })
-                .on_rpc_started(|_ctx, _handles| {
-                    println!("RPC started");
-                    Ok(())
-                })
                 .on_component_initialized(|_ctx| {
                     println!("All components initialized");
+                    Ok(())
+                })
+                .on_rpc_started(|_ctx, _handles| {
+                    println!("RPC started");
                     Ok(())
                 })
                 .launch()


### PR DESCRIPTION
Refactors RPC addon architecture to migrate RPC hooks from build-time storage to launch-time configuration, while maintaining the Node generic parameter for type safety.

  - moved `on_rpc_started` and `extend_rpc_modules` from being stored in RPC addons to being passed at launch
  - introduced `NodeBuilderWithRpcHooks` wrapper for configuring RPC hooks
  - kept the N parameter in `RpcAddOns` with `PhantomData` for proper hook typing
