### PR TITLE
Expose payload builder event handle

### DIFF
--- a/crates/payload/builder/src/service.rs
+++ b/crates/payload/builder/src/service.rs
@@ -260,6 +260,12 @@ where
         PayloadBuilderHandle::new(self.service_tx.clone())
     }
 
+    /// Create clone on payload_events sending handle that could be used by builder to produce
+    /// additional events during block building
+    pub fn payload_events_handle(&self) -> broadcast::Sender<Events<T>> {
+        self.payload_events.clone()
+    }
+
     /// Returns true if the given payload is currently being built.
     fn contains_payload(&self, id: PayloadId) -> bool {
         self.payload_jobs.iter().any(|(_, job_id)| *job_id == id)


### PR DESCRIPTION
This handle could be used by block builder to send additional events
In our case we want to send built_payload event more often