### PR TITLE
refactor: Fix incorrect length parameter in StorageTrieEntry::from_compact

### DIFF
--- a/crates/trie/common/src/storage.rs
+++ b/crates/trie/common/src/storage.rs
@@ -25,8 +25,8 @@ impl reth_codecs::Compact for StorageTrieEntry {
     }
 
     fn from_compact(buf: &[u8], len: usize) -> (Self, &[u8]) {
-        let (nibbles, buf) = StoredNibblesSubKey::from_compact(buf, 33);
-        let (node, buf) = BranchNodeCompact::from_compact(buf, len - 33);
+        let (nibbles, buf) = StoredNibblesSubKey::from_compact(buf, 65);
+        let (node, buf) = BranchNodeCompact::from_compact(buf, len - 65);
         let this = Self { nibbles, node };
         (this, buf)
     }


### PR DESCRIPTION
## Description
Fix incorrect length parameter in StorageTrieEntry::from_compact
## Problem
In crates/trie/common/src/storage.rs, the StorageTrieEntry::from_compact method incorrectly passes 33 as the length parameter to StoredNibblesSubKey::from_compact, but StoredNibblesSubKey has a fixed size of 65 bytes (64 bytes for the nibbles data + 1 byte for the length).
## Analysis
The current code works by coincidence because:
1. StoredNibblesSubKey::from_compact ignores the len parameter and always reads exactly 65 bytes from the buffer
2. BranchNodeCompact::from_compact also ignores the len parameter and processes the remaining buffer
3. Both implementations advance the buffer pointer correctly, so the final result is correct despite the wrong length parameter

However, this is fragile and could break if the internal implementations change. The correct approach is to pass the actual fixed size of StoredNibblesSubKey.
## Solution
Change the length parameter from 33 to 65 to match the actual fixed size of StoredNibblesSubKey.