### PR TITLE
fix(stages): use correct block number in error message

### DIFF
--- a/crates/stages/api/src/stage.rs
+++ b/crates/stages/api/src/stage.rs
@@ -111,7 +111,7 @@ impl ExecInput {
             // body.
             let end_block_body = provider
                 .block_body_indices(end_block_number)?
-                .ok_or(ProviderError::BlockBodyIndicesNotFound(target_block))?;
+                .ok_or(ProviderError::BlockBodyIndicesNotFound(end_block_number))?;
             (end_block_number, false, end_block_body.next_tx_num())
         };
 


### PR DESCRIPTION
Fix error message in next_block_range_with_transaction_threshold to use end_block_number instead of target_block when block body indices are not found. This makes the error message more accurate and helps with debugging