### PR TITLE
refactor(witness): remove unnecessary curly braces in closure

### DIFF
--- a/crates/engine/invalid-block-hooks/src/witness.rs
+++ b/crates/engine/invalid-block-hooks/src/witness.rs
@@ -64,19 +64,15 @@ impl BundleStateSorted {
             .state
             .clone()
             .into_iter()
-            .map(|(address, account)| {
-                {
-                    (
-                        address,
-                        BundleAccountSorted {
-                            info: account.info,
-                            original_info: account.original_info,
-                            status: account.status,
-                            storage: BTreeMap::from_iter(account.storage),
-                        },
-                    )
-                }
-            })
+            .map(|(address, account)| (
+                address,
+                BundleAccountSorted {
+                    info: account.info,
+                    original_info: account.original_info,
+                    status: account.status,
+                    storage: BTreeMap::from_iter(account.storage),
+                },
+            ))
             .collect();
 
         let contracts = BTreeMap::from_iter(bundle_state.contracts.clone());

--- a/crates/engine/invalid-block-hooks/src/witness.rs
+++ b/crates/engine/invalid-block-hooks/src/witness.rs
@@ -64,15 +64,17 @@ impl BundleStateSorted {
             .state
             .clone()
             .into_iter()
-            .map(|(address, account)| (
-                address,
-                BundleAccountSorted {
-                    info: account.info,
-                    original_info: account.original_info,
-                    status: account.status,
-                    storage: BTreeMap::from_iter(account.storage),
-                },
-            ))
+            .map(|(address, account)| {
+                (
+                    address,
+                    BundleAccountSorted {
+                        info: account.info,
+                        original_info: account.original_info,
+                        status: account.status,
+                        storage: BTreeMap::from_iter(account.storage),
+                    },
+                )
+            })
             .collect();
 
         let contracts = BTreeMap::from_iter(bundle_state.contracts.clone());


### PR DESCRIPTION
Remove unnecessary curly braces in BundleStateSorted::from_bundle_state
map closure for cleaner code style.