### PR TITLE
chore: remove redundant words in comment

### DIFF
--- a/crates/transaction-pool/src/config.rs
+++ b/crates/transaction-pool/src/config.rs
@@ -115,7 +115,7 @@ impl SubPoolLimit {
         Self { max_txs, max_size }
     }
 
-    /// Creates a an unlimited [`SubPoolLimit`]
+    /// Creates an unlimited [`SubPoolLimit`]
     pub const fn max() -> Self {
         Self::new(usize::MAX, usize::MAX)
     }

--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -396,7 +396,7 @@ pub fn should_skip(path: &Path) -> bool {
         | "typeTwoBerlin.json"
 
         // Test checks if nonce overflows. We are handling this correctly but we are not parsing
-        // exception in testsuite There are more nonce overflow tests that are in internal
+        // exception in testsuite There are more nonce overflow tests that are internal
         // call/create, and those tests are passing and are enabled.
         | "CreateTransactionHighNonce.json"
 


### PR DESCRIPTION
remove redundant words in comment