### PR TITLE
chore: Expose payload builder handle and metrics

### DIFF
--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -42,6 +42,10 @@ pub(crate) struct EngineMetrics {
     pub(crate) pipeline_runs: Counter,
     /// The total count of forkchoice updated messages received.
     pub(crate) forkchoice_updated_messages: Counter,
+    /// The total count of forkchoice updated messages with payload received.
+    pub(crate) forkchoice_with_attributes_updated_messages: Counter,
+    /// Newly arriving block hash is not present in executed blocks cache storage
+    pub(crate) executed_new_block_cache_miss: Counter,
     /// The total count of new payload messages received.
     pub(crate) new_payload_messages: Counter,
     /// Histogram of persistence operation durations (in seconds)

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -652,6 +652,7 @@ where
         // get the executed new head block
         let Some(new_head_block) = self.state.tree_state.blocks_by_hash.get(&new_head) else {
             debug!(target: "engine::tree", new_head=?new_head, "New head block not found in inmemory tree state");
+            self.metrics.engine.executed_new_block_cache_miss.increment(1);
             return Ok(None)
         };
 
@@ -838,6 +839,9 @@ where
     ) -> ProviderResult<TreeOutcome<OnForkChoiceUpdated>> {
         trace!(target: "engine::tree", ?attrs, "invoked forkchoice update");
         self.metrics.engine.forkchoice_updated_messages.increment(1);
+        if attrs.is_some() {
+            self.metrics.engine.forkchoice_with_attributes_updated_messages.increment(1);
+        }
         self.canonical_in_memory_state.on_forkchoice_update_received();
 
         if let Some(on_updated) = self.pre_validate_forkchoice_update(state)? {

--- a/crates/payload/builder/src/service.rs
+++ b/crates/payload/builder/src/service.rs
@@ -260,6 +260,12 @@ where
         PayloadBuilderHandle::new(self.service_tx.clone())
     }
 
+    /// Create clone on `payload_events` sending handle that could be used by builder to produce
+    /// additional events during block building
+    pub fn payload_events_handle(&self) -> broadcast::Sender<Events<T>> {
+        self.payload_events.clone()
+    }
+
     /// Returns true if the given payload is currently being built.
     fn contains_payload(&self, id: PayloadId) -> bool {
         self.payload_jobs.iter().any(|(_, job_id)| *job_id == id)


### PR DESCRIPTION
1. I've exposed payload builder handle. In our core we use it to add intermidiate executed blocks in the cache (we cannot guarantee which executed block will be included to the chain, so we need to preserve all of them, so we would use cache for executed block when it arrives trough p2p or newPayload).
2. Added metrics that are useful for builders, FCU with attributes and number of cache misses for executed block.