### PR TITLE
fix(network): push header before next header check in `get_headers_response`

### DIFF
--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -116,7 +116,7 @@ where
 
                 match direction {
                     HeadersDirection::Rising => {
-                        if let Some(next) = header.number.checked_add(skip) {
+                        if let Some(next) = number.checked_add(skip) {
                             block = next.into()
                         } else {
                             break

--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -104,9 +104,19 @@ where
 
         for _ in 0..limit {
             if let Some(header) = self.client.header_by_hash_or_number(block).unwrap_or_default() {
+                let number = header.number();
+                let parent_hash = header.parent_hash();
+
+                total_bytes += header.length();
+                headers.push(header);
+
+                if headers.len() >= MAX_HEADERS_SERVE || total_bytes > SOFT_RESPONSE_LIMIT {
+                    break
+                }
+
                 match direction {
                     HeadersDirection::Rising => {
-                        if let Some(next) = (header.number() + 1).checked_add(skip) {
+                        if let Some(next) = header.number.checked_add(skip) {
                             block = next.into()
                         } else {
                             break
@@ -117,23 +127,16 @@ where
                             // prevent under flows for block.number == 0 and `block.number - skip <
                             // 0`
                             if let Some(next) =
-                                header.number().checked_sub(1).and_then(|num| num.checked_sub(skip))
+                                number.checked_sub(1).and_then(|num| num.checked_sub(skip))
                             {
                                 block = next.into()
                             } else {
                                 break
                             }
                         } else {
-                            block = header.parent_hash().into()
+                            block = parent_hash.into()
                         }
                     }
-                }
-
-                total_bytes += header.length();
-                headers.push(header);
-
-                if headers.len() >= MAX_HEADERS_SERVE || total_bytes > SOFT_RESPONSE_LIMIT {
-                    break
                 }
             } else {
                 break


### PR DESCRIPTION
This PR is a robustness fix that pushes the header to result before checking the next header in `get_headers_response`. Previously, when hitting a limit, one valid header was omitted from the response.

The spec: https://github.com/ethereum/devp2p/blob/40ab248bf7e017e83cc9812a4e048446709623e8/caps/eth.md#blockheaders-0x04