### PR TITLE
chore(cli-docs): remove extra prompt char from update.sh log output

### DIFF
--- a/docs/cli/update.sh
+++ b/docs/cli/update.sh
@@ -17,5 +17,5 @@ cmd=(
   --out-dir "$VOCS_PAGES_ROOT/cli/"
   "$RETH"
 )
-echo "Running: $" "${cmd[*]}"
+echo "Running: ${cmd[*]}"
 "${cmd[@]}"


### PR DESCRIPTION
Removes an unnecessary “$” from the log line in docs/cli/update.sh, prevents confusion when copying commands from logs; aligns with typical logging style.

before 
`  Running: $ <path>/help.rs --root-dir /docs --out-dir /pages/cli reth
`

after

`  Running: <path>/help.rs --root-dir /docs --out-dir /pages/cli reth
`