### PR TITLE
fix(forkchoice): correct doc comment typo in ForkchoiceStateHash

### DIFF
--- a/crates/engine/primitives/src/forkchoice.rs
+++ b/crates/engine/primitives/src/forkchoice.rs
@@ -172,7 +172,7 @@ impl From<PayloadStatusEnum> for ForkchoiceStatus {
     }
 }
 
-/// A helper type to check represent hashes of a [`ForkchoiceState`]
+/// A helper type to represent hashes of a [`ForkchoiceState`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ForkchoiceStateHash {
     /// Head hash of the [`ForkchoiceState`].


### PR DESCRIPTION
Replace “to check represent” with “to represent” in the doc comment for ForkchoiceStateHash. No functional changes, documentation-only edit.