### PR TITLE
Use .as_slice() for parent_beacon_block_root in payload_id hashing

### DIFF
--- a/crates/ethereum/engine-primitives/src/payload.rs
+++ b/crates/ethereum/engine-primitives/src/payload.rs
@@ -418,7 +418,7 @@ pub fn payload_id(parent: &B256, attributes: &PayloadAttributes) -> PayloadId {
     }
 
     if let Some(parent_beacon_block) = attributes.parent_beacon_block_root {
-        hasher.update(parent_beacon_block);
+        hasher.update(parent_beacon_block.as_slice());
     }
 
     let out = hasher.finalize();


### PR DESCRIPTION
- Align hashing with other B256 fields by calling .as_slice()
- Edited payload_id to hash parent_beacon_block_root via .as_slice() for consistency with other fields.
- Verified by running crate tests; all green.