### PR TITLE
docs: add optimism Access-list spec

### DIFF
--- a/crates/optimism/txpool/src/supervisor/access_list.rs
+++ b/crates/optimism/txpool/src/supervisor/access_list.rs
@@ -32,7 +32,7 @@ pub fn parse_access_list_items_to_inbox_entries<'a>(
 /// Max 3 inbox entries can exist per [`AccessListItem`] that points to [`CROSS_L2_INBOX_ADDRESS`].
 ///
 /// Returns `Vec::new()` if [`AccessListItem`] address doesn't point to [`CROSS_L2_INBOX_ADDRESS`].
-// TODO: add url to spec once [pr](https://github.com/ethereum-optimism/specs/pull/612) is merged
+// Access-list spec: <https://github.com/ethereum-optimism/specs/blob/main/specs/interop/supervisor.md#access-list-contents>
 fn parse_access_list_item_to_inbox_entries(
     access_list_item: &AccessListItem,
 ) -> Option<impl Iterator<Item = &B256>> {


### PR DESCRIPTION
As https://github.com/ethereum-optimism/specs/pull/612 was merged, so try to add the optimism Access-list spec in the reth docs.