### PR TITLE
feat: make MockEthProvider more generic

### DIFF
--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -5,7 +5,7 @@ use crate::{
     StateProvider, StateProviderBox, StateProviderFactory, StateReader, StateRootProvider,
     TransactionVariant, TransactionsProvider,
 };
-use alloy_consensus::{constants::EMPTY_ROOT_HASH, transaction::TransactionMeta, Header};
+use alloy_consensus::{constants::EMPTY_ROOT_HASH, transaction::TransactionMeta, BlockHeader};
 use alloy_eips::{BlockHashOrNumber, BlockId, BlockNumberOrTag};
 use alloy_primitives::{
     keccak256, map::HashMap, Address, BlockHash, BlockNumber, Bytes, StorageKey, StorageValue,
@@ -19,11 +19,12 @@ use reth_db_api::{
     models::{AccountBeforeTx, StoredBlockBodyIndices},
 };
 use reth_ethereum_engine_primitives::EthEngineTypes;
-use reth_ethereum_primitives::{EthPrimitives, Receipt};
+use reth_ethereum_primitives::EthPrimitives;
 use reth_execution_types::ExecutionOutcome;
 use reth_node_types::NodeTypes;
 use reth_primitives_traits::{
-    Account, Bytecode, GotExpected, NodePrimitives, RecoveredBlock, SealedHeader, SignerRecoverable,
+    Account, Block, BlockBody, Bytecode, GotExpected, NodePrimitives, RecoveredBlock, SealedHeader,
+    SignedTransaction, SignerRecoverable,
 };
 use reth_prune_types::PruneModes;
 use reth_stages_types::{StageCheckpoint, StageId};
@@ -48,16 +49,14 @@ use tokio::sync::broadcast;
 
 /// A mock implementation for Provider interfaces.
 #[derive(Debug)]
-pub struct MockEthProvider<
-    T: NodePrimitives = reth_ethereum_primitives::EthPrimitives,
-    ChainSpec = reth_chainspec::ChainSpec,
-> {
+pub struct MockEthProvider<T: NodePrimitives = EthPrimitives, ChainSpec = reth_chainspec::ChainSpec>
+{
     ///local block store
     pub blocks: Arc<Mutex<HashMap<B256, T::Block>>>,
     /// Local header store
-    pub headers: Arc<Mutex<HashMap<B256, Header>>>,
+    pub headers: Arc<Mutex<HashMap<B256, <T::Block as Block>::Header>>>,
     /// Local receipt store indexed by block number
-    pub receipts: Arc<Mutex<HashMap<BlockNumber, Vec<Receipt>>>>,
+    pub receipts: Arc<Mutex<HashMap<BlockNumber, Vec<T::Receipt>>>>,
     /// Local account store
     pub accounts: Arc<Mutex<HashMap<Address, ExtendedAccount>>>,
     /// Local chain spec
@@ -106,31 +105,31 @@ impl<T: NodePrimitives> MockEthProvider<T, reth_chainspec::ChainSpec> {
     }
 }
 
-impl<ChainSpec> MockEthProvider<reth_ethereum_primitives::EthPrimitives, ChainSpec> {
+impl<T: NodePrimitives, ChainSpec> MockEthProvider<T, ChainSpec> {
     /// Add block to local block store
-    pub fn add_block(&self, hash: B256, block: reth_ethereum_primitives::Block) {
-        self.add_header(hash, block.header.clone());
+    pub fn add_block(&self, hash: B256, block: T::Block) {
+        self.add_header(hash, block.header().clone());
         self.blocks.lock().insert(hash, block);
     }
 
     /// Add multiple blocks to local block store
-    pub fn extend_blocks(
-        &self,
-        iter: impl IntoIterator<Item = (B256, reth_ethereum_primitives::Block)>,
-    ) {
+    pub fn extend_blocks(&self, iter: impl IntoIterator<Item = (B256, T::Block)>) {
         for (hash, block) in iter {
-            self.add_header(hash, block.header.clone());
+            self.add_header(hash, block.header().clone());
             self.add_block(hash, block)
         }
     }
 
     /// Add header to local header store
-    pub fn add_header(&self, hash: B256, header: Header) {
+    pub fn add_header(&self, hash: B256, header: <T::Block as Block>::Header) {
         self.headers.lock().insert(hash, header);
     }
 
     /// Add multiple headers to local header store
-    pub fn extend_headers(&self, iter: impl IntoIterator<Item = (B256, Header)>) {
+    pub fn extend_headers(
+        &self,
+        iter: impl IntoIterator<Item = (B256, <T::Block as Block>::Header)>,
+    ) {
         for (hash, header) in iter {
             self.add_header(hash, header)
         }
@@ -149,12 +148,12 @@ impl<ChainSpec> MockEthProvider<reth_ethereum_primitives::EthPrimitives, ChainSp
     }
 
     /// Add receipts to local receipt store
-    pub fn add_receipts(&self, block_number: BlockNumber, receipts: Vec<Receipt>) {
+    pub fn add_receipts(&self, block_number: BlockNumber, receipts: Vec<T::Receipt>) {
         self.receipts.lock().insert(block_number, receipts);
     }
 
     /// Add multiple receipts to local receipt store
-    pub fn extend_receipts(&self, iter: impl IntoIterator<Item = (BlockNumber, Vec<Receipt>)>) {
+    pub fn extend_receipts(&self, iter: impl IntoIterator<Item = (BlockNumber, Vec<T::Receipt>)>) {
         for (block_number, receipts) in iter {
             self.add_receipts(block_number, receipts);
         }
@@ -175,10 +174,7 @@ impl<ChainSpec> MockEthProvider<reth_ethereum_primitives::EthPrimitives, ChainSp
     }
 
     /// Set chain spec.
-    pub fn with_chain_spec<C>(
-        self,
-        chain_spec: C,
-    ) -> MockEthProvider<reth_ethereum_primitives::EthPrimitives, C> {
+    pub fn with_chain_spec<C>(self, chain_spec: C) -> MockEthProvider<T, C> {
         MockEthProvider {
             blocks: self.blocks,
             headers: self.headers,
@@ -300,27 +296,27 @@ impl<T: NodePrimitives, ChainSpec: EthChainSpec + 'static> DBProvider
     }
 }
 
-impl<ChainSpec: EthChainSpec + Send + Sync + 'static> HeaderProvider
-    for MockEthProvider<reth_ethereum_primitives::EthPrimitives, ChainSpec>
+impl<T: NodePrimitives, ChainSpec: EthChainSpec + Send + Sync + 'static> HeaderProvider
+    for MockEthProvider<T, ChainSpec>
 {
-    type Header = Header;
+    type Header = <T::Block as Block>::Header;
 
-    fn header(&self, block_hash: &BlockHash) -> ProviderResult<Option<Header>> {
+    fn header(&self, block_hash: &BlockHash) -> ProviderResult<Option<Self::Header>> {
         let lock = self.headers.lock();
         Ok(lock.get(block_hash).cloned())
     }
 
-    fn header_by_number(&self, num: u64) -> ProviderResult<Option<Header>> {
+    fn header_by_number(&self, num: u64) -> ProviderResult<Option<Self::Header>> {
         let lock = self.headers.lock();
-        Ok(lock.values().find(|h| h.number == num).cloned())
+        Ok(lock.values().find(|h| h.number() == num).cloned())
     }
 
     fn header_td(&self, hash: &BlockHash) -> ProviderResult<Option<U256>> {
         let lock = self.headers.lock();
         Ok(lock.get(hash).map(|target| {
             lock.values()
-                .filter(|h| h.number < target.number)
-                .fold(target.difficulty, |td, h| td + h.difficulty)
+                .filter(|h| h.number() < target.number())
+                .fold(target.difficulty(), |td, h| td + h.difficulty())
         }))
     }
 
@@ -328,30 +324,36 @@ impl<ChainSpec: EthChainSpec + Send + Sync + 'static> HeaderProvider
         let lock = self.headers.lock();
         let sum = lock
             .values()
-            .filter(|h| h.number <= number)
-            .fold(U256::ZERO, |td, h| td + h.difficulty);
+            .filter(|h| h.number() <= number)
+            .fold(U256::ZERO, |td, h| td + h.difficulty());
         Ok(Some(sum))
     }
 
-    fn headers_range(&self, range: impl RangeBounds<BlockNumber>) -> ProviderResult<Vec<Header>> {
+    fn headers_range(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> ProviderResult<Vec<Self::Header>> {
         let lock = self.headers.lock();
 
         let mut headers: Vec<_> =
-            lock.values().filter(|header| range.contains(&header.number)).cloned().collect();
-        headers.sort_by_key(|header| header.number);
+            lock.values().filter(|header| range.contains(&header.number())).cloned().collect();
+        headers.sort_by_key(|header| header.number());
 
         Ok(headers)
     }
 
-    fn sealed_header(&self, number: BlockNumber) -> ProviderResult<Option<SealedHeader>> {
+    fn sealed_header(
+        &self,
+        number: BlockNumber,
+    ) -> ProviderResult<Option<SealedHeader<Self::Header>>> {
         Ok(self.header_by_number(number)?.map(SealedHeader::seal_slow))
     }
 
     fn sealed_headers_while(
         &self,
         range: impl RangeBounds<BlockNumber>,
-        mut predicate: impl FnMut(&SealedHeader) -> bool,
-    ) -> ProviderResult<Vec<SealedHeader>> {
+        mut predicate: impl FnMut(&SealedHeader<Self::Header>) -> bool,
+    ) -> ProviderResult<Vec<SealedHeader<Self::Header>>> {
         Ok(self
             .headers_range(range)?
             .into_iter()
@@ -373,16 +375,16 @@ where
     }
 }
 
-impl<ChainSpec: EthChainSpec + 'static> TransactionsProvider
-    for MockEthProvider<reth_ethereum_primitives::EthPrimitives, ChainSpec>
+impl<T: NodePrimitives, ChainSpec: EthChainSpec + 'static> TransactionsProvider
+    for MockEthProvider<T, ChainSpec>
 {
-    type Transaction = reth_ethereum_primitives::TransactionSigned;
+    type Transaction = T::SignedTx;
 
     fn transaction_id(&self, tx_hash: TxHash) -> ProviderResult<Option<TxNumber>> {
         let lock = self.blocks.lock();
         let tx_number = lock
             .values()
-            .flat_map(|block| &block.body.transactions)
+            .flat_map(|block| block.body().transactions())
             .position(|tx| *tx.tx_hash() == tx_hash)
             .map(|pos| pos as TxNumber);
 
@@ -392,7 +394,7 @@ impl<ChainSpec: EthChainSpec + 'static> TransactionsProvider
     fn transaction_by_id(&self, id: TxNumber) -> ProviderResult<Option<Self::Transaction>> {
         let lock = self.blocks.lock();
         let transaction =
-            lock.values().flat_map(|block| &block.body.transactions).nth(id as usize).cloned();
+            lock.values().flat_map(|block| block.body().transactions()).nth(id as usize).cloned();
 
         Ok(transaction)
     }
@@ -403,14 +405,14 @@ impl<ChainSpec: EthChainSpec + 'static> TransactionsProvider
     ) -> ProviderResult<Option<Self::Transaction>> {
         let lock = self.blocks.lock();
         let transaction =
-            lock.values().flat_map(|block| &block.body.transactions).nth(id as usize).cloned();
+            lock.values().flat_map(|block| block.body().transactions()).nth(id as usize).cloned();
 
         Ok(transaction)
     }
 
     fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Self::Transaction>> {
         Ok(self.blocks.lock().iter().find_map(|(_, block)| {
-            block.body.transactions.iter().find(|tx| *tx.tx_hash() == hash).cloned()
+            block.body().transactions_iter().find(|tx| *tx.tx_hash() == hash).cloned()
         }))
     }
 
@@ -420,16 +422,16 @@ impl<ChainSpec: EthChainSpec + 'static> TransactionsProvider
     ) -> ProviderResult<Option<(Self::Transaction, TransactionMeta)>> {
         let lock = self.blocks.lock();
         for (block_hash, block) in lock.iter() {
-            for (index, tx) in block.body.transactions.iter().enumerate() {
+            for (index, tx) in block.body().transactions_iter().enumerate() {
                 if *tx.tx_hash() == hash {
                     let meta = TransactionMeta {
                         tx_hash: hash,
                         index: index as u64,
                         block_hash: *block_hash,
-                        block_number: block.header.number,
-                        base_fee: block.header.base_fee_per_gas,
-                        excess_blob_gas: block.header.excess_blob_gas,
-                        timestamp: block.header.timestamp,
+                        block_number: block.header().number(),
+                        base_fee: block.header().base_fee_per_gas(),
+                        excess_blob_gas: block.header().excess_blob_gas(),
+                        timestamp: block.header().timestamp(),
                     };
                     return Ok(Some((tx.clone(), meta)))
                 }
@@ -442,10 +444,10 @@ impl<ChainSpec: EthChainSpec + 'static> TransactionsProvider
         let lock = self.blocks.lock();
         let mut current_tx_number: TxNumber = 0;
         for block in lock.values() {
-            if current_tx_number + (block.body.transactions.len() as TxNumber) > id {
-                return Ok(Some(block.header.number))
+            if current_tx_number + (block.body().transaction_count() as TxNumber) > id {
+                return Ok(Some(block.header().number()))
             }
-            current_tx_number += block.body.transactions.len() as TxNumber;
+            current_tx_number += block.body().transaction_count() as TxNumber;
         }
         Ok(None)
     }
@@ -454,7 +456,7 @@ impl<ChainSpec: EthChainSpec + 'static> TransactionsProvider
         &self,
         id: BlockHashOrNumber,
     ) -> ProviderResult<Option<Vec<Self::Transaction>>> {
-        Ok(self.block(id)?.map(|b| b.body.transactions))
+        Ok(self.block(id)?.map(|b| b.body().clone_transactions()))
     }
 
     fn transactions_by_block_range(
@@ -464,8 +466,8 @@ impl<ChainSpec: EthChainSpec + 'static> TransactionsProvider
         // init btreemap so we can return in order
         let mut map = BTreeMap::new();
         for (_, block) in self.blocks.lock().iter() {
-            if range.contains(&block.number) {
-                map.insert(block.number, block.body.transactions.clone());
+            if range.contains(&block.header().number()) {
+                map.insert(block.header().number(), block.body().clone_transactions());
             }
         }
 
@@ -479,7 +481,7 @@ impl<ChainSpec: EthChainSpec + 'static> TransactionsProvider
         let lock = self.blocks.lock();
         let transactions = lock
             .values()
-            .flat_map(|block| &block.body.transactions)
+            .flat_map(|block| block.body().transactions())
             .enumerate()
             .filter(|&(tx_number, _)| range.contains(&(tx_number as TxNumber)))
             .map(|(_, tx)| tx.clone())
@@ -495,7 +497,7 @@ impl<ChainSpec: EthChainSpec + 'static> TransactionsProvider
         let lock = self.blocks.lock();
         let transactions = lock
             .values()
-            .flat_map(|block| &block.body.transactions)
+            .flat_map(|block| block.body().transactions())
             .enumerate()
             .filter_map(|(tx_number, tx)| {
                 if range.contains(&(tx_number as TxNumber)) {
@@ -519,7 +521,7 @@ where
     T: NodePrimitives,
     ChainSpec: Send + Sync + 'static,
 {
-    type Receipt = Receipt;
+    type Receipt = T::Receipt;
 
     fn receipt(&self, _id: TxNumber) -> ProviderResult<Option<Self::Receipt>> {
         Ok(None)
@@ -540,7 +542,7 @@ where
                 // Find block number by hash first
                 let headers_lock = self.headers.lock();
                 if let Some(header) = headers_lock.get(&hash) {
-                    Ok(receipts_lock.get(&header.number).cloned())
+                    Ok(receipts_lock.get(&header.number()).cloned())
                 } else {
                     Ok(None)
                 }
@@ -566,7 +568,7 @@ where
         let mut result = Vec::new();
         for block_number in block_range {
             // Only include blocks that exist in headers (i.e., have been added to the provider)
-            if headers_lock.values().any(|header| header.number == block_number) {
+            if headers_lock.values().any(|header| header.number() == block_number) {
                 if let Some(block_receipts) = receipts_lock.get(&block_number) {
                     result.push(block_receipts.clone());
                 } else {
@@ -593,7 +595,7 @@ impl<T: NodePrimitives, ChainSpec: Send + Sync + 'static> BlockHashReader
     fn block_hash(&self, number: u64) -> ProviderResult<Option<B256>> {
         let lock = self.headers.lock();
         let hash =
-            lock.iter().find_map(|(hash, header)| (header.number == number).then_some(*hash));
+            lock.iter().find_map(|(hash, header)| (header.number() == number).then_some(*hash));
         Ok(hash)
     }
 
@@ -604,9 +606,9 @@ impl<T: NodePrimitives, ChainSpec: Send + Sync + 'static> BlockHashReader
     ) -> ProviderResult<Vec<B256>> {
         let lock = self.headers.lock();
         let mut hashes: Vec<_> =
-            lock.iter().filter(|(_, header)| (start..end).contains(&header.number)).collect();
+            lock.iter().filter(|(_, header)| (start..end).contains(&header.number())).collect();
 
-        hashes.sort_by_key(|(_, header)| header.number);
+        hashes.sort_by_key(|(_, header)| header.number());
 
         Ok(hashes.into_iter().map(|(hash, _)| *hash).collect())
     }
@@ -621,16 +623,16 @@ impl<T: NodePrimitives, ChainSpec: Send + Sync + 'static> BlockNumReader
 
         Ok(lock
             .iter()
-            .find(|(_, header)| header.number == best_block_number)
-            .map(|(hash, header)| ChainInfo { best_hash: *hash, best_number: header.number })
+            .find(|(_, header)| header.number() == best_block_number)
+            .map(|(hash, header)| ChainInfo { best_hash: *hash, best_number: header.number() })
             .unwrap_or_default())
     }
 
     fn best_block_number(&self) -> ProviderResult<BlockNumber> {
         let lock = self.headers.lock();
         lock.iter()
-            .max_by_key(|h| h.1.number)
-            .map(|(_, header)| header.number)
+            .max_by_key(|h| h.1.number())
+            .map(|(_, header)| header.number())
             .ok_or(ProviderError::BestBlockNotFound)
     }
 
@@ -640,7 +642,7 @@ impl<T: NodePrimitives, ChainSpec: Send + Sync + 'static> BlockNumReader
 
     fn block_number(&self, hash: B256) -> ProviderResult<Option<alloy_primitives::BlockNumber>> {
         let lock = self.headers.lock();
-        Ok(lock.get(&hash).map(|header| header.number))
+        Ok(lock.get(&hash).map(|header| header.number()))
     }
 }
 
@@ -661,10 +663,10 @@ impl<T: NodePrimitives, ChainSpec: EthChainSpec + Send + Sync + 'static> BlockId
 }
 
 //look
-impl<ChainSpec: EthChainSpec + Send + Sync + 'static> BlockReader
-    for MockEthProvider<reth_ethereum_primitives::EthPrimitives, ChainSpec>
+impl<T: NodePrimitives, ChainSpec: EthChainSpec + Send + Sync + 'static> BlockReader
+    for MockEthProvider<T, ChainSpec>
 {
-    type Block = reth_ethereum_primitives::Block;
+    type Block = T::Block;
 
     fn find_block_by_hash(
         &self,
@@ -678,7 +680,9 @@ impl<ChainSpec: EthChainSpec + Send + Sync + 'static> BlockReader
         let lock = self.blocks.lock();
         match id {
             BlockHashOrNumber::Hash(hash) => Ok(lock.get(&hash).cloned()),
-            BlockHashOrNumber::Number(num) => Ok(lock.values().find(|b| b.number == num).cloned()),
+            BlockHashOrNumber::Number(num) => {
+                Ok(lock.values().find(|b| b.header().number() == num).cloned())
+            }
         }
     }
 
@@ -688,7 +692,7 @@ impl<ChainSpec: EthChainSpec + Send + Sync + 'static> BlockReader
 
     fn pending_block_and_receipts(
         &self,
-    ) -> ProviderResult<Option<(RecoveredBlock<Self::Block>, Vec<Receipt>)>> {
+    ) -> ProviderResult<Option<(RecoveredBlock<Self::Block>, Vec<T::Receipt>)>> {
         Ok(None)
     }
 
@@ -711,9 +715,12 @@ impl<ChainSpec: EthChainSpec + Send + Sync + 'static> BlockReader
     fn block_range(&self, range: RangeInclusive<BlockNumber>) -> ProviderResult<Vec<Self::Block>> {
         let lock = self.blocks.lock();
 
-        let mut blocks: Vec<_> =
-            lock.values().filter(|block| range.contains(&block.number)).cloned().collect();
-        blocks.sort_by_key(|block| block.number);
+        let mut blocks: Vec<_> = lock
+            .values()
+            .filter(|block| range.contains(&block.header().number()))
+            .cloned()
+            .collect();
+        blocks.sort_by_key(|block| block.header().number());
 
         Ok(blocks)
     }
@@ -733,26 +740,29 @@ impl<ChainSpec: EthChainSpec + Send + Sync + 'static> BlockReader
     }
 }
 
-impl<ChainSpec> BlockReaderIdExt
-    for MockEthProvider<reth_ethereum_primitives::EthPrimitives, ChainSpec>
+impl<T, ChainSpec> BlockReaderIdExt for MockEthProvider<T, ChainSpec>
 where
     ChainSpec: EthChainSpec + Send + Sync + 'static,
+    T: NodePrimitives,
 {
-    fn block_by_id(&self, id: BlockId) -> ProviderResult<Option<reth_ethereum_primitives::Block>> {
+    fn block_by_id(&self, id: BlockId) -> ProviderResult<Option<T::Block>> {
         match id {
             BlockId::Number(num) => self.block_by_number_or_tag(num),
             BlockId::Hash(hash) => self.block_by_hash(hash.block_hash),
         }
     }
 
-    fn sealed_header_by_id(&self, id: BlockId) -> ProviderResult<Option<SealedHeader>> {
+    fn sealed_header_by_id(
+        &self,
+        id: BlockId,
+    ) -> ProviderResult<Option<SealedHeader<<T::Block as Block>::Header>>> {
         self.header_by_id(id)?.map_or_else(|| Ok(None), |h| Ok(Some(SealedHeader::seal_slow(h))))
     }
 
-    fn header_by_id(&self, id: BlockId) -> ProviderResult<Option<Header>> {
+    fn header_by_id(&self, id: BlockId) -> ProviderResult<Option<<T::Block as Block>::Header>> {
         match self.block_by_id(id)? {
             None => Ok(None),
-            Some(block) => Ok(Some(block.header)),
+            Some(block) => Ok(Some(block.into_header())),
         }
     }
 }
@@ -989,9 +999,12 @@ impl<T: NodePrimitives, ChainSpec: Send + Sync> ChangeSetReader for MockEthProvi
 }
 
 impl<T: NodePrimitives, ChainSpec: Send + Sync> StateReader for MockEthProvider<T, ChainSpec> {
-    type Receipt = Receipt;
+    type Receipt = T::Receipt;
 
-    fn get_state(&self, _block: BlockNumber) -> ProviderResult<Option<ExecutionOutcome>> {
+    fn get_state(
+        &self,
+        _block: BlockNumber,
+    ) -> ProviderResult<Option<ExecutionOutcome<Self::Receipt>>> {
         Ok(None)
     }
 }
@@ -1019,7 +1032,7 @@ mod tests {
 
     #[test]
     fn test_mock_provider_receipts() {
-        let provider = MockEthProvider::new();
+        let provider = MockEthProvider::<EthPrimitives>::new();
 
         let block_hash = BlockHash::random();
         let block_number = 1u64;
@@ -1050,7 +1063,7 @@ mod tests {
 
     #[test]
     fn test_mock_provider_receipts_multiple_blocks() {
-        let provider = MockEthProvider::new();
+        let provider = MockEthProvider::<EthPrimitives>::new();
 
         let block1_hash = BlockHash::random();
         let block2_hash = BlockHash::random();


### PR DESCRIPTION
Update the `MockEthProvider` in order to be able to use it with any primitives types, not just `EthPrimitives`.