### PR TITLE
fix: block_meta was not commited

### DIFF
--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -66,7 +66,7 @@ impl<N: NodePrimitives> StaticFileWriters<N> {
     }
 
     pub(crate) fn commit(&self) -> ProviderResult<()> {
-        for writer_lock in [&self.headers, &self.transactions, &self.receipts] {
+        for writer_lock in [&self.headers, &self.transactions, &self.receipts, &self.block_meta] {
             let mut writer = writer_lock.write();
             if let Some(writer) = writer.as_mut() {
                 writer.commit()?;


### PR DESCRIPTION
Seems StaticFileWriters will commit the `headers, transactions, receipts`, but the `block_meta` was not committed, I'm not sure if this is a bug or not?