### PR TITLE
docs(e2s_file): clarify automatic version insertion and entries behavior

### DIFF
--- a/crates/era/src/e2s_file.rs
+++ b/crates/era/src/e2s_file.rs
@@ -36,7 +36,7 @@ impl<R: Read + Seek> E2StoreReader<R> {
         Entry::read(&mut self.reader)
     }
 
-    /// Iterate through all entries, including the version entry
+    /// Read all entries from the file, including the version entry
     pub fn entries(&mut self) -> Result<Vec<Entry>, E2sError> {
         // Reset reader to beginning
         self.reader.seek(SeekFrom::Start(0))?;
@@ -74,7 +74,7 @@ impl<W: Write> E2StoreWriter<W> {
     }
 
     /// Write the version entry as the first entry in the file.
-    /// This must be called before writing any other entries.
+    /// If not called explicitly, it will be written automatically before the first non-version entry.
     pub fn write_version(&mut self) -> Result<(), E2sError> {
         if self.has_written_version {
             return Ok(());

--- a/crates/era/src/e2s_file.rs
+++ b/crates/era/src/e2s_file.rs
@@ -74,7 +74,8 @@ impl<W: Write> E2StoreWriter<W> {
     }
 
     /// Write the version entry as the first entry in the file.
-    /// If not called explicitly, it will be written automatically before the first non-version entry.
+    /// If not called explicitly, it will be written automatically before the first non-version
+    /// entry.
     pub fn write_version(&mut self) -> Result<(), E2sError> {
         if self.has_written_version {
             return Ok(());


### PR DESCRIPTION
Update write_version docs to state the version is auto-written before the first non-version entry if not explicit.
Change entries docs to “Read all entries” (it returns Vec<Entry>, not an iterator).
