### PR TITLE
feat(node): add --override.<hardfork> cli args

### DIFF
--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -31,7 +31,8 @@ pub use info::ChainInfo;
 pub use spec::test_fork_ids;
 pub use spec::{
     make_genesis_header, BaseFeeParams, BaseFeeParamsKind, ChainSpec, ChainSpecBuilder,
-    ChainSpecProvider, DepositContract, ForkBaseFeeParams, DEV, HOLESKY, HOODI, MAINNET, SEPOLIA,
+    ChainSpecProvider, DepositContract, ForkBaseFeeParams, HardforksOverrides, DEV, HOLESKY, HOODI,
+    MAINNET, SEPOLIA,
 };
 
 use reth_primitives_traits::sync::OnceLock;

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -768,6 +768,22 @@ impl EthereumHardforks for ChainSpec {
     }
 }
 
+/// A trait for applying hardfork overrides to a chainspec.
+pub trait HardforksOverrides {
+    /// Apply the given hardfork timestamp overrides to the chainspec.
+    fn apply_hardforks_overrides<H: Hardfork>(&self, overrides: Vec<(H, u64)>) -> Self;
+}
+
+impl HardforksOverrides for ChainSpec {
+    fn apply_hardforks_overrides<H: Hardfork>(&self, overrides: Vec<(H, u64)>) -> Self {
+        let mut spec = self.clone();
+        for (hf, ts) in overrides {
+            spec.hardforks.insert(hf, ForkCondition::Timestamp(ts));
+        }
+        spec
+    }
+}
+
 /// A trait for reading the current chainspec.
 #[auto_impl::auto_impl(&, Arc)]
 pub trait ChainSpecProvider: Debug + Send + Sync {

--- a/crates/ethereum/cli/src/interface.rs
+++ b/crates/ethereum/cli/src/interface.rs
@@ -2,7 +2,7 @@
 
 use crate::chainspec::EthereumChainSpecParser;
 use clap::{Parser, Subcommand};
-use reth_chainspec::{ChainSpec, EthChainSpec, Hardforks};
+use reth_chainspec::{ChainSpec, EthChainSpec, Hardforks, HardforksOverrides};
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_commands::{
     common::{CliComponentsBuilder, CliHeader, CliNodeTypes},
@@ -124,7 +124,10 @@ impl<C: ChainSpecParser, Ext: clap::Args + fmt::Debug> Cli<C, Ext> {
         ) -> eyre::Result<()>,
     ) -> eyre::Result<()>
     where
-        N: CliNodeTypes<Primitives: NodePrimitives<BlockHeader: CliHeader>, ChainSpec: Hardforks>,
+        N: CliNodeTypes<
+            Primitives: NodePrimitives<BlockHeader: CliHeader>,
+            ChainSpec: Hardforks + HardforksOverrides,
+        >,
         C: ChainSpecParser<ChainSpec = N::ChainSpec>,
     {
         self.with_runner_and_components(CliRunner::try_default_runtime()?, components, launcher)
@@ -178,7 +181,10 @@ impl<C: ChainSpecParser, Ext: clap::Args + fmt::Debug> Cli<C, Ext> {
         ) -> eyre::Result<()>,
     ) -> eyre::Result<()>
     where
-        N: CliNodeTypes<Primitives: NodePrimitives<BlockHeader: CliHeader>, ChainSpec: Hardforks>,
+        N: CliNodeTypes<
+            Primitives: NodePrimitives<BlockHeader: CliHeader>,
+            ChainSpec: Hardforks + EthChainSpec + HardforksOverrides,
+        >,
         C: ChainSpecParser<ChainSpec = N::ChainSpec>,
     {
         // Add network name if available to the logs dir

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -332,6 +332,11 @@ impl<DB, ChainSpec> WithLaunchContext<NodeBuilder<DB, ChainSpec>> {
     pub const fn config(&self) -> &NodeConfig<ChainSpec> {
         self.builder.config()
     }
+
+    /// Returns a mutable reference to the node builder's config.
+    pub const fn config_mut(&mut self) -> &mut NodeConfig<ChainSpec> {
+        self.builder.config_mut()
+    }
 }
 
 impl<DB, ChainSpec> WithLaunchContext<NodeBuilder<DB, ChainSpec>>

--- a/crates/node/core/src/args/hardforks_overrides.rs
+++ b/crates/node/core/src/args/hardforks_overrides.rs
@@ -1,0 +1,22 @@
+use clap::Args;
+use reth_ethereum_forks::EthereumHardfork;
+
+/// CLI args to override Ethereum hardfork activations.
+#[derive(Debug, Clone, Default, Args, PartialEq, Eq)]
+#[command(next_help_heading = "Hardfork Overrides")]
+pub struct EthereumHardforkOverrideArgs {
+    /// Override Prague hardfork activation timestamp
+    #[arg(long = "override.prague", value_name = "TIMESTAMP")]
+    pub prague: Option<u64>,
+}
+
+impl EthereumHardforkOverrideArgs {
+    /// Get the overrides as a vector of (hardfork, timestamp) pairs.
+    pub fn as_vec(&self) -> Vec<(EthereumHardfork, u64)> {
+        let mut overrides = Vec::new();
+        if let Some(ts) = self.prague {
+            overrides.push((EthereumHardfork::Prague, ts));
+        }
+        overrides
+    }
+}

--- a/crates/node/core/src/args/mod.rs
+++ b/crates/node/core/src/args/mod.rs
@@ -68,5 +68,9 @@ pub use ress_args::RessArgs;
 mod era;
 pub use era::{DefaultEraHost, EraArgs, EraSourceArgs};
 
+/// Hardfork overrides
+mod hardforks_overrides;
+pub use hardforks_overrides::EthereumHardforkOverrideArgs;
+
 mod error;
 pub mod types;

--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -53,6 +53,7 @@ pub use dev::OP_DEV;
 pub use op::OP_MAINNET;
 pub use op_sepolia::OP_SEPOLIA;
 
+pub use reth_chainspec::HardforksOverrides;
 /// Re-export for convenience
 pub use reth_optimism_forks::*;
 
@@ -324,6 +325,12 @@ impl Hardforks for OpChainSpec {
 
     fn fork_filter(&self, head: Head) -> ForkFilter {
         self.inner.fork_filter(head)
+    }
+}
+
+impl HardforksOverrides for OpChainSpec {
+    fn apply_hardforks_overrides<H: Hardfork>(&self, overrides: Vec<(H, u64)>) -> Self {
+        Self { inner: self.inner.apply_hardforks_overrides(overrides) }
     }
 }
 

--- a/crates/optimism/node/src/args.rs
+++ b/crates/optimism/node/src/args.rs
@@ -3,6 +3,7 @@
 //! clap [Args](clap::Args) for optimism rollup configuration
 
 use op_alloy_consensus::interop::SafetyLevel;
+use reth_optimism_forks::OpHardfork;
 use reth_optimism_txpool::supervisor::DEFAULT_SUPERVISOR_URL;
 
 /// Parameters for rollup configuration
@@ -66,6 +67,38 @@ pub struct RollupArgs {
     /// Minimum suggested priority fee (tip) in wei, default `1_000_000`
     #[arg(long, default_value_t = 1_000_000)]
     pub min_suggested_priority_fee: u64,
+
+    /// Override Canyon OP hardfork activation timestamp
+    #[arg(long = "override.canyon", value_name = "TIMESTAMP")]
+    pub canyon: Option<u64>,
+
+    /// Override Ecotone OP hardfork activation timestamp
+    #[arg(long = "override.ecotone", value_name = "TIMESTAMP")]
+    pub ecotone: Option<u64>,
+
+    /// Override Fjord OP hardfork activation timestamp
+    #[arg(long = "override.fjord", value_name = "TIMESTAMP")]
+    pub fjord: Option<u64>,
+
+    /// Override Granite OP hardfork activation timestamp
+    #[arg(long = "override.granite", value_name = "TIMESTAMP")]
+    pub granite: Option<u64>,
+
+    /// Override Holocene OP hardfork activation timestamp
+    #[arg(long = "override.holocene", value_name = "TIMESTAMP")]
+    pub holocene: Option<u64>,
+
+    /// Override Isthmus OP hardfork activation timestamp
+    #[arg(long = "override.isthmus", value_name = "TIMESTAMP")]
+    pub isthmus: Option<u64>,
+
+    /// Override Jovian OP hardfork activation timestamp
+    #[arg(long = "override.jovian", value_name = "TIMESTAMP")]
+    pub jovian: Option<u64>,
+
+    /// Override Interop OP hardfork activation timestamp
+    #[arg(long = "override.interop", value_name = "TIMESTAMP")]
+    pub interop: Option<u64>,
 }
 
 impl Default for RollupArgs {
@@ -81,7 +114,49 @@ impl Default for RollupArgs {
             sequencer_headers: Vec::new(),
             historical_rpc: None,
             min_suggested_priority_fee: 1_000_000,
+            canyon: None,
+            ecotone: None,
+            fjord: None,
+            granite: None,
+            holocene: None,
+            isthmus: None,
+            jovian: None,
+            interop: None,
         }
+    }
+}
+
+impl RollupArgs {
+    /// Get the OP hardfork overrides as a vector of (hardfork, timestamp) pairs.
+    pub fn op_hardforks_as_vec(&self) -> Vec<(OpHardfork, u64)> {
+        let mut overrides = Vec::new();
+
+        if let Some(ts) = self.canyon {
+            overrides.push((OpHardfork::Canyon, ts));
+        }
+        if let Some(ts) = self.ecotone {
+            overrides.push((OpHardfork::Ecotone, ts));
+        }
+        if let Some(ts) = self.fjord {
+            overrides.push((OpHardfork::Fjord, ts));
+        }
+        if let Some(ts) = self.granite {
+            overrides.push((OpHardfork::Granite, ts));
+        }
+        if let Some(ts) = self.holocene {
+            overrides.push((OpHardfork::Holocene, ts));
+        }
+        if let Some(ts) = self.isthmus {
+            overrides.push((OpHardfork::Isthmus, ts));
+        }
+        if let Some(ts) = self.jovian {
+            overrides.push((OpHardfork::Jovian, ts));
+        }
+        if let Some(ts) = self.interop {
+            overrides.push((OpHardfork::Interop, ts));
+        }
+
+        overrides
     }
 }
 
@@ -167,6 +242,42 @@ mod tests {
             "--rollup.enable-tx-conditional",
             "--rollup.sequencer-http",
             "http://host:port",
+        ])
+        .args;
+        assert_eq!(args, expected_args);
+    }
+
+    #[test]
+    fn test_parse_optimism_hardfork_overrides() {
+        let expected_args = RollupArgs {
+            canyon: Some(1),
+            ecotone: Some(2),
+            fjord: Some(3),
+            granite: Some(4),
+            holocene: Some(5),
+            isthmus: Some(6),
+            jovian: Some(7),
+            interop: Some(8),
+            ..Default::default()
+        };
+        let args = CommandParser::<RollupArgs>::parse_from([
+            "reth",
+            "--override.canyon",
+            "1",
+            "--override.ecotone",
+            "2",
+            "--override.fjord",
+            "3",
+            "--override.granite",
+            "4",
+            "--override.holocene",
+            "5",
+            "--override.isthmus",
+            "6",
+            "--override.jovian",
+            "7",
+            "--override.interop",
+            "8",
         ])
         .args;
         assert_eq!(args, expected_args);

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -835,6 +835,10 @@ ERA:
           The ERA1 files are read from the remote host using HTTP GET requests parsing headers
           and bodies.
 
+Hardfork Overrides:
+      --override.prague <TIMESTAMP>
+          Override Prague hardfork activation timestamp
+
 Ress:
       --ress.enable
           Enable support for `ress` subprotocol


### PR DESCRIPTION
## Motivation
Close #16523

## Solution
- Added a new trait `HardforksOverrides` to apply hardfork timestamp overrides to chainspec.
- Updated relevant structures and CLI arguments to support these overrides for both Ethereum and OP chainspecs.
- Added unit tests on CLI args

## Remarks
- It may be necessary to restrict the `--override.<hardfork>` cli args to dev mode
- Eth Hardfork overrides are applied in `NodeCommand` impl as they are defined in `EthereumHardforkOverrideArgs`
- OP ones are applied in the op-reth main bin as as they are defined in `RollupArgs`
- A follow-up task may be to merge `HardforksOverrides` into alloy's existing `EthereumHardforks` trait
- It would be nice to add integration test, but I am not sure at which level (Cli, NodeCommand...)