### PR TITLE
feat(examples): Add custom header extensions to payload attributes in `custom_node` example

### DIFF
--- a/crates/optimism/evm/src/build.rs
+++ b/crates/optimism/evm/src/build.rs
@@ -32,7 +32,7 @@ impl<ChainSpec: OpHardforks> OpBlockAssembler<ChainSpec> {
     /// Builds a block for `input` without any bounds on header `H`.
     pub fn assemble_block<
         F: for<'a> BlockExecutorFactory<
-            ExecutionCtx<'a> = OpBlockExecutionCtx,
+            ExecutionCtx<'a>: Into<OpBlockExecutionCtx>,
             Transaction: SignedTransaction,
             Receipt: Receipt + DepositReceipt,
         >,
@@ -51,6 +51,7 @@ impl<ChainSpec: OpHardforks> OpBlockAssembler<ChainSpec> {
             state_provider,
             ..
         } = input;
+        let ctx = ctx.into();
 
         let timestamp = evm_env.block_env.timestamp.saturating_to();
 

--- a/examples/custom-node/src/engine_api.rs
+++ b/examples/custom-node/src/engine_api.rs
@@ -1,5 +1,5 @@
 use crate::{
-    engine::{CustomExecutionData, CustomPayloadTypes},
+    engine::{CustomExecutionData, CustomPayloadAttributes, CustomPayloadTypes},
     primitives::CustomNodePrimitives,
     CustomNode,
 };
@@ -8,7 +8,6 @@ use alloy_rpc_types_engine::{
 };
 use async_trait::async_trait;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc, RpcModule};
-use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use reth_ethereum::node::api::{
     AddOnsContext, BeaconConsensusEngineHandle, EngineApiMessageVersion, FullNodeComponents,
 };
@@ -51,7 +50,7 @@ pub trait CustomEngineApi {
     async fn fork_choice_updated(
         &self,
         fork_choice_state: ForkchoiceState,
-        payload_attributes: Option<OpPayloadAttributes>,
+        payload_attributes: Option<CustomPayloadAttributes>,
     ) -> RpcResult<ForkchoiceUpdated>;
 
     #[method(name = "getPayload")]
@@ -91,7 +90,7 @@ impl CustomEngineApiServer for CustomEngineApi {
     async fn fork_choice_updated(
         &self,
         fork_choice_state: ForkchoiceState,
-        payload_attributes: Option<OpPayloadAttributes>,
+        payload_attributes: Option<CustomPayloadAttributes>,
     ) -> RpcResult<ForkchoiceUpdated> {
         Ok(self
             .inner

--- a/examples/custom-node/src/evm/assembler.rs
+++ b/examples/custom-node/src/evm/assembler.rs
@@ -1,9 +1,9 @@
 use crate::{
     chainspec::CustomChainSpec,
+    evm::executor::CustomBlockExecutionCtx,
     primitives::{Block, CustomHeader, CustomTransaction},
 };
 use alloy_evm::block::{BlockExecutionError, BlockExecutorFactory};
-use alloy_op_evm::OpBlockExecutionCtx;
 use reth_ethereum::{
     evm::primitives::execute::{BlockAssembler, BlockAssemblerInput},
     primitives::Receipt,
@@ -25,7 +25,7 @@ impl CustomBlockAssembler {
 impl<F> BlockAssembler<F> for CustomBlockAssembler
 where
     F: for<'a> BlockExecutorFactory<
-        ExecutionCtx<'a> = OpBlockExecutionCtx,
+        ExecutionCtx<'a> = CustomBlockExecutionCtx,
         Transaction = CustomTransaction,
         Receipt: Receipt + DepositReceipt,
     >,

--- a/examples/custom-node/src/evm/config.rs
+++ b/examples/custom-node/src/evm/config.rs
@@ -136,9 +136,12 @@ pub struct CustomNextBlockEnvAttributes {
     extension: u64,
 }
 
-impl<H: BlockHeader> BuildPendingEnv<H> for CustomNextBlockEnvAttributes {
-    fn build_pending_env(parent: &SealedHeader<H>) -> Self {
-        Self { inner: OpNextBlockEnvAttributes::build_pending_env(parent), extension: 0 }
+impl BuildPendingEnv<CustomHeader> for CustomNextBlockEnvAttributes {
+    fn build_pending_env(parent: &SealedHeader<CustomHeader>) -> Self {
+        Self {
+            inner: OpNextBlockEnvAttributes::build_pending_env(parent),
+            extension: parent.extension,
+        }
     }
 }
 

--- a/examples/custom-node/src/evm/config.rs
+++ b/examples/custom-node/src/evm/config.rs
@@ -130,7 +130,7 @@ impl ConfigureEngineEvm<CustomExecutionData> for CustomEvmConfig {
 }
 
 /// Additional parameters required for executing next block custom transactions.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct CustomNextBlockEnvAttributes {
     inner: OpNextBlockEnvAttributes,
     extension: u64,

--- a/examples/custom-node/src/evm/config.rs
+++ b/examples/custom-node/src/evm/config.rs
@@ -1,7 +1,7 @@
 use crate::{
     chainspec::CustomChainSpec,
-    engine::CustomExecutionData,
-    evm::{alloy::CustomEvmFactory, CustomBlockAssembler},
+    engine::{CustomExecutionData, CustomPayloadBuilderAttributes},
+    evm::{alloy::CustomEvmFactory, executor::CustomBlockExecutionCtx, CustomBlockAssembler},
     primitives::{Block, CustomHeader, CustomNodePrimitives, CustomTransaction},
 };
 use alloy_consensus::BlockHeader;
@@ -12,15 +12,18 @@ use alloy_rpc_types_engine::PayloadError;
 use op_revm::OpSpecId;
 use reth_engine_primitives::ExecutableTxIterator;
 use reth_ethereum::{
-    node::api::ConfigureEvm,
+    chainspec::EthChainSpec,
+    node::api::{BuildNextEnv, ConfigureEvm, PayloadBuilderError},
     primitives::{SealedBlock, SealedHeader},
 };
 use reth_node_builder::{ConfigureEngineEvm, NewPayloadError};
 use reth_op::{
+    chainspec::OpHardforks,
     evm::primitives::{EvmEnvFor, ExecutionCtxFor},
     node::{OpEvmConfig, OpNextBlockEnvAttributes, OpRethReceiptBuilder},
     primitives::SignedTransaction,
 };
+use reth_rpc_api::eth::helpers::pending_block::BuildPendingEnv;
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
@@ -46,7 +49,7 @@ impl CustomEvmConfig {
 impl ConfigureEvm for CustomEvmConfig {
     type Primitives = CustomNodePrimitives;
     type Error = <OpEvmConfig as ConfigureEvm>::Error;
-    type NextBlockEnvCtx = <OpEvmConfig as ConfigureEvm>::NextBlockEnvCtx;
+    type NextBlockEnvCtx = CustomNextBlockEnvAttributes;
     type BlockExecutorFactory = Self;
     type BlockAssembler = CustomBlockAssembler;
 
@@ -65,16 +68,19 @@ impl ConfigureEvm for CustomEvmConfig {
     fn next_evm_env(
         &self,
         parent: &CustomHeader,
-        attributes: &OpNextBlockEnvAttributes,
+        attributes: &CustomNextBlockEnvAttributes,
     ) -> Result<EvmEnv<OpSpecId>, Self::Error> {
-        self.inner.next_evm_env(parent, attributes)
+        self.inner.next_evm_env(parent, &attributes.inner)
     }
 
-    fn context_for_block(&self, block: &SealedBlock<Block>) -> OpBlockExecutionCtx {
-        OpBlockExecutionCtx {
-            parent_hash: block.header().parent_hash(),
-            parent_beacon_block_root: block.header().parent_beacon_block_root(),
-            extra_data: block.header().extra_data().clone(),
+    fn context_for_block(&self, block: &SealedBlock<Block>) -> CustomBlockExecutionCtx {
+        CustomBlockExecutionCtx {
+            inner: OpBlockExecutionCtx {
+                parent_hash: block.header().parent_hash(),
+                parent_beacon_block_root: block.header().parent_beacon_block_root(),
+                extra_data: block.header().extra_data().clone(),
+            },
+            extension: block.extension,
         }
     }
 
@@ -82,11 +88,14 @@ impl ConfigureEvm for CustomEvmConfig {
         &self,
         parent: &SealedHeader<CustomHeader>,
         attributes: Self::NextBlockEnvCtx,
-    ) -> OpBlockExecutionCtx {
-        OpBlockExecutionCtx {
-            parent_hash: parent.hash(),
-            parent_beacon_block_root: attributes.parent_beacon_block_root,
-            extra_data: attributes.extra_data,
+    ) -> CustomBlockExecutionCtx {
+        CustomBlockExecutionCtx {
+            inner: OpBlockExecutionCtx {
+                parent_hash: parent.hash(),
+                parent_beacon_block_root: attributes.inner.parent_beacon_block_root,
+                extra_data: attributes.inner.extra_data,
+            },
+            extension: attributes.extension,
         }
     }
 }
@@ -100,7 +109,10 @@ impl ConfigureEngineEvm<CustomExecutionData> for CustomEvmConfig {
         &self,
         payload: &'a CustomExecutionData,
     ) -> ExecutionCtxFor<'a, Self> {
-        self.inner.context_for_payload(&payload.inner)
+        CustomBlockExecutionCtx {
+            inner: self.inner.context_for_payload(&payload.inner),
+            extension: payload.extension,
+        }
     }
 
     fn tx_iterator_for_payload(
@@ -114,5 +126,36 @@ impl ConfigureEngineEvm<CustomExecutionData> for CustomEvmConfig {
             let signer = tx.try_recover().map_err(NewPayloadError::other)?;
             Ok::<_, NewPayloadError>(WithEncoded::new(encoded, tx.with_signer(signer)))
         })
+    }
+}
+
+/// Additional parameters required for executing next block custom transactions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CustomNextBlockEnvAttributes {
+    inner: OpNextBlockEnvAttributes,
+    extension: u64,
+}
+
+impl<H: BlockHeader> BuildPendingEnv<H> for CustomNextBlockEnvAttributes {
+    fn build_pending_env(parent: &SealedHeader<H>) -> Self {
+        Self { inner: OpNextBlockEnvAttributes::build_pending_env(parent), extension: 0 }
+    }
+}
+
+impl<H, ChainSpec> BuildNextEnv<CustomPayloadBuilderAttributes, H, ChainSpec>
+    for CustomNextBlockEnvAttributes
+where
+    H: BlockHeader,
+    ChainSpec: EthChainSpec + OpHardforks,
+{
+    fn build_next_env(
+        attributes: &CustomPayloadBuilderAttributes,
+        parent: &SealedHeader<H>,
+        chain_spec: &ChainSpec,
+    ) -> Result<Self, PayloadBuilderError> {
+        let inner =
+            OpNextBlockEnvAttributes::build_next_env(&attributes.inner, parent, chain_spec)?;
+
+        Ok(CustomNextBlockEnvAttributes { inner, extension: attributes.extension })
     }
 }

--- a/examples/custom-node/src/evm/executor.rs
+++ b/examples/custom-node/src/evm/executor.rs
@@ -99,7 +99,7 @@ impl BlockExecutorFactory for CustomEvmConfig {
 }
 
 /// Additional parameters for executing custom transactions.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct CustomBlockExecutionCtx {
     pub inner: OpBlockExecutionCtx,
     pub extension: u64,

--- a/examples/custom-node/src/evm/executor.rs
+++ b/examples/custom-node/src/evm/executor.rs
@@ -70,7 +70,7 @@ where
 
 impl BlockExecutorFactory for CustomEvmConfig {
     type EvmFactory = CustomEvmFactory;
-    type ExecutionCtx<'a> = OpBlockExecutionCtx;
+    type ExecutionCtx<'a> = CustomBlockExecutionCtx;
     type Transaction = CustomTransaction;
     type Receipt = OpReceipt;
 
@@ -81,7 +81,7 @@ impl BlockExecutorFactory for CustomEvmConfig {
     fn create_executor<'a, DB, I>(
         &'a self,
         evm: CustomEvm<&'a mut State<DB>, I, PrecompilesMap>,
-        ctx: OpBlockExecutionCtx,
+        ctx: CustomBlockExecutionCtx,
     ) -> impl BlockExecutorFor<'a, Self, DB, I>
     where
         DB: Database + 'a,
@@ -90,10 +90,23 @@ impl BlockExecutorFactory for CustomEvmConfig {
         CustomBlockExecutor {
             inner: OpBlockExecutor::new(
                 evm,
-                ctx,
+                ctx.inner,
                 self.inner.chain_spec().clone(),
                 *self.inner.executor_factory.receipt_builder(),
             ),
         }
+    }
+}
+
+/// Additional parameters for executing custom transactions.
+#[derive(Debug, Default, Clone)]
+pub struct CustomBlockExecutionCtx {
+    pub inner: OpBlockExecutionCtx,
+    pub extension: u64,
+}
+
+impl From<CustomBlockExecutionCtx> for OpBlockExecutionCtx {
+    fn from(value: CustomBlockExecutionCtx) -> Self {
+        value.inner
     }
 }


### PR DESCRIPTION
Closes #17565

Uses `CustomPayloadAttributes` in custom node components, wrapping `OpPayloadAttributes` and a custom extension. Likewise with `CustomPayloadBuilderAttributes`.

### Manual implementations

To make Optimism components work, you need to manually implement:
* `OpAttributes` for `CustomPayloadBuilderAttributes`
* `BuildPendingEnv` and `BuildNextEnv<CustomPayloadBuilderAttributes, ...>` for `CustomNextBlockEnvAttributes`
* `From<CustomBlockExecutionCtx>` for `OpBlockExecutionCtx`
  * `OpBlockAssembler` had `ExecutionCtx` set firmly to `OpBlockExecutionCtx`. Therefore, it expected `BlockAssemblerInput` to contain it in the `execution_ctx` field. In this PR this requirement is relaxed to `Into<OpBlockExecutionCtx>`.