### PR TITLE
chore: add ownership check to prevent race conditions for removing the lockfile

### DIFF
--- a/crates/storage/db/src/lockfile.rs
+++ b/crates/storage/db/src/lockfile.rs
@@ -65,12 +65,28 @@ impl Drop for StorageLock {
     fn drop(&mut self) {
         // The lockfile is not created in disable-lock mode, so we don't need to delete it.
         #[cfg(any(test, not(feature = "disable-lock")))]
-        if Arc::strong_count(&self.0) == 1 && self.0.file_path.exists() {
-            // TODO: should only happen during tests that the file does not exist: tempdir is
-            // getting dropped first. However, tempdir shouldn't be dropped
-            // before any of the storage providers.
-            if let Err(err) = reth_fs_util::remove_file(&self.0.file_path) {
-                reth_tracing::tracing::error!(%err, "Failed to delete lock file");
+        {
+            let file_path = &self.0.file_path;
+            if Arc::strong_count(&self.0) == 1 && file_path.exists() {
+                if let Ok(Some(process_uid)) = ProcessUID::parse(file_path) {
+                    // Only remove if the lock file belongs to our process
+                    if process_uid.pid == process::id() as usize {
+                        if let Err(err) = reth_fs_util::remove_file(file_path) {
+                            reth_tracing::tracing::error!(%err, "Failed to delete lock file");
+                        }
+                    } else {
+                        reth_tracing::tracing::warn!(
+                            "Lock file belongs to different process (PID: {}), not removing",
+                            process_uid.pid
+                        );
+                    }
+                } else {
+                    // If we can't parse the lock file, still try to remove it
+                    // as it might be corrupted or from a previous run
+                    if let Err(err) = reth_fs_util::remove_file(file_path) {
+                        reth_tracing::tracing::error!(%err, "Failed to delete lock file");
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Add an ownership check to reduce the race conditions for removing the lockfile.