### PR TITLE
chore: fix typo

### DIFF
--- a/crates/storage/db-api/src/models/integer_list.rs
+++ b/crates/storage/db-api/src/models/integer_list.rs
@@ -70,14 +70,14 @@ impl IntegerList {
         self.0.clear();
     }
 
-    /// Serializes a [`IntegerList`] into a sequence of bytes.
+    /// Serializes an [`IntegerList`] into a sequence of bytes.
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut vec = Vec::with_capacity(self.0.serialized_size());
         self.0.serialize_into(&mut vec).expect("not able to encode IntegerList");
         vec
     }
 
-    /// Serializes a [`IntegerList`] into a sequence of bytes.
+    /// Serializes an [`IntegerList`] into a sequence of bytes.
     pub fn to_mut_bytes<B: bytes::BufMut>(&self, buf: &mut B) {
         self.0.serialize_into(buf.writer()).unwrap();
     }


### PR DESCRIPTION
Fix incorrect article usage in documentation comments for IntegerList serialization methods

Changes:
- Line 73: "Serializes a [`IntegerList`]" → "Serializes an [`IntegerList`]"
- Line 80: "Serializes a [`IntegerList`]" → "Serializes an [`IntegerList`]"