### PR TITLE
fix: remove unused import from execute.rs

### DIFF
--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -10,7 +10,6 @@ use alloy_evm::{
     Evm, EvmEnv, EvmFactory, RecoveredTx, ToTxEnv,
 };
 use alloy_primitives::{Address, B256};
-use core::fmt::Debug;
 pub use reth_execution_errors::{
     BlockExecutionError, BlockValidationError, InternalBlockExecutionError,
 };


### PR DESCRIPTION
Removed unused import core::fmt::Debug from crates/evm/evm/src/execute.rs.