### PR TITLE
perf: optimize condition ordering in ParkedPool for better short-circuiting

### DIFF
--- a/crates/transaction-pool/src/pool/parked.rs
+++ b/crates/transaction-pool/src/pool/parked.rs
@@ -186,7 +186,7 @@ impl<T: ParkedOrd> ParkedPool<T> {
 
         let mut removed = Vec::new();
 
-        while limit.is_exceeded(self.len(), self.size()) && !self.last_sender_submission.is_empty()
+        while !self.last_sender_submission.is_empty() && limit.is_exceeded(self.len(), self.size())
         {
             // NOTE: This will not panic due to `!last_sender_transaction.is_empty()`
             let sender_id = self.last_sender_submission.last().expect("not empty").sender_id;


### PR DESCRIPTION
Reorder conditions in ParkedPool::truncate_pool to leverage logical short-circuiting.

Using LLVMCA the diff is:

1000 fewer instructions when pool is empty
1384 fewer CPU cycles per check
700 fewer micro-operations

https://godbolt.org/z/oTYY5h3v5