### PR TITLE
fix: import should count on the delta

### DIFF
--- a/crates/cli/commands/src/import_core.rs
+++ b/crates/cli/commands/src/import_core.rs
@@ -102,7 +102,6 @@ where
     let provider = provider_factory.provider()?;
     let starting_imported_blocks = provider.tx_ref().entries::<tables::HeaderNumbers>()?;
     let starting_imported_txns = provider.tx_ref().entries::<tables::TransactionHashNumbers>()?;
-    drop(provider);
 
     let mut total_decoded_blocks = 0;
     let mut total_decoded_txns = 0;
@@ -139,8 +138,6 @@ where
         pipeline.set_tip(tip);
         debug!(target: "reth::import", ?tip, "Tip manually set");
 
-        let provider = provider_factory.provider()?;
-
         let latest_block_number =
             provider.get_stage_checkpoint(StageId::Finish)?.map(|ch| ch.block_number);
         tokio::spawn(reth_node_events::node::handle_events(None, latest_block_number, events));
@@ -159,8 +156,6 @@ where
             .sealed_header(provider_factory.last_block_number()?)?
             .expect("should have genesis");
     }
-
-    let provider = provider_factory.provider()?;
 
     let total_imported_blocks = provider.tx_ref().entries::<tables::HeaderNumbers>()?;
     let total_imported_txns = provider.tx_ref().entries::<tables::TransactionHashNumbers>()?;

--- a/crates/e2e-test-utils/src/setup_import.rs
+++ b/crates/e2e-test-utils/src/setup_import.rs
@@ -166,13 +166,10 @@ pub async fn setup_engine_with_chain_import(
             result.is_complete()
         );
 
-        // The import counts genesis block in total_imported_blocks, so we expect
-        // total_imported_blocks to be total_decoded_blocks + 1
-        let expected_imported = result.total_decoded_blocks + 1; // +1 for genesis
-        if result.total_imported_blocks != expected_imported {
+        if result.total_decoded_blocks != result.total_imported_blocks {
             debug!(target: "e2e::import",
-                "Import block count mismatch: expected {} (decoded {} + genesis), got {}",
-                expected_imported, result.total_decoded_blocks, result.total_imported_blocks
+                "Import block count mismatch: decoded {} != imported {}",
+                result.total_decoded_blocks, result.total_imported_blocks
             );
             return Err(eyre::eyre!("Chain import block count mismatch for node {}", idx));
         }
@@ -351,7 +348,7 @@ mod tests {
             .unwrap();
 
             assert_eq!(result.total_decoded_blocks, 5);
-            assert_eq!(result.total_imported_blocks, 6); // +1 for genesis
+            assert_eq!(result.total_imported_blocks, 5);
 
             // Verify stage checkpoints exist
             let provider = provider_factory.database_provider_ro().unwrap();
@@ -508,7 +505,7 @@ mod tests {
 
         // Verify the import was successful
         assert_eq!(result.total_decoded_blocks, 10);
-        assert_eq!(result.total_imported_blocks, 11); // +1 for genesis
+        assert_eq!(result.total_imported_blocks, 10);
         assert_eq!(result.total_decoded_txns, 0);
         assert_eq!(result.total_imported_txns, 0);
 


### PR DESCRIPTION
We're using the count in table to count the imported blocks, this is incorrect, we should use the delta count to check.