### PR TITLE
perf: iterate through nibbles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5986,9 +5986,9 @@ dependencies = [
 
 [[package]]
 name = "nybbles"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "675b3a54e5b12af997abc8b6638b0aee51a28caedab70d4967e0d5db3a3f1d06"
+checksum = "2ff79de40513a478a9e374a480f897c2df829d48dcc64a83e4792a57fe231c64"
 dependencies = [
  "alloy-rlp",
  "arbitrary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -546,7 +546,7 @@ linked_hash_set = "0.1"
 lz4 = "1.28.1"
 modular-bitfield = "0.11.2"
 notify = { version = "8.0.0", default-features = false, features = ["macos_fsevent"] }
-nybbles = { version = "0.4.0", default-features = false }
+nybbles = { version = "0.4.2", default-features = false }
 once_cell = { version = "1.19", default-features = false, features = ["critical-section"] }
 parking_lot = "0.12"
 paste = "1.0"

--- a/crates/trie/common/src/nibbles.rs
+++ b/crates/trie/common/src/nibbles.rs
@@ -28,7 +28,9 @@ impl reth_codecs::Compact for StoredNibbles {
     where
         B: bytes::BufMut + AsMut<[u8]>,
     {
-        buf.put_slice(&self.0.to_vec());
+        for i in 0..self.0.len() {
+            buf.put_u8(self.0.get_byte(i).unwrap());
+        }
         self.0.len()
     }
 
@@ -77,7 +79,9 @@ impl reth_codecs::Compact for StoredNibblesSubKey {
         assert!(self.0.len() <= 64);
 
         // right-pad with zeros
-        buf.put_slice(&self.0.to_vec());
+        for i in 0..self.0.len() {
+            buf.put_u8(self.0.get_byte(i).unwrap());
+        }
         static ZERO: &[u8; 64] = &[0; 64];
         buf.put_slice(&ZERO[self.0.len()..]);
 

--- a/crates/trie/common/src/nibbles.rs
+++ b/crates/trie/common/src/nibbles.rs
@@ -29,7 +29,7 @@ impl reth_codecs::Compact for StoredNibbles {
         B: bytes::BufMut + AsMut<[u8]>,
     {
         for i in 0..self.0.len() {
-            buf.put_u8(self.0.get_byte(i).unwrap());
+            buf.put_u8(self.0.get_unchecked(i));
         }
         self.0.len()
     }
@@ -80,7 +80,7 @@ impl reth_codecs::Compact for StoredNibblesSubKey {
 
         // right-pad with zeros
         for i in 0..self.0.len() {
-            buf.put_u8(self.0.get_byte(i).unwrap());
+            buf.put_u8(self.0.get_unchecked(i));
         }
         static ZERO: &[u8; 64] = &[0; 64];
         buf.put_slice(&ZERO[self.0.len()..]);

--- a/crates/trie/common/src/nibbles.rs
+++ b/crates/trie/common/src/nibbles.rs
@@ -28,8 +28,8 @@ impl reth_codecs::Compact for StoredNibbles {
     where
         B: bytes::BufMut + AsMut<[u8]>,
     {
-        for i in 0..self.0.len() {
-            buf.put_u8(self.0.get_unchecked(i));
+        for i in self.0.iter() {
+            buf.put_u8(i);
         }
         self.0.len()
     }
@@ -79,8 +79,8 @@ impl reth_codecs::Compact for StoredNibblesSubKey {
         assert!(self.0.len() <= 64);
 
         // right-pad with zeros
-        for i in 0..self.0.len() {
-            buf.put_u8(self.0.get_unchecked(i));
+        for i in self.0.iter() {
+            buf.put_u8(i);
         }
         static ZERO: &[u8; 64] = &[0; 64];
         buf.put_slice(&ZERO[self.0.len()..]);


### PR DESCRIPTION
fix #17810 by iterating through the nibbles and putting to buffer directly without creating a new Vec in the heap