### PR TITLE
perf: remove some clones around `eth` tracing

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -412,8 +412,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
 
         let mut inspector = AccessListInspector::new(initial);
 
-        let (result, (evm_env, mut tx_env)) =
-            self.inspect(&mut db, evm_env, tx_env, &mut inspector)?;
+        let result = self.inspect(&mut db, evm_env.clone(), tx_env.clone(), &mut inspector)?;
         let access_list = inspector.into_access_list();
         tx_env.set_access_list(access_list.clone());
         match result.result {

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -302,10 +302,11 @@ where
                         let frame = self
                             .eth_api()
                             .spawn_with_call_at(call, at, overrides, move |db, evm_env, tx_env| {
-                                let (res, (_, tx_env)) =
+                                let gas_limit = tx_env.gas_limit();
+                                let res =
                                     this.eth_api().inspect(db, evm_env, tx_env, &mut inspector)?;
                                 let frame = inspector
-                                    .with_transaction_gas_limit(tx_env.gas_limit())
+                                    .with_transaction_gas_limit(gas_limit)
                                     .into_geth_builder()
                                     .geth_call_traces(call_config, res.result.gas_used());
                                 Ok(frame.into())
@@ -328,14 +329,15 @@ where
                                 // see <https://github.com/rust-lang/rust/issues/100013>
                                 let db = db.0;
 
-                                let (res, (_, tx_env)) = this.eth_api().inspect(
+                                let gas_limit = tx_env.gas_limit();
+                                let res = this.eth_api().inspect(
                                     &mut *db,
                                     evm_env,
                                     tx_env,
                                     &mut inspector,
                                 )?;
                                 let frame = inspector
-                                    .with_transaction_gas_limit(tx_env.gas_limit())
+                                    .with_transaction_gas_limit(gas_limit)
                                     .into_geth_builder()
                                     .geth_prestate_traces(&res, &prestate_config, db)
                                     .map_err(Eth::Error::from_eth_err)?;
@@ -369,7 +371,7 @@ where
                                     index: None,
                                 };
 
-                                let (res, _) = this.eth_api().inspect(
+                                let res = this.eth_api().inspect(
                                     &mut *db,
                                     evm_env,
                                     tx_env,
@@ -396,11 +398,11 @@ where
                             .inner
                             .eth_api
                             .spawn_with_call_at(call, at, overrides, move |db, evm_env, tx_env| {
-                                let (_res, (_, tx_env)) =
-                                    this.eth_api().inspect(db, evm_env, tx_env, &mut inspector)?;
+                                let gas_limit = tx_env.gas_limit();
+                                this.eth_api().inspect(db, evm_env, tx_env, &mut inspector)?;
                                 let tx_info = TransactionInfo::default();
                                 let frame: FlatCallFrame = inspector
-                                    .with_transaction_gas_limit(tx_env.gas_limit())
+                                    .with_transaction_gas_limit(gas_limit)
                                     .into_parity_builder()
                                     .into_localized_transaction_traces(tx_info);
                                 Ok(frame)
@@ -430,7 +432,7 @@ where
                             let mut inspector =
                                 revm_inspectors::tracing::js::JsInspector::new(code, config)
                                     .map_err(Eth::Error::from_eth_err)?;
-                            let (res, _) = this.eth_api().inspect(
+                            let res = this.eth_api().inspect(
                                 &mut *db,
                                 evm_env.clone(),
                                 tx_env.clone(),
@@ -460,9 +462,9 @@ where
         let (res, tx_gas_limit, inspector) = self
             .eth_api()
             .spawn_with_call_at(call, at, overrides, move |db, evm_env, tx_env| {
-                let (res, (_, tx_env)) =
-                    this.eth_api().inspect(db, evm_env, tx_env, &mut inspector)?;
-                Ok((res, tx_env.gas_limit(), inspector))
+                let gas_limit = tx_env.gas_limit();
+                let res = this.eth_api().inspect(db, evm_env, tx_env, &mut inspector)?;
+                Ok((res, gas_limit, inspector))
             })
             .await?;
         let gas_used = res.result.gas_used();
@@ -742,8 +744,7 @@ where
                 GethDebugTracerType::BuiltInTracer(tracer) => match tracer {
                     GethDebugBuiltInTracerType::FourByteTracer => {
                         let mut inspector = FourByteInspector::default();
-                        let (res, _) =
-                            self.eth_api().inspect(db, evm_env, tx_env, &mut inspector)?;
+                        let res = self.eth_api().inspect(db, evm_env, tx_env, &mut inspector)?;
                         return Ok((FourByteFrame::from(&inspector).into(), res.state))
                     }
                     GethDebugBuiltInTracerType::CallTracer => {
@@ -758,10 +759,10 @@ where
                             ))
                         });
 
-                        let (res, (_, tx_env)) =
-                            self.eth_api().inspect(db, evm_env, tx_env, &mut inspector)?;
+                        let gas_limit = tx_env.gas_limit();
+                        let res = self.eth_api().inspect(db, evm_env, tx_env, &mut inspector)?;
 
-                        inspector.set_transaction_gas_limit(tx_env.gas_limit());
+                        inspector.set_transaction_gas_limit(gas_limit);
 
                         let frame = inspector
                             .geth_builder()
@@ -780,10 +781,11 @@ where
                                 TracingInspectorConfig::from_geth_prestate_config(&prestate_config),
                             )
                         });
-                        let (res, (_, tx_env)) =
+                        let gas_limit = tx_env.gas_limit();
+                        let res =
                             self.eth_api().inspect(&mut *db, evm_env, tx_env, &mut inspector)?;
 
-                        inspector.set_transaction_gas_limit(tx_env.gas_limit());
+                        inspector.set_transaction_gas_limit(gas_limit);
                         let frame = inspector
                             .geth_builder()
                             .geth_prestate_traces(&res, &prestate_config, db)
@@ -803,7 +805,7 @@ where
                         let mut inspector = MuxInspector::try_from_config(mux_config)
                             .map_err(Eth::Error::from_eth_err)?;
 
-                        let (res, _) =
+                        let res =
                             self.eth_api().inspect(&mut *db, evm_env, tx_env, &mut inspector)?;
                         let frame = inspector
                             .try_into_mux_frame(&res, db, tx_info)
@@ -820,10 +822,10 @@ where
                             TracingInspectorConfig::from_flat_call_config(&flat_call_config),
                         );
 
-                        let (res, (_, tx_env)) =
-                            self.eth_api().inspect(db, evm_env, tx_env, &mut inspector)?;
+                        let gas_limit = tx_env.gas_limit();
+                        let res = self.eth_api().inspect(db, evm_env, tx_env, &mut inspector)?;
                         let frame: FlatCallFrame = inspector
-                            .with_transaction_gas_limit(tx_env.gas_limit())
+                            .with_transaction_gas_limit(gas_limit)
                             .into_parity_builder()
                             .into_localized_transaction_traces(tx_info);
 
@@ -844,8 +846,12 @@ where
                             transaction_context.unwrap_or_default(),
                         )
                         .map_err(Eth::Error::from_eth_err)?;
-                    let (res, (evm_env, tx_env)) =
-                        self.eth_api().inspect(&mut *db, evm_env, tx_env, &mut inspector)?;
+                    let res = self.eth_api().inspect(
+                        &mut *db,
+                        evm_env.clone(),
+                        tx_env.clone(),
+                        &mut inspector,
+                    )?;
 
                     let state = res.state.clone();
                     let result = inspector
@@ -866,10 +872,11 @@ where
             let inspector_config = TracingInspectorConfig::from_geth_config(config);
             TracingInspector::new(inspector_config)
         });
-        let (res, (_, tx_env)) = self.eth_api().inspect(db, evm_env, tx_env, &mut inspector)?;
+        let gas_limit = tx_env.gas_limit();
+        let res = self.eth_api().inspect(db, evm_env, tx_env, &mut inspector)?;
         let gas_used = res.result.gas_used();
         let return_value = res.result.into_output().unwrap_or_default();
-        inspector.set_transaction_gas_limit(tx_env.gas_limit());
+        inspector.set_transaction_gas_limit(gas_limit);
         let frame = inspector.geth_builder().geth_traces(gas_used, return_value, *config);
 
         Ok((frame.into(), res.state))

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -101,7 +101,7 @@ where
                 // <https://github.com/rust-lang/rust/issues/100013>
                 let db = db.0;
 
-                let (res, _) = this.eth_api().inspect(&mut *db, evm_env, tx_env, &mut inspector)?;
+                let res = this.eth_api().inspect(&mut *db, evm_env, tx_env, &mut inspector)?;
                 let trace_res = inspector
                     .into_parity_builder()
                     .into_trace_results_with_state(&res, &trace_request.trace_types, &db)
@@ -166,8 +166,7 @@ where
                     )?;
                     let config = TracingInspectorConfig::from_parity_config(&trace_types);
                     let mut inspector = TracingInspector::new(config);
-                    let (res, _) =
-                        this.eth_api().inspect(&mut db, evm_env, tx_env, &mut inspector)?;
+                    let res = this.eth_api().inspect(&mut db, evm_env, tx_env, &mut inspector)?;
 
                     let trace_res = inspector
                         .into_parity_builder()


### PR DESCRIPTION
Basically #16665 but for tracing, which is a huge bottleneck for indexers of performance chains. We should also do the equivalence of #16958, and hopefully much more...