### PR TITLE
feat(rpc): Add `RpcTxConverter` to allow for providing custom converters with extra context

### DIFF
--- a/crates/optimism/rpc/src/error.rs
+++ b/crates/optimism/rpc/src/error.rs
@@ -11,7 +11,7 @@ use reth_rpc_eth_api::{AsEthApiError, EthTxEnvError, TransactionConversionError}
 use reth_rpc_eth_types::{error::api::FromEvmHalt, EthApiError};
 use reth_rpc_server_types::result::{internal_rpc_err, rpc_err};
 use revm::context_interface::result::{EVMError, InvalidTransaction};
-use std::fmt::Display;
+use std::{convert::Infallible, fmt::Display};
 
 /// Optimism specific errors, that extend [`EthApiError`].
 #[derive(Debug, thiserror::Error)]
@@ -210,5 +210,11 @@ impl From<ProviderError> for OpEthApiError {
 impl From<BlockError> for OpEthApiError {
     fn from(value: BlockError) -> Self {
         Self::Eth(EthApiError::from(value))
+    }
+}
+
+impl From<Infallible> for OpEthApiError {
+    fn from(value: Infallible) -> Self {
+        match value {}
     }
 }

--- a/crates/optimism/rpc/src/eth/transaction.rs
+++ b/crates/optimism/rpc/src/eth/transaction.rs
@@ -112,7 +112,7 @@ impl<Provider> OpTxInfoMapper<Provider> {
     }
 }
 
-impl<T, Provider> TxInfoMapper<&T> for OpTxInfoMapper<Provider>
+impl<T, Provider> TxInfoMapper<T> for OpTxInfoMapper<Provider>
 where
     T: OpTransaction + SignedTransaction,
     Provider: ReceiptProvider<Receipt: DepositReceipt>,


### PR DESCRIPTION
Part of #17545

### Motivation
Custom nodes with custom transactions need their own Consensus Transaction -> Rpc Transaction Response algorithm.

The input for this conversion is the consensus transaction, it's signer address and an associated TxInfo type.

### Solution
Adds a new trait called `RpcTxConverter` with two blanket implementations:
* `()` assuming `Tx` implements `IntoRpcTx` and is used as default for `RpcConverter`
* `Fn(Tx, Address, TxInfo) -> RpcTx` and can be applied using `RpcConverter::with_rpc_tx_converter`

### Discussion
Compared to TxEnv and SimTx, custom conversions are easy to achieve thanks to `TxInfoMapper` being able to generate a custom extra context object that is then used as part of the input for `IntoRpcTx`. This is being actively used for Optimism deposit transactions.

Therefore, it is somewhat questionable how useful this change is. At the very least it is being consistent with `SimTxConverter` and `TxEnvConverter`. To make it more useful, we may merge `TxInfoMapper` with `RpcTxConverter`, but then we're broadening the scope of the custom overrides (just tx info vs rpc tx conversion).
