### PR TITLE
chore: add test of rlp encode of legacy transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10475,6 +10475,7 @@ dependencies = [
  "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
+ "alloy-rlp",
  "rand 0.8.5",
  "rand 0.9.2",
  "reth-ethereum-primitives",

--- a/testing/testing-utils/Cargo.toml
+++ b/testing/testing-utils/Cargo.toml
@@ -19,6 +19,7 @@ alloy-genesis.workspace = true
 alloy-primitives = { workspace = true, features = ["rand"] }
 alloy-consensus.workspace = true
 alloy-eips.workspace = true
+alloy-rlp.workspace = true
 
 rand.workspace = true
 secp256k1 = { workspace = true, features = ["rand"] }

--- a/testing/testing-utils/src/generators.rs
+++ b/testing/testing-utils/src/generators.rs
@@ -529,7 +529,7 @@ mod tests {
     #[test]
     fn test_sign_eip_155() {
         // reference: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md#example
-        let transaction = Transaction::Legacy(TxLegacy {
+        let tx_legacy = TxLegacy {
             chain_id: Some(1),
             nonce: 9,
             gas_price: 20 * 10_u128.pow(9),
@@ -537,12 +537,14 @@ mod tests {
             to: TxKind::Call(hex!("3535353535353535353535353535353535353535").into()),
             value: U256::from(10_u128.pow(18)),
             input: Bytes::default(),
-        });
+        };
+        let transaction = Transaction::Legacy(tx_legacy.clone());
 
-        // TODO resolve dependency issue
-        // let expected =
-        // hex!("ec098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a764000080018080");
-        // assert_eq!(expected, &alloy_rlp::encode(transaction));
+        // Test RLP encoding
+        let expected =
+            hex!("ec098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a764000080018080");
+        let encoded = alloy_rlp::encode(&tx_legacy);
+        assert_eq!(expected.as_ref(), &encoded);
 
         let hash = transaction.signature_hash();
         let expected =


### PR DESCRIPTION
Add a test of rlp encode of legacy transaction, remove a TODO.