### PR TITLE
chore: Remove `BlockMeta` variants and unused code

### DIFF
--- a/crates/cli/commands/src/db/get.rs
+++ b/crates/cli/commands/src/db/get.rs
@@ -72,7 +72,6 @@ impl Command {
                     StaticFileSegment::Receipts => {
                         (table_key::<tables::Receipts>(&key)?, <ReceiptMask<ReceiptTy<N>>>::MASK)
                     }
-                    StaticFileSegment::BlockMeta => todo!(),
                 };
 
                 let content = tool.provider_factory.static_file_provider().find_static_file(
@@ -113,9 +112,6 @@ impl Command {
                                         content[0].as_slice(),
                                     )?;
                                     println!("{}", serde_json::to_string_pretty(&receipt)?);
-                                }
-                                StaticFileSegment::BlockMeta => {
-                                    todo!()
                                 }
                             }
                         }

--- a/crates/stages/stages/src/stages/s3/filelist.rs
+++ b/crates/stages/stages/src/stages/s3/filelist.rs
@@ -6,16 +6,10 @@ pub(crate) static DOWNLOAD_FILE_LIST: [[(&str, B256); 3]; 2] = [
         ("static_file_transactions_0_499999", B256::ZERO),
         ("static_file_transactions_0_499999.off", B256::ZERO),
         ("static_file_transactions_0_499999.conf", B256::ZERO),
-        // ("static_file_blockmeta_0_499999", B256::ZERO),
-        // ("static_file_blockmeta_0_499999.off", B256::ZERO),
-        // ("static_file_blockmeta_0_499999.conf", B256::ZERO),
     ],
     [
         ("static_file_transactions_500000_999999", B256::ZERO),
         ("static_file_transactions_500000_999999.off", B256::ZERO),
         ("static_file_transactions_500000_999999.conf", B256::ZERO),
-        // ("static_file_blockmeta_500000_999999", B256::ZERO),
-        // ("static_file_blockmeta_500000_999999.off", B256::ZERO),
-        // ("static_file_blockmeta_500000_999999.conf", B256::ZERO),
     ],
 ];

--- a/crates/static-file/static-file/src/static_file_producer.rs
+++ b/crates/static-file/static-file/src/static_file_producer.rs
@@ -187,7 +187,6 @@ where
             headers: stages_checkpoints[0],
             receipts: stages_checkpoints[1],
             transactions: stages_checkpoints[2],
-            block_meta: stages_checkpoints[2],
         };
         let targets = self.get_static_file_targets(highest_static_files)?;
         self.run(targets)?;
@@ -226,9 +225,6 @@ where
                     highest_static_files.transactions,
                     finalized_block_number,
                 )
-            }),
-            block_meta: finalized_block_numbers.block_meta.and_then(|finalized_block_number| {
-                self.get_static_file_target(highest_static_files.block_meta, finalized_block_number)
             }),
         };
 
@@ -328,7 +324,6 @@ mod tests {
                 headers: Some(1),
                 receipts: Some(1),
                 transactions: Some(1),
-                block_meta: None,
             })
             .expect("get static file targets");
         assert_eq!(
@@ -336,19 +331,13 @@ mod tests {
             StaticFileTargets {
                 headers: Some(0..=1),
                 receipts: Some(0..=1),
-                transactions: Some(0..=1),
-                block_meta: None
+                transactions: Some(0..=1)
             }
         );
         assert_matches!(static_file_producer.run(targets), Ok(_));
         assert_eq!(
             provider_factory.static_file_provider().get_highest_static_files(),
-            HighestStaticFiles {
-                headers: Some(1),
-                receipts: Some(1),
-                transactions: Some(1),
-                block_meta: None
-            }
+            HighestStaticFiles { headers: Some(1), receipts: Some(1), transactions: Some(1) }
         );
 
         let targets = static_file_producer
@@ -356,7 +345,6 @@ mod tests {
                 headers: Some(3),
                 receipts: Some(3),
                 transactions: Some(3),
-                block_meta: None,
             })
             .expect("get static file targets");
         assert_eq!(
@@ -364,19 +352,13 @@ mod tests {
             StaticFileTargets {
                 headers: Some(2..=3),
                 receipts: Some(2..=3),
-                transactions: Some(2..=3),
-                block_meta: None
+                transactions: Some(2..=3)
             }
         );
         assert_matches!(static_file_producer.run(targets), Ok(_));
         assert_eq!(
             provider_factory.static_file_provider().get_highest_static_files(),
-            HighestStaticFiles {
-                headers: Some(3),
-                receipts: Some(3),
-                transactions: Some(3),
-                block_meta: None
-            }
+            HighestStaticFiles { headers: Some(3), receipts: Some(3), transactions: Some(3) }
         );
 
         let targets = static_file_producer
@@ -384,7 +366,6 @@ mod tests {
                 headers: Some(4),
                 receipts: Some(4),
                 transactions: Some(4),
-                block_meta: None,
             })
             .expect("get static file targets");
         assert_eq!(
@@ -392,8 +373,7 @@ mod tests {
             StaticFileTargets {
                 headers: Some(4..=4),
                 receipts: Some(4..=4),
-                transactions: Some(4..=4),
-                block_meta: None
+                transactions: Some(4..=4)
             }
         );
         assert_matches!(
@@ -402,12 +382,7 @@ mod tests {
         );
         assert_eq!(
             provider_factory.static_file_provider().get_highest_static_files(),
-            HighestStaticFiles {
-                headers: Some(3),
-                receipts: Some(3),
-                transactions: Some(3),
-                block_meta: None
-            }
+            HighestStaticFiles { headers: Some(3), receipts: Some(3), transactions: Some(3) }
         );
     }
 
@@ -435,7 +410,6 @@ mod tests {
                         headers: Some(1),
                         receipts: Some(1),
                         transactions: Some(1),
-                        block_meta: None,
                     })
                     .expect("get static file targets");
                 assert_matches!(locked_producer.run(targets.clone()), Ok(_));

--- a/crates/static-file/types/src/lib.rs
+++ b/crates/static-file/types/src/lib.rs
@@ -36,9 +36,6 @@ pub struct HighestStaticFiles {
     /// Highest static file block of transactions, inclusive.
     /// If [`None`], no static file is available.
     pub transactions: Option<BlockNumber>,
-    /// Highest static file block of transactions, inclusive.
-    /// If [`None`], no static file is available.
-    pub block_meta: Option<BlockNumber>,
 }
 
 impl HighestStaticFiles {
@@ -48,7 +45,6 @@ impl HighestStaticFiles {
             StaticFileSegment::Headers => self.headers,
             StaticFileSegment::Transactions => self.transactions,
             StaticFileSegment::Receipts => self.receipts,
-            StaticFileSegment::BlockMeta => self.block_meta,
         }
     }
 
@@ -58,13 +54,12 @@ impl HighestStaticFiles {
             StaticFileSegment::Headers => &mut self.headers,
             StaticFileSegment::Transactions => &mut self.transactions,
             StaticFileSegment::Receipts => &mut self.receipts,
-            StaticFileSegment::BlockMeta => &mut self.block_meta,
         }
     }
 
     /// Returns an iterator over all static file segments
     fn iter(&self) -> impl Iterator<Item = Option<BlockNumber>> {
-        [self.headers, self.transactions, self.receipts, self.block_meta].into_iter()
+        [self.headers, self.transactions, self.receipts].into_iter()
     }
 
     /// Returns the minimum block of all segments.
@@ -87,17 +82,12 @@ pub struct StaticFileTargets {
     pub receipts: Option<RangeInclusive<BlockNumber>>,
     /// Targeted range of transactions.
     pub transactions: Option<RangeInclusive<BlockNumber>>,
-    /// Targeted range of block meta.
-    pub block_meta: Option<RangeInclusive<BlockNumber>>,
 }
 
 impl StaticFileTargets {
     /// Returns `true` if any of the targets are [Some].
     pub const fn any(&self) -> bool {
-        self.headers.is_some() ||
-            self.receipts.is_some() ||
-            self.transactions.is_some() ||
-            self.block_meta.is_some()
+        self.headers.is_some() || self.receipts.is_some() || self.transactions.is_some()
     }
 
     /// Returns `true` if all targets are either [`None`] or has beginning of the range equal to the
@@ -107,7 +97,6 @@ impl StaticFileTargets {
             (self.headers.as_ref(), static_files.headers),
             (self.receipts.as_ref(), static_files.receipts),
             (self.transactions.as_ref(), static_files.transactions),
-            (self.block_meta.as_ref(), static_files.block_meta),
         ]
         .iter()
         .all(|(target_block_range, highest_static_file_block)| {
@@ -136,12 +125,8 @@ mod tests {
 
     #[test]
     fn test_highest_static_files_highest() {
-        let files = HighestStaticFiles {
-            headers: Some(100),
-            receipts: Some(200),
-            transactions: None,
-            block_meta: None,
-        };
+        let files =
+            HighestStaticFiles { headers: Some(100), receipts: Some(200), transactions: None };
 
         // Test for headers segment
         assert_eq!(files.highest(StaticFileSegment::Headers), Some(100));
@@ -168,20 +153,12 @@ mod tests {
         // Modify transactions value
         *files.as_mut(StaticFileSegment::Transactions) = Some(350);
         assert_eq!(files.transactions, Some(350));
-
-        // Modify block meta value
-        *files.as_mut(StaticFileSegment::BlockMeta) = Some(350);
-        assert_eq!(files.block_meta, Some(350));
     }
 
     #[test]
     fn test_highest_static_files_min() {
-        let files = HighestStaticFiles {
-            headers: Some(300),
-            receipts: Some(100),
-            transactions: None,
-            block_meta: None,
-        };
+        let files =
+            HighestStaticFiles { headers: Some(300), receipts: Some(100), transactions: None };
 
         // Minimum value among the available segments
         assert_eq!(files.min_block_num(), Some(100));
@@ -193,12 +170,8 @@ mod tests {
 
     #[test]
     fn test_highest_static_files_max() {
-        let files = HighestStaticFiles {
-            headers: Some(300),
-            receipts: Some(100),
-            transactions: Some(500),
-            block_meta: Some(500),
-        };
+        let files =
+            HighestStaticFiles { headers: Some(300), receipts: Some(100), transactions: Some(500) };
 
         // Maximum value among the available segments
         assert_eq!(files.max_block_num(), Some(500));

--- a/crates/static-file/types/src/segment.rs
+++ b/crates/static-file/types/src/segment.rs
@@ -37,10 +37,6 @@ pub enum StaticFileSegment {
     #[strum(serialize = "receipts")]
     /// Static File segment responsible for the `Receipts` table.
     Receipts,
-    #[strum(serialize = "blockmeta")]
-    /// Static File segment responsible for the `BlockBodyIndices`, `BlockOmmers`,
-    /// `BlockWithdrawals` tables.
-    BlockMeta,
 }
 
 impl StaticFileSegment {
@@ -50,15 +46,13 @@ impl StaticFileSegment {
             Self::Headers => "headers",
             Self::Transactions => "transactions",
             Self::Receipts => "receipts",
-            Self::BlockMeta => "blockmeta",
         }
     }
 
     /// Returns an iterator over all segments.
     pub fn iter() -> impl Iterator<Item = Self> {
-        // The order of segments is significant and must be maintained to ensure correctness. For
-        // example, Transactions require BlockBodyIndices from Blockmeta to be sound.
-        [Self::Headers, Self::BlockMeta, Self::Transactions, Self::Receipts].into_iter()
+        // The order of segments is significant and must be maintained to ensure correctness.
+        [Self::Headers, Self::Transactions, Self::Receipts].into_iter()
     }
 
     /// Returns the default configuration of the segment.
@@ -69,7 +63,7 @@ impl StaticFileSegment {
     /// Returns the number of columns for the segment
     pub const fn columns(&self) -> usize {
         match self {
-            Self::Headers | Self::BlockMeta => 3,
+            Self::Headers => 3,
             Self::Transactions | Self::Receipts => 1,
         }
     }
@@ -133,11 +127,6 @@ impl StaticFileSegment {
         matches!(self, Self::Headers)
     }
 
-    /// Returns `true` if the segment is `StaticFileSegment::BlockMeta`.
-    pub const fn is_block_meta(&self) -> bool {
-        matches!(self, Self::BlockMeta)
-    }
-
     /// Returns `true` if the segment is `StaticFileSegment::Receipts`.
     pub const fn is_receipts(&self) -> bool {
         matches!(self, Self::Receipts)
@@ -150,7 +139,7 @@ impl StaticFileSegment {
 
     /// Returns `true` if a segment row is linked to a block.
     pub const fn is_block_based(&self) -> bool {
-        matches!(self, Self::Headers | Self::BlockMeta)
+        matches!(self, Self::Headers)
     }
 }
 

--- a/crates/storage/db/src/static_file/masks.rs
+++ b/crates/storage/db/src/static_file/masks.rs
@@ -1,13 +1,10 @@
 use crate::{
     add_static_file_mask,
     static_file::mask::{ColumnSelectorOne, ColumnSelectorTwo},
-    BlockBodyIndices, HeaderTerminalDifficulties,
+    HeaderTerminalDifficulties,
 };
 use alloy_primitives::BlockHash;
-use reth_db_api::{
-    models::{StaticFileBlockWithdrawals, StoredBlockOmmers},
-    table::Table,
-};
+use reth_db_api::table::Table;
 
 // HEADER MASKS
 add_static_file_mask! {
@@ -44,18 +41,4 @@ add_static_file_mask! {
 add_static_file_mask! {
     #[doc = "Mask for selecting a single transaction from Transactions static file segment"]
     TransactionMask<T>, T, 0b1
-}
-
-// BLOCK_META MASKS
-add_static_file_mask! {
-    #[doc = "Mask for a `StoredBlockBodyIndices` from `BlockMeta` static file segment"]
-    BodyIndicesMask, <BlockBodyIndices as Table>::Value, 0b001
-}
-add_static_file_mask! {
-    #[doc = "Mask for a `StoredBlockOmmers` from `BlockMeta` static file segment"]
-    OmmersMask<H>, StoredBlockOmmers<H>, 0b010
-}
-add_static_file_mask! {
-    #[doc = "Mask for a `StaticFileBlockWithdrawals` from `BlockMeta` static file segment"]
-    WithdrawalsMask, StaticFileBlockWithdrawals, 0b100
 }

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -540,29 +540,14 @@ impl<N: ProviderNodeTypes> BlockBodyIndicesProvider for ProviderFactory<N> {
         &self,
         number: BlockNumber,
     ) -> ProviderResult<Option<StoredBlockBodyIndices>> {
-        self.static_file_provider.get_with_static_file_or_database(
-            StaticFileSegment::BlockMeta,
-            number,
-            |static_file| static_file.block_body_indices(number),
-            || self.provider()?.block_body_indices(number),
-        )
+        self.provider()?.block_body_indices(number)
     }
 
     fn block_body_indices_range(
         &self,
         range: RangeInclusive<BlockNumber>,
     ) -> ProviderResult<Vec<StoredBlockBodyIndices>> {
-        self.static_file_provider.get_range_with_static_file_or_database(
-            StaticFileSegment::BlockMeta,
-            *range.start()..*range.end() + 1,
-            |static_file, range, _| {
-                static_file.block_body_indices_range(range.start..=range.end.saturating_sub(1))
-            },
-            |range, _| {
-                self.provider()?.block_body_indices_range(range.start..=range.end.saturating_sub(1))
-            },
-            |_| true,
-        )
+        self.provider()?.block_body_indices_range(range)
     }
 }
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1633,27 +1633,14 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> BlockBodyIndicesProvider
     for DatabaseProvider<TX, N>
 {
     fn block_body_indices(&self, num: u64) -> ProviderResult<Option<StoredBlockBodyIndices>> {
-        self.static_file_provider.get_with_static_file_or_database(
-            StaticFileSegment::BlockMeta,
-            num,
-            |static_file| static_file.block_body_indices(num),
-            || Ok(self.tx.get::<tables::BlockBodyIndices>(num)?),
-        )
+        Ok(self.tx.get::<tables::BlockBodyIndices>(num)?)
     }
 
     fn block_body_indices_range(
         &self,
         range: RangeInclusive<BlockNumber>,
     ) -> ProviderResult<Vec<StoredBlockBodyIndices>> {
-        self.static_file_provider.get_range_with_static_file_or_database(
-            StaticFileSegment::BlockMeta,
-            *range.start()..*range.end() + 1,
-            |static_file, range, _| {
-                static_file.block_body_indices_range(range.start..=range.end.saturating_sub(1))
-            },
-            |range, _| self.cursor_read_collect::<tables::BlockBodyIndices>(range),
-            |_| true,
-        )
+        self.cursor_read_collect::<tables::BlockBodyIndices>(range)
     }
 }
 

--- a/crates/storage/provider/src/providers/static_file/jar.rs
+++ b/crates/storage/provider/src/providers/static_file/jar.rs
@@ -11,16 +11,12 @@ use alloy_eips::{eip2718::Encodable2718, BlockHashOrNumber};
 use alloy_primitives::{Address, BlockHash, BlockNumber, TxHash, TxNumber, B256, U256};
 use reth_chainspec::ChainInfo;
 use reth_db::static_file::{
-    BlockHashMask, BodyIndicesMask, HeaderMask, HeaderWithHashMask, ReceiptMask, StaticFileCursor,
-    TDWithHashMask, TotalDifficultyMask, TransactionMask,
+    BlockHashMask, HeaderMask, HeaderWithHashMask, ReceiptMask, StaticFileCursor, TDWithHashMask,
+    TotalDifficultyMask, TransactionMask,
 };
-use reth_db_api::{
-    models::StoredBlockBodyIndices,
-    table::{Decompress, Value},
-};
+use reth_db_api::table::{Decompress, Value};
 use reth_node_types::NodePrimitives;
 use reth_primitives_traits::{SealedHeader, SignedTransaction};
-use reth_storage_api::BlockBodyIndicesProvider;
 use reth_storage_errors::provider::{ProviderError, ProviderResult};
 use std::{
     fmt::Debug,
@@ -358,26 +354,5 @@ impl<N: NodePrimitives<SignedTx: Decompress + SignedTransaction, Receipt: Decomp
         // Related to indexing tables. StaticFile should get the tx_range and call static file
         // provider with `receipt()` instead for each
         Err(ProviderError::UnsupportedProvider)
-    }
-}
-
-impl<N: NodePrimitives> BlockBodyIndicesProvider for StaticFileJarProvider<'_, N> {
-    fn block_body_indices(&self, num: u64) -> ProviderResult<Option<StoredBlockBodyIndices>> {
-        self.cursor()?.get_one::<BodyIndicesMask>(num.into())
-    }
-
-    fn block_body_indices_range(
-        &self,
-        range: RangeInclusive<BlockNumber>,
-    ) -> ProviderResult<Vec<StoredBlockBodyIndices>> {
-        let mut cursor = self.cursor()?;
-        let mut indices = Vec::with_capacity((range.end() - range.start() + 1) as usize);
-
-        for num in range {
-            if let Some(block) = cursor.get_one::<BodyIndicesMask>(num.into())? {
-                indices.push(block)
-            }
-        }
-        Ok(indices)
     }
 }

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -22,8 +22,8 @@ use reth_chainspec::{ChainInfo, ChainSpecProvider, EthChainSpec};
 use reth_db::{
     lockfile::StorageLock,
     static_file::{
-        iter_static_files, BlockHashMask, BodyIndicesMask, HeaderMask, HeaderWithHashMask,
-        ReceiptMask, StaticFileCursor, TDWithHashMask, TransactionMask,
+        iter_static_files, BlockHashMask, HeaderMask, HeaderWithHashMask, ReceiptMask,
+        StaticFileCursor, TDWithHashMask, TransactionMask,
     },
 };
 use reth_db_api::{
@@ -776,11 +776,6 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         };
 
         for segment in StaticFileSegment::iter() {
-            // Not integrated yet
-            if segment.is_block_meta() {
-                continue
-            }
-
             if has_receipt_pruning && segment.is_receipts() {
                 // Pruned nodes (including full node) do not store receipts as static files.
                 continue
@@ -877,13 +872,6 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                         highest_tx,
                         highest_block,
                     )?,
-                StaticFileSegment::BlockMeta => self
-                    .ensure_invariants::<_, tables::BlockBodyIndices>(
-                        provider,
-                        segment,
-                        highest_block,
-                        highest_block,
-                    )?,
             } {
                 update_unwind_target(unwind);
             }
@@ -969,7 +957,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         let checkpoint_block_number = provider
             .get_stage_checkpoint(match segment {
                 StaticFileSegment::Headers => StageId::Headers,
-                StaticFileSegment::Transactions | StaticFileSegment::BlockMeta => StageId::Bodies,
+                StaticFileSegment::Transactions => StageId::Bodies,
                 StaticFileSegment::Receipts => StageId::Execution,
             })?
             .unwrap_or_default()
@@ -1070,7 +1058,6 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
             headers: self.get_highest_static_file_block(StaticFileSegment::Headers),
             receipts: self.get_highest_static_file_block(StaticFileSegment::Receipts),
             transactions: self.get_highest_static_file_block(StaticFileSegment::Transactions),
-            block_meta: self.get_highest_static_file_block(StaticFileSegment::BlockMeta),
         }
     }
 
@@ -1804,28 +1791,15 @@ impl<N: FullNodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>>
 }
 
 impl<N: NodePrimitives> BlockBodyIndicesProvider for StaticFileProvider<N> {
-    fn block_body_indices(&self, num: u64) -> ProviderResult<Option<StoredBlockBodyIndices>> {
-        self.get_segment_provider_from_block(StaticFileSegment::BlockMeta, num, None)
-            .and_then(|provider| provider.block_body_indices(num))
-            .or_else(|err| {
-                if let ProviderError::MissingStaticFileBlock(_, _) = err {
-                    Ok(None)
-                } else {
-                    Err(err)
-                }
-            })
+    fn block_body_indices(&self, _num: u64) -> ProviderResult<Option<StoredBlockBodyIndices>> {
+        Err(ProviderError::UnsupportedProvider)
     }
 
     fn block_body_indices_range(
         &self,
-        range: RangeInclusive<BlockNumber>,
+        _range: RangeInclusive<BlockNumber>,
     ) -> ProviderResult<Vec<StoredBlockBodyIndices>> {
-        self.fetch_range_with_predicate(
-            StaticFileSegment::BlockMeta,
-            *range.start()..*range.end() + 1,
-            |cursor, number| cursor.get_one::<BodyIndicesMask>(number.into()),
-            |_| true,
-        )
+        Err(ProviderError::UnsupportedProvider)
     }
 }
 

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -6,9 +6,7 @@ use alloy_consensus::BlockHeader;
 use alloy_primitives::{BlockHash, BlockNumber, TxNumber, U256};
 use parking_lot::{lock_api::RwLockWriteGuard, RawRwLock, RwLock};
 use reth_codecs::Compact;
-use reth_db_api::models::{
-    CompactU256, StoredBlockBodyIndices, StoredBlockOmmers, StoredBlockWithdrawals,
-};
+use reth_db_api::models::CompactU256;
 use reth_nippy_jar::{NippyJar, NippyJarError, NippyJarWriter};
 use reth_node_types::NodePrimitives;
 use reth_static_file_types::{SegmentHeader, SegmentRangeInclusive, StaticFileSegment};
@@ -31,7 +29,6 @@ pub(crate) struct StaticFileWriters<N> {
     headers: RwLock<Option<StaticFileProviderRW<N>>>,
     transactions: RwLock<Option<StaticFileProviderRW<N>>>,
     receipts: RwLock<Option<StaticFileProviderRW<N>>>,
-    block_meta: RwLock<Option<StaticFileProviderRW<N>>>,
 }
 
 impl<N> Default for StaticFileWriters<N> {
@@ -40,7 +37,6 @@ impl<N> Default for StaticFileWriters<N> {
             headers: Default::default(),
             transactions: Default::default(),
             receipts: Default::default(),
-            block_meta: Default::default(),
         }
     }
 }
@@ -55,7 +51,6 @@ impl<N: NodePrimitives> StaticFileWriters<N> {
             StaticFileSegment::Headers => self.headers.write(),
             StaticFileSegment::Transactions => self.transactions.write(),
             StaticFileSegment::Receipts => self.receipts.write(),
-            StaticFileSegment::BlockMeta => self.block_meta.write(),
         };
 
         if write_guard.is_none() {
@@ -231,7 +226,6 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
                 StaticFileSegment::Receipts => {
                     self.prune_receipt_data(to_delete, last_block_number.expect("should exist"))?
                 }
-                StaticFileSegment::BlockMeta => todo!(),
             }
         }
 
@@ -550,61 +544,6 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
         Ok(())
     }
 
-    /// Appends [`StoredBlockBodyIndices`], [`StoredBlockOmmers`] and [`StoredBlockWithdrawals`] to
-    /// static file.
-    ///
-    /// It **CALLS** `increment_block()` since it's a block based segment.
-    pub fn append_eth_block_meta(
-        &mut self,
-        body_indices: &StoredBlockBodyIndices,
-        ommers: &StoredBlockOmmers<N::BlockHeader>,
-        withdrawals: &StoredBlockWithdrawals,
-        expected_block_number: BlockNumber,
-    ) -> ProviderResult<()>
-    where
-        N::BlockHeader: Compact,
-    {
-        self.append_block_meta(body_indices, ommers, withdrawals, expected_block_number)
-    }
-
-    /// Appends [`StoredBlockBodyIndices`] and any other two arbitrary types belonging to the block
-    /// body to static file.
-    ///
-    /// It **CALLS** `increment_block()` since it's a block based segment.
-    pub fn append_block_meta<F1, F2>(
-        &mut self,
-        body_indices: &StoredBlockBodyIndices,
-        field1: &F1,
-        field2: &F2,
-        expected_block_number: BlockNumber,
-    ) -> ProviderResult<()>
-    where
-        N::BlockHeader: Compact,
-        F1: Compact,
-        F2: Compact,
-    {
-        let start = Instant::now();
-        self.ensure_no_queued_prune()?;
-
-        debug_assert!(self.writer.user_header().segment() == StaticFileSegment::BlockMeta);
-
-        self.increment_block(expected_block_number)?;
-
-        self.append_column(body_indices)?;
-        self.append_column(field1)?;
-        self.append_column(field2)?;
-
-        if let Some(metrics) = &self.metrics {
-            metrics.record_segment_operation(
-                StaticFileSegment::BlockMeta,
-                StaticFileProviderOperation::Append,
-                Some(start.elapsed()),
-            );
-        }
-
-        Ok(())
-    }
-
     /// Appends transaction to static file.
     ///
     /// It **DOES NOT CALL** `increment_block()`, it should be handled elsewhere. There might be
@@ -729,12 +668,6 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
     /// Adds an instruction to prune `to_delete` headers during commit.
     pub fn prune_headers(&mut self, to_delete: u64) -> ProviderResult<()> {
         debug_assert_eq!(self.writer.user_header().segment(), StaticFileSegment::Headers);
-        self.queue_prune(to_delete, None)
-    }
-
-    /// Adds an instruction to prune `to_delete` block meta rows during commit.
-    pub fn prune_block_meta(&mut self, to_delete: u64) -> ProviderResult<()> {
-        debug_assert_eq!(self.writer.user_header().segment(), StaticFileSegment::BlockMeta);
         self.queue_prune(to_delete, None)
     }
 

--- a/docs/vocs/docs/pages/cli/reth/db/clear/static-file.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/clear/static-file.mdx
@@ -14,7 +14,6 @@ Arguments:
           - headers:      Static File segment responsible for the `CanonicalHeaders`, `Headers`, `HeaderTerminalDifficulties` tables
           - transactions: Static File segment responsible for the `Transactions` table
           - receipts:     Static File segment responsible for the `Receipts` table
-          - block-meta:   Static File segment responsible for the `BlockBodyIndices`, `BlockOmmers`, `BlockWithdrawals` tables
 
 Options:
   -h, --help

--- a/docs/vocs/docs/pages/cli/reth/db/get/static-file.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/get/static-file.mdx
@@ -14,7 +14,6 @@ Arguments:
           - headers:      Static File segment responsible for the `CanonicalHeaders`, `Headers`, `HeaderTerminalDifficulties` tables
           - transactions: Static File segment responsible for the `Transactions` table
           - receipts:     Static File segment responsible for the `Receipts` table
-          - block-meta:   Static File segment responsible for the `BlockBodyIndices`, `BlockOmmers`, `BlockWithdrawals` tables
 
   <KEY>
           The key to get content for


### PR DESCRIPTION
Closes #17828

- Removed `BlockMeta` from `StaticFileSegment` and all related code paths (writer APIs, masks, readers, CLI, producer).
- `block_body_indices` now served only from the database; static-file masks and reads for it were deleted.
- Updated `HighestStaticFiles` and `StaticFileTargets` to drop `block_meta`; adjusted tests accordingly.
- Minor cleanup in S3 static file list.

### Remark
To preserve existing trait bounds (since `BlockReader` requires `BlockBodyIndicesProvider`), I added a minimal impl for `StaticFileProvider` that returns `UnsupportedProvider`. This avoids rippling trait changes while removing `BlockMeta` support, but maybe some further modifications are needed.
