### PR TITLE
perf: use unwrap and save 198 cycles 

### DIFF
--- a/crates/transaction-pool/src/pool/parked.rs
+++ b/crates/transaction-pool/src/pool/parked.rs
@@ -189,7 +189,8 @@ impl<T: ParkedOrd> ParkedPool<T> {
         while limit.is_exceeded(self.len(), self.size()) && !self.last_sender_submission.is_empty()
         {
             // NOTE: This will not panic due to `!last_sender_transaction.is_empty()`
-            let sender_id = self.last_sender_submission.last().expect("not empty").sender_id;
+            // Unwrap here is safe because we checked that there is at least one sender
+            let sender_id = self.last_sender_submission.last().unwrap().sender_id;
             let list = self.get_txs_by_sender(sender_id);
 
             // Drop transactions from this sender until the pool is under limits

--- a/crates/transaction-pool/src/pool/parked.rs
+++ b/crates/transaction-pool/src/pool/parked.rs
@@ -189,7 +189,6 @@ impl<T: ParkedOrd> ParkedPool<T> {
         while limit.is_exceeded(self.len(), self.size()) && !self.last_sender_submission.is_empty()
         {
             // NOTE: This will not panic due to `!last_sender_transaction.is_empty()`
-            // Unwrap here is safe because we checked that there is at least one sender
             let sender_id = self.last_sender_submission.last().unwrap().sender_id;
             let list = self.get_txs_by_sender(sender_id);
 


### PR DESCRIPTION
Since we've checked that there's at least one sender in the pool, we can use unwrap here and save 198 cycles

https://godbolt.org/z/YK5TxoPs8