### PR TITLE
feat: P2PStream buffer removal

### DIFF
--- a/crates/net/eth-wire/rust-toolchain.toml
+++ b/crates/net/eth-wire/rust-toolchain.toml
@@ -1,5 +1,0 @@
-[toolchain]
-channel = "nightly"
-profile = "minimal"
-components = ["rustfmt","clippy"]
-

--- a/crates/net/eth-wire/rust-toolchain.toml
+++ b/crates/net/eth-wire/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "nightly"
+profile = "minimal"
+components = ["rustfmt","clippy"]
+

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -16,7 +16,6 @@ use reth_codecs::add_arbitrary_tests;
 use reth_metrics::metrics::counter;
 use reth_primitives_traits::GotExpected;
 use std::{
-    collections::VecDeque,
     future::Future,
     io,
     pin::Pin,
@@ -51,14 +50,6 @@ const PING_TIMEOUT: Duration = Duration::from_secs(15);
 /// [`PING_INTERVAL`] determines the amount of time to wait between sending `p2p` ping messages
 /// when the peer is responsive.
 const PING_INTERVAL: Duration = Duration::from_secs(60);
-
-/// [`MAX_P2P_CAPACITY`] is the maximum number of messages that can be buffered to be sent in the
-/// `p2p` stream.
-///
-/// Note: this default is rather low because it is expected that the [`P2PStream`] wraps an
-/// [`ECIESStream`](reth_ecies::stream::ECIESStream) which internally already buffers a few MB of
-/// encoded data.
-const MAX_P2P_CAPACITY: usize = 2;
 
 /// An un-authenticated [`P2PStream`]. This is consumed and returns a [`P2PStream`] after the
 /// `Hello` handshake is completed.
@@ -203,6 +194,38 @@ where
     }
 }
 
+#[derive(Debug)]
+enum Outgoing {
+    Message(Bytes),
+    Disconnect(Bytes),
+    Empty,
+}
+
+impl Outgoing {
+    #[inline] fn is_disconnect(&self) -> bool { matches!(self, Outgoing::Disconnect(_)) }
+    #[inline] fn is_message(&self)    -> bool { matches!(self, Outgoing::Message(_)) }
+
+    fn drain_disconnect(&mut self) -> Option<Bytes> {
+        if let Outgoing::Disconnect(disc) = self {
+            let out = disc.clone();
+            *self = Outgoing::Empty;
+            Some(out)
+        } else {
+            None
+        }
+    }
+
+    fn drain_message(&mut self) -> Option<Bytes> {
+        if let Outgoing::Message(msg) = self {
+            let out = msg.clone();
+            *self = Outgoing::Empty;
+            Some(out)
+        } else {
+            None
+        }
+    }
+}
+
 /// A `P2PStream` wraps over any `Stream` that yields bytes and makes it compatible with `p2p`
 /// protocol messages.
 ///
@@ -245,12 +268,8 @@ pub struct P2PStream<S> {
     /// The supported capability for this stream.
     shared_capabilities: SharedCapabilities,
 
-    /// Outgoing messages buffered for sending to the underlying stream.
-    outgoing_messages: VecDeque<Bytes>,
-
-    /// Maximum number of messages that we can buffer here before the [Sink] impl returns
-    /// [`Poll::Pending`].
-    outgoing_message_buffer_capacity: usize,
+    /// The outgoing message
+    outgoing: Outgoing,
 
     /// Whether this stream is currently in the process of disconnecting by sending a disconnect
     /// message.
@@ -268,8 +287,7 @@ impl<S> P2PStream<S> {
             decoder: snap::raw::Decoder::new(),
             pinger: Pinger::new(PING_INTERVAL, PING_TIMEOUT),
             shared_capabilities,
-            outgoing_messages: VecDeque::new(),
-            outgoing_message_buffer_capacity: MAX_P2P_CAPACITY,
+            outgoing: Outgoing::Empty,
             disconnecting: false,
         }
     }
@@ -277,15 +295,6 @@ impl<S> P2PStream<S> {
     /// Returns a reference to the inner stream.
     pub const fn inner(&self) -> &S {
         &self.inner
-    }
-
-    /// Sets a custom outgoing message buffer capacity.
-    ///
-    /// # Panics
-    ///
-    /// If the provided capacity is `0`.
-    pub const fn set_outgoing_message_buffer_capacity(&mut self, capacity: usize) {
-        self.outgoing_message_buffer_capacity = capacity;
     }
 
     /// Returns the shared capabilities for this stream.
@@ -296,19 +305,16 @@ impl<S> P2PStream<S> {
         &self.shared_capabilities
     }
 
-    /// Returns `true` if the stream has outgoing capacity.
-    fn has_outgoing_capacity(&self) -> bool {
-        self.outgoing_messages.len() < self.outgoing_message_buffer_capacity
-    }
-
     /// Queues in a _snappy_ encoded [`P2PMessage::Pong`] message.
     fn send_pong(&mut self) {
-        self.outgoing_messages.push_back(Bytes::from(alloy_rlp::encode(P2PMessage::Pong)));
+        let pong = Outgoing::Message(Bytes::from(alloy_rlp::encode(P2PMessage::Pong)));
+        self.outgoing = pong;
     }
 
     /// Queues in a _snappy_ encoded [`P2PMessage::Ping`] message.
     pub fn send_ping(&mut self) {
-        self.outgoing_messages.push_back(Bytes::from(alloy_rlp::encode(P2PMessage::Ping)));
+        let ping = Outgoing::Message(Bytes::from(alloy_rlp::encode(P2PMessage::Ping)));
+        self.outgoing = ping;
     }
 }
 
@@ -332,8 +338,6 @@ impl<S> DisconnectP2P for P2PStream<S> {
     ///
     /// Returns an error only if the message fails to compress.
     fn start_disconnect(&mut self, reason: DisconnectReason) -> Result<(), P2PStreamError> {
-        // clear any buffered messages and queue in
-        self.outgoing_messages.clear();
         let disconnect = P2PMessage::Disconnect(reason);
         let mut buf = Vec::with_capacity(disconnect.length());
         disconnect.encode(&mut buf);
@@ -357,7 +361,7 @@ impl<S> DisconnectP2P for P2PStream<S> {
         // message
         compressed[0] = buf[0];
 
-        self.outgoing_messages.push_back(compressed.into());
+        self.outgoing = Outgoing::Disconnect(compressed.into());
         self.disconnecting = true;
         Ok(())
     }
@@ -554,7 +558,7 @@ where
         }
 
         match this.inner.poll_ready_unpin(cx) {
-            Poll::Pending => {}
+            Poll::Pending => return Poll::Ready(Ok(())),
             Poll::Ready(Err(err)) => return Poll::Ready(Err(P2PStreamError::Io(err))),
             Poll::Ready(Ok(())) => {
                 let flushed = this.poll_flush(cx);
@@ -564,12 +568,7 @@ where
             }
         }
 
-        if self.has_outgoing_capacity() {
-            // still has capacity
-            Poll::Ready(Ok(()))
-        } else {
-            Poll::Pending
-        }
+        return Poll::Ready(Ok(()))  
     }
 
     fn start_send(self: Pin<&mut Self>, item: Bytes) -> Result<(), Self::Error> {
@@ -585,12 +584,7 @@ where
             return Err(P2PStreamError::EmptyProtocolMessage)
         }
 
-        // ensure we have free capacity
-        if !self.has_outgoing_capacity() {
-            return Err(P2PStreamError::SendBufferFull)
-        }
-
-        let this = self.project();
+        let mut this = self.project();
 
         let mut compressed = BytesMut::zeroed(1 + snap::raw::max_compress_len(item.len() - 1));
         let compressed_size =
@@ -610,32 +604,34 @@ where
         // all messages sent in this stream are subprotocol messages, so we need to switch the
         // message id based on the offset
         compressed[0] = item[0] + MAX_RESERVED_MESSAGE_ID + 1;
-        this.outgoing_messages.push_back(compressed.freeze());
-
+        this.inner.start_send_unpin(compressed.freeze())?;
+    
         Ok(())
     }
 
     /// Returns `Poll::Ready(Ok(()))` when no buffered items remain.
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         let mut this = self.project();
-        let poll_res = loop {
-            match this.inner.as_mut().poll_ready(cx) {
-                Poll::Pending => break Poll::Pending,
-                Poll::Ready(Err(err)) => break Poll::Ready(Err(err.into())),
-                Poll::Ready(Ok(())) => {
-                    let Some(message) = this.outgoing_messages.pop_front() else {
-                        break Poll::Ready(Ok(()))
-                    };
-                    if let Err(err) = this.inner.as_mut().start_send(message) {
-                        break Poll::Ready(Err(err.into()))
-                    }
-                }
+
+        // Disconnect has priority; ignore any future messages once chosen.
+        if this.outgoing.is_disconnect() {
+            ready!(this.inner.as_mut().poll_ready(cx).map_err(P2PStreamError::from))?;
+            if let Some(frame) = this.outgoing.drain_disconnect() {
+                this.inner.as_mut().start_send(frame).map_err(P2PStreamError::from)?;
             }
-        };
+          
+            return this.inner.as_mut().poll_flush(cx).map_err(P2PStreamError::from);
+        }
 
-        ready!(this.inner.as_mut().poll_flush(cx))?;
+        // Normal ping/pong messages
+        if this.outgoing.is_message() {
+            ready!(this.inner.as_mut().poll_ready(cx).map_err(P2PStreamError::from))?;
+            if let Some(frame) = this.outgoing.drain_message() {
+                this.inner.as_mut().start_send(frame).map_err(P2PStreamError::from)?;
+            }
+        }
 
-        poll_res
+        this.inner.as_mut().poll_flush(cx).map_err(Into::into)
     }
 
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
@@ -857,12 +853,11 @@ mod tests {
             let (mut p2p_stream, _) =
                 UnauthedP2PStream::new(stream).handshake(server_hello).await.unwrap();
 
-            // Unrolled `disconnect` method, without compression
-            p2p_stream.outgoing_messages.clear();
-
-            p2p_stream.outgoing_messages.push_back(Bytes::from(alloy_rlp::encode(
-                P2PMessage::Disconnect(DisconnectReason::SubprotocolSpecific),
-            )));
+            p2p_stream.outgoing = Outgoing::Disconnect(
+                Bytes::from(alloy_rlp::encode(
+                    P2PMessage::Disconnect(DisconnectReason::SubprotocolSpecific),
+                ))
+            );
             p2p_stream.disconnecting = true;
             p2p_stream.close().await.unwrap();
         });


### PR DESCRIPTION
Part of #12202 

**Summary**

This PR removes `P2PStream`’s internal outgoing queue and routes frames directly to the underlying sink, while introducing a small single-slot state (`Outgoing`) to prioritize disconnects and handle one in-flight message. The goal is to reduce duplicate buffering and simplify flow control.

**Key changes**

* **Drop explicit buffering in `P2PStream`:** stop pushing frames into `outgoing_messages` and send them immediately via `inner.start_send_unpin(...)`. Backpressure is now delegated to the inner sink.
* **Add `Outgoing` state machine:** `enum Outgoing { Message(Bytes), Disconnect(Bytes), Empty }` with helpers to check/drain the pending frame. This gives disconnects priority and replaces ad-hoc queue handling for special frames.
* **Ping/Pong path simplified:** `send_ping`/`send_pong` now stage a single encoded frame in `Outgoing` instead of enqueuing.
* **Disconnect flow updated:** `start_disconnect` composes the frame and stores it in `Outgoing::Disconnect`, ensuring it’s flushed before any other traffic.

**Rationale**

* Avoid double-buffering, reduce allocations and latency by sending directly to the transport.
* Make disconnect semantics explicit and prioritized via a simple state instead of queue juggling.