### PR TITLE
fix(db): make db get --raw work with DupSort tables

### DIFF
--- a/crates/cli/commands/src/db/get.rs
+++ b/crates/cli/commands/src/db/get.rs
@@ -1,8 +1,11 @@
 use alloy_consensus::Header;
 use alloy_primitives::{hex, BlockHash};
 use clap::Parser;
-use reth_db::static_file::{
-    ColumnSelectorOne, ColumnSelectorTwo, HeaderWithHashMask, ReceiptMask, TransactionMask,
+use reth_db::{
+    static_file::{
+        ColumnSelectorOne, ColumnSelectorTwo, HeaderWithHashMask, ReceiptMask, TransactionMask,
+    },
+    RawDupSort,
 };
 use reth_db_api::{
     table::{Decompress, DupSort, Table},
@@ -177,9 +180,21 @@ impl<N: ProviderNodeTypes> TableViewer<()> for GetValueViewer<'_, N> {
         // process dupsort table
         let subkey = table_subkey::<T>(self.subkey.as_deref())?;
 
-        match self.tool.get_dup::<T>(key, subkey)? {
+        let content = if self.raw {
+            self.tool
+                .get_dup::<RawDupSort<T>>(RawKey::from(key), RawKey::from(subkey))?
+                .map(|content| hex::encode_prefixed(content.raw_value()))
+        } else {
+            self.tool
+                .get_dup::<T>(key, subkey)?
+                .as_ref()
+                .map(serde_json::to_string_pretty)
+                .transpose()?
+        };
+
+        match content {
             Some(content) => {
-                println!("{}", serde_json::to_string_pretty(&content)?);
+                println!("{content}");
             }
             None => {
                 error!(target: "reth::cli", "No content for the given table subkey.");


### PR DESCRIPTION
Currently when you pass `--raw` to `reth db get` on a dupsort table, it doesn't do anything, for example:
```
./op-reth db get --chain base mdbx StoragesTrie --raw 0x00019059cbc4038299362610d7fe9300a940f54b08ad60546ff5ff03d8b7407f ' {
  "length": 1,
  "nibbles": "0x2000000000000000000000000000000000000000000000000000000000000000"
}'
2025-08-13T01:41:05.036761Z  INFO Initialized tracing, debug log directory: /home/ubuntu/.cache/reth/logs/base
2025-08-13T01:41:05.040717Z  INFO Opening storage db_path="/home/ubuntu/.local/share/reth/base/db" sf_path="/home/ubuntu/.local/share/reth/base/static_files"
2025-08-13T01:41:05.046831Z  INFO Verifying storage consistency.
{
  "nibbles": {
    "length": 1,
    "nibbles": "0xb000000000000000000000000000000000000000000000000000000000000000"
  },
  "node": {
    "state_mask": 2182,
    "tree_mask": 0,
    "hash_mask": 2048,
    "hashes": [
      "0x7204ab9eb299705fb9aa56a76048444158a9a1cf6c600237082c726ac10d92fb"
    ],
    "root_hash": null
  }
}
```
which is the same json output that you get without passing `--raw`

This is because the `raw` flag is not involved in the `GetValueViewer` in dupsort tables, this PR fixes that