### PR TITLE
chore(backfill): remove unused BlockHeader import in job.rs

### DIFF
--- a/crates/exex/exex/src/backfill/job.rs
+++ b/crates/exex/exex/src/backfill/job.rs
@@ -5,7 +5,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use alloy_consensus::BlockHeader;
 use alloy_primitives::BlockNumber;
 use reth_ethereum_primitives::Receipt;
 use reth_evm::execute::{BlockExecutionError, BlockExecutionOutput, Executor};


### PR DESCRIPTION
Remove use alloy_consensus::BlockHeader; from crates/exex/exex/src/backfill/job.rs
Import is unused, no functional changes
Reduces noise/warnings and keeps the module clean