### PR TITLE
fix(call): overwrite gas when exceed the RPC_DEFAULT_GAS_CAP

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -37,7 +37,7 @@ use reth_rpc_eth_types::{
     cache::db::{StateCacheDbRefMutWrapper, StateProviderTraitObjWrapper},
     error::{api::FromEvmHalt, ensure_success, FromEthApiError},
     simulate::{self, EthSimulateError},
-    EthApiError, RevertError, RpcInvalidTransactionError, StateCacheDb,
+    EthApiError, RevertError, StateCacheDb,
 };
 use reth_storage_api::{BlockIdReader, ProviderTx};
 use revm::{
@@ -48,7 +48,7 @@ use revm::{
     Database, DatabaseCommit,
 };
 use revm_inspectors::{access_list::AccessListInspector, transfer::TransferInspector};
-use tracing::trace;
+use tracing::{trace, warn};
 
 /// Result type for `eth_simulateV1` RPC method.
 pub type SimulatedBlocksResult<N, E> = Result<Vec<SimulatedBlock<RpcBlock<N>>>, E>;
@@ -728,11 +728,12 @@ pub trait Call:
         DB: Database + DatabaseCommit + OverrideBlockHashes,
         EthApiError: From<<DB as Database>::Error>,
     {
-        if request.as_ref().gas_limit() > Some(self.call_gas_limit()) {
-            // configured gas exceeds limit
-            return Err(
-                EthApiError::InvalidTransaction(RpcInvalidTransactionError::GasTooHigh).into()
-            )
+        if let Some(requested_gas) = request.as_ref().gas_limit() {
+            let global_gas_cap = self.call_gas_limit();
+            if global_gas_cap != 0 && global_gas_cap < requested_gas {
+                warn!(target: "rpc::eth::call", ?request, ?global_gas_cap, "Capping gas limit to global gas cap");
+                request.as_mut().set_gas_limit(global_gas_cap);
+            }
         }
 
         // apply configured gas cap


### PR DESCRIPTION
Recently, we switched node from geth to reth, reth got a discrepancy result from  geth

Request:
```
curl -X POST  <ethereum geth-url or reth-url>
  -H 'Content-Type: application/json' \
  --data '{
    "jsonrpc": "2.0",
    "id": 1,
    "method": "eth_call",
    "params": [
      {
        "to": "0xA9A003D8dfcaF3fCbFF6c7886B991b3dC64F87EC",
        "from": "0x74B9a66E9b12145C02426BCe913BFd8E5850302A",
        "data": "0x54efc6e50000000000000000000000000000000000000000000000000000000000000001",
        "value": "0x0",
        "gas": "0x2faf08100",
        "gasPrice": "0x32ed60ed"
      },
      "latest"
    ]
  }'
  
```

Geth result:
{"jsonrpc":"2.0","id":1,"error":{"code":-32003,"message":"insufficient funds for gas * price + value: have 40433651070486113 want 469929704750000000"}}  --> **this is expected**

reth result
{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"intrinsic gas too high"}}


This discrepancy is because the implementation logic a little different:

Geth checks the input gasLimit, and sets the gasLimit with RPCGasCap (50000000) if the input gasLimit exceeds RPCGasCap

https://github.com/ethereum/go-ethereum/blob/60cbf64f9c77761cf809120d5ff6c5716df0be5b/internal/ethapi/transaction_args.go#L207-L210

But reth just checks the input gasLimit, returns intrinsic gas too high if exceeds it.

https://github.com/paradigmxyz/reth/blob/fa31b9edcc91395ab97322f64d2d99c421dc113f/crates/rpc/rpc-eth-api/src/helpers/call.rs#L731-L735


There are two issues:

1. Some apps like rundler (for EIP4337) just set a very large gasLimit as the default value for eth_call, geth returns the right result for some requests since geth overwrites the gasLimit for the requests, but reth doesn't.  the runder sets the default gasLimit : 550000000 https://github.com/alchemyplatform/rundler/blob/main/bin/rundler/src/cli/mod.rs#L415

2. The return error `intrinsic gas too high` is definitely misleading


