### PR TITLE
Update generate-jwt.sh

### DIFF
--- a/etc/generate-jwt.sh
+++ b/etc/generate-jwt.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
+set -euo pipefail
 # Borrowed from EthStaker's prepare for the merge guide
 # See https://github.com/eth-educators/ethstaker-guides/blob/main/docs/prepare-for-the-merge.md#configuring-a-jwt-token-file
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-mkdir -p "${SCRIPT_DIR}/jwttoken"
-if [[ ! -f "${SCRIPT_DIR}/jwttoken/jwt.hex" ]]
+install -d -m 700 "${SCRIPT_DIR}/jwttoken"
+JWT_FILE="${SCRIPT_DIR}/jwttoken/jwt.hex"
+if [[ ! -f "$JWT_FILE" ]]
 then
-  openssl rand -hex 32 | tr -d "\n" | tee > "${SCRIPT_DIR}/jwttoken/jwt.hex"
+  umask 077
+  openssl rand -hex 32 | tr -d "\n" > "$JWT_FILE"
+  chmod 600 "$JWT_FILE"
 else
-  echo "${SCRIPT_DIR}/jwttoken/jwt.hex already exists!"
+  echo "$JWT_FILE already exists!"
 fi


### PR DESCRIPTION


### Description/Motivation

Improve reliability and security of the JWT token generation script.

- • Reliability: enable `set -euo pipefail` to fail fast on errors and unset variables.
- • Security:
  - create the `jwttoken` directory with strict permissions using `install -d -m 700`;
  - write the token to a single `JWT_FILE` path with `umask 077` and enforce `chmod 600`;
  - avoid `tee` to prevent leaking the secret to stdout.
- • Maintainability: introduce `JWT_FILE` variable, use `[[ ! -f "$JWT_FILE" ]]` for accurate existence checks, and improve the user-facing message.

