### PR TITLE
chore: remove myself from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,9 @@
 *                           @gakonst
-bin/                        @onbjerg
 crates/blockchain-tree-api/ @rakita @rkrasiuk @mattsse @Rjected
 crates/blockchain-tree/     @rakita @rkrasiuk @mattsse @Rjected
 crates/chain-state/         @fgimenez @mattsse @rkrasiuk
 crates/chainspec/           @Rjected @joshieDo @mattsse
-crates/cli/                 @onbjerg @mattsse
-crates/config/              @onbjerg
+crates/cli/                 @mattsse
 crates/consensus/           @rkrasiuk @mattsse @Rjected
 crates/e2e-test-utils/      @mattsse @Rjected
 crates/engine               @rkrasiuk @mattsse @Rjected
@@ -16,12 +14,10 @@ crates/ethereum-forks/      @mattsse @Rjected
 crates/ethereum/            @mattsse @Rjected
 crates/etl/                 @joshieDo @shekhirin
 crates/evm/                 @rakita @mattsse @Rjected
-crates/exex/                @onbjerg @shekhirin
-crates/fs-util/             @onbjerg
-crates/metrics/             @onbjerg
+crates/exex/                @shekhirin
 crates/net/                 @mattsse @Rjected
-crates/net/downloaders/     @onbjerg @rkrasiuk
-crates/node/                @mattsse @Rjected @onbjerg @klkvr
+crates/net/downloaders/     @rkrasiuk
+crates/node/                @mattsse @Rjected @klkvr
 crates/optimism/            @mattsse @Rjected @fgimenez
 crates/payload/             @mattsse @Rjected
 crates/primitives-traits/   @Rjected @RomanHodulak @mattsse @klkvr
@@ -30,21 +26,20 @@ crates/prune/               @shekhirin @joshieDo
 crates/ress                 @rkrasiuk
 crates/revm/                @mattsse @rakita
 crates/rpc/                 @mattsse @Rjected @RomanHodulak
-crates/stages/              @onbjerg @rkrasiuk @shekhirin
+crates/stages/              @rkrasiuk @shekhirin
 crates/static-file/         @joshieDo @shekhirin
 crates/storage/codecs/      @joshieDo
 crates/storage/db-api/      @joshieDo @rakita
-crates/storage/db-common/   @Rjected @onbjerg
+crates/storage/db-common/   @Rjected
 crates/storage/db/          @joshieDo @rakita
-crates/storage/errors/      @rakita @onbjerg
+crates/storage/errors/      @rakita
 crates/storage/libmdbx-rs/  @rakita @shekhirin
 crates/storage/nippy-jar/   @joshieDo @shekhirin
 crates/storage/provider/    @rakita @joshieDo @shekhirin
 crates/storage/storage-api/ @joshieDo @rkrasiuk
 crates/tasks/               @mattsse
 crates/tokio-util/          @fgimenez
-crates/tracing/             @onbjerg
 crates/transaction-pool/    @mattsse
 crates/trie/                @rkrasiuk @Rjected @shekhirin @mediocregopher
-etc/                        @Rjected @onbjerg @shekhirin
-.github/                    @onbjerg @gakonst @DaniPopes
+etc/                        @Rjected @shekhirin
+.github/                    @gakonst @DaniPopes


### PR DESCRIPTION
I don't have enough context to review most of these changes anyway.

I didn't provide a replacement for paths where I was the only owner (e.g. `bin/`) as I am unsure who to put