### PR TITLE
wip:feat: update chain on fcu unwind

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -856,6 +856,9 @@ where
                         self.process_payload_attributes(attr, &canonical_header, state, version);
                     return Ok(TreeOutcome::new(updated))
                 }
+
+                // TODO: here we'd need to actually set the Latest block to the `canonical_header`, like in step 3.
+
             }
 
             // 2. Client software MAY skip an update of the forkchoice state and MUST NOT begin a


### PR DESCRIPTION
ref #17798

just a smol comment re what would need to be done here in order to support this usecase that isn't allowed by the ethereum spec, but I'm unsure if we should even support unwinding the chain like this.
the intended use case for this was originally so that op can build an alternative chain based on a canonical ancestor block. the limitation with how we currently handle this is that this doesn't reset the node's LATEST state so until the new alternative block is applied the current head block remains the LATEST.

we effectively would need to do step 3 here as well, but this becomes slightly more difficult if a child block of the new head is already committed to disk

https://github.com/paradigmxyz/reth/blob/f3a3ffff60c1dee2a73743ddd851a2e8458d8dfe/crates/engine/tree/src/tree/mod.rs#L876-L893
