### PR TITLE
feat: implement the disable_peer_tx_broadcast flag in bsc-p2p exampe

### DIFF
--- a/examples/bsc-p2p/src/main.rs
+++ b/examples/bsc-p2p/src/main.rs
@@ -53,12 +53,17 @@ async fn main() {
 
     let bsc_boot_nodes = boot_nodes();
 
+    // Example: Allow transaction broadcasting (default behavior)
+    let bsc_handshake = BscHandshake(false);
+
+    info!("BSC P2P node configured with disable_peer_tx_broadcast={}", bsc_handshake.0);
+
     let net_cfg = NetworkConfig::builder(secret_key)
         .boot_nodes(bsc_boot_nodes.clone())
         .set_head(head())
         .with_pow()
         .listener_addr(local_addr)
-        .eth_rlpx_handshake(Arc::new(BscHandshake::default()))
+        .eth_rlpx_handshake(Arc::new(bsc_handshake))
         .build(NoopProvider::eth(bsc_chain_spec()));
 
     let net_cfg = net_cfg.set_discovery_v4(

--- a/examples/bsc-p2p/src/upgrade_status.rs
+++ b/examples/bsc-p2p/src/upgrade_status.rs
@@ -44,11 +44,9 @@ impl UpgradeStatus {
 }
 
 /// The extension to define whether to enable or disable the flag.
-/// This flag currently is ignored, and will be supported later.
 #[derive(Debug, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UpgradeStatusExtension {
-    // TODO: support disable_peer_tx_broadcast flag
     /// To notify a peer to disable the broadcast of transactions or not.
     pub disable_peer_tx_broadcast: bool,
 }


### PR DESCRIPTION
Implement the `disable_peer_tx_broadcast` flag in the bsc-p2p example.