### PR TITLE
chore: fix typos and improve documentation

### DIFF
--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -503,7 +503,7 @@ pub struct RpcRegistryInner<
     executor: Box<dyn TaskSpawner + 'static>,
     evm_config: EvmConfig,
     consensus: Consensus,
-    /// Holds a all `eth_` namespace handlers
+    /// Holds all `eth_` namespace handlers
     eth: EthHandlers<EthApi>,
     /// to put trace calls behind semaphore
     blocking_pool_guard: BlockingTaskGuard,

--- a/crates/storage/db-api/src/models/integer_list.rs
+++ b/crates/storage/db-api/src/models/integer_list.rs
@@ -70,14 +70,14 @@ impl IntegerList {
         self.0.clear();
     }
 
-    /// Serializes a [`IntegerList`] into a sequence of bytes.
+    /// Serializes an [`IntegerList`] into a sequence of bytes.
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut vec = Vec::with_capacity(self.0.serialized_size());
         self.0.serialize_into(&mut vec).expect("not able to encode IntegerList");
         vec
     }
 
-    /// Serializes a [`IntegerList`] into a sequence of bytes.
+    /// Serializes an [`IntegerList`] into a sequence of bytes.
     pub fn to_mut_bytes<B: bytes::BufMut>(&self, buf: &mut B) {
         self.0.serialize_into(buf.writer()).unwrap();
     }

--- a/crates/storage/db-api/src/models/storage_sharded_key.rs
+++ b/crates/storage/db-api/src/models/storage_sharded_key.rs
@@ -19,16 +19,16 @@ const STORAGE_SHARD_KEY_BYTES_SIZE: usize = 20 + 32 + 8;
 /// Sometimes data can be too big to be saved for a single key. This helps out by dividing the data
 /// into different shards. Example:
 ///
-/// `Address | StorageKey | 200` -> data is from transition 0 to 200.
+/// `Address | StorageKey | 200` -> data is from block 0 to 200.
 ///
-/// `Address | StorageKey | 300` -> data is from transition 201 to 300.
+/// `Address | StorageKey | 300` -> data is from block 201 to 300.
 #[derive(
     Debug, Default, Clone, Eq, Ord, PartialOrd, PartialEq, AsRef, Serialize, Deserialize, Hash,
 )]
 pub struct StorageShardedKey {
     /// Storage account address.
     pub address: Address,
-    /// Storage slot with highest transition id.
+    /// Storage slot with highest block number.
     #[as_ref]
     pub sharded_key: ShardedKey<B256>,
 }
@@ -70,14 +70,14 @@ impl Decode for StorageShardedKey {
         if value.len() != STORAGE_SHARD_KEY_BYTES_SIZE {
             return Err(DatabaseError::Decode)
         }
-        let tx_num_index = value.len() - 8;
+        let block_num_index = value.len() - 8;
 
-        let highest_tx_number = u64::from_be_bytes(
-            value[tx_num_index..].try_into().map_err(|_| DatabaseError::Decode)?,
+        let highest_block_number = u64::from_be_bytes(
+            value[block_num_index..].try_into().map_err(|_| DatabaseError::Decode)?,
         );
         let address = Address::decode(&value[..20])?;
         let storage_key = B256::decode(&value[20..52])?;
 
-        Ok(Self { address, sharded_key: ShardedKey::new(storage_key, highest_tx_number) })
+        Ok(Self { address, sharded_key: ShardedKey::new(storage_key, highest_block_number) })
     }
 }

--- a/crates/storage/nippy-jar/src/compression/mod.rs
+++ b/crates/storage/nippy-jar/src/compression/mod.rs
@@ -14,7 +14,7 @@ pub trait Compression: Serialize + for<'a> Deserialize<'a> {
     /// Returns decompressed data.
     fn decompress(&self, value: &[u8]) -> Result<Vec<u8>, NippyJarError>;
 
-    /// Appends compressed data from `src` to `dest`. `dest`. Requires `dest` to have sufficient
+    /// Appends compressed data from `src` to `dest`. Requires `dest` to have sufficient
     /// capacity.
     ///
     /// Returns number of bytes written to `dest`.

--- a/crates/transaction-pool/src/pool/pending.rs
+++ b/crates/transaction-pool/src/pool/pending.rs
@@ -99,7 +99,7 @@ impl<T: TransactionOrdering> PendingPool<T> {
     /// time in pool (were added earlier) are returned first.
     ///
     /// NOTE: while this iterator returns transaction that pool considers valid at this point, they
-    /// could potentially be become invalid at point of execution. Therefore, this iterator
+    /// could potentially become invalid at point of execution. Therefore, this iterator
     /// provides a way to mark transactions that the consumer of this iterator considers invalid. In
     /// which case the transaction's subgraph is also automatically marked invalid, See (1.).
     /// Invalid transactions are skipped.


### PR DESCRIPTION
Applied documentation and comment fixes from multiple closed PRs that were not yet applied to the codebase:

- Fixed grammar error in pending.rs comment ("be become" → "become") - from #17769
- Fixed article usage in IntegerList documentation ("a" → "an") - from #17806  
- Removed redundant word in RPC builder comment ("a all" → "all") - from #17807
- Fixed terminology consistency in StorageShardedKey (changed "transition" to "block" and renamed variables accordingly) - from #17778
- Removed duplicated word in nippy-jar comment (removed duplicate "dest.") - from #17773

These are all minor documentation improvements that enhance code clarity without affecting functionality.