### PR TITLE
fix: replace unsafe unwrap with proper error handling

### DIFF
--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -393,7 +393,9 @@ where
     }
 
     let block = provider_rw.last_block_number()?;
-    let hash = provider_rw.block_hash(block)?.unwrap();
+    let hash = provider_rw
+        .block_hash(block)?
+        .ok_or_else(|| eyre::eyre!("Block hash not found for block {}", block))?;
     let expected_state_root = provider_rw
         .header_by_number(block)?
         .ok_or_else(|| ProviderError::HeaderNotFound(block.into()))?


### PR DESCRIPTION
fix: replace unsafe unwrap with proper error handling

Replace unwrap() with ok_or_else() for block hash retrieval to prevent panic when block hash is not found. This provides better error messages and follows proper error handling patterns.