### PR TITLE
perf: avoid unnecessary iterator clone in CORS validation

### DIFF
--- a/crates/rpc/rpc-builder/src/cors.rs
+++ b/crates/rpc/rpc-builder/src/cors.rs
@@ -28,7 +28,7 @@ pub(crate) fn create_cors_layer(http_cors_domains: &str) -> Result<CorsLayer, Co
             .allow_headers(Any),
         _ => {
             let iter = http_cors_domains.split(',');
-            if iter.clone().any(|o| o == "*") {
+            if http_cors_domains.contains('*') {
                 return Err(CorsDomainError::WildCardNotAllowed {
                     input: http_cors_domains.to_string(),
                 })


### PR DESCRIPTION
perf: avoid unnecessary iterator clone in CORS validation

Replace iter.clone().any() with direct string contains check for wildcard detection. This eliminates an unnecessary iterator clone and improves performance in the CORS domain validation path.