### PR TITLE
bench(transaction): align raw-get metric with safe path; assert mdbx_get success

### DIFF
--- a/crates/storage/libmdbx-rs/benches/transaction.rs
+++ b/crates/storage/libmdbx-rs/benches/transaction.rs
@@ -49,9 +49,9 @@ fn bench_get_rand_raw(c: &mut Criterion) {
                     key_val.iov_len = key.len();
                     key_val.iov_base = key.as_bytes().as_ptr().cast_mut().cast();
 
-                    mdbx_get(txn, dbi, &raw const key_val, &raw mut data_val);
-
-                    i += key_val.iov_len;
+                    let rc = mdbx_get(txn, dbi, &raw const key_val, &raw mut data_val);
+                    assert_eq!(0, rc);
+                    i += data_val.iov_len;
                 }
                 black_box(i);
             })


### PR DESCRIPTION
## Reason:


- The safe benchmark (txn.get::<ObjectLength>(...)) measures value length, while the raw benchmark summed key length, producing inconsistent metrics.
- Without checking the return code, the raw path could silently mis-measure on failures.


## Goal:


- Ensure apples-to-apples comparison between safe and raw implementations.
- Improve reliability of the benchmark by catching retrieval errors early.