### PR TITLE
chore(tx-pool): Simplify syntax

### DIFF
--- a/crates/optimism/txpool/src/validator.rs
+++ b/crates/optimism/txpool/src/validator.rs
@@ -163,7 +163,7 @@ where
         origin: TransactionOrigin,
         transaction: Tx,
     ) -> TransactionValidationOutcome<Tx> {
-        self.validate_one_with_state(origin, transaction, &mut None).await
+        self.validate_one_with_state(origin, transaction, None).await
     }
 
     /// Validates a single transaction with a provided state provider.
@@ -181,7 +181,7 @@ where
         &self,
         origin: TransactionOrigin,
         transaction: Tx,
-        state: &mut Option<Box<dyn AccountInfoReader>>,
+        state: Option<Box<dyn AccountInfoReader>>,
     ) -> TransactionValidationOutcome<Tx> {
         if transaction.is_eip4844() {
             return TransactionValidationOutcome::Invalid(

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -132,7 +132,7 @@ where
         origin: TransactionOrigin,
         transaction: Tx,
     ) -> TransactionValidationOutcome<Tx> {
-        self.inner.validate_one_with_provider(origin, transaction, &mut None)
+        self.inner.validate_one_with_provider(origin, transaction, None)
     }
 
     /// Validates a single transaction with the provided state provider.
@@ -145,7 +145,7 @@ where
         &self,
         origin: TransactionOrigin,
         transaction: Tx,
-        state: &mut Option<Box<dyn AccountInfoReader>>,
+        state: Option<Box<dyn AccountInfoReader>>,
     ) -> TransactionValidationOutcome<Tx> {
         self.inner.validate_one_with_provider(origin, transaction, state)
     }
@@ -265,27 +265,24 @@ where
         &self,
         origin: TransactionOrigin,
         transaction: Tx,
-        maybe_state: &mut Option<Box<dyn AccountInfoReader>>,
+        maybe_state: Option<Box<dyn AccountInfoReader>>,
     ) -> TransactionValidationOutcome<Tx> {
         match self.validate_one_no_state(origin, transaction) {
             Ok(transaction) => {
                 // stateless checks passed, pass transaction down stateful validation pipeline
                 // If we don't have a state provider yet, fetch the latest state
-                if maybe_state.is_none() {
-                    match self.client.latest() {
-                        Ok(new_state) => {
-                            *maybe_state = Some(Box::new(new_state));
-                        }
+                let state = match maybe_state {
+                    Some(s) => s,
+                    None => match self.client.latest() {
+                        Ok(new_state) => Box::new(new_state) as Box<dyn AccountInfoReader>,
                         Err(err) => {
                             return TransactionValidationOutcome::Error(
                                 *transaction.hash(),
                                 Box::new(err),
                             )
                         }
-                    }
-                }
-
-                let state = maybe_state.as_deref().expect("provider is set");
+                    },
+                };
 
                 self.validate_one_against_state(origin, transaction, state)
             }
@@ -714,10 +711,9 @@ where
         &self,
         transactions: Vec<(TransactionOrigin, Tx)>,
     ) -> Vec<TransactionValidationOutcome<Tx>> {
-        let mut provider = None;
         transactions
             .into_iter()
-            .map(|(origin, tx)| self.validate_one_with_provider(origin, tx, &mut provider))
+            .map(|(origin, tx)| self.validate_one_with_provider(origin, tx, None))
             .collect()
     }
 
@@ -727,10 +723,9 @@ where
         origin: TransactionOrigin,
         transactions: impl IntoIterator<Item = Tx> + Send,
     ) -> Vec<TransactionValidationOutcome<Tx>> {
-        let mut provider = None;
         transactions
             .into_iter()
-            .map(|tx| self.validate_one_with_provider(origin, tx, &mut provider))
+            .map(|tx| self.validate_one_with_provider(origin, tx, None))
             .collect()
     }
 


### PR DESCRIPTION
Removes redundant mutable reference to an `Option` and call to `expect`, by casting state provider to trait object