### PR TITLE
feat: add log.file.name cli arg

### DIFF
--- a/crates/node/core/src/args/log.rs
+++ b/crates/node/core/src/args/log.rs
@@ -35,6 +35,10 @@ pub struct LogArgs {
     #[arg(long = "log.file.directory", value_name = "PATH", global = true, default_value_t)]
     pub log_file_directory: PlatformPath<LogsDir>,
 
+    /// The prefix name of the log files.
+    #[arg(long = "log.file.name", value_name = "NAME", global = true, default_value = "reth.log")]
+    pub log_file_name: String,
+
     /// The maximum size (in MB) of one log file.
     #[arg(long = "log.file.max-size", value_name = "SIZE", global = true, default_value_t = 200)]
     pub log_file_max_size: u64,
@@ -86,6 +90,7 @@ impl LogArgs {
     fn file_info(&self) -> FileInfo {
         FileInfo::new(
             self.log_file_directory.clone().into(),
+            self.log_file_name.clone(),
             self.log_file_max_size * MB_TO_BYTES,
             self.log_file_max_files,
         )

--- a/crates/tracing/src/layers.rs
+++ b/crates/tracing/src/layers.rs
@@ -18,8 +18,6 @@ pub type FileWorkerGuard = tracing_appender::non_blocking::WorkerGuard;
 ///  A boxed tracing [Layer].
 pub(crate) type BoxedLayer<S> = Box<dyn Layer<S> + Send + Sync>;
 
-const RETH_LOG_FILE_NAME: &str = "reth.log";
-
 /// Default [directives](Directive) for [`EnvFilter`] which disables high-frequency debug logs from
 /// `hyper`, `hickory-resolver`, `jsonrpsee-server`, and `discv5`.
 const DEFAULT_ENV_FILTER_DIRECTIVES: [&str; 5] = [
@@ -140,8 +138,8 @@ pub struct FileInfo {
 
 impl FileInfo {
     /// Creates a new `FileInfo` instance.
-    pub fn new(dir: PathBuf, max_size_bytes: u64, max_files: usize) -> Self {
-        Self { dir, file_name: RETH_LOG_FILE_NAME.to_string(), max_size_bytes, max_files }
+    pub fn new(dir: PathBuf, file_name: String, max_size_bytes: u64, max_files: usize) -> Self {
+        Self { dir, file_name, max_size_bytes, max_files }
     }
 
     /// Creates the log directory if it doesn't exist.

--- a/crates/tracing/src/layers.rs
+++ b/crates/tracing/src/layers.rs
@@ -138,7 +138,12 @@ pub struct FileInfo {
 
 impl FileInfo {
     /// Creates a new `FileInfo` instance.
-    pub fn new(dir: PathBuf, file_name: String, max_size_bytes: u64, max_files: usize) -> Self {
+    pub const fn new(
+        dir: PathBuf,
+        file_name: String,
+        max_size_bytes: u64,
+        max_files: usize,
+    ) -> Self {
         Self { dir, file_name, max_size_bytes, max_files }
     }
 

--- a/docs/vocs/docs/pages/cli/reth.mdx
+++ b/docs/vocs/docs/pages/cli/reth.mdx
@@ -69,6 +69,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/config.mdx
+++ b/docs/vocs/docs/pages/cli/reth/config.mdx
@@ -54,6 +54,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/db.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db.mdx
@@ -118,6 +118,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/db/checksum.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/checksum.mdx
@@ -71,6 +71,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/db/clear.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/clear.mdx
@@ -63,6 +63,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/db/clear/mdbx.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/clear/mdbx.mdx
@@ -62,6 +62,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/db/clear/static-file.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/clear/static-file.mdx
@@ -65,6 +65,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/db/diff.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/diff.mdx
@@ -98,6 +98,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/db/drop.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/drop.mdx
@@ -61,6 +61,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/db/get.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/get.mdx
@@ -63,6 +63,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/db/get/mdbx.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/get/mdbx.mdx
@@ -71,6 +71,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/db/get/static-file.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/get/static-file.mdx
@@ -71,6 +71,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/db/list.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/list.mdx
@@ -104,6 +104,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/db/path.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/path.mdx
@@ -58,6 +58,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/db/stats.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/stats.mdx
@@ -71,6 +71,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/db/version.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/version.mdx
@@ -58,6 +58,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/download.mdx
+++ b/docs/vocs/docs/pages/cli/reth/download.mdx
@@ -116,6 +116,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/dump-genesis.mdx
+++ b/docs/vocs/docs/pages/cli/reth/dump-genesis.mdx
@@ -57,6 +57,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/export-era.mdx
+++ b/docs/vocs/docs/pages/cli/reth/export-era.mdx
@@ -122,6 +122,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/import-era.mdx
+++ b/docs/vocs/docs/pages/cli/reth/import-era.mdx
@@ -117,6 +117,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/import.mdx
+++ b/docs/vocs/docs/pages/cli/reth/import.mdx
@@ -118,6 +118,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/init-state.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init-state.mdx
@@ -141,6 +141,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/init.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init.mdx
@@ -106,6 +106,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -907,6 +907,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/p2p.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p.mdx
@@ -55,6 +55,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/p2p/body.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/body.mdx
@@ -262,6 +262,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/p2p/bootnode.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/bootnode.mdx
@@ -71,6 +71,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/p2p/header.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/header.mdx
@@ -262,6 +262,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/p2p/rlpx.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/rlpx.mdx
@@ -52,6 +52,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/p2p/rlpx/ping.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/rlpx/ping.mdx
@@ -52,6 +52,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/prune.mdx
+++ b/docs/vocs/docs/pages/cli/reth/prune.mdx
@@ -106,6 +106,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/re-execute.mdx
+++ b/docs/vocs/docs/pages/cli/reth/re-execute.mdx
@@ -119,6 +119,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/recover.mdx
+++ b/docs/vocs/docs/pages/cli/reth/recover.mdx
@@ -52,6 +52,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/recover/storage-tries.mdx
+++ b/docs/vocs/docs/pages/cli/reth/recover/storage-tries.mdx
@@ -106,6 +106,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/stage.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage.mdx
@@ -55,6 +55,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/stage/drop.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/drop.mdx
@@ -120,6 +120,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/stage/dump.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump.mdx
@@ -113,6 +113,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/stage/dump/account-hashing.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump/account-hashing.mdx
@@ -70,6 +70,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/stage/dump/execution.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump/execution.mdx
@@ -70,6 +70,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/stage/dump/merkle.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump/merkle.mdx
@@ -70,6 +70,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/stage/dump/storage-hashing.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump/storage-hashing.mdx
@@ -70,6 +70,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/stage/run.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/run.mdx
@@ -328,6 +328,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/stage/unwind.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/unwind.mdx
@@ -114,6 +114,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/stage/unwind/num-blocks.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/unwind/num-blocks.mdx
@@ -62,6 +62,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 

--- a/docs/vocs/docs/pages/cli/reth/stage/unwind/to-block.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/unwind/to-block.mdx
@@ -62,6 +62,11 @@ Logging:
 
           [default: <CACHE_DIR>/logs]
 
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
       --log.file.max-size <SIZE>
           The maximum size (in MB) of one log file
 


### PR DESCRIPTION
Small non-breaking feature that add `--log.file.name` argument to cli, default to `reth.log`.
`FileInfo` now take the filename, and is instantiated once at startup.

This allows more customization and also allows rewriting default value when using `Cli` as a lib.