### PR TITLE
fix: respect pure precompiles for caching

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -63,6 +63,7 @@ mod payload_processor;
 pub mod payload_validator;
 mod persistence_state;
 pub mod precompile_cache;
+mod precompile_utils;
 #[cfg(test)]
 mod tests;
 // TODO(alexey): compare trie updates in `insert_block_inner`

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -6,6 +6,7 @@ use crate::tree::{
         executor::WorkloadExecutor, multiproof::MultiProofMessage, ExecutionCache,
     },
     precompile_cache::{CachedPrecompile, PrecompileCacheMap},
+    precompile_utils::PrecompileMapExt,
     ExecutionEnv, StateProviderBuilder,
 };
 use alloy_evm::Database;
@@ -273,7 +274,9 @@ where
         let mut evm = evm_config.evm_with_env(state_provider, evm_env);
 
         if !precompile_cache_disabled {
-            evm.precompiles_mut().map_precompiles(|address, precompile| {
+            // Only cache pure precompiles (addresses 0x01-0x0a) to avoid caching stateful
+            // precompiles
+            evm.precompiles_mut().map_pure_precompiles(|address, precompile| {
                 CachedPrecompile::wrap(
                     precompile,
                     precompile_cache_map.cache_for_address(*address),

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -8,6 +8,7 @@ use crate::tree::{
     payload_processor::PayloadProcessor,
     persistence_state::CurrentPersistenceAction,
     precompile_cache::{CachedPrecompile, CachedPrecompileMetrics, PrecompileCacheMap},
+    precompile_utils::PrecompileMapExt,
     sparse_trie::StateRootComputeOutcome,
     ConsistentDbView, EngineApiMetrics, EngineApiTreeState, ExecutionEnv, PayloadHandle,
     PersistenceState, PersistingKind, StateProviderBuilder, StateProviderDatabase, TreeConfig,
@@ -669,7 +670,9 @@ where
         let mut executor = self.evm_config.create_executor(evm, ctx);
 
         if !self.config.precompile_cache_disabled() {
-            executor.evm_mut().precompiles_mut().map_precompiles(|address, precompile| {
+            // Only cache pure precompiles (addresses 0x01-0x0a) to avoid caching stateful
+            // precompiles
+            executor.evm_mut().precompiles_mut().map_pure_precompiles(|address, precompile| {
                 let metrics = self
                     .precompile_cache_metrics
                     .entry(*address)

--- a/crates/engine/tree/src/tree/precompile_utils.rs
+++ b/crates/engine/tree/src/tree/precompile_utils.rs
@@ -1,0 +1,52 @@
+//! Utilities for working with precompiles
+
+use alloy_evm::precompiles::{DynPrecompile, PrecompilesMap};
+use alloy_primitives::Address;
+
+/// Extension trait for PrecompilesMap to add pure precompile mapping functionality
+pub trait PrecompileMapExt {
+    /// Maps only pure precompiles (addresses 0x01-0x0a) with the given closure.
+    ///
+    /// Pure precompiles are those that don't have side effects or depend on contract state,
+    /// and are safe to cache. These are the standard Ethereum precompiles at addresses 0x01-0x0a.
+    fn map_pure_precompiles<F>(&mut self, f: F)
+    where
+        F: FnMut(&Address, DynPrecompile) -> DynPrecompile;
+}
+
+impl PrecompileMapExt for PrecompilesMap {
+    fn map_pure_precompiles<F>(&mut self, mut f: F)
+    where
+        F: FnMut(&Address, DynPrecompile) -> DynPrecompile,
+    {
+        // Pure precompiles are at addresses 0x01 to 0x0a
+        let pure_addresses: Vec<Address> = (1..=0xa)
+            .map(|i| {
+                let mut bytes = [0u8; 20];
+                bytes[19] = i;
+                Address::from(bytes)
+            })
+            .collect();
+
+        // Use the existing map_precompiles method but only apply to pure addresses
+        self.map_precompiles(|address, precompile| {
+            if pure_addresses.contains(address) {
+                f(address, precompile)
+            } else {
+                // Leave non-pure precompiles unchanged
+                precompile
+            }
+        });
+    }
+}
+
+/// Checks if the given address is a pure precompile address (0x01-0x0a)
+#[allow(dead_code)]
+fn is_pure_precompile(address: &Address) -> bool {
+    let addr_bytes = address.as_slice();
+    // Check if it's one of the standard Ethereum precompiles (0x01-0x0a)
+    addr_bytes.len() == 20 &&
+        addr_bytes[0..19].iter().all(|&b| b == 0) &&
+        addr_bytes[19] >= 0x01 &&
+        addr_bytes[19] <= 0x0a
+}

--- a/examples/precompile-cache/src/main.rs
+++ b/examples/precompile-cache/src/main.rs
@@ -1,4 +1,8 @@
 //! This example shows how to implement a node with a custom EVM that uses a stateful precompile
+//!
+//! Note: This example demonstrates caching ALL precompiles. For production use,
+//! consider using map_pure_precompiles to only cache pure precompiles (addresses 0x01-0x0a)
+//! to avoid issues with stateful precompiles.
 
 #![warn(unused_crate_dependencies)]
 


### PR DESCRIPTION
## Summary

This PR fixes an issue where all precompiles were being cached, including stateful ones that shouldn't be cached. The fix ensures that only pure precompiles (addresses 0x01-0x0a) are cached.

https://github.com/paradigmxyz/reth/issues/17870

## Solution
- Updated `payload_validator.rs` and [reth/crates/engine/tree/src/tree/payload_processor/prewarm.rs](https://github.com/paradigmxyz/reth/blob/b64eed99b5ce92e785665a37c89dcc8805486160/crates/engine/tree/src/tree/payload_processor/prewarm.rs#L276-L276) to use `map_pure_precompiles` instead of `map_precompiles`

## Note

This is a temporary implementation until the alloy-evm PR (alloy-rs/evm#153) is merged, which will provide the `map_pure_precompiles` method natively in the alloy-evm library.

- [ ] PR is marked as draft until alloy-evm PR is merged