### PR TITLE
chore: enforce zstd is only present for legacy transaction

### DIFF
--- a/crates/ethereum/primitives/src/transaction.rs
+++ b/crates/ethereum/primitives/src/transaction.rs
@@ -611,24 +611,23 @@ impl reth_codecs::Compact for TransactionSigned {
 
         let zstd_bit = bitflags >> 3;
         let (transaction, buf) = if zstd_bit != 0 {
+            let transaction_type = (bitflags & 0b110) >> 1;
+            // Enforce zstd is only present at a "top" level type
+            if transaction_type != 0 {
+                panic!("zstd compression is only allowed for Legacy transactions");
+            }
+
             if cfg!(feature = "std") {
                 reth_zstd_compressors::TRANSACTION_DECOMPRESSOR.with(|decompressor| {
                     let mut decompressor = decompressor.borrow_mut();
-
-                    // TODO: enforce that zstd is only present at a "top" level type
-
-                    let transaction_type = (bitflags & 0b110) >> 1;
                     let (transaction, _) =
                         Transaction::from_compact(decompressor.decompress(buf), transaction_type);
-
                     (transaction, buf)
                 })
             } else {
                 let mut decompressor = reth_zstd_compressors::create_tx_decompressor();
-                let transaction_type = (bitflags & 0b110) >> 1;
                 let (transaction, _) =
                     Transaction::from_compact(decompressor.decompress(buf), transaction_type);
-
                 (transaction, buf)
             }
         } else {


### PR DESCRIPTION
The zstd was only used for legacy transaction, remove this TODO