### PR TITLE
feat: add 2 StaticFileProducer metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10330,11 +10330,13 @@ version = "1.6.0"
 dependencies = [
  "alloy-primitives",
  "assert_matches",
+ "metrics",
  "parking_lot",
  "rayon",
  "reth-codecs",
  "reth-db",
  "reth-db-api",
+ "reth-metrics",
  "reth-primitives-traits",
  "reth-provider",
  "reth-prune-types",

--- a/crates/static-file/static-file/Cargo.toml
+++ b/crates/static-file/static-file/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 # reth
 reth-codecs.workspace = true
 reth-db-api.workspace = true
+reth-metrics.workspace = true
 reth-provider.workspace = true
 reth-storage-errors.workspace = true
 reth-tokio-util.workspace = true
@@ -29,6 +30,7 @@ alloy-primitives.workspace = true
 tracing.workspace = true
 rayon.workspace = true
 parking_lot = { workspace = true, features = ["send_guard", "arc_lock"] }
+metrics.workspace = true
 
 [dev-dependencies]
 reth-db = { workspace = true, features = ["test-utils"] }

--- a/crates/static-file/static-file/src/lib.rs
+++ b/crates/static-file/static-file/src/lib.rs
@@ -8,6 +8,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
+mod metrics;
 pub mod segments;
 mod static_file_producer;
 

--- a/crates/static-file/static-file/src/metrics.rs
+++ b/crates/static-file/static-file/src/metrics.rs
@@ -1,0 +1,24 @@
+use metrics;
+use reth_metrics::{metrics::Histogram, Metrics};
+
+/// Metrics for the static file producer.
+#[derive(Metrics)]
+#[metrics(scope = "static_file_producer")]
+pub(crate) struct StaticFileProducerMetrics {
+    /// Time taken to process individual segments
+    segment_duration_seconds: Histogram,
+    /// Time taken for the entire static file producer run
+    producer_duration_seconds: Histogram,
+}
+
+impl StaticFileProducerMetrics {
+    /// Record the duration of processing a single segment
+    pub(crate) fn record_segment_duration(&self, duration: std::time::Duration) {
+        self.segment_duration_seconds.record(duration.as_secs_f64());
+    }
+
+    /// Record the duration of the entire producer run
+    pub(crate) fn record_producer_duration(&self, duration: std::time::Duration) {
+        self.producer_duration_seconds.record(duration.as_secs_f64());
+    }
+}

--- a/crates/static-file/static-file/src/metrics.rs
+++ b/crates/static-file/static-file/src/metrics.rs
@@ -1,4 +1,3 @@
-use metrics;
 use reth_metrics::{metrics::Histogram, Metrics};
 
 /// Metrics for the static file producer.

--- a/crates/static-file/static-file/src/static_file_producer.rs
+++ b/crates/static-file/static-file/src/static_file_producer.rs
@@ -1,6 +1,8 @@
 //! Support for producing static files.
 
-use crate::{segments, segments::Segment, StaticFileProducerEvent};
+use crate::{
+    metrics::StaticFileProducerMetrics, segments, segments::Segment, StaticFileProducerEvent,
+};
 use alloy_primitives::BlockNumber;
 use parking_lot::Mutex;
 use rayon::prelude::*;
@@ -67,11 +69,18 @@ pub struct StaticFileProducerInner<Provider> {
     /// files. See [`StaticFileProducerInner::get_static_file_targets`].
     prune_modes: PruneModes,
     event_sender: EventSender<StaticFileProducerEvent>,
+    /// Metrics for tracking performance
+    metrics: StaticFileProducerMetrics,
 }
 
 impl<Provider> StaticFileProducerInner<Provider> {
     fn new(provider: Provider, prune_modes: PruneModes) -> Self {
-        Self { provider, prune_modes, event_sender: Default::default() }
+        Self {
+            provider,
+            prune_modes,
+            event_sender: Default::default(),
+            metrics: StaticFileProducerMetrics::default(),
+        }
     }
 }
 
@@ -150,7 +159,8 @@ where
             let provider = self.provider.database_provider_ro()?.disable_long_read_transaction_safety();
             segment.copy_to_static_files(provider,  block_range.clone())?;
 
-            let elapsed = start.elapsed(); // TODO(alexey): track in metrics
+            let elapsed = start.elapsed();
+            self.metrics.record_segment_duration(elapsed);
             debug!(target: "static_file", segment = %segment.segment(), ?block_range, ?elapsed, "Finished StaticFileProducer segment");
 
             Ok(())
@@ -163,7 +173,8 @@ where
                 .update_index(segment.segment(), Some(*block_range.end()))?;
         }
 
-        let elapsed = start.elapsed(); // TODO(alexey): track in metrics
+        let elapsed = start.elapsed();
+        self.metrics.record_producer_duration(elapsed);
         debug!(target: "static_file", ?targets, ?elapsed, "StaticFileProducer finished");
 
         self.event_sender


### PR DESCRIPTION
Add below metrics for the `StaticFileProducer`:

- `static_file_producer_segment_duration_seconds` - Histogram for segment processing time
- `static_file_producer_producer_duration_seconds` - Histogram for total producer execution time