### PR TITLE
chore(pool): replace saturating_sub with unchecked_sub

### DIFF
--- a/crates/transaction-pool/src/identifier.rs
+++ b/crates/transaction-pool/src/identifier.rs
@@ -47,8 +47,8 @@ impl SenderIdentifiers {
 
     /// Returns the current identifier and increments the counter.
     fn next_id(&mut self) -> SenderId {
-        let id = self.id;
-        self.id += 1;
+        let id = self.id
+        self.id = self.id.wrapping_add(1);
         id.into()
     }
 }

--- a/crates/transaction-pool/src/identifier.rs
+++ b/crates/transaction-pool/src/identifier.rs
@@ -48,7 +48,7 @@ impl SenderIdentifiers {
     /// Returns the current identifier and increments the counter.
     fn next_id(&mut self) -> SenderId {
         let id = self.id;
-        self.id = self.id.wrapping_add(1);
+        self.id += 1;
         id.into()
     }
 }

--- a/crates/transaction-pool/src/identifier.rs
+++ b/crates/transaction-pool/src/identifier.rs
@@ -47,7 +47,7 @@ impl SenderIdentifiers {
 
     /// Returns the current identifier and increments the counter.
     fn next_id(&mut self) -> SenderId {
-        let id = self.id
+        let id = self.id;
         self.id = self.id.wrapping_add(1);
         id.into()
     }

--- a/crates/transaction-pool/src/identifier.rs
+++ b/crates/transaction-pool/src/identifier.rs
@@ -101,13 +101,15 @@ impl TransactionId {
     /// This returns `transaction_nonce - 1` if `transaction_nonce` is higher than the
     /// `on_chain_nonce`
     pub fn ancestor(transaction_nonce: u64, on_chain_nonce: u64, sender: SenderId) -> Option<Self> {
+        // SAFETY: transaction_nonce > on_chain_nonce ⇒ transaction_nonce >= 1
         (transaction_nonce > on_chain_nonce)
-            .then(|| Self::new(sender, transaction_nonce.saturating_sub(1)))
+            .then(|| Self::new(sender, unsafe { transaction_nonce.unchecked_sub(1) }))
     }
 
     /// Returns the [`TransactionId`] that would come before this transaction.
     pub fn unchecked_ancestor(&self) -> Option<Self> {
-        (self.nonce != 0).then(|| Self::new(self.sender, self.nonce - 1))
+        // SAFETY: self.nonce != 0 ⇒ self.nonce >= 1
+        (self.nonce != 0).then(|| Self::new(self.sender, unsafe {self.nonce.unchecked_sub(1)}))
     }
 
     /// Returns the [`TransactionId`] that directly follows this transaction: `self.nonce + 1`

--- a/crates/transaction-pool/src/identifier.rs
+++ b/crates/transaction-pool/src/identifier.rs
@@ -102,14 +102,13 @@ impl TransactionId {
     /// `on_chain_nonce`
     pub fn ancestor(transaction_nonce: u64, on_chain_nonce: u64, sender: SenderId) -> Option<Self> {
         // SAFETY: transaction_nonce > on_chain_nonce ⇒ transaction_nonce >= 1
-        (transaction_nonce > on_chain_nonce)
-            .then(|| Self::new(sender, unsafe { transaction_nonce.unchecked_sub(1) }))
+        (transaction_nonce > on_chain_nonce).then(|| Self::new(sender, transaction_nonce - 1))
     }
 
     /// Returns the [`TransactionId`] that would come before this transaction.
     pub fn unchecked_ancestor(&self) -> Option<Self> {
         // SAFETY: self.nonce != 0 ⇒ self.nonce >= 1
-        (self.nonce != 0).then(|| Self::new(self.sender, unsafe {self.nonce.unchecked_sub(1)}))
+        (self.nonce != 0).then(|| Self::new(self.sender, self.nonce - 1))
     }
 
     /// Returns the [`TransactionId`] that directly follows this transaction: `self.nonce + 1`


### PR DESCRIPTION
Guarantees from prior pool validation ensure transaction_nonce > on_chain_nonce,  
which implies transaction_nonce >= 1. This makes unchecked_sub(1) safe here,  
removing the redundant saturating_sub overhead.