### PR TITLE
chore(tx-pool): Rm redundant async block

### DIFF
--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -206,12 +206,9 @@ pub trait TransactionValidator: Debug + Send + Sync {
         &self,
         transactions: Vec<(TransactionOrigin, Self::Transaction)>,
     ) -> impl Future<Output = Vec<TransactionValidationOutcome<Self::Transaction>>> + Send {
-        async {
-            futures_util::future::join_all(
-                transactions.into_iter().map(|(origin, tx)| self.validate_transaction(origin, tx)),
-            )
-            .await
-        }
+        futures_util::future::join_all(
+            transactions.into_iter().map(|(origin, tx)| self.validate_transaction(origin, tx)),
+        )
     }
 
     /// Validates a batch of transactions with that given origin.


### PR DESCRIPTION
Removes redundant async block in tx validator