### PR TITLE
refactor(examples): Replace `CustomTransactionEnvelope` with `Signed<TxPayment>` as the variant type in the custom node example

### DIFF
--- a/examples/custom-node/src/evm/env.rs
+++ b/examples/custom-node/src/evm/env.rs
@@ -1,4 +1,4 @@
-use crate::primitives::{CustomTransaction, CustomTransactionEnvelope, TxPayment};
+use crate::primitives::{CustomTransaction, TxPayment};
 use alloy_eips::{eip2930::AccessList, Typed2718};
 use alloy_evm::{FromRecoveredTx, FromTxWithEncoded, IntoTxEnv};
 use alloy_primitives::{Address, Bytes, TxKind, B256, U256};
@@ -283,18 +283,6 @@ impl FromRecoveredTx<TxPayment> for TxEnv {
     }
 }
 
-impl FromRecoveredTx<CustomTransactionEnvelope> for TxEnv {
-    fn from_recovered_tx(tx: &CustomTransactionEnvelope, sender: Address) -> Self {
-        Self::from_recovered_tx(tx.inner.tx(), sender)
-    }
-}
-
-impl FromTxWithEncoded<CustomTransactionEnvelope> for TxEnv {
-    fn from_encoded_tx(tx: &CustomTransactionEnvelope, sender: Address, _encoded: Bytes) -> Self {
-        Self::from_recovered_tx(tx.inner.tx(), sender)
-    }
-}
-
 impl FromTxWithEncoded<TxPayment> for TxEnv {
     fn from_encoded_tx(tx: &TxPayment, sender: Address, _encoded: Bytes) -> Self {
         Self::from_recovered_tx(tx, sender)
@@ -318,7 +306,7 @@ impl FromRecoveredTx<CustomTransaction> for CustomTxEnv {
         match tx {
             CustomTransaction::Op(tx) => Self::from_recovered_tx(tx, sender),
             CustomTransaction::Payment(tx) => {
-                Self::Payment(PaymentTxEnv(TxEnv::from_recovered_tx(tx, sender)))
+                Self::Payment(PaymentTxEnv(TxEnv::from_recovered_tx(tx.tx(), sender)))
             }
         }
     }
@@ -329,7 +317,7 @@ impl FromTxWithEncoded<CustomTransaction> for CustomTxEnv {
         match tx {
             CustomTransaction::Op(tx) => Self::from_encoded_tx(tx, sender, encoded),
             CustomTransaction::Payment(tx) => {
-                Self::Payment(PaymentTxEnv(TxEnv::from_encoded_tx(tx, sender, encoded)))
+                Self::Payment(PaymentTxEnv(TxEnv::from_encoded_tx(tx.tx(), sender, encoded)))
             }
         }
     }

--- a/examples/custom-node/src/primitives/tx.rs
+++ b/examples/custom-node/src/primitives/tx.rs
@@ -1,15 +1,10 @@
 use super::TxPayment;
 use alloy_consensus::{
-    crypto::{
-        secp256k1::{recover_signer, recover_signer_unchecked},
-        RecoveryError,
-    },
-    transaction::SignerRecoverable,
-    Signed, Transaction, TransactionEnvelope,
+    crypto::RecoveryError, transaction::SignerRecoverable, Signed, TransactionEnvelope,
 };
-use alloy_eips::{eip2718::Eip2718Result, Decodable2718, Encodable2718, Typed2718};
-use alloy_primitives::{Sealed, Signature, TxHash, B256};
-use alloy_rlp::{BufMut, Decodable, Encodable, Result as RlpResult};
+use alloy_eips::Encodable2718;
+use alloy_primitives::{Sealed, Signature, B256};
+use alloy_rlp::BufMut;
 use op_alloy_consensus::{OpTxEnvelope, TxDeposit};
 use reth_codecs::{
     alloy::transaction::{CompactEnvelope, FromTxCompact, ToTxCompact},
@@ -17,10 +12,9 @@ use reth_codecs::{
 };
 use reth_ethereum::primitives::{serde_bincode_compat::RlpBincode, InMemorySize};
 use reth_op::{primitives::SignedTransaction, OpTransaction};
-use revm_primitives::{Address, Bytes};
-use serde::{Deserialize, Serialize};
+use revm_primitives::Address;
 
-/// Either [`OpTxEnvelope`] or [`CustomTransactionEnvelope`].
+/// Either [`OpTxEnvelope`] or [`TxPayment`].
 #[derive(Debug, Clone, TransactionEnvelope)]
 #[envelope(tx_type_name = TxTypeCustom)]
 pub enum CustomTransaction {
@@ -29,166 +23,7 @@ pub enum CustomTransaction {
     Op(OpTxEnvelope),
     /// A [`TxPayment`] tagged with type 0x7E.
     #[envelope(ty = 42)]
-    Payment(CustomTransactionEnvelope),
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Hash, Eq, PartialEq)]
-pub struct CustomTransactionEnvelope {
-    pub inner: Signed<TxPayment>,
-}
-
-impl Transaction for CustomTransactionEnvelope {
-    fn chain_id(&self) -> Option<alloy_primitives::ChainId> {
-        self.inner.tx().chain_id()
-    }
-
-    fn nonce(&self) -> u64 {
-        self.inner.tx().nonce()
-    }
-
-    fn gas_limit(&self) -> u64 {
-        self.inner.tx().gas_limit()
-    }
-
-    fn gas_price(&self) -> Option<u128> {
-        self.inner.tx().gas_price()
-    }
-
-    fn max_fee_per_gas(&self) -> u128 {
-        self.inner.tx().max_fee_per_gas()
-    }
-
-    fn max_priority_fee_per_gas(&self) -> Option<u128> {
-        self.inner.tx().max_priority_fee_per_gas()
-    }
-
-    fn max_fee_per_blob_gas(&self) -> Option<u128> {
-        self.inner.tx().max_fee_per_blob_gas()
-    }
-
-    fn priority_fee_or_price(&self) -> u128 {
-        self.inner.tx().priority_fee_or_price()
-    }
-
-    fn effective_gas_price(&self, base_fee: Option<u64>) -> u128 {
-        self.inner.tx().effective_gas_price(base_fee)
-    }
-
-    fn is_dynamic_fee(&self) -> bool {
-        self.inner.tx().is_dynamic_fee()
-    }
-
-    fn kind(&self) -> revm_primitives::TxKind {
-        self.inner.tx().kind()
-    }
-
-    fn is_create(&self) -> bool {
-        false
-    }
-
-    fn value(&self) -> revm_primitives::U256 {
-        self.inner.tx().value()
-    }
-
-    fn input(&self) -> &Bytes {
-        // CustomTransactions have no input data
-        static EMPTY_BYTES: Bytes = Bytes::new();
-        &EMPTY_BYTES
-    }
-
-    fn access_list(&self) -> Option<&alloy_eips::eip2930::AccessList> {
-        self.inner.tx().access_list()
-    }
-
-    fn blob_versioned_hashes(&self) -> Option<&[B256]> {
-        self.inner.tx().blob_versioned_hashes()
-    }
-
-    fn authorization_list(&self) -> Option<&[alloy_eips::eip7702::SignedAuthorization]> {
-        self.inner.tx().authorization_list()
-    }
-}
-
-impl SignerRecoverable for CustomTransactionEnvelope {
-    fn recover_signer(&self) -> Result<Address, RecoveryError> {
-        let signature_hash = self.inner.signature_hash();
-        recover_signer(self.inner.signature(), signature_hash)
-    }
-
-    fn recover_signer_unchecked(&self) -> Result<Address, RecoveryError> {
-        let signature_hash = self.inner.signature_hash();
-        recover_signer_unchecked(self.inner.signature(), signature_hash)
-    }
-}
-
-impl SignedTransaction for CustomTransactionEnvelope {
-    fn tx_hash(&self) -> &TxHash {
-        self.inner.hash()
-    }
-}
-
-impl Typed2718 for CustomTransactionEnvelope {
-    fn ty(&self) -> u8 {
-        self.inner.tx().ty()
-    }
-}
-
-impl Decodable2718 for CustomTransactionEnvelope {
-    fn typed_decode(ty: u8, buf: &mut &[u8]) -> Eip2718Result<Self> {
-        Ok(Self { inner: Signed::<TxPayment>::typed_decode(ty, buf)? })
-    }
-
-    fn fallback_decode(buf: &mut &[u8]) -> Eip2718Result<Self> {
-        Ok(Self { inner: Signed::<TxPayment>::fallback_decode(buf)? })
-    }
-}
-
-impl Encodable2718 for CustomTransactionEnvelope {
-    fn encode_2718_len(&self) -> usize {
-        self.inner.encode_2718_len()
-    }
-
-    fn encode_2718(&self, out: &mut dyn BufMut) {
-        self.inner.encode_2718(out)
-    }
-}
-
-impl Decodable for CustomTransactionEnvelope {
-    fn decode(buf: &mut &[u8]) -> RlpResult<Self> {
-        let inner = Signed::<TxPayment>::decode_2718(buf)?;
-        Ok(CustomTransactionEnvelope { inner })
-    }
-}
-
-impl Encodable for CustomTransactionEnvelope {
-    fn encode(&self, out: &mut dyn BufMut) {
-        self.inner.tx().encode(out)
-    }
-}
-
-impl InMemorySize for CustomTransactionEnvelope {
-    fn size(&self) -> usize {
-        self.inner.tx().size()
-    }
-}
-
-impl FromTxCompact for CustomTransactionEnvelope {
-    type TxType = TxTypeCustom;
-
-    fn from_tx_compact(buf: &[u8], _tx_type: Self::TxType, signature: Signature) -> (Self, &[u8])
-    where
-        Self: Sized,
-    {
-        let (tx, buf) = TxPayment::from_compact(buf, buf.len());
-        let tx = Signed::new_unhashed(tx, signature);
-        (CustomTransactionEnvelope { inner: tx }, buf)
-    }
-}
-
-impl ToTxCompact for CustomTransactionEnvelope {
-    fn to_tx_compact(&self, buf: &mut (impl BufMut + AsMut<[u8]>)) {
-        self.inner.tx().to_compact(buf);
-    }
+    Payment(Signed<TxPayment>),
 }
 
 impl RlpBincode for CustomTransaction {}
@@ -197,7 +32,7 @@ impl reth_codecs::alloy::transaction::Envelope for CustomTransaction {
     fn signature(&self) -> &Signature {
         match self {
             CustomTransaction::Op(tx) => tx.signature(),
-            CustomTransaction::Payment(tx) => tx.inner.signature(),
+            CustomTransaction::Payment(tx) => tx.signature(),
         }
     }
 
@@ -218,12 +53,13 @@ impl FromTxCompact for CustomTransaction {
     {
         match tx_type {
             TxTypeCustom::Op(tx_type) => {
-                let (tx, len) = OpTxEnvelope::from_tx_compact(buf, tx_type, signature);
-                (Self::Op(tx), len)
+                let (tx, buf) = OpTxEnvelope::from_tx_compact(buf, tx_type, signature);
+                (Self::Op(tx), buf)
             }
             TxTypeCustom::Payment => {
-                let (tx, len) = CustomTransactionEnvelope::from_tx_compact(buf, tx_type, signature);
-                (Self::Payment(tx), len)
+                let (tx, buf) = TxPayment::from_compact(buf, buf.len());
+                let tx = Signed::new_unhashed(tx, signature);
+                (Self::Payment(tx), buf)
             }
         }
     }
@@ -233,7 +69,9 @@ impl ToTxCompact for CustomTransaction {
     fn to_tx_compact(&self, buf: &mut (impl BufMut + AsMut<[u8]>)) {
         match self {
             CustomTransaction::Op(tx) => tx.to_tx_compact(buf),
-            CustomTransaction::Payment(tx) => tx.to_tx_compact(buf),
+            CustomTransaction::Payment(tx) => {
+                tx.tx().to_compact(buf);
+            }
         }
     }
 }
@@ -251,28 +89,18 @@ impl Compact for CustomTransaction {
     }
 }
 
-impl OpTransaction for CustomTransactionEnvelope {
-    fn is_deposit(&self) -> bool {
-        false
-    }
-
-    fn as_deposit(&self) -> Option<&Sealed<TxDeposit>> {
-        None
-    }
-}
-
 impl OpTransaction for CustomTransaction {
     fn is_deposit(&self) -> bool {
         match self {
             CustomTransaction::Op(op) => op.is_deposit(),
-            CustomTransaction::Payment(payment) => payment.is_deposit(),
+            CustomTransaction::Payment(_) => false,
         }
     }
 
     fn as_deposit(&self) -> Option<&Sealed<TxDeposit>> {
         match self {
             CustomTransaction::Op(op) => op.as_deposit(),
-            CustomTransaction::Payment(payment) => payment.as_deposit(),
+            CustomTransaction::Payment(_) => None,
         }
     }
 }
@@ -297,7 +125,7 @@ impl SignedTransaction for CustomTransaction {
     fn tx_hash(&self) -> &B256 {
         match self {
             CustomTransaction::Op(tx) => SignedTransaction::tx_hash(tx),
-            CustomTransaction::Payment(tx) => SignedTransaction::tx_hash(tx),
+            CustomTransaction::Payment(tx) => tx.hash(),
         }
     }
 }


### PR DESCRIPTION
The `Signed<TxPayment>` is wrapped in `CustomTransactionEnvelope`.

Since `TxPayment` is already a custom type, there is no need to introduce the wrapper. Doing so increases the amount of traits that need to be reimplemented, increasing bloat and decreasing readability.