### PR TITLE
feat: bubble up `revm` feature flags via `revm-reth`

### DIFF
--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -62,9 +62,9 @@ optional-eip3541 = ["revm/optional_eip3541"]
 optional-eip3607 = ["revm/optional_eip3607"]
 optional-no-base-fee = ["revm/optional_no_base_fee"]
 optional-checks = [
-    "revm/optional_balance_check",
-    "revm/optional_block_gas_limit",
-    "revm/optional_eip3541",
-    "revm/optional_eip3607",
-    "revm/optional_no_base_fee",
+    "optional-balance-check",
+    "optional-block-gas-limit",
+    "optional-eip3541",
+    "optional-eip3607",
+    "optional-no-base-fee",
 ]

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -56,6 +56,11 @@ serde = [
     "reth-storage-api/serde",
 ]
 portable = ["revm/portable"]
+optional-balance-check = ["revm/optional_balance_check"]
+optional-block-gas-limit = ["revm/optional_block_gas_limit"]
+optional-eip3541 = ["revm/optional_eip3541"]
+optional-eip3607 = ["revm/optional_eip3607"]
+optional-no-base-fee = ["revm/optional_no_base_fee"]
 optional-checks = [
     "revm/optional_balance_check",
     "revm/optional_block_gas_limit",

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -56,3 +56,10 @@ serde = [
     "reth-storage-api/serde",
 ]
 portable = ["revm/portable"]
+optional-checks = [
+    "revm/optional_balance_check",
+    "revm/optional_block_gas_limit",
+    "revm/optional_eip3541",
+    "revm/optional_eip3607",
+    "revm/optional_no_base_fee",
+]


### PR DESCRIPTION
Closes #17895

This PR introduces feature flags for `revm-reth` to bubble up `revm` optional features.