### PR TITLE
docs(trie): document MDBX ordering assumptions in TrieWalker and Trie…

### DIFF
--- a/crates/rpc/rpc-eth-types/src/builder/config.rs
+++ b/crates/rpc/rpc-eth-types/src/builder/config.rs
@@ -37,7 +37,7 @@ impl std::str::FromStr for PendingBlockKind {
             "none" => Ok(Self::None),
             "full" => Ok(Self::Full),
             _ => Err(format!(
-                "Invalid pending block kind: {s}. Valid options are: empty, non-empty, latest"
+                 "Invalid pending block kind: {s}. Valid options are: empty, none, full"
             )),
         }
     }

--- a/crates/rpc/rpc-eth-types/src/builder/config.rs
+++ b/crates/rpc/rpc-eth-types/src/builder/config.rs
@@ -37,8 +37,7 @@ impl std::str::FromStr for PendingBlockKind {
             "none" => Ok(Self::None),
             "full" => Ok(Self::Full),
             _ => Err(format!(
-                "Invalid pending block kind: {}. Valid options are: empty, none, full",
-                s
+                "Invalid pending block kind: {s}. Valid options are: empty, non-empty, latest"
             )),
         }
     }

--- a/crates/rpc/rpc-eth-types/src/builder/config.rs
+++ b/crates/rpc/rpc-eth-types/src/builder/config.rs
@@ -37,7 +37,7 @@ impl std::str::FromStr for PendingBlockKind {
             "none" => Ok(Self::None),
             "full" => Ok(Self::Full),
             _ => Err(format!(
-                 "Invalid pending block kind: {s}. Valid options are: empty, none, full"
+                "Invalid pending block kind: {s}. Valid options are: empty, none, full"
             )),
         }
     }

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -43,18 +43,13 @@ struct SeekedHashedEntry<V> {
     result: Option<(B256, V)>,
 }
 
-/// `TrieNodeIter` iterates over existing intermediate branch nodes (via `TrieWalker`)
-/// and updated leaf nodes (via the `Hashed` table).
-///
-/// ## Important
-/// - The `Hashed` table in MDBX stores keys by their **Keccak256 hash**, not
-///   lexicographically.
-/// - Iteration depends on being able to seek entries in this hashed order.
-/// - Proof fetching relies on lexicographic traversal (`TrieWalker`), while
-///   hash building requires combining this with hashed table lookups.
-///
-/// These assumptions about MDBX key ordering must hold for proofs and
-/// hashing to be correct.
+/// TrieNodeIter assumes that MDBX allows seeking into the hashed trie table
+/// and iterating from that point in lexicographic order of the hashed keys.
+/// Hash building requires combining sequential trie traversal with lookups
+/// into this hashed table. The correctness of this process depends on the
+/// cursor guaranteeing stable lexicographic ordering, so that iteration
+/// over hashed entries matches the trie’s traversal order. If ordering
+/// diverged, node hashes would be computed incorrectly.
 #[derive(Debug)]
 pub struct TrieNodeIter<C, H: HashedCursor> {
     /// The walker over intermediate nodes.

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -43,13 +43,12 @@ struct SeekedHashedEntry<V> {
     result: Option<(B256, V)>,
 }
 
-/// TrieNodeIter assumes that MDBX allows seeking into the hashed trie table
-/// and iterating from that point in lexicographic order of the hashed keys.
-/// Hash building requires combining sequential trie traversal with lookups
-/// into this hashed table. The correctness of this process depends on the
-/// cursor guaranteeing stable lexicographic ordering, so that iteration
-/// over hashed entries matches the trie’s traversal order. If ordering
-/// diverged, node hashes would be computed incorrectly.
+/// Iterates over trie nodes for hash building.
+///
+/// This iterator depends on the ordering guarantees of [`TrieCursor`],
+/// and additionally uses hashed cursor lookups when operating on storage tries.
+
+
 #[derive(Debug)]
 pub struct TrieNodeIter<C, H: HashedCursor> {
     /// The walker over intermediate nodes.

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -43,7 +43,18 @@ struct SeekedHashedEntry<V> {
     result: Option<(B256, V)>,
 }
 
-/// An iterator over existing intermediate branch nodes and updated leaf nodes.
+/// `TrieNodeIter` iterates over existing intermediate branch nodes (via `TrieWalker`)
+/// and updated leaf nodes (via the `Hashed` table).
+///
+/// ## Important
+/// - The `Hashed` table in MDBX stores keys by their **Keccak256 hash**, not
+///   lexicographically.
+/// - Iteration depends on being able to seek entries in this hashed order.
+/// - Proof fetching relies on lexicographic traversal (`TrieWalker`), while
+///   hash building requires combining this with hashed table lookups.
+///
+/// These assumptions about MDBX key ordering must hold for proofs and
+/// hashing to be correct.
 #[derive(Debug)]
 pub struct TrieNodeIter<C, H: HashedCursor> {
     /// The walker over intermediate nodes.

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -48,7 +48,6 @@ struct SeekedHashedEntry<V> {
 /// This iterator depends on the ordering guarantees of [`TrieCursor`],
 /// and additionally uses hashed cursor lookups when operating on storage tries.
 
-
 #[derive(Debug)]
 pub struct TrieNodeIter<C, H: HashedCursor> {
     /// The walker over intermediate nodes.
@@ -216,7 +215,7 @@ where
                             *key,
                             self.walker.hash().unwrap(),
                             self.walker.children_are_in_trie(),
-                        ))))
+                        ))));
                     }
                 }
             }
@@ -226,7 +225,7 @@ where
                 // Check if the walker's key is less than the key of the current hashed entry
                 if self.walker.key().is_some_and(|key| key < &Nibbles::unpack(hashed_key)) {
                     self.should_check_walker_key = false;
-                    continue
+                    continue;
                 }
 
                 // Set the next hashed entry as a leaf node and return
@@ -235,7 +234,7 @@ where
 
                 #[cfg(feature = "metrics")]
                 self.metrics.inc_leaf_nodes_returned();
-                return Ok(Some(TrieElement::Leaf(hashed_key, value)))
+                return Ok(Some(TrieElement::Leaf(hashed_key, value)));
             }
 
             // Handle seeking and advancing based on the previous hashed key
@@ -279,9 +278,9 @@ where
                     // the database, so the walker will advance to the branch node after it. Because
                     // of this, we need to check that the current walker key has a prefix of the key
                     // that we seeked to.
-                    if can_skip_node &&
-                        self.walker.key().is_some_and(|key| key.starts_with(&seek_prefix)) &&
-                        self.walker.children_are_in_trie()
+                    if can_skip_node
+                        && self.walker.key().is_some_and(|key| key.starts_with(&seek_prefix))
+                        && self.walker.children_are_in_trie()
                     {
                         trace!(
                             target: "trie::node_iter",
@@ -291,7 +290,7 @@ where
                         );
 
                         self.should_check_walker_key = false;
-                        continue
+                        continue;
                     }
 
                     self.current_hashed_entry = self.seek_hashed_entry(seek_key)?;

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -47,7 +47,6 @@ struct SeekedHashedEntry<V> {
 ///
 /// This iterator depends on the ordering guarantees of [`TrieCursor`],
 /// and additionally uses hashed cursor lookups when operating on storage tries.
-
 #[derive(Debug)]
 pub struct TrieNodeIter<C, H: HashedCursor> {
     /// The walker over intermediate nodes.
@@ -278,9 +277,9 @@ where
                     // the database, so the walker will advance to the branch node after it. Because
                     // of this, we need to check that the current walker key has a prefix of the key
                     // that we seeked to.
-                    if can_skip_node
-                        && self.walker.key().is_some_and(|key| key.starts_with(&seek_prefix))
-                        && self.walker.children_are_in_trie()
+                    if can_skip_node &&
+                        self.walker.key().is_some_and(|key| key.starts_with(&seek_prefix)) &&
+                        self.walker.children_are_in_trie()
                     {
                         trace!(
                             target: "trie::node_iter",

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -214,7 +214,7 @@ where
                             *key,
                             self.walker.hash().unwrap(),
                             self.walker.children_are_in_trie(),
-                        ))));
+                        ))))
                     }
                 }
             }
@@ -224,7 +224,7 @@ where
                 // Check if the walker's key is less than the key of the current hashed entry
                 if self.walker.key().is_some_and(|key| key < &Nibbles::unpack(hashed_key)) {
                     self.should_check_walker_key = false;
-                    continue;
+                    continue
                 }
 
                 // Set the next hashed entry as a leaf node and return
@@ -233,7 +233,7 @@ where
 
                 #[cfg(feature = "metrics")]
                 self.metrics.inc_leaf_nodes_returned();
-                return Ok(Some(TrieElement::Leaf(hashed_key, value)));
+                return Ok(Some(TrieElement::Leaf(hashed_key, value)))
             }
 
             // Handle seeking and advancing based on the previous hashed key
@@ -289,7 +289,7 @@ where
                         );
 
                         self.should_check_walker_key = false;
-                        continue;
+                        continue
                     }
 
                     self.current_hashed_entry = self.seek_hashed_entry(seek_key)?;

--- a/crates/trie/trie/src/trie_cursor/mod.rs
+++ b/crates/trie/trie/src/trie_cursor/mod.rs
@@ -35,25 +35,8 @@ pub trait TrieCursorFactory {
     ) -> Result<Self::StorageTrieCursor, DatabaseError>;
 }
 
-/// A cursor for navigating a trie that works with both Tables and `DupSort` tables.
-///
-/// # Ordering assumptions
-///
-/// MDBX stores keys in **lexicographic byte order**. The trie uses this property for
-/// traversal and proof construction:
-///
-/// - [`TrieWalker`] depends on lexicographic ordering to walk the trie in key order,
-///   which is required for proof fetching.
-/// - [`TrieNodeIter`] also relies on lexicographic ordering when iterating over nodes,
-///   but may additionally use hashed lookups for storage tries (see its own docs).
-///
-/// These behaviors are surfaced through the [`TrieCursor`] API. Implementations must
-/// preserve the underlying MDBX ordering guarantees when seeking, advancing, or reading
-/// entries.
-///
-/// Consumers of this trait (e.g. [`TrieWalker`], [`TrieNodeIter`]) can rely on this
-/// documented behavior instead of duplicating assumptions.
-
+/// A cursor for traversing stored trie nodes. The cursor must iterate over keys in
+/// lexicographical order.
 #[auto_impl::auto_impl(&mut, Box)]
 pub trait TrieCursor: Send + Sync {
     /// Move the cursor to the key and return if it is an exact match.

--- a/crates/trie/trie/src/trie_cursor/mod.rs
+++ b/crates/trie/trie/src/trie_cursor/mod.rs
@@ -35,7 +35,29 @@ pub trait TrieCursorFactory {
     ) -> Result<Self::StorageTrieCursor, DatabaseError>;
 }
 
+
 /// A cursor for navigating a trie that works with both Tables and `DupSort` tables.
+///
+/// # Ordering assumptions
+///
+/// MDBX stores keys in **lexicographic byte order**. The trie uses this property for
+/// traversal and proof construction:
+///
+/// - [`TrieWalker`] depends on lexicographic ordering to walk the trie in key order,
+///   which is required for proof fetching.
+/// - [`TrieNodeIter`] also relies on lexicographic ordering when iterating over nodes,
+///   but may additionally use hashed lookups for storage tries (see its own docs).
+///
+/// These behaviors are surfaced through the [`TrieCursor`] API. Implementations must
+/// preserve the underlying MDBX ordering guarantees when seeking, advancing, or reading
+/// entries.
+///
+/// Consumers of this trait (e.g. [`TrieWalker`], [`TrieNodeIter`]) can rely on this
+/// documented behavior instead of duplicating assumptions.
+
+
+
+
 #[auto_impl::auto_impl(&mut, Box)]
 pub trait TrieCursor: Send + Sync {
     /// Move the cursor to the key and return if it is an exact match.

--- a/crates/trie/trie/src/trie_cursor/mod.rs
+++ b/crates/trie/trie/src/trie_cursor/mod.rs
@@ -35,7 +35,6 @@ pub trait TrieCursorFactory {
     ) -> Result<Self::StorageTrieCursor, DatabaseError>;
 }
 
-
 /// A cursor for navigating a trie that works with both Tables and `DupSort` tables.
 ///
 /// # Ordering assumptions
@@ -54,9 +53,6 @@ pub trait TrieCursorFactory {
 ///
 /// Consumers of this trait (e.g. [`TrieWalker`], [`TrieNodeIter`]) can rely on this
 /// documented behavior instead of duplicating assumptions.
-
-
-
 
 #[auto_impl::auto_impl(&mut, Box)]
 pub trait TrieCursor: Send + Sync {

--- a/crates/trie/trie/src/walker.rs
+++ b/crates/trie/trie/src/walker.rs
@@ -10,12 +10,11 @@ use tracing::{instrument, trace};
 #[cfg(feature = "metrics")]
 use crate::metrics::WalkerMetrics;
 
-/// TrieWalker depends on the MDBX cursor iterating the trie table in strict
-/// lexicographic key order. This is critical because the physical ordering of
-/// keys in the DB must mirror the logical path order of the trie: walking the
-/// cursor yields the same sequence of nodes as walking the trie structure.
-/// Proof fetching assumes this alignment; without lexicographic ordering,
-/// traversed proofs would not correspond to actual trie paths.   
+/// Traverses the trie in lexicographic order.
+///
+/// This iterator depends on the ordering guarantees of [`TrieCursor`].
+
+  
 #[derive(Debug)]
 pub struct TrieWalker<C> {
     /// A mutable reference to a trie cursor instance used for navigating the trie.

--- a/crates/trie/trie/src/walker.rs
+++ b/crates/trie/trie/src/walker.rs
@@ -13,7 +13,6 @@ use crate::metrics::WalkerMetrics;
 /// Traverses the trie in lexicographic order.
 ///
 /// This iterator depends on the ordering guarantees of [`TrieCursor`].
-
 #[derive(Debug)]
 pub struct TrieWalker<C> {
     /// A mutable reference to a trie cursor instance used for navigating the trie.
@@ -316,8 +315,8 @@ impl<C: TrieCursor> TrieWalker<C> {
 
         // Check if the walker needs to backtrack to the previous level in the trie during its
         // traversal.
-        if subnode.position().is_last_child()
-            || (subnode.position().is_parent() && !allow_root_to_child_nibble)
+        if subnode.position().is_last_child() ||
+            (subnode.position().is_parent() && !allow_root_to_child_nibble)
         {
             self.stack.pop();
             self.move_to_next_sibling(false)?;

--- a/crates/trie/trie/src/walker.rs
+++ b/crates/trie/trie/src/walker.rs
@@ -10,21 +10,12 @@ use tracing::{instrument, trace};
 #[cfg(feature = "metrics")]
 use crate::metrics::WalkerMetrics;
 
-/// `TrieWalker` is a structure that enables traversal of a Merkle trie.
-/// 
-/// It allows moving through the trie in a depth-first manner, skipping certain branches
-/// if they have not changed. This is primarily used in **proof fetching** and other
-/// trie operations.
-///
-/// ## Important
-/// - `TrieWalker` navigates the `Trie` table stored in **MDBX**.
-/// - The `Trie` table stores keys in **lexicographic order** of path nibbles.
-/// - This ordering allows efficient prefix iteration and skipping of subtrees.
-/// - The implementation *assumes* this ordering; if MDBX changes its ordering
-///   guarantees, traversal logic would break.
-///
-/// In short: proof correctness depends on MDBX preserving lexicographic ordering
-/// for trie table keys.
+/// TrieWalker depends on the MDBX cursor iterating the trie table in strict
+/// lexicographic key order. This is critical because the physical ordering of
+/// keys in the DB must mirror the logical path order of the trie: walking the
+/// cursor yields the same sequence of nodes as walking the trie structure.
+/// Proof fetching assumes this alignment; without lexicographic ordering,
+/// traversed proofs would not correspond to actual trie paths.   
 #[derive(Debug)]
 pub struct TrieWalker<C> {
     /// A mutable reference to a trie cursor instance used for navigating the trie.

--- a/crates/trie/trie/src/walker.rs
+++ b/crates/trie/trie/src/walker.rs
@@ -11,8 +11,20 @@ use tracing::{instrument, trace};
 use crate::metrics::WalkerMetrics;
 
 /// `TrieWalker` is a structure that enables traversal of a Merkle trie.
+/// 
 /// It allows moving through the trie in a depth-first manner, skipping certain branches
-/// if they have not changed.
+/// if they have not changed. This is primarily used in **proof fetching** and other
+/// trie operations.
+///
+/// ## Important
+/// - `TrieWalker` navigates the `Trie` table stored in **MDBX**.
+/// - The `Trie` table stores keys in **lexicographic order** of path nibbles.
+/// - This ordering allows efficient prefix iteration and skipping of subtrees.
+/// - The implementation *assumes* this ordering; if MDBX changes its ordering
+///   guarantees, traversal logic would break.
+///
+/// In short: proof correctness depends on MDBX preserving lexicographic ordering
+/// for trie table keys.
 #[derive(Debug)]
 pub struct TrieWalker<C> {
     /// A mutable reference to a trie cursor instance used for navigating the trie.

--- a/crates/trie/trie/src/walker.rs
+++ b/crates/trie/trie/src/walker.rs
@@ -265,7 +265,7 @@ impl<C: TrieCursor> TrieWalker<C> {
         let Some((key, node)) = self.node(false)? else {
             // If no next node is found, clear the stack.
             self.stack.clear();
-            return Ok(());
+            return Ok(())
         };
 
         // Overwrite the root node's first nibble
@@ -284,7 +284,7 @@ impl<C: TrieCursor> TrieWalker<C> {
                 #[cfg(feature = "metrics")]
                 self.metrics.inc_out_of_order_subnode(1);
                 self.move_to_next_sibling(false)?;
-                return Ok(());
+                return Ok(())
             }
         }
 
@@ -320,13 +320,13 @@ impl<C: TrieCursor> TrieWalker<C> {
         {
             self.stack.pop();
             self.move_to_next_sibling(false)?;
-            return Ok(());
+            return Ok(())
         }
 
         subnode.inc_nibble();
 
         if subnode.node.is_none() {
-            return self.consume_node();
+            return self.consume_node()
         }
 
         // Find the next sibling with state.
@@ -334,11 +334,11 @@ impl<C: TrieCursor> TrieWalker<C> {
             let position = subnode.position();
             if subnode.state_flag() {
                 trace!(target: "trie::walker", ?position, "found next sibling with state");
-                return Ok(());
+                return Ok(())
             }
             if position.is_last_child() {
                 trace!(target: "trie::walker", ?position, "checked all siblings");
-                break;
+                break
             }
             subnode.inc_nibble();
         }

--- a/crates/trie/trie/src/walker.rs
+++ b/crates/trie/trie/src/walker.rs
@@ -14,7 +14,6 @@ use crate::metrics::WalkerMetrics;
 ///
 /// This iterator depends on the ordering guarantees of [`TrieCursor`].
 
-  
 #[derive(Debug)]
 pub struct TrieWalker<C> {
     /// A mutable reference to a trie cursor instance used for navigating the trie.
@@ -267,7 +266,7 @@ impl<C: TrieCursor> TrieWalker<C> {
         let Some((key, node)) = self.node(false)? else {
             // If no next node is found, clear the stack.
             self.stack.clear();
-            return Ok(())
+            return Ok(());
         };
 
         // Overwrite the root node's first nibble
@@ -286,7 +285,7 @@ impl<C: TrieCursor> TrieWalker<C> {
                 #[cfg(feature = "metrics")]
                 self.metrics.inc_out_of_order_subnode(1);
                 self.move_to_next_sibling(false)?;
-                return Ok(())
+                return Ok(());
             }
         }
 
@@ -317,18 +316,18 @@ impl<C: TrieCursor> TrieWalker<C> {
 
         // Check if the walker needs to backtrack to the previous level in the trie during its
         // traversal.
-        if subnode.position().is_last_child() ||
-            (subnode.position().is_parent() && !allow_root_to_child_nibble)
+        if subnode.position().is_last_child()
+            || (subnode.position().is_parent() && !allow_root_to_child_nibble)
         {
             self.stack.pop();
             self.move_to_next_sibling(false)?;
-            return Ok(())
+            return Ok(());
         }
 
         subnode.inc_nibble();
 
         if subnode.node.is_none() {
-            return self.consume_node()
+            return self.consume_node();
         }
 
         // Find the next sibling with state.
@@ -336,11 +335,11 @@ impl<C: TrieCursor> TrieWalker<C> {
             let position = subnode.position();
             if subnode.state_flag() {
                 trace!(target: "trie::walker", ?position, "found next sibling with state");
-                return Ok(())
+                return Ok(());
             }
             if position.is_last_child() {
                 trace!(target: "trie::walker", ?position, "checked all siblings");
-                break
+                break;
             }
             subnode.inc_nibble();
         }


### PR DESCRIPTION
PR Description
Summary

This PR adds documentation to TrieWalker and TrieNodeIter explaining the assumptions they rely on regarding MDBX key ordering.

Changes

Documented how:

Trie table keys are stored and traversed in lexicographic order.

Hashed table keys follow a different ordering.

Both interact when performing proof fetching and hash building.

Why

These assumptions were previously implicit in the code. Documenting them clarifies how iteration and traversal behave in relation to MDBX key ordering, making the trie implementation easier to understand and maintain.

Closes #17905 