### PR TITLE
fix: convert anchor() method from recursive to iterative

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -588,11 +588,11 @@ impl<N: NodePrimitives> BlockState<N> {
 
     /// Returns the hash and block of the on disk block this state can be traced back to.
     pub fn anchor(&self) -> BlockNumHash {
-        if let Some(parent) = &self.parent {
-            parent.anchor()
-        } else {
-            self.block.recovered_block().parent_num_hash()
+        let mut current = self;
+        while let Some(parent) = &current.parent {
+            current = parent;
         }
+        current.block.recovered_block().parent_num_hash()
     }
 
     /// Returns the executed block that determines the state.


### PR DESCRIPTION
Previously, the anchor() method used unbounded recursion when walking up the parent chain to find the disk anchor block. This could cause stack overflow for very long in-memory chains.

The method now uses an iterative approach with a while loop, eliminating the recursion and preventing potential stack overflow issues.