### PR TITLE
fix(ress/provider): return zero headers when request.limit == 0

### DIFF
--- a/crates/ress/protocol/src/provider.rs
+++ b/crates/ress/protocol/src/provider.rs
@@ -14,6 +14,9 @@ pub trait RessProtocolProvider: Send + Sync {
 
     /// Return block headers.
     fn headers(&self, request: GetHeaders) -> ProviderResult<Vec<Header>> {
+        if request.limit == 0 {
+            return Ok(Vec::new());
+        }
         let mut total_bytes = 0;
         let mut block_hash = request.start_hash;
         let mut headers = Vec::new();


### PR DESCRIPTION
Reason: The README specifies “up to limit” headers. With limit == 0, the previous implementation still returned one header due to pushing before checking the limit, which violates the spec and is inconsistent with other paths.

Goal: Align RessProtocolProvider::headers behavior with the protocol documentation and with other implementations (e.g., file client and eth requests) that yield zero headers for a zero limit, avoiding over-fetching and surprising API semantics.

Change: Add an early return Ok(Vec::new()) when request.limit == 0. Other limits (MAX_HEADERS_SERVE, SOFT_RESPONSE_LIMIT) remain unchanged.

Impact: Correctness improvement for the edge case only; no API or behavior changes for non-zero limits. Tests pass.