### PR TITLE
chore: fix clippy in nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1754549159,
-        "narHash": "sha256-47e1Ar09kZlv2HvZilaNRFzRybIiJYNQ2MSvofbiw5o=",
+        "lastModified": 1755499663,
+        "narHash": "sha256-OxHGov+A4qR4kpO3e1I3LFR78IAKvDFnWoWsDWvFhKU=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "5fe110751342a023d8c7ddce7fbf8311dca9f58d",
+        "rev": "d1ff4457857ad551e8d6c7c79324b44fac518b8b",
         "type": "github"
       },
       "original": {
@@ -63,11 +63,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1754496778,
-        "narHash": "sha256-fPDLP3z9XaYQBfSCemEdloEONz/uPyr35RHPRy9Vx8M=",
+        "lastModified": 1755004716,
+        "narHash": "sha256-TbhPR5Fqw5LjAeI3/FOPhNNFQCF3cieKCJWWupeZmiA=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "529d3b935d68bdf9120fe4d7f8eded7b56271697",
+        "rev": "b2a58b8c6eff3c3a2c8b5c70dbf69ead78284194",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -34,10 +34,9 @@
 
         cargoTOML = builtins.fromTOML (builtins.readFile ./Cargo.toml);
         packageVersion = cargoTOML.workspace.package.version;
-        rustVersion = cargoTOML.workspace.package."rust-version";
 
         rustStable = fenix.packages.${system}.stable.withComponents [
-          "cargo" "rustc" "rust-src"
+          "cargo" "rustc" "rust-src" "clippy"
         ];
 
         rustNightly = fenix.packages.${system}.latest;
@@ -118,7 +117,6 @@
         in craneLib.devShell (composeAttrOverrides {
           packages = nativeBuildInputs ++ [
             rustNightly.rust-analyzer
-            rustNightly.clippy
             rustNightly.rustfmt
           ];
         } overrides);


### PR DESCRIPTION
Previously we would get errors like:

```
error[E0514]: found crate `colorchoice` compiled by an incompatible version of rustc
  --> /home/mediocregopher/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/anstream-0.6.20/src/lib.rs:86:9
   |
86 | pub use colorchoice::ColorChoice;
   |         ^^^^^^^^^^^
   |
   = note: the following crate versions were found:
           crate `colorchoice` compiled by <unknown rustc version>: /home/mediocregopher/src/ithaca/reth/target/debug/deps/libcolorchoice-1c33225c2be24026.rmeta
   = help: please recompile that crate using this compiler (rustc 1.88.0 (6b00bc388 2025-06-23)) (consider running `cargo clean` first)
```

This forces us to use a stable clippy version, rather than nightly, but it's better than not working at all.