### PR TITLE
fix(optimism): correct string formatting in error message

### DIFF
--- a/crates/optimism/rpc/src/eth/mod.rs
+++ b/crates/optimism/rpc/src/eth/mod.rs
@@ -375,7 +375,7 @@ where
             Some(
                 SequencerClient::new_with_headers(&url, sequencer_headers)
                     .await
-                    .wrap_err_with(|| "Failed to init sequencer client with: {url}")?,
+                    .wrap_err_with(|| format!("Failed to init sequencer client with: {url}"))?,
             )
         } else {
             None


### PR DESCRIPTION
The error message contains `{url}` but uses closure syntax instead of proper string formatting. This will literally print `{url}` instead of the actual URL value.

This fix uses `format!` macro to properly interpolate url.