### PR TITLE
fix(trie): replace rayon with tokio for I/O operations in parallel trie

### DIFF
--- a/crates/storage/provider/src/providers/consistent_view.rs
+++ b/crates/storage/provider/src/providers/consistent_view.rs
@@ -41,7 +41,7 @@ where
         Ok(Self::new(provider, tip))
     }
 
-    /// Creates new read-only provider and performs consistency checks on the current tip.
+    /// Creates new read-only handle to the database and performs consistency checks on the current tip.
     pub fn provider_ro(&self) -> ProviderResult<Factory::Provider> {
         // Create a new provider.
         let provider_ro = self.factory.database_provider_ro()?;

--- a/crates/storage/provider/src/providers/consistent_view.rs
+++ b/crates/storage/provider/src/providers/consistent_view.rs
@@ -41,7 +41,7 @@ where
         Ok(Self::new(provider, tip))
     }
 
-    /// Creates new read-only handle to the database and performs consistency checks on the current tip.
+    /// Creates new read-only provider and performs consistency checks on the current tip.
     pub fn provider_ro(&self) -> ProviderResult<Factory::Provider> {
         // Create a new provider.
         let provider_ro = self.factory.database_provider_ro()?;

--- a/crates/trie/parallel/Cargo.toml
+++ b/crates/trie/parallel/Cargo.toml
@@ -34,7 +34,7 @@ thiserror.workspace = true
 derive_more.workspace = true
 rayon.workspace = true
 itertools.workspace = true
-tokio = { workspace = true, features = ["rt"] }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
 
 # `metrics` feature
 reth-metrics = { workspace = true, optional = true }

--- a/crates/trie/parallel/Cargo.toml
+++ b/crates/trie/parallel/Cargo.toml
@@ -34,7 +34,7 @@ thiserror.workspace = true
 derive_more.workspace = true
 rayon.workspace = true
 itertools.workspace = true
-tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 # `metrics` feature
 reth-metrics = { workspace = true, optional = true }

--- a/crates/trie/parallel/src/root.rs
+++ b/crates/trie/parallel/src/root.rs
@@ -82,7 +82,7 @@ where
     }
 
     /// Computes the state root by calculating storage roots in parallel for modified accounts,
-    /// then walking the state trie to build the final root hash.
+    /// then walking the state trie to build the final state root hash.
     fn calculate(
         self,
         retain_updates: bool,

--- a/crates/trie/parallel/src/root.rs
+++ b/crates/trie/parallel/src/root.rs
@@ -111,8 +111,7 @@ where
 
             let (tx, rx) = mpsc::sync_channel(1);
 
-            // Spawn a blocking task to calculate this account's storage root from database I/O
-            // while the main thread continues processing other accounts in parallel
+            // Spawn a blocking task to calculate account's storage root from database I/O
             let handle = get_runtime_handle();
             drop(handle.spawn_blocking(move || {
                 let result = (|| -> Result<_, ParallelStateRootError> {

--- a/crates/trie/parallel/src/root.rs
+++ b/crates/trie/parallel/src/root.rs
@@ -33,6 +33,10 @@ use tracing::*;
 /// it needs to rely on database state saying the same until
 /// the last transaction is open.
 /// See docs of using [`ConsistentDbView`] for caveats.
+///
+/// Note: This implementation only serves as a fallback for the sparse trie-based
+/// state root calculation. The sparse trie approach is more efficient as it avoids traversing
+/// the entire trie, only operating on the modified parts.
 #[derive(Debug)]
 pub struct ParallelStateRoot<Factory> {
     /// Consistent view of the database.

--- a/crates/trie/parallel/src/root.rs
+++ b/crates/trie/parallel/src/root.rs
@@ -111,7 +111,7 @@ where
 
             let (tx, rx) = mpsc::sync_channel(1);
 
-            // Use tokio blocking pool for I/O operations
+            // Use tokio blocking pool for database operations
             let handle = get_runtime_handle();
             drop(handle.spawn_blocking(move || {
                 let result = (|| -> Result<_, ParallelStateRootError> {

--- a/crates/trie/parallel/src/root.rs
+++ b/crates/trie/parallel/src/root.rs
@@ -111,7 +111,8 @@ where
 
             let (tx, rx) = mpsc::sync_channel(1);
 
-            // Use tokio blocking pool for database operations
+            // Spawn a blocking task to calculate this account's storage root from database I/O
+            // while the main thread continues processing other accounts in parallel
             let handle = get_runtime_handle();
             drop(handle.spawn_blocking(move || {
                 let result = (|| -> Result<_, ParallelStateRootError> {


### PR DESCRIPTION
Fixes #17288

## Summary

Replaces `rayon::spawn_fifo` with `tokio::task::spawn_blocking` for database I/O operations in parallel trie computation. Rayon's CPU-bound thread pool was incorrectly used for I/O-heavy operations, causing thread pool starvation.

## Changes

- Replace `rayon::spawn_fifo` with `tokio::task::spawn_blocking` in `calculate()`
- Add `get_runtime_handle()` helper that creates runtime if not in Tokio context (e.g., Tree Task thread)
- Use fire-and-forget pattern with channels for result communication