### PR TITLE
Igor/feat/force fcu return rebased

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -720,10 +720,29 @@ where
         let new_head_number = canonical_header.number();
         let new_head_hash = canonical_header.hash();
 
-        // Detect and log the type of chain state update
+        // Log the type of chain state update being performed
+        self.log_chain_update_type(current_head_number, new_head_number, new_head_hash);
+
+        // Update tree state with the new canonical head
+        self.state.tree_state.set_canonical_head(canonical_header.num_hash());
+
+        // Handle the state update based on whether this is an unwind scenario
+        if new_head_number < current_head_number {
+            self.handle_chain_unwind(current_head_number, canonical_header)
+        } else {
+            self.handle_chain_advance_or_same_height(canonical_header)
+        }
+    }
+
+    /// Logs the type of chain state update being performed.
+    fn log_chain_update_type(
+        &self,
+        current_head_number: u64,
+        new_head_number: u64,
+        new_head_hash: B256,
+    ) {
         match new_head_number.cmp(&current_head_number) {
             std::cmp::Ordering::Less => {
-                // Unwind scenario: we're reverting to an earlier canonical block
                 debug!(
                     target: "engine::tree",
                     current_head = current_head_number,
@@ -733,7 +752,6 @@ where
                 );
             }
             std::cmp::Ordering::Greater => {
-                // Forward progress: updating to a later canonical block
                 debug!(
                     target: "engine::tree",
                     previous_head = current_head_number,
@@ -743,7 +761,6 @@ where
                 );
             }
             std::cmp::Ordering::Equal => {
-                // Same block number, potentially different hash (shouldn't normally happen)
                 debug!(
                     target: "engine::tree",
                     head_number = new_head_number,
@@ -752,39 +769,154 @@ where
                 );
             }
         }
+    }
 
-        // Update tree state
-        self.state.tree_state.set_canonical_head(canonical_header.num_hash());
+    /// Handles chain unwind scenarios by collecting blocks to remove and performing a reorg.
+    fn handle_chain_unwind(
+        &mut self,
+        current_head_number: u64,
+        canonical_header: &SealedHeader<N::BlockHeader>,
+    ) -> ProviderResult<()> {
+        let new_head_number = canonical_header.number();
+        let new_head_hash = canonical_header.hash();
 
-        // CRITICAL: Load the canonical ancestor's block into memory to ensure
-        // state provider can access it. Without this, the state provider will
-        // fall back to stale database state causing "nonce too low" errors.
+        debug!(
+            target: "engine::tree",
+            from = current_head_number,
+            to = new_head_number,
+            "Handling unwind: collecting blocks to remove from in-memory state"
+        );
 
-        // For now, just update the canonical head header
-        // A more complete fix would load the block state into memory,
-        // but that requires handling the reorg properly (removing higher blocks)
-        self.canonical_in_memory_state.set_canonical_head(canonical_header.clone());
+        // Collect blocks that need to be removed from memory
+        let old_blocks = self.collect_blocks_for_removal(new_head_number, current_head_number);
 
-        // Try to load the block if available (for debugging/logging)
-        if let Some(_executed_block) = self.canonical_block_by_hash(new_head_hash)? {
+        // Load and apply the canonical ancestor block
+        self.apply_canonical_ancestor_via_reorg(canonical_header, old_blocks)
+    }
+
+    /// Collects blocks from memory that need to be removed during an unwind.
+    fn collect_blocks_for_removal(
+        &self,
+        new_head_number: u64,
+        current_head_number: u64,
+    ) -> Vec<ExecutedBlock<N>> {
+        let mut old_blocks = Vec::new();
+        let mut found_blocks_to_remove = false;
+
+        for block_num in (new_head_number + 1)..=current_head_number {
+            if let Some(block_state) = self.canonical_in_memory_state.state_by_number(block_num) {
+                let executed_block = block_state.block_ref().block.clone();
+                old_blocks.push(executed_block);
+                found_blocks_to_remove = true;
+                debug!(
+                    target: "engine::tree",
+                    block_number = block_num,
+                    "Collected block for removal from in-memory state"
+                );
+            }
+        }
+
+        if !found_blocks_to_remove {
             debug!(
                 target: "engine::tree",
-                block_number = new_head_number,
-                block_hash = ?new_head_hash,
-                "Found canonical ancestor block (but not loading into memory yet)"
+                "No blocks found in memory to remove, will clear and reset state"
             );
+        }
 
-            // TODO: To properly fix the state issue, we need to:
-            // 1. Remove blocks higher than canonical ancestor from in-memory state
-            // 2. Load the canonical ancestor's state into memory
-            // 3. Update as a reorg rather than a commit
-            // This requires more complex handling of the in-memory state
-        } else {
-            warn!(
-                target: "engine::tree",
-                block_hash = ?new_head_hash,
-                "Could not find canonical ancestor block"
-            );
+        old_blocks
+    }
+
+    /// Applies the canonical ancestor block via a reorg operation.
+    fn apply_canonical_ancestor_via_reorg(
+        &mut self,
+        canonical_header: &SealedHeader<N::BlockHeader>,
+        old_blocks: Vec<ExecutedBlock<N>>,
+    ) -> ProviderResult<()> {
+        let new_head_hash = canonical_header.hash();
+        let new_head_number = canonical_header.number();
+
+        // Try to load the canonical ancestor's block
+        match self.canonical_block_by_hash(new_head_hash)? {
+            Some(executed_block) => {
+                let block_with_trie = ExecutedBlockWithTrieUpdates {
+                    block: executed_block,
+                    trie: ExecutedTrieUpdates::Missing,
+                };
+
+                // Perform the reorg to properly handle the unwind
+                self.canonical_in_memory_state.update_chain(NewCanonicalChain::Reorg {
+                    new: vec![block_with_trie],
+                    old: old_blocks,
+                });
+
+                // CRITICAL: Update the canonical head after the reorg
+                // This ensures get_canonical_head() returns the correct block
+                self.canonical_in_memory_state.set_canonical_head(canonical_header.clone());
+
+                debug!(
+                    target: "engine::tree",
+                    block_number = new_head_number,
+                    block_hash = ?new_head_hash,
+                    "Successfully loaded canonical ancestor into memory via reorg"
+                );
+            }
+            None => {
+                // Fallback: update header only if block cannot be found
+                warn!(
+                    target: "engine::tree",
+                    block_hash = ?new_head_hash,
+                    "Could not find canonical ancestor block, updating header only"
+                );
+                self.canonical_in_memory_state.set_canonical_head(canonical_header.clone());
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Handles chain advance or same height scenarios.
+    fn handle_chain_advance_or_same_height(
+        &mut self,
+        canonical_header: &SealedHeader<N::BlockHeader>,
+    ) -> ProviderResult<()> {
+        let new_head_number = canonical_header.number();
+        let new_head_hash = canonical_header.hash();
+
+        // Update the canonical head header
+        self.canonical_in_memory_state.set_canonical_head(canonical_header.clone());
+
+        // Load the block into memory if it's not already present
+        self.ensure_block_in_memory(new_head_number, new_head_hash)
+    }
+
+    /// Ensures a block is loaded into memory if not already present.
+    fn ensure_block_in_memory(
+        &mut self,
+        block_number: u64,
+        block_hash: B256,
+    ) -> ProviderResult<()> {
+        // Check if block is already in memory
+        if self.canonical_in_memory_state.state_by_number(block_number).is_some() {
+            return Ok(());
+        }
+
+        // Try to load the block from storage
+        if let Some(executed_block) = self.canonical_block_by_hash(block_hash)? {
+            let block_with_trie = ExecutedBlockWithTrieUpdates {
+                block: executed_block,
+                trie: ExecutedTrieUpdates::Missing,
+            };
+
+            self.canonical_in_memory_state
+                .update_chain(NewCanonicalChain::Commit { new: vec![block_with_trie] });
+
+            debug!(
+            >>>>>>> 3dc92322b (fix: Properly handle unwinds in forkchoiceUpdated)
+                            target: "engine::tree",
+                            block_number,
+                            block_hash = ?block_hash,
+                            "Added canonical block to in-memory state"
+                        );
         }
 
         Ok(())

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -23,6 +23,7 @@ use std::{
     str::FromStr,
     sync::mpsc::{channel, Sender},
 };
+use tokio::sync::oneshot;
 
 /// Mock engine validator for tests
 #[derive(Debug, Clone)]
@@ -866,4 +867,91 @@ async fn test_engine_tree_live_sync_transition_required_blocks_requested() {
         }
         _ => panic!("Unexpected event: {event:#?}"),
     }
+}
+
+#[tokio::test]
+async fn test_fcu_with_canonical_ancestor_updates_latest_block() {
+    // Test for issue where FCU with canonical ancestor doesn't update Latest block state
+    // This was causing "nonce too low" errors when discard_reorged_transactions is enabled
+    
+    reth_tracing::init_test_tracing();
+    let chain_spec = MAINNET.clone();
+    
+    // Create test harness
+    let mut test_harness = TestHarness::new(chain_spec.clone());
+    
+    // Set engine kind to OpStack to ensure the fix is triggered
+    test_harness.tree.engine_kind = EngineApiKind::OpStack;
+    let mut test_block_builder = TestBlockBuilder::eth().with_chain_spec((*chain_spec).clone());
+    
+    // Create a chain of blocks
+    let blocks: Vec<_> = test_block_builder.get_executed_blocks(1..5).collect();
+    test_harness = test_harness.with_blocks(blocks.clone());
+    
+    // Set block 4 as the current canonical head
+    let current_head = blocks[3].recovered_block().clone(); // Block 4 (0-indexed as blocks[3])
+    let current_head_sealed = current_head.clone_sealed_header();
+    test_harness.tree.state.tree_state.set_canonical_head(current_head.num_hash());
+    test_harness.tree.canonical_in_memory_state.set_canonical_head(current_head_sealed);
+    
+    // Verify the current head is set correctly
+    assert_eq!(
+        test_harness.tree.state.tree_state.canonical_block_number(),
+        current_head.number()
+    );
+    assert_eq!(
+        test_harness.tree.state.tree_state.canonical_block_hash(),
+        current_head.hash()
+    );
+    
+    // Now perform FCU to a canonical ancestor (block 2)
+    let ancestor_block = blocks[1].recovered_block().clone(); // Block 2 (0-indexed as blocks[1])
+    
+    // Send FCU to the canonical ancestor
+    let (tx, rx) = oneshot::channel();
+    test_harness
+        .tree
+        .on_engine_message(FromEngine::Request(
+            BeaconEngineMessage::ForkchoiceUpdated {
+                state: ForkchoiceState {
+                    head_block_hash: ancestor_block.hash(),
+                    safe_block_hash: B256::ZERO,
+                    finalized_block_hash: B256::ZERO,
+                },
+                payload_attrs: None,
+                tx,
+                version: EngineApiMessageVersion::default(),
+            }
+            .into(),
+        ))
+        .unwrap();
+    
+    // Verify FCU succeeds
+    let response = rx.await.unwrap().unwrap().await.unwrap();
+    assert!(response.payload_status.is_valid());
+    
+    // The critical test: verify that Latest block has been updated to the canonical ancestor
+    // Check tree state
+    assert_eq!(
+        test_harness.tree.state.tree_state.canonical_block_number(),
+        ancestor_block.number(),
+        "Tree state: Latest block number should be updated to canonical ancestor"
+    );
+    assert_eq!(
+        test_harness.tree.state.tree_state.canonical_block_hash(),
+        ancestor_block.hash(),
+        "Tree state: Latest block hash should be updated to canonical ancestor"
+    );
+    
+    // Also verify canonical in-memory state is synchronized
+    assert_eq!(
+        test_harness.tree.canonical_in_memory_state.get_canonical_head().number,
+        ancestor_block.number(),
+        "In-memory state: Latest block number should be updated to canonical ancestor"
+    );
+    assert_eq!(
+        test_harness.tree.canonical_in_memory_state.get_canonical_head().hash(),
+        ancestor_block.hash(),
+        "In-memory state: Latest block hash should be updated to canonical ancestor"
+    );
 }


### PR DESCRIPTION
Fix FCU when new head is an ancestor (unwind). Previously we only updated the header, leaving in-memory canonical state stale, causing tx validation issues (e.g., "nonce too low"). Now we detect unwind, reorg in-memory state (remove old blocks, load ancestor), and keep TreeState and CanonicalInMemoryState in sync.

## Code Changes
-  tree/mod.rs:
  - Add: `log_chain_update_type`, `handle_chain_unwind`, `collect_blocks_for_removal`, `apply_canonical_ancestor_via_reorg`, `handle_chain_advance_or_same_height`, `ensure_block_in_memory`.
  - Replace header-only update with:
    ```rust
    self.log_chain_update_type(...);
    self.state.tree_state.set_canonical_head(canonical_header.num_hash());
    if new_head_number < current_head_number {
        self.handle_chain_unwind(current_head_number, canonical_header)
    } else {
        self.handle_chain_advance_or_same_height(canonical_header)
    }
    ```
  - Reorg on unwind:
    ```rust
    self.canonical_in_memory_state.update_chain(NewCanonicalChain::Reorg { new, old });
    self.canonical_in_memory_state.set_canonical_head(canonical_header.clone());
    ```
  - Advance/same-height: ensure block committed into memory if missing.
  - Interim method `update_latest_block_to_canonical_ancestor` added, then superseded by full unwind handling.
-  tree/tests.rs:
  - New test `test_fcu_with_canonical_ancestor_updates_latest_block` asserting both TreeState and in-memory head match the ancestor after FCU.

## Reason for Changes
Correctness: prevent stale in-memory state on reorgs that led to txpool/state provider errors.

## Impact of Changes
-  Correct state after unwinds; eliminate nonce/state desync errors.
-  Low overhead; clearer logging.

## Test Plan
-  Run: `cargo test -p engine_tree test_fcu_with_canonical_ancestor_updates_latest_block`.

## How the reviewer should test the fix
-  Unwind: head=4 → FCU to 2; verify removal of [3,4] and head=2 in both states.
-  Advance: head=2 → FCU to 3; verify block 3 committed and head updated.
-  Check logs for correct classification.

## Other useful info
If ancestor block missing from storage, we warn and still update header to avoid desync.

Closes https://github.com/paradigmxyz/reth/issues/17798