### PR TITLE
feat(rpc): Add `EvmEnvConverter` for custom effects on the `EvmEnv`

### DIFF
--- a/crates/rpc/rpc-convert/src/evm.rs
+++ b/crates/rpc/rpc-convert/src/evm.rs
@@ -1,0 +1,34 @@
+use reth_evm::EvmEnv;
+use std::{convert::Infallible, fmt::Debug};
+
+/// Performs an [`EvmEnv`] to [`EvmEnv`] conversion accompanied by the `TxReq`.
+///
+/// The `TxReq` represents the transaction request this [`EvmEnv`] has been created for.
+///
+/// Allows for custom effects on the [`EvmEnv`]. Default implementation `()` passes the input
+/// argument with no change.
+pub trait EvmEnvConverter<TxReq>: Clone + Debug + Unpin + Send + Sync + 'static {
+    /// An associated error that can occur during the conversion.
+    type Err;
+
+    /// Performs the conversion.
+    ///
+    /// See [`EvmEnvConverter`] for more details.
+    fn convert_evm_env<Spec>(
+        &self,
+        request: &TxReq,
+        evm_env: EvmEnv<Spec>,
+    ) -> Result<EvmEnv<Spec>, Self::Err>;
+}
+
+impl<TxReq> EvmEnvConverter<TxReq> for () {
+    type Err = Infallible;
+
+    fn convert_evm_env<Spec>(
+        &self,
+        _request: &TxReq,
+        evm_env: EvmEnv<Spec>,
+    ) -> Result<EvmEnv<Spec>, Self::Err> {
+        Ok(evm_env)
+    }
+}

--- a/crates/rpc/rpc-convert/src/lib.rs
+++ b/crates/rpc/rpc-convert/src/lib.rs
@@ -11,12 +11,14 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 pub mod block;
+mod evm;
 mod fees;
 pub mod receipt;
 mod rpc;
 pub mod transaction;
 
 pub use block::TryFromBlockResponse;
+pub use evm::EvmEnvConverter;
 pub use fees::{CallFees, CallFeesError};
 pub use receipt::TryFromReceiptResponse;
 pub use rpc::*;

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -760,6 +760,7 @@ pub trait Call:
         }
 
         let request_gas = request.as_ref().gas_limit();
+        evm_env = self.tx_resp_builder().evm_env(&request, evm_env)?;
         let mut tx_env = self.create_txn_env(&evm_env, request, &mut *db)?;
 
         // lower the basefee to 0 to avoid breaking EVM invariants (basefee < gasprice): <https://github.com/ethereum/go-ethereum/blob/355228b011ef9a85ebc0f21e7196f892038d49f0/internal/ethapi/api.go#L700-L704>


### PR DESCRIPTION
Closes #17935

Adds a new converter to `RpcConvert` that can apply custom effects on the `EvmEnv`.

The conversion is `EvmEnv` -> `EvmEnv` meaning there is no different type at the output.
