### PR TITLE
feat: Add transaction propagation kind 'None'

### DIFF
--- a/crates/net/network/src/transactions/config.rs
+++ b/crates/net/network/src/transactions/config.rs
@@ -125,6 +125,8 @@ pub enum TransactionPropagationKind {
     All,
     /// Propagate transactions to only trusted peers.
     Trusted,
+    /// Do not propagate transactions
+    None,
 }
 
 impl TransactionPropagationPolicy for TransactionPropagationKind {
@@ -132,6 +134,7 @@ impl TransactionPropagationPolicy for TransactionPropagationKind {
         match self {
             Self::All => true,
             Self::Trusted => peer.peer_kind.is_trusted(),
+            Self::None => false,
         }
     }
 
@@ -147,6 +150,7 @@ impl FromStr for TransactionPropagationKind {
         match s {
             "All" | "all" => Ok(Self::All),
             "Trusted" | "trusted" => Ok(Self::Trusted),
+            "None" | "none" => Ok(Self::None),
             _ => Err(format!("Invalid transaction propagation policy: {s}")),
         }
     }


### PR DESCRIPTION
We need to have a way to ensure that node won't leak any txs, while preserving option to receive transaction trough p2p.
Right now we are using `--rollup.disable-tx-pool-gossip` but this disables all gossiping, including incoming txs.