### PR TITLE
feat(txpool): add disable balance check flag on ingress

### DIFF
--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -472,6 +472,7 @@ where
             .with_max_tx_gas_limit(ctx.config().txpool.max_tx_gas_limit)
             .with_minimum_priority_fee(ctx.config().txpool.minimum_priority_fee)
             .with_additional_tasks(ctx.config().txpool.additional_validation_tasks)
+            .with_disable_balance_check(ctx.config().txpool.disable_balance_check)
             .build_with_tasks(ctx.task_executor().clone(), blob_store.clone());
 
         if validator.validator().eip4844() {

--- a/crates/node/core/src/args/txpool.rs
+++ b/crates/node/core/src/args/txpool.rs
@@ -79,6 +79,10 @@ pub struct TxPoolArgs {
     #[arg(long = "txpool.max-tx-gas")]
     pub max_tx_gas_limit: Option<u64>,
 
+    /// Disable balance checking for transactions entering the transaction pool
+    #[arg(long = "txpool.disable-balance-check")]
+    pub disable_balance_check: bool,
+
     /// Price bump percentage to replace an already existing blob transaction
     #[arg(long = "blobpool.pricebump", default_value_t = REPLACE_BLOB_PRICE_BUMP)]
     pub blob_transaction_price_bump: u128,
@@ -156,6 +160,7 @@ impl Default for TxPoolArgs {
             minimum_priority_fee: None,
             enforced_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
             max_tx_gas_limit: None,
+            disable_balance_check: false,
             blob_transaction_price_bump: REPLACE_BLOB_PRICE_BUMP,
             max_tx_input_bytes: DEFAULT_MAX_TX_INPUT_BYTES,
             max_cached_entries: DEFAULT_MAX_CACHED_BLOBS,

--- a/crates/node/core/src/args/txpool.rs
+++ b/crates/node/core/src/args/txpool.rs
@@ -217,6 +217,7 @@ impl RethTransactionPoolConfig for TxPoolArgs {
             new_tx_listener_buffer_size: self.new_tx_listener_buffer_size,
             max_new_pending_txs_notifications: self.max_new_pending_txs_notifications,
             max_queued_lifetime: self.max_queued_lifetime,
+            disable_balance_check: self.disable_balance_check,
         }
     }
 

--- a/crates/transaction-pool/src/config.rs
+++ b/crates/transaction-pool/src/config.rs
@@ -65,6 +65,8 @@ pub struct PoolConfig {
     pub max_new_pending_txs_notifications: usize,
     /// Maximum lifetime for transactions in the pool
     pub max_queued_lifetime: Duration,
+    /// Whether balance checking is disabled on transaction ingress
+    pub disable_balance_check: bool,
 }
 
 impl PoolConfig {
@@ -96,6 +98,7 @@ impl Default for PoolConfig {
             new_tx_listener_buffer_size: NEW_TX_LISTENER_BUFFER_SIZE,
             max_new_pending_txs_notifications: MAX_NEW_PENDING_TXS_NOTIFICATIONS,
             max_queued_lifetime: MAX_QUEUED_TRANSACTION_LIFETIME,
+            disable_balance_check: false,
         }
     }
 }


### PR DESCRIPTION
Adds a `--txpool.disable-balance-check` flag to the TxPool args. The flag makes the EthereumTransactionValidator ignore whether the sender has enough of a balance to successfully pay the gas or not.