### PR TITLE
fix: replace todo!() with Ok(None) in NoopProvider transaction_block

### DIFF
--- a/crates/storage/storage-api/src/noop.rs
+++ b/crates/storage/storage-api/src/noop.rs
@@ -269,7 +269,7 @@ impl<C: Send + Sync, N: NodePrimitives> TransactionsProvider for NoopProvider<C,
     }
 
     fn transaction_block(&self, _id: TxNumber) -> ProviderResult<Option<BlockNumber>> {
-        todo!()
+        Ok(None)
     }
 
     fn transactions_by_block(


### PR DESCRIPTION
The current implementation uses `todo!()` which causes a panic when called:

```
thread 'main' panicked at 'not yet implemented', crates/storage/storage-api/src/noop.rs:272:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

actual usage with double unwrap in pruning code that would trigger this panic:
```rust
// In crates/prune/prune/src/segments/user/receipts_by_logs.rs:358
provider.transaction_block(tx_num).unwrap().unwrap() > tip - 128
```

If NoopProvider is used in pruning tests, this would cause:
```
thread 'test' panicked at 'not yet implemented'
```

