### PR TITLE
docs(evm,engine): clarify state update flow and fix trait/API doc inaccuracies

### DIFF
--- a/crates/engine/tree/benches/state_root_task.rs
+++ b/crates/engine/tree/benches/state_root_task.rs
@@ -1,5 +1,5 @@
 //! Benchmark for `StateRootTask` complete workflow, including sending state
-//! updates using the incoming messages sender and waiting for the final result.
+//! updates via the `state_hook` obtained from the `PayloadProcessor` handle and waiting for the final result.
 
 #![allow(missing_docs)]
 

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -551,7 +551,7 @@ where
     }
 }
 
-/// A helper trait marking a 'static type that can be converted into an [`ExecutableTx`] for block
+/// A helper trait for types that can be converted into an [`ExecutableTx`] for the block
 /// executor.
 pub trait ExecutableTxFor<Evm: ConfigureEvm>:
     ToTxEnv<TxEnvFor<Evm>> + RecoveredTx<TxTy<Evm::Primitives>>

--- a/crates/evm/evm/src/lib.rs
+++ b/crates/evm/evm/src/lib.rs
@@ -256,7 +256,7 @@ pub trait ConfigureEvm: Clone + Debug + Send + Sync + Unpin {
         attributes: Self::NextBlockEnvCtx,
     ) -> ExecutionCtxFor<'_, Self>;
 
-    /// Returns a [`TxEnv`] from a transaction and [`Address`].
+    /// Returns a [`TxEnv`] derived from the provided transaction.
     fn tx_env(&self, transaction: impl IntoTxEnv<TxEnvFor<Self>>) -> TxEnvFor<Self> {
         transaction.into_tx_env()
     }


### PR DESCRIPTION
crates/engine/tree/benches/state_root_task.rs: clarify that state updates are sent via state_hook from the PayloadProcessor handle, not an “incoming messages sender”.
crates/evm/evm/src/execute.rs: correct ExecutableTxFor doc by removing misleading 'static mention; describe it as a helper for types convertible to ExecutableTx.
crates/evm/evm/src/lib.rs: fix tx_env doc to remove incorrect Address reference and state it derives TxEnv from the provided transaction.

