### PR TITLE
feat(rpc): Add `local_pending_state` that creates a state provider out of a mem-pool built pending block

### DIFF
--- a/crates/rpc/rpc-eth-types/src/pending_block.rs
+++ b/crates/rpc/rpc-eth-types/src/pending_block.rs
@@ -8,6 +8,9 @@ use alloy_consensus::BlockHeader;
 use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_primitives::B256;
 use derive_more::Constructor;
+use reth_chain_state::{
+    BlockState, ExecutedBlock, ExecutedBlockWithTrieUpdates, ExecutedTrieUpdates,
+};
 use reth_ethereum_primitives::Receipt;
 use reth_evm::EvmEnv;
 use reth_primitives_traits::{Block, NodePrimitives, RecoveredBlock, SealedHeader};
@@ -73,13 +76,59 @@ impl<B: Block, R> PendingBlockEnvOrigin<B, R> {
     }
 }
 
+/// A type alias for an [`Arc`] wrapped [`RecoveredBlock`].
+pub type PendingRecoveredBlock<N> = Arc<RecoveredBlock<<N as NodePrimitives>::Block>>;
+
+/// A type alias for an [`Arc`] wrapped vector of [`NodePrimitives::Receipt`].
+pub type PendingBlockReceipts<N> = Arc<Vec<<N as NodePrimitives>::Receipt>>;
+
+/// A type alias for a pair of an [`Arc`] wrapped [`RecoveredBlock`] and a vector of
+/// [`NodePrimitives::Receipt`].
+pub type PendingBlockAndReceipts<N> = (PendingRecoveredBlock<N>, PendingBlockReceipts<N>);
+
 /// Locally built pending block for `pending` tag.
-#[derive(Debug, Constructor)]
+#[derive(Debug, Clone, Constructor)]
 pub struct PendingBlock<N: NodePrimitives> {
     /// Timestamp when the pending block is considered outdated.
     pub expires_at: Instant,
-    /// The locally built pending block.
-    pub block: Arc<RecoveredBlock<N::Block>>,
     /// The receipts for the pending block
-    pub receipts: Arc<Vec<N::Receipt>>,
+    pub receipts: PendingBlockReceipts<N>,
+    /// The locally built pending block with execution output.
+    pub executed_block: ExecutedBlock<N>,
+}
+
+impl<N: NodePrimitives> PendingBlock<N> {
+    /// Creates a new instance of [`PendingBlock`] with `executed_block` as its output that should
+    /// not be used past `expires_at`.
+    pub fn with_executed_block(expires_at: Instant, executed_block: ExecutedBlock<N>) -> Self {
+        Self {
+            expires_at,
+            receipts: Arc::new(
+                executed_block.execution_output.receipts.iter().flatten().cloned().collect(),
+            ),
+            executed_block,
+        }
+    }
+
+    /// Returns the locally built pending [`RecoveredBlock`].
+    pub const fn block(&self) -> &PendingRecoveredBlock<N> {
+        &self.executed_block.recovered_block
+    }
+
+    /// Converts this [`PendingBlock`] into a pair of [`RecoveredBlock`] and a vector of
+    /// [`NodePrimitives::Receipt`]s, taking self.
+    pub fn into_block_and_receipts(self) -> PendingBlockAndReceipts<N> {
+        (self.executed_block.recovered_block, self.receipts)
+    }
+}
+
+impl<N: NodePrimitives> From<PendingBlock<N>> for BlockState<N> {
+    fn from(pending_block: PendingBlock<N>) -> Self {
+        Self::new(ExecutedBlockWithTrieUpdates::<N>::new(
+            pending_block.executed_block.recovered_block,
+            pending_block.executed_block.execution_output,
+            pending_block.executed_block.hashed_state,
+            ExecutedTrieUpdates::Missing,
+        ))
+    }
 }


### PR DESCRIPTION
Following-up on #17924

Adds a `local_pending_state` that returns a state provider that only uses a pool-built pending block, not the consensus one.
