### PR TITLE
fix: allow at most one in-flight tx

### DIFF
--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -810,7 +810,7 @@ impl<T: TransactionOrdering> TxPool<T> {
     ///    This is due to the possibility of the account being sweeped by an unrelated account.
     /// 2. In case the pool is tracking a pending / queued transaction from a specific account, at
     ///    most one in-flight transaction is allowed; any additional delegated tranasctions
-    ///    (`.skip(1)`) will be rejected.
+    ///    from that account will be rejected.
     fn validate_auth(
         &self,
         transaction: &ValidPoolTransaction<T::Transaction>,

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -809,8 +809,8 @@ impl<T: TransactionOrdering> TxPool<T> {
     ///    delegation will only be allowed a single transaction slot instead of the standard limit.
     ///    This is due to the possibility of the account being sweeped by an unrelated account.
     /// 2. In case the pool is tracking a pending / queued transaction from a specific account, at
-    ///    most one in-flight transaction is allowed; any additional delegated tranasctions
-    ///    from that account will be rejected.
+    ///    most one in-flight transaction is allowed; any additional delegated tranasctions from
+    ///    that account will be rejected.
     fn validate_auth(
         &self,
         transaction: &ValidPoolTransaction<T::Transaction>,
@@ -823,7 +823,7 @@ impl<T: TransactionOrdering> TxPool<T> {
 
         if let Some(authority_list) = &transaction.authority_ids {
             for sender_id in authority_list {
-                if self.all_transactions.txs_iter(*sender_id).skip(1).next().is_some() {
+                if self.all_transactions.txs_iter(*sender_id).nth(1).is_some() {
                     return Err(PoolError::new(
                         *transaction.hash(),
                         PoolErrorKind::InvalidTransaction(InvalidPoolTransactionError::Eip7702(

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -809,7 +809,7 @@ impl<T: TransactionOrdering> TxPool<T> {
     ///    delegation will only be allowed a single transaction slot instead of the standard limit.
     ///    This is due to the possibility of the account being sweeped by an unrelated account.
     /// 2. In case the pool is tracking a pending / queued transaction from a specific account, at
-    ///    most one in-flight transaction is allowed; any additional delegated tranasctions from
+    ///    most one in-flight transaction is allowed; any additional delegated transactions from
     ///    that account will be rejected.
     fn validate_auth(
         &self,

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -808,9 +808,9 @@ impl<T: TransactionOrdering> TxPool<T> {
     /// 1. Any account with a deployed delegation or an in-flight authorization to deploy a
     ///    delegation will only be allowed a single transaction slot instead of the standard limit.
     ///    This is due to the possibility of the account being sweeped by an unrelated account.
-    /// 2. In case the pool is tracking a pending / queued transaction from a specific account, it
-    ///    will reject new transactions with delegations from that account with standard in-flight
-    ///    transactions.
+    /// 2. In case the pool is tracking a pending / queued transaction from a specific account, at
+    ///    most one in-flight transaction is allowed; any additional delegated tranasctions
+    ///    (`.skip(1)`) will be rejected.
     fn validate_auth(
         &self,
         transaction: &ValidPoolTransaction<T::Transaction>,
@@ -823,7 +823,7 @@ impl<T: TransactionOrdering> TxPool<T> {
 
         if let Some(authority_list) = &transaction.authority_ids {
             for sender_id in authority_list {
-                if self.all_transactions.txs_iter(*sender_id).next().is_some() {
+                if self.all_transactions.txs_iter(*sender_id).skip(1).next().is_some() {
                     return Err(PoolError::new(
                         *transaction.hash(),
                         PoolErrorKind::InvalidTransaction(InvalidPoolTransactionError::Eip7702(


### PR DESCRIPTION
In reth, the condition is >0, while in geth, the check is >1.
reference:
https://github.com/ethereum/go-ethereum/blob/85077be58edea572f29c3b1a6a055077f1a56a8b/core/txpool/legacypool/legacypool.go#L661-L663