### PR TITLE
feat(engine): set default_memory_block_buffer_target to zero

### DIFF
--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -4,7 +4,7 @@
 pub const DEFAULT_PERSISTENCE_THRESHOLD: u64 = 2;
 
 /// How close to the canonical head we persist blocks.
-pub const DEFAULT_MEMORY_BLOCK_BUFFER_TARGET: u64 = 2;
+pub const DEFAULT_MEMORY_BLOCK_BUFFER_TARGET: u64 = 0;
 
 /// Default maximum concurrency for proof tasks
 pub const DEFAULT_MAX_PROOF_TASK_CONCURRENCY: u64 = 256;

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -786,7 +786,7 @@ Engine:
       --engine.memory-block-buffer-target <MEMORY_BLOCK_BUFFER_TARGET>
           Configure the target number of blocks to keep in memory
 
-          [default: 2]
+          [default: 0]
 
       --engine.legacy-state-root
           Enable legacy state root

--- a/docs/vocs/docs/pages/sdk/examples/standalone-components.mdx
+++ b/docs/vocs/docs/pages/sdk/examples/standalone-components.mdx
@@ -80,9 +80,8 @@ let factory = EthereumNode::provider_factory_builder()
 Reth buffers new blocks in memory before persisting them to disk for performance optimization. If your external process needs immediate access to the latest blocks, configure the node to persist blocks immediately:
 
 - `--engine.persistence-threshold 0` - Persists new canonical blocks to disk immediately
-- `--engine.memory-block-buffer-target 0` - Disables in-memory block buffering
 
-Use both flags together to ensure external processes can read new blocks without delay.
+Using this flag ensurs external processes can read new blocks without delay.
 
 As soon as the reth process has persisted the block data, the external reader can read it from the database.
 

--- a/docs/vocs/docs/pages/sdk/examples/standalone-components.mdx
+++ b/docs/vocs/docs/pages/sdk/examples/standalone-components.mdx
@@ -81,7 +81,7 @@ Reth buffers new blocks in memory before persisting them to disk for performance
 
 - `--engine.persistence-threshold 0` - Persists new canonical blocks to disk immediately
 
-Using this flag ensurs external processes can read new blocks without delay.
+Using this flag ensures external processes can read new blocks without delay.
 
 As soon as the reth process has persisted the block data, the external reader can read it from the database.
 


### PR DESCRIPTION
This PR:
- sets the `DEFAULT_MEMORY_BLOCK_BUFFER_TARGET` to zero
- Updates the docs to reflect this change

resolves https://github.com/paradigmxyz/reth/issues/17945