### PR TITLE
chore(engine): rename block validation task

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -389,7 +389,10 @@ where
             evm_config,
         );
         let incoming = task.incoming_tx.clone();
-        std::thread::Builder::new().name("Tree Task".to_string()).spawn(|| task.run()).unwrap();
+        std::thread::Builder::new()
+            .name("Engine block validation task".to_string())
+            .spawn(|| task.run())
+            .unwrap();
         (incoming, outgoing)
     }
 

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -389,10 +389,7 @@ where
             evm_config,
         );
         let incoming = task.incoming_tx.clone();
-        std::thread::Builder::new()
-            .name("Engine block validation task".to_string())
-            .spawn(|| task.run())
-            .unwrap();
+        std::thread::Builder::new().name("Engine Task".to_string()).spawn(|| task.run()).unwrap();
         (incoming, outgoing)
     }
 

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -381,7 +381,7 @@ async fn test_tree_persist_blocks() {
         .collect();
     let test_harness = TestHarness::new(chain_spec).with_blocks(blocks.clone());
     std::thread::Builder::new()
-        .name("Tree Task".to_string())
+        .name("Engine block validation task".to_string())
         .spawn(|| test_harness.tree.run())
         .unwrap();
 

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -381,7 +381,7 @@ async fn test_tree_persist_blocks() {
         .collect();
     let test_harness = TestHarness::new(chain_spec).with_blocks(blocks.clone());
     std::thread::Builder::new()
-        .name("Engine block validation task".to_string())
+        .name("Engine Task".to_string())
         .spawn(|| test_harness.tree.run())
         .unwrap();
 


### PR DESCRIPTION
This PR renames the block validation task in engine from "Tree task" to "Engine Task"

resolves https://github.com/paradigmxyz/reth/issues/17962