### PR TITLE
feat: remove the not used executor in sparse_trie

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -377,7 +377,6 @@ where
 
         let task =
             SparseTrieTask::<_, ConfiguredSparseTrie, SerialSparseTrie>::new_with_cleared_trie(
-                self.executor.clone(),
                 sparse_trie_rx,
                 proof_task_handle,
                 self.trie_metrics.clone(),

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -1,9 +1,6 @@
 //! Sparse Trie task related functionality.
 
-use crate::tree::payload_processor::{
-    executor::WorkloadExecutor,
-    multiproof::{MultiProofTaskMetrics, SparseTrieUpdate},
-};
+use crate::tree::payload_processor::multiproof::{MultiProofTaskMetrics, SparseTrieUpdate};
 use alloy_primitives::B256;
 use rayon::iter::{ParallelBridge, ParallelIterator};
 use reth_trie::{updates::TrieUpdates, Nibbles};
@@ -26,9 +23,6 @@ where
     BPF::AccountNodeProvider: TrieNodeProvider + Send + Sync,
     BPF::StorageNodeProvider: TrieNodeProvider + Send + Sync,
 {
-    /// Executor used to spawn subtasks.
-    #[expect(unused)] // TODO use this for spawning trie tasks
-    pub(super) executor: WorkloadExecutor,
     /// Receives updates from the state root task.
     pub(super) updates: mpsc::Receiver<SparseTrieUpdate>,
     /// `SparseStateTrie` used for computing the state root.
@@ -48,19 +42,12 @@ where
 {
     /// Creates a new sparse trie, pre-populating with a [`ClearedSparseStateTrie`].
     pub(super) fn new_with_cleared_trie(
-        executor: WorkloadExecutor,
         updates: mpsc::Receiver<SparseTrieUpdate>,
         blinded_provider_factory: BPF,
         metrics: MultiProofTaskMetrics,
         sparse_state_trie: ClearedSparseStateTrie<A, S>,
     ) -> Self {
-        Self {
-            executor,
-            updates,
-            metrics,
-            trie: sparse_state_trie.into_inner(),
-            blinded_provider_factory,
-        }
+        Self { updates, metrics, trie: sparse_state_trie.into_inner(), blinded_provider_factory }
     }
 
     /// Runs the sparse trie task to completion.


### PR DESCRIPTION
The current parallel processing approach was using rayon and ConfiguredSparseTrie, so no need the executor field in the `SparseTrie` struct anymore.