### PR TITLE
Update flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     crane.url = "github:ipetkov/crane";
 
     fenix = {
-      url = "github:nix-community/fenix";
+      url = "github:nix-community/fenix/monthly";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };


### PR DESCRIPTION
url = "github:nix-community/fenix/monthly"; # use stable release channel “stable release channel" more precisely reflects the intent of the monthly branch tracking Fenix's stable releases