### PR TITLE
chore: remove unused pooled_transaction_hashes_max

### DIFF
--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -559,10 +559,6 @@ where
         self.pool.pooled_transactions_hashes()
     }
 
-    fn pooled_transaction_hashes_max(&self, max: usize) -> Vec<TxHash> {
-        self.pooled_transaction_hashes().into_iter().take(max).collect()
-    }
-
     fn pooled_transactions(&self) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
         self.pool.pooled_transactions()
     }

--- a/crates/transaction-pool/src/noop.rs
+++ b/crates/transaction-pool/src/noop.rs
@@ -145,10 +145,6 @@ impl<T: EthPoolTransaction> TransactionPool for NoopTransactionPool<T> {
         vec![]
     }
 
-    fn pooled_transaction_hashes_max(&self, _max: usize) -> Vec<TxHash> {
-        vec![]
-    }
-
     fn pooled_transactions(&self) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
         vec![]
     }

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -302,11 +302,6 @@ pub trait TransactionPool: Clone + Debug + Send + Sync {
     /// Consumer: P2P
     fn pooled_transaction_hashes(&self) -> Vec<TxHash>;
 
-    /// Returns only the first `max` hashes of transactions in the pool.
-    ///
-    /// Consumer: P2P
-    fn pooled_transaction_hashes_max(&self, max: usize) -> Vec<TxHash>;
-
     /// Returns the _full_ transaction objects all transactions in the pool that are allowed to be
     /// propagated.
     ///


### PR DESCRIPTION
This PR removed the unused `pooled_transaction_hashes_max` method. And also, the implementation of this functions consume all the transactions from pool but only take `max`, it's wasteful.

```rust
    fn pooled_transaction_hashes_max(&self, max: usize) -> Vec<TxHash> {
        self.pooled_transaction_hashes().into_iter().take(max).collect()
    }
```