### PR TITLE
refactor(txpool): use proper method to get transaction by ID

### DIFF
--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -723,7 +723,7 @@ where
     ) -> Option<Arc<ValidPoolTransaction<Self::Transaction>>> {
         let transaction_id = TransactionId::new(self.pool.get_sender_id(sender), nonce);
 
-        self.inner().get_pool_data().all().get(&transaction_id).map(|tx| tx.transaction.clone())
+        self.pool.get_transaction_by_transaction_id(&transaction_id)
     }
 
     fn get_transactions_by_origin(


### PR DESCRIPTION
Replace direct pool data access with get_transaction_by_transaction_id method for better encapsulation and consistency (same with the other methods, using `self.pool.get_xxx()`).