### PR TITLE
perf: optimize canonical_hashes_range to O(n) complexity

### DIFF
--- a/crates/chain-state/src/memory_overlay.rs
+++ b/crates/chain-state/src/memory_overlay.rs
@@ -87,10 +87,11 @@ impl<N: NodePrimitives> BlockHashReader for MemoryOverlayStateProviderRef<'_, N>
         let mut in_memory_hashes = Vec::new();
         for block in &self.in_memory {
             if range.contains(&block.recovered_block().number()) {
-                in_memory_hashes.insert(0, block.recovered_block().hash());
+                in_memory_hashes.push(block.recovered_block().hash());
                 earliest_block_number = Some(block.recovered_block().number());
             }
         }
+        in_memory_hashes.reverse();
 
         let mut hashes =
             self.historical.canonical_hashes_range(start, earliest_block_number.unwrap_or(end))?;

--- a/crates/chain-state/src/memory_overlay.rs
+++ b/crates/chain-state/src/memory_overlay.rs
@@ -85,12 +85,17 @@ impl<N: NodePrimitives> BlockHashReader for MemoryOverlayStateProviderRef<'_, N>
         let range = start..end;
         let mut earliest_block_number = None;
         let mut in_memory_hashes = Vec::new();
+
         for block in &self.in_memory {
             if range.contains(&block.recovered_block().number()) {
                 in_memory_hashes.push(block.recovered_block().hash());
                 earliest_block_number = Some(block.recovered_block().number());
             }
         }
+
+        // `self.in_memory` stores executed blocks in ascending order (oldest to newest).
+        // However, `in_memory_hashes` should be constructed in descending order (newest to oldest),
+        // so we reverse the vector after collecting the hashes.
         in_memory_hashes.reverse();
 
         let mut hashes =


### PR DESCRIPTION
Replace inefficient O(n²) insert(0, ...) pattern with push + reverse. This reduces complexity from O(n²) to O(n) where n is the number of in-memory blocks in range.