### PR TITLE
chore(cli): add log about state root computation for init-state

### DIFF
--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -428,6 +428,8 @@ where
     // write state to db
     dump_state(collector, provider_rw, block)?;
 
+    info!(target: "reth::cli", "All accounts written to database, starting state root computation");
+
     // compute and compare state root. this advances the stage checkpoints.
     let computed_state_root = compute_state_root(provider_rw)?;
     if computed_state_root == expected_state_root {

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -428,7 +428,7 @@ where
     // write state to db
     dump_state(collector, provider_rw, block)?;
 
-    info!(target: "reth::cli", "All accounts written to database, starting state root computation");
+    info!(target: "reth::cli", "All accounts written to database, starting state root computation (may take some time)");
 
     // compute and compare state root. this advances the stage checkpoints.
     let computed_state_root = compute_state_root(provider_rw)?;


### PR DESCRIPTION
for commands like: `cargo r --release --bin op-reth --manifest-path crates/optimism/bin/Cargo.toml -- init-state --without-ovm --chain optimism --datadir ../op-mainnet world_trie_state.jsonl` we get logs like:
```
.....
2025-08-21T10:42:37.888501Z  INFO reth::cli: Writing accounts to db total_inserted_accounts=4007565
2025-08-21T10:44:47.394008Z  INFO reth::cli: Computed state root matches state root in state dump computed_state_root=0x920314c198da844a041d63bf6cbe8b59583165fd2229d1b3f599da812fd424cb
.....
```
note the +2min between the 2 log entries, this is spent in state root calculation without notifying, can take much longer without `--release`