### PR TITLE
chore(db): remove empty TODO comment

### DIFF
--- a/crates/storage/db-api/src/mock.rs
+++ b/crates/storage/db-api/src/mock.rs
@@ -16,7 +16,6 @@ use core::ops::Bound;
 use std::{collections::BTreeMap, ops::RangeBounds};
 
 /// Mock database used for testing with inner `BTreeMap` structure
-// TODO
 #[derive(Clone, Debug, Default)]
 pub struct DatabaseMock {
     /// Main data. TODO (Make it table aware)


### PR DESCRIPTION
Remove empty `// TODO` comment from `DatabaseMock` that provides no guidance.