### PR TITLE
feat(optimism): Add new `reth-optimism-flashblocks` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9267,6 +9267,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-optimism-flashblocks"
+version = "1.6.0"
+
+[[package]]
 name = "reth-optimism-forks"
 version = "1.6.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ members = [
     "crates/optimism/cli",
     "crates/optimism/consensus",
     "crates/optimism/evm/",
+    "crates/optimism/flashblocks/",
     "crates/optimism/hardforks/",
     "crates/optimism/node/",
     "crates/optimism/payload/",
@@ -430,6 +431,7 @@ reth-rpc-engine-api = { path = "crates/rpc/rpc-engine-api" }
 reth-rpc-eth-api = { path = "crates/rpc/rpc-eth-api" }
 reth-rpc-eth-types = { path = "crates/rpc/rpc-eth-types", default-features = false }
 reth-rpc-layer = { path = "crates/rpc/rpc-layer" }
+reth-optimism-flashblocks = { path = "crates/optimism/flashblocks" }
 reth-rpc-server-types = { path = "crates/rpc/rpc-server-types" }
 reth-rpc-convert = { path = "crates/rpc/rpc-convert" }
 reth-stages = { path = "crates/stages/stages" }

--- a/crates/optimism/flashblocks/Cargo.toml
+++ b/crates/optimism/flashblocks/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "reth-optimism-flashblocks"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+
+[dev-dependencies]

--- a/crates/optimism/flashblocks/src/lib.rs
+++ b/crates/optimism/flashblocks/src/lib.rs
@@ -1,0 +1,1 @@
+//! A downstream integration of Flashblocks.


### PR DESCRIPTION
Part of #17858

Adds a new crate for the Flashblocks integration.

Flashblocks are not part of Ethereum specification so they do not belong to any existing crate.

We have decided to put Flashblocks integration in the Optimism subfolder, they are intended for `op-reth`.
