### PR TITLE
fix(cli): make --datadir option global for consistency

### DIFF
--- a/crates/node/core/src/args/datadir_args.rs
+++ b/crates/node/core/src/args/datadir_args.rs
@@ -16,7 +16,7 @@ pub struct DatadirArgs {
     /// - Linux: `$XDG_DATA_HOME/reth/` or `$HOME/.local/share/reth/`
     /// - Windows: `{FOLDERID_RoamingAppData}/reth/`
     /// - macOS: `$HOME/Library/Application Support/reth/`
-    #[arg(long, value_name = "DATA_DIR", verbatim_doc_comment, default_value_t)]
+    #[arg(long, value_name = "DATA_DIR", verbatim_doc_comment, default_value_t, global = true)]
     pub datadir: MaybePlatformPath<DataDirPath>,
 
     /// The absolute path to store static files in.


### PR DESCRIPTION
The `--datadir` option is not global, causing inconsistent CLI behavior compared to other fundamental options like `--chain`.

**Current behavior (confusing)**:
```bash
$ reth db stats --datadir /custom/path
error: unexpected argument '--datadir' found
  tip: 'db --datadir' exists

$ reth db --datadir /custom/path stats  # works, but unintuitive
```

After this change
Both patterns work (consistent with `--chain` behavior):
```bash
reth db --datadir /custom/path stats     # existing (still works)  
reth db stats --datadir /custom/path     # new (now works)
reth --datadir /custom/path db stats     # also works
```