### PR TITLE
feat(optimism): Add `FlashBlock` payload schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9269,6 +9269,14 @@ dependencies = [
 [[package]]
 name = "reth-optimism-flashblocks"
 version = "1.6.0"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rpc-types-engine",
+ "alloy-serde",
+ "reth-optimism-primitives",
+ "serde",
+]
 
 [[package]]
 name = "reth-optimism-forks"

--- a/crates/optimism/flashblocks/Cargo.toml
+++ b/crates/optimism/flashblocks/Cargo.toml
@@ -11,5 +11,16 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
+# reth
+reth-optimism-primitives = { workspace = true, features = ["serde"] }
+
+# alloy
+alloy-eips = { workspace = true, features = ["serde"] }
+alloy-serde.workspace = true
+alloy-primitives = { workspace = true, features = ["serde"] }
+alloy-rpc-types-engine = { workspace = true, features = ["serde"] }
+
+# io
+serde.workspace = true
 
 [dev-dependencies]

--- a/crates/optimism/flashblocks/src/lib.rs
+++ b/crates/optimism/flashblocks/src/lib.rs
@@ -1,1 +1,7 @@
 //! A downstream integration of Flashblocks.
+
+pub use payload::{
+    ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, FlashBlock, Metadata,
+};
+
+mod payload;

--- a/crates/optimism/flashblocks/src/payload.rs
+++ b/crates/optimism/flashblocks/src/payload.rs
@@ -1,0 +1,95 @@
+use alloy_eips::eip4895::Withdrawal;
+use alloy_primitives::{Address, Bloom, Bytes, B256, U256};
+use alloy_rpc_types_engine::PayloadId;
+use reth_optimism_primitives::OpReceipt;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// Represents a Flashblock, a real-time block-like structure emitted by the Base L2 chain.
+///
+/// A Flashblock provides a snapshot of a block’s effects before finalization,
+/// allowing faster insight into state transitions, balance changes, and logs.
+/// It includes a diff of the block’s execution and associated metadata.
+///
+/// See: [Base Flashblocks Documentation](https://docs.base.org/chain/flashblocks)
+#[derive(Default, Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct FlashBlock {
+    /// The unique payload ID as assigned by the execution engine for this block.
+    pub payload_id: PayloadId,
+    /// A sequential index that identifies the order of this Flashblock.
+    pub index: u64,
+    /// A subset of block header fields.
+    pub base: Option<ExecutionPayloadBaseV1>,
+    /// The execution diff representing state transitions and transactions.
+    pub diff: ExecutionPayloadFlashblockDeltaV1,
+    /// Additional metadata about the block such as receipts and balances.
+    pub metadata: Metadata,
+}
+
+/// Provides metadata about the block that may be useful for indexing or analysis.
+#[derive(Default, Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Metadata {
+    /// The number of the block in the L2 chain.
+    pub block_number: u64,
+    /// A map of addresses to their updated balances after the block execution.
+    /// This represents balance changes due to transactions, rewards, or system transfers.
+    pub new_account_balances: BTreeMap<Address, U256>,
+    /// Execution receipts for all transactions in the block.
+    /// Contains logs, gas usage, and other EVM-level metadata.
+    pub receipts: BTreeMap<B256, BTreeMap<String, OpReceipt>>,
+}
+
+/// Represents the base configuration of an execution payload that remains constant
+/// throughout block construction. This includes fundamental block properties like
+/// parent hash, block number, and other header fields that are determined at
+/// block creation and cannot be modified.
+#[derive(Clone, Debug, Eq, PartialEq, Default, Deserialize, Serialize)]
+pub struct ExecutionPayloadBaseV1 {
+    /// Ecotone parent beacon block root
+    pub parent_beacon_block_root: B256,
+    /// The parent hash of the block.
+    pub parent_hash: B256,
+    /// The fee recipient of the block.
+    pub fee_recipient: Address,
+    /// The previous randao of the block.
+    pub prev_randao: B256,
+    /// The block number.
+    #[serde(with = "alloy_serde::quantity")]
+    pub block_number: u64,
+    /// The gas limit of the block.
+    #[serde(with = "alloy_serde::quantity")]
+    pub gas_limit: u64,
+    /// The timestamp of the block.
+    #[serde(with = "alloy_serde::quantity")]
+    pub timestamp: u64,
+    /// The extra data of the block.
+    pub extra_data: Bytes,
+    /// The base fee per gas of the block.
+    pub base_fee_per_gas: U256,
+}
+
+/// Represents the modified portions of an execution payload within a flashblock.
+/// This structure contains only the fields that can be updated during block construction,
+/// such as state root, receipts, logs, and new transactions. Other immutable block fields
+/// like parent hash and block number are excluded since they remain constant throughout
+/// the block's construction.
+#[derive(Clone, Debug, Eq, PartialEq, Default, Deserialize, Serialize)]
+pub struct ExecutionPayloadFlashblockDeltaV1 {
+    /// The state root of the block.
+    pub state_root: B256,
+    /// The receipts root of the block.
+    pub receipts_root: B256,
+    /// The logs bloom of the block.
+    pub logs_bloom: Bloom,
+    /// The gas used of the block.
+    #[serde(with = "alloy_serde::quantity")]
+    pub gas_used: u64,
+    /// The block hash of the block.
+    pub block_hash: B256,
+    /// The transactions of the block.
+    pub transactions: Vec<Bytes>,
+    /// Array of [`Withdrawal`] enabled with V2
+    pub withdrawals: Vec<Withdrawal>,
+    /// The withdrawals root of the block.
+    pub withdrawals_root: B256,
+}


### PR DESCRIPTION
Part of https://github.com/paradigmxyz/reth/issues/17858

Adds the `FlashBlock` schema for the upcoming websocket subscription implementation.

Some parts have been pulled from https://github.com/base/node-reth repository, because the specification of `FlashBlock` that lives in `alloy-rpc-types-mev` is older.