### PR TITLE
fix(revm-inspectors): update revm-inspectors to fix js tracer opcode gas calculation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10874,9 +10874,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a76ba086ca57a718368e46e792a81c5eb7a30366956aa6293adbcec8b1181ce"
+checksum = "9d3f54151c26870f50a3d7e8688e30a0f3578dd57bc69450caa1df11a7713906"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -469,7 +469,7 @@ revm-context = { version = "9.0.1", default-features = false }
 revm-context-interface = { version = "8.0.1", default-features = false }
 revm-database-interface = { version = "7.0.1", default-features = false }
 op-revm = { version = "9.0.1", default-features = false }
-revm-inspectors = "0.28.0"
+revm-inspectors = "0.28.1"
 
 # eth
 alloy-chains = { version = "0.2.5", default-features = false }


### PR DESCRIPTION
Previous implementation has a bug where the js tracer `getCost()` function was using a cumulative calculation of execution instead of a single opcode cost which is not in line with other clients that support js tracers.