### PR TITLE
feat(optimism): Add `FlashBlockWsStream` for streaming flashblocks from a websocket connection

### DIFF
--- a/.github/assets/check_wasm.sh
+++ b/.github/assets/check_wasm.sh
@@ -40,6 +40,7 @@ exclude_crates=(
   reth-node-events
   reth-node-metrics
   reth-optimism-cli
+  reth-optimism-flashblocks
   reth-optimism-node
   reth-optimism-payload-builder
   reth-optimism-rpc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9274,8 +9274,16 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "alloy-serde",
+ "brotli",
+ "eyre",
+ "futures-util",
  "reth-optimism-primitives",
  "serde",
+ "serde_json",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -531,6 +531,7 @@ bincode = "1.3"
 bitflags = "2.4"
 boyer-moore-magiclen = "0.2.16"
 bytes = { version = "1.5", default-features = false }
+brotli = "8"
 cfg-if = "1.0"
 clap = "4"
 dashmap = "6.0"

--- a/crates/optimism/flashblocks/Cargo.toml
+++ b/crates/optimism/flashblocks/Cargo.toml
@@ -21,6 +21,18 @@ alloy-primitives = { workspace = true, features = ["serde"] }
 alloy-rpc-types-engine = { workspace = true, features = ["serde"] }
 
 # io
+tokio.workspace = true
+tokio-tungstenite.workspace = true
 serde.workspace = true
+serde_json.workspace = true
+url.workspace = true
+futures-util.workspace = true
+brotli.workspace = true
+
+# debug
+tracing.workspace = true
+
+# errors
+eyre.workspace = true
 
 [dev-dependencies]

--- a/crates/optimism/flashblocks/src/lib.rs
+++ b/crates/optimism/flashblocks/src/lib.rs
@@ -3,5 +3,7 @@
 pub use payload::{
     ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, FlashBlock, Metadata,
 };
+pub use ws::FlashBlockWsStream;
 
 mod payload;
+mod ws;

--- a/crates/optimism/flashblocks/src/ws/decoding.rs
+++ b/crates/optimism/flashblocks/src/ws/decoding.rs
@@ -1,0 +1,66 @@
+use crate::{ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, FlashBlock, Metadata};
+use alloy_rpc_types_engine::PayloadId;
+use serde::{Deserialize, Serialize};
+use std::{fmt::Debug, io::Read};
+
+#[derive(Clone, Debug, PartialEq, Default, Deserialize, Serialize)]
+struct FlashblocksPayloadV1 {
+    /// The payload id of the flashblock
+    pub payload_id: PayloadId,
+    /// The index of the flashblock in the block
+    pub index: u64,
+    /// The base execution payload configuration
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base: Option<ExecutionPayloadBaseV1>,
+    /// The delta/diff containing modified portions of the execution payload
+    pub diff: ExecutionPayloadFlashblockDeltaV1,
+    /// Additional metadata associated with the flashblock
+    pub metadata: serde_json::Value,
+}
+
+impl FlashBlock {
+    pub(crate) fn decode(bytes: &[u8]) -> eyre::Result<Self> {
+        try_decode_message(bytes)
+    }
+}
+
+fn try_decode_message(bytes: &[u8]) -> eyre::Result<FlashBlock> {
+    let text = try_parse_message(bytes)?;
+
+    let payload: FlashblocksPayloadV1 = match serde_json::from_str(&text) {
+        Ok(m) => m,
+        Err(e) => {
+            return Err(eyre::eyre!("failed to parse message: {}", e));
+        }
+    };
+
+    let metadata: Metadata = match serde_json::from_value(payload.metadata.clone()) {
+        Ok(m) => m,
+        Err(e) => {
+            return Err(eyre::eyre!("failed to parse message metadata: {}", e));
+        }
+    };
+
+    Ok(FlashBlock {
+        payload_id: payload.payload_id,
+        index: payload.index,
+        base: payload.base,
+        diff: payload.diff,
+        metadata,
+    })
+}
+
+fn try_parse_message(bytes: &[u8]) -> eyre::Result<String> {
+    if let Ok(text) = String::from_utf8(bytes.to_vec()) {
+        if text.trim_start().starts_with('{') {
+            return Ok(text);
+        }
+    }
+
+    let mut decompressor = brotli::Decompressor::new(bytes, 4096);
+    let mut decompressed = Vec::new();
+    decompressor.read_to_end(&mut decompressed)?;
+
+    let text = String::from_utf8(decompressed)?;
+    Ok(text)
+}

--- a/crates/optimism/flashblocks/src/ws/decoding.rs
+++ b/crates/optimism/flashblocks/src/ws/decoding.rs
@@ -1,7 +1,8 @@
 use crate::{ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, FlashBlock, Metadata};
+use alloy_primitives::bytes::Bytes;
 use alloy_rpc_types_engine::PayloadId;
 use serde::{Deserialize, Serialize};
-use std::{fmt::Debug, io::Read};
+use std::{fmt::Debug, io};
 
 #[derive(Clone, Debug, PartialEq, Default, Deserialize, Serialize)]
 struct FlashblocksPayloadV1 {
@@ -19,48 +20,46 @@ struct FlashblocksPayloadV1 {
 }
 
 impl FlashBlock {
-    pub(crate) fn decode(bytes: &[u8]) -> eyre::Result<Self> {
-        try_decode_message(bytes)
+    /// Decodes `bytes` into [`FlashBlock`].
+    ///
+    /// This function is specific to the Base Optimism websocket encoding.
+    ///
+    /// It is assumed that the `bytes` are encoded in JSON and optionally compressed using brotli.
+    /// Whether the `bytes` is compressed or not is determined by looking at the first
+    /// non ascii-whitespace character.
+    pub(crate) fn decode(bytes: Bytes) -> eyre::Result<Self> {
+        let bytes = try_parse_message(bytes)?;
+
+        let payload: FlashblocksPayloadV1 = serde_json::from_slice(&bytes)
+            .map_err(|e| eyre::eyre!("failed to parse message: {e}"))?;
+
+        let metadata: Metadata = serde_json::from_value(payload.metadata.clone())
+            .map_err(|e| eyre::eyre!("failed to parse message metadata: {e}"))?;
+
+        Ok(Self {
+            payload_id: payload.payload_id,
+            index: payload.index,
+            base: payload.base,
+            diff: payload.diff,
+            metadata,
+        })
     }
 }
 
-fn try_decode_message(bytes: &[u8]) -> eyre::Result<FlashBlock> {
-    let text = try_parse_message(bytes)?;
-
-    let payload: FlashblocksPayloadV1 = match serde_json::from_str(&text) {
-        Ok(m) => m,
-        Err(e) => {
-            return Err(eyre::eyre!("failed to parse message: {}", e));
-        }
-    };
-
-    let metadata: Metadata = match serde_json::from_value(payload.metadata.clone()) {
-        Ok(m) => m,
-        Err(e) => {
-            return Err(eyre::eyre!("failed to parse message metadata: {}", e));
-        }
-    };
-
-    Ok(FlashBlock {
-        payload_id: payload.payload_id,
-        index: payload.index,
-        base: payload.base,
-        diff: payload.diff,
-        metadata,
-    })
-}
-
-fn try_parse_message(bytes: &[u8]) -> eyre::Result<String> {
-    if let Ok(text) = String::from_utf8(bytes.to_vec()) {
-        if text.trim_start().starts_with('{') {
-            return Ok(text);
-        }
+/// Maps `bytes` into a potentially different [`Bytes`].
+///
+/// If the bytes start with a "{" character, prepended by any number of ASCII-whitespaces,
+/// then it assumes that it is JSON-encoded and returns it as-is.
+///
+/// Otherwise, the `bytes` are passed through a brotli decompressor and returned.
+fn try_parse_message(bytes: Bytes) -> eyre::Result<Bytes> {
+    if bytes.trim_ascii_start().starts_with(b"{") {
+        return Ok(bytes);
     }
 
-    let mut decompressor = brotli::Decompressor::new(bytes, 4096);
+    let mut decompressor = brotli::Decompressor::new(bytes.as_ref(), 4096);
     let mut decompressed = Vec::new();
-    decompressor.read_to_end(&mut decompressed)?;
+    io::copy(&mut decompressor, &mut decompressed)?;
 
-    let text = String::from_utf8(decompressed)?;
-    Ok(text)
+    Ok(decompressed.into())
 }

--- a/crates/optimism/flashblocks/src/ws/mod.rs
+++ b/crates/optimism/flashblocks/src/ws/mod.rs
@@ -1,0 +1,4 @@
+pub use stream::FlashBlockWsStream;
+
+mod decoding;
+mod stream;

--- a/crates/optimism/flashblocks/src/ws/stream.rs
+++ b/crates/optimism/flashblocks/src/ws/stream.rs
@@ -1,0 +1,102 @@
+use crate::FlashBlock;
+use eyre::eyre;
+use futures_util::{stream::SplitStream, FutureExt, Stream, StreamExt};
+use std::{
+    fmt::{Debug, Formatter},
+    future::Future,
+    pin::Pin,
+    task::{ready, Context, Poll},
+};
+use tokio::net::TcpStream;
+use tokio_tungstenite::{
+    connect_async,
+    tungstenite::{handshake::client::Response, Error, Message},
+    MaybeTlsStream, WebSocketStream,
+};
+use url::Url;
+
+/// An asynchronous stream of [`FlashBlock`] from a websocket connection.
+pub struct FlashBlockWsStream {
+    ws_url: Url,
+    state: State,
+    connect: ConnectFuture,
+    stream: Option<SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>>,
+}
+
+impl Stream for FlashBlockWsStream {
+    type Item = eyre::Result<FlashBlock>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if self.state == State::Initial {
+            self.connect();
+        }
+
+        if self.state == State::Connect {
+            match ready!(self.connect.poll_unpin(cx)) {
+                Ok((stream, _)) => self.stream(stream),
+                Err(err) => {
+                    self.state = State::Initial;
+
+                    return Poll::Ready(Some(Err(err.into())))
+                }
+            }
+        }
+
+        let msg = ready!(self
+            .stream
+            .as_mut()
+            .expect("Stream state be unreachable without stream")
+            .poll_next_unpin(cx));
+
+        Poll::Ready(msg.map(|msg| match msg {
+            Ok(Message::Binary(bytes)) => FlashBlock::decode(&bytes),
+            Ok(msg) => Err(eyre!("Unexpected websocket message: {msg:?}")),
+            Err(err) => Err(err.into()),
+        }))
+    }
+}
+
+impl FlashBlockWsStream {
+    fn connect(&mut self) {
+        let ws_url = self.ws_url.clone();
+
+        Pin::new(&mut self.connect)
+            .set(Box::pin(async move { connect_async(ws_url.as_str()).await }));
+
+        self.state = State::Connect;
+    }
+
+    fn stream(&mut self, stream: WebSocketStream<MaybeTlsStream<TcpStream>>) {
+        self.stream.replace(stream.split().1);
+
+        self.state = State::Stream;
+    }
+}
+
+impl Debug for FlashBlockWsStream {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FlashBlockStream")
+            .field("ws_url", &self.ws_url)
+            .field("state", &self.state)
+            .field("connect", &"Pin<Box<dyn Future<..>>>")
+            .field("stream", &self.stream)
+            .finish()
+    }
+}
+
+#[derive(Default, Debug, Eq, PartialEq)]
+enum State {
+    #[default]
+    Initial,
+    Connect,
+    Stream,
+}
+
+type ConnectFuture = Pin<
+    Box<
+        dyn Future<Output = Result<(WebSocketStream<MaybeTlsStream<TcpStream>>, Response), Error>>
+            + Send
+            + Sync
+            + 'static,
+    >,
+>;


### PR DESCRIPTION
Part of #17858

Adds a stream responsible for yielding `FlashBlock`s received from a websocket connection.
