### PR TITLE
docs(op): op chains don't require deposit contracts, so as dev chain

### DIFF
--- a/crates/optimism/chainspec/src/dev.rs
+++ b/crates/optimism/chainspec/src/dev.rs
@@ -27,7 +27,6 @@ pub static OP_DEV: LazyLock<Arc<OpChainSpec>> = LazyLock::new(|| {
             paris_block_and_final_difficulty: Some((0, U256::from(0))),
             hardforks,
             base_fee_params: BaseFeeParamsKind::Constant(BaseFeeParams::ethereum()),
-            deposit_contract: None, // TODO: do we even have?
             ..Default::default()
         },
     }


### PR DESCRIPTION
No need to set the deposit contract address for the op chains, so remove it in the docs.