### PR TITLE
chore: remove not used block/receipt memory limiter constants

### DIFF
--- a/crates/rpc/rpc-server-types/src/constants.rs
+++ b/crates/rpc/rpc-server-types/src/constants.rs
@@ -104,18 +104,6 @@ pub mod gas_oracle {
 
 /// Cache specific constants
 pub mod cache {
-    // TODO: memory based limiter is currently disabled pending <https://github.com/paradigmxyz/reth/issues/3503>
-    /// Default cache size for the block cache: 500MB
-    ///
-    /// With an average block size of ~100kb this should be able to cache ~5000 blocks.
-    pub const DEFAULT_BLOCK_CACHE_SIZE_BYTES_MB: usize = 500;
-
-    /// Default cache size for the receipts cache: 500MB
-    pub const DEFAULT_RECEIPT_CACHE_SIZE_BYTES_MB: usize = 500;
-
-    /// Default cache size for the env cache: 1MB
-    pub const DEFAULT_ENV_CACHE_SIZE_BYTES_MB: usize = 1;
-
     /// Default cache size for the block cache: 5000 blocks.
     pub const DEFAULT_BLOCK_CACHE_MAX_LEN: u32 = 5000;
 


### PR DESCRIPTION
Currently we are using the length limiter of the block receipt cache, the memory limiter was not used anymore, so try to remove those not used constants.