### PR TITLE
feat(reth-bench): add --advance option for relative block ranges

### DIFF
--- a/bin/reth-bench/README.md
+++ b/bin/reth-bench/README.md
@@ -92,6 +92,20 @@ This should NOT be the node that is being used for the benchmark. The node behin
 the benchmark. The node being benchmarked will not have these blocks.
 Note that this assumes that the benchmark node's engine API is running on `http://127.0.0.1:8551`, which is set as a default value in `reth-bench`. To configure this value, use the `--engine-rpc-url` flag.
 
+#### Using the `--advance` argument
+
+The `--advance` argument allows you to benchmark a relative number of blocks from the current head, without manually specifying `--from` and `--to`.
+
+```bash
+# Benchmark the next 10 blocks from the current head
+reth-bench new-payload-fcu --advance 10 --jwt-secret <jwt_file_path> --rpc-url <rpc-url>
+
+# Benchmark the next 50 blocks with a different subcommand
+reth-bench new-payload-only --advance 50 --jwt-secret <jwt_file_path> --rpc-url <rpc-url>
+
+
+
+
 ### Observe Outputs
 
 After running the command, `reth-bench` will output benchmark results, showing processing speeds and gas usage, which are useful metrics for analyzing the node's performance.

--- a/bin/reth-bench/src/bench/context.rs
+++ b/bin/reth-bench/src/bench/context.rs
@@ -71,11 +71,10 @@ impl BenchContext {
 
             let head_block = block_provider
                 .get_block_by_number(BlockNumberOrTag::Latest)
-                .full()
                 .await?
                 .ok_or_else(|| eyre::eyre!("Failed to fetch latest block for --advance"))?;
             let head_number = head_block.header.number;
-            (Some(head_number + 1), Some(head_number + advance))
+            (Some(head_number), Some(head_number + advance))
         } else {
             (bench_args.from, bench_args.to)
         };

--- a/bin/reth-bench/src/bench/context.rs
+++ b/bin/reth-bench/src/bench/context.rs
@@ -65,6 +65,10 @@ impl BenchContext {
         //     - `to = head + advance`
         // - Otherwise, uses the values from `--from` and `--to`.
         let (from, to) = if let Some(advance) = bench_args.advance {
+            if advance == 0 {
+                return Err(eyre::eyre!("--advance must be greater than 0"));
+            }
+
             let head_block = block_provider
                 .get_block_by_number(BlockNumberOrTag::Latest)
                 .full()

--- a/bin/reth-bench/src/bench/context.rs
+++ b/bin/reth-bench/src/bench/context.rs
@@ -58,31 +58,6 @@ impl BenchContext {
             .await?
             .is_empty();
 
-        // Computes the block range for the benchmark.
-        //
-        // - If `--advance` is provided, fetches the latest block and sets:
-        //     - `from = head + 1`
-        //     - `to = head + advance`
-        // - Otherwise, uses the values from `--from` and `--to`.
-        let (from, to) = if let Some(advance) = bench_args.advance {
-            if advance == 0 {
-                return Err(eyre::eyre!("--advance must be greater than 0"));
-            }
-
-            let head_block = block_provider
-                .get_block_by_number(BlockNumberOrTag::Latest)
-                .await?
-                .ok_or_else(|| eyre::eyre!("Failed to fetch latest block for --advance"))?;
-            let head_number = head_block.header.number;
-            (Some(head_number), Some(head_number + advance))
-        } else {
-            (bench_args.from, bench_args.to)
-        };
-
-        // If neither `--from` nor `--to` are provided, we will run the benchmark continuously,
-        // starting at the latest block.
-        let mut benchmark_mode = BenchMode::new(from, to)?;
-
         // construct the authenticated provider
         let auth_jwt = bench_args
             .auth_jwtsecret
@@ -103,6 +78,31 @@ impl BenchContext {
         let auth_transport = AuthenticatedTransportConnect::new(auth_url, jwt);
         let client = ClientBuilder::default().connect_with(auth_transport).await?;
         let auth_provider = RootProvider::<AnyNetwork>::new(client);
+
+        // Computes the block range for the benchmark.
+        //
+        // - If `--advance` is provided, fetches the latest block and sets:
+        //     - `from = head + 1`
+        //     - `to = head + advance`
+        // - Otherwise, uses the values from `--from` and `--to`.
+        let (from, to) = if let Some(advance) = bench_args.advance {
+            if advance == 0 {
+                return Err(eyre::eyre!("--advance must be greater than 0"));
+            }
+
+            let head_block = auth_provider
+                .get_block_by_number(BlockNumberOrTag::Latest)
+                .await?
+                .ok_or_else(|| eyre::eyre!("Failed to fetch latest block for --advance"))?;
+            let head_number = head_block.header.number;
+            (Some(head_number), Some(head_number + advance))
+        } else {
+            (bench_args.from, bench_args.to)
+        };
+
+        // If neither `--from` nor `--to` are provided, we will run the benchmark continuously,
+        // starting at the latest block.
+        let mut benchmark_mode = BenchMode::new(from, to)?;
 
         let first_block = match benchmark_mode {
             BenchMode::Continuous => {

--- a/crates/node/core/src/args/benchmark_args.rs
+++ b/crates/node/core/src/args/benchmark_args.rs
@@ -15,6 +15,12 @@ pub struct BenchmarkArgs {
     #[arg(long, verbatim_doc_comment)]
     pub to: Option<u64>,
 
+    /// Number of blocks to advance from the current head block.
+    /// When specified, automatically sets --from to current head + 1 and --to to current head +
+    /// advance. Cannot be used together with explicit --from and --to arguments.
+    #[arg(long, conflicts_with_all = &["from", "to"], verbatim_doc_comment)]
+    pub advance: Option<u64>,
+
     /// Path to a JWT secret to use for the authenticated engine-API RPC server.
     ///
     /// This will perform JWT authentication for all requests to the given engine RPC url.


### PR DESCRIPTION
- Introduces a new CLI argument `--advance` to specify a relative number
  of blocks to benchmark from the current head.
- Automatically computes `from` = head + 1 and `to` = head + advance.
- No changes needed to `BenchMode::new()`; existing validation works as expected.
- Simplifies benchmarking consecutive block ranges and reduces manual calculations.

closes #17995 
