### PR TITLE
refactor(eth-wire): remove EthVersion::total_messages in favor of EthMessageID::max

### DIFF
--- a/crates/net/eth-wire-types/src/message.rs
+++ b/crates/net/eth-wire-types/src/message.rs
@@ -505,7 +505,7 @@ impl EthMessageID {
     ///
     /// This is used for message ID multiplexing.
     ///
-    /// https://github.com/ethereum/go-ethereum/blob/85077be58edea572f29c3b1a6a055077f1a56a8b/eth/protocols/eth/protocol.go#L45-L47
+    /// <https://github.com/ethereum/go-ethereum/blob/85077be58edea572f29c3b1a6a055077f1a56a8b/eth/protocols/eth/protocol.go#L45-L47>
     pub const fn message_count(version: EthVersion) -> u8 {
         Self::max(version) + 1
     }

--- a/crates/net/eth-wire-types/src/message.rs
+++ b/crates/net/eth-wire-types/src/message.rs
@@ -500,6 +500,15 @@ impl EthMessageID {
             Self::Receipts.to_u8()
         }
     }
+
+    /// Returns the total number of message types for the given version.
+    ///
+    /// This is used for message ID multiplexing.
+    ///
+    /// https://github.com/ethereum/go-ethereum/blob/85077be58edea572f29c3b1a6a055077f1a56a8b/eth/protocols/eth/protocol.go#L45-L47
+    pub const fn message_count(version: EthVersion) -> u8 {
+        Self::max(version) + 1
+    }
 }
 
 impl Encodable for EthMessageID {

--- a/crates/net/eth-wire-types/src/version.rs
+++ b/crates/net/eth-wire-types/src/version.rs
@@ -36,19 +36,6 @@ impl EthVersion {
     /// All known eth versions
     pub const ALL_VERSIONS: &'static [Self] = &[Self::Eth69, Self::Eth68, Self::Eth67, Self::Eth66];
 
-    /// Returns the total number of messages the protocol version supports.
-    pub const fn total_messages(&self) -> u8 {
-        match self {
-            Self::Eth66 => 15,
-            Self::Eth67 | Self::Eth68 => {
-                // eth/67,68 are eth/66 minus GetNodeData and NodeData messages
-                13
-            }
-            // eth69 is both eth67 and eth68 minus NewBlockHashes and NewBlock + BlockRangeUpdate
-            Self::Eth69 => 12,
-        }
-    }
-
     /// Returns true if the version is eth/66
     pub const fn is_eth66(&self) -> bool {
         matches!(self, Self::Eth66)
@@ -261,13 +248,5 @@ mod tests {
             let result = EthVersion::decode(&mut slice);
             assert_eq!(result, expected);
         }
-    }
-
-    #[test]
-    fn test_eth_version_total_messages() {
-        assert_eq!(EthVersion::Eth66.total_messages(), 15);
-        assert_eq!(EthVersion::Eth67.total_messages(), 13);
-        assert_eq!(EthVersion::Eth68.total_messages(), 13);
-        assert_eq!(EthVersion::Eth69.total_messages(), 12);
     }
 }

--- a/crates/net/eth-wire/src/capability.rs
+++ b/crates/net/eth-wire/src/capability.rs
@@ -134,7 +134,7 @@ impl SharedCapability {
     /// Returns the number of protocol messages supported by this capability.
     pub const fn num_messages(&self) -> u8 {
         match self {
-            Self::Eth { version, .. } => EthMessageID::max(*version) + 1,
+            Self::Eth { version, .. } => EthMessageID::message_count(*version),
             Self::UnknownCapability { messages, .. } => *messages,
         }
     }

--- a/crates/net/eth-wire/src/eth_snap_stream.rs
+++ b/crates/net/eth-wire/src/eth_snap_stream.rs
@@ -236,9 +236,9 @@ where
                     Err(EthSnapStreamError::InvalidMessage(self.eth_version, err.to_string()))
                 }
             }
-        } else if message_id > EthMessageID::max(self.eth_version)
-            && message_id
-                <= EthMessageID::message_count(self.eth_version) + SnapMessageId::TrieNodes as u8
+        } else if message_id > EthMessageID::max(self.eth_version) &&
+            message_id <=
+                EthMessageID::message_count(self.eth_version) + SnapMessageId::TrieNodes as u8
         {
             // Checks for multiplexed snap message IDs :
             // - message_id > EthMessageID::max() : ensures it's not an eth message

--- a/crates/net/eth-wire/src/eth_snap_stream.rs
+++ b/crates/net/eth-wire/src/eth_snap_stream.rs
@@ -236,14 +236,14 @@ where
                     Err(EthSnapStreamError::InvalidMessage(self.eth_version, err.to_string()))
                 }
             }
-        } else if message_id > EthMessageID::max(self.eth_version) &&
-            message_id <=
-                EthMessageID::message_count(self.eth_version) + SnapMessageId::TrieNodes as u8
+        } else if message_id > EthMessageID::max(self.eth_version)
+            && message_id
+                <= EthMessageID::message_count(self.eth_version) + SnapMessageId::TrieNodes as u8
         {
             // Checks for multiplexed snap message IDs :
             // - message_id > EthMessageID::max() : ensures it's not an eth message
-            // - message_id <= EthMessageID::message_count() + snap_max : ensures it's within valid snap
-            //   range
+            // - message_id <= EthMessageID::message_count() + snap_max : ensures it's within valid
+            //   snap range
             // Message IDs are assigned lexicographically during capability negotiation
             // So real_snap_id = multiplexed_id - num_eth_messages
             let adjusted_message_id = message_id - EthMessageID::message_count(self.eth_version);

--- a/crates/net/eth-wire/src/eth_snap_stream.rs
+++ b/crates/net/eth-wire/src/eth_snap_stream.rs
@@ -238,15 +238,15 @@ where
             }
         } else if message_id > EthMessageID::max(self.eth_version) &&
             message_id <=
-                EthMessageID::max(self.eth_version) + 1 + SnapMessageId::TrieNodes as u8
+                EthMessageID::message_count(self.eth_version) + SnapMessageId::TrieNodes as u8
         {
             // Checks for multiplexed snap message IDs :
             // - message_id > EthMessageID::max() : ensures it's not an eth message
-            // - message_id <= EthMessageID::max() + 1 + snap_max : ensures it's within valid snap
+            // - message_id <= EthMessageID::message_count() + snap_max : ensures it's within valid snap
             //   range
             // Message IDs are assigned lexicographically during capability negotiation
             // So real_snap_id = multiplexed_id - num_eth_messages
-            let adjusted_message_id = message_id - (EthMessageID::max(self.eth_version) + 1);
+            let adjusted_message_id = message_id - EthMessageID::message_count(self.eth_version);
             let mut buf = &bytes[1..];
 
             match SnapProtocolMessage::decode(adjusted_message_id, &mut buf) {
@@ -276,7 +276,7 @@ where
         let encoded = message.encode();
 
         let message_id = encoded[0];
-        let adjusted_id = message_id + EthMessageID::max(self.eth_version) + 1;
+        let adjusted_id = message_id + EthMessageID::message_count(self.eth_version);
 
         let mut adjusted = Vec::with_capacity(encoded.len());
         adjusted.push(adjusted_id);

--- a/crates/net/eth-wire/src/protocol.rs
+++ b/crates/net/eth-wire/src/protocol.rs
@@ -26,7 +26,7 @@ impl Protocol {
     /// Returns the corresponding eth capability for the given version.
     pub const fn eth(version: EthVersion) -> Self {
         let cap = Capability::eth(version);
-        let messages = EthMessageID::max(version) + 1;
+        let messages = EthMessageID::message_count(version);
         Self::new(cap, messages)
     }
 
@@ -79,7 +79,7 @@ mod tests {
     #[test]
     fn test_protocol_eth_message_count() {
         // Test that Protocol::eth() returns correct message counts for each version
-        // This ensures that EthMessageID::max(version) + 1 produces the expected results
+        // This ensures that EthMessageID::message_count() produces the expected results
         assert_eq!(Protocol::eth(EthVersion::Eth66).messages(), 17);
         assert_eq!(Protocol::eth(EthVersion::Eth67).messages(), 17);
         assert_eq!(Protocol::eth(EthVersion::Eth68).messages(), 17);

--- a/crates/net/eth-wire/src/protocol.rs
+++ b/crates/net/eth-wire/src/protocol.rs
@@ -1,6 +1,6 @@
 //! A Protocol defines a P2P subprotocol in an `RLPx` connection
 
-use crate::{Capability, EthVersion};
+use crate::{Capability, EthMessageID, EthVersion};
 
 /// Type that represents a [Capability] and the number of messages it uses.
 ///
@@ -26,7 +26,7 @@ impl Protocol {
     /// Returns the corresponding eth capability for the given version.
     pub const fn eth(version: EthVersion) -> Self {
         let cap = Capability::eth(version);
-        let messages = version.total_messages();
+        let messages = EthMessageID::max(version) + 1;
         Self::new(cap, messages)
     }
 
@@ -70,4 +70,19 @@ pub(crate) struct ProtoVersion {
     pub(crate) messages: u8,
     /// Version of the protocol
     pub(crate) version: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_protocol_eth_message_count() {
+        // Test that Protocol::eth() returns correct message counts for each version
+        // This ensures that EthMessageID::max(version) + 1 produces the expected results
+        assert_eq!(Protocol::eth(EthVersion::Eth66).messages(), 17);
+        assert_eq!(Protocol::eth(EthVersion::Eth67).messages(), 17);
+        assert_eq!(Protocol::eth(EthVersion::Eth68).messages(), 17);
+        assert_eq!(Protocol::eth(EthVersion::Eth69).messages(), 18);
+    }
 }


### PR DESCRIPTION
## Summary

  Remove incorrect `EthVersion::total_messages()` method and replace duplicate `EthMessageID::max(version) + 1` calculations with a dedicated `message_count()` function.

  ## Motivation

  The `EthVersion::total_messages()` method returned incorrect hardcoded values that didn't match the actual message IDs. Additionally, the codebase had multiple instances of `EthMessageID::max(version) +
  1` scattered throughout, which creates code duplication and makes the intent less clear. This pattern is used for message ID multiplexing where we need the total count of message types for a given
  Ethereum protocol version.

  ## Changes

  - Remove `EthVersion::total_messages()` with incorrect hardcoded counts
  - Add `EthMessageID::message_count(version)` function that encapsulates `max(version) + 1`
  - Replace all occurrences of `EthMessageID::max(version) + 1` with the new function:
    - `crates/net/eth-wire/src/capability.rs`: Updated `num_messages()` method
    - `crates/net/eth-wire/src/protocol.rs`: Updated `Protocol::eth()` method
    - `crates/net/eth-wire/src/eth_snap_stream.rs`: Updated message ID calculations and comments
  - Improve code clarity by using a descriptive function name instead of manual arithmetic
  - Add documentation referencing the Go-Ethereum implementation for context
  - Add tests to verify correct message counts

  ## Refs
  https://github.com/ethereum/go-ethereum/blob/85077be58edea572f29c3b1a6a055077f1a56a8b/eth/protocols/eth/protocol.go#L45-L47