### PR TITLE
test(engine): add e2e tests for forkchoice update with finalized blocks

### DIFF
--- a/crates/e2e-test-utils/src/testsuite/actions/custom_fcu.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions/custom_fcu.rs
@@ -44,34 +44,37 @@ pub fn resolve_block_reference<Engine: EngineTypes>(
     }
 }
 
-/// Action to test FCU behavior with finalized blocks and forks.
-///
-/// This tests the specific scenario:
-/// 1. We have a chain: genesis -> ... -> `block_A` -> `block_B` -> `block_C`
-/// 2. We finalize `block_B` (with head at `block_C`)
-/// 3. We try to reorg to a different fork that branches before `block_B`
+/// Action to send a custom forkchoice update with specific finalized, safe, and head blocks
 #[derive(Debug)]
-pub struct TestReorgBehindFinalized<Engine> {
-    /// Block to finalize first
-    pub block_to_finalize: BlockReference,
-    /// Current head when finalizing
-    pub current_head: BlockReference,
-    /// Fork block that branches before finalized (attempting invalid reorg)
-    pub fork_block: BlockReference,
-    /// Node index to send to
+pub struct SendForkchoiceUpdate<Engine> {
+    /// The finalized block reference
+    pub finalized: BlockReference,
+    /// The safe block reference
+    pub safe: BlockReference,
+    /// The head block reference
+    pub head: BlockReference,
+    /// Expected payload status (None means accept any non-error)
+    pub expected_status: Option<PayloadStatusEnum>,
+    /// Node index to send to (None means active node)
     pub node_idx: Option<usize>,
     /// Tracks engine type
     _phantom: PhantomData<Engine>,
 }
 
-impl<Engine> TestReorgBehindFinalized<Engine> {
-    /// Create a new test for reorg behind finalized
+impl<Engine> SendForkchoiceUpdate<Engine> {
+    /// Create a new custom forkchoice update action
     pub const fn new(
-        block_to_finalize: BlockReference,
-        current_head: BlockReference,
-        fork_block: BlockReference,
+        finalized: BlockReference,
+        safe: BlockReference,
+        head: BlockReference,
     ) -> Self {
-        Self { block_to_finalize, current_head, fork_block, node_idx: None, _phantom: PhantomData }
+        Self { finalized, safe, head, expected_status: None, node_idx: None, _phantom: PhantomData }
+    }
+
+    /// Set expected status for the FCU response
+    pub fn with_expected_status(mut self, status: PayloadStatusEnum) -> Self {
+        self.expected_status = Some(status);
+        self
     }
 
     /// Set the target node index
@@ -81,73 +84,143 @@ impl<Engine> TestReorgBehindFinalized<Engine> {
     }
 }
 
-impl<Engine> Action<Engine> for TestReorgBehindFinalized<Engine>
+impl<Engine> Action<Engine> for SendForkchoiceUpdate<Engine>
+where
+    Engine: EngineTypes,
+{
+    fn execute<'a>(&'a mut self, env: &'a mut Environment<Engine>) -> BoxFuture<'a, Result<()>> {
+        Box::pin(async move {
+            let finalized_hash = resolve_block_reference(&self.finalized, env)?;
+            let safe_hash = resolve_block_reference(&self.safe, env)?;
+            let head_hash = resolve_block_reference(&self.head, env)?;
+
+            let fork_choice_state = ForkchoiceState {
+                head_block_hash: head_hash,
+                safe_block_hash: safe_hash,
+                finalized_block_hash: finalized_hash,
+            };
+
+            debug!(
+                "Sending FCU - finalized: {finalized_hash}, safe: {safe_hash}, head: {head_hash}"
+            );
+
+            let node_idx = self.node_idx.unwrap_or(env.active_node_idx);
+            if node_idx >= env.node_clients.len() {
+                return Err(eyre::eyre!("Node index {node_idx} out of bounds"));
+            }
+
+            let engine = env.node_clients[node_idx].engine.http_client();
+            let fcu_response =
+                EngineApiClient::<Engine>::fork_choice_updated_v3(&engine, fork_choice_state, None)
+                    .await?;
+
+            debug!(
+                "Node {node_idx}: FCU response - status: {:?}, latest_valid_hash: {:?}",
+                fcu_response.payload_status.status, fcu_response.payload_status.latest_valid_hash
+            );
+
+            // If we have an expected status, validate it
+            if let Some(expected) = &self.expected_status {
+                match (&fcu_response.payload_status.status, expected) {
+                    (PayloadStatusEnum::Valid, PayloadStatusEnum::Valid) => {
+                        debug!("Node {node_idx}: FCU returned VALID as expected");
+                    }
+                    (
+                        PayloadStatusEnum::Invalid { validation_error },
+                        PayloadStatusEnum::Invalid { .. },
+                    ) => {
+                        debug!(
+                            "Node {node_idx}: FCU returned INVALID as expected: {validation_error:?}"
+                        );
+                    }
+                    (PayloadStatusEnum::Syncing, PayloadStatusEnum::Syncing) => {
+                        debug!("Node {node_idx}: FCU returned SYNCING as expected");
+                    }
+                    (PayloadStatusEnum::Accepted, PayloadStatusEnum::Accepted) => {
+                        debug!("Node {node_idx}: FCU returned ACCEPTED as expected");
+                    }
+                    (actual, expected) => {
+                        return Err(eyre::eyre!(
+                            "Node {node_idx}: FCU status mismatch. Expected {expected:?}, got {actual:?}"
+                        ));
+                    }
+                }
+            } else {
+                // Just validate it's not an error
+                if matches!(fcu_response.payload_status.status, PayloadStatusEnum::Invalid { .. }) {
+                    return Err(eyre::eyre!(
+                        "Node {node_idx}: FCU returned unexpected INVALID status: {:?}",
+                        fcu_response.payload_status.status
+                    ));
+                }
+            }
+
+            Ok(())
+        })
+    }
+}
+
+/// Action to finalize a specific block with a given head
+#[derive(Debug)]
+pub struct FinalizeBlock<Engine> {
+    /// Block to finalize
+    pub block_to_finalize: BlockReference,
+    /// Current head block (if None, uses the finalized block)
+    pub head: Option<BlockReference>,
+    /// Node index to send to (None means active node)
+    pub node_idx: Option<usize>,
+    /// Tracks engine type
+    _phantom: PhantomData<Engine>,
+}
+
+impl<Engine> FinalizeBlock<Engine> {
+    /// Create a new finalize block action
+    pub const fn new(block_to_finalize: BlockReference) -> Self {
+        Self { block_to_finalize, head: None, node_idx: None, _phantom: PhantomData }
+    }
+
+    /// Set the head block (if different from finalized)
+    pub fn with_head(mut self, head: BlockReference) -> Self {
+        self.head = Some(head);
+        self
+    }
+
+    /// Set the target node index
+    pub const fn with_node_idx(mut self, idx: usize) -> Self {
+        self.node_idx = Some(idx);
+        self
+    }
+}
+
+impl<Engine> Action<Engine> for FinalizeBlock<Engine>
 where
     Engine: EngineTypes,
 {
     fn execute<'a>(&'a mut self, env: &'a mut Environment<Engine>) -> BoxFuture<'a, Result<()>> {
         Box::pin(async move {
             let finalized_hash = resolve_block_reference(&self.block_to_finalize, env)?;
-            let head_hash = resolve_block_reference(&self.current_head, env)?;
-            let fork_hash = resolve_block_reference(&self.fork_block, env)?;
-
-            let node_idx = self.node_idx.unwrap_or(env.active_node_idx);
-            let engine = env.node_clients[node_idx].engine.http_client();
-
-            // Step 1: Finalize a block with proper head
-            let fork_choice_state = ForkchoiceState {
-                head_block_hash: head_hash,
-                safe_block_hash: finalized_hash,
-                finalized_block_hash: finalized_hash,
+            let head_hash = if let Some(ref head_ref) = self.head {
+                resolve_block_reference(head_ref, env)?
+            } else {
+                finalized_hash
             };
 
-            debug!(
-                "Node {node_idx}: Setting finalized={finalized_hash}, safe={finalized_hash}, head={head_hash}"
+            // Use SendForkchoiceUpdate to do the actual work
+            let mut fcu_action = SendForkchoiceUpdate::new(
+                BlockReference::Hash(finalized_hash),
+                BlockReference::Hash(finalized_hash), // safe = finalized
+                BlockReference::Hash(head_hash),
             );
 
-            let fcu_response =
-                EngineApiClient::<Engine>::fork_choice_updated_v3(&engine, fork_choice_state, None)
-                    .await?;
-
-            // This should be valid
-            if !matches!(fcu_response.payload_status.status, PayloadStatusEnum::Valid) {
-                return Err(eyre::eyre!(
-                    "Node {node_idx}: Failed to finalize block. Status: {:?}",
-                    fcu_response.payload_status.status
-                ));
+            if let Some(idx) = self.node_idx {
+                fcu_action = fcu_action.with_node_idx(idx);
             }
 
-            debug!(
-                "Node {node_idx}: Block {finalized_hash} successfully finalized with head at {head_hash}"
-            );
+            fcu_action.execute(env).await?;
 
-            // Step 2: Try to reorg to a fork that branches before the finalized block
-            let reorg_fork_choice_state = ForkchoiceState {
-                head_block_hash: fork_hash,
-                safe_block_hash: fork_hash,
-                finalized_block_hash: finalized_hash, // Keep finalized the same
-            };
+            debug!("Block {finalized_hash} successfully finalized with head at {head_hash}");
 
-            debug!(
-                "Node {node_idx}: Attempting reorg to fork {fork_hash} while keeping finalized at {finalized_hash}"
-            );
-
-            let reorg_response = EngineApiClient::<Engine>::fork_choice_updated_v3(
-                &engine,
-                reorg_fork_choice_state,
-                None,
-            )
-            .await?;
-
-            match &reorg_response.payload_status.status {
-                PayloadStatusEnum::Valid => {
-                    debug!("Node {node_idx}: FCU accepted as VALID");
-                    Ok(())
-                }
-                other_status => Err(eyre::eyre!(
-                    "Node {node_idx}: Expected FCU to return VALID, but got {other_status:?}"
-                )),
-            }
+            Ok(())
         })
     }
 }

--- a/crates/e2e-test-utils/src/testsuite/actions/custom_fcu.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions/custom_fcu.rs
@@ -1,0 +1,162 @@
+//! Custom forkchoice update actions for testing specific FCU scenarios.
+
+use crate::testsuite::{Action, Environment};
+use alloy_primitives::B256;
+use alloy_rpc_types_engine::{ForkchoiceState, PayloadStatusEnum};
+use eyre::Result;
+use futures_util::future::BoxFuture;
+use reth_node_api::EngineTypes;
+use reth_rpc_api::clients::EngineApiClient;
+use std::marker::PhantomData;
+use tracing::debug;
+
+/// Reference to a block for forkchoice update
+#[derive(Debug, Clone)]
+pub enum BlockReference {
+    /// Direct block hash
+    Hash(B256),
+    /// Tagged block reference
+    Tag(String),
+    /// Latest block on the active node
+    Latest,
+}
+
+/// Helper function to resolve a block reference to a hash
+pub fn resolve_block_reference<Engine: EngineTypes>(
+    reference: &BlockReference,
+    env: &Environment<Engine>,
+) -> Result<B256> {
+    match reference {
+        BlockReference::Hash(hash) => Ok(*hash),
+        BlockReference::Tag(tag) => {
+            let (block_info, _) = env
+                .block_registry
+                .get(tag)
+                .ok_or_else(|| eyre::eyre!("Block tag '{tag}' not found in registry"))?;
+            Ok(block_info.hash)
+        }
+        BlockReference::Latest => {
+            let block_info = env
+                .current_block_info()
+                .ok_or_else(|| eyre::eyre!("No current block information available"))?;
+            Ok(block_info.hash)
+        }
+    }
+}
+
+/// Action to test if reth allows reorgs that would change blocks behind finalized.
+///
+/// This tests the specific scenario:
+/// 1. We have a chain: genesis -> ... -> `block_A` -> `block_B` -> `block_C`
+/// 2. We finalize `block_B` (with head at `block_C`)
+/// 3. We try to reorg to a different fork that branches before `block_B`
+///
+/// According to consensus rules, once `block_B` is finalized, we cannot accept
+/// any fork that doesn't include `block_B` in its history.
+#[derive(Debug)]
+pub struct TestReorgBehindFinalized<Engine> {
+    /// Block to finalize first
+    pub block_to_finalize: BlockReference,
+    /// Current head when finalizing
+    pub current_head: BlockReference,
+    /// Fork block that branches before finalized (attempting invalid reorg)
+    pub fork_block: BlockReference,
+    /// Node index to send to
+    pub node_idx: Option<usize>,
+    /// Tracks engine type
+    _phantom: PhantomData<Engine>,
+}
+
+impl<Engine> TestReorgBehindFinalized<Engine> {
+    /// Create a new test for reorg behind finalized
+    pub const fn new(
+        block_to_finalize: BlockReference,
+        current_head: BlockReference,
+        fork_block: BlockReference,
+    ) -> Self {
+        Self { block_to_finalize, current_head, fork_block, node_idx: None, _phantom: PhantomData }
+    }
+
+    /// Set the target node index
+    pub const fn with_node_idx(mut self, idx: usize) -> Self {
+        self.node_idx = Some(idx);
+        self
+    }
+}
+
+impl<Engine> Action<Engine> for TestReorgBehindFinalized<Engine>
+where
+    Engine: EngineTypes,
+{
+    fn execute<'a>(&'a mut self, env: &'a mut Environment<Engine>) -> BoxFuture<'a, Result<()>> {
+        Box::pin(async move {
+            let finalized_hash = resolve_block_reference(&self.block_to_finalize, env)?;
+            let head_hash = resolve_block_reference(&self.current_head, env)?;
+            let fork_hash = resolve_block_reference(&self.fork_block, env)?;
+
+            let node_idx = self.node_idx.unwrap_or(env.active_node_idx);
+            let engine = env.node_clients[node_idx].engine.http_client();
+
+            // Step 1: Finalize a block with proper head
+            let fork_choice_state = ForkchoiceState {
+                head_block_hash: head_hash,
+                safe_block_hash: finalized_hash,
+                finalized_block_hash: finalized_hash,
+            };
+
+            debug!(
+                "Node {node_idx}: Setting finalized={finalized_hash}, safe={finalized_hash}, head={head_hash}"
+            );
+
+            let fcu_response =
+                EngineApiClient::<Engine>::fork_choice_updated_v3(&engine, fork_choice_state, None)
+                    .await?;
+
+            // This should be valid
+            if !matches!(fcu_response.payload_status.status, PayloadStatusEnum::Valid) {
+                return Err(eyre::eyre!(
+                    "Node {node_idx}: Failed to finalize block. Status: {:?}",
+                    fcu_response.payload_status.status
+                ));
+            }
+
+            debug!(
+                "Node {node_idx}: Block {finalized_hash} successfully finalized with head at {head_hash}"
+            );
+
+            // Step 2: Try to reorg to a fork that branches before the finalized block
+            // This should be rejected because it would require changing the finalized block
+            let reorg_fork_choice_state = ForkchoiceState {
+                head_block_hash: fork_hash,
+                safe_block_hash: fork_hash,
+                finalized_block_hash: finalized_hash, // Keep finalized the same
+            };
+
+            debug!(
+                "Node {node_idx}: Attempting reorg to fork {fork_hash} while keeping finalized at {finalized_hash}"
+            );
+
+            let reorg_response = EngineApiClient::<Engine>::fork_choice_updated_v3(
+                &engine,
+                reorg_fork_choice_state,
+                None,
+            )
+            .await?;
+
+            // This should return INVALID because the fork doesn't contain the finalized block
+            match &reorg_response.payload_status.status {
+                PayloadStatusEnum::Invalid { validation_error } => {
+                    debug!(
+                        "Node {node_idx}: Reorg correctly rejected with error: {validation_error}"
+                    );
+                    Ok(())
+                }
+                other_status => {
+                    Err(eyre::eyre!(
+                        "Node {node_idx}: Expected FCU to return INVALID for reorg to fork not containing finalized block, but got {other_status:?}"
+                    ))
+                }
+            }
+        })
+    }
+}

--- a/crates/e2e-test-utils/src/testsuite/actions/mod.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions/mod.rs
@@ -9,12 +9,14 @@ use reth_rpc_api::clients::EngineApiClient;
 use std::future::Future;
 use tracing::debug;
 
+pub mod custom_fcu;
 pub mod engine_api;
 pub mod fork;
 pub mod node_ops;
 pub mod produce_blocks;
 pub mod reorg;
 
+pub use custom_fcu::{BlockReference, TestReorgBehindFinalized};
 pub use engine_api::{ExpectedPayloadStatus, SendNewPayload, SendNewPayloads};
 pub use fork::{CreateFork, ForkBase, SetForkBase, SetForkBaseFromBlockInfo, ValidateFork};
 pub use node_ops::{

--- a/crates/e2e-test-utils/src/testsuite/actions/mod.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions/mod.rs
@@ -16,7 +16,7 @@ pub mod node_ops;
 pub mod produce_blocks;
 pub mod reorg;
 
-pub use custom_fcu::{BlockReference, TestReorgBehindFinalized};
+pub use custom_fcu::{BlockReference, FinalizeBlock, SendForkchoiceUpdate};
 pub use engine_api::{ExpectedPayloadStatus, SendNewPayload, SendNewPayloads};
 pub use fork::{CreateFork, ForkBase, SetForkBase, SetForkBaseFromBlockInfo, ValidateFork};
 pub use node_ops::{

--- a/crates/engine/tree/tests/e2e-testsuite/fcu_finalized_blocks.rs
+++ b/crates/engine/tree/tests/e2e-testsuite/fcu_finalized_blocks.rs
@@ -1,0 +1,72 @@
+//! E2E test for forkchoice update with finalized blocks.
+//!
+//! This test verifies the behavior when attempting to reorg behind a finalized block.
+
+use eyre::Result;
+use reth_chainspec::{ChainSpecBuilder, MAINNET};
+use reth_e2e_test_utils::testsuite::{
+    actions::{
+        BlockReference, CaptureBlock, CreateFork, MakeCanonical, ProduceBlocks,
+        TestReorgBehindFinalized,
+    },
+    setup::{NetworkSetup, Setup},
+    TestBuilder,
+};
+use reth_engine_tree::tree::TreeConfig;
+use reth_ethereum_engine_primitives::EthEngineTypes;
+use reth_node_ethereum::EthereumNode;
+use std::sync::Arc;
+
+/// Creates the standard setup for engine tree e2e tests.
+fn default_engine_tree_setup() -> Setup<EthEngineTypes> {
+    Setup::default()
+        .with_chain_spec(Arc::new(
+            ChainSpecBuilder::default()
+                .chain(MAINNET.chain)
+                .genesis(
+                    serde_json::from_str(include_str!(
+                        "../../../../e2e-test-utils/src/testsuite/assets/genesis.json"
+                    ))
+                    .unwrap(),
+                )
+                .cancun_activated()
+                .build(),
+        ))
+        .with_network(NetworkSetup::single_node())
+        .with_tree_config(
+            TreeConfig::default().with_legacy_state_root(false).with_has_enough_parallelism(true),
+        )
+}
+
+/// This test:
+/// 1. Creates a main chain and finalizes a block
+/// 2. Creates a fork that branches BEFORE the finalized block
+/// 3. Attempts to switch to that fork (which would require changing history behind finalized)
+#[tokio::test]
+async fn test_reorg_to_fork_behind_finalized() -> Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let test = TestBuilder::new()
+        .with_setup(default_engine_tree_setup())
+        // Build main chain: blocks 1-10
+        .with_action(ProduceBlocks::<EthEngineTypes>::new(10))
+        .with_action(MakeCanonical::new())
+        // Capture blocks for the test
+        .with_action(CaptureBlock::new("block_5")) // Will be fork point
+        .with_action(CaptureBlock::new("block_7")) // Will be finalized
+        .with_action(CaptureBlock::new("block_10")) // Current head
+        // Create a fork from block 5 (before block 7 which will be finalized)
+        .with_action(CreateFork::<EthEngineTypes>::new(5, 5)) // Fork from block 5, add 5 blocks
+        .with_action(CaptureBlock::new("fork_tip"))
+        // Test the scenario: finalize block 7, then try to reorg to the fork
+        .with_action(TestReorgBehindFinalized::<EthEngineTypes>::new(
+            BlockReference::Tag("block_7".to_string()), // Finalize block 7
+            BlockReference::Tag("block_10".to_string()), // Current head at block 10
+            BlockReference::Tag("fork_tip".to_string()), /* Try to switch to fork that doesn't
+                                                         * contain block 7 */
+        ));
+
+    test.run::<EthereumNode>().await?;
+
+    Ok(())
+}

--- a/crates/engine/tree/tests/e2e-testsuite/main.rs
+++ b/crates/engine/tree/tests/e2e-testsuite/main.rs
@@ -1,5 +1,7 @@
 //! E2E test implementations using the e2e test framework for engine tree functionality.
 
+mod fcu_finalized_blocks;
+
 use eyre::Result;
 use reth_chainspec::{ChainSpecBuilder, MAINNET};
 use reth_e2e_test_utils::testsuite::{


### PR DESCRIPTION
This test:
* creates a main chain and finalizes a block
* creates a fork that branches BEFORE the finalized block
* attempts to switch to that fork 