### PR TITLE
feat(node): reduce the status logging

### DIFF
--- a/crates/node/events/src/node.rs
+++ b/crates/node/events/src/node.rs
@@ -37,8 +37,6 @@ struct NodeState {
     current_stage: Option<CurrentStage>,
     /// The latest block reached by either pipeline or consensus engine.
     latest_block: Option<BlockNumber>,
-    /// The time of the latest block seen by the pipeline
-    latest_block_time: Option<u64>,
     /// Hash of the head block last set by fork choice update
     head_block_hash: Option<B256>,
     /// Hash of the safe block last set by fork choice update
@@ -58,7 +56,6 @@ impl NodeState {
             peers_info,
             current_stage: None,
             latest_block,
-            latest_block_time: None,
             head_block_hash: None,
             safe_block_hash: None,
             finalized_block_hash: None,
@@ -270,8 +267,6 @@ impl NodeState {
             }
             ConsensusEngineEvent::CanonicalChainCommitted(head, elapsed) => {
                 self.latest_block = Some(head.number());
-                self.latest_block_time = Some(head.timestamp());
-
                 info!(number=head.number(), hash=?head.hash(), ?elapsed, "Canonical chain committed");
             }
             ConsensusEngineEvent::ForkBlockAdded(executed, elapsed) => {


### PR DESCRIPTION
In our environment, we saw too much `Status` logs in the logfile when in the history block syncing, about 1-5 per second.
These are some normal logs, which have taken up space for other WARN or ERROR logs.

```
  2025-08-22T06:12:40.680033Z  INFO Status connected_peers=0 latest_block=12374479
  2025-08-22T06:12:41.587088Z  INFO Status connected_peers=0 latest_block=12671366
  2025-08-22T06:12:42.454107Z  INFO Status connected_peers=0 latest_block=12217896
  2025-08-22T06:12:42.696468Z  INFO Status connected_peers=0 latest_block=12799810
  2025-08-22T06:12:43.789727Z  INFO Status connected_peers=0 latest_block=12574586
  2025-08-22T06:12:44.263340Z  INFO Status connected_peers=0 latest_block=12260995
  2025-08-22T06:12:45.635862Z  INFO Status connected_peers=0 latest_block=12818741
  2025-08-22T06:12:45.739079Z  INFO Status connected_peers=0 latest_block=12535927
  2025-08-22T06:12:45.781302Z  INFO Status connected_peers=0 latest_block=12173819
  2025-08-22T06:12:46.102764Z  INFO Status connected_peers=0 latest_block=12107645
  2025-08-22T06:12:47.199997Z  INFO Status connected_peers=0 latest_block=12042678
  2025-08-22T06:12:47.777714Z  INFO Status connected_peers=0 latest_block=12555402
  2025-08-22T06:12:47.951047Z  INFO Status connected_peers=0 latest_block=12239560
  2025-08-22T06:12:48.004262Z  INFO Status connected_peers=0 latest_block=12085962
  2025-08-22T06:12:48.586964Z  INFO Status connected_peers=0 latest_block=12130324
  2025-08-22T06:12:51.827405Z  INFO Status connected_peers=0 latest_block=12743728
  2025-08-22T06:12:51.831545Z  INFO Status connected_peers=0 latest_block=12356718
  2025-08-22T06:12:51.993803Z  INFO Status connected_peers=0 latest_block=12725601
  2025-08-22T06:12:52.048052Z  INFO Status connected_peers=0 latest_block=12651947
  2025-08-22T06:12:52.197361Z  INFO Status connected_peers=0 latest_block=12445526
  2025-08-22T06:12:52.393697Z  INFO Status connected_peers=0 latest_block=12688900
  2025-08-22T06:12:52.452897Z  INFO Status connected_peers=0 latest_block=12781397
  2025-08-22T06:12:52.802390Z  INFO Status connected_peers=0 latest_block=12613645
  2025-08-22T06:12:53.113878Z  INFO Status connected_peers=0 latest_block=12498800
```

We use the `latest_block_timestamp` to check the log interval, but when we're handling the hitory logs,
the `block_timestamp` was stall, so proposal to reduce those logs to use current timestamp instead.