### PR TITLE
fix: make ensure target syntax error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -420,7 +420,7 @@ lint-typos: ensure-typos
 
 ensure-typos:
 	@if ! command -v typos &> /dev/null; then \
-		echo "typos not found. Please install it by running the command `cargo install typos-cli` or refer to the following link for more information: https://github.com/crate-ci/typos" \
+		echo "typos not found. Please install it by running the command 'cargo install typos-cli' or refer to the following link for more information: https://github.com/crate-ci/typos" \
 		exit 1; \
     fi
 
@@ -439,7 +439,7 @@ lint-toml: ensure-dprint
 
 ensure-dprint:
 	@if ! command -v dprint &> /dev/null; then \
-		echo "dprint not found. Please install it by running the command `cargo install --locked dprint` or refer to the following link for more information: https://github.com/dprint/dprint" \
+		echo "dprint not found. Please install it by running the command 'cargo install --locked dprint' or refer to the following link for more information: https://github.com/dprint/dprint" \
 		exit 1; \
     fi
 


### PR DESCRIPTION
When run `make ensure-typos`, it will auto-run the `cargo install typos-cli` to install the typos, but from the output message, seems it will let the use to install it manually, so I think it was the syntax error use of the bash script.