### PR TITLE
fix: correct logical error in delete_outside_range error message

### DIFF
--- a/crates/era-downloader/src/client.rs
+++ b/crates/era-downloader/src/client.rs
@@ -129,7 +129,7 @@ impl<Http: HttpClient + Clone> EraClient<Http> {
                     if let Some(number) = self.file_name_to_number(name) {
                         if number < index || number >= last {
                             eprintln!("Deleting file {}", entry.path().display());
-                            eprintln!("{number} < {index} || {number} > {last}");
+                            eprintln!("{number} < {index} || {number} >= {last}");
                             reth_fs_util::remove_file(entry.path())?;
                         }
                     }


### PR DESCRIPTION
The error message in delete_outside_range method had incorrect logic:
- Code condition: number < index || number >= last
- Error message: number < index || number > last

Fixed message to use >= instead of > to match the actual code logic.