### PR TITLE
chore: remove msrv from clippy.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ If you want to contribute, or follow along with contributor discussion, you can 
 
 <!--
 When updating this, also update:
-- clippy.toml
 - Cargo.toml
 - .github/workflows/lint.yml
 -->

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,4 +1,3 @@
-msrv = "1.88"
 too-large-for-stack = 128
 doc-valid-idents = [
     "P2P",


### PR DESCRIPTION
It is inferred from Cargo.toml's values for each crate.