### PR TITLE
chore: apply spelling and typo fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -420,7 +420,7 @@ lint-typos: ensure-typos
 
 ensure-typos:
 	@if ! command -v typos &> /dev/null; then \
-		echo "typos not found. Please install it by running the command `cargo install typos-cli` or refer to the following link for more information: https://github.com/crate-ci/typos" \
+		echo "typos not found. Please install it by running the command 'cargo install typos-cli' or refer to the following link for more information: https://github.com/crate-ci/typos"; \
 		exit 1; \
     fi
 
@@ -439,7 +439,7 @@ lint-toml: ensure-dprint
 
 ensure-dprint:
 	@if ! command -v dprint &> /dev/null; then \
-		echo "dprint not found. Please install it by running the command `cargo install --locked dprint` or refer to the following link for more information: https://github.com/dprint/dprint" \
+		echo "dprint not found. Please install it by running the command 'cargo install --locked dprint' or refer to the following link for more information: https://github.com/dprint/dprint"; \
 		exit 1; \
     fi
 

--- a/crates/net/network-api/src/lib.rs
+++ b/crates/net/network-api/src/lib.rs
@@ -192,7 +192,7 @@ pub trait Peers: PeersInfo {
     /// Disconnect an existing connection to the given peer using the provided reason
     fn disconnect_peer_with_reason(&self, peer: PeerId, reason: DisconnectReason);
 
-    /// Connect to the given peer. NOTE: if the maximum number out outbound sessions is reached,
+    /// Connect to the given peer. NOTE: if the maximum number of outbound sessions is reached,
     /// this won't do anything. See `reth_network::SessionManager::dial_outbound`.
     fn connect_peer(&self, peer: PeerId, tcp_addr: SocketAddr) {
         self.connect_peer_kind(peer, PeerKind::Static, tcp_addr, None)

--- a/crates/net/p2p/src/bodies/response.rs
+++ b/crates/net/p2p/src/bodies/response.rs
@@ -22,7 +22,7 @@ where
         }
     }
 
-    /// Return the reference to the response header
+    /// Return the difficulty of the response header
     pub fn difficulty(&self) -> U256 {
         match self {
             Self::Full(block) => block.difficulty(),

--- a/crates/optimism/chainspec/src/dev.rs
+++ b/crates/optimism/chainspec/src/dev.rs
@@ -27,7 +27,7 @@ pub static OP_DEV: LazyLock<Arc<OpChainSpec>> = LazyLock::new(|| {
             paris_block_and_final_difficulty: Some((0, U256::from(0))),
             hardforks,
             base_fee_params: BaseFeeParamsKind::Constant(BaseFeeParams::ethereum()),
-            deposit_contract: None, // TODO: do we even have?
+            deposit_contract: None,
             ..Default::default()
         },
     }

--- a/crates/optimism/cli/src/commands/import_receipts.rs
+++ b/crates/optimism/cli/src/commands/import_receipts.rs
@@ -315,7 +315,6 @@ mod test {
         let db = TestStageDB::default();
         init_genesis(&db.factory).unwrap();
 
-        // todo: where does import command init receipts ? probably somewhere in pipeline
         let provider_factory =
             create_test_provider_factory_with_node_types::<OpNode>(OP_MAINNET.clone());
         let ImportReceiptsResult { total_decoded_receipts, total_filtered_out_dup_txns } =

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -729,7 +729,7 @@ where
             info.cumulative_gas_used += gas_used;
             info.cumulative_da_bytes_used += tx_da_size;
 
-            // update add to total fees
+            // update and add to total fees
             let miner_fee = tx
                 .effective_tip_per_gas(base_fee)
                 .expect("fee is always valid; execution succeeded");

--- a/crates/optimism/txpool/src/supervisor/client.rs
+++ b/crates/optimism/txpool/src/supervisor/client.rs
@@ -28,7 +28,7 @@ use std::{
 use tracing::trace;
 
 /// Supervisor hosted by op-labs
-// TODO: This should be changes to actual supervisor url
+// TODO: This should be changed to actual supervisor url
 pub const DEFAULT_SUPERVISOR_URL: &str = "http://localhost:1337/";
 
 /// The default request timeout to use

--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -50,7 +50,7 @@ pub const MERKLE_STAGE_DEFAULT_INCREMENTAL_THRESHOLD: u64 = 7_000;
 
 /// The merkle hashing stage uses input from
 /// [`AccountHashingStage`][crate::stages::AccountHashingStage] and
-/// [`StorageHashingStage`][crate::stages::AccountHashingStage] to calculate intermediate hashes
+/// [`StorageHashingStage`][crate::stages::StorageHashingStage] to calculate intermediate hashes
 /// and state roots.
 ///
 /// This stage should be run with the above two stages, otherwise it is a no-op.

--- a/crates/storage/provider/src/providers/static_file/mod.rs
+++ b/crates/storage/provider/src/providers/static_file/mod.rs
@@ -74,7 +74,7 @@ mod tests {
 
     fn assert_eyre<T: PartialEq + Debug>(got: T, expected: T, msg: &str) -> eyre::Result<()> {
         if got != expected {
-            eyre::bail!("{msg} | got: {got:?} expected: {expected:?})");
+            eyre::bail!("{msg} | got: {got:?} expected: {expected:?}");
         }
         Ok(())
     }


### PR DESCRIPTION
Combined minor spelling and typo fixes from multiple closed PRs that were labeled 'spelling'. These PRs were closed as individual changes weren't worth separate PRs, but the fixes are still valid.

Fixes from:
- #18038: Remove unnecessary TODO comments
- #18024: Fix Makefile ensure target syntax errors  
- #17942: Fix incorrect doc comment for difficulty() method
- #17925: Fix grammar in TODO comment
- #17882: Fix typos in comments
- #17788: Fix formatting issues in error messages
- #17760: Fix doc link to StorageHashingStage