### PR TITLE
fix(static_file_provider): Exception for Gnosis and Chiado

### DIFF
--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -18,7 +18,7 @@ use alloy_primitives::{
 use dashmap::DashMap;
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use parking_lot::RwLock;
-use reth_chainspec::{ChainInfo, ChainSpecProvider, EthChainSpec};
+use reth_chainspec::{ChainInfo, ChainSpecProvider, EthChainSpec, NamedChain};
 use reth_db::{
     lockfile::StorageLock,
     static_file::{
@@ -782,8 +782,8 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
             }
 
             if segment.is_receipts() &&
-                (provider.chain_spec().chain_id() == 100 ||
-                    provider.chain_spec().chain_id() == 10200)
+                (NamedChain::Gnosis == provider.chain_spec().chain_id() ||
+                    NamedChain::Chiado == provider.chain_spec().chain_id())
             {
                 // Gnosis and Chiado's historical import is broken and does not work with this
                 // check. They are importing receipts along with importing

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -781,6 +781,16 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                 continue
             }
 
+            if segment.is_receipts() &&
+                (provider.chain_spec().chain_id() == 100 ||
+                    provider.chain_spec().chain_id() == 10200)
+            {
+                // Gnosis and Chiado's historical import is broken and does not work with this
+                // check. They are importing receipts along with importing
+                // headers/bodies.
+                continue;
+            }
+
             let initial_highest_block = self.get_highest_static_file_block(segment);
 
             //  File consistency is broken if:


### PR DESCRIPTION
fix(static_file_provider): handle broken historical import for Gnosis and Chiado receipts.

For Gnosis and Chiado, we cannot execute pre-merge. That's why during ERA imports, we import the receipts too, as we cannot produce them with execution. Then we import a post-merge state and resume normal operations.

The receipts segment's consistency checking always results in a full rewind. Like Optimism made an exception for the full check, we should suppress this check only for the Receipts segment.

100 => Gnosis (Mainnet)
10200 => Chiado (Testnet)