### PR TITLE
fix: Fix state root related metrics

### DIFF
--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -69,9 +69,9 @@ pub(crate) struct BlockValidationMetrics {
     pub(crate) state_root_storage_tries_updated_total: Counter,
     /// Total number of times the parallel state root computation fell back to regular.
     pub(crate) state_root_parallel_fallback_total: Counter,
-    /// Histogram of state root duration
+    /// Histogram of state root duration, ie the time spent blocked waiting for the state root.
     pub(crate) state_root_histogram: Histogram,
-    /// Latest state root duration
+    /// Latest state root duration, ie the time spent blocked waiting for the state root.
     pub(crate) state_root_duration: Gauge,
     /// Trie input computation duration
     pub(crate) trie_input_duration: Histogram,

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -429,12 +429,11 @@ where
             handle.cache_metrics(),
         );
 
-        let (output, execution_finish) = if self.config.state_provider_metrics() {
+        let output = if self.config.state_provider_metrics() {
             let state_provider = InstrumentedStateProvider::from_state_provider(&state_provider);
-            let (output, execution_finish) =
-                ensure_ok!(self.execute_block(&state_provider, env, &input, &mut handle));
+            let output = ensure_ok!(self.execute_block(&state_provider, env, &input, &mut handle));
             state_provider.record_total_latency();
-            (output, execution_finish)
+            output
         } else {
             ensure_ok!(self.execute_block(&state_provider, env, &input, &mut handle))
         };
@@ -495,7 +494,7 @@ where
                 debug!(target: "engine::tree", block=?block_num_hash, "Using sparse trie state root algorithm");
                 match handle.state_root() {
                     Ok(StateRootComputeOutcome { state_root, trie_updates }) => {
-                        let elapsed = execution_finish.elapsed();
+                        let elapsed = root_time.elapsed();
                         info!(target: "engine::tree", ?state_root, ?elapsed, "State root task finished");
                         // we double check the state root here for good measure
                         if state_root == block.header().state_root() {
@@ -647,7 +646,7 @@ where
         env: ExecutionEnv<Evm>,
         input: &BlockOrPayload<T>,
         handle: &mut PayloadHandle<impl ExecutableTxFor<Evm>, Err>,
-    ) -> Result<(BlockExecutionOutput<N::Receipt>, Instant), InsertBlockErrorKind>
+    ) -> Result<BlockExecutionOutput<N::Receipt>, InsertBlockErrorKind>
     where
         S: StateProvider,
         Err: core::error::Error + Send + Sync + 'static,
@@ -694,7 +693,7 @@ where
         let execution_finish = Instant::now();
         let execution_time = execution_finish.duration_since(execution_start);
         debug!(target: "engine::tree", elapsed = ?execution_time, number=?num_hash.number, "Executed block");
-        Ok((output, execution_finish))
+        Ok(output)
     }
 
     /// Compute state root for the given hashed post state in parallel.

--- a/crates/trie/sparse/src/metrics.rs
+++ b/crates/trie/sparse/src/metrics.rs
@@ -21,19 +21,20 @@ pub(crate) struct SparseStateTrieMetrics {
 
 impl SparseStateTrieMetrics {
     /// Record the metrics into the histograms
-    pub(crate) fn record(&self) {
+    pub(crate) fn record(&mut self) {
+        use core::mem::take;
         self.histograms
             .multiproof_skipped_account_nodes
-            .record(self.multiproof_skipped_account_nodes as f64);
+            .record(take(&mut self.multiproof_skipped_account_nodes) as f64);
         self.histograms
             .multiproof_total_account_nodes
-            .record(self.multiproof_total_account_nodes as f64);
+            .record(take(&mut self.multiproof_total_account_nodes) as f64);
         self.histograms
             .multiproof_skipped_storage_nodes
-            .record(self.multiproof_skipped_storage_nodes as f64);
+            .record(take(&mut self.multiproof_skipped_storage_nodes) as f64);
         self.histograms
             .multiproof_total_storage_nodes
-            .record(self.multiproof_total_storage_nodes as f64);
+            .record(take(&mut self.multiproof_total_storage_nodes) as f64);
     }
 
     /// Increment the skipped account nodes counter by the given count

--- a/etc/grafana/dashboards/overview.json
+++ b/etc/grafana/dashboards/overview.json
@@ -4635,7 +4635,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "reth_sparse_state_trie_multiproof_total_account_nodes{$instance_label=\"$instance\",quantile=~\"(0|0.5|0.9|0.95|1)\"}",
+          "expr": "reth_sparse_state_trie_multiproof_skipped_account_nodes{$instance_label=\"$instance\",quantile=~\"(0|0.5|0.9|0.95|1)\"}",
           "hide": false,
           "instant": false,
           "legendFormat": "Account {{quantile}} percentile",
@@ -4643,7 +4643,7 @@
           "refId": "A"
         }
       ],
-      "title": "Total multiproof account nodes",
+      "title": "Redundant multiproof account nodes",
       "type": "timeseries"
     },
     {
@@ -4735,14 +4735,14 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "reth_sparse_state_trie_multiproof_total_storage_nodes{$instance_label=\"$instance\",quantile=~\"(0|0.5|0.9|0.95|1)\"}",
+          "expr": "reth_sparse_state_trie_multiproof_skipped_storage_nodes{$instance_label=\"$instance\",quantile=~\"(0|0.5|0.9|0.95|1)\"}",
           "instant": false,
           "legendFormat": "Storage {{quantile}} percentile",
           "range": true,
           "refId": "Branch Nodes"
         }
       ],
-      "title": "Total multiproof storage nodes",
+      "title": "Redundant multiproof storage nodes",
       "type": "timeseries"
     },
     {
@@ -4851,7 +4851,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Histogram for state root latency, the duration between finishing execution and receiving the state root",
+      "description": "Histogram for state root latency, the time spent blocked waiting for the state root.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -4962,7 +4962,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "reth_sync_block_validation_state_root_histogram{\"$instance_label\"=\"$instance\"}",
+          "expr": "reth_sync_block_validation_state_root_histogram{$instance_label=\"$instance\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -11957,6 +11957,6 @@
   "timezone": "",
   "title": "Reth",
   "uid": "2k8BXz24x",
-  "version": 2,
+  "version": 3,
   "weekStart": ""
 }

--- a/etc/grafana/dashboards/overview.json
+++ b/etc/grafana/dashboards/overview.json
@@ -4437,14 +4437,14 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "reth_sparse_state_trie_multiproof_skipped_storage_nodes{$instance_label=\"$instance\",quantile=~\"(0|0.5|0.9|0.95|1)\"}",
+          "expr": "reth_sparse_state_trie_multiproof_total_account_nodes{$instance_label=\"$instance\",quantile=~\"(0|0.5|0.9|0.95|1)\"}",
           "instant": false,
-          "legendFormat": "Storage {{quantile}} percentile",
+          "legendFormat": "Account {{quantile}} percentile",
           "range": true,
           "refId": "Branch Nodes"
         }
       ],
-      "title": "Redundant multiproof storage nodes",
+      "title": "Total multiproof account nodes",
       "type": "timeseries"
     },
     {
@@ -4536,14 +4536,14 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "reth_sparse_state_trie_multiproof_skipped_account_nodes{$instance_label=\"$instance\",quantile=~\"(0|0.5|0.9|0.95|1)\"}",
+          "expr": "reth_sparse_state_trie_multiproof_total_storage_nodes{$instance_label=\"$instance\",quantile=~\"(0|0.5|0.9|0.95|1)\"}",
           "instant": false,
-          "legendFormat": "Account {{quantile}} percentile",
+          "legendFormat": "Storage {{quantile}} percentile",
           "range": true,
           "refId": "Branch Nodes"
         }
       ],
-      "title": "Redundant multiproof account nodes",
+      "title": "Total multiproof storage nodes",
       "type": "timeseries"
     },
     {
@@ -4906,32 +4906,7 @@
           },
           "unit": "s"
         },
-        "overrides": [
-          {
-            "__systemRef": "hideSeriesFrom",
-            "matcher": {
-              "id": "byNames",
-              "options": {
-                "mode": "exclude",
-                "names": [
-                  "State Root Duration p0.95"
-                ],
-                "prefix": "All except:",
-                "readOnly": true
-              }
-            },
-            "properties": [
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": true
-                }
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
         "h": 8,


### PR DESCRIPTION
* Properly clear total/redundant proof counters once they are recorded, otherwise they grow monotonically and become meaningless.

* Correctly measure state root latency; previously we were including all steps between execution completion and waiting on the state root, which is not correct. We now accurately show that very often the state root is not a significant blocker for payload processing.

* Fix state root latency graph in grafana.

* Re-order total/redundant proof graphs in grafana, their layout was confusing previously.

## Total/Redundant Proofs

Before:
<img width="1911" height="614" alt="shot-1756139491" src="https://github.com/user-attachments/assets/e74c720b-bf4e-4261-8235-ed234aa9730f" />

After:
<img width="1914" height="607" alt="shot-1756139517" src="https://github.com/user-attachments/assets/80425743-d6bf-457f-a26f-19111916ffc1" />

## State Root Latency

Before/After of the code fix:
<img width="1901" height="836" alt="shot-1756139558" src="https://github.com/user-attachments/assets/bc14ed80-60a1-48e8-be43-f014ed35e904" />
