### PR TITLE
fix(era): SlotIndex offset support negative value

### DIFF
--- a/crates/era-utils/src/export.rs
+++ b/crates/era-utils/src/export.rs
@@ -153,8 +153,8 @@ where
         let mut writer = Era1Writer::new(file);
         writer.write_version()?;
 
-        let mut offsets = Vec::<u64>::with_capacity(block_count);
-        let mut position = VERSION_ENTRY_SIZE as u64;
+        let mut offsets = Vec::<i64>::with_capacity(block_count);
+        let mut position = VERSION_ENTRY_SIZE as i64;
         let mut blocks_written = 0;
         let mut final_header_data = Vec::new();
 
@@ -179,7 +179,7 @@ where
             let body_size = compressed_body.data.len() + ENTRY_HEADER_SIZE;
             let receipts_size = compressed_receipts.data.len() + ENTRY_HEADER_SIZE;
             let difficulty_size = 32 + ENTRY_HEADER_SIZE; // U256 is 32 + 8 bytes header overhead
-            let total_size = (header_size + body_size + receipts_size + difficulty_size) as u64;
+            let total_size = (header_size + body_size + receipts_size + difficulty_size) as i64;
 
             let block_tuple = BlockTuple::new(
                 compressed_header,

--- a/crates/era/src/e2s_types.rs
+++ b/crates/era/src/e2s_types.rs
@@ -173,13 +173,13 @@ pub trait IndexEntry: Sized {
     fn entry_type() -> [u8; 2];
 
     /// Create a new instance with starting number and offsets
-    fn new(starting_number: u64, offsets: Vec<u64>) -> Self;
+    fn new(starting_number: u64, offsets: Vec<i64>) -> Self;
 
     /// Get the starting number - can be starting slot or block number for example
     fn starting_number(&self) -> u64;
 
     /// Get the offsets vector
-    fn offsets(&self) -> &[u64];
+    fn offsets(&self) -> &[i64];
 
     /// Convert to an [`Entry`] for storage in an e2store file
     /// Format: starting-number | offset1 | offset2 | ... | count
@@ -193,7 +193,7 @@ pub trait IndexEntry: Sized {
         data.extend(self.offsets().iter().flat_map(|offset| offset.to_le_bytes()));
 
         // Encode count - 8 bytes again
-        let count = self.offsets().len() as u64;
+        let count = self.offsets().len() as i64;
         data.extend_from_slice(&count.to_le_bytes());
 
         Entry::new(Self::entry_type(), data)
@@ -219,7 +219,7 @@ pub trait IndexEntry: Sized {
 
         // Extract count from last 8 bytes
         let count_bytes = &entry.data[entry.data.len() - 8..];
-        let count = u64::from_le_bytes(
+        let count = i64::from_le_bytes(
             count_bytes
                 .try_into()
                 .map_err(|_| E2sError::Ssz("Failed to read count bytes".to_string()))?,
@@ -247,7 +247,7 @@ pub trait IndexEntry: Sized {
             let start = 8 + i * 8;
             let end = start + 8;
             let offset_bytes = &entry.data[start..end];
-            let offset = u64::from_le_bytes(
+            let offset = i64::from_le_bytes(
                 offset_bytes
                     .try_into()
                     .map_err(|_| E2sError::Ssz(format!("Failed to read offset {i} bytes")))?,

--- a/crates/era/src/era1_file.rs
+++ b/crates/era/src/era1_file.rs
@@ -447,7 +447,7 @@ mod tests {
 
         let mut offsets = Vec::with_capacity(block_count);
         for i in 0..block_count {
-            offsets.push(i as u64 * 100);
+            offsets.push(i as i64 * 100);
         }
         let block_index = BlockIndex::new(start_block, offsets);
         let group = Era1Group::new(blocks, accumulator, block_index);

--- a/crates/era/src/era1_types.rs
+++ b/crates/era/src/era1_types.rs
@@ -57,12 +57,12 @@ pub struct BlockIndex {
     starting_number: BlockNumber,
 
     /// Offsets to data at each block number
-    offsets: Vec<u64>,
+    offsets: Vec<i64>,
 }
 
 impl BlockIndex {
     /// Get the offset for a specific block number
-    pub fn offset_for_block(&self, block_number: BlockNumber) -> Option<u64> {
+    pub fn offset_for_block(&self, block_number: BlockNumber) -> Option<i64> {
         if block_number < self.starting_number {
             return None;
         }
@@ -73,7 +73,7 @@ impl BlockIndex {
 }
 
 impl IndexEntry for BlockIndex {
-    fn new(starting_number: u64, offsets: Vec<u64>) -> Self {
+    fn new(starting_number: u64, offsets: Vec<i64>) -> Self {
         Self { starting_number, offsets }
     }
 
@@ -85,7 +85,7 @@ impl IndexEntry for BlockIndex {
         self.starting_number
     }
 
-    fn offsets(&self) -> &[u64] {
+    fn offsets(&self) -> &[i64] {
         &self.offsets
     }
 }

--- a/crates/era/src/era_types.rs
+++ b/crates/era/src/era_types.rs
@@ -79,12 +79,12 @@ pub struct SlotIndex {
 
     /// Offsets to data at each slot
     /// 0 indicates no data for that slot
-    pub offsets: Vec<u64>,
+    pub offsets: Vec<i64>,
 }
 
 impl SlotIndex {
     /// Create a new slot index
-    pub const fn new(starting_slot: u64, offsets: Vec<u64>) -> Self {
+    pub const fn new(starting_slot: u64, offsets: Vec<i64>) -> Self {
         Self { starting_slot, offsets }
     }
 
@@ -94,7 +94,7 @@ impl SlotIndex {
     }
 
     /// Get the offset for a specific slot
-    pub fn get_offset(&self, slot_index: usize) -> Option<u64> {
+    pub fn get_offset(&self, slot_index: usize) -> Option<i64> {
         self.offsets.get(slot_index).copied()
     }
 
@@ -105,7 +105,7 @@ impl SlotIndex {
 }
 
 impl IndexEntry for SlotIndex {
-    fn new(starting_number: u64, offsets: Vec<u64>) -> Self {
+    fn new(starting_number: u64, offsets: Vec<i64>) -> Self {
         Self { starting_slot: starting_number, offsets }
     }
 
@@ -117,7 +117,7 @@ impl IndexEntry for SlotIndex {
         self.starting_slot
     }
 
-    fn offsets(&self) -> &[u64] {
+    fn offsets(&self) -> &[i64] {
         &self.offsets
     }
 }
@@ -271,5 +271,19 @@ mod tests {
         assert_eq!(era_group.other_entries[0].data, vec![1, 2, 3, 4]);
         assert_eq!(era_group.other_entries[1].entry_type, [0x02, 0x02]);
         assert_eq!(era_group.other_entries[1].data, vec![5, 6, 7, 8]);
+    }
+
+    #[test]
+    fn test_index_with_negative_offset() {
+        let mut data = Vec::new();
+        data.extend_from_slice(&0u64.to_le_bytes());
+        data.extend_from_slice(&(-1024i64).to_le_bytes());
+        data.extend_from_slice(&0i64.to_le_bytes());
+        data.extend_from_slice(&2i64.to_le_bytes());
+
+        let entry = Entry::new(SLOT_INDEX, data);
+        let index = SlotIndex::from_entry(&entry).unwrap();
+        let parsed_offset = index.offsets[0];
+        assert_eq!(parsed_offset, -1024);
     }
 }


### PR DESCRIPTION
ref https://github.com/status-im/nimbus-eth2/blob/stable/docs/e2store.md

```shell
Each entry in the slot index is a fixed-length 8-byte two's complement signed integer in little-endian, meaning that the entry for slot N can be found at index (N * 8) + 16 in the index.
```