### PR TITLE
fix: use deterministic RNG in state_root_task benchmark

### DIFF
--- a/crates/engine/tree/benches/state_root_task.rs
+++ b/crates/engine/tree/benches/state_root_task.rs
@@ -44,8 +44,7 @@ fn create_bench_state_updates(params: &BenchParams) -> Vec<EvmState> {
     let mut rng = runner.rng().clone();
     let all_addresses: Vec<Address> = (0..params.num_accounts)
         .map(|_| {
-            // TODO: rand08
-            Address::random()
+            Address::random_with(&mut rng)
         })
         .collect();
     let mut updates = Vec::new();

--- a/crates/engine/tree/benches/state_root_task.rs
+++ b/crates/engine/tree/benches/state_root_task.rs
@@ -42,11 +42,8 @@ struct BenchParams {
 fn create_bench_state_updates(params: &BenchParams) -> Vec<EvmState> {
     let mut runner = TestRunner::deterministic();
     let mut rng = runner.rng().clone();
-    let all_addresses: Vec<Address> = (0..params.num_accounts)
-        .map(|_| {
-            Address::random_with(&mut rng)
-        })
-        .collect();
+    let all_addresses: Vec<Address> =
+        (0..params.num_accounts).map(|_| Address::random_with(&mut rng)).collect();
     let mut updates = Vec::new();
 
     for _ in 0..params.updates_per_account {


### PR DESCRIPTION
Replace Address::random() with Address::random_with(&mut rng) to use the passed RNG parameter instead of global thread_rng()