### PR TITLE
perf(payload): do not clone full attributes for timestamp validation

### DIFF
--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -455,6 +455,10 @@ where
         Ok(self.config.attributes.clone())
     }
 
+    fn payload_timestamp(&self) -> Result<u64, PayloadBuilderError> {
+        Ok(self.config.attributes.timestamp())
+    }
+
     fn resolve_kind(
         &mut self,
         kind: PayloadKind,

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -75,6 +75,10 @@
 //!     Ok(self.attributes.clone())
 //! }
 //!
+//! fn payload_timestamp(&self) -> Result<u64, PayloadBuilderError> {
+//!     Ok(self.attributes.timestamp)
+//! }
+//!
 //! fn resolve_kind(&mut self, _kind: PayloadKind) -> (Self::ResolvePayloadFuture, KeepPayloadJobAlive) {
 //!        let payload = self.best_payload();
 //!        (futures_util::future::ready(payload), KeepPayloadJobAlive::No)

--- a/crates/payload/builder/src/noop.rs
+++ b/crates/payload/builder/src/noop.rs
@@ -50,7 +50,7 @@ where
                     tx.send(Ok(id)).ok()
                 }
                 PayloadServiceCommand::BestPayload(_, tx) => tx.send(None).ok(),
-                PayloadServiceCommand::PayloadAttributes(_, tx) => tx.send(None).ok(),
+                PayloadServiceCommand::PayloadTimestamp(_, tx) => tx.send(None).ok(),
                 PayloadServiceCommand::Resolve(_, _, tx) => tx.send(None).ok(),
                 PayloadServiceCommand::Subscribe(_) => None,
             };

--- a/crates/payload/builder/src/service.rs
+++ b/crates/payload/builder/src/service.rs
@@ -73,14 +73,14 @@ where
         self.inner.best_payload(id).await
     }
 
-    /// Returns the payload attributes associated with the given identifier.
+    /// Returns the payload timestamp associated with the given identifier.
     ///
-    /// Note: this returns the attributes of the payload and does not resolve the job.
-    pub async fn payload_attributes(
+    /// Note: this returns the timestamp of the payload and does not resolve the job.
+    pub async fn payload_timestamp(
         &self,
         id: PayloadId,
-    ) -> Option<Result<T::PayloadBuilderAttributes, PayloadBuilderError>> {
-        self.inner.payload_attributes(id).await
+    ) -> Option<Result<u64, PayloadBuilderError>> {
+        self.inner.payload_timestamp(id).await
     }
 }
 
@@ -166,15 +166,15 @@ impl<T: PayloadTypes> PayloadBuilderHandle<T> {
         Ok(PayloadEvents { receiver: rx.await? })
     }
 
-    /// Returns the payload attributes associated with the given identifier.
+    /// Returns the payload timestamp associated with the given identifier.
     ///
-    /// Note: this returns the attributes of the payload and does not resolve the job.
-    pub async fn payload_attributes(
+    /// Note: this returns the timestamp of the payload and does not resolve the job.
+    pub async fn payload_timestamp(
         &self,
         id: PayloadId,
-    ) -> Option<Result<T::PayloadBuilderAttributes, PayloadBuilderError>> {
+    ) -> Option<Result<u64, PayloadBuilderError>> {
         let (tx, rx) = oneshot::channel();
-        self.to_service.send(PayloadServiceCommand::PayloadAttributes(id, tx)).ok()?;
+        self.to_service.send(PayloadServiceCommand::PayloadTimestamp(id, tx)).ok()?;
         rx.await.ok()?
     }
 }
@@ -331,22 +331,19 @@ where
     Gen::Job: PayloadJob<PayloadAttributes = T::PayloadBuilderAttributes>,
     <Gen::Job as PayloadJob>::BuiltPayload: Into<T::BuiltPayload>,
 {
-    /// Returns the payload attributes for the given payload.
-    fn payload_attributes(
-        &self,
-        id: PayloadId,
-    ) -> Option<Result<<Gen::Job as PayloadJob>::PayloadAttributes, PayloadBuilderError>> {
-        let attributes = self
+    /// Returns the payload timestamp for the given payload.
+    fn payload_timestamp(&self, id: PayloadId) -> Option<Result<u64, PayloadBuilderError>> {
+        let timestamp = self
             .payload_jobs
             .iter()
             .find(|(_, job_id)| *job_id == id)
-            .map(|(j, _)| j.payload_attributes());
+            .map(|(j, _)| j.payload_timestamp());
 
-        if attributes.is_none() {
-            trace!(target: "payload_builder", %id, "no matching payload job found to get attributes for");
+        if timestamp.is_none() {
+            trace!(target: "payload_builder", %id, "no matching payload job found to get timestamp for");
         }
 
-        attributes
+        timestamp
     }
 }
 
@@ -431,9 +428,9 @@ where
                     PayloadServiceCommand::BestPayload(id, tx) => {
                         let _ = tx.send(this.best_payload(id));
                     }
-                    PayloadServiceCommand::PayloadAttributes(id, tx) => {
-                        let attributes = this.payload_attributes(id);
-                        let _ = tx.send(attributes);
+                    PayloadServiceCommand::PayloadTimestamp(id, tx) => {
+                        let timestamp = this.payload_timestamp(id);
+                        let _ = tx.send(timestamp);
                     }
                     PayloadServiceCommand::Resolve(id, strategy, tx) => {
                         let _ = tx.send(this.resolve(id, strategy));
@@ -461,11 +458,8 @@ pub enum PayloadServiceCommand<T: PayloadTypes> {
     ),
     /// Get the best payload so far
     BestPayload(PayloadId, oneshot::Sender<Option<Result<T::BuiltPayload, PayloadBuilderError>>>),
-    /// Get the payload attributes for the given payload
-    PayloadAttributes(
-        PayloadId,
-        oneshot::Sender<Option<Result<T::PayloadBuilderAttributes, PayloadBuilderError>>>,
-    ),
+    /// Get the payload timestamp for the given payload
+    PayloadTimestamp(PayloadId, oneshot::Sender<Option<Result<u64, PayloadBuilderError>>>),
     /// Resolve the payload and return the payload
     Resolve(
         PayloadId,
@@ -488,7 +482,7 @@ where
             Self::BestPayload(f0, f1) => {
                 f.debug_tuple("BestPayload").field(&f0).field(&f1).finish()
             }
-            Self::PayloadAttributes(f0, f1) => {
+            Self::PayloadTimestamp(f0, f1) => {
                 f.debug_tuple("PayloadAttributes").field(&f0).field(&f1).finish()
             }
             Self::Resolve(f0, f1, _f2) => f.debug_tuple("Resolve").field(&f0).field(&f1).finish(),

--- a/crates/payload/builder/src/test_utils.rs
+++ b/crates/payload/builder/src/test_utils.rs
@@ -98,6 +98,10 @@ impl PayloadJob for TestPayloadJob {
         Ok(self.attr.clone())
     }
 
+    fn payload_timestamp(&self) -> Result<u64, PayloadBuilderError> {
+        Ok(self.attr.timestamp)
+    }
+
     fn resolve_kind(
         &mut self,
         _kind: PayloadKind,

--- a/crates/payload/builder/src/traits.rs
+++ b/crates/payload/builder/src/traits.rs
@@ -36,6 +36,14 @@ pub trait PayloadJob: Future<Output = Result<(), PayloadBuilderError>> + Send + 
     /// Returns the payload attributes for the payload being built.
     fn payload_attributes(&self) -> Result<Self::PayloadAttributes, PayloadBuilderError>;
 
+    /// Returns the payload timestamp for the payload being built.
+    /// The default implementation allocates full attributes only to
+    /// extract the timestamp. Provide your own implementation if you
+    /// need performance here.
+    fn payload_timestamp(&self) -> Result<u64, PayloadBuilderError> {
+        Ok(self.payload_attributes()?.timestamp())
+    }
+
     /// Called when the payload is requested by the CL.
     ///
     /// This is invoked on [`engine_getPayloadV2`](https://github.com/ethereum/execution-apis/blob/main/src/engine/shanghai.md#engine_getpayloadv2) and [`engine_getPayloadV1`](https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md#engine_getpayloadv1).

--- a/examples/custom-payload-builder/src/job.rs
+++ b/examples/custom-payload-builder/src/job.rs
@@ -1,6 +1,9 @@
 use futures_util::Future;
 use reth_basic_payload_builder::{HeaderForPayload, PayloadBuilder, PayloadConfig};
-use reth_ethereum::{node::api::PayloadKind, tasks::TaskSpawner};
+use reth_ethereum::{
+    node::api::{PayloadBuilderAttributes, PayloadKind},
+    tasks::TaskSpawner,
+};
 use reth_payload_builder::{KeepPayloadJobAlive, PayloadBuilderError, PayloadJob};
 
 use std::{
@@ -42,6 +45,10 @@ where
 
     fn payload_attributes(&self) -> Result<Self::PayloadAttributes, PayloadBuilderError> {
         Ok(self.config.attributes.clone())
+    }
+
+    fn payload_timestamp(&self) -> Result<u64, PayloadBuilderError> {
+        Ok(self.config.attributes.timestamp())
     }
 
     fn resolve_kind(


### PR DESCRIPTION
EngineAPI only needs a payload's timestamp to validate its version based on hardfork activations:
https://github.com/paradigmxyz/reth/blob/7703e6fb9dafe0281457f13a92366227a289c6ba/crates/rpc/rpc-engine-api/src/engine_api.rs#L402-L406

However, the current implementation passes (owned and cloned) full attributes around, which is noticeable friction for performance chains with low block time and large (custom) attributes.

This PR **demotes full attributes fetching methods to timestamp fetching only**. If it's too noisy/breaking, I can add a new method for timestamp instead, but getting rid of `PayloadJob::payload_attributes` is still nice, so we can transfer attributes to the block builder instead of cloning a full one in the `PayloadJob`. And custom payload jobs can still provide the full attributes outside of the `PayloadJob` trait if they want to.