### PR TITLE
feat(optimism): Add constructors to `FlashBlockService` and `FlashBlockWsStream`

### DIFF
--- a/crates/optimism/flashblocks/src/service.rs
+++ b/crates/optimism/flashblocks/src/service.rs
@@ -54,6 +54,11 @@ impl<
         Builder: PendingEnvBuilder<EvmConfig>,
     > FlashBlockService<N, S, EvmConfig, Provider, Builder>
 {
+    /// Constructs a new `FlashBlockService` that receives [`FlashBlock`]s from `rx` stream.
+    pub const fn new(rx: S, evm_config: EvmConfig, provider: Provider, builder: Builder) -> Self {
+        Self { rx, current: None, blocks: Vec::new(), evm_config, provider, builder }
+    }
+
     /// Adds the `block` into the collection.
     ///
     /// Depending on its index and associated block number, it may:

--- a/crates/optimism/flashblocks/src/ws/stream.rs
+++ b/crates/optimism/flashblocks/src/ws/stream.rs
@@ -28,6 +28,18 @@ pub struct FlashBlockWsStream {
     stream: Option<SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>>,
 }
 
+impl FlashBlockWsStream {
+    /// Creates a new websocket stream over `ws_url`.
+    pub fn new(ws_url: Url) -> Self {
+        Self {
+            ws_url,
+            state: State::default(),
+            connect: Box::pin(async move { Err(Error::ConnectionClosed) }),
+            stream: None,
+        }
+    }
+}
+
 impl Stream for FlashBlockWsStream {
     type Item = eyre::Result<FlashBlock>;
 


### PR DESCRIPTION
Part of #17858

Adds public functions for creating an instance of `FlashBlockService` and `FlashBlockWsStream`.