### PR TITLE
feat(net): implement support of subprotocols

### DIFF
--- a/crates/net/eth-wire/src/multiplex.rs
+++ b/crates/net/eth-wire/src/multiplex.rs
@@ -137,7 +137,7 @@ impl<St> RlpxProtocolMultiplexer<St> {
     /// This accepts a closure that does a handshake with the remote peer and returns a tuple of the
     /// primary stream and extra data.
     ///
-    /// See also [`UnauthedEthStream::handshake`]
+    /// See also [`UnauthedEthStream::handshake`](crate::UnauthedEthStream)
     pub async fn into_satellite_stream_with_tuple_handshake<F, Fut, Err, Primary, Extra>(
         mut self,
         cap: &Capability,

--- a/crates/net/eth-wire/src/multiplex.rs
+++ b/crates/net/eth-wire/src/multiplex.rs
@@ -774,14 +774,17 @@ impl<'a> Future for ProtocolsPoller<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_utils::{
-        connect_passthrough, eth_handshake, eth_hello,
-        proto::{test_hello, TestProtoMessage},
-    }, UnauthedEthStream, UnauthedP2PStream};
+    use crate::{
+        handshake::EthHandshake,
+        test_utils::{
+            connect_passthrough, eth_handshake, eth_hello,
+            proto::{test_hello, TestProtoMessage},
+        },
+        UnauthedEthStream, UnauthedP2PStream,
+    };
     use reth_eth_wire_types::EthNetworkPrimitives;
     use tokio::{net::TcpListener, sync::oneshot};
     use tokio_util::codec::Decoder;
-    use crate::handshake::EthHandshake;
 
     #[tokio::test]
     async fn eth_satellite() {

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -1150,18 +1150,20 @@ async fn authenticate_stream<N: NetworkPrimitives>(
                 .ok();
         }
 
-        let (multiplex_stream, their_status) =
-            match multiplex_stream.into_eth_satellite_stream(status, fork_filter).await {
-                Ok((multiplex_stream, their_status)) => (multiplex_stream, their_status),
-                Err(err) => {
-                    return PendingSessionEvent::Disconnected {
-                        remote_addr,
-                        session_id,
-                        direction,
-                        error: Some(PendingSessionHandshakeError::Eth(err)),
-                    }
+        let (multiplex_stream, their_status) = match multiplex_stream
+            .into_eth_satellite_stream(status, fork_filter, handshake.clone())
+            .await
+        {
+            Ok((multiplex_stream, their_status)) => (multiplex_stream, their_status),
+            Err(err) => {
+                return PendingSessionEvent::Disconnected {
+                    remote_addr,
+                    session_id,
+                    direction,
+                    error: Some(PendingSessionHandshakeError::Eth(err)),
                 }
-            };
+            }
+        };
 
         (multiplex_stream.into(), their_status)
     };

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -1151,7 +1151,7 @@ async fn authenticate_stream<N: NetworkPrimitives>(
         }
 
         let (multiplex_stream, their_status) = match multiplex_stream
-            .into_eth_satellite_stream(status, fork_filter, handshake.clone())
+            .into_eth_satellite_stream(status, fork_filter, handshake)
             .await
         {
             Ok((multiplex_stream, their_status)) => (multiplex_stream, their_status),


### PR DESCRIPTION
## Summary

  Implements support for subprotocols in the RLP multiplexer, enabling proper concurrent handling of satellite protocols alongside the primary ETH protocol.

  ## Changes

  - **Multiplexer Enhancement**: Added `ProtocolsPoller` to concurrently poll multiple protocol streams in the main multiplexer loop
  - **Handshake Injection**: Updated `into_eth_satellite_stream` to accept `Arc<dyn EthRlpxHandshake>` for flexible handshake implementations
  - **Protocol Adapter**: Created `ProxyUnauth` adapter to enable injected handshake to work over multiplexed `ProtocolProxy`
  - **Session Integration**: Updated session management to pass handshake dependency to multiplexer