### PR TITLE
fix: clarify locking behavior comment in InMemoryState

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -43,8 +43,9 @@ pub(crate) struct InMemoryStateMetrics {
 ///
 /// # Locking behavior on state updates
 ///
-/// All update calls must be atomic, meaning that they must acquire all locks at once, before
-/// modifying the state. This is to ensure that the internal state is always consistent.
+/// All update calls must acquire all locks at once before modifying state to ensure the internal
+/// state remains consistent. This prevents readers from observing partially updated state where
+/// the numbers and blocks maps are out of sync.
 /// Update functions ensure that the numbers write lock is always acquired first, because lookup by
 /// numbers first read the numbers map and then the blocks map.
 /// By acquiring the numbers lock first, we ensure that read-only lookups don't deadlock updates.


### PR DESCRIPTION
previous comment implied `Atomicity` but looking at the code, it's just locks.
The Compiler or CPU can still order the code anyway it deems fit