### PR TITLE
feat: add module manipulation methods and RPC server arg helpers

### DIFF
--- a/crates/node/core/src/args/rpc_server.rs
+++ b/crates/node/core/src/args/rpc_server.rs
@@ -260,10 +260,23 @@ impl RpcServerArgs {
         self
     }
 
+    /// Configures modules for WS-RPC server.
+    pub fn with_ws_api(mut self, ws_api: RpcModuleSelection) -> Self {
+        self.ws_api = Some(ws_api);
+        self
+    }
+
     /// Enables the Auth IPC
     pub const fn with_auth_ipc(mut self) -> Self {
         self.auth_ipc = true;
         self
+    }
+
+    /// Configures modules for both the HTTP-RPC server and WS-RPC server.
+    ///
+    /// This is the same as calling both [`Self::with_http_api`] and [`Self::with_ws_api`].
+    pub fn with_api(self, api: RpcModuleSelection) -> Self {
+        self.with_http_api(api.clone()).with_ws_api(api)
     }
 
     /// Change rpc port numbers based on the instance number, if provided.
@@ -332,6 +345,14 @@ impl RpcServerArgs {
         self = self.with_auth_unused_port();
         self = self.with_ipc_random_path();
         self
+    }
+
+    /// Apply a function to the args.
+    pub fn apply<F>(self, f: F) -> Self
+    where
+        F: FnOnce(Self) -> Self,
+    {
+        f(self)
     }
 }
 


### PR DESCRIPTION
Adds utility methods to `RpcModuleSelection` for dynamically adding modules to selections, and extends `RpcServerArgs` with helper methods for configuration.

## Changes

### RpcModuleSelection methods
- `push(&mut self, module)` - Mutates selection by adding a module  
- `append(self, module) -> Self` - Returns new selection with module added
- `extend(&mut self, iter)` - Mutates selection by adding modules from iterator
- `extended(self, iter) -> Self` - Returns new selection with modules from iterator added
- `is_all()` - Const helper method to check if selection is `All` variant

### RpcServerArgs methods
- `with_ws_api()` - Configures modules for WS-RPC server
- `with_api()` - Configures modules for both HTTP and WS servers at once
- `apply()` - Apply a function to the args for flexible chaining

All methods properly handle the `All`, `Standard`, and `Selection` variants, converting to `Selection` when modifications are needed while preserving `All` variant behavior (no-op for mutations, returns `All` for immutable operations).