### PR TITLE
chore(nix): add `cargo-nextest` to `devShell`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -118,6 +118,7 @@
           packages = nativeBuildInputs ++ [
             rustNightly.rust-analyzer
             rustNightly.rustfmt
+            pkgs.cargo-nextest
           ];
         } overrides);
       }


### PR DESCRIPTION
To run `cargo nextest run --workspace` in a Nix dev shell.