### PR TITLE
fix(net): update latest eth version eth ETH69

### DIFF
--- a/crates/net/eth-wire-types/src/version.rs
+++ b/crates/net/eth-wire-types/src/version.rs
@@ -31,7 +31,7 @@ pub enum EthVersion {
 
 impl EthVersion {
     /// The latest known eth version
-    pub const LATEST: Self = Self::Eth68;
+    pub const LATEST: Self = Self::Eth69;
 
     /// All known eth versions
     pub const ALL_VERSIONS: &'static [Self] = &[Self::Eth69, Self::Eth68, Self::Eth67, Self::Eth66];


### PR DESCRIPTION
The latest Ethereum protocol version is now ETH69, update it.