### PR TITLE
feat: add NoopNetwork example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3606,6 +3606,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "example-node-builder-api"
+version = "0.0.0"
+dependencies = [
+ "eyre",
+ "reth-ethereum",
+ "reth-tracing",
+]
+
+[[package]]
 name = "example-node-custom-rpc"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,6 +161,7 @@ members = [
     "examples/network-txpool/",
     "examples/network/",
     "examples/network-proxy/",
+    "examples/node-builder-api/",
     "examples/node-custom-rpc/",
     "examples/node-event-hooks/",
     "examples/op-db-access/",

--- a/crates/ethereum/reth/Cargo.toml
+++ b/crates/ethereum/reth/Cargo.toml
@@ -124,6 +124,7 @@ node = [
     "provider",
     "consensus",
     "evm",
+    "network",
     "node-api",
     "dep:reth-node-ethereum",
     "dep:reth-node-builder",

--- a/crates/node/builder/src/components/builder.rs
+++ b/crates/node/builder/src/components/builder.rs
@@ -493,6 +493,13 @@ impl<Tx> Default for NoopTransactionPoolBuilder<Tx> {
 #[derive(Debug, Clone)]
 pub struct NoopNetworkBuilder<Net = EthNetworkPrimitives>(PhantomData<Net>);
 
+impl NoopNetworkBuilder {
+    /// Returns the instance with ethereum types.
+    pub fn eth() -> Self {
+        Self::default()
+    }
+}
+
 impl<N, Pool, Net> NetworkBuilder<N, Pool> for NoopNetworkBuilder<Net>
 where
     N: FullNodeTypes,

--- a/crates/optimism/reth/Cargo.toml
+++ b/crates/optimism/reth/Cargo.toml
@@ -108,6 +108,7 @@ node = [
     "provider",
     "consensus",
     "evm",
+    "network",
     "node-api",
     "dep:reth-optimism-node",
     "dep:reth-node-builder",

--- a/examples/node-builder-api/Cargo.toml
+++ b/examples/node-builder-api/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "example-node-builder-api"
+version = "0.0.0"
+publish = false
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+reth-ethereum = { workspace = true, features = ["node", "pool", "node-api", "cli", "test-utils"] }
+reth-tracing.workspace = true
+
+eyre.workspace = true

--- a/examples/node-builder-api/src/main.rs
+++ b/examples/node-builder-api/src/main.rs
@@ -1,0 +1,29 @@
+//! This example showcases various Nodebuilder use cases
+
+use reth_ethereum::{
+    cli::interface::Cli,
+    node::{builder::components::NoopNetworkBuilder, node::EthereumAddOns, EthereumNode},
+};
+
+/// Maps the ethereum node's network component to the noop implementation.
+///
+/// This installs the [`NoopNetworkBuilder`] that does not launch a real network.
+pub fn noop_network() {
+    Cli::parse_args()
+        .run(|builder, _| async move {
+            let handle = builder
+                // use the default ethereum node types
+                .with_types::<EthereumNode>()
+                // Configure the components of the node
+                // use default ethereum components but use the Noop network that does nothing but
+                .with_components(EthereumNode::components().network(NoopNetworkBuilder::eth()))
+                .with_add_ons(EthereumAddOns::default())
+                .launch()
+                .await?;
+
+            handle.wait_for_node_exit().await
+        })
+        .unwrap();
+}
+
+fn main() {}


### PR DESCRIPTION
adds a new example crate intended to demonstrate certain nodebuilder usecases

this one uses a noopnetwork