### PR TITLE
feat(optimism): Add `flashblocks_url` as part of rollup args of the `op-reth` CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9397,6 +9397,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/crates/optimism/node/Cargo.toml
+++ b/crates/optimism/node/Cargo.toml
@@ -63,6 +63,7 @@ tokio.workspace = true
 clap.workspace = true
 serde.workspace = true
 eyre.workspace = true
+url.workspace = true
 
 # test-utils dependencies
 reth-e2e-test-utils = { workspace = true, optional = true }

--- a/crates/optimism/node/src/args.rs
+++ b/crates/optimism/node/src/args.rs
@@ -4,6 +4,7 @@
 
 use op_alloy_consensus::interop::SafetyLevel;
 use reth_optimism_txpool::supervisor::DEFAULT_SUPERVISOR_URL;
+use url::Url;
 
 /// Parameters for rollup configuration
 #[derive(Debug, Clone, PartialEq, Eq, clap::Args)]
@@ -66,6 +67,13 @@ pub struct RollupArgs {
     /// Minimum suggested priority fee (tip) in wei, default `1_000_000`
     #[arg(long, default_value_t = 1_000_000)]
     pub min_suggested_priority_fee: u64,
+
+    /// A URL pointing to a secure websocket subscription that streams out flashblocks.
+    ///
+    /// If given, the flashblocks are received to build pending block. All request with "pending"
+    /// block tag will use the pending state based on flashblocks.
+    #[arg(long)]
+    pub flashblocks_url: Option<Url>,
 }
 
 impl Default for RollupArgs {
@@ -81,6 +89,7 @@ impl Default for RollupArgs {
             sequencer_headers: Vec::new(),
             historical_rpc: None,
             min_suggested_priority_fee: 1_000_000,
+            flashblocks_url: None,
         }
     }
 }

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -66,6 +66,7 @@ use reth_transaction_pool::{
 use reth_trie_common::KeccakKeyHasher;
 use serde::de::DeserializeOwned;
 use std::{marker::PhantomData, sync::Arc};
+use url::Url;
 
 /// Marker trait for Optimism node types with standard engine, chain spec, and primitives.
 pub trait OpNodeTypes:
@@ -175,6 +176,7 @@ impl OpNode {
             .with_enable_tx_conditional(self.args.enable_tx_conditional)
             .with_min_suggested_priority_fee(self.args.min_suggested_priority_fee)
             .with_historical_rpc(self.args.historical_rpc.clone())
+            .with_flashblocks(self.args.flashblocks_url.clone())
     }
 
     /// Instantiates the [`ProviderFactoryBuilder`] for an opstack node.
@@ -660,6 +662,8 @@ pub struct OpAddOnsBuilder<NetworkT, RpcMiddleware = Identity> {
     rpc_middleware: RpcMiddleware,
     /// Optional tokio runtime to use for the RPC server.
     tokio_runtime: Option<tokio::runtime::Handle>,
+    /// A URL pointing to a secure websocket service that streams out flashblocks.
+    flashblocks_url: Option<Url>,
 }
 
 impl<NetworkT> Default for OpAddOnsBuilder<NetworkT> {
@@ -674,6 +678,7 @@ impl<NetworkT> Default for OpAddOnsBuilder<NetworkT> {
             _nt: PhantomData,
             rpc_middleware: Identity::new(),
             tokio_runtime: None,
+            flashblocks_url: None,
         }
     }
 }
@@ -734,6 +739,7 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
             min_suggested_priority_fee,
             tokio_runtime,
             _nt,
+            flashblocks_url,
             ..
         } = self;
         OpAddOnsBuilder {
@@ -746,7 +752,14 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
             _nt,
             rpc_middleware,
             tokio_runtime,
+            flashblocks_url,
         }
+    }
+
+    /// With a URL pointing to a flashblocks secure websocket subscription.
+    pub fn with_flashblocks(mut self, flashblocks_url: Option<Url>) -> Self {
+        self.flashblocks_url = flashblocks_url;
+        self
     }
 }
 
@@ -771,6 +784,7 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
             historical_rpc,
             rpc_middleware,
             tokio_runtime,
+            flashblocks_url,
             ..
         } = self;
 
@@ -779,7 +793,8 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
                 OpEthApiBuilder::default()
                     .with_sequencer(sequencer_url.clone())
                     .with_sequencer_headers(sequencer_headers.clone())
-                    .with_min_suggested_priority_fee(min_suggested_priority_fee),
+                    .with_min_suggested_priority_fee(min_suggested_priority_fee)
+                    .with_flashblocks(flashblocks_url),
                 PVB::default(),
                 EB::default(),
                 EVB::default(),


### PR DESCRIPTION
Part of #17858 

Adds a command line argument that, if provided, makes the op-reth node launch the flashblocks subscription.
