### PR TITLE
feat(optimism): Implement conversion of `ExecutionPayloadBaseV1` into `OpNextBlockEnvAttributes`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9324,6 +9324,7 @@ dependencies = [
  "reth-errors",
  "reth-evm",
  "reth-execution-types",
+ "reth-optimism-evm",
  "reth-optimism-primitives",
  "reth-primitives-traits",
  "reth-revm",

--- a/crates/optimism/flashblocks/Cargo.toml
+++ b/crates/optimism/flashblocks/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 [dependencies]
 # reth
 reth-optimism-primitives = { workspace = true, features = ["serde"] }
+reth-optimism-evm.workspace = true
 reth-chain-state = { workspace = true, features = ["serde"] }
 reth-primitives-traits = { workspace = true, features = ["serde"] }
 reth-execution-types = { workspace = true, features = ["serde"] }

--- a/crates/optimism/flashblocks/src/payload.rs
+++ b/crates/optimism/flashblocks/src/payload.rs
@@ -1,6 +1,7 @@
 use alloy_eips::eip4895::Withdrawal;
 use alloy_primitives::{Address, Bloom, Bytes, B256, U256};
 use alloy_rpc_types_engine::PayloadId;
+use reth_optimism_evm::OpNextBlockEnvAttributes;
 use reth_optimism_primitives::OpReceipt;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -92,4 +93,17 @@ pub struct ExecutionPayloadFlashblockDeltaV1 {
     pub withdrawals: Vec<Withdrawal>,
     /// The withdrawals root of the block.
     pub withdrawals_root: B256,
+}
+
+impl From<ExecutionPayloadBaseV1> for OpNextBlockEnvAttributes {
+    fn from(value: ExecutionPayloadBaseV1) -> Self {
+        Self {
+            timestamp: value.timestamp,
+            suggested_fee_recipient: value.fee_recipient,
+            prev_randao: value.prev_randao,
+            gas_limit: value.gas_limit,
+            parent_beacon_block_root: Some(value.parent_beacon_block_root),
+            extra_data: value.extra_data,
+        }
+    }
 }


### PR DESCRIPTION
Part of #17858 

To provide `OpNextBlockEnvAttributes` from flashblock data, we need a way to supply `ExecutionPayloadBaseV1` from flashblock to the `next_evm_env`.
