### PR TITLE
feat(optimism): Remove builder of next block environment from `FlashBlockService`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9324,6 +9324,7 @@ dependencies = [
  "reth-errors",
  "reth-evm",
  "reth-execution-types",
+ "reth-optimism-evm",
  "reth-optimism-primitives",
  "reth-primitives-traits",
  "reth-revm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3447,6 +3447,7 @@ dependencies = [
  "reth-network-peers",
  "reth-node-builder",
  "reth-op",
+ "reth-optimism-flashblocks",
  "reth-optimism-forks",
  "reth-payload-builder",
  "reth-rpc-api",

--- a/crates/optimism/flashblocks/Cargo.toml
+++ b/crates/optimism/flashblocks/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 [dependencies]
 # reth
 reth-optimism-primitives = { workspace = true, features = ["serde"] }
+reth-optimism-evm.workspace = true
 reth-chain-state = { workspace = true, features = ["serde"] }
 reth-primitives-traits = { workspace = true, features = ["serde"] }
 reth-execution-types = { workspace = true, features = ["serde"] }

--- a/crates/optimism/flashblocks/src/app.rs
+++ b/crates/optimism/flashblocks/src/app.rs
@@ -1,4 +1,4 @@
-use crate::{FlashBlockService, FlashBlockWsStream};
+use crate::{ExecutionPayloadBaseV1, FlashBlockService, FlashBlockWsStream};
 use futures_util::StreamExt;
 use reth_evm::ConfigureEvm;
 use reth_primitives_traits::{BlockTy, HeaderTy, NodePrimitives, ReceiptTy};
@@ -23,7 +23,10 @@ where
     N: NodePrimitives,
     EvmConfig: ConfigureEvm<
             Primitives = N,
-            NextBlockEnvCtx: BuildPendingEnv<N::BlockHeader> + Unpin + 'static,
+            NextBlockEnvCtx: BuildPendingEnv<N::BlockHeader>
+                                 + From<ExecutionPayloadBaseV1>
+                                 + Unpin
+                                 + 'static,
         > + 'static,
     Provider: StateProviderFactory
         + BlockReaderIdExt<
@@ -35,7 +38,7 @@ where
         + 'static,
 {
     let stream = FlashBlockWsStream::new(ws_url);
-    let mut service = FlashBlockService::new(stream, evm_config, provider, ());
+    let mut service = FlashBlockService::new(stream, evm_config, provider);
     let (tx, rx) = watch::channel(None);
 
     tokio::spawn(async move {

--- a/crates/optimism/flashblocks/src/payload.rs
+++ b/crates/optimism/flashblocks/src/payload.rs
@@ -1,6 +1,7 @@
 use alloy_eips::eip4895::Withdrawal;
 use alloy_primitives::{Address, Bloom, Bytes, B256, U256};
 use alloy_rpc_types_engine::PayloadId;
+use reth_optimism_evm::OpNextBlockEnvAttributes;
 use reth_optimism_primitives::OpReceipt;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -92,4 +93,17 @@ pub struct ExecutionPayloadFlashblockDeltaV1 {
     pub withdrawals: Vec<Withdrawal>,
     /// The withdrawals root of the block.
     pub withdrawals_root: B256,
+}
+
+impl From<ExecutionPayloadBaseV1> for OpNextBlockEnvAttributes {
+    fn from(value: ExecutionPayloadBaseV1) -> Self {
+        Self {
+            timestamp: value.timestamp,
+            suggested_fee_recipient: value.fee_recipient,
+            prev_randao: value.prev_randao,
+            gas_limit: value.gas_limit,
+            parent_beacon_block_root: Some(value.parent_beacon_block_root),
+            extra_data: value.extra_data,
+        }
+    }
 }

--- a/crates/optimism/rpc/src/eth/mod.rs
+++ b/crates/optimism/rpc/src/eth/mod.rs
@@ -20,7 +20,9 @@ use reqwest::Url;
 use reth_evm::ConfigureEvm;
 use reth_node_api::{FullNodeComponents, FullNodeTypes, HeaderTy};
 use reth_node_builder::rpc::{EthApiBuilder, EthApiCtx};
-use reth_optimism_flashblocks::{launch_wss_flashblocks_service, FlashBlockRx};
+use reth_optimism_flashblocks::{
+    launch_wss_flashblocks_service, ExecutionPayloadBaseV1, FlashBlockRx,
+};
 use reth_rpc::eth::{core::EthApiInner, DevSigner};
 use reth_rpc_eth_api::{
     helpers::{
@@ -390,7 +392,11 @@ impl<NetworkT> OpEthApiBuilder<NetworkT> {
 impl<N, NetworkT> EthApiBuilder<N> for OpEthApiBuilder<NetworkT>
 where
     N: FullNodeComponents<
-        Evm: ConfigureEvm<NextBlockEnvCtx: BuildPendingEnv<HeaderTy<N::Types>> + Unpin>,
+        Evm: ConfigureEvm<
+            NextBlockEnvCtx: BuildPendingEnv<HeaderTy<N::Types>>
+                                 + From<ExecutionPayloadBaseV1>
+                                 + Unpin,
+        >,
     >,
     NetworkT: RpcTypes,
     OpRpcConvert<N, NetworkT>: RpcConvert<Network = NetworkT>,

--- a/examples/custom-node/Cargo.toml
+++ b/examples/custom-node/Cargo.toml
@@ -12,6 +12,7 @@ reth-codecs.workspace = true
 reth-network-peers.workspace = true
 reth-node-builder.workspace = true
 reth-optimism-forks.workspace = true
+reth-optimism-flashblocks.workspace = true
 reth-db-api.workspace = true
 reth-op = { workspace = true, features = ["node", "pool", "rpc"] }
 reth-payload-builder.workspace = true

--- a/examples/custom-node/src/evm/config.rs
+++ b/examples/custom-node/src/evm/config.rs
@@ -23,6 +23,7 @@ use reth_op::{
     node::{OpEvmConfig, OpNextBlockEnvAttributes, OpRethReceiptBuilder},
     primitives::SignedTransaction,
 };
+use reth_optimism_flashblocks::ExecutionPayloadBaseV1;
 use reth_rpc_api::eth::helpers::pending_block::BuildPendingEnv;
 use std::sync::Arc;
 
@@ -134,6 +135,12 @@ impl ConfigureEngineEvm<CustomExecutionData> for CustomEvmConfig {
 pub struct CustomNextBlockEnvAttributes {
     inner: OpNextBlockEnvAttributes,
     extension: u64,
+}
+
+impl From<ExecutionPayloadBaseV1> for CustomNextBlockEnvAttributes {
+    fn from(value: ExecutionPayloadBaseV1) -> Self {
+        Self { inner: value.into(), extension: 0 }
+    }
 }
 
 impl BuildPendingEnv<CustomHeader> for CustomNextBlockEnvAttributes {


### PR DESCRIPTION
Part of #17858 

Removes the next evm env attributes builder from `FlashBlockService` and uses the flashblock base instead.
