### PR TITLE
chore: make `caller_gas_allowance` an RPC trait method

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -9,10 +9,7 @@ use crate::{
 };
 use alloy_consensus::BlockHeader;
 use alloy_eips::eip2930::AccessListResult;
-use alloy_evm::{
-    call::caller_gas_allowance,
-    overrides::{apply_block_overrides, apply_state_overrides, OverrideBlockHashes},
-};
+use alloy_evm::overrides::{apply_block_overrides, apply_state_overrides, OverrideBlockHashes};
 use alloy_network::TransactionBuilder;
 use alloy_primitives::{Bytes, B256, U256};
 use alloy_rpc_types_eth::{
@@ -404,8 +401,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
             evm_env.cfg_env.disable_eip3607 = true;
 
             if request.as_ref().gas_limit().is_none() && tx_env.gas_price() > 0 {
-                let cap =
-                    caller_gas_allowance(&mut db, &tx_env).map_err(Self::Error::from_eth_err)?;
+                let cap = this.caller_gas_allowance(&mut db, &tx_env)?;
                 // no gas limit was provided in the request, so we need to cap the request's gas
                 // limit
                 tx_env.set_gas_limit(cap.min(evm_env.block_env.gas_limit));
@@ -478,6 +474,15 @@ pub trait Call:
 
     /// Returns the maximum number of blocks accepted for `eth_simulateV1`.
     fn max_simulate_blocks(&self) -> u64;
+
+    /// Returns the max gas limit that the caller can afford given a transaction environment.
+    fn caller_gas_allowance(
+        &self,
+        mut db: impl Database<Error: Into<EthApiError>>,
+        env: &TxEnvFor<Self::Evm>,
+    ) -> Result<u64, Self::Error> {
+        alloy_evm::call::caller_gas_allowance(&mut db, env).map_err(Self::Error::from_eth_err)
+    }
 
     /// Executes the closure with the state that corresponds to the given [`BlockId`].
     fn with_state_at_block<F, R>(
@@ -794,7 +799,7 @@ pub trait Call:
             if tx_env.gas_price() > 0 {
                 // If gas price is specified, cap transaction gas limit with caller allowance
                 trace!(target: "rpc::eth::call", ?tx_env, "Applying gas limit cap with caller allowance");
-                let cap = caller_gas_allowance(db, &tx_env).map_err(EthApiError::from_call_err)?;
+                let cap = self.caller_gas_allowance(db, &tx_env)?;
                 // ensure we cap gas_limit to the block's
                 tx_env.set_gas_limit(cap.min(evm_env.block_env.gas_limit));
             }

--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -2,7 +2,7 @@
 
 use super::{Call, LoadPendingBlock};
 use crate::{AsEthApiError, FromEthApiError, IntoEthApiError};
-use alloy_evm::{call::caller_gas_allowance, overrides::apply_state_overrides};
+use alloy_evm::overrides::apply_state_overrides;
 use alloy_network::TransactionBuilder;
 use alloy_primitives::{TxKind, U256};
 use alloy_rpc_types_eth::{state::StateOverride, BlockId};
@@ -102,8 +102,7 @@ pub trait EstimateCall: Call {
         // The caller allowance is check by doing `(account.balance - tx.value) / tx.gas_price`
         if tx_env.gas_price() > 0 {
             // cap the highest gas limit by max gas caller can afford with given gas price
-            highest_gas_limit = highest_gas_limit
-                .min(caller_gas_allowance(&mut db, &tx_env).map_err(Self::Error::from_eth_err)?);
+            highest_gas_limit = highest_gas_limit.min(self.caller_gas_allowance(&mut db, &tx_env)?);
         }
 
         // If the provided gas limit is less than computed cap, use that


### PR DESCRIPTION
Extracts `caller_gas_allowance` into `Call` trait method allowing custom EthApi implementations to override it