### PR TITLE
fix(optimism): Prevent old pending flashblock from being returned from `pending_flashblock`

### DIFF
--- a/crates/optimism/rpc/src/eth/pending_block.rs
+++ b/crates/optimism/rpc/src/eth/pending_block.rs
@@ -45,7 +45,7 @@ where
         )>,
         Self::Error,
     > {
-        if let Some(block) = self.pending_flashblock() {
+        if let Ok(Some(block)) = self.pending_flashblock() {
             return Ok(Some(block));
         }
 


### PR DESCRIPTION
Part of #17858 #18102 

Adds similar checks as in `pool_pending_block` for `pending_flashblock` to verify that `latest` is its parent.
