### PR TITLE
feat: add EIP-7934 block size check to validateBuilderSubmissionV5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9923,6 +9923,7 @@ dependencies = [
  "reth-chain-state",
  "reth-chainspec",
  "reth-consensus",
+ "reth-consensus-common",
  "reth-db-api",
  "reth-engine-primitives",
  "reth-errors",

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -37,6 +37,7 @@ reth-rpc-eth-types.workspace = true
 reth-rpc-server-types.workspace = true
 reth-network-types.workspace = true
 reth-consensus.workspace = true
+reth-consensus-common.workspace = true
 reth-node-api.workspace = true
 reth-trie-common.workspace = true
 


### PR DESCRIPTION
Fixes #18110

add EIP-7934 block size validation to validateBuilderSubmissionV5

Enforce MAX_RLP_BLOCK_SIZE limit when Osaka hardfork is active.