### PR TITLE
perf(engine): only clone headers instead of full blocks for tree tasks

### DIFF
--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -606,18 +606,17 @@ where
         })
     }
 
-    /// Return sealed block from database or in-memory state by hash.
+    /// Return sealed block header from database or in-memory state by hash.
     fn sealed_header_by_hash(
         &self,
         hash: B256,
         state: &EngineApiTreeState<N>,
     ) -> ProviderResult<Option<SealedHeader<N::BlockHeader>>> {
         // check memory first
-        let block =
-            state.tree_state.block_by_hash(hash).map(|block| block.as_ref().clone_sealed_header());
+        let header = state.tree_state.sealed_header_by_hash(&hash);
 
-        if block.is_some() {
-            Ok(block)
+        if header.is_some() {
+            Ok(header)
         } else {
             self.provider.sealed_header_by_hash(hash)
         }

--- a/crates/engine/tree/src/tree/state.rs
+++ b/crates/engine/tree/src/tree/state.rs
@@ -7,7 +7,7 @@ use alloy_primitives::{
     BlockNumber, B256,
 };
 use reth_chain_state::{EthPrimitives, ExecutedBlockWithTrieUpdates};
-use reth_primitives_traits::{AlloyBlockHeader, NodePrimitives, SealedBlock};
+use reth_primitives_traits::{AlloyBlockHeader, NodePrimitives, SealedHeader};
 use reth_trie::updates::TrieUpdates;
 use std::{
     collections::{btree_map, hash_map, BTreeMap, VecDeque},
@@ -85,9 +85,12 @@ impl<N: NodePrimitives> TreeState<N> {
         self.blocks_by_hash.get(&hash)
     }
 
-    /// Returns the block by hash.
-    pub(crate) fn block_by_hash(&self, hash: B256) -> Option<Arc<SealedBlock<N::Block>>> {
-        self.blocks_by_hash.get(&hash).map(|b| Arc::new(b.recovered_block().sealed_block().clone()))
+    /// Returns the sealed block header by hash.
+    pub(crate) fn sealed_header_by_hash(
+        &self,
+        hash: &B256,
+    ) -> Option<SealedHeader<N::BlockHeader>> {
+        self.blocks_by_hash.get(hash).map(|b| b.sealed_block().sealed_header().clone())
     }
 
     /// Returns all available blocks for the given hash that lead back to the canonical chain, from

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -760,7 +760,7 @@ async fn test_get_canonical_blocks_to_persist() {
     let fork_block_hash = fork_block.recovered_block().hash();
     test_harness.tree.state.tree_state.insert_executed(fork_block);
 
-    assert!(test_harness.tree.state.tree_state.block_by_hash(fork_block_hash).is_some());
+    assert!(test_harness.tree.state.tree_state.sealed_header_by_hash(&fork_block_hash).is_some());
 
     let blocks_to_persist = test_harness.tree.get_canonical_blocks_to_persist().unwrap();
     assert_eq!(blocks_to_persist.len(), expected_blocks_to_persist_length);


### PR DESCRIPTION
(Part 2 of #18088)

(15+16)/46 ~ 67% of `EngineApiTreeHandler::advance_persistence` is spent on cloning a full block (more specifically in `find_disk_reorg`), even when all tree tasks only need a header (reference).

<img width="1107" height="699" alt="image" src="https://github.com/user-attachments/assets/42be8e9a-4beb-42f0-9c13-e747fc9a8a1d" />
