### PR TITLE
fix(optimism): Fix endless poll on the FlashBlockService

### DIFF
--- a/crates/optimism/flashblocks/src/service.rs
+++ b/crates/optimism/flashblocks/src/service.rs
@@ -176,16 +176,15 @@ impl<
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
-        loop {
-            match this.rx.poll_next_unpin(cx) {
-                Poll::Ready(Some(Ok(flashblock))) => {
-                    this.add_flash_block(flashblock);
-                    return Poll::Ready(Some(this.execute()));
-                }
-                Poll::Ready(Some(Err(err))) => return Poll::Ready(Some(Err(err))),
-                Poll::Ready(None) => return Poll::Ready(None),
-                Poll::Pending => return Poll::Pending,
+
+        match this.rx.poll_next_unpin(cx) {
+            Poll::Ready(Some(Ok(flashblock))) => {
+                this.add_flash_block(flashblock);
+                Poll::Ready(Some(this.execute()))
             }
+            Poll::Ready(Some(Err(err))) => Poll::Ready(Some(Err(err))),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
         }
     }
 }

--- a/crates/optimism/flashblocks/src/service.rs
+++ b/crates/optimism/flashblocks/src/service.rs
@@ -178,10 +178,13 @@ impl<
         let this = self.get_mut();
         loop {
             match this.rx.poll_next_unpin(cx) {
-                Poll::Ready(Some(Ok(flashblock))) => this.add_flash_block(flashblock),
+                Poll::Ready(Some(Ok(flashblock))) => {
+                    this.add_flash_block(flashblock);
+                    return Poll::Ready(Some(this.execute()));
+                }
                 Poll::Ready(Some(Err(err))) => return Poll::Ready(Some(Err(err))),
                 Poll::Ready(None) => return Poll::Ready(None),
-                Poll::Pending => return Poll::Ready(Some(this.execute())),
+                Poll::Pending => return Poll::Pending,
             }
         }
     }


### PR DESCRIPTION
The current implementation of `FlashBlockService::poll_next`, when used together with `launch_wss_flashblocks_service`, results in excessive invocations of poll_next.

Outputs thousands of:
```bash
ERROR Missing base flashblock
ERROR Missing base flashblock
ERROR Missing base flashblock
ERROR Missing base flashblock
ERROR Missing base flashblock
ERROR Missing base flashblock
...
```

Relates to #17858