### PR TITLE
fix(optimism): Verify that flashblocks are not old according to canon state

### DIFF
--- a/crates/chain-state/src/notifications.rs
+++ b/crates/chain-state/src/notifications.rs
@@ -122,13 +122,33 @@ impl<N: NodePrimitives> CanonStateNotification<N> {
         }
     }
 
-    /// Get the new tip of the chain.
+    /// Gets the new tip of the chain.
     ///
     /// Returns the new tip for [`Self::Reorg`] and [`Self::Commit`] variants which commit at least
     /// 1 new block.
+    ///
+    /// # Panics
+    ///
+    /// If chain doesn't have any blocks.
     pub fn tip(&self) -> &RecoveredBlock<N::Block> {
         match self {
             Self::Commit { new } | Self::Reorg { new, .. } => new.tip(),
+        }
+    }
+
+    /// Gets the new tip of the chain.
+    ///
+    /// If the chain has no blocks, it returns `None`. Otherwise, it returns the new tip for
+    /// [`Self::Reorg`] and [`Self::Commit`] variants.
+    pub fn tip_checked(&self) -> Option<&RecoveredBlock<N::Block>> {
+        match self {
+            Self::Commit { new } | Self::Reorg { new, .. } => {
+                if new.is_empty() {
+                    None
+                } else {
+                    Some(new.tip())
+                }
+            }
         }
     }
 

--- a/crates/optimism/flashblocks/src/app.rs
+++ b/crates/optimism/flashblocks/src/app.rs
@@ -1,5 +1,6 @@
 use crate::{ExecutionPayloadBaseV1, FlashBlockService, FlashBlockWsStream};
 use futures_util::StreamExt;
+use reth_chain_state::CanonStateSubscriptions;
 use reth_evm::ConfigureEvm;
 use reth_primitives_traits::{BlockTy, HeaderTy, NodePrimitives, ReceiptTy};
 use reth_rpc_eth_api::helpers::pending_block::BuildPendingEnv;
@@ -29,6 +30,7 @@ where
                                  + 'static,
         > + 'static,
     Provider: StateProviderFactory
+        + CanonStateSubscriptions<Primitives = N>
         + BlockReaderIdExt<
             Header = HeaderTy<N>,
             Block = BlockTy<N>,

--- a/crates/optimism/flashblocks/src/app.rs
+++ b/crates/optimism/flashblocks/src/app.rs
@@ -46,7 +46,7 @@ where
     tokio::spawn(async move {
         while let Some(block) = service.next().await {
             if let Ok(block) = block.inspect_err(|e| tracing::error!("{e}")) {
-                let _ = tx.send(Some(block)).inspect_err(|e| tracing::error!("{e}"));
+                let _ = tx.send(block).inspect_err(|e| tracing::error!("{e}"));
             }
         }
     });

--- a/crates/optimism/flashblocks/src/service.rs
+++ b/crates/optimism/flashblocks/src/service.rs
@@ -171,6 +171,12 @@ impl<
 
     /// Compares tip from the last notification of [`CanonStateSubscriptions`] with last computed
     /// pending block and verifies that the tip is the parent of the pending block.
+    ///
+    /// Returns:
+    /// * `Ok(Some(true))` if tip == parent
+    /// * `Ok(Some(false))` if tip != parent
+    /// * `Ok(None)` if there weren't any new notifications or the pending block is not built
+    /// * `Err` if the cannon state receiver returned an error
     fn verify_pending_block_integrity(
         &mut self,
         cx: &mut Context<'_>,

--- a/crates/rpc/rpc-eth-types/src/pending_block.rs
+++ b/crates/rpc/rpc-eth-types/src/pending_block.rs
@@ -6,7 +6,7 @@ use std::{sync::Arc, time::Instant};
 
 use alloy_consensus::BlockHeader;
 use alloy_eips::{BlockId, BlockNumberOrTag};
-use alloy_primitives::B256;
+use alloy_primitives::{BlockHash, B256};
 use derive_more::Constructor;
 use reth_chain_state::{
     BlockState, ExecutedBlock, ExecutedBlockWithTrieUpdates, ExecutedTrieUpdates,
@@ -125,6 +125,11 @@ impl<N: NodePrimitives> PendingBlock<N> {
     /// cloning from borrowed self.
     pub fn to_block_and_receipts(&self) -> PendingBlockAndReceipts<N> {
         (self.executed_block.recovered_block.clone(), self.receipts.clone())
+    }
+
+    /// Returns a hash of the parent block for this `executed_block`.
+    pub fn parent_hash(&self) -> BlockHash {
+        self.executed_block.recovered_block().parent_hash()
     }
 }
 


### PR DESCRIPTION
Part of #17858 #18102

Subscribes to canon state and performs integrity checks before executing flashblocks.
