### PR TITLE
Behzad/feat gas profile

### DIFF
--- a/crates/node/core/src/args/txpool.rs
+++ b/crates/node/core/src/args/txpool.rs
@@ -136,6 +136,11 @@ pub struct TxPoolArgs {
     /// Max batch size for transaction pool insertions
     #[arg(long = "txpool.max-batch-size", default_value_t = 1)]
     pub max_batch_size: usize,
+
+    /// Clear mempool after each canonical state change (for sequenced mode).
+    /// This ensures no transactions remain in the pool after block production.
+    #[arg(long = "txpool.clear-on-canonical-state-change")]
+    pub clear_on_canonical_state_change: bool,
 }
 
 impl TxPoolArgs {
@@ -188,6 +193,7 @@ impl Default for TxPoolArgs {
             transactions_backup_path: None,
             disable_transactions_backup: false,
             max_batch_size: 1,
+            clear_on_canonical_state_change: false,
         }
     }
 }
@@ -230,6 +236,7 @@ impl RethTransactionPoolConfig for TxPoolArgs {
             new_tx_listener_buffer_size: self.new_tx_listener_buffer_size,
             max_new_pending_txs_notifications: self.max_new_pending_txs_notifications,
             max_queued_lifetime: self.max_queued_lifetime,
+            clear_on_canonical_state_change: self.clear_on_canonical_state_change,
         }
     }
 

--- a/crates/transaction-pool/src/config.rs
+++ b/crates/transaction-pool/src/config.rs
@@ -65,6 +65,8 @@ pub struct PoolConfig {
     pub max_new_pending_txs_notifications: usize,
     /// Maximum lifetime for transactions in the pool
     pub max_queued_lifetime: Duration,
+    /// Clear mempool after canonical state change (for sequenced mode)
+    pub clear_on_canonical_state_change: bool,
 }
 
 impl PoolConfig {
@@ -112,6 +114,7 @@ impl Default for PoolConfig {
             new_tx_listener_buffer_size: NEW_TX_LISTENER_BUFFER_SIZE,
             max_new_pending_txs_notifications: MAX_NEW_PENDING_TXS_NOTIFICATIONS,
             max_queued_lifetime: MAX_QUEUED_TRANSACTION_LIFETIME,
+            clear_on_canonical_state_change: false,
         }
     }
 }

--- a/crates/transaction-pool/src/pool/blob.rs
+++ b/crates/transaction-pool/src/pool/blob.rs
@@ -239,6 +239,13 @@ impl<T: PoolTransaction> BlobTransactions<T> {
         self.by_id.get(id)
     }
 
+    /// Clears all transactions from the pool.
+    pub(crate) fn clear(&mut self) {
+        self.by_id.clear();
+        self.all.clear();
+        self.size_of = Default::default();
+    }
+    
     /// Asserts that the bijection between `by_id` and `all` is valid.
     #[cfg(any(test, feature = "test-utils"))]
     pub(crate) fn assert_invariants(&self) {

--- a/crates/transaction-pool/src/pool/parked.rs
+++ b/crates/transaction-pool/src/pool/parked.rs
@@ -245,6 +245,14 @@ impl<T: ParkedOrd> ParkedPool<T> {
         self.by_id.get(id)
     }
 
+    /// Clears all transactions from the pool.
+    pub(crate) fn clear(&mut self) {
+        self.by_id.clear();
+        self.last_sender_submission.clear();
+        self.sender_transaction_count.clear();
+        self.size_of = Default::default();
+    }
+    
     /// Asserts that all subpool invariants
     #[cfg(any(test, feature = "test-utils"))]
     pub(crate) fn assert_invariants(&self) {

--- a/crates/transaction-pool/src/pool/pending.rs
+++ b/crates/transaction-pool/src/pool/pending.rs
@@ -548,6 +548,14 @@ impl<T: TransactionOrdering> PendingPool<T> {
         &self.independent_transactions
     }
 
+    /// Clears all transactions from the pool.
+    pub(crate) fn clear(&mut self) {
+        self.by_id.clear();
+        self.independent_transactions.clear();
+        self.highest_nonces.clear();
+        self.size_of = Default::default();
+    }
+    
     /// Asserts that the bijection between `by_id` and `all` is valid.
     #[cfg(any(test, feature = "test-utils"))]
     pub(crate) fn assert_invariants(&self) {

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -1148,6 +1148,24 @@ impl<T: TransactionOrdering> TxPool<T> {
     pub(crate) fn is_empty(&self) -> bool {
         self.all_transactions.is_empty()
     }
+    
+    /// Clears all transactions from the pool
+    pub(crate) fn clear_all(&mut self) {
+        // Clear all sub-pools
+        self.pending_pool.clear();
+        self.basefee_pool.clear();
+        self.queued_pool.clear();
+        self.blob_pool.clear();
+        
+        // Clear all transactions
+        self.all_transactions.clear();
+        
+        // Clear sender info
+        self.sender_info.clear();
+        
+        // Update metrics
+        self.update_size_metrics();
+    }
 
     /// Asserts all invariants of the  pool's:
     ///
@@ -2003,6 +2021,14 @@ impl<T: PoolTransaction> AllTransactions<T> {
     /// Whether the pool is empty
     pub(crate) fn is_empty(&self) -> bool {
         self.txs.is_empty()
+    }
+    
+    /// Clears all transactions from the pool
+    pub(crate) fn clear(&mut self) {
+        self.txs.clear();
+        self.by_hash.clear();
+        self.tx_counter.clear();
+        self.auths.clear();
     }
 
     /// Asserts that the bijection between `by_hash` and `txs` is valid.

--- a/simple_mempool_test.sh
+++ b/simple_mempool_test.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+# Simplified test that works with dev mode auto-mining
+
+echo "=== MEMPOOL CLEAR TEST (Simplified) ==="
+
+# 1. Check initial state
+echo -e "\n1. Initial mempool status:"
+curl -s -X POST http://localhost:8545 \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"txpool_status","params":[],"id":1}' | jq '.result'
+
+# 2. Get current nonce
+NONCE=$(cast nonce 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --rpc-url http://localhost:8545)
+echo -e "\n2. Current nonce: $NONCE"
+
+# 3. Send transactions with gaps (these will be queued)
+echo -e "\n3. Sending transactions with nonce gaps..."
+echo "   Sending tx with nonce $(($NONCE + 2)) (gap - will be queued)"
+TX1=$(cast send --rpc-url http://localhost:8545 \
+  --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 \
+  --nonce $(($NONCE + 2)) \
+  0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb7 --value 0.001ether \
+  --async 2>/dev/null)
+echo "   TX1: ${TX1:0:10}..."
+
+echo "   Sending tx with nonce $(($NONCE + 3)) (gap - will be queued)"
+TX2=$(cast send --rpc-url http://localhost:8545 \
+  --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 \
+  --nonce $(($NONCE + 3)) \
+  0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb7 --value 0.001ether \
+  --async 2>/dev/null)
+echo "   TX2: ${TX2:0:10}..."
+
+sleep 1
+
+# 4. Check mempool (should have queued transactions)
+echo -e "\n4. Mempool after sending (should have queued txs):"
+MEMPOOL_BEFORE=$(curl -s -X POST http://localhost:8545 \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"txpool_status","params":[],"id":1}' | jq '.result')
+echo "$MEMPOOL_BEFORE"
+
+QUEUED_BEFORE=$(echo $MEMPOOL_BEFORE | jq -r '.queued' | xargs printf "%d")
+if [ "$QUEUED_BEFORE" -gt 0 ]; then
+    echo "   ✓ Successfully created $QUEUED_BEFORE queued transactions"
+else
+    echo "   ⚠ No queued transactions created - test may not work properly"
+fi
+
+# 5. Trigger block production by sending a valid transaction
+echo -e "\n5. Triggering block production..."
+echo "   Sending valid tx with nonce $NONCE to trigger mining"
+TRIGGER_TX=$(cast send --rpc-url http://localhost:8545 \
+  --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 \
+  --nonce $NONCE \
+  0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb7 --value 0.001ether 2>&1)
+
+if echo "$TRIGGER_TX" | grep -q "blockNumber"; then
+    BLOCK=$(echo "$TRIGGER_TX" | grep blockNumber | awk '{print $2}')
+    echo "   ✓ Transaction mined in block $BLOCK"
+else
+    echo "   Transaction sent, waiting for mining..."
+fi
+
+sleep 2
+
+# 6. Final check
+echo -e "\n6. FINAL MEMPOOL STATUS:"
+MEMPOOL_AFTER=$(curl -s -X POST http://localhost:8545 \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"txpool_status","params":[],"id":1}' | jq '.result')
+echo "$MEMPOOL_AFTER"
+
+PENDING_AFTER=$(echo $MEMPOOL_AFTER | jq -r '.pending' | xargs printf "%d")
+QUEUED_AFTER=$(echo $MEMPOOL_AFTER | jq -r '.queued' | xargs printf "%d")
+
+echo -e "\n=== TEST RESULT ==="
+if [ "$QUEUED_BEFORE" -gt 0 ] && [ "$PENDING_AFTER" -eq 0 ] && [ "$QUEUED_AFTER" -eq 0 ]; then
+    echo "✅ SUCCESS! Mempool was completely cleared!"
+    echo "   Before: $QUEUED_BEFORE queued transactions"
+    echo "   After:  0 transactions (all cleared)"
+    echo ""
+    echo "The --txpool.clear-on-canonical-state-change flag is working perfectly!"
+    echo "All transactions (including queued ones) were removed when the block became canonical."
+else
+    echo "❌ Test did not demonstrate clearing as expected"
+    echo "   Before: Queued=$QUEUED_BEFORE"
+    echo "   After:  Pending=$PENDING_AFTER, Queued=$QUEUED_AFTER"
+    
+    if [ "$QUEUED_BEFORE" -eq 0 ]; then
+        echo "   Issue: Could not create queued transactions to test with"
+    elif [ "$QUEUED_AFTER" -gt 0 ]; then
+        echo "   Issue: Queued transactions were not cleared"
+    fi
+fi


### PR DESCRIPTION
  ## Summary

 Adds a new flag `--txpool.clear-on-canonical-state-change` to completely clear the transaction pool after each canonical state change via Fork Choice Update (FCU). This feature is essential for L2 implementations where the L1 acts as the sequencer and strict transaction ordering between L1 and L2 must be maintained.

  ## Motivation

In certain L2 architectures (particularly those built on non-Ethereum L1s like Kaspa), the L1 blockchain acts as the sequencer rather than having a separate L2 sequencer. In this model:
  - Transactions must maintain strict ordering between L1 and L2
  - No transactions should remain in the mempool after block production
  - Transaction reinsertion or queuing after canonical state changes breaks L1-L2 consensus

This flag ensures the mempool is completely cleared after each block becomes canonical, preventing any transaction persistence that could lead to ordering discrepancies.

  ## Changes

  - Added `--txpool.clear-on-canonical-state-change` CLI flag
  - Implemented `clear_all()` methods for all transaction sub-pools (pending, basefee, queued, blob)
  - Modified canonical state change handler to conditionally clear the entire pool when flag is enabled
  - Ensures proper cleanup of all transaction metadata and sender information

  ## Testing Instructions

  ### 1. Setup JWT Secret

  Create a JWT secret file for Engine API authentication:

  ```bash
  mkdir -p ./tmp
  echo "ce5b60c3dbfe1486747b0d6ae6f7852351369de64d7b268af50f255fd771a61e" > ./tmp/jwt_secret.txt

  2. Build Reth

  Build the modified reth binary with the new feature:

  cargo build --release

  3. Run Reth Node

  Start reth in development mode with the mempool clearing flag enabled:

  ./target/release/reth node \
      --dev \
      --txpool.clear-on-canonical-state-change \
      --authrpc.jwtsecret ./tmp/jwt_secret.txt \
      --authrpc.addr 127.0.0.1 \
      --authrpc.port 8551 \
      --http \
      --http.api all

  Important parameters:
  - --dev: Runs in development mode with auto-mining
  - --txpool.clear-on-canonical-state-change: Enables the new mempool clearing feature
  - --http.api all: Enables all RPC APIs including txpool methods

  4. Run Test Script

  In a separate terminal, run the test script to verify mempool clearing:

  chmod +x ./simple_mempool_test.sh
  ./simple_mempool_test.sh

  Expected Test Output

  The test script will:
  1. Check initial mempool status (should be empty)
  2. Send transactions with nonce gaps to create queued transactions
  3. Trigger block production with a valid transaction
  4. Verify the mempool is completely cleared after the block becomes canonical

  Success output:
✅ SUCCESS! Mempool was completely cleared!
      Before: 2 queued transactions
      After:  0 transactions (all cleared)

  
  
This change is opt-in via the CLI flag and has no impact on default reth behavior. When enabled, it ensures deterministic transaction ordering for L2s that rely on L1 sequencing.
