### PR TITLE
feat(txpool): Add option to discard reorged transactions

### DIFF
--- a/crates/node/builder/src/components/pool.rs
+++ b/crates/node/builder/src/components/pool.rs
@@ -247,6 +247,7 @@ where
             reth_transaction_pool::maintain::MaintainPoolConfig {
                 max_tx_lifetime: pool_config.max_queued_lifetime,
                 no_local_exemptions: pool_config.local_transactions_config.no_exemptions,
+                discard_reorged_transactions: ctx.config().txpool.discard_reorged_transactions,
                 ..Default::default()
             },
         ),

--- a/crates/node/core/src/args/txpool.rs
+++ b/crates/node/core/src/args/txpool.rs
@@ -136,6 +136,17 @@ pub struct TxPoolArgs {
     /// Max batch size for transaction pool insertions
     #[arg(long = "txpool.max-batch-size", default_value_t = 1)]
     pub max_batch_size: usize,
+
+    /// Discard reorged transactions instead of re-injecting them into the mempool.
+    ///
+    /// When enabled, transactions from reorged blocks are permanently discarded rather
+    /// than being re-added to the transaction pool. This is useful for custom chains
+    /// that have different transaction validity rules or require strict control over
+    /// mempool contents after reorgs.
+    ///
+    /// Default: false (re-inject transactions to preserve standard Ethereum behavior)
+    #[arg(long = "txpool.discard-reorged-transactions")]
+    pub discard_reorged_transactions: bool,
 }
 
 impl TxPoolArgs {
@@ -188,6 +199,7 @@ impl Default for TxPoolArgs {
             transactions_backup_path: None,
             disable_transactions_backup: false,
             max_batch_size: 1,
+            discard_reorged_transactions: false,
         }
     }
 }


### PR DESCRIPTION
Introduces a new configuration option to control how transactions from reorged blocks are handled.

Previously, transactions from reorged blocks were always re-injected into the transaction pool. While this is standard Ethereum behavior, some custom chains may have different validity rules or require stricter control over the mempool, making re-injection undesirable.

This change adds the `--txpool.discard-reorged-transactions` flag. When enabled, transactions from reorged blocks are permanently discarded instead of being re-added to the pool.

The default behavior remains unchanged, preserving compatibility with standard networks by re-injecting transactions.