### PR TITLE
fix(net/network): check if there are any idle trusted peers at all

### DIFF
--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -259,7 +259,7 @@ impl PeersManager {
             // are allowed (max_inbound == 0), in which case we still need to allow new pending
             // incoming connections until all trusted peers are connected.
             let num_idle_trusted_peers = self.num_idle_trusted_peers();
-            if num_idle_trusted_peers <= self.trusted_peer_ids.len() {
+            if num_idle_trusted_peers > 0 {
                 // we still want to limit concurrent pending connections
                 let max_inbound =
                     self.trusted_peer_ids.len().max(self.connection_info.config.max_inbound);


### PR DESCRIPTION
The condition `num_idle_trusted_peers <= self.trusted_peer_ids.len()` is mathematically always true since `num_idle_trusted_peers` counts a subset of `trusted_peer_ids`.

This PR changes to `num_idle_trusted_peers > 0` to only accept connections when there are actually trusted peers in idle status.

I'm not entirely confident this completely fixes the issue. Please tell me if I missed something.