### PR TITLE
feat: generalize impl EngineValidatorAddOn for OpAddOns

### DIFF
--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -622,11 +622,11 @@ where
     }
 }
 
-impl<N, NetworkT, PVB, EB, EVB, RpcMiddleware> EngineValidatorAddOn<N>
-    for OpAddOns<N, OpEthApiBuilder<NetworkT>, PVB, EB, EVB, RpcMiddleware>
+impl<N, EAB, PVB, EB, EVB, RpcMiddleware> EngineValidatorAddOn<N>
+    for OpAddOns<N, EAB, PVB, EB, EVB, RpcMiddleware>
 where
     N: FullNodeComponents,
-    OpEthApiBuilder<NetworkT>: EthApiBuilder<N>,
+    EAB: EthApiBuilder<N>,
     PVB: Send,
     EB: EngineApiBuilder<N>,
     EVB: EngineValidatorBuilder<N>,

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -622,11 +622,11 @@ where
     }
 }
 
-impl<N, EAB, PVB, EB, EVB, RpcMiddleware> EngineValidatorAddOn<N>
-    for OpAddOns<N, EAB, PVB, EB, EVB, RpcMiddleware>
+impl<N, EthB, PVB, EB, EVB, RpcMiddleware> EngineValidatorAddOn<N>
+    for OpAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>
 where
     N: FullNodeComponents,
-    EAB: EthApiBuilder<N>,
+    EthB: EthApiBuilder<N>,
     PVB: Send,
     EB: EngineApiBuilder<N>,
     EVB: EngineValidatorBuilder<N>,


### PR DESCRIPTION
Fairly self descriptive. Makes swapping eth apis possible without making a custom AddOns.