### PR TITLE
perf(engine): pre-allocate channel handles in prewarm task

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -88,7 +88,7 @@ where
         let max_concurrency = self.max_concurrency;
 
         self.executor.spawn_blocking(move || {
-            let mut handles = Vec::new();
+            let mut handles = Vec::with_capacity(max_concurrency);
             let (done_tx, done_rx) = mpsc::channel();
             let mut executing = 0;
             while let Ok(executable) = pending.recv() {


### PR DESCRIPTION
Pre-allocate channel handles Vec to max_concurrency (64) to eliminate 6 reallocations.

Without pre-allocation, Vec grows 0→1→2→4→8→16→32→64, triggering realloc+memcpy at each step.
Single upfront allocation avoids 6 heap allocations and memory fragmentation in hot path.