### PR TITLE
perf(engine): pre-allocate Vec capacity in payload processor

### DIFF
--- a/crates/engine/tree/benches/state_root_task.rs
+++ b/crates/engine/tree/benches/state_root_task.rs
@@ -44,7 +44,7 @@ fn create_bench_state_updates(params: &BenchParams) -> Vec<EvmState> {
     let mut rng = runner.rng().clone();
     let all_addresses: Vec<Address> =
         (0..params.num_accounts).map(|_| Address::random_with(&mut rng)).collect();
-    let mut updates = Vec::new();
+    let mut updates = Vec::with_capacity(params.updates_per_account);
 
     for _ in 0..params.updates_per_account {
         let mut state_update = EvmState::default();
@@ -122,7 +122,7 @@ fn setup_provider(
     for update in state_updates {
         let provider_rw = factory.provider_rw()?;
 
-        let mut account_updates = Vec::new();
+        let mut account_updates = Vec::with_capacity(update.len());
 
         for (address, account) in update {
             // only process self-destructs if account exists, always process

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -594,7 +594,7 @@ mod tests {
     fn create_mock_state_updates(num_accounts: usize, updates_per_account: usize) -> Vec<EvmState> {
         let mut rng = generators::rng();
         let all_addresses: Vec<Address> = (0..num_accounts).map(|_| rng.random()).collect();
-        let mut updates = Vec::new();
+        let mut updates = Vec::with_capacity(updates_per_account);
 
         for _ in 0..updates_per_account {
             let num_accounts_in_update = rng.random_range(1..=num_accounts);


### PR DESCRIPTION
Pre-allocate Vec with exact known sizes to avoid reallocation overhead.

Vec grows dynamically causing memory copies on each reallocation. avoids over-allocation seen in removed sparse_trie case.