### PR TITLE
fix(trie): Fix call to update_account in witness

### DIFF
--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -196,7 +196,11 @@ where
                 .get(&hashed_address)
                 .ok_or(TrieWitnessError::MissingAccount(hashed_address))?
                 .unwrap_or_default();
-            sparse_trie.update_account(hashed_address, account, &blinded_provider_factory)?;
+
+            if !sparse_trie.update_account(hashed_address, account, &blinded_provider_factory)? {
+                let nibbles = Nibbles::unpack(hashed_address);
+                sparse_trie.remove_account_leaf(&nibbles, &blinded_provider_factory)?;
+            }
 
             while let Ok(node) = rx.try_recv() {
                 self.witness.insert(keccak256(&node), node);


### PR DESCRIPTION
In 8193fcff9 (#17643) the behavior of `update_account` was changed so that it does not call `remove_account_leaf` on its own, but rather returns a boolean indicating that the caller should do so. This change in behavior was not accounted for in the witness code which also calls this method.