### PR TITLE
feat(optimism): add FlashblocksRx getter

### DIFF
--- a/crates/optimism/rpc/src/eth/mod.rs
+++ b/crates/optimism/rpc/src/eth/mod.rs
@@ -94,6 +94,11 @@ impl<N: RpcNodeCore, Rpc: RpcConvert> OpEthApi<N, Rpc> {
         self.inner.sequencer_client()
     }
 
+    /// Returns a cloned Flashblocks receiver, if any.
+    pub fn flashblocks_rx(&self) -> Option<FlashBlockRx<N::Primitives>> {
+        self.inner.flashblocks_rx.clone()
+    }
+
     /// Build a [`OpEthApi`] using [`OpEthApiBuilder`].
     pub const fn builder() -> OpEthApiBuilder<Rpc> {
         OpEthApiBuilder::new()


### PR DESCRIPTION
Add a getter for the FlashblockRx receiver, so it can be subscribed to in `on_rpc_started` for example.