### PR TITLE
refactor(revm): (#18150) use hardfork activation helpers

### DIFF
--- a/crates/ethereum/evm/src/config.rs
+++ b/crates/ethereum/evm/src/config.rs
@@ -1,12 +1,11 @@
-use reth_chainspec::{EthChainSpec, EthereumHardforks};
-use reth_ethereum_forks::{EthereumHardfork, Hardforks};
+use reth_chainspec::EthereumHardforks;
 use reth_primitives_traits::BlockHeader;
 use revm::primitives::hardfork::SpecId;
 
 /// Map the latest active hardfork at the given header to a revm [`SpecId`].
 pub fn revm_spec<C, H>(chain_spec: &C, header: &H) -> SpecId
 where
-    C: EthereumHardforks + EthChainSpec + Hardforks,
+    C: EthereumHardforks,
     H: BlockHeader,
 {
     revm_spec_by_timestamp_and_block_number(chain_spec, header.timestamp(), header.number())
@@ -19,80 +18,37 @@ pub fn revm_spec_by_timestamp_and_block_number<C>(
     block_number: u64,
 ) -> SpecId
 where
-    C: EthereumHardforks + EthChainSpec + Hardforks,
+    C: EthereumHardforks,
 {
-    if chain_spec
-        .fork(EthereumHardfork::Osaka)
-        .active_at_timestamp_or_number(timestamp, block_number)
-    {
+    if chain_spec.is_osaka_active_at_timestamp(timestamp) {
         SpecId::OSAKA
-    } else if chain_spec
-        .fork(EthereumHardfork::Prague)
-        .active_at_timestamp_or_number(timestamp, block_number)
-    {
+    } else if chain_spec.is_prague_active_at_timestamp(timestamp) {
         SpecId::PRAGUE
-    } else if chain_spec
-        .fork(EthereumHardfork::Cancun)
-        .active_at_timestamp_or_number(timestamp, block_number)
-    {
+    } else if chain_spec.is_cancun_active_at_timestamp(timestamp) {
         SpecId::CANCUN
-    } else if chain_spec
-        .fork(EthereumHardfork::Shanghai)
-        .active_at_timestamp_or_number(timestamp, block_number)
-    {
+    } else if chain_spec.is_shanghai_active_at_timestamp(timestamp) {
         SpecId::SHANGHAI
-    } else if chain_spec.is_paris_active_at_block(block_number) {
+    }
+    else if chain_spec.is_paris_active_at_block(block_number) {
         SpecId::MERGE
-    } else if chain_spec
-        .fork(EthereumHardfork::London)
-        .active_at_timestamp_or_number(timestamp, block_number)
-    {
+    } else if chain_spec.is_london_active_at_block(block_number) {
         SpecId::LONDON
-    } else if chain_spec
-        .fork(EthereumHardfork::Berlin)
-        .active_at_timestamp_or_number(timestamp, block_number)
-    {
+    } else if chain_spec.is_berlin_active_at_block(block_number) {
         SpecId::BERLIN
-    } else if chain_spec
-        .fork(EthereumHardfork::Istanbul)
-        .active_at_timestamp_or_number(timestamp, block_number)
-    {
+    } else if chain_spec.is_istanbul_active_at_block(block_number) {
         SpecId::ISTANBUL
-    } else if chain_spec
-        .fork(EthereumHardfork::Petersburg)
-        .active_at_timestamp_or_number(timestamp, block_number)
-    {
+    } else if chain_spec.is_petersburg_active_at_block(block_number) {
         SpecId::PETERSBURG
-    } else if chain_spec
-        .fork(EthereumHardfork::Byzantium)
-        .active_at_timestamp_or_number(timestamp, block_number)
-    {
+    } else if chain_spec.is_byzantium_active_at_block(block_number) {
         SpecId::BYZANTIUM
-    } else if chain_spec
-        .fork(EthereumHardfork::SpuriousDragon)
-        .active_at_timestamp_or_number(timestamp, block_number)
-    {
+    } else if chain_spec.is_spurious_dragon_active_at_block(block_number) {
         SpecId::SPURIOUS_DRAGON
-    } else if chain_spec
-        .fork(EthereumHardfork::Tangerine)
-        .active_at_timestamp_or_number(timestamp, block_number)
-    {
+    } else if chain_spec.is_tangerine_active_at_block(block_number) {
         SpecId::TANGERINE
-    } else if chain_spec
-        .fork(EthereumHardfork::Homestead)
-        .active_at_timestamp_or_number(timestamp, block_number)
-    {
+    } else if chain_spec.is_homestead_active_at_block(block_number) {
         SpecId::HOMESTEAD
-    } else if chain_spec
-        .fork(EthereumHardfork::Frontier)
-        .active_at_timestamp_or_number(timestamp, block_number)
-    {
-        SpecId::FRONTIER
     } else {
-        panic!(
-            "invalid hardfork chainspec: expected at least one hardfork, got {}",
-            chain_spec.display_hardforks()
-        )
+        SpecId::FRONTIER
     }
 }
 


### PR DESCRIPTION
This PR simplifies the logic for mapping an active hardfork to a `revm::SpecId`.

It replaces the manual block number comparisons with the new, more explicit activation helper functions (`is_berlin_active_at_block`, etc.) that were introduced in the `alloy-hardforks` crate. This improves code clarity and maintainability.

Closes #18150

### Dependencies
-   **alloy-rs/hardforks#57**
