### PR TITLE
perf(txpool): eliminate allocations in basefee enforcement

### DIFF
--- a/crates/transaction-pool/src/pool/parked.rs
+++ b/crates/transaction-pool/src/pool/parked.rs
@@ -295,22 +295,6 @@ impl<T: PoolTransaction> ParkedPool<BasefeeOrd<T>> {
         transactions
     }
 
-    /// Removes all transactions and their dependent transaction from the subpool that no longer
-    /// satisfy the given basefee.
-    ///
-    /// Legacy method maintained for compatibility with read-only queries.
-    /// For basefee enforcement, prefer `enforce_basefee_with_handler` for better performance.
-    ///
-    /// Note: the transactions are not returned in a particular order.
-    #[cfg(test)]
-    pub(crate) fn enforce_basefee(&mut self, basefee: u64) -> Vec<Arc<ValidPoolTransaction<T>>> {
-        let mut removed = Vec::new();
-        self.enforce_basefee_with_handler(basefee, |tx| {
-            removed.push(tx);
-        });
-        removed
-    }
-
     /// Removes all transactions from this subpool that can afford the given basefee,
     /// invoking the provided handler for each transaction as it is removed.
     ///
@@ -365,6 +349,22 @@ impl<T: PoolTransaction> ParkedPool<BasefeeOrd<T>> {
                 );
             }
         }
+    }
+
+    /// Removes all transactions and their dependent transaction from the subpool that no longer
+    /// satisfy the given basefee.
+    ///
+    /// Legacy method maintained for compatibility with read-only queries.
+    /// For basefee enforcement, prefer `enforce_basefee_with_handler` for better performance.
+    ///
+    /// Note: the transactions are not returned in a particular order.
+    #[cfg(test)]
+    pub(crate) fn enforce_basefee(&mut self, basefee: u64) -> Vec<Arc<ValidPoolTransaction<T>>> {
+        let mut removed = Vec::new();
+        self.enforce_basefee_with_handler(basefee, |tx| {
+            removed.push(tx);
+        });
+        removed
     }
 }
 
@@ -1160,5 +1160,4 @@ mod tests {
         // Verify transactions were removed from pool
         assert_eq!(pool.len(), 1); // Only the 300 fee tx should remain
     }
-
 }

--- a/crates/transaction-pool/src/pool/parked.rs
+++ b/crates/transaction-pool/src/pool/parked.rs
@@ -306,7 +306,7 @@ impl<T: PoolTransaction> ParkedPool<BasefeeOrd<T>> {
     /// still cannot afford the basefee, higher-nonce transactions from that sender are skipped.
     ///
     /// Note: the transactions are not returned in a particular order.
-    pub(crate) fn enforce_basefee_with_handler<F>(&mut self, basefee: u64, mut tx_handler: F)
+    pub(crate) fn enforce_basefee_with<F>(&mut self, basefee: u64, mut tx_handler: F)
     where
         F: FnMut(Arc<ValidPoolTransaction<T>>),
     {
@@ -355,13 +355,13 @@ impl<T: PoolTransaction> ParkedPool<BasefeeOrd<T>> {
     /// satisfy the given basefee.
     ///
     /// Legacy method maintained for compatibility with read-only queries.
-    /// For basefee enforcement, prefer `enforce_basefee_with_handler` for better performance.
+    /// For basefee enforcement, prefer `enforce_basefee_with` for better performance.
     ///
     /// Note: the transactions are not returned in a particular order.
     #[cfg(test)]
     pub(crate) fn enforce_basefee(&mut self, basefee: u64) -> Vec<Arc<ValidPoolTransaction<T>>> {
         let mut removed = Vec::new();
-        self.enforce_basefee_with_handler(basefee, |tx| {
+        self.enforce_basefee_with(basefee, |tx| {
             removed.push(tx);
         });
         removed
@@ -1142,7 +1142,7 @@ mod tests {
         let mut processed_txs = Vec::new();
         let mut handler_call_count = 0;
 
-        pool.enforce_basefee_with_handler(400, |tx| {
+        pool.enforce_basefee_with(400, |tx| {
             processed_txs.push(tx);
             handler_call_count += 1;
         });

--- a/crates/transaction-pool/src/pool/parked.rs
+++ b/crates/transaction-pool/src/pool/parked.rs
@@ -311,7 +311,7 @@ impl<T: PoolTransaction> ParkedPool<BasefeeOrd<T>> {
         removed
     }
 
-    /// Removes all transactions from this subpool that can now afford the given basefee,
+    /// Removes all transactions from this subpool that can afford the given basefee,
     /// invoking the provided handler for each transaction as it is removed.
     ///
     /// This method enforces the basefee constraint by identifying transactions that now

--- a/crates/transaction-pool/src/pool/parked.rs
+++ b/crates/transaction-pool/src/pool/parked.rs
@@ -315,12 +315,6 @@ impl<T: PoolTransaction> ParkedPool<BasefeeOrd<T>> {
         for id in to_remove {
             if let Some(tx) = self.remove_transaction(&id) {
                 tx_handler(tx);
-            } else {
-                tracing::warn!(
-                    target: "reth::txpool::parked",
-                    ?id,
-                    "Failed to remove transaction during basefee enforcement - possible data structure inconsistency"
-                );
             }
         }
     }

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -310,7 +310,6 @@ impl<T: TransactionOrdering> TxPool<T> {
                         meta.state.insert(TxState::ENOUGH_FEE_CAP_BLOCK);
                         meta.subpool = meta.state.into();
 
-                        // Inline add_transaction_to_subpool logic (minus unreachable basefee arm)
                         trace!(target: "txpool", hash=%tx.transaction.hash(), pool=?meta.subpool, "Adding transaction to a subpool");
                         match meta.subpool {
                             SubPool::Queued => self.queued_pool.add_transaction(tx),
@@ -321,8 +320,8 @@ impl<T: TransactionOrdering> TxPool<T> {
                                 self.blob_pool.add_transaction(tx);
                             }
                             SubPool::BaseFee => {
-                                // Unreachable as transactions from BaseFee pool with decreased
-                                // basefee are guaranteed to become Pending
+                                // This should be unreachable as transactions from BaseFee pool with
+                                // decreased basefee are guaranteed to become Pending
                                 unreachable!("BaseFee transactions should become Pending after basefee decrease");
                             }
                         }

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -301,14 +301,14 @@ impl<T: TransactionOrdering> TxPool<T> {
                 //   ENOUGH_BLOB_FEE_CAP_BLOCK.
                 // With the lower base fee they gain ENOUGH_FEE_CAP_BLOCK, so we can set the bit and
                 // insert directly into Pending (skip generic routing).
-                self.basefee_pool.enforce_basefee_with_handler(
+                self.basefee_pool.enforce_basefee_with(
                     self.all_transactions.pending_fees.base_fee,
                     |tx| {
                         // Update transaction state — guaranteed Pending by the invariants above
                         let meta =
                             self.all_transactions.txs.get_mut(tx.id()).expect("tx exists in set");
                         meta.state.insert(TxState::ENOUGH_FEE_CAP_BLOCK);
-                        meta.subpool = SubPool::Pending;
+                        meta.subpool = meta.state.into();
 
                         self.pending_pool
                             .add_transaction(tx, self.all_transactions.pending_fees.base_fee);

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -2976,7 +2976,7 @@ mod tests {
     }
 
     #[test]
-    fn test_basefee_decrease_zero_allocation_optimization() {
+    fn basefee_decrease_promotes_affordable_and_keeps_unaffordable() {
         use alloy_primitives::address;
         let mut f = MockTransactionFactory::default();
         let mut pool = TxPool::new(MockOrdering::default(), Default::default());

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -309,7 +309,6 @@ impl<T: TransactionOrdering> TxPool<T> {
                             self.all_transactions.txs.get_mut(tx.id()).expect("tx exists in set");
                         meta.state.insert(TxState::ENOUGH_FEE_CAP_BLOCK);
                         meta.subpool = meta.state.into();
-
                         self.pending_pool
                             .add_transaction(tx, self.all_transactions.pending_fees.base_fee);
                     },


### PR DESCRIPTION
## Summary

Closes #18151

Optimizes transaction pool basefee enforcement by eliminating Vec allocations during base fee decreases. This addresses performance bottlenecks identified in #18151 by replacing the allocation-heavy approach with zero-allocation closure-based processing.

`BASE_FEE_POOL_BITS + ENOUGH_FEE_CAP_BLOCK = PENDING_POOL_BITS`. When basefee decreases, qualifying transactions can only transition BaseFee → Pending, enabling direct routing without generic dispatch.


## Changes

- **New method**: `enforce_basefee_with_handler()` processes transactions via closure instead of collecting into Vec
- **Direct routing**: Leverages mathematical certainty that BaseFee → Pending transitions are deterministic
- **Optimized flow**: Eliminates generic routing overhead by directly updating transaction state and inserting into pending pool
- **Backward compatibility**: Maintains `enforce_basefee()` method for test compatibility using `#[cfg(test)]`

## Performance Impact

**Before**: 2 Vec allocations per basefee enforcement cycle
- `Vec<TransactionId>` from `satisfy_base_fee_ids()`  
- `Vec<Arc<ValidPoolTransaction<T>>>` from `enforce_basefee()`

**After**: Zero allocations with immediate processing via closure


