### PR TITLE
fix(optimism): find fb attrs in base fb

### DIFF
--- a/crates/optimism/flashblocks/src/service.rs
+++ b/crates/optimism/flashblocks/src/service.rs
@@ -125,8 +125,8 @@ impl<
 
         let attrs = self
             .blocks
-            .iter()
-            .find_map(|v| v.base.clone())
+            .first()
+            .and_then(|v| v.base.clone())
             .ok_or_eyre("Missing base flashblock")?;
 
         if attrs.parent_hash != latest.hash() {


### PR DESCRIPTION
No need to iter on all flashblocks to find base, it is only included in the first base flashblocks (index == 0) and omitted in all subsequent fbs.