### PR TITLE
test(optimism): Test that streaming flashblocks from remote source is successful

### DIFF
--- a/crates/optimism/flashblocks/Cargo.toml
+++ b/crates/optimism/flashblocks/Cargo.toml
@@ -32,7 +32,7 @@ alloy-rpc-types-engine = { workspace = true, features = ["serde"] }
 
 # io
 tokio.workspace = true
-tokio-tungstenite.workspace = true
+tokio-tungstenite = { workspace = true, features = ["rustls-tls-native-roots"] }
 serde.workspace = true
 serde_json.workspace = true
 url.workspace = true

--- a/crates/optimism/flashblocks/src/payload.rs
+++ b/crates/optimism/flashblocks/src/payload.rs
@@ -37,7 +37,7 @@ pub struct Metadata {
     pub new_account_balances: BTreeMap<Address, U256>,
     /// Execution receipts for all transactions in the block.
     /// Contains logs, gas usage, and other EVM-level metadata.
-    pub receipts: BTreeMap<B256, BTreeMap<String, OpReceipt>>,
+    pub receipts: BTreeMap<B256, OpReceipt>,
 }
 
 /// Represents the base configuration of an execution payload that remains constant

--- a/crates/optimism/flashblocks/tests/it/main.rs
+++ b/crates/optimism/flashblocks/tests/it/main.rs
@@ -1,0 +1,5 @@
+//! Integration tests.
+//!
+//! All the individual modules are rooted here to produce a single binary.
+
+mod stream;

--- a/crates/optimism/flashblocks/tests/it/stream.rs
+++ b/crates/optimism/flashblocks/tests/it/stream.rs
@@ -1,0 +1,15 @@
+use futures_util::stream::StreamExt;
+use reth_optimism_flashblocks::WsFlashBlockStream;
+
+#[tokio::test]
+async fn test_streaming_flashblocks_from_remote_source_is_successful() {
+    let items = 3;
+    let ws_url = "wss://sepolia.flashblocks.base.org/ws".parse().unwrap();
+    let stream = WsFlashBlockStream::new(ws_url);
+
+    let blocks: Vec<_> = stream.take(items).collect().await;
+
+    for block in blocks {
+        assert!(block.is_ok());
+    }
+}


### PR DESCRIPTION
Part of #17858 

Adds an integration test that streams flashblocks from base.

It uncovered that the schema has changed.

Fix included.

