### PR TITLE
refactor: remove unnecessary PathBuf clone in CLI help generator

### DIFF
--- a/docs/cli/help.rs
+++ b/docs/cli/help.rs
@@ -120,7 +120,7 @@ fn main() -> io::Result<()> {
         output.iter().map(|(cmd, _)| cmd_summary(cmd, 0)).chain(once("\n".to_string())).collect();
 
     println!("Writing SUMMARY.mdx to \"{}\"", out_dir.to_string_lossy());
-    write_file(&out_dir.clone().join("SUMMARY.mdx"), &summary)?;
+    write_file(&out_dir.join("SUMMARY.mdx"), &summary)?;
 
     // Generate README.md.
     if args.readme {


### PR DESCRIPTION
Remove redundant clone() call when joining paths in docs/cli/help.rs. The join() method already creates a new PathBuf, making the clone() unnecessary.