### PR TITLE
chore: avoid using hashmap hashers directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7403,7 +7403,6 @@ dependencies = [
 name = "reth-cli-commands"
 version = "1.6.0"
 dependencies = [
- "ahash",
  "alloy-chains",
  "alloy-consensus",
  "alloy-eips",

--- a/crates/cli/commands/Cargo.toml
+++ b/crates/cli/commands/Cargo.toml
@@ -68,7 +68,6 @@ futures.workspace = true
 tokio.workspace = true
 
 # misc
-ahash.workspace = true
 human_bytes.workspace = true
 eyre.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }

--- a/crates/cli/commands/src/db/checksum.rs
+++ b/crates/cli/commands/src/db/checksum.rs
@@ -2,7 +2,7 @@ use crate::{
     common::CliNodeTypes,
     db::get::{maybe_json_value_parser, table_key},
 };
-use ahash::RandomState;
+use alloy_primitives::map::foldhash::fast::FixedState;
 use clap::Parser;
 use reth_chainspec::EthereumHardforks;
 use reth_db::DatabaseEnv;
@@ -102,7 +102,7 @@ impl<N: ProviderNodeTypes> TableViewer<(u64, Duration)> for ChecksumViewer<'_, N
         };
 
         let start_time = Instant::now();
-        let mut hasher = RandomState::with_seeds(1, 2, 3, 4).build_hasher();
+        let mut hasher = FixedState::with_seed(u64::from_be_bytes(*b"RETHRETH")).build_hasher();
         let mut total = 0;
 
         let limit = self.limit.unwrap_or(usize::MAX);

--- a/crates/net/network/src/cache.rs
+++ b/crates/net/network/src/cache.rs
@@ -1,9 +1,10 @@
 //! Network cache support
 
+use alloy_primitives::map::DefaultHashBuilder;
 use core::hash::BuildHasher;
 use derive_more::{Deref, DerefMut};
 use itertools::Itertools;
-use schnellru::{ByLength, Limiter, RandomState, Unlimited};
+use schnellru::{ByLength, Limiter, Unlimited};
 use std::{fmt, hash::Hash};
 
 /// A minimal LRU cache based on a [`LruMap`](schnellru::LruMap) with limited capacity.
@@ -133,9 +134,10 @@ where
     }
 }
 
-/// Wrapper of [`schnellru::LruMap`] that implements [`fmt::Debug`].
+/// Wrapper of [`schnellru::LruMap`] that implements [`fmt::Debug`] and with the common hash
+/// builder.
 #[derive(Deref, DerefMut, Default)]
-pub struct LruMap<K, V, L = ByLength, S = RandomState>(schnellru::LruMap<K, V, L, S>)
+pub struct LruMap<K, V, L = ByLength, S = DefaultHashBuilder>(schnellru::LruMap<K, V, L, S>)
 where
     K: Hash + PartialEq,
     L: Limiter<K, V>,
@@ -171,7 +173,7 @@ where
 {
     /// Returns a new cache with default limiter and hash builder.
     pub fn new(max_length: u32) -> Self {
-        Self(schnellru::LruMap::new(ByLength::new(max_length)))
+        Self(schnellru::LruMap::with_hasher(ByLength::new(max_length), Default::default()))
     }
 }
 
@@ -181,7 +183,7 @@ where
 {
     /// Returns a new cache with [`Unlimited`] limiter and default hash builder.
     pub fn new_unlimited() -> Self {
-        Self(schnellru::LruMap::new(Unlimited))
+        Self(schnellru::LruMap::with_hasher(Unlimited, Default::default()))
     }
 }
 

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -2492,7 +2492,7 @@ mod tests {
     use crate::trie::ChangedSubtrie;
     use alloy_primitives::{
         b256, hex,
-        map::{foldhash::fast::RandomState, B256Set, DefaultHashBuilder, HashMap},
+        map::{B256Set, DefaultHashBuilder, HashMap},
         B256, U256,
     };
     use alloy_rlp::{Decodable, Encodable};
@@ -2548,7 +2548,7 @@ mod tests {
     impl MockTrieNodeProvider {
         /// Creates a new empty mock provider
         fn new() -> Self {
-            Self { nodes: HashMap::with_hasher(RandomState::default()) }
+            Self { nodes: HashMap::default() }
         }
 
         /// Adds a revealed node at the specified path

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -1938,8 +1938,6 @@ impl SparseTrieUpdates {
 mod find_leaf_tests {
     use super::*;
     use crate::provider::DefaultTrieNodeProvider;
-    use alloy_primitives::map::foldhash::fast::RandomState;
-    // Assuming this exists
     use alloy_rlp::Encodable;
     use assert_matches::assert_matches;
     use reth_primitives_traits::Account;
@@ -2102,7 +2100,7 @@ mod find_leaf_tests {
         let blinded_hash = B256::repeat_byte(0xBB);
         let leaf_path = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x3, 0x4]);
 
-        let mut nodes = alloy_primitives::map::HashMap::with_hasher(RandomState::default());
+        let mut nodes = alloy_primitives::map::HashMap::default();
         // Create path to the blinded node
         nodes.insert(
             Nibbles::default(),
@@ -2143,7 +2141,7 @@ mod find_leaf_tests {
         let path_to_blind = Nibbles::from_nibbles_unchecked([0x1]);
         let search_path = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x3, 0x4]);
 
-        let mut nodes = HashMap::with_hasher(RandomState::default());
+        let mut nodes = HashMap::default();
 
         // Root is a branch with child 0x1 (blinded) and 0x5 (revealed leaf)
         // So we set Bit 1 and Bit 5 in the state_mask
@@ -2158,7 +2156,7 @@ mod find_leaf_tests {
             SparseNode::new_leaf(Nibbles::from_nibbles_unchecked([0x6, 0x7, 0x8])),
         );
 
-        let mut values = HashMap::with_hasher(RandomState::default());
+        let mut values = HashMap::default();
         values.insert(path_revealed_leaf, VALUE_A());
 
         let sparse = SerialSparseTrie {


### PR DESCRIPTION
Some code assumes that hashmap hasher is a certain type, when it's currently a type alias configurable by cfg.