### PR TITLE
refactor: replace magic numbers with Ipv4Addr::LOCALHOST

### DIFF
--- a/examples/beacon-api-sidecar-fetcher/src/main.rs
+++ b/examples/beacon-api-sidecar-fetcher/src/main.rs
@@ -86,7 +86,7 @@ impl Default for BeaconSidecarConfig {
     /// Default setup for lighthouse client
     fn default() -> Self {
         Self {
-            cl_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), // Equivalent to Ipv4Addr::LOCALHOST
+            cl_addr: IpAddr::V4(Ipv4Addr::LOCALHOST),
             cl_port: 5052,
         }
     }


### PR DESCRIPTION
Replace hardcoded `Ipv4Addr::new(127, 0, 0, 1)` with the standard library constant `Ipv4Addr::LOCALHOST` for better readability and consistency with the rest of the codebase.

Changes:
- Updated default value in clap arg annotation  
- Updated Default impl for BeaconSidecarConfig
- Removed redundant comment explaining the equivalence

Tested equivalence with a quick rustc test to make sure both values are identical. This aligns with how localhost addresses are handled throughout the reth codebase.