### PR TITLE
txpool: make --txpool.max-tx-gas a u64 with 0=disabled

### DIFF
--- a/crates/node/core/src/args/txpool.rs
+++ b/crates/node/core/src/args/txpool.rs
@@ -75,9 +75,9 @@ pub struct TxPoolArgs {
     pub enforced_gas_limit: u64,
 
     /// Maximum gas limit for individual transactions. Transactions exceeding this limit will be
-    /// rejected by the transaction pool
-    #[arg(long = "txpool.max-tx-gas")]
-    pub max_tx_gas_limit: Option<u64>,
+    /// rejected by the transaction pool (0 = disabled)
+    #[arg(long = "txpool.max-tx-gas", default_value_t = 0)]
+    pub max_tx_gas_limit: u64,
 
     /// Price bump percentage to replace an already existing blob transaction
     #[arg(long = "blobpool.pricebump", default_value_t = REPLACE_BLOB_PRICE_BUMP)]
@@ -173,7 +173,7 @@ impl Default for TxPoolArgs {
             minimal_protocol_basefee: MIN_PROTOCOL_BASE_FEE,
             minimum_priority_fee: None,
             enforced_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
-            max_tx_gas_limit: None,
+            max_tx_gas_limit: 0,
             blob_transaction_price_bump: REPLACE_BLOB_PRICE_BUMP,
             max_tx_input_bytes: DEFAULT_MAX_TX_INPUT_BYTES,
             max_cached_entries: DEFAULT_MAX_CACHED_BLOBS,

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -530,7 +530,7 @@ TxPool:
           [default: 30000000]
 
       --txpool.max-tx-gas <MAX_TX_GAS_LIMIT>
-          Maximum gas limit for individual transactions. Transactions exceeding this limit will be rejected by the transaction pool
+          Maximum gas limit for individual transactions. Transactions exceeding this limit will be rejected by the transaction pool (0 = disabled)
 
       --blobpool.pricebump <BLOB_TRANSACTION_PRICE_BUMP>
           Price bump percentage to replace an already existing blob transaction


### PR DESCRIPTION
`--txpool.max-tx-gas` was initially implemented as an `Option<u64>`, but that makes it easy to provide a zero value that will reject all transactions from the mempool. This change treats zero as disabled, and defaults the option to zero instead of None.