### PR TITLE
fix: Pass prefix set from init_from_state_dump into compute_state_root

### DIFF
--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -588,7 +588,7 @@ where
 /// database.
 fn compute_state_root<Provider>(
     provider: &Provider,
-    mut prefix_sets: Option<TriePrefixSets>,
+    prefix_sets: Option<TriePrefixSets>,
 ) -> Result<B256, InitStorageError>
 where
     Provider: DBProvider<Tx: DbTxMut> + TrieWriter,
@@ -603,7 +603,7 @@ where
         let mut state_root =
             StateRootComputer::from_tx(tx).with_intermediate_state(intermediate_state);
 
-        if let Some(sets) = prefix_sets.take() {
+        if let Some(sets) = prefix_sets.clone() {
             state_root = state_root.with_prefix_sets(sets);
         }
 

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -2,7 +2,7 @@
 
 use alloy_consensus::BlockHeader;
 use alloy_genesis::GenesisAccount;
-use alloy_primitives::{map::HashMap, Address, B256, U256};
+use alloy_primitives::{keccak256, map::HashMap, Address, B256, U256};
 use reth_chainspec::EthChainSpec;
 use reth_codecs::Compact;
 use reth_config::config::EtlConfig;
@@ -19,7 +19,10 @@ use reth_provider::{
 };
 use reth_stages_types::{StageCheckpoint, StageId};
 use reth_static_file_types::StaticFileSegment;
-use reth_trie::{IntermediateStateRootState, StateRoot as StateRootComputer, StateRootProgress};
+use reth_trie::{
+    prefix_set::{TriePrefixSets, TriePrefixSetsMut},
+    IntermediateStateRootState, Nibbles, StateRoot as StateRootComputer, StateRootProgress,
+};
 use reth_trie_db::DatabaseStateRoot;
 use serde::{Deserialize, Serialize};
 use std::io::BufRead;
@@ -144,7 +147,7 @@ where
     insert_genesis_state(&provider_rw, alloc.iter())?;
 
     // compute state root to populate trie tables
-    compute_state_root(&provider_rw)?;
+    compute_state_root(&provider_rw, None)?;
 
     // insert sync stage
     for stage in StageId::ALL {
@@ -425,13 +428,14 @@ where
     // remaining lines are accounts
     let collector = parse_accounts(&mut reader, etl_config)?;
 
-    // write state to db
-    dump_state(collector, provider_rw, block)?;
+    // write state to db and collect prefix sets
+    let mut prefix_sets = TriePrefixSetsMut::default();
+    dump_state(collector, provider_rw, block, &mut prefix_sets)?;
 
     info!(target: "reth::cli", "All accounts written to database, starting state root computation (may take some time)");
 
     // compute and compare state root. this advances the stage checkpoints.
-    let computed_state_root = compute_state_root(provider_rw)?;
+    let computed_state_root = compute_state_root(provider_rw, Some(prefix_sets.freeze()))?;
     if computed_state_root == expected_state_root {
         info!(target: "reth::cli",
             ?computed_state_root,
@@ -507,6 +511,7 @@ fn dump_state<Provider>(
     mut collector: Collector<Address, GenesisAccount>,
     provider_rw: &Provider,
     block: u64,
+    prefix_sets: &mut TriePrefixSetsMut,
 ) -> Result<(), eyre::Error>
 where
     Provider: StaticFileProviderFactory
@@ -525,6 +530,22 @@ where
         let (address, account) = entry?;
         let (address, _) = Address::from_compact(address.as_slice(), address.len());
         let (account, _) = GenesisAccount::from_compact(account.as_slice(), account.len());
+
+        // Add to prefix sets
+        let hashed_address = keccak256(address);
+        prefix_sets.account_prefix_set.insert(Nibbles::unpack(hashed_address));
+
+        // Add storage keys to prefix sets if storage exists
+        if let Some(ref storage) = account.storage {
+            for key in storage.keys() {
+                let hashed_key = keccak256(key);
+                prefix_sets
+                    .storage_prefix_sets
+                    .entry(hashed_address)
+                    .or_default()
+                    .insert(Nibbles::unpack(hashed_key));
+            }
+        }
 
         accounts.push((address, account));
 
@@ -565,7 +586,10 @@ where
 
 /// Computes the state root (from scratch) based on the accounts and storages present in the
 /// database.
-fn compute_state_root<Provider>(provider: &Provider) -> Result<B256, InitStorageError>
+fn compute_state_root<Provider>(
+    provider: &Provider,
+    mut prefix_sets: Option<TriePrefixSets>,
+) -> Result<B256, InitStorageError>
 where
     Provider: DBProvider<Tx: DbTxMut> + TrieWriter,
 {
@@ -576,10 +600,14 @@ where
     let mut total_flushed_updates = 0;
 
     loop {
-        match StateRootComputer::from_tx(tx)
-            .with_intermediate_state(intermediate_state)
-            .root_with_progress()?
-        {
+        let mut state_root =
+            StateRootComputer::from_tx(tx).with_intermediate_state(intermediate_state);
+
+        if let Some(sets) = prefix_sets.take() {
+            state_root = state_root.with_prefix_sets(sets);
+        }
+
+        match state_root.root_with_progress()? {
             StateRootProgress::Progress(state, _, updates) => {
                 let updated_len = provider.write_trie_updates(&updates)?;
                 total_flushed_updates += updated_len;

--- a/crates/trie/common/src/prefix_set.rs
+++ b/crates/trie/common/src/prefix_set.rs
@@ -55,7 +55,7 @@ impl TriePrefixSetsMut {
 }
 
 /// Collection of trie prefix sets.
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 pub struct TriePrefixSets {
     /// A set of account prefixes that have changed.
     pub account_prefix_set: PrefixSet,


### PR DESCRIPTION
init_from_state_dump is intended to be usable when there is already state data in the db, after genesis. However if we do not pass the prefix sets of changed accounts/storage slots into the state root computation then the trie db tables are not populated correctly and we get a state root mismatch.

Fixes #18165 