### PR TITLE
fix: struct serialization to match actual fields

### DIFF
--- a/bin/reth-bench/src/bench/output.rs
+++ b/bin/reth-bench/src/bench/output.rs
@@ -52,7 +52,7 @@ impl Serialize for NewPayloadResult {
     {
         // convert the time to microseconds
         let time = self.latency.as_micros();
-        let mut state = serializer.serialize_struct("NewPayloadResult", 3)?;
+        let mut state = serializer.serialize_struct("NewPayloadResult", 2)?;
         state.serialize_field("gas_used", &self.gas_used)?;
         state.serialize_field("latency", &time)?;
         state.end()


### PR DESCRIPTION
noticed the struct was documented as having 3 fields, but only `gas_used` and `latency` were being serialized.
this update ensures the serialized output correctly reflects the actual fields.
