### PR TITLE
feat(optimism): Handle incoming flashblocks against current pending block number

### DIFF
--- a/crates/optimism/flashblocks/src/service.rs
+++ b/crates/optimism/flashblocks/src/service.rs
@@ -25,7 +25,7 @@ use std::{
     time::{Duration, Instant},
 };
 use tokio::pin;
-use tracing::{debug, error, info};
+use tracing::{debug, error};
 
 /// The `FlashBlockService` maintains an in-memory [`PendingBlock`] built out of a sequence of
 /// [`FlashBlock`]s.


### PR DESCRIPTION
Close #18191
Relevant #17858

When handling a received flashblock (in `add_flash_block` of Flashblock service):
- fetch latest block number to calculate pending block height
- Correctly handle flashblock based on its `flashblock.metadata.block_number`