### PR TITLE
perf(reth-engine-local): use VecDeque reduce removal operations

### DIFF
--- a/crates/engine/local/src/miner.rs
+++ b/crates/engine/local/src/miner.rs
@@ -13,6 +13,7 @@ use reth_payload_primitives::{
 use reth_provider::BlockReader;
 use reth_transaction_pool::TransactionPool;
 use std::{
+    collections::VecDeque,
     future::Future,
     pin::Pin,
     task::{Context, Poll},
@@ -108,7 +109,7 @@ pub struct LocalMiner<T: PayloadTypes, B, Pool: TransactionPool + Unpin> {
     /// Timestamp for the next block.
     last_timestamp: u64,
     /// Stores latest mined blocks.
-    last_block_hashes: Vec<B256>,
+    last_block_hashes: VecDeque<B256>,
 }
 
 impl<T, B, Pool> LocalMiner<T, B, Pool>
@@ -134,7 +135,7 @@ where
             mode,
             payload_builder,
             last_timestamp: latest_header.timestamp(),
-            last_block_hashes: vec![latest_header.hash()],
+            last_block_hashes: VecDeque::from([latest_header.hash()]),
         }
     }
 
@@ -162,7 +163,7 @@ where
     /// Returns current forkchoice state.
     fn forkchoice_state(&self) -> ForkchoiceState {
         ForkchoiceState {
-            head_block_hash: *self.last_block_hashes.last().expect("at least 1 block exists"),
+            head_block_hash: *self.last_block_hashes.back().expect("at least 1 block exists"),
             safe_block_hash: *self
                 .last_block_hashes
                 .get(self.last_block_hashes.len().saturating_sub(32))
@@ -230,11 +231,10 @@ where
         }
 
         self.last_timestamp = timestamp;
-        self.last_block_hashes.push(block.hash());
+        self.last_block_hashes.push_back(block.hash());
         // ensure we keep at most 64 blocks
         if self.last_block_hashes.len() > 64 {
-            self.last_block_hashes =
-                self.last_block_hashes.split_off(self.last_block_hashes.len() - 64);
+            self.last_block_hashes.pop_front();
         }
 
         Ok(())


### PR DESCRIPTION
use `VecDeque` can redude `self.last_block_hashes.split_off(self.last_block_hashes.len() - 64);` removal operations.