### PR TITLE
Cap initial pre-range by local to_block in receipts log pruner

### DIFF
--- a/crates/prune/prune/src/segments/user/receipts_by_logs.rs
+++ b/crates/prune/prune/src/segments/user/receipts_by_logs.rs
@@ -105,7 +105,10 @@ where
             if block_ranges.is_empty() {
                 let init = last_pruned_block.map(|b| b + 1).unwrap_or_default();
                 if init < *start_block {
-                    block_ranges.push((init, *start_block - 1, 0));
+                    let end = (*start_block - 1).min(to_block);
+                    if init <= end {
+                        block_ranges.push((init, end, 0));
+                    }
                 }
             }
 


### PR DESCRIPTION
- Clamp the first pre-range end to min(start_block - 1, to_block).
- Skip adding the range if it becomes empty (init > end).
- Ensures deletions never exceed the safety boundary (MINIMUM_PRUNING_DISTANCE) and aligns behavior with subsequent ranges.