### PR TITLE
fix: filter zero storage values when computing withdrawals root in genesis header

### DIFF
--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -500,7 +500,13 @@ pub fn make_op_genesis_header(genesis: &Genesis, hardforks: &ChainHardforks) -> 
         if let Some(predeploy) = genesis.alloc.get(&ADDRESS_L2_TO_L1_MESSAGE_PASSER) {
             if let Some(storage) = &predeploy.storage {
                 header.withdrawals_root =
-                    Some(storage_root_unhashed(storage.iter().map(|(k, v)| (*k, (*v).into()))))
+                    Some(storage_root_unhashed(storage.iter().filter_map(|(k, v)| {
+                        if v.is_zero() {
+                            None
+                        } else {
+                            Some((*k, (*v).into()))
+                        }
+                    })));
             }
         }
     }
@@ -518,6 +524,27 @@ mod tests {
     use reth_optimism_forks::{OpHardfork, OpHardforks};
 
     use crate::*;
+
+    #[test]
+    fn test_storage_root_consistency() {
+        use alloy_primitives::{B256, U256};
+        use std::str::FromStr;
+
+        let k1 = B256::from_str("0x0000000000000000000000000000000000000000000000000000000000000001").unwrap();
+        let v1 = U256::from_str("0x0000000000000000000000000000000000000000000000000000000000000000").unwrap();
+        let k2 = B256::from_str("0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc").unwrap();
+        let v2 = U256::from_str("0x000000000000000000000000c0d3c0d3c0d3c0d3c0d3c0d3c0d3c0d3c0d30016").unwrap();
+        let k3 = B256::from_str("0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103").unwrap();
+        let v3 = U256::from_str("0x0000000000000000000000004200000000000000000000000000000000000018").unwrap();
+        let root_expected = B256::from_str("0x8ed4baae3a927be3dea54996b4d5899f8c01e7594bf50b17dc1e741388ce3d12").unwrap();
+        
+        let storage_origin = vec![(k1, v1), (k2, v2), (k3, v3)];
+        let storage_fix = vec![(k2, v2), (k3, v3)];
+        let root_origin = storage_root_unhashed(storage_origin);
+        let root_fix = storage_root_unhashed(storage_fix);
+        assert_ne!(root_origin, root_fix);
+        assert_eq!(root_fix, root_expected);
+    }
 
     #[test]
     fn base_mainnet_forkids() {

--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -530,20 +530,38 @@ mod tests {
         use alloy_primitives::{B256, U256};
         use std::str::FromStr;
 
-        let k1 = B256::from_str("0x0000000000000000000000000000000000000000000000000000000000000001").unwrap();
-        let v1 = U256::from_str("0x0000000000000000000000000000000000000000000000000000000000000000").unwrap();
-        let k2 = B256::from_str("0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc").unwrap();
-        let v2 = U256::from_str("0x000000000000000000000000c0d3c0d3c0d3c0d3c0d3c0d3c0d3c0d3c0d30016").unwrap();
-        let k3 = B256::from_str("0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103").unwrap();
-        let v3 = U256::from_str("0x0000000000000000000000004200000000000000000000000000000000000018").unwrap();
-        let root_expected = B256::from_str("0x8ed4baae3a927be3dea54996b4d5899f8c01e7594bf50b17dc1e741388ce3d12").unwrap();
-        
+        let k1 =
+            B256::from_str("0x0000000000000000000000000000000000000000000000000000000000000001")
+                .unwrap();
+        let v1 =
+            U256::from_str("0x0000000000000000000000000000000000000000000000000000000000000000")
+                .unwrap();
+        let k2 =
+            B256::from_str("0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc")
+                .unwrap();
+        let v2 =
+            U256::from_str("0x000000000000000000000000c0d3c0d3c0d3c0d3c0d3c0d3c0d3c0d3c0d30016")
+                .unwrap();
+        let k3 =
+            B256::from_str("0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103")
+                .unwrap();
+        let v3 =
+            U256::from_str("0x0000000000000000000000004200000000000000000000000000000000000018")
+                .unwrap();
+        let origin_root =
+            B256::from_str("0x5d5ba3a8093ede3901ad7a569edfb7b9aecafa54730ba0bf069147cbcc00e345")
+                .unwrap();
+        let expected_root =
+            B256::from_str("0x8ed4baae3a927be3dea54996b4d5899f8c01e7594bf50b17dc1e741388ce3d12")
+                .unwrap();
+
         let storage_origin = vec![(k1, v1), (k2, v2), (k3, v3)];
         let storage_fix = vec![(k2, v2), (k3, v3)];
         let root_origin = storage_root_unhashed(storage_origin);
         let root_fix = storage_root_unhashed(storage_fix);
         assert_ne!(root_origin, root_fix);
-        assert_eq!(root_fix, root_expected);
+        assert_eq!(root_origin, origin_root);
+        assert_eq!(root_fix, expected_root);
     }
 
     #[test]


### PR DESCRIPTION
## Description

This PR fixes an issue in the `make_op_genesis_header` function where zero-value storage slots were incorrectly included in the storage root calculation for the L2ToL1MessagePasser predeploy.

## Problem

When computing the withdrawals root for the Isthmus hardfork, the function was including all storage key-value pairs, including those with zero values. However, in Ethereum's standard behavior, zero-value storage slots should be omitted from the Merkle tree calculation, as they are considered "non-existent" in the state.

For example, in the genesis configuration for the L2ToL1MessagePasser predeploy:
```json
"4200000000000000000000000000000000000016": {
  "code": "0x60806040526004361061005e5760003560e01c80635c60da1b116100435780635c60da1b146100be5780638f283970146100f8578063f851a440146101185761006d565b80633659cfe6146100755780634f1ef286146100955761006d565b3661006d5761006b61012d565b005b61006b61012d565b34801561008157600080fd5b5061006b6100903660046106d9565b610224565b6100a86100a33660046106f4565b610296565b6040516100b59190610777565b60405180910390f35b3480156100ca57600080fd5b506100d3610419565b60405173ffffffffffffffffffffffffffffffffffffffff90911681526020016100b5565b34801561010457600080fd5b5061006b6101133660046106d9565b6104b0565b34801561012457600080fd5b506100d3610517565b60006101577f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc5490565b905073ffffffffffffffffffffffffffffffffffffffff8116610201576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152602560248201527f50726f78793a20696d706c656d656e746174696f6e206e6f7420696e6974696160448201527f6c697a656400000000000000000000000000000000000000000000000000000060648201526084015b60405180910390fd5b3660008037600080366000845af43d6000803e8061021e573d6000f35b503d6000f35b7fb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d61035473ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff16148061027d575033155b1561028e5761028b816105a3565b50565b61028b61012d565b60606102c07fb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d61035490565b73ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff1614806102f7575033155b1561040a57610305846105a3565b6000808573ffffffffffffffffffffffffffffffffffffffff16858560405161032f9291906107ea565b600060405180830381855af49150503d806000811461036a576040519150601f19603f3d011682016040523d82523d6000602084013e61036f565b606091505b509150915081610401576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152603960248201527f50726f78793a2064656c656761746563616c6c20746f206e657720696d706c6560448201527f6d656e746174696f6e20636f6e7472616374206661696c65640000000000000060648201526084016101f8565b91506104129050565b61041261012d565b9392505050565b60006104437fb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d61035490565b73ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff16148061047a575033155b156104a557507f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc5490565b6104ad61012d565b90565b7fb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d61035473ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff161480610509575033155b1561028e5761028b8161060b565b60006105417fb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d61035490565b73ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff161480610578575033155b156104a557507fb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d61035490565b7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc81905560405173ffffffffffffffffffffffffffffffffffffffff8216907fbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b90600090a250565b60006106357fb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d61035490565b7fb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d61038390556040805173ffffffffffffffffffffffffffffffffffffffff8084168252851660208201529192507f7e644d79422f17c01e4894b5f4f588d331ebfa28653d42ae832dc59e38c9798f910160405180910390a15050565b803573ffffffffffffffffffffffffffffffffffffffff811681146106d457600080fd5b919050565b6000602082840312156106eb57600080fd5b610412826106b0565b60008060006040848603121561070957600080fd5b610712846106b0565b9250602084013567ffffffffffffffff8082111561072f57600080fd5b818601915086601f83011261074357600080fd5b81358181111561075257600080fd5b87602082850101111561076457600080fd5b6020830194508093505050509250925092565b600060208083528351808285015260005b818110156107a457858101830151858201604001528201610788565b818111156107b6576000604083870101525b50601f017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe016929092016040019392505050565b818382376000910190815291905056fea164736f6c634300080f000a",
  "storage": {
    "0x0000000000000000000000000000000000000000000000000000000000000001": "0x0000000000000000000000000000000000000000000000000000000000000000",
    "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc": "0x000000000000000000000000c0d3c0d3c0d3c0d3c0d3c0d3c0d3c0d3c0d30016",
    "0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103": "0x0000000000000000000000004200000000000000000000000000000000000018"
  },
  "balance": "0x0"
}
```
The first storage slot `0x0000000000000000000000000000000000000000000000000000000000000001` has a zero value `0x0000000000000000000000000000000000000000000000000000000000000000`, which should be excluded from the storage root calculation according to Ethereum standards.

**Impact**: This bug causes incorrect withdrawals root calculation. The expected storage root (after filtering zero values) should be `0x8ed4baae3a927be3dea54996b4d5899f8c01e7594bf50b17dc1e741388ce3d12`, but the current implementation produces `0x5d5ba3a8093ede3901ad7a569edfb7b9aecafa54730ba0bf069147cbcc00e345` due to including the zero-value storage slot.

## Solution

- Added filtering logic using `filter_map` to exclude zero-value storage slots
- Used `U256::is_zero()` method to properly identify zero values
- Maintained the existing type conversion logic for non-zero values

## Verification
The fix aligns with op-geth's implementation, which correctly filters out zero-value storage slots:

```go
func TestStorageRootForMessagePasser(t *testing.T) {
    db := rawdb.NewMemoryDatabase()
    tdb := triedb.NewDatabase(db, nil)
    sdb := state.NewDatabase(tdb, nil)
    st, err := state.New(types.EmptyRootHash, sdb)
    if err != nil {
        t.Fatalf("new state: %v", err)
    }

    addr := params.OptimismL2ToL1MessagePasser
    k1 := common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001")
    v1 := common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000")
    k2 := common.HexToHash("0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc")
    v2 := common.HexToHash("0x000000000000000000000000c0d3c0d3c0d3c0d3c0d3c0d3c0d3c0d3c0d30016")
    k3 := common.HexToHash("0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103")
    v3 := common.HexToHash("0x0000000000000000000000004200000000000000000000000000000000000018")

    st.SetState(addr, k1, v1)
    st.SetState(addr, k2, v2)
    st.SetState(addr, k3, v3)

    st.IntermediateRoot(false)

    got := st.GetStorageRoot(addr)
    want := common.HexToHash("0x8ed4baae3a927be3dea54996b4d5899f8c01e7594bf50b17dc1e741388ce3d12")
    if got != want {
        t.Fatalf("storage root mismatch: have %x, want %x", got, want)
    }
}
```

This confirms that our fix follows the same logic as the reference implementation in op-geth, ensuring compatibility and correctness.

## Changes

- **Modified**: `crates/optimism/chainspec/src/lib.rs`
  - Updated `make_op_genesis_header` function to filter out zero storage values
  - Added comprehensive test case `test_storage_root_consistency` to verify the fix

## Testing

- Added unit test that verifies:
  - Storage root calculation differs when zero values are included vs excluded
  - The filtered result matches the expected root hash
  - The fix correctly handles the specific case of zero-value storage slots

## Impact

- **Breaking**: No breaking changes
- **Performance**: Minimal impact, only adds a filter operation during genesis header creation
- **Compatibility**: Improves compatibility with Ethereum's standard storage root calculation

## Related

This fix ensures that the withdrawals root calculation in the genesis header follows Ethereum's standard behavior for storage root computation, where zero-value slots are omitted from the Merkle tree.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Tests added/updated and passing
- [x] Documentation updated (if applicable)
- [x] No breaking changes introduced