### PR TITLE
chore: safe None check

### DIFF
--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -964,7 +964,10 @@ where
                 let Some(latest) = self.blockchain_db().latest_header()? else { return Ok(()) };
                 if latest.number() > merge_block {
                     let provider = self.blockchain_db().static_file_provider();
-                    if provider.get_lowest_transaction_static_file_block() < Some(merge_block) {
+                    if provider
+                        .get_lowest_transaction_static_file_block()
+                        .is_some_and(|lowest| lowest < merge_block)
+                    {
                         info!(target: "reth::cli", merge_block, "Expiring pre-merge transactions");
                         provider.delete_transactions_below(merge_block)?;
                     } else {


### PR DESCRIPTION
shoul avoid using None comparison because this would always be true if get_lowest_transaction_static_file_block returns None 