### PR TITLE
feat(optimism): Warn if `FlashBlockService` has stopped

### DIFF
--- a/crates/optimism/flashblocks/src/service.rs
+++ b/crates/optimism/flashblocks/src/service.rs
@@ -23,7 +23,7 @@ use std::{
     time::{Duration, Instant},
 };
 use tokio::pin;
-use tracing::{debug, trace};
+use tracing::{debug, trace, warn};
 
 /// The `FlashBlockService` maintains an in-memory [`PendingBlock`] built out of a sequence of
 /// [`FlashBlock`]s.
@@ -85,6 +85,8 @@ where
                 let _ = tx.send(block).inspect_err(|e| tracing::error!("{e}"));
             }
         }
+
+        warn!("Flashblock service has stopped");
     }
 
     /// Returns the cached reads at the given head hash.


### PR DESCRIPTION
Part of #17858 

Adds a warning log if the `FlashBlockService::run` reaches the end.
