### PR TITLE
perf(e2e-test-utils): optimize block checking by fetching header instead of full block

### DIFF
--- a/crates/e2e-test-utils/src/node.rs
+++ b/crates/e2e-test-utils/src/node.rs
@@ -161,8 +161,8 @@ where
             }
 
             if check {
-                if let Some(latest_block) = self.inner.provider.block_by_number(number)? {
-                    assert_eq!(latest_block.header().hash_slow(), expected_block_hash);
+                if let Some(latest_header) = self.inner.provider.header_by_number(number)? {
+                    assert_eq!(latest_header.hash_slow(), expected_block_hash);
                     break
                 }
                 assert!(


### PR DESCRIPTION
Optimizes the `wait_block` function in e2e test utilities by fetching only the block header instead of the full block when checking for block hash validation

- **Before**: `provider.block_by_number(number)?.header().hash_slow()`
- **After**: `provider.header_by_number(number)?.hash_slow()`