### PR TITLE
fix(download): use updated merkle base URL

### DIFF
--- a/crates/cli/commands/src/download.rs
+++ b/crates/cli/commands/src/download.rs
@@ -17,7 +17,7 @@ use tokio::task;
 use tracing::info;
 
 const BYTE_UNITS: [&str; 4] = ["B", "KB", "MB", "GB"];
-const MERKLE_BASE_URL: &str = "https://snapshots.merkle.io";
+const MERKLE_BASE_URL: &str = "https://downloads.merkle.io";
 const EXTENSION_TAR_FILE: &str = ".tar.lz4";
 
 #[derive(Debug, Parser)]


### PR DESCRIPTION
Currently `reth download` errors, the subdomain was changed