### PR TITLE
refactor(optimism): Extract pending block building responsibility out of `FlashBlockService`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9339,6 +9339,7 @@ dependencies = [
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",
  "reth-storage-api",
+ "reth-tasks",
  "serde",
  "serde_json",
  "test-case",

--- a/crates/optimism/flashblocks/Cargo.toml
+++ b/crates/optimism/flashblocks/Cargo.toml
@@ -23,6 +23,7 @@ reth-rpc-eth-api.workspace = true
 reth-rpc-eth-types.workspace = true
 reth-errors.workspace = true
 reth-storage-api.workspace = true
+reth-tasks.workspace = true
 
 # alloy
 alloy-eips = { workspace = true, features = ["serde"] }

--- a/crates/optimism/flashblocks/src/lib.rs
+++ b/crates/optimism/flashblocks/src/lib.rs
@@ -10,6 +10,7 @@ pub use ws::{WsConnect, WsFlashBlockStream};
 mod payload;
 mod sequence;
 mod service;
+mod worker;
 mod ws;
 
 /// Receiver of the most recent [`PendingBlock`] built out of [`FlashBlock`]s.

--- a/crates/optimism/flashblocks/src/service.rs
+++ b/crates/optimism/flashblocks/src/service.rs
@@ -3,18 +3,24 @@ use crate::{
     worker::{BuildArgs, FlashBlockBuilder},
     ExecutionPayloadBaseV1, FlashBlock,
 };
+use alloy_eips::eip2718::WithEncoded;
+use alloy_primitives::B256;
 use futures_util::{FutureExt, Stream, StreamExt};
 use reth_chain_state::{CanonStateNotification, CanonStateNotifications, CanonStateSubscriptions};
 use reth_evm::ConfigureEvm;
-use reth_primitives_traits::{AlloyBlockHeader, BlockTy, HeaderTy, NodePrimitives, ReceiptTy};
+use reth_primitives_traits::{
+    AlloyBlockHeader, BlockTy, HeaderTy, NodePrimitives, ReceiptTy, Recovered,
+};
+use reth_revm::cached::CachedReads;
 use reth_rpc_eth_types::PendingBlock;
 use reth_storage_api::{BlockReaderIdExt, StateProviderFactory};
+use reth_tasks::TaskExecutor;
 use std::{
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
     time::Instant,
 };
-use tokio::pin;
+use tokio::{pin, sync::oneshot};
 use tracing::{debug, trace, warn};
 
 /// The `FlashBlockService` maintains an in-memory [`PendingBlock`] built out of a sequence of
@@ -32,13 +38,22 @@ pub struct FlashBlockService<
     rebuild: bool,
     builder: FlashBlockBuilder<EvmConfig, Provider>,
     canon_receiver: CanonStateNotifications<N>,
+    spawner: TaskExecutor,
+    job: Option<BuildJob<N>>,
+    /// Cached state reads for the current block.
+    /// Current `PendingBlock` is built out of a sequence of `FlashBlocks`, and executed again when
+    /// fb received on top of the same block. Avoid redundant I/O across multiple executions
+    /// within the same block.
+    cached_state: Option<(B256, CachedReads)>,
 }
 
 impl<N, S, EvmConfig, Provider> FlashBlockService<N, S, EvmConfig, Provider>
 where
     N: NodePrimitives,
-    S: Stream<Item = eyre::Result<FlashBlock>> + Unpin,
-    EvmConfig: ConfigureEvm<Primitives = N, NextBlockEnvCtx: From<ExecutionPayloadBaseV1> + Unpin>,
+    S: Stream<Item = eyre::Result<FlashBlock>> + Unpin + 'static,
+    EvmConfig: ConfigureEvm<Primitives = N, NextBlockEnvCtx: From<ExecutionPayloadBaseV1> + Unpin>
+        + Clone
+        + 'static,
     Provider: StateProviderFactory
         + CanonStateSubscriptions<Primitives = N>
         + BlockReaderIdExt<
@@ -46,10 +61,12 @@ where
             Block = BlockTy<N>,
             Transaction = N::SignedTx,
             Receipt = ReceiptTy<N>,
-        > + Unpin,
+        > + Unpin
+        + Clone
+        + 'static,
 {
     /// Constructs a new `FlashBlockService` that receives [`FlashBlock`]s from `rx` stream.
-    pub fn new(rx: S, evm_config: EvmConfig, provider: Provider) -> Self {
+    pub fn new(rx: S, evm_config: EvmConfig, provider: Provider, spawner: TaskExecutor) -> Self {
         Self {
             rx,
             current: None,
@@ -57,6 +74,9 @@ where
             canon_receiver: provider.subscribe_to_canonical_state(),
             builder: FlashBlockBuilder::new(evm_config, provider),
             rebuild: false,
+            spawner,
+            job: None,
+            cached_state: None,
         }
     }
 
@@ -73,10 +93,12 @@ where
         warn!("Flashblock service has stopped");
     }
 
-    /// Returns the [`PendingBlock`] made purely out of [`FlashBlock`]s that were received earlier.
+    /// Returns the [`BuildArgs`] made purely out of [`FlashBlock`]s that were received earlier.
     ///
-    /// Returns None if the flashblock doesn't attach to the latest header.
-    fn execute(&mut self) -> eyre::Result<Option<PendingBlock<N>>> {
+    /// Returns `None` if the flashblock have no `base`.
+    fn build_args(
+        &mut self,
+    ) -> Option<BuildArgs<impl IntoIterator<Item = WithEncoded<Recovered<N::SignedTx>>>>> {
         let Some(base) = self.blocks.payload_base() else {
             trace!(
                 flashblock_number = ?self.blocks.block_number(),
@@ -84,10 +106,14 @@ where
                 "Missing flashblock payload base"
             );
 
-            return Ok(None)
+            return None
         };
 
-        self.builder.execute(BuildArgs { base, transactions: self.blocks.ready_transactions() })
+        Some(BuildArgs {
+            base,
+            transactions: self.blocks.ready_transactions().collect::<Vec<_>>(),
+            cached_state: self.cached_state.take(),
+        })
     }
 
     /// Takes out `current` [`PendingBlock`] if `state` is not preceding it.
@@ -100,8 +126,10 @@ where
 impl<N, S, EvmConfig, Provider> Stream for FlashBlockService<N, S, EvmConfig, Provider>
 where
     N: NodePrimitives,
-    S: Stream<Item = eyre::Result<FlashBlock>> + Unpin,
-    EvmConfig: ConfigureEvm<Primitives = N, NextBlockEnvCtx: From<ExecutionPayloadBaseV1> + Unpin>,
+    S: Stream<Item = eyre::Result<FlashBlock>> + Unpin + 'static,
+    EvmConfig: ConfigureEvm<Primitives = N, NextBlockEnvCtx: From<ExecutionPayloadBaseV1> + Unpin>
+        + Clone
+        + 'static,
     Provider: StateProviderFactory
         + CanonStateSubscriptions<Primitives = N>
         + BlockReaderIdExt<
@@ -109,12 +137,51 @@ where
             Block = BlockTy<N>,
             Transaction = N::SignedTx,
             Receipt = ReceiptTy<N>,
-        > + Unpin,
+        > + Unpin
+        + Clone
+        + 'static,
 {
     type Item = eyre::Result<Option<PendingBlock<N>>>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
+
+        let result = if let Some((now, rx)) = &mut this.job {
+            let result = ready!(rx.poll_unpin(cx)).unwrap();
+            Some((*now, result))
+        } else {
+            None
+        };
+
+        if let Some((now, result)) = result {
+            this.job.take();
+
+            match result {
+                Ok(Some((new_pending, cached_reads))) => {
+                    // built a new pending block
+                    this.current = Some(new_pending.clone());
+                    this.cached_state = Some((new_pending.block().hash(), cached_reads));
+                    this.rebuild = false;
+
+                    trace!(
+                        parent_hash = %new_pending.block().parent_hash(),
+                        block_number = new_pending.block().number(),
+                        flash_blocks = this.blocks.count(),
+                        elapsed = ?now.elapsed(),
+                        "Built new block with flashblocks"
+                    );
+
+                    return Poll::Ready(Some(Ok(Some(new_pending))));
+                }
+                Ok(None) => {
+                    // nothing to do because tracked flashblock doesn't attach to latest
+                }
+                Err(err) => {
+                    // we can ignore this error
+                    debug!(%err, "failed to execute flashblock");
+                }
+            }
+        }
 
         // consume new flashblocks while they're ready
         while let Poll::Ready(Some(result)) = this.rx.poll_next_unpin(cx) {
@@ -147,25 +214,22 @@ where
             return Poll::Pending
         }
 
-        let now = Instant::now();
         // try to build a block on top of latest
-        match this.execute() {
-            Ok(Some(new_pending)) => {
-                // built a new pending block
-                this.current = Some(new_pending.clone());
-                this.rebuild = false;
-                trace!(parent_hash=%new_pending.block().parent_hash(), block_number=new_pending.block().number(), flash_blocks=this.blocks.count(), elapsed=?now.elapsed(), "Built new block with flashblocks");
-                return Poll::Ready(Some(Ok(Some(new_pending))));
-            }
-            Ok(None) => {
-                // nothing to do because tracked flashblock doesn't attach to latest
-            }
-            Err(err) => {
-                // we can ignore this error
-                debug!(%err, "failed to execute flashblock");
-            }
+        if let Some(args) = this.build_args() {
+            let now = Instant::now();
+
+            let (tx, rx) = oneshot::channel();
+            let builder = this.builder.clone();
+
+            this.spawner.spawn_blocking(async move {
+                let _ = tx.send(builder.execute(args));
+            });
+            this.job.replace((now, rx));
         }
 
         Poll::Pending
     }
 }
+
+type BuildJob<N> =
+    (Instant, oneshot::Receiver<eyre::Result<Option<(PendingBlock<N>, CachedReads)>>>);

--- a/crates/optimism/flashblocks/src/worker.rs
+++ b/crates/optimism/flashblocks/src/worker.rs
@@ -1,0 +1,124 @@
+use crate::ExecutionPayloadBaseV1;
+use alloy_eips::{eip2718::WithEncoded, BlockNumberOrTag};
+use alloy_primitives::B256;
+use reth_chain_state::{CanonStateSubscriptions, ExecutedBlock};
+use reth_errors::RethError;
+use reth_evm::{
+    execute::{BlockBuilder, BlockBuilderOutcome},
+    ConfigureEvm,
+};
+use reth_execution_types::ExecutionOutcome;
+use reth_primitives_traits::{
+    AlloyBlockHeader, BlockTy, HeaderTy, NodePrimitives, ReceiptTy, Recovered,
+};
+use reth_revm::{cached::CachedReads, database::StateProviderDatabase, db::State};
+use reth_rpc_eth_types::{EthApiError, PendingBlock};
+use reth_storage_api::{noop::NoopProvider, BlockReaderIdExt, StateProviderFactory};
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
+use tracing::trace;
+
+/// The `FlashBlockBuilder` builds [`PendingBlock`] out of a sequence of transactions.
+#[derive(Debug)]
+pub(crate) struct FlashBlockBuilder<EvmConfig, Provider> {
+    evm_config: EvmConfig,
+    provider: Provider,
+    /// Cached state reads for the current block.
+    /// Current `PendingBlock` is built out of a sequence of `FlashBlocks`, and executed again when
+    /// fb received on top of the same block. Avoid redundant I/O across multiple executions
+    /// within the same block.
+    cached_state: Option<(B256, CachedReads)>,
+}
+
+impl<EvmConfig, Provider> FlashBlockBuilder<EvmConfig, Provider> {
+    pub(crate) const fn new(evm_config: EvmConfig, provider: Provider) -> Self {
+        Self { evm_config, provider, cached_state: None }
+    }
+}
+
+pub(crate) struct BuildArgs<I> {
+    pub base: ExecutionPayloadBaseV1,
+    pub transactions: I,
+}
+
+impl<N, EvmConfig, Provider> FlashBlockBuilder<EvmConfig, Provider>
+where
+    N: NodePrimitives,
+    EvmConfig: ConfigureEvm<Primitives = N, NextBlockEnvCtx: From<ExecutionPayloadBaseV1> + Unpin>,
+    Provider: StateProviderFactory
+        + CanonStateSubscriptions<Primitives = N>
+        + BlockReaderIdExt<
+            Header = HeaderTy<N>,
+            Block = BlockTy<N>,
+            Transaction = N::SignedTx,
+            Receipt = ReceiptTy<N>,
+        > + Unpin,
+{
+    /// Returns the [`PendingBlock`] made purely out of transactions and [`ExecutionPayloadBaseV1`]
+    /// in `args`.
+    ///
+    /// Returns `None` if the flashblock doesn't attach to the latest header.
+    pub(crate) fn execute<I: IntoIterator<Item = WithEncoded<Recovered<N::SignedTx>>>>(
+        &mut self,
+        args: BuildArgs<I>,
+    ) -> eyre::Result<Option<PendingBlock<N>>> {
+        trace!("Building new pending block from flashblocks");
+
+        let latest = self
+            .provider
+            .latest_header()?
+            .ok_or(EthApiError::HeaderNotFound(BlockNumberOrTag::Latest.into()))?;
+        let latest_hash = latest.hash();
+
+        if args.base.parent_hash != latest_hash {
+            trace!(flashblock_parent = ?args.base.parent_hash, local_latest=?latest.num_hash(),"Skipping non consecutive flashblock");
+            // doesn't attach to the latest block
+            return Ok(None)
+        }
+
+        let state_provider = self.provider.history_by_block_hash(latest.hash())?;
+
+        let mut request_cache = self
+            .cached_state
+            .take()
+            .filter(|(hash, _)| hash == &latest_hash)
+            .map(|(_, state)| state)
+            .unwrap_or_default();
+        let cached_db = request_cache.as_db_mut(StateProviderDatabase::new(&state_provider));
+        let mut state = State::builder().with_database(cached_db).with_bundle_update().build();
+
+        let mut builder = self
+            .evm_config
+            .builder_for_next_block(&mut state, &latest, args.base.into())
+            .map_err(RethError::other)?;
+
+        builder.apply_pre_execution_changes()?;
+
+        for tx in args.transactions {
+            let _gas_used = builder.execute_transaction(tx)?;
+        }
+
+        let BlockBuilderOutcome { execution_result, block, hashed_state, .. } =
+            builder.finish(NoopProvider::default())?;
+
+        let execution_outcome = ExecutionOutcome::new(
+            state.take_bundle(),
+            vec![execution_result.receipts],
+            block.number(),
+            vec![execution_result.requests],
+        );
+
+        self.cached_state.replace((latest_hash, request_cache));
+
+        Ok(Some(PendingBlock::with_executed_block(
+            Instant::now() + Duration::from_secs(1),
+            ExecutedBlock {
+                recovered_block: block.into(),
+                execution_output: Arc::new(execution_outcome),
+                hashed_state: Arc::new(hashed_state),
+            },
+        )))
+    }
+}

--- a/crates/optimism/flashblocks/src/worker.rs
+++ b/crates/optimism/flashblocks/src/worker.rs
@@ -31,6 +31,10 @@ impl<EvmConfig, Provider> FlashBlockBuilder<EvmConfig, Provider> {
     pub(crate) const fn new(evm_config: EvmConfig, provider: Provider) -> Self {
         Self { evm_config, provider }
     }
+
+    pub(crate) const fn provider(&self) -> &Provider {
+        &self.provider
+    }
 }
 
 pub(crate) struct BuildArgs<I> {
@@ -60,7 +64,7 @@ where
         &self,
         mut args: BuildArgs<I>,
     ) -> eyre::Result<Option<(PendingBlock<N>, CachedReads)>> {
-        trace!("Building new pending block from flashblocks");
+        trace!("Attempting new pending block from flashblocks");
 
         let latest = self
             .provider

--- a/crates/optimism/rpc/src/eth/mod.rs
+++ b/crates/optimism/rpc/src/eth/mod.rs
@@ -467,8 +467,9 @@ where
                 stream,
                 ctx.components.evm_config().clone(),
                 ctx.components.provider().clone(),
+                ctx.components.task_executor().clone(),
             );
-            ctx.components.task_executor().spawn_blocking(Box::pin(service.run(tx)));
+            ctx.components.task_executor().spawn(Box::pin(service.run(tx)));
             Some(rx)
         } else {
             None


### PR DESCRIPTION
Part of #17858 
Towards #18219

The `FlashBlockService` has too many responsibilities and it's becoming too tangled up. Moreover, to spawn blocking tasks for block building we're going to need an independent unit that performs only these jobs.