### PR TITLE
feat(optimism): Respond to close messages in `WsFlashBlockStream`

### DIFF
--- a/crates/optimism/flashblocks/src/ws/stream.rs
+++ b/crates/optimism/flashblocks/src/ws/stream.rs
@@ -12,7 +12,7 @@ use std::{
 use tokio::net::TcpStream;
 use tokio_tungstenite::{
     connect_async,
-    tungstenite::{Bytes, Error, Message},
+    tungstenite::{protocol::CloseFrame, Bytes, Error, Message},
     MaybeTlsStream, WebSocketStream,
 };
 use tracing::debug;
@@ -88,11 +88,11 @@ where
                 }
             }
 
-            while let State::Stream(pong) = &mut this.state {
-                if pong.is_some() {
+            while let State::Stream(msg) = &mut this.state {
+                if msg.is_some() {
                     let mut sink = Pin::new(this.sink.as_mut().unwrap());
                     let _ = ready!(sink.as_mut().poll_ready(cx));
-                    if let Some(pong) = pong.take() {
+                    if let Some(pong) = msg.take() {
                         let _ = sink.as_mut().start_send(pong);
                     }
                     let _ = ready!(sink.as_mut().poll_flush(cx));
@@ -112,6 +112,7 @@ where
                         return Poll::Ready(Some(FlashBlock::decode(bytes)))
                     }
                     Ok(Message::Ping(bytes)) => this.ping(bytes),
+                    Ok(Message::Close(frame)) => this.close(frame),
                     Ok(msg) => debug!("Received unexpected message: {:?}", msg),
                     Err(err) => return Poll::Ready(Some(Err(err.into()))),
                 }
@@ -143,6 +144,12 @@ where
     fn ping(&mut self, pong: Bytes) {
         if let State::Stream(current) = &mut self.state {
             current.replace(Message::Pong(pong));
+        }
+    }
+
+    fn close(&mut self, frame: Option<CloseFrame>) {
+        if let State::Stream(current) = &mut self.state {
+            current.replace(Message::Close(frame));
         }
     }
 }


### PR DESCRIPTION
Part of #17858 

Part of the websocket specification [states](https://www.rfc-editor.org/rfc/rfc6455#section-5.5.1) that the application must respond to close messages.

Similarly to ping messages, this change introduces responding to close messages.