### PR TITLE
chore: remove redundant payload trait bounds

### DIFF
--- a/crates/payload/builder/src/traits.rs
+++ b/crates/payload/builder/src/traits.rs
@@ -17,7 +17,7 @@ use std::future::Future;
 /// empty.
 ///
 /// Note: A `PayloadJob` need to be cancel safe because it might be dropped after the CL has requested the payload via `engine_getPayloadV1` (see also [engine API docs](https://github.com/ethereum/execution-apis/blob/6709c2a795b707202e93c4f2867fa0bf2640a84f/src/engine/paris.md#engine_getpayloadv1))
-pub trait PayloadJob: Future<Output = Result<(), PayloadBuilderError>> + Send + Sync {
+pub trait PayloadJob: Future<Output = Result<(), PayloadBuilderError>> {
     /// Represents the payload attributes type that is used to spawn this payload job.
     type PayloadAttributes: PayloadBuilderAttributes + std::fmt::Debug;
     /// Represents the future that resolves the block that's returned to the CL.
@@ -93,7 +93,7 @@ pub enum KeepPayloadJobAlive {
 }
 
 /// A type that knows how to create new jobs for creating payloads.
-pub trait PayloadJobGenerator: Send + Sync {
+pub trait PayloadJobGenerator {
     /// The type that manages the lifecycle of a payload.
     ///
     /// This type is a future that yields better payloads.


### PR DESCRIPTION
Was unnecessarily strict for downstream implementations!