### PR TITLE
refactor: change PendingPool and PendingTransaction visibility to pub

### DIFF
--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -113,7 +113,7 @@ mod best;
 mod blob;
 mod listener;
 mod parked;
-pub(crate) mod pending;
+pub mod pending;
 pub(crate) mod size;
 pub(crate) mod state;
 pub mod txpool;

--- a/crates/transaction-pool/src/pool/pending.rs
+++ b/crates/transaction-pool/src/pool/pending.rs
@@ -522,6 +522,11 @@ impl<T: TransactionOrdering> PendingPool<T> {
         &self.independent_transactions
     }
 
+    /// Subscribes to new transactions
+    pub fn new_transaction_receiver(&self) -> broadcast::Receiver<PendingTransaction<T>> {
+        self.new_transaction_notifier.subscribe()
+    }
+
     /// Whether the pool is empty
     #[cfg(test)]
     pub(crate) fn is_empty(&self) -> bool {

--- a/crates/transaction-pool/src/pool/pending.rs
+++ b/crates/transaction-pool/src/pool/pending.rs
@@ -1,3 +1,5 @@
+//! Pending transactions
+
 use crate::{
     identifier::{SenderId, TransactionId},
     pool::{
@@ -510,6 +512,16 @@ impl<T: TransactionOrdering> PendingPool<T> {
         self.by_id.len()
     }
 
+    /// All transactions grouped by id
+    pub fn by_id(&self) -> &BTreeMap<TransactionId, PendingTransaction<T>> {
+        &self.by_id
+    }
+
+    /// Independent transactions
+    pub fn independent_transactions(&self) -> &FxHashMap<SenderId, PendingTransaction<T>> {
+        &self.independent_transactions
+    }
+
     /// Whether the pool is empty
     #[cfg(test)]
     pub(crate) fn is_empty(&self) -> bool {
@@ -569,18 +581,18 @@ impl<T: TransactionOrdering> PendingPool<T> {
 
 /// A transaction that is ready to be included in a block.
 #[derive(Debug)]
-pub(crate) struct PendingTransaction<T: TransactionOrdering> {
+pub struct PendingTransaction<T: TransactionOrdering> {
     /// Identifier that tags when transaction was submitted in the pool.
-    pub(crate) submission_id: u64,
+    pub submission_id: u64,
     /// Actual transaction.
-    pub(crate) transaction: Arc<ValidPoolTransaction<T::Transaction>>,
+    pub transaction: Arc<ValidPoolTransaction<T::Transaction>>,
     /// The priority value assigned by the used `Ordering` function.
-    pub(crate) priority: Priority<T::PriorityValue>,
+    pub priority: Priority<T::PriorityValue>,
 }
 
 impl<T: TransactionOrdering> PendingTransaction<T> {
     /// The next transaction of the sender: `nonce + 1`
-    pub(crate) fn unlocks(&self) -> TransactionId {
+    pub fn unlocks(&self) -> TransactionId {
         self.transaction.transaction_id.descendant()
     }
 }

--- a/crates/transaction-pool/src/pool/pending.rs
+++ b/crates/transaction-pool/src/pool/pending.rs
@@ -513,12 +513,12 @@ impl<T: TransactionOrdering> PendingPool<T> {
     }
 
     /// All transactions grouped by id
-    pub fn by_id(&self) -> &BTreeMap<TransactionId, PendingTransaction<T>> {
+    pub const fn by_id(&self) -> &BTreeMap<TransactionId, PendingTransaction<T>> {
         &self.by_id
     }
 
     /// Independent transactions
-    pub fn independent_transactions(&self) -> &FxHashMap<SenderId, PendingTransaction<T>> {
+    pub const fn independent_transactions(&self) -> &FxHashMap<SenderId, PendingTransaction<T>> {
         &self.independent_transactions
     }
 

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -1188,18 +1188,19 @@ impl<T: TransactionOrdering> Drop for TxPool<T> {
     }
 }
 
-// Additional test impls
-#[cfg(any(test, feature = "test-utils"))]
 impl<T: TransactionOrdering> TxPool<T> {
-    pub(crate) const fn pending(&self) -> &PendingPool<T> {
+    /// Pending subpool
+    pub const fn pending(&self) -> &PendingPool<T> {
         &self.pending_pool
     }
 
-    pub(crate) const fn base_fee(&self) -> &ParkedPool<BasefeeOrd<T::Transaction>> {
+    /// Base fee subpool
+    pub const fn base_fee(&self) -> &ParkedPool<BasefeeOrd<T::Transaction>> {
         &self.basefee_pool
     }
 
-    pub(crate) const fn queued(&self) -> &ParkedPool<QueuedOrd<T::Transaction>> {
+    /// Queued sub pool
+    pub const fn queued(&self) -> &ParkedPool<QueuedOrd<T::Transaction>> {
         &self.queued_pool
     }
 }

--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -335,12 +335,12 @@ impl<T: PoolTransaction> ValidPoolTransaction<T> {
     }
 
     /// Returns the internal identifier for the sender of this transaction
-    pub(crate) const fn sender_id(&self) -> SenderId {
+    pub const fn sender_id(&self) -> SenderId {
         self.transaction_id.sender
     }
 
     /// Returns the internal identifier for this transaction.
-    pub(crate) const fn id(&self) -> &TransactionId {
+    pub const fn id(&self) -> &TransactionId {
         &self.transaction_id
     }
 


### PR DESCRIPTION
In RISE, we are customizing `BestTransactions`. To enable this, certain fields must be made `pub`. This PR updates their visibility accordingly.