### PR TITLE
feat(optimism): flashblock completed sequences

### DIFF
--- a/crates/optimism/flashblocks/src/lib.rs
+++ b/crates/optimism/flashblocks/src/lib.rs
@@ -9,6 +9,7 @@ pub use ws::{WsConnect, WsFlashBlockStream};
 
 mod payload;
 mod sequence;
+pub use sequence::FlashBlockCompleteSequence;
 mod service;
 mod worker;
 mod ws;

--- a/crates/optimism/flashblocks/src/sequence.rs
+++ b/crates/optimism/flashblocks/src/sequence.rs
@@ -96,9 +96,6 @@ impl FlashBlockCompleteSequence {
     /// * vector is not empty
     /// * first flashblock have the base payload
     /// * sequence of flashblocks is sound (successive index from 0, same payload id, ...)
-    ///
-    /// Also see [`TryFrom`] implementation of `FlashBlockCompleteSequence` for
-    /// [`FlashBlockPendingSequence`]
     pub fn new(blocks: Vec<FlashBlock>) -> eyre::Result<Self> {
         let first_block = blocks.first().ok_or_eyre("No flashblocks in sequence")?;
 

--- a/crates/optimism/flashblocks/src/sequence.rs
+++ b/crates/optimism/flashblocks/src/sequence.rs
@@ -85,10 +85,21 @@ where
     }
 }
 
-pub(crate) struct FlashBlockCompleteSequence(Vec<FlashBlock>);
+/// A complete sequence of flashblocks, often corresponding to a full block.
+/// Ensure invariants of a complete flashblocks sequence.
+#[derive(Debug)]
+pub struct FlashBlockCompleteSequence(Vec<FlashBlock>);
 
 impl FlashBlockCompleteSequence {
-    fn new(blocks: Vec<FlashBlock>) -> eyre::Result<Self> {
+    /// Create a complete sequence from a vector of flashblocks.
+    /// Ensure that:
+    /// * vector is not empty
+    /// * first flashblock have the base payload
+    /// * sequence of flashblocks is sound (successive index from 0, same payload id, ...)
+    ///
+    /// Also see [`TryFrom`] implementation of `FlashBlockCompleteSequence` for
+    /// [`FlashBlockPendingSequence`]
+    pub fn new(blocks: Vec<FlashBlock>) -> eyre::Result<Self> {
         let first_block = blocks.first().ok_or_eyre("No flashblocks in sequence")?;
 
         // Ensure that first flashblock have base
@@ -107,17 +118,17 @@ impl FlashBlockCompleteSequence {
     }
 
     /// Returns the block number
-    fn block_number(&self) -> u64 {
+    pub fn block_number(&self) -> u64 {
         self.0.first().unwrap().metadata.block_number
     }
 
     /// Returns the payload base of the first flashblock.
-    fn payload_base(&self) -> &ExecutionPayloadBaseV1 {
+    pub fn payload_base(&self) -> &ExecutionPayloadBaseV1 {
         self.0.first().unwrap().base.as_ref().unwrap()
     }
 
     /// Returns the number of flashblocks in the sequence.
-    const fn count(&self) -> usize {
+    pub const fn count(&self) -> usize {
         self.0.len()
     }
 }

--- a/crates/optimism/flashblocks/src/service.rs
+++ b/crates/optimism/flashblocks/src/service.rs
@@ -1,5 +1,5 @@
 use crate::{
-    sequence::{FlashBlockPendingSequence, FlashBlockSequence},
+    sequence::FlashBlockPendingSequence,
     worker::{BuildArgs, FlashBlockBuilder},
     ExecutionPayloadBaseV1, FlashBlock,
 };

--- a/crates/optimism/flashblocks/src/service.rs
+++ b/crates/optimism/flashblocks/src/service.rs
@@ -1,5 +1,5 @@
 use crate::{
-    sequence::FlashBlockSequence,
+    sequence::{FlashBlockPendingSequence, FlashBlockSequence},
     worker::{BuildArgs, FlashBlockBuilder},
     ExecutionPayloadBaseV1, FlashBlock,
 };
@@ -34,7 +34,7 @@ pub struct FlashBlockService<
 > {
     rx: S,
     current: Option<PendingBlock<N>>,
-    blocks: FlashBlockSequence<N::SignedTx>,
+    blocks: FlashBlockPendingSequence<N::SignedTx>,
     rebuild: bool,
     builder: FlashBlockBuilder<EvmConfig, Provider>,
     canon_receiver: CanonStateNotifications<N>,
@@ -70,7 +70,7 @@ where
         Self {
             rx,
             current: None,
-            blocks: FlashBlockSequence::new(),
+            blocks: FlashBlockPendingSequence::new(),
             canon_receiver: provider.subscribe_to_canonical_state(),
             builder: FlashBlockBuilder::new(evm_config, provider),
             rebuild: false,


### PR DESCRIPTION
part of #18255

Split the current `FlashBlockSequence` in two kinds:
- Pending as `FlashBlockPendingSequence`: used to iteratively build the pending block
- Completed as `FlashBlockCompletedSequence`: will be used towards #18255 (can also be useful in #18244 to define a `broadcast::Receiver<Option< FlashBlockSequence >>`)

