### PR TITLE
fix: correct spelling in expected_failures.yaml comment

### DIFF
--- a/.github/assets/hive/expected_failures.yaml
+++ b/.github/assets/hive/expected_failures.yaml
@@ -36,7 +36,7 @@ engine-api: []
 # no fix due to https://github.com/paradigmxyz/reth/issues/8732
 engine-cancun:
   - Invalid PayloadAttributes, Missing BeaconRoot, Syncing=True (Cancun) (reth)
-  # the test fails with older verions of the code for which it passed before, probably related to changes
+  # the test fails with older versions of the code for which it passed before, probably related to changes
   # in hive or its dependencies
   - Blob Transaction Ordering, Multiple Clients (Cancun) (reth)
 


### PR DESCRIPTION
Hey devs!
Fixed `verions` to `versions` in test failure comment for better readability and documentation clarity.