### PR TITLE
fix(e2e): persist accepted header in CheckPayloadAccepted and align timestamp

### DIFF
--- a/crates/e2e-test-utils/src/testsuite/actions/produce_blocks.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions/produce_blocks.rs
@@ -590,7 +590,7 @@ where
                 // at least one client passes all the check, save the header in Env
                 if !accepted_check {
                     accepted_check = true;
-                    // save the header in Env
+                    // save the current block info in Env
                     env.set_current_block_info(BlockInfo {
                         hash: rpc_latest_header.hash,
                         number: rpc_latest_header.inner.number,

--- a/crates/e2e-test-utils/src/testsuite/actions/produce_blocks.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions/produce_blocks.rs
@@ -256,8 +256,8 @@ where
                 debug!("No payload ID returned, generating fresh payload attributes for forking");
 
                 let fresh_payload_attributes = PayloadAttributes {
-                    timestamp: env.active_node_state()?.latest_header_time
-                        + env.block_timestamp_increment,
+                    timestamp: env.active_node_state()?.latest_header_time +
+                        env.block_timestamp_increment,
                     prev_randao: B256::random(),
                     suggested_fee_recipient: alloy_primitives::Address::random(),
                     withdrawals: Some(vec![]),
@@ -597,7 +597,8 @@ where
                         timestamp: rpc_latest_header.inner.timestamp,
                     })?;
 
-                    // align latest header time and forkchoice state with the accepted canonical head
+                    // align latest header time and forkchoice state with the accepted canonical
+                    // head
                     env.active_node_state_mut()?.latest_header_time =
                         rpc_latest_header.inner.timestamp;
                     env.active_node_state_mut()?.latest_fork_choice_state.head_block_hash =


### PR DESCRIPTION
Update CheckPayloadAccepted to call env.set_current_block_info(...) when a node accepts the broadcasted payload. This ensures Environment.current_block_info stays consistent with the canonical head. Also align latest_header_time to the RPC header timestamp (canonical view) and update forkchoice head. Without this, the env could remain stale despite the comment “save the header in Env,” causing downstream actions relying on current_block_info to read outdated state.