### PR TITLE
feat(op-reth/flashblocks): subscribe to the flashblock sequences produced

### DIFF
--- a/crates/optimism/flashblocks/src/lib.rs
+++ b/crates/optimism/flashblocks/src/lib.rs
@@ -7,6 +7,8 @@ use reth_rpc_eth_types::PendingBlock;
 pub use service::FlashBlockService;
 pub use ws::{WsConnect, WsFlashBlockStream};
 
+use crate::sequence::FlashBlockCompleteSequence;
+
 mod payload;
 mod sequence;
 mod service;
@@ -15,4 +17,10 @@ mod ws;
 /// Receiver of the most recent [`PendingBlock`] built out of [`FlashBlock`]s.
 ///
 /// [`FlashBlock`]: crate::FlashBlock
-pub type FlashBlockRx<N> = tokio::sync::watch::Receiver<Option<PendingBlock<N>>>;
+pub type PendingBlockRx<N> = tokio::sync::watch::Receiver<Option<PendingBlock<N>>>;
+
+/// Receiver of the sequences of [`FlashBlock`]s built.
+///
+/// [`FlashBlock`]: crate::FlashBlock
+pub type FlashBlockCompleteSequenceRx =
+    tokio::sync::broadcast::Receiver<FlashBlockCompleteSequence>;

--- a/crates/optimism/flashblocks/src/lib.rs
+++ b/crates/optimism/flashblocks/src/lib.rs
@@ -7,8 +7,6 @@ use reth_rpc_eth_types::PendingBlock;
 pub use service::FlashBlockService;
 pub use ws::{WsConnect, WsFlashBlockStream};
 
-use crate::sequence::FlashBlockCompleteSequence;
-
 mod payload;
 mod sequence;
 pub use sequence::FlashBlockCompleteSequence;

--- a/crates/optimism/flashblocks/src/sequence.rs
+++ b/crates/optimism/flashblocks/src/sequence.rs
@@ -1,7 +1,7 @@
 use crate::{ExecutionPayloadBaseV1, FlashBlock};
 use alloy_eips::eip2718::WithEncoded;
-use eyre::{bail, OptionExt};
 use core::mem;
+use eyre::{bail, OptionExt};
 use reth_primitives_traits::{Recovered, SignedTransaction};
 use std::collections::BTreeMap;
 use tokio::sync::broadcast;

--- a/crates/optimism/flashblocks/src/service.rs
+++ b/crates/optimism/flashblocks/src/service.rs
@@ -1,7 +1,4 @@
-use crate::{
-    sequence::{FlashBlockPendingSequence, FlashBlockSequence},
-    ExecutionPayloadBaseV1, FlashBlock,
-};
+use crate::{sequence::FlashBlockPendingSequence, ExecutionPayloadBaseV1, FlashBlock};
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::B256;
 use futures_util::{FutureExt, Stream, StreamExt};

--- a/crates/optimism/flashblocks/src/service.rs
+++ b/crates/optimism/flashblocks/src/service.rs
@@ -1,4 +1,7 @@
-use crate::{sequence::FlashBlockSequence, ExecutionPayloadBaseV1, FlashBlock};
+use crate::{
+    sequence::{FlashBlockPendingSequence, FlashBlockSequence},
+    ExecutionPayloadBaseV1, FlashBlock,
+};
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::B256;
 use futures_util::{FutureExt, Stream, StreamExt};
@@ -35,7 +38,7 @@ pub struct FlashBlockService<
 > {
     rx: S,
     current: Option<PendingBlock<N>>,
-    blocks: FlashBlockSequence<N::SignedTx>,
+    blocks: FlashBlockPendingSequence<N::SignedTx>,
     rebuild: bool,
     evm_config: EvmConfig,
     provider: Provider,
@@ -66,7 +69,7 @@ where
         Self {
             rx,
             current: None,
-            blocks: FlashBlockSequence::new(),
+            blocks: FlashBlockPendingSequence::new(),
             evm_config,
             canon_receiver: provider.subscribe_to_canonical_state(),
             provider,

--- a/crates/optimism/flashblocks/src/service.rs
+++ b/crates/optimism/flashblocks/src/service.rs
@@ -1,4 +1,8 @@
-use crate::{sequence::FlashBlockPendingSequence, worker::{BuildArgs, FlashBlockBuilder}, ExecutionPayloadBaseV1, FlashBlock, FlashBlockCompleteSequence};
+use crate::{
+    sequence::FlashBlockPendingSequence,
+    worker::{BuildArgs, FlashBlockBuilder},
+    ExecutionPayloadBaseV1, FlashBlock, FlashBlockCompleteSequence,
+};
 use alloy_eips::eip2718::WithEncoded;
 use alloy_primitives::B256;
 use futures_util::{FutureExt, Stream, StreamExt};
@@ -16,8 +20,10 @@ use std::{
     task::{ready, Context, Poll},
     time::Instant,
 };
-use tokio::{pin, sync::oneshot};
-use tokio::sync::broadcast;
+use tokio::{
+    pin,
+    sync::{broadcast, oneshot},
+};
 use tracing::{debug, trace, warn};
 
 /// The `FlashBlockService` maintains an in-memory [`PendingBlock`] built out of a sequence of

--- a/crates/optimism/flashblocks/src/service.rs
+++ b/crates/optimism/flashblocks/src/service.rs
@@ -1,8 +1,4 @@
-use crate::{
-    sequence::FlashBlockPendingSequence,
-    worker::{BuildArgs, FlashBlockBuilder},
-    ExecutionPayloadBaseV1, FlashBlock,
-};
+use crate::{sequence::FlashBlockPendingSequence, worker::{BuildArgs, FlashBlockBuilder}, ExecutionPayloadBaseV1, FlashBlock, FlashBlockCompleteSequence};
 use alloy_eips::eip2718::WithEncoded;
 use alloy_primitives::B256;
 use futures_util::{FutureExt, Stream, StreamExt};
@@ -21,6 +17,7 @@ use std::{
     time::Instant,
 };
 use tokio::{pin, sync::oneshot};
+use tokio::sync::broadcast;
 use tracing::{debug, trace, warn};
 
 /// The `FlashBlockService` maintains an in-memory [`PendingBlock`] built out of a sequence of

--- a/crates/optimism/rpc/src/eth/mod.rs
+++ b/crates/optimism/rpc/src/eth/mod.rs
@@ -335,7 +335,7 @@ pub struct OpEthApiInner<N: RpcNodeCore, Rpc: RpcConvert> {
     pending_block_rx: Option<PendingBlockRx<N::Primitives>>,
     /// Flashblocks receiver.
     ///
-    /// If set, then it provides sequences of [`FlashBlock`]s built.
+    /// If set, then it provides sequences of flashblock built.
     flashblock_rx: Option<FlashBlockCompleteSequenceRx>,
 }
 

--- a/crates/optimism/rpc/src/eth/mod.rs
+++ b/crates/optimism/rpc/src/eth/mod.rs
@@ -22,7 +22,8 @@ use reth_evm::ConfigureEvm;
 use reth_node_api::{FullNodeComponents, FullNodeTypes, HeaderTy};
 use reth_node_builder::rpc::{EthApiBuilder, EthApiCtx};
 use reth_optimism_flashblocks::{
-    ExecutionPayloadBaseV1, FlashBlockRx, FlashBlockService, WsFlashBlockStream,
+    ExecutionPayloadBaseV1, FlashBlockCompleteSequenceRx, FlashBlockService, PendingBlockRx,
+    WsFlashBlockStream,
 };
 use reth_rpc::eth::{core::EthApiInner, DevSigner};
 use reth_rpc_eth_api::{
@@ -76,13 +77,15 @@ impl<N: RpcNodeCore, Rpc: RpcConvert> OpEthApi<N, Rpc> {
         eth_api: EthApiNodeBackend<N, Rpc>,
         sequencer_client: Option<SequencerClient>,
         min_suggested_priority_fee: U256,
-        flashblocks_rx: Option<FlashBlockRx<N::Primitives>>,
+        pending_block_rx: Option<PendingBlockRx<N::Primitives>>,
+        flashblock_rx: Option<FlashBlockCompleteSequenceRx>,
     ) -> Self {
         let inner = Arc::new(OpEthApiInner {
             eth_api,
             sequencer_client,
             min_suggested_priority_fee,
-            flashblocks_rx,
+            pending_block_rx,
+            flashblock_rx,
         });
         Self { inner }
     }
@@ -96,9 +99,14 @@ impl<N: RpcNodeCore, Rpc: RpcConvert> OpEthApi<N, Rpc> {
         self.inner.sequencer_client()
     }
 
-    /// Returns a cloned Flashblocks receiver, if any.
-    pub fn flashblocks_rx(&self) -> Option<FlashBlockRx<N::Primitives>> {
-        self.inner.flashblocks_rx.clone()
+    /// Returns a cloned pending block receiver, if any.
+    pub fn pending_block_rx(&self) -> Option<PendingBlockRx<N::Primitives>> {
+        self.inner.pending_block_rx.clone()
+    }
+
+    /// Returns a flashblock receiver, if any, by resubscribing to it.
+    pub fn flashblock_rx(&self) -> Option<FlashBlockCompleteSequenceRx> {
+        self.inner.flashblock_rx.as_ref().map(|rx| rx.resubscribe())
     }
 
     /// Build a [`OpEthApi`] using [`OpEthApiBuilder`].
@@ -119,7 +127,7 @@ impl<N: RpcNodeCore, Rpc: RpcConvert> OpEthApi<N, Rpc> {
             PendingBlockEnvOrigin::DerivedFromLatest(parent) => parent,
         };
 
-        let Some(rx) = self.inner.flashblocks_rx.as_ref() else { return Ok(None) };
+        let Some(rx) = self.inner.pending_block_rx.as_ref() else { return Ok(None) };
         let pending_block = rx.borrow();
         let Some(pending_block) = pending_block.as_ref() else { return Ok(None) };
 
@@ -321,10 +329,14 @@ pub struct OpEthApiInner<N: RpcNodeCore, Rpc: RpcConvert> {
     ///
     /// See also <https://github.com/ethereum-optimism/op-geth/blob/d4e0fe9bb0c2075a9bff269fb975464dd8498f75/eth/gasprice/optimism-gasprice.go#L38-L38>
     min_suggested_priority_fee: U256,
-    /// Flashblocks receiver.
+    /// Pending block receiver.
     ///
     /// If set, then it provides current pending block based on received Flashblocks.
-    flashblocks_rx: Option<FlashBlockRx<N::Primitives>>,
+    pending_block_rx: Option<PendingBlockRx<N::Primitives>>,
+    /// Flashblocks receiver.
+    ///
+    /// If set, then it provides sequences of [`FlashBlock`]s built.
+    flashblock_rx: Option<FlashBlockCompleteSequenceRx>,
 }
 
 impl<N: RpcNodeCore, Rpc: RpcConvert> fmt::Debug for OpEthApiInner<N, Rpc> {
@@ -459,20 +471,23 @@ where
             None
         };
 
-        let flashblocks_rx = if let Some(ws_url) = flashblocks_url {
+        let rxs = if let Some(ws_url) = flashblocks_url {
             info!(target: "reth:cli", %ws_url,  "Launching flashblocks service");
-            let (tx, rx) = watch::channel(None);
+            let (tx, pending_block_rx) = watch::channel(None);
             let stream = WsFlashBlockStream::new(ws_url);
             let service = FlashBlockService::new(
                 stream,
                 ctx.components.evm_config().clone(),
                 ctx.components.provider().clone(),
             );
+            let flashblock_rx = service.subscribe_block_sequence();
             ctx.components.task_executor().spawn_blocking(Box::pin(service.run(tx)));
-            Some(rx)
+            Some((pending_block_rx, flashblock_rx))
         } else {
             None
         };
+
+        let (pending_block_rx, flashblock_rx) = rxs.unzip();
 
         let eth_api = ctx.eth_api_builder().with_rpc_converter(rpc_converter).build_inner();
 
@@ -480,7 +495,8 @@ where
             eth_api,
             sequencer_client,
             U256::from(min_suggested_priority_fee),
-            flashblocks_rx,
+            pending_block_rx,
+            flashblock_rx,
         ))
     }
 }

--- a/crates/optimism/rpc/src/historical.rs
+++ b/crates/optimism/rpc/src/historical.rs
@@ -386,12 +386,12 @@ mod tests {
     #[test]
     fn parses_transaction_hash_from_params() {
         let hash = "0xdbdfa0f88b2cf815fdc1621bd20c2bd2b0eed4f0c56c9be2602957b5a60ec702";
-        let params_str = format!(r#"["{}"]"#, hash);
+        let params_str = format!(r#"["{hash}"]"#);
         let params = Params::new(Some(&params_str));
         let result = parse_transaction_hash_from_params(&params);
         assert!(result.is_ok());
         let parsed_hash = result.unwrap();
-        assert_eq!(format!("{:?}", parsed_hash), hash);
+        assert_eq!(format!("{parsed_hash:?}"), hash);
     }
 
     /// Tests that invalid transaction hash returns error.


### PR DESCRIPTION
## Description

This PR exposes methods to allow broadcasting/subscription to the flashblock sequences produced. Notable changes:
- Renamed `FlashBlockRx` to `PendingBlockRx` and used `FlashBlockRx` as a name for that new channel
- Added a simple test to ensure that we're broadcasting the flashblocks properly.

Close #18244 

Depends (and rebased) on #18272 