### PR TITLE
perf(db): do not heap-allocate the stage key per query

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1642,7 +1642,11 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> BlockBodyIndicesProvider
 
 impl<TX: DbTx, N: NodeTypes> StageCheckpointReader for DatabaseProvider<TX, N> {
     fn get_stage_checkpoint(&self, id: StageId) -> ProviderResult<Option<StageCheckpoint>> {
-        Ok(self.tx.get::<tables::StageCheckpoints>(id.to_string())?)
+        Ok(if let Some(encoded) = id.get_pre_encoded() {
+            self.tx.get_by_encoded_key::<tables::StageCheckpoints>(encoded)?
+        } else {
+            self.tx.get::<tables::StageCheckpoints>(id.to_string())?
+        })
     }
 
     /// Get stage checkpoint progress.


### PR DESCRIPTION
0.6/19 ~ 3% of `BlockchainProvider::latest` is spent on heap-allocating a `String` for `StageId::Finish` to be used for a database query.

<img width="1132" height="135" alt="image" src="https://github.com/user-attachments/assets/4471ded0-5356-48ef-aed8-fd7855782886" />

This is bad because:
- It is in hot paths like validating new mempool transactions (as bad as creating a `latest` provider per new transaction).
- It scales poorly for nodes under heavy load, where heap allocation is more expensive than normally.

This PR pre-allocates pre-defined stage ids only once, to reference them for database queries, instead of allocating anew per query.