### PR TITLE
wip: feat(e2e-test-utils): add transaction actions and utilities (need add more stuff)

### DIFF
--- a/crates/e2e-test-utils/src/testsuite/actions/mod.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions/mod.rs
@@ -31,9 +31,7 @@ pub use produce_blocks::{
     UpdateBlockInfoToLatestPayload, ValidateCanonicalTag,
 };
 pub use reorg::{ReorgTarget, ReorgTo, SetReorgTarget};
-pub use transactions::{
-    create_approve_tx, create_test_approve_tx, create_transfer_tx, ProduceBlockWithTransactions,
-};
+pub use transactions::{create_approve_tx, create_transfer_tx, ProduceBlockWithTransactions};
 
 /// An action that can be performed on an instance.
 ///

--- a/crates/e2e-test-utils/src/testsuite/actions/mod.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions/mod.rs
@@ -31,7 +31,9 @@ pub use produce_blocks::{
     UpdateBlockInfoToLatestPayload, ValidateCanonicalTag,
 };
 pub use reorg::{ReorgTarget, ReorgTo, SetReorgTarget};
-pub use transactions::{create_approve_tx, create_transfer_tx, ProduceBlockWithTransactions};
+pub use transactions::{
+    create_approve_tx, create_test_approve_tx, create_transfer_tx, ProduceBlockWithTransactions,
+};
 
 /// An action that can be performed on an instance.
 ///

--- a/crates/e2e-test-utils/src/testsuite/actions/mod.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions/mod.rs
@@ -15,6 +15,7 @@ pub mod fork;
 pub mod node_ops;
 pub mod produce_blocks;
 pub mod reorg;
+pub mod transactions;
 
 pub use custom_fcu::{BlockReference, FinalizeBlock, SendForkchoiceUpdate};
 pub use engine_api::{ExpectedPayloadStatus, SendNewPayload, SendNewPayloads};
@@ -30,6 +31,9 @@ pub use produce_blocks::{
     UpdateBlockInfoToLatestPayload, ValidateCanonicalTag,
 };
 pub use reorg::{ReorgTarget, ReorgTo, SetReorgTarget};
+pub use transactions::{
+    create_approve_tx, create_test_approve_tx, create_transfer_tx, ProduceBlockWithTransactions,
+};
 
 /// An action that can be performed on an instance.
 ///

--- a/crates/e2e-test-utils/src/testsuite/actions/transactions.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions/transactions.rs
@@ -29,7 +29,6 @@ use eyre::Result;
 use futures_util::future::BoxFuture;
 use reth_node_api::{EngineTypes, PayloadTypes};
 use reth_rpc_api::clients::EthApiClient;
-use std::str::FromStr;
 use tracing::debug;
 
 /// Action to produce blocks with real storage-modifying transactions.
@@ -257,4 +256,18 @@ pub async fn create_transfer_tx(
     signed.encode_2718(&mut encoded);
 
     Ok(Bytes::from(encoded))
+}
+
+/// Helper to create approve transaction for the default test token contract.
+/// The default contract address is 0x77d34361f991fa724ff1db9b1d760063a16770db
+/// which is used in the trie corruption tests.
+pub async fn create_test_approve_tx(
+    spender: Address,
+    amount: U256,
+    nonce: u64,
+    chain_id: u64,
+) -> Result<Bytes> {
+    let token_address = Address::parse_checksummed("0x77d34361f991fa724ff1db9b1d760063a16770db", None)
+        .map_err(|e| eyre::eyre!("Invalid test token address: {}", e))?;
+    create_approve_tx(token_address, spender, amount, nonce, chain_id).await
 }

--- a/crates/e2e-test-utils/src/testsuite/actions/transactions.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions/transactions.rs
@@ -1,0 +1,260 @@
+//! Transaction-related actions for the e2e testing framework.
+//!
+//! This module provides actions for producing blocks with real transactions,
+//! which is useful for testing scenarios that require actual state modifications
+//! through transaction execution (e.g., storage changes, trie updates, etc.).
+//!
+//! The main action is [`ProduceBlockWithTransactions`] which:
+//! 1. Sends raw signed transactions to the node's transaction pool
+//! 2. Triggers block production to include those transactions
+//! 3. Makes the block canonical
+//! 4. Verifies transaction inclusion
+//!
+//! Also provides transaction creation utilities for common test scenarios.
+
+use crate::{
+    testsuite::{
+        actions::{Action, CaptureBlock, MakeCanonical, ProduceBlocks},
+        Environment,
+    },
+    wallet::Wallet,
+};
+use alloy_consensus::{Signed, TxEnvelope, TxLegacy};
+use alloy_eips::eip2718::Encodable2718;
+use alloy_network::TxSignerSync;
+use alloy_primitives::{Address, Bytes, TxKind, B256, U256};
+use alloy_rpc_types_engine::{ExecutionPayloadEnvelopeV3, PayloadAttributes};
+use alloy_rpc_types_eth::{Block, Header, Receipt, Transaction, TransactionRequest};
+use eyre::Result;
+use futures_util::future::BoxFuture;
+use reth_node_api::{EngineTypes, PayloadTypes};
+use reth_rpc_api::clients::EthApiClient;
+use std::str::FromStr;
+use tracing::debug;
+
+/// Action to produce blocks with real storage-modifying transactions.
+///
+/// This action sends transactions to the node's transaction pool and then
+/// triggers block production to include them.
+#[derive(Debug)]
+pub struct ProduceBlockWithTransactions {
+    /// Transactions to send (as raw signed transaction bytes)
+    pub transactions: Vec<Bytes>,
+    /// Tag to capture the block with
+    pub block_tag: String,
+    /// Optional node index to send transactions to
+    pub node_idx: Option<usize>,
+}
+
+impl ProduceBlockWithTransactions {
+    /// Create a new `ProduceBlockWithTransactions` action
+    pub fn new(transactions: Vec<Bytes>, block_tag: impl Into<String>) -> Self {
+        Self { transactions, block_tag: block_tag.into(), node_idx: None }
+    }
+
+    /// Set the node index to send transactions to
+    pub fn with_node_idx(mut self, idx: usize) -> Self {
+        self.node_idx = Some(idx);
+        self
+    }
+}
+
+impl<Engine> Action<Engine> for ProduceBlockWithTransactions
+where
+    Engine: EngineTypes + PayloadTypes,
+    Engine::PayloadAttributes: From<PayloadAttributes> + Clone,
+    Engine::ExecutionPayloadEnvelopeV3: Into<ExecutionPayloadEnvelopeV3>,
+{
+    fn execute<'a>(&'a mut self, env: &'a mut Environment<Engine>) -> BoxFuture<'a, Result<()>> {
+        Box::pin(async move {
+            let node_idx = self.node_idx.unwrap_or(env.active_node_idx);
+
+            if node_idx >= env.node_clients.len() {
+                return Err(eyre::eyre!("Node index out of bounds: {}", node_idx));
+            }
+
+            debug!("Sending {} transactions to node {}", self.transactions.len(), node_idx);
+
+            // Send transactions to the node via RPC
+            let mut tx_hashes = Vec::new();
+
+            for (idx, tx_bytes) in self.transactions.iter().enumerate() {
+                // Send raw transaction using eth_sendRawTransaction
+                let tx_hash = EthApiClient::<
+                    TransactionRequest,
+                    Transaction,
+                    Block,
+                    Receipt,
+                    Header,
+                >::send_raw_transaction(&env.node_clients[node_idx].rpc, tx_bytes.clone())
+                .await?;
+
+                tx_hashes.push(tx_hash);
+                debug!("Sent transaction {}: hash {}", idx + 1, tx_hash);
+            }
+
+            // Wait a bit for transactions to be in the pool
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+            // Now produce a block that includes these transactions
+            // We use ProduceBlocks which will trigger block production
+            debug!("Producing block to include transactions");
+            let mut produce = ProduceBlocks::<Engine>::new(1);
+            produce.execute(env).await?;
+
+            // Make the block canonical
+            let mut make_canonical = MakeCanonical::new();
+            make_canonical.execute(env).await?;
+
+            // Capture the block with our tag
+            let mut capture = CaptureBlock::new(&self.block_tag);
+            capture.execute(env).await?;
+
+            // Verify transactions were included
+            let (block_info, _) = env
+                .block_registry
+                .get(&self.block_tag)
+                .ok_or_else(|| eyre::eyre!("Block tag '{}' not found in registry", self.block_tag))?
+                .clone();
+
+            // Get the block to check transactions
+            let block = EthApiClient::<
+                TransactionRequest,
+                Transaction,
+                Block,
+                Receipt,
+                Header,
+            >::block_by_hash(&env.node_clients[node_idx].rpc, block_info.hash, true)
+            .await?
+            .ok_or_else(|| eyre::eyre!("Block not found for hash"))?;
+
+            debug!(
+                "Block {} created with {} transactions",
+                block_info.number,
+                block.transactions.len()
+            );
+
+            // Check if our transactions were included
+            let block_tx_hashes: Vec<B256> = block.transactions.hashes().collect();
+            let mut included_count = 0;
+            for tx_hash in &tx_hashes {
+                if block_tx_hashes.contains(tx_hash) {
+                    included_count += 1;
+                }
+            }
+
+            if included_count == tx_hashes.len() {
+                debug!("All {} transactions included in block", tx_hashes.len());
+            } else {
+                debug!(
+                    "Only {}/{} transactions included in block",
+                    included_count,
+                    tx_hashes.len()
+                );
+            }
+
+            Ok(())
+        })
+    }
+}
+
+// Transaction creation utilities
+
+/// Create a transaction that calls approve() on a token contract.
+/// This modifies storage in a way that can trigger trie node creation/deletion.
+///
+/// # Arguments
+/// * `token_address` - Address of the token contract
+/// * `spender` - Address to approve for spending
+/// * `amount` - Amount to approve
+/// * `nonce` - Transaction nonce
+/// * `chain_id` - Chain ID for the transaction
+pub async fn create_approve_tx(
+    token_address: Address,
+    spender: Address,
+    amount: U256,
+    nonce: u64,
+    chain_id: u64,
+) -> Result<Bytes> {
+    // The approve(address spender, uint256 amount) selector: 0x095ea7b3
+    let mut data = Vec::with_capacity(68);
+    data.extend_from_slice(&[0x09, 0x5e, 0xa7, 0xb3]); // approve selector
+    data.extend_from_slice(&[0u8; 12]); // padding for address
+    data.extend_from_slice(spender.as_slice()); // spender address (20 bytes)
+
+    // Encode amount as 32 bytes
+    let amount_bytes = amount.to_be_bytes::<32>();
+    data.extend_from_slice(&amount_bytes);
+
+    // Get test wallet (funded account from genesis)
+    let wallet = Wallet::new(1).with_chain_id(chain_id);
+    let signers = wallet.wallet_gen();
+    let signer =
+        signers.into_iter().next().ok_or_else(|| eyre::eyre!("Failed to create test signer"))?;
+
+    // Create transaction calling the contract
+    let mut tx = TxLegacy {
+        chain_id: Some(chain_id),
+        nonce,
+        gas_price: 20_000_000_000, // 20 gwei
+        gas_limit: 100_000,
+        to: TxKind::Call(token_address),
+        value: U256::ZERO, // No ETH sent
+        input: data.into(),
+    };
+
+    // Sign the transaction
+    let signature = signer.sign_transaction_sync(&mut tx)?;
+
+    // Build the signed transaction
+    let signed = TxEnvelope::Legacy(Signed::new_unchecked(tx, signature, B256::ZERO));
+
+    // Encode to bytes
+    let mut encoded = Vec::new();
+    signed.encode_2718(&mut encoded);
+
+    Ok(Bytes::from(encoded))
+}
+
+/// Create a simple transfer transaction that sends ETH.
+///
+/// # Arguments
+/// * `to` - Recipient address
+/// * `value` - Amount of ETH to send (in wei)
+/// * `nonce` - Transaction nonce
+/// * `chain_id` - Chain ID for the transaction
+pub async fn create_transfer_tx(
+    to: Address,
+    value: U256,
+    nonce: u64,
+    chain_id: u64,
+) -> Result<Bytes> {
+    // Get test wallet (funded account from genesis)
+    let wallet = Wallet::new(1).with_chain_id(chain_id);
+    let signers = wallet.wallet_gen();
+    let signer =
+        signers.into_iter().next().ok_or_else(|| eyre::eyre!("Failed to create test signer"))?;
+
+    // Create simple transfer transaction
+    let mut tx = TxLegacy {
+        chain_id: Some(chain_id),
+        nonce,
+        gas_price: 20_000_000_000, // 20 gwei
+        gas_limit: 21_000,         // Standard gas for transfer
+        to: TxKind::Call(to),
+        value,
+        input: Bytes::new(), // Empty data for simple transfer
+    };
+
+    // Sign the transaction
+    let signature = signer.sign_transaction_sync(&mut tx)?;
+
+    // Build the signed transaction
+    let signed = TxEnvelope::Legacy(Signed::new_unchecked(tx, signature, B256::ZERO));
+
+    // Encode to bytes
+    let mut encoded = Vec::new();
+    signed.encode_2718(&mut encoded);
+
+    Ok(Bytes::from(encoded))
+}

--- a/crates/e2e-test-utils/src/testsuite/actions/transactions.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions/transactions.rs
@@ -159,13 +159,6 @@ where
 
 /// Create a transaction that calls `approve()` on a token contract.
 /// This modifies storage in a way that can trigger trie node creation/deletion.
-///
-/// # Arguments
-/// * `token_address` - Address of the token contract
-/// * `spender` - Address to approve for spending
-/// * `amount` - Amount to approve
-/// * `nonce` - Transaction nonce
-/// * `chain_id` - Chain ID for the transaction
 pub async fn create_approve_tx(
     token_address: Address,
     spender: Address,
@@ -214,12 +207,6 @@ pub async fn create_approve_tx(
 }
 
 /// Create a simple transfer transaction that sends ETH.
-///
-/// # Arguments
-/// * `to` - Recipient address
-/// * `value` - Amount of ETH to send (in wei)
-/// * `nonce` - Transaction nonce
-/// * `chain_id` - Chain ID for the transaction
 pub async fn create_transfer_tx(
     to: Address,
     value: U256,
@@ -257,8 +244,6 @@ pub async fn create_transfer_tx(
 }
 
 /// Helper to create approve transaction for the default test token contract.
-/// The default contract address is 0x77d34361f991fa724ff1db9b1d760063a16770db
-/// which is used in the trie corruption tests.
 pub async fn create_test_approve_tx(
     spender: Address,
     amount: U256,

--- a/crates/e2e-test-utils/src/testsuite/actions/transactions.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions/transactions.rs
@@ -52,7 +52,7 @@ impl ProduceBlockWithTransactions {
     }
 
     /// Set the node index to send transactions to
-    pub fn with_node_idx(mut self, idx: usize) -> Self {
+    pub const fn with_node_idx(mut self, idx: usize) -> Self {
         self.node_idx = Some(idx);
         self
     }
@@ -110,11 +110,10 @@ where
             capture.execute(env).await?;
 
             // Verify transactions were included
-            let (block_info, _) = env
+            let (block_info, _) = *env
                 .block_registry
                 .get(&self.block_tag)
-                .ok_or_else(|| eyre::eyre!("Block tag '{}' not found in registry", self.block_tag))?
-                .clone();
+                .ok_or_else(|| eyre::eyre!("Block tag '{}' not found in registry", self.block_tag))?;
 
             // Get the block to check transactions
             let block = EthApiClient::<
@@ -159,7 +158,7 @@ where
 
 // Transaction creation utilities
 
-/// Create a transaction that calls approve() on a token contract.
+/// Create a transaction that calls `approve()` on a token contract.
 /// This modifies storage in a way that can trigger trie node creation/deletion.
 ///
 /// # Arguments

--- a/crates/e2e-test-utils/src/testsuite/actions/transactions.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions/transactions.rs
@@ -110,10 +110,9 @@ where
             capture.execute(env).await?;
 
             // Verify transactions were included
-            let (block_info, _) = *env
-                .block_registry
-                .get(&self.block_tag)
-                .ok_or_else(|| eyre::eyre!("Block tag '{}' not found in registry", self.block_tag))?;
+            let (block_info, _) = *env.block_registry.get(&self.block_tag).ok_or_else(|| {
+                eyre::eyre!("Block tag '{}' not found in registry", self.block_tag)
+            })?;
 
             // Get the block to check transactions
             let block = EthApiClient::<
@@ -266,7 +265,8 @@ pub async fn create_test_approve_tx(
     nonce: u64,
     chain_id: u64,
 ) -> Result<Bytes> {
-    let token_address = Address::parse_checksummed("0x77d34361f991fa724ff1db9b1d760063a16770db", None)
-        .map_err(|e| eyre::eyre!("Invalid test token address: {}", e))?;
+    let token_address =
+        Address::parse_checksummed("0x77d34361f991fa724ff1db9b1d760063a16770db", None)
+            .map_err(|e| eyre::eyre!("Invalid test token address: {}", e))?;
     create_approve_tx(token_address, spender, amount, nonce, chain_id).await
 }

--- a/crates/node/core/src/version.rs
+++ b/crates/node/core/src/version.rs
@@ -113,14 +113,7 @@ pub fn default_reth_version_metadata() -> RethCliVersionConsts {
         vergen_git_sha: Cow::Owned(env!("VERGEN_GIT_SHA_SHORT").to_string()),
         vergen_build_timestamp: Cow::Owned(env!("VERGEN_BUILD_TIMESTAMP").to_string()),
         vergen_cargo_target_triple: Cow::Owned(env!("VERGEN_CARGO_TARGET_TRIPLE").to_string()),
-        vergen_cargo_features: Cow::Owned({
-            let features = env!("VERGEN_CARGO_FEATURES");
-            if features.is_empty() {
-                String::new()
-            } else {
-                features.to_string()
-            }
-        }),
+        vergen_cargo_features: Cow::Owned(env!("VERGEN_CARGO_FEATURES").to_string()),
         short_version: Cow::Owned(env!("RETH_SHORT_VERSION").to_string()),
         long_version: Cow::Owned(format!(
             "{}\n{}\n{}\n{}\n{}",

--- a/crates/node/core/src/version.rs
+++ b/crates/node/core/src/version.rs
@@ -113,7 +113,14 @@ pub fn default_reth_version_metadata() -> RethCliVersionConsts {
         vergen_git_sha: Cow::Owned(env!("VERGEN_GIT_SHA_SHORT").to_string()),
         vergen_build_timestamp: Cow::Owned(env!("VERGEN_BUILD_TIMESTAMP").to_string()),
         vergen_cargo_target_triple: Cow::Owned(env!("VERGEN_CARGO_TARGET_TRIPLE").to_string()),
-        vergen_cargo_features: Cow::Owned(env!("VERGEN_CARGO_FEATURES").to_string()),
+        vergen_cargo_features: Cow::Owned({
+            let features = env!("VERGEN_CARGO_FEATURES");
+            if features.is_empty() {
+                String::new()
+            } else {
+                features.to_string()
+            }
+        }),
         short_version: Cow::Owned(env!("RETH_SHORT_VERSION").to_string()),
         long_version: Cow::Owned(format!(
             "{}\n{}\n{}\n{}\n{}",


### PR DESCRIPTION
## Summary

- Add `ProduceBlockWithTransactions` action for creating blocks with real transactions
- Add transaction creation utilities (`create_approve_tx`, `create_transfer_tx`, `create_test_approve_tx`)  
- Enable testing scenarios that require actual state modifications through transaction execution

## Changes

- **New module**: `crates/e2e-test-utils/src/testsuite/actions/transactions.rs`
- **Updated exports**: Added transaction utilities to actions module

## Use Cases

The new action enables testing:
- Trie node creation/deletion scenarios
- Storage modifications through contract interactions
- Transaction pool and block production integration
- State transitions requiring real transaction execution

## API

```rust
// Create transactions and produce block containing them
let tx = create_test_approve_tx(spender, amount, nonce, chain_id).await?;
let mut action = ProduceBlockWithTransactions::new(vec![tx], "test_block");
action.execute(&mut env).await?;
```