### PR TITLE
perf(db): reuse MDBX DBIs for the same tx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2746,6 +2746,7 @@ version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
+ "arbitrary",
  "cfg-if",
  "crossbeam-utils",
  "hashbrown 0.14.5",
@@ -7607,6 +7608,7 @@ dependencies = [
  "arbitrary",
  "assert_matches",
  "codspeed-criterion-compat",
+ "dashmap 6.1.0",
  "derive_more",
  "eyre",
  "metrics",

--- a/crates/storage/db/Cargo.toml
+++ b/crates/storage/db/Cargo.toml
@@ -39,6 +39,7 @@ derive_more.workspace = true
 rustc-hash = { workspace = true, optional = true, features = ["std"] }
 sysinfo = { workspace = true, features = ["system"] }
 parking_lot = { workspace = true, optional = true }
+dashmap.workspace = true
 
 # arbitrary utils
 strum = { workspace = true, features = ["derive"], optional = true }
@@ -91,6 +92,7 @@ arbitrary = [
     "alloy-consensus/arbitrary",
     "reth-primitives-traits/arbitrary",
     "reth-prune-types/arbitrary",
+    "dashmap/arbitrary",
 ]
 op = [
     "reth-db-api/op",


### PR DESCRIPTION
`MDBX_dbi` is an index into the MDBX environment to a table handle. We can safely share this index around unless we manually close and remove table handles from the MDBX environment (we don't).

This PR takes the first step of sharing the DBIs across queries of the same DB transaction, which already yields lots of hits; each hit makes the query 6%-82% faster. For example, every single `get` was trying to create a new table handle (`mdbx_dbi_open`)... 
https://github.com/paradigmxyz/reth/blob/0cdd54838b4311e00a71606ce618d6869a2a0704/crates/storage/db/src/implementation/mdbx/tx.rs#L293

A step further would be to pre-create and share the DBIs across all transactions.

No screenshot this one, as this path is literally everywhere :melting_face:. 