### PR TITLE
chore: fix various typos in comments and documentation

### DIFF
--- a/crates/chain-state/src/memory_overlay.rs
+++ b/crates/chain-state/src/memory_overlay.rs
@@ -21,7 +21,7 @@ pub struct MemoryOverlayStateProviderRef<
     'a,
     N: NodePrimitives = reth_ethereum_primitives::EthPrimitives,
 > {
-    /// Historical state provider for state lookups that are not found in in-memory blocks.
+    /// Historical state provider for state lookups that are not found in memory blocks.
     pub(crate) historical: Box<dyn StateProvider + 'a>,
     /// The collection of executed parent blocks. Expected order is newest to oldest.
     pub(crate) in_memory: Vec<ExecutedBlockWithTrieUpdates<N>>,

--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -804,7 +804,7 @@ impl PeersManager {
         }
     }
 
-    /// Connect to the given peer. NOTE: if the maximum number out outbound sessions is reached,
+    /// Connect to the given peer. NOTE: if the maximum number of outbound sessions is reached,
     /// this won't do anything. See `reth_network::SessionManager::dial_outbound`.
     #[cfg_attr(not(test), expect(dead_code))]
     pub(crate) fn add_and_connect(

--- a/crates/node/core/src/args/pruning.rs
+++ b/crates/node/core/src/args/pruning.rs
@@ -111,7 +111,7 @@ impl PruningArgs {
     where
         ChainSpec: EthereumHardforks,
     {
-        // Initialise with a default prune configuration.
+        // Initialize with a default prune configuration.
         let mut config = PruneConfig::default();
 
         // If --full is set, use full node defaults.

--- a/crates/optimism/flashblocks/src/sequence.rs
+++ b/crates/optimism/flashblocks/src/sequence.rs
@@ -34,7 +34,7 @@ where
             return Ok(())
         }
 
-        // only insert if we we previously received the same block, assume we received index 0
+        // only insert if we previously received the same block, assume we received index 0
         if self.block_number() == Some(flashblock.metadata.block_number) {
             trace!(number=%flashblock.block_number(), index = %flashblock.index, block_count = self.inner.len()  ,"Received followup flashblock");
             self.inner.insert(flashblock.index, PreparedFlashBlock::new(flashblock)?);

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -2025,7 +2025,7 @@ mod tests {
                     "partial mem data"
                 );
 
-                // Test range in in-memory to unbounded end
+                // Test range in memory to unbounded end
                 assert_eq!(provider.$method(in_mem_range.start() + 1..)?, &in_memory_data[1..], "unbounded mem data");
 
                 // Test last element in-memory

--- a/crates/transaction-pool/src/error.rs
+++ b/crates/transaction-pool/src/error.rs
@@ -93,7 +93,7 @@ impl PoolError {
     ///
     /// Not all error variants are caused by the incorrect composition of the transaction (See also
     /// [`InvalidPoolTransactionError`]) and can be caused by the current state of the transaction
-    /// pool. For example the transaction pool is already full or the error was caused my an
+    /// pool. For example the transaction pool is already full or the error was caused by an
     /// internal error, such as database errors.
     ///
     /// This function returns true only if the transaction will never make it into the pool because


### PR DESCRIPTION
This PR fixes several typos found in comments and documentation across the codebase.

## Changes

- Fixed typos in comments:
  - "caused my an" → "caused by an" in transaction pool error documentation
  - "maximum number out outbound" → "maximum number of outbound" in network peers documentation

- Standardized spelling to American English:
  - "initialise" → "initialize" in pruning args documentation

- Fixed doubled word typos:
  - "we we" → "we" in flashblocks sequence
  - "in in-memory" → "in memory" in multiple documentation locations

These changes improve code readability and consistency without affecting functionality.