### PR TITLE
fix: remove extra whitespace in let binding assignment

### DIFF
--- a/crates/storage/db-api/src/models/mod.rs
+++ b/crates/storage/db-api/src/models/mod.rs
@@ -256,7 +256,7 @@ macro_rules! impl_compression_fixed_compact {
                 }
 
                 fn compress_to_buf<B: bytes::BufMut + AsMut<[u8]>>(&self, buf: &mut B) {
-                    let _  = Compact::to_compact(self, buf);
+                    let _ = Compact::to_compact(self, buf);
                 }
             }
 


### PR DESCRIPTION
Removes extra whitespace in macro to ensure consistent formatting across the codebase and prevent linter warnings.