### PR TITLE
fix: DB benches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7609,6 +7609,7 @@ dependencies = [
  "reth-metrics",
  "reth-nippy-jar",
  "reth-primitives-traits",
+ "reth-prune-types",
  "reth-static-file-types",
  "reth-storage-errors",
  "reth-tracing",

--- a/crates/prune/types/Cargo.toml
+++ b/crates/prune/types/Cargo.toml
@@ -45,6 +45,7 @@ std = [
     "thiserror/std",
 ]
 test-utils = [
+    "std",
     "dep:arbitrary",
     "reth-codecs?/test-utils",
 ]

--- a/crates/storage/db/Cargo.toml
+++ b/crates/storage/db/Cargo.toml
@@ -46,6 +46,7 @@ strum = { workspace = true, features = ["derive"], optional = true }
 [dev-dependencies]
 # reth libs with arbitrary
 reth-primitives-traits = { workspace = true, features = ["reth-codec"] }
+reth-prune-types.workspace = true
 
 alloy-primitives = { workspace = true, features = ["getrandom"] }
 alloy-consensus.workspace = true
@@ -81,6 +82,7 @@ test-utils = [
     "reth-db-api/test-utils",
     "reth-nippy-jar/test-utils",
     "reth-primitives-traits/test-utils",
+    "reth-prune-types/test-utils",
 ]
 bench = ["reth-db-api/bench"]
 arbitrary = [
@@ -88,6 +90,7 @@ arbitrary = [
     "alloy-primitives/arbitrary",
     "alloy-consensus/arbitrary",
     "reth-primitives-traits/arbitrary",
+    "reth-prune-types/arbitrary",
 ]
 op = [
     "reth-db-api/op",


### PR DESCRIPTION
Otherwise, `cargo bench -p reth-db --features test-utils --bench get` will error out:

```
error[E0433]: failed to resolve: could not find `std` in the list of imported crates
 --> crates/prune/types/src/mode.rs:6:54
  |
6 | #[cfg_attr(any(test, feature = "test-utils"), derive(arbitrary::Arbitrary))]
  |                                                      ^^^^^^^^^^^^^^^^^^^^ could not find `std` in the list of imported crates
  |
  = note: this error originates in the derive macro `arbitrary::Arbitrary` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0433]: failed to resolve: could not find `std` in the list of imported crates
 --> crates/prune/types/src/checkpoint.rs:8:63
  |
8 | #[cfg_attr(any(test, feature = "test-utils"), derive(Default, arbitrary::Arbitrary))]
  |                                                               ^^^^^^^^^^^^^^^^^^^^ could not find `std` in the list of imported crates
  |
  = note: this error originates in the derive macro `arbitrary::Arbitrary` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find value `RECURSIVE_COUNT_PruneCheckpoint` in this scope
 --> crates/prune/types/src/checkpoint.rs:8:63
  |
8 | #[cfg_attr(any(test, feature = "test-utils"), derive(Default, arbitrary::Arbitrary))]
  |                                                               ^^^^^^^^^^^^^^^^^^^^ not found in this scope
  |
  = note: this error originates in the derive macro `arbitrary::Arbitrary` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find value `RECURSIVE_COUNT_PruneMode` in this scope
 --> crates/prune/types/src/mode.rs:6:54
  |
6 | #[cfg_attr(any(test, feature = "test-utils"), derive(arbitrary::Arbitrary))]
  |                                                      ^^^^^^^^^^^^^^^^^^^^ not found in this scope
  |
  = note: this error originates in the derive macro `arbitrary::Arbitrary` (in Nightly builds, run with -Z macro-backtrace for more info)
```