### PR TITLE
refactor: remove redundant double .into() conversion in eth core

### DIFF
--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -360,7 +360,7 @@ where
             signers,
             eth_cache,
             gas_oracle,
-            gas_cap: gas_cap.into().into(),
+            gas_cap: gas_cap.into(),
             max_simulate_blocks,
             eth_proof_window,
             starting_block,


### PR DESCRIPTION
Remove redundant double `.into().into()` conversion when initializing gas_cap field.

The function parameter is already `impl Into<GasCap>`, so only one `.into()` conversion is needed. The second `.into()` is redundant and adds unnecessary overhead.