### PR TITLE
chore(trie): dont warn on blinded node reveals

### DIFF
--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -21,7 +21,7 @@ use std::{
     cmp::{Ord, Ordering, PartialOrd},
     sync::mpsc,
 };
-use tracing::{instrument, trace, warn};
+use tracing::{debug, instrument, trace};
 
 /// The maximum length of a path, in nibbles, which belongs to the upper subtrie of a
 /// [`ParallelSparseTrie`]. All longer paths belong to a lower subtrie.
@@ -334,7 +334,7 @@ impl SparseTrieInterface for ParallelSparseTrie {
                     if let Some(reveal_path) = reveal_path {
                         let subtrie = self.subtrie_for_path_mut(&reveal_path);
                         if subtrie.nodes.get(&reveal_path).expect("node must exist").is_hash() {
-                            warn!(
+                            debug!(
                                 target: "trie::parallel_sparse",
                                 child_path = ?reveal_path,
                                 leaf_full_path = ?full_path,
@@ -615,7 +615,7 @@ impl SparseTrieInterface for ParallelSparseTrie {
                 let remaining_child_node =
                     match remaining_child_subtrie.nodes.get(&remaining_child_path).unwrap() {
                         SparseNode::Hash(_) => {
-                            warn!(
+                            debug!(
                                 target: "trie::parallel_sparse",
                                 child_path = ?remaining_child_path,
                                 leaf_full_path = ?full_path,
@@ -1542,7 +1542,7 @@ impl SparseSubtrie {
                 LeafUpdateStep::Complete { reveal_path, .. } => {
                     if let Some(reveal_path) = reveal_path {
                         if self.nodes.get(&reveal_path).expect("node must exist").is_hash() {
-                            warn!(
+                            debug!(
                                 target: "trie::parallel_sparse",
                                 child_path = ?reveal_path,
                                 leaf_full_path = ?full_path,

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -24,7 +24,7 @@ use reth_trie_common::{
     TrieNode, CHILD_INDEX_RANGE, EMPTY_ROOT_HASH,
 };
 use smallvec::SmallVec;
-use tracing::{trace, warn};
+use tracing::{debug, trace};
 
 /// The level below which the sparse trie hashes are calculated in
 /// [`SerialSparseTrie::update_subtrie_hashes`].
@@ -640,7 +640,7 @@ impl SparseTrieInterface for SerialSparseTrie {
                         if self.updates.is_some() {
                             // Check if the extension node child is a hash that needs to be revealed
                             if self.nodes.get(&current).unwrap().is_hash() {
-                                warn!(
+                                debug!(
                                     target: "trie::sparse",
                                     leaf_full_path = ?full_path,
                                     child_path = ?current,
@@ -815,7 +815,7 @@ impl SparseTrieInterface for SerialSparseTrie {
                         trace!(target: "trie::sparse", ?removed_path, ?child_path, "Branch node has only one child");
 
                         if self.nodes.get(&child_path).unwrap().is_hash() {
-                            warn!(
+                            debug!(
                                 target: "trie::sparse",
                                 ?child_path,
                                 leaf_full_path = ?full_path,


### PR DESCRIPTION
For now these are still expected, there seem to be some edge-cases that are still not handled. It's not worthwhile to scare uses with WARNs for these, as they do not indicate anything is actually wrong, the sparse tries will simply fallback to the behavior they already have in stable.