### PR TITLE
fix(stateless): verify_execution_witness doc for pre-state mismatch

### DIFF
--- a/crates/stateless/src/trie.rs
+++ b/crates/stateless/src/trie.rs
@@ -167,8 +167,8 @@ impl StatelessTrie for StatelessSparseTrie {
 /// The bytecode has a separate mapping because the [`SparseStateTrie`] does not store the
 /// contract bytecode, only the hash of it (code hash).
 ///
-/// If the roots do not match, it returns `None`, indicating the witness is invalid
-/// for the given `pre_state_root`.
+/// If the roots do not match, it returns an error indicating the witness is invalid
+/// for the given `pre_state_root` (see `StatelessValidationError::PreStateRootMismatch`).
 // Note: This approach might be inefficient for ZKVMs requiring minimal memory operations, which
 // would explain why they have for the most part re-implemented this function.
 fn verify_execution_witness(


### PR DESCRIPTION
The docstring incorrectly stated that a pre-state root mismatch returns None. The function actually returns an error (StatelessValidationError::PreStateRootMismatch). This change aligns the documentation with the real API behavior and prevents confusion for callers expecting Result-based error handling.