### PR TITLE
fix(bench): fix deadlock in test data generation

### DIFF
--- a/crates/stages/stages/benches/setup/mod.rs
+++ b/crates/stages/stages/benches/setup/mod.rs
@@ -161,8 +161,9 @@ pub(crate) fn txs_testdata(num_blocks: u64) -> TestStageDB {
 
         let offset = transitions.len() as u64;
 
-        let provider_rw = db.factory.provider_rw().unwrap();
         db.insert_changesets(transitions, None).unwrap();
+
+        let provider_rw = db.factory.provider_rw().unwrap();
         provider_rw.write_trie_updates(&updates).unwrap();
         provider_rw.commit().unwrap();
 


### PR DESCRIPTION
`insert_changesets` was trying to create another write transaction when there was already an active one.