### PR TITLE
chore: remove unused BlockHeader import in test_utils.rs

### DIFF
--- a/crates/exex/exex/src/backfill/test_utils.rs
+++ b/crates/exex/exex/src/backfill/test_utils.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use alloy_consensus::{constants::ETH_TO_WEI, BlockHeader, Header, TxEip2930};
+use alloy_consensus::{constants::ETH_TO_WEI, Header, TxEip2930};
 use alloy_genesis::{Genesis, GenesisAccount};
 use alloy_primitives::{b256, Address, TxKind, U256};
 use reth_chainspec::{ChainSpec, ChainSpecBuilder, EthereumHardfork, MAINNET, MIN_TRANSACTION_GAS};


### PR DESCRIPTION
removed an unnecessary alloy_consensus::BlockHeader import from crates/exex/exex/src/backfill/test_utils.rs. The file uses the concrete Header type directly and does not rely on the BlockHeader trait bounds or trait methods. Keeping the unused import could cause lint warnings and add confusion for readers. No functional changes.