### PR TITLE
docs(static-file): fix wrapper reference to StaticFileProducerInner

### DIFF
--- a/crates/static-file/static-file/src/static_file_producer.rs
+++ b/crates/static-file/static-file/src/static_file_producer.rs
@@ -1,4 +1,4 @@
-\//! Support for producing static files.
+//! Support for producing static files.
 
 use crate::{segments, segments::Segment, StaticFileProducerEvent};
 use alloy_primitives::BlockNumber;

--- a/crates/static-file/static-file/src/static_file_producer.rs
+++ b/crates/static-file/static-file/src/static_file_producer.rs
@@ -1,4 +1,4 @@
-//! Support for producing static files.
+\//! Support for producing static files.
 
 use crate::{segments, segments::Segment, StaticFileProducerEvent};
 use alloy_primitives::BlockNumber;
@@ -30,7 +30,7 @@ pub type StaticFileProducerResult = ProviderResult<StaticFileTargets>;
 pub type StaticFileProducerWithResult<Provider> =
     (StaticFileProducer<Provider>, StaticFileProducerResult);
 
-/// Static File producer. It's a wrapper around [`StaticFileProducer`] that allows to share it
+/// Static File producer. It's a wrapper around [`StaticFileProducerInner`] that allows to share it
 /// between threads.
 #[derive(Debug)]
 pub struct StaticFileProducer<Provider>(Arc<Mutex<StaticFileProducerInner<Provider>>>);


### PR DESCRIPTION
Replace incorrect doc reference to StaticFileProducer with StaticFileProducerInner.
This change is necessary to prevent confusion: StaticFileProducer<T> is an Arc<Mutex<StaticFileProducerInner<T>>> wrapper, so the documentation must correctly point to the inner type it wraps.