### PR TITLE
fix(ci): pin teku image to fix kurtosis-op build

### DIFF
--- a/.github/assets/kurtosis_op_network_params.yaml
+++ b/.github/assets/kurtosis_op_network_params.yaml
@@ -4,6 +4,7 @@ ethereum_package:
       el_extra_params:
         - "--rpc.eth-proof-window=100"
       cl_type: teku
+      cl_image: "consensys/teku:25.7"
   network_params:
     preset: minimal
     genesis_delay: 5


### PR DESCRIPTION
Closes #18306 

with the default teku image `consensys/teku:latest` we started getting:
`2025-09-09 10:24:40.216 FATAL - Teku failed to start
  java.util.concurrent.CompletionException: java.lang.IllegalArgumentException: Genesis block root 0x8d7ab9dd0b24f639527634d2d55c6d8416bc5f4195ef8fbb9b42d9cc5fda7a1e does not match genesis state latest block root 0x9a93f48c8b8c444cc74b5ce82ea6354d15f4e9a4c254c5478cfde6ac19edaba9`

successful execution from this branch https://github.com/paradigmxyz/reth/actions/runs/17579861069