### PR TITLE
chore: make `new` work with runtime maps

### DIFF
--- a/crates/stateless/src/witness_db.rs
+++ b/crates/stateless/src/witness_db.rs
@@ -55,7 +55,7 @@ where
     ///    to 256 including the current block number). It assumes these hashes correspond to a
     ///    contiguous chain of blocks. The caller is responsible for verifying the contiguity and
     ///    the block limit.
-    pub(crate) const fn new(
+    pub(crate) fn new(
         trie: &'a T,
         bytecode: B256Map<Bytecode>,
         ancestor_hashes: BTreeMap<u64, B256>,


### PR DESCRIPTION
removed `const` from `fn new` so it can take already-initialized `BTreeMap` and `B256Map`. now it works with runtime data without issues.