### PR TITLE
fix(trie): correct NodeNotFoundInProvider error to say “revealing”

### DIFF
--- a/crates/evm/execution-errors/src/trie.rs
+++ b/crates/evm/execution-errors/src/trie.rs
@@ -171,7 +171,7 @@ pub enum SparseTrieErrorKind {
     #[error(transparent)]
     Rlp(#[from] alloy_rlp::Error),
     /// Node not found in provider during revealing.
-    #[error("node {path:?} not found in provider during removal")]
+    #[error("node {path:?} not found in provider during revealing")]
     NodeNotFoundInProvider {
         /// Path to the missing node.
         path: Nibbles,


### PR DESCRIPTION
The error is raised when the provider fails to return a blinded node during the revealing step, not during removal.
Call sites in sparse and sparse-parallel trigger this when fetching nodes via provider to reveal children (including in remove flows before structural changes).
Aligns the error text with actual control flow and existing comments (“during revealing”)