### PR TITLE
fix(prune): TransactionLookup pruning issues with pre-merge expiry

### DIFF
--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -975,7 +975,7 @@ where
                         info!(target: "reth::cli", merge_block, "Expiring pre-merge transactions");
                         static_provider.delete_transactions_below(merge_block)?;
 
-                        // Clear the entire TransactionHashNumbers table since we can't determine
+                        // Clear the entire `TransactionHashNumbers` table since we can't determine
                         // which entries correspond to the deleted pre-merge transactions
                         info!(target: "reth::cli", "Clearing TransactionHashNumbers table after pre-merge expiry");
                         let provider_rw = self.provider_factory().provider_rw()?;

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -952,7 +952,7 @@ where
     ///
     /// If the node is configured to prune pre-merge transactions and it has synced past the merge
     /// block, it will delete the pre-merge transaction static files if they still exist.
-    /// It will also clear the TransactionHashNumbers table since we can't determine which
+    /// It will also clear the `TransactionHashNumbers` table since we can't determine which
     /// entries correspond to deleted transactions.
     pub fn expire_pre_merge_transactions(&self) -> eyre::Result<()>
     where

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -952,10 +952,14 @@ where
     ///
     /// If the node is configured to prune pre-merge transactions and it has synced past the merge
     /// block, it will delete the pre-merge transaction static files if they still exist.
+    /// It will also clear the TransactionHashNumbers table since we can't determine which
+    /// entries correspond to deleted transactions.
     pub fn expire_pre_merge_transactions(&self) -> eyre::Result<()>
     where
         T: FullNodeTypes<Provider: StaticFileProviderFactory>,
     {
+        use reth_db_api::{tables, transaction::DbTxMut};
+
         if self.node_config().pruning.bodies_pre_merge {
             if let Some(merge_block) =
                 self.chain_spec().ethereum_fork_activation(EthereumHardfork::Paris).block_number()
@@ -963,13 +967,20 @@ where
                 // Ensure we only expire transactions after we synced past the merge block.
                 let Some(latest) = self.blockchain_db().latest_header()? else { return Ok(()) };
                 if latest.number() > merge_block {
-                    let provider = self.blockchain_db().static_file_provider();
-                    if provider
+                    let static_provider = self.blockchain_db().static_file_provider();
+                    if static_provider
                         .get_lowest_transaction_static_file_block()
                         .is_some_and(|lowest| lowest < merge_block)
                     {
                         info!(target: "reth::cli", merge_block, "Expiring pre-merge transactions");
-                        provider.delete_transactions_below(merge_block)?;
+                        static_provider.delete_transactions_below(merge_block)?;
+
+                        // Clear the entire TransactionHashNumbers table since we can't determine
+                        // which entries correspond to the deleted pre-merge transactions
+                        info!(target: "reth::cli", "Clearing TransactionHashNumbers table after pre-merge expiry");
+                        let provider_rw = self.provider_factory().provider_rw()?;
+                        provider_rw.tx_ref().clear::<tables::TransactionHashNumbers>()?;
+                        provider_rw.commit()?;
                     } else {
                         debug!(target: "reth::cli", merge_block, "No pre-merge transactions to expire");
                     }

--- a/crates/prune/prune/src/builder.rs
+++ b/crates/prune/prune/src/builder.rs
@@ -7,7 +7,8 @@ use reth_exex_types::FinishedExExHeight;
 use reth_primitives_traits::NodePrimitives;
 use reth_provider::{
     providers::StaticFileProvider, BlockReader, DBProvider, DatabaseProviderFactory,
-    NodePrimitivesProvider, PruneCheckpointWriter, StaticFileProviderFactory,
+    NodePrimitivesProvider, PruneCheckpointReader, PruneCheckpointWriter,
+    StaticFileProviderFactory,
 };
 use reth_prune_types::PruneModes;
 use std::time::Duration;
@@ -80,6 +81,7 @@ impl PrunerBuilder {
     where
         PF: DatabaseProviderFactory<
                 ProviderRW: PruneCheckpointWriter
+                                + PruneCheckpointReader
                                 + BlockReader<Transaction: Encodable2718>
                                 + StaticFileProviderFactory<
                     Primitives: NodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>,
@@ -111,7 +113,8 @@ impl PrunerBuilder {
                 Primitives: NodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>,
             > + DBProvider<Tx: DbTxMut>
             + BlockReader<Transaction: Encodable2718>
-            + PruneCheckpointWriter,
+            + PruneCheckpointWriter
+            + PruneCheckpointReader,
     {
         let segments = SegmentSet::<Provider>::from_components(static_file_provider, self.segments);
 

--- a/crates/prune/prune/src/segments/set.rs
+++ b/crates/prune/prune/src/segments/set.rs
@@ -6,8 +6,8 @@ use alloy_eips::eip2718::Encodable2718;
 use reth_db_api::{table::Value, transaction::DbTxMut};
 use reth_primitives_traits::NodePrimitives;
 use reth_provider::{
-    providers::StaticFileProvider, BlockReader, DBProvider, PruneCheckpointWriter,
-    StaticFileProviderFactory,
+    providers::StaticFileProvider, BlockReader, DBProvider, PruneCheckpointReader,
+    PruneCheckpointWriter, StaticFileProviderFactory,
 };
 use reth_prune_types::PruneModes;
 
@@ -51,6 +51,7 @@ where
             Primitives: NodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>,
         > + DBProvider<Tx: DbTxMut>
         + PruneCheckpointWriter
+        + PruneCheckpointReader
         + BlockReader<Transaction: Encodable2718>,
 {
     /// Creates a [`SegmentSet`] from an existing components, such as [`StaticFileProvider`] and

--- a/crates/prune/prune/src/segments/user/transaction_lookup.rs
+++ b/crates/prune/prune/src/segments/user/transaction_lookup.rs
@@ -6,9 +6,9 @@ use crate::{
 use alloy_eips::eip2718::Encodable2718;
 use rayon::prelude::*;
 use reth_db_api::{tables, transaction::DbTxMut};
-use reth_provider::{BlockReader, DBProvider};
+use reth_provider::{BlockReader, DBProvider, PruneCheckpointReader};
 use reth_prune_types::{PruneMode, PrunePurpose, PruneSegment, SegmentOutputCheckpoint};
-use tracing::{instrument, trace};
+use tracing::{debug, instrument, trace};
 
 #[derive(Debug)]
 pub struct TransactionLookup {
@@ -23,7 +23,8 @@ impl TransactionLookup {
 
 impl<Provider> Segment<Provider> for TransactionLookup
 where
-    Provider: DBProvider<Tx: DbTxMut> + BlockReader<Transaction: Encodable2718>,
+    Provider:
+        DBProvider<Tx: DbTxMut> + BlockReader<Transaction: Encodable2718> + PruneCheckpointReader,
 {
     fn segment(&self) -> PruneSegment {
         PruneSegment::TransactionLookup
@@ -38,7 +39,24 @@ where
     }
 
     #[instrument(level = "trace", target = "pruner", skip(self, provider), ret)]
-    fn prune(&self, provider: &Provider, input: PruneInput) -> Result<SegmentOutput, PrunerError> {
+    fn prune(
+        &self,
+        provider: &Provider,
+        mut input: PruneInput,
+    ) -> Result<SegmentOutput, PrunerError> {
+        // If TransactionLookup pruning is enabled on a node which had history pruning already
+        // enabled, then we can't start TransactionLookup pruning from 0 because there is no tx data
+        // from then. Instead we fallback to the Transactions prune checkpoint.
+        if input.previous_checkpoint.is_none() {
+            input.previous_checkpoint =
+                provider.get_prune_checkpoint(PruneSegment::Transactions)?;
+            debug!(
+                target: "pruner",
+                transactions_checkpoint = ?input.previous_checkpoint,
+                "No TransactionLookup checkpoint found, using Transactions checkpoint as fallback"
+            );
+        }
+
         let (start, end) = match input.get_next_tx_num_range(provider)? {
             Some(range) => range,
             None => {


### PR DESCRIPTION
This fixes an issue with pre-merge expiry and TransactionLookup pruning.

When pre-merge history has already been expired, and
   `--prune.transactionlookup.distance` is enabled for the first time,
   it is not possible for the pruner to prune the lookups because it is
   missing all pre-merge txs, and so cannot index into the
   TransactionHashNumbers table by hash to delete them.

   The fix is to fallback to the Transaction prune checkpoint when the
   TransactionLookup checkpoint is not present or lagging behind. This way if txs have
   been previously pruned the TransactionLookup pruning will start
   there.