### PR TITLE
fix: remove unnecessary unsafe block in main.rs

### DIFF
--- a/bin/reth/src/main.rs
+++ b/bin/reth/src/main.rs
@@ -15,7 +15,7 @@ fn main() {
 
     // Enable backtraces unless a RUST_BACKTRACE value has already been explicitly provided.
     if std::env::var_os("RUST_BACKTRACE").is_none() {
-        unsafe { std::env::set_var("RUST_BACKTRACE", "1") };
+        std::env::set_var("RUST_BACKTRACE", "1");
     }
 
     if let Err(err) =


### PR DESCRIPTION


Remove redundant `unsafe` wrapper around `std::env::set_var()` call in the main binary entry point.

**Problem:**
- `std::env::set_var()` is a safe function and doesn't require `unsafe`
- Unnecessary `unsafe` blocks create confusion and increase audit complexity
- Risk of incorrect unsafe usage being copied to this location in the future

**Solution:**
- Remove the `unsafe` block while keeping the same functionality
- Maintains identical behavior with cleaner, safer code

