### PR TITLE
fix: fix search in vocs doc

### DIFF
--- a/docs/vocs/vocs.config.ts
+++ b/docs/vocs/vocs.config.ts
@@ -10,6 +10,9 @@ export default defineConfig({
   ogImageUrl: '/reth-prod.png',
   sidebar,
   basePath,
+  search: {
+    fuzzy: true
+  },
   topNav: [
     { text: 'Run', link: '/run/ethereum' },
     { text: 'SDK', link: '/sdk' },


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/18353.

Fuzzy to enable fuzzy matching when doing the `search`.
How to check: 
```
bun run build
bun run preview
```
eg. try docer instead of docker.