### PR TITLE
fix: add is_osaka check before erroring in default_ethereum_payload

### DIFF
--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -271,7 +271,7 @@ where
                     break 'sidecar Err(Eip4844PoolTransactionError::MissingEip4844BlobSidecar)
                 };
 
-                if chain_spec.is_osaka_active_at_timestamp(attributes.timestamp) {
+                if is_osaka {
                     if sidecar.is_eip7594() {
                         Ok(sidecar)
                     } else {
@@ -359,7 +359,7 @@ where
     let sealed_block = Arc::new(block.sealed_block().clone());
     debug!(target: "payload_builder", id=%attributes.id, sealed_block_header = ?sealed_block.sealed_header(), "sealed built block");
 
-    if sealed_block.rlp_length() > MAX_RLP_BLOCK_SIZE {
+    if is_osaka && sealed_block.rlp_length() > MAX_RLP_BLOCK_SIZE {
         return Err(PayloadBuilderError::other(ConsensusError::BlockTooLarge {
             rlp_length: sealed_block.rlp_length(),
             max_rlp_length: MAX_RLP_BLOCK_SIZE,


### PR DESCRIPTION
Currently we don't check for `is_osaka` before erroring in `default_ethereum_payload`. 

This could result in a scenario where valid full blocks are discarded by the proposer before osaka

The below check exists but only helps prevent erroring after osaka
```rust
        if is_osaka && estimated_block_size_with_tx > MAX_RLP_BLOCK_SIZE {
            best_txs.mark_invalid(
                &pool_tx,
                InvalidPoolTransactionError::OversizedData(
                    estimated_block_size_with_tx,
                    MAX_RLP_BLOCK_SIZE,
                ),
            );
            continue;
        }
```
