### PR TITLE
feat(engine): check header validity after invalid transaction

### DIFF
--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -270,6 +270,41 @@ where
         }
     }
 
+    /// Handles execution errors by checking if header validation errors should take precedence.
+    ///
+    /// When an execution error occurs, this function checks if there are any header validation
+    /// errors that should be reported instead, as header validation errors have higher priority.
+    fn handle_execution_error<T: PayloadTypes<BuiltPayload: BuiltPayload<Primitives = N>>>(
+        &self,
+        input: BlockOrPayload<T>,
+        execution_err: InsertBlockErrorKind,
+        parent_block: &SealedHeader<N::BlockHeader>,
+    ) -> Result<ExecutedBlockWithTrieUpdates<N>, InsertPayloadError<N::Block>>
+    where
+        V: PayloadValidator<T, Block = N::Block>,
+    {
+        // If execution failed, we should first check if there are any header validation
+        // errors that take precedence over the execution error
+        let block = self.convert_to_block(input)?;
+
+        // Validate block consensus rules which includes header validation
+        if let Err(consensus_err) = self.validate_block_inner(&block) {
+            // Header validation error takes precedence over execution error
+            return Err(InsertBlockError::new(block.into_sealed_block(), consensus_err.into()).into())
+        }
+
+        // Also validate against the parent
+        if let Err(consensus_err) =
+            self.consensus.validate_header_against_parent(block.sealed_header(), parent_block)
+        {
+            // Parent validation error takes precedence over execution error
+            return Err(InsertBlockError::new(block.into_sealed_block(), consensus_err.into()).into())
+        }
+
+        // No header validation errors, return the original execution error
+        Err(InsertBlockError::new(block.into_sealed_block(), execution_err).into())
+    }
+
     /// Validates a block that has already been converted from a payload.
     ///
     /// This method performs:
@@ -422,53 +457,17 @@ where
         );
 
         // Execute the block and handle any execution errors
-        let output = {
-            let execution_result = if self.config.state_provider_metrics() {
-                let state_provider =
-                    InstrumentedStateProvider::from_state_provider(&state_provider);
-                let result = self.execute_block(&state_provider, env, &input, &mut handle);
-                state_provider.record_total_latency();
-                result
-            } else {
-                self.execute_block(&state_provider, env, &input, &mut handle)
-            };
+        let execution_result = if self.config.state_provider_metrics() {
+            let state_provider = InstrumentedStateProvider::from_state_provider(&state_provider);
+            let result = self.execute_block(&state_provider, env, &input, &mut handle);
+            state_provider.record_total_latency();
+            result
+        } else {
+            self.execute_block(&state_provider, env, &input, &mut handle)
+        };
 
-            match execution_result {
-                Ok(result) => result,
-                Err(execution_err) => {
-                    // If execution failed, we should first check if there are any header validation
-                    // errors that take precedence over the execution error
-                    let block = self.convert_to_block(input)?;
-
-                    // Validate block consensus rules which includes header validation
-                    if let Err(consensus_err) = self.validate_block_inner(&block) {
-                        // Header validation error takes precedence over execution error
-                        return Err(InsertBlockError::new(
-                            block.into_sealed_block(),
-                            consensus_err.into(),
-                        )
-                        .into())
-                    }
-
-                    // Also validate against the parent
-                    if let Err(consensus_err) = self
-                        .consensus
-                        .validate_header_against_parent(block.sealed_header(), &parent_block)
-                    {
-                        // Parent validation error takes precedence over execution error
-                        return Err(InsertBlockError::new(
-                            block.into_sealed_block(),
-                            consensus_err.into(),
-                        )
-                        .into())
-                    }
-
-                    // No header validation errors, return the original execution error
-                    return Err(
-                        InsertBlockError::new(block.into_sealed_block(), execution_err).into()
-                    )
-                }
-            }
+        let Ok(output) = execution_result else {
+            return self.handle_execution_error(input, execution_result.unwrap_err(), &parent_block)
         };
 
         // after executing the block we can stop executing transactions

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -283,6 +283,13 @@ where
     where
         V: PayloadValidator<T, Block = N::Block>,
     {
+        debug!(
+            target: "engine::tree",
+            ?execution_err,
+            block = ?input.num_hash(),
+            "Block execution failed, checking for header validation errors"
+        );
+
         // If execution failed, we should first check if there are any header validation
         // errors that take precedence over the execution error
         let block = self.convert_to_block(input)?;

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -457,17 +457,16 @@ where
         );
 
         // Execute the block and handle any execution errors
-        let execution_result = if self.config.state_provider_metrics() {
+        let output = match if self.config.state_provider_metrics() {
             let state_provider = InstrumentedStateProvider::from_state_provider(&state_provider);
             let result = self.execute_block(&state_provider, env, &input, &mut handle);
             state_provider.record_total_latency();
             result
         } else {
             self.execute_block(&state_provider, env, &input, &mut handle)
-        };
-
-        let Ok(output) = execution_result else {
-            return self.handle_execution_error(input, execution_result.unwrap_err(), &parent_block)
+        } {
+            Ok(output) => output,
+            Err(err) => return self.handle_execution_error(input, err, &parent_block),
         };
 
         // after executing the block we can stop executing transactions

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -421,13 +421,54 @@ where
             handle.cache_metrics(),
         );
 
-        let output = if self.config.state_provider_metrics() {
-            let state_provider = InstrumentedStateProvider::from_state_provider(&state_provider);
-            let output = ensure_ok!(self.execute_block(&state_provider, env, &input, &mut handle));
-            state_provider.record_total_latency();
-            output
-        } else {
-            ensure_ok!(self.execute_block(&state_provider, env, &input, &mut handle))
+        // Execute the block and handle any execution errors
+        let output = {
+            let execution_result = if self.config.state_provider_metrics() {
+                let state_provider =
+                    InstrumentedStateProvider::from_state_provider(&state_provider);
+                let result = self.execute_block(&state_provider, env, &input, &mut handle);
+                state_provider.record_total_latency();
+                result
+            } else {
+                self.execute_block(&state_provider, env, &input, &mut handle)
+            };
+
+            match execution_result {
+                Ok(result) => result,
+                Err(execution_err) => {
+                    // If execution failed, we should first check if there are any header validation
+                    // errors that take precedence over the execution error
+                    let block = self.convert_to_block(input)?;
+
+                    // Validate block consensus rules which includes header validation
+                    if let Err(consensus_err) = self.validate_block_inner(&block) {
+                        // Header validation error takes precedence over execution error
+                        return Err(InsertBlockError::new(
+                            block.into_sealed_block(),
+                            consensus_err.into(),
+                        )
+                        .into())
+                    }
+
+                    // Also validate against the parent
+                    if let Err(consensus_err) = self
+                        .consensus
+                        .validate_header_against_parent(block.sealed_header(), &parent_block)
+                    {
+                        // Parent validation error takes precedence over execution error
+                        return Err(InsertBlockError::new(
+                            block.into_sealed_block(),
+                            consensus_err.into(),
+                        )
+                        .into())
+                    }
+
+                    // No header validation errors, return the original execution error
+                    return Err(
+                        InsertBlockError::new(block.into_sealed_block(), execution_err).into()
+                    )
+                }
+            }
         };
 
         // after executing the block we can stop executing transactions


### PR DESCRIPTION
After recent changes towards improving performance, transactions are executed early in the block processing flow. if we get an error in transaction execution we return it right away. this was causing some eest tests to fail like:

`2025-08-21T19:56:43.2662135Z E   pytest_plugins.consume.simulators.simulator_logic.test_via_engine.LoggedError: Client returned unexpected validation error: got:
  "[TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS] EVM reported invalid transaction (0x3de929cecd7e4b3ea27f672acb8ba0d9f51316c1d35c802c44a0c333cea0c400): blob gas price is 
  greater than max fee per blob gas" expected: "BlockException.INCORRECT_EXCESS_BLOB_GAS"`

With both an invalid header and an invalid transaction, the test expects to receive the exception about the failure validating the header, and we are returning the tx execution failure instead.

With the changes in this PR, when a transaction fails, we run several validations that are now postponed, returning an eventual error on them instead of the tx error. This makes the test pass without affecting performance in the happy path