### PR TITLE
feat(storage): bump MDBX map size to 8TB

### DIFF
--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -116,7 +116,7 @@ impl DatabaseArguments {
         Self {
             client_version,
             geometry: Geometry {
-                size: Some(0..(4 * TERABYTE)),
+                size: Some(0..(8 * TERABYTE)),
                 growth_step: Some(4 * GIGABYTE as isize),
                 shrink_threshold: Some(0),
                 page_size: Some(PageSize::Set(default_page_size())),


### PR DESCRIPTION
Base is at 3.5TB, slowly approaching 4TB. BSC is already setting this to 8TB manually.

Let's bump to 8TB by default, there's no harm in it, as this size isn't pre-allocated.