### PR TITLE
fix(docs): include .vocs to retain search-index

### DIFF
--- a/docs/vocs/docs/public/_config.yml
+++ b/docs/vocs/docs/public/_config.yml
@@ -1,0 +1,3 @@
+# Include the .vocs directory which contains the search index
+include:
+  - .vocs


### PR DESCRIPTION
Closes #18353

Ref: https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll#configuring-jekyll-in-your-github-pages-site

Jekyll ignores directories starting with "." which in our case is `.vocs` containing the `search-index` due to which the search doesn't work