### PR TITLE
fix(reth-bench): requests param of newPayloadV4

### DIFF
--- a/bin/reth-bench/src/valid_payload.rs
+++ b/bin/reth-bench/src/valid_payload.rs
@@ -174,7 +174,11 @@ pub(crate) fn block_to_new_payload(
                             payload,
                             cancun.versioned_hashes.clone(),
                             cancun.parent_beacon_block_root,
-                            prague.requests.requests_hash(),
+                            if let alloy_eips::eip7685::RequestsOrHash::Requests(requests) = &prague.requests {
+                                requests.iter().collect::<Vec<_>>()
+                            } else {
+                                Vec::new()
+                            },
                         ))?,
                     )
                 }


### PR DESCRIPTION
I faced this error while trying out reth-bench:

```
  thread 'main' panicked at bin/reth-bench/src/main.rs:39:10:
  called `Result::unwrap()` on an `Err` value: server returned an error response: error code -32602: invalid argument 3: json: cannot unmarshal string into Go value of type
  []hexutil.Bytes
```

It looks like the requestsHash is being passed to newPayloadV4 instead of the full list.