### PR TITLE
refactor: keep only task_executor.clone()

### DIFF
--- a/bin/reth/src/ress.rs
+++ b/bin/reth/src/ress.rs
@@ -29,7 +29,6 @@ where
     info!(target: "reth::cli", "Installing ress subprotocol");
     let pending_state = PendingState::default();
 
-    // Spawn maintenance task for pending state.
     task_executor.spawn(maintain_pending_state(
         engine_events,
         provider.clone(),
@@ -40,7 +39,7 @@ where
     let provider = RethRessProtocolProvider::new(
         provider,
         evm_config,
-        Box::new(task_executor.clone()),
+        task_executor.clone(),
         args.max_witness_window,
         args.witness_max_parallel,
         args.witness_cache_size,


### PR DESCRIPTION
dropped `Box::new(task_executor.clone())` - `RethRessProtocolProvider::new` handles it fine.


code works the same, just a bit cleaner and leaner.
