### PR TITLE
fix(engine): avoid block fetching inconsistencies for checks during reorgs

### DIFF
--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -794,7 +794,7 @@ where
         block: &RecoveredBlock<N::Block>,
     ) -> ProviderResult<bool> {
         let provider = self.provider.database_provider_ro()?;
-        let last_persisted_block = provider.last_block_number()?;
+        let last_persisted_block = provider.best_block_number()?;
         let last_persisted_hash = provider
             .block_hash(last_persisted_block)?
             .ok_or(ProviderError::HeaderNotFound(last_persisted_block.into()))?;


### PR DESCRIPTION
We were getting errors like `no header found for Number(3)` in some reorg-related hive tests.
`last_block_number` used in `block_connects_to_last_persisted` checks both db and static files, during a reorg the data returned by each can be not consistent given that the changes done to them are not atomic. 

`best_block_number` only checks db and avoids the discrepancy