### PR TITLE
feat(op-reth): specialize get_transaction_receipt to check pending flashblocks

### DIFF
--- a/crates/optimism/rpc/src/eth/mod.rs
+++ b/crates/optimism/rpc/src/eth/mod.rs
@@ -118,7 +118,8 @@ impl<N: RpcNodeCore, Rpc: RpcConvert> OpEthApi<N, Rpc> {
     /// If flashblocks receiver is not set, then it always returns `None`.
     pub fn pending_flashblock(&self) -> eyre::Result<Option<BlockAndReceipts<N::Primitives>>>
     where
-        Self: LoadPendingBlock,
+        OpEthApiError: FromEvmError<N::Evm>,
+        Rpc: RpcConvert<Primitives = N::Primitives>,
     {
         let pending = self.pending_block_env_and_cfg()?;
         let parent = match pending.origin {

--- a/crates/optimism/rpc/src/eth/transaction.rs
+++ b/crates/optimism/rpc/src/eth/transaction.rs
@@ -101,7 +101,7 @@ where
                             .find(|(_, (_, tx))| *tx.tx_hash() == hash)
                         {
                             let (signer, tx) = tx_with_sender;
-                            
+
                             // Get the corresponding receipt
                             if let Some(receipt) = receipts.get(index) {
                                 // Create TransactionMeta for the pending transaction


### PR DESCRIPTION
Reolves #18371 

This PR specializes the `get_transaction_receipt` endpoint for OP-Reth to also lookup transactions in the pending flashblock when they are not found in historical data. With flashblocks, the pending block should be considered as "confirmed/mined" for transaction receipt purposes.