### PR TITLE
refactor!: more type-safety in cli

### DIFF
--- a/crates/cli/commands/src/common.rs
+++ b/crates/cli/commands/src/common.rs
@@ -5,7 +5,7 @@ use clap::Parser;
 use reth_chainspec::EthChainSpec;
 use reth_cli::chainspec::ChainSpecParser;
 use reth_config::{config::EtlConfig, Config};
-use reth_consensus::{noop::NoopConsensus, ConsensusError, FullConsensus};
+use reth_consensus::noop::NoopConsensus;
 use reth_db::{init_db, open_db_read_only, DatabaseEnv};
 use reth_db_common::init::init_genesis;
 use reth_downloaders::{bodies::noop::NoopBodiesDownloader, headers::noop::NoopHeaderDownloader};
@@ -229,7 +229,7 @@ impl CliHeader for alloy_consensus::Header {
 
 /// Helper trait with a common set of requirements for the
 /// [`NodeTypes`] in CLI.
-pub trait CliNodeTypes: NodeTypesForProvider {
+pub trait CliNodeTypes: Node<FullTypesAdapter<Self>> + NodeTypesForProvider {
     type Evm: ConfigureEvm<Primitives = Self::Primitives>;
     type NetworkPrimitives: NetPrimitivesFor<Self::Primitives>;
 }
@@ -242,32 +242,29 @@ where
     type NetworkPrimitives = <<<N::ComponentsBuilder as NodeComponentsBuilder<FullTypesAdapter<Self>>>::Components as NodeComponents<FullTypesAdapter<Self>>>::Network as NetworkEventListenerProvider>::Primitives;
 }
 
+type EvmFor<N> = <<<N as Node<FullTypesAdapter<N>>>::ComponentsBuilder as NodeComponentsBuilder<
+    FullTypesAdapter<N>,
+>>::Components as NodeComponents<FullTypesAdapter<N>>>::Evm;
+
+type ConsensusFor<N> =
+    <<<N as Node<FullTypesAdapter<N>>>::ComponentsBuilder as NodeComponentsBuilder<
+        FullTypesAdapter<N>,
+    >>::Components as NodeComponents<FullTypesAdapter<N>>>::Consensus;
+
 /// Helper trait aggregating components required for the CLI.
 pub trait CliNodeComponents<N: CliNodeTypes>: Send + Sync + 'static {
-    /// Evm to use.
-    type Evm: ConfigureEvm<Primitives = N::Primitives> + 'static;
-    /// Consensus implementation.
-    type Consensus: FullConsensus<N::Primitives, Error = ConsensusError> + Clone + 'static;
-
     /// Returns the configured EVM.
-    fn evm_config(&self) -> &Self::Evm;
+    fn evm_config(&self) -> &EvmFor<N>;
     /// Returns the consensus implementation.
-    fn consensus(&self) -> &Self::Consensus;
+    fn consensus(&self) -> &ConsensusFor<N>;
 }
 
-impl<N: CliNodeTypes, E, C> CliNodeComponents<N> for (E, C)
-where
-    E: ConfigureEvm<Primitives = N::Primitives> + 'static,
-    C: FullConsensus<N::Primitives, Error = ConsensusError> + Clone + 'static,
-{
-    type Evm = E;
-    type Consensus = C;
-
-    fn evm_config(&self) -> &Self::Evm {
+impl<N: CliNodeTypes> CliNodeComponents<N> for (EvmFor<N>, ConsensusFor<N>) {
+    fn evm_config(&self) -> &EvmFor<N> {
         &self.0
     }
 
-    fn consensus(&self) -> &Self::Consensus {
+    fn consensus(&self) -> &ConsensusFor<N> {
         &self.1
     }
 }

--- a/crates/ethereum/cli/src/interface.rs
+++ b/crates/ethereum/cli/src/interface.rs
@@ -161,7 +161,7 @@ impl<C: ChainSpecParser, Ext: clap::Args + fmt::Debug, Rpc: RpcModuleValidator> 
         C: ChainSpecParser<ChainSpec = ChainSpec>,
     {
         let components = |spec: Arc<C::ChainSpec>| {
-            (EthEvmConfig::ethereum(spec.clone()), EthBeaconConsensus::new(spec))
+            (EthEvmConfig::ethereum(spec.clone()), Arc::new(EthBeaconConsensus::new(spec)))
         };
 
         self.with_runner_and_components::<EthereumNode>(

--- a/crates/optimism/cli/src/app.rs
+++ b/crates/optimism/cli/src/app.rs
@@ -68,7 +68,7 @@ where
         let _ = install_prometheus_recorder();
 
         let components = |spec: Arc<OpChainSpec>| {
-            (OpExecutorProvider::optimism(spec.clone()), OpBeaconConsensus::new(spec))
+            (OpExecutorProvider::optimism(spec.clone()), Arc::new(OpBeaconConsensus::new(spec)))
         };
 
         match self.cli.command {


### PR DESCRIPTION
Changes `CliNodeComponents` to require the same types as node's configured components to be provided