### PR TITLE
chore: use decode exact fo raw recovery

### DIFF
--- a/crates/rpc/rpc-eth-types/src/utils.rs
+++ b/crates/rpc/rpc-eth-types/src/utils.rs
@@ -16,7 +16,7 @@ pub fn recover_raw_transaction<T: SignedTransaction>(mut data: &[u8]) -> EthResu
     }
 
     let transaction =
-        T::decode_2718(&mut data).map_err(|_| EthApiError::FailedToDecodeSignedTransaction)?;
+        T::decode_2718_exact(&mut data).map_err(|_| EthApiError::FailedToDecodeSignedTransaction)?;
 
     SignedTransaction::try_into_recovered(transaction)
         .or(Err(EthApiError::InvalidTransactionSignature))


### PR DESCRIPTION
this currently allows trailing bytes

because we might use this to broadcast+forward we should enforce exact here