### PR TITLE
fix: still use real chain id for no-op network

### DIFF
--- a/crates/net/network-api/src/noop.rs
+++ b/crates/net/network-api/src/noop.rs
@@ -31,6 +31,7 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct NoopNetwork<Net = EthNetworkPrimitives> {
+    chain_id: u64,
     peers_handle: PeersHandle,
     _marker: PhantomData<Net>,
 }
@@ -40,15 +41,23 @@ impl<Net> NoopNetwork<Net> {
     pub fn new() -> Self {
         let (tx, _) = mpsc::unbounded_channel();
 
-        Self { peers_handle: PeersHandle::new(tx), _marker: PhantomData }
+        Self {
+            chain_id: 1, // mainnet
+            peers_handle: PeersHandle::new(tx),
+            _marker: PhantomData,
+        }
+    }
+
+    /// Creates a new [`NoopNetwork`] from an existing one but with a new chain id.
+    pub const fn with_chain_id(mut self, chain_id: u64) -> Self {
+        self.chain_id = chain_id;
+        self
     }
 }
 
 impl Default for NoopNetwork<EthNetworkPrimitives> {
     fn default() -> Self {
-        let (tx, _) = mpsc::unbounded_channel();
-
-        Self { peers_handle: PeersHandle::new(tx), _marker: PhantomData }
+        Self::new()
     }
 }
 
@@ -77,8 +86,7 @@ where
     }
 
     fn chain_id(&self) -> u64 {
-        // mainnet
-        1
+        self.chain_id
     }
 
     fn is_syncing(&self) -> bool {

--- a/crates/node/builder/src/components/builder.rs
+++ b/crates/node/builder/src/components/builder.rs
@@ -7,6 +7,7 @@ use crate::{
     },
     BuilderContext, ConfigureEvm, FullNodeTypes,
 };
+use reth_chainspec::EthChainSpec;
 use reth_consensus::{noop::NoopConsensus, ConsensusError, FullConsensus};
 use reth_network::{types::NetPrimitivesFor, EthNetworkPrimitives, NetworkPrimitives};
 use reth_network_api::{noop::NoopNetwork, FullNetwork};
@@ -515,10 +516,10 @@ where
 
     async fn build_network(
         self,
-        _ctx: &BuilderContext<N>,
+        ctx: &BuilderContext<N>,
         _pool: Pool,
     ) -> eyre::Result<Self::Network> {
-        Ok(NoopNetwork::new())
+        Ok(NoopNetwork::new().with_chain_id(ctx.chain_spec().chain_id()))
     }
 }
 


### PR DESCRIPTION
As RPC still reads the chain id via the `Network` component:

https://github.com/paradigmxyz/reth/blob/60568cca8fd2496a490aba407ae0f897d06a0914/crates/rpc/rpc-eth-api/src/helpers/spec.rs#L46-L49