### PR TITLE
feat(op-reth): implement flashblock caching with block selection logic

### DIFF
--- a/crates/optimism/flashblocks/src/lib.rs
+++ b/crates/optimism/flashblocks/src/lib.rs
@@ -22,5 +22,5 @@ pub type PendingBlockRx<N> = tokio::sync::watch::Receiver<Option<PendingBlock<N>
 /// Receiver of the sequences of [`FlashBlock`]s built.
 ///
 /// [`FlashBlock`]: crate::FlashBlock
-pub type FlashBlockCompleteSequenceRx =
-    tokio::sync::broadcast::Receiver<FlashBlockCompleteSequence>;
+pub type FlashBlockCompleteSequenceRx<T = ()> =
+    tokio::sync::broadcast::Receiver<FlashBlockCompleteSequence<T>>;

--- a/crates/optimism/flashblocks/src/service.rs
+++ b/crates/optimism/flashblocks/src/service.rs
@@ -107,7 +107,9 @@ where
     fn build_args(
         &mut self,
     ) -> Option<BuildArgs<impl IntoIterator<Item = WithEncoded<Recovered<N::SignedTx>>>>> {
-        let Some(base) = self.blocks.payload_base() else {
+        let target_block_number = self.builder.provider().latest_header().ok().flatten()?.number() + 1;
+        
+        let Some(base) = self.blocks.payload_base_for_block(target_block_number) else {
             trace!(
                 flashblock_number = ?self.blocks.block_number(),
                 count = %self.blocks.count(),
@@ -127,7 +129,7 @@ where
 
         Some(BuildArgs {
             base,
-            transactions: self.blocks.ready_transactions().collect::<Vec<_>>(),
+            transactions: self.blocks.ready_transactions_for_block(target_block_number)?.collect::<Vec<_>>(),
             cached_state: self.cached_state.take(),
         })
     }

--- a/crates/optimism/rpc/src/eth/mod.rs
+++ b/crates/optimism/rpc/src/eth/mod.rs
@@ -78,7 +78,7 @@ impl<N: RpcNodeCore, Rpc: RpcConvert> OpEthApi<N, Rpc> {
         sequencer_client: Option<SequencerClient>,
         min_suggested_priority_fee: U256,
         pending_block_rx: Option<PendingBlockRx<N::Primitives>>,
-        flashblock_rx: Option<FlashBlockCompleteSequenceRx>,
+        flashblock_rx: Option<FlashBlockCompleteSequenceRx<<N::Primitives as reth_primitives_traits::NodePrimitives>::SignedTx>>,
     ) -> Self {
         let inner = Arc::new(OpEthApiInner {
             eth_api,
@@ -105,7 +105,7 @@ impl<N: RpcNodeCore, Rpc: RpcConvert> OpEthApi<N, Rpc> {
     }
 
     /// Returns a flashblock receiver, if any, by resubscribing to it.
-    pub fn flashblock_rx(&self) -> Option<FlashBlockCompleteSequenceRx> {
+    pub fn flashblock_rx(&self) -> Option<FlashBlockCompleteSequenceRx<<N::Primitives as reth_primitives_traits::NodePrimitives>::SignedTx>> {
         self.inner.flashblock_rx.as_ref().map(|rx| rx.resubscribe())
     }
 
@@ -319,7 +319,10 @@ impl<N: RpcNodeCore, Rpc: RpcConvert> fmt::Debug for OpEthApi<N, Rpc> {
 }
 
 /// Container type `OpEthApi`
-pub struct OpEthApiInner<N: RpcNodeCore, Rpc: RpcConvert> {
+pub struct OpEthApiInner<N: RpcNodeCore, Rpc: RpcConvert>
+where
+    N::Primitives: reth_primitives_traits::NodePrimitives,
+{
     /// Gateway to node's core components.
     eth_api: EthApiNodeBackend<N, Rpc>,
     /// Sequencer client, configured to forward submitted transactions to sequencer of given OP
@@ -336,7 +339,7 @@ pub struct OpEthApiInner<N: RpcNodeCore, Rpc: RpcConvert> {
     /// Flashblocks receiver.
     ///
     /// If set, then it provides sequences of flashblock built.
-    flashblock_rx: Option<FlashBlockCompleteSequenceRx>,
+    flashblock_rx: Option<FlashBlockCompleteSequenceRx<<N::Primitives as reth_primitives_traits::NodePrimitives>::SignedTx>>,
 }
 
 impl<N: RpcNodeCore, Rpc: RpcConvert> fmt::Debug for OpEthApiInner<N, Rpc> {


### PR DESCRIPTION
Closes #18373 

This PR adds a flashblock caching mechanism to store the last 3 completed flashblock sequences by block number. The `build_args` method is modified to select flashblocks based on local chain tip + 1. This enables building blocks when flashblocks arrive out-of-order relative to local chain progression, with new methods `ready_transactions_for_block()` and `payload_base_for_block()` handling retrieval from both current sequence and cache.

Also I'm unable to test this PR locally, should I write unit tests for it? I have ran the op-reth node with flashblocks enabled but I can't figure out from the logs whether the implementation is correct. I'm running the following command:

```
op-reth node \
--chain base-sepolia \
--rollup.sequencer-http https://sepolia-sequencer.base.org \
--flashblocks-url "wss://sepolia.flashblocks.base.org/ws" \
--http \
--ws \
--authrpc.port 9551 \
--authrpc.jwtsecret ./jwt.hex
```