### PR TITLE
fix(cli): Silent Log Dropping in File Logging

### DIFF
--- a/crates/tracing/src/layers.rs
+++ b/crates/tracing/src/layers.rs
@@ -5,6 +5,7 @@ use std::{
 
 use rolling_file::{RollingConditionBasic, RollingFileAppender};
 use tracing_appender::non_blocking::WorkerGuard;
+use tracing_appender::non_blocking::NonBlockingBuilder;
 use tracing_subscriber::{filter::Directive, EnvFilter, Layer, Registry};
 
 use crate::formatter::LogFormat;
@@ -164,16 +165,20 @@ impl FileInfo {
     /// # Returns
     /// A tuple containing the non-blocking writer and its associated worker guard.
     fn create_log_writer(&self) -> (tracing_appender::non_blocking::NonBlocking, WorkerGuard) {
-        let log_dir = self.create_log_dir();
-        let (writer, guard) = tracing_appender::non_blocking(
-            RollingFileAppender::new(
-                log_dir.join(&self.file_name),
-                RollingConditionBasic::new().max_size(self.max_size_bytes),
-                self.max_files,
-            )
-            .expect("Could not initialize file logging"),
-        );
-        (writer, guard)
+    let log_dir = self.create_log_dir();
+    let appender = RollingFileAppender::new(
+        log_dir.join(&self.file_name),
+        RollingConditionBasic::new().max_size(self.max_size_bytes),
+        self.max_files,
+    )
+    .expect("Could not initialize file logging");
+
+    let (writer, guard) = NonBlockingBuilder::default()
+        .lossy(false)
+        .buffered_lines_limit(10000)
+        .finish(appender);
+
+    (writer, guard)
     }
 }
 

--- a/crates/tracing/src/layers.rs
+++ b/crates/tracing/src/layers.rs
@@ -28,6 +28,12 @@ const DEFAULT_ENV_FILTER_DIRECTIVES: [&str; 5] = [
     "jsonrpsee-server=off",
 ];
 
+/// Buffer size for non-blocking file logging writer.
+/// This value (10,000 lines) handles typical Reth logging bursts (10-100 seconds buffer)
+/// with reasonable memory usage (~1.5MB), keeping the blocking from lossy(false) as a rare
+/// fallback for extreme cases only.
+const FILE_LOGGING_BUFFER_SIZE: usize = 10000;
+
 /// Manages the collection of layers for a tracing subscriber.
 ///
 /// `Layers` acts as a container for different logging layers such as stdout, file, or journald.
@@ -172,8 +178,10 @@ impl FileInfo {
         )
         .expect("Could not initialize file logging");
 
-        let (writer, guard) =
-            NonBlockingBuilder::default().lossy(false).buffered_lines_limit(10000).finish(appender);
+        let (writer, guard) = NonBlockingBuilder::default()
+            .lossy(false)
+            .buffered_lines_limit(FILE_LOGGING_BUFFER_SIZE)
+            .finish(appender);
 
         (writer, guard)
     }

--- a/crates/tracing/src/layers.rs
+++ b/crates/tracing/src/layers.rs
@@ -4,8 +4,7 @@ use std::{
 };
 
 use rolling_file::{RollingConditionBasic, RollingFileAppender};
-use tracing_appender::non_blocking::WorkerGuard;
-use tracing_appender::non_blocking::NonBlockingBuilder;
+use tracing_appender::non_blocking::{NonBlockingBuilder, WorkerGuard};
 use tracing_subscriber::{filter::Directive, EnvFilter, Layer, Registry};
 
 use crate::formatter::LogFormat;
@@ -165,20 +164,18 @@ impl FileInfo {
     /// # Returns
     /// A tuple containing the non-blocking writer and its associated worker guard.
     fn create_log_writer(&self) -> (tracing_appender::non_blocking::NonBlocking, WorkerGuard) {
-    let log_dir = self.create_log_dir();
-    let appender = RollingFileAppender::new(
-        log_dir.join(&self.file_name),
-        RollingConditionBasic::new().max_size(self.max_size_bytes),
-        self.max_files,
-    )
-    .expect("Could not initialize file logging");
+        let log_dir = self.create_log_dir();
+        let appender = RollingFileAppender::new(
+            log_dir.join(&self.file_name),
+            RollingConditionBasic::new().max_size(self.max_size_bytes),
+            self.max_files,
+        )
+        .expect("Could not initialize file logging");
 
-    let (writer, guard) = NonBlockingBuilder::default()
-        .lossy(false)
-        .buffered_lines_limit(10000)
-        .finish(appender);
+        let (writer, guard) =
+            NonBlockingBuilder::default().lossy(false).buffered_lines_limit(10000).finish(appender);
 
-    (writer, guard)
+        (writer, guard)
     }
 }
 


### PR DESCRIPTION
This PR addresses issue #18261, where the file logging layer (--log.file.filter) silently drops log messages when the bounded channel buffer fills under high-frequency logging. The root cause was the use of tracing_appender::non_blocking with its default lossy behavior.

Changes Made:
1. Modified FileInfo::create_log_writer to use NonBlockingBuilder with:
 (a) lossy(false) to ensure no log messages are dropped by blocking the sender when the buffer is full.
 (b) buffered_lines_limit(10000) to increase the buffer size, reducing the likelihood of blocking under typical workloads.
2. Added import for tracing_appender::non_blocking::NonBlockingBuilder.

Impact:
1. Guarantees all filtered log messages are written to disk, aligning with user expectations for --log.file.filter.
2. Eliminates silent log dropping, improving reliability for debugging production issues.
3. Maintains minimal performance impact by using a larger buffer to handle bursts, with blocking as a fallback only under extreme load.