### PR TITLE
fix(docs): disable jekyll which removes the search-index

### DIFF
--- a/docs/vocs/docs/public/_config.yml
+++ b/docs/vocs/docs/public/_config.yml
@@ -1,3 +1,0 @@
-# Include the .vocs directory which contains the search index
-include:
-  - .vocs


### PR DESCRIPTION
Possibly closes #18353 

Disable jekyll 
