### PR TITLE
chore: fixed broken link in history-expiry.mdx

### DIFF
--- a/docs/vocs/docs/pages/guides/history-expiry.mdx
+++ b/docs/vocs/docs/pages/guides/history-expiry.mdx
@@ -6,7 +6,7 @@ description: Usage of tools for importing, exporting and pruning historical bloc
 
 In this chapter, we will learn how to use tools for dealing with historical data, it's import, export and removal.
 
-We will use [reth cli](../cli/cli) to import and export historical data.
+We will use [reth cli](/cli/cli) to import and export historical data.
 
 ## Enabling Pre-merge history expiry
 
@@ -49,7 +49,7 @@ When enabled, the import from ERA1 files runs as its own separate stage before a
 
 ### Manual import
 
-If you want to import block headers and transactions from ERA1 files without running the synchronization pipeline, you may use the [`import-era`](../cli/reth/import-era) command.
+If you want to import block headers and transactions from ERA1 files without running the synchronization pipeline, you may use the [`import-era`](/cli/reth/import-era) command.
 
 ### Options
 
@@ -68,7 +68,7 @@ Both options cannot be used at the same time. If no option is specified, the rem
 In this section we discuss how to export blocks data into ERA1 files.
 
 ### Manual export
-You can manually export block data from your database to ERA1 files using the [`export-era`](../cli/reth/export-era) command.
+You can manually export block data from your database to ERA1 files using the [`export-era`](/cli/reth/export-era) command.
 
 The CLI reads block headers, bodies, and receipts from your local database and packages them into the standardized ERA1 format with up to 8,192 blocks per file.
 


### PR DESCRIPTION
Hi! I fixed a few relative links in the history expiry guide:

https://reth.rs/guides/history-expiry
<img width="1280" height="241" alt="image" src="https://github.com/user-attachments/assets/15524bd0-4a5e-4e0b-b081-c0d5699683db" />


- `../cli/cli` → `/cli/cli`  
- `../cli/reth/import-era` → `/cli/reth/import-era`  
- `../cli/reth/export-era` → `/cli/reth/export-era`  