### PR TITLE
fix: dont update canon chain to ancestor for opstack

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1076,7 +1076,11 @@ where
                 // canonical ancestor. This ensures that state providers and the
                 // transaction pool operate with the correct chain state after
                 // forkchoice update processing.
-                self.update_latest_block_to_canonical_ancestor(&canonical_header)?;
+                if self.config.always_process_payload_attributes_on_canonical_head() {
+                    // TODO(mattsse): This behavior is technically a different setting and we need a
+                    // new config setting for this
+                    self.update_latest_block_to_canonical_ancestor(&canonical_header)?;
+                }
             }
 
             // 2. Client software MAY skip an update of the forkchoice state and MUST NOT begin a

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -881,7 +881,11 @@ async fn test_fcu_with_canonical_ancestor_updates_latest_block() {
     let mut test_harness = TestHarness::new(chain_spec.clone());
 
     // Set engine kind to OpStack to ensure the fix is triggered
-    test_harness.tree.engine_kind = EngineApiKind::OpStack;
+    test_harness.tree.config = test_harness
+        .tree
+        .config
+        .clone()
+        .with_always_process_payload_attributes_on_canonical_head(true);
     let mut test_block_builder = TestBlockBuilder::eth().with_chain_spec((*chain_spec).clone());
 
     // Create a chain of blocks


### PR DESCRIPTION
we introduced this behaviour in #17938 which seemed fine but is actually slightly problematic in op-boost setups where multiple clients trigger fcu+payloadattributes

so we should only do this if the extra setting is configured and also add an additional setting for this instead

cc @pycckuu 