### PR TITLE
perf: downsize mempool tx priority from `U256` to `u128`

### DIFF
--- a/crates/transaction-pool/src/ordering.rs
+++ b/crates/transaction-pool/src/ordering.rs
@@ -1,5 +1,4 @@
 use crate::traits::PoolTransaction;
-use alloy_primitives::U256;
 use std::{cmp::Ordering, fmt::Debug, marker::PhantomData};
 
 /// Priority of the transaction that can be missing.
@@ -71,7 +70,7 @@ impl<T> TransactionOrdering for CoinbaseTipOrdering<T>
 where
     T: PoolTransaction + 'static,
 {
-    type PriorityValue = U256;
+    type PriorityValue = u128;
     type Transaction = T;
 
     /// Source: <https://github.com/ethereum/go-ethereum/blob/7f756dc1185d7f1eeeacb1d12341606b7135f9ea/core/txpool/legacypool/list.go#L469-L482>.
@@ -82,7 +81,7 @@ where
         transaction: &Self::Transaction,
         base_fee: u64,
     ) -> Priority<Self::PriorityValue> {
-        transaction.effective_tip_per_gas(base_fee).map(U256::from).into()
+        transaction.effective_tip_per_gas(base_fee).into()
     }
 }
 

--- a/crates/transaction-pool/src/pool/best.rs
+++ b/crates/transaction-pool/src/pool/best.rs
@@ -394,7 +394,6 @@ mod tests {
         test_utils::{MockOrdering, MockTransaction, MockTransactionFactory},
         BestTransactions, Priority,
     };
-    use alloy_primitives::U256;
 
     #[test]
     fn test_best_iter() {
@@ -665,7 +664,7 @@ mod tests {
         let pending_tx = PendingTransaction {
             submission_id: 10,
             transaction: Arc::new(valid_new_tx.clone()),
-            priority: Priority::Value(U256::from(1000)),
+            priority: Priority::Value(1000),
         };
         tx_sender.send(pending_tx.clone()).unwrap();
 
@@ -712,7 +711,7 @@ mod tests {
         let pending_tx1 = PendingTransaction {
             submission_id: 10,
             transaction: Arc::new(valid_new_tx1.clone()),
-            priority: Priority::Value(U256::from(1000)),
+            priority: Priority::Value(1000),
         };
         tx_sender.send(pending_tx1.clone()).unwrap();
 
@@ -735,7 +734,7 @@ mod tests {
         let pending_tx2 = PendingTransaction {
             submission_id: 11, // Different submission ID
             transaction: Arc::new(valid_new_tx2.clone()),
-            priority: Priority::Value(U256::from(1000)),
+            priority: Priority::Value(1000),
         };
         tx_sender.send(pending_tx2.clone()).unwrap();
 
@@ -981,7 +980,7 @@ mod tests {
         let pending_tx = PendingTransaction {
             submission_id: 10,
             transaction: Arc::new(valid_new_higher_fee_tx.clone()),
-            priority: Priority::Value(U256::from(u64::MAX)),
+            priority: Priority::Value(u128::MAX),
         };
         tx_sender.send(pending_tx).unwrap();
 


### PR DESCRIPTION
Found this in our hot paths. We may need to restructure a bunch for `/// NOTE: The implementation is incomplete for missing base fee.`, but this is a quick win for now..