### PR TITLE
chore(storage): remove unused `primed_dbis`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8638,7 +8638,6 @@ dependencies = [
  "codspeed-criterion-compat",
  "dashmap 6.1.0",
  "derive_more",
- "indexmap 2.11.0",
  "parking_lot",
  "rand 0.9.2",
  "reth-mdbx-sys",

--- a/crates/storage/libmdbx-rs/Cargo.toml
+++ b/crates/storage/libmdbx-rs/Cargo.toml
@@ -17,7 +17,6 @@ reth-mdbx-sys.workspace = true
 bitflags.workspace = true
 byteorder.workspace = true
 derive_more.workspace = true
-indexmap.workspace = true
 parking_lot.workspace = true
 smallvec.workspace = true
 thiserror.workspace = true

--- a/crates/storage/libmdbx-rs/benches/transaction.rs
+++ b/crates/storage/libmdbx-rs/benches/transaction.rs
@@ -66,8 +66,6 @@ fn bench_put_rand(c: &mut Criterion) {
 
     let txn = env.begin_ro_txn().unwrap();
     let db = txn.open_db(None).unwrap();
-    txn.prime_for_permaopen(db);
-    let db = txn.commit_and_rebind_open_dbs().unwrap().2.remove(0);
 
     let mut items: Vec<(String, String)> = (0..n).map(|n| (get_key(n), get_data(n))).collect();
     items.shuffle(&mut StdRng::from_seed(Default::default()));

--- a/crates/storage/libmdbx-rs/src/transaction.rs
+++ b/crates/storage/libmdbx-rs/src/transaction.rs
@@ -7,7 +7,6 @@ use crate::{
     Cursor, Error, Stat, TableObject,
 };
 use ffi::{MDBX_txn_flags_t, MDBX_TXN_RDONLY, MDBX_TXN_READWRITE};
-use indexmap::IndexSet;
 use parking_lot::{Mutex, MutexGuard};
 use std::{
     ffi::{c_uint, c_void},
@@ -94,7 +93,6 @@ where
 
         let inner = TransactionInner {
             txn,
-            primed_dbis: Mutex::new(IndexSet::new()),
             committed: AtomicBool::new(false),
             env,
             _marker: Default::default(),
@@ -173,50 +171,25 @@ where
     ///
     /// Any pending operations will be saved.
     pub fn commit(self) -> Result<(bool, CommitLatency)> {
-        self.commit_and_rebind_open_dbs().map(|v| (v.0, v.1))
-    }
+        let result = self.txn_execute(|txn| {
+            if K::IS_READ_ONLY {
+                #[cfg(feature = "read-tx-timeouts")]
+                self.env().txn_manager().remove_active_read_transaction(txn);
 
-    pub fn prime_for_permaopen(&self, db: Database) {
-        self.inner.primed_dbis.lock().insert(db.dbi());
-    }
-
-    /// Commits the transaction and returns table handles permanently open until dropped.
-    pub fn commit_and_rebind_open_dbs(self) -> Result<(bool, CommitLatency, Vec<Database>)> {
-        let result = {
-            let result = self.txn_execute(|txn| {
-                if K::IS_READ_ONLY {
-                    #[cfg(feature = "read-tx-timeouts")]
-                    self.env().txn_manager().remove_active_read_transaction(txn);
-
-                    let mut latency = CommitLatency::new();
-                    mdbx_result(unsafe {
-                        ffi::mdbx_txn_commit_ex(txn, latency.mdb_commit_latency())
-                    })
+                let mut latency = CommitLatency::new();
+                mdbx_result(unsafe { ffi::mdbx_txn_commit_ex(txn, latency.mdb_commit_latency()) })
                     .map(|v| (v, latency))
-                } else {
-                    let (sender, rx) = sync_channel(0);
-                    self.env()
-                        .txn_manager()
-                        .send_message(TxnManagerMessage::Commit { tx: TxnPtr(txn), sender });
-                    rx.recv().unwrap()
-                }
-            })?;
+            } else {
+                let (sender, rx) = sync_channel(0);
+                self.env()
+                    .txn_manager()
+                    .send_message(TxnManagerMessage::Commit { tx: TxnPtr(txn), sender });
+                rx.recv().unwrap()
+            }
+        })?;
 
-            self.inner.set_committed();
-            result
-        };
-        result.map(|(v, latency)| {
-            (
-                v,
-                latency,
-                self.inner
-                    .primed_dbis
-                    .lock()
-                    .iter()
-                    .map(|&dbi| Database::new_from_ptr(dbi, self.env().clone()))
-                    .collect(),
-            )
-        })
+        self.inner.set_committed();
+        result
     }
 
     /// Opens a handle to an MDBX database.
@@ -308,8 +281,6 @@ where
 {
     /// The transaction pointer itself.
     txn: TransactionPtr,
-    /// A set of database handles that are primed for permaopen.
-    primed_dbis: Mutex<IndexSet<ffi::MDBX_dbi>>,
     /// Whether the transaction has committed.
     committed: AtomicBool,
     env: Environment,


### PR DESCRIPTION
Remove the unused `primed_dbis` that don't make much sense in the first place.

P/s: This is a code-deletion only PR. If you check the diff with `w=1`, the only addition is an auto-formatted line.