### PR TITLE
docs(op): decompress the state file before init-state

### DIFF
--- a/docs/vocs/docs/pages/run/faq/sync-op-mainnet.mdx
+++ b/docs/vocs/docs/pages/run/faq/sync-op-mainnet.mdx
@@ -6,20 +6,35 @@ description: Syncing Reth with OP Mainnet and Bedrock state.
 
 To sync OP mainnet, Bedrock state needs to be imported as a starting point. There are currently two ways:
 
--   Minimal bootstrap **(recommended)**: only state snapshot at Bedrock block is imported without any OVM historical data.
--   Full bootstrap **(not recommended)**: state, blocks and receipts are imported. \*Not recommended for now: [storage consistency issue](https://github.com/paradigmxyz/reth/pull/11099) tldr: sudden crash may break the node
+- Minimal bootstrap **(recommended)**: only state snapshot at Bedrock block is imported without any OVM historical data.
+- Full bootstrap **(not recommended)**: state, blocks and receipts are imported.
 
 ## Minimal bootstrap (recommended)
 
 **The state snapshot at Bedrock block is required.** It can be exported from [op-geth](https://github.com/testinprod-io/op-erigon/blob/pcw109550/bedrock-db-migration/bedrock-migration.md#export-state) (**.jsonl**) or downloaded directly from [here](https://mega.nz/file/GdZ1xbAT#a9cBv3AqzsTGXYgX7nZc_3fl--tcBmOAIwIA5ND6kwc).
 
-Import the state snapshot
+### 1. Download and decompress
+
+After you downloaded the state file, ensure the state file is decompressed into **.jsonl** format:
+
+```sh
+$ unzstd /path/to/world_trie_state.jsonl.zstd
+```
+
+### 2. Import the state
+
+Import the state snapshot:
 
 ```sh
 $ op-reth init-state --without-ovm --chain optimism --datadir op-mainnet world_trie_state.jsonl
 ```
 
-Sync the node to a recent finalized block (e.g. 125200000) to catch up close to the tip, before pairing with op-node.
+### 3. Sync from Bedrock to tip
+
+Running the node with `--debug.tip <block-hash>` syncs the node without help from CL until a fixed tip. The
+block hash can be taken from the latest block on [https://optimistic.etherscan.io](https://optimistic.etherscan.io).
+
+Eg, sync the node to a recent finalized block (e.g. 125200000) to catch up close to the tip, before pairing with op-node.
 
 ```sh
 $ op-reth node --chain optimism --datadir op-mainnet --debug.tip 0x098f87b75c8b861c775984f9d5dbe7b70cbbbc30fc15adb03a5044de0144f2d0 # block #125200000
@@ -38,8 +53,8 @@ execution in reth's sync pipeline.
 
 Importing OP mainnet Bedrock datadir requires exported data:
 
--   Blocks [and receipts] below Bedrock
--   State snapshot at first Bedrock block
+- Blocks [and receipts] below Bedrock
+- State snapshot at first Bedrock block
 
 ### Manual Export Steps
 
@@ -86,10 +101,7 @@ Import of >4 million OP mainnet accounts at Bedrock, completes in 10 minutes.
 $ op-reth init-state --chain optimism <state-dump>
 ```
 
-## Sync from Bedrock to tip
-
-Running the node with `--debug.tip <block-hash>`syncs the node without help from CL until a fixed tip. The
-block hash can be taken from the latest block on [https://optimistic.etherscan.io](https://optimistic.etherscan.io).
+### Start with op-node
 
 Use `op-node` to track the tip. Start `op-node` with `--syncmode=execution-layer` and `--l2.enginekind=reth`. If `op-node`'s RPC
 connection to L1 is over localhost, `--l1.trustrpc` can be set to improve performance.


### PR DESCRIPTION
When I'm following the https://reth.rs/run/faq/sync-op-mainnet/#minimal-bootstrap-recommended, failed to init the state, log as below:

```
$ op-reth init-state --without-ovm --chain optimism --datadir op-data ~/world_trie_state_op_mainnet_b2c2b6e7edb919a0b856b9fd9aa02b11ead5305e63cdb33386babd82b9bc4cfe.jsonl.zst
2025-09-13T03:46:41.120305Z  INFO Initialized tracing, debug log directory: /root/.cache/reth/logs/optimism
2025-09-13T03:46:41.121363Z  INFO Reth init-state starting
2025-09-13T03:46:41.131142Z  INFO Opening storage db_path="op-data/db" sf_path="op-data/static_files"
2025-09-13T03:46:41.551442Z  INFO Verifying storage consistency.
2025-09-13T03:46:41.558333Z  INFO Setting up dummy EVM chain before importing state. new_tip=NumHash { number: 105235063, hash: 0xdbf6a80fef073de06add9b0d14026d6e5a86c85f6d102c36d3d8e9cf89c2afd3 }
2025-09-13T03:51:00.043148Z  INFO Appending first valid block.
2025-09-13T03:51:00.049648Z  INFO Set up finished.
2025-09-13T03:51:00.119485Z  INFO Initiating state dump
Error: stream did not contain valid UTF-8

Location:
    /root/code/reth/crates/storage/db-common/src/init.rs:469:5
```

Found this issue was caused by the `.jsonl.zst` file format, it only allow the jsonl file, not the compressed one.