### PR TITLE
perf(db): open MDBX DBIs only once at startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2746,7 +2746,6 @@ version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
- "arbitrary",
  "cfg-if",
  "crossbeam-utils",
  "hashbrown 0.14.5",
@@ -7608,7 +7607,6 @@ dependencies = [
  "arbitrary",
  "assert_matches",
  "codspeed-criterion-compat",
- "dashmap 6.1.0",
  "derive_more",
  "eyre",
  "metrics",

--- a/crates/storage/db/Cargo.toml
+++ b/crates/storage/db/Cargo.toml
@@ -39,7 +39,6 @@ derive_more.workspace = true
 rustc-hash = { workspace = true, optional = true, features = ["std"] }
 sysinfo = { workspace = true, features = ["system"] }
 parking_lot = { workspace = true, optional = true }
-dashmap.workspace = true
 
 # arbitrary utils
 strum = { workspace = true, features = ["derive"], optional = true }
@@ -92,7 +91,6 @@ arbitrary = [
     "alloy-consensus/arbitrary",
     "reth-primitives-traits/arbitrary",
     "reth-prune-types/arbitrary",
-    "dashmap/arbitrary",
 ]
 op = [
     "reth-db-api/op",

--- a/crates/storage/db/src/mdbx.rs
+++ b/crates/storage/db/src/mdbx.rs
@@ -41,7 +41,7 @@ pub fn init_db_for<P: AsRef<Path>, TS: TableSet>(
     args: DatabaseArguments,
 ) -> eyre::Result<DatabaseEnv> {
     let client_version = args.client_version().clone();
-    let db = create_db(path, args)?;
+    let mut db = create_db(path, args)?;
     db.create_tables_for::<TS>()?;
     db.record_client_version(client_version)?;
     Ok(db)


### PR DESCRIPTION
Part 2 of #18292: Cache DBIs at startup time to reuse throughout the program's lifetime instead of just per transaction.

<img width="1267" height="362" alt="image" src="https://github.com/user-attachments/assets/472005a2-1095-42bb-9739-edaba883a8f1" />

<img width="836" height="149" alt="image" src="https://github.com/user-attachments/assets/5efc8e9b-f0a1-4dc1-bef2-466fabe9ec30" />

---

`reth-bench` for the first 300 blocks of Shanghai:

```
$ reth-bench new-payload-fcu --advance 300
```

f66e19717135db253462069991f41950201720f6 (`main`):
```
2025-09-13T09:46:50.043037Z  INFO Total Ggas/s: 0.6499 total_duration=7.062721087s total_gas_used=4590139398 blocks_processed=300
```

This branch on f66e19717135db253462069991f41950201720f6:
```
2025-09-13T09:56:17.725214Z  INFO Total Ggas/s: 0.6967 total_duration=6.588003416s total_gas_used=4590139398 blocks_processed=300
```

Speedup:
- Ggas/s: 0.6499 -> 0.6967 ~ 7.2% higher execution throughput
- Duration: 7.062721087s -> 6.588003416s ~ 7.2% lower payload latency
- Best win: From 39.2ms down to 13.3ms payload latency