### PR TITLE
chore: clean up TS warnings in search index & file finder

### DIFF
--- a/docs/vocs/scripts/fix-search-index.ts
+++ b/docs/vocs/scripts/fix-search-index.ts
@@ -14,6 +14,7 @@ async function fixSearchIndex() {
     if (!searchIndexFile) {
       console.error('❌ No search index file found in .vocs directory');
       process.exit(1);
+      return;
     }
     
     console.log(`📁 Found search index: ${searchIndexFile}`);
@@ -55,7 +56,7 @@ async function fixSearchIndex() {
 }
 
 async function findFiles(dir: string, extension: string, files: string[] = []): Promise<string[]> {
-  const { readdir, stat } = await import('fs/promises');
+  const { readdir } = await import('fs/promises');
   const entries = await readdir(dir, { withFileTypes: true });
   
   for (const entry of entries) {
@@ -65,7 +66,7 @@ async function findFiles(dir: string, extension: string, files: string[] = []): 
     if (entry.name === '.vocs' || entry.name === 'docs' || entry.name === '_site') continue;
     
     if (entry.isDirectory()) {
-      await findFiles(fullPath, extension, files);
+      files = await findFiles(fullPath, extension, files);
     } else if (entry.name.endsWith(extension)) {
       files.push(fullPath);
     }


### PR DESCRIPTION
fixed a couple of small TS issues:

* added `return` after `process.exit(1)` in `fixSearchIndex`.
* dropped unused `stat` import.
* made the recursive `findFiles` call actually use its return value.