### PR TITLE
docs: typo fix from "friendless" to "friendly", with love ❤️

### DIFF
--- a/docs/vocs/docs/pages/introduction/why-reth.mdx
+++ b/docs/vocs/docs/pages/introduction/why-reth.mdx
@@ -17,7 +17,7 @@ Reth secures real value on Ethereum mainnet today, trusted by institutions like 
 Reth pushes the performance frontier across every dimension, from L2 sequencers to MEV block building.
 
 -   **L2 Sequencer Performance**: Used by [Base](https://www.base.org/), other production L2s and also rollup-as-a-service providers such as [Conduit](https://conduit.xyz) which require high throughput and fast block times.
--   **MEV & Block Building**: [rbuilder](https://github.com/flashbots/rbuilder) is an open-source implementation of a block builder built on Reth due to developer friendless and blazing fast performance.
+-   **MEV & Block Building**: [rbuilder](https://github.com/flashbots/rbuilder) is an open-source implementation of a block builder built on Reth due to developer friendliness and blazing fast performance.
 
 ## Infinitely Customizable
 


### PR DESCRIPTION
spotted a tiny typo that accidentally called developers "friendless."
fixed to "developer friendliness" so we’re clear: **devs are awesome and welcome here**! ❤️
