### PR TITLE
fix: drop broken `/exex/tracking-state` link

### DIFF
--- a/docs/vocs/docs/pages/exex/hello-world.mdx
+++ b/docs/vocs/docs/pages/exex/hello-world.mdx
@@ -92,4 +92,4 @@ What we've arrived at is the [minimal ExEx example](https://github.com/paradigmx
 
 ## What's next?
 
-Let's do something a bit more interesting, and see how you can [keep track of some state](/exex/tracking-state) inside your ExEx.
+Let's do something a bit more interesting, and see how you can keep track of some state inside your ExEx.


### PR DESCRIPTION
removed the invalid link
p.s. couldn’t find the right one for `exec` :(
