### PR TITLE
docs: Fix broken debug link

### DIFF
--- a/docs/vocs/docs/pages/jsonrpc/trace.mdx
+++ b/docs/vocs/docs/pages/jsonrpc/trace.mdx
@@ -6,7 +6,7 @@ description: Trace API for inspecting Ethereum state and transactions.
 
 The `trace` API provides several methods to inspect the Ethereum state, including Parity-style traces.
 
-A similar module exists (with other debug functions) with Geth-style traces ([`debug`](/jsonrpc/debug)).
+A similar module exists (with other debug functions) with Geth-style traces ([`debug`](https://github.com/paradigmxyz/reth/blob/main/docs/vocs/docs/pages/jsonrpc/debug.mdx)).
 
 The `trace` API gives deeper insight into transaction processing.
 


### PR DESCRIPTION
noticed the debug link was pointing to a non-working address.
updated it to the correct production URL so everything resolves as expected.
