### PR TITLE
chore: move and rename PendingBlockAndReceipts to BlockAndReceipts

### DIFF
--- a/crates/optimism/rpc/src/eth/mod.rs
+++ b/crates/optimism/rpc/src/eth/mod.rs
@@ -35,8 +35,7 @@ use reth_rpc_eth_api::{
     RpcNodeCoreExt, RpcTypes, SignableTxRequest,
 };
 use reth_rpc_eth_types::{
-    pending_block::PendingBlockAndReceipts, EthStateCache, FeeHistoryCache, GasPriceOracle,
-    PendingBlockEnvOrigin,
+    block::BlockAndReceipts, EthStateCache, FeeHistoryCache, GasPriceOracle, PendingBlockEnvOrigin,
 };
 use reth_storage_api::{ProviderHeader, ProviderTx};
 use reth_tasks::{
@@ -114,10 +113,10 @@ impl<N: RpcNodeCore, Rpc: RpcConvert> OpEthApi<N, Rpc> {
         OpEthApiBuilder::new()
     }
 
-    /// Returns a [`PendingBlockAndReceipts`] that is built out of flashblocks.
+    /// Returns a [`BlockAndReceipts`] that is built out of flashblocks.
     ///
     /// If flashblocks receiver is not set, then it always returns `None`.
-    pub fn pending_flashblock(&self) -> eyre::Result<Option<PendingBlockAndReceipts<N::Primitives>>>
+    pub fn pending_flashblock(&self) -> eyre::Result<Option<BlockAndReceipts<N::Primitives>>>
     where
         Self: LoadPendingBlock,
     {

--- a/crates/optimism/rpc/src/eth/pending_block.rs
+++ b/crates/optimism/rpc/src/eth/pending_block.rs
@@ -9,8 +9,7 @@ use reth_rpc_eth_api::{
     FromEvmError, RpcConvert, RpcNodeCore,
 };
 use reth_rpc_eth_types::{
-    builder::config::PendingBlockKind, pending_block::PendingBlockAndReceipts, EthApiError,
-    PendingBlock,
+    block::BlockAndReceipts, builder::config::PendingBlockKind, EthApiError, PendingBlock,
 };
 use reth_storage_api::{BlockReader, BlockReaderIdExt, ReceiptProvider};
 
@@ -38,7 +37,7 @@ where
     /// Returns the locally built pending block
     async fn local_pending_block(
         &self,
-    ) -> Result<Option<PendingBlockAndReceipts<Self::Primitives>>, Self::Error> {
+    ) -> Result<Option<BlockAndReceipts<Self::Primitives>>, Self::Error> {
         if let Ok(Some(pending)) = self.pending_flashblock() {
             return Ok(Some(pending));
         }
@@ -59,6 +58,6 @@ where
             .receipts_by_block(block_id)?
             .ok_or(EthApiError::ReceiptsNotFound(block_id.into()))?;
 
-        Ok(Some(PendingBlockAndReceipts { block: Arc::new(block), receipts: Arc::new(receipts) }))
+        Ok(Some(BlockAndReceipts { block: Arc::new(block), receipts: Arc::new(receipts) }))
     }
 }

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -19,8 +19,8 @@ use reth_primitives_traits::{transaction::error::InvalidTransactionError, Header
 use reth_revm::{database::StateProviderDatabase, db::State};
 use reth_rpc_convert::RpcConvert;
 use reth_rpc_eth_types::{
-    builder::config::PendingBlockKind, pending_block::PendingBlockAndReceipts, EthApiError,
-    PendingBlock, PendingBlockEnv, PendingBlockEnvOrigin,
+    block::BlockAndReceipts, builder::config::PendingBlockKind, EthApiError, PendingBlock,
+    PendingBlockEnv, PendingBlockEnvOrigin,
 };
 use reth_storage_api::{
     BlockReader, BlockReaderIdExt, ProviderBlock, ProviderHeader, ProviderReceipt, ProviderTx,
@@ -199,8 +199,7 @@ pub trait LoadPendingBlock:
     /// Returns the locally built pending block
     fn local_pending_block(
         &self,
-    ) -> impl Future<Output = Result<Option<PendingBlockAndReceipts<Self::Primitives>>, Self::Error>>
-           + Send
+    ) -> impl Future<Output = Result<Option<BlockAndReceipts<Self::Primitives>>, Self::Error>> + Send
     where
         Self: SpawnBlocking,
         Self::Pool:
@@ -215,7 +214,7 @@ pub trait LoadPendingBlock:
 
             Ok(match pending.origin {
                 PendingBlockEnvOrigin::ActualPending(block, receipts) => {
-                    Some(PendingBlockAndReceipts { block, receipts })
+                    Some(BlockAndReceipts { block, receipts })
                 }
                 PendingBlockEnvOrigin::DerivedFromLatest(..) => {
                     self.pool_pending_block().await?.map(PendingBlock::into_block_and_receipts)

--- a/crates/rpc/rpc-eth-types/src/block.rs
+++ b/crates/rpc/rpc-eth-types/src/block.rs
@@ -1,0 +1,43 @@
+//! Block related types for RPC API.
+
+use std::sync::Arc;
+
+use alloy_primitives::TxHash;
+use reth_primitives_traits::{IndexedTx, NodePrimitives, RecoveredBlock};
+
+/// A type alias for an [`Arc`] wrapped [`RecoveredBlock`].
+pub type RecoveredBlockArc<N> = Arc<RecoveredBlock<<N as NodePrimitives>::Block>>;
+
+/// A type alias for an [`Arc`] wrapped vector of [`NodePrimitives::Receipt`].
+pub type BlockReceiptsArc<N> = Arc<Vec<<N as NodePrimitives>::Receipt>>;
+
+/// A pair of an [`Arc`] wrapped [`RecoveredBlock`] and its corresponding receipts.
+///
+/// This type is used throughout the RPC layer to efficiently pass around
+/// blocks with their execution receipts, avoiding unnecessary cloning.
+#[derive(Debug, Clone)]
+pub struct BlockAndReceipts<N: NodePrimitives> {
+    /// The recovered block.
+    pub block: RecoveredBlockArc<N>,
+    /// The receipts for the block.
+    pub receipts: BlockReceiptsArc<N>,
+}
+
+impl<N: NodePrimitives> BlockAndReceipts<N> {
+    /// Creates a new [`BlockAndReceipts`] instance.
+    pub const fn new(block: RecoveredBlockArc<N>, receipts: BlockReceiptsArc<N>) -> Self {
+        Self { block, receipts }
+    }
+
+    /// Finds a transaction by hash and returns it along with its corresponding receipt.
+    ///
+    /// Returns `None` if the transaction is not found in this block.
+    pub fn find_transaction_and_receipt_by_hash(
+        &self,
+        tx_hash: TxHash,
+    ) -> Option<(IndexedTx<'_, N::Block>, &N::Receipt)> {
+        let indexed_tx = self.block.find_indexed(tx_hash)?;
+        let receipt = self.receipts.get(indexed_tx.index())?;
+        Some((indexed_tx, receipt))
+    }
+}

--- a/crates/rpc/rpc-eth-types/src/lib.rs
+++ b/crates/rpc/rpc-eth-types/src/lib.rs
@@ -8,6 +8,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
+pub mod block;
 pub mod builder;
 pub mod cache;
 pub mod error;


### PR DESCRIPTION
moves `PendingBlockAndReceipts` from `pending_block.rs` to new `block.rs` module and renames it to `BlockAndReceipts`. Removes unused type aliases `PendingRecoveredBlock` and `PendingBlockReceipts`.