### PR TITLE
chore: remove type aliases

### DIFF
--- a/crates/rpc/rpc-eth-types/src/block.rs
+++ b/crates/rpc/rpc-eth-types/src/block.rs
@@ -3,13 +3,7 @@
 use std::sync::Arc;
 
 use alloy_primitives::TxHash;
-use reth_primitives_traits::{IndexedTx, NodePrimitives, RecoveredBlock};
-
-/// A type alias for an [`Arc`] wrapped [`RecoveredBlock`].
-pub type RecoveredBlockArc<N> = Arc<RecoveredBlock<<N as NodePrimitives>::Block>>;
-
-/// A type alias for an [`Arc`] wrapped vector of [`NodePrimitives::Receipt`].
-pub type BlockReceiptsArc<N> = Arc<Vec<<N as NodePrimitives>::Receipt>>;
+use reth_primitives_traits::{BlockTy, IndexedTx, NodePrimitives, ReceiptTy, RecoveredBlock};
 
 /// A pair of an [`Arc`] wrapped [`RecoveredBlock`] and its corresponding receipts.
 ///
@@ -18,14 +12,17 @@ pub type BlockReceiptsArc<N> = Arc<Vec<<N as NodePrimitives>::Receipt>>;
 #[derive(Debug, Clone)]
 pub struct BlockAndReceipts<N: NodePrimitives> {
     /// The recovered block.
-    pub block: RecoveredBlockArc<N>,
+    pub block: Arc<RecoveredBlock<BlockTy<N>>>,
     /// The receipts for the block.
-    pub receipts: BlockReceiptsArc<N>,
+    pub receipts: Arc<Vec<ReceiptTy<N>>>,
 }
 
 impl<N: NodePrimitives> BlockAndReceipts<N> {
     /// Creates a new [`BlockAndReceipts`] instance.
-    pub const fn new(block: RecoveredBlockArc<N>, receipts: BlockReceiptsArc<N>) -> Self {
+    pub const fn new(
+        block: Arc<RecoveredBlock<BlockTy<N>>>,
+        receipts: Arc<Vec<ReceiptTy<N>>>,
+    ) -> Self {
         Self { block, receipts }
     }
 

--- a/crates/rpc/rpc-eth-types/src/pending_block.rs
+++ b/crates/rpc/rpc-eth-types/src/pending_block.rs
@@ -4,7 +4,7 @@
 
 use std::{sync::Arc, time::Instant};
 
-use crate::block::{BlockAndReceipts, BlockReceiptsArc, RecoveredBlockArc};
+use crate::block::BlockAndReceipts;
 use alloy_consensus::BlockHeader;
 use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_primitives::{BlockHash, B256};
@@ -14,7 +14,9 @@ use reth_chain_state::{
 };
 use reth_ethereum_primitives::Receipt;
 use reth_evm::EvmEnv;
-use reth_primitives_traits::{Block, NodePrimitives, RecoveredBlock, SealedHeader};
+use reth_primitives_traits::{
+    Block, BlockTy, NodePrimitives, ReceiptTy, RecoveredBlock, SealedHeader,
+};
 
 /// Configured [`EvmEnv`] for a pending block.
 #[derive(Debug, Clone, Constructor)]
@@ -87,7 +89,7 @@ pub struct PendingBlock<N: NodePrimitives> {
     /// Timestamp when the pending block is considered outdated.
     pub expires_at: Instant,
     /// The receipts for the pending block
-    pub receipts: BlockReceiptsArc<N>,
+    pub receipts: Arc<Vec<ReceiptTy<N>>>,
     /// The locally built pending block with execution output.
     pub executed_block: ExecutedBlock<N>,
 }
@@ -106,7 +108,7 @@ impl<N: NodePrimitives> PendingBlock<N> {
     }
 
     /// Returns the locally built pending [`RecoveredBlock`].
-    pub const fn block(&self) -> &RecoveredBlockArc<N> {
+    pub const fn block(&self) -> &Arc<RecoveredBlock<BlockTy<N>>> {
         &self.executed_block.recovered_block
     }
 


### PR DESCRIPTION
these are only used for the type itself and we can use the helper aliases instead