### PR TITLE
fix(engine): perform cache updates with guard

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -548,9 +548,14 @@ impl ExecutionCache {
         self.inner.write().take();
     }
 
-    /// Stores the provider cache
-    pub(crate) fn save_cache(&self, cache: SavedCache) {
-        self.inner.write().replace(cache);
+    /// Updates the cache with a closure that has exclusive access to the guard.
+    /// This ensures that all cache operations happen atomically.
+    pub(crate) fn update_with_guard<F>(&self, update_fn: F)
+    where
+        F: FnOnce(&mut Option<SavedCache>),
+    {
+        let mut guard = self.inner.write();
+        update_fn(&mut guard);
     }
 }
 

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -142,6 +142,7 @@ where
         self.execution_cache.update_with_guard(|cached| {
             let cache = SavedCache::new(hash, caches, metrics);
 
+            // Note: Write lock is held while insert which could block readers briefly
             if cache.cache().insert_state(&state).is_err() {
                 return;
             }

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -145,7 +145,7 @@ where
             // Insert state into cache while holding the lock
             if cache.cache().insert_state(&state).is_err() {
                 // Clear the cache on error to prevent having a polluted cache
-                *cached = None;
+                cached.take();
                 return;
             }
 

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -145,7 +145,7 @@ where
             // Insert state into cache while holding the lock
             if cache.cache().insert_state(&state).is_err() {
                 // Clear the cache on error to prevent having a polluted cache
-                cached.take();
+                *cached = None;
                 return;
             }
 

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -142,8 +142,10 @@ where
         self.execution_cache.update_with_guard(|cached| {
             let cache = SavedCache::new(hash, caches, metrics);
 
-            // Note: Write lock is held while insert which could block readers briefly
+            // Insert state into cache while holding the lock
             if cache.cache().insert_state(&state).is_err() {
+                // Clear the cache on error to prevent having a polluted cache
+                *cached = None;
                 return;
             }
 

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -132,22 +132,25 @@ where
     /// Save the state to the shared cache for the given block.
     fn save_cache(self, state: BundleState) {
         let start = Instant::now();
-        // Create cache and insert state atomically under lock
-        self.execution_cache.update_with_guard(|guard| {
-            let cache = SavedCache::new(
-                self.ctx.env.hash,
-                self.ctx.cache.clone(),
-                self.ctx.cache_metrics.clone(),
-            );
 
-            // Insert state into cache
-            if cache.cache().insert_state(&state).is_ok() {
-                cache.update_metrics();
-                debug!(target: "engine::caching", "Updated state caches");
+        // Precompute outside the lock
+        let hash = self.ctx.env.hash;
+        let caches = self.ctx.cache.clone();
+        let metrics = self.ctx.cache_metrics.clone();
 
-                // Update the reference
-                guard.replace(cache);
+        // Perform all cache operations atomically under the lock
+        self.execution_cache.update_with_guard(|cached| {
+            let cache = SavedCache::new(hash, caches, metrics);
+
+            if cache.cache().insert_state(&state).is_err() {
+                return;
             }
+
+            cache.update_metrics();
+            debug!(target: "engine::caching", "Updated state caches");
+
+            // Updates the cache and drop the old cache
+            *cached = Some(cache);
         });
 
         self.ctx.metrics.cache_saving_duration.set(start.elapsed().as_secs_f64());

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -150,7 +150,7 @@ where
             cache.update_metrics();
             debug!(target: "engine::caching", "Updated state caches");
 
-            // Updates the cache and drop the old cache
+            // Replace the shared cache with the new one; the previous cache (if any) is dropped.
             *cached = Some(cache);
         });
 


### PR DESCRIPTION
## Summary

This PR fixes a race condition in cache updates where cache outcomes were being inserted before obtaining the mutex lock, which could lead to synchronization issues.

## Problem

As identified in #18409, the current implementation has a problematic order of operations:
1. Cache outcomes are inserted
2. Metrics are updated  
3. **Then** the mutex is acquired to save the cache

This creates a window where another thread could replace the cache, causing the first thread's changes to be lost.

## Solution  

This PR ensures all cache operations happen atomically by:
- Adding `update_with_guard` method to `ExecutionCache` that takes a closure with exclusive access to the mutex guard
- Refactoring `PrewarmCacheTask::save_cache` to perform all operations (state insertion, metrics update, cache replacement) under the lock

## TODO
- [x] Reth Bench Compare on Mainnet to see regression by 2000
- [x] Run Reproduction Script https://gist.github.com/yongkangc/16f80fb48a3fe8180bd7e990c97124c8
- [x] Benching to see deadlock or any other race condition