### PR TITLE
docs: fix incorrect transaction type count

### DIFF
--- a/docs/vocs/docs/pages/run/faq/transactions.mdx
+++ b/docs/vocs/docs/pages/run/faq/transactions.mdx
@@ -4,7 +4,7 @@ description: Overview of Ethereum transaction types in Reth.
 
 # Transaction types
 
-Over time, the Ethereum network has undergone various upgrades and improvements to enhance transaction efficiency, security, and user experience. Four significant transaction types that have evolved are:
+Over time, the Ethereum network has undergone various upgrades and improvements to enhance transaction efficiency, security, and user experience. Five significant transaction types that have evolved are:
 
 - Legacy Transactions,
 - EIP-2930 Transactions,


### PR DESCRIPTION
the text says *"Four significant transaction types that have evolved are:"* but the list actually includes **five**: Legacy, EIP-2930, EIP-1559, EIP-4844, and EIP-7702.
Updated the wording to say *"Five"* so it matches the list.
