### PR TITLE
perf: Enforce EIP-7825 transaction gas limit for Osaka

### DIFF
--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -153,6 +153,18 @@ where
     if let Err(error) = block.ensure_transaction_root_valid() {
         return Err(ConsensusError::BodyTransactionRootDiff(error.into()))
     }
+    // EIP-7825 validation
+    if chain_spec.is_osaka_active_at_timestamp(block.timestamp()) {
+        for tx in block.body().transactions() {
+            if tx.gas_limit() > MAX_TX_GAS_LIMIT_OSAKA {
+                return Err(ConsensusError::TransactionGasLimitTooHigh {
+                    tx_hash: tx.hash(),
+                    gas_limit: tx.gas_limit(),
+                    max_allowed: MAX_TX_GAS_LIMIT_OSAKA,
+                });
+            }
+        }
+    }
 
     Ok(())
 }

--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -5,7 +5,7 @@ use alloy_consensus::{
 };
 use alloy_eips::{eip4844::DATA_GAS_PER_BLOB, eip7840::BlobParams};
 use reth_chainspec::{EthChainSpec, EthereumHardfork, EthereumHardforks};
-use reth_consensus::ConsensusError;
+use reth_consensus::{ConsensusError, TxGasLimitTooHighErr};
 use reth_primitives_traits::{
     constants::{
         GAS_LIMIT_BOUND_DIVISOR, MAXIMUM_GAS_LIMIT_BLOCK, MAX_TX_GAS_LIMIT_OSAKA, MINIMUM_GAS_LIMIT,
@@ -159,11 +159,12 @@ where
     if chain_spec.is_osaka_active_at_timestamp(block.timestamp()) {
         for tx in block.body().transactions() {
             if tx.gas_limit() > MAX_TX_GAS_LIMIT_OSAKA {
-                return Err(ConsensusError::TransactionGasLimitTooHigh {
+                return Err(TxGasLimitTooHighErr {
                     tx_hash: *tx.tx_hash(),
                     gas_limit: tx.gas_limit(),
                     max_allowed: MAX_TX_GAS_LIMIT_OSAKA,
-                });
+                }
+                .into());
             }
         }
     }

--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -7,8 +7,10 @@ use alloy_eips::{eip4844::DATA_GAS_PER_BLOB, eip7840::BlobParams};
 use reth_chainspec::{EthChainSpec, EthereumHardfork, EthereumHardforks};
 use reth_consensus::ConsensusError;
 use reth_primitives_traits::{
-    constants::{GAS_LIMIT_BOUND_DIVISOR, MAXIMUM_GAS_LIMIT_BLOCK, MINIMUM_GAS_LIMIT},
-    Block, BlockBody, BlockHeader, GotExpected, SealedBlock, SealedHeader,
+    constants::{
+        GAS_LIMIT_BOUND_DIVISOR, MAXIMUM_GAS_LIMIT_BLOCK, MAX_TX_GAS_LIMIT_OSAKA, MINIMUM_GAS_LIMIT,
+    },
+    Block, BlockBody, BlockHeader, GotExpected, SealedBlock, SealedHeader, SignedTransaction,
 };
 
 /// The maximum RLP length of a block, defined in [EIP-7934](https://eips.ethereum.org/EIPS/eip-7934).
@@ -158,7 +160,7 @@ where
         for tx in block.body().transactions() {
             if tx.gas_limit() > MAX_TX_GAS_LIMIT_OSAKA {
                 return Err(ConsensusError::TransactionGasLimitTooHigh {
-                    tx_hash: tx.hash(),
+                    tx_hash: *tx.tx_hash(),
                     gas_limit: tx.gas_limit(),
                     max_allowed: MAX_TX_GAS_LIMIT_OSAKA,
                 });

--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -1,7 +1,7 @@
 //! Collection of methods for block validation.
 
 use alloy_consensus::{
-    constants::MAXIMUM_EXTRA_DATA_SIZE, BlockHeader as _, EMPTY_OMMER_ROOT_HASH,
+    constants::MAXIMUM_EXTRA_DATA_SIZE, BlockHeader as _, Transaction, EMPTY_OMMER_ROOT_HASH,
 };
 use alloy_eips::{eip4844::DATA_GAS_PER_BLOB, eip7840::BlobParams};
 use reth_chainspec::{EthChainSpec, EthereumHardfork, EthereumHardforks};

--- a/crates/consensus/consensus/src/lib.rs
+++ b/crates/consensus/consensus/src/lib.rs
@@ -406,8 +406,11 @@ pub enum ConsensusError {
     /// EIP-7825: Transaction gas limit exceeds maximum allowed
     #[error("transaction {tx_hash} gas limit {gas_limit} exceeds maximum {max_allowed}")]
     TransactionGasLimitTooHigh {
-        tx_hash: TxHash,
+        /// Hash of the transaction that violates the rule
+        tx_hash: B256,
+        /// The gas limit of the transaction
         gas_limit: u64,
+        /// The maximum allowed gas limit
         max_allowed: u64,
     },
 

--- a/crates/consensus/consensus/src/lib.rs
+++ b/crates/consensus/consensus/src/lib.rs
@@ -11,7 +11,7 @@
 
 extern crate alloc;
 
-use alloc::{fmt::Debug, string::String, vec::Vec};
+use alloc::{boxed::Box, fmt::Debug, string::String, vec::Vec};
 use alloy_consensus::Header;
 use alloy_primitives::{BlockHash, BlockNumber, Bloom, B256};
 use reth_execution_types::BlockExecutionResult;

--- a/crates/consensus/consensus/src/lib.rs
+++ b/crates/consensus/consensus/src/lib.rs
@@ -403,6 +403,14 @@ pub enum ConsensusError {
         /// The maximum allowed RLP length.
         max_rlp_length: usize,
     },
+    /// EIP-7825: Transaction gas limit exceeds maximum allowed
+    #[error("transaction {tx_hash} gas limit {gas_limit} exceeds maximum {max_allowed}")]
+    TransactionGasLimitTooHigh {
+        tx_hash: TxHash,
+        gas_limit: u64,
+        max_allowed: u64,
+    },
+
     /// Other, likely an injected L2 error.
     #[error("{0}")]
     Other(String),

--- a/crates/consensus/consensus/src/lib.rs
+++ b/crates/consensus/consensus/src/lib.rs
@@ -404,16 +404,8 @@ pub enum ConsensusError {
         max_rlp_length: usize,
     },
     /// EIP-7825: Transaction gas limit exceeds maximum allowed
-    #[error("transaction {tx_hash} gas limit {gas_limit} exceeds maximum {max_allowed}")]
-    TransactionGasLimitTooHigh {
-        /// Hash of the transaction that violates the rule
-        tx_hash: B256,
-        /// The gas limit of the transaction
-        gas_limit: u64,
-        /// The maximum allowed gas limit
-        max_allowed: u64,
-    },
-
+    #[error(transparent)]
+    TransactionGasLimitTooHigh(Box<TxGasLimitTooHighErr>),
     /// Other, likely an injected L2 error.
     #[error("{0}")]
     Other(String),
@@ -432,7 +424,25 @@ impl From<InvalidTransactionError> for ConsensusError {
     }
 }
 
+impl From<TxGasLimitTooHighErr> for ConsensusError {
+    fn from(value: TxGasLimitTooHighErr) -> Self {
+        Self::TransactionGasLimitTooHigh(Box::new(value))
+    }
+}
+
 /// `HeaderConsensusError` combines a `ConsensusError` with the `SealedHeader` it relates to.
 #[derive(thiserror::Error, Debug)]
 #[error("Consensus error: {0}, Invalid header: {1:?}")]
 pub struct HeaderConsensusError<H>(ConsensusError, SealedHeader<H>);
+
+/// EIP-7825: Transaction gas limit exceeds maximum allowed
+#[derive(thiserror::Error, Debug, Eq, PartialEq, Clone)]
+#[error("transaction {tx_hash} gas limit {gas_limit} exceeds maximum {max_allowed}")]
+pub struct TxGasLimitTooHighErr {
+    /// Hash of the transaction that violates the rule
+    pub tx_hash: B256,
+    /// The gas limit of the transaction
+    pub gas_limit: u64,
+    /// The maximum allowed gas limit
+    pub max_allowed: u64,
+}


### PR DESCRIPTION
Adds pre-execution (already exists in revm) validation similar to the other EL clients to save resources by not trying to execute transactions that exceed the maximum gas limit defined by EIP-7825. Introduces a new ConsensusError variant for transactions exceeding this limit.