### PR TITLE
fix(rpc): add validation for missing headers in debug execution witness

### DIFF
--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -670,7 +670,6 @@ where
         };
 
         let range = smallest..block_number;
-        // TODO: Check if headers_range errors when one of the headers in the range is missing
         exec_witness.headers = self
             .provider()
             .headers_range(range)


### PR DESCRIPTION
Add comprehensive checks to ensure all required headers are present and contiguous in the `debug_execution_witness` RPC