### PR TITLE
docs(engine): improve cache naming and documentation

### DIFF
--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -300,7 +300,7 @@ pub(crate) struct ExecutionCache {
     /// Cache for contract bytecode, keyed by code hash.
     code_cache: Cache<B256, Option<Bytecode>>,
 
-    /// Hierarchical storage cache organized by account address.
+    /// Per-account storage cache: outer cache keyed by Address, inner cache tracks that account’s storage slots.
     storage_cache: Cache<Address, AccountStorageCache>,
 
     /// Cache for basic account information (nonce, balance, code hash).

--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -300,7 +300,8 @@ pub(crate) struct ExecutionCache {
     /// Cache for contract bytecode, keyed by code hash.
     code_cache: Cache<B256, Option<Bytecode>>,
 
-    /// Per-account storage cache: outer cache keyed by Address, inner cache tracks that account’s storage slots.
+    /// Per-account storage cache: outer cache keyed by Address, inner cache tracks that account’s
+    /// storage slots.
     storage_cache: Cache<Address, AccountStorageCache>,
 
     /// Cache for basic account information (nonce, balance, code hash).
@@ -363,7 +364,7 @@ impl ExecutionCache {
     ///
     /// ## Error Handling
     ///
-    /// Returns an error if the state updates are inconsistent and should be discarded. 
+    /// Returns an error if the state updates are inconsistent and should be discarded.
     pub(crate) fn insert_state(&self, state_updates: &BundleState) -> Result<(), ()> {
         // Insert bytecodes
         for (code_hash, bytecode) in &state_updates.contracts {

--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -260,11 +260,6 @@ impl<S: StorageRootProvider> StorageRootProvider for CachedStateProvider<S> {
     /// 2. Traverses the account's storage trie to collect proof nodes
     /// 3. Returns a [`StorageMultiProof`] containing the minimal set of trie nodes needed to verify
     ///    all the requested storage slots
-    ///
-    /// ## Relationship to Caching:
-    /// Storage multiproofs are not directly cached, but they rely on the underlying
-    /// storage data that IS cached. When generating proofs, cached storage values
-    /// can be used instead of fetching from disk, improving proof generation speed.
     fn storage_multiproof(
         &self,
         address: Address,

--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -1,4 +1,23 @@
-//! Implements a state provider that has a shared cache in front of it.
+//! Execution cache implementation for block processing.
+//!
+//! This module provides a caching layer on top of state providers to optimize
+//! state access during block execution. The cache system works in conjunction
+//! with prewarming to improve performance.
+//!
+//! ## Architecture
+//!
+//! The caching system consists of:
+//! - [`ExecutionCache`]: Main cache structure holding account, storage, and bytecode caches
+//! - [`CachedStateProvider`]: Wrapper that adds caching to any [`StateProvider`]
+//! - [`AccountStorageCache`]: Hierarchical storage cache organized by account
+//! - [`SlotStatus`]: Enum representing cache hit/miss status for storage slots
+//!
+//! ## Cache Behavior
+//!
+//! On read: checks cache first, returns cached value on hit, fetches from
+//! underlying provider on miss and caches the result.
+//!
+//! On write: after execution, touched state is inserted via [`ExecutionCache::insert_state`].
 use alloy_primitives::{Address, StorageKey, StorageValue, B256};
 use metrics::Gauge;
 use mini_moka::sync::CacheBuilder;
@@ -27,7 +46,7 @@ pub(crate) struct CachedStateProvider<S> {
     state_provider: S,
 
     /// The caches used for the provider
-    caches: ProviderCaches,
+    caches: ExecutionCache,
 
     /// Metrics for the cached state provider
     metrics: CachedStateMetrics,
@@ -37,11 +56,11 @@ impl<S> CachedStateProvider<S>
 where
     S: StateProvider,
 {
-    /// Creates a new [`CachedStateProvider`] from a [`ProviderCaches`], state provider, and
+    /// Creates a new [`CachedStateProvider`] from an [`ExecutionCache`], state provider, and
     /// [`CachedStateMetrics`].
     pub(crate) const fn new_with_caches(
         state_provider: S,
-        caches: ProviderCaches,
+        caches: ExecutionCache,
         metrics: CachedStateMetrics,
     ) -> Self {
         Self { state_provider, caches, metrics }
@@ -128,14 +147,18 @@ impl<S: AccountReader> AccountReader for CachedStateProvider<S> {
     }
 }
 
-/// Represents the status of a storage slot in the cache
+/// Represents the status of a storage slot in the cache.
+///
+/// The distinction between `NotCached` and `Empty` is crucial for performance:
+/// - `NotCached` means we need to query the database
+/// - `Empty` means we already know the slot is zero (no database query needed)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum SlotStatus {
-    /// The account's storage cache doesn't exist
+    /// The account's storage cache doesn't exist.
     NotCached,
-    /// The storage slot is empty (either not in cache or explicitly None)
+    /// The storage slot exists in cache and is empty (value is zero).
     Empty,
-    /// The storage slot has a value
+    /// The storage slot exists in cache and has a specific non-zero value.
     Value(StorageValue),
 }
 
@@ -248,6 +271,23 @@ impl<S: StorageRootProvider> StorageRootProvider for CachedStateProvider<S> {
         self.state_provider.storage_proof(address, slot, hashed_storage)
     }
 
+    /// Generate a storage multiproof for multiple storage slots.
+    ///
+    /// A **storage multiproof** is a cryptographic proof that can verify the values
+    /// of multiple storage slots for a single account in a single verification step.
+    /// Instead of generating separate proofs for each slot (which would be inefficient),
+    /// a multiproof bundles the necessary trie nodes to prove all requested slots.
+    ///
+    /// ## How it works:
+    /// 1. Takes an account address and a list of storage slot keys
+    /// 2. Traverses the account's storage trie to collect proof nodes
+    /// 3. Returns a [`StorageMultiProof`] containing the minimal set of trie nodes
+    ///    needed to verify all the requested storage slots
+    ///
+    /// ## Relationship to Caching:
+    /// Storage multiproofs are not directly cached, but they rely on the underlying
+    /// storage data that IS cached. When generating proofs, cached storage values
+    /// can be used instead of fetching from disk, improving proof generation speed.
     fn storage_multiproof(
         &self,
         address: Address,
@@ -278,20 +318,24 @@ impl<S: HashedPostStateProvider> HashedPostStateProvider for CachedStateProvider
     }
 }
 
-/// The set of caches that are used in the [`CachedStateProvider`].
+/// Execution cache used during block processing.
+///
+/// Optimizes state access by maintaining in-memory copies of frequently accessed
+/// accounts, storage slots, and bytecode. Works in conjunction with prewarming
+/// to reduce database I/O during block execution.
 #[derive(Debug, Clone)]
-pub(crate) struct ProviderCaches {
-    /// The cache for bytecode
+pub(crate) struct ExecutionCache {
+    /// Cache for contract bytecode, keyed by code hash.
     code_cache: Cache<B256, Option<Bytecode>>,
 
-    /// The cache for storage, organized hierarchically by account
+    /// Hierarchical storage cache organized by account address.
     storage_cache: Cache<Address, AccountStorageCache>,
 
-    /// The cache for basic accounts
+    /// Cache for basic account information (nonce, balance, code hash).
     account_cache: Cache<Address, Option<Account>>,
 }
 
-impl ProviderCaches {
+impl ExecutionCache {
     /// Get storage value from hierarchical cache.
     ///
     /// Returns a `SlotStatus` indicating whether:
@@ -330,18 +374,26 @@ impl ProviderCaches {
         self.storage_cache.iter().map(|addr| addr.len()).sum()
     }
 
-    /// Inserts the [`BundleState`] entries into the cache.
+    /// Inserts the post-execution state changes into the cache.
     ///
-    /// Entries are inserted in the following order:
-    /// 1. Bytecodes
-    /// 2. Storage slots
-    /// 3. Accounts
+    /// This method is called after transaction execution to update the cache with
+    /// the touched and modified state. The insertion order is critical:
     ///
-    /// The order is important, because the access patterns are Account -> Bytecode and Account ->
-    /// Storage slot. If we update the account first, it may point to a code hash that doesn't have
-    /// the associated bytecode anywhere yet.
+    /// 1. **Bytecodes**: Insert contract code first
+    /// 2. **Storage slots**: Update storage values for each account  
+    /// 3. **Accounts**: Update account info (nonce, balance, code hash)
     ///
-    /// Returns an error if the state can't be cached and should be discarded.
+    /// ## Why This Order Matters
+    ///
+    /// Account information references bytecode via code hash. If we update accounts
+    /// before bytecode, we might create cache entries pointing to non-existent code.
+    /// The current order ensures cache consistency.
+    ///
+    /// ## Error Handling
+    ///
+    /// Returns `Err(())` if the state updates are inconsistent (e.g., modified account
+    /// with `None` info that should have been destroyed). In this case, the entire
+    /// cache update should be discarded to maintain consistency.
     pub(crate) fn insert_state(&self, state_updates: &BundleState) -> Result<(), ()> {
         // Insert bytecodes
         for (code_hash, bytecode) in &state_updates.contracts {
@@ -388,9 +440,9 @@ impl ProviderCaches {
     }
 }
 
-/// A builder for [`ProviderCaches`].
+/// A builder for [`ExecutionCache`].
 #[derive(Debug)]
-pub(crate) struct ProviderCacheBuilder {
+pub(crate) struct ExecutionCacheBuilder {
     /// Code cache entries
     code_cache_entries: u64,
 
@@ -401,9 +453,9 @@ pub(crate) struct ProviderCacheBuilder {
     account_cache_entries: u64,
 }
 
-impl ProviderCacheBuilder {
-    /// Build a [`ProviderCaches`] struct, so that provider caches can be easily cloned.
-    pub(crate) fn build_caches(self, total_cache_size: u64) -> ProviderCaches {
+impl ExecutionCacheBuilder {
+    /// Build an [`ExecutionCache`] struct, so that execution caches can be easily cloned.
+    pub(crate) fn build_caches(self, total_cache_size: u64) -> ExecutionCache {
         let storage_cache_size = (total_cache_size * 8888) / 10000; // 88.88% of total
         let account_cache_size = (total_cache_size * 556) / 10000; // 5.56% of total
         let code_cache_size = (total_cache_size * 556) / 10000; // 5.56% of total
@@ -464,11 +516,11 @@ impl ProviderCacheBuilder {
             .time_to_idle(TIME_TO_IDLE)
             .build_with_hasher(DefaultHashBuilder::default());
 
-        ProviderCaches { code_cache, storage_cache, account_cache }
+        ExecutionCache { code_cache, storage_cache, account_cache }
     }
 }
 
-impl Default for ProviderCacheBuilder {
+impl Default for ExecutionCacheBuilder {
     fn default() -> Self {
         // With weigher and max_capacity in place, these numbers represent
         // the maximum number of entries that can be stored, not the actual
@@ -493,7 +545,7 @@ pub(crate) struct SavedCache {
     hash: B256,
 
     /// The caches used for the provider.
-    caches: ProviderCaches,
+    caches: ExecutionCache,
 
     /// Metrics for the cached state provider
     metrics: CachedStateMetrics,
@@ -503,7 +555,7 @@ impl SavedCache {
     /// Creates a new instance with the internals
     pub(super) const fn new(
         hash: B256,
-        caches: ProviderCaches,
+        caches: ExecutionCache,
         metrics: CachedStateMetrics,
     ) -> Self {
         Self { hash, caches, metrics }
@@ -515,16 +567,16 @@ impl SavedCache {
     }
 
     /// Splits the cache into its caches and metrics, consuming it.
-    pub(crate) fn split(self) -> (ProviderCaches, CachedStateMetrics) {
+    pub(crate) fn split(self) -> (ExecutionCache, CachedStateMetrics) {
         (self.caches, self.metrics)
     }
 
-    /// Returns the [`ProviderCaches`] belonging to the tracked hash.
-    pub(crate) const fn cache(&self) -> &ProviderCaches {
+    /// Returns the [`ExecutionCache`] belonging to the tracked hash.
+    pub(crate) const fn cache(&self) -> &ExecutionCache {
         &self.caches
     }
 
-    /// Updates the metrics for the [`ProviderCaches`].
+    /// Updates the metrics for the [`ExecutionCache`].
     pub(crate) fn update_metrics(&self) {
         self.metrics.storage_cache_size.set(self.caches.total_storage_slots() as f64);
         self.metrics.account_cache_size.set(self.caches.account_cache.entry_count() as f64);
@@ -532,10 +584,13 @@ impl SavedCache {
     }
 }
 
-/// Cache for an account's storage slots
+/// Cache for an individual account's storage slots.
+///
+/// This represents the second level of the hierarchical storage cache.
+/// Each account gets its own `AccountStorageCache` to store accessed storage slots.
 #[derive(Debug, Clone)]
 pub(crate) struct AccountStorageCache {
-    /// The storage slots for this account
+    /// Map of storage keys to their cached values.
     slots: Cache<StorageKey, Option<StorageValue>>,
 }
 
@@ -692,7 +747,7 @@ mod tests {
         let provider = MockEthProvider::default();
         provider.extend_accounts(vec![(address, account)]);
 
-        let caches = ProviderCacheBuilder::default().build_caches(1000);
+        let caches = ExecutionCacheBuilder::default().build_caches(1000);
         let state_provider =
             CachedStateProvider::new_with_caches(provider, caches, CachedStateMetrics::zeroed());
 
@@ -715,7 +770,7 @@ mod tests {
         let provider = MockEthProvider::default();
         provider.extend_accounts(vec![(address, account)]);
 
-        let caches = ProviderCacheBuilder::default().build_caches(1000);
+        let caches = ExecutionCacheBuilder::default().build_caches(1000);
         let state_provider =
             CachedStateProvider::new_with_caches(provider, caches, CachedStateMetrics::zeroed());
 
@@ -733,7 +788,7 @@ mod tests {
         let storage_value = U256::from(1);
 
         // insert into caches directly
-        let caches = ProviderCacheBuilder::default().build_caches(1000);
+        let caches = ExecutionCacheBuilder::default().build_caches(1000);
         caches.insert_storage(address, storage_key, Some(storage_value));
 
         // check that the storage is empty
@@ -748,7 +803,7 @@ mod tests {
         let address = Address::random();
 
         // just create empty caches
-        let caches = ProviderCacheBuilder::default().build_caches(1000);
+        let caches = ExecutionCacheBuilder::default().build_caches(1000);
 
         // check that the storage is empty
         let slot_status = caches.get_storage(&address, &storage_key);
@@ -763,7 +818,7 @@ mod tests {
         let storage_key = StorageKey::random();
 
         // insert into caches directly
-        let caches = ProviderCacheBuilder::default().build_caches(1000);
+        let caches = ExecutionCacheBuilder::default().build_caches(1000);
         caches.insert_storage(address, storage_key, None);
 
         // check that the storage is empty

--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -1,23 +1,4 @@
 //! Execution cache implementation for block processing.
-//!
-//! This module provides a caching layer on top of state providers to optimize
-//! state access during block execution. The cache system works in conjunction
-//! with prewarming to improve performance.
-//!
-//! ## Architecture
-//!
-//! The caching system consists of:
-//! - [`ExecutionCache`]: Main cache structure holding account, storage, and bytecode caches
-//! - [`CachedStateProvider`]: Wrapper that adds caching to any [`StateProvider`]
-//! - [`AccountStorageCache`]: Hierarchical storage cache organized by account
-//! - [`SlotStatus`]: Enum representing cache hit/miss status for storage slots
-//!
-//! ## Cache Behavior
-//!
-//! On read: checks cache first, returns cached value on hit, fetches from
-//! underlying provider on miss and caches the result.
-//!
-//! On write: after execution, touched state is inserted via [`ExecutionCache::insert_state`].
 use alloy_primitives::{Address, StorageKey, StorageValue, B256};
 use metrics::Gauge;
 use mini_moka::sync::CacheBuilder;

--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -368,9 +368,7 @@ impl ExecutionCache {
     ///
     /// ## Error Handling
     ///
-    /// Returns `Err(())` if the state updates are inconsistent (e.g., modified account
-    /// with `None` info that should have been destroyed). In this case, the entire
-    /// cache update should be discarded to maintain consistency.
+    /// Returns an error if the state updates are inconsistent and should be discarded. 
     pub(crate) fn insert_state(&self, state_updates: &BundleState) -> Result<(), ()> {
         // Insert bytecodes
         for (code_hash, bytecode) in &state_updates.contracts {

--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -129,10 +129,6 @@ impl<S: AccountReader> AccountReader for CachedStateProvider<S> {
 }
 
 /// Represents the status of a storage slot in the cache.
-///
-/// The distinction between `NotCached` and `Empty` is crucial for performance:
-/// - `NotCached` means we need to query the database
-/// - `Empty` means we already know the slot is zero (no database query needed)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum SlotStatus {
     /// The account's storage cache doesn't exist.

--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -281,8 +281,8 @@ impl<S: StorageRootProvider> StorageRootProvider for CachedStateProvider<S> {
     /// ## How it works:
     /// 1. Takes an account address and a list of storage slot keys
     /// 2. Traverses the account's storage trie to collect proof nodes
-    /// 3. Returns a [`StorageMultiProof`] containing the minimal set of trie nodes
-    ///    needed to verify all the requested storage slots
+    /// 3. Returns a [`StorageMultiProof`] containing the minimal set of trie nodes needed to verify
+    ///    all the requested storage slots
     ///
     /// ## Relationship to Caching:
     /// Storage multiproofs are not directly cached, but they rely on the underlying
@@ -380,7 +380,7 @@ impl ExecutionCache {
     /// the touched and modified state. The insertion order is critical:
     ///
     /// 1. **Bytecodes**: Insert contract code first
-    /// 2. **Storage slots**: Update storage values for each account  
+    /// 2. **Storage slots**: Update storage values for each account
     /// 3. **Accounts**: Update account info (nonce, balance, code hash)
     ///
     /// ## Why This Order Matters

--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -356,9 +356,9 @@ impl ExecutionCache {
     /// This method is called after transaction execution to update the cache with
     /// the touched and modified state. The insertion order is critical:
     ///
-    /// 1. **Bytecodes**: Insert contract code first
-    /// 2. **Storage slots**: Update storage values for each account
-    /// 3. **Accounts**: Update account info (nonce, balance, code hash)
+    /// 1. Bytecodes: Insert contract code first
+    /// 2. Storage slots: Update storage values for each account
+    /// 3. Accounts: Update account info (nonce, balance, code hash)
     ///
     /// ## Why This Order Matters
     ///

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -1,7 +1,10 @@
 //! Entrypoint for payload processing.
 
 use crate::tree::{
-    cached_state::{CachedStateMetrics, ExecutionCacheBuilder, ExecutionCache as StateExecutionCache, SavedCache},
+    cached_state::{
+        CachedStateMetrics, ExecutionCache as StateExecutionCache, ExecutionCacheBuilder,
+        SavedCache,
+    },
     payload_processor::{
         prewarm::{PrewarmCacheTask, PrewarmContext, PrewarmTaskEvent},
         sparse_trie::StateRootComputeOutcome,

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -1,7 +1,7 @@
 //! Entrypoint for payload processing.
 
 use crate::tree::{
-    cached_state::{CachedStateMetrics, ProviderCacheBuilder, ProviderCaches, SavedCache},
+    cached_state::{CachedStateMetrics, ExecutionCacheBuilder, ExecutionCache as StateExecutionCache, SavedCache},
     payload_processor::{
         prewarm::{PrewarmCacheTask, PrewarmContext, PrewarmTaskEvent},
         sparse_trie::StateRootComputeOutcome,
@@ -354,7 +354,7 @@ where
     /// instance.
     fn cache_for(&self, parent_hash: B256) -> SavedCache {
         self.execution_cache.get_cache_for(parent_hash).unwrap_or_else(|| {
-            let cache = ProviderCacheBuilder::default().build_caches(self.cross_block_cache_size);
+            let cache = ExecutionCacheBuilder::default().build_caches(self.cross_block_cache_size);
             SavedCache::new(parent_hash, cache, CachedStateMetrics::zeroed())
         })
     }
@@ -452,7 +452,7 @@ impl<Tx, Err> PayloadHandle<Tx, Err> {
     }
 
     /// Returns a clone of the caches used by prewarming
-    pub(super) fn caches(&self) -> ProviderCaches {
+    pub(super) fn caches(&self) -> StateExecutionCache {
         self.prewarm_handle.cache.clone()
     }
 
@@ -486,7 +486,7 @@ impl<Tx, Err> PayloadHandle<Tx, Err> {
 #[derive(Debug)]
 pub(crate) struct CacheTaskHandle {
     /// The shared cache the task operates with.
-    cache: ProviderCaches,
+    cache: StateExecutionCache,
     /// Metrics for the caches
     cache_metrics: CachedStateMetrics,
     /// Channel to the spawned prewarm task if any

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -6,15 +6,18 @@
 //!
 //! ## How Prewarming Works
 //!
-//! 1. Incoming transactions are split into two streams: one for prewarming
-//!    (executed in parallel) and one for actual execution (executed sequentially)
+//! 1. Incoming transactions are split into two streams: one for prewarming (executed in parallel)
+//!    and one for actual execution (executed sequentially)
 //! 2. Prewarming tasks execute transactions in parallel using shared caches
 //! 3. When actual block execution happens, it benefits from the warmed cache
 
 use crate::tree::{
-    cached_state::{CachedStateMetrics, CachedStateProvider, ExecutionCache as StateExecutionCache, SavedCache},
+    cached_state::{
+        CachedStateMetrics, CachedStateProvider, ExecutionCache as StateExecutionCache, SavedCache,
+    },
     payload_processor::{
-        executor::WorkloadExecutor, multiproof::MultiProofMessage, ExecutionCache as PayloadExecutionCache,
+        executor::WorkloadExecutor, multiproof::MultiProofMessage,
+        ExecutionCache as PayloadExecutionCache,
     },
     precompile_cache::{CachedPrecompile, PrecompileCacheMap},
     ExecutionEnv, StateProviderBuilder,

--- a/crates/engine/tree/src/tree/persistence_state.rs
+++ b/crates/engine/tree/src/tree/persistence_state.rs
@@ -1,3 +1,25 @@
+//! Persistence state management for background database operations.
+//!
+//! This module manages the state of background tasks that persist cached data
+//! to the database. The persistence system works asynchronously to avoid blocking
+//! block execution while ensuring data durability.
+//!
+//! ## Background Persistence
+//!
+//! The execution engine maintains an in-memory cache of state changes that need
+//! to be persisted to disk. Rather than writing synchronously (which would slow
+//! down block processing), persistence happens in background tasks.
+//!
+//! ## Persistence Actions
+//!
+//! - **Saving Blocks**: Persist newly executed blocks and their state changes
+//! - **Removing Blocks**: Remove invalid blocks during chain reorganizations
+//!
+//! ## Coordination
+//!
+//! The [`PersistenceState`] tracks ongoing persistence operations and coordinates
+//! between the main execution thread and background persistence workers.
+
 use alloy_eips::BlockNumHash;
 use alloy_primitives::B256;
 use std::time::Instant;


### PR DESCRIPTION
Improves cache-related code clarity and documentation as requested in #18451.

part of the comments are from Claude (LMAO much better than my own version)

## Changes

- Rename `ProviderCaches` → `ExecutionCache` for clearer purpose
- Rename `ProviderCacheBuilder` → `ExecutionCacheBuilder`
- Resolve naming conflicts with payload processor types

- Add module-level docs explaining cache architecture and behavior
- Clarify `SlotStatus::Empty` vs `SlotStatus::NotCached` distinction
- Document `storage_multiproof` concept and relationship to caching
- Explain cache lifecycle and relationship with prewarming
- Add background persistence documentation

Closes #18451