### PR TITLE
fix(engine): remove redundant method-level where bound in InvalidBlockWitnessHook

### DIFF
--- a/crates/engine/invalid-block-hooks/src/witness.rs
+++ b/crates/engine/invalid-block-hooks/src/witness.rs
@@ -145,10 +145,7 @@ where
         block: &RecoveredBlock<N::Block>,
         output: &BlockExecutionOutput<N::Receipt>,
         trie_updates: Option<(&TrieUpdates, B256)>,
-    ) -> eyre::Result<()>
-    where
-        N: NodePrimitives,
-    {
+    ) -> eyre::Result<()> {
         // TODO(alexey): unify with `DebugApi::debug_execution_witness`
 
         let mut executor = self.evm_config.batch_executor(StateProviderDatabase::new(


### PR DESCRIPTION
The method on_invalid_block redundantly declared where N: NodePrimitives while the enclosing impl already constrained N. This duplication provided no additional guarantees, reduced readability, and was inconsistent with the project’s style where impl-level bounds are not repeated on methods. Removing the redundant bound keeps a single source of truth and maintains identical semantics.