### PR TITLE
docs(engine): fix LiveSync target doc and clarify disable-parallel-sparse-trie semantics

### DIFF
--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -339,7 +339,7 @@ impl TreeConfig {
         self
     }
 
-    /// Setter for using the parallel sparse trie
+    /// Setter for whether to disable the parallel sparse trie
     pub const fn with_disable_parallel_sparse_trie(
         mut self,
         disable_parallel_sparse_trie: bool,

--- a/crates/engine/primitives/src/event.rs
+++ b/crates/engine/primitives/src/event.rs
@@ -90,7 +90,7 @@ pub enum ConsensusEngineLiveSyncProgress {
     DownloadingBlocks {
         /// The number of blocks remaining to download.
         remaining_blocks: u64,
-        /// The target block hash and number to download.
+        /// The target block hash to download.
         target: B256,
     },
 }

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -89,7 +89,7 @@ where
             Option<ClearedSparseStateTrie<ConfiguredSparseTrie, ConfiguredSparseTrie>>,
         >,
     >,
-    /// Whether to use the parallel sparse trie.
+    /// Whether to disable the parallel sparse trie.
     disable_parallel_sparse_trie: bool,
     /// A cleared trie input, kept around to be reused so allocations can be minimized.
     trie_input: Option<TrieInput>,


### PR DESCRIPTION
- Correct the ConsensusEngineLiveSyncProgress::DownloadingBlocks.target comment to state it carries only the block hash, matching its B256 type and usage. This removes the misleading mention of a block number and aligns with how it’s logged and consumed.
- Clarify the “disable parallel sparse trie” semantics across engine docs by updating:
  - crates/engine/primitives/src/config.rs setter doc to explicitly indicate it disables the feature.
  - crates/engine/tree/src/tree/payload_processor/mod.rs field doc to reflect it disables the feature.