### PR TITLE
refactor: remove anyhow dependency from nippy-jar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8818,7 +8818,6 @@ dependencies = [
 name = "reth-nippy-jar"
 version = "1.7.0"
 dependencies = [
- "anyhow",
  "bincode 1.3.3",
  "derive_more",
  "lz4_flex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -665,7 +665,6 @@ snmalloc-rs = { version = "0.3.7", features = ["build_cc"] }
 
 aes = "0.8.1"
 ahash = "0.8"
-anyhow = "1.0"
 bindgen = { version = "0.70", default-features = false }
 block-padding = "0.3.2"
 cc = "=1.2.15"

--- a/crates/storage/nippy-jar/Cargo.toml
+++ b/crates/storage/nippy-jar/Cargo.toml
@@ -26,7 +26,6 @@ memmap2.workspace = true
 bincode.workspace = true
 serde = { workspace = true, features = ["derive"] }
 tracing.workspace = true
-anyhow.workspace = true
 thiserror.workspace = true
 derive_more.workspace = true
 

--- a/crates/storage/nippy-jar/src/error.rs
+++ b/crates/storage/nippy-jar/src/error.rs
@@ -25,8 +25,8 @@ pub enum NippyJarError {
     Bincode(#[from] Box<bincode::ErrorKind>),
 
     /// An error occurred with the Elias-Fano encoding/decoding process.
-    #[error(transparent)]
-    EliasFano(#[from] anyhow::Error),
+    #[error("Elias-Fano encoding/decoding error: {0}")]
+    EliasFano(String),
 
     /// Compression was enabled, but the compressor is not ready yet.
     #[error("compression was enabled, but it's not ready yet")]


### PR DESCRIPTION
Removes unnecessary anyhow dependency from the nippy-jar crate.

The EliasFano error variant was the only usage of anyhow::Error in the codebase, and it was never actually used. Replaced it with a simple String type to maintain the same functionality while reducing dependencies.