### PR TITLE
fix(cli): disallow --instance 0

### DIFF
--- a/crates/cli/commands/src/node.rs
+++ b/crates/cli/commands/src/node.rs
@@ -59,7 +59,7 @@ pub struct NodeCommand<C: ChainSpecParser, Ext: clap::Args + fmt::Debug = NoArgs
     /// - `HTTP_RPC_PORT`: default - `instance` + 1
     /// - `WS_RPC_PORT`: default + `instance` * 2 - 2
     /// - `IPC_PATH`: default + `-instance`
-    #[arg(long, value_name = "INSTANCE", global = true, value_parser = value_parser!(u16).range(..=200))]
+    #[arg(long, value_name = "INSTANCE", global = true, value_parser = value_parser!(u16).range(1..=200))]
     pub instance: Option<u16>,
 
     /// Sets all ports to unused, allowing the OS to choose random unused ports when sockets are


### PR DESCRIPTION
Running reth nodes with argument `--instance 0` fails in DEBUG builds with message:

```
thread 'main' panicked at /Users/user/.cargo/git/checkouts/reth-e231042ee7db3fb7/8c2d5cc/crates/node/core/src/args/network.rs:322:13:
assertion `left != right` failed: instance must be non-zero
  left: 0
 right: 0
```

Indeed, `instance == 0` is rejected here:

https://github.com/paradigmxyz/reth/blob/d1c966020b93d12795d855d5471c16ed46689d52/crates/node/core/src/args/network.rs#L327-L329

The CLI documentation also immplies the same (since `default + instance - 1` might underflow for specific values of default):

https://github.com/paradigmxyz/reth/blob/d1c966020b93d12795d855d5471c16ed46689d52/crates/cli/commands/src/node.rs#L57

