### PR TITLE
fix(trie): Don't run repair-trie if MerkleExecute is incomplete

### DIFF
--- a/crates/trie/trie/src/verify.rs
+++ b/crates/trie/trie/src/verify.rs
@@ -28,7 +28,7 @@ enum BranchNode {
 /// of the trie tables.
 ///
 /// [`BranchNode`]s are iterated over such that:
-/// * Account nodes and storage nodes may be interspersed.
+/// * Account nodes and storage nodes may be interleaved.
 /// * Storage nodes for the same account will be ordered by ascending path relative to each other.
 /// * Account nodes will be ordered by ascending path relative to each other.
 /// * All storage nodes for one account will finish before storage nodes for another account are


### PR DESCRIPTION
This handles the case of someone dropping/partially completing the MerkleExecute stage and then subsequently running repair-trie.