### PR TITLE
chore: skip prewarm transact errors

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -336,7 +336,8 @@ where
                         sender=%tx.signer(),
                         "Error when executing prewarm transaction",
                     );
-                    return
+                    // skip error because we can ignore these errors and continue with the next tx
+                    continue
                 }
             };
             metrics.execution_duration.record(start.elapsed());


### PR DESCRIPTION
this would terminate the task making and ignoring any new incoming txs

because this is prewarming we can continue with the next tx, distributed here

https://github.com/paradigmxyz/reth/blob/f25008cd93394c2955fa6bcd369087c4f5ba00c2/crates/engine/tree/src/tree/payload_processor/prewarm.rs#L110-L110
