### PR TITLE
chore(engine): avoid panic on mpsc send in sparse trie worker

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -204,7 +204,12 @@ where
 
             SparseStateTrieResult::Ok((address, storage_trie))
         })
-        .for_each_init(|| tx.clone(), |tx, result| { let _ = tx.send(result); });
+        .for_each_init(
+            || tx.clone(),
+            |tx, result| {
+                let _ = tx.send(result);
+            },
+        );
     drop(tx);
 
     // Defer leaf removals until after updates/additions, so that we don't delete an intermediate

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -204,7 +204,7 @@ where
 
             SparseStateTrieResult::Ok((address, storage_trie))
         })
-        .for_each_init(|| tx.clone(), |tx, result| tx.send(result).unwrap());
+        .for_each_init(|| tx.clone(), |tx, result| { let _ = tx.send(result); });
     drop(tx);
 
     // Defer leaf removals until after updates/additions, so that we don't delete an intermediate


### PR DESCRIPTION
Replace tx.send(...).unwrap() with a non-panicking send in the sparse trie parallel worker. The receiver may exit early on the first error (result?), closing the channel; unwrap() would panic in Rayon workers when the channel is closed. Other modules use soft send (let _ = send(...)) in similar patterns. This change prevents spurious panics and aligns with repository conventions.