### PR TITLE
fix(docs): correct BlockBody root docs and RecoveredBlock “safer variant” references

### DIFF
--- a/crates/primitives-traits/src/block/body.rs
+++ b/crates/primitives-traits/src/block/body.rs
@@ -109,7 +109,7 @@ pub trait BlockBody:
 
     /// Calculate the withdrawals root for the block body.
     ///
-    /// Returns `RecoveryError` if there are no withdrawals in the block.
+    /// Returns `Some(root)` if withdrawals are present, otherwise `None`.
     fn calculate_withdrawals_root(&self) -> Option<B256> {
         self.withdrawals().map(|withdrawals| {
             alloy_consensus::proofs::calculate_withdrawals_root(withdrawals.as_slice())
@@ -121,7 +121,7 @@ pub trait BlockBody:
 
     /// Calculate the ommers root for the block body.
     ///
-    /// Returns `RecoveryError` if there are no ommers in the block.
+    /// Returns `Some(root)` if ommers are present, otherwise `None`.
     fn calculate_ommers_root(&self) -> Option<B256> {
         self.ommers().map(alloy_consensus::proofs::calculate_ommers_root)
     }

--- a/crates/primitives-traits/src/block/recovered.rs
+++ b/crates/primitives-traits/src/block/recovered.rs
@@ -103,7 +103,7 @@ impl<B: Block> RecoveredBlock<B> {
         Self { block, senders }
     }
 
-    /// A safer variant of [`Self::new_unhashed`] that checks if the number of senders is equal to
+    /// A safer variant of [`Self::new`] that checks if the number of senders is equal to
     /// the number of transactions in the block and recovers the senders from the transactions, if
     /// not using [`SignedTransaction::recover_signer`](crate::transaction::signed::SignedTransaction)
     /// to recover the senders.
@@ -216,7 +216,7 @@ impl<B: Block> RecoveredBlock<B> {
         Ok(Self::new(block, senders, hash))
     }
 
-    /// A safer variant of [`Self::new_unhashed`] that checks if the number of senders is equal to
+    /// A safer variant of [`Self::new_sealed`] that checks if the number of senders is equal to
     /// the number of transactions in the block and recovers the senders from the transactions, if
     /// not using [`SignedTransaction::recover_signer_unchecked`](crate::transaction::signed::SignedTransaction)
     /// to recover the senders.
@@ -230,7 +230,7 @@ impl<B: Block> RecoveredBlock<B> {
         Self::try_new(block, senders, hash)
     }
 
-    /// A safer variant of [`Self::new`] that checks if the number of senders is equal to
+    /// A safer variant of [`Self::new_sealed`] that checks if the number of senders is equal to
     /// the number of transactions in the block and recovers the senders from the transactions, if
     /// not using [`SignedTransaction::recover_signer_unchecked`](crate::transaction::signed::SignedTransaction)
     /// to recover the senders.


### PR DESCRIPTION
- body.rs: clarify roots return Option; say “Returns Some(root)… otherwise None.”
- recovered.rs: point “A safer variant of …” to correct base methods (new, new_sealed).
- Rationale: functions return Option<B256> and callers match on Option; safer variants should reference the non-safe equivalents with identical inputs. No code changes.