### PR TITLE
fix: don't override existing tables in `create_tables_for`

### DIFF
--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -496,7 +496,7 @@ impl DatabaseEnv {
     /// after the default [`Self::create_tables`] are created.
     pub fn create_tables_for<TS: TableSet>(mut self: &mut Arc<Self>) -> Result<(), DatabaseError> {
         let handles = self._create_tables::<TS>()?;
-        if let Some(db) = Arc::get_mut(&mut self) {
+        if let Some(db) = Arc::get_mut(self) {
             // Note: The db is unique and the dbis as well, and they can also be cloned.
             let dbis = Arc::make_mut(&mut db.dbis);
             dbis.extend(handles);

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -469,14 +469,47 @@ impl DatabaseEnv {
     }
 
     /// Creates all the tables defined in [`Tables`], if necessary.
+    ///
+    /// This keeps tracks of the created table handles and stores them for better efficiency.
     pub fn create_tables(&mut self) -> Result<(), DatabaseError> {
-        self.create_tables_for::<Tables>()
+        self.create_and_track_tables_for::<Tables>()
     }
 
     /// Creates all the tables defined in the given [`TableSet`], if necessary.
-    pub fn create_tables_for<TS: TableSet>(&mut self) -> Result<(), DatabaseError> {
+    ///
+    /// This keeps tracks of the created table handles and stores them for better efficiency.
+    pub fn create_and_track_tables_for<TS: TableSet>(&mut self) -> Result<(), DatabaseError> {
+        let handles = self._create_tables::<TS>()?;
+        // Note: This is okay because self has mutable access here and `DatabaseEnv` must be Arc'ed
+        // before it can be shared.
+        let dbis = Arc::make_mut(&mut self.dbis);
+        dbis.extend(handles);
+
+        Ok(())
+    }
+
+    /// Creates all the tables defined in [`Tables`], if necessary.
+    ///
+    /// If this type is unique the created handle for the tables will be updated.
+    ///
+    /// This is recommended to be called during initialization to create and track additional tables
+    /// after the default [`Self::create_tables`] are created.
+    pub fn create_tables_for<TS: TableSet>(mut self: &mut Arc<Self>) -> Result<(), DatabaseError> {
+        let handles = self._create_tables::<TS>()?;
+        if let Some(db) = Arc::get_mut(&mut self) {
+            // Note: The db is unique and the dbis as well, and they can also be cloned.
+            let dbis = Arc::make_mut(&mut db.dbis);
+            dbis.extend(handles);
+        }
+        Ok(())
+    }
+
+    /// Creates the tables and returns the identifiers of the tables.
+    fn _create_tables<TS: TableSet>(
+        &self,
+    ) -> Result<Vec<(&'static str, ffi::MDBX_dbi)>, DatabaseError> {
+        let mut handles = Vec::new();
         let tx = self.inner.begin_rw_txn().map_err(|e| DatabaseError::InitTx(e.into()))?;
-        let dbis = Arc::get_mut(&mut self.dbis).expect("no transactions should open");
 
         for table in TS::tables() {
             let flags =
@@ -485,12 +518,11 @@ impl DatabaseEnv {
             let db = tx
                 .create_db(Some(table.name()), flags)
                 .map_err(|e| DatabaseError::CreateTable(e.into()))?;
-            dbis.insert(table.name(), db.dbi());
+            handles.push((table.name(), db.dbi()));
         }
 
         tx.commit().map_err(|e| DatabaseError::Commit(e.into()))?;
-
-        Ok(())
+        Ok(handles)
     }
 
     /// Records version that accesses the database with write privileges.

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -476,7 +476,7 @@ impl DatabaseEnv {
     /// Creates all the tables defined in the given [`TableSet`], if necessary.
     pub fn create_tables_for<TS: TableSet>(&mut self) -> Result<(), DatabaseError> {
         let tx = self.inner.begin_rw_txn().map_err(|e| DatabaseError::InitTx(e.into()))?;
-        let mut dbis = HashMap::with_capacity(Tables::ALL.len());
+        let dbis = Arc::get_mut(&mut self.dbis).expect("no transactions should open");
 
         for table in TS::tables() {
             let flags =
@@ -489,7 +489,6 @@ impl DatabaseEnv {
         }
 
         tx.commit().map_err(|e| DatabaseError::Commit(e.into()))?;
-        self.dbis = Arc::new(dbis);
 
         Ok(())
     }

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -494,7 +494,7 @@ impl DatabaseEnv {
     ///
     /// This is recommended to be called during initialization to create and track additional tables
     /// after the default [`Self::create_tables`] are created.
-    pub fn create_tables_for<TS: TableSet>(mut self: &mut Arc<Self>) -> Result<(), DatabaseError> {
+    pub fn create_tables_for<TS: TableSet>(self: &mut Arc<Self>) -> Result<(), DatabaseError> {
         let handles = self._create_tables::<TS>()?;
         if let Some(db) = Arc::get_mut(self) {
             // Note: The db is unique and the dbis as well, and they can also be cloned.

--- a/crates/storage/db/src/mdbx.rs
+++ b/crates/storage/db/src/mdbx.rs
@@ -42,7 +42,7 @@ pub fn init_db_for<P: AsRef<Path>, TS: TableSet>(
 ) -> eyre::Result<DatabaseEnv> {
     let client_version = args.client_version().clone();
     let mut db = create_db(path, args)?;
-    db.create_tables_for::<TS>()?;
+    db.create_and_update_tables_for::<TS>()?;
     db.record_client_version(client_version)?;
     Ok(db)
 }

--- a/crates/storage/db/src/mdbx.rs
+++ b/crates/storage/db/src/mdbx.rs
@@ -42,7 +42,7 @@ pub fn init_db_for<P: AsRef<Path>, TS: TableSet>(
 ) -> eyre::Result<DatabaseEnv> {
     let client_version = args.client_version().clone();
     let mut db = create_db(path, args)?;
-    db.create_and_update_tables_for::<TS>()?;
+    db.create_and_track_tables_for::<TS>()?;
     db.record_client_version(client_version)?;
     Ok(db)
 }


### PR DESCRIPTION
This should be called before database is cloned or any transactions are opened so we can do `get_mut` internally