### PR TITLE
feat(optimism): Implement `local_pending_state` for RPC that uses `pending_flashblock`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9483,6 +9483,7 @@ dependencies = [
  "op-alloy-rpc-types-engine",
  "op-revm",
  "reqwest",
+ "reth-chain-state",
  "reth-chainspec",
  "reth-evm",
  "reth-metrics",

--- a/crates/optimism/rpc/Cargo.toml
+++ b/crates/optimism/rpc/Cargo.toml
@@ -26,6 +26,7 @@ reth-rpc-api.workspace = true
 reth-node-api.workspace = true
 reth-node-builder.workspace = true
 reth-chainspec.workspace = true
+reth-chain-state.workspace = true
 reth-rpc-engine-api.workspace = true
 
 # op-reth

--- a/crates/optimism/rpc/src/eth/mod.rs
+++ b/crates/optimism/rpc/src/eth/mod.rs
@@ -35,7 +35,7 @@ use reth_rpc_eth_api::{
     RpcNodeCoreExt, RpcTypes, SignableTxRequest,
 };
 use reth_rpc_eth_types::{
-    block::BlockAndReceipts, EthStateCache, FeeHistoryCache, GasPriceOracle, PendingBlockEnvOrigin,
+    EthStateCache, FeeHistoryCache, GasPriceOracle, PendingBlock, PendingBlockEnvOrigin,
 };
 use reth_storage_api::{ProviderHeader, ProviderTx};
 use reth_tasks::{
@@ -113,10 +113,10 @@ impl<N: RpcNodeCore, Rpc: RpcConvert> OpEthApi<N, Rpc> {
         OpEthApiBuilder::new()
     }
 
-    /// Returns a [`BlockAndReceipts`] that is built out of flashblocks.
+    /// Returns a [`PendingBlock`] that is built out of flashblocks.
     ///
     /// If flashblocks receiver is not set, then it always returns `None`.
-    pub fn pending_flashblock(&self) -> eyre::Result<Option<BlockAndReceipts<N::Primitives>>>
+    pub fn pending_flashblock(&self) -> eyre::Result<Option<PendingBlock<N::Primitives>>>
     where
         OpEthApiError: FromEvmError<N::Evm>,
         Rpc: RpcConvert<Primitives = N::Primitives>,
@@ -138,7 +138,7 @@ impl<N: RpcNodeCore, Rpc: RpcConvert> OpEthApi<N, Rpc> {
             parent.hash() == pending_block.block().parent_hash() &&
             now <= pending_block.expires_at
         {
-            return Ok(Some(pending_block.to_block_and_receipts()));
+            return Ok(Some(pending_block.clone()));
         }
 
         Ok(None)

--- a/crates/optimism/rpc/src/eth/pending_block.rs
+++ b/crates/optimism/rpc/src/eth/pending_block.rs
@@ -1,17 +1,21 @@
 //! Loads OP pending block for a RPC response.
 
-use std::sync::Arc;
-
 use crate::{OpEthApi, OpEthApiError};
+use alloy_consensus::BlockHeader;
 use alloy_eips::BlockNumberOrTag;
+use reth_chain_state::BlockState;
 use reth_rpc_eth_api::{
-    helpers::{pending_block::PendingEnvBuilder, LoadPendingBlock},
+    helpers::{pending_block::PendingEnvBuilder, LoadPendingBlock, SpawnBlocking},
     FromEvmError, RpcConvert, RpcNodeCore,
 };
 use reth_rpc_eth_types::{
-    block::BlockAndReceipts, builder::config::PendingBlockKind, EthApiError, PendingBlock,
+    block::BlockAndReceipts, builder::config::PendingBlockKind, error::FromEthApiError,
+    EthApiError, PendingBlock,
 };
-use reth_storage_api::{BlockReader, BlockReaderIdExt, ReceiptProvider};
+use reth_storage_api::{
+    BlockReader, BlockReaderIdExt, ReceiptProvider, StateProviderBox, StateProviderFactory,
+};
+use std::sync::Arc;
 
 impl<N, Rpc> LoadPendingBlock for OpEthApi<N, Rpc>
 where
@@ -39,7 +43,7 @@ where
         &self,
     ) -> Result<Option<BlockAndReceipts<Self::Primitives>>, Self::Error> {
         if let Ok(Some(pending)) = self.pending_flashblock() {
-            return Ok(Some(pending));
+            return Ok(Some(pending.into_block_and_receipts()));
         }
 
         // See: <https://github.com/ethereum-optimism/op-geth/blob/f2e69450c6eec9c35d56af91389a1c47737206ca/miner/worker.go#L367-L375>
@@ -59,5 +63,24 @@ where
             .ok_or(EthApiError::ReceiptsNotFound(block_id.into()))?;
 
         Ok(Some(BlockAndReceipts { block: Arc::new(block), receipts: Arc::new(receipts) }))
+    }
+
+    /// Returns a [`StateProviderBox`] on a mem-pool built pending block overlaying latest.
+    async fn local_pending_state(&self) -> Result<Option<StateProviderBox>, Self::Error>
+    where
+        Self: SpawnBlocking,
+    {
+        let Ok(Some(pending_block)) = self.pending_flashblock() else {
+            return Ok(None);
+        };
+
+        let latest_historical = self
+            .provider()
+            .history_by_block_hash(pending_block.block().parent_hash())
+            .map_err(Self::Error::from_eth_err)?;
+
+        let state = BlockState::from(pending_block);
+
+        Ok(Some(Box::new(state.state_provider(latest_historical)) as StateProviderBox))
     }
 }

--- a/crates/optimism/rpc/src/eth/transaction.rs
+++ b/crates/optimism/rpc/src/eth/transaction.rs
@@ -86,6 +86,7 @@ where
                 // if flashblocks are supported, attempt to find id from the pending block
                 if let Ok(Some(pending_block)) = this.pending_flashblock() {
                     tx_receipt = pending_block
+                        .into_block_and_receipts()
                         .find_transaction_and_receipt_by_hash(hash)
                         .map(|(tx, receipt)| (tx.tx().clone(), tx.meta(), receipt.clone()));
                 }


### PR DESCRIPTION
Closes #18515

The Optimism RPC implementation has overriden the pending flashblock, but it came short on `local_pending_state`, which uses the default.

In this change, `local_pending_state` is overriden too.

The `pending_flashblock` return type has been changed to `PendingBlock`, even though it is a tiny bit less optimal, because in all the other use-cases it gets converted into block and receipts immediately. Regardless, this return type makes more sense.
