### PR TITLE
feat(engine): fallback for when both state root task and parallel state root failed

### DIFF
--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -501,7 +501,7 @@ where
                         }
                     }
                     Err(error) => {
-                        debug!(target: "engine::tree", %error, "Background parallel state root computation failed");
+                        debug!(target: "engine::tree", %error, "State root task failed");
                     }
                 }
             } else {
@@ -521,15 +521,8 @@ where
                         );
                         maybe_state_root = Some((result.0, result.1, root_time.elapsed()));
                     }
-                    Err(ParallelStateRootError::Provider(ProviderError::ConsistentView(error))) => {
-                        debug!(target: "engine::tree", %error, "Parallel state root computation failed consistency check, falling back");
-                    }
                     Err(error) => {
-                        return Err(InsertBlockError::new(
-                            block.into_sealed_block(),
-                            InsertBlockErrorKind::Other(Box::new(error)),
-                        )
-                        .into())
+                        debug!(target: "engine::tree", %error, "Parallel state root computation failed");
                     }
                 }
             }


### PR DESCRIPTION
Instead of just failing when `self.compute_state_root_parallel` returns an error, we should try the last resort method: sequential `state_provider.state_root_with_updates` that doesn't use `TrieInput`.