### PR TITLE
feat: relax `OpEngineValidatorBuilder` for more custom payload types

### DIFF
--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -1201,7 +1201,12 @@ pub struct OpEngineValidatorBuilder;
 
 impl<Node> PayloadValidatorBuilder<Node> for OpEngineValidatorBuilder
 where
-    Node: FullNodeComponents<Types: OpNodeTypes>,
+    Node: FullNodeComponents<
+        Types: NodeTypes<
+            ChainSpec: OpHardforks,
+            Payload: PayloadTypes<ExecutionData = OpExecutionData>,
+        >,
+    >,
 {
     type Validator = OpEngineValidator<
         Node::Provider,


### PR DESCRIPTION
We override `PayloadAttributes` and `PayloadBuilderAttributes` in our custom `PayloadTypes`, but keep `type ExecutionData = OpExecutionData`. This PR enables custom chains, like ours, to reuse `OpEngineValidatorBuilder` instead of writing a manual wrapper.