### PR TITLE
chore(engine): remove calldata exception workaround

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2528,21 +2528,9 @@ where
         self.emit_event(EngineApiEvent::BeaconConsensus(ConsensusEngineEvent::InvalidBlock(
             Box::new(block),
         )));
-        // Temporary fix for EIP-7623 test compatibility:
-        // Map gas floor errors to the expected format for test compatibility
-        // TODO: Remove this workaround once https://github.com/paradigmxyz/reth/issues/18369 is resolved
-        let mut error_str = validation_err.to_string();
-        if error_str.contains("gas floor") && error_str.contains("exceeds the gas limit") {
-            // Replace "gas floor" with "call gas cost" for compatibility with some tests
-            error_str = error_str.replace("gas floor", "call gas cost");
-            // The test also expects the error to contain
-            // "TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST"
-            error_str =
-                format!("TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST: {}", error_str);
-        }
 
         Ok(PayloadStatus::new(
-            PayloadStatusEnum::Invalid { validation_error: error_str },
+            PayloadStatusEnum::Invalid { validation_error: validation_err.to_string() },
             latest_valid_hash,
         ))
     }


### PR DESCRIPTION
## Description

Removes the exception workaround in this PR: #18013

With this removal all the failing calldata tests in hive now pass: https://hive.ethpandaops.io/#/test/fusaka/1758110192-fac69d0700d4cd656860e7a7fd2d7907?testnumber=20638

## Related Issues

#18369 