### PR TITLE
fix(rpc): use flashblock when preparing tx response on gettxreceipt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9499,6 +9499,7 @@ dependencies = [
  "reth-primitives-traits",
  "reth-rpc",
  "reth-rpc-api",
+ "reth-rpc-convert",
  "reth-rpc-engine-api",
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",

--- a/crates/optimism/rpc/Cargo.toml
+++ b/crates/optimism/rpc/Cargo.toml
@@ -28,6 +28,7 @@ reth-node-builder.workspace = true
 reth-chainspec.workspace = true
 reth-chain-state.workspace = true
 reth-rpc-engine-api.workspace = true
+reth-rpc-convert.workspace = true
 
 # op-reth
 reth-optimism-evm.workspace = true

--- a/crates/optimism/rpc/src/eth/transaction.rs
+++ b/crates/optimism/rpc/src/eth/transaction.rs
@@ -93,8 +93,8 @@ where
                     {
                         // Build tx receipt from pending block and receipts directly inline.
                         // This avoids canonical cache lookup that would be done by the
-                        // `build_transaction_receipt` which would result in a block not found issue.
-                        // See: https://github.com/paradigmxyz/reth/issues/18529 
+                        // `build_transaction_receipt` which would result in a block not found
+                        // issue. See: https://github.com/paradigmxyz/reth/issues/18529
                         let meta = tx.meta();
                         let all_receipts = &block_and_receipts.receipts;
                         let mut gas_used = 0;

--- a/crates/optimism/rpc/src/eth/transaction.rs
+++ b/crates/optimism/rpc/src/eth/transaction.rs
@@ -1,15 +1,17 @@
 //! Loads and formats OP transaction RPC response.
 
 use crate::{OpEthApi, OpEthApiError, SequencerClient};
+use alloy_consensus::TxReceipt as _;
 use alloy_primitives::{Bytes, B256};
 use alloy_rpc_types_eth::TransactionInfo;
 use op_alloy_consensus::{transaction::OpTransactionInfo, OpTransaction};
 use reth_optimism_primitives::DepositReceipt;
-use reth_primitives_traits::SignedTransaction;
+use reth_primitives_traits::{SignedTransaction, SignerRecoverable};
+use reth_rpc_convert::transaction::ConvertReceiptInput;
 use reth_rpc_eth_api::{
     helpers::{spec::SignersForRpc, EthTransactions, LoadReceipt, LoadTransaction},
-    try_into_op_tx_info, FromEthApiError, FromEvmError, RpcConvert, RpcNodeCore, RpcReceipt,
-    TxInfoMapper,
+    try_into_op_tx_info, EthApiTypes as _, FromEthApiError, FromEvmError, RpcConvert, RpcNodeCore,
+    RpcReceipt, TxInfoMapper,
 };
 use reth_rpc_eth_types::utils::recover_raw_transaction;
 use reth_storage_api::{errors::ProviderError, ReceiptProvider};
@@ -80,15 +82,49 @@ where
         let this = self.clone();
         async move {
             // first attempt to fetch the mined transaction receipt data
-            let mut tx_receipt = this.load_transaction_and_receipt(hash).await?;
+            let tx_receipt = this.load_transaction_and_receipt(hash).await?;
 
             if tx_receipt.is_none() {
                 // if flashblocks are supported, attempt to find id from the pending block
                 if let Ok(Some(pending_block)) = this.pending_flashblock() {
-                    tx_receipt = pending_block
-                        .into_block_and_receipts()
-                        .find_transaction_and_receipt_by_hash(hash)
-                        .map(|(tx, receipt)| (tx.tx().clone(), tx.meta(), receipt.clone()));
+                    let block_and_receipts = pending_block.into_block_and_receipts();
+                    if let Some((tx, receipt)) =
+                        block_and_receipts.find_transaction_and_receipt_by_hash(hash)
+                    {
+                        // Build tx receipt from pending block and receipts directly inline.
+                        // This avoids canonical cache lookup that would be done by the
+                        // `build_transaction_receipt` which would result in a block not found issue.
+                        // See: https://github.com/paradigmxyz/reth/issues/18529 
+                        let meta = tx.meta();
+                        let all_receipts = &block_and_receipts.receipts;
+                        let mut gas_used = 0;
+                        let mut next_log_index = 0;
+
+                        if meta.index > 0 {
+                            for r in all_receipts.iter().take(meta.index as usize) {
+                                gas_used = r.cumulative_gas_used();
+                                next_log_index += r.logs().len();
+                            }
+                        }
+
+                        return Ok(Some(
+                            this.tx_resp_builder()
+                                .convert_receipts(vec![ConvertReceiptInput {
+                                    tx: tx
+                                        .tx()
+                                        .clone()
+                                        .try_into_recovered_unchecked()
+                                        .map_err(Self::Error::from_eth_err)?
+                                        .as_recovered_ref(),
+                                    gas_used: receipt.cumulative_gas_used() - gas_used,
+                                    receipt: receipt.clone(),
+                                    next_log_index,
+                                    meta,
+                                }])?
+                                .pop()
+                                .unwrap(),
+                        ))
+                    }
                 }
             }
             let Some((tx, meta, receipt)) = tx_receipt else { return Ok(None) };

--- a/crates/rpc/rpc-eth-api/src/helpers/receipt.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/receipt.rs
@@ -9,6 +9,24 @@ use reth_rpc_convert::{transaction::ConvertReceiptInput, RpcConvert};
 use reth_rpc_eth_types::{error::FromEthApiError, EthApiError};
 use reth_storage_api::{ProviderReceipt, ProviderTx};
 
+/// Calculates the gas used and next log index for a transaction at the given index
+pub fn calculate_gas_used_and_next_log_index(
+    tx_index: u64,
+    all_receipts: &[impl TxReceipt],
+) -> (u64, usize) {
+    let mut gas_used = 0;
+    let mut next_log_index = 0;
+
+    if tx_index > 0 {
+        for receipt in all_receipts.iter().take(tx_index as usize) {
+            gas_used = receipt.cumulative_gas_used();
+            next_log_index += receipt.logs().len();
+        }
+    }
+
+    (gas_used, next_log_index)
+}
+
 /// Assembles transaction receipt data w.r.t to network.
 ///
 /// Behaviour shared by several `eth_` RPC methods, not exclusive to `eth_` receipts RPC methods.
@@ -41,15 +59,8 @@ pub trait LoadReceipt:
                 .map_err(Self::Error::from_eth_err)?
                 .ok_or(EthApiError::HeaderNotFound(hash.into()))?;
 
-            let mut gas_used = 0;
-            let mut next_log_index = 0;
-
-            if meta.index > 0 {
-                for receipt in all_receipts.iter().take(meta.index as usize) {
-                    gas_used = receipt.cumulative_gas_used();
-                    next_log_index += receipt.logs().len();
-                }
-            }
+            let (gas_used, next_log_index) =
+                calculate_gas_used_and_next_log_index(meta.index, &all_receipts);
 
             Ok(self
                 .tx_resp_builder()


### PR DESCRIPTION
Fixes #18529

Inline build of tx receipt using flashblock's `BlockAndReceipts` instead of calling `build_transaction_receipt` method to avoid fetching the receipts from canonical block.