### PR TITLE
feat: Maintain WAL committed bounds on insert (fix lowest and max-highest)

### DIFF
--- a/crates/exex/exex/src/wal/cache.rs
+++ b/crates/exex/exex/src/wal/cache.rs
@@ -116,7 +116,12 @@ impl BlockCache {
                 self.committed_blocks.insert(block.hash(), (file_id, cached_block));
             }
 
-            self.highest_committed_block_height = Some(committed_chain.tip().number());
+            let tip = committed_chain.tip().number();
+            let first = committed_chain.first().number();
+            self.highest_committed_block_height =
+                Some(self.highest_committed_block_height.map_or(tip, |h| h.max(tip)));
+            self.lowest_committed_block_height =
+                Some(self.lowest_committed_block_height.map_or(first, |l| l.min(first)));
         }
     }
 


### PR DESCRIPTION
This change ensures BlockCache maintains accurate committed block height bounds during inserts:
- highest_committed_block_height is now updated via max with the committed tip.
- lowest_committed_block_height is now updated via min with the committed chain’s first block.

Why necessary:
- Previously, only highest_committed_block_height was overwritten to the committed tip and lowest_committed_block_height was never updated on insert: 
if let Some(committed_chain) = &committed_chain {
    for block in committed_chain.blocks().values() { ... }
    self.highest_committed_block_height = Some(committed_chain.tip().number());
}

- This led to inconsistent and stale metrics across multiple inserts, since lowest_committed_block_height remained None/stale until a finalize path recomputed bounds, while Grafana panels explicitly display both:
- \"expr\": \"reth_exex_wal_lowest_committed_block_height{...}\", ... \"legendFormat\": \"Lowest Block\" ...
\"expr\": \"reth_exex_wal_highest_committed_block_height{...}\", ... \"legendFormat\": \"Highest Block\" ...

- Metrics are updated on each commit/finalize event:
if let Some(lowest_committed_block_height) = block_cache.lowest_committed_block_height { ... }
if let Some(highest_committed_block_height) = block_cache.highest_committed_block_height { ... }

so keeping both bounds accurate at insert time is required for correctness of displayed metrics.

Removal path already recomputes both bounds from retained entries, which supports the intent that both bounds reflect current cache contents:
self.lowest_committed_block_height = lowest_committed_block_height;
self.highest_committed_block_height = highest_committed_block_height;