### PR TITLE
feat(rpc): Add `convert_receipt_with_block` method to `ReceiptConverter`

### DIFF
--- a/crates/optimism/rpc/src/eth/receipt.rs
+++ b/crates/optimism/rpc/src/eth/receipt.rs
@@ -11,7 +11,7 @@ use reth_node_api::NodePrimitives;
 use reth_optimism_evm::RethL1BlockInfo;
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_primitives::OpReceipt;
-use reth_primitives_traits::Block;
+use reth_primitives_traits::SealedBlock;
 use reth_rpc_eth_api::{
     helpers::LoadReceipt,
     transaction::{ConvertReceiptInput, ReceiptConverter},
@@ -63,13 +63,13 @@ where
             .block_by_number(block_number)?
             .ok_or(EthApiError::HeaderNotFound(block_number.into()))?;
 
-        self.convert_receipts_with_block(inputs, &block)
+        self.convert_receipts_with_block(inputs, &SealedBlock::new_unhashed(block))
     }
 
     fn convert_receipts_with_block(
         &self,
         inputs: Vec<ConvertReceiptInput<'_, N>>,
-        block: &N::Block,
+        block: &SealedBlock<N::Block>,
     ) -> Result<Vec<Self::RpcReceipt>, Self::Error> {
         let mut l1_block_info = match reth_optimism_evm::extract_l1_info(block.body()) {
             Ok(l1_block_info) => l1_block_info,

--- a/crates/optimism/rpc/src/eth/receipt.rs
+++ b/crates/optimism/rpc/src/eth/receipt.rs
@@ -1,7 +1,7 @@
 //! Loads and formats OP receipt RPC response.
 
 use crate::{eth::RpcNodeCore, OpEthApi, OpEthApiError};
-use alloy_consensus::{Receipt, TxReceipt};
+use alloy_consensus::{BlockHeader, Receipt, TxReceipt};
 use alloy_eips::eip2718::Encodable2718;
 use alloy_rpc_types_eth::{Log, TransactionReceipt};
 use op_alloy_consensus::{OpReceiptEnvelope, OpTransaction};
@@ -44,7 +44,8 @@ impl<Provider> OpReceiptConverter<Provider> {
 impl<Provider, N> ReceiptConverter<N> for OpReceiptConverter<Provider>
 where
     N: NodePrimitives<SignedTx: OpTransaction, Receipt = OpReceipt>,
-    Provider: BlockReader + ChainSpecProvider<ChainSpec: OpHardforks> + Debug + 'static,
+    Provider:
+        BlockReader<Block = N::Block> + ChainSpecProvider<ChainSpec: OpHardforks> + Debug + 'static,
 {
     type RpcReceipt = OpTransactionReceipt;
     type Error = OpEthApiError;
@@ -62,12 +63,20 @@ where
             .block_by_number(block_number)?
             .ok_or(EthApiError::HeaderNotFound(block_number.into()))?;
 
+        self.convert_receipts_with_block(inputs, block)
+    }
+
+    fn convert_receipts_with_block(
+        &self,
+        inputs: Vec<ConvertReceiptInput<'_, N>>,
+        block: N::Block,
+    ) -> Result<Vec<Self::RpcReceipt>, Self::Error> {
         let mut l1_block_info = match reth_optimism_evm::extract_l1_info(block.body()) {
             Ok(l1_block_info) => l1_block_info,
             Err(err) => {
-                // If it is the genesis block (i.e block number is 0), there is no L1 info, so
+                // If it is the genesis block (i.e. block number is 0), there is no L1 info, so
                 // we return an empty l1_block_info.
-                if block_number == 0 {
+                if block.header().number() == 0 {
                     return Ok(vec![]);
                 }
                 return Err(err.into());

--- a/crates/optimism/rpc/src/eth/receipt.rs
+++ b/crates/optimism/rpc/src/eth/receipt.rs
@@ -63,13 +63,13 @@ where
             .block_by_number(block_number)?
             .ok_or(EthApiError::HeaderNotFound(block_number.into()))?;
 
-        self.convert_receipts_with_block(inputs, block)
+        self.convert_receipts_with_block(inputs, &block)
     }
 
     fn convert_receipts_with_block(
         &self,
         inputs: Vec<ConvertReceiptInput<'_, N>>,
-        block: N::Block,
+        block: &N::Block,
     ) -> Result<Vec<Self::RpcReceipt>, Self::Error> {
         let mut l1_block_info = match reth_optimism_evm::extract_l1_info(block.body()) {
             Ok(l1_block_info) => l1_block_info,

--- a/crates/optimism/rpc/src/eth/transaction.rs
+++ b/crates/optimism/rpc/src/eth/transaction.rs
@@ -106,18 +106,21 @@ where
 
                         return Ok(Some(
                             this.tx_resp_builder()
-                                .convert_receipts(vec![ConvertReceiptInput {
-                                    tx: tx
-                                        .tx()
-                                        .clone()
-                                        .try_into_recovered_unchecked()
-                                        .map_err(Self::Error::from_eth_err)?
-                                        .as_recovered_ref(),
-                                    gas_used: receipt.cumulative_gas_used() - gas_used,
-                                    receipt: receipt.clone(),
-                                    next_log_index,
-                                    meta,
-                                }])?
+                                .convert_receipts_with_block(
+                                    vec![ConvertReceiptInput {
+                                        tx: tx
+                                            .tx()
+                                            .clone()
+                                            .try_into_recovered_unchecked()
+                                            .map_err(Self::Error::from_eth_err)?
+                                            .as_recovered_ref(),
+                                        gas_used: receipt.cumulative_gas_used() - gas_used,
+                                        receipt: receipt.clone(),
+                                        next_log_index,
+                                        meta,
+                                    }],
+                                    block_and_receipts.sealed_block(),
+                                )?
                                 .pop()
                                 .unwrap(),
                         ))

--- a/crates/rpc/rpc-convert/src/transaction.rs
+++ b/crates/rpc/rpc-convert/src/transaction.rs
@@ -55,6 +55,16 @@ pub trait ReceiptConverter<N: NodePrimitives>: Debug + 'static {
         &self,
         receipts: Vec<ConvertReceiptInput<'_, N>>,
     ) -> Result<Vec<Self::RpcReceipt>, Self::Error>;
+
+    /// Converts a set of primitive receipts to RPC representations. It is guaranteed that all
+    /// receipts are from `block`.
+    fn convert_receipts_with_block(
+        &self,
+        receipts: Vec<ConvertReceiptInput<'_, N>>,
+        _block: N::Block,
+    ) -> Result<Vec<Self::RpcReceipt>, Self::Error> {
+        self.convert_receipts(receipts)
+    }
 }
 
 /// A type that knows how to convert a consensus header into an RPC header.

--- a/crates/rpc/rpc-convert/src/transaction.rs
+++ b/crates/rpc/rpc-convert/src/transaction.rs
@@ -61,7 +61,7 @@ pub trait ReceiptConverter<N: NodePrimitives>: Debug + 'static {
     fn convert_receipts_with_block(
         &self,
         receipts: Vec<ConvertReceiptInput<'_, N>>,
-        _block: N::Block,
+        _block: &N::Block,
     ) -> Result<Vec<Self::RpcReceipt>, Self::Error> {
         self.convert_receipts(receipts)
     }

--- a/crates/rpc/rpc-eth-api/src/helpers/block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/block.rs
@@ -158,7 +158,10 @@ pub trait EthBlocks:
                     })
                     .collect::<Vec<_>>();
 
-                return self.tx_resp_builder().convert_receipts(inputs).map(Some)
+                return self
+                    .tx_resp_builder()
+                    .convert_receipts_with_block(inputs, block.sealed_block())
+                    .map(Some)
             }
 
             Ok(None)

--- a/crates/rpc/rpc-eth-types/src/block.rs
+++ b/crates/rpc/rpc-eth-types/src/block.rs
@@ -3,7 +3,9 @@
 use std::sync::Arc;
 
 use alloy_primitives::TxHash;
-use reth_primitives_traits::{BlockTy, IndexedTx, NodePrimitives, ReceiptTy, RecoveredBlock};
+use reth_primitives_traits::{
+    BlockTy, IndexedTx, NodePrimitives, ReceiptTy, RecoveredBlock, SealedBlock,
+};
 
 /// A pair of an [`Arc`] wrapped [`RecoveredBlock`] and its corresponding receipts.
 ///
@@ -36,5 +38,10 @@ impl<N: NodePrimitives> BlockAndReceipts<N> {
         let indexed_tx = self.block.find_indexed(tx_hash)?;
         let receipt = self.receipts.get(indexed_tx.index())?;
         Some((indexed_tx, receipt))
+    }
+
+    /// Returns the underlying sealed block.
+    pub fn sealed_block(&self) -> &SealedBlock<BlockTy<N>> {
+        self.block.sealed_block()
     }
 }


### PR DESCRIPTION
Closes #18540

Adds a method for converting receipts with block as a parameter. This is useful for L2 engine and can be used to avoid a block fetch.
