### PR TITLE
chore: fix MockProvider block tracking to match real provider behavior

### DIFF
--- a/examples/bsc-p2p/src/block_import/parlia.rs
+++ b/examples/bsc-p2p/src/block_import/parlia.rs
@@ -63,15 +63,13 @@ mod tests {
     #[derive(Clone)]
     struct MockProvider {
         blocks: HashMap<BlockNumber, B256>,
-        head_number: BlockNumber,
-        head_hash: B256,
     }
 
     impl MockProvider {
         fn new(head_number: BlockNumber, head_hash: B256) -> Self {
             let mut blocks = HashMap::new();
             blocks.insert(head_number, head_hash);
-            Self { blocks, head_number, head_hash }
+            Self { blocks }
         }
     }
 
@@ -91,15 +89,17 @@ mod tests {
 
     impl BlockNumReader for MockProvider {
         fn chain_info(&self) -> Result<ChainInfo, ProviderError> {
-            Ok(ChainInfo { best_hash: self.head_hash, best_number: self.head_number })
+            let head_number = *self.blocks.keys().max().unwrap_or(&0);
+            let head_hash = self.blocks.get(&head_number).copied().unwrap_or(B256::zero());
+            Ok(ChainInfo { best_hash: head_hash, best_number: head_number })
         }
 
         fn best_block_number(&self) -> Result<BlockNumber, ProviderError> {
-            Ok(self.head_number)
+            Ok(*self.blocks.keys().max().unwrap_or(&0))
         }
 
         fn last_block_number(&self) -> Result<BlockNumber, ProviderError> {
-            Ok(self.head_number)
+            Ok(*self.blocks.keys().max().unwrap_or(&0))
         }
 
         fn block_number(&self, hash: B256) -> Result<Option<BlockNumber>, ProviderError> {


### PR DESCRIPTION
cleaned up how MockProvider tracks blocks to avoid inconsistencies.

* removed `head_number` and `head_hash` — now `blocks` HashMap is the single source of truth.
* updated `best_block_number`, `last_block_number`, and `chain_info` to compute the best block dynamically from the keys of `blocks`.
* `chain_info` now derives `best_hash` and `best_number` directly from `blocks`, matching real provider logic.

**these changes fix the previous mismatch between separate fields and `blocks`, making the test provider behavior consistent and more realistic.**