### PR TITLE
chore(consensus): update EIP-7825 error message format

### DIFF
--- a/crates/consensus/consensus/src/lib.rs
+++ b/crates/consensus/consensus/src/lib.rs
@@ -437,7 +437,7 @@ pub struct HeaderConsensusError<H>(ConsensusError, SealedHeader<H>);
 
 /// EIP-7825: Transaction gas limit exceeds maximum allowed
 #[derive(thiserror::Error, Debug, Eq, PartialEq, Clone)]
-#[error("transaction {tx_hash} gas limit {gas_limit} exceeds maximum {max_allowed}")]
+#[error("transaction gas limit ({gas_limit}) is greater than the cap ({max_allowed})")]
 pub struct TxGasLimitTooHighErr {
     /// Hash of the transaction that violates the rule
     pub tx_hash: B256,


### PR DESCRIPTION
fixes `consume-engine tests/osaka` eest failures, for instance in `tests/osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_limit::py::test_tx_gas_limit_cap_access_list_with_diff_addr[fork_Osaka-blockchain_test_engine_from_state_test-exceed_tx_gas_li
  mit_True-correct_intrinsic_cost_in_transaction_gas_limit_True]-reth FAILED [1/1]`:

```
 =================================== FAILURES ===================================
  _ tests/osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_limit.py::test_tx_gas_limit_cap_access_list_with_diff_addr[fork_Osaka-blockchain_test_engine_from_state_test-exceed_tx_gas_l
  imit_True-correct_intrinsic_cost_in_transaction_gas_limit_True]-reth _
  src/pytest_plugins/consume/simulators/simulator_logic/test_via_engine.py:126: in test_blockchain_via_engine
      raise LoggedError(message)
  E   pytest_plugins.consume.simulators.simulator_logic.test_via_engine.LoggedError: Undefined exception message: expected exception: "TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM",
  returned exception: "transaction 0xd1d93e2014af0a1f0b52642b7a9ffb882f4631b03a75f33291e70b557605bdbf gas limit 16778100 exceeds maximum 16777216" (mapper: "RethExceptionMapper")
```  

successful execution from this branch: https://github.com/paradigmxyz/reth/actions/runs/17827583370/job/50685994149