### PR TITLE
feat(net): correct per-response size metric to avoid capacity/empty-block inflation

### DIFF
--- a/crates/net/downloaders/src/bodies/request.rs
+++ b/crates/net/downloaders/src/bodies/request.rs
@@ -170,7 +170,7 @@ where
         let bodies_len = bodies.len();
         let mut bodies = bodies.into_iter().peekable();
 
-        let mut total_size = bodies_capacity * mem::size_of::<C::Body>();
+        let mut total_size = 0;
         while bodies.peek().is_some() {
             let next_header = match self.pending_headers.pop_front() {
                 Some(header) => header,
@@ -178,8 +178,6 @@ where
             };
 
             if next_header.is_empty() {
-                // increment empty block body metric
-                total_size += mem::size_of::<C::Body>();
                 self.buffer.push(BlockResponse::Empty(next_header));
             } else {
                 let next_body = bodies.next().unwrap();

--- a/crates/net/downloaders/src/bodies/request.rs
+++ b/crates/net/downloaders/src/bodies/request.rs
@@ -12,7 +12,6 @@ use reth_network_peers::{PeerId, WithPeerId};
 use reth_primitives_traits::{Block, GotExpected, InMemorySize, SealedBlock, SealedHeader};
 use std::{
     collections::VecDeque,
-    mem,
     pin::Pin,
     sync::Arc,
     task::{ready, Context, Poll},
@@ -166,7 +165,6 @@ where
     where
         C::Body: InMemorySize,
     {
-        let bodies_capacity = bodies.capacity();
         let bodies_len = bodies.len();
         let mut bodies = bodies.into_iter().peekable();
 


### PR DESCRIPTION
This change fixes downloaders.bodies.response.response_size_bytes in BodiesRequestFuture::try_buffer_blocks to reflect only the sizes of actual bodies received:
- Initialize total_size to 0 instead of using bodies.capacity() * size_of::<C::Body>().
- Do not add any size for empty headers.
- Sum only next_body.size() for non-empty bodies.

Rationale:
- The metric is documented as the size (in bytes) of an individual bodies response. Including the input Vec capacity reflects local allocation details and double-counts memory since BlockBody::size() already accounts for internal capacities. Adding a pseudo-size for empty headers further inflates the metric while response_length counts only real bodies, skewing dashboards (e.g., average size = size/length).
- Elsewhere we include capacities only for buffer footprint metrics (e.g., buffer_bodies_response), not for per-response sizing. This change aligns semantics with documentation and Grafana usage, yielding accurate and comparable observability without affecting functional behavior.