### PR TITLE
fix(rpc/simulate): block number/timestamp not checked

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -138,6 +138,23 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                             .map_err(Self::Error::from_eth_err)?;
                     }
 
+                    // Validate block number and timestamp
+                    if validation {
+                        if evm_env.block_env.number.to::<u64>() <= parent.number() {
+                            return Err(EthApiError::other(
+                                EthSimulateError::BlockNumberNotIncreased,
+                            )
+                            .into());
+                        }
+
+                        if evm_env.block_env.timestamp.to::<u64>() < parent.timestamp() {
+                            return Err(EthApiError::other(
+                                EthSimulateError::BlockTimestampNotIncreased,
+                            )
+                            .into());
+                        }
+                    }
+
                     let block_gas_limit = evm_env.block_env.gas_limit;
                     let chain_id = evm_env.cfg_env.chain_id;
 

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -150,7 +150,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                     }
 
                     let current_timestamp = evm_env.block_env.timestamp.to::<u64>();
-                    if current_timestamp < parent_timestamp {
+                    if current_timestamp <= parent_timestamp {
                         return Err(EthApiError::other(
                             EthSimulateError::BlockTimestampNotIncreased,
                         )

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -40,6 +40,12 @@ pub enum EthSimulateError {
     /// Max gas limit for entire operation exceeded.
     #[error("Client adjustable limit reached")]
     GasLimitReached,
+    /// Block number in sequence did not increase.
+    #[error("Block number in sequence did not increase")]
+    BlockNumberNotIncreased,
+    /// Block timestamp in sequence did not increase or stay the same.
+    #[error("Block timestamp in sequence did not increase or stay the same")]
+    BlockTimestampNotIncreased,
 }
 
 impl EthSimulateError {
@@ -47,6 +53,8 @@ impl EthSimulateError {
         match self {
             Self::BlockGasLimitExceeded => -38015,
             Self::GasLimitReached => -38026,
+            Self::BlockNumberNotIncreased => -38020,
+            Self::BlockTimestampNotIncreased => -38021,
         }
     }
 }

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -41,11 +41,21 @@ pub enum EthSimulateError {
     #[error("Client adjustable limit reached")]
     GasLimitReached,
     /// Block number in sequence did not increase.
-    #[error("Block number in sequence did not increase")]
-    BlockNumberNotIncreased,
+    #[error("block numbers must be in order: {current} <= {previous}")]
+    BlockNumberNotIncreased {
+        /// Current block number.
+        current: u64,
+        /// Previous block number.
+        previous: u64,
+    },
     /// Block timestamp in sequence did not increase or stay the same.
-    #[error("Block timestamp in sequence did not increase or stay the same")]
-    BlockTimestampNotIncreased,
+    #[error("block timestamps must be in order: {current} <= {previous}")]
+    BlockTimestampNotIncreased {
+        /// Current block timestamp.
+        current: u64,
+        /// Previous block timestamp.
+        previous: u64,
+    },
 }
 
 impl EthSimulateError {
@@ -53,8 +63,8 @@ impl EthSimulateError {
         match self {
             Self::BlockGasLimitExceeded => -38015,
             Self::GasLimitReached => -38026,
-            Self::BlockNumberNotIncreased => -38020,
-            Self::BlockTimestampNotIncreased => -38021,
+            Self::BlockNumberNotIncreased { current: _, previous: _ } => -38020,
+            Self::BlockTimestampNotIncreased { current: _, previous: _ } => -38021,
         }
     }
 }


### PR DESCRIPTION
Fix the issue of `eth_simulateV1` not check the block number and timestamp issue.

when calling with the below request:

```json
{
    "jsonrpc": "2.0",
    "id": 1,
    "method": "eth_simulateV1",
    "params": [
        {
            "blockStateCalls": [
                {
                    "blockOverrides": { "number": "0x91" },
                    "calls": [ { "from": "0xc100000000000000000000000000000000000000", "input": "0x4360005260206000f3" } ]
                },
                {
                    "blockOverrides": { "number": "0x87" },
                    "calls": [ { "from": "0xc000000000000000000000000000000000000000", "input": "0x4360005260206000f3" } ]
                }
            ]
        },
        "latest"
    ]
}
```

geth return as error:

```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "error": {
    "code": -38020,
    "message": "block numbers must be in order: 145 \u003c= 23387288"
  }
}
```

but reth can successfully execute it:

```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": [
    {
      "hash": "0xd9da862edeb8c90afd4f068fdec3392fe7e460b7855d4332991ae6246c6d7350",
      "parentHash": "0x176348bef02508d7698cf5b39cd622a7ea277a4c25d536a2e6c13da10713ad5a",
      "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
      "miner": "0x4838b106fce9647bdf1e7877bf73ce8b0bad5f97",
      "stateRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
      "transactionsRoot": "0x487480d708e5c17783485da0f128962ea9971acddf216b568b09ba669d15c64b",
      "receiptsRoot": "0x272f9721d2518637583443bb497e8fd6399c10a298960c41f6f17d2c2b3a2aa2",
      "logsBloom": "...",
      "difficulty": "0x0",
      "number": "0x91",
      "gasLimit": "0x2adf998",
      "gasUsed": "0xe893",
      "timestamp": "0x68cb7cf3",
      "extraData": "0x726574682f76312e372e302f6c696e7578",
      "mixHash": "0xead56a0a19ca30870185899b4dd368284558283f446b1e1dc9f33a898ae0986b",
      "nonce": "0x0000000000000000",
      "baseFeePerGas": "0x0",
      "withdrawalsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
      "blobGasUsed": "0x0",
      "excessBlobGas": "0x100000",
      "parentBeaconBlockRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
      "requestsHash": "0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
      "size": "0x297",
      "uncles": [],
      "transactions": [
        "0xbf3a17737bd18fa1fcb7cb6b3b074b8fc67e0468ad1cbc47f793cf3fe6dddf1e"
      ],
      "withdrawals": [],
      "calls": [
        {
          "returnData": "0x0000000000000000000000000000000000000000000000000000000000000091",
          "logs": [],
          "gasUsed": "0xe893",
          "status": "0x1"
        }
      ]
    },
    {
      "hash": "0x63a8f159c8c89b2f795889dc85699c47cfda282e194027b5eeac069b630939d9",
      "parentHash": "0xd9da862edeb8c90afd4f068fdec3392fe7e460b7855d4332991ae6246c6d7350",
      "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
      "miner": "0x4838b106fce9647bdf1e7877bf73ce8b0bad5f97",
      "stateRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
      "transactionsRoot": "0x487480d708e5c17783485da0f128962ea9971acddf216b568b09ba669d15c64b",
      "receiptsRoot": "0x272f9721d2518637583443bb497e8fd6399c10a298960c41f6f17d2c2b3a2aa2",
      "logsBloom": "...",
      "difficulty": "0x0",
      "number": "0x87",
      "gasLimit": "0x2adf998",
      "gasUsed": "0xe893",
      "timestamp": "0x68cb7cff",
      "extraData": "0x726574682f76312e372e302f6c696e7578",
      "mixHash": "0xb5b39f9be6df53d0bd21d7dc05ec275027017b13c92ed41f2b3152ef790ee5c0",
      "nonce": "0x0000000000000000",
      "baseFeePerGas": "0x0",
      "withdrawalsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
      "blobGasUsed": "0x0",
      "excessBlobGas": "0x40000",
      "parentBeaconBlockRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
      "requestsHash": "0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
      "size": "0x297",
      "uncles": [],
      "transactions": [
        "0xbf3a17737bd18fa1fcb7cb6b3b074b8fc67e0468ad1cbc47f793cf3fe6dddf1e"
      ],
      "withdrawals": [],
      "calls": [
        {
          "returnData": "0x0000000000000000000000000000000000000000000000000000000000000087",
          "logs": [],
          "gasUsed": "0xe893",
          "status": "0x1"
        }
      ]
    }
  ]
}
```