### PR TITLE
feat: add `Future` AT to `LaunchNode` and allow customizing local attributes builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9605,6 +9605,7 @@ dependencies = [
  "alloy-rpc-types-engine",
  "assert_matches",
  "auto_impl",
+ "either",
  "op-alloy-rpc-types-engine",
  "reth-chain-state",
  "reth-chainspec",

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -662,9 +662,9 @@ where
     ///
     /// This is equivalent to [`WithLaunchContext::launch`], but will enable the debugging features,
     /// if they are configured.
-    pub async fn launch_with_debug_capabilities(
+    pub fn launch_with_debug_capabilities(
         self,
-    ) -> eyre::Result<<DebugNodeLauncher as LaunchNode<NodeBuilderWithComponents<T, CB, AO>>>::Node>
+    ) -> <DebugNodeLauncher as LaunchNode<NodeBuilderWithComponents<T, CB, AO>>>::Future
     where
         T::Types: DebugNode<NodeAdapter<T, CB::Components>>,
         DebugNodeLauncher: LaunchNode<NodeBuilderWithComponents<T, CB, AO>>,
@@ -678,7 +678,7 @@ where
             builder.config.datadir(),
             engine_tree_config,
         ));
-        builder.launch_with(launcher).await
+        builder.launch_with(launcher)
     }
 
     /// Returns an [`EngineNodeLauncher`] that can be used to launch the node with engine API

--- a/crates/node/builder/src/builder/states.rs
+++ b/crates/node/builder/src/builder/states.rs
@@ -251,11 +251,11 @@ where
     AO: RethRpcAddOns<NodeAdapter<T, CB::Components>>,
 {
     /// Launches the node with the given launcher.
-    pub async fn launch_with<L>(self, launcher: L) -> eyre::Result<L::Node>
+    pub fn launch_with<L>(self, launcher: L) -> L::Future
     where
         L: LaunchNode<Self>,
     {
-        launcher.launch_node(self).await
+        launcher.launch_node(self)
     }
 
     /// Sets the hook that is run once the rpc server is started.

--- a/crates/node/builder/src/launch/debug.rs
+++ b/crates/node/builder/src/launch/debug.rs
@@ -1,12 +1,19 @@
 use super::LaunchNode;
 use crate::{rpc::RethRpcAddOns, EngineNodeLauncher, Node, NodeHandle};
+use alloy_consensus::transaction::Either;
 use alloy_provider::network::AnyNetwork;
 use jsonrpsee::core::{DeserializeOwned, Serialize};
 use reth_chainspec::EthChainSpec;
 use reth_consensus_debug_client::{DebugConsensusClient, EtherscanBlockProvider, RpcBlockProvider};
 use reth_engine_local::LocalMiner;
-use reth_node_api::{BlockTy, FullNodeComponents, PayloadAttributesBuilder, PayloadTypes};
-use std::sync::Arc;
+use reth_node_api::{
+    BlockTy, FullNodeComponents, PayloadAttrTy, PayloadAttributesBuilder, PayloadTypes,
+};
+use std::{
+    future::{Future, IntoFuture},
+    pin::Pin,
+    sync::Arc,
+};
 use tracing::info;
 
 /// [`Node`] extension with support for debugging utilities.
@@ -104,16 +111,54 @@ impl<L> DebugNodeLauncher<L> {
     }
 }
 
-impl<L, Target, N, AddOns> LaunchNode<Target> for DebugNodeLauncher<L>
+/// Future for the [`DebugNodeLauncher`].
+#[expect(missing_debug_implementations, clippy::type_complexity)]
+pub struct DebugNodeLauncherFuture<L, Target, N>
+where
+    N: FullNodeComponents<Types: DebugNode<N>>,
+{
+    inner: L,
+    target: Target,
+    local_payload_attributes_builder:
+        Option<Box<dyn PayloadAttributesBuilder<PayloadAttrTy<N::Types>>>>,
+    map_attributes:
+        Option<Box<dyn Fn(PayloadAttrTy<N::Types>) -> PayloadAttrTy<N::Types> + Send + Sync>>,
+}
+
+impl<L, Target, N, AddOns> DebugNodeLauncherFuture<L, Target, N>
 where
     N: FullNodeComponents<Types: DebugNode<N>>,
     AddOns: RethRpcAddOns<N>,
     L: LaunchNode<Target, Node = NodeHandle<N, AddOns>>,
 {
-    type Node = NodeHandle<N, AddOns>;
+    pub fn with_payload_attributes_builder(
+        self,
+        builder: impl PayloadAttributesBuilder<PayloadAttrTy<N::Types>>,
+    ) -> Self {
+        Self {
+            inner: self.inner,
+            target: self.target,
+            local_payload_attributes_builder: Some(Box::new(builder)),
+            map_attributes: None,
+        }
+    }
 
-    async fn launch_node(self, target: Target) -> eyre::Result<Self::Node> {
-        let handle = self.inner.launch_node(target).await?;
+    pub fn map_debug_payload_attributes(
+        self,
+        f: impl Fn(PayloadAttrTy<N::Types>) -> PayloadAttrTy<N::Types> + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            inner: self.inner,
+            target: self.target,
+            local_payload_attributes_builder: None,
+            map_attributes: Some(Box::new(f)),
+        }
+    }
+
+    async fn launch_node(self) -> eyre::Result<NodeHandle<N, AddOns>> {
+        let Self { inner, target, local_payload_attributes_builder, map_attributes } = self;
+
+        let handle = inner.launch_node(target).await?;
 
         let config = &handle.node.config;
         if let Some(url) = config.debug.rpc_consensus_url.clone() {
@@ -179,11 +224,23 @@ where
             let pool = handle.node.pool.clone();
             let payload_builder_handle = handle.node.payload_builder_handle.clone();
 
+            let builder = if let Some(builder) = local_payload_attributes_builder {
+                Either::Left(builder)
+            } else {
+                let local = N::Types::local_payload_attributes_builder(&chain_spec);
+                let builder = if let Some(f) = map_attributes {
+                    Either::Left(move |block_number| f(local.build(block_number)))
+                } else {
+                    Either::Right(local)
+                };
+                Either::Right(builder)
+            };
+
             let dev_mining_mode = handle.node.config.dev_mining_mode(pool);
             handle.node.task_executor.spawn_critical("local engine", async move {
                 LocalMiner::new(
                     blockchain_db,
-                    N::Types::local_payload_attributes_builder(&chain_spec),
+                    builder,
                     beacon_engine_handle,
                     dev_mining_mode,
                     payload_builder_handle,
@@ -194,5 +251,40 @@ where
         }
 
         Ok(handle)
+    }
+}
+
+impl<L, Target, N, AddOns> IntoFuture for DebugNodeLauncherFuture<L, Target, N>
+where
+    Target: Send + 'static,
+    N: FullNodeComponents<Types: DebugNode<N>>,
+    AddOns: RethRpcAddOns<N> + 'static,
+    L: LaunchNode<Target, Node = NodeHandle<N, AddOns>> + 'static,
+{
+    type Output = eyre::Result<NodeHandle<N, AddOns>>;
+    type IntoFuture = Pin<Box<dyn Future<Output = eyre::Result<NodeHandle<N, AddOns>>> + Send>>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(self.launch_node())
+    }
+}
+
+impl<L, Target, N, AddOns> LaunchNode<Target> for DebugNodeLauncher<L>
+where
+    Target: Send + 'static,
+    N: FullNodeComponents<Types: DebugNode<N>>,
+    AddOns: RethRpcAddOns<N> + 'static,
+    L: LaunchNode<Target, Node = NodeHandle<N, AddOns>> + 'static,
+{
+    type Node = NodeHandle<N, AddOns>;
+    type Future = DebugNodeLauncherFuture<L, Target, N>;
+
+    fn launch_node(self, target: Target) -> Self::Future {
+        DebugNodeLauncherFuture {
+            inner: self.inner,
+            target,
+            local_payload_attributes_builder: None,
+            map_attributes: None,
+        }
     }
 }

--- a/crates/node/builder/src/launch/mod.rs
+++ b/crates/node/builder/src/launch/mod.rs
@@ -10,7 +10,7 @@ pub(crate) mod engine;
 pub use common::LaunchContext;
 pub use exex::ExExLauncher;
 
-use std::future::Future;
+use std::future::IntoFuture;
 
 /// A general purpose trait that launches a new node of any kind.
 ///
@@ -21,22 +21,26 @@ use std::future::Future;
 ///
 /// See also [`EngineNodeLauncher`](crate::EngineNodeLauncher) and
 /// [`NodeBuilderWithComponents::launch_with`](crate::NodeBuilderWithComponents)
-pub trait LaunchNode<Target> {
+pub trait LaunchNode<Target>: Send {
     /// The node type that is created.
     type Node;
 
+    /// The future type that is returned.
+    type Future: IntoFuture<Output = eyre::Result<Self::Node>, IntoFuture: Send>;
+
     /// Create and return a new node asynchronously.
-    fn launch_node(self, target: Target) -> impl Future<Output = eyre::Result<Self::Node>>;
+    fn launch_node(self, target: Target) -> Self::Future;
 }
 
 impl<F, Target, Fut, Node> LaunchNode<Target> for F
 where
     F: FnOnce(Target) -> Fut + Send,
-    Fut: Future<Output = eyre::Result<Node>> + Send,
+    Fut: IntoFuture<Output = eyre::Result<Node>, IntoFuture: Send> + Send,
 {
     type Node = Node;
+    type Future = Fut;
 
-    fn launch_node(self, target: Target) -> impl Future<Output = eyre::Result<Self::Node>> {
+    fn launch_node(self, target: Target) -> Self::Future {
         self(target)
     }
 }

--- a/crates/payload/primitives/Cargo.toml
+++ b/crates/payload/primitives/Cargo.toml
@@ -37,14 +37,15 @@ assert_matches.workspace = true
 [features]
 default = ["std"]
 std = [
-    "reth-chainspec/std",
-    "alloy-eips/std",
-    "alloy-primitives/std",
-    "alloy-rpc-types-engine/std",
-    "op-alloy-rpc-types-engine?/std",
-    "serde/std",
-    "thiserror/std",
-    "reth-primitives-traits/std",
+	"reth-chainspec/std",
+	"alloy-eips/std",
+	"alloy-primitives/std",
+	"alloy-rpc-types-engine/std",
+	"op-alloy-rpc-types-engine?/std",
+	"serde/std",
+	"thiserror/std",
+	"reth-primitives-traits/std",
+	"either/std"
 ]
 op = [
     "dep:op-alloy-rpc-types-engine",

--- a/crates/payload/primitives/Cargo.toml
+++ b/crates/payload/primitives/Cargo.toml
@@ -26,6 +26,7 @@ op-alloy-rpc-types-engine = { workspace = true, optional = true }
 
 # misc
 auto_impl.workspace = true
+either.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, default-features = false, features = ["sync"] }

--- a/crates/payload/primitives/Cargo.toml
+++ b/crates/payload/primitives/Cargo.toml
@@ -37,15 +37,15 @@ assert_matches.workspace = true
 [features]
 default = ["std"]
 std = [
-	"reth-chainspec/std",
-	"alloy-eips/std",
-	"alloy-primitives/std",
-	"alloy-rpc-types-engine/std",
-	"op-alloy-rpc-types-engine?/std",
-	"serde/std",
-	"thiserror/std",
-	"reth-primitives-traits/std",
-	"either/std"
+    "reth-chainspec/std",
+    "alloy-eips/std",
+    "alloy-primitives/std",
+    "alloy-rpc-types-engine/std",
+    "op-alloy-rpc-types-engine?/std",
+    "serde/std",
+    "thiserror/std",
+    "reth-primitives-traits/std",
+    "either/std",
 ]
 op = [
     "dep:op-alloy-rpc-types-engine",

--- a/crates/payload/primitives/src/traits.rs
+++ b/crates/payload/primitives/src/traits.rs
@@ -1,6 +1,7 @@
 //! Core traits for working with execution payloads.
 
-use alloc::vec::Vec;
+use crate::PayloadBuilderError;
+use alloc::{boxed::Box, vec::Vec};
 use alloy_eips::{
     eip4895::{Withdrawal, Withdrawals},
     eip7685::Requests,
@@ -10,8 +11,6 @@ use alloy_rpc_types_engine::{PayloadAttributes as EthPayloadAttributes, PayloadI
 use core::fmt;
 use reth_chain_state::ExecutedBlockWithTrieUpdates;
 use reth_primitives_traits::{NodePrimitives, SealedBlock, SealedHeader};
-
-use crate::PayloadBuilderError;
 
 /// Represents a successfully built execution payload (block).
 ///


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/18534

Adds `Future: IntoFuture` AT to `LaunchNode`. For `EngineNodeLauncher` it's just a boxed future, and for `DebugNodeLauncher` it's a custom type with helpers to either override local payload attributes builder entirely, or to map the payload attributes produced by the basic builder defined on the node itself.