### PR TITLE
chore(chainspec): reuse local hardforks in DEV instead of cloning again

### DIFF
--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -211,7 +211,7 @@ pub static DEV: LazyLock<Arc<ChainSpec>> = LazyLock::new(|| {
         genesis_header: SealedHeader::seal_slow(make_genesis_header(&genesis, &hardforks)),
         genesis,
         paris_block_and_final_difficulty: Some((0, U256::from(0))),
-        hardforks: DEV_HARDFORKS.clone(),
+        hardforks,
         base_fee_params: BaseFeeParamsKind::Constant(BaseFeeParams::ethereum()),
         deposit_contract: None, // TODO: do we even have?
         ..Default::default()


### PR DESCRIPTION
Replace redundant DEV_HARDFORKS.clone() with the already cloned local hardforks when constructing DEV ChainSpec.
This removes an unnecessary allocation and aligns DEV with the pattern used by MAINNET/SEPOLIA/HOLESKY/HOODI and OP_DEV, improving consistency without changing behavior.