### PR TITLE
feat(rpc): make send_raw_transaction_sync timeout configurable

### DIFF
--- a/crates/node/core/src/args/rpc_server.rs
+++ b/crates/node/core/src/args/rpc_server.rs
@@ -40,6 +40,9 @@ pub(crate) const RPC_DEFAULT_MAX_RESPONSE_SIZE_MB: u32 = 160;
 /// Default number of incoming connections.
 pub(crate) const RPC_DEFAULT_MAX_CONNECTIONS: u32 = 500;
 
+/// Default timeout for send raw transaction sync in seconds.
+pub(crate) const RPC_DEFAULT_SEND_RAW_TX_SYNC_TIMEOUT_SECS: u64 = 30;
+
 /// Parameters for configuring the rpc more granularity via CLI
 #[derive(Debug, Clone, Args, PartialEq, Eq)]
 #[command(next_help_heading = "RPC")]
@@ -244,6 +247,14 @@ pub struct RpcServerArgs {
     /// Gas price oracle configuration.
     #[command(flatten)]
     pub gas_price_oracle: GasPriceOracleArgs,
+
+    /// Timeout in seconds for `send_raw_transaction_sync` RPC method.
+    #[arg(
+        long = "rpc.send-raw-transaction-sync-timeout",
+        value_name = "SECONDS",
+        default_value_t = RPC_DEFAULT_SEND_RAW_TX_SYNC_TIMEOUT_SECS
+    )]
+    pub rpc_send_raw_transaction_sync_timeout: u64,
 }
 
 impl RpcServerArgs {
@@ -359,6 +370,12 @@ impl RpcServerArgs {
     {
         f(self)
     }
+
+    /// Configures the timeout for send raw transaction sync.
+    pub const fn with_send_raw_transaction_sync_timeout(mut self, timeout_secs: u64) -> Self {
+        self.rpc_send_raw_transaction_sync_timeout = timeout_secs;
+        self
+    }
 }
 
 impl Default for RpcServerArgs {
@@ -403,6 +420,7 @@ impl Default for RpcServerArgs {
             rpc_proof_permits: constants::DEFAULT_PROOF_PERMITS,
             rpc_forwarder: None,
             builder_disallow: Default::default(),
+            rpc_send_raw_transaction_sync_timeout: RPC_DEFAULT_SEND_RAW_TX_SYNC_TIMEOUT_SECS,
         }
     }
 }

--- a/crates/optimism/rpc/src/eth/transaction.rs
+++ b/crates/optimism/rpc/src/eth/transaction.rs
@@ -23,7 +23,7 @@ use reth_transaction_pool::{
 };
 use std::{
     fmt::{Debug, Formatter},
-    future::Future,
+    future::Future, time::Duration,
 };
 
 impl<N, Rpc> EthTransactions for OpEthApi<N, Rpc>
@@ -34,6 +34,10 @@ where
 {
     fn signers(&self) -> &SignersForRpc<Self::Provider, Self::NetworkTypes> {
         self.inner.eth_api.signers()
+    }
+
+    fn send_raw_transaction_sync_timeout(&self) -> Duration {
+        self.inner.eth_api.send_raw_transaction_sync_timeout()
     }
 
     /// Decodes and recovers the transaction and submits it to the pool.

--- a/crates/optimism/rpc/src/eth/transaction.rs
+++ b/crates/optimism/rpc/src/eth/transaction.rs
@@ -23,7 +23,8 @@ use reth_transaction_pool::{
 };
 use std::{
     fmt::{Debug, Formatter},
-    future::Future, time::Duration,
+    future::Future,
+    time::Duration,
 };
 
 impl<N, Rpc> EthTransactions for OpEthApi<N, Rpc>

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -32,8 +32,7 @@ use reth_storage_api::{
 use reth_transaction_pool::{
     AddedTransactionOutcome, PoolTransaction, TransactionOrigin, TransactionPool,
 };
-use std::sync::Arc;
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 /// Transaction related functions for the [`EthApiServer`](crate::EthApiServer) trait in
 /// the `eth_` namespace.

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -33,6 +33,7 @@ use reth_transaction_pool::{
     AddedTransactionOutcome, PoolTransaction, TransactionOrigin, TransactionPool,
 };
 use std::sync::Arc;
+use std::time::Duration;
 
 /// Transaction related functions for the [`EthApiServer`](crate::EthApiServer) trait in
 /// the `eth_` namespace.
@@ -62,6 +63,9 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
     /// Signer access in default (L1) trait method implementations.
     fn signers(&self) -> &SignersForRpc<Self::Provider, Self::NetworkTypes>;
 
+    /// Returns the timeout duration for `send_raw_transaction_sync` RPC method.
+    fn send_raw_transaction_sync_timeout(&self) -> Duration;
+
     /// Decodes and recovers the transaction and submits it to the pool.
     ///
     /// Returns the hash of the transaction.
@@ -81,11 +85,11 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
         Self: LoadReceipt + 'static,
     {
         let this = self.clone();
+        let timeout_duration = self.send_raw_transaction_sync_timeout();
         async move {
             let hash = EthTransactions::send_raw_transaction(&this, tx).await?;
             let mut stream = this.provider().canonical_state_stream();
-            const TIMEOUT_DURATION: tokio::time::Duration = tokio::time::Duration::from_secs(30);
-            tokio::time::timeout(TIMEOUT_DURATION, async {
+            tokio::time::timeout(timeout_duration, async {
                 while let Some(notification) = stream.next().await {
                     let chain = notification.committed();
                     for block in chain.blocks_iter() {
@@ -98,14 +102,14 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
                 }
                 Err(Self::Error::from_eth_err(TransactionConfirmationTimeout {
                     hash,
-                    duration: TIMEOUT_DURATION,
+                    duration: timeout_duration,
                 }))
             })
             .await
             .unwrap_or_else(|_elapsed| {
                 Err(Self::Error::from_eth_err(TransactionConfirmationTimeout {
                     hash,
-                    duration: TIMEOUT_DURATION,
+                    duration: timeout_duration,
                 }))
             })
         }

--- a/crates/rpc/rpc-eth-types/src/builder/config.rs
+++ b/crates/rpc/rpc-eth-types/src/builder/config.rs
@@ -10,15 +10,12 @@ use reqwest::Url;
 use reth_rpc_server_types::constants::{
     default_max_tracing_requests, DEFAULT_ETH_PROOF_WINDOW, DEFAULT_MAX_BLOCKS_PER_FILTER,
     DEFAULT_MAX_LOGS_PER_RESPONSE, DEFAULT_MAX_SIMULATE_BLOCKS, DEFAULT_MAX_TRACE_FILTER_BLOCKS,
-    DEFAULT_PROOF_PERMITS,
+    DEFAULT_PROOF_PERMITS, RPC_DEFAULT_SEND_RAW_TX_SYNC_TIMEOUT_SECS,
 };
 use serde::{Deserialize, Serialize};
 
 /// Default value for stale filter ttl
 pub const DEFAULT_STALE_FILTER_TTL: Duration = Duration::from_secs(5 * 60);
-
-/// Default value for send raw transaction sync timeout
-pub const DEFAULT_SEND_RAW_TRANSACTION_SYNC_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Config for the locally built pending block
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Default)]
@@ -128,7 +125,7 @@ impl Default for EthConfig {
             max_batch_size: 1,
             pending_block_kind: PendingBlockKind::Full,
             raw_tx_forwarder: ForwardConfig::default(),
-            send_raw_transaction_sync_timeout: DEFAULT_SEND_RAW_TRANSACTION_SYNC_TIMEOUT,
+            send_raw_transaction_sync_timeout: RPC_DEFAULT_SEND_RAW_TX_SYNC_TIMEOUT_SECS,
         }
     }
 }

--- a/crates/rpc/rpc-eth-types/src/builder/config.rs
+++ b/crates/rpc/rpc-eth-types/src/builder/config.rs
@@ -17,6 +17,9 @@ use serde::{Deserialize, Serialize};
 /// Default value for stale filter ttl
 pub const DEFAULT_STALE_FILTER_TTL: Duration = Duration::from_secs(5 * 60);
 
+/// Default value for send raw transaction sync timeout
+pub const DEFAULT_SEND_RAW_TRANSACTION_SYNC_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// Config for the locally built pending block
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
@@ -93,6 +96,8 @@ pub struct EthConfig {
     pub pending_block_kind: PendingBlockKind,
     /// The raw transaction forwarder.
     pub raw_tx_forwarder: ForwardConfig,
+    /// Timeout duration for `send_raw_transaction_sync` RPC method.
+    pub send_raw_transaction_sync_timeout: Duration,
 }
 
 impl EthConfig {
@@ -123,6 +128,7 @@ impl Default for EthConfig {
             max_batch_size: 1,
             pending_block_kind: PendingBlockKind::Full,
             raw_tx_forwarder: ForwardConfig::default(),
+            send_raw_transaction_sync_timeout: DEFAULT_SEND_RAW_TRANSACTION_SYNC_TIMEOUT,
         }
     }
 }
@@ -205,6 +211,12 @@ impl EthConfig {
         if let Some(tx_forwarder) = tx_forwarder {
             self.raw_tx_forwarder.tx_forwarder = Some(tx_forwarder);
         }
+        self
+    }
+
+    /// Configures the timeout duration for `send_raw_transaction_sync` RPC method.
+    pub const fn send_raw_transaction_sync_timeout(mut self, timeout: Duration) -> Self {
+        self.send_raw_transaction_sync_timeout = timeout;
         self
     }
 }

--- a/crates/rpc/rpc-server-types/src/constants.rs
+++ b/crates/rpc/rpc-server-types/src/constants.rs
@@ -1,4 +1,4 @@
-use std::cmp::max;
+use std::{cmp::max, time::Duration};
 
 /// The default port for the http server
 pub const DEFAULT_HTTP_RPC_PORT: u16 = 8545;
@@ -60,6 +60,9 @@ pub const DEFAULT_TX_FEE_CAP_WEI: u128 = 1_000_000_000_000_000_000u128;
 /// Maximum eth historical proof window. Equivalent to roughly 6 months of data on a 12
 /// second block time, and a month on a 2 second block time.
 pub const MAX_ETH_PROOF_WINDOW: u64 = 28 * 24 * 60 * 60 / 2;
+
+/// Default timeout for send raw transaction sync in seconds.
+pub const RPC_DEFAULT_SEND_RAW_TX_SYNC_TIMEOUT_SECS: Duration = Duration::from_secs(30);
 
 /// GPO specific constants
 pub mod gas_oracle {

--- a/crates/rpc/rpc/src/eth/builder.rs
+++ b/crates/rpc/rpc/src/eth/builder.rs
@@ -18,7 +18,7 @@ use reth_rpc_server_types::constants::{
     DEFAULT_ETH_PROOF_WINDOW, DEFAULT_MAX_SIMULATE_BLOCKS, DEFAULT_PROOF_PERMITS,
 };
 use reth_tasks::{pool::BlockingTaskPool, TaskSpawner, TokioTaskExecutor};
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 /// A helper to build the `EthApi` handler instance.
 ///
@@ -43,6 +43,7 @@ pub struct EthApiBuilder<N: RpcNodeCore, Rpc, NextEnv = ()> {
     max_batch_size: usize,
     pending_block_kind: PendingBlockKind,
     raw_tx_forwarder: ForwardConfig,
+    send_raw_transaction_sync_timeout: Duration,
 }
 
 impl<Provider, Pool, Network, EvmConfig, ChainSpec>
@@ -92,6 +93,7 @@ impl<N: RpcNodeCore, Rpc, NextEnv> EthApiBuilder<N, Rpc, NextEnv> {
             max_batch_size,
             pending_block_kind,
             raw_tx_forwarder,
+            send_raw_transaction_sync_timeout,
         } = self;
         EthApiBuilder {
             components,
@@ -111,6 +113,7 @@ impl<N: RpcNodeCore, Rpc, NextEnv> EthApiBuilder<N, Rpc, NextEnv> {
             max_batch_size,
             pending_block_kind,
             raw_tx_forwarder,
+            send_raw_transaction_sync_timeout,
         }
     }
 }
@@ -141,6 +144,7 @@ where
             max_batch_size: 1,
             pending_block_kind: PendingBlockKind::Full,
             raw_tx_forwarder: ForwardConfig::default(),
+            send_raw_transaction_sync_timeout: Duration::from_secs(30),
         }
     }
 }
@@ -178,6 +182,7 @@ where
             max_batch_size,
             pending_block_kind,
             raw_tx_forwarder,
+            send_raw_transaction_sync_timeout,
         } = self;
         EthApiBuilder {
             components,
@@ -197,6 +202,7 @@ where
             max_batch_size,
             pending_block_kind,
             raw_tx_forwarder,
+            send_raw_transaction_sync_timeout,
         }
     }
 
@@ -223,6 +229,7 @@ where
             max_batch_size,
             pending_block_kind,
             raw_tx_forwarder,
+            send_raw_transaction_sync_timeout,
         } = self;
         EthApiBuilder {
             components,
@@ -242,6 +249,7 @@ where
             max_batch_size,
             pending_block_kind,
             raw_tx_forwarder,
+            send_raw_transaction_sync_timeout,
         }
     }
 
@@ -468,6 +476,7 @@ where
             max_batch_size,
             pending_block_kind,
             raw_tx_forwarder,
+            send_raw_transaction_sync_timeout,
         } = self;
 
         let provider = components.provider().clone();
@@ -507,6 +516,7 @@ where
             max_batch_size,
             pending_block_kind,
             raw_tx_forwarder.forwarder_client(),
+            send_raw_transaction_sync_timeout,
         )
     }
 
@@ -524,5 +534,11 @@ where
         NextEnv: PendingEnvBuilder<N::Evm>,
     {
         EthApi { inner: Arc::new(self.build_inner()) }
+    }
+
+    /// Sets the timeout for `send_raw_transaction_sync` RPC method.
+    pub const fn send_raw_transaction_sync_timeout(mut self, timeout: Duration) -> Self {
+        self.send_raw_transaction_sync_timeout = timeout;
+        self
     }
 }

--- a/crates/rpc/rpc/src/eth/helpers/transaction.rs
+++ b/crates/rpc/rpc/src/eth/helpers/transaction.rs
@@ -1,5 +1,7 @@
 //! Contains RPC handler implementations specific to transactions
 
+use std::time::Duration;
+
 use crate::EthApi;
 use alloy_primitives::{hex, Bytes, B256};
 use reth_rpc_convert::RpcConvert;
@@ -20,6 +22,12 @@ where
     fn signers(&self) -> &SignersForRpc<Self::Provider, Self::NetworkTypes> {
         self.inner.signers()
     }
+
+    #[inline]
+    fn send_raw_transaction_sync_timeout(&self) -> Duration {
+        self.inner.send_raw_transaction_sync_timeout()
+    }
+
 
     /// Decodes and recovers the transaction and submits it to the pool.
     ///

--- a/crates/rpc/rpc/src/eth/helpers/transaction.rs
+++ b/crates/rpc/rpc/src/eth/helpers/transaction.rs
@@ -28,7 +28,6 @@ where
         self.inner.send_raw_transaction_sync_timeout()
     }
 
-
     /// Decodes and recovers the transaction and submits it to the pool.
     ///
     /// Returns the hash of the transaction.

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -468,6 +468,11 @@ Gas Price Oracle:
       --gpo.default-suggested-fee <DEFAULT_SUGGESTED_FEE>
           The default gas price to use if there are no blocks to use
 
+      --rpc.send-raw-transaction-sync-timeout <SECONDS>
+          Timeout for `send_raw_transaction_sync` RPC method
+
+          [default: 30s]
+
 TxPool:
       --txpool.pending-max-count <PENDING_MAX_COUNT>
           Max number of transaction in the pending sub-pool


### PR DESCRIPTION
Resolves #18551
This PR makes the timeout for `send_raw_transaction_sync` RPC method configurable instead of hardcoded to 30 seconds. The change includes:

- Added `send_raw_transaction_sync_timeout` field to `EthConfig` with default value of 30 seconds
- Added CLI argument `--rpc.send-raw-transaction-sync-timeout` to allow users to customize the timeout
- Updated the `send_raw_transaction_sync` method to use the configurable timeout
- Implemented the required trait method in the `EthApi` implementation