### PR TITLE
chore(evm): add public constructor to `BlockAssemblerInput`

### DIFF
--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -200,7 +200,9 @@ pub struct BlockAssemblerInput<'a, 'b, F: BlockExecutorFactory, H = Header> {
 }
 
 impl<'a, 'b, F: BlockExecutorFactory, H> BlockAssemblerInput<'a, 'b, F, H> {
+
     /// Creates a new [`BlockAssemblerInput`].
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         evm_env: EvmEnv<<F::EvmFactory as EvmFactory>::Spec>,
         execution_ctx: F::ExecutionCtx<'a>,

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -199,6 +199,31 @@ pub struct BlockAssemblerInput<'a, 'b, F: BlockExecutorFactory, H = Header> {
     pub state_root: B256,
 }
 
+impl<'a, 'b, F: BlockExecutorFactory, H> BlockAssemblerInput<'a, 'b, F, H> {
+    /// Creates a new [`BlockAssemblerInput`].
+    pub fn new(
+        evm_env: EvmEnv<<F::EvmFactory as EvmFactory>::Spec>,
+        execution_ctx: F::ExecutionCtx<'a>,
+        parent: &'a SealedHeader<H>,
+        transactions: Vec<F::Transaction>,
+        output: &'b BlockExecutionResult<F::Receipt>,
+        bundle_state: &'a BundleState,
+        state_provider: &'b dyn StateProvider,
+        state_root: B256,
+    ) -> Self {
+        Self {
+            evm_env,
+            execution_ctx,
+            parent,
+            transactions,
+            output,
+            bundle_state,
+            state_provider,
+            state_root,
+        }
+    }
+}
+
 /// A type that knows how to assemble a block from execution results.
 ///
 /// The [`BlockAssembler`] is the final step in block production. After transactions

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -200,7 +200,6 @@ pub struct BlockAssemblerInput<'a, 'b, F: BlockExecutorFactory, H = Header> {
 }
 
 impl<'a, 'b, F: BlockExecutorFactory, H> BlockAssemblerInput<'a, 'b, F, H> {
-
     /// Creates a new [`BlockAssemblerInput`].
     #[expect(clippy::too_many_arguments)]
     pub fn new(


### PR DESCRIPTION
The struct `BlockAssemblerInput` is marked `#[non_exhaustive]` which makes it not able to be instantiated from external crates without a constructor. 