### PR TITLE
fix(optimism): always enable interop maintenance task if activated

### DIFF
--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -957,9 +957,7 @@ where
         debug!(target: "reth::cli", "Spawned txpool maintenance task");
 
         // The Op txpool maintenance task is only spawned when interop is active
-        if ctx.chain_spec().is_interop_active_at_timestamp(ctx.head().timestamp) &&
-            self.supervisor_http == DEFAULT_SUPERVISOR_URL
-        {
+        if ctx.chain_spec().is_interop_active_at_timestamp(ctx.head().timestamp) {
             // spawn the Op txpool maintenance task
             let chain_events = ctx.provider().canonical_state_stream();
             ctx.task_executor().spawn_critical(


### PR DESCRIPTION
I'm trying to add the grafana dashboard for op-reth(ref https://github.com/paradigmxyz/reth/pull/17897#pullrequestreview-3136109355),
couldn't found the interop related metrics, and check with the code,
found the check of supervisor_url is incorrect, it will prevent the interop maintainance task to be activated.