### PR TITLE
fix(cache): Ensure execution cache remains locked until updated

### DIFF
--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -543,8 +543,7 @@ impl SavedCache {
         (self.caches, self.metrics)
     }
 
-    /// Checks if the cache is currently available to be checked out.
-    /// It is considered available if no other component holds a reference to its usage guard.
+    /// Returns true if the cache is idle (no other tasks are using it).
     pub(crate) fn is_available(&self) -> bool {
         Arc::strong_count(&self.usage_guard) == 1
     }

--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -542,7 +542,7 @@ impl SavedCache {
         (self.caches, self.metrics)
     }
 
-    /// Returns true if the cache is idle (no other tasks are using it).
+    /// Returns true if the cache is available for use (no other tasks are currently using it).
     pub(crate) fn is_available(&self) -> bool {
         Arc::strong_count(&self.usage_guard) == 1
     }

--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -803,7 +803,6 @@ mod tests {
     }
 
     // Tests for SavedCache locking mechanism
-
     #[test]
     fn test_saved_cache_is_available() {
         let execution_cache = ExecutionCacheBuilder::default().build_caches(1000);

--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -552,11 +552,7 @@ impl SavedCache {
     /// Returns a guard if the cache is available, marking it as "in-use".
     /// Holding the returned guard keeps the cache locked.
     pub(crate) fn try_lock(&self) -> Option<Arc<()>> {
-        if self.is_available() {
-            Some(self.usage_guard.clone())
-        } else {
-            None
-        }
+        self.is_available().then(|| self.usage_guard.clone())
     }
 
     /// Returns the [`ExecutionCache`] belonging to the tracked hash.
@@ -628,7 +624,7 @@ impl Default for AccountStorageCache {
 }
 
 #[cfg(test)]
-mod inline_tests {
+mod tests {
     use super::*;
     use alloy_primitives::{B256, U256};
     use rand::Rng;

--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -538,7 +538,6 @@ impl SavedCache {
     }
 
     /// Splits the cache into its caches and metrics, consuming it.
-    #[allow(dead_code)]
     pub(crate) fn split(self) -> (ExecutionCache, CachedStateMetrics) {
         (self.caches, self.metrics)
     }

--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -538,6 +538,7 @@ impl SavedCache {
     }
 
     /// Splits the cache into its caches and metrics, consuming it.
+    #[allow(dead_code)]
     pub(crate) fn split(self) -> (ExecutionCache, CachedStateMetrics) {
         (self.caches, self.metrics)
     }
@@ -552,6 +553,11 @@ impl SavedCache {
         self.metrics.storage_cache_size.set(self.caches.total_storage_slots() as f64);
         self.metrics.account_cache_size.set(self.caches.account_cache.entry_count() as f64);
         self.metrics.code_cache_size.set(self.caches.code_cache.entry_count() as f64);
+    }
+
+    /// Returns the metrics for this cache.
+    pub(crate) const fn metrics(&self) -> &CachedStateMetrics {
+        &self.metrics
     }
 }
 
@@ -606,7 +612,7 @@ impl Default for AccountStorageCache {
 }
 
 #[cfg(test)]
-mod tests {
+mod inline_tests {
     use super::*;
     use alloy_primitives::{B256, U256};
     use rand::Rng;

--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -558,11 +558,6 @@ impl SavedCache {
         self.metrics.account_cache_size.set(self.caches.account_cache.entry_count() as f64);
         self.metrics.code_cache_size.set(self.caches.code_cache.entry_count() as f64);
     }
-
-    /// Returns the metrics for this cache.
-    pub(crate) const fn metrics(&self) -> &CachedStateMetrics {
-        &self.metrics
-    }
 }
 
 /// Cache for an individual account's storage slots.

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -568,10 +568,10 @@ impl ExecutionCache {
     /// - No other tasks are currently using it (checked via Arc reference count)
     pub(crate) fn get_cache_for(&self, parent_hash: B256) -> Option<SavedCache> {
         let cache = self.inner.read();
-        cache.as_ref().and_then(|cache| {
-            (cache.executed_block_hash() == parent_hash && cache.is_available())
-                .then(|| cache.clone())
-        })
+        cache
+            .as_ref()
+            .filter(|c| c.executed_block_hash() == parent_hash && c.is_available())
+            .cloned()
     }
 
     /// Clears the tracked cache

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -334,7 +334,6 @@ where
             self.executor.clone(),
             self.execution_cache.clone(),
             prewarm_ctx,
-            saved_cache,
             to_multi_proof,
         );
 

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -534,8 +534,6 @@ impl CacheTaskHandle {
 
 impl Drop for CacheTaskHandle {
     fn drop(&mut self) {
-        // Release the guard once prewarming is done.
-        // The guard will be dropped naturally here.
         // Ensure we always terminate on drop
         self.terminate_caching(None);
     }

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -326,7 +326,7 @@ where
             terminate_execution: Arc::new(AtomicBool::new(false)),
             precompile_cache_disabled: self.precompile_cache_disabled,
             precompile_cache_map: self.precompile_cache_map.clone(),
-// Pass the guard to the context. This locks the cache for the lifetime of the prewarm
+            // Pass the guard to the context. This locks the cache for the lifetime of the prewarm
             // task.
             cache_usage_guard: Some(saved_cache.usage_guard.clone()),
         };
@@ -347,11 +347,7 @@ where
             });
         }
 
-        CacheTaskHandle {
-            saved_cache,
-            cache_usage_guard,
-            to_prewarm_task: Some(to_prewarm_task),
-        }
+        CacheTaskHandle { saved_cache, cache_usage_guard, to_prewarm_task: Some(to_prewarm_task) }
     }
 
     /// Takes the trie input from the inner payload processor, if it exists.

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -610,14 +610,6 @@ impl ExecutionCache {
         F: FnOnce(&mut Option<SavedCache>),
     {
         let mut guard = self.inner.write();
-
-        if let Some(cache) = guard.as_ref() {
-            debug_assert!(
-                cache.is_available(),
-                "Attempting to update cache while it's in use. This is a race condition!"
-            );
-        }
-
         update_fn(&mut guard);
     }
 }

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -574,7 +574,7 @@ struct ExecutionCache {
 }
 
 impl ExecutionCache {
-    /// Returns a lease over the cache if the stored cache is for `parent_hash` and currently idle.
+    /// Returns the idle cache for `parent_hash` with a lock guard, or None if unavailable.
     pub(crate) fn get_cache_for(&self, parent_hash: B256) -> Option<(SavedCache, Arc<()>)> {
         let guard = self.inner.write();
         let cache = guard.as_ref()?;

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -556,7 +556,7 @@ impl Drop for CacheTaskHandle {
 /// - Runs concurrently but must not interfere with cache saves
 #[derive(Clone, Debug, Default)]
 struct ExecutionCache {
-    /// Guarded cache identified by block hash.
+    /// Guarded cloneable cache identified by a block hash.
     inner: Arc<RwLock<Option<SavedCache>>>,
 }
 

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -315,7 +315,6 @@ where
         }
 
         let (cache, cache_metrics) = self.cache_for(env.parent_hash).split();
-
         // configure prewarming
         let prewarm_ctx = PrewarmContext {
             env,
@@ -344,7 +343,7 @@ where
             });
         }
 
-        CacheTaskHandle { cache, cache_metrics, to_prewarm_task: Some(to_prewarm_task) }
+        CacheTaskHandle { cache, to_prewarm_task: Some(to_prewarm_task), cache_metrics }
     }
 
     /// Takes the trie input from the inner payload processor, if it exists.
@@ -462,11 +461,12 @@ impl<Tx, Err> PayloadHandle<Tx, Err> {
 
     /// Returns a clone of the caches used by prewarming
     pub(super) fn caches(&self) -> StateExecutionCache {
-        self.prewarm_handle.cache()
+        self.prewarm_handle.cache().clone()
     }
 
+    /// Returns a clone of the cache metrics used by prewarming
     pub(super) fn cache_metrics(&self) -> CachedStateMetrics {
-        self.prewarm_handle.cache_metrics()
+        self.prewarm_handle.cache_metrics().clone()
     }
 
     /// Terminates the pre-warming transaction processing.
@@ -503,14 +503,6 @@ pub(crate) struct CacheTaskHandle {
 }
 
 impl CacheTaskHandle {
-    fn cache(&self) -> StateExecutionCache {
-        self.cache.clone()
-    }
-
-    fn cache_metrics(&self) -> CachedStateMetrics {
-        self.cache_metrics.clone()
-    }
-
     /// Terminates the pre-warming transaction processing.
     ///
     /// Note: This does not terminate the task yet.

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -461,12 +461,12 @@ impl<Tx, Err> PayloadHandle<Tx, Err> {
 
     /// Returns a clone of the caches used by prewarming
     pub(super) fn caches(&self) -> StateExecutionCache {
-        self.prewarm_handle.cache().clone()
+        self.prewarm_handle.cache.clone()
     }
 
     /// Returns a clone of the cache metrics used by prewarming
     pub(super) fn cache_metrics(&self) -> CachedStateMetrics {
-        self.prewarm_handle.cache_metrics().clone()
+        self.prewarm_handle.cache_metrics.clone()
     }
 
     /// Terminates the pre-warming transaction processing.

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -315,14 +315,14 @@ where
         }
 
         let saved_cache = self.cache_for(env.parent_hash);
-        let cache_clone = saved_cache.cache().clone();
-        let cache_metrics_clone = saved_cache.metrics().clone();
+        let (cache, cache_metrics) = saved_cache.clone().split();
+
         // configure prewarming
         let prewarm_ctx = PrewarmContext {
             env,
             evm_config: self.evm_config.clone(),
-            cache: cache_clone.clone(),
-            cache_metrics: cache_metrics_clone.clone(),
+            cache: cache.clone(),
+            cache_metrics: cache_metrics.clone(),
             provider: provider_builder,
             metrics: PrewarmMetrics::default(),
             terminate_execution: Arc::new(AtomicBool::new(false)),
@@ -346,11 +346,7 @@ where
             });
         }
 
-        CacheTaskHandle {
-            cache: cache_clone,
-            cache_metrics: cache_metrics_clone,
-            to_prewarm_task: Some(to_prewarm_task),
-        }
+        CacheTaskHandle { cache, cache_metrics, to_prewarm_task: Some(to_prewarm_task) }
     }
 
     /// Takes the trie input from the inner payload processor, if it exists.

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -314,13 +314,14 @@ where
             transactions = mpsc::channel().1;
         }
 
-        let (cache, cache_metrics) = self.cache_for(env.parent_hash).split();
+        let saved_cache = self.cache_for(env.parent_hash);
+        let cache = saved_cache.cache().clone();
+        let cache_metrics = saved_cache.metrics().clone();
         // configure prewarming
         let prewarm_ctx = PrewarmContext {
             env,
             evm_config: self.evm_config.clone(),
-            cache: cache.clone(),
-            cache_metrics: cache_metrics.clone(),
+            saved_cache,
             provider: provider_builder,
             metrics: PrewarmMetrics::default(),
             terminate_execution: Arc::new(AtomicBool::new(false)),

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -326,9 +326,6 @@ where
             terminate_execution: Arc::new(AtomicBool::new(false)),
             precompile_cache_disabled: self.precompile_cache_disabled,
             precompile_cache_map: self.precompile_cache_map.clone(),
-            // Pass the guard to the context. This locks the cache for the lifetime of the prewarm
-            // task.
-            cache_usage_guard: Some(saved_cache.usage_guard.clone()),
         };
 
         let (prewarm_task, to_prewarm_task) = PrewarmCacheTask::new(

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -577,14 +577,11 @@ struct ExecutionCache {
 impl ExecutionCache {
     /// Returns the idle cache for `parent_hash`, or `None` if unavailable.
     pub(crate) fn get_cache_for(&self, parent_hash: B256) -> Option<SavedCache> {
-        let guard = self.inner.write();
-        let cache = guard.as_ref()?;
-
-        if cache.executed_block_hash() != parent_hash || !cache.is_available() {
-            return None
-        }
-
-        Some(cache.clone())
+        let guard = self.inner.read();
+        guard.as_ref().and_then(|cache| {
+            (cache.executed_block_hash() == parent_hash && cache.is_available())
+                .then(|| cache.clone())
+        })
     }
 
     /// Clears the tracked cache

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -583,11 +583,7 @@ impl ExecutionCache {
             return None
         }
 
-        if let Some(lock) = cache.try_lock() {
-            Some((cache.clone(), lock))
-        } else {
-            None
-        }
+        cache.try_lock().map(|lock| (cache.clone(), lock))
     }
 
     /// Clears the tracked cache

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -561,7 +561,11 @@ struct ExecutionCache {
 }
 
 impl ExecutionCache {
-    /// Returns the idle cache for `parent_hash`, or `None` if unavailable.
+    /// Returns the cache for `parent_hash` if it's available for use.
+    ///
+    /// A cache is considered available when:
+    /// - It exists and matches the requested parent hash
+    /// - No other tasks are currently using it (checked via Arc reference count)
     pub(crate) fn get_cache_for(&self, parent_hash: B256) -> Option<SavedCache> {
         let cache = self.inner.read();
         cache.as_ref().and_then(|cache| {

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -496,7 +496,9 @@ impl<Tx, Err> PayloadHandle<Tx, Err> {
 /// Access to the spawned [`PrewarmCacheTask`].
 #[derive(Debug)]
 pub(crate) struct CacheTaskHandle {
+    /// The shared cache the task operates with.
     cache: StateExecutionCache,
+    /// Metrics for the caches
     cache_metrics: CachedStateMetrics,
     /// Channel to the spawned prewarm task if any
     to_prewarm_task: Option<Sender<PrewarmTaskEvent>>,

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -314,8 +314,7 @@ where
             transactions = mpsc::channel().1;
         }
 
-        let saved_cache = self.cache_for(env.parent_hash);
-        let (cache, cache_metrics) = saved_cache.clone().split();
+        let (cache, cache_metrics) = self.cache_for(env.parent_hash).split();
 
         // configure prewarming
         let prewarm_ctx = PrewarmContext {

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -575,8 +575,8 @@ struct ExecutionCache {
 impl ExecutionCache {
     /// Returns the idle cache for `parent_hash`, or `None` if unavailable.
     pub(crate) fn get_cache_for(&self, parent_hash: B256) -> Option<SavedCache> {
-        let guard = self.inner.read();
-        guard.as_ref().and_then(|cache| {
+        let cache = self.inner.read();
+        cache.as_ref().and_then(|cache| {
             (cache.executed_block_hash() == parent_hash && cache.is_available())
                 .then(|| cache.clone())
         })

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -549,6 +549,24 @@ impl Drop for CacheTaskHandle {
 ///  - Update cache upon successful payload execution
 ///
 /// This process assumes that payloads are received sequentially.
+///
+/// ## Cache Safety
+///
+/// **CRITICAL**: Cache update operations require exclusive access. All concurrent cache users
+/// (such as prewarming tasks) must be terminated before calling `update_with_guard`, otherwise
+/// the cache may be corrupted or cleared.
+///
+/// ## Cache vs Prewarming Distinction
+///
+/// **`ExecutionCache`**:
+/// - Stores parent block's execution state after completion
+/// - Used to fetch parent data for next block's execution
+/// - Must be exclusively accessed during save operations
+///
+/// **`PrewarmCacheTask`**:
+/// - Speculatively loads accounts/storage that might be used in transaction execution
+/// - Prepares data for state root proof computation
+/// - Runs concurrently but must not interfere with cache saves
 #[derive(Clone, Debug, Default)]
 struct ExecutionCache {
     /// Guarded cache identified by block hash.
@@ -578,7 +596,19 @@ impl ExecutionCache {
         self.inner.write().take();
     }
 
-    /// Updates the cache with a closure that has exclusive access.
+    /// Updates the cache with a closure that has exclusive access to the guard.
+    /// This ensures that all cache operations happen atomically.
+    ///
+    /// ## CRITICAL SAFETY REQUIREMENT
+    ///
+    /// **Before calling this method, you MUST ensure there are no other active cache users.**
+    /// This includes:
+    /// - No running [`PrewarmCacheTask`] instances that could write to the cache
+    /// - No concurrent transactions that might access the cached state
+    /// - All prewarming operations must be completed or cancelled
+    ///
+    /// Violating this requirement can result in cache corruption, incorrect state data,
+    /// and potential consensus failures.
     pub(crate) fn update_with_guard<F>(&self, update_fn: F)
     where
         F: FnOnce(&mut Option<SavedCache>),

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -155,11 +155,8 @@ where
     fn save_cache(self, state: BundleState) {
         let start = Instant::now();
 
-        let Self {
-            execution_cache,
-            ctx: PrewarmContext { env, metrics, saved_cache, .. },
-            ..
-        } = self;
+        let Self { execution_cache, ctx: PrewarmContext { env, metrics, saved_cache, .. }, .. } =
+            self;
         let hash = env.hash;
 
         // Perform all cache operations atomically under the lock

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -155,8 +155,11 @@ where
     fn save_cache(self, state: BundleState) {
         let start = Instant::now();
 
-        let Self { execution_cache, ctx, .. } = self;
-        let PrewarmContext { env, metrics, saved_cache, .. } = ctx;
+        let Self {
+            execution_cache,
+            ctx: PrewarmContext { env, metrics, saved_cache, .. },
+            ..
+        } = self;
         let hash = env.hash;
 
         // Perform all cache operations atomically under the lock

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -151,9 +151,6 @@ where
     fn save_cache(self, state: BundleState) {
         let start = Instant::now();
 
-        if let Some(saved_cache) = self.execution_cache.get_cache_for(self.ctx.env.parent_hash) {
-            drop(saved_cache)
-        }
         let hash = self.ctx.env.hash;
         let caches = self.ctx.cache;
         let metrics = self.ctx.cache_metrics;

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -151,7 +151,7 @@ where
     /// This consumes the `SavedCache` held by the task, which releases its usage guard and allows
     /// the new, warmed cache to be inserted.
     ///
-    /// This method is called from `run()` only after all execution tasks are complete,
+    /// This method is called from `run()` only after all execution tasks are complete.
     fn save_cache(self, state: BundleState) {
         let start = Instant::now();
 

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -162,7 +162,7 @@ where
         // Perform all cache operations atomically under the lock
         execution_cache.update_with_guard(|cached| {
 
-            // consumes the `SavedCache` held by the task, which releases its usage guard
+            // consumes the `SavedCache` held by the prewarming task, which releases its usage guard
             let (caches, cache_metrics) = saved_cache.split();
             let new_cache = SavedCache::new(hash, caches, cache_metrics);
 

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -63,7 +63,7 @@ where
     /// Receiver for events produced by tx execution
     actions_rx: Receiver<PrewarmTaskEvent>,
     /// Holds the saved cache clone, keeping the usage guard alive.
-    cache_guard: SavedCache,
+    saved_cache: SavedCache,
 }
 
 impl<N, P, Evm> PrewarmCacheTask<N, P, Evm>
@@ -77,7 +77,7 @@ where
         executor: WorkloadExecutor,
         execution_cache: PayloadExecutionCache,
         ctx: PrewarmContext<N, P, Evm>,
-        cache_guard: SavedCache,
+        saved_cache: SavedCache,
         to_multi_proof: Option<Sender<MultiProofMessage>>,
     ) -> (Self, Sender<PrewarmTaskEvent>) {
         let (actions_tx, actions_rx) = channel();
@@ -85,7 +85,7 @@ where
             Self {
                 executor,
                 execution_cache,
-                cache_guard,
+                saved_cache,
                 ctx,
                 max_concurrency: 64,
                 to_multi_proof,
@@ -157,9 +157,9 @@ where
     fn save_cache(self, state: BundleState) {
         let start = Instant::now();
 
-        let PrewarmCacheTask { execution_cache, ctx, cache_guard, .. } = self;
+        let PrewarmCacheTask { execution_cache, ctx, saved_cache, .. } = self;
 
-        drop(cache_guard);
+        drop(saved_cache);
         let hash = ctx.env.hash;
         let caches = ctx.cache;
         let metrics = ctx.cache_metrics;

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -63,7 +63,7 @@ where
     /// Receiver for events produced by tx execution
     actions_rx: Receiver<PrewarmTaskEvent>,
     /// RAII guard that keeps the cache locked for the duration of the task.
-    _usage_guard: Arc<()>,
+    _cache_usage_guard: Arc<()>,
 }
 
 impl<N, P, Evm> PrewarmCacheTask<N, P, Evm>
@@ -85,7 +85,7 @@ where
             Self {
                 executor,
                 execution_cache,
-                _usage_guard: usage_guard,
+                _cache_usage_guard: usage_guard,
                 ctx,
                 max_concurrency: 64,
                 to_multi_proof,
@@ -157,7 +157,7 @@ where
     fn save_cache(self, state: BundleState) {
         let start = Instant::now();
 
-        drop(self._usage_guard);
+        drop(self._cache_usage_guard);
         let hash = self.ctx.env.hash;
         let caches = self.ctx.cache;
         let metrics = self.ctx.cache_metrics;

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -155,7 +155,7 @@ where
     fn save_cache(self, state: BundleState) {
         let start = Instant::now();
 
-        let PrewarmCacheTask { execution_cache, ctx, .. } = self;
+        let Self { execution_cache, ctx, .. } = self;
         let PrewarmContext { env, metrics, saved_cache, .. } = ctx;
         let hash = env.hash;
 


### PR DESCRIPTION
closes #18541

**Problem:**
- Prevent a possible race condition where the ExecutionCache can be updated while a background prewarming task is still using it by another background prewarming task. 
-  e.g  having a fork block and for `cache_for` to be called before the previous prewarm task exits


**Solution** - using `Arc<()>` as a lightweight, reference-counted lock:
- When the `PrewarmCacheTask` is spawned, it is given its own clone of the `usage_guard`.
- This task holds onto the guard for its entire lifetime. As long as the task is running, the `strong_count` remains > 1, keeping the cache safely locked.
- When the task finishes, its guard is dropped automatically (RAII), decrementing the count and helping to release the lock.