### PR TITLE
fix(engine): handle RemovingBlocks persistence action during reorganization

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -965,17 +965,24 @@ where
         let Some(action) = self.persistence_state.current_action() else {
             return PersistingKind::NotPersisting
         };
-        // Check that the persistince action is saving blocks, not removing them.
-        let CurrentPersistenceAction::SavingBlocks { highest } = action else {
-            return PersistingKind::PersistingNotDescendant
-        };
-
-        // The block being validated can only be a descendant if its number is higher than
-        // the highest block persisting. Otherwise, it's likely a fork of a lower block.
-        if block.block.number > highest.number &&
-            self.state.tree_state.is_descendant(*highest, block)
-        {
-            return PersistingKind::PersistingDescendant
+        match action {
+            CurrentPersistenceAction::SavingBlocks { highest } => {
+                // The block being validated can only be a descendant if its number is higher than
+                // the highest block persisting. Otherwise, it's likely a fork of a lower block.
+                if block.block.number > highest.number &&
+                    self.state.tree_state.is_descendant(*highest, block)
+                {
+                    return PersistingKind::PersistingDescendant
+                }
+            }
+            CurrentPersistenceAction::RemovingBlocks { new_tip_num } => {
+                // During reorganization, blocks above the new tip are being removed.
+                // If the incoming block number is higher than the removal point,
+                // it should be treated as not persisting to allow normal validation.
+                if block.block.number > *new_tip_num {
+                    return PersistingKind::NotPersisting
+                }
+            }
         }
 
         // In all other cases, the block is not a descendant.


### PR DESCRIPTION
fix the issue https://github.com/paradigmxyz/reth/issues/18408


Thanks @acerone85 for the detailed issue report, I think I partly understood the issue.

During reorganization, when `find_disk_reorg()` detects the need to remove blocks and starts a `RemoveBlocks` operation, incoming blocks were incorrectly classified as `PersistingNotDescendant`. 

This disabled parallel state root computation, forcing sequential computation that tried to access headers already removed by the ongoing removal job, resulting in fatal errors.

The race condition sequence:
1. Reorganization detected → `remove_blocks()` called → persistence state set to `RemovingBlocks`
2. New block arrives at height H+2 while removal is in progress
3. `persisting_kind_for()` sees `RemovingBlocks` → returns `PersistingNotDescendant`
4. Parallel state root disabled → sequential computation fails with "no header found"
