### PR TITLE
chore: fix error type for msg conversion

### DIFF
--- a/crates/errors/src/error.rs
+++ b/crates/errors/src/error.rs
@@ -46,7 +46,10 @@ impl RethError {
 
     /// Create a new `RethError` from a given message.
     pub fn msg(msg: impl Display) -> Self {
-        Self::Other(msg.to_string().into())
+        Self::Other(Box::new(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            msg.to_string(),
+        )))
     }
 }
 


### PR DESCRIPTION
Hey, ran into a little mismatch here - `msg.to_string()` gives a `String`, but `Self::Other` wants a `Box<dyn Error + Send + Sync>`.

Just wrapped the string in a box so it plays nicely with the expected type. Should clear up the compile error.