### PR TITLE
chore: Fix key generation with boxed RNG

### DIFF
--- a/testing/testing-utils/src/genesis_allocator.rs
+++ b/testing/testing-utils/src/genesis_allocator.rs
@@ -71,7 +71,7 @@ impl<'a> GenesisAllocator<'a> {
     /// Returns the key pair for the account and the account's address.
     pub fn new_funded_account(&mut self, balance: U256) -> (Keypair, Address) {
         let secp = Secp256k1::new();
-        let pair = Keypair::new(&secp, &mut self.rng);
+        let pair = Keypair::new(&secp, &mut *self.rng);
         let address = public_key_to_address(pair.public_key());
 
         self.alloc.insert(address, GenesisAccount::default().with_balance(balance));
@@ -88,7 +88,7 @@ impl<'a> GenesisAllocator<'a> {
         code: Bytes,
     ) -> (Keypair, Address) {
         let secp = Secp256k1::new();
-        let pair = Keypair::new(&secp, &mut self.rng);
+        let pair = Keypair::new(&secp, &mut *self.rng);
         let address = public_key_to_address(pair.public_key());
 
         self.alloc
@@ -106,7 +106,7 @@ impl<'a> GenesisAllocator<'a> {
         storage: BTreeMap<B256, B256>,
     ) -> (Keypair, Address) {
         let secp = Secp256k1::new();
-        let pair = Keypair::new(&secp, &mut self.rng);
+        let pair = Keypair::new(&secp, &mut *self.rng);
         let address = public_key_to_address(pair.public_key());
 
         self.alloc.insert(
@@ -126,7 +126,7 @@ impl<'a> GenesisAllocator<'a> {
         storage: BTreeMap<B256, B256>,
     ) -> (Keypair, Address) {
         let secp = Secp256k1::new();
-        let pair = Keypair::new(&secp, &mut self.rng);
+        let pair = Keypair::new(&secp, &mut *self.rng);
         let address = public_key_to_address(pair.public_key());
 
         self.alloc.insert(
@@ -142,7 +142,7 @@ impl<'a> GenesisAllocator<'a> {
     /// Returns the key pair for the account and the account's address.
     pub fn new_account_with_code(&mut self, code: Bytes) -> (Keypair, Address) {
         let secp = Secp256k1::new();
-        let pair = Keypair::new(&secp, &mut self.rng);
+        let pair = Keypair::new(&secp, &mut *self.rng);
         let address = public_key_to_address(pair.public_key());
 
         self.alloc.insert(address, GenesisAccount::default().with_code(Some(code)));
@@ -163,7 +163,7 @@ impl<'a> GenesisAllocator<'a> {
     /// Returns the key pair for the account and the account's address.
     pub fn add_account(&mut self, account: GenesisAccount) -> Address {
         let secp = Secp256k1::new();
-        let pair = Keypair::new(&secp, &mut self.rng);
+        let pair = Keypair::new(&secp, &mut *self.rng);
         let address = public_key_to_address(pair.public_key());
 
         self.alloc.insert(address, account);


### PR DESCRIPTION
I noticed that key generation was failing when using a boxed RNG.

Updated all instances of:

```rust
Keypair::new(&secp, &mut self.rng)
```

to:

```rust
Keypair::new(&secp, &mut *self.rng)
```

This ensures `self.rng` (a `Box<dyn RngCore>`) is correctly passed as `&mut dyn RngCore`.
The change fixes the mismatch and allows key creation to work as intended.

