### PR TITLE
chore: clippy manual_string_new warning in version.rs

### DIFF
--- a/crates/node/core/src/version.rs
+++ b/crates/node/core/src/version.rs
@@ -108,13 +108,13 @@ pub fn version_metadata() -> &'static RethCliVersionConsts {
 pub fn default_reth_version_metadata() -> RethCliVersionConsts {
     RethCliVersionConsts {
         name_client: Cow::Borrowed("Reth"),
-        cargo_pkg_version: Cow::Owned(env!("CARGO_PKG_VERSION").to_string()),
-        vergen_git_sha_long: Cow::Owned(env!("VERGEN_GIT_SHA").to_string()),
-        vergen_git_sha: Cow::Owned(env!("VERGEN_GIT_SHA_SHORT").to_string()),
-        vergen_build_timestamp: Cow::Owned(env!("VERGEN_BUILD_TIMESTAMP").to_string()),
-        vergen_cargo_target_triple: Cow::Owned(env!("VERGEN_CARGO_TARGET_TRIPLE").to_string()),
-        vergen_cargo_features: Cow::Owned(env!("VERGEN_CARGO_FEATURES").to_string()),
-        short_version: Cow::Owned(env!("RETH_SHORT_VERSION").to_string()),
+        cargo_pkg_version: Cow::Borrowed(env!("CARGO_PKG_VERSION")),
+        vergen_git_sha_long: Cow::Borrowed(env!("VERGEN_GIT_SHA")),
+        vergen_git_sha: Cow::Borrowed(env!("VERGEN_GIT_SHA_SHORT")),
+        vergen_build_timestamp: Cow::Borrowed(env!("VERGEN_BUILD_TIMESTAMP")),
+        vergen_cargo_target_triple: Cow::Borrowed(env!("VERGEN_CARGO_TARGET_TRIPLE")),
+        vergen_cargo_features: Cow::Borrowed(env!("VERGEN_CARGO_FEATURES")),
+        short_version: Cow::Borrowed(env!("RETH_SHORT_VERSION")),
         long_version: Cow::Owned(format!(
             "{}\n{}\n{}\n{}\n{}",
             env!("RETH_LONG_VERSION_0"),
@@ -124,8 +124,8 @@ pub fn default_reth_version_metadata() -> RethCliVersionConsts {
             env!("RETH_LONG_VERSION_4"),
         )),
 
-        build_profile_name: Cow::Owned(env!("RETH_BUILD_PROFILE").to_string()),
-        p2p_client_version: Cow::Owned(env!("RETH_P2P_CLIENT_VERSION").to_string()),
+        build_profile_name: Cow::Borrowed(env!("RETH_BUILD_PROFILE")),
+        p2p_client_version: Cow::Borrowed(env!("RETH_P2P_CLIENT_VERSION")),
         extra_data: Cow::Owned(default_extra_data()),
     }
 }


### PR DESCRIPTION
## Summary
Use `Cow::Borrowed` instead of `Cow::Owned` for all compile-time constant strings from `env!()` macro to avoid unnecessary heap allocations.

The `env!()` macro returns `&'static str` - compile-time constants that live for the entire program. Using `Cow::Owned(...to_string())` unnecessarily allocates these strings on the heap when we can just borrow the existing static references.
