### PR TITLE
chore(consensus): add eip6110 deposit log validation

### DIFF
--- a/crates/consensus/consensus/src/lib.rs
+++ b/crates/consensus/consensus/src/lib.rs
@@ -268,6 +268,10 @@ pub enum ConsensusError {
     #[error("unexpected requests hash")]
     RequestsHashUnexpected,
 
+    /// Error when deposit event data layout is invalid
+    #[error("failed to decode deposit requests from receipts")]
+    InvalidDepositEventLayout,
+
     /// Error when withdrawals are missing.
     #[error("missing withdrawals")]
     BodyWithdrawalsMissing,

--- a/crates/ethereum/consensus/src/lib.rs
+++ b/crates/ethereum/consensus/src/lib.rs
@@ -29,6 +29,7 @@ use reth_primitives_traits::{
 };
 
 mod validation;
+pub use validation::DepositContractProvider;
 pub use validation::validate_block_post_execution;
 
 /// Ethereum beacon consensus
@@ -52,9 +53,9 @@ impl<ChainSpec: EthChainSpec + EthereumHardforks> EthBeaconConsensus<ChainSpec> 
     }
 }
 
-impl<ChainSpec, N> FullConsensus<N> for EthBeaconConsensus<ChainSpec>
+impl<CS, N> FullConsensus<N> for EthBeaconConsensus<CS>
 where
-    ChainSpec: Send + Sync + EthChainSpec<Header = N::BlockHeader> + EthereumHardforks + Debug,
+    CS: Send + Sync + EthChainSpec<Header = N::BlockHeader> + EthereumHardforks + DepositContractProvider + Debug,
     N: NodePrimitives,
 {
     fn validate_block_post_execution(
@@ -62,7 +63,7 @@ where
         block: &RecoveredBlock<N::Block>,
         result: &BlockExecutionResult<N::Receipt>,
     ) -> Result<(), ConsensusError> {
-        validate_block_post_execution(block, &self.chain_spec, &result.receipts, &result.requests)
+        validate_block_post_execution(block, self.chain_spec.as_ref(), &result.receipts, &result.requests)
     }
 }
 

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -59,6 +59,7 @@ use reth_transaction_pool::{
 };
 use revm::context::TxEnv;
 use std::{default::Default, marker::PhantomData, sync::Arc, time::SystemTime};
+use reth_ethereum_consensus::DepositContractProvider;
 
 /// Type configuration for a regular Ethereum node.
 #[derive(Debug, Default, Clone, Copy)]
@@ -78,7 +79,7 @@ impl EthereumNode {
     where
         Node: FullNodeTypes<
             Types: NodeTypes<
-                ChainSpec: Hardforks + EthereumHardforks + EthExecutorSpec,
+                ChainSpec: Hardforks + EthereumHardforks + EthExecutorSpec + DepositContractProvider,
                 Primitives = EthPrimitives,
             >,
         >,
@@ -544,12 +545,9 @@ pub struct EthereumConsensusBuilder {
 
 impl<Node> ConsensusBuilder<Node> for EthereumConsensusBuilder
 where
-    Node: FullNodeTypes<
-        Types: NodeTypes<ChainSpec: EthChainSpec + EthereumHardforks, Primitives = EthPrimitives>,
-    >,
+    Node: FullNodeTypes<Types: NodeTypes<ChainSpec: EthChainSpec + EthereumHardforks + DepositContractProvider, Primitives = EthPrimitives>>,
 {
     type Consensus = Arc<EthBeaconConsensus<<Node::Types as NodeTypes>::ChainSpec>>;
-
     async fn build_consensus(self, ctx: &BuilderContext<Node>) -> eyre::Result<Self::Consensus> {
         Ok(Arc::new(EthBeaconConsensus::new(ctx.chain_spec())))
     }


### PR DESCRIPTION
## Description

The current EIP-6110 implementation does not validate the deposit log length or internal ABI structure as required by the EIP specification. This causes EEST test failures where invalid deposit event errors are not distinctly caught for the appropriate reason.

> Note this PR is here to aid a proper solution and prompt discussion.

## Solution

This PR implements the deposit event layout validation as specified in EIP-6110's `is_valid_deposit_event_data` [function](https://eips.ethereum.org/EIPS/eip-6110#block-validity), where the function returns False for incorrect validations.

1. **Log Length**: Valiadate that the log length is exactly 576 bytes.
2. **Offset**: Validate that ABI offsets match the required values.
3. **Size**: Validate that field sizes match the required values.

## Hive `eest/consume-engine`

Following this PR, the failing EIP-6110 tests now pass:
https://hive.ethpandaops.io/#/test/fusaka/1758204471-aa8d60fbce3ef54fecbaf57a3fd84ef3?page=1&testnumber=17831

Requires: https://github.com/ethereum/hive/pull/1344

## Alternative Option

This is not my preference but as an alternative solution we can note this spec mismatch within EEST and accept the current errors for the test:
- https://github.com/ethereum/execution-spec-tests/pull/2177