### PR TITLE
chore(payload-builder): relax Sync bounds on resolve futures

### DIFF
--- a/crates/payload/builder/src/service.rs
+++ b/crates/payload/builder/src/service.rs
@@ -30,7 +30,7 @@ use tokio::sync::{
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{debug, info, trace, warn};
 
-type PayloadFuture<P> = Pin<Box<dyn Future<Output = Result<P, PayloadBuilderError>> + Send + Sync>>;
+type PayloadFuture<P> = Pin<Box<dyn Future<Output = Result<P, PayloadBuilderError>> + Send>>;
 
 /// A communication channel to the [`PayloadBuilderService`] that can retrieve payloads.
 ///

--- a/crates/payload/builder/src/traits.rs
+++ b/crates/payload/builder/src/traits.rs
@@ -23,7 +23,6 @@ pub trait PayloadJob: Future<Output = Result<(), PayloadBuilderError>> {
     /// Represents the future that resolves the block that's returned to the CL.
     type ResolvePayloadFuture: Future<Output = Result<Self::BuiltPayload, PayloadBuilderError>>
         + Send
-        + Sync
         + 'static;
     /// Represents the built payload type that is returned to the CL.
     type BuiltPayload: BuiltPayload + Clone + std::fmt::Debug;


### PR DESCRIPTION
Removed unnecessary Sync bound from PayloadFuture and ResolvePayloadFuture. The resolve future is not shared across threads; it is produced by the service, sent over a oneshot, and awaited by a single consumer. Tokio channels and task spawning only require Send, not Sync. Keeping Sync restricts valid implementations (e.g., futures wrapping non-Sync internals) without functional benefit. This change relaxes constraints while preserving behavior.