### PR TITLE
perf(persistence): lookup segment operation once

### DIFF
--- a/crates/storage/provider/src/providers/static_file/metrics.rs
+++ b/crates/storage/provider/src/providers/static_file/metrics.rs
@@ -66,18 +66,15 @@ impl StaticFileProviderMetrics {
         operation: StaticFileProviderOperation,
         duration: Option<Duration>,
     ) {
-        self.segment_operations
+        let segment_operation = self
+            .segment_operations
             .get(&(segment, operation))
-            .expect("segment operation metrics should exist")
-            .calls_total
-            .increment(1);
+            .expect("segment operation metrics should exist");
+
+        segment_operation.calls_total.increment(1);
 
         if let Some(duration) = duration {
-            self.segment_operations
-                .get(&(segment, operation))
-                .expect("segment operation metrics should exist")
-                .write_duration_seconds
-                .record(duration.as_secs_f64());
+            segment_operation.write_duration_seconds.record(duration.as_secs_f64());
         }
     }
 


### PR DESCRIPTION
Random low-hanging fruit as we seek to flush blocks as fast as possible... More of a clarity than perf really.

<img width="1209" height="286" alt="image" src="https://github.com/user-attachments/assets/1a7fa236-855d-44a3-aa3a-9b4ca409fda8" />

