### PR TITLE
fix(rpc-engine): don't fetch the pruned block

### DIFF
--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -578,7 +578,13 @@ where
                 }
             }
 
+            // Check if the requested range starts before the earliest available block due to pruning/expiry
+            let earliest_block = inner.provider.earliest_block_number().unwrap_or(0);
             for num in start..=end {
+                if num < earliest_block {
+                    result.push(None);
+                    continue;
+                }
                 let block_result = inner.provider.block(BlockHashOrNumber::Number(num));
                 match block_result {
                     Ok(block) => {


### PR DESCRIPTION
closes https://github.com/paradigmxyz/reth/issues/18500

Don't fetch the blocks before earliest block, this will prevent the warning log and also improve the performance.