### PR TITLE
refactor(codecs): remove redundant CompactEnvelope trait

### DIFF
--- a/crates/storage/codecs/src/alloy/transaction/ethereum.rs
+++ b/crates/storage/codecs/src/alloy/transaction/ethereum.rs
@@ -112,7 +112,9 @@ impl<Eip4844: Compact + Transaction + RlpEcdsaEncodableTx> Envelope
     }
 }
 
-// Direct impl for EthereumTxEnvelope since we can't use generic impl due to trait conflicts
+// Direct impl for EthereumTxEnvelope
+// Note: We cannot use a generic impl<T: Envelope + ...> due to Rust's orphan rules
+// conflicting with the existing impl<T: Compact> Compact for &T in lib.rs
 impl<Eip4844: Compact + RlpEcdsaEncodableTx + Transaction + Send + Sync> Compact
     for EthereumTxEnvelope<Eip4844>
 {
@@ -191,7 +193,7 @@ impl<Eip4844: Compact + RlpEcdsaEncodableTx + Transaction + Send + Sync> Compact
             {
                 let mut decompressor = reth_zstd_compressors::create_tx_decompressor();
                 let decompressed = decompressor.decompress(buf);
-                let (tx_type, tx_buf) = T::TxType::from_compact(decompressed, tx_bits);
+                let (tx_type, tx_buf) = TxType::from_compact(decompressed, tx_bits);
                 let (tx, _) = Self::from_tx_compact(tx_buf, tx_type, signature);
 
                 (tx, buf)

--- a/crates/storage/codecs/src/alloy/transaction/mod.rs
+++ b/crates/storage/codecs/src/alloy/transaction/mod.rs
@@ -56,7 +56,7 @@ where
 cond_mod!(eip1559, eip2930, eip4844, eip7702, legacy, txtype);
 
 mod ethereum;
-pub use ethereum::{CompactEnvelope, Envelope, FromTxCompact, ToTxCompact};
+pub use ethereum::{Envelope, FromTxCompact, ToTxCompact};
 
 #[cfg(all(feature = "test-utils", feature = "op"))]
 pub mod optimism;

--- a/crates/storage/codecs/src/alloy/transaction/optimism.rs
+++ b/crates/storage/codecs/src/alloy/transaction/optimism.rs
@@ -10,10 +10,10 @@ use crate::{
     Compact,
 };
 use alloy_consensus::{
-    constants::EIP7702_TX_TYPE_ID, Signed, TxEip1559, TxEip2930, TxEip7702, TxLegacy,
+    constants::EIP7702_TX_TYPE_ID, Signed, Transaction, TxEip1559, TxEip2930, TxEip7702, TxLegacy,
 };
 use alloy_primitives::{Address, Bytes, Sealed, Signature, TxKind, B256, U256};
-use bytes::{Buf, BufMut};
+use bytes::BufMut;
 use op_alloy_consensus::{OpTxEnvelope, OpTxType, OpTypedTransaction, TxDeposit as AlloyTxDeposit};
 use reth_codecs_derive::add_arbitrary_tests;
 
@@ -235,7 +235,8 @@ impl Envelope for OpTxEnvelope {
     }
 }
 
-// Direct impl for OpTxEnvelope since we can't use generic impl due to trait conflicts
+// Direct impl for OpTxEnvelope
+// Note: We cannot use a generic impl<T: Envelope + ...> due to Rust's orphan rules
 impl Compact for OpTxEnvelope {
     fn to_compact<B>(&self, buf: &mut B) -> usize
     where
@@ -287,6 +288,7 @@ impl Compact for OpTxEnvelope {
     }
 
     fn from_compact(mut buf: &[u8], _len: usize) -> (Self, &[u8]) {
+        use bytes::Buf;
         let flags = buf.get_u8() as usize;
 
         let sig_bit = flags & 1;


### PR DESCRIPTION
Removes the redundant `CompactEnvelope` trait and replaces it with direct `Compact` implementations for transaction envelopes.

- Remove `CompactEnvelope` trait definition from `ethereum.rs`
- Implement `Compact` directly for `EthereumTxEnvelope<Eip4844>` and `OpTxEnvelope`
- Remove redundant `Compact` implementations that only delegated to `CompactEnvelope`
- Update module exports to remove references to deleted trait


Fixes #18591