### PR TITLE
fix(payload): reversed-order test for validate_execution_requests

### DIFF
--- a/crates/payload/primitives/Cargo.toml
+++ b/crates/payload/primitives/Cargo.toml
@@ -22,7 +22,7 @@ reth-chain-state.workspace = true
 alloy-eips.workspace = true
 alloy-primitives.workspace = true
 alloy-rpc-types-engine = { workspace = true, features = ["serde"] }
-op-alloy-rpc-types-engine = { workspace = true, optional = true }
+op-alloy-rpc-types-engine = { workspace = true, optional = true, features = ["serde"] }
 
 # misc
 auto_impl.workspace = true

--- a/crates/payload/primitives/src/lib.rs
+++ b/crates/payload/primitives/src/lib.rs
@@ -521,7 +521,7 @@ mod tests {
         let mut requests_valid_reversed = valid_requests;
         requests_valid_reversed.reverse();
         assert_matches!(
-            validate_execution_requests(&requests_with_empty),
+            validate_execution_requests(&requests_valid_reversed),
             Err(EngineObjectValidationError::InvalidParams(_))
         );
 


### PR DESCRIPTION
The test intended to validate out-of-order detection created a reversed version of a valid request list but mistakenly asserted on requests_with_empty, duplicating an earlier case and not exercising the out-of-order path. This change asserts on requests_valid_reversed, ensuring the validator correctly flags descending request_type sequences as OutOfOrderExecutionRequest per EIP-7685 (strict ascending order, no duplicates, no empty data).