### PR TITLE
chore(ci): unpin teku image for kurtosis-op

### DIFF
--- a/.github/assets/kurtosis_op_network_params.yaml
+++ b/.github/assets/kurtosis_op_network_params.yaml
@@ -4,7 +4,6 @@ ethereum_package:
       el_extra_params:
         - "--rpc.eth-proof-window=100"
       cl_type: teku
-      cl_image: "consensys/teku:25.7"
   network_params:
     preset: minimal
     genesis_delay: 5


### PR DESCRIPTION
we started getting teku errors like:
```
== SERVICE 'cl-1-teku-reth' LOGS ===================================
  2025-09-19 18:32:44.824 WARN  - Ignoring unknown items in network configuration: EIP7928_FORK_VERSION,EIP7441_FORK_VERSION,SYNC_MESSAGE_DUE_BPS_GLOAS,MAX_REQUEST_PAYLOADS,PAYLOAD_ATTESTATION_DUE_BPS,EIP7805_FORK_EPOCH,AGGREGATE_DUE_BPS_GLOAS,EPOCHS_PER_SHUFFLING_PHASE,AGGREGATE_DUE_BPS,ATTESTATION_DUE_BPS,EIP7805_FORK_VERSION,PROPOSER_SELECTION_GAP,CONTRIBUTION_DUE_BPS_GLOAS,CONTRIBUTION_DUE_BPS,VIEW_FREEZE_CUTOFF_BPS,MAX_BYTES_PER_INCLUSION_LIST,GLOAS_FORK_EPOCH,EIP7441_FORK_EPOCH,PROPOSER_INCLUSION_LIST_CUTOFF_BPS,ATTESTATION_DUE_BPS_GLOAS,MAX_REQUEST_INCLUSION_LIST,SYNC_MESSAGE_DUE_BPS,INCLUSION_LIST_SUBMISSION_DUE_BPS,SLOT_DURATION_MS,GLOAS_FORK_VERSION,EIP7928_FORK_EPOCH,PROPOSER_REORG_CUTOFF_BPS
  2025-09-19 18:32:44.840 FATAL - The specified network configuration had missing or invalid values for constants RESP_TIMEOUT, TTFB_TIMEOUT
```

looks like there have been changes in optimism-package not compatible with the teku pinned version, this PR unpins it

successful execution from this branch https://github.com/paradigmxyz/reth/actions/runs/17880362531