### PR TITLE
fix(db): add descriptive message to expect() call in MDBX test

### DIFF
--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -1441,8 +1441,11 @@ mod tests {
             let key = ShardedKey::new(real_key, if i == shards { u64::MAX } else { i * 100 });
             let list = IntegerList::new_pre_sorted([i * 100u64]);
 
-            db.update(|tx| tx.put::<AccountsHistory>(key.clone(), list.clone()).expect("Failed to put AccountsHistory"))
-                .unwrap();
+            db.update(|tx| {
+                tx.put::<AccountsHistory>(key.clone(), list.clone())
+                    .expect("Failed to put AccountsHistory")
+            })
+            .unwrap();
         }
 
         // Seek value with non existing key.

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -1441,7 +1441,7 @@ mod tests {
             let key = ShardedKey::new(real_key, if i == shards { u64::MAX } else { i * 100 });
             let list = IntegerList::new_pre_sorted([i * 100u64]);
 
-            db.update(|tx| tx.put::<AccountsHistory>(key.clone(), list.clone()).expect(""))
+            db.update(|tx| tx.put::<AccountsHistory>(key.clone(), list.clone()).expect("Failed to put AccountsHistory"))
                 .unwrap();
         }
 


### PR DESCRIPTION
Replace empty expect("") with meaningful error message "Failed to put AccountsHistory" to improve debugging experience when database operations fail