### PR TITLE
feat(db): add MDBX put-append for fast ordered puts

### DIFF
--- a/crates/storage/db-api/src/transaction.rs
+++ b/crates/storage/db-api/src/transaction.rs
@@ -50,6 +50,12 @@ pub trait DbTxMut: Send + Sync {
 
     /// Put value to database
     fn put<T: Table>(&self, key: T::Key, value: T::Value) -> Result<(), DatabaseError>;
+    /// Append value with the largest key to database. This should have the same
+    /// outcome as `put`, but databases like MDBX provide dedicated modes to make
+    /// it much faster, typically from O(logN) down to O(1) thanks to no lookup.
+    fn append<T: Table>(&self, key: T::Key, value: T::Value) -> Result<(), DatabaseError> {
+        self.put::<T>(key, value)
+    }
     /// Delete value from database
     fn delete<T: Table>(&self, key: T::Key, value: Option<T::Value>)
         -> Result<bool, DatabaseError>;

--- a/crates/storage/db/Cargo.toml
+++ b/crates/storage/db/Cargo.toml
@@ -112,3 +112,8 @@ harness = false
 name = "get"
 required-features = ["test-utils"]
 harness = false
+
+[[bench]]
+name = "put"
+required-features = ["test-utils"]
+harness = false

--- a/crates/storage/db/benches/put.rs
+++ b/crates/storage/db/benches/put.rs
@@ -1,0 +1,44 @@
+#![allow(missing_docs)]
+
+use alloy_primitives::B256;
+use criterion::{criterion_group, criterion_main, Criterion};
+use reth_db::{test_utils::create_test_rw_db_with_path, CanonicalHeaders, Database};
+use reth_db_api::transaction::DbTxMut;
+
+mod utils;
+use utils::BENCH_DB_PATH;
+
+const NUM_BLOCKS: u64 = 1_000_000;
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets = put
+}
+criterion_main!(benches);
+
+// Small benchmark showing that `append` is much faster than `put` when keys are put in order
+fn put(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Put");
+
+    let setup = || {
+        let _ = std::fs::remove_dir_all(BENCH_DB_PATH);
+        create_test_rw_db_with_path(BENCH_DB_PATH).tx_mut().expect("tx")
+    };
+
+    group.bench_function("put", |b| {
+        b.iter_with_setup(setup, |tx| {
+            for i in 0..NUM_BLOCKS {
+                tx.put::<CanonicalHeaders>(i, B256::ZERO).unwrap();
+            }
+        })
+    });
+
+    group.bench_function("append", |b| {
+        b.iter_with_setup(setup, |tx| {
+            for i in 0..NUM_BLOCKS {
+                tx.append::<CanonicalHeaders>(i, B256::ZERO).unwrap();
+            }
+        })
+    });
+}

--- a/crates/storage/db/src/metrics.rs
+++ b/crates/storage/db/src/metrics.rs
@@ -197,8 +197,10 @@ impl TransactionOutcome {
 pub(crate) enum Operation {
     /// Database get operation.
     Get,
-    /// Database put operation.
-    Put,
+    /// Database put upsert operation.
+    PutUpsert,
+    /// Database put append operation.
+    PutAppend,
     /// Database delete operation.
     Delete,
     /// Database cursor upsert operation.
@@ -220,7 +222,8 @@ impl Operation {
     pub(crate) const fn as_str(&self) -> &'static str {
         match self {
             Self::Get => "get",
-            Self::Put => "put",
+            Self::PutUpsert => "put-upsert",
+            Self::PutAppend => "put-append",
             Self::Delete => "delete",
             Self::CursorUpsert => "cursor-upsert",
             Self::CursorInsert => "cursor-insert",

--- a/crates/storage/errors/src/db.rs
+++ b/crates/storage/errors/src/db.rs
@@ -106,8 +106,10 @@ pub enum DatabaseWriteOperation {
     CursorInsert,
     /// Append duplicate cursor.
     CursorAppendDup,
-    /// Put.
-    Put,
+    /// Put upsert.
+    PutUpsert,
+    /// Put append.
+    PutAppend,
 }
 
 /// Database log level.


### PR DESCRIPTION
We only want 2 things in life:
1. Flush blocks to disk as fast as possible.
2. Commit write transactions as fast as possible.

This led us to `DatabaseProvider::insert_block`, which is still using put-upsert instead of put-append for tables with naturally increasing keys (like `BlockNumber`) in the happy/hot paths. For example:
https://github.com/paradigmxyz/reth/blob/4ddf3ddb45aedce284135c04e995c0c99d35baa3/crates/storage/provider/src/providers/database/provider.rs#L2747-L2755

This PR first adds `DbTxMut::append` with the optimised implementation for MDBX, and a benchmark to show how put-append is much faster than put-upsert in this scenario:
```
$ cargo bench -p reth-db --features test-utils --bench put
Benchmarking Put/put: Warming up for 3.0000 s
Put/put                 time:   [138.67 ms 138.76 ms 138.86 ms]

Benchmarking Put/append: Warming up for 3.0000 s
Put/append              time:   [80.353 ms 80.538 ms 80.722 ms]
```

Actual integration into key paths should be done in separate PRs with proper testing and benchmarks. Some places may be able to simply fall back to `put`, while others may want to report an error for different handling if the key is unexpectedly not the highest.