### PR TITLE
fix(handshake): validate peer TD from their_status_message during eth handshake

### DIFF
--- a/crates/net/eth-wire/src/handshake.rs
+++ b/crates/net/eth-wire/src/handshake.rs
@@ -178,8 +178,8 @@ where
                     .into());
                 }
 
-                // Ensure total difficulty is reasonable
-                if let StatusMessage::Legacy(s) = status {
+                // Ensure peer's total difficulty is reasonable
+                if let StatusMessage::Legacy(s) = their_status_message {
                     if s.total_difficulty.bit_len() > 160 {
                         unauth
                             .disconnect(DisconnectReason::ProtocolBreach)


### PR DESCRIPTION
- Switch total difficulty bit-length validation to inspect the peer’s legacy Status message (their_status_message) rather than our own status.
- This aligns the TD check with other peer-response validations (genesis/version/chain/forkid) and the Ethereum handshake’s intent: vet the peer’s claims, not our self-sent data.
- Without this change, a misreporting peer’s excessive TD would not be caught, while our own TD was redundantly validated after being sent.