### PR TITLE
chore: enforce max tx gas limit on estimate and accesslit

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -398,9 +398,6 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
             // <https://github.com/ethereum/go-ethereum/blob/8990c92aea01ca07801597b00c0d83d4e2d9b811/internal/ethapi/api.go#L1476-L1476>
             evm_env.cfg_env.disable_base_fee = true;
 
-            // Disable EIP-7825 transaction gas limit to support larger transactions
-            evm_env.cfg_env.tx_gas_limit_cap = Some(u64::MAX);
-
             // Disabled because eth_createAccessList is sometimes used with non-eoa senders
             evm_env.cfg_env.disable_eip3607 = true;
 

--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -53,9 +53,6 @@ pub trait EstimateCall: Call {
         // <https://github.com/ethereum/go-ethereum/blob/ee8e83fa5f6cb261dad2ed0a7bbcde4930c41e6c/internal/ethapi/api.go#L985>
         evm_env.cfg_env.disable_base_fee = true;
 
-        // Disable EIP-7825 transaction gas limit to support larger transactions
-        evm_env.cfg_env.tx_gas_limit_cap = Some(u64::MAX);
-
         // set nonce to None so that the correct nonce is chosen by the EVM
         request.as_mut().take_nonce();
 


### PR DESCRIPTION
these should be enforced here to not allow invalid txs because these are used when filling txs


geth ref https://github.com/ethereum/go-ethereum/pull/32348