### PR TITLE
refactor(engine): simplify on_new_payload

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -575,17 +575,12 @@ where
         Ok(outcome)
     }
 
-    /// Executes and validates a payload during normal sync operations.
-    ///
-    /// Attempts to insert the payload into the tree during normal sync operation.
+    /// Processes a payload during normal sync operation.
     ///
     /// Returns:
-    /// - `PayloadStatus::Valid` - When the payload is successfully inserted and validated
-    /// - `PayloadStatus::Syncing` - When the payload cannot be fully validated because its parent
-    ///   is missing (block is buffered for later processing)
-    /// - Error statuses for invalid payloads
-    ///
-    /// This function is called when the node is not performing backfill sync.
+    /// - `Valid`: Payload successfully validated and inserted
+    /// - `Syncing`: Parent missing, payload buffered for later
+    /// - Error status: Payload is invalid
     fn try_insert_payload(
         &mut self,
         payload: T::ExecutionData,
@@ -625,21 +620,14 @@ where
         }
     }
 
-    /// Attempts to buffer a payload for later processing during backfill sync.
+    /// Stores a payload for later processing during backfill sync.
     ///
-    /// "Buffer" in this context means to temporarily store the payload in memory for deferred
-    /// processing. This is necessary because during backfill sync, the node is still downloading
-    /// historical blocks and doesn't yet have the complete state required to validate the
-    /// payload's execution.
+    /// During backfill, the node lacks the state needed to validate payloads,
+    /// so they are buffered (stored in memory) until their parent blocks are synced.
     ///
     /// Returns:
-    /// - `PayloadStatus::Syncing` - When the payload is successfully validated and buffered for
-    ///   later processing once the backfill sync completes
-    /// - Error statuses for malformed or invalid payloads
-    ///
-    /// This function is called when the node is performing backfill sync and cannot
-    /// immediately validate the payload's execution. The buffered payloads will be processed
-    /// when the sync catches up to their parent blocks.
+    /// - `Syncing`: Payload successfully buffered
+    /// - Error status: Payload is malformed or invalid
     fn try_buffer_payload(
         &mut self,
         payload: T::ExecutionData,

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1850,10 +1850,10 @@ where
     /// 3. Checking if this ancestor is in the `invalid_headers` map
     ///
     /// If an invalid ancestor is found, this function handles two scenarios:
-    /// 1. **Well-formed payload**: The payload is marked as invalid since it descends from
-    ///    a known-bad block, which violates consensus rules
-    /// 2. **Malformed payload**: Returns an appropriate error status since the payload
-    ///    cannot be validated due to its own structural issues
+    /// 1. **Well-formed payload**: The payload is marked as invalid since it descends from a
+    ///    known-bad block, which violates consensus rules
+    /// 2. **Malformed payload**: Returns an appropriate error status since the payload cannot be
+    ///    validated due to its own structural issues
     ///
     /// Returns `Ok(Some(PayloadStatus))` if the payload is invalid due to an invalid ancestor,
     /// `Ok(None)` if no invalid ancestor is found, or `Err(...)` if an internal error occurs.

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -1301,15 +1301,15 @@ mod check_invalid_ancestors_tests {
     }
 }
 
-/// Test suite for `execute_payload_during_normal_sync` and `buffer_payload_for_backfill_sync`
+/// Test suite for `try_insert_payload` and `try_buffer_payload`
 /// methods
 #[cfg(test)]
 mod payload_execution_tests {
     use super::*;
 
-    /// Test `execute_payload_during_normal_sync` with different `InsertPayloadOk` variants
+    /// Test `try_insert_payload` with different `InsertPayloadOk` variants
     #[test]
-    fn test_execute_payload_during_normal_sync_variants() {
+    fn test_try_insert_payload_variants() {
         reth_tracing::init_test_tracing();
 
         let mut test_harness = TestHarness::new(HOLESKY.clone());
@@ -1328,12 +1328,12 @@ mod payload_execution_tests {
         };
 
         // Test the function directly
-        let result = test_harness.tree.execute_payload_during_normal_sync(payload);
+        let result = test_harness.tree.try_insert_payload(payload);
         // Should handle the payload gracefully
         assert!(result.is_ok(), "Should handle valid payload without error");
     }
 
-    /// Test `buffer_payload_for_backfill_sync` with validation errors
+    /// Test `try_buffer_payload` with validation errors
     #[test]
     fn test_buffer_payload_validation_errors() {
         reth_tracing::init_test_tracing();
@@ -1344,7 +1344,7 @@ mod payload_execution_tests {
         let malformed_payload = create_malformed_payload();
 
         // Test buffering during backfill sync
-        let result = test_harness.tree.buffer_payload_for_backfill_sync(malformed_payload);
+        let result = test_harness.tree.try_buffer_payload(malformed_payload);
         assert!(result.is_ok(), "Should handle malformed payload gracefully");
         let status = result.unwrap();
         assert!(
@@ -1353,7 +1353,7 @@ mod payload_execution_tests {
         );
     }
 
-    /// Test `buffer_payload_for_backfill_sync` with valid payload
+    /// Test `try_buffer_payload` with valid payload
     #[test]
     fn test_buffer_payload_valid_payload() {
         reth_tracing::init_test_tracing();
@@ -1374,7 +1374,7 @@ mod payload_execution_tests {
         };
 
         // Test buffering during backfill sync
-        let result = test_harness.tree.buffer_payload_for_backfill_sync(payload);
+        let result = test_harness.tree.try_buffer_payload(payload);
         assert!(result.is_ok(), "Should handle valid payload gracefully");
         let status = result.unwrap();
         // The payload may be invalid due to missing withdrawals root, so accept either status

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -1224,7 +1224,7 @@ mod check_invalid_ancestors_tests {
         assert!(status.is_invalid(), "Status should be invalid when parent is invalid");
     }
 
-    /// Test genesis block handling (parent_hash = B256::ZERO)
+    /// Test genesis block handling (parent_hash = `B256::ZERO`)
     #[test]
     fn test_genesis_block_handling() {
         reth_tracing::init_test_tracing();
@@ -1288,8 +1288,7 @@ mod check_invalid_ancestors_tests {
 
         // Intentionally corrupt the block to make it malformed
         // Modify the block after creation to make validation fail
-        let block_with_senders = block.clone();
-        let (sealed_block, _senders) = block_with_senders.split_sealed();
+        let (sealed_block, _senders) = block.split_sealed();
         let unsealed_block = sealed_block.unseal();
 
         // Create payload with wrong hash (this makes it malformed)
@@ -1302,12 +1301,13 @@ mod check_invalid_ancestors_tests {
     }
 }
 
-/// Test suite for execute_payload_during_normal_sync and buffer_payload_for_backfill_sync methods
+/// Test suite for `execute_payload_during_normal_sync` and `buffer_payload_for_backfill_sync`
+/// methods
 #[cfg(test)]
 mod payload_execution_tests {
     use super::*;
 
-    /// Test execute_payload_during_normal_sync with different InsertPayloadOk variants
+    /// Test `execute_payload_during_normal_sync` with different `InsertPayloadOk` variants
     #[test]
     fn test_execute_payload_during_normal_sync_variants() {
         reth_tracing::init_test_tracing();
@@ -1333,7 +1333,7 @@ mod payload_execution_tests {
         assert!(result.is_ok(), "Should handle valid payload without error");
     }
 
-    /// Test buffer_payload_for_backfill_sync with validation errors
+    /// Test `buffer_payload_for_backfill_sync` with validation errors
     #[test]
     fn test_buffer_payload_validation_errors() {
         reth_tracing::init_test_tracing();
@@ -1353,7 +1353,7 @@ mod payload_execution_tests {
         );
     }
 
-    /// Test buffer_payload_for_backfill_sync with valid payload
+    /// Test `buffer_payload_for_backfill_sync` with valid payload
     #[test]
     fn test_buffer_payload_valid_payload() {
         reth_tracing::init_test_tracing();

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -1170,7 +1170,7 @@ mod check_invalid_ancestors_tests {
         };
 
         // Check for invalid ancestors - should return None since none are marked invalid
-        let result = test_harness.tree.check_invalid_ancestors(&payload).unwrap();
+        let result = test_harness.tree.find_invalid_ancestor(&payload);
         assert!(result.is_none(), "Should return None when no invalid ancestors exist");
     }
 
@@ -1212,11 +1212,15 @@ mod check_invalid_ancestors_tests {
         };
 
         // Check for invalid ancestors - should detect invalid parent
-        let result = test_harness.tree.check_invalid_ancestors(&payload2).unwrap();
+        let invalid_ancestor = test_harness.tree.find_invalid_ancestor(&payload2);
         assert!(
-            result.is_some(),
-            "Should return Some(PayloadStatus) when invalid parent is detected"
+            invalid_ancestor.is_some(),
+            "Should find invalid ancestor when parent is marked as invalid"
         );
-        assert!(result.unwrap().is_invalid(), "Status should be invalid when parent is invalid");
+
+        // Now test that handling the payload with invalid ancestor returns invalid status
+        let invalid = invalid_ancestor.unwrap();
+        let status = test_harness.tree.handle_invalid_ancestor_payload(payload2, invalid).unwrap();
+        assert!(status.is_invalid(), "Status should be invalid when parent is invalid");
     }
 }

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -1146,12 +1146,12 @@ fn test_on_new_payload_malformed_payload() {
     }
 }
 
-/// Test suite for the check_invalid_ancestors method
+/// Test suite for the `check_invalid_ancestors` method
 #[cfg(test)]
 mod check_invalid_ancestors_tests {
     use super::*;
 
-    /// Test that find_invalid_ancestor returns None when no invalid ancestors exist
+    /// Test that `find_invalid_ancestor` returns None when no invalid ancestors exist
     #[test]
     fn test_find_invalid_ancestor_no_invalid() {
         reth_tracing::init_test_tracing();
@@ -1174,7 +1174,7 @@ mod check_invalid_ancestors_tests {
         assert!(result.is_none(), "Should return None when no invalid ancestors exist");
     }
 
-    /// Test that find_invalid_ancestor detects an invalid parent
+    /// Test that `find_invalid_ancestor` detects an invalid parent
     #[test]
     fn test_find_invalid_ancestor_with_invalid_parent() {
         reth_tracing::init_test_tracing();
@@ -1224,7 +1224,7 @@ mod check_invalid_ancestors_tests {
         assert!(status.is_invalid(), "Status should be invalid when parent is invalid");
     }
 
-    /// Test genesis block handling (parent_hash = `B256::ZERO`)
+    /// Test genesis block handling (`parent_hash` = `B256::ZERO`)
     #[test]
     fn test_genesis_block_handling() {
         reth_tracing::init_test_tracing();


### PR DESCRIPTION
closes https://github.com/paradigmxyz/reth/issues/18448

where on_new_payload is one of the most important functions in reth and we want to simplify that.  Broke that down into smaller functions, where it can be tested. 