### PR TITLE
chore(eth-wire): clarify docs and fix timeout_timer comment

### DIFF
--- a/crates/net/eth-wire/src/pinger.rs
+++ b/crates/net/eth-wire/src/pinger.rs
@@ -7,13 +7,13 @@ use std::{
 use tokio::time::{Instant, Interval, Sleep};
 use tokio_stream::Stream;
 
-/// The pinger is a state machine that is created with a maximum number of pongs that can be
-/// missed.
+/// The pinger is a simple state machine that sends a ping, waits for a pong,
+/// and transitions to timeout if the pong is not received within the timeout.
 #[derive(Debug)]
 pub(crate) struct Pinger {
     /// The timer used for the next ping.
     ping_interval: Interval,
-    /// The timer used for the next ping.
+    /// The timer used to detect a ping timeout.
     timeout_timer: Pin<Box<Sleep>>,
     /// The timeout duration for each ping.
     timeout: Duration,
@@ -38,7 +38,7 @@ impl Pinger {
     }
 
     /// Mark a pong as received, and transition the pinger to the `Ready` state if it was in the
-    /// `WaitingForPong` state. Unsets the sleep timer.
+    /// `WaitingForPong` state. Resets readiness by resetting the ping interval.
     pub(crate) fn on_pong(&mut self) -> Result<(), PingerError> {
         match self.state {
             PingState::Ready => Err(PingerError::UnexpectedPong),

--- a/crates/net/eth-wire/src/test_utils.rs
+++ b/crates/net/eth-wire/src/test_utils.rs
@@ -62,7 +62,7 @@ pub async fn connect_passthrough(
     p2p_stream
 }
 
-/// An Rplx subprotocol for testing
+/// An Rlpx subprotocol for testing
 pub mod proto {
     use super::*;
     use crate::{protocol::Protocol, Capability};

--- a/crates/net/eth-wire/tests/fuzz_roundtrip.rs
+++ b/crates/net/eth-wire/tests/fuzz_roundtrip.rs
@@ -19,8 +19,8 @@ where
 }
 
 /// This method delegates to `roundtrip_encoding`, but is used to enforce that each type input to
-/// the macro has a proper Default, Clone, and Serialize impl. These trait implementations are
-/// necessary for test-fuzz to autogenerate a corpus.
+/// the macro has proper `Clone` and `Serialize` impls. These trait implementations are necessary
+/// for test-fuzz to autogenerate a corpus.
 ///
 /// If it makes sense to remove a Default impl from a type that we fuzz, this should prevent the
 /// fuzz test from compiling, rather than failing at runtime.


### PR DESCRIPTION
fuzz_roundtrip.rs - Default was deleted so needed to update comment
test_utils.rs - typo
pinger.rs - Update top-level Pinger doc to reflect current model: one ping → wait for pong → single timeout transition.
Fix incorrect timeout_timer field comment to indicate it tracks ping timeouts (not next ping).
Adjust on_pong doc to describe actual behavior (reset state and ping interval), removing mention of unsetting the sleep timer.