### PR TITLE
docs: rm 8MB stack size comment in BlockingTaskPool

### DIFF
--- a/crates/tasks/src/pool.rs
+++ b/crates/tasks/src/pool.rs
@@ -72,10 +72,7 @@ impl BlockingTaskPool {
     /// Uses [`rayon::ThreadPoolBuilder::build`](rayon::ThreadPoolBuilder::build) defaults but
     /// increases the stack size to 8MB.
     pub fn build() -> Result<Self, rayon::ThreadPoolBuildError> {
-        Self::builder()
-            .stack_size(8 * 1024 * 1024)
-            .build()
-            .map(Self::new)
+        Self::builder().stack_size(8 * 1024 * 1024).build().map(Self::new)
     }
 
     /// Asynchronous wrapper around Rayon's

--- a/crates/tasks/src/pool.rs
+++ b/crates/tasks/src/pool.rs
@@ -69,10 +69,11 @@ impl BlockingTaskPool {
 
     /// Convenience function to build a new threadpool with the default configuration.
     ///
-    /// Uses [`rayon::ThreadPoolBuilder::build`](rayon::ThreadPoolBuilder::build) defaults but
-    /// increases the stack size to 8MB.
+    /// Uses [`rayon::ThreadPoolBuilder::build`](rayon::ThreadPoolBuilder::build) defaults.
+    /// If a different stack size or other parameters are needed, they can be configured via
+    /// [`rayon::ThreadPoolBuilder`] returned by [`Self::builder`].
     pub fn build() -> Result<Self, rayon::ThreadPoolBuildError> {
-        Self::builder().stack_size(8 * 1024 * 1024).build().map(Self::new)
+        Self::builder().build().map(Self::new)
     }
 
     /// Asynchronous wrapper around Rayon's

--- a/crates/tasks/src/pool.rs
+++ b/crates/tasks/src/pool.rs
@@ -72,7 +72,10 @@ impl BlockingTaskPool {
     /// Uses [`rayon::ThreadPoolBuilder::build`](rayon::ThreadPoolBuilder::build) defaults but
     /// increases the stack size to 8MB.
     pub fn build() -> Result<Self, rayon::ThreadPoolBuildError> {
-        Self::builder().build().map(Self::new)
+        Self::builder()
+            .stack_size(8 * 1024 * 1024)
+            .build()
+            .map(Self::new)
     }
 
     /// Asynchronous wrapper around Rayon's


### PR DESCRIPTION


### Description
- **What**: Explicitly set Rayon thread pool stack size to 8MB in `BlockingTaskPool::build`.
- **Why**: Documentation claimed 8MB, but code didn’t enforce it. This prevents unexpected stack overflows in CPU-bound tasks and aligns behavior with docs.
- **Change**: Add `.stack_size(8 * 1024 * 1024)` to the pool builder.
- **Impact**: More predictable stack for heavy tracing/CPU workloads; no API changes.
