### PR TITLE
fix(cli): bootnode default address

### DIFF
--- a/docs/vocs/docs/pages/cli/reth/p2p/bootnode.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/bootnode.mdx
@@ -10,9 +10,9 @@ Usage: reth p2p bootnode [OPTIONS]
 
 Options:
       --addr <ADDR>
-          Listen address for the bootnode (default: ":30301")
+          Listen address for the bootnode (default: "0.0.0.0:30301")
 
-          [default: :30301]
+          [default: 0.0.0.0:30301]
 
       --gen-key <GEN_KEY>
           Generate a new node key and save it to the specified file


### PR DESCRIPTION
Running 
```bash
reth p2p bootnode
```

returns a parse error on the default listening address.

```bash
INFO Bootnode started with config: Command { addr: ":30301", gen_key: "", node_key: "", nat: Any, v5: false }
Error: invalid socket address syntax
```