### PR TITLE
fix: implement missing else branch in Compact derive from_compact generation

### DIFF
--- a/crates/storage/codecs/derive/src/compact/structs.rs
+++ b/crates/storage/codecs/derive/src/compact/structs.rs
@@ -155,7 +155,9 @@ impl<'a> StructHandler<'a> {
                     let (#name, new_buf) = #ident_type::#from_compact_ident(buf, flags.#len() as usize);
                 });
             } else {
-                todo!()
+                self.lines.push(quote! {
+                    let (#name, new_buf) = #ident_type::#from_compact_ident(buf, flags.#len() as usize);
+                });
             }
             self.lines.push(quote! {
                 buf = new_buf;

--- a/crates/storage/codecs/derive/src/compact/structs.rs
+++ b/crates/storage/codecs/derive/src/compact/structs.rs
@@ -67,7 +67,7 @@ impl<'a> StructHandler<'a> {
                 })
             }
 
-            return
+            return;
         }
 
         let name = format_ident!("{name}");
@@ -98,7 +98,8 @@ impl<'a> StructHandler<'a> {
 
     /// Generates `from_compact` code for a struct field.
     fn from(&mut self, field_descriptor: &StructFieldDescriptor, known_types: &[&str]) {
-        let StructFieldDescriptor { name, ftype, is_compact: _, use_alt_impl, .. } = field_descriptor;
+        let StructFieldDescriptor { name, ftype, is_compact: _, use_alt_impl, .. } =
+            field_descriptor;
 
         let (name, len) = if name.is_empty() {
             self.is_wrapper = true;


### PR DESCRIPTION
Replace `todo!()` with proper implementation that reads length from flags and calls `from_compact_ident`, matching the logic used in the `is_compact` case.
