### PR TITLE
chore(primitive-traits): remove redundant auto-trait bounds from FullNodePrimitives

### DIFF
--- a/crates/primitives-traits/src/node.rs
+++ b/crates/primitives-traits/src/node.rs
@@ -35,15 +35,7 @@ where
             BlockBody: FullBlockBody<Transaction = Self::SignedTx>,
             SignedTx: FullSignedTx,
             Receipt: FullReceipt,
-        > + Send
-        + Sync
-        + Unpin
-        + Clone
-        + Default
-        + fmt::Debug
-        + PartialEq
-        + Eq
-        + 'static,
+        >,
 {
 }
 
@@ -54,15 +46,7 @@ impl<T> FullNodePrimitives for T where
             BlockBody: FullBlockBody<Transaction = Self::SignedTx>,
             SignedTx: FullSignedTx,
             Receipt: FullReceipt,
-        > + Send
-        + Sync
-        + Unpin
-        + Clone
-        + Default
-        + fmt::Debug
-        + PartialEq
-        + Eq
-        + 'static
+        >
 {
 }
 

--- a/crates/primitives-traits/src/node.rs
+++ b/crates/primitives-traits/src/node.rs
@@ -30,23 +30,23 @@ pub trait NodePrimitives:
 pub trait FullNodePrimitives
 where
     Self: NodePrimitives<
-            Block: FullBlock<Header = Self::BlockHeader, Body = Self::BlockBody>,
-            BlockHeader: FullBlockHeader,
-            BlockBody: FullBlockBody<Transaction = Self::SignedTx>,
-            SignedTx: FullSignedTx,
-            Receipt: FullReceipt,
-        >,
+        Block: FullBlock<Header = Self::BlockHeader, Body = Self::BlockBody>,
+        BlockHeader: FullBlockHeader,
+        BlockBody: FullBlockBody<Transaction = Self::SignedTx>,
+        SignedTx: FullSignedTx,
+        Receipt: FullReceipt,
+    >,
 {
 }
 
 impl<T> FullNodePrimitives for T where
     T: NodePrimitives<
-            Block: FullBlock<Header = Self::BlockHeader, Body = Self::BlockBody>,
-            BlockHeader: FullBlockHeader,
-            BlockBody: FullBlockBody<Transaction = Self::SignedTx>,
-            SignedTx: FullSignedTx,
-            Receipt: FullReceipt,
-        >
+        Block: FullBlock<Header = Self::BlockHeader, Body = Self::BlockBody>,
+        BlockHeader: FullBlockHeader,
+        BlockBody: FullBlockBody<Transaction = Self::SignedTx>,
+        SignedTx: FullSignedTx,
+        Receipt: FullReceipt,
+    >
 {
 }
 


### PR DESCRIPTION
Why: The auto-trait bounds (Send, Sync, Unpin, Clone, Default, Debug, PartialEq, Eq, 'static) were already enforced by NodePrimitives, and FullNodePrimitives requires Self: NodePrimitives<...>. Duplicating them in FullNodePrimitives and its blanket impl was unnecessary and inconsistent with other Full* traits (FullBlock, FullBlockBody, FullBlockHeader) that rely on their base traits’ bounds without repetition.
What: Removed duplicated bounds from the FullNodePrimitives trait and its blanket implementation, keeping only the NodePrimitives-related constraints. This preserves semantics, improves readability, and aligns with established style in the crate.