### PR TITLE
fix: Prevent potential underflow in static file header healing

### DIFF
--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -201,7 +201,8 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
         } else {
             self.user_header().tx_len().unwrap_or_default()
         };
-        let pruned_rows = expected_rows - self.writer.rows() as u64;
+        let actual_rows = self.writer.rows() as u64;
+        let pruned_rows = expected_rows.saturating_sub(actual_rows);
         if pruned_rows > 0 {
             self.user_header_mut().prune(pruned_rows);
         }


### PR DESCRIPTION

### Description
- Replace a risky subtraction with saturating_sub in ensure_end_range_consistency to avoid potential u64 underflow when actual rows exceed expected rows.
- Ensures header pruning only occurs when expected_rows > actual_rows, preserving data integrity.
- Impact: Safer header healing; no behavior change in normal cases.

