### PR TITLE
chore(observability): add tokio runtime with custom thread naming

### DIFF
--- a/crates/cli/runner/src/lib.rs
+++ b/crates/cli/runner/src/lib.rs
@@ -172,7 +172,7 @@ pub fn tokio_runtime() -> Result<tokio::runtime::Runtime, std::io::Error> {
         .thread_name_fn(|| {
             static IDX: AtomicUsize = AtomicUsize::new(0);
             let id = IDX.fetch_add(1, Ordering::Relaxed);
-            format!("cli-tokio-{id}")
+            format!("tokio-{id}")
         })
         .build()
 }

--- a/crates/cli/runner/src/lib.rs
+++ b/crates/cli/runner/src/lib.rs
@@ -172,7 +172,7 @@ pub fn tokio_runtime() -> Result<tokio::runtime::Runtime, std::io::Error> {
         .thread_name_fn(|| {
             static IDX: AtomicUsize = AtomicUsize::new(0);
             let id = IDX.fetch_add(1, Ordering::Relaxed);
-            format!("reth-cli-tokio-{id}")
+            format!("cli-tokio-{id}")
         })
         .build()
 }

--- a/crates/cli/runner/src/lib.rs
+++ b/crates/cli/runner/src/lib.rs
@@ -11,7 +11,15 @@
 //! Entrypoint for running commands.
 
 use reth_tasks::{TaskExecutor, TaskManager};
-use std::{future::Future, pin::pin, sync::mpsc, time::Duration};
+use std::{
+    future::Future,
+    pin::pin,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        mpsc,
+    },
+    time::Duration,
+};
 use tracing::{debug, error, trace};
 
 /// Executes CLI commands.
@@ -159,7 +167,14 @@ pub struct CliContext {
 /// Creates a new default tokio multi-thread [Runtime](tokio::runtime::Runtime) with all features
 /// enabled
 pub fn tokio_runtime() -> Result<tokio::runtime::Runtime, std::io::Error> {
-    tokio::runtime::Builder::new_multi_thread().enable_all().build()
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_name_fn(|| {
+            static IDX: AtomicUsize = AtomicUsize::new(0);
+            let id = IDX.fetch_add(1, Ordering::Relaxed);
+            format!("reth-cli-tokio-{id}")
+        })
+        .build()
 }
 
 /// Runs the given future to completion or until a critical task panicked.

--- a/crates/engine/tree/src/tree/payload_processor/executor.rs
+++ b/crates/engine/tree/src/tree/payload_processor/executor.rs
@@ -88,7 +88,7 @@ impl WorkloadExecutorInner {
                         .thread_keep_alive(Duration::from_secs(15))
                         .thread_name_fn(|| {
                             let id = THREAD_COUNTER.fetch_add(1, Ordering::Relaxed);
-                            format!("reth-wkpool-tokio-{}", id)
+                            format!("wkp-tokio{}", id)
                         })
                         .build()
                         .unwrap()

--- a/crates/engine/tree/src/tree/payload_processor/executor.rs
+++ b/crates/engine/tree/src/tree/payload_processor/executor.rs
@@ -2,7 +2,10 @@
 
 use rayon::ThreadPool as RayonPool;
 use std::{
-    sync::{Arc, OnceLock},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, OnceLock,
+    },
     time::Duration,
 };
 use tokio::{
@@ -71,6 +74,7 @@ impl WorkloadExecutorInner {
             Handle::try_current().unwrap_or_else(|_| {
                 // Create a new runtime if no runtime is available
                 static RT: OnceLock<Runtime> = OnceLock::new();
+                static THREAD_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
                 let rt = RT.get_or_init(|| {
                     Builder::new_multi_thread()
@@ -82,6 +86,10 @@ impl WorkloadExecutorInner {
                         // new block, and instead reuse the existing
                         // threads.
                         .thread_keep_alive(Duration::from_secs(15))
+                        .thread_name_fn(|| {
+                            let id = THREAD_COUNTER.fetch_add(1, Ordering::Relaxed);
+                            format!("reth-wkpool-tokio-{}", id)
+                        })
                         .build()
                         .unwrap()
                 });

--- a/crates/engine/tree/src/tree/payload_processor/executor.rs
+++ b/crates/engine/tree/src/tree/payload_processor/executor.rs
@@ -88,7 +88,7 @@ impl WorkloadExecutorInner {
                         .thread_keep_alive(Duration::from_secs(15))
                         .thread_name_fn(|| {
                             let id = THREAD_COUNTER.fetch_add(1, Ordering::Relaxed);
-                            format!("wkp-tokio{}", id)
+                            format!("tokio-payload-{id}")
                         })
                         .build()
                         .unwrap()

--- a/crates/tasks/src/pool.rs
+++ b/crates/tasks/src/pool.rs
@@ -72,7 +72,7 @@ impl BlockingTaskPool {
     /// Uses [`rayon::ThreadPoolBuilder::build`](rayon::ThreadPoolBuilder::build) defaults but
     /// increases the stack size to 8MB.
     pub fn build() -> Result<Self, rayon::ThreadPoolBuildError> {
-        Self::builder().thread_name(|i| format!("blk-rayon-{}", i)).build().map(Self::new)
+        Self::builder().thread_name(|i| format!("rayon-blck-{i}")).build().map(Self::new)
     }
 
     /// Asynchronous wrapper around Rayon's

--- a/crates/tasks/src/pool.rs
+++ b/crates/tasks/src/pool.rs
@@ -72,7 +72,7 @@ impl BlockingTaskPool {
     /// Uses [`rayon::ThreadPoolBuilder::build`](rayon::ThreadPoolBuilder::build) defaults but
     /// increases the stack size to 8MB.
     pub fn build() -> Result<Self, rayon::ThreadPoolBuildError> {
-        Self::builder().build().map(Self::new)
+        Self::builder().thread_name(|i| format!("reth-blocking-rayon-{}", i)).build().map(Self::new)
     }
 
     /// Asynchronous wrapper around Rayon's

--- a/crates/tasks/src/pool.rs
+++ b/crates/tasks/src/pool.rs
@@ -72,7 +72,7 @@ impl BlockingTaskPool {
     /// Uses [`rayon::ThreadPoolBuilder::build`](rayon::ThreadPoolBuilder::build) defaults but
     /// increases the stack size to 8MB.
     pub fn build() -> Result<Self, rayon::ThreadPoolBuildError> {
-        Self::builder().thread_name(|i| format!("reth-blocking-rayon-{}", i)).build().map(Self::new)
+        Self::builder().thread_name(|i| format!("blk-rayon-{}", i)).build().map(Self::new)
     }
 
     /// Asynchronous wrapper around Rayon's

--- a/crates/tasks/src/pool.rs
+++ b/crates/tasks/src/pool.rs
@@ -72,7 +72,7 @@ impl BlockingTaskPool {
     /// Uses [`rayon::ThreadPoolBuilder::build`](rayon::ThreadPoolBuilder::build) defaults but
     /// increases the stack size to 8MB.
     pub fn build() -> Result<Self, rayon::ThreadPoolBuildError> {
-        Self::builder().thread_name(|i| format!("rayon-blck-{i}")).build().map(Self::new)
+        Self::builder().thread_name(|i| format!("rayon-{i}")).build().map(Self::new)
     }
 
     /// Asynchronous wrapper around Rayon's

--- a/crates/trie/parallel/src/root.rs
+++ b/crates/trie/parallel/src/root.rs
@@ -296,7 +296,7 @@ fn get_runtime_handle() -> Handle {
                 .thread_keep_alive(Duration::from_secs(15))
                 .thread_name_fn(|| {
                     let id = THREAD_COUNTER.fetch_add(1, Ordering::Relaxed);
-                    format!("trie-tokio{}", id)
+                    format!("tokio-trie-{id}")
                 })
                 .build()
                 .expect("Failed to create tokio runtime")

--- a/crates/trie/parallel/src/root.rs
+++ b/crates/trie/parallel/src/root.rs
@@ -296,7 +296,7 @@ fn get_runtime_handle() -> Handle {
                 .thread_keep_alive(Duration::from_secs(15))
                 .thread_name_fn(|| {
                     let id = THREAD_COUNTER.fetch_add(1, Ordering::Relaxed);
-                    format!("reth-trie-tokio-{}", id)
+                    format!("trie-tokio{}", id)
                 })
                 .build()
                 .expect("Failed to create tokio runtime")

--- a/crates/trie/parallel/src/root.rs
+++ b/crates/trie/parallel/src/root.rs
@@ -20,7 +20,10 @@ use reth_trie::{
 use reth_trie_db::{DatabaseHashedCursorFactory, DatabaseTrieCursorFactory};
 use std::{
     collections::HashMap,
-    sync::{mpsc, Arc, OnceLock},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        mpsc, Arc, OnceLock,
+    },
     time::Duration,
 };
 use thiserror::Error;
@@ -283,6 +286,7 @@ fn get_runtime_handle() -> Handle {
     Handle::try_current().unwrap_or_else(|_| {
         // Create a new runtime if no runtime is available
         static RT: OnceLock<Runtime> = OnceLock::new();
+        static THREAD_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
         let rt = RT.get_or_init(|| {
             Builder::new_multi_thread()
@@ -290,6 +294,10 @@ fn get_runtime_handle() -> Handle {
                 // This prevents the costly process of spawning new threads on every
                 // new block, and instead reuses the existing threads.
                 .thread_keep_alive(Duration::from_secs(15))
+                .thread_name_fn(|| {
+                    let id = THREAD_COUNTER.fetch_add(1, Ordering::Relaxed);
+                    format!("reth-trie-tokio-{}", id)
+                })
                 .build()
                 .expect("Failed to create tokio runtime")
         });


### PR DESCRIPTION
Closes: https://github.com/paradigmxyz/reth/issues/18624 - All threads looked identical - impossible to debug or profile

- better observability of tokio threads for profiling, similar to how we doing it on rayon i.e reth-rayon-36

**Changes**:
  - All major thread pools now have descriptive names for easy identification:
    - Main CLI runtime: `cli-tokio-{id}` (e.g., `reth-cli-tokio-0`, `reth-cli-tokio-1`)
    - Workload executor: `wkp-tokio-{id}` (e.g., `reth-wkpool-tokio-0`, `reth-wkpool-tokio-1`)
    - Trie operations: `trie-tokio-{id}` (e.g., `reth-trie-tokio-0`, `reth-trie-tokio-1`)
    - CPU blocking tasks: `blk-rayon-{id}` (e.g., `reth-blocking-rayon-0`, `reth-blocking-rayon-1`)
    - Global CPU pool: `reth-rayon-{id}` (e.g., `reth-rayon-0`, `reth-rayon-1`)