### PR TITLE
chore: emit build-new-payload events in caller scope

### DIFF
--- a/crates/payload/builder/src/noop.rs
+++ b/crates/payload/builder/src/noop.rs
@@ -42,10 +42,10 @@ where
         let this = self.get_mut();
         loop {
             let Some(cmd) = ready!(this.command_rx.poll_next_unpin(cx)) else {
-                return Poll::Ready(())
+                return Poll::Ready(());
             };
             match cmd {
-                PayloadServiceCommand::BuildNewPayload(attr, tx) => {
+                PayloadServiceCommand::BuildNewPayload(attr, tx, _span) => {
                     let id = attr.payload_id();
                     tx.send(Ok(id)).ok()
                 }


### PR DESCRIPTION
Adds the current span of the caller to `PayloadServiceCommand::BuildNewPayload` so that the payload builder service can emit all events inside that span.

As a follow-up one could also propagate that span to the job pushed into `payload_jobs` so that events that occur while processing the job can also be related back to the original call.