### PR TITLE
fix(engine): remove redundant parent_to_child removal during eviction

### DIFF
--- a/crates/engine/tree/src/tree/block_buffer.rs
+++ b/crates/engine/tree/src/tree/block_buffer.rs
@@ -74,9 +74,7 @@ impl<B: Block> BlockBuffer<B> {
         if self.block_queue.len() >= self.max_blocks {
             // Evict oldest block if limit is hit
             if let Some(evicted_hash) = self.block_queue.pop_front() {
-                if let Some(evicted_block) = self.remove_block(&evicted_hash) {
-                    self.remove_from_parent(evicted_block.parent_hash(), &evicted_hash);
-                }
+                self.remove_block(&evicted_hash);
             }
         }
         self.block_queue.push_back(hash);

--- a/crates/engine/tree/src/tree/block_buffer.rs
+++ b/crates/engine/tree/src/tree/block_buffer.rs
@@ -493,4 +493,57 @@ mod tests {
 
         assert_buffer_lengths(&buffer, 3);
     }
+
+    #[test]
+    fn eviction_parent_child_cleanup() {
+        let mut rng = generators::rng();
+
+        let main_parent = BlockNumHash::new(9, rng.random());
+        let block1 = create_block(&mut rng, 10, main_parent.hash);
+        let block2 = create_block(&mut rng, 11, block1.hash());
+        // Unrelated block to trigger eviction
+        let unrelated_parent = rng.random();
+        let unrelated_block = create_block(&mut rng, 12, unrelated_parent);
+
+        // Capacity 2 so third insert evicts the oldest (block1)
+        let mut buffer = BlockBuffer::new(2);
+
+        buffer.insert_block(block1.clone());
+        buffer.insert_block(block2.clone());
+
+        // Pre-eviction: parent_to_child contains main_parent -> {block1}, block1 -> {block2}
+        assert!(buffer
+            .parent_to_child
+            .get(&main_parent.hash)
+            .and_then(|s| s.get(&block1.hash()))
+            .is_some());
+        assert!(buffer
+            .parent_to_child
+            .get(&block1.hash())
+            .and_then(|s| s.get(&block2.hash()))
+            .is_some());
+
+        // Insert unrelated block to evict block1
+        buffer.insert_block(unrelated_block);
+
+        // Evicted block1 should be fully removed from collections
+        assert_block_removal(&buffer, &block1);
+
+        // Cleanup: parent_to_child must no longer have (main_parent -> block1)
+        assert!(buffer
+            .parent_to_child
+            .get(&main_parent.hash)
+            .and_then(|s| s.get(&block1.hash()))
+            .is_none());
+
+        // But the mapping (block1 -> block2) must remain so descendants can still be tracked
+        assert!(buffer
+            .parent_to_child
+            .get(&block1.hash())
+            .and_then(|s| s.get(&block2.hash()))
+            .is_some());
+
+        // And lowest ancestor for block2 becomes itself after its parent is evicted
+        assert_eq!(buffer.lowest_ancestor(&block2.hash()), Some(&block2));
+    }
 }


### PR DESCRIPTION
- Drop duplicate remove_from_parent call in insert_block eviction path; remove_block already handles it.
- No functional changes; micro-optimization and slight simplification.
- Tests and metrics unaffected; eviction remains FIFO via block_queue.