### PR TITLE
Harden PayloadId against targeted collisions via process-scoped keyed hashing

### DIFF
--- a/crates/ethereum/engine-primitives/Cargo.toml
+++ b/crates/ethereum/engine-primitives/Cargo.toml
@@ -27,6 +27,7 @@ alloy-rlp.workspace = true
 serde.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
+rand.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true
@@ -45,4 +46,5 @@ std = [
     "thiserror/std",
     "reth-engine-primitives/std",
     "reth-primitives-traits/std",
+    "rand/std",
 ]

--- a/crates/ethereum/engine-primitives/src/lib.rs
+++ b/crates/ethereum/engine-primitives/src/lib.rs
@@ -11,6 +11,9 @@
 
 extern crate alloc;
 
+#[cfg_attr(not(feature = "std"), allow(unused_imports))]
+use rand as _;
+
 mod payload;
 pub use payload::{payload_id, BlobSidecars, EthBuiltPayload, EthPayloadBuilderAttributes};
 

--- a/crates/ethereum/engine-primitives/src/payload.rs
+++ b/crates/ethereum/engine-primitives/src/payload.rs
@@ -436,8 +436,9 @@ fn payload_id_secret() -> &'static [u8; 32] {
 pub fn payload_id(parent: &B256, attributes: &PayloadAttributes) -> PayloadId {
     use sha2::Digest;
     let mut hasher = sha2::Sha256::new();
-    // Key the hash with a process-local secret to mitigate intentional collisions against a 64-bit id.
-    // The Engine API treats PayloadId as an opaque identifier local to the process, so this remains compliant.
+    // Key the hash with a process-local secret to mitigate intentional collisions against a 64-bit
+    // id. The Engine API treats PayloadId as an opaque identifier local to the process, so this
+    // remains compliant.
     hasher.update(payload_id_secret());
     hasher.update(parent.as_slice());
     hasher.update(&attributes.timestamp.to_be_bytes()[..]);

--- a/crates/ethereum/engine-primitives/src/payload.rs
+++ b/crates/ethereum/engine-primitives/src/payload.rs
@@ -496,7 +496,7 @@ mod tests {
         assert_eq!(id1, id2);
 
         // Changing any field must change the id
-        let mut changed = attributes.clone();
+        let mut changed = attributes;
         changed.timestamp += 1;
         let id_changed = payload_id(&parent, &changed);
         assert_ne!(id1, id_changed);
@@ -534,7 +534,7 @@ mod tests {
 
         let id = payload_id(&parent, &attributes);
         // Changing withdrawals should change the id
-        let mut attributes2 = attributes.clone();
+        let mut attributes2 = attributes;
         if let Some(w) = &mut attributes2.withdrawals {
             w.push(Withdrawal {
                 index: 3,
@@ -575,7 +575,7 @@ mod tests {
         let id_with = payload_id(&parent, &attributes);
 
         // Removing the beacon root should change the id
-        let mut without = attributes.clone();
+        let mut without = attributes;
         without.parent_beacon_block_root = None;
         let id_without = payload_id(&parent, &without);
         assert_ne!(id_with, id_without);


### PR DESCRIPTION


### Description
- Switch `payload_id()` to SHA-256 keyed with a process-local secret, then truncate to 8 bytes.
- Keeps the API unchanged while making the 64-bit ID resilient to crafted collisions.
- Adds a per-process secret (random at runtime; deterministic in tests) and updates tests to assert stability and uniqueness properties.
- Minimal surface change: only `engine-primitives` crate; added `rand` as a workspace dependency.