### PR TITLE
fix: prevent priority inversion in transaction pool iterator

### DIFF
--- a/crates/transaction-pool/src/pool/pending.rs
+++ b/crates/transaction-pool/src/pool/pending.rs
@@ -111,7 +111,7 @@ impl<T: TransactionOrdering> PendingPool<T> {
             independent: self.independent_transactions.values().cloned().collect(),
             invalid: Default::default(),
             new_transaction_receiver: Some(self.new_transaction_notifier.subscribe()),
-            last_priority: None,
+            accepting_new_txs: true,
             skip_blobs: false,
         }
     }


### PR DESCRIPTION
## Summary

This PR fixes a critical priority inversion bug in the transaction pool iterator that was incorrectly addressed in #17699.

## Problem

PR #17699 attempted to prevent priority inversion by checking if new transactions had higher priority than the last yielded transaction. However, this approach had a critical flaw:

### The Bug
When block building starts and transactions are being popped from the pool, new transactions can still arrive via the broadcast channel. The current implementation would:
1. Block transactions with `priority > last_priority` 
2. Allow transactions with `priority < last_priority` through

This creates priority inversion where a lower-priority transaction arriving later gets included before a higher-priority transaction that arrived earlier.

Suppose an arb opportunity happens. If we are in the middle of a batch it makes sense to lower priority fee to slip in in the current batch. Or maybe just send a low and high priority fee tx in case we are in the middle of a batch. 
### Example Scenario
```
1. Pool has transactions with priority 100 and 10
2. Block builder pops priority 100, then priority 10 (last_priority = 10)
3. New tx with priority 50 arrives → blocked (50 > 10) 
4. New tx with priority 5 arrives → allowed through (5 < 10)
5. Result: Block contains [100, 10, 5] while priority 50 waits

Priority inversion: tx with priority 5 (arrived second) gets included before tx with priority 50 (arrived first)
```

## Solution

Instead of trying to filter transactions by priority, we prevent ALL new transactions from being added once block building starts:

1. Add `accepting_new_txs` flag to `BestTransactions` iterator
2. Set flag to `false` after the first transaction is popped
3. Check this flag in `add_new_transactions()` - if false, return early without processing new transactions
4. Add `reset_for_new_block()` method to reset the flag when moving to the next block

This ensures:
- **No priority inversion**: New transactions can't jump ahead of existing ones
- **Simpler logic**: No complex priority comparisons needed
- **Deterministic ordering**: Each block works with a consistent snapshot of transactions
- **No transaction loss**: Transactions remain in the channel for the next block

## Testing

Added test `test_no_new_transactions_after_first_pop` that demonstrates:
- New transactions sent after first pop are blocked
- Transactions remain available for the next block
- Priority ordering is maintained

The test shows:
- Block 1: [100, 10] (only initial transactions)
- Block 2: [50, 5] (new transactions processed in correct order)

## Changes
- Added `accepting_new_txs` flag to `BestTransactions` struct
- Modified `add_new_transactions()` to check the flag
- Set flag to false in iterator after first transaction is returned
- Added `reset_for_new_block()` public method for block transitions
- Added comprehensive test