### PR TITLE
refactor(engine): simplify validate_block_with_state

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -250,7 +250,7 @@ where
         }
     }
 
-    /// Spawn cache prewarming exclusively.
+    /// Spawns a task that exclusively handles cache prewarming for transaction execution.
     ///
     /// Returns a [`PayloadHandle`] to communicate with the task.
     pub(super) fn spawn_cache_exclusive<P, I: ExecutableTxIterator<Evm>>(

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -851,6 +851,8 @@ where
                         trie_input,
                         &self.config,
                     )
+                // if prefix sets are not empty, we spawn a task that exclusively handles cache
+                // prewarming for transaction execution
                 } else {
                     debug!(
                         target: "engine::tree",
@@ -858,7 +860,7 @@ where
                         "Disabling state root task due to non-empty prefix sets"
                     );
                     *strategy = StateRootStrategy::Parallel;
-                    self.payload_processor.spawn_execution_only(env, txs, provider_builder)
+                    self.payload_processor.spawn_cache_exclusive(env, txs, provider_builder)
                 };
 
                 // record prewarming initialization duration

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -826,10 +826,10 @@ where
     /// The method handles strategy fallbacks if the preferred approach fails, ensuring
     /// block execution always completes with a valid state root.
     #[allow(clippy::too_many_arguments)]
-    fn spawn_payload_processor(
+    fn spawn_payload_processor<T: ExecutableTxIterator<Evm>>(
         &mut self,
         env: ExecutionEnv<Evm>,
-        txs: impl ExecutableTxIterator<Evm>,
+        txs: T,
         provider_builder: StateProviderBuilder<N, P>,
         persisting_kind: PersistingKind,
         parent_hash: B256,
@@ -837,7 +837,10 @@ where
         block_num_hash: NumHash,
         strategy: &mut StateRootStrategy,
     ) -> Result<
-        PayloadHandle<impl ExecutableTxFor<Evm>, impl core::error::Error + Send + Sync + 'static>,
+        PayloadHandle<
+            impl ExecutableTxFor<Evm> + use<N, P, Evm, V, T>,
+            impl core::error::Error + Send + Sync + 'static + use<N, P, Evm, V, T>,
+        >,
         InsertBlockErrorKind,
     > {
         match strategy {

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -358,7 +358,7 @@ where
             };
         }
 
-        /// A helper macro for errors after block conversion
+        /// A helper macro for handling errors after the input has been converted to a block
         macro_rules! ensure_ok_post_block {
             ($expr:expr, $block:expr) => {
                 match $expr {

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -411,11 +411,11 @@ where
         let mut handle = ensure_ok!(self.spawn_payload_processor(
             env.clone(),
             txs,
-                provider_builder,
-                persisting_kind,
-                parent_hash,
+            provider_builder,
+            persisting_kind,
+            parent_hash,
             ctx.state(),
-                block_num_hash,
+            block_num_hash,
             &mut strategy,
         ));
 

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -343,7 +343,7 @@ where
         Evm: ConfigureEngineEvm<T::ExecutionData, Primitives = N>,
     {
         /// A helper macro that returns the block in case there was an error
-        /// This macro is used for early returns before we convert the input to a block
+        /// This macro is used for early returns before block conversion
         macro_rules! ensure_ok {
             ($expr:expr) => {
                 match $expr {

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -159,6 +159,11 @@ impl TestHarness {
         Self::with_persistence_channel(chain_spec, action_tx, action_rx)
     }
 
+    #[expect(dead_code)]
+    fn with_test_channel(chain_spec: Arc<ChainSpec>) -> (Self, TestChannelHandle) {
+        let (action_tx, action_rx, handle) = TestChannel::spawn_channel();
+        (Self::with_persistence_channel(chain_spec, action_tx, action_rx), handle)
+    }
 
     fn with_persistence_channel(
         chain_spec: Arc<ChainSpec>,

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -159,11 +159,6 @@ impl TestHarness {
         Self::with_persistence_channel(chain_spec, action_tx, action_rx)
     }
 
-    #[expect(dead_code)]
-    fn with_test_channel(chain_spec: Arc<ChainSpec>) -> (Self, TestChannelHandle) {
-        let (action_tx, action_rx, handle) = TestChannel::spawn_channel();
-        (Self::with_persistence_channel(chain_spec, action_tx, action_rx), handle)
-    }
 
     fn with_persistence_channel(
         chain_spec: Arc<ChainSpec>,

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -1457,36 +1457,6 @@ fn test_validate_block_synchronous_strategy_during_persistence() {
     assert!(result.is_ok() || result.is_err(), "Validation should complete")
 }
 
-/// Test trie updates are preserved when block connects to persisted ancestor
-#[test]
-fn test_validate_block_preserves_trie_updates_when_connected_to_persisted() {
-    reth_tracing::init_test_tracing();
-
-    let mut test_harness = ValidatorTestHarness::new(MAINNET.clone());
-
-    // Set up a chain where the block connects to last persisted
-    let mut block_factory = TestBlockFactory::new(MAINNET.as_ref().clone());
-    let genesis_hash = MAINNET.genesis_hash();
-
-    // Create a block that should retain trie updates
-    let valid_block = block_factory.create_valid_block(genesis_hash);
-
-    // Call validate_block_with_state
-    let result = test_harness.validate_block_direct(valid_block);
-
-    // Check trie update retention logic
-    match result {
-        Ok(executed_block) => {
-            // Trie updates should be present when connecting to persisted block
-            // (may be Missing due to test environment, but logic should execute)
-            assert!(executed_block.trie.is_present() || executed_block.trie.is_missing());
-        }
-        Err(_) => {
-            // May fail due to environment, but retention logic should execute
-        }
-    }
-}
-
 /// Test trie update discard when not connecting to last persisted block
 #[test]
 fn test_validate_block_trie_update_discard() {

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -446,23 +446,6 @@ impl ValidatorTestHarness {
         self.harness.tree.persistence_state.in_progress()
     }
 
-    /// Seed in-memory ancestor blocks with `ExecutedTrieUpdates` markers
-    fn seed_ancestor_with_trie_updates(
-        &mut self,
-        block: ExecutedBlockWithTrieUpdates,
-        has_updates: bool,
-    ) {
-        let mut block = block;
-        if has_updates {
-            // Keep existing trie updates
-        } else {
-            // Mark as missing
-            block.trie = ExecutedTrieUpdates::Missing;
-        }
-
-        self.harness.tree.state.tree_state.insert_executed(block);
-    }
-
     /// Call `validate_block_with_state` directly with block
     fn validate_block_direct(
         &mut self,

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -397,27 +397,6 @@ impl ValidatorTestHarness {
         Self { harness, validator, metrics: TestMetrics::default() }
     }
 
-    /// Create with custom tree config for strategy control
-    #[allow(dead_code)]
-    fn with_config(mut self, config: TreeConfig, chain_spec: Arc<ChainSpec>) -> Self {
-        // Recreate validator with custom config
-        let consensus = Arc::new(EthBeaconConsensus::new(chain_spec));
-        let provider = self.harness.provider.clone();
-        let payload_validator = MockEngineValidator;
-        let evm_config = MockEvmConfig::default();
-
-        self.validator = BasicEngineValidator::new(
-            provider,
-            consensus,
-            evm_config,
-            payload_validator,
-            config,
-            Box::new(NoopInvalidBlockHook::default()),
-        );
-
-        self
-    }
-
     /// Configure `PersistenceState` for specific `PersistingKind` scenarios
     fn start_persistence_operation(&mut self, action: CurrentPersistenceAction) {
         use crate::tree::persistence_state::CurrentPersistenceAction;

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -1511,34 +1511,6 @@ fn test_validate_block_trie_update_discard() {
     assert_eq!(test_harness.validation_call_count(), 0); // No calls yet
 }
 
-/// Test `validate_block_with_state` with payload input (`ExecutionData`)
-#[test]
-fn test_validate_payload_with_state_direct() {
-    reth_tracing::init_test_tracing();
-
-    // Use real test data
-    let s = include_str!("../../test-data/holesky/1.rlp");
-    let data = Bytes::from_str(s).unwrap();
-    let block = Block::decode(&mut data.as_ref()).unwrap();
-    let sealed = block.seal_slow();
-    let hash = sealed.hash();
-    let block = sealed.into_block();
-    let payload = ExecutionPayloadV1::from_block_unchecked(hash, &block);
-
-    let mut test_harness = ValidatorTestHarness::new(HOLESKY.clone());
-
-    // Call validate_payload directly (which calls `validate_block_with_state`)
-    let result = test_harness.validate_payload_direct(ExecutionData {
-        payload: payload.into(),
-        sidecar: ExecutionPayloadSidecar::none(),
-    });
-
-    // Verify that validate_block_with_state was executed for the payload
-    // The result may be an error due to test environment limitations,
-    // but the key test is that the validation logic executes properly
-    assert!(result.is_ok() || result.is_err(), "Validation should complete for payload input")
-}
-
 /// Test multiple validation scenarios including valid, consensus-invalid, and execution-invalid
 /// blocks with proper result validation
 #[test]


### PR DESCRIPTION
closes: https://github.com/paradigmxyz/reth/issues/18658

the core changes are:
- reducing the complexity of how we choose our stateroot algo
- abstracting post validation stage 

Initially had a much grander idea of the change, but it made the pr too big and hard to review. 