### PR TITLE
Precise ETH parsing: replace f64 with safe integer-based decimal parser

### DIFF
--- a/crates/cli/util/src/parsers.rs
+++ b/crates/cli/util/src/parsers.rs
@@ -148,9 +148,7 @@ pub fn parse_ether_value(value: &str) -> eyre::Result<u128> {
         frac.parse::<u128>()?
     };
 
-    int_wei
-        .checked_add(frac_wei)
-        .ok_or_else(|| eyre::eyre!("Overflow in result"))
+    int_wei.checked_add(frac_wei).ok_or_else(|| eyre::eyre!("Overflow in result"))
 }
 
 #[cfg(test)]

--- a/crates/cli/util/src/parsers.rs
+++ b/crates/cli/util/src/parsers.rs
@@ -109,7 +109,7 @@ pub fn parse_ether_value(value: &str) -> eyre::Result<u128> {
     if s.starts_with('-') {
         return Err(eyre::eyre!("Ether value cannot be negative"))
     }
-    
+
     let (int_part_raw, frac_part_raw) = match s.split_once('.') {
         Some((i, f)) => (i, f),
         None => (s, ""),


### PR DESCRIPTION

- Motivation
  - Avoids floating‑point rounding errors.
  - Rejects NaN/∞ and malformed inputs explicitly.
  - Prevents silent overflows when scaling to wei.

- What changed
  - Rewrote parse_ether_value to parse decimal strings into wei using pure integer math.
  - Supports up to 18 fractional digits; right‑pads shorter fractions with zeros.
  - Validates input (non‑empty, non‑negative, digits only, ≤18 decimals).
  - Overflow‑safe via checked operations.

- Behavior notes
  - Inputs like ".5" are accepted (interpreted as 0.5 ETH).
  - More strict than before: rejects scientific notation, extra decimals, and non‑digit chars.

