### PR TITLE
chore(engine): remove unused EngineServiceError from engine service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7986,7 +7986,6 @@ dependencies = [
  "reth-prune",
  "reth-stages-api",
  "reth-tasks",
- "thiserror 2.0.16",
  "tokio",
  "tokio-stream",
 ]

--- a/crates/engine/service/Cargo.toml
+++ b/crates/engine/service/Cargo.toml
@@ -31,7 +31,6 @@ futures.workspace = true
 pin-project.workspace = true
 
 # misc
-thiserror.workspace = true
 
 [dev-dependencies]
 reth-engine-tree = { workspace = true, features = ["test-utils"] }

--- a/crates/engine/service/src/service.rs
+++ b/crates/engine/service/src/service.rs
@@ -138,11 +138,6 @@ where
     }
 }
 
-/// Potential error returned by `EngineService`.
-#[derive(Debug, thiserror::Error)]
-#[error("Engine service error.")]
-pub struct EngineServiceError {}
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Delete dead error type EngineServiceError which was not referenced anywhere.
Aligns with project’s pattern of using rich error enums only when needed.