### PR TITLE
Harden JWT generation script: strict perms, secure umask, safer bash defaults

### DIFF
--- a/etc/generate-jwt.sh
+++ b/etc/generate-jwt.sh
@@ -2,11 +2,24 @@
 # Borrowed from EthStaker's prepare for the merge guide
 # See https://github.com/eth-educators/ethstaker-guides/blob/main/docs/prepare-for-the-merge.md#configuring-a-jwt-token-file
 
+set -euo pipefail  # Fail fast and safer bash defaults
+
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-mkdir -p "${SCRIPT_DIR}/jwttoken"
-if [[ ! -f "${SCRIPT_DIR}/jwttoken/jwt.hex" ]]
+JWT_DIR="${SCRIPT_DIR}/jwttoken"
+JWT_FILE="${JWT_DIR}/jwt.hex"
+
+# Ensure directory exists with restrictive permissions
+mkdir -p "${JWT_DIR}"
+chmod 700 "${JWT_DIR}"
+
+# Ensure private permissions for newly created files
+umask 077
+
+if [[ ! -f "${JWT_FILE}" ]]
 then
-  openssl rand -hex 32 | tr -d "\n" | tee > "${SCRIPT_DIR}/jwttoken/jwt.hex"
+# Write 32-byte hex key without trailing newline
+  openssl rand -hex 32 | tr -d "\n" > "${JWT_FILE}"
+  chmod 600 "${JWT_FILE}"
 else
-  echo "${SCRIPT_DIR}/jwttoken/jwt.hex already exists!"
+  echo "${JWT_FILE} already exists!"
 fi


### PR DESCRIPTION


### Description
Tighten security of the JWT secret generation script to prevent accidental disclosure via permissive filesystem permissions and improve script robustness.

### Changes
- Add `set -euo pipefail` for safer bash defaults
- Create `jwttoken/` with `700` permissions
- Write `jwt.hex` with `600` permissions
- Set `umask 077` before file creation
- Remove unnecessary `tee`; write directly via `>`
- Keep comments concise and in English

### Rationale
Ensure the JWT secret is not group/world-readable and reduce risks from shell pitfalls.

### Impact
- No behavior change to consumers; only hardened defaults
- Backwards-compatible

