### PR TITLE
Fix JWT claims: set iat=now and exp=now+60 to match spec

### DIFF
--- a/crates/rpc/rpc-layer/src/auth_client_layer.rs
+++ b/crates/rpc/rpc-layer/src/auth_client_layer.rs
@@ -62,17 +62,8 @@ where
 /// <https://github.com/ethereum/execution-apis/blob/main/src/engine/authentication.md#jwt-claims>.
 /// The token is valid for 60 seconds.
 pub fn secret_to_bearer_header(secret: &JwtSecret) -> HeaderValue {
-    format!(
-        "Bearer {}",
-        secret
-            .encode(&Claims {
-                iat: (SystemTime::now().duration_since(UNIX_EPOCH).unwrap() +
-                    Duration::from_secs(60))
-                .as_secs(),
-                exp: None,
-            })
-            .unwrap()
-    )
-    .parse()
-    .unwrap()
+    // Use correct JWT timing semantics: iat = now, exp = now + 60 seconds
+    let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+    let claims = Claims { iat: now, exp: Some(now + 60) };
+    format!("Bearer {}", secret.encode(&claims).unwrap()).parse().unwrap()
 }


### PR DESCRIPTION


### PR Description
- Align JWT claim semantics with the Engine API: `iat` is now the current timestamp and `exp` is explicitly set to 60 seconds later.
- Prevents tokens from being “not yet valid” and enforces the intended 60s validity window.

- Changes:
  - Update `secret_to_bearer_header` in `crates/rpc/rpc-layer/src/auth_client_layer.rs`.
  - Add a brief comment explaining the timing semantics.



