### PR TITLE
feat: support empty `SUPPORTED_CHAINS` for `ChainSpecParser`

### DIFF
--- a/crates/cli/cli/src/chainspec.rs
+++ b/crates/cli/cli/src/chainspec.rs
@@ -39,6 +39,11 @@ pub trait ChainSpecParser: Clone + Send + Sync + 'static {
     /// List of supported chains.
     const SUPPORTED_CHAINS: &'static [&'static str];
 
+    /// The default value for the chain spec parser.
+    fn default_value() -> Option<&'static str> {
+        Self::SUPPORTED_CHAINS.first().copied()
+    }
+
     /// Parses the given string into a chain spec.
     ///
     /// # Arguments

--- a/crates/cli/commands/src/common.rs
+++ b/crates/cli/commands/src/common.rs
@@ -48,7 +48,7 @@ pub struct EnvironmentArgs<C: ChainSpecParser> {
         long,
         value_name = "CHAIN_OR_PATH",
         long_help = C::help_message(),
-        default_value = C::SUPPORTED_CHAINS[0],
+        default_value = C::default_value(),
         value_parser = C::parser(),
         global = true
     )]

--- a/crates/cli/commands/src/dump_genesis.rs
+++ b/crates/cli/commands/src/dump_genesis.rs
@@ -15,7 +15,7 @@ pub struct DumpGenesisCommand<C: ChainSpecParser> {
         long,
         value_name = "CHAIN_OR_PATH",
         long_help = C::help_message(),
-        default_value = C::SUPPORTED_CHAINS[0],
+        default_value = C::default_value(),
         value_parser = C::parser()
     )]
     chain: Arc<C::ChainSpec>,

--- a/crates/cli/commands/src/node.rs
+++ b/crates/cli/commands/src/node.rs
@@ -32,7 +32,7 @@ pub struct NodeCommand<C: ChainSpecParser, Ext: clap::Args + fmt::Debug = NoArgs
         long,
         value_name = "CHAIN_OR_PATH",
         long_help = C::help_message(),
-        default_value = C::SUPPORTED_CHAINS[0],
+        default_value = C::default_value(),
         default_value_if("dev", "true", "dev"),
         value_parser = C::parser(),
         required = false,

--- a/crates/cli/commands/src/p2p/mod.rs
+++ b/crates/cli/commands/src/p2p/mod.rs
@@ -151,7 +151,7 @@ pub struct DownloadArgs<C: ChainSpecParser> {
         long,
         value_name = "CHAIN_OR_PATH",
         long_help = C::help_message(),
-        default_value = C::SUPPORTED_CHAINS[0],
+        default_value = C::default_value(),
         value_parser = C::parser()
     )]
     chain: Arc<C::ChainSpec>,

--- a/crates/ethereum/cli/src/interface.rs
+++ b/crates/ethereum/cli/src/interface.rs
@@ -481,4 +481,34 @@ mod tests {
             _ => panic!("Expected Stage command"),
         };
     }
+
+    #[test]
+    fn parse_empty_supported_chains() {
+        #[derive(Debug, Clone, Default)]
+        struct FileChainSpecParser;
+
+        impl ChainSpecParser for FileChainSpecParser {
+            type ChainSpec = ChainSpec;
+
+            const SUPPORTED_CHAINS: &'static [&'static str] = &[];
+
+            fn parse(s: &str) -> eyre::Result<Arc<Self::ChainSpec>> {
+                EthereumChainSpecParser::parse(s)
+            }
+        }
+
+        let cli = Cli::<FileChainSpecParser>::try_parse_from([
+            "reth", "stage", "unwind", "--chain", "sepolia", "to-block", "100",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Stage(cmd) => match cmd.command {
+                stage::Subcommands::Unwind(cmd) => {
+                    assert_eq!(cmd.chain_spec().unwrap().chain_id(), SEPOLIA.chain_id());
+                }
+                _ => panic!("Expected Unwind command"),
+            },
+            _ => panic!("Expected Stage command"),
+        };
+    }
 }


### PR DESCRIPTION
Adds a way to define parser that doesn't have a default value that might mess with `global = true`