### PR TITLE
fix(engine): align sparse trie removal log target with engine::root::sparse

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -253,7 +253,7 @@ where
 
     // Remove accounts
     for address in removed_accounts {
-        trace!(target: "trie::sparse", ?address, "Removing account");
+        trace!(target: "engine::root::sparse", ?address, "Removing account");
         let nibbles = Nibbles::unpack(address);
         trie.remove_account_leaf(&nibbles, blinded_provider_factory)?;
     }


### PR DESCRIPTION
Replace tracing target "trie::sparse" with "engine::root::sparse" in the engine-layer sparse trie task (account removal block) to maintain logging taxonomy consistency. Engine orchestration and its detailed sparse-trie work use engine::root and engine::root::sparse, while trie library code uses trie::sparse. This change keeps engine logs grouped correctly and avoids mixing with library-level logs. No functional behavior changes.