### PR TITLE
perf(engine): reduce cloning on terminate caching

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -519,9 +519,7 @@ impl CacheTaskHandle {
     pub(super) fn terminate_caching(&mut self, block_output: Option<&BundleState>) {
         if let Some(tx) = self.to_prewarm_task.take() {
             // Only clone when we have an active task and a state to send
-            let event = PrewarmTaskEvent::Terminate {
-                block_output: block_output.cloned()
-            };
+            let event = PrewarmTaskEvent::Terminate { block_output: block_output.cloned() };
             let _ = tx.send(event);
         }
     }

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -643,7 +643,7 @@ where
         }
 
         // terminate prewarming task with good state output
-        handle.terminate_caching(Some(output.state.clone()));
+        handle.terminate_caching(Some(&output.state));
 
         // If the block doesn't connect to the database tip, we don't save its trie updates, because
         // they may be incorrect as they were calculated on top of the forked block.


### PR DESCRIPTION
Basically we only want to clone when we know that there is an active prewarming task during cache termination. 

when would there **not** be an active prewarming task during cache termination? 
- validation failing early i.e https://github.com/paradigmxyz/reth/blob/15240f509cdf634db554c540fda20ceb1864e05f/crates/engine/tree/src/tree/payload_validator.rs#L625 
- prewarming disabled
- when the PayloadHandle or CacheTaskHandle is dropped