### PR TITLE
fix(primitives-traits): delegate is_create for Extended::Other to fix create-detection

### DIFF
--- a/crates/primitives-traits/src/extended.rs
+++ b/crates/primitives-traits/src/extended.rs
@@ -95,7 +95,7 @@ where
     fn is_create(&self) -> bool {
         match self {
             Self::BuiltIn(tx) => tx.is_create(),
-            Self::Other(_tx) => false,
+            Self::Other(tx) => tx.is_create(),
         }
     }
 


### PR DESCRIPTION
Previously, Extended<B, T>::is_create() returned false for the Other variant while delegating kind() to both variants. This inconsistency could misclassify custom transactions that perform contract creation, breaking any logic that relies on is_create() (e.g., routing, accounting, or EVM pre-execution checks).
This change updates is_create() to delegate to the inner transaction for both BuiltIn and Other, aligning behavior with kind() and other delegated methods, ensuring correct create-detection for custom transaction types.