### PR TITLE
feat(downloaders): add file-client feature gate

### DIFF
--- a/crates/net/downloaders/Cargo.toml
+++ b/crates/net/downloaders/Cargo.toml
@@ -40,7 +40,7 @@ pin-project.workspace = true
 tokio = { workspace = true, features = ["sync", "fs", "io-util"] }
 tokio-stream.workspace = true
 tokio-util = { workspace = true, features = ["codec"] }
-async-compression = { workspace = true, features = ["gzip", "tokio"] }
+async-compression = { workspace = true, features = ["gzip", "tokio"], optional = true }
 
 # metrics
 reth-metrics.workspace = true
@@ -55,6 +55,7 @@ tempfile = { workspace = true, optional = true }
 itertools.workspace = true
 
 [dev-dependencies]
+async-compression = { workspace = true, features = ["gzip", "tokio"] }
 reth-ethereum-primitives.workspace = true
 reth-chainspec.workspace = true
 reth-db = { workspace = true, features = ["test-utils"] }
@@ -71,6 +72,8 @@ rand.workspace = true
 tempfile.workspace = true
 
 [features]
+default = []
+file-client = ["dep:async-compression"]
 test-utils = [
     "tempfile",
     "reth-db-api",

--- a/crates/net/downloaders/src/lib.rs
+++ b/crates/net/downloaders/src/lib.rs
@@ -25,20 +25,24 @@ pub mod metrics;
 ///
 /// Contains [`FileClient`](file_client::FileClient) to read block data from files,
 /// efficiently buffering headers and bodies for retrieval.
+#[cfg(any(test, feature = "file-client"))]
 pub mod file_client;
 
 /// Module managing file-based data retrieval and buffering of receipts.
 ///
 /// Contains [`ReceiptFileClient`](receipt_file_client::ReceiptFileClient) to read receipt data from
 /// files, efficiently buffering receipts for retrieval.
+#[cfg(any(test, feature = "file-client"))]
 pub mod receipt_file_client;
 
 /// Module with a codec for reading and encoding block bodies in files.
 ///
 /// Enables decoding and encoding `Block` types within file contexts.
+#[cfg(any(test, feature = "file-client"))]
 pub mod file_codec;
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;
 
+#[cfg(any(test, feature = "file-client"))]
 pub use file_client::{DecodedFileChunk, FileClientError};


### PR DESCRIPTION
Add optional file-client feature to gate file_codec, file_client, and receipt_file_client modules behind async-compression dependency.

- Make async-compression dependency optional
- Add file-client feature that enables async-compression
- Gate related modules with cfg(any(test, feature = "file-client"))
- Reduce default compilation dependencies when file client is not needed

Closes #18698