### PR TITLE
Secure install_geth.sh: add optional SHA256 verification and named downloads

### DIFF
--- a/.github/assets/install_geth.sh
+++ b/.github/assets/install_geth.sh
@@ -7,11 +7,19 @@ set -eo pipefail
 GETH_BUILD=${GETH_BUILD:-"1.13.4-3f907d6a"}
 
 name="geth-linux-amd64-$GETH_BUILD"
+url="https://gethstore.blob.core.windows.net/builds/$name.tar.gz"
+tarball="$name.tar.gz"
 
 mkdir -p "$HOME/bin"
-wget "https://gethstore.blob.core.windows.net/builds/$name.tar.gz"
-tar -xvf "$name.tar.gz"
-rm "$name.tar.gz"
+wget -O "$tarball" "$url"
+# Optional integrity check: set GETH_SHA256 to expected checksum to verify the tarball.
+# Example: export GETH_SHA256="<expected_sha256>"; the script will verify and abort on mismatch.
+if [ -n "${GETH_SHA256:-}" ]; then
+  echo "$GETH_SHA256  $tarball" | sha256sum -c -
+fi
+
+tar -xvf "$tarball"
+rm "$tarball"
 mv "$name/geth" "$HOME/bin/geth"
 rm -rf "$name"
 chmod +x "$HOME/bin/geth"


### PR DESCRIPTION


### Description
- Added optional SHA256 integrity check via `GETH_SHA256` env var to prevent supply-chain tampering.
- Switched to named variables (`url`, `tarball`) and explicit `wget -O` for clarity and reliability.
- Retained original behavior when `GETH_SHA256` is not provided.

#### Why
- Downloaded binaries were installed without integrity/authenticity verification, exposing a potential MITM risk.

#### How
- Verify archive when `GETH_SHA256` is set:
  - `echo "$GETH_SHA256  $tarball" | sha256sum -c -`
- Keep logic otherwise unchanged (extract, move, chmod).

