### PR TITLE
chore: remove unused once_cell dependency from reth-primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,6 @@ checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
  "getrandom 0.3.3",
- "once_cell",
  "version_check",
  "zerocopy",
 ]

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -24,8 +24,7 @@ alloy-consensus.workspace = true
 # for eip-4844
 c-kzg = { workspace = true, features = ["serde"], optional = true }
 
-# misc
-once_cell.workspace = true
+
 
 [dev-dependencies]
 # eth

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -2,11 +2,9 @@
 
 use crate::Recovered;
 pub use alloy_consensus::transaction::PooledTransaction;
-use once_cell as _;
 #[expect(deprecated)]
 pub use pooled::PooledTransactionsElementEcRecovered;
 pub use reth_primitives_traits::{
-    sync::{LazyLock, OnceLock},
     transaction::{
         error::{
             InvalidTransactionError, TransactionConversionError, TryFromRecoveredTransactionError,


### PR DESCRIPTION
Remove dead code from reth-primitives crate:
- Remove unused `once_cell` dependency from Cargo.toml
- Remove unused `LazyLock` and `OnceLock` imports from transaction module
- Clean up `once_cell/std` feature flag

The once_cell dependency was left over from refactoring and is no longer used anywhere in the primitives crate