### PR TITLE
chore: update spawn maintenance tasks vis

### DIFF
--- a/crates/node/builder/src/components/pool.rs
+++ b/crates/node/builder/src/components/pool.rs
@@ -256,7 +256,7 @@ where
 }
 
 /// Spawn all maintenance tasks for a transaction pool (backup + main maintenance).
-fn spawn_maintenance_tasks<Node, Pool>(
+pub fn spawn_maintenance_tasks<Node, Pool>(
     ctx: &BuilderContext<Node>,
     pool: Pool,
     pool_config: &PoolConfig,


### PR DESCRIPTION
This PR updates the visibility of `spawn_maintenance_tasks()` so it can be called directly by node implementations.

Currently if a node uses a custom transaction ordering policy, pool maintenance tasks need to be manually spawned with the task executor. With this change, nodes can now initialize a pool with their custom ordering and then spawn its maintenance tasks using the provided `spawn_maintenance_tasks()` function.

```rust
// Tx pool with custom ordering policy
let transaction_pool = reth_transaction_pool::Pool::new(
    validator,
    custom_ordering,
    blob_store,
    pool_config.clone(),
);

// Spawn maintenance tasks
spawn_maintenance_tasks(ctx, transaction_pool.clone(), &pool_config)?;
```