### PR TITLE
perf: avoid redundant bytecode hash calculation in RPC provider

### DIFF
--- a/crates/storage/rpc-provider/src/lib.rs
+++ b/crates/storage/rpc-provider/src/lib.rs
@@ -1063,16 +1063,15 @@ impl<P: Clone, Node: NodeTypes, N> RpcBlockchainStateProvider<P, Node, N> {
         {
             Ok(None)
         } else {
-            let bytecode = if account_info.code.is_empty() {
-                None
-            } else {
-                Some(Bytecode::new_raw(account_info.code))
-            };
+            // Use account_info.code_hash() directly instead of creating Bytecode and calling
+            // hash_slow()
+            let bytecode_hash =
+                if account_info.code.is_empty() { None } else { Some(account_info.code_hash()) };
 
             Ok(Some(Account {
                 balance: account_info.balance,
                 nonce: account_info.nonce,
-                bytecode_hash: bytecode.as_ref().map(|b| b.hash_slow()),
+                bytecode_hash,
             }))
         }
     }

--- a/crates/storage/rpc-provider/src/lib.rs
+++ b/crates/storage/rpc-provider/src/lib.rs
@@ -1063,8 +1063,6 @@ impl<P: Clone, Node: NodeTypes, N> RpcBlockchainStateProvider<P, Node, N> {
         {
             Ok(None)
         } else {
-            // Use account_info.code_hash() directly instead of creating Bytecode and calling
-            // hash_slow()
             let bytecode_hash =
                 if account_info.code.is_empty() { None } else { Some(account_info.code_hash()) };
 


### PR DESCRIPTION
redundant hash computation in RpcBlockchainStateProvider.get_account() by using account_info.code_hash() directly instead of creating a Bytecode object and calling hash_slow().

Previously:
- account_info.code_hash() was called for caching
- Bytecode::new_raw() + hash_slow() was called for the return value

Now:
- account_info.code_hash() is used directly for both caching and return value

reduces unnecessary hash computations