### PR TITLE
fix(engine): resolve race condition during block reorganization

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -602,8 +602,8 @@ where
                         latest_valid_hash = Some(block_hash);
                         PayloadStatusEnum::Valid
                     }
-                    InsertPayloadOk::Inserted(BlockStatus::Disconnected { .. })
-                    | InsertPayloadOk::AlreadySeen(BlockStatus::Disconnected { .. }) => {
+                    InsertPayloadOk::Inserted(BlockStatus::Disconnected { .. }) |
+                    InsertPayloadOk::AlreadySeen(BlockStatus::Disconnected { .. }) => {
                         // not known to be invalid, but we don't know anything else
                         PayloadStatusEnum::Syncing
                     }
@@ -987,8 +987,8 @@ where
             CurrentPersistenceAction::SavingBlocks { highest } => {
                 // The block being validated can only be a descendant if its number is higher than
                 // the highest block persisting. Otherwise, it's likely a fork of a lower block.
-                if block.block.number > highest.number
-                    && self.state.tree_state.is_descendant(*highest, block)
+                if block.block.number > highest.number &&
+                    self.state.tree_state.is_descendant(*highest, block)
                 {
                     return PersistingKind::PersistingDescendant;
                 }
@@ -1083,8 +1083,8 @@ where
 
             // For OpStack, or if explicitly configured, the proposers are allowed to reorg their
             // own chain at will, so we need to always trigger a new payload job if requested.
-            if self.engine_kind.is_opstack()
-                || self.config.always_process_payload_attributes_on_canonical_head()
+            if self.engine_kind.is_opstack() ||
+                self.config.always_process_payload_attributes_on_canonical_head()
             {
                 if let Some(attr) = attrs {
                     debug!(target: "engine::tree", head = canonical_header.number(), "handling payload attributes for canonical head");
@@ -1300,8 +1300,8 @@ where
 
                         // if the parent is the canonical head, we can insert the block as the
                         // pending block
-                        if self.state.tree_state.canonical_block_hash()
-                            == block.recovered_block().parent_hash()
+                        if self.state.tree_state.canonical_block_hash() ==
+                            block.recovered_block().parent_hash()
                         {
                             debug!(target: "engine::tree", pending=?block_num_hash, "updating pending block");
                             self.canonical_in_memory_state.set_pending_block(block.clone());
@@ -1585,8 +1585,8 @@ where
         }
 
         let min_block = self.persistence_state.last_persisted_block.number;
-        self.state.tree_state.canonical_block_number().saturating_sub(min_block)
-            > self.config.persistence_threshold()
+        self.state.tree_state.canonical_block_number().saturating_sub(min_block) >
+            self.config.persistence_threshold()
     }
 
     /// Returns a batch of consecutive canonical blocks to persist in the range
@@ -1822,8 +1822,8 @@ where
     fn prepare_invalid_response(&mut self, mut parent_hash: B256) -> ProviderResult<PayloadStatus> {
         // Edge case: the `latestValid` field is the zero hash if the parent block is the terminal
         // PoW block, which we need to identify by looking at the parent's block difficulty
-        if let Some(parent) = self.sealed_header_by_hash(parent_hash)?
-            && !parent.difficulty().is_zero()
+        if let Some(parent) = self.sealed_header_by_hash(parent_hash)? &&
+            !parent.difficulty().is_zero()
         {
             parent_hash = B256::ZERO;
         }
@@ -1973,8 +1973,8 @@ where
             match self.insert_block(child) {
                 Ok(res) => {
                     debug!(target: "engine::tree", child =?child_num_hash, ?res, "connected buffered block");
-                    if self.is_sync_target_head(child_num_hash.hash)
-                        && matches!(res, InsertPayloadOk::Inserted(BlockStatus::Valid))
+                    if self.is_sync_target_head(child_num_hash.hash) &&
+                        matches!(res, InsertPayloadOk::Inserted(BlockStatus::Valid))
                     {
                         self.make_canonical(child_num_hash.hash)?;
                     }
@@ -2685,8 +2685,8 @@ where
                 return Err(OnForkChoiceUpdated::invalid_state());
             }
             Ok(Some(finalized)) => {
-                if Some(finalized.num_hash())
-                    != self.canonical_in_memory_state.get_finalized_num_hash()
+                if Some(finalized.num_hash()) !=
+                    self.canonical_in_memory_state.get_finalized_num_hash()
                 {
                     // we're also persisting the finalized block on disk so we can reload it on
                     // restart this is required by optimism which queries the finalized block: <https://github.com/ethereum-optimism/optimism/blob/c383eb880f307caa3ca41010ec10f30f08396b2e/op-node/rollup/sync/start.go#L65-L65>

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2930,7 +2930,7 @@ pub enum InsertPayloadOk {
 }
 
 /// Whether or not the blocks are currently persisting and the input block is a descendant.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PersistingKind {
     /// The blocks are not currently persisting.
     NotPersisting,

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -982,21 +982,35 @@ where
         let Some(action) = self.persistence_state.current_action() else {
             return PersistingKind::NotPersisting
         };
-        // Check that the persistince action is saving blocks, not removing them.
-        let CurrentPersistenceAction::SavingBlocks { highest } = action else {
-            return PersistingKind::PersistingNotDescendant
-        };
 
-        // The block being validated can only be a descendant if its number is higher than
-        // the highest block persisting. Otherwise, it's likely a fork of a lower block.
-        if block.block.number > highest.number &&
-            self.state.tree_state.is_descendant(*highest, block)
-        {
-            return PersistingKind::PersistingDescendant
+        match action {
+            CurrentPersistenceAction::SavingBlocks { highest } => {
+                // The block being validated can only be a descendant if its number is higher than
+                // the highest block persisting. Otherwise, it's likely a fork of a lower block.
+                if block.block.number > highest.number &&
+                    self.state.tree_state.is_descendant(*highest, block)
+                {
+                    return PersistingKind::PersistingDescendant
+                }
+                // In all other cases, the block is not a descendant.
+                PersistingKind::PersistingNotDescendant
+            }
+            CurrentPersistenceAction::RemovingBlocks { new_tip_num } => {
+                // During block removal, we can still allow parallel state root computation
+                // for blocks that are descendants of the canonical chain and are not being removed.
+                // A block is safe to process in parallel if:
+                // 1. It's a descendant of the current canonical head, AND
+                // 2. Its number is greater than the new tip (not being removed)
+                let canonical_head = self.state.tree_state.current_canonical_head;
+                if block.block.number > *new_tip_num &&
+                    self.state.tree_state.is_descendant(canonical_head, block)
+                {
+                    return PersistingKind::PersistingDescendant
+                }
+                // If the block is being removed or is not a canonical descendant, don't run in parallel
+                PersistingKind::PersistingNotDescendant
+            }
         }
-
-        // In all other cases, the block is not a descendant.
-        PersistingKind::PersistingNotDescendant
     }
 
     /// Invoked when we receive a new forkchoice update message. Calls into the blockchain tree

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -35,9 +35,9 @@ use reth_primitives_traits::{
     AlloyBlockHeader, BlockTy, GotExpected, NodePrimitives, RecoveredBlock, SealedHeader,
 };
 use reth_provider::{
-    BlockExecutionOutput, BlockNumReader, BlockReader, DBProvider,
-    DatabaseProviderFactory, ExecutionOutcome, HashedPostStateProvider, HeaderProvider,
-    ProviderError, StateProvider, StateProviderFactory, StateReader, StateRootProvider,
+    BlockExecutionOutput, BlockNumReader, BlockReader, DBProvider, DatabaseProviderFactory,
+    ExecutionOutcome, HashedPostStateProvider, HeaderProvider, ProviderError, StateProvider,
+    StateProviderFactory, StateReader, StateRootProvider,
 };
 use reth_revm::db::State;
 use reth_trie::{updates::TrieUpdates, HashedPostState, KeccakKeyHasher, TrieInput};
@@ -115,8 +115,8 @@ impl<'a, N: NodePrimitives> TreeCtx<'a, N> {
             CurrentPersistenceAction::SavingBlocks { highest } => {
                 // The block being validated can only be a descendant if its number is higher than
                 // the highest block persisting. Otherwise, it's likely a fork of a lower block.
-                if block.block.number > highest.number
-                    && self.state().tree_state.is_descendant(*highest, block)
+                if block.block.number > highest.number &&
+                    self.state().tree_state.is_descendant(*highest, block)
                 {
                     return PersistingKind::PersistingDescendant;
                 }
@@ -405,9 +405,9 @@ where
         //    accounting for the prefix sets.
         let has_ancestors_with_missing_trie_updates =
             self.has_ancestors_with_missing_trie_updates(input.block_with_parent(), ctx.state());
-        let mut use_state_root_task = run_parallel_state_root
-            && self.config.use_state_root_task()
-            && !has_ancestors_with_missing_trie_updates;
+        let mut use_state_root_task = run_parallel_state_root &&
+            self.config.use_state_root_task() &&
+            !has_ancestors_with_missing_trie_updates;
 
         debug!(
             target: "engine::tree",
@@ -828,7 +828,9 @@ where
         let last_persisted = ctx.persistence().last_persisted_block;
 
         // If we're in the middle of a reorganization, be more careful
-        if let Some(CurrentPersistenceAction::RemovingBlocks { new_tip_num }) = ctx.persistence().current_action() {
+        if let Some(CurrentPersistenceAction::RemovingBlocks { new_tip_num }) =
+            ctx.persistence().current_action()
+        {
             // During removal, blocks at or below the new tip are being removed
             if block.number() <= *new_tip_num {
                 // Block is being removed or already removed

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -816,7 +816,7 @@ where
     ///
     /// This checks if the block connects to the last persisted block.
     ///
-    /// During reorganization, we use PersistenceState to avoid race conditions
+    /// During reorganization, we use `PersistenceState` to avoid race conditions
     /// between database updates and static file removal.
     fn block_connects_to_last_persisted(
         &self,

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -803,7 +803,8 @@ async fn test_race_condition_fix_during_block_removal() {
         test_block_builder.get_executed_block_with_number(3, fork_block2.recovered_block().hash());
 
     // Insert fork blocks
-    test_harness.tree.state.tree_state.insert_executed(fork_block2.clone());
+    test_harness.tree.state.tree_state.insert_executed(fork_block2);
+    #[allow(clippy::redundant_clone)]
     test_harness.tree.state.tree_state.insert_executed(fork_block3.clone());
 
     // Trigger reorganization by setting new canonical head to fork_block3


### PR DESCRIPTION
## Problem
Race condition occurs when new blocks arrive during reorganization while block removal is in progress. This causes `PersistingKind::PersistingNotDescendant` classification, preventing parallel state root computation and leading to fatal error "no header found for Number(14)".

## Solution
Modified `persisting_kind_for` method to handle `RemovingBlocks` operations intelligently:
- Allow parallel state root computation for blocks that are canonical descendants and not being removed
- Only block parallel computation for blocks that are actually being removed

## Changes
- Updated `persisting_kind_for` in `payload_validator.rs` and `mod.rs`
- Added test case to verify the fix

Fixes #18408