### PR TITLE
chore(node): compact duration formatting in stage progress logs

### DIFF
--- a/crates/node/events/src/node.rs
+++ b/crates/node/events/src/node.rs
@@ -606,6 +606,8 @@ impl Display for Eta {
                     f,
                     "{}",
                     humantime::format_duration(Duration::from_secs(remaining.as_secs()))
+                        .to_string()
+                        .replace(' ', "")
                 )
             }
         }
@@ -631,6 +633,6 @@ mod tests {
         }
         .to_string();
 
-        assert_eq!(eta, "13m 37s");
+        assert_eq!(eta, "13m37s");
     }
 }


### PR DESCRIPTION
Remove whitespace from duration formatting in stage progress logs for a more compact display:  

```diff
-INFO Executing stage pipeline_stages=10/15 stage=MerkleExecute checkpoint=141070000 target=141607851 stage_eta=9m 58s
+INFO Executing stage pipeline_stages=10/15 stage=MerkleExecute checkpoint=141070000 target=141607851 stage_eta=9m58s
```