### PR TITLE
chore: Accept range in HashedPostState::from_reverts

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2566,7 +2566,7 @@ where
         } else {
             let revert_state = HashedPostState::from_reverts::<KeccakKeyHasher>(
                 provider.tx_ref(),
-                block_number + 1,
+                block_number + 1..,
             )
             .map_err(ProviderError::from)?;
             debug!(

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -996,7 +996,7 @@ where
         } else {
             let revert_state = HashedPostState::from_reverts::<KeccakKeyHasher>(
                 provider.tx_ref(),
-                block_number + 1,
+                block_number + 1..,
             )
             .map_err(ProviderError::from)?;
             debug!(

--- a/crates/storage/db-api/src/models/accounts.rs
+++ b/crates/storage/db-api/src/models/accounts.rs
@@ -1,14 +1,13 @@
 //! Account related models and types.
 
-use std::ops::{Range, RangeInclusive};
-
 use crate::{
     impl_fixed_arbitrary,
     table::{Decode, Encode},
     DatabaseError,
 };
-use alloy_primitives::{Address, BlockNumber, StorageKey};
+use alloy_primitives::{Address, BlockNumber, StorageKey, B256};
 use serde::{Deserialize, Serialize};
+use std::ops::{Bound, Range, RangeBounds, RangeInclusive};
 
 /// [`BlockNumber`] concatenated with [`Address`].
 ///
@@ -67,6 +66,81 @@ impl Decode for BlockNumberAddress {
     fn decode(value: &[u8]) -> Result<Self, DatabaseError> {
         let num = u64::from_be_bytes(value[..8].try_into().map_err(|_| DatabaseError::Decode)?);
         let hash = Address::from_slice(&value[8..]);
+        Ok(Self((num, hash)))
+    }
+}
+
+/// A [`RangeBounds`] over a range of [`BlockNumberAddress`]s. Used to conveniently convert from a
+/// range of [`BlockNumber`]s.
+#[derive(Debug)]
+pub struct BlockNumberAddressRange {
+    /// Starting bound of the range.
+    pub start: Bound<BlockNumberAddress>,
+    /// Ending bound of the range.
+    pub end: Bound<BlockNumberAddress>,
+}
+
+impl RangeBounds<BlockNumberAddress> for BlockNumberAddressRange {
+    fn start_bound(&self) -> Bound<&BlockNumberAddress> {
+        self.start.as_ref()
+    }
+
+    fn end_bound(&self) -> Bound<&BlockNumberAddress> {
+        self.end.as_ref()
+    }
+}
+
+impl<R: RangeBounds<BlockNumber>> From<R> for BlockNumberAddressRange {
+    fn from(r: R) -> Self {
+        let start = match r.start_bound() {
+            Bound::Included(n) => Bound::Included(BlockNumberAddress((*n, Address::ZERO))),
+            Bound::Excluded(n) => Bound::Included(BlockNumberAddress((n + 1, Address::ZERO))),
+            Bound::Unbounded => Bound::Unbounded,
+        };
+
+        let end = match r.end_bound() {
+            Bound::Included(n) => Bound::Excluded(BlockNumberAddress((n + 1, Address::ZERO))),
+            Bound::Excluded(n) => Bound::Excluded(BlockNumberAddress((*n, Address::ZERO))),
+            Bound::Unbounded => Bound::Unbounded,
+        };
+
+        Self { start, end }
+    }
+}
+
+/// [`BlockNumber`] concatenated with [`B256`] (hashed address).
+///
+/// Since it's used as a key, it isn't compressed when encoding it.
+#[derive(
+    Debug, Default, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Ord, PartialOrd, Hash,
+)]
+pub struct BlockNumberHashedAddress(pub (BlockNumber, B256));
+
+impl From<(BlockNumber, B256)> for BlockNumberHashedAddress {
+    fn from(tpl: (BlockNumber, B256)) -> Self {
+        Self(tpl)
+    }
+}
+
+impl Encode for BlockNumberHashedAddress {
+    type Encoded = [u8; 40];
+
+    fn encode(self) -> Self::Encoded {
+        let block_number = self.0 .0;
+        let hashed_address = self.0 .1;
+
+        let mut buf = [0u8; 40];
+
+        buf[..8].copy_from_slice(&block_number.to_be_bytes());
+        buf[8..].copy_from_slice(hashed_address.as_slice());
+        buf
+    }
+}
+
+impl Decode for BlockNumberHashedAddress {
+    fn decode(value: &[u8]) -> Result<Self, DatabaseError> {
+        let num = u64::from_be_bytes(value[..8].try_into().map_err(|_| DatabaseError::Decode)?);
+        let hash = B256::from_slice(&value[8..]);
         Ok(Self((num, hash)))
     }
 }

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -133,7 +133,7 @@ impl<'b, Provider: DBProvider + BlockNumReader> HistoricalStateProviderRef<'b, P
             );
         }
 
-        Ok(HashedPostState::from_reverts::<KeccakKeyHasher>(self.tx(), self.block_number)?)
+        Ok(HashedPostState::from_reverts::<KeccakKeyHasher>(self.tx(), self.block_number..)?)
     }
 
     /// Retrieve revert hashed storage for this history provider and target address.

--- a/crates/trie/db/src/state.rs
+++ b/crates/trie/db/src/state.rs
@@ -1,11 +1,11 @@
 use crate::{DatabaseHashedCursorFactory, DatabaseTrieCursorFactory, PrefixSetLoader};
 use alloy_primitives::{
     map::{AddressMap, B256Map},
-    Address, BlockNumber, B256, U256,
+    BlockNumber, B256, U256,
 };
 use reth_db_api::{
     cursor::DbCursorRO,
-    models::{AccountBeforeTx, BlockNumberAddress},
+    models::{AccountBeforeTx, BlockNumberAddress, BlockNumberAddressRange},
     tables,
     transaction::DbTx,
     DatabaseError,
@@ -16,7 +16,10 @@ use reth_trie::{
     updates::TrieUpdates, HashedPostState, HashedStorage, KeccakKeyHasher, KeyHasher, StateRoot,
     StateRootProgress, TrieInput,
 };
-use std::{collections::HashMap, ops::RangeInclusive};
+use std::{
+    collections::HashMap,
+    ops::{RangeBounds, RangeInclusive},
+};
 use tracing::debug;
 
 /// Extends [`StateRoot`] with operations specific for working with a database transaction.
@@ -124,9 +127,12 @@ pub trait DatabaseStateRoot<'a, TX>: Sized {
 
 /// Extends [`HashedPostState`] with operations specific for working with a database transaction.
 pub trait DatabaseHashedPostState<TX>: Sized {
-    /// Initializes [`HashedPostState`] from reverts. Iterates over state reverts from the specified
-    /// block up to the current tip and aggregates them into hashed state in reverse.
-    fn from_reverts<KH: KeyHasher>(tx: &TX, from: BlockNumber) -> Result<Self, DatabaseError>;
+    /// Initializes [`HashedPostState`] from reverts. Iterates over state reverts in the specified
+    /// range and aggregates them into hashed state in reverse.
+    fn from_reverts<KH: KeyHasher>(
+        tx: &TX,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> Result<Self, DatabaseError>;
 }
 
 impl<'a, TX: DbTx> DatabaseStateRoot<'a, TX>
@@ -220,21 +226,24 @@ impl<'a, TX: DbTx> DatabaseStateRoot<'a, TX>
 }
 
 impl<TX: DbTx> DatabaseHashedPostState<TX> for HashedPostState {
-    fn from_reverts<KH: KeyHasher>(tx: &TX, from: BlockNumber) -> Result<Self, DatabaseError> {
+    fn from_reverts<KH: KeyHasher>(
+        tx: &TX,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> Result<Self, DatabaseError> {
         // Iterate over account changesets and record value before first occurring account change.
+        let account_range = (range.start_bound(), range.end_bound()); // to avoid cloning
         let mut accounts = HashMap::new();
         let mut account_changesets_cursor = tx.cursor_read::<tables::AccountChangeSets>()?;
-        for entry in account_changesets_cursor.walk_range(from..)? {
+        for entry in account_changesets_cursor.walk_range(account_range)? {
             let (_, AccountBeforeTx { address, info }) = entry?;
             accounts.entry(address).or_insert(info);
         }
 
         // Iterate over storage changesets and record value before first occurring storage change.
+        let storage_range: BlockNumberAddressRange = range.into();
         let mut storages = AddressMap::<B256Map<U256>>::default();
         let mut storage_changesets_cursor = tx.cursor_read::<tables::StorageChangeSets>()?;
-        for entry in
-            storage_changesets_cursor.walk_range(BlockNumberAddress((from, Address::ZERO))..)?
-        {
+        for entry in storage_changesets_cursor.walk_range(storage_range)? {
             let (BlockNumberAddress((_, address)), storage) = entry?;
             let account_storage = storages.entry(address).or_default();
             account_storage.entry(storage.key).or_insert(storage.value);
@@ -250,8 +259,8 @@ impl<TX: DbTx> DatabaseHashedPostState<TX> for HashedPostState {
                     KH::hash_key(address),
                     HashedStorage::from_iter(
                         // The `wiped` flag indicates only whether previous storage entries
-                        // should be looked up in db or not. For reverts it's a noop since all
-                        // wiped changes had been written as storage reverts.
+                        // should be looked up in db or not. For reverts it's a noop since all
+                        // wiped changes had been written as storage reverts.
                         false,
                         storage.into_iter().map(|(slot, value)| (KH::hash_key(slot), value)),
                     ),


### PR DESCRIPTION
When implementing trie changesets we'll need to be able to query the HashedPostState revert just for specific blocks (in order to compute their PrefixSets). This allows for doing that with minimal other changes.

A range helper for BlockNumberAddress is added for convenience.