### PR TITLE
fix: Apply WS CORS regardless of HTTP being enabled

### DIFF
--- a/crates/rpc/rpc-builder/src/config.rs
+++ b/crates/rpc/rpc-builder/src/config.rs
@@ -195,13 +195,16 @@ impl RethRpcServerConfig for RpcServerArgs {
                 .with_http_address(socket_address)
                 .with_http(self.http_ws_server_builder())
                 .with_http_cors(self.http_corsdomain.clone())
-                .with_http_disable_compression(self.http_disable_compression)
-                .with_ws_cors(self.ws_allowed_origins.clone());
+                .with_http_disable_compression(self.http_disable_compression);
         }
 
         if self.ws {
             let socket_address = SocketAddr::new(self.ws_addr, self.ws_port);
-            config = config.with_ws_address(socket_address).with_ws(self.http_ws_server_builder());
+            // Ensure WS CORS is applied regardless of HTTP being enabled
+            config = config
+                .with_ws_address(socket_address)
+                .with_ws(self.http_ws_server_builder())
+                .with_ws_cors(self.ws_allowed_origins.clone());
         }
 
         if self.is_ipc_enabled() {


### PR DESCRIPTION

### Description
- Fixes an issue where `ws.origins` was only applied when HTTP was enabled.
- Now `with_ws_cors(...)` is set inside the WS branch, ensuring WS CORS is honored for WS-only setups.

### Changes
- `crates/rpc/rpc-builder/src/config.rs`: move `with_ws_cors(...)` into `if self.ws { ... }` with a clarifying comment.

