### PR TITLE
fix(era-utils): fix off-by-one for Excluded end bound in process_iter

### DIFF
--- a/crates/era-utils/src/history.rs
+++ b/crates/era-utils/src/history.rs
@@ -289,9 +289,13 @@ where
         Bound::Excluded(&number) => number.saturating_sub(1),
         Bound::Unbounded => 0,
     };
-    let target = match block_numbers.end_bound() {
-        Bound::Included(&number) => Some(number),
-        Bound::Excluded(&number) => Some(number.saturating_add(1)),
+    // Convert the end bound to an exclusive upper bound to avoid off-by-one issues.
+    // Included(end) => end_exclusive = Some(end + 1) (None if overflow)
+    // Excluded(end) => end_exclusive = Some(end)
+    // Unbounded      => end_exclusive = None
+    let end_exclusive = match block_numbers.end_bound() {
+        Bound::Included(&number) => number.checked_add(1),
+        Bound::Excluded(&number) => Some(number),
         Bound::Unbounded => None,
     };
 
@@ -302,8 +306,8 @@ where
         if number <= last_header_number {
             continue;
         }
-        if let Some(target) = target &&
-            number > target
+        if let Some(end_exclusive) = end_exclusive &&
+            number >= end_exclusive
         {
             break;
         }

--- a/crates/era-utils/src/history.rs
+++ b/crates/era-utils/src/history.rs
@@ -286,16 +286,12 @@ where
 {
     let mut last_header_number = match block_numbers.start_bound() {
         Bound::Included(&number) => number,
-        Bound::Excluded(&number) => number.saturating_sub(1),
+        Bound::Excluded(&number) => number.saturating_add(1),
         Bound::Unbounded => 0,
     };
-    // Convert the end bound to an exclusive upper bound to avoid off-by-one issues.
-    // Included(end) => end_exclusive = Some(end + 1) (None if overflow)
-    // Excluded(end) => end_exclusive = Some(end)
-    // Unbounded      => end_exclusive = None
-    let end_exclusive = match block_numbers.end_bound() {
-        Bound::Included(&number) => number.checked_add(1),
-        Bound::Excluded(&number) => Some(number),
+    let target = match block_numbers.end_bound() {
+        Bound::Included(&number) => Some(number),
+        Bound::Excluded(&number) => Some(number.saturating_sub(1)),
         Bound::Unbounded => None,
     };
 
@@ -306,8 +302,8 @@ where
         if number <= last_header_number {
             continue;
         }
-        if let Some(end_exclusive) = end_exclusive &&
-            number >= end_exclusive
+        if let Some(target) = target &&
+            number > target
         {
             break;
         }


### PR DESCRIPTION
Previously, process_iter computed target = end + 1 for Bound::Excluded(end) and stopped on number > target, which allowed processing up to end + 1 and was incorrect, especially at u64::MAX. This change standardizes to an exclusive end bound: Included(end) becomes end.checked_add(1) (None on overflow), Excluded(end) becomes Some(end), and the loop exits on number >= end_exclusive. This fixes the off-by-one and aligns range handling with the rest of the codebase.