### PR TITLE
chore(trie): Overlay arguments for write trie changeset methods

### DIFF
--- a/crates/storage/db-api/src/cursor.rs
+++ b/crates/storage/db-api/src/cursor.rs
@@ -87,7 +87,7 @@ pub trait DbDupCursorRO<T: DupSort> {
     /// | `key`  | `subkey` | **Equivalent starting position**        |
     /// |--------|----------|-----------------------------------------|
     /// | `None` | `None`   | [`DbCursorRO::first()`]                 |
-    /// | `Some` | `None`   | [`DbCursorRO::seek()`]               |
+    /// | `Some` | `None`   | [`DbCursorRO::seek_exact()`]            |
     /// | `None` | `Some`   | [`DbDupCursorRO::seek_by_key_subkey()`] |
     /// | `Some` | `Some`   | [`DbDupCursorRO::seek_by_key_subkey()`] |
     fn walk_dup(

--- a/crates/storage/provider/src/changesets_utils/trie.rs
+++ b/crates/storage/provider/src/changesets_utils/trie.rs
@@ -83,9 +83,9 @@ where
     }
 }
 
-/// Returns an iterator which produces the values to be inserted into
-/// [`tables::StoragesTrieChangeSets`] for an account whose storage was wiped during a block. It is
-/// expected that this is called prior to inserting the block's trie updates.
+/// Returns an iterator which produces the values to be inserted into the `StoragesTrieChangeSets`
+/// table for an account whose storage was wiped during a block. It is expected that this is called
+/// prior to inserting the block's trie updates.
 ///
 /// ## Arguments
 ///

--- a/crates/storage/provider/src/changesets_utils/trie.rs
+++ b/crates/storage/provider/src/changesets_utils/trie.rs
@@ -1,18 +1,15 @@
-use alloy_primitives::B256;
 use itertools::{merge_join_by, EitherOrBoth};
-use reth_db_api::{cursor::DbDupCursorRO, tables, DatabaseError};
-use reth_trie::{BranchNodeCompact, Nibbles, StorageTrieEntry, StoredNibblesSubKey};
+use reth_db_api::DatabaseError;
+use reth_trie::{trie_cursor::TrieCursor, BranchNodeCompact, Nibbles};
 use std::cmp::{Ord, Ordering};
 
-/// Combines a sorted iterator of trie node paths and a [`tables::StoragesTrie`] cursor into a new
+/// Combines a sorted iterator of trie node paths and a storage trie cursor into a new
 /// iterator which produces the current values of all given paths in the same order.
 #[derive(Debug)]
 pub struct StorageTrieCurrentValuesIter<'cursor, P, C> {
-    /// The address of the account whose storage is being iterated.
-    hashed_address: B256,
     /// Sorted iterator of node paths which we want the values of.
     paths: P,
-    /// Cursor over [`tables::StoragesTrie`].
+    /// Storage trie cursor.
     cursor: &'cursor mut C,
     /// Current value at the cursor, allows us to treat the cursor as a peekable iterator.
     cursor_current: Option<(Nibbles, BranchNodeCompact)>,
@@ -20,24 +17,18 @@ pub struct StorageTrieCurrentValuesIter<'cursor, P, C> {
 
 impl<'cursor, P, C> StorageTrieCurrentValuesIter<'cursor, P, C>
 where
-    C: DbDupCursorRO<tables::StoragesTrie>,
+    P: Iterator<Item = Nibbles>,
+    C: TrieCursor,
 {
     /// Instantiate a [`StorageTrieCurrentValuesIter`] from a sorted paths iterator and a cursor.
-    pub fn new(
-        hashed_address: B256,
-        paths: P,
-        cursor: &'cursor mut C,
-    ) -> Result<Self, DatabaseError> {
-        let mut new_self = Self { hashed_address, paths, cursor, cursor_current: None };
+    pub fn new(paths: P, cursor: &'cursor mut C) -> Result<Self, DatabaseError> {
+        let mut new_self = Self { paths, cursor, cursor_current: None };
         new_self.seek_cursor(Nibbles::default())?;
         Ok(new_self)
     }
 
     fn seek_cursor(&mut self, path: Nibbles) -> Result<(), DatabaseError> {
-        self.cursor_current = self
-            .cursor
-            .seek_by_key_subkey(self.hashed_address, StoredNibblesSubKey(path))?
-            .map(|e| (e.nibbles.0, e.node));
+        self.cursor_current = self.cursor.seek(path)?;
         Ok(())
     }
 }
@@ -45,7 +36,7 @@ where
 impl<'cursor, P, C> Iterator for StorageTrieCurrentValuesIter<'cursor, P, C>
 where
     P: Iterator<Item = Nibbles>,
-    C: DbDupCursorRO<tables::StoragesTrie>,
+    C: TrieCursor,
 {
     type Item = Result<(Nibbles, Option<BranchNodeCompact>), DatabaseError>;
 
@@ -57,10 +48,10 @@ where
 
         // If the path is ahead of the cursor then seek the cursor forward to catch up. The cursor
         // will seek either to `curr_path` or beyond it.
-        if self.cursor_current.as_ref().is_some_and(|(cursor_path, _)| curr_path > *cursor_path) {
-            if let Err(err) = self.seek_cursor(curr_path) {
-                return Some(Err(err))
-            }
+        if self.cursor_current.as_ref().is_some_and(|(cursor_path, _)| curr_path > *cursor_path)
+            && let Err(err) = self.seek_cursor(curr_path)
+        {
+            return Some(Err(err))
         }
 
         // If there is a path but the cursor is empty then that path has no node.
@@ -111,12 +102,12 @@ pub fn storage_trie_wiped_changeset_iter(
     curr_values_of_changed: impl Iterator<
         Item = Result<(Nibbles, Option<BranchNodeCompact>), DatabaseError>,
     >,
-    all_nodes: impl Iterator<Item = Result<(B256, StorageTrieEntry), DatabaseError>>,
+    all_nodes: impl Iterator<Item = Result<(Nibbles, BranchNodeCompact), DatabaseError>>,
 ) -> Result<
     impl Iterator<Item = Result<(Nibbles, Option<BranchNodeCompact>), DatabaseError>>,
     DatabaseError,
 > {
-    let all_nodes = all_nodes.map(|e| e.map(|e| (e.1.nibbles.0, Some(e.1.node))));
+    let all_nodes = all_nodes.map(|e| e.map(|(nibbles, node)| (nibbles, Some(node))));
 
     let merged = merge_join_by(curr_values_of_changed, all_nodes, |a, b| match (a, b) {
         (Err(_), _) => Ordering::Less,

--- a/crates/storage/provider/src/changesets_utils/trie.rs
+++ b/crates/storage/provider/src/changesets_utils/trie.rs
@@ -48,8 +48,8 @@ where
 
         // If the path is ahead of the cursor then seek the cursor forward to catch up. The cursor
         // will seek either to `curr_path` or beyond it.
-        if self.cursor_current.as_ref().is_some_and(|(cursor_path, _)| curr_path > *cursor_path)
-            && let Err(err) = self.seek_cursor(curr_path)
+        if self.cursor_current.as_ref().is_some_and(|(cursor_path, _)| curr_path > *cursor_path) &&
+            let Err(err) = self.seek_cursor(curr_path)
         {
             return Some(Err(err))
         }

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -63,11 +63,12 @@ use reth_storage_api::{
 use reth_storage_errors::provider::{ProviderResult, RootMismatch};
 use reth_trie::{
     prefix_set::{PrefixSet, PrefixSetMut, TriePrefixSets},
+    trie_cursor::{InMemoryTrieCursor, TrieCursor, TrieCursorIter},
     updates::{StorageTrieUpdates, StorageTrieUpdatesSorted, TrieUpdates, TrieUpdatesSorted},
-    HashedPostStateSorted, Nibbles, StateRoot, StoredNibbles, StoredNibblesSubKey,
-    TrieChangeSetsEntry,
+    BranchNodeCompact, HashedPostStateSorted, Nibbles, StateRoot, StoredNibbles,
+    StoredNibblesSubKey, TrieChangeSetsEntry,
 };
-use reth_trie_db::{DatabaseStateRoot, DatabaseStorageTrieCursor};
+use reth_trie_db::{DatabaseAccountTrieCursor, DatabaseStateRoot, DatabaseStorageTrieCursor};
 use revm_database::states::{
     PlainStateReverts, PlainStorageChangeset, PlainStorageRevert, StateChangeset,
 };
@@ -2355,16 +2356,32 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> TrieWriter for DatabaseProvider
         &self,
         block_number: BlockNumber,
         trie_updates: &TrieUpdatesSorted,
+        updates_overlay: Option<&TrieUpdatesSorted>,
     ) -> ProviderResult<usize> {
         let mut num_entries = 0;
 
         let mut changeset_cursor =
             self.tx_ref().cursor_dup_write::<tables::AccountsTrieChangeSets>()?;
-        let mut curr_values_cursor = self.tx_ref().cursor_read::<tables::AccountsTrie>()?;
+        let curr_values_cursor = self.tx_ref().cursor_read::<tables::AccountsTrie>()?;
+
+        // Wrap the cursor in DatabaseAccountTrieCursor
+        let mut db_account_cursor = DatabaseAccountTrieCursor::new(curr_values_cursor);
+
+        // Static empty array for when updates_overlay is None
+        static EMPTY_ACCOUNT_UPDATES: Vec<(Nibbles, Option<BranchNodeCompact>)> = Vec::new();
+
+        // Get the overlay updates for account trie, or use an empty array
+        let account_overlay_updates = updates_overlay
+            .map(|overlay| overlay.account_nodes_ref())
+            .unwrap_or(&EMPTY_ACCOUNT_UPDATES);
+
+        // Wrap the cursor in InMemoryTrieCursor with the overlay
+        let mut in_memory_account_cursor =
+            InMemoryTrieCursor::new(Some(&mut db_account_cursor), account_overlay_updates);
 
         for (path, _) in trie_updates.account_nodes_ref() {
             num_entries += 1;
-            let node = curr_values_cursor.seek_exact(StoredNibbles(*path))?.map(|e| e.1);
+            let node = in_memory_account_cursor.seek_exact(*path)?.map(|(_, node)| node);
             changeset_cursor.append_dup(
                 block_number,
                 TrieChangeSetsEntry { nibbles: StoredNibblesSubKey(*path), node },
@@ -2374,8 +2391,11 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> TrieWriter for DatabaseProvider
         let mut storage_updates = trie_updates.storage_tries.iter().collect::<Vec<_>>();
         storage_updates.sort_unstable_by(|a, b| a.0.cmp(b.0));
 
-        num_entries +=
-            self.write_storage_trie_changesets(block_number, storage_updates.into_iter())?;
+        num_entries += self.write_storage_trie_changesets(
+            block_number,
+            storage_updates.into_iter(),
+            updates_overlay,
+        )?;
 
         Ok(num_entries)
     }
@@ -2417,6 +2437,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> StorageTrieWriter for DatabaseP
         &self,
         block_number: BlockNumber,
         storage_tries: impl Iterator<Item = (&'a B256, &'a StorageTrieUpdatesSorted)>,
+        updates_overlay: Option<&TrieUpdatesSorted>,
     ) -> ProviderResult<usize> {
         let mut num_written = 0;
 
@@ -2426,23 +2447,60 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> StorageTrieWriter for DatabaseP
         // We hold two cursors to the same table because we use them simultaneously when an
         // account's storage is wiped. We keep them outside the for-loop so they can be re-used
         // between accounts.
-        let mut changed_curr_values_cursor =
-            self.tx_ref().cursor_dup_read::<tables::StoragesTrie>()?;
-        let mut wiped_nodes_cursor = self.tx_ref().cursor_dup_read::<tables::StoragesTrie>()?;
+        let changed_curr_values_cursor = self.tx_ref().cursor_dup_read::<tables::StoragesTrie>()?;
+        let wiped_nodes_cursor = self.tx_ref().cursor_dup_read::<tables::StoragesTrie>()?;
+
+        // DatabaseStorageTrieCursor requires ownership of the cursor. The easiest way to deal with
+        // this is to create this outer variable with an initial dummy account, and overwrite it on
+        // every loop for every real account.
+        let mut changed_curr_values_cursor = DatabaseStorageTrieCursor::new(
+            changed_curr_values_cursor,
+            B256::default(), // Will be set per iteration
+        );
+        let mut wiped_nodes_cursor = DatabaseStorageTrieCursor::new(
+            wiped_nodes_cursor,
+            B256::default(), // Will be set per iteration
+        );
+
+        // Static empty array for when updates_overlay is None
+        static EMPTY_UPDATES: Vec<(Nibbles, Option<BranchNodeCompact>)> = Vec::new();
 
         for (hashed_address, storage_trie_updates) in storage_tries {
             let changeset_key = BlockNumberHashedAddress((block_number, *hashed_address));
 
+            // Update the hashed address for the cursors
+            changed_curr_values_cursor =
+                DatabaseStorageTrieCursor::new(changed_curr_values_cursor.cursor, *hashed_address);
+
+            // Get the overlay updates for this storage trie, or use an empty array
+            let overlay_updates = updates_overlay
+                .and_then(|overlay| overlay.storage_tries.get(hashed_address))
+                .map(|updates| updates.storage_nodes_ref())
+                .unwrap_or(&EMPTY_UPDATES);
+
+            // Wrap the cursor in InMemoryTrieCursor with the overlay
+            let mut in_memory_changed_cursor =
+                InMemoryTrieCursor::new(Some(&mut changed_curr_values_cursor), overlay_updates);
+
             // Create an iterator which produces the current values of all updated paths, or None if
             // they are currently unset.
             let curr_values_of_changed = StorageTrieCurrentValuesIter::new(
-                *hashed_address,
                 storage_trie_updates.storage_nodes.iter().map(|e| e.0),
-                &mut changed_curr_values_cursor,
+                &mut in_memory_changed_cursor,
             )?;
 
             if storage_trie_updates.is_deleted() {
-                let all_nodes = wiped_nodes_cursor.walk_dup(Some(*hashed_address), None)?;
+                // Create an iterator that starts from the beginning of the storage trie for this
+                // account
+                wiped_nodes_cursor =
+                    DatabaseStorageTrieCursor::new(wiped_nodes_cursor.cursor, *hashed_address);
+
+                // Wrap the wiped nodes cursor in InMemoryTrieCursor with the overlay
+                let mut in_memory_wiped_cursor =
+                    InMemoryTrieCursor::new(Some(&mut wiped_nodes_cursor), overlay_updates);
+
+                let all_nodes = TrieCursorIter::new(&mut in_memory_wiped_cursor);
+
                 for wiped in storage_trie_wiped_changeset_iter(curr_values_of_changed, all_nodes)? {
                     let (path, node) = wiped?;
                     num_written += 1;
@@ -3579,7 +3637,8 @@ mod tests {
         let trie_updates = TrieUpdatesSorted { account_nodes, storage_tries };
 
         // Write the changesets
-        let num_written = provider_rw.write_trie_changesets(block_number, &trie_updates).unwrap();
+        let num_written =
+            provider_rw.write_trie_changesets(block_number, &trie_updates, None).unwrap();
 
         // Verify number of entries written
         // Account changesets: 2 (one update, one removal)
@@ -3680,6 +3739,253 @@ mod tests {
                         TrieChangeSetsEntry {
                             nibbles: StoredNibblesSubKey(storage_nibbles3),
                             node: Some(storage_node2), // Existing node in wiped storage
+                        }
+                    ),
+                ]
+            );
+        }
+
+        provider_rw.commit().unwrap();
+    }
+
+    #[test]
+    fn test_write_trie_changesets_with_overlay() {
+        use reth_db_api::models::BlockNumberHashedAddress;
+        use reth_trie::BranchNodeCompact;
+
+        let factory = create_test_provider_factory();
+        let provider_rw = factory.provider_rw().unwrap();
+
+        let block_number = 1u64;
+
+        // Create some test nibbles and nodes
+        let account_nibbles1 = Nibbles::from_nibbles([0x1, 0x2, 0x3, 0x4]);
+        let account_nibbles2 = Nibbles::from_nibbles([0x5, 0x6, 0x7, 0x8]);
+
+        let node1 = BranchNodeCompact::new(
+            0b1111_1111_1111_1111, // state_mask
+            0b0000_0000_0000_0000, // tree_mask
+            0b0000_0000_0000_0000, // hash_mask
+            vec![],                // hashes
+            None,                  // root hash
+        );
+
+        // NOTE: Unlike the previous test, we're NOT pre-populating the database
+        // All node values will come from the overlay
+
+        // Create the overlay with existing values that would normally be in the DB
+        let node1_old = BranchNodeCompact::new(
+            0b1010_1010_1010_1010, // Different mask to show it's the overlay "existing" value
+            0b0000_0000_0000_0000,
+            0b0000_0000_0000_0000,
+            vec![],
+            None,
+        );
+
+        // Create overlay account nodes
+        let overlay_account_nodes = vec![
+            (account_nibbles1, Some(node1_old.clone())), // This simulates existing node in overlay
+        ];
+
+        // Create account trie updates: one Some (update) and one None (removal)
+        let account_nodes = vec![
+            (account_nibbles1, Some(node1)), // This will update overlay node
+            (account_nibbles2, None),        // This will be a removal (no existing node)
+        ];
+
+        // Create storage trie updates
+        let storage_address1 = B256::from([1u8; 32]); // Normal storage trie
+        let storage_address2 = B256::from([2u8; 32]); // Wiped storage trie
+
+        let storage_nibbles1 = Nibbles::from_nibbles([0xa, 0xb]);
+        let storage_nibbles2 = Nibbles::from_nibbles([0xc, 0xd]);
+        let storage_nibbles3 = Nibbles::from_nibbles([0xe, 0xf]);
+
+        let storage_node1 = BranchNodeCompact::new(
+            0b1111_0000_0000_0000,
+            0b0000_0000_0000_0000,
+            0b0000_0000_0000_0000,
+            vec![],
+            None,
+        );
+
+        let storage_node2 = BranchNodeCompact::new(
+            0b0000_1111_0000_0000,
+            0b0000_0000_0000_0000,
+            0b0000_0000_0000_0000,
+            vec![],
+            None,
+        );
+
+        // Create old versions for overlay
+        let storage_node1_old = BranchNodeCompact::new(
+            0b1010_0000_0000_0000, // Different mask to show it's an old value
+            0b0000_0000_0000_0000,
+            0b0000_0000_0000_0000,
+            vec![],
+            None,
+        );
+
+        // Create overlay storage nodes
+        let mut overlay_storage_tries = B256Map::default();
+
+        // Overlay for normal storage (storage_address1)
+        let overlay_storage_trie1 = StorageTrieUpdatesSorted {
+            is_deleted: false,
+            storage_nodes: vec![
+                (storage_nibbles1, Some(storage_node1_old.clone())), /* Simulates existing in
+                                                                      * overlay */
+            ],
+        };
+
+        // Overlay for wiped storage (storage_address2)
+        let overlay_storage_trie2 = StorageTrieUpdatesSorted {
+            is_deleted: false,
+            storage_nodes: vec![
+                (storage_nibbles1, Some(storage_node1.clone())), // Existing in overlay
+                (storage_nibbles3, Some(storage_node2.clone())), // Also existing in overlay
+            ],
+        };
+
+        overlay_storage_tries.insert(storage_address1, overlay_storage_trie1);
+        overlay_storage_tries.insert(storage_address2, overlay_storage_trie2);
+
+        let overlay = TrieUpdatesSorted {
+            account_nodes: overlay_account_nodes,
+            storage_tries: overlay_storage_tries,
+        };
+
+        // Normal storage trie: one Some (update) and one None (new)
+        let storage_trie1 = StorageTrieUpdatesSorted {
+            is_deleted: false,
+            storage_nodes: vec![
+                (storage_nibbles1, Some(storage_node1.clone())), // This will update overlay node
+                (storage_nibbles2, None),                        // This is a new node
+            ],
+        };
+
+        // Wiped storage trie
+        let storage_trie2 = StorageTrieUpdatesSorted {
+            is_deleted: true,
+            storage_nodes: vec![
+                (storage_nibbles1, Some(storage_node1.clone())), // Updated node from overlay
+                (storage_nibbles2, Some(storage_node2.clone())), /* Updated node not in overlay
+                                                                  * storage_nibbles3 is in
+                                                                  * overlay
+                                                                  * but not updated */
+            ],
+        };
+
+        let mut storage_tries = B256Map::default();
+        storage_tries.insert(storage_address1, storage_trie1);
+        storage_tries.insert(storage_address2, storage_trie2);
+
+        let trie_updates = TrieUpdatesSorted { account_nodes, storage_tries };
+
+        // Write the changesets WITH OVERLAY
+        let num_written =
+            provider_rw.write_trie_changesets(block_number, &trie_updates, Some(&overlay)).unwrap();
+
+        // Verify number of entries written
+        // Account changesets: 2 (one update from overlay, one removal)
+        // Storage changesets:
+        //   - Normal storage: 2 (one update from overlay, one new)
+        //   - Wiped storage: 3 (two updated, one existing from overlay not updated)
+        // Total: 2 + 2 + 3 = 7
+        assert_eq!(num_written, 7);
+
+        // Verify account changesets were written correctly
+        {
+            let mut cursor =
+                provider_rw.tx_ref().cursor_dup_read::<tables::AccountsTrieChangeSets>().unwrap();
+
+            // Get all entries for this block to see what was written
+            let all_entries = cursor
+                .walk_dup(Some(block_number), None)
+                .unwrap()
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap();
+
+            // Assert the full value of all_entries in a single assert_eq
+            assert_eq!(
+                all_entries,
+                vec![
+                    (
+                        block_number,
+                        TrieChangeSetsEntry {
+                            nibbles: StoredNibblesSubKey(account_nibbles1),
+                            node: Some(node1_old), // Value from overlay, not DB
+                        }
+                    ),
+                    (
+                        block_number,
+                        TrieChangeSetsEntry {
+                            nibbles: StoredNibblesSubKey(account_nibbles2),
+                            node: None,
+                        }
+                    ),
+                ]
+            );
+        }
+
+        // Verify storage changesets were written correctly
+        {
+            let mut cursor =
+                provider_rw.tx_ref().cursor_dup_read::<tables::StoragesTrieChangeSets>().unwrap();
+
+            // Check normal storage trie changesets
+            let key1 = BlockNumberHashedAddress((block_number, storage_address1));
+            let entries1 =
+                cursor.walk_dup(Some(key1), None).unwrap().collect::<Result<Vec<_>, _>>().unwrap();
+
+            assert_eq!(
+                entries1,
+                vec![
+                    (
+                        key1,
+                        TrieChangeSetsEntry {
+                            nibbles: StoredNibblesSubKey(storage_nibbles1),
+                            node: Some(storage_node1_old), // Old value from overlay
+                        }
+                    ),
+                    (
+                        key1,
+                        TrieChangeSetsEntry {
+                            nibbles: StoredNibblesSubKey(storage_nibbles2),
+                            node: None, // New node, no previous value
+                        }
+                    ),
+                ]
+            );
+
+            // Check wiped storage trie changesets
+            let key2 = BlockNumberHashedAddress((block_number, storage_address2));
+            let entries2 =
+                cursor.walk_dup(Some(key2), None).unwrap().collect::<Result<Vec<_>, _>>().unwrap();
+
+            assert_eq!(
+                entries2,
+                vec![
+                    (
+                        key2,
+                        TrieChangeSetsEntry {
+                            nibbles: StoredNibblesSubKey(storage_nibbles1),
+                            node: Some(storage_node1), // Value from overlay
+                        }
+                    ),
+                    (
+                        key2,
+                        TrieChangeSetsEntry {
+                            nibbles: StoredNibblesSubKey(storage_nibbles2),
+                            node: None, // Was not in overlay
+                        }
+                    ),
+                    (
+                        key2,
+                        TrieChangeSetsEntry {
+                            nibbles: StoredNibblesSubKey(storage_nibbles3),
+                            node: Some(storage_node2), /* Existing node from overlay in wiped
+                                                        * storage */
                         }
                     ),
                 ]

--- a/crates/storage/provider/src/writer/mod.rs
+++ b/crates/storage/provider/src/writer/mod.rs
@@ -190,7 +190,7 @@ where
             // `TrieUpdatesSorted`, and then the `trie` field of `ExecutedBlockWithTrieUpdates` to
             // carry a TrieUpdatesSorted.
             let trie_updates_sorted = (*trie_updates).clone().into_sorted();
-            self.database().write_trie_changesets(block_number, &trie_updates_sorted)?;
+            self.database().write_trie_changesets(block_number, &trie_updates_sorted, None)?;
 
             self.database().write_trie_updates(&trie_updates)?;
         }

--- a/crates/storage/storage-api/src/trie.rs
+++ b/crates/storage/storage-api/src/trie.rs
@@ -103,11 +103,18 @@ pub trait TrieWriter: Send + Sync {
     /// The intended usage of this method is to call it _prior_ to calling `write_trie_updates` with
     /// the same [`TrieUpdates`].
     ///
+    /// The `updates_overlay` parameter allows providing additional in-memory trie updates that
+    /// should be considered when looking up current node values. When provided, these overlay
+    /// updates are applied on top of the database state, allowing the method to see a view that
+    /// includes both committed database values and pending in-memory changes. This is useful
+    /// when writing changesets for updates that depend on previous uncommitted trie changes.
+    ///
     /// Returns the number of keys written.
     fn write_trie_changesets(
         &self,
         block_number: BlockNumber,
         trie_updates: &TrieUpdatesSorted,
+        updates_overlay: Option<&TrieUpdatesSorted>,
     ) -> ProviderResult<usize>;
 }
 
@@ -130,10 +137,18 @@ pub trait StorageTrieWriter: Send + Sync {
     /// The intended usage of this method is to call it _prior_ to calling
     /// `write_storage_trie_updates` with the same set of [`StorageTrieUpdates`].
     ///
+    /// The `updates_overlay` parameter allows providing additional in-memory trie updates that
+    /// should be considered when looking up current node values. When provided, these overlay
+    /// updates are applied on top of the database state for each storage trie, allowing the
+    /// method to see a view that includes both committed database values and pending in-memory
+    /// changes. This is useful when writing changesets for storage updates that depend on
+    /// previous uncommitted trie changes.
+    ///
     /// Returns the number of keys written.
     fn write_storage_trie_changesets<'a>(
         &self,
         block_number: BlockNumber,
         storage_tries: impl Iterator<Item = (&'a B256, &'a StorageTrieUpdatesSorted)>,
+        updates_overlay: Option<&TrieUpdatesSorted>,
     ) -> ProviderResult<usize>;
 }

--- a/crates/trie/trie/src/trie_cursor/mod.rs
+++ b/crates/trie/trie/src/trie_cursor/mod.rs
@@ -58,3 +58,48 @@ pub trait TrieCursor: Send + Sync {
     /// Get the current entry.
     fn current(&mut self) -> Result<Option<Nibbles>, DatabaseError>;
 }
+
+/// Iterator wrapper for `TrieCursor` types
+#[derive(Debug)]
+pub struct TrieCursorIter<'a, C> {
+    cursor: &'a mut C,
+    /// The initial value from seek, if any
+    initial: Option<Result<(Nibbles, BranchNodeCompact), DatabaseError>>,
+}
+
+impl<'a, C> TrieCursorIter<'a, C> {
+    /// Create a new iterator from a mutable reference to a cursor. The Iterator will start from the
+    /// empty path.
+    pub fn new(cursor: &'a mut C) -> Self
+    where
+        C: TrieCursor,
+    {
+        let initial = cursor.seek(Nibbles::default()).transpose();
+        Self { cursor, initial }
+    }
+}
+
+impl<'a, C> From<&'a mut C> for TrieCursorIter<'a, C>
+where
+    C: TrieCursor,
+{
+    fn from(cursor: &'a mut C) -> Self {
+        Self::new(cursor)
+    }
+}
+
+impl<'a, C> Iterator for TrieCursorIter<'a, C>
+where
+    C: TrieCursor,
+{
+    type Item = Result<(Nibbles, BranchNodeCompact), DatabaseError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // If we have an initial value from seek, return it first
+        if let Some(initial) = self.initial.take() {
+            return Some(initial);
+        }
+
+        self.cursor.next().transpose()
+    }
+}


### PR DESCRIPTION
This allows for passing optional overlays into the `write_trie_changesets` and `write_storage_trie_changesets` provider methods.

The overlay is a TrieUpdates which is used to augment the state of the trie db tables. Using the overlay we can write changesets as if the DB is at a previous block, which will be used during pipeline sync.

Implementing this change required refactoring the
StorageTrieCurrentValuesIter utility to accept a TrieCursor rather than a normal DbCursor. It also required implementing a TrieCursorIter which wraps a TrieCursor into an Iterator, for passing in to `storage_trie_wiped_changeset_iter`. Using both of these changes we could use an InMemoryTrieCursor instead of a direct db cursor.