### PR TITLE
fix: increase backoff timeout

### DIFF
--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -637,8 +637,11 @@ impl PeersManager {
                 if let Some(kind) = err.should_backoff() {
                     if peer.is_trusted() || peer.is_static() {
                         // provide a bit more leeway for trusted peers and use a lower backoff so
-                        // that we keep re-trying them after backing off shortly
-                        let backoff = self.backoff_durations.low / 2;
+                        // that we keep re-trying them after backing off shortly, but we should at
+                        // least backoff for the low duration to not violate the ip based inbound
+                        // connection throttle that peer has in place, because this peer might not
+                        // have us registered as a trusted peer.
+                        let backoff = self.backoff_durations.low;
                         backoff_until = Some(std::time::Instant::now() + backoff);
                     } else {
                         // Increment peer.backoff_counter

--- a/crates/net/network/tests/it/connect.rs
+++ b/crates/net/network/tests/it/connect.rs
@@ -428,7 +428,7 @@ async fn test_trusted_peer_only() {
     let outgoing_peer_id1 = event_stream.next_session_established().await.unwrap();
     assert_eq!(outgoing_peer_id1, *handle1.peer_id());
 
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    tokio::time::sleep(Duration::from_secs(2)).await;
     assert_eq!(handle.num_connected_peers(), 2);
 
     // check that handle0 and handle1 both have peers.


### PR DESCRIPTION
the default for low is 30s which matches the usual ip based throttle

so if we have a peer as trusted but that peer has us not marked as trusted we would always encounter the remote's ip throttle on repeated connection attempts