### PR TITLE
chore(trie): demote verbose proof debug logs to TRACE

### DIFF
--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -35,6 +35,7 @@ use reth_trie_common::{
 use reth_trie_db::{DatabaseHashedCursorFactory, DatabaseTrieCursorFactory};
 use std::sync::{mpsc::Receiver, Arc};
 use tracing::debug;
+use tracing::trace;
 
 /// Parallel proof calculator.
 ///
@@ -137,7 +138,7 @@ where
         let prefix_set = PrefixSetMut::from(target_slots.iter().map(Nibbles::unpack));
         let prefix_set = prefix_set.freeze();
 
-        debug!(
+        trace!(
             target: "trie::parallel_proof",
             total_targets,
             ?hashed_address,
@@ -151,7 +152,7 @@ where
             )))
         })?;
 
-        debug!(
+        trace!(
             target: "trie::parallel_proof",
             total_targets,
             ?hashed_address,
@@ -199,7 +200,7 @@ where
         );
         let storage_root_targets_len = storage_root_targets.len();
 
-        debug!(
+        trace!(
             target: "trie::parallel_proof",
             total_targets = storage_root_targets_len,
             "Starting parallel proof generation"
@@ -343,7 +344,7 @@ where
             (HashMap::default(), HashMap::default())
         };
 
-        debug!(
+        trace!(
             target: "trie::parallel_proof",
             total_targets = storage_root_targets_len,
             duration = ?stats.duration(),

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -34,7 +34,6 @@ use reth_trie_common::{
 };
 use reth_trie_db::{DatabaseHashedCursorFactory, DatabaseTrieCursorFactory};
 use std::sync::{mpsc::Receiver, Arc};
-use tracing::debug;
 use tracing::trace;
 
 /// Parallel proof calculator.

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -40,8 +40,7 @@ use std::{
     time::Instant,
 };
 use tokio::runtime::Handle;
-use tracing::debug;
-use tracing::trace;
+use tracing::{debug, trace};
 
 #[cfg(feature = "metrics")]
 use crate::proof_task_metrics::ProofTaskMetrics;

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -41,6 +41,7 @@ use std::{
 };
 use tokio::runtime::Handle;
 use tracing::debug;
+use tracing::trace;
 
 #[cfg(feature = "metrics")]
 use crate::proof_task_metrics::ProofTaskMetrics;
@@ -266,7 +267,7 @@ where
         result_sender: Sender<StorageProofResult>,
         tx_sender: Sender<ProofTaskMessage<Tx>>,
     ) {
-        debug!(
+        trace!(
             target: "trie::proof_task",
             hashed_address=?input.hashed_address,
             "Starting storage proof task calculation"
@@ -313,7 +314,7 @@ where
             })
         });
 
-        debug!(
+        trace!(
             target: "trie::proof_task",
             hashed_address=?input.hashed_address,
             prefix_set = ?input.prefix_set.len(),
@@ -344,7 +345,7 @@ where
         result_sender: Sender<TrieNodeProviderResult>,
         tx_sender: Sender<ProofTaskMessage<Tx>>,
     ) {
-        debug!(
+        trace!(
             target: "trie::proof_task",
             ?path,
             "Starting blinded account node retrieval"
@@ -360,7 +361,7 @@ where
 
         let start = Instant::now();
         let result = blinded_provider_factory.account_node_provider().trie_node(&path);
-        debug!(
+        trace!(
             target: "trie::proof_task",
             ?path,
             elapsed = ?start.elapsed(),
@@ -388,7 +389,7 @@ where
         result_sender: Sender<TrieNodeProviderResult>,
         tx_sender: Sender<ProofTaskMessage<Tx>>,
     ) {
-        debug!(
+        trace!(
             target: "trie::proof_task",
             ?account,
             ?path,
@@ -405,7 +406,7 @@ where
 
         let start = Instant::now();
         let result = blinded_provider_factory.storage_node_provider(account).trie_node(&path);
-        debug!(
+        trace!(
             target: "trie::proof_task",
             ?account,
             ?path,


### PR DESCRIPTION
Demote high-frequency proof logs from DEBUG to TRACE in trie::proof_task and trie::parallel_proof.
Updated crates/trie/parallel/src/proof_task.rs and crates/trie/parallel/src/proof.rs to use trace! for:
- start/finish of storage proof task calculation
- blinded account/storage node retrieval start/finish
- per-address storage proof generation start/finish
- parallel proof generation start and decoded proof stats

Added use tracing::trace; where needed
fix #18737 