### PR TITLE
fix: prevent integer underflow in pipeline unwind target calculation

### DIFF
--- a/crates/stages/api/src/pipeline/mod.rs
+++ b/crates/stages/api/src/pipeline/mod.rs
@@ -617,7 +617,10 @@ impl<N: ProviderNodeTypes> Pipeline<N> {
                 "Stage is missing static file data."
             );
 
-            Ok(Some(ControlFlow::Unwind { target: block.block.number - 1, bad_block: block }))
+            Ok(Some(ControlFlow::Unwind {
+                target: block.block.number.saturating_sub(1),
+                bad_block: block,
+            }))
         } else if err.is_fatal() {
             error!(target: "sync::pipeline", stage = %stage_id, "Stage encountered a fatal error: {err}");
             Err(err.into())


### PR DESCRIPTION
Replace potentially unsafe subtraction with saturating_sub to prevent integer underflow when block number is 0. This ensures the pipeline unwind operation cannot panic due to arithmetic overflow