### PR TITLE
fix(rpc): fix eth_config impl

### DIFF
--- a/crates/ethereum/node/tests/e2e/rpc.rs
+++ b/crates/ethereum/node/tests/e2e/rpc.rs
@@ -323,7 +323,7 @@ async fn test_eth_config() -> eyre::Result<()> {
 
     let config = provider.client().request_noparams::<EthConfig>("eth_config").await?;
 
-    assert_eq!(config.last.unwrap().activation_time, 0);
+    assert_eq!(config.last.unwrap().activation_time, osaka_timestamp);
     assert_eq!(config.current.activation_time, prague_timestamp);
     assert_eq!(config.next.unwrap().activation_time, osaka_timestamp);
 

--- a/crates/rpc/rpc-eth-api/src/helpers/config.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/config.rs
@@ -12,8 +12,7 @@ use reth_node_api::NodePrimitives;
 use reth_revm::db::EmptyDB;
 use reth_rpc_eth_types::EthApiError;
 use reth_storage_api::BlockReaderIdExt;
-use revm::precompile::PrecompileId;
-use std::{borrow::Borrow, collections::BTreeMap};
+use std::collections::BTreeMap;
 
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "eth"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "eth"))]
@@ -100,7 +99,7 @@ where
 
         let mut fork_timestamps =
             chain_spec.forks_iter().filter_map(|(_, cond)| cond.as_timestamp()).collect::<Vec<_>>();
-        fork_timestamps.sort();
+        fork_timestamps.sort_unstable();
         fork_timestamps.dedup();
 
         let (current_fork_idx, current_fork_timestamp) = fork_timestamps
@@ -135,7 +134,7 @@ where
             return Ok(config);
         }
 
-        let last_fork_timestamp = fork_timestamps.get(fork_timestamps.len() - 1).copied().unwrap();
+        let last_fork_timestamp = fork_timestamps.last().copied().unwrap();
         let fake_header = {
             let mut header = latest;
             header.timestamp = last_fork_timestamp;
@@ -172,33 +171,7 @@ fn evm_to_precompiles_map(
     precompiles
         .addresses()
         .filter_map(|address| {
-            Some((precompile_to_str(precompiles.get(address)?.precompile_id()), *address))
+            Some((precompiles.get(address)?.precompile_id().name().to_string(), *address))
         })
         .collect()
-}
-
-// TODO: move
-fn precompile_to_str(id: &PrecompileId) -> String {
-    let str = match id {
-        PrecompileId::EcRec => "ECREC",
-        PrecompileId::Sha256 => "SHA256",
-        PrecompileId::Ripemd160 => "RIPEMD160",
-        PrecompileId::Identity => "ID",
-        PrecompileId::ModExp => "MODEXP",
-        PrecompileId::Bn254Add => "BN254_ADD",
-        PrecompileId::Bn254Mul => "BN254_MUL",
-        PrecompileId::Bn254Pairing => "BN254_PAIRING",
-        PrecompileId::Blake2F => "BLAKE2F",
-        PrecompileId::KzgPointEvaluation => "KZG_POINT_EVALUATION",
-        PrecompileId::Bls12G1Add => "BLS12_G1ADD",
-        PrecompileId::Bls12G1Msm => "BLS12_G1MSM",
-        PrecompileId::Bls12G2Add => "BLS12_G2ADD",
-        PrecompileId::Bls12G2Msm => "BLS12_G2MSM",
-        PrecompileId::Bls12Pairing => "BLS12_PAIRING_CHECK",
-        PrecompileId::Bls12MapFpToGp1 => "BLS12_MAP_FP_TO_G1",
-        PrecompileId::Bls12MapFp2ToGp2 => "BLS12_MAP_FP2_TO_G2",
-        PrecompileId::P256Verify => "P256VERIFY",
-        PrecompileId::Custom(custom) => custom.borrow(),
-    };
-    str.to_owned()
 }


### PR DESCRIPTION
There are two changes here:

- Name of the `P256` precompile was wrong, it must be `P256VERIFY` according to other clients (nethermind is wrong too, writing a PR in a moment)
- There was a misunderstanding when handling the case where `next` is `null` (and what the `last` config means). In the EIP it is poorly explained, but in short, it is not the *"previous"* config, but rather the *"final"* config scheduled. That means, if we have configs `[1, 2, 3, 4]` and we are at `2`, `last = 4` and `next = 3`, not `last = 1` as it is the case with reth (the others do it correctly)
- Moreover, it does not handle the case from the EIPs that say:
> "next" and "last" will be null if the client is not configured to support a future fork.
- Sorted the `fork_timestamps` before checking for the current timestamp (should not be a perf drainer as the array is very small), just in case they are unordered and we claim to be on the wrong fork

The `unwrap` on line 138 is safe as, by the check on line 111 we ensure there is at least one element, and with the `else` on line 133 we ensure we return early if that is the case, so that we only continue execution if there are more than 1 element (so that `next = last = current + 1` if there are 2, and `next = current + 1` and last is the last/final configured fork.