### PR TITLE
docs: add note to launch on --dev mode

### DIFF
--- a/docs/vocs/docs/snippets/sources/exex/hello-world/src/bin/1.rs
+++ b/docs/vocs/docs/snippets/sources/exex/hello-world/src/bin/1.rs
@@ -2,6 +2,7 @@ use reth_node_ethereum::EthereumNode;
 
 fn main() -> eyre::Result<()> {
     reth::cli::Cli::parse_args().run(async move |builder, _| {
+        // Use launch_with_debug_capabilities() for --dev mode
         let handle = builder.node(EthereumNode::default()).launch().await?;
 
         handle.wait_for_node_exit().await

--- a/docs/vocs/docs/snippets/sources/exex/hello-world/src/bin/1.rs
+++ b/docs/vocs/docs/snippets/sources/exex/hello-world/src/bin/1.rs
@@ -2,8 +2,7 @@ use reth_node_ethereum::EthereumNode;
 
 fn main() -> eyre::Result<()> {
     reth::cli::Cli::parse_args().run(async move |builder, _| {
-        // Use launch_with_debug_capabilities() for --dev mode
-        let handle = builder.node(EthereumNode::default()).launch().await?;
+        let handle = builder.node(EthereumNode::default()).launch_with_debug_capabilities().await?;
 
         handle.wait_for_node_exit().await
     })

--- a/docs/vocs/docs/snippets/sources/exex/hello-world/src/bin/2.rs
+++ b/docs/vocs/docs/snippets/sources/exex/hello-world/src/bin/2.rs
@@ -9,11 +9,10 @@ async fn my_exex<Node: FullNodeComponents>(mut _ctx: ExExContext<Node>) -> eyre:
 
 fn main() -> eyre::Result<()> {
     reth::cli::Cli::parse_args().run(async move |builder, _| {
-        // Use launch_with_debug_capabilities() for --dev mode
         let handle = builder
             .node(EthereumNode::default())
             .install_exex("my-exex", async move |ctx| Ok(my_exex(ctx)))
-            .launch()
+            .launch_with_debug_capabilities()
             .await?;
 
         handle.wait_for_node_exit().await

--- a/docs/vocs/docs/snippets/sources/exex/hello-world/src/bin/2.rs
+++ b/docs/vocs/docs/snippets/sources/exex/hello-world/src/bin/2.rs
@@ -9,6 +9,7 @@ async fn my_exex<Node: FullNodeComponents>(mut _ctx: ExExContext<Node>) -> eyre:
 
 fn main() -> eyre::Result<()> {
     reth::cli::Cli::parse_args().run(async move |builder, _| {
+        // Use launch_with_debug_capabilities() for --dev mode
         let handle = builder
             .node(EthereumNode::default())
             .install_exex("my-exex", async move |ctx| Ok(my_exex(ctx)))

--- a/docs/vocs/docs/snippets/sources/exex/hello-world/src/bin/3.rs
+++ b/docs/vocs/docs/snippets/sources/exex/hello-world/src/bin/3.rs
@@ -30,11 +30,10 @@ async fn my_exex<Node: FullNodeComponents<Types: NodeTypes<Primitives = EthPrimi
 
 fn main() -> eyre::Result<()> {
     reth::cli::Cli::parse_args().run(async move |builder, _| {
-        // Use launch_with_debug_capabilities() for --dev mode
         let handle = builder
             .node(EthereumNode::default())
             .install_exex("my-exex", async move |ctx| Ok(my_exex(ctx)))
-            .launch()
+            .launch_with_debug_capabilities()
             .await?;
 
         handle.wait_for_node_exit().await

--- a/docs/vocs/docs/snippets/sources/exex/hello-world/src/bin/3.rs
+++ b/docs/vocs/docs/snippets/sources/exex/hello-world/src/bin/3.rs
@@ -30,6 +30,7 @@ async fn my_exex<Node: FullNodeComponents<Types: NodeTypes<Primitives = EthPrimi
 
 fn main() -> eyre::Result<()> {
     reth::cli::Cli::parse_args().run(async move |builder, _| {
+        // Use launch_with_debug_capabilities() for --dev mode
         let handle = builder
             .node(EthereumNode::default())
             .install_exex("my-exex", async move |ctx| Ok(my_exex(ctx)))

--- a/docs/vocs/docs/snippets/sources/exex/remote/src/exex.rs
+++ b/docs/vocs/docs/snippets/sources/exex/remote/src/exex.rs
@@ -72,6 +72,7 @@ fn main() -> eyre::Result<()> {
             }))
             .serve("[::1]:10000".parse().unwrap());
 
+        // Use launch_with_debug_capabilities() for --dev mode
         let handle = builder
             .node(EthereumNode::default())
             .install_exex("remote-exex", |ctx| async move { Ok(remote_exex(ctx, notifications)) })

--- a/docs/vocs/docs/snippets/sources/exex/remote/src/exex.rs
+++ b/docs/vocs/docs/snippets/sources/exex/remote/src/exex.rs
@@ -72,11 +72,10 @@ fn main() -> eyre::Result<()> {
             }))
             .serve("[::1]:10000".parse().unwrap());
 
-        // Use launch_with_debug_capabilities() for --dev mode
         let handle = builder
             .node(EthereumNode::default())
             .install_exex("remote-exex", |ctx| async move { Ok(remote_exex(ctx, notifications)) })
-            .launch()
+            .launch_with_debug_capabilities()
             .await?;
 
         handle.node.task_executor.spawn_critical("gRPC server", async move {

--- a/docs/vocs/docs/snippets/sources/exex/tracking-state/src/bin/1.rs
+++ b/docs/vocs/docs/snippets/sources/exex/tracking-state/src/bin/1.rs
@@ -48,6 +48,7 @@ impl<Node: FullNodeComponents<Types: NodeTypes<Primitives = EthPrimitives>>> Fut
 
 fn main() -> eyre::Result<()> {
     reth::cli::Cli::parse_args().run(async move |builder, _| {
+        // Use launch_with_debug_capabilities() for --dev mode
         let handle = builder
             .node(EthereumNode::default())
             .install_exex("my-exex", async move |ctx| Ok(MyExEx { ctx }))

--- a/docs/vocs/docs/snippets/sources/exex/tracking-state/src/bin/1.rs
+++ b/docs/vocs/docs/snippets/sources/exex/tracking-state/src/bin/1.rs
@@ -48,11 +48,10 @@ impl<Node: FullNodeComponents<Types: NodeTypes<Primitives = EthPrimitives>>> Fut
 
 fn main() -> eyre::Result<()> {
     reth::cli::Cli::parse_args().run(async move |builder, _| {
-        // Use launch_with_debug_capabilities() for --dev mode
         let handle = builder
             .node(EthereumNode::default())
             .install_exex("my-exex", async move |ctx| Ok(MyExEx { ctx }))
-            .launch()
+            .launch_with_debug_capabilities()
             .await?;
 
         handle.wait_for_node_exit().await

--- a/docs/vocs/docs/snippets/sources/exex/tracking-state/src/bin/2.rs
+++ b/docs/vocs/docs/snippets/sources/exex/tracking-state/src/bin/2.rs
@@ -68,6 +68,7 @@ impl<Node: FullNodeComponents<Types: NodeTypes<Primitives = EthPrimitives>>> Fut
 
 fn main() -> eyre::Result<()> {
     reth::cli::Cli::parse_args().run(async move |builder, _| {
+        // Use launch_with_debug_capabilities() for --dev mode
         let handle = builder
             .node(EthereumNode::default())
             .install_exex("my-exex", async move |ctx| Ok(MyExEx::new(ctx)))

--- a/docs/vocs/docs/snippets/sources/exex/tracking-state/src/bin/2.rs
+++ b/docs/vocs/docs/snippets/sources/exex/tracking-state/src/bin/2.rs
@@ -68,11 +68,10 @@ impl<Node: FullNodeComponents<Types: NodeTypes<Primitives = EthPrimitives>>> Fut
 
 fn main() -> eyre::Result<()> {
     reth::cli::Cli::parse_args().run(async move |builder, _| {
-        // Use launch_with_debug_capabilities() for --dev mode
         let handle = builder
             .node(EthereumNode::default())
             .install_exex("my-exex", async move |ctx| Ok(MyExEx::new(ctx)))
-            .launch()
+            .launch_with_debug_capabilities()
             .await?;
 
         handle.wait_for_node_exit().await


### PR DESCRIPTION
Closes #18690

- Add tip about using `launch_with_debug_capabilities()` for **--dev** mode
- Add inline comments in code snippets for dev mode guidance
- Explain that regular launcher expects external consensus client