### PR TITLE
test: add missing Drop trait tests for CancelOnDrop

### DIFF
--- a/crates/revm/src/cancelled.rs
+++ b/crates/revm/src/cancelled.rs
@@ -108,4 +108,40 @@ mod tests {
         c.cancel();
         assert!(cloned_cancel.is_cancelled());
     }
+
+    #[test]
+    fn test_cancelondrop_clone_behavior() {
+        let cancel = CancelOnDrop::default();
+        assert!(!cancel.is_cancelled());
+
+        // Clone the CancelOnDrop
+        let cloned_cancel = cancel.clone();
+        assert!(!cloned_cancel.is_cancelled());
+
+        // Drop the original - this should set the cancelled flag
+        drop(cancel);
+
+        // The cloned instance should now see the cancelled flag as true
+        assert!(cloned_cancel.is_cancelled());
+    }
+
+    #[test]
+    fn test_cancelondrop_multiple_clones() {
+        let cancel = CancelOnDrop::default();
+        let clone1 = cancel.clone();
+        let clone2 = cancel.clone();
+        let clone3 = cancel.clone();
+
+        assert!(!cancel.is_cancelled());
+        assert!(!clone1.is_cancelled());
+        assert!(!clone2.is_cancelled());
+        assert!(!clone3.is_cancelled());
+
+        // Drop one clone - this should cancel all instances
+        drop(clone1);
+
+        assert!(cancel.is_cancelled());
+        assert!(clone2.is_cancelled());
+        assert!(clone3.is_cancelled());
+    }
 }


### PR DESCRIPTION
Addresses a gap in test coverage by adding two new
test cases that verify the Drop trait implementation for CancelOnDrop:

1. test_cancelondrop_clone_behavior: Verifies that when the original
   CancelOnDrop instance is dropped, all cloned instances correctly
   reflect the cancelled state through the shared Arc<AtomicBool>.

2. test_cancelondrop_multiple_clones: Tests the behavior when one of
   multiple clones is dropped, ensuring that the cancellation signal
   propagates to all remaining instances.

These tests are needed because:
- CancelOnDrop is used in payload building systems where premature
  cancellation could lead to inconsistent state
- The Drop trait behavior was previously untested, creating potential
  for silent bugs in concurrent environments
- The shared state through Arc<AtomicBool> requires explicit testing
  to ensure proper synchronization across clones