### PR TITLE
fix: Normalize CORS domain parsing: trim tokens, ignore empties, enforce wildcard rule

### DIFF
--- a/crates/rpc/rpc-builder/src/cors.rs
+++ b/crates/rpc/rpc-builder/src/cors.rs
@@ -31,7 +31,7 @@ pub(crate) fn create_cors_layer(http_cors_domains: &str) -> Result<CorsLayer, Co
             // This makes common inputs like "https://a.com, https://b.com" robust.
             let items: Vec<&str> =
                 list.split(',').map(|s| s.trim()).filter(|s| !s.is_empty()).collect();
-    
+
             // After normalization, wildcard is not allowed as part of a list
             if items.iter().any(|o| *o == "*") {
                 return Err(CorsDomainError::WildCardNotAllowed {

--- a/crates/rpc/rpc-builder/src/cors.rs
+++ b/crates/rpc/rpc-builder/src/cors.rs
@@ -29,17 +29,14 @@ pub(crate) fn create_cors_layer(http_cors_domains: &str) -> Result<CorsLayer, Co
         list => {
             // Normalize the comma-separated list: trim each token and drop empties
             // This makes common inputs like "https://a.com, https://b.com" robust.
-            let items: Vec<&str> = list
-                .split(',')
-                .map(|s| s.trim())
-                .filter(|s| !s.is_empty())
-                .collect();
-
+            let items: Vec<&str> =
+                list.split(',').map(|s| s.trim()).filter(|s| !s.is_empty()).collect();
+    
             // After normalization, wildcard is not allowed as part of a list
             if items.iter().any(|o| *o == "*") {
                 return Err(CorsDomainError::WildCardNotAllowed {
                     input: http_cors_domains.to_string(),
-                    })
+                })
             }
 
             let origins = items

--- a/crates/rpc/rpc-builder/src/cors.rs
+++ b/crates/rpc/rpc-builder/src/cors.rs
@@ -26,7 +26,7 @@ pub(crate) fn create_cors_layer(http_cors_domains: &str) -> Result<CorsLayer, Co
             .allow_methods([Method::GET, Method::POST])
             .allow_origin(Any)
             .allow_headers(Any),
-       list => {
+        list => {
             // Normalize the comma-separated list: trim each token and drop empties
             // This makes common inputs like "https://a.com, https://b.com" robust.
             let items: Vec<&str> = list
@@ -37,7 +37,9 @@ pub(crate) fn create_cors_layer(http_cors_domains: &str) -> Result<CorsLayer, Co
 
             // After normalization, wildcard is not allowed as part of a list
             if items.iter().any(|o| *o == "*") {
-                return Err(CorsDomainError::WildCardNotAllowed { input: http_cors_domains.to_string() })
+                return Err(CorsDomainError::WildCardNotAllowed {
+                    input: http_cors_domains.to_string(),
+                    })
             }
 
             let origins = items

--- a/crates/rpc/rpc-builder/src/cors.rs
+++ b/crates/rpc/rpc-builder/src/cors.rs
@@ -39,10 +39,10 @@ pub(crate) fn create_cors_layer(http_cors_domains: &str) -> Result<CorsLayer, Co
                 })
             }
 
-            let origins = items
-                .into_iter()
+            let origins = iter
                 .map(|domain| {
-                    HeaderValue::from_str(domain)
+                    domain
+                        .parse::<HeaderValue>()
                         .map_err(|_| CorsDomainError::InvalidHeader { domain: domain.to_string() })
                 })
                 .collect::<Result<Vec<HeaderValue>, _>>()?;

--- a/crates/rpc/rpc-builder/src/cors.rs
+++ b/crates/rpc/rpc-builder/src/cors.rs
@@ -33,7 +33,7 @@ pub(crate) fn create_cors_layer(http_cors_domains: &str) -> Result<CorsLayer, Co
                 list.split(',').map(|s| s.trim()).filter(|s| !s.is_empty()).collect();
 
             // After normalization, wildcard is not allowed as part of a list
-            if items.iter().any(|o| *o == "*") {
+            if items.contains(&"*") {
                 return Err(CorsDomainError::WildCardNotAllowed {
                     input: http_cors_domains.to_string(),
                 })


### PR DESCRIPTION


### Description
- Summary: Normalize comma-separated CORS domains in `create_cors_layer` to make configuration robust and predictable.
- What: Update `crates/rpc/rpc-builder/src/cors.rs` to:
  - Trim each token
  - Ignore empty tokens
  - Check for `*` after normalization
  - Parse via `HeaderValue::from_str`
- Why: Prevent false negatives with spaced lists (e.g., `"https://a.com, https://b.com"`) and consistently reject wildcard in mixed lists.

