### PR TITLE
chore(evm): mark ExecuteOutput as unused and slated for removal

### DIFF
--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -132,6 +132,11 @@ pub trait Executor<DB: Database>: Sized {
 }
 
 /// Helper type for the output of executing a block.
+///
+/// Deprecated: this type is unused within reth and will be removed in the next
+/// major release. Use `reth_execution_types::BlockExecutionResult` or
+/// `reth_execution_types::BlockExecutionOutput`.
+#[deprecated(note = "Use reth_execution_types::BlockExecutionResult or BlockExecutionOutput")]
 #[derive(Debug, Clone)]
 pub struct ExecuteOutput<R> {
     /// Receipts obtained after executing a block.


### PR DESCRIPTION
Marked reth_evm::execute::ExecuteOutput as deprecated with guidance to use reth_execution_types::BlockExecutionResult or BlockExecutionOutput.
Added doc note explaining the type is unused internally and will be removed in the next major release.