### PR TITLE
fix(era1): correct BlockIndex tag and required block_index comment

### DIFF
--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -57,7 +57,7 @@ where
         Self { provider, incoming, pruner, metrics: PersistenceMetrics::default(), sync_metrics_tx }
     }
 
-    /// Prunes block data before the given block hash according to the configured prune
+    /// Prunes block data before the given block number according to the configured prune
     /// configuration.
     fn prune_before(&mut self, block_num: u64) -> Result<PrunerOutput, PrunerError> {
         debug!(target: "engine::persistence", ?block_num, "Running pruner");
@@ -273,7 +273,7 @@ impl<T: NodePrimitives> PersistenceHandle<T> {
         self.send_action(PersistenceAction::SaveFinalizedBlock(finalized_block))
     }
 
-    /// Persists the finalized block number on disk.
+    /// Persists the safe block number on disk.
     pub fn save_safe_block_number(
         &self,
         safe_block: u64,

--- a/crates/engine/tree/src/tree/state.rs
+++ b/crates/engine/tree/src/tree/state.rs
@@ -20,7 +20,7 @@ use tracing::debug;
 const DEFAULT_PERSISTED_TRIE_UPDATES_RETENTION: u64 = EPOCH_SLOTS * 2;
 
 /// Number of blocks to retain persisted trie updates for OP Stack chains
-/// OP Stack chains only need `EPOCH_BLOCKS` as reorgs are relevant only when
+/// OP Stack chains only need `EPOCH_SLOTS` as reorgs are relevant only when
 /// op-node reorgs to the same chain twice
 const OPSTACK_PERSISTED_TRIE_UPDATES_RETENTION: u64 = EPOCH_SLOTS;
 
@@ -348,11 +348,11 @@ impl<N: NodePrimitives> TreeState<N> {
         }
     }
 
-    /// Determines if the second block is a direct descendant of the first block.
+    /// Determines if the second block is a descendant of the first block.
     ///
     /// If the two blocks are the same, this returns `false`.
     pub(crate) fn is_descendant(&self, first: BlockNumHash, second: BlockWithParent) -> bool {
-        // If the second block's parent is the first block's hash, then it is a direct descendant
+        // If the second block's parent is the first block's hash, then it is a direct child
         // and we can return early.
         if second.parent == first.hash {
             return true

--- a/crates/era/src/era1_types.rs
+++ b/crates/era/src/era1_types.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use alloy_primitives::BlockNumber;
 
-/// `BlockIndex` record: ['i', '2']
+/// `BlockIndex` record: ['f', '2']
 pub const BLOCK_INDEX: [u8; 2] = [0x66, 0x32];
 
 /// File content in an Era1 file
@@ -26,7 +26,7 @@ pub struct Era1Group {
     /// Accumulator is hash tree root of block headers and difficulties
     pub accumulator: Accumulator,
 
-    /// Block index, optional, omitted for genesis era
+    /// Block index, required
     pub block_index: BlockIndex,
 }
 


### PR DESCRIPTION
Align comments with implementation and spec. BlockIndex tag is ['f','2'], not ['i','2'], avoiding confusion with SlotIndex. Also clarify Era1Group.block_index is required; the reader enforces presence and errors if missing. These changes prevent misleading documentation and improve maintainability.

ALSO FIXED

- Correct OP Stack retention comment to use EPOCH_SLOTS to match code.
- Align is_descendant documentation with actual behavior (any-depth descendant) and clarify the direct-child fast path comment.

AND ALSO FIXED

- Update prune_before doc to say “block number” (pruner takes tip block number)
- Correct save_safe_block_number doc to “safe block number”