### PR TITLE
chore: remove unused Debug import

### DIFF
--- a/crates/engine/tree/src/download.rs
+++ b/crates/engine/tree/src/download.rs
@@ -13,7 +13,6 @@ use reth_primitives_traits::{Block, RecoveredBlock, SealedBlock};
 use std::{
     cmp::{Ordering, Reverse},
     collections::{binary_heap::PeekMut, BinaryHeap, HashSet, VecDeque},
-    fmt::Debug,
     sync::Arc,
     task::{Context, Poll},
 };


### PR DESCRIPTION
Remove unused std::fmt::Debug import from crates/engine/tree/src/download.rs.
The import was not referenced anywhere in the file.