### PR TITLE
chore: replace triehash with alloy-trie

### DIFF
--- a/crates/optimism/consensus/src/validation/isthmus.rs
+++ b/crates/optimism/consensus/src/validation/isthmus.rs
@@ -146,7 +146,7 @@ mod test {
     };
     use reth_revm::db::BundleState;
     use reth_storage_api::StateProviderFactory;
-    use reth_trie::{test_utils::storage_root_prehashed, HashedStorage};
+    use reth_trie::{test_utils::storage_root_unhashed, HashedStorage};
     use reth_trie_common::HashedPostState;
 
     #[test]
@@ -169,7 +169,7 @@ mod test {
 
         // init test db
         // note: must be empty (default) chain spec to ensure storage is empty after init genesis,
-        // otherwise can't use `storage_root_prehashed` to determine storage root later
+        // otherwise can't use `storage_root_unhashed` to determine storage root later
         let provider_factory = create_test_provider_factory_with_node_types::<OpNode>(Arc::new(
             OpChainSpecBuilder::default().chain(Chain::dev()).genesis(Default::default()).build(),
         ));
@@ -182,7 +182,7 @@ mod test {
 
         // create block header with withdrawals root set to storage root of l2tol1-msg-passer
         let header = Header {
-            withdrawals_root: Some(storage_root_prehashed(init_storage.storage)),
+            withdrawals_root: Some(storage_root_unhashed(init_storage.storage)),
             ..Default::default()
         };
 

--- a/crates/storage/provider/src/writer/mod.rs
+++ b/crates/storage/provider/src/writer/mod.rs
@@ -242,7 +242,7 @@ mod tests {
     use reth_primitives_traits::{Account, StorageEntry};
     use reth_storage_api::{DatabaseProviderFactory, HashedPostStateProvider};
     use reth_trie::{
-        test_utils::{state_root, storage_root_prehashed},
+        test_utils::{state_root, storage_root_unhashed},
         HashedPostState, HashedStorage, StateRoot, StorageRoot, StorageRootProgress,
     };
     use reth_trie_db::{DatabaseStateRoot, DatabaseStorageRoot};
@@ -1351,7 +1351,7 @@ mod tests {
         else {
             panic!("no threshold for root");
         };
-        assert_eq!(storage_root, storage_root_prehashed(init_storage.storage));
+        assert_eq!(storage_root, storage_root_unhashed(init_storage.storage));
         assert!(!storage_updates.is_empty());
         provider_rw
             .write_storage_trie_updates(core::iter::once((&hashed_address, &storage_updates)))
@@ -1373,6 +1373,6 @@ mod tests {
 
         // re-calculate database storage root
         let storage_root = StorageRoot::overlay_root(tx, address, updated_storage.clone()).unwrap();
-        assert_eq!(storage_root, storage_root_prehashed(updated_storage.storage));
+        assert_eq!(storage_root, storage_root_unhashed(updated_storage.storage));
     }
 }

--- a/crates/trie/db/tests/fuzz_in_memory_nodes.rs
+++ b/crates/trie/db/tests/fuzz_in_memory_nodes.rs
@@ -10,7 +10,7 @@ use reth_db::{
 use reth_primitives_traits::{Account, StorageEntry};
 use reth_provider::test_utils::create_test_provider_factory;
 use reth_trie::{
-    test_utils::{state_root_prehashed, storage_root_prehashed},
+    test_utils::{state_root_prehashed, storage_root_unhashed},
     trie_cursor::InMemoryTrieCursorFactory,
     updates::TrieUpdates,
     HashedPostState, HashedStorage, StateRoot, StorageRoot,
@@ -127,7 +127,7 @@ proptest! {
                 storage.clear();
             }
             storage.append(&mut storage_update);
-            let expected_root = storage_root_prehashed(storage.clone());
+            let expected_root = storage_root_unhashed(storage.clone());
             assert_eq!(expected_root, storage_root);
         }
     }

--- a/crates/trie/db/tests/trie.rs
+++ b/crates/trie/db/tests/trie.rs
@@ -19,7 +19,7 @@ use reth_provider::{
 };
 use reth_trie::{
     prefix_set::{PrefixSetMut, TriePrefixSets},
-    test_utils::{state_root, state_root_prehashed, storage_root, storage_root_prehashed},
+    test_utils::{state_root, state_root_prehashed, storage_root, storage_root_unhashed},
     triehash::KeccakHasher,
     updates::StorageTrieUpdates,
     BranchNodeCompact, HashBuilder, IntermediateStateRootState, Nibbles, StateRoot,
@@ -321,7 +321,7 @@ fn storage_root_regression() {
     let tx = factory.provider_rw().unwrap();
 
     let account3_storage_root = StorageRoot::from_tx(tx.tx_ref(), address3).root().unwrap();
-    let expected_root = storage_root_prehashed(storage);
+    let expected_root = storage_root_unhashed(storage);
     assert_eq!(expected_root, account3_storage_root);
 }
 

--- a/crates/trie/trie/Cargo.toml
+++ b/crates/trie/trie/Cargo.toml
@@ -40,9 +40,6 @@ itertools.workspace = true
 reth-metrics = { workspace = true, optional = true }
 metrics = { workspace = true, optional = true }
 
-# `test-utils` feature
-triehash = { workspace = true, optional = true }
-
 [dev-dependencies]
 # reth
 reth-ethereum-primitives = { workspace = true, features = ["arbitrary", "std"] }
@@ -85,12 +82,12 @@ serde = [
     "reth-ethereum-primitives/serde",
 ]
 test-utils = [
-    "triehash",
     "reth-primitives-traits/test-utils",
     "reth-trie-common/test-utils",
     "reth-ethereum-primitives/test-utils",
     "reth-trie-sparse/test-utils",
     "reth-stages-types/test-utils",
+    "alloy-trie/ethereum"
 ]
 
 [[bench]]

--- a/crates/trie/trie/Cargo.toml
+++ b/crates/trie/trie/Cargo.toml
@@ -87,7 +87,7 @@ test-utils = [
     "reth-ethereum-primitives/test-utils",
     "reth-trie-sparse/test-utils",
     "reth-stages-types/test-utils",
-    "alloy-trie/ethereum"
+    "alloy-trie/ethereum",
 ]
 
 [[bench]]

--- a/crates/trie/trie/src/test_utils.rs
+++ b/crates/trie/trie/src/test_utils.rs
@@ -6,7 +6,8 @@ pub use alloy_trie::root::{
     storage_root, storage_root_unhashed, storage_root_unhashed as storage_root_prehashed,
 };
 
-/// Compute the state root of a given set of accounts using [`triehash::sec_trie_root`].
+/// Compute the state root of a given set of accounts using
+/// [`alloy_trie::root::state_root_unhashed`].
 pub fn state_root<I, S>(accounts: I) -> B256
 where
     I: IntoIterator<Item = (Address, (Account, S))>,
@@ -21,7 +22,7 @@ where
 }
 
 /// Compute the state root of a given set of accounts with prehashed keys using
-/// [`triehash::trie_root`].
+/// [`alloy_trie::root::state_root`].
 pub fn state_root_prehashed<I, S>(accounts: I) -> B256
 where
     I: IntoIterator<Item = (B256, (Account, S))>,


### PR DESCRIPTION
replaces feature gated triehash functions with alloy-trie, this removes triehash dep entirely from the final dep graph, including the rlp crate