### PR TITLE
fix: use cryptographically secure RNG for node secret key generation

### DIFF
--- a/crates/cli/util/src/load_secret_key.rs
+++ b/crates/cli/util/src/load_secret_key.rs
@@ -1,3 +1,4 @@
+use rand_08::rngs::OsRng;
 use reth_fs_util::{self as fs, FsPathError};
 use secp256k1::{Error as SecretKeyBaseError, SecretKey};
 use std::{
@@ -5,7 +6,6 @@ use std::{
     path::{Path, PathBuf},
 };
 use thiserror::Error;
-use rand_08::rngs::OsRng;
 
 /// Convenience function to create a new random [`SecretKey`]
 /// Note: Use OS-backed CSPRNG for generating long-term node identity.

--- a/crates/cli/util/src/load_secret_key.rs
+++ b/crates/cli/util/src/load_secret_key.rs
@@ -5,10 +5,12 @@ use std::{
     path::{Path, PathBuf},
 };
 use thiserror::Error;
+use rand_08::rngs::OsRng;
 
 /// Convenience function to create a new random [`SecretKey`]
+/// Note: Use OS-backed CSPRNG for generating long-term node identity.
 pub fn rng_secret_key() -> SecretKey {
-    SecretKey::new(&mut rand_08::thread_rng())
+    SecretKey::new(&mut OsRng)
 }
 
 /// Errors returned by loading a [`SecretKey`], including IO errors.


### PR DESCRIPTION


**Description:**
Replace `thread_rng()` with `OsRng` in `rng_secret_key()` function to ensure cryptographically secure entropy for node identity keys.

**Changes:**
- Use `rand_08::rngs::OsRng` instead of `rand_08::thread_rng()`

**Why:**
`thread_rng()` is not guaranteed to be cryptographically secure and may use predictable PRNGs in some environments. For long-term node identity keys, we should use OS-backed CSPRNG to ensure proper entropy.