### PR TITLE
fix(primitives-traits): use size_of::<H>() for ommers capacity in BlockBody

### DIFF
--- a/crates/primitives-traits/src/size.rs
+++ b/crates/primitives-traits/src/size.rs
@@ -97,7 +97,7 @@ impl<T: InMemorySize, H: InMemorySize> InMemorySize for alloy_consensus::BlockBo
         self.transactions.iter().map(T::size).sum::<usize>() +
             self.transactions.capacity() * core::mem::size_of::<T>() +
             self.ommers.iter().map(H::size).sum::<usize>() +
-            self.ommers.capacity() * core::mem::size_of::<Header>() +
+            self.ommers.capacity() * core::mem::size_of::<H>() +
             self.withdrawals
                 .as_ref()
                 .map_or(core::mem::size_of::<Option<Withdrawals>>(), Withdrawals::total_size)


### PR DESCRIPTION
Problem: Block body memory estimate multiplied ommers.capacity() by size_of::<Header>(), breaking genericity and under/over-estimating when H != Header.
Fix: Use core::mem::size_of::<H>() to correctly account for the actual ommer header type.
Why necessary: Ensures accurate memory estimation across custom header types and aligns with the generic BlockBody<T, H> design.