### PR TITLE
chore: prune unused TxHashRef dependency from broadcast tests

### DIFF
--- a/crates/net/eth-wire-types/src/broadcast.rs
+++ b/crates/net/eth-wire-types/src/broadcast.rs
@@ -801,7 +801,6 @@ pub struct BlockRangeUpdate {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_consensus::{transaction::TxHashRef, Typed2718};
     use alloy_eips::eip2718::Encodable2718;
     use alloy_primitives::{b256, hex, Signature, U256};
     use reth_ethereum_primitives::{Transaction, TransactionSigned};


### PR DESCRIPTION
- drop alloy_consensus::TxHashRef and Typed2718 from the tests module in `crates/net/eth-wire-types/src/broadcast.rs`
- cargo check/test/clippy plus ripgrep confirm TxHashRef / Typed2718 have no remaining references, so the import is provably dead