### PR TITLE
fix: correct TxTypeCustom extended identifier decoding

### DIFF
--- a/examples/custom-node/src/primitives/tx_type.rs
+++ b/examples/custom-node/src/primitives/tx_type.rs
@@ -30,7 +30,10 @@ impl Compact for TxTypeCustom {
                 },
                 buf,
             ),
-            v => Self::from_compact(buf, v),
+            v => {
+                let (inner, buf) = TxTypeCustom::from_compact(buf, v);
+                (inner, buf)
+            }
         }
     }
 }


### PR DESCRIPTION
- stop TxTypeCustom::from_compact from calling itself with the same identifier
- delegate extended identifiers back to the generated enum to decode Optimism variants safely
