### PR TITLE
feat(op-reth): custom FlashBlock decoder from bytes

### DIFF
--- a/crates/optimism/flashblocks/src/lib.rs
+++ b/crates/optimism/flashblocks/src/lib.rs
@@ -1,7 +1,8 @@
 //! A downstream integration of Flashblocks.
 
 pub use payload::{
-    ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, FlashBlock, Metadata,
+    ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, FlashBlock, FlashBlockDecoder,
+    Metadata,
 };
 use reth_rpc_eth_types::PendingBlock;
 pub use service::FlashBlockService;

--- a/crates/optimism/flashblocks/src/payload.rs
+++ b/crates/optimism/flashblocks/src/payload.rs
@@ -1,5 +1,5 @@
 use alloy_eips::eip4895::Withdrawal;
-use alloy_primitives::{Address, Bloom, Bytes, B256, U256};
+use alloy_primitives::{bytes, Address, Bloom, Bytes, B256, U256};
 use alloy_rpc_types_engine::PayloadId;
 use reth_optimism_evm::OpNextBlockEnvAttributes;
 use reth_optimism_primitives::OpReceipt;
@@ -36,6 +36,19 @@ impl FlashBlock {
     /// Returns the first parent hash of this flashblock.
     pub fn parent_hash(&self) -> Option<B256> {
         Some(self.base.as_ref()?.parent_hash)
+    }
+}
+
+/// A trait for decoding flashblocks from bytes.
+pub trait FlashBlockDecoder: Send + 'static {
+    /// Decodes `bytes` into a [`FlashBlock`].
+    fn decode(&self, bytes: bytes::Bytes) -> eyre::Result<FlashBlock>;
+}
+
+/// Default implementation of the decoder.
+impl FlashBlockDecoder for () {
+    fn decode(&self, bytes: bytes::Bytes) -> eyre::Result<FlashBlock> {
+        FlashBlock::decode(bytes)
     }
 }
 

--- a/crates/optimism/flashblocks/src/ws/stream.rs
+++ b/crates/optimism/flashblocks/src/ws/stream.rs
@@ -1,4 +1,4 @@
-use crate::FlashBlock;
+use crate::{FlashBlock, FlashBlockDecoder};
 use futures_util::{
     stream::{SplitSink, SplitStream},
     FutureExt, Sink, Stream, StreamExt,
@@ -28,6 +28,7 @@ pub struct WsFlashBlockStream<Stream, Sink, Connector> {
     ws_url: Url,
     state: State,
     connector: Connector,
+    decoder: Box<dyn FlashBlockDecoder>,
     connect: ConnectFuture<Sink, Stream>,
     stream: Option<Stream>,
     sink: Option<Sink>,
@@ -40,10 +41,16 @@ impl WsFlashBlockStream<WsStream, WsSink, WsConnector> {
             ws_url,
             state: State::default(),
             connector: WsConnector,
+            decoder: Box::new(()),
             connect: Box::pin(async move { Err(Error::ConnectionClosed)? }),
             stream: None,
             sink: None,
         }
+    }
+
+    /// Sets the [`FlashBlock`] decoder for the websocket stream.
+    pub fn with_decoder(self, decoder: Box<dyn FlashBlockDecoder>) -> Self {
+        Self { decoder, ..self }
     }
 }
 
@@ -53,6 +60,7 @@ impl<Stream, S, C> WsFlashBlockStream<Stream, S, C> {
         Self {
             ws_url,
             state: State::default(),
+            decoder: Box::new(()),
             connector,
             connect: Box::pin(async move { Err(Error::ConnectionClosed)? }),
             stream: None,
@@ -111,10 +119,10 @@ where
 
                 match msg {
                     Ok(Message::Binary(bytes)) => {
-                        return Poll::Ready(Some(FlashBlock::decode(bytes)))
+                        return Poll::Ready(Some(this.decoder.decode(bytes)))
                     }
                     Ok(Message::Text(bytes)) => {
-                        return Poll::Ready(Some(FlashBlock::decode(bytes.into())))
+                        return Poll::Ready(Some(this.decoder.decode(bytes.into())))
                     }
                     Ok(Message::Ping(bytes)) => this.ping(bytes),
                     Ok(Message::Close(frame)) => this.close(frame),


### PR DESCRIPTION
It's now possible to specify an adapter type for flashblocks.

```rust
/// A trait for decoding flashblocks from bytes.
pub trait FlashBlockDecoder: Send + 'static {
    /// Decodes `bytes` into a [`FlashBlock`].
    fn decode(&self, bytes: bytes::Bytes) -> eyre::Result<FlashBlock>;
}
```

```rust
let stream = WsFlashBlockStream::new(ws_url).with_decoder(MyDecoder);
```