### PR TITLE
fix: prevent integer overflow in e2store entry data length

### DIFF
--- a/crates/era/src/e2s_types.rs
+++ b/crates/era/src/e2s_types.rs
@@ -150,11 +150,9 @@ impl Entry {
 
     /// Write the entry to [`Entry`] writer
     pub fn write<W: Write>(&self, writer: &mut W) -> io::Result<()> {
-        let data_len = u32::try_from(self.data.len())
-            .map_err(|_| io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "Entry data too large: exceeds u32::MAX"
-            ))?;
+        let data_len = u32::try_from(self.data.len()).map_err(|_| {
+            io::Error::new(io::ErrorKind::InvalidInput, "Entry data too large: exceeds u32::MAX")
+        })?;
         let header = Header::new(self.entry_type, data_len);
         header.write(writer)?;
         writer.write_all(&self.data)

--- a/crates/era/src/e2s_types.rs
+++ b/crates/era/src/e2s_types.rs
@@ -150,7 +150,12 @@ impl Entry {
 
     /// Write the entry to [`Entry`] writer
     pub fn write<W: Write>(&self, writer: &mut W) -> io::Result<()> {
-        let header = Header::new(self.entry_type, self.data.len() as u32);
+        let data_len = u32::try_from(self.data.len())
+            .map_err(|_| io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Entry data too large: exceeds u32::MAX"
+            ))?;
+        let header = Header::new(self.entry_type, data_len);
         header.write(writer)?;
         writer.write_all(&self.data)
     }

--- a/crates/era/src/era1_file.rs
+++ b/crates/era/src/era1_file.rs
@@ -242,11 +242,7 @@ impl<R: Read + Seek> Era1Reader<R> {
 
         let count = u32::try_from(block_index.offsets().len())
             .map_err(|_| E2sError::Ssz("Too many offsets: exceeds u32::MAX".to_string()))?;
-        let id = Era1Id::new(
-            network_name,
-            block_index.starting_number(),
-            count,
-        );
+        let id = Era1Id::new(network_name, block_index.starting_number(), count);
 
         Ok(Era1File::new(group, id))
     }

--- a/crates/era/src/era1_file.rs
+++ b/crates/era/src/era1_file.rs
@@ -240,10 +240,12 @@ impl<R: Read + Seek> Era1Reader<R> {
             group.add_entry(entry);
         }
 
+        let count = u32::try_from(block_index.offsets().len())
+            .map_err(|_| E2sError::Ssz("Too many offsets: exceeds u32::MAX".to_string()))?;
         let id = Era1Id::new(
             network_name,
             block_index.starting_number(),
-            block_index.offsets().len() as u32,
+            count,
         );
 
         Ok(Era1File::new(group, id))


### PR DESCRIPTION
Fix potential integer overflow when converting usize to u32 in e2store file operations.

Changes:
- Add safe type conversion using TryFrom in Entry::write() method
- Add safe type conversion in Era1Reader::read() for offset count
- Return descriptive error messages when data exceeds u32::MAX

Why this change is necessary:

The e2store file format specification limits entry data length to u32::MAX (4GB).

Previously, direct casting from usize to u32 could cause silent integer overflow on 64-bit systems when data.len() > u32::MAX, leading to incorrect header values and potential data corruption. 
