### PR TITLE
fix(transaction-pool): Fix wrong assertion

### DIFF
--- a/crates/transaction-pool/src/pool/parked.rs
+++ b/crates/transaction-pool/src/pool/parked.rs
@@ -247,7 +247,7 @@ impl<T: ParkedOrd> ParkedPool<T> {
         assert_eq!(
             self.last_sender_submission.len(),
             self.sender_transaction_count.len(),
-            "last_sender_transaction.len() != sender_to_last_transaction.len()"
+            "last_sender_submission.len() != sender_transaction_count.len()"
         );
     }
 }

--- a/crates/transaction-pool/src/pool/pending.rs
+++ b/crates/transaction-pool/src/pool/pending.rs
@@ -571,16 +571,16 @@ impl<T: TransactionOrdering> PendingPool<T> {
     pub(crate) fn assert_invariants(&self) {
         assert!(
             self.independent_transactions.len() <= self.by_id.len(),
-            "independent.len() > all.len()"
+            "independent_transactions.len() > by_id.len()"
         );
         assert!(
             self.highest_nonces.len() <= self.by_id.len(),
-            "independent_descendants.len() > all.len()"
+            "highest_nonces.len() > by_id.len()"
         );
         assert_eq!(
             self.highest_nonces.len(),
             self.independent_transactions.len(),
-            "independent.len() = independent_descendants.len()"
+            "highest_nonces.len() != independent_transactions.len()"
         );
     }
 }

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -2110,7 +2110,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
     #[cfg(any(test, feature = "test-utils"))]
     pub(crate) fn assert_invariants(&self) {
         assert_eq!(self.by_hash.len(), self.txs.len(), "by_hash.len() != txs.len()");
-        assert!(self.auths.len() <= self.txs.len(), "auths > txs.len()");
+        assert!(self.auths.len() <= self.txs.len(), "auths.len() > txs.len()");
     }
 }
 

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -1476,8 +1476,8 @@ impl MockFeeRange {
         max_fee_blob: Range<u128>,
     ) -> Self {
         assert!(
-            max_fee.start <= priority_fee.end,
-            "max_fee_range should be strictly below the priority fee range"
+            max_fee.start >= priority_fee.end,
+            "max_fee_range should be strictly above the priority fee range"
         );
         Self {
             gas_price: gas_price.try_into().unwrap(),


### PR DESCRIPTION
In reth/crates/transaction-pool/src/test_utils/mock.rs,  the assertion assert!(max_fee.start <= priority_fee.end,"max_fee_range should be strictly below the priority fee range"); is wrong.
```rust
#[derive(Debug, Clone)]
pub struct MockFeeRange {
    /// The range of `gas_price` or legacy and access list transactions
    pub gas_price: Uniform<u128>,
    /// The range of priority fees for EIP-1559 and EIP-4844 transactions
    pub priority_fee: Uniform<u128>,
    /// The range of max fees for EIP-1559 and EIP-4844 transactions
    pub max_fee: Uniform<u128>,
    /// The range of max fees per blob gas for EIP-4844 transactions
    pub max_fee_blob: Uniform<u128>,
}
...
pub fn new(
        gas_price: Range<u128>,
        priority_fee: Range<u128>,
        max_fee: Range<u128>,
        max_fee_blob: Range<u128>,
    ) -> Self {
        assert!(
            max_fee.start <= priority_fee.end,
            "max_fee_range should be strictly below the priority fee range"
        );
        Self {
            gas_price: gas_price.try_into().unwrap(),
            priority_fee: priority_fee.try_into().unwrap(),
            max_fee: max_fee.try_into().unwrap(),
            max_fee_blob: max_fee_blob.try_into().unwrap(),
        }
    }
```
There are also some wrong messages, which should be updated  to be consistent , like outdated message in reth-main/crates/transaction-pool/src/pool/pending.rs.
```rust
pub(crate) fn assert_invariants(&self) {
        assert!(
            self.independent_transactions.len() <= self.by_id.len(),
            "independent.len() > all.len()"
        );
        assert!(
            self.highest_nonces.len() <= self.by_id.len(),
            "independent_descendants.len() > all.len()"
        );
        assert_eq!(
            self.highest_nonces.len(),
            self.independent_transactions.len(),
            "independent.len() = independent_descendants.len()"
        );
    }
```