### PR TITLE
refactor(engine): small nits - remove shallow abstraction for decoded_storage_proof

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -452,7 +452,7 @@ where
                 "Starting dedicated storage proof calculation",
             );
             let start = Instant::now();
-            let result = ParallelProof::new(
+            let proof_result = ParallelProof::new(
                 config.consistent_view,
                 config.nodes_sorted,
                 config.state_sorted,
@@ -461,7 +461,7 @@ where
             )
             .with_branch_node_masks(true)
             .with_multi_added_removed_keys(Some(multi_added_removed_keys))
-            .decoded_storage_proof(hashed_address, proof_targets);
+            .storage_proof(hashed_address, proof_targets);
             let elapsed = start.elapsed();
             trace!(
                 target: "engine::root",
@@ -472,7 +472,7 @@ where
                 "Storage multiproofs calculated",
             );
 
-            match result {
+            match proof_result {
                 Ok(proof) => {
                     let _ = state_root_message_sender.send(MultiProofMessage::ProofCalculated(
                         Box::new(ProofCalculated {
@@ -527,7 +527,7 @@ where
             );
 
             let start = Instant::now();
-            let result = ParallelProof::new(
+            let proof_result = ParallelProof::new(
                 config.consistent_view,
                 config.nodes_sorted,
                 config.state_sorted,
@@ -548,7 +548,7 @@ where
                 "Multiproof calculated",
             );
 
-            match result {
+            match proof_result {
                 Ok(proof) => {
                     let _ = state_root_message_sender.send(MultiProofMessage::ProofCalculated(
                         Box::new(ProofCalculated {

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -161,16 +161,6 @@ where
         proof_result
     }
 
-    /// Generate a [`DecodedStorageMultiProof`] for the given proof by first calling
-    /// `storage_proof`, then decoding the proof nodes.
-    pub fn decoded_storage_proof(
-        self,
-        hashed_address: B256,
-        target_slots: B256Set,
-    ) -> Result<DecodedStorageMultiProof, ParallelStateRootError> {
-        self.storage_proof(hashed_address, target_slots)
-    }
-
     /// Generate a state multiproof according to specified targets.
     pub fn decoded_multiproof(
         self,


### PR DESCRIPTION
smol nits from what we talked about yesterday @mattsse 
- remove `decoded_storage_proof` as its not needed as an abstraction and makes it harder to read
- rename function `spawn_storage_proof` to `queue_storage_proof` which is more representative
- rename result to `proof_result` to make it easier to read 