### PR TITLE
refactor: remove redundant Setup::new() method

### DIFF
--- a/crates/e2e-test-utils/src/testsuite/setup.rs
+++ b/crates/e2e-test-utils/src/testsuite/setup.rs
@@ -82,11 +82,6 @@ impl<I> Setup<I>
 where
     I: EngineTypes,
 {
-    /// Create a new setup with default values
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     /// Set the chain specification
     pub fn with_chain_spec(mut self, chain_spec: Arc<ChainSpec>) -> Self {
         self.chain_spec = Some(chain_spec);


### PR DESCRIPTION
Remove the redundant Setup::new() method from e2e-test-utils Setup struct. The method was simply calling Self::default(), which is unnecessary as users can directly call Setup::default(). This cleanup reduces code duplication and follows DRY principles. All existing code already uses Setup::default() pattern, confirming the method was unused.