### PR TITLE
fix(op-reth): forward pre-bedrock transaction RPC calls to historical endpoint

### DIFF
--- a/crates/optimism/rpc/src/historical.rs
+++ b/crates/optimism/rpc/src/historical.rs
@@ -175,7 +175,10 @@ where
     /// the response if it was forwarded.
     async fn maybe_forward_request(&self, req: &Request<'_>) -> Option<MethodResponse> {
         let should_forward = match req.method_name() {
-            "debug_traceTransaction" => self.should_forward_transaction(req),
+            "debug_traceTransaction" |
+            "eth_getTransactionByHash" |
+            "eth_getTransactionReceipt" |
+            "eth_getRawTransactionByHash" => self.should_forward_transaction(req),
             method => self.should_forward_block_request(method, req),
         };
 


### PR DESCRIPTION
Closes #18782

In https://github.com/paradigmxyz/reth/pull/17971 only `debug_traceTransaction` calls were forwarded to the historical endpoint, with these changes we forward too `eth_getTransactionByHash`, `eth_getTransactionReceipt` and `eth_getRawTransactionByHash`