### PR TITLE
fix: remove the leading hash comparison from RecoveredBlock<B>::PartialEq.

### DIFF
--- a/crates/primitives-traits/src/block/recovered.rs
+++ b/crates/primitives-traits/src/block/recovered.rs
@@ -458,9 +458,7 @@ impl<B: Block> Eq for RecoveredBlock<B> {}
 
 impl<B: Block> PartialEq for RecoveredBlock<B> {
     fn eq(&self, other: &Self) -> bool {
-        self.hash_ref().eq(other.hash_ref()) &&
-            self.block.eq(&other.block) &&
-            self.senders.eq(&other.senders)
+        self.block.eq(&other.block) && self.senders.eq(&other.senders)
     }
 }
 


### PR DESCRIPTION
This check is redundant because SealedBlock<B> derives PartialEq and its first field, SealedHeader, implements PartialEq by comparing only the header hash. Therefore, self.block == other.block already verifies header hash equality and proceeds to body comparison. Keeping an additional self.hash_ref() == other.hash_ref() causes duplicate work and potential double lazy-hash initialization without changing semantics.