### PR TITLE
chore: drop unused once_cell dependency from reth-primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9697,7 +9697,6 @@ dependencies = [
  "arbitrary",
  "c-kzg",
  "codspeed-criterion-compat",
- "once_cell",
  "proptest",
  "proptest-arbitrary-interop",
  "reth-codecs",

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -25,7 +25,6 @@ alloy-consensus.workspace = true
 c-kzg = { workspace = true, features = ["serde"], optional = true }
 
 # misc
-once_cell.workspace = true
 
 [dev-dependencies]
 # eth
@@ -51,7 +50,6 @@ std = [
     "alloy-consensus/std",
     "alloy-eips/std",
     "alloy-genesis/std",
-    "once_cell/std",
     "reth-ethereum-forks/std",
     "reth-ethereum-primitives/std",
     "alloy-rlp/std",

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -2,7 +2,6 @@
 
 use crate::Recovered;
 pub use alloy_consensus::transaction::PooledTransaction;
-use once_cell as _;
 #[expect(deprecated)]
 pub use pooled::PooledTransactionsElementEcRecovered;
 pub use reth_primitives_traits::{


### PR DESCRIPTION
Closes #18705  (follow-up)

- addresses the previous review feedback from #18705 (we keep using `reth_primitives_traits::sync::{LazyLock, OnceLock}` so `no_std` remains supported)
- keeps the change scoped to `reth-primitives` only: no `Cargo.lock` touch, other crates still depend on `once_cell`