### PR TITLE
fix(storage): clean up HeaderNumbers entries during block unwinds

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -2833,6 +2833,11 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider + 'static> BlockWrite
     }
 
     fn remove_blocks_above(&self, block: BlockNumber) -> ProviderResult<()> {
+        // Clean up HeaderNumbers for blocks being removed, we must clear all indexes from MDBX.
+        for hash in self.canonical_hashes_range(block + 1, self.last_block_number()? + 1)? {
+            self.tx.delete::<tables::HeaderNumbers>(hash, None)?;
+        }
+
         // Get highest static file block for the total block range
         let highest_static_file_block = self
             .static_file_provider()


### PR DESCRIPTION
 Fixes a bug where HeaderNumbers entries were not cleaned up during reorgs, causing stale hash-to-number mappings.

When blocks are unwound during a reorg, their headers are removed from static files but their HeaderNumbers table entries were left behind. This caused lookups by hash to return incorrect block numbers or find headers that are no longer part of the canonical chain.

This fixes the hive test failure: `engine-withdrawals/Withdrawals Fork on Canonical Block 8 / Side Block 9 - 10 Block Re-Org`

  * we have blocks 1-15 in the canonical chain (and persisted to disk/static files)
  * fork starting on block 6 up to block 18 arrives (different hashes at same block numbers)
  * receive FCU for block 18 that triggers reorg: unwind to block 5, re-persist blocks 6-18 from fork
  * receive FCU for old block 15 (0x97c1df... - the previous head before reorg)
  * we incorrectly return VALID because find_canonical_header finds *a* block 15 in storage (but it's the NEW fork's block 15 with hash 0xb34600..., not the old 0x97c1df...)
  * CLMocker asks for latest block and reth returns block 18
  * CLMocker expected block 15 (since FCU said it was VALID) but got block 18 and the test fails
