### PR TITLE
fix(ress): avoid panic on Missing trie updates in ress provider witness construction

### DIFF
--- a/crates/ress/provider/src/lib.rs
+++ b/crates/ress/provider/src/lib.rs
@@ -165,7 +165,10 @@ where
             if let Some(trie_updates) = block.trie.as_ref() {
                 trie_input.append_cached_ref(trie_updates, &block.hashed_state);
             } else {
-                trace!(target: "reth::ress_provider", ancestor = ?block.recovered_block().num_hash(), "Skipping missing trie updates");
+                trace!(target: "reth::ress_provider", ancestor = ?block.recovered_block().num_hash(), "Missing trie updates for ancestor block");
+                return Err(ProviderError::TrieWitnessError(
+                    "missing trie updates for ancestor".to_owned(),
+                ));
             }
         }
         let mut hashed_state = db.into_state();

--- a/crates/ress/provider/src/lib.rs
+++ b/crates/ress/provider/src/lib.rs
@@ -162,7 +162,11 @@ where
         let witness_state_provider = self.provider.state_by_block_hash(ancestor_hash)?;
         let mut trie_input = TrieInput::default();
         for block in executed_ancestors.into_iter().rev() {
-            trie_input.append_cached_ref(block.trie.as_ref().unwrap(), &block.hashed_state);
+            if let Some(trie_updates) = block.trie.as_ref() {
+                trie_input.append_cached_ref(trie_updates, &block.hashed_state);
+            } else {
+                trace!(target: "reth::ress_provider", ancestor = ?block.recovered_block().num_hash(), "Skipping missing trie updates");
+            }
         }
         let mut hashed_state = db.into_state();
         hashed_state.extend(record.hashed_state);


### PR DESCRIPTION
This change removes an unwrap on trie updates during witness construction and safely handles ExecutedTrieUpdates::Missing by skipping cached trie appends and emitting a trace. Missing can legitimately occur for fork blocks on historical state, and such blocks are inserted into PendingState by the engine. The unwrap could therefore panic at runtime when ancestors contain Missing trie updates. The fix preserves correctness (witness is still computed from hashed state) with only a minor potential performance impact when cached trie updates are unavailable. Added trace to aid diagnostics.