### PR TITLE
feat: impl Debug for FnLauncher

### DIFF
--- a/crates/cli/commands/src/launcher.rs
+++ b/crates/cli/commands/src/launcher.rs
@@ -66,6 +66,12 @@ impl<F> FnLauncher<F> {
     }
 }
 
+impl<F> fmt::Debug for FnLauncher<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FnLauncher").field("func", &"<function>").finish()
+    }
+}
+
 impl<C, Ext, F> Launcher<C, Ext> for FnLauncher<F>
 where
     C: ChainSpecParser,


### PR DESCRIPTION
The `FnLauncher` is used extensively in node launch contexts where Debug trait is expected (similar to how `Ext: clap::Args + fmt::Debug` is required throughout the CLI system). This implementation will improve error reporting when launcher failures occur.