### PR TITLE
chore: Use nightly cargo doc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -487,7 +487,7 @@ rustdocs: ## Runs `cargo docs` to generate the Rust documents in the `target/doc
 	--show-type-layout \
 	--generate-link-to-definition \
 	--enable-index-page -Zunstable-options -D warnings" \
-	cargo +nightly docs \
+	cargo +nightly doc \
 	--document-private-items
 
 cargo-test:
@@ -509,7 +509,7 @@ test:
 pr:
 	make lint && \
 	make update-book-cli && \
-	cargo docs --document-private-items && \
+	cargo doc --document-private-items && \
 	make test
 
 check-features:

--- a/docs/vocs/scripts/build-cargo-docs.sh
+++ b/docs/vocs/scripts/build-cargo-docs.sh
@@ -9,6 +9,6 @@ echo "Building cargo docs..."
 
 # Build the documentation
 export RUSTDOCFLAGS="--cfg docsrs --show-type-layout --generate-link-to-definition --enable-index-page -Zunstable-options"
-cargo docs --exclude "example-*"
+cargo +nightly doc --no-deps --workspace --exclude "example-*"
 
 echo "Cargo docs built successfully at ./target/doc"


### PR DESCRIPTION
Replace all cargo docs calls with cargo doc and pin nightly where -Zunstable-options is used.