### PR TITLE
fix: Add eth69 status validation

### DIFF
--- a/crates/net/eth-wire/src/errors/eth.rs
+++ b/crates/net/eth-wire/src/errors/eth.rs
@@ -110,4 +110,15 @@ pub enum EthHandshakeError {
         /// The maximum allowed bit length for the total difficulty.
         maximum: usize,
     },
+    #[error("earliest block > latest block: got {got}, latest {latest}")]
+    /// Earliest block > latest block.
+    EarliestBlockGreaterThanLatestBlock {
+        /// The earliest block.
+        got: u64,
+        /// The latest block.
+        latest: u64,
+    },
+    #[error("blockhash is zero")]
+    /// Blockhash is zero.
+    BlockhashZero,
 }

--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -32,9 +32,6 @@ use tracing::{debug, trace};
 // https://github.com/ethereum/go-ethereum/blob/30602163d5d8321fbc68afdcbbaf2362b2641bde/eth/protocols/eth/protocol.go#L50
 pub const MAX_MESSAGE_SIZE: usize = 10 * 1024 * 1024;
 
-/// [`MAX_STATUS_SIZE`] is the maximum cap on the size of the initial status message
-pub(crate) const MAX_STATUS_SIZE: usize = 500 * 1024;
-
 /// An un-authenticated [`EthStream`]. This is consumed and returns a [`EthStream`] after the
 /// `Status` handshake is completed.
 #[pin_project]

--- a/crates/net/eth-wire/src/handshake.rs
+++ b/crates/net/eth-wire/src/handshake.rs
@@ -215,7 +215,7 @@ where
                         .into());
                     }
 
-                    if s.blockhash == FixedBytes::<32>::ZERO {
+                    if s.blockhash.is_zero() {
                         return Err(EthHandshakeError::BlockhashZero.into());
                     }
                 }

--- a/crates/net/eth-wire/src/handshake.rs
+++ b/crates/net/eth-wire/src/handshake.rs
@@ -1,6 +1,6 @@
 use crate::{
     errors::{EthHandshakeError, EthStreamError, P2PStreamError},
-    ethstream::MAX_STATUS_SIZE,
+    ethstream::MAX_MESSAGE_SIZE,
     CanDisconnect,
 };
 use bytes::{Bytes, BytesMut};
@@ -110,7 +110,7 @@ where
             }
         };
 
-        if their_msg.len() > MAX_STATUS_SIZE {
+        if their_msg.len() > MAX_MESSAGE_SIZE {
             unauth
                 .disconnect(DisconnectReason::ProtocolBreach)
                 .await

--- a/crates/net/eth-wire/src/handshake.rs
+++ b/crates/net/eth-wire/src/handshake.rs
@@ -3,7 +3,6 @@ use crate::{
     ethstream::MAX_MESSAGE_SIZE,
     CanDisconnect,
 };
-use alloy_primitives::FixedBytes;
 use bytes::{Bytes, BytesMut};
 use futures::{Sink, SinkExt, Stream};
 use reth_eth_wire_types::{


### PR DESCRIPTION
This add some validation to the eth69 handshake as done in other clients like [geth](https://github.com/ethereum/go-ethereum/blob/057667151b1940e7403a97bc9fcbc207cd5b5045/eth/protocols/eth/handshake.go#L212) as well as bump the maximum size of the status package to match other clients.