### PR TITLE
fix: track inemorysize more accurately

### DIFF
--- a/crates/ethereum/primitives/src/receipt.rs
+++ b/crates/ethereum/primitives/src/receipt.rs
@@ -334,7 +334,11 @@ impl<T: TxTy> InMemorySize for Receipt<T> {
         self.tx_type.size() +
             core::mem::size_of::<bool>() +
             core::mem::size_of::<u64>() +
-            self.logs.capacity() * core::mem::size_of::<Log>()
+            self.logs.capacity() * core::mem::size_of::<Log>() +
+            self.logs
+                .iter()
+                .map(|log| log.data.data.len() + core::mem::size_of_val(log.topics()))
+                .sum::<usize>()
     }
 }
 

--- a/crates/ethereum/primitives/src/receipt.rs
+++ b/crates/ethereum/primitives/src/receipt.rs
@@ -334,11 +334,7 @@ impl<T: TxTy> InMemorySize for Receipt<T> {
         self.tx_type.size() +
             core::mem::size_of::<bool>() +
             core::mem::size_of::<u64>() +
-            self.logs.capacity() * core::mem::size_of::<Log>() +
-            self.logs
-                .iter()
-                .map(|log| log.data.data.len() + core::mem::size_of_val(log.topics()))
-                .sum::<usize>()
+            self.logs.iter().map(|log| log.size()).sum::<usize>()
     }
 }
 


### PR DESCRIPTION
the logs memory calc ignored heap data

and was overcalculating tx+ommers