### PR TITLE
chore(node): remove no-op impl for LaunchContextWith WithComponents

### DIFF
--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -67,8 +67,8 @@ use reth_node_metrics::{
 };
 use reth_provider::{
     providers::{NodeTypesForProvider, ProviderNodeTypes, StaticFileProvider},
-    BlockHashReader, BlockNumReader, BlockReaderIdExt, ChainSpecProvider, ProviderError,
-    ProviderFactory, ProviderResult, StageCheckpointReader, StateProviderFactory,
+    BlockHashReader, BlockNumReader, BlockReaderIdExt, ProviderError,
+    ProviderFactory, ProviderResult, StageCheckpointReader,
     StaticFileProviderFactory,
 };
 use reth_prune::{PruneModes, PrunerBuilder};

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -1067,19 +1067,6 @@ where
     }
 }
 
-impl<T, CB>
-    LaunchContextWith<
-        Attached<WithConfigs<<T::Types as NodeTypes>::ChainSpec>, WithComponents<T, CB>>,
-    >
-where
-    T: FullNodeTypes<
-        Provider: StateProviderFactory + ChainSpecProvider,
-        Types: NodeTypesForProvider,
-    >,
-    CB: NodeComponentsBuilder<T>,
-{
-}
-
 /// Joins two attachments together, preserving access to both values.
 ///
 /// This type enables the launch process to accumulate state while maintaining

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -67,9 +67,8 @@ use reth_node_metrics::{
 };
 use reth_provider::{
     providers::{NodeTypesForProvider, ProviderNodeTypes, StaticFileProvider},
-    BlockHashReader, BlockNumReader, BlockReaderIdExt, ProviderError,
-    ProviderFactory, ProviderResult, StageCheckpointReader,
-    StaticFileProviderFactory,
+    BlockHashReader, BlockNumReader, BlockReaderIdExt, ProviderError, ProviderFactory,
+    ProviderResult, StageCheckpointReader, StaticFileProviderFactory,
 };
 use reth_prune::{PruneModes, PrunerBuilder};
 use reth_rpc_builder::config::RethRpcServerConfig;


### PR DESCRIPTION
Delete an empty inherent impl block for LaunchContextWith<Attached<WithConfigs<..>, WithComponents<..>>> that provided no methods or items. This impl did not affect trait coherence or method availability and appears to be leftover scaffolding. No functional changes; code compiles cleanly with no new lints.