### PR TITLE
feat: OverlayStateProvider

### DIFF
--- a/crates/cli/commands/src/db/repair_trie.rs
+++ b/crates/cli/commands/src/db/repair_trie.rs
@@ -120,23 +120,23 @@ fn verify_and_repair<N: ProviderNodeTypes>(
     // Get a read-write database provider
     let mut provider_rw = provider_factory.provider_rw()?;
 
-    // Check that a pipeline sync isn't in progress.
+    // Check that a pipeline sync isn't in progress
     verify_checkpoints(provider_rw.as_ref())?;
 
+    // Create cursors for making modifications with
     let tx = provider_rw.tx_mut();
     tx.disable_long_read_transaction_safety();
+    let mut account_trie_cursor = tx.cursor_write::<tables::AccountsTrie>()?;
+    let mut storage_trie_cursor = tx.cursor_dup_write::<tables::StoragesTrie>()?;
 
-    // Create the hashed cursor factory
+    // Create the cursor factories. These cannot accept the `&mut` tx above because they require it
+    // to be AsRef.
+    let tx = provider_rw.tx_ref();
     let hashed_cursor_factory = DatabaseHashedCursorFactory::new(tx);
-
-    // Create the trie cursor factory
     let trie_cursor_factory = DatabaseTrieCursorFactory::new(tx);
 
     // Create the verifier
     let verifier = Verifier::new(trie_cursor_factory, hashed_cursor_factory)?;
-
-    let mut account_trie_cursor = tx.cursor_write::<tables::AccountsTrie>()?;
-    let mut storage_trie_cursor = tx.cursor_dup_write::<tables::StoragesTrie>()?;
 
     let mut inconsistent_nodes = 0;
     let start_time = Instant::now();

--- a/crates/cli/commands/src/db/repair_trie.rs
+++ b/crates/cli/commands/src/db/repair_trie.rs
@@ -120,7 +120,7 @@ fn verify_and_repair<N: ProviderNodeTypes>(
     // Get a read-write database provider
     let mut provider_rw = provider_factory.provider_rw()?;
 
-    // Check that a pipeline sync isn't in progress
+    // Check that a pipeline sync isn't in progress.
     verify_checkpoints(provider_rw.as_ref())?;
 
     // Create cursors for making modifications with

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -17,6 +17,7 @@ mod state;
 pub use state::{
     historical::{HistoricalStateProvider, HistoricalStateProviderRef, LowestAvailableBlocks},
     latest::{LatestStateProvider, LatestStateProviderRef},
+    overlay::OverlayStateProvider,
 };
 
 mod consistent_view;

--- a/crates/storage/provider/src/providers/state/mod.rs
+++ b/crates/storage/provider/src/providers/state/mod.rs
@@ -2,3 +2,4 @@
 pub(crate) mod historical;
 pub(crate) mod latest;
 pub(crate) mod macros;
+pub(crate) mod overlay;

--- a/crates/storage/provider/src/providers/state/overlay.rs
+++ b/crates/storage/provider/src/providers/state/overlay.rs
@@ -1,0 +1,125 @@
+use alloy_primitives::{BlockNumber, B256};
+use reth_storage_api::DBProvider;
+use reth_storage_errors::{ProviderResult, db::DatabaseError};
+use reth_trie::{
+    hashed_cursor::{HashedCursorFactory, HashedPostStateCursorFactory},
+    trie_cursor::{InMemoryTrieCursorFactory, TrieCursorFactory},
+    updates::TrieUpdatesSorted,
+    HashedPostStateSorted,
+};
+use reth_trie_db::{DatabaseHashedCursorFactory, DatabaseTrieCursorFactory};
+use std::sync::Arc;
+
+/// State provider with in-memory overlay from trie updates and hashed post state.
+///
+/// This provider uses in-memory trie updates and hashed post state as an overlay
+/// on top of a database provider, implementing [`TrieCursorFactory`] and [`HashedCursorFactory`]
+/// using the in-memory overlay factories.
+#[derive(Debug, Clone)]
+pub struct OverlayStateProvider<Provider: DBProvider> {
+    /// The in-memory trie cursor factory that wraps the database cursor factory.
+    trie_cursor_factory:
+        InMemoryTrieCursorFactory<DatabaseTrieCursorFactory<Arc<Provider::Tx>>, Arc<TrieUpdatesSorted>>,
+    /// The hashed cursor factory that wraps the database cursor factory.
+    hashed_cursor_factory: HashedPostStateCursorFactory<
+        DatabaseHashedCursorFactory<Arc<Provider::Tx>>,
+        Arc<HashedPostStateSorted>,
+    >,
+}
+
+impl<Provider> OverlayStateProvider<Provider>
+where
+    Provider: DBProvider,
+{
+    /// Create new overlay state provider.
+    pub fn new(
+        provider: Provider,
+        trie_updates: Arc<TrieUpdatesSorted>,
+        hashed_post_state: Arc<HashedPostStateSorted>,
+    ) -> Self {
+        // Wrap the transaction in an Arc so it can be shared between both cursor factories
+        let tx = Arc::new(provider.into_tx());
+
+        // Create the trie cursor factory
+        let db_trie_cursor_factory = DatabaseTrieCursorFactory::new(tx.clone());
+        let trie_cursor_factory =
+            InMemoryTrieCursorFactory::new(db_trie_cursor_factory, trie_updates);
+
+        // Create the hashed cursor factory
+        let db_hashed_cursor_factory = DatabaseHashedCursorFactory::new(tx);
+        let hashed_cursor_factory =
+            HashedPostStateCursorFactory::new(db_hashed_cursor_factory, hashed_post_state);
+
+        Self { trie_cursor_factory, hashed_cursor_factory }
+    }
+
+    /// Create a new overlay state provider by first reverting hashed state and trie to the given
+    /// `block_number`, and then applying the provided `HashedPostStateSorted` and
+    /// `TrieUpdatesSorted` on top of those reverts.
+    pub fn with_reverts(
+        _provider: Provider,
+        _trie_updates: Arc<TrieUpdatesSorted>,
+        _hashed_post_state: Arc<HashedPostStateSorted>,
+        _block_number: BlockNumber,
+    ) -> ProviderResult<Self> {
+        todo!()
+    }
+}
+
+impl<Provider> TrieCursorFactory for OverlayStateProvider<Provider>
+where
+    Provider: DBProvider,
+    InMemoryTrieCursorFactory<DatabaseTrieCursorFactory<Arc<Provider::Tx>>, Arc<TrieUpdatesSorted>>:
+        TrieCursorFactory,
+{
+    type AccountTrieCursor = <InMemoryTrieCursorFactory<
+        DatabaseTrieCursorFactory<Arc<Provider::Tx>>,
+        Arc<TrieUpdatesSorted>,
+    > as TrieCursorFactory>::AccountTrieCursor;
+
+    type StorageTrieCursor = <InMemoryTrieCursorFactory<
+        DatabaseTrieCursorFactory<Arc<Provider::Tx>>,
+        Arc<TrieUpdatesSorted>,
+    > as TrieCursorFactory>::StorageTrieCursor;
+
+    fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor, DatabaseError> {
+        self.trie_cursor_factory.account_trie_cursor()
+    }
+
+    fn storage_trie_cursor(
+        &self,
+        hashed_address: B256,
+    ) -> Result<Self::StorageTrieCursor, DatabaseError> {
+        self.trie_cursor_factory.storage_trie_cursor(hashed_address)
+    }
+}
+
+impl<Provider> HashedCursorFactory for OverlayStateProvider<Provider>
+where
+    Provider: DBProvider,
+    HashedPostStateCursorFactory<
+        DatabaseHashedCursorFactory<Arc<Provider::Tx>>,
+        Arc<HashedPostStateSorted>,
+    >: HashedCursorFactory,
+{
+    type AccountCursor = <HashedPostStateCursorFactory<
+        DatabaseHashedCursorFactory<Arc<Provider::Tx>>,
+        Arc<HashedPostStateSorted>,
+    > as HashedCursorFactory>::AccountCursor;
+
+    type StorageCursor = <HashedPostStateCursorFactory<
+        DatabaseHashedCursorFactory<Arc<Provider::Tx>>,
+        Arc<HashedPostStateSorted>,
+    > as HashedCursorFactory>::StorageCursor;
+
+    fn hashed_account_cursor(&self) -> Result<Self::AccountCursor, DatabaseError> {
+        self.hashed_cursor_factory.hashed_account_cursor()
+    }
+
+    fn hashed_storage_cursor(
+        &self,
+        hashed_address: B256,
+    ) -> Result<Self::StorageCursor, DatabaseError> {
+        self.hashed_cursor_factory.hashed_storage_cursor(hashed_address)
+    }
+}

--- a/crates/storage/provider/src/providers/state/overlay.rs
+++ b/crates/storage/provider/src/providers/state/overlay.rs
@@ -1,6 +1,6 @@
-use alloy_primitives::{BlockNumber, B256};
+use alloy_primitives::B256;
+use reth_db_api::DatabaseError;
 use reth_storage_api::DBProvider;
-use reth_storage_errors::{ProviderResult, db::DatabaseError};
 use reth_trie::{
     hashed_cursor::{HashedCursorFactory, HashedPostStateCursorFactory},
     trie_cursor::{InMemoryTrieCursorFactory, TrieCursorFactory},
@@ -19,66 +19,52 @@ use std::sync::Arc;
 pub struct OverlayStateProvider<Provider: DBProvider> {
     /// The in-memory trie cursor factory that wraps the database cursor factory.
     trie_cursor_factory:
-        InMemoryTrieCursorFactory<DatabaseTrieCursorFactory<Arc<Provider::Tx>>, Arc<TrieUpdatesSorted>>,
+        InMemoryTrieCursorFactory<DatabaseTrieCursorFactory<Provider::Tx>, Arc<TrieUpdatesSorted>>,
     /// The hashed cursor factory that wraps the database cursor factory.
     hashed_cursor_factory: HashedPostStateCursorFactory<
-        DatabaseHashedCursorFactory<Arc<Provider::Tx>>,
+        DatabaseHashedCursorFactory<Provider::Tx>,
         Arc<HashedPostStateSorted>,
     >,
 }
 
 impl<Provider> OverlayStateProvider<Provider>
 where
-    Provider: DBProvider,
+    Provider: DBProvider + Clone,
 {
-    /// Create new overlay state provider.
+    /// Create new overlay state provider. The `Provider` must be cloneable, which generally means
+    /// it should be wrapped in an `Arc`.
     pub fn new(
         provider: Provider,
         trie_updates: Arc<TrieUpdatesSorted>,
         hashed_post_state: Arc<HashedPostStateSorted>,
     ) -> Self {
-        // Wrap the transaction in an Arc so it can be shared between both cursor factories
-        let tx = Arc::new(provider.into_tx());
-
         // Create the trie cursor factory
-        let db_trie_cursor_factory = DatabaseTrieCursorFactory::new(tx.clone());
+        let db_trie_cursor_factory = DatabaseTrieCursorFactory::new(provider.clone().into_tx());
         let trie_cursor_factory =
             InMemoryTrieCursorFactory::new(db_trie_cursor_factory, trie_updates);
 
         // Create the hashed cursor factory
-        let db_hashed_cursor_factory = DatabaseHashedCursorFactory::new(tx);
+        let db_hashed_cursor_factory = DatabaseHashedCursorFactory::new(provider.into_tx());
         let hashed_cursor_factory =
             HashedPostStateCursorFactory::new(db_hashed_cursor_factory, hashed_post_state);
 
         Self { trie_cursor_factory, hashed_cursor_factory }
     }
-
-    /// Create a new overlay state provider by first reverting hashed state and trie to the given
-    /// `block_number`, and then applying the provided `HashedPostStateSorted` and
-    /// `TrieUpdatesSorted` on top of those reverts.
-    pub fn with_reverts(
-        _provider: Provider,
-        _trie_updates: Arc<TrieUpdatesSorted>,
-        _hashed_post_state: Arc<HashedPostStateSorted>,
-        _block_number: BlockNumber,
-    ) -> ProviderResult<Self> {
-        todo!()
-    }
 }
 
 impl<Provider> TrieCursorFactory for OverlayStateProvider<Provider>
 where
-    Provider: DBProvider,
-    InMemoryTrieCursorFactory<DatabaseTrieCursorFactory<Arc<Provider::Tx>>, Arc<TrieUpdatesSorted>>:
+    Provider: DBProvider + Clone,
+    InMemoryTrieCursorFactory<DatabaseTrieCursorFactory<Provider::Tx>, Arc<TrieUpdatesSorted>>:
         TrieCursorFactory,
 {
     type AccountTrieCursor = <InMemoryTrieCursorFactory<
-        DatabaseTrieCursorFactory<Arc<Provider::Tx>>,
+        DatabaseTrieCursorFactory<Provider::Tx>,
         Arc<TrieUpdatesSorted>,
     > as TrieCursorFactory>::AccountTrieCursor;
 
     type StorageTrieCursor = <InMemoryTrieCursorFactory<
-        DatabaseTrieCursorFactory<Arc<Provider::Tx>>,
+        DatabaseTrieCursorFactory<Provider::Tx>,
         Arc<TrieUpdatesSorted>,
     > as TrieCursorFactory>::StorageTrieCursor;
 
@@ -96,19 +82,19 @@ where
 
 impl<Provider> HashedCursorFactory for OverlayStateProvider<Provider>
 where
-    Provider: DBProvider,
+    Provider: DBProvider + Clone,
     HashedPostStateCursorFactory<
-        DatabaseHashedCursorFactory<Arc<Provider::Tx>>,
+        DatabaseHashedCursorFactory<Provider::Tx>,
         Arc<HashedPostStateSorted>,
     >: HashedCursorFactory,
 {
     type AccountCursor = <HashedPostStateCursorFactory<
-        DatabaseHashedCursorFactory<Arc<Provider::Tx>>,
+        DatabaseHashedCursorFactory<Provider::Tx>,
         Arc<HashedPostStateSorted>,
     > as HashedCursorFactory>::AccountCursor;
 
     type StorageCursor = <HashedPostStateCursorFactory<
-        DatabaseHashedCursorFactory<Arc<Provider::Tx>>,
+        DatabaseHashedCursorFactory<Provider::Tx>,
         Arc<HashedPostStateSorted>,
     > as HashedCursorFactory>::StorageCursor;
 

--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -486,6 +486,12 @@ impl HashedPostStateSorted {
     }
 }
 
+impl AsRef<Self> for HashedPostStateSorted {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
 /// Sorted account state optimized for iterating during state trie calculation.
 #[derive(Clone, Eq, PartialEq, Default, Debug)]
 pub struct HashedAccountsSorted {

--- a/crates/trie/common/src/updates.rs
+++ b/crates/trie/common/src/updates.rs
@@ -449,6 +449,12 @@ impl TrieUpdatesSorted {
     }
 }
 
+impl AsRef<Self> for TrieUpdatesSorted {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
 /// Sorted storage trie updates reference used for serializing to file.
 #[derive(PartialEq, Eq, Clone, Default, Debug)]
 #[cfg_attr(any(test, feature = "serde"), derive(serde::Serialize))]

--- a/crates/trie/db/src/hashed_cursor.rs
+++ b/crates/trie/db/src/hashed_cursor.rs
@@ -10,22 +10,22 @@ use reth_trie::hashed_cursor::{HashedCursor, HashedCursorFactory, HashedStorageC
 
 /// A struct wrapping database transaction that implements [`HashedCursorFactory`].
 #[derive(Debug)]
-pub struct DatabaseHashedCursorFactory<'a, TX>(&'a TX);
+pub struct DatabaseHashedCursorFactory<T>(T);
 
-impl<TX> Clone for DatabaseHashedCursorFactory<'_, TX> {
+impl<T: Clone> Clone for DatabaseHashedCursorFactory<T> {
     fn clone(&self) -> Self {
-        Self(self.0)
+        Self(self.0.clone())
     }
 }
 
-impl<'a, TX> DatabaseHashedCursorFactory<'a, TX> {
+impl<T> DatabaseHashedCursorFactory<T> {
     /// Create new database hashed cursor factory.
-    pub const fn new(tx: &'a TX) -> Self {
+    pub const fn new(tx: T) -> Self {
         Self(tx)
     }
 }
 
-impl<TX: DbTx> HashedCursorFactory for DatabaseHashedCursorFactory<'_, TX> {
+impl<TX: DbTx> HashedCursorFactory for DatabaseHashedCursorFactory<&TX> {
     type AccountCursor = DatabaseHashedAccountCursor<<TX as DbTx>::Cursor<tables::HashedAccounts>>;
     type StorageCursor =
         DatabaseHashedStorageCursor<<TX as DbTx>::DupCursor<tables::HashedStorages>>;

--- a/crates/trie/db/src/hashed_cursor.rs
+++ b/crates/trie/db/src/hashed_cursor.rs
@@ -9,14 +9,8 @@ use reth_primitives_traits::Account;
 use reth_trie::hashed_cursor::{HashedCursor, HashedCursorFactory, HashedStorageCursor};
 
 /// A struct wrapping database transaction that implements [`HashedCursorFactory`].
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DatabaseHashedCursorFactory<T>(T);
-
-impl<T: Clone> Clone for DatabaseHashedCursorFactory<T> {
-    fn clone(&self) -> Self {
-        Self(self.0.clone())
-    }
-}
 
 impl<T> DatabaseHashedCursorFactory<T> {
     /// Create new database hashed cursor factory.

--- a/crates/trie/db/src/proof.rs
+++ b/crates/trie/db/src/proof.rs
@@ -32,7 +32,7 @@ pub trait DatabaseProof<'a, TX> {
 }
 
 impl<'a, TX: DbTx> DatabaseProof<'a, TX>
-    for Proof<DatabaseTrieCursorFactory<'a, TX>, DatabaseHashedCursorFactory<'a, TX>>
+    for Proof<DatabaseTrieCursorFactory<&'a TX>, DatabaseHashedCursorFactory<&'a TX>>
 {
     /// Create a new [Proof] instance from database transaction.
     fn from_tx(tx: &'a TX) -> Self {
@@ -104,7 +104,7 @@ pub trait DatabaseStorageProof<'a, TX> {
 }
 
 impl<'a, TX: DbTx> DatabaseStorageProof<'a, TX>
-    for StorageProof<DatabaseTrieCursorFactory<'a, TX>, DatabaseHashedCursorFactory<'a, TX>>
+    for StorageProof<DatabaseTrieCursorFactory<&'a TX>, DatabaseHashedCursorFactory<&'a TX>>
 {
     fn from_tx(tx: &'a TX, address: Address) -> Self {
         Self::new(DatabaseTrieCursorFactory::new(tx), DatabaseHashedCursorFactory::new(tx), address)

--- a/crates/trie/db/src/state.rs
+++ b/crates/trie/db/src/state.rs
@@ -136,7 +136,7 @@ pub trait DatabaseHashedPostState<TX>: Sized {
 }
 
 impl<'a, TX: DbTx> DatabaseStateRoot<'a, TX>
-    for StateRoot<DatabaseTrieCursorFactory<'a, TX>, DatabaseHashedCursorFactory<'a, TX>>
+    for StateRoot<DatabaseTrieCursorFactory<&'a TX>, DatabaseHashedCursorFactory<&'a TX>>
 {
     fn from_tx(tx: &'a TX) -> Self {
         Self::new(DatabaseTrieCursorFactory::new(tx), DatabaseHashedCursorFactory::new(tx))

--- a/crates/trie/db/src/storage.rs
+++ b/crates/trie/db/src/storage.rs
@@ -35,7 +35,7 @@ pub trait DatabaseHashedStorage<TX>: Sized {
 }
 
 impl<'a, TX: DbTx> DatabaseStorageRoot<'a, TX>
-    for StorageRoot<DatabaseTrieCursorFactory<'a, TX>, DatabaseHashedCursorFactory<'a, TX>>
+    for StorageRoot<DatabaseTrieCursorFactory<&'a TX>, DatabaseHashedCursorFactory<&'a TX>>
 {
     fn from_tx(tx: &'a TX, address: Address) -> Self {
         Self::new(

--- a/crates/trie/db/src/trie_cursor.rs
+++ b/crates/trie/db/src/trie_cursor.rs
@@ -28,8 +28,6 @@ impl<T> DatabaseTrieCursorFactory<T> {
     }
 }
 
-/// Implementation for DatabaseTrieCursorFactory holding a reference to a DbTx.
-/// The factory uses AsRef internally to access the transaction.
 impl<TX> TrieCursorFactory for DatabaseTrieCursorFactory<&TX>
 where
     TX: DbTx,

--- a/crates/trie/db/src/trie_cursor.rs
+++ b/crates/trie/db/src/trie_cursor.rs
@@ -13,23 +13,27 @@ use reth_trie::{
 
 /// Wrapper struct for database transaction implementing trie cursor factory trait.
 #[derive(Debug)]
-pub struct DatabaseTrieCursorFactory<'a, TX>(&'a TX);
+pub struct DatabaseTrieCursorFactory<T>(T);
 
-impl<TX> Clone for DatabaseTrieCursorFactory<'_, TX> {
+impl<T: Clone> Clone for DatabaseTrieCursorFactory<T> {
     fn clone(&self) -> Self {
-        Self(self.0)
+        Self(self.0.clone())
     }
 }
 
-impl<'a, TX> DatabaseTrieCursorFactory<'a, TX> {
+impl<T> DatabaseTrieCursorFactory<T> {
     /// Create new [`DatabaseTrieCursorFactory`].
-    pub const fn new(tx: &'a TX) -> Self {
+    pub const fn new(tx: T) -> Self {
         Self(tx)
     }
 }
 
-/// Implementation of the trie cursor factory for a database transaction.
-impl<TX: DbTx> TrieCursorFactory for DatabaseTrieCursorFactory<'_, TX> {
+/// Implementation for DatabaseTrieCursorFactory holding a reference to a DbTx.
+/// The factory uses AsRef internally to access the transaction.
+impl<TX> TrieCursorFactory for DatabaseTrieCursorFactory<&TX>
+where
+    TX: DbTx,
+{
     type AccountTrieCursor = DatabaseAccountTrieCursor<<TX as DbTx>::Cursor<tables::AccountsTrie>>;
     type StorageTrieCursor =
         DatabaseStorageTrieCursor<<TX as DbTx>::DupCursor<tables::StoragesTrie>>;

--- a/crates/trie/db/src/trie_cursor.rs
+++ b/crates/trie/db/src/trie_cursor.rs
@@ -12,14 +12,8 @@ use reth_trie::{
 };
 
 /// Wrapper struct for database transaction implementing trie cursor factory trait.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DatabaseTrieCursorFactory<T>(T);
-
-impl<T: Clone> Clone for DatabaseTrieCursorFactory<T> {
-    fn clone(&self) -> Self {
-        Self(self.0.clone())
-    }
-}
 
 impl<T> DatabaseTrieCursorFactory<T> {
     /// Create new [`DatabaseTrieCursorFactory`].

--- a/crates/trie/db/src/witness.rs
+++ b/crates/trie/db/src/witness.rs
@@ -21,7 +21,7 @@ pub trait DatabaseTrieWitness<'a, TX> {
 }
 
 impl<'a, TX: DbTx> DatabaseTrieWitness<'a, TX>
-    for TrieWitness<DatabaseTrieCursorFactory<'a, TX>, DatabaseHashedCursorFactory<'a, TX>>
+    for TrieWitness<DatabaseTrieCursorFactory<&'a TX>, DatabaseHashedCursorFactory<&'a TX>>
 {
     fn from_tx(tx: &'a TX) -> Self {
         Self::new(DatabaseTrieCursorFactory::new(tx), DatabaseHashedCursorFactory::new(tx))

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -243,8 +243,8 @@ where
     fn create_factories(
         &self,
     ) -> (
-        InMemoryTrieCursorFactory<'_, DatabaseTrieCursorFactory<'_, Tx>>,
-        HashedPostStateCursorFactory<'_, DatabaseHashedCursorFactory<'_, Tx>>,
+        InMemoryTrieCursorFactory<DatabaseTrieCursorFactory<&Tx>, &Arc<TrieUpdatesSorted>>,
+        HashedPostStateCursorFactory<DatabaseHashedCursorFactory<&Tx>, &Arc<HashedPostStateSorted>>,
     ) {
         let trie_cursor_factory = InMemoryTrieCursorFactory::new(
             DatabaseTrieCursorFactory::new(&self.tx),


### PR DESCRIPTION
This works towards #18466, though there's still a couple features needed.

The goal of the OverlayStateProvider is to automatically overlay HashedPostState and TrieUpdates onto any DB accesses which are being performed without the code using the provider needing to be aware of it.

The OverlayStateProvider is conceptually similar to the HistoricalStateProvider, except that:
* It can accept arbitrary overlay data in its constructor.
* It implements Hashed/TrieCursorFactory traits, making it useful for the MultiProofTask.

To make this possible I modified the signatures of the in-memory cursor factories for both Hashed and Trie tables to use AsRefs rather than just pointers. I also had to refactor the database cursor factories signatures wrt to references lifetimes. This gives us more flexibility in how we pass the overlay data into them while dealing with rust's ownership rules; I could not figure out any other way to do it.

The next PR will introduce OverlayStateProviderFactory and implement the `from_reverts` method on it. Combined together the factory can act essentially like the ConsistentDbView for proofs, except it will actually handle changes to persistence state gracefully rather than erroring.