### PR TITLE
perf: optimize account cache updates to reduce duplicate lookups

### DIFF
--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -329,12 +329,7 @@ impl ExecutionCache {
         key: StorageKey,
         value: Option<StorageValue>,
     ) {
-        let account_cache = self.storage_cache.get(&address).unwrap_or_else(|| {
-            let account_cache = AccountStorageCache::default();
-            self.storage_cache.insert(address, account_cache.clone());
-            account_cache
-        });
-        account_cache.insert_storage(key, value);
+        self.insert_storage_bulk(address, [(key, value)]);
     }
 
     /// Insert multiple storage values into hierarchical cache for a single account


### PR DESCRIPTION
Optimize account cache updates by introducing bulk storage insertion to eliminate redundant cache lookups

## Changes:
- Added `insert_storage_bulk()` method that performs single cache lookup per account
- Modified `insert_state()` to use bulk insertion instead of individual calls per storage slot
- Reduced cache lookups from O(n) to O(1) for accounts with multiple storage slots

## Impact:
- No breaking changes to existing API
- Resolves inefficiency identified in issue #18818