### PR TITLE
refactor(trie): simplify ProofTaskManager with crossbeam select! and …

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10743,6 +10743,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "codspeed-criterion-compat",
+ "crossbeam-channel",
  "derive_more",
  "itertools 0.14.0",
  "metrics",

--- a/crates/trie/parallel/Cargo.toml
+++ b/crates/trie/parallel/Cargo.toml
@@ -35,6 +35,7 @@ derive_more.workspace = true
 rayon.workspace = true
 itertools.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"] }
+crossbeam-channel.workspace = true
 
 # `metrics` feature
 reth-metrics = { workspace = true, optional = true }


### PR DESCRIPTION
…guard conditions

Replace VecDeque-based manual queuing with crossbeam's select! macro using guard conditions for natural backpressure. This eliminates dual-queue management where tasks were queued in both a VecDeque and the channel, simplifying the manager loop to a pure event-driven architecture.

Key improvements:
- Remove VecDeque from ProofTaskManager - channel serves as the natural queue
- Split channels: task_rx for incoming tasks, tx_return_rx for returned transactions
- Guard condition on task reception: only receive when has_available_tx() is true
- Remove queue_proof_task, try_spawn_next - logic absorbed into select! loop
- Remove ProofTaskMessage wrapper enum - direct channel communication
- Add backpressure test: 100 tasks with max_concurrency=2

The guard condition implements backpressure by blocking task reception when all transaction slots are in use, allowing the channel to naturally queue pending work. This prepares for thread pool integration (#18735) where select! will coordinate multiple worker channels.

Related: #18735