### PR TITLE
feat(flashblocks): relax Sync bounds on Sink and connect futures

### DIFF
--- a/crates/optimism/flashblocks/src/ws/stream.rs
+++ b/crates/optimism/flashblocks/src/ws/stream.rs
@@ -72,8 +72,8 @@ impl<Stream, S, C> WsFlashBlockStream<Stream, S, C> {
 impl<Str, S, C> Stream for WsFlashBlockStream<Str, S, C>
 where
     Str: Stream<Item = Result<Message, Error>> + Unpin,
-    S: Sink<Message> + Send + Sync + Unpin,
-    C: WsConnect<Stream = Str, Sink = S> + Clone + Send + Sync + 'static + Unpin,
+    S: Sink<Message> + Send + Unpin,
+    C: WsConnect<Stream = Str, Sink = S> + Clone + Send + 'static + Unpin,
 {
     type Item = eyre::Result<FlashBlock>;
 
@@ -136,7 +136,7 @@ where
 
 impl<Stream, S, C> WsFlashBlockStream<Stream, S, C>
 where
-    C: WsConnect<Stream = Stream, Sink = S> + Clone + Send + Sync + 'static,
+    C: WsConnect<Stream = Stream, Sink = S> + Clone + Send + 'static,
 {
     fn connect(&mut self) {
         let ws_url = self.ws_url.clone();
@@ -191,7 +191,7 @@ type Ws = WebSocketStream<MaybeTlsStream<TcpStream>>;
 type WsStream = SplitStream<Ws>;
 type WsSink = SplitSink<Ws, Message>;
 type ConnectFuture<Sink, Stream> =
-    Pin<Box<dyn Future<Output = eyre::Result<(Sink, Stream)>> + Send + Sync + 'static>>;
+    Pin<Box<dyn Future<Output = eyre::Result<(Sink, Stream)>> + Send + 'static>>;
 
 /// The `WsConnect` trait allows for connecting to a websocket.
 ///
@@ -215,7 +215,7 @@ pub trait WsConnect {
     fn connect(
         &mut self,
         ws_url: Url,
-    ) -> impl Future<Output = eyre::Result<(Self::Sink, Self::Stream)>> + Send + Sync;
+    ) -> impl Future<Output = eyre::Result<(Self::Sink, Self::Stream)>> + Send;
 }
 
 /// Establishes a secure websocket subscription.
@@ -374,7 +374,7 @@ mod tests {
         fn connect(
             &mut self,
             _ws_url: Url,
-        ) -> impl Future<Output = eyre::Result<(Self::Sink, Self::Stream)>> + Send + Sync {
+        ) -> impl Future<Output = eyre::Result<(Self::Sink, Self::Stream)>> + Send {
             future::ready(Ok((NoopSink, self.0.clone())))
         }
     }
@@ -392,7 +392,7 @@ mod tests {
         fn connect(
             &mut self,
             _ws_url: Url,
-        ) -> impl Future<Output = eyre::Result<(Self::Sink, Self::Stream)>> + Send + Sync {
+        ) -> impl Future<Output = eyre::Result<(Self::Sink, Self::Stream)>> + Send {
             future::ready(Ok((FakeSink::default(), self.0.clone())))
         }
     }
@@ -414,7 +414,7 @@ mod tests {
         fn connect(
             &mut self,
             _ws_url: Url,
-        ) -> impl Future<Output = eyre::Result<(Self::Sink, Self::Stream)>> + Send + Sync {
+        ) -> impl Future<Output = eyre::Result<(Self::Sink, Self::Stream)>> + Send {
             future::ready(Err(eyre::eyre!("{}", &self.0)))
         }
     }


### PR DESCRIPTION
Removed +Sync from S: Sink<Message> and C bounds in Stream impl, from the inherent impl bound for connect, from ConnectFuture type alias, and from WsConnect::connect return type. Updated test connector implementations accordingly.

Reason: WsFlashBlockStream and FlashBlockService drive the stream within a single spawned task and do not share sink/stream/futures across threads. Requiring Sync is unnecessary and restricts compatibility because many Future/Sink types are Send but intentionally not Sync. Relaxing to Send preserves safety and broadens compatibility without changing behavior.