### PR TITLE
examples: add show_chain_id example to print Ethereum Mainnet chain ID

### DIFF
--- a/examples/show_chain_id.rs
+++ b/examples/show_chain_id.rs
@@ -1,0 +1,6 @@
+use reth_primitives::ChainSpec;
+
+fn main() {
+    let chain = ChainSpec::mainnet();
+    println!("Ethereum Mainnet Chain ID: {}", chain.chain().id());
+}


### PR DESCRIPTION
This PR adds a new example under the `examples/` directory:

- **File**: examples/show_chain_id.rs
- **Purpose**: Demonstrates how to use `reth_primitives::ChainSpec` to access the Ethereum Mainnet chain ID.
- **Usage**:
  ```bash
  cargo run --example show_chain_id
