### PR TITLE
chore: correct deprecated note message

### DIFF
--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -17,7 +17,7 @@ pub type BlockBody<T = TransactionSigned, H = Header> = alloy_consensus::BlockBo
 pub type SealedBlock<B = Block> = reth_primitives_traits::block::SealedBlock<B>;
 
 /// Helper type for constructing the block
-#[deprecated(note = "Use `RecoveredBlock` instead")]
+#[deprecated(note = "Use `SealedBlock` instead")]
 pub type SealedBlockFor<B = Block> = reth_primitives_traits::block::SealedBlock<B>;
 
 /// Ethereum recovered block


### PR DESCRIPTION
I notice that there might be minor mismatch due to copy-paste of '#[deprecated(note = "Use `RecoveredBlock` instead")]' , which the first one should be '#[deprecated(note = "Use `SealedBlock` instead")]' , 

because we are setting type SealedBlockFor<B = Block> to alias reth_primitives_traits::block::SealedBlock<B> instead of reth_primitives_traits::block::RecoveredBlock<B>