### PR TITLE
fix(sim): clamp bundle timeout to max instead of falling back to default

### DIFF
--- a/crates/rpc/rpc/src/eth/sim_bundle.rs
+++ b/crates/rpc/rpc/src/eth/sim_bundle.rs
@@ -422,7 +422,6 @@ where
 
         let override_timeout = overrides.timeout;
 
-        // Clamp user-provided timeout to MAX_SIM_TIMEOUT instead of falling back to default.
         let timeout = override_timeout
             .map(Duration::from_secs)
             .map(|d| d.min(MAX_SIM_TIMEOUT))

--- a/crates/rpc/rpc/src/eth/sim_bundle.rs
+++ b/crates/rpc/rpc/src/eth/sim_bundle.rs
@@ -422,9 +422,10 @@ where
 
         let override_timeout = overrides.timeout;
 
+        // Clamp user-provided timeout to MAX_SIM_TIMEOUT instead of falling back to default.
         let timeout = override_timeout
             .map(Duration::from_secs)
-            .filter(|&custom_duration| custom_duration <= MAX_SIM_TIMEOUT)
+            .map(|d| d.min(MAX_SIM_TIMEOUT))
             .unwrap_or(DEFAULT_SIM_TIMEOUT);
 
         let bundle_res =


### PR DESCRIPTION


**Problem**
When users specify a `timeout` value greater than `MAX_SIM_TIMEOUT` in bundle simulation, the current logic silently falls back to `DEFAULT_SIM_TIMEOUT` instead of clamping to the maximum allowed value. This leads to unexpected behavior where large timeout values result in shorter-than-expected timeouts.

**Solution**
Replace the `filter()` + `unwrap_or()` pattern with explicit `min()` clamping to ensure predictable timeout behavior.

