### PR TITLE
refactor(storage): remove redundant clone in blockchain provider tests

### DIFF
--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -892,9 +892,11 @@ mod tests {
                 .iter()
                 .map(|block| {
                     let senders = block.senders().expect("failed to recover senders");
-                    let block_receipts = receipts.get(block.number as usize).unwrap().clone();
-                    let execution_outcome =
-                        ExecutionOutcome { receipts: vec![block_receipts], ..Default::default() };
+                    let block_receipts = receipts.get(block.number as usize).unwrap();
+                    let execution_outcome = ExecutionOutcome {
+                        receipts: vec![block_receipts.clone()],
+                        ..Default::default()
+                    };
 
                     ExecutedBlockWithTrieUpdates::new(
                         Arc::new(RecoveredBlock::new_sealed(block.clone(), senders)),


### PR DESCRIPTION
Removed unnecessary clone() call in test helper function. Instead of cloning the receipts early and then moving, just clone when actually needed in the vec! macro.