### PR TITLE
chore: relax trait bounds for EmptyBodyStorage in storage API

### DIFF
--- a/crates/storage/storage-api/src/chain.rs
+++ b/crates/storage/storage-api/src/chain.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 use alloy_consensus::Header;
 use alloy_primitives::BlockNumber;
 use core::marker::PhantomData;
-use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
+use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
 use reth_db_api::{
     cursor::{DbCursorRO, DbCursorRW},
     models::StoredBlockOmmers,
@@ -206,7 +206,6 @@ impl<T, H> Default for EmptyBodyStorage<T, H> {
 impl<Provider, T, H> BlockBodyWriter<Provider, alloy_consensus::BlockBody<T, H>>
     for EmptyBodyStorage<T, H>
 where
-    Provider: DBProvider<Tx: DbTxMut>,
     T: SignedTransaction,
     H: FullBlockHeader,
 {
@@ -231,7 +230,7 @@ where
 
 impl<Provider, T, H> BlockBodyReader<Provider> for EmptyBodyStorage<T, H>
 where
-    Provider: ChainSpecProvider<ChainSpec: EthChainSpec + EthereumHardforks> + DBProvider,
+    Provider: ChainSpecProvider<ChainSpec: EthereumHardforks>,
     T: SignedTransaction,
     H: FullBlockHeader,
 {


### PR DESCRIPTION
- Remove unnecessary DBProvider bounds from EmptyBodyStorage’s BlockBodyReader and BlockBodyWriter.
- Drop EthChainSpec bound from EmptyBodyStorage’s BlockBodyReader; only EthereumHardforks is needed.
- Clean up unused EthChainSpec import.

EmptyBodyStorage is a noop storage: its reader does not access the database and only checks Shanghai activation via EthereumHardforks; its writer is a no-op and does not need a DB transaction.