### PR TITLE
feat(rpc): support custom transaction error types in EthApiError

### DIFF
--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -450,18 +450,32 @@ impl From<InvalidHeader> for EthApiError {
     }
 }
 
-impl<T> From<EVMError<T, InvalidTransaction>> for EthApiError
+impl<T, TxError> From<EVMError<T, TxError>> for EthApiError
 where
     T: Into<Self>,
+    TxError: reth_evm::InvalidTxError,
 {
-    fn from(err: EVMError<T, InvalidTransaction>) -> Self {
+    fn from(err: EVMError<T, TxError>) -> Self {
         match err {
-            EVMError::Transaction(invalid_tx) => match invalid_tx {
-                InvalidTransaction::NonceTooLow { tx, state } => {
-                    Self::InvalidTransaction(RpcInvalidTransactionError::NonceTooLow { tx, state })
+            EVMError::Transaction(invalid_tx) => {
+                // Try to get the underlying InvalidTransaction if available
+                if let Some(eth_tx_err) = invalid_tx.as_invalid_tx_err() {
+                    // Handle the special NonceTooLow case
+                    match eth_tx_err {
+                        InvalidTransaction::NonceTooLow { tx, state } => {
+                            Self::InvalidTransaction(RpcInvalidTransactionError::NonceTooLow {
+                                tx: *tx,
+                                state: *state,
+                            })
+                        }
+                        _ => RpcInvalidTransactionError::from(eth_tx_err.clone()).into(),
+                    }
+                } else {
+                    // For custom transaction errors that don't wrap InvalidTransaction,
+                    // convert to a custom error message
+                    Self::EvmCustom(invalid_tx.to_string())
                 }
-                _ => RpcInvalidTransactionError::from(invalid_tx).into(),
-            },
+            }
             EVMError::Header(err) => err.into(),
             EVMError::Database(err) => err.into(),
             EVMError::Custom(err) => Self::EvmCustom(err),


### PR DESCRIPTION
Makes the `From<EVMError>` implementation for `EthApiError` support any transaction error type implementing `InvalidTxError`, instead of hardcoding `InvalidTransaction`.

This allows downstream projects to define their own transaction validation errors while still being compatible with reth's RPC error handling.

- generalized `From<EVMError<T, InvalidTransaction>>` to `From<EVMError<T, TxError: InvalidTxError>>`
- uses `TxError::as_invalid_tx_err()` to extract standard errors when available
- falls back to custom error messages for non-standard error variants
