### PR TITLE
chore(cli): remove unnecessary ProviderFactory clone in db_ro_exec!

### DIFF
--- a/crates/cli/commands/src/db/mod.rs
+++ b/crates/cli/commands/src/db/mod.rs
@@ -62,7 +62,7 @@ macro_rules! db_ro_exec {
     ($env:expr, $tool:ident, $N:ident, $command:block) => {
         let Environment { provider_factory, .. } = $env.init::<$N>(AccessRights::RO)?;
 
-        let $tool = DbTool::new(provider_factory.clone())?;
+        let $tool = DbTool::new(provider_factory)?;
         $command;
     };
 }


### PR DESCRIPTION
Removed the redundant clone when constructing DbTool in the db_ro_exec! macro. DbTool::new takes ProviderFactory by value and does not require retaining the original variable. Other call sites already pass the factory by move, so cloning here was inconsistent and caused unnecessary Arc clones. This change aligns usage across the codebase and avoids minor overhead without changing behavior.