### PR TITLE
fix(network): prevent metric leak in outgoing message queue on session teardown

### DIFF
--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -924,6 +924,16 @@ impl<N: NetworkPrimitives> QueuedOutgoingMessages<N> {
     }
 }
 
+impl<N: NetworkPrimitives> Drop for QueuedOutgoingMessages<N> {
+    fn drop(&mut self) {
+        // Ensure gauge is decremented for any remaining items to avoid metric leak on teardown.
+        let remaining = self.messages.len();
+        if remaining > 0 {
+            self.count.decrement(remaining as f64);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION

## Summary

Fixes a metric leak in `QueuedOutgoingMessages` where the `Gauge` counter could become permanently inflated when sessions terminate with messages still queued.

## Problem

The `Gauge` metric was only decremented on explicit `pop_front()` calls, but never when the queue was destroyed. If a session terminated with pending messages in the queue, the metric would remain artificially high indefinitely, causing:

- Inaccurate monitoring data
- Potential false alerts
- Difficulty in diagnosing queue health

## Solution

Added a `Drop` implementation for `QueuedOutgoingMessages` that decrements the gauge by the number of remaining messages when the struct is destroyed.

