### PR TITLE
fix: replace allow(unused_imports) with expect(unused_imports) in fuzz module

### DIFF
--- a/crates/storage/db-api/src/tables/codecs/fuzz/mod.rs
+++ b/crates/storage/db-api/src/tables/codecs/fuzz/mod.rs
@@ -19,7 +19,12 @@ macro_rules! impl_fuzzer_with_input {
                 #[expect(unused_imports)]
                 use reth_primitives_traits::*;
 
-                #[expect(unused_imports)]
+                // Use input types via explicit path to avoid blanket imports
+                // NOTE: We keep a blanket import from `inputs` guarded with `allow(unused_imports)`
+                // because macro instantiations vary: sometimes `$input_type` originates from
+                // `super::inputs`, other times it does not. Using `expect(unused_imports)` here can
+                // cause `unfulfilled-lint-expectations` when the import becomes used in CI.
+                #[allow(unused_imports)]
                 use super::inputs::*;
 
                 use crate::models::*;

--- a/crates/storage/db-api/src/tables/codecs/fuzz/mod.rs
+++ b/crates/storage/db-api/src/tables/codecs/fuzz/mod.rs
@@ -19,7 +19,7 @@ macro_rules! impl_fuzzer_with_input {
                 #[expect(unused_imports)]
                 use reth_primitives_traits::*;
 
-                #[allow(unused_imports)]
+                #[expect(unused_imports)]
                 use super::inputs::*;
 
                 use crate::models::*;


### PR DESCRIPTION
Align lint handling by replacing unconditional `allow` with `expect` for unused imports in the fuzz module. `expect(unused_imports)` preserves useful warnings while documenting intent, improving signal-to-noise and consistency with adjacent imports.
