### PR TITLE
docs: remove outdated TODO comment in network documentation

### DIFF
--- a/docs/crates/network.md
+++ b/docs/crates/network.md
@@ -93,7 +93,6 @@ where
         NetworkManager::builder(config).await?.request_handler(client).split_with_handle();
 
     tokio::task::spawn(network);
-    // TODO: tokio::task::spawn(txpool);
     tokio::task::spawn(eth);
     Ok(handle)
 }


### PR DESCRIPTION
Remove outdated TODO comment for txpool spawning in network documentation.

The txpool variable is already prefixed with underscore (_txpool), indicating it's intentionally unused in this simplified example. The actual txpool integration happens through the builder pattern elsewhere in the codebase