### PR TITLE
chore(trie): Implement OverlayStateProviderFactory

### DIFF
--- a/crates/storage/errors/src/provider.rs
+++ b/crates/storage/errors/src/provider.rs
@@ -137,6 +137,14 @@ pub enum ProviderError {
     /// Missing trie updates.
     #[error("missing trie updates for block {0}")]
     MissingTrieUpdates(B256),
+    /// Insufficient changesets to revert to the requested block.
+    #[error("insufficient changesets to revert to block #{requested}. Available changeset range: {available:?}")]
+    InsufficientChangesets {
+        /// The block number requested for reversion
+        requested: BlockNumber,
+        /// The available range of blocks with changesets
+        available: core::ops::RangeInclusive<BlockNumber>,
+    },
     /// Any other error type wrapped into a cloneable [`AnyError`].
     #[error(transparent)]
     Other(#[from] AnyError),

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -2487,10 +2487,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> TrieReader for DatabaseProvider
         let storage_tries = storage_tries
             .into_iter()
             .map(|(address, nodes)| {
-                (address, StorageTrieUpdatesSorted {
-                    storage_nodes: nodes,
-                    is_deleted: false,
-                })
+                (address, StorageTrieUpdatesSorted { storage_nodes: nodes, is_deleted: false })
             })
             .collect();
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -2447,7 +2447,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> TrieWriter for DatabaseProvider
 }
 
 impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> TrieReader for DatabaseProvider<TX, N> {
-    fn revert_trie(&self, from: BlockNumber) -> ProviderResult<TrieUpdatesSorted> {
+    fn trie_reverts(&self, from: BlockNumber) -> ProviderResult<TrieUpdatesSorted> {
         let tx = self.tx_ref();
 
         // Read account trie changes directly into a Vec - data is already sorted by nibbles

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -17,7 +17,7 @@ mod state;
 pub use state::{
     historical::{HistoricalStateProvider, HistoricalStateProviderRef, LowestAvailableBlocks},
     latest::{LatestStateProvider, LatestStateProviderRef},
-    overlay::OverlayStateProvider,
+    overlay::{OverlayStateProvider, OverlayStateProviderFactory},
 };
 
 mod consistent_view;

--- a/crates/storage/provider/src/providers/state/overlay.rs
+++ b/crates/storage/provider/src/providers/state/overlay.rs
@@ -1,14 +1,107 @@
-use alloy_primitives::B256;
+use alloy_primitives::{BlockNumber, B256};
 use reth_db_api::DatabaseError;
-use reth_storage_api::DBProvider;
+use reth_storage_api::{DBProvider, DatabaseProviderFactory, TrieReader};
 use reth_trie::{
     hashed_cursor::{HashedCursorFactory, HashedPostStateCursorFactory},
     trie_cursor::{InMemoryTrieCursorFactory, TrieCursorFactory},
     updates::TrieUpdatesSorted,
-    HashedPostStateSorted,
+    HashedPostState, HashedPostStateSorted, KeccakKeyHasher,
 };
-use reth_trie_db::{DatabaseHashedCursorFactory, DatabaseTrieCursorFactory};
+use reth_trie_db::{
+    DatabaseHashedCursorFactory, DatabaseHashedPostState, DatabaseTrieCursorFactory,
+};
 use std::sync::Arc;
+
+/// Factory for creating overlay state providers with optional reverts and overlays.
+///
+/// This factory allows building an `OverlayStateProvider` whose DB state has been reverted to a
+/// particular block, and/or with additional overlay information added on top.
+#[derive(Debug, Clone)]
+pub struct OverlayStateProviderFactory<F> {
+    /// The underlying database provider factory
+    factory: F,
+    /// Optional block number for collecting reverts
+    block_number: Option<BlockNumber>,
+    /// Optional trie overlay
+    trie_overlay: Option<Arc<TrieUpdatesSorted>>,
+    /// Optional hashed state overlay
+    hashed_state_overlay: Option<Arc<HashedPostStateSorted>>,
+}
+
+impl<F> OverlayStateProviderFactory<F>
+where
+    F: DatabaseProviderFactory,
+    F::Provider: Clone + TrieReader,
+{
+    /// Create a new overlay state provider factory
+    pub fn new(factory: F) -> Self {
+        Self { factory, block_number: None, trie_overlay: None, hashed_state_overlay: None }
+    }
+
+    /// Set the block number for collecting reverts
+    pub fn with_block_number(mut self, block_number: Option<BlockNumber>) -> Self {
+        self.block_number = block_number;
+        self
+    }
+
+    /// Set the trie overlay
+    pub fn with_trie_overlay(mut self, trie_overlay: Option<Arc<TrieUpdatesSorted>>) -> Self {
+        self.trie_overlay = trie_overlay;
+        self
+    }
+
+    /// Set the hashed state overlay
+    pub fn with_hashed_state_overlay(
+        mut self,
+        hashed_state_overlay: Option<Arc<HashedPostStateSorted>>,
+    ) -> Self {
+        self.hashed_state_overlay = hashed_state_overlay;
+        self
+    }
+
+    /// Create the overlay state provider
+    pub fn provider(self) -> Result<OverlayStateProvider<F::Provider>, DatabaseError> {
+        // Get a read-only provider
+        let provider = self
+            .factory
+            .database_provider_ro()
+            .map_err(|_| DatabaseError::Other("Failed to get database provider".into()))?;
+
+        let trie_updates: Arc<TrieUpdatesSorted>;
+        let hashed_state: Arc<HashedPostStateSorted>;
+
+        // If block_number is provided, collect reverts
+        if let Some(from_block) = self.block_number {
+            // Collect trie reverts
+            let mut trie_updates_mut = provider
+                .revert_trie(from_block)
+                .map_err(|e| DatabaseError::Other(format!("Failed to revert trie: {}", e)))?;
+
+            // Collect state reverts using HashedPostState::from_reverts
+            let reverted_state =
+                HashedPostState::from_reverts::<KeccakKeyHasher>(provider.tx_ref(), from_block..)?;
+            let mut hashed_state_mut = reverted_state.into_sorted();
+
+            // Extend with overlays if provided
+            if let Some(trie_overlay) = &self.trie_overlay {
+                trie_updates_mut.extend_ref(trie_overlay);
+            }
+
+            if let Some(hashed_state_overlay) = &self.hashed_state_overlay {
+                hashed_state_mut.extend_ref(hashed_state_overlay);
+            }
+
+            trie_updates = Arc::new(trie_updates_mut);
+            hashed_state = Arc::new(hashed_state_mut);
+        } else {
+            // If no block_number, use overlays directly or defaults
+            trie_updates = self.trie_overlay.unwrap_or_default();
+            hashed_state = self.hashed_state_overlay.unwrap_or_default();
+        }
+
+        Ok(OverlayStateProvider::new(provider, trie_updates, hashed_state))
+    }
+}
 
 /// State provider with in-memory overlay from trie updates and hashed post state.
 ///

--- a/crates/storage/provider/src/providers/state/overlay.rs
+++ b/crates/storage/provider/src/providers/state/overlay.rs
@@ -59,8 +59,8 @@ where
         self
     }
 
-    /// Create the overlay state provider
-    pub fn provider(self) -> Result<OverlayStateProvider<F::Provider>, DatabaseError> {
+    /// Create a read-only [`OverlayStateProvider`].
+    pub fn provider_ro(&self) -> Result<OverlayStateProvider<F::Provider>, DatabaseError> {
         // Get a read-only provider
         let provider = self
             .factory
@@ -95,8 +95,12 @@ where
             hashed_state = Arc::new(hashed_state_mut);
         } else {
             // If no block_number, use overlays directly or defaults
-            trie_updates = self.trie_overlay.unwrap_or_default();
-            hashed_state = self.hashed_state_overlay.unwrap_or_default();
+            trie_updates =
+                self.trie_overlay.clone().unwrap_or_else(|| Arc::new(TrieUpdatesSorted::default()));
+            hashed_state = self
+                .hashed_state_overlay
+                .clone()
+                .unwrap_or_else(|| Arc::new(HashedPostStateSorted::default()));
         }
 
         Ok(OverlayStateProvider::new(provider, trie_updates, hashed_state))

--- a/crates/storage/provider/src/providers/state/overlay.rs
+++ b/crates/storage/provider/src/providers/state/overlay.rs
@@ -36,12 +36,12 @@ where
     F::Provider: Clone + TrieReader + StageCheckpointReader,
 {
     /// Create a new overlay state provider factory
-    pub fn new(factory: F) -> Self {
+    pub const fn new(factory: F) -> Self {
         Self { factory, block_number: None, trie_overlay: None, hashed_state_overlay: None }
     }
 
     /// Set the block number for collecting reverts
-    pub fn with_block_number(mut self, block_number: Option<BlockNumber>) -> Self {
+    pub const fn with_block_number(mut self, block_number: Option<BlockNumber>) -> Self {
         self.block_number = block_number;
         self
     }

--- a/crates/storage/storage-api/src/trie.rs
+++ b/crates/storage/storage-api/src/trie.rs
@@ -89,6 +89,14 @@ pub trait StateProofProvider: Send + Sync {
     fn witness(&self, input: TrieInput, target: HashedPostState) -> ProviderResult<Vec<Bytes>>;
 }
 
+/// Trie Reader
+#[auto_impl::auto_impl(&, Arc, Box)]
+pub trait TrieReader: Send + Sync {
+    /// Returns the [`TrieUpdatesSorted`] for reverting the trie database to its state prior to the
+    /// given block having been processed.
+    fn revert_trie(&self, from: BlockNumber) -> ProviderResult<TrieUpdatesSorted>;
+}
+
 /// Trie Writer
 #[auto_impl::auto_impl(&, Arc, Box)]
 pub trait TrieWriter: Send + Sync {

--- a/crates/storage/storage-api/src/trie.rs
+++ b/crates/storage/storage-api/src/trie.rs
@@ -94,7 +94,7 @@ pub trait StateProofProvider: Send + Sync {
 pub trait TrieReader: Send + Sync {
     /// Returns the [`TrieUpdatesSorted`] for reverting the trie database to its state prior to the
     /// given block having been processed.
-    fn revert_trie(&self, from: BlockNumber) -> ProviderResult<TrieUpdatesSorted>;
+    fn trie_reverts(&self, from: BlockNumber) -> ProviderResult<TrieUpdatesSorted>;
 }
 
 /// Trie Writer

--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -694,6 +694,10 @@ impl Iterator for ChunkedHashedPostState {
 /// Helper function to extend a sorted vector with another sorted vector,
 /// taking into account removed items.
 /// Values from `other` take precedence for duplicate keys, and items in `removed` are excluded.
+///
+/// TODO(mediocregopher): Once https://github.com/paradigmxyz/reth/issues/18848 is completed this
+/// function will not be necessary, `extend_sorted_vec` in `updates.rs` can be used for both
+/// TrieUpdates and HashedPostState.
 fn extend_sorted_vec_with_removed<K, V, S>(
     target: &mut Vec<(K, V)>,
     other: &[(K, V)],

--- a/crates/trie/common/src/lib.rs
+++ b/crates/trie/common/src/lib.rs
@@ -57,6 +57,9 @@ pub mod updates;
 
 pub mod added_removed_keys;
 
+/// Utilities used by other modules in this crate.
+mod utils;
+
 /// Bincode-compatible serde implementations for trie types.
 ///
 /// `bincode` crate allows for more efficient serialization of trie types, because it allows

--- a/crates/trie/common/src/updates.rs
+++ b/crates/trie/common/src/updates.rs
@@ -877,7 +877,7 @@ pub mod serde_bincode_compat {
 }
 
 #[cfg(all(test, feature = "serde"))]
-mod tests {
+mod serde_tests {
     use super::*;
 
     #[test]

--- a/crates/trie/common/src/utils.rs
+++ b/crates/trie/common/src/utils.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 /// Helper function to extend a sorted vector with another sorted vector.
 /// Values from `other` take precedence for duplicate keys.
 ///

--- a/crates/trie/common/src/utils.rs
+++ b/crates/trie/common/src/utils.rs
@@ -1,0 +1,51 @@
+/// Helper function to extend a sorted vector with another sorted vector.
+/// Values from `other` take precedence for duplicate keys.
+///
+/// This function efficiently merges two sorted vectors by:
+/// 1. Iterating through the target vector with mutable references
+/// 2. Using a peekable iterator for the other vector
+/// 3. For each target item, processing other items that come before or equal to it
+/// 4. Collecting items from other that need to be inserted
+/// 5. Appending and re-sorting only if new items were added
+pub(crate) fn extend_sorted_vec<K, V>(target: &mut Vec<(K, V)>, other: &[(K, V)])
+where
+    K: Clone + Ord + core::hash::Hash + Eq,
+    V: Clone,
+{
+    if other.is_empty() {
+        return;
+    }
+
+    let mut other_iter = other.iter().peekable();
+    let mut to_insert = Vec::new();
+
+    // Iterate through target and update/collect items from other
+    for target_item in target.iter_mut() {
+        while let Some(other_item) = other_iter.peek() {
+            use core::cmp::Ordering;
+            match other_item.0.cmp(&target_item.0) {
+                Ordering::Less => {
+                    // Other item comes before current target item, collect it
+                    to_insert.push(other_iter.next().unwrap().clone());
+                }
+                Ordering::Equal => {
+                    // Same key, update target with other's value
+                    target_item.1 = other_iter.next().unwrap().1.clone();
+                    break;
+                }
+                Ordering::Greater => {
+                    // Other item comes after current target item, keep target unchanged
+                    break;
+                }
+            }
+        }
+    }
+
+    // Append collected new items, as well as any remaining from `other` which are necessarily also
+    // new, and sort if needed
+    if !to_insert.is_empty() || other_iter.peek().is_some() {
+        target.extend(to_insert);
+        target.extend(other_iter.cloned());
+        target.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+    }
+}


### PR DESCRIPTION
This implements the OverlayStateProviderFactory, which intends on replacing the ConsistentDbView for use with proof fetching.

When creating a new OverlayStateProvider, the OverlayStateProviderFactory can be configured to first revert that provider's state to a particular block number (similar to the HistoricalStateProvider) and then also apply some other overlay state on top of it. This gives us full flexibility in computing proofs on top of re-org chains, even if they are based on block prior to the db tip.

It uses a new method `trie_reverts` to fetch trie changesets, alongside HashedPostState reverts using the existing method for that. With these two it is able to revert to any previous block for every provider it generates, ensuring a consistent view of the data. In the future if we switch to using tx children then the factory can fetch the reverts as part of its own constructor, rather than on every new provider.

This PR required adding the ability to extend the HashedPostStateSorted and TrieUpdatesSorted types. This is implemented fairly efficiently by updating the collection in-place with updates/removals, and then appending additions onto the back and sorting.

Closes #18466 