### PR TITLE
docs(engine): fix outdated comment on TreeMetrics

### DIFF
--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -27,7 +27,7 @@ pub(crate) struct EngineApiMetrics {
     pub(crate) executor: ExecutorMetrics,
     /// Metrics for block validation
     pub(crate) block_validation: BlockValidationMetrics,
-    /// A copy of legacy blockchain tree metrics, to be replaced when we replace the old tree
+    /// Canonical chain and reorg related metrics
     pub tree: TreeMetrics,
 }
 


### PR DESCRIPTION
We still use / set these, so the comment is outdated