### PR TITLE
feat: make `ChainSpec` generic over header

### DIFF
--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -31,7 +31,7 @@ use reth_network_peers::{
     holesky_nodes, hoodi_nodes, mainnet_nodes, op_nodes, op_testnet_nodes, sepolia_nodes,
     NodeRecord,
 };
-use reth_primitives_traits::{sync::LazyLock, SealedHeader};
+use reth_primitives_traits::{sync::LazyLock, BlockHeader, SealedHeader};
 
 /// Helper method building a [`Header`] given [`Genesis`] and [`ChainHardforks`].
 pub fn make_genesis_header(genesis: &Genesis, hardforks: &ChainHardforks) -> Header {
@@ -282,7 +282,7 @@ impl core::ops::Deref for ChainSpec {
 /// - The genesis block of the chain ([`Genesis`])
 /// - What hardforks are activated, and under which conditions
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ChainSpec {
+pub struct ChainSpec<H: BlockHeader = Header> {
     /// The chain ID
     pub chain: Chain,
 
@@ -290,7 +290,7 @@ pub struct ChainSpec {
     pub genesis: Genesis,
 
     /// The header corresponding to the genesis block.
-    pub genesis_header: SealedHeader,
+    pub genesis_header: SealedHeader<H>,
 
     /// The block at which [`EthereumHardfork::Paris`] was activated and the final difficulty at
     /// this block.
@@ -312,7 +312,7 @@ pub struct ChainSpec {
     pub blob_params: BlobScheduleBlobParams,
 }
 
-impl Default for ChainSpec {
+impl<H: BlockHeader> Default for ChainSpec<H> {
     fn default() -> Self {
         Self {
             chain: Default::default(),
@@ -334,6 +334,13 @@ impl ChainSpec {
         genesis.into()
     }
 
+    /// Build a chainspec using [`ChainSpecBuilder`]
+    pub fn builder() -> ChainSpecBuilder {
+        ChainSpecBuilder::default()
+    }
+}
+
+impl<H: BlockHeader> ChainSpec<H> {
     /// Get information about the chain itself
     pub const fn chain(&self) -> Chain {
         self.chain
@@ -365,12 +372,12 @@ impl ChainSpec {
     }
 
     /// Get the header for the genesis block.
-    pub fn genesis_header(&self) -> &Header {
+    pub fn genesis_header(&self) -> &H {
         &self.genesis_header
     }
 
     /// Get the sealed header for the genesis block.
-    pub fn sealed_genesis_header(&self) -> SealedHeader {
+    pub fn sealed_genesis_header(&self) -> SealedHeader<H> {
         SealedHeader::new(self.genesis_header().clone(), self.genesis_hash())
     }
 
@@ -419,7 +426,7 @@ impl ChainSpec {
     }
 
     /// Get the fork filter for the given hardfork
-    pub fn hardfork_fork_filter<H: Hardfork + Clone>(&self, fork: H) -> Option<ForkFilter> {
+    pub fn hardfork_fork_filter<HF: Hardfork + Clone>(&self, fork: HF) -> Option<ForkFilter> {
         match self.hardforks.fork(fork.clone()) {
             ForkCondition::Never => None,
             _ => Some(self.fork_filter(self.satisfy(self.hardforks.fork(fork)))),
@@ -433,7 +440,7 @@ impl ChainSpec {
 
     /// Get the fork id for the given hardfork.
     #[inline]
-    pub fn hardfork_fork_id<H: Hardfork + Clone>(&self, fork: H) -> Option<ForkId> {
+    pub fn hardfork_fork_id<HF: Hardfork + Clone>(&self, fork: HF) -> Option<ForkId> {
         let condition = self.hardforks.fork(fork);
         match condition {
             ForkCondition::Never => None,
@@ -598,11 +605,6 @@ impl ChainSpec {
         None
     }
 
-    /// Build a chainspec using [`ChainSpecBuilder`]
-    pub fn builder() -> ChainSpecBuilder {
-        ChainSpecBuilder::default()
-    }
-
     /// Returns the known bootnode records for the given chain.
     pub fn bootnodes(&self) -> Option<Vec<NodeRecord>> {
         use NamedChain as C;
@@ -622,6 +624,32 @@ impl ChainSpec {
             chain if chain.is_optimism() && chain.is_testnet() => Some(op_testnet_nodes()),
             chain if chain.is_optimism() => Some(op_nodes()),
             _ => None,
+        }
+    }
+
+    /// Convert header to another type.
+    pub fn map_header<NewH: BlockHeader>(self, f: impl FnOnce(H) -> NewH) -> ChainSpec<NewH> {
+        let Self {
+            chain,
+            genesis,
+            genesis_header,
+            paris_block_and_final_difficulty,
+            hardforks,
+            deposit_contract,
+            base_fee_params,
+            prune_delete_limit,
+            blob_params,
+        } = self;
+        ChainSpec {
+            chain,
+            genesis,
+            genesis_header: SealedHeader::new_unhashed(f(genesis_header.into_header())),
+            paris_block_and_final_difficulty,
+            hardforks,
+            deposit_contract,
+            base_fee_params,
+            prune_delete_limit,
+            blob_params,
         }
     }
 }
@@ -736,8 +764,8 @@ impl From<Genesis> for ChainSpec {
     }
 }
 
-impl Hardforks for ChainSpec {
-    fn fork<H: Hardfork>(&self, fork: H) -> ForkCondition {
+impl<H: BlockHeader> Hardforks for ChainSpec<H> {
+    fn fork<HF: Hardfork>(&self, fork: HF) -> ForkCondition {
         self.hardforks.fork(fork)
     }
 
@@ -758,7 +786,7 @@ impl Hardforks for ChainSpec {
     }
 }
 
-impl EthereumHardforks for ChainSpec {
+impl<H: BlockHeader> EthereumHardforks for ChainSpec<H> {
     fn ethereum_fork_activation(&self, fork: EthereumHardfork) -> ForkCondition {
         self.fork(fork)
     }
@@ -2457,7 +2485,7 @@ Post-merge hard forks (timestamp based):
 
     #[test]
     fn check_fork_id_chainspec_with_fork_condition_never() {
-        let spec = ChainSpec {
+        let spec: ChainSpec = ChainSpec {
             chain: Chain::mainnet(),
             genesis: Genesis::default(),
             hardforks: ChainHardforks::new(vec![(
@@ -2474,7 +2502,7 @@ Post-merge hard forks (timestamp based):
 
     #[test]
     fn check_fork_filter_chainspec_with_fork_condition_never() {
-        let spec = ChainSpec {
+        let spec: ChainSpec = ChainSpec {
             chain: Chain::mainnet(),
             genesis: Genesis::default(),
             hardforks: ChainHardforks::new(vec![(


### PR DESCRIPTION
Allows `ChainSpec` to store a custom header type. Spec with custom header does not yet have complete support for all helpers `From<Genesis>` does not work but this should still simplify things slightly for custom chainspecs