### PR TITLE
chore(cli): rename disable-caching-and-prewarming to disable-prewarming

### DIFF
--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -69,8 +69,8 @@ pub struct TreeConfig {
     /// Whether to always compare trie updates from the state root task to the trie updates from
     /// the regular state root calculation.
     always_compare_trie_updates: bool,
-    /// Whether to disable cross-block caching and parallel prewarming.
-    disable_caching_and_prewarming: bool,
+    /// Whether to disable parallel prewarming.
+    disable_prewarming: bool,
     /// Whether to disable the parallel sparse trie state root algorithm.
     disable_parallel_sparse_trie: bool,
     /// Whether to enable state provider metrics.
@@ -121,7 +121,7 @@ impl Default for TreeConfig {
             max_execute_block_batch_size: DEFAULT_MAX_EXECUTE_BLOCK_BATCH_SIZE,
             legacy_state_root: false,
             always_compare_trie_updates: false,
-            disable_caching_and_prewarming: false,
+            disable_prewarming: false,
             disable_parallel_sparse_trie: false,
             state_provider_metrics: false,
             cross_block_cache_size: DEFAULT_CROSS_BLOCK_CACHE_SIZE,
@@ -150,7 +150,7 @@ impl TreeConfig {
         max_execute_block_batch_size: usize,
         legacy_state_root: bool,
         always_compare_trie_updates: bool,
-        disable_caching_and_prewarming: bool,
+        disable_prewarming: bool,
         disable_parallel_sparse_trie: bool,
         state_provider_metrics: bool,
         cross_block_cache_size: u64,
@@ -173,7 +173,7 @@ impl TreeConfig {
             max_execute_block_batch_size,
             legacy_state_root,
             always_compare_trie_updates,
-            disable_caching_and_prewarming,
+            disable_prewarming,
             disable_parallel_sparse_trie,
             state_provider_metrics,
             cross_block_cache_size,
@@ -251,9 +251,9 @@ impl TreeConfig {
         self.disable_parallel_sparse_trie
     }
 
-    /// Returns whether or not cross-block caching and parallel prewarming should be used.
-    pub const fn disable_caching_and_prewarming(&self) -> bool {
-        self.disable_caching_and_prewarming
+    /// Returns whether or not parallel prewarming should be used.
+    pub const fn disable_prewarming(&self) -> bool {
+        self.disable_prewarming
     }
 
     /// Returns whether to always compare trie updates from the state root task to the trie updates
@@ -343,12 +343,9 @@ impl TreeConfig {
         self
     }
 
-    /// Setter for whether to disable cross-block caching and parallel prewarming.
-    pub const fn without_caching_and_prewarming(
-        mut self,
-        disable_caching_and_prewarming: bool,
-    ) -> Self {
-        self.disable_caching_and_prewarming = disable_caching_and_prewarming;
+    /// Setter for whether to disable parallel prewarming.
+    pub const fn without_prewarming(mut self, disable_prewarming: bool) -> Self {
+        self.disable_prewarming = disable_prewarming;
         self
     }
 

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -117,7 +117,7 @@ where
             execution_cache: Default::default(),
             trie_metrics: Default::default(),
             cross_block_cache_size: config.cross_block_cache_size(),
-            disable_transaction_prewarming: config.disable_caching_and_prewarming(),
+            disable_transaction_prewarming: config.disable_prewarming(),
             evm_config,
             precompile_cache_disabled: config.precompile_cache_disabled(),
             precompile_cache_map,

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -30,9 +30,9 @@ pub struct EngineArgs {
     #[deprecated]
     pub caching_and_prewarming_enabled: bool,
 
-    /// Disable cross-block caching and parallel prewarming
-    #[arg(long = "engine.disable-caching-and-prewarming")]
-    pub caching_and_prewarming_disabled: bool,
+    /// Disable parallel prewarming
+    #[arg(long = "engine.disable-prewarming")]
+    pub prewarming_disabled: bool,
 
     /// CAUTION: This CLI flag has no effect anymore, use --engine.disable-parallel-sparse-trie
     /// if you want to disable usage of the `ParallelSparseTrie`.
@@ -119,7 +119,7 @@ impl Default for EngineArgs {
             legacy_state_root_task_enabled: false,
             state_root_task_compare_updates: false,
             caching_and_prewarming_enabled: true,
-            caching_and_prewarming_disabled: false,
+            prewarming_disabled: false,
             parallel_sparse_trie_enabled: true,
             parallel_sparse_trie_disabled: false,
             state_provider_metrics: false,
@@ -145,7 +145,7 @@ impl EngineArgs {
             .with_persistence_threshold(self.persistence_threshold)
             .with_memory_block_buffer_target(self.memory_block_buffer_target)
             .with_legacy_state_root(self.legacy_state_root_task_enabled)
-            .without_caching_and_prewarming(self.caching_and_prewarming_disabled)
+            .without_prewarming(self.prewarming_disabled)
             .with_disable_parallel_sparse_trie(self.parallel_sparse_trie_disabled)
             .with_state_provider_metrics(self.state_provider_metrics)
             .with_always_compare_trie_updates(self.state_root_task_compare_updates)

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -812,8 +812,8 @@ Engine:
       --engine.legacy-state-root
           Enable legacy state root
 
-      --engine.disable-caching-and-prewarming
-          Disable cross-block caching and parallel prewarming
+      --engine.disable-prewarming
+          Disable parallel prewarming
 
       --engine.disable-parallel-sparse-trie
           Disable the parallel sparse trie in the engine


### PR DESCRIPTION
This does not actually disable caching, so this is renaming the flag to reflect that. Technically breaking for those using this CLI flag