### PR TITLE
chore(engine): remove unused local Rayon pool from WorkloadExecutor

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/executor.rs
+++ b/crates/engine/tree/src/tree/payload_processor/executor.rs
@@ -1,10 +1,6 @@
 //! Executor for mixed I/O and CPU workloads.
 
-use rayon::ThreadPool as RayonPool;
-use std::{
-    sync::{Arc, OnceLock},
-    time::Duration,
-};
+use std::{sync::OnceLock, time::Duration};
 use tokio::{
     runtime::{Builder, Handle, Runtime},
     task::JoinHandle,
@@ -12,9 +8,8 @@ use tokio::{
 
 /// An executor for mixed I/O and CPU workloads.
 ///
-/// This type has access to its own rayon pool and uses tokio to spawn blocking tasks.
-///
-/// It will reuse an existing tokio runtime if available or create its own.
+/// This type uses tokio to spawn blocking tasks and will reuse an existing tokio
+/// runtime if available or create its own.
 #[derive(Debug, Clone)]
 pub struct WorkloadExecutor {
     inner: WorkloadExecutorInner,
@@ -22,21 +17,11 @@ pub struct WorkloadExecutor {
 
 impl Default for WorkloadExecutor {
     fn default() -> Self {
-        Self { inner: WorkloadExecutorInner::new(rayon::ThreadPoolBuilder::new().build().unwrap()) }
+        Self { inner: WorkloadExecutorInner::new() }
     }
 }
 
 impl WorkloadExecutor {
-    /// Creates a new executor with the given number of threads for cpu bound work (rayon).
-    #[expect(unused)]
-    pub(super) fn with_num_cpu_threads(cpu_threads: usize) -> Self {
-        Self {
-            inner: WorkloadExecutorInner::new(
-                rayon::ThreadPoolBuilder::new().num_threads(cpu_threads).build().unwrap(),
-            ),
-        }
-    }
-
     /// Returns the handle to the tokio runtime
     pub(super) const fn handle(&self) -> &Handle {
         &self.inner.handle
@@ -51,22 +36,15 @@ impl WorkloadExecutor {
     {
         self.inner.handle.spawn_blocking(func)
     }
-
-    /// Returns access to the rayon pool
-    #[expect(unused)]
-    pub(super) const fn rayon_pool(&self) -> &Arc<rayon::ThreadPool> {
-        &self.inner.rayon_pool
-    }
 }
 
 #[derive(Debug, Clone)]
 struct WorkloadExecutorInner {
     handle: Handle,
-    rayon_pool: Arc<RayonPool>,
 }
 
 impl WorkloadExecutorInner {
-    fn new(rayon_pool: rayon::ThreadPool) -> Self {
+    fn new() -> Self {
         fn get_runtime_handle() -> Handle {
             Handle::try_current().unwrap_or_else(|_| {
                 // Create a new runtime if no runtime is available
@@ -90,6 +68,6 @@ impl WorkloadExecutorInner {
             })
         }
 
-        Self { handle: get_runtime_handle(), rayon_pool: Arc::new(rayon_pool) }
+        Self { handle: get_runtime_handle() }
     }
 }


### PR DESCRIPTION
Remove the per-instance Rayon thread pool from WorkloadExecutor and delete unused methods with_num_cpu_threads(...) and rayon_pool(). The local pool was never referenced; parallelism in the payload processor uses Tokio spawn_blocking and the global Rayon pool configured at node launch. Keeping a private pool consumed resources without benefit, making it dead code.