### PR TITLE
fix: correct grammatical error in stream_codec.rs comment

### DIFF
--- a/crates/rpc/ipc/src/stream_codec.rs
+++ b/crates/rpc/ipc/src/stream_codec.rs
@@ -24,7 +24,7 @@
 // IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-// This basis of this file has been taken from the deprecated jsonrpc codebase:
+// This file is based on the deprecated jsonrpc codebase:
 // https://github.com/paritytech/jsonrpc
 
 use bytes::BytesMut;


### PR DESCRIPTION

## Summary
Fixes a grammatical error in the comment describing the file's origin.

- **Change**: Corrected "This basis of this file has been taken from" → "This file is based on"

