### PR TITLE
chore: update hive expected/ignored failures

### DIFF
--- a/.github/assets/hive/expected_failures.yaml
+++ b/.github/assets/hive/expected_failures.yaml
@@ -28,7 +28,6 @@ engine-withdrawals:
   - Withdraw zero amount (Paris) (reth)
   - Empty Withdrawals (Paris) (reth)
   - Corrupted Block Hash Payload (INVALID) (Paris) (reth)
-  - Withdrawals Fork on Block 1 - 8 Block Re-Org NewPayload (Paris) (reth)
   - Withdrawals Fork on Canonical Block 8 / Side Block 7 - 10 Block Re-Org (Paris) (reth)
 
 engine-api: []

--- a/.github/assets/hive/ignored_tests.yaml
+++ b/.github/assets/hive/ignored_tests.yaml
@@ -30,5 +30,7 @@ engine-api:
   - Invalid Missing Ancestor Syncing ReOrg, Transaction Nonce, EmptyTxs=False, CanonicalReOrg=False, Invalid P9 (Paris) (reth)
   - Invalid Missing Ancestor Syncing ReOrg, Transaction Signature, EmptyTxs=False, CanonicalReOrg=True, Invalid P9 (Paris) (reth)
   - Invalid Missing Ancestor Syncing ReOrg, Transaction Signature, EmptyTxs=False, CanonicalReOrg=False, Invalid P9 (Paris) (reth)
+  - Invalid Missing Ancestor ReOrg, StateRoot, EmptyTxs=False, Invalid P9 (Cancun) (reth)
+  - Invalid Missing Ancestor ReOrg, StateRoot, EmptyTxs=False, Invalid P10 (Cancun) (reth)
   - Multiple New Payloads Extending Canonical Chain, Wait for Canonical Payload (Paris) (reth)
   - Multiple New Payloads Extending Canonical Chain, Set Head to First Payload Received (Paris) (reth)

--- a/.github/assets/hive/ignored_tests.yaml
+++ b/.github/assets/hive/ignored_tests.yaml
@@ -21,6 +21,7 @@ engine-cancun:
   - Transaction Re-Org, New Payload on Revert Back (Cancun) (reth)
   - Transaction Re-Org, Re-Org to Different Block (Cancun) (reth)
   - Transaction Re-Org, Re-Org Out (Cancun) (reth)
+  - Invalid Missing Ancestor ReOrg, StateRoot, EmptyTxs=False, Invalid P9 (Cancun) (reth)
   - Multiple New Payloads Extending Canonical Chain, Wait for Canonical Payload (Cancun) (reth)
 engine-api:
   - Transaction Re-Org, Re-Org Out (Paris) (reth)
@@ -30,7 +31,6 @@ engine-api:
   - Invalid Missing Ancestor Syncing ReOrg, Transaction Nonce, EmptyTxs=False, CanonicalReOrg=False, Invalid P9 (Paris) (reth)
   - Invalid Missing Ancestor Syncing ReOrg, Transaction Signature, EmptyTxs=False, CanonicalReOrg=True, Invalid P9 (Paris) (reth)
   - Invalid Missing Ancestor Syncing ReOrg, Transaction Signature, EmptyTxs=False, CanonicalReOrg=False, Invalid P9 (Paris) (reth)
-  - Invalid Missing Ancestor ReOrg, StateRoot, EmptyTxs=False, Invalid P9 (Cancun) (reth)
-  - Invalid Missing Ancestor ReOrg, StateRoot, EmptyTxs=False, Invalid P10 (Cancun) (reth)
+  - Invalid Missing Ancestor ReOrg, StateRoot, EmptyTxs=True, Invalid P10 (Paris) (reth)
   - Multiple New Payloads Extending Canonical Chain, Wait for Canonical Payload (Paris) (reth)
   - Multiple New Payloads Extending Canonical Chain, Set Head to First Payload Received (Paris) (reth)


### PR DESCRIPTION
`Withdrawals Fork on Block 1 - 8 Block Re-Org NewPayload (Paris) (reth)` is both in expected and in ignored failures, given that it passes sometimes, removed it here from expected.

Also added two more flaky `Invalid Missing Ancestor` tests to ignored.