### PR TITLE
fix: streamline payload conversion in custom engine API

### DIFF
--- a/examples/custom-node/src/engine_api.rs
+++ b/examples/custom-node/src/engine_api.rs
@@ -35,7 +35,7 @@ impl From<OpBuiltPayload<CustomNodePrimitives>> for CustomExecutionPayloadEnvelo
         let block = sealed_block.into_block();
 
         Self {
-            execution_payload: ExecutionPayloadV3::from_block_unchecked(hash, &block.clone()),
+            execution_payload: ExecutionPayloadV3::from_block_unchecked(hash, &block),
             extension,
         }
     }


### PR DESCRIPTION
- Replace `block.clone()` with `block` when building `ExecutionPayloadV3`
