### PR TITLE
refactor(trie): use Vec<(B256, Option<...>)> in HashedPostStateCursors

### DIFF
--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -8,7 +8,7 @@ use crate::{
 use alloc::{borrow::Cow, vec::Vec};
 use alloy_primitives::{
     keccak256,
-    map::{hash_map, B256Map, B256Set, HashMap, HashSet},
+    map::{hash_map, B256Map, HashMap, HashSet},
     Address, B256, U256,
 };
 use itertools::Itertools;
@@ -322,21 +322,8 @@ impl HashedPostState {
     }
 
     /// Converts hashed post state into [`HashedPostStateSorted`].
-    pub fn into_sorted(self) -> HashedPostStateSorted {
-        let mut accounts = Vec::new();
-        for (hashed_address, info) in self.accounts {
-            accounts.push((hashed_address, info));
-        }
-        accounts.sort_unstable_by_key(|(address, _)| *address);
-        let accounts = HashedAccountsSorted { accounts };
-
-        let storages = self
-            .storages
-            .into_iter()
-            .map(|(hashed_address, storage)| (hashed_address, storage.into_sorted()))
-            .collect();
-
-        HashedPostStateSorted { accounts, storages }
+    pub fn into_sorted(mut self) -> HashedPostStateSorted {
+        self.drain_into_sorted()
     }
 
     /// Converts hashed post state into [`HashedPostStateSorted`], but keeping the maps allocated by
@@ -432,10 +419,7 @@ impl HashedStorage {
 
     /// Converts hashed storage into [`HashedStorageSorted`].
     pub fn into_sorted(self) -> HashedStorageSorted {
-        let mut storage_slots = Vec::new();
-        for (hashed_slot, value) in self.storage {
-            storage_slots.push((hashed_slot, value));
-        }
+        let mut storage_slots = self.storage.into_iter().collect::<Vec<_>>();
         storage_slots.sort_unstable_by_key(|(key, _)| *key);
 
         HashedStorageSorted { storage_slots, wiped: self.wiped }

--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -323,17 +323,12 @@ impl HashedPostState {
 
     /// Converts hashed post state into [`HashedPostStateSorted`].
     pub fn into_sorted(self) -> HashedPostStateSorted {
-        let mut updated_accounts = Vec::new();
-        let mut destroyed_accounts = HashSet::default();
+        let mut accounts = Vec::new();
         for (hashed_address, info) in self.accounts {
-            if let Some(info) = info {
-                updated_accounts.push((hashed_address, info));
-            } else {
-                destroyed_accounts.insert(hashed_address);
-            }
+            accounts.push((hashed_address, info));
         }
-        updated_accounts.sort_unstable_by_key(|(address, _)| *address);
-        let accounts = HashedAccountsSorted { accounts: updated_accounts, destroyed_accounts };
+        accounts.sort_unstable_by_key(|(address, _)| *address);
+        let accounts = HashedAccountsSorted { accounts };
 
         let storages = self
             .storages
@@ -352,17 +347,12 @@ impl HashedPostState {
     /// This allows us to reuse the allocated space. This allocates new space for the sorted hashed
     /// post state, like `into_sorted`.
     pub fn drain_into_sorted(&mut self) -> HashedPostStateSorted {
-        let mut updated_accounts = Vec::new();
-        let mut destroyed_accounts = HashSet::default();
+        let mut accounts = Vec::new();
         for (hashed_address, info) in self.accounts.drain() {
-            if let Some(info) = info {
-                updated_accounts.push((hashed_address, info));
-            } else {
-                destroyed_accounts.insert(hashed_address);
-            }
+            accounts.push((hashed_address, info));
         }
-        updated_accounts.sort_unstable_by_key(|(address, _)| *address);
-        let accounts = HashedAccountsSorted { accounts: updated_accounts, destroyed_accounts };
+        accounts.sort_unstable_by_key(|(address, _)| *address);
+        let accounts = HashedAccountsSorted { accounts };
 
         let storages = self
             .storages
@@ -442,18 +432,13 @@ impl HashedStorage {
 
     /// Converts hashed storage into [`HashedStorageSorted`].
     pub fn into_sorted(self) -> HashedStorageSorted {
-        let mut non_zero_valued_slots = Vec::new();
-        let mut zero_valued_slots = HashSet::default();
+        let mut storage_slots = Vec::new();
         for (hashed_slot, value) in self.storage {
-            if value.is_zero() {
-                zero_valued_slots.insert(hashed_slot);
-            } else {
-                non_zero_valued_slots.push((hashed_slot, value));
-            }
+            storage_slots.push((hashed_slot, value));
         }
-        non_zero_valued_slots.sort_unstable_by_key(|(key, _)| *key);
+        storage_slots.sort_unstable_by_key(|(key, _)| *key);
 
-        HashedStorageSorted { non_zero_valued_slots, zero_valued_slots, wiped: self.wiped }
+        HashedStorageSorted { storage_slots, wiped: self.wiped }
     }
 }
 
@@ -495,30 +480,23 @@ impl AsRef<Self> for HashedPostStateSorted {
 /// Sorted account state optimized for iterating during state trie calculation.
 #[derive(Clone, Eq, PartialEq, Default, Debug)]
 pub struct HashedAccountsSorted {
-    /// Sorted collection of hashed addresses and their account info.
-    pub accounts: Vec<(B256, Account)>,
-    /// Set of destroyed account keys.
-    pub destroyed_accounts: B256Set,
+    /// Sorted collection of hashed addresses and their account info. None indicates that an account
+    /// was destroyed.
+    pub accounts: Vec<(B256, Option<Account>)>,
 }
 
 impl HashedAccountsSorted {
     /// Returns a sorted iterator over updated accounts.
-    pub fn accounts_sorted(&self) -> impl Iterator<Item = (B256, Option<Account>)> {
-        self.accounts
-            .iter()
-            .map(|(address, account)| (*address, Some(*account)))
-            .chain(self.destroyed_accounts.iter().map(|address| (*address, None)))
-            .sorted_by_key(|entry| *entry.0)
+    pub fn accounts_sorted(&self) -> impl Iterator<Item = (B256, Option<Account>)> + '_ {
+        self.accounts.iter().map(|(address, account)| (*address, *account))
     }
 }
 
 /// Sorted hashed storage optimized for iterating during state trie calculation.
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub struct HashedStorageSorted {
-    /// Sorted hashed storage slots with non-zero value.
-    pub non_zero_valued_slots: Vec<(B256, U256)>,
-    /// Slots that have been zero valued.
-    pub zero_valued_slots: B256Set,
+    /// Sorted hashed storage slots. U256::ZERO indicates that a slot was deleted.
+    pub storage_slots: Vec<(B256, U256)>,
     /// Flag indicating whether the storage was wiped or not.
     pub wiped: bool,
 }
@@ -530,12 +508,8 @@ impl HashedStorageSorted {
     }
 
     /// Returns a sorted iterator over updated storage slots.
-    pub fn storage_slots_sorted(&self) -> impl Iterator<Item = (B256, U256)> {
-        self.non_zero_valued_slots
-            .iter()
-            .map(|(hashed_slot, value)| (*hashed_slot, *value))
-            .chain(self.zero_valued_slots.iter().map(|hashed_slot| (*hashed_slot, U256::ZERO)))
-            .sorted_by_key(|entry| *entry.0)
+    pub fn storage_slots_sorted(&self) -> impl Iterator<Item = (B256, U256)> + '_ {
+        self.storage_slots.iter().map(|(hashed_slot, value)| (*hashed_slot, *value))
     }
 }
 

--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -479,7 +479,7 @@ impl HashedAccountsSorted {
 /// Sorted hashed storage optimized for iterating during state trie calculation.
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub struct HashedStorageSorted {
-    /// Sorted hashed storage slots. U256::ZERO indicates that a slot was deleted.
+    /// Sorted hashed storage slots. `U256::ZERO` indicates that a slot was deleted.
     pub storage_slots: Vec<(B256, U256)>,
     /// Flag indicating whether the storage was wiped or not.
     pub wiped: bool,

--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -464,8 +464,8 @@ impl AsRef<Self> for HashedPostStateSorted {
 /// Sorted account state optimized for iterating during state trie calculation.
 #[derive(Clone, Eq, PartialEq, Default, Debug)]
 pub struct HashedAccountsSorted {
-    /// Sorted collection of hashed addresses and their account info. None indicates that an account
-    /// was destroyed.
+    /// Sorted collection of hashed addresses and their account info. None indicates that an
+    /// account was destroyed.
     pub accounts: Vec<(B256, Option<Account>)>,
 }
 

--- a/crates/trie/trie/src/hashed_cursor/post_state.rs
+++ b/crates/trie/trie/src/hashed_cursor/post_state.rs
@@ -77,7 +77,6 @@ where
         temp_cursor.seek(account).is_some_and(|(addr, acc)| addr == *account && acc.is_none())
     }
 
-
     fn seek_inner(&mut self, key: B256) -> Result<Option<(B256, Account)>, DatabaseError> {
         // Take the next account from the post state with the key greater than or equal to the
         // sought key.
@@ -86,7 +85,9 @@ where
         // It's an exact match, return the account from post state without looking up in the
         // database.
         if post_state_entry.is_some_and(|entry| entry.0 == key) {
-            return Ok(post_state_entry.and_then(|(address, account)| account.map(|acc| (address, acc))))
+            return Ok(
+                post_state_entry.and_then(|(address, account)| account.map(|acc| (address, acc)))
+            )
         }
 
         // It's not an exact match, reposition to the first greater or equal account that wasn't
@@ -215,12 +216,11 @@ where
     /// Check if the slot was zeroed out in post state without advancing the cursor.
     fn is_slot_zeroed(&self, slot: &B256) -> bool {
         // Create a temporary cursor to search without modifying the main cursor position
-        self.storage_data.map_or(false, |data| {
+        self.storage_data.is_some_and(|data| {
             let mut temp_cursor = ForwardInMemoryCursor::new(data);
             temp_cursor.seek(slot).is_some_and(|(s, value)| s == *slot && value.is_zero())
         })
     }
-
 
     /// Find the storage entry in post state or database that's greater or equal to provided subkey.
     fn seek_inner(&mut self, subkey: B256) -> Result<Option<(B256, U256)>, DatabaseError> {
@@ -241,10 +241,7 @@ where
         }
 
         // Compare two entries and return the lowest.
-        Ok(Self::compare_entries(
-            post_state_entry.filter(|(_, value)| !value.is_zero()),
-            db_entry,
-        ))
+        Ok(Self::compare_entries(post_state_entry.filter(|(_, value)| !value.is_zero()), db_entry))
     }
 
     /// Find the storage entry that is right after current cursor position.
@@ -269,10 +266,7 @@ where
         }
 
         // Compare two entries and return the lowest.
-        Ok(Self::compare_entries(
-            post_state_entry.filter(|(_, value)| !value.is_zero()),
-            db_entry,
-        ))
+        Ok(Self::compare_entries(post_state_entry.filter(|(_, value)| !value.is_zero()), db_entry))
     }
 
     /// Return the storage entry with the lowest hashed storage key (hashed slot).


### PR DESCRIPTION
## Summary
Replaces separate `HashSet` collections with unified `Vec<(B256, Option<...>)>` pattern in `HashedPostStateCursors` for improved efficiency.

## Changes
- **HashedAccountsSorted**: `accounts: Vec<(B256, Option<Account>)>` where `None` indicates destroyed account
- **HashedStorageSorted**: `storage_slots: Vec<(B256, U256)>` where `U256::ZERO` indicates deleted slot
- **Cursors**: Updated `HashedPostStateAccountCursor` and `HashedPostStateStorageCursor` logic
- **Removed**: `destroyed_accounts: B256Set` and `zero_valued_slots: B256Set`

Closes: #18848