### PR TITLE
feat: Use generic `HeaderTy` for `reth db get static-file headers`

### DIFF
--- a/crates/cli/commands/src/db/get.rs
+++ b/crates/cli/commands/src/db/get.rs
@@ -12,7 +12,7 @@ use reth_db_api::{
     tables, RawKey, RawTable, Receipts, TableViewer, Transactions,
 };
 use reth_db_common::DbTool;
-use reth_node_api::{ReceiptTy, TxTy};
+use reth_node_api::{HeaderTy, ReceiptTy, TxTy};
 use reth_node_builder::NodeTypesWithDB;
 use reth_provider::{providers::ProviderNodeTypes, StaticFileProviderFactory};
 use reth_static_file_types::StaticFileSegment;
@@ -96,7 +96,7 @@ impl Command {
                         } else {
                             match segment {
                                 StaticFileSegment::Headers => {
-                                    let header = Header::decompress(content[0].as_slice())?;
+                                    let header = HeaderTy::<N>::decompress(content[0].as_slice())?;
                                     let block_hash = BlockHash::decompress(content[1].as_slice())?;
                                     println!(
                                         "Header\n{}\n\nBlockHash\n{}",


### PR DESCRIPTION
### Description

This PR adds support for custom headers in the `reth db get static-file headers <N>` command, to make it more consistent with other parts of `StaticFileProviderRW` which uses [NodePrimitives::BlockHeader](https://github.com/paradigmxyz/reth/blob/b550387602f8acd190a2b115bd340a1e21d11671/crates/storage/provider/src/providers/static_file/writer.rs#L536).

### Motivation

This patch is particularly relevant for NodeBuilder API usages e.g., [reth-hl](https://github.com/hl-archive-node/nanoreth), which will rely on a custom header type with a dedicated `Compact` trait implementation.

### Example output

```
# target/debug/reth-hl db get static-file headers 1
2025-10-06T04:12:10.012167Z  INFO Initialized tracing, debug log directory: /root/.cache/reth/logs/hyperliquid
2025-10-06T04:12:10.045997Z  INFO Opening storage db_path="/root/.local/share/reth/hyperliquid/db" sf_path="/root/.local/share/reth/hyperliquid/static_files"
2025-10-06T04:12:10.100576Z  INFO Verifying storage consistency.
Header
{
  "inner": {
    "parentHash": "0xd8fcc13b6a195b88b7b2da3722ff6cad767b13a8c1e9ffb1c73aa9d216d895f0",
    "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
    "miner": "0x0000000000000000000000000000000000000000",
    "stateRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
    "transactionsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
    "receiptsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
    "difficulty": "0x0",
    "number": "0x1",
    "gasLimit": "0x1e8480",
    "gasUsed": "0x0",
    "timestamp": "0x67b40034",
    "extraData": "0x",
    "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
    "nonce": "0x0000000000000000",
    "baseFeePerGas": "0x5f5e100",
    "withdrawalsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
    "blobGasUsed": "0x0",
    "excessBlobGas": "0x0",
    "parentBeaconBlockRoot": "0x0000000000000000000000000000000000000000000000000000000000000000"
  },
  "extras": {
    "logs_bloom_with_system_txs": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
    "system_tx_count": 0
  }
}

BlockHash
"0xde151843548b88d06f201d86e860e45fbf07d49612f1934fba5746abd942fb01"
```