### PR TITLE
chore(era-downloader): remove unnecessary Sync bounds from internal futures

### DIFF
--- a/crates/era-downloader/src/stream.rs
+++ b/crates/era-downloader/src/stream.rs
@@ -180,8 +180,7 @@ impl<Http: HttpClient + Clone + Send + Sync + 'static + Unpin> Stream for EraStr
     }
 }
 
-type DownloadFuture =
-    Pin<Box<dyn Future<Output = eyre::Result<EraRemoteMeta>> + Send + Sync + 'static>>;
+type DownloadFuture = Pin<Box<dyn Future<Output = eyre::Result<EraRemoteMeta>> + Send + 'static>>;
 
 struct DownloadStream {
     downloads: FuturesOrdered<DownloadFuture>,
@@ -220,11 +219,11 @@ impl Stream for DownloadStream {
 
 struct StartingStream<Http> {
     client: EraClient<Http>,
-    files_count: Pin<Box<dyn Future<Output = usize> + Send + Sync + 'static>>,
-    next_url: Pin<Box<dyn Future<Output = eyre::Result<Option<Url>>> + Send + Sync + 'static>>,
-    delete_outside_range: Pin<Box<dyn Future<Output = eyre::Result<()>> + Send + Sync + 'static>>,
-    recover_index: Pin<Box<dyn Future<Output = Option<usize>> + Send + Sync + 'static>>,
-    fetch_file_list: Pin<Box<dyn Future<Output = eyre::Result<()>> + Send + Sync + 'static>>,
+    files_count: Pin<Box<dyn Future<Output = usize> + Send + 'static>>,
+    next_url: Pin<Box<dyn Future<Output = eyre::Result<Option<Url>>> + Send + 'static>>,
+    delete_outside_range: Pin<Box<dyn Future<Output = eyre::Result<()>> + Send + 'static>>,
+    recover_index: Pin<Box<dyn Future<Output = Option<usize>> + Send + 'static>>,
+    fetch_file_list: Pin<Box<dyn Future<Output = eyre::Result<()>> + Send + 'static>>,
     state: State,
     max_files: usize,
     index: usize,


### PR DESCRIPTION
Removed +Sync from DownloadFuture and the five pinned futures in StartingStream.

Rationale: These futures are created and polled exclusively within a single task via &mut self and are never shared across threads or exposed through the public API. Requiring Sync implies shared references can be sent across threads, which is not needed here and unnecessarily restricts captured types.

Safety: We retain +Send and 'static so futures remain movable across threads when needed by the executor, while not enforcing thread-safe shared access. Polling sites and containers (FuturesOrdered, local poll in StartingStream) do not require Sync. No behavioral change; only relaxed type bounds to improve composability.