### PR TITLE
fix(engine): re-insert storage cache and use arc

### DIFF
--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -302,7 +302,7 @@ pub(crate) struct ExecutionCache {
 
     /// Per-account storage cache: outer cache keyed by Address, inner cache tracks that account’s
     /// storage slots.
-    storage_cache: Cache<Address, AccountStorageCache>,
+    storage_cache: Cache<Address, Arc<AccountStorageCache>>,
 
     /// Cache for basic account information (nonce, balance, code hash).
     account_cache: Cache<Address, Option<Account>>,
@@ -340,15 +340,15 @@ impl ExecutionCache {
     where
         I: IntoIterator<Item = (StorageKey, Option<StorageValue>)>,
     {
-        let account_cache = self.storage_cache.get(&address).unwrap_or_else(|| {
-            let account_cache = AccountStorageCache::default();
-            self.storage_cache.insert(address, account_cache.clone());
-            account_cache
-        });
+        let account_cache = self.storage_cache.get(&address).unwrap_or_default();
 
         for (key, value) in storage_entries {
             account_cache.insert_storage(key, value);
         }
+
+        // Insert to the cache so that moka picks up on the changed size, even though the actual
+        // value (the Arc<AccountStorageCache>) is the same
+        self.storage_cache.insert(address, account_cache);
     }
 
     /// Invalidate storage for specific account
@@ -452,7 +452,7 @@ impl ExecutionCacheBuilder {
         const TIME_TO_IDLE: Duration = Duration::from_secs(3600); // 1 hour
 
         let storage_cache = CacheBuilder::new(self.storage_cache_entries)
-            .weigher(|_key: &Address, value: &AccountStorageCache| -> u32 {
+            .weigher(|_key: &Address, value: &Arc<AccountStorageCache>| -> u32 {
                 // values based on results from measure_storage_cache_overhead test
                 let base_weight = 39_000;
                 let slots_weight = value.len() * 218;


### PR DESCRIPTION
Fixes execution cache-related memory growth by re-inserting storage caches every time they are modified, this causes moka to pick up on the change and re-weigh the cache.

Previous memory usage:
<img width="2349" height="1282" alt="Screenshot 2025-10-03 at 3 29 31 PM" src="https://github.com/user-attachments/assets/b7a284a5-d032-4285-8943-d2bbf17b1a72" />


Memory usage with this PR:
<img width="1304" height="800" alt="Screenshot 2025-10-03 at 5 42 50 PM" src="https://github.com/user-attachments/assets/13ff482f-863f-463a-9a05-6e9b9df8c7c1" />
