### PR TITLE
fix(engine): flatten storage cache

### DIFF
--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -355,6 +355,8 @@ impl ExecutionCache {
 
     /// Invalidates the storage for all addresses in the set
     pub(crate) fn invalidate_storages(&self, addresses: HashSet<&Address>) {
+        // NOTE: this must collect because the invalidate function should not be called while we
+        // hold an iter for it
         let storage_entries = self
             .storage_cache
             .iter()

--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -302,7 +302,8 @@ pub(crate) struct ExecutionCache {
     /// Cache for contract bytecode, keyed by code hash.
     code_cache: Cache<B256, Option<Bytecode>>,
 
-    /// Flattened storage cache: composite key of (`Address`, `StorageKey`) maps directly to values.
+    /// Flattened storage cache: composite key of (`Address`, `StorageKey`) maps directly to
+    /// values.
     storage_cache: Cache<(Address, StorageKey), Option<StorageValue>>,
 
     /// Cache for basic account information (nonce, balance, code hash).
@@ -357,7 +358,8 @@ impl ExecutionCache {
         let storage_entries = self
             .storage_cache
             .iter()
-            .filter_map(|entry| addresses.contains(&entry.key().0).then_some(*entry.key()));
+            .filter_map(|entry| addresses.contains(&entry.key().0).then_some(*entry.key()))
+            .collect::<Vec<_>>();
         for key in storage_entries {
             self.storage_cache.invalidate(&key)
         }
@@ -427,7 +429,7 @@ impl ExecutionCache {
             self.account_cache.insert(*addr, Some(Account::from(account_info)));
         }
 
-        // invalidate storage for all destroyed acocunts
+        // invalidate storage for all destroyed accounts
         self.invalidate_storages(invalidated_accounts);
 
         Ok(())

--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -302,7 +302,7 @@ pub(crate) struct ExecutionCache {
     /// Cache for contract bytecode, keyed by code hash.
     code_cache: Cache<B256, Option<Bytecode>>,
 
-    /// Flattened storage cache: composite key of (Address, StorageKey) maps directly to values.
+    /// Flattened storage cache: composite key of (`Address`, `StorageKey`) maps directly to values.
     storage_cache: Cache<(Address, StorageKey), Option<StorageValue>>,
 
     /// Cache for basic account information (nonce, balance, code hash).
@@ -462,7 +462,7 @@ impl ExecutionCacheBuilder {
                 // Size of composite key (Address + StorageKey) + Option<StorageValue>
                 // Address: 20 bytes, StorageKey: 32 bytes, Option<StorageValue>: 33 bytes
                 // Plus some overhead for the hash map entry
-                120 as u32
+                120_u32
             })
             .max_capacity(storage_cache_size)
             .time_to_live(EXPIRY_TIME)


### PR DESCRIPTION
This fixes memory growth caused by growing execution caches, an alternative to https://github.com/paradigmxyz/reth/pull/18879

This instead removes the cache hierarchy, so cache updates are always picked up by the moka weigher.

Previous memory usage:
<img width="2349" height="1282" alt="Screenshot 2025-10-03 at 3 29 31 PM" src="https://github.com/user-attachments/assets/a5fc884c-6fb3-4a23-895b-321182e4cabc" />


New memory usage:
<img width="2349" height="1282" alt="Screenshot 2025-10-03 at 5 07 15 PM" src="https://github.com/user-attachments/assets/8b295a8c-5419-4d65-bc84-7983074f5b35" />

This also has slightly higher cache hitrate than #18879
