### PR TITLE
perf(tree): worker pooling for storage in multiproof generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10739,6 +10739,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "codspeed-criterion-compat",
+ "crossbeam-channel",
  "dashmap 6.1.0",
  "derive_more",
  "itertools 0.14.0",

--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -414,7 +414,7 @@ impl TreeConfig {
     }
 
     /// Setter for the number of reserved CPU cores for any non-reth processes
-    pub fn with_reserved_cpu_cores(mut self, reserved_cpu_cores: usize) -> Self {
+    pub const fn with_reserved_cpu_cores(mut self, reserved_cpu_cores: usize) -> Self {
         self.reserved_cpu_cores = reserved_cpu_cores;
         self
     }

--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -17,6 +17,21 @@ pub const DEFAULT_MULTIPROOF_TASK_CHUNK_SIZE: usize = 10;
 /// This will be deducted from the thread count of main reth global threadpool.
 pub const DEFAULT_RESERVED_CPU_CORES: usize = 1;
 
+/// Upper limit for storage proof workers to prevent excessive memory usage.
+const MAX_STORAGE_PROOF_WORKERS: usize = 12;
+
+/// Upper limit for account proof workers to prevent excessive memory usage.
+const MAX_ACCOUNT_PROOF_WORKERS: usize = 4;
+
+/// Lower limit for storage proof workers to maintain pipeline progress.
+const MIN_STORAGE_PROOF_WORKERS: usize = 2;
+
+/// Lower limit for account proof workers to keep the pool active.
+const MIN_ACCOUNT_PROOF_WORKERS: usize = 1;
+
+/// Default `(storage, account)` worker counts used when CPU detection fails.
+const FALLBACK_PROOF_WORKERS: (usize, usize) = (6, 2);
+
 /// Default maximum concurrency for prewarm task.
 pub const DEFAULT_PREWARM_MAX_CONCURRENCY: usize = 16;
 
@@ -24,6 +39,61 @@ const DEFAULT_BLOCK_BUFFER_LIMIT: u32 = 256;
 const DEFAULT_MAX_INVALID_HEADER_CACHE_LENGTH: u32 = 256;
 const DEFAULT_MAX_EXECUTE_BLOCK_BATCH_SIZE: usize = 4;
 const DEFAULT_CROSS_BLOCK_CACHE_SIZE: u64 = 4 * 1024 * 1024 * 1024;
+
+/// Calculates optimal `(storage, account)` proof worker counts based on available CPU cores.
+///
+/// Each worker runs in a dedicated blocking thread via `tokio::spawn_blocking`. The allocation
+/// strategy:
+/// 1. Query available logical CPUs via `available_parallelism`
+/// 2. Reserve `reserved_cpu_cores` for other tasks (e.g., networking, RPC)
+/// 3. Allocate remaining cores with a 3:1 ratio favoring storage proofs (which are more intensive)
+/// 4. Clamp results to `[MIN, MAX]` bounds to handle both low-core and high-core systems
+///
+/// Returns `(6, 2)` if CPU detection fails.
+pub fn default_proof_workers(reserved_cpu_cores: usize) -> (usize, usize) {
+    #[cfg(feature = "std")]
+    {
+        if let Ok(parallelism) = std::thread::available_parallelism() {
+            return split_proof_worker_budget(parallelism.get(), reserved_cpu_cores);
+        }
+    }
+
+    FALLBACK_PROOF_WORKERS
+}
+
+#[cfg(feature = "std")]
+/// Splits the usable CPU budget into storage/account threads while applying the fixed 3:1 ratio
+/// and clamping to the configured min/max bounds.
+fn split_proof_worker_budget(parallelism: usize, reserved_cpu_cores: usize) -> (usize, usize) {
+    const STORAGE_WEIGHT: usize = 3;
+    const ACCOUNT_WEIGHT: usize = 1;
+    const TOTAL_WEIGHT: usize = STORAGE_WEIGHT + ACCOUNT_WEIGHT;
+
+    let usable = parallelism.saturating_sub(reserved_cpu_cores);
+    let budget = usable.max(MIN_STORAGE_PROOF_WORKERS + MIN_ACCOUNT_PROOF_WORKERS);
+
+    let mut storage = (budget * STORAGE_WEIGHT) / TOTAL_WEIGHT;
+    let mut account = budget.saturating_sub(storage);
+
+    storage = storage.clamp(MIN_STORAGE_PROOF_WORKERS, MAX_STORAGE_PROOF_WORKERS);
+    account = account.clamp(MIN_ACCOUNT_PROOF_WORKERS, MAX_ACCOUNT_PROOF_WORKERS);
+
+    (storage, account)
+}
+
+/// Default number of storage proof workers, derived from available parallelism.
+///
+/// Uses [`default_proof_workers`] with [`DEFAULT_RESERVED_CPU_CORES`].
+pub fn default_storage_proof_workers() -> usize {
+    default_proof_workers(DEFAULT_RESERVED_CPU_CORES).0
+}
+
+/// Default number of account proof workers, derived from available parallelism.
+///
+/// Uses [`default_proof_workers`] with [`DEFAULT_RESERVED_CPU_CORES`].
+pub fn default_account_proof_workers() -> usize {
+    default_proof_workers(DEFAULT_RESERVED_CPU_CORES).1
+}
 
 /// Determines if the host has enough parallelism to run the payload processor.
 ///
@@ -81,6 +151,10 @@ pub struct TreeConfig {
     has_enough_parallelism: bool,
     /// Maximum number of concurrent proof tasks
     max_proof_task_concurrency: u64,
+    /// Number of workers dedicated to storage proof execution
+    storage_proof_workers: usize,
+    /// Number of workers dedicated to account proof execution
+    account_proof_workers: usize,
     /// Whether multiproof task should chunk proof targets.
     multiproof_chunking_enabled: bool,
     /// Multiproof task chunk size for proof targets.
@@ -127,6 +201,8 @@ impl Default for TreeConfig {
             cross_block_cache_size: DEFAULT_CROSS_BLOCK_CACHE_SIZE,
             has_enough_parallelism: has_enough_parallelism(),
             max_proof_task_concurrency: DEFAULT_MAX_PROOF_TASK_CONCURRENCY,
+            storage_proof_workers: default_storage_proof_workers(),
+            account_proof_workers: default_account_proof_workers(),
             multiproof_chunking_enabled: true,
             multiproof_chunk_size: DEFAULT_MULTIPROOF_TASK_CHUNK_SIZE,
             reserved_cpu_cores: DEFAULT_RESERVED_CPU_CORES,
@@ -156,6 +232,8 @@ impl TreeConfig {
         cross_block_cache_size: u64,
         has_enough_parallelism: bool,
         max_proof_task_concurrency: u64,
+        storage_proof_workers: usize,
+        account_proof_workers: usize,
         multiproof_chunking_enabled: bool,
         multiproof_chunk_size: usize,
         reserved_cpu_cores: usize,
@@ -179,6 +257,8 @@ impl TreeConfig {
             cross_block_cache_size,
             has_enough_parallelism,
             max_proof_task_concurrency,
+            storage_proof_workers,
+            account_proof_workers,
             multiproof_chunking_enabled,
             multiproof_chunk_size,
             reserved_cpu_cores,
@@ -218,6 +298,16 @@ impl TreeConfig {
     /// Return the maximum proof task concurrency.
     pub const fn max_proof_task_concurrency(&self) -> u64 {
         self.max_proof_task_concurrency
+    }
+
+    /// Return the number of storage proof workers.
+    pub const fn storage_proof_workers(&self) -> usize {
+        self.storage_proof_workers
+    }
+
+    /// Return the number of account proof workers.
+    pub const fn account_proof_workers(&self) -> usize {
+        self.account_proof_workers
     }
 
     /// Return whether the multiproof task chunking is enabled.
@@ -398,6 +488,18 @@ impl TreeConfig {
         self
     }
 
+    /// Setter for number of storage proof workers.
+    pub const fn with_storage_proof_workers(mut self, storage_proof_workers: usize) -> Self {
+        self.storage_proof_workers = storage_proof_workers;
+        self
+    }
+
+    /// Setter for number of account proof workers.
+    pub const fn with_account_proof_workers(mut self, account_proof_workers: usize) -> Self {
+        self.account_proof_workers = account_proof_workers;
+        self
+    }
+
     /// Setter for whether multiproof task should chunk proof targets.
     pub const fn with_multiproof_chunking_enabled(
         mut self,
@@ -414,8 +516,11 @@ impl TreeConfig {
     }
 
     /// Setter for the number of reserved CPU cores for any non-reth processes
-    pub const fn with_reserved_cpu_cores(mut self, reserved_cpu_cores: usize) -> Self {
+    pub fn with_reserved_cpu_cores(mut self, reserved_cpu_cores: usize) -> Self {
         self.reserved_cpu_cores = reserved_cpu_cores;
+        let (storage_workers, account_workers) = default_proof_workers(reserved_cpu_cores);
+        self.storage_proof_workers = storage_workers;
+        self.account_proof_workers = account_workers;
         self
     }
 

--- a/crates/engine/tree/benches/state_root_task.rs
+++ b/crates/engine/tree/benches/state_root_task.rs
@@ -228,16 +228,25 @@ fn bench_state_root(c: &mut Criterion) {
                     },
                     |(genesis_hash, mut payload_processor, provider, state_updates)| {
                         black_box({
-                            let mut handle = payload_processor.spawn(
-                                Default::default(),
-                                core::iter::empty::<
-                                    Result<Recovered<TransactionSigned>, core::convert::Infallible>,
-                                >(),
-                                StateProviderBuilder::new(provider.clone(), genesis_hash, None),
-                                ConsistentDbView::new_with_latest_tip(provider).unwrap(),
-                                TrieInput::default(),
-                                &TreeConfig::default(),
-                            );
+                            let mut handle = payload_processor
+                                .spawn(
+                                    Default::default(),
+                                    core::iter::empty::<
+                                        Result<
+                                            Recovered<TransactionSigned>,
+                                            core::convert::Infallible,
+                                        >,
+                                    >(),
+                                    StateProviderBuilder::new(
+                                        provider.clone(),
+                                        genesis_hash,
+                                        None,
+                                    ),
+                                    ConsistentDbView::new_with_latest_tip(provider).unwrap(),
+                                    TrieInput::default(),
+                                    &TreeConfig::default(),
+                                )
+                                .expect("failed to spawn payload processor task");
 
                             let mut state_hook = handle.state_hook();
 

--- a/crates/engine/tree/benches/state_root_task.rs
+++ b/crates/engine/tree/benches/state_root_task.rs
@@ -237,11 +237,7 @@ fn bench_state_root(c: &mut Criterion) {
                                             core::convert::Infallible,
                                         >,
                                     >(),
-                                    StateProviderBuilder::new(
-                                        provider.clone(),
-                                        genesis_hash,
-                                        None,
-                                    ),
+                                    StateProviderBuilder::new(provider.clone(), genesis_hash, None),
                                     ConsistentDbView::new_with_latest_tip(provider).unwrap(),
                                     TrieInput::default(),
                                     &TreeConfig::default(),

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -196,12 +196,15 @@ where
             state_root_config.prefix_sets.clone(),
         );
         let max_proof_task_concurrency = config.max_proof_task_concurrency() as usize;
+        let storage_worker_count = config.storage_proof_workers();
         let proof_task = ProofTaskManager::new(
             self.executor.handle().clone(),
             state_root_config.consistent_view.clone(),
             task_ctx,
             max_proof_task_concurrency,
-        );
+            storage_worker_count,
+        )
+        .expect("Failed to create ProofTaskManager with storage workers");
 
         // We set it to half of the proof task concurrency, because often for each multiproof we
         // spawn one Tokio task for the account proof, and one Tokio task for the storage proof.

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -196,13 +196,11 @@ where
             state_root_config.prefix_sets.clone(),
         );
         let max_proof_task_concurrency = config.max_proof_task_concurrency() as usize;
-        let storage_worker_count = config.storage_proof_workers();
         let proof_task_handle = new_proof_task_handle(
             self.executor.handle().clone(),
             state_root_config.consistent_view.clone(),
             task_ctx,
             max_proof_task_concurrency,
-            storage_worker_count,
         )?;
 
         // We set it to half of the proof task concurrency, because often for each multiproof we

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -32,7 +32,7 @@ use reth_provider::{
 use reth_revm::{db::BundleState, state::EvmState};
 use reth_trie::TrieInput;
 use reth_trie_parallel::{
-    proof_task::{ProofTaskCtx, ProofTaskManager},
+    proof_task::{new_proof_task_handle, ProofTaskCtx},
     root::ParallelStateRootError,
 };
 use reth_trie_sparse::{
@@ -196,15 +196,13 @@ where
             state_root_config.prefix_sets.clone(),
         );
         let max_proof_task_concurrency = config.max_proof_task_concurrency() as usize;
-        let storage_worker_count = config.storage_proof_workers();
-        let proof_task = ProofTaskManager::new(
+        let proof_task_handle = new_proof_task_handle(
             self.executor.handle().clone(),
             state_root_config.consistent_view.clone(),
             task_ctx,
             max_proof_task_concurrency,
-            storage_worker_count,
         )
-        .expect("Failed to create ProofTaskManager with storage workers");
+        .expect("Failed to create proof task handle");
 
         // We set it to half of the proof task concurrency, because often for each multiproof we
         // spawn one Tokio task for the account proof, and one Tokio task for the storage proof.
@@ -212,7 +210,7 @@ where
         let multi_proof_task = MultiProofTask::new(
             state_root_config,
             self.executor.clone(),
-            proof_task.handle(),
+            proof_task_handle.clone(),
             to_sparse_trie,
             max_multi_proof_task_concurrency,
             config.multiproof_chunking_enabled().then_some(config.multiproof_chunk_size()),
@@ -241,19 +239,7 @@ where
         let (state_root_tx, state_root_rx) = channel();
 
         // Spawn the sparse trie task using any stored trie and parallel trie configuration.
-        self.spawn_sparse_trie_task(sparse_trie_rx, proof_task.handle(), state_root_tx);
-
-        // spawn the proof task
-        self.executor.spawn_blocking(move || {
-            if let Err(err) = proof_task.run() {
-                // At least log if there is an error at any point
-                tracing::error!(
-                    target: "engine::root",
-                    ?err,
-                    "Storage proof task returned an error"
-                );
-            }
-        });
+        self.spawn_sparse_trie_task(sparse_trie_rx, proof_task_handle, state_root_tx);
 
         PayloadHandle {
             to_multi_proof,

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -58,7 +58,7 @@ use configured_sparse_trie::ConfiguredSparseTrie;
 /// Default parallelism thresholds to use with the [`ParallelSparseTrie`].
 ///
 /// These values were determined by performing benchmarks using gradually increasing values to judge
-/// the affects. Below 100 throughput would generally be equal or slightly less, while above 150 it
+/// the effects. Below 100 throughput would generally be equal or slightly less, while above 150 it
 /// would deteriorate to the point where PST might as well not be used.
 pub const PARALLEL_SPARSE_TRIE_PARALLELISM_THRESHOLDS: ParallelismThresholds =
     ParallelismThresholds { min_revealed_nodes: 100, min_updated_nodes: 100 };
@@ -69,7 +69,7 @@ pub struct PayloadProcessor<Evm>
 where
     Evm: ConfigureEvm,
 {
-    /// The executor used by to spawn tasks.
+    /// The executor used to spawn tasks.
     executor: WorkloadExecutor,
     /// The most recent cache used for execution.
     execution_cache: ExecutionCache,
@@ -162,7 +162,6 @@ where
     /// Responsible for calculating the state root based on the received [`SparseTrieUpdate`].
     ///
     /// This task runs until there are no further updates to process.
-    ///
     ///
     /// This returns a handle to await the final state root and to interact with the tasks (e.g.
     /// canceling)

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -166,6 +166,7 @@ where
     ///
     /// This returns a handle to await the final state root and to interact with the tasks (e.g.
     /// canceling)
+    #[allow(clippy::type_complexity)]
     pub fn spawn<P, I: ExecutableTxIterator<Evm>>(
         &mut self,
         env: ExecutionEnv<Evm>,
@@ -847,18 +848,19 @@ mod tests {
             PrecompileCacheMap::default(),
         );
         let provider = BlockchainProvider::new(factory).unwrap();
-        let mut handle = payload_processor
-            .spawn(
-                Default::default(),
-                core::iter::empty::<
-                    Result<Recovered<TransactionSigned>, core::convert::Infallible>,
-                >(),
-                StateProviderBuilder::new(provider.clone(), genesis_hash, None),
-                ConsistentDbView::new_with_latest_tip(provider).unwrap(),
-                TrieInput::from_state(hashed_state),
-                &TreeConfig::default(),
-            )
-            .expect("failed to spawn payload processor task");
+        let mut handle =
+            payload_processor
+                .spawn(
+                    Default::default(),
+                    core::iter::empty::<
+                        Result<Recovered<TransactionSigned>, core::convert::Infallible>,
+                    >(),
+                    StateProviderBuilder::new(provider.clone(), genesis_hash, None),
+                    ConsistentDbView::new_with_latest_tip(provider).unwrap(),
+                    TrieInput::from_state(hashed_state),
+                    &TreeConfig::default(),
+                )
+                .expect("failed to spawn payload processor task");
 
         let mut state_hook = handle.state_hook();
 

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -208,7 +208,7 @@ where
 
         // We set it to half of the proof task concurrency, because often for each multiproof we
         // spawn one Tokio task for the account proof, and one Tokio task for the storage proof.
-        let max_multi_proof_task_concurrency = max_proof_task_concurrency / 2;
+        let max_multi_proof_task_concurrency = (max_proof_task_concurrency / 2).max(1);
         let multi_proof_task = MultiProofTask::new(
             state_root_config,
             self.executor.clone(),

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -1204,7 +1204,7 @@ mod tests {
     use alloy_primitives::map::B256Set;
     use reth_provider::{providers::ConsistentDbView, test_utils::create_test_provider_factory};
     use reth_trie::{MultiProof, TrieInput};
-    use reth_trie_parallel::proof_task::{ProofTaskCtx, ProofTaskManager};
+    use reth_trie_parallel::proof_task::{new_proof_task_handle, ProofTaskCtx};
     use revm_primitives::{B256, U256};
     use std::sync::Arc;
 
@@ -1231,17 +1231,16 @@ mod tests {
             config.state_sorted.clone(),
             config.prefix_sets.clone(),
         );
-        let proof_task = ProofTaskManager::new(
+        let proof_task_handle = new_proof_task_handle(
             executor.handle().clone(),
             config.consistent_view.clone(),
             task_ctx,
-            1,
-            1, // storage_worker_count for test
+            1, // max_concurrency for test
         )
-        .expect("Failed to create ProofTaskManager for multiproof test");
+        .expect("Failed to create proof task handle for multiproof test");
         let channel = channel();
 
-        MultiProofTask::new(config, executor, proof_task.handle(), channel.0, 1, None)
+        MultiProofTask::new(config, executor, proof_task_handle, channel.0, 1, None)
     }
 
     #[test]

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -1236,7 +1236,6 @@ mod tests {
             config.consistent_view.clone(),
             task_ctx,
             1, // max_concurrency for test
-            1, // storage worker count for test
         )
         .expect("Failed to create proof task handle for multiproof test");
         let channel = channel();

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -1236,6 +1236,7 @@ mod tests {
             config.consistent_view.clone(),
             task_ctx,
             1, // max_concurrency for test
+            1, // storage worker count for test
         )
         .expect("Failed to create proof task handle for multiproof test");
         let channel = channel();

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -1236,7 +1236,9 @@ mod tests {
             config.consistent_view.clone(),
             task_ctx,
             1,
-        );
+            1, // storage_worker_count for test
+        )
+        .expect("Failed to create ProofTaskManager for multiproof test");
         let channel = channel();
 
         MultiProofTask::new(config, executor, proof_task.handle(), channel.0, 1, None)

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -878,15 +878,14 @@ where
                 let spawn_start = Instant::now();
                 let (handle, strategy) = if trie_input.prefix_sets.is_empty() {
                     (
-                        self.payload_processor
-                            .spawn(
-                                env,
-                                txs,
-                                provider_builder,
-                                consistent_view,
-                                trie_input,
-                                &self.config,
-                            )?,
+                        self.payload_processor.spawn(
+                            env,
+                            txs,
+                            provider_builder,
+                            consistent_view,
+                            trie_input,
+                            &self.config,
+                        )?,
                         StateRootStrategy::StateRootTask,
                     )
                 // if prefix sets are not empty, we spawn a task that exclusively handles cache

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -878,14 +878,15 @@ where
                 let spawn_start = Instant::now();
                 let (handle, strategy) = if trie_input.prefix_sets.is_empty() {
                     (
-                        self.payload_processor.spawn(
-                            env,
-                            txs,
-                            provider_builder,
-                            consistent_view,
-                            trie_input,
-                            &self.config,
-                        ),
+                        self.payload_processor
+                            .spawn(
+                                env,
+                                txs,
+                                provider_builder,
+                                consistent_view,
+                                trie_input,
+                                &self.config,
+                            )?,
                         StateRootStrategy::StateRootTask,
                     )
                 // if prefix sets are not empty, we spawn a task that exclusively handles cache

--- a/crates/trie/parallel/Cargo.toml
+++ b/crates/trie/parallel/Cargo.toml
@@ -36,6 +36,7 @@ derive_more.workspace = true
 rayon.workspace = true
 itertools.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"] }
+crossbeam-channel.workspace = true
 
 # `metrics` feature
 reth-metrics = { workspace = true, optional = true }

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -500,7 +500,6 @@ mod tests {
         assert_eq!(parallel_result, sequential_result_decoded);
 
         // Drop the handle to release transaction pool resources
-        // Note: No manager loop to join in the new design - handle manages lifecycle via Drop
         drop(proof_task_handle);
     }
 }

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -461,7 +461,6 @@ mod tests {
             consistent_view.clone(),
             task_ctx,
             1, // max_concurrency for test
-            1, // storage worker count for test
         )
         .expect("Failed to create proof task");
 

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -122,7 +122,7 @@ where
         let input = StorageProofInput::new(
             hashed_address,
             prefix_set,
-            target_slots,
+            Arc::new(target_slots),
             self.collect_branch_node_masks,
             self.multi_added_removed_keys.clone(),
         );
@@ -447,8 +447,14 @@ mod tests {
 
         let task_ctx =
             ProofTaskCtx::new(Default::default(), Default::default(), Default::default());
-        let proof_task =
-            ProofTaskManager::new(rt.handle().clone(), consistent_view.clone(), task_ctx, 1);
+        let proof_task = ProofTaskManager::new(
+            rt.handle().clone(),
+            consistent_view.clone(),
+            task_ctx,
+            1,
+            1, // storage_worker_count for test
+        )
+        .expect("Failed to create proof task");
         let proof_task_handle = proof_task.handle();
 
         // keep the join handle around to make sure it does not return any errors

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -450,6 +450,7 @@ mod tests {
             consistent_view.clone(),
             task_ctx,
             1, // max_concurrency for test
+            1, // storage worker count for test
         )
         .expect("Failed to create proof task");
 

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -306,9 +306,9 @@ where
             );
         }
 
-        // Note: Transaction return to pool is handled by dispatch_task() after spawn_blocking
-        // completes. The Arc<ProofTaskTx> is moved into the closure and returned as the result,
-        // then sent back to the pool automatically. No explicit return needed here.
+        // Note: Transaction return to pool is handled automatically.
+        // The Arc<ProofTaskTx> is moved into the closure and returned as the result,
+        // then sent back to the pool. No explicit return needed here.
     }
 }
 

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -303,9 +303,6 @@ where
             );
         }
 
-        // Note: Transaction return to pool is handled automatically.
-        // The Arc<ProofTaskTx> is moved into the closure and returned as the result,
-        // then sent back to the pool. No explicit return needed here.
     }
 }
 

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -616,7 +616,7 @@ mod tests {
             runtime.handle().clone(),
             consistent_view,
             task_ctx,
-            4, // max_concurrency (results in worker_count = 4/2 = 2)
+            2, // max_concurrency (results in worker_count = 2)
         )
         .expect("failed to create proof task handle");
 

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -61,8 +61,7 @@ where
     Factory: DatabaseProviderFactory<Provider: BlockReader> + Clone + Send + Sync + 'static,
 {
     let queue_capacity = max_concurrency.max(1);
-    let worker_count = (queue_capacity / 2).max(1); // Right now we are only using half of the queue capacity for storage proofs. TODO: Update this
-                                                    // when we have account proof workers.
+    let worker_count = queue_capacity; // TODO: Update this when we have account proof workers.
 
     let (task_sender, task_receiver) = bounded(queue_capacity);
 

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -55,13 +55,12 @@ pub fn new_proof_task_handle<Factory>(
     view: ConsistentDbView<Factory>,
     task_ctx: ProofTaskCtx,
     max_concurrency: usize,
-    storage_worker_count: usize,
 ) -> ProviderResult<ProofTaskManagerHandle<<Factory::Provider as DBProvider>::Tx>>
 where
     Factory: DatabaseProviderFactory<Provider: BlockReader> + Clone + Send + Sync + 'static,
 {
     let queue_capacity = max_concurrency.max(1);
-    let worker_count = storage_worker_count.max(1).min(queue_capacity);
+    let worker_count = queue_capacity / 2; // Right now we are only using half of the queue capacity for storage proofs. TODO: Update this when we have account proof workers.
 
     let (task_sender, task_receiver) = bounded(queue_capacity);
 
@@ -618,8 +617,7 @@ mod tests {
             runtime.handle().clone(),
             consistent_view,
             task_ctx,
-            4, // queue capacity
-            2, // storage worker count
+            2, // queue capacity (and worker count)
         )
         .expect("failed to create proof task handle");
 

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -181,7 +181,7 @@ where
             // same hashed address, and we want to differentiate them during trace analysis.
             span_id = self.id,
         );
-        let _span_guard: tracing::span::Entered<'_> = span.enter();
+        let span_guard = span.enter();
 
         let target_slots_len = target_slots.len();
         let proof_start = Instant::now();
@@ -212,6 +212,8 @@ where
             proof_time = ?proof_start.elapsed(),
             "Completed storage proof task calculation"
         );
+
+        drop(span_guard);
 
         // Send the result back (log error if receiver dropped)
         if let Err(e) = result_sender.send(decoded_result) {


### PR DESCRIPTION
This PR aims to add worker pooling to our existing proof generation. This is the first pr to perform this migration. 

**Core logic:**
1. Determine workers based on parallelism 
2. Spawn x workers each with its own tx
3. Queue storage proofs via crossbeam channels to the workers

**Changes:**
- Use tokio blocking pool
- Replaced `ProofTaskManager` with a new `new_proof_task_handle` function for improved task management. We removed ProofTaskManager here as it was an intemediary that is not needed with direct wiring.

Issues closed:
- https://github.com/paradigmxyz/reth/issues/18735
- Parent: https://github.com/paradigmxyz/reth/issues/18800

References:
- Overall POC: https://github.com/paradigmxyz/reth/pull/18829
- Previously we had a PR up by [Rhovian](https://github.com/paradigmxyz/reth/pull/18752/files#diff-80873d1f05ecc984c7b969c759680e5fe91323687ff40d1b54e27644a9cd8d78). However the issue was that this is a larger refactors with significant back and forth, and therefore we had to bring this refactor in internally.

Next Steps: 
- Moving Account and Blinded nodes to adopt the same infrastructure