### PR TITLE
refactor: eliminate redundant allocation in precompile cache example

### DIFF
--- a/examples/precompile-cache/src/main.rs
+++ b/examples/precompile-cache/src/main.rs
@@ -176,7 +176,7 @@ where
     async fn build_evm(self, ctx: &BuilderContext<Node>) -> eyre::Result<Self::EVM> {
         let evm_config = EthEvmConfig::new_with_evm_factory(
             ctx.chain_spec(),
-            MyEvmFactory { precompile_cache: self.precompile_cache.clone() },
+            MyEvmFactory { precompile_cache: self.precompile_cache },
         );
         Ok(evm_config)
     }


### PR DESCRIPTION
Replace unnecessary clone with move operation in MyExecutorBuilder when creating MyEvmFactory. Since build_evm consumes self, the precompile_cache field can be moved directly, avoiding an extra Arc clone