### PR TITLE
chore(optimism): Remove redundant inherent with_conditional

### DIFF
--- a/crates/optimism/txpool/src/transaction.rs
+++ b/crates/optimism/txpool/src/transaction.rs
@@ -83,12 +83,6 @@ impl<Cons: SignedTransaction, Pooled> OpPooledTransaction<Cons, Pooled> {
     pub fn encoded_2718(&self) -> &Bytes {
         self.encoded_2718.get_or_init(|| self.inner.transaction().encoded_2718().into())
     }
-
-    /// Conditional setter.
-    pub fn with_conditional(mut self, conditional: TransactionConditional) -> Self {
-        self.conditional = Some(Box::new(conditional));
-        self
-    }
 }
 
 impl<Cons, Pooled> MaybeConditionalTransaction for OpPooledTransaction<Cons, Pooled> {


### PR DESCRIPTION
Remove the inherent OpPooledTransaction::with_conditional method and rely on the default with_conditional provided by MaybeConditionalTransaction. This eliminates duplicated API surface and aligns with the interop pattern (which only uses the trait default). No in-repo usages were found; behavior remains unchanged for callers that import the trait.