### PR TITLE
fix: remove noisy stderr prints in ERA1 cleanup (EraClient::delete_outside_range)

### DIFF
--- a/crates/era-downloader/src/client.rs
+++ b/crates/era-downloader/src/client.rs
@@ -128,8 +128,6 @@ impl<Http: HttpClient + Clone> EraClient<Http> {
                     let Some(number) = self.file_name_to_number(name) &&
                     (number < index || number >= last)
                 {
-                    eprintln!("Deleting file {}", entry.path().display());
-                    eprintln!("{number} < {index} || {number} >= {last}");
                     reth_fs_util::remove_file(entry.path())?;
                 }
             }


### PR DESCRIPTION

### Summary
Remove two `eprintln!` calls from library code to avoid noisy stderr output during ERA1 file cleanup.

### Why
- Library code should not write directly to stderr.
- Unnecessary prints pollute CLI/test output and bypass the project’s logging (`tracing`).

### Changes
- Delete two `eprintln!` lines in `crates/era-downloader/src/client.rs` within `EraClient::delete_outside_range`.

