### PR TITLE
fix: misleading error message in db list: show actual table name

### DIFF
--- a/crates/cli/commands/src/db/list.rs
+++ b/crates/cli/commands/src/db/list.rs
@@ -97,7 +97,7 @@ impl<N: NodeTypes> TableViewer<()> for ListTableViewer<'_, N> {
     fn view<T: Table>(&self) -> Result<(), Self::Error> {
         self.tool.provider_factory.db_ref().view(|tx| {
             let table_db = tx.inner.open_db(Some(self.args.table.name())).wrap_err("Could not open db.")?;
-            let stats = tx.inner.db_stat(&table_db).wrap_err(format!("Could not find table: {}", stringify!($table)))?;
+            let stats = tx.inner.db_stat(&table_db).wrap_err(format!("Could not find table: {}", self.args.table.name()))?;
             let total_entries = stats.entries();
             let final_entry_idx = total_entries.saturating_sub(1);
             if self.args.skip > final_entry_idx {


### PR DESCRIPTION

### Summary
Replace `stringify!($table)` with `self.args.table.name()` to display the real table name in error context.

### Why
- The previous message printed the literal `"$table"`, confusing users during troubleshooting.
- Accurate error messages improve CLI usability and supportability.

### Changes
- Update error context in `ListTableViewer::view` to use `self.args.table.name()`.

