### PR TITLE
ci: cache hive simulator images to reduce prepare-hive job time

### DIFF
--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -34,6 +34,10 @@ jobs:
           repository: ethereum/hive
           path: hivetests
 
+      - name: Get hive commit hash
+        id: hive-commit
+        run: echo "hash=$(cd hivetests && git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
       - uses: actions/setup-go@v6
         with:
           go-version: "^1.13.1"
@@ -44,7 +48,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ./hive_assets
-          key: hive-assets-${{ hashFiles('hivetests/**', '.github/assets/hive/build_simulators.sh') }}
+          key: hive-assets-${{ steps.hive-commit.outputs.hash }}-${{ hashFiles('.github/assets/hive/build_simulators.sh') }}
 
       - name: Build hive assets
         if: steps.cache-hive.outputs.cache-hit != 'true'

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -39,8 +39,29 @@ jobs:
           go-version: "^1.13.1"
       - run: go version
 
+      - name: Restore hive assets cache
+        id: cache-hive
+        uses: actions/cache@v4
+        with:
+          path: ./hive_assets
+          key: hive-assets-${{ hashFiles('hivetests/**', '.github/assets/hive/build_simulators.sh') }}
+
       - name: Build hive assets
+        if: steps.cache-hive.outputs.cache-hit != 'true'
         run: .github/assets/hive/build_simulators.sh
+
+      - name: Load cached Docker images
+        if: steps.cache-hive.outputs.cache-hit == 'true'
+        run: |
+          cd hive_assets
+          for tar_file in *.tar; do
+            if [ -f "$tar_file" ]; then
+              echo "Loading $tar_file..."
+              docker load -i "$tar_file"
+            fi
+          done
+          # Make hive binary executable
+          chmod +x hive
 
       - name: Upload hive assets
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
then cache key depends on latest hive master commit seen on the build. `prepare-hive` job goes from ~15m https://github.com/paradigmxyz/reth/actions/runs/18340183869 to 6m https://github.com/paradigmxyz/reth/actions/runs/18341295331 when the cache is available