### PR TITLE
chore: make clippy happy

### DIFF
--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -2272,7 +2272,7 @@ mod tests {
 
             // Invalid/Non-existent argument should return `None`
             {
-                call_method!($arg_count, provider, $method, |_,_,_,_| ( ($invalid_args, None)), tx_num, tx_hash, &in_memory_blocks[0], &receipts);
+                call_method!($arg_count, provider, $method, |_,_,_,_|  ($invalid_args, None), tx_num, tx_hash, &in_memory_blocks[0], &receipts);
             }
 
             // Check that the item is only in memory and not in database
@@ -2283,7 +2283,7 @@ mod tests {
                 call_method!($arg_count, provider, $method, |_,_,_,_| (args.clone(), expected_item), tx_num, tx_hash, last_mem_block, &receipts);
 
                 // Ensure the item is not in storage
-                call_method!($arg_count, provider.database, $method, |_,_,_,_| ( (args, None)), tx_num, tx_hash, last_mem_block, &receipts);
+                call_method!($arg_count, provider.database, $method, |_,_,_,_|  (args, None), tx_num, tx_hash, last_mem_block, &receipts);
             }
         )*
     }};


### PR DESCRIPTION
Attempt to make clippy happy and to fix 
```
error: unnecessary parentheses
    --> crates/storage/provider/src/providers/blockchain_provider.rs:2275:71
     |
2275 |                   call_method!($arg_count, provider, $method, |_,_,_,_| ( ($invalid_args, None)), tx_num, tx_hash, &in_memory_blocks[0], &r...
     |                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^ help: remove them: `($invalid_args, None)`
...
2296 | /         test_non_range!([
2297 | |             (
2298 | |                 ONE,
2299 | |                 header,
...    |
2523 | |         ]);
     | |__________- in this macro invocation
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#double_parens
     = note: `-D clippy::double-parens` implied by `-D warnings`
     = help: to override `-D warnings` add `#[allow(clippy::double_parens)]`
     = note: this error originates in the macro `test_non_range` (in Nightly builds, run with -Z macro-backtrace for more info)

error: unnecessary parentheses
    --> crates/storage/provider/src/providers/blockchain_provider.rs:2286:80
     |
2286 |                   call_method!($arg_count, provider.database, $method, |_,_,_,_| ( (args, None)), tx_num, tx_hash, last_mem_block, &receipts);
     |                                                                                  ^^^^^^^^^^^^^^^ help: remove them: `(args, None)`
...
```