### PR TITLE
chore(node): simplify EngineApiExt bounds by removing redundant constraints

### DIFF
--- a/crates/node/builder/src/engine_api_ext.rs
+++ b/crates/node/builder/src/engine_api_ext.rs
@@ -5,7 +5,6 @@
 use crate::rpc::EngineApiBuilder;
 use eyre::Result;
 use reth_node_api::{AddOnsContext, FullNodeComponents};
-use reth_rpc_api::IntoEngineApiRpcModule;
 
 /// Provides access to an `EngineApi` instance with a callback
 #[derive(Debug)]
@@ -27,7 +26,7 @@ impl<N, B, F> EngineApiBuilder<N> for EngineApiExt<B, F>
 where
     B: EngineApiBuilder<N>,
     N: FullNodeComponents,
-    B::EngineApi: IntoEngineApiRpcModule + Send + Sync + Clone + 'static,
+    B::EngineApi: Clone,
     F: FnOnce(B::EngineApi) + Send + Sync + 'static,
 {
     type EngineApi = B::EngineApi;


### PR DESCRIPTION
- Removed duplicated IntoEngineApiRpcModule + Send + Sync bounds from B::EngineApi in EngineApiExt since EngineApiBuilder already guarantees them.
- Kept only B::EngineApi: Clone, which is required to pass the API value into the callback.

This reduces redundancy, unused import