### PR TITLE
perf(tests): remove redundant format! in ef-tests run_only

### DIFF
--- a/testing/ef-tests/tests/tests.rs
+++ b/testing/ef-tests/tests/tests.rs
@@ -93,7 +93,7 @@ macro_rules! blockchain_test {
                 .join("ethereum-tests")
                 .join("BlockchainTests");
 
-            BlockchainTests::new(suite_path).run_only(&format!("{}", stringify!($dir)));
+            BlockchainTests::new(suite_path).run_only(stringify!($dir));
         }
     };
 }


### PR DESCRIPTION


Description:
- Summary: Replace unnecessary string formatting with a direct literal in tests to avoid temporary allocation and improve readability.
- Change: In testing/ef-tests/tests/tests.rs, use stringify!($dir) instead of &format!("{}", stringify!($dir)).
- Rationale: Eliminates one allocation and simplifies the code.
