### PR TITLE
chore: align node_config threshold constant

### DIFF
--- a/crates/node/core/src/node_config.rs
+++ b/crates/node/core/src/node_config.rs
@@ -36,11 +36,8 @@ use tracing::*;
 use crate::args::EraArgs;
 pub use reth_engine_primitives::{
     DEFAULT_MAX_PROOF_TASK_CONCURRENCY, DEFAULT_MEMORY_BLOCK_BUFFER_TARGET,
-    DEFAULT_RESERVED_CPU_CORES,
+    DEFAULT_PERSISTENCE_THRESHOLD, DEFAULT_RESERVED_CPU_CORES,
 };
-
-/// Triggers persistence when the number of canonical blocks in memory exceeds this threshold.
-pub const DEFAULT_PERSISTENCE_THRESHOLD: u64 = 2;
 
 /// Default size of cross-block cache in megabytes.
 pub const DEFAULT_CROSS_BLOCK_CACHE_SIZE_MB: u64 = 4 * 1024;


### PR DESCRIPTION
Remove the redundant DEFAULT_PERSISTENCE_THRESHOLD in node_config. Re-export the canonical constant from reth_engine_primitives instead. Keeps a single source of truth and avoids future drift.