### PR TITLE
fix: replace blocking file removal with async operation in IPC server

### DIFF
--- a/crates/rpc/ipc/src/server/mod.rs
+++ b/crates/rpc/ipc/src/server/mod.rs
@@ -127,8 +127,8 @@ where
         trace!(endpoint = ?self.endpoint, "starting ipc server");
 
         if cfg!(unix) {
-            // ensure the file does not exist
-            if std::fs::remove_file(&self.endpoint).is_ok() {
+            // ensure the file does not exist (avoid blocking the async runtime)
+            if tokio::fs::remove_file(&self.endpoint).await.is_ok() {
                 debug!(endpoint = ?self.endpoint, "removed existing IPC endpoint file");
             }
         }


### PR DESCRIPTION

## Summary

Replaces a blocking `std::fs::remove_file` call with the asynchronous `tokio::fs::remove_file(...).await` in the IPC server's `start_inner` function to prevent runtime blocking.

## Problem

The `start_inner` function in `crates/rpc/ipc/src/server/mod.rs` contained a blocking call to `std::fs::remove_file` within an async context. This could block the tokio runtime thread and potentially degrade performance by causing head-of-line blocking, where other async tasks on the same executor could be delayed.

## Solution

- Replaced `std::fs::remove_file(&self.endpoint)` with `tokio::fs::remove_file(&self.endpoint).await`
- Maintains the same functionality while being non-blocking

