### PR TITLE
refactor: use to_owned() for bytecode cloning in cached state

### DIFF
--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -382,7 +382,7 @@ impl ExecutionCache {
     pub(crate) fn insert_state(&self, state_updates: &BundleState) -> Result<(), ()> {
         // Insert bytecodes
         for (code_hash, bytecode) in &state_updates.contracts {
-            self.code_cache.insert(*code_hash, Some(Bytecode(bytecode.clone())));
+            self.code_cache.insert(*code_hash, Some(Bytecode(bytecode.to_owned())));
         }
 
         for (addr, account) in &state_updates.state {


### PR DESCRIPTION

## Summary

Replaces `.clone()` with the more idiomatic `.to_owned()` when cloning referenced bytecode in the execution cache's `insert_state` method.

## Changes

- Changed `bytecode.clone()` to `bytecode.to_owned()` in `crates/engine/tree/src/tree/cached_state.rs`

## Rationale

Using `.to_owned()` instead of `.clone()` when converting from a reference to an owned value is more idiomatic in Rust and makes the intent clearer:
- `.to_owned()` explicitly signals we're taking ownership of borrowed data


