### PR TITLE
fix(cli): allow disabling invalid block hooks by removing default “witness”

### DIFF
--- a/crates/node/core/src/args/debug.rs
+++ b/crates/node/core/src/args/debug.rs
@@ -78,8 +78,7 @@ pub struct DebugArgs {
     #[arg(
         long = "debug.invalid-block-hook",
         help_heading = "Debug",
-        value_parser = InvalidBlockSelectionValueParser::default(),
-        default_value = "witness"
+        value_parser = InvalidBlockSelectionValueParser::default()
     )]
     pub invalid_block_hook: Option<InvalidBlockSelection>,
 
@@ -116,7 +115,7 @@ impl Default for DebugArgs {
             reorg_frequency: None,
             reorg_depth: None,
             engine_api_store: None,
-            invalid_block_hook: Some(InvalidBlockSelection::default()),
+            invalid_block_hook: None,
             healthy_node_rpc_url: None,
             ethstats: None,
         }
@@ -347,6 +346,7 @@ mod tests {
         let default_args = DebugArgs::default();
         let args = CommandParser::<DebugArgs>::parse_from(["reth"]).args;
         assert_eq!(args, default_args);
+        assert!(args.invalid_block_hook.is_none());
     }
 
     #[test]

--- a/crates/node/core/src/args/debug.rs
+++ b/crates/node/core/src/args/debug.rs
@@ -9,7 +9,7 @@ use std::{collections::HashSet, ffi::OsStr, fmt, path::PathBuf, str::FromStr};
 use strum::{AsRefStr, EnumIter, IntoStaticStr, ParseError, VariantArray, VariantNames};
 
 /// Parameters for debugging purposes
-#[derive(Debug, Clone, Args, PartialEq, Eq)]
+#[derive(Debug, Clone, Args, PartialEq, Eq, Default)]
 #[command(next_help_heading = "Debug")]
 pub struct DebugArgs {
     /// Flag indicating whether the node should be terminated after the pipeline sync.
@@ -100,26 +100,6 @@ pub struct DebugArgs {
     /// Example: `nodename:secret@host:port`
     #[arg(long = "ethstats", help_heading = "Debug")]
     pub ethstats: Option<String>,
-}
-
-impl Default for DebugArgs {
-    fn default() -> Self {
-        Self {
-            terminate: false,
-            tip: None,
-            max_block: None,
-            etherscan: None,
-            rpc_consensus_url: None,
-            skip_fcu: None,
-            skip_new_payload: None,
-            reorg_frequency: None,
-            reorg_depth: None,
-            engine_api_store: None,
-            invalid_block_hook: None,
-            healthy_node_rpc_url: None,
-            ethstats: None,
-        }
-    }
 }
 
 /// Describes the invalid block hooks that should be installed.

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -666,9 +666,9 @@ Debug:
           Determines which type of invalid block hook to install
 
           Example: `witness,prestate`
-
-          [default: witness]
           [possible values: witness, pre-state, opcode]
+
+          Note: Disabled by default. Specify this flag to enable hooks.
 
       --debug.healthy-node-rpc-url <URL>
           The RPC URL of a healthy node to use for comparing invalid block hook results against.


### PR DESCRIPTION
Problem: The --debug.invalid-block-hook flag used default_value = "witness" with Option<_>, which always parsed as Some(Witness). This made the None branch (installing NoopInvalidBlockHook) unreachable via CLI, so users couldn’t disable hooks.

Solution: Removed the clap default for --debug.invalid-block-hook and set DebugArgs::default().invalid_block_hook = None. Updated tests to expect None by default and amended CLI docs to state hooks are disabled by default.

Impact: Omitting the flag now disables invalid block hooks; users must pass the flag to enable hooks (e.g., --debug.invalid-block-hook witness).