### PR TITLE
chore(trie): Remove ExecutedBlockWithTrieUpdates

### DIFF
--- a/crates/chain-state/benches/canonical_hashes_range.rs
+++ b/crates/chain-state/benches/canonical_hashes_range.rs
@@ -2,7 +2,7 @@
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use reth_chain_state::{
-    test_utils::TestBlockBuilder, ExecutedBlockWithTrieUpdates, MemoryOverlayStateProviderRef,
+    test_utils::TestBlockBuilder, ExecutedBlock, MemoryOverlayStateProviderRef,
 };
 use reth_ethereum_primitives::EthPrimitives;
 use reth_storage_api::{noop::NoopProvider, BlockHashReader};
@@ -84,10 +84,7 @@ fn bench_canonical_hashes_range(c: &mut Criterion) {
 
 fn setup_provider_with_blocks(
     num_blocks: usize,
-) -> (
-    MemoryOverlayStateProviderRef<'static, EthPrimitives>,
-    Vec<ExecutedBlockWithTrieUpdates<EthPrimitives>>,
-) {
+) -> (MemoryOverlayStateProviderRef<'static, EthPrimitives>, Vec<ExecutedBlock<EthPrimitives>>) {
     let mut builder = TestBlockBuilder::<EthPrimitives>::default();
 
     let blocks: Vec<_> = builder.get_executed_blocks(1000..1000 + num_blocks as u64).collect();

--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -242,7 +242,7 @@ impl<N: NodePrimitives> CanonicalInMemoryState<N> {
     /// Updates the pending block with the given block.
     ///
     /// Note: This assumes that the parent block of the pending block is canonical.
-    pub fn set_pending_block(&self, pending: ExecutedBlockWithTrieUpdates<N>) {
+    pub fn set_pending_block(&self, pending: ExecutedBlock<N>) {
         // fetch the state of the pending block's parent block
         let parent = self.state_by_hash(pending.recovered_block().parent_hash());
         let pending = BlockState::with_parent(pending, parent);
@@ -258,7 +258,7 @@ impl<N: NodePrimitives> CanonicalInMemoryState<N> {
     /// them to their parent blocks.
     fn update_blocks<I, R>(&self, new_blocks: I, reorged: R)
     where
-        I: IntoIterator<Item = ExecutedBlockWithTrieUpdates<N>>,
+        I: IntoIterator<Item = ExecutedBlock<N>>,
         R: IntoIterator<Item = ExecutedBlock<N>>,
     {
         {
@@ -568,22 +568,19 @@ impl<N: NodePrimitives> CanonicalInMemoryState<N> {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct BlockState<N: NodePrimitives = EthPrimitives> {
     /// The executed block that determines the state after this block has been executed.
-    block: ExecutedBlockWithTrieUpdates<N>,
+    block: ExecutedBlock<N>,
     /// The block's parent block if it exists.
     parent: Option<Arc<BlockState<N>>>,
 }
 
 impl<N: NodePrimitives> BlockState<N> {
     /// [`BlockState`] constructor.
-    pub const fn new(block: ExecutedBlockWithTrieUpdates<N>) -> Self {
+    pub const fn new(block: ExecutedBlock<N>) -> Self {
         Self { block, parent: None }
     }
 
     /// [`BlockState`] constructor with parent.
-    pub const fn with_parent(
-        block: ExecutedBlockWithTrieUpdates<N>,
-        parent: Option<Arc<Self>>,
-    ) -> Self {
+    pub const fn with_parent(block: ExecutedBlock<N>, parent: Option<Arc<Self>>) -> Self {
         Self { block, parent }
     }
 
@@ -597,12 +594,12 @@ impl<N: NodePrimitives> BlockState<N> {
     }
 
     /// Returns the executed block that determines the state.
-    pub fn block(&self) -> ExecutedBlockWithTrieUpdates<N> {
+    pub fn block(&self) -> ExecutedBlock<N> {
         self.block.clone()
     }
 
     /// Returns a reference to the executed block that determines the state.
-    pub const fn block_ref(&self) -> &ExecutedBlockWithTrieUpdates<N> {
+    pub const fn block_ref(&self) -> &ExecutedBlock<N> {
         &self.block
     }
 
@@ -730,6 +727,8 @@ pub struct ExecutedBlock<N: NodePrimitives = EthPrimitives> {
     pub execution_output: Arc<ExecutionOutcome<N::Receipt>>,
     /// Block's hashed state.
     pub hashed_state: Arc<HashedPostState>,
+    /// Trie updates that result from calculating the state root for the block.
+    pub trie_updates: Arc<TrieUpdates>,
 }
 
 impl<N: NodePrimitives> Default for ExecutedBlock<N> {
@@ -738,6 +737,7 @@ impl<N: NodePrimitives> Default for ExecutedBlock<N> {
             recovered_block: Default::default(),
             execution_output: Default::default(),
             hashed_state: Default::default(),
+            trie_updates: Default::default(),
         }
     }
 }
@@ -767,113 +767,16 @@ impl<N: NodePrimitives> ExecutedBlock<N> {
         &self.hashed_state
     }
 
+    /// Returns a reference to the trie updates resulting from the execution outcome
+    #[inline]
+    pub fn trie_updates(&self) -> &TrieUpdates {
+        &self.trie_updates
+    }
+
     /// Returns a [`BlockNumber`] of the block.
     #[inline]
     pub fn block_number(&self) -> BlockNumber {
         self.recovered_block.header().number()
-    }
-}
-
-/// Trie updates that result from calculating the state root for the block.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ExecutedTrieUpdates {
-    /// Trie updates present. State root was calculated, and the trie updates can be applied to the
-    /// database.
-    Present(Arc<TrieUpdates>),
-    /// Trie updates missing. State root was calculated, but the trie updates cannot be applied to
-    /// the current database state. To apply the updates, the state root must be recalculated, and
-    /// new trie updates must be generated.
-    ///
-    /// This can happen when processing fork chain blocks that are building on top of the
-    /// historical database state. Since we don't store the historical trie state, we cannot
-    /// generate the trie updates for it.
-    Missing,
-}
-
-impl ExecutedTrieUpdates {
-    /// Creates a [`ExecutedTrieUpdates`] with present but empty trie updates.
-    pub fn empty() -> Self {
-        Self::Present(Arc::default())
-    }
-
-    /// Sets the trie updates to the provided value as present.
-    pub fn set_present(&mut self, updates: Arc<TrieUpdates>) {
-        *self = Self::Present(updates);
-    }
-
-    /// Takes the present trie updates, leaving the state as missing.
-    pub fn take_present(&mut self) -> Option<Arc<TrieUpdates>> {
-        match self {
-            Self::Present(updates) => {
-                let updates = core::mem::take(updates);
-                *self = Self::Missing;
-                Some(updates)
-            }
-            Self::Missing => None,
-        }
-    }
-
-    /// Returns a reference to the trie updates if present.
-    #[allow(clippy::missing_const_for_fn)] // false positive
-    pub fn as_ref(&self) -> Option<&TrieUpdates> {
-        match self {
-            Self::Present(updates) => Some(updates),
-            Self::Missing => None,
-        }
-    }
-
-    /// Returns `true` if the trie updates are present.
-    pub const fn is_present(&self) -> bool {
-        matches!(self, Self::Present(_))
-    }
-
-    /// Returns `true` if the trie updates are missing.
-    pub const fn is_missing(&self) -> bool {
-        matches!(self, Self::Missing)
-    }
-}
-
-/// An [`ExecutedBlock`] with its [`TrieUpdates`].
-///
-/// We store it as separate type because [`TrieUpdates`] are only available for blocks stored in
-/// memory and can't be obtained for canonical persisted blocks.
-#[derive(
-    Clone, Debug, PartialEq, Eq, derive_more::Deref, derive_more::DerefMut, derive_more::Into,
-)]
-pub struct ExecutedBlockWithTrieUpdates<N: NodePrimitives = EthPrimitives> {
-    /// Inner [`ExecutedBlock`].
-    #[deref]
-    #[deref_mut]
-    #[into]
-    pub block: ExecutedBlock<N>,
-    /// Trie updates that result from calculating the state root for the block.
-    ///
-    /// If [`ExecutedTrieUpdates::Missing`], the trie updates should be computed when persisting
-    /// the block **on top of the canonical parent**.
-    pub trie: ExecutedTrieUpdates,
-}
-
-impl<N: NodePrimitives> ExecutedBlockWithTrieUpdates<N> {
-    /// [`ExecutedBlock`] constructor.
-    pub const fn new(
-        recovered_block: Arc<RecoveredBlock<N::Block>>,
-        execution_output: Arc<ExecutionOutcome<N::Receipt>>,
-        hashed_state: Arc<HashedPostState>,
-        trie: ExecutedTrieUpdates,
-    ) -> Self {
-        Self { block: ExecutedBlock { recovered_block, execution_output, hashed_state }, trie }
-    }
-
-    /// Returns a reference to the trie updates for the block, if present.
-    #[inline]
-    pub fn trie_updates(&self) -> Option<&TrieUpdates> {
-        self.trie.as_ref()
-    }
-
-    /// Converts the value into [`SealedBlock`].
-    pub fn into_sealed_block(self) -> SealedBlock<N::Block> {
-        let block = Arc::unwrap_or_clone(self.block.recovered_block);
-        block.into_sealed_block()
     }
 }
 
@@ -883,18 +786,14 @@ pub enum NewCanonicalChain<N: NodePrimitives = EthPrimitives> {
     /// A simple append to the current canonical head
     Commit {
         /// all blocks that lead back to the canonical head
-        new: Vec<ExecutedBlockWithTrieUpdates<N>>,
+        new: Vec<ExecutedBlock<N>>,
     },
     /// A reorged chain consists of two chains that trace back to a shared ancestor block at which
     /// point they diverge.
     Reorg {
         /// All blocks of the _new_ chain
-        new: Vec<ExecutedBlockWithTrieUpdates<N>>,
+        new: Vec<ExecutedBlock<N>>,
         /// All blocks of the _old_ chain
-        ///
-        /// These are not [`ExecutedBlockWithTrieUpdates`] because we don't always have the trie
-        /// updates for the old canonical chain. For example, in case of node being restarted right
-        /// before the reorg [`TrieUpdates`] can't be fetched from database.
         old: Vec<ExecutedBlock<N>>,
     },
 }
@@ -1257,7 +1156,7 @@ mod tests {
             block1.recovered_block().hash()
         );
 
-        let chain = NewCanonicalChain::Reorg { new: vec![block2.clone()], old: vec![block1.block] };
+        let chain = NewCanonicalChain::Reorg { new: vec![block2.clone()], old: vec![block1] };
         state.update_chain(chain);
         assert_eq!(
             state.head_state().unwrap().block_ref().recovered_block().hash(),
@@ -1540,7 +1439,7 @@ mod tests {
         // Test reorg notification
         let chain_reorg = NewCanonicalChain::Reorg {
             new: vec![block1a.clone(), block2a.clone()],
-            old: vec![block1.block.clone(), block2.block.clone()],
+            old: vec![block1.clone(), block2.clone()],
         };
 
         assert_eq!(

--- a/crates/chain-state/src/memory_overlay.rs
+++ b/crates/chain-state/src/memory_overlay.rs
@@ -1,4 +1,4 @@
-use super::ExecutedBlockWithTrieUpdates;
+use super::ExecutedBlock;
 use alloy_consensus::BlockHeader;
 use alloy_primitives::{keccak256, Address, BlockNumber, Bytes, StorageKey, StorageValue, B256};
 use reth_errors::ProviderResult;
@@ -24,7 +24,7 @@ pub struct MemoryOverlayStateProviderRef<
     /// Historical state provider for state lookups that are not found in memory blocks.
     pub(crate) historical: Box<dyn StateProvider + 'a>,
     /// The collection of executed parent blocks. Expected order is newest to oldest.
-    pub(crate) in_memory: Vec<ExecutedBlockWithTrieUpdates<N>>,
+    pub(crate) in_memory: Vec<ExecutedBlock<N>>,
     /// Lazy-loaded in-memory trie data.
     pub(crate) trie_input: OnceLock<TrieInput>,
 }
@@ -41,10 +41,7 @@ impl<'a, N: NodePrimitives> MemoryOverlayStateProviderRef<'a, N> {
     /// - `in_memory` - the collection of executed ancestor blocks in reverse.
     /// - `historical` - a historical state provider for the latest ancestor block stored in the
     ///   database.
-    pub fn new(
-        historical: Box<dyn StateProvider + 'a>,
-        in_memory: Vec<ExecutedBlockWithTrieUpdates<N>>,
-    ) -> Self {
+    pub fn new(historical: Box<dyn StateProvider + 'a>, in_memory: Vec<ExecutedBlock<N>>) -> Self {
         Self { historical, in_memory, trie_input: OnceLock::new() }
     }
 
@@ -60,7 +57,7 @@ impl<'a, N: NodePrimitives> MemoryOverlayStateProviderRef<'a, N> {
                 self.in_memory
                     .iter()
                     .rev()
-                    .map(|block| (block.hashed_state.as_ref(), block.trie.as_ref())),
+                    .map(|block| (block.hashed_state.as_ref(), block.trie_updates.as_ref())),
             )
         })
     }

--- a/crates/chain-state/src/test_utils.rs
+++ b/crates/chain-state/src/test_utils.rs
@@ -221,7 +221,7 @@ impl<N: NodePrimitives> TestBlockBuilder<N> {
         }
     }
 
-    /// Generates an [`ExecutedBlockWithTrieUpdates`] that includes the given receipts.
+    /// Generates an [`ExecutedBlock`] that includes the given receipts.
     pub fn get_executed_block_with_receipts(
         &mut self,
         receipts: Vec<Vec<Receipt>>,
@@ -231,7 +231,7 @@ impl<N: NodePrimitives> TestBlockBuilder<N> {
         self.get_executed_block(number, receipts, parent_hash)
     }
 
-    /// Generates an [`ExecutedBlockWithTrieUpdates`] with the given [`BlockNumber`].
+    /// Generates an [`ExecutedBlock`] with the given [`BlockNumber`].
     pub fn get_executed_block_with_number(
         &mut self,
         block_number: BlockNumber,

--- a/crates/chain-state/src/test_utils.rs
+++ b/crates/chain-state/src/test_utils.rs
@@ -1,6 +1,6 @@
 use crate::{
-    in_memory::ExecutedBlockWithTrieUpdates, CanonStateNotification, CanonStateNotifications,
-    CanonStateSubscriptions, ExecutedTrieUpdates,
+    in_memory::ExecutedBlock, CanonStateNotification, CanonStateNotifications,
+    CanonStateSubscriptions,
 };
 use alloy_consensus::{Header, SignableTransaction, TxEip1559, TxReceipt, EMPTY_ROOT_HASH};
 use alloy_eips::{
@@ -23,7 +23,7 @@ use reth_primitives_traits::{
     SignedTransaction,
 };
 use reth_storage_api::NodePrimitivesProvider;
-use reth_trie::{root::state_root_unhashed, HashedPostState};
+use reth_trie::{root::state_root_unhashed, updates::TrieUpdates, HashedPostState};
 use revm_database::BundleState;
 use revm_state::AccountInfo;
 use std::{
@@ -198,27 +198,27 @@ impl<N: NodePrimitives> TestBlockBuilder<N> {
         fork
     }
 
-    /// Gets an [`ExecutedBlockWithTrieUpdates`] with [`BlockNumber`], receipts and parent hash.
+    /// Gets an [`ExecutedBlock`] with [`BlockNumber`], receipts and parent hash.
     fn get_executed_block(
         &mut self,
         block_number: BlockNumber,
         receipts: Vec<Vec<Receipt>>,
         parent_hash: B256,
-    ) -> ExecutedBlockWithTrieUpdates {
+    ) -> ExecutedBlock {
         let block_with_senders = self.generate_random_block(block_number, parent_hash);
 
         let (block, senders) = block_with_senders.split_sealed();
-        ExecutedBlockWithTrieUpdates::new(
-            Arc::new(RecoveredBlock::new_sealed(block, senders)),
-            Arc::new(ExecutionOutcome::new(
+        ExecutedBlock {
+            recovered_block: Arc::new(RecoveredBlock::new_sealed(block, senders)),
+            execution_output: Arc::new(ExecutionOutcome::new(
                 BundleState::default(),
                 receipts,
                 block_number,
                 vec![Requests::default()],
             )),
-            Arc::new(HashedPostState::default()),
-            ExecutedTrieUpdates::empty(),
-        )
+            hashed_state: Arc::new(HashedPostState::default()),
+            trie_updates: Arc::new(TrieUpdates::default()),
+        }
     }
 
     /// Generates an [`ExecutedBlockWithTrieUpdates`] that includes the given receipts.
@@ -226,7 +226,7 @@ impl<N: NodePrimitives> TestBlockBuilder<N> {
         &mut self,
         receipts: Vec<Vec<Receipt>>,
         parent_hash: B256,
-    ) -> ExecutedBlockWithTrieUpdates {
+    ) -> ExecutedBlock {
         let number = rand::rng().random::<u64>();
         self.get_executed_block(number, receipts, parent_hash)
     }
@@ -236,7 +236,7 @@ impl<N: NodePrimitives> TestBlockBuilder<N> {
         &mut self,
         block_number: BlockNumber,
         parent_hash: B256,
-    ) -> ExecutedBlockWithTrieUpdates {
+    ) -> ExecutedBlock {
         self.get_executed_block(block_number, vec![vec![]], parent_hash)
     }
 
@@ -244,7 +244,7 @@ impl<N: NodePrimitives> TestBlockBuilder<N> {
     pub fn get_executed_blocks(
         &mut self,
         range: Range<u64>,
-    ) -> impl Iterator<Item = ExecutedBlockWithTrieUpdates> + '_ {
+    ) -> impl Iterator<Item = ExecutedBlock> + '_ {
         let mut parent_hash = B256::default();
         range.map(move |number| {
             let current_parent_hash = parent_hash;

--- a/crates/engine/primitives/src/event.rs
+++ b/crates/engine/primitives/src/event.rs
@@ -10,7 +10,7 @@ use core::{
     fmt::{Display, Formatter, Result},
     time::Duration,
 };
-use reth_chain_state::ExecutedBlockWithTrieUpdates;
+use reth_chain_state::ExecutedBlock;
 use reth_ethereum_primitives::EthPrimitives;
 use reth_primitives_traits::{NodePrimitives, SealedBlock, SealedHeader};
 
@@ -24,11 +24,11 @@ pub enum ConsensusEngineEvent<N: NodePrimitives = EthPrimitives> {
     /// The fork choice state was updated, and the current fork choice status
     ForkchoiceUpdated(ForkchoiceState, ForkchoiceStatus),
     /// A block was added to the fork chain.
-    ForkBlockAdded(ExecutedBlockWithTrieUpdates<N>, Duration),
+    ForkBlockAdded(ExecutedBlock<N>, Duration),
     /// A new block was received from the consensus engine
     BlockReceived(BlockNumHash),
     /// A block was added to the canonical chain, and the elapsed time validating the block
-    CanonicalBlockAdded(ExecutedBlockWithTrieUpdates<N>, Duration),
+    CanonicalBlockAdded(ExecutedBlock<N>, Duration),
     /// A canonical chain was committed, and the elapsed time committing the data
     CanonicalChainCommitted(Box<SealedHeader<N::BlockHeader>>, Duration),
     /// The consensus engine processed an invalid block.

--- a/crates/engine/tree/src/engine.rs
+++ b/crates/engine/tree/src/engine.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use alloy_primitives::B256;
 use futures::{Stream, StreamExt};
-use reth_chain_state::ExecutedBlockWithTrieUpdates;
+use reth_chain_state::ExecutedBlock;
 use reth_engine_primitives::{BeaconEngineMessage, ConsensusEngineEvent};
 use reth_ethereum_primitives::EthPrimitives;
 use reth_payload_primitives::PayloadTypes;
@@ -246,7 +246,7 @@ pub enum EngineApiRequest<T: PayloadTypes, N: NodePrimitives> {
     /// A request received from the consensus engine.
     Beacon(BeaconEngineMessage<T>),
     /// Request to insert an already executed block, e.g. via payload building.
-    InsertExecutedBlock(ExecutedBlockWithTrieUpdates<N>),
+    InsertExecutedBlock(ExecutedBlock<N>),
 }
 
 impl<T: PayloadTypes, N: NodePrimitives> Display for EngineApiRequest<T, N> {

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -1,7 +1,7 @@
 use crate::metrics::PersistenceMetrics;
 use alloy_consensus::BlockHeader;
 use alloy_eips::BlockNumHash;
-use reth_chain_state::ExecutedBlockWithTrieUpdates;
+use reth_chain_state::ExecutedBlock;
 use reth_errors::ProviderError;
 use reth_ethereum_primitives::EthPrimitives;
 use reth_primitives_traits::NodePrimitives;
@@ -140,7 +140,7 @@ where
 
     fn on_save_blocks(
         &self,
-        blocks: Vec<ExecutedBlockWithTrieUpdates<N::Primitives>>,
+        blocks: Vec<ExecutedBlock<N::Primitives>>,
     ) -> Result<Option<BlockNumHash>, PersistenceError> {
         debug!(target: "engine::persistence", first=?blocks.first().map(|b| b.recovered_block.num_hash()), last=?blocks.last().map(|b| b.recovered_block.num_hash()), "Saving range of blocks");
         let start_time = Instant::now();
@@ -180,7 +180,7 @@ pub enum PersistenceAction<N: NodePrimitives = EthPrimitives> {
     ///
     /// First, header, transaction, and receipt-related data should be written to static files.
     /// Then the execution history-related data will be written to the database.
-    SaveBlocks(Vec<ExecutedBlockWithTrieUpdates<N>>, oneshot::Sender<Option<BlockNumHash>>),
+    SaveBlocks(Vec<ExecutedBlock<N>>, oneshot::Sender<Option<BlockNumHash>>),
 
     /// Removes block data above the given block number from the database.
     ///
@@ -257,7 +257,7 @@ impl<T: NodePrimitives> PersistenceHandle<T> {
     /// If there are no blocks to persist, then `None` is sent in the sender.
     pub fn save_blocks(
         &self,
-        blocks: Vec<ExecutedBlockWithTrieUpdates<T>>,
+        blocks: Vec<ExecutedBlock<T>>,
         tx: oneshot::Sender<Option<BlockNumHash>>,
     ) -> Result<(), SendError<PersistenceAction<T>>> {
         self.send_action(PersistenceAction::SaveBlocks(blocks, tx))

--- a/crates/engine/tree/src/tree/error.rs
+++ b/crates/engine/tree/src/tree/error.rs
@@ -1,7 +1,6 @@
 //! Internal errors for the tree module.
 
 use alloy_consensus::BlockHeader;
-use alloy_primitives::B256;
 use reth_consensus::ConsensusError;
 use reth_errors::{BlockExecutionError, BlockValidationError, ProviderError};
 use reth_evm::execute::InternalBlockExecutionError;
@@ -19,20 +18,6 @@ pub enum AdvancePersistenceError {
     /// A provider error
     #[error(transparent)]
     Provider(#[from] ProviderError),
-    /// Missing ancestor.
-    ///
-    /// This error occurs when we need to compute the state root for a block with missing trie
-    /// updates, but the ancestor block is not available. State root computation requires the state
-    /// from the parent block as a starting point.
-    ///
-    /// A block may be missing the trie updates when it's a fork chain block building on top of the
-    /// historical database state. Since we don't store the historical trie state, we cannot
-    /// generate the trie updates for it until the moment when database is unwound to the canonical
-    /// chain.
-    ///
-    /// Also see [`reth_chain_state::ExecutedTrieUpdates::Missing`].
-    #[error("Missing ancestor with hash {0}")]
-    MissingAncestor(B256),
 }
 
 #[derive(thiserror::Error)]

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -13,10 +13,8 @@ use alloy_rpc_types_engine::{
     ForkchoiceState, PayloadStatus, PayloadStatusEnum, PayloadValidationError,
 };
 use error::{InsertBlockError, InsertBlockFatalError};
-use persistence_state::CurrentPersistenceAction;
 use reth_chain_state::{
-    CanonicalInMemoryState, ExecutedBlock, ExecutedBlockWithTrieUpdates, ExecutedTrieUpdates,
-    MemoryOverlayStateProvider, NewCanonicalChain,
+    CanonicalInMemoryState, ExecutedBlock, MemoryOverlayStateProvider, NewCanonicalChain,
 };
 use reth_consensus::{Consensus, FullConsensus};
 use reth_engine_primitives::{
@@ -31,14 +29,12 @@ use reth_payload_primitives::{
 };
 use reth_primitives_traits::{NodePrimitives, RecoveredBlock, SealedBlock, SealedHeader};
 use reth_provider::{
-    providers::ConsistentDbView, BlockNumReader, BlockReader, DBProvider, DatabaseProviderFactory,
-    HashedPostStateProvider, ProviderError, StateProviderBox, StateProviderFactory, StateReader,
-    StateRootProvider, TransactionVariant,
+    providers::ConsistentDbView, BlockReader, DatabaseProviderFactory, HashedPostStateProvider,
+    ProviderError, StateProviderBox, StateProviderFactory, StateReader, TransactionVariant,
+    TrieReader,
 };
 use reth_revm::database::StateProviderDatabase;
 use reth_stages_api::ControlFlow;
-use reth_trie::{HashedPostState, TrieInput};
-use reth_trie_db::DatabaseHashedPostState;
 use revm::state::EvmState;
 use state::TreeState;
 use std::{
@@ -78,7 +74,6 @@ pub use payload_processor::*;
 pub use payload_validator::{BasicEngineValidator, EngineValidator};
 pub use persistence_state::PersistenceState;
 pub use reth_engine_primitives::TreeConfig;
-use reth_trie::KeccakKeyHasher;
 
 pub mod state;
 
@@ -101,7 +96,7 @@ pub struct StateProviderBuilder<N: NodePrimitives, P> {
     /// The historical block hash to fetch state from.
     historical: B256,
     /// The blocks that form the chain from historical to target and are in memory.
-    overlay: Option<Vec<ExecutedBlockWithTrieUpdates<N>>>,
+    overlay: Option<Vec<ExecutedBlock<N>>>,
 }
 
 impl<N: NodePrimitives, P> StateProviderBuilder<N, P> {
@@ -110,7 +105,7 @@ impl<N: NodePrimitives, P> StateProviderBuilder<N, P> {
     pub const fn new(
         provider_factory: P,
         historical: B256,
-        overlay: Option<Vec<ExecutedBlockWithTrieUpdates<N>>>,
+        overlay: Option<Vec<ExecutedBlock<N>>>,
     ) -> Self {
         Self { provider_factory, historical, overlay }
     }
@@ -318,6 +313,7 @@ where
         + StateProviderFactory
         + StateReader<Receipt = N::Receipt>
         + HashedPostStateProvider
+        + TrieReader
         + Clone
         + 'static,
     <P as DatabaseProviderFactory>::Provider:
@@ -823,7 +819,7 @@ where
 
         for block_num in (new_head_number + 1)..=current_head_number {
             if let Some(block_state) = self.canonical_in_memory_state.state_by_number(block_num) {
-                let executed_block = block_state.block_ref().block.clone();
+                let executed_block = block_state.block_ref().clone();
                 old_blocks.push(executed_block);
                 debug!(
                     target: "engine::tree",
@@ -855,14 +851,9 @@ where
         // Try to load the canonical ancestor's block
         match self.canonical_block_by_hash(new_head_hash)? {
             Some(executed_block) => {
-                let block_with_trie = ExecutedBlockWithTrieUpdates {
-                    block: executed_block,
-                    trie: ExecutedTrieUpdates::Missing,
-                };
-
                 // Perform the reorg to properly handle the unwind
                 self.canonical_in_memory_state.update_chain(NewCanonicalChain::Reorg {
-                    new: vec![block_with_trie],
+                    new: vec![executed_block],
                     old: old_blocks,
                 });
 
@@ -915,13 +906,8 @@ where
 
         // Try to load the block from storage
         if let Some(executed_block) = self.canonical_block_by_hash(block_hash)? {
-            let block_with_trie = ExecutedBlockWithTrieUpdates {
-                block: executed_block,
-                trie: ExecutedTrieUpdates::Missing,
-            };
-
             self.canonical_in_memory_state
-                .update_chain(NewCanonicalChain::Commit { new: vec![block_with_trie] });
+                .update_chain(NewCanonicalChain::Commit { new: vec![executed_block] });
 
             debug!(
                 target: "engine::tree",
@@ -974,29 +960,6 @@ where
         }
 
         Ok(true)
-    }
-
-    /// Returns the persisting kind for the input block.
-    fn persisting_kind_for(&self, block: BlockWithParent) -> PersistingKind {
-        // Check that we're currently persisting.
-        let Some(action) = self.persistence_state.current_action() else {
-            return PersistingKind::NotPersisting
-        };
-        // Check that the persistince action is saving blocks, not removing them.
-        let CurrentPersistenceAction::SavingBlocks { highest } = action else {
-            return PersistingKind::PersistingNotDescendant
-        };
-
-        // The block being validated can only be a descendant if its number is higher than
-        // the highest block persisting. Otherwise, it's likely a fork of a lower block.
-        if block.block.number > highest.number &&
-            self.state.tree_state.is_descendant(*highest, block)
-        {
-            return PersistingKind::PersistingDescendant
-        }
-
-        // In all other cases, the block is not a descendant.
-        PersistingKind::PersistingNotDescendant
     }
 
     /// Invoked when we receive a new forkchoice update message. Calls into the blockchain tree
@@ -1197,7 +1160,7 @@ where
 
     /// Helper method to save blocks and set the persistence state. This ensures we keep track of
     /// the current persistence action while we're saving blocks.
-    fn persist_blocks(&mut self, blocks_to_persist: Vec<ExecutedBlockWithTrieUpdates<N>>) {
+    fn persist_blocks(&mut self, blocks_to_persist: Vec<ExecutedBlock<N>>) {
         if blocks_to_persist.is_empty() {
             debug!(target: "engine::tree", "Returned empty set of blocks to persist");
             return
@@ -1588,17 +1551,9 @@ where
     /// Returns a batch of consecutive canonical blocks to persist in the range
     /// `(last_persisted_number .. canonical_head - threshold]`. The expected
     /// order is oldest -> newest.
-    ///
-    /// If any blocks are missing trie updates, all blocks are persisted, not taking `threshold`
-    /// into account.
-    ///
-    /// For those blocks that didn't have the trie updates calculated, runs the state root
-    /// calculation, and saves the trie updates.
-    ///
-    /// Returns an error if the state root calculation fails.
     fn get_canonical_blocks_to_persist(
-        &mut self,
-    ) -> Result<Vec<ExecutedBlockWithTrieUpdates<N>>, AdvancePersistenceError> {
+        &self,
+    ) -> Result<Vec<ExecutedBlock<N>>, AdvancePersistenceError> {
         // We will calculate the state root using the database, so we need to be sure there are no
         // changes
         debug_assert!(!self.persistence_state.in_progress());
@@ -1607,27 +1562,16 @@ where
         let mut current_hash = self.state.tree_state.canonical_block_hash();
         let last_persisted_number = self.persistence_state.last_persisted_block.number;
         let canonical_head_number = self.state.tree_state.canonical_block_number();
-        let all_blocks_have_trie_updates = self
-            .state
-            .tree_state
-            .blocks_by_hash
-            .values()
-            .all(|block| block.trie_updates().is_some());
 
-        let target_number = if all_blocks_have_trie_updates {
-            // Persist only up to block buffer target if all blocks have trie updates
-            canonical_head_number.saturating_sub(self.config.memory_block_buffer_target())
-        } else {
-            // Persist all blocks if any block is missing trie updates
-            canonical_head_number
-        };
+        // Persist only up to block buffer target
+        let target_number =
+            canonical_head_number.saturating_sub(self.config.memory_block_buffer_target());
 
         debug!(
             target: "engine::tree",
             ?current_hash,
             ?last_persisted_number,
             ?canonical_head_number,
-            ?all_blocks_have_trie_updates,
             ?target_number,
             "Returning canonical blocks to persist"
         );
@@ -1645,48 +1589,6 @@ where
 
         // Reverse the order so that the oldest block comes first
         blocks_to_persist.reverse();
-
-        // Calculate missing trie updates
-        for block in &mut blocks_to_persist {
-            if block.trie.is_present() {
-                continue
-            }
-
-            debug!(
-                target: "engine::tree",
-                block = ?block.recovered_block().num_hash(),
-                "Calculating trie updates before persisting"
-            );
-
-            let provider = self
-                .state_provider_builder(block.recovered_block().parent_hash())?
-                .ok_or(AdvancePersistenceError::MissingAncestor(
-                    block.recovered_block().parent_hash(),
-                ))?
-                .build()?;
-
-            let mut trie_input = self.compute_trie_input(
-                self.persisting_kind_for(block.recovered_block.block_with_parent()),
-                self.provider.database_provider_ro()?,
-                block.recovered_block().parent_hash(),
-                None,
-            )?;
-            // Extend with block we are generating trie updates for.
-            trie_input.append_ref(block.hashed_state());
-            let (_root, updates) = provider.state_root_from_nodes_with_updates(trie_input)?;
-            debug_assert_eq!(_root, block.recovered_block().state_root());
-
-            // Update trie updates in both tree state and blocks to persist that we return
-            let trie_updates = Arc::new(updates);
-            let tree_state_block = self
-                .state
-                .tree_state
-                .blocks_by_hash
-                .get_mut(&block.recovered_block().hash())
-                .expect("blocks to persist are constructed from tree state blocks");
-            tree_state_block.trie.set_present(trie_updates.clone());
-            block.trie.set_present(trie_updates);
-        }
 
         Ok(blocks_to_persist)
     }
@@ -1726,7 +1628,7 @@ where
         trace!(target: "engine::tree", ?hash, "Fetching executed block by hash");
         // check memory first
         if let Some(block) = self.state.tree_state.executed_block_by_hash(hash) {
-            return Ok(Some(block.block.clone()))
+            return Ok(Some(block.clone()))
         }
 
         let (block, senders) = self
@@ -1739,11 +1641,13 @@ where
             .get_state(block.header().number())?
             .ok_or_else(|| ProviderError::StateForNumberNotFound(block.header().number()))?;
         let hashed_state = self.provider.hashed_post_state(execution_output.state());
+        let trie_updates = self.provider.get_block_trie_updates(block.number())?;
 
         Ok(Some(ExecutedBlock {
             recovered_block: Arc::new(RecoveredBlock::new_sealed(block, senders)),
             execution_output: Arc::new(execution_output),
             hashed_state: Arc::new(hashed_state),
+            trie_updates: Arc::new(trie_updates.into()),
         }))
     }
 
@@ -2171,25 +2075,7 @@ where
 
             self.update_reorg_metrics(old.len());
             self.reinsert_reorged_blocks(new.clone());
-            // Try reinserting the reorged canonical chain. This is only possible if we have
-            // `persisted_trie_updates` for those blocks.
-            let old = old
-                .iter()
-                .filter_map(|block| {
-                    let trie = self
-                        .state
-                        .tree_state
-                        .persisted_trie_updates
-                        .get(&block.recovered_block.hash())?
-                        .1
-                        .clone();
-                    Some(ExecutedBlockWithTrieUpdates {
-                        block: block.clone(),
-                        trie: ExecutedTrieUpdates::Present(trie),
-                    })
-                })
-                .collect::<Vec<_>>();
-            self.reinsert_reorged_blocks(old);
+            self.reinsert_reorged_blocks(old.clone());
         }
 
         // update the tracked in-memory state with the new chain
@@ -2216,7 +2102,7 @@ where
     }
 
     /// This reinserts any blocks in the new chain that do not already exist in the tree
-    fn reinsert_reorged_blocks(&mut self, new_chain: Vec<ExecutedBlockWithTrieUpdates<N>>) {
+    fn reinsert_reorged_blocks(&mut self, new_chain: Vec<ExecutedBlock<N>>) {
         for block in new_chain {
             if self
                 .state
@@ -2387,11 +2273,7 @@ where
         &mut self,
         block_id: BlockWithParent,
         input: Input,
-        execute: impl FnOnce(
-            &mut V,
-            Input,
-            TreeCtx<'_, N>,
-        ) -> Result<ExecutedBlockWithTrieUpdates<N>, Err>,
+        execute: impl FnOnce(&mut V, Input, TreeCtx<'_, N>) -> Result<ExecutedBlock<N>, Err>,
         convert_to_block: impl FnOnce(&mut Self, Input) -> Result<RecoveredBlock<N::Block>, Err>,
     ) -> Result<InsertPayloadOk, Err>
     where
@@ -2484,109 +2366,6 @@ where
             .record(block_insert_start.elapsed().as_secs_f64());
         debug!(target: "engine::tree", block=?block_num_hash, "Finished inserting block");
         Ok(InsertPayloadOk::Inserted(BlockStatus::Valid))
-    }
-
-    /// Computes the trie input at the provided parent hash.
-    ///
-    /// The goal of this function is to take in-memory blocks and generate a [`TrieInput`] that
-    /// serves as an overlay to the database blocks.
-    ///
-    /// It works as follows:
-    /// 1. Collect in-memory blocks that are descendants of the provided parent hash using
-    ///    [`TreeState::blocks_by_hash`].
-    /// 2. If the persistence is in progress, and the block that we're computing the trie input for
-    ///    is a descendant of the currently persisting blocks, we need to be sure that in-memory
-    ///    blocks are not overlapping with the database blocks that may have been already persisted.
-    ///    To do that, we're filtering out in-memory blocks that are lower than the highest database
-    ///    block.
-    /// 3. Once in-memory blocks are collected and optionally filtered, we compute the
-    ///    [`HashedPostState`] from them.
-    fn compute_trie_input<TP: DBProvider + BlockNumReader>(
-        &self,
-        persisting_kind: PersistingKind,
-        provider: TP,
-        parent_hash: B256,
-        allocated_trie_input: Option<TrieInput>,
-    ) -> ProviderResult<TrieInput> {
-        // get allocated trie input or use a default trie input
-        let mut input = allocated_trie_input.unwrap_or_default();
-
-        let best_block_number = provider.best_block_number()?;
-
-        let (mut historical, mut blocks) = self
-            .state
-            .tree_state
-            .blocks_by_hash(parent_hash)
-            .map_or_else(|| (parent_hash.into(), vec![]), |(hash, blocks)| (hash.into(), blocks));
-
-        // If the current block is a descendant of the currently persisting blocks, then we need to
-        // filter in-memory blocks, so that none of them are already persisted in the database.
-        if persisting_kind.is_descendant() {
-            // Iterate over the blocks from oldest to newest.
-            while let Some(block) = blocks.last() {
-                let recovered_block = block.recovered_block();
-                if recovered_block.number() <= best_block_number {
-                    // Remove those blocks that lower than or equal to the highest database
-                    // block.
-                    blocks.pop();
-                } else {
-                    // If the block is higher than the best block number, stop filtering, as it's
-                    // the first block that's not in the database.
-                    break
-                }
-            }
-
-            historical = if let Some(block) = blocks.last() {
-                // If there are any in-memory blocks left after filtering, set the anchor to the
-                // parent of the oldest block.
-                (block.recovered_block().number() - 1).into()
-            } else {
-                // Otherwise, set the anchor to the original provided parent hash.
-                parent_hash.into()
-            };
-        }
-
-        if blocks.is_empty() {
-            debug!(target: "engine::tree", %parent_hash, "Parent found on disk");
-        } else {
-            debug!(target: "engine::tree", %parent_hash, %historical, blocks = blocks.len(), "Parent found in memory");
-        }
-
-        // Convert the historical block to the block number.
-        let block_number = provider
-            .convert_hash_or_number(historical)?
-            .ok_or_else(|| ProviderError::BlockHashNotFound(historical.as_hash().unwrap()))?;
-
-        // Retrieve revert state for historical block.
-        let revert_state = if block_number == best_block_number {
-            // We do not check against the `last_block_number` here because
-            // `HashedPostState::from_reverts` only uses the database tables, and not static files.
-            debug!(target: "engine::tree", block_number, best_block_number, "Empty revert state");
-            HashedPostState::default()
-        } else {
-            let revert_state = HashedPostState::from_reverts::<KeccakKeyHasher>(
-                provider.tx_ref(),
-                block_number + 1..,
-            )
-            .map_err(ProviderError::from)?;
-            debug!(
-                target: "engine::tree",
-                block_number,
-                best_block_number,
-                accounts = revert_state.accounts.len(),
-                storages = revert_state.storages.len(),
-                "Non-empty revert state"
-            );
-            revert_state
-        };
-        input.append(revert_state);
-
-        // Extend with contents of parent in-memory blocks.
-        input.extend_with_blocks(
-            blocks.iter().rev().map(|block| (block.hashed_state(), block.trie_updates())),
-        );
-
-        Ok(input)
     }
 
     /// Handles an error that occurred while inserting a block.

--- a/crates/optimism/flashblocks/src/worker.rs
+++ b/crates/optimism/flashblocks/src/worker.rs
@@ -124,6 +124,7 @@ where
                 recovered_block: block.into(),
                 execution_output: Arc::new(execution_outcome),
                 hashed_state: Arc::new(hashed_state),
+                trie_updates: Arc::default(),
             },
         );
         let pending_flashblock = PendingFlashBlock::new(

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -11,7 +11,7 @@ use alloy_primitives::{B256, U256};
 use alloy_rpc_types_debug::ExecutionWitness;
 use alloy_rpc_types_engine::PayloadId;
 use reth_basic_payload_builder::*;
-use reth_chain_state::{ExecutedBlock, ExecutedBlockWithTrieUpdates, ExecutedTrieUpdates};
+use reth_chain_state::ExecutedBlock;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_evm::{
     execute::{
@@ -379,13 +379,11 @@ impl<Txs> OpBuilder<'_, Txs> {
         );
 
         // create the executed block data
-        let executed: ExecutedBlockWithTrieUpdates<N> = ExecutedBlockWithTrieUpdates {
-            block: ExecutedBlock {
-                recovered_block: Arc::new(block),
-                execution_output: Arc::new(execution_outcome),
-                hashed_state: Arc::new(hashed_state),
-            },
-            trie: ExecutedTrieUpdates::Present(Arc::new(trie_updates)),
+        let executed: ExecutedBlock<N> = ExecutedBlock {
+            recovered_block: Arc::new(block),
+            execution_output: Arc::new(execution_outcome),
+            hashed_state: Arc::new(hashed_state),
+            trie_updates: Arc::new(trie_updates),
         };
 
         let no_tx_pool = ctx.attributes().no_tx_pool();

--- a/crates/optimism/payload/src/payload.rs
+++ b/crates/optimism/payload/src/payload.rs
@@ -16,7 +16,7 @@ use op_alloy_consensus::{encode_holocene_extra_data, encode_jovian_extra_data, E
 use op_alloy_rpc_types_engine::{
     OpExecutionPayloadEnvelopeV3, OpExecutionPayloadEnvelopeV4, OpExecutionPayloadV4,
 };
-use reth_chain_state::ExecutedBlockWithTrieUpdates;
+use reth_chain_state::ExecutedBlock;
 use reth_chainspec::EthChainSpec;
 use reth_optimism_evm::OpNextBlockEnvAttributes;
 use reth_optimism_forks::OpHardforks;
@@ -176,7 +176,7 @@ pub struct OpBuiltPayload<N: NodePrimitives = OpPrimitives> {
     /// Sealed block
     pub(crate) block: Arc<SealedBlock<N::Block>>,
     /// Block execution data for the payload, if any.
-    pub(crate) executed_block: Option<ExecutedBlockWithTrieUpdates<N>>,
+    pub(crate) executed_block: Option<ExecutedBlock<N>>,
     /// The fees of the block
     pub(crate) fees: U256,
 }
@@ -189,7 +189,7 @@ impl<N: NodePrimitives> OpBuiltPayload<N> {
         id: PayloadId,
         block: Arc<SealedBlock<N::Block>>,
         fees: U256,
-        executed_block: Option<ExecutedBlockWithTrieUpdates<N>>,
+        executed_block: Option<ExecutedBlock<N>>,
     ) -> Self {
         Self { id, block, fees, executed_block }
     }
@@ -226,7 +226,7 @@ impl<N: NodePrimitives> BuiltPayload for OpBuiltPayload<N> {
         self.fees
     }
 
-    fn executed_block(&self) -> Option<ExecutedBlockWithTrieUpdates<N>> {
+    fn executed_block(&self) -> Option<ExecutedBlock<N>> {
         self.executed_block.clone()
     }
 

--- a/crates/payload/primitives/src/traits.rs
+++ b/crates/payload/primitives/src/traits.rs
@@ -9,7 +9,7 @@ use alloy_eips::{
 use alloy_primitives::{Address, B256, U256};
 use alloy_rpc_types_engine::{PayloadAttributes as EthPayloadAttributes, PayloadId};
 use core::fmt;
-use reth_chain_state::ExecutedBlockWithTrieUpdates;
+use reth_chain_state::ExecutedBlock;
 use reth_primitives_traits::{NodePrimitives, SealedBlock, SealedHeader};
 
 /// Represents a successfully built execution payload (block).
@@ -30,7 +30,7 @@ pub trait BuiltPayload: Send + Sync + fmt::Debug {
     /// Returns the complete execution result including state updates.
     ///
     /// Returns `None` if execution data is not available or not tracked.
-    fn executed_block(&self) -> Option<ExecutedBlockWithTrieUpdates<Self::Primitives>> {
+    fn executed_block(&self) -> Option<ExecutedBlock<Self::Primitives>> {
         None
     }
 

--- a/crates/ress/provider/src/pending_state.rs
+++ b/crates/ress/provider/src/pending_state.rs
@@ -5,7 +5,7 @@ use alloy_primitives::{
 };
 use futures::StreamExt;
 use parking_lot::RwLock;
-use reth_chain_state::ExecutedBlockWithTrieUpdates;
+use reth_chain_state::ExecutedBlock;
 use reth_ethereum_primitives::EthPrimitives;
 use reth_node_api::{ConsensusEngineEvent, NodePrimitives};
 use reth_primitives_traits::{Bytecode, RecoveredBlock};
@@ -20,14 +20,14 @@ pub struct PendingState<N: NodePrimitives>(Arc<RwLock<PendingStateInner<N>>>);
 
 #[derive(Default, Debug)]
 struct PendingStateInner<N: NodePrimitives> {
-    blocks_by_hash: B256Map<ExecutedBlockWithTrieUpdates<N>>,
+    blocks_by_hash: B256Map<ExecutedBlock<N>>,
     invalid_blocks_by_hash: B256Map<Arc<RecoveredBlock<N::Block>>>,
     block_hashes_by_number: BTreeMap<BlockNumber, B256HashSet>,
 }
 
 impl<N: NodePrimitives> PendingState<N> {
     /// Insert executed block with trie updates.
-    pub fn insert_block(&self, block: ExecutedBlockWithTrieUpdates<N>) {
+    pub fn insert_block(&self, block: ExecutedBlock<N>) {
         let mut this = self.0.write();
         let block_hash = block.recovered_block.hash();
         this.block_hashes_by_number
@@ -46,13 +46,13 @@ impl<N: NodePrimitives> PendingState<N> {
     }
 
     /// Returns only valid executed blocks by hash.
-    pub fn executed_block(&self, hash: &B256) -> Option<ExecutedBlockWithTrieUpdates<N>> {
+    pub fn executed_block(&self, hash: &B256) -> Option<ExecutedBlock<N>> {
         self.0.read().blocks_by_hash.get(hash).cloned()
     }
 
     /// Returns valid recovered block.
     pub fn recovered_block(&self, hash: &B256) -> Option<Arc<RecoveredBlock<N::Block>>> {
-        self.executed_block(hash).map(|b| b.recovered_block.clone())
+        self.executed_block(hash).map(|b| b.recovered_block)
     }
 
     /// Returns invalid recovered block.

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -369,7 +369,7 @@ pub trait LoadPendingBlock:
             }
         }
 
-        let BlockBuilderOutcome { execution_result, block, hashed_state, .. } =
+        let BlockBuilderOutcome { execution_result, block, hashed_state, trie_updates } =
             builder.finish(NoopProvider::default()).map_err(Self::Error::from_eth_err)?;
 
         let execution_outcome = ExecutionOutcome::new(
@@ -383,6 +383,7 @@ pub trait LoadPendingBlock:
             recovered_block: block.into(),
             execution_output: Arc::new(execution_outcome),
             hashed_state: Arc::new(hashed_state),
+            trie_updates: Arc::new(trie_updates),
         })
     }
 }

--- a/crates/rpc/rpc-eth-types/src/pending_block.rs
+++ b/crates/rpc/rpc-eth-types/src/pending_block.rs
@@ -9,9 +9,7 @@ use alloy_consensus::BlockHeader;
 use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_primitives::{BlockHash, B256};
 use derive_more::Constructor;
-use reth_chain_state::{
-    BlockState, ExecutedBlock, ExecutedBlockWithTrieUpdates, ExecutedTrieUpdates,
-};
+use reth_chain_state::{BlockState, ExecutedBlock};
 use reth_ethereum_primitives::Receipt;
 use reth_evm::EvmEnv;
 use reth_primitives_traits::{
@@ -135,11 +133,6 @@ impl<N: NodePrimitives> PendingBlock<N> {
 
 impl<N: NodePrimitives> From<PendingBlock<N>> for BlockState<N> {
     fn from(pending_block: PendingBlock<N>) -> Self {
-        Self::new(ExecutedBlockWithTrieUpdates::<N>::new(
-            pending_block.executed_block.recovered_block,
-            pending_block.executed_block.execution_output,
-            pending_block.executed_block.hashed_state,
-            ExecutedTrieUpdates::Missing,
-        ))
+        Self::new(pending_block.executed_block)
     }
 }

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -4,7 +4,7 @@ use crate::{
     BlockReader, BlockReaderIdExt, BlockSource, ChainSpecProvider, ChangeSetReader, HeaderProvider,
     ProviderError, PruneCheckpointReader, ReceiptProvider, ReceiptProviderIdExt,
     StageCheckpointReader, StateReader, StaticFileProviderFactory, TransactionVariant,
-    TransactionsProvider,
+    TransactionsProvider, TrieReader,
 };
 use alloy_consensus::{transaction::TransactionMeta, BlockHeader};
 use alloy_eips::{
@@ -28,6 +28,7 @@ use reth_storage_api::{
     StorageChangeSetReader, TryIntoHistoricalStateProvider,
 };
 use reth_storage_errors::provider::ProviderResult;
+use reth_trie::updates::TrieUpdatesSorted;
 use revm_database::states::PlainStorageRevert;
 use std::{
     ops::{Add, Bound, RangeBounds, RangeInclusive, Sub},
@@ -1458,6 +1459,19 @@ impl<N: ProviderNodeTypes> StateReader for ConsistentProvider<N> {
     }
 }
 
+impl<N: ProviderNodeTypes> TrieReader for ConsistentProvider<N> {
+    fn trie_reverts(&self, from: BlockNumber) -> ProviderResult<TrieUpdatesSorted> {
+        self.storage_provider.trie_reverts(from)
+    }
+
+    fn get_block_trie_updates(
+        &self,
+        block_number: BlockNumber,
+    ) -> ProviderResult<TrieUpdatesSorted> {
+        self.storage_provider.get_block_trie_updates(block_number)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{
@@ -1468,9 +1482,7 @@ mod tests {
     use alloy_primitives::B256;
     use itertools::Itertools;
     use rand::Rng;
-    use reth_chain_state::{
-        ExecutedBlock, ExecutedBlockWithTrieUpdates, ExecutedTrieUpdates, NewCanonicalChain,
-    };
+    use reth_chain_state::{ExecutedBlock, NewCanonicalChain};
     use reth_db_api::models::AccountBeforeTx;
     use reth_ethereum_primitives::Block;
     use reth_execution_types::ExecutionOutcome;
@@ -1573,15 +1585,13 @@ mod tests {
         let in_memory_block_senders =
             first_in_mem_block.senders().expect("failed to recover senders");
         let chain = NewCanonicalChain::Commit {
-            new: vec![ExecutedBlockWithTrieUpdates::new(
-                Arc::new(RecoveredBlock::new_sealed(
+            new: vec![ExecutedBlock {
+                recovered_block: Arc::new(RecoveredBlock::new_sealed(
                     first_in_mem_block.clone(),
                     in_memory_block_senders,
                 )),
-                Default::default(),
-                Default::default(),
-                ExecutedTrieUpdates::empty(),
-            )],
+                ..Default::default()
+            }],
         };
         consistent_provider.canonical_in_memory_state.update_chain(chain);
         let consistent_provider = provider.consistent_provider()?;
@@ -1615,16 +1625,12 @@ mod tests {
         );
 
         // Insert the last block into the pending state
-        provider.canonical_in_memory_state.set_pending_block(ExecutedBlockWithTrieUpdates {
-            block: ExecutedBlock {
-                recovered_block: Arc::new(RecoveredBlock::new_sealed(
-                    last_in_mem_block.clone(),
-                    Default::default(),
-                )),
-                execution_output: Default::default(),
-                hashed_state: Default::default(),
-            },
-            trie: ExecutedTrieUpdates::empty(),
+        provider.canonical_in_memory_state.set_pending_block(ExecutedBlock {
+            recovered_block: Arc::new(RecoveredBlock::new_sealed(
+                last_in_mem_block.clone(),
+                Default::default(),
+            )),
+            ..Default::default()
         });
 
         // Now the last block should be found in memory
@@ -1683,15 +1689,13 @@ mod tests {
         let in_memory_block_senders =
             first_in_mem_block.senders().expect("failed to recover senders");
         let chain = NewCanonicalChain::Commit {
-            new: vec![ExecutedBlockWithTrieUpdates::new(
-                Arc::new(RecoveredBlock::new_sealed(
+            new: vec![ExecutedBlock {
+                recovered_block: Arc::new(RecoveredBlock::new_sealed(
                     first_in_mem_block.clone(),
                     in_memory_block_senders,
                 )),
-                Default::default(),
-                Default::default(),
-                ExecutedTrieUpdates::empty(),
-            )],
+                ..Default::default()
+            }],
         };
         consistent_provider.canonical_in_memory_state.update_chain(chain);
 
@@ -1788,9 +1792,12 @@ mod tests {
                 .first()
                 .map(|block| {
                     let senders = block.senders().expect("failed to recover senders");
-                    ExecutedBlockWithTrieUpdates::new(
-                        Arc::new(RecoveredBlock::new_sealed(block.clone(), senders)),
-                        Arc::new(ExecutionOutcome {
+                    ExecutedBlock {
+                        recovered_block: Arc::new(RecoveredBlock::new_sealed(
+                            block.clone(),
+                            senders,
+                        )),
+                        execution_output: Arc::new(ExecutionOutcome {
                             bundle: BundleState::new(
                                 in_memory_state.into_iter().map(|(address, (account, _))| {
                                     (address, None, Some(account.into()), Default::default())
@@ -1803,9 +1810,8 @@ mod tests {
                             first_block: first_in_memory_block,
                             ..Default::default()
                         }),
-                        Default::default(),
-                        ExecutedTrieUpdates::empty(),
-                    )
+                        ..Default::default()
+                    }
                 })
                 .unwrap()],
         };

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -34,12 +34,13 @@ use reth_stages_types::{StageCheckpoint, StageId};
 use reth_storage_api::{
     BlockBodyIndicesProvider, BytecodeReader, DBProvider, DatabaseProviderFactory,
     HashedPostStateProvider, NodePrimitivesProvider, StageCheckpointReader, StateProofProvider,
-    StorageRootProvider,
+    StorageRootProvider, TrieReader,
 };
 use reth_storage_errors::provider::{ConsistentViewError, ProviderError, ProviderResult};
 use reth_trie::{
-    updates::TrieUpdates, AccountProof, HashedPostState, HashedStorage, MultiProof,
-    MultiProofTargets, StorageMultiProof, StorageProof, TrieInput,
+    updates::{TrieUpdates, TrieUpdatesSorted},
+    AccountProof, HashedPostState, HashedStorage, MultiProof, MultiProofTargets, StorageMultiProof,
+    StorageProof, TrieInput,
 };
 use std::{
     collections::BTreeMap,
@@ -994,6 +995,19 @@ impl<T: NodePrimitives, ChainSpec: Send + Sync> StateReader for MockEthProvider<
         _block: BlockNumber,
     ) -> ProviderResult<Option<ExecutionOutcome<Self::Receipt>>> {
         Ok(None)
+    }
+}
+
+impl<T: NodePrimitives, ChainSpec: Send + Sync> TrieReader for MockEthProvider<T, ChainSpec> {
+    fn trie_reverts(&self, _from: BlockNumber) -> ProviderResult<TrieUpdatesSorted> {
+        Ok(TrieUpdatesSorted::default())
+    }
+
+    fn get_block_trie_updates(
+        &self,
+        _block_number: BlockNumber,
+    ) -> ProviderResult<TrieUpdatesSorted> {
+        Ok(TrieUpdatesSorted::default())
     }
 }
 

--- a/crates/storage/provider/src/traits/full.rs
+++ b/crates/storage/provider/src/traits/full.rs
@@ -3,7 +3,7 @@
 use crate::{
     AccountReader, BlockReader, BlockReaderIdExt, ChainSpecProvider, ChangeSetReader,
     DatabaseProviderFactory, HashedPostStateProvider, StageCheckpointReader, StateProviderFactory,
-    StateReader, StaticFileProviderFactory,
+    StateReader, StaticFileProviderFactory, TrieReader,
 };
 use reth_chain_state::{CanonStateSubscriptions, ForkChoiceSubscriptions};
 use reth_node_types::{BlockTy, HeaderTy, NodeTypesWithDB, ReceiptTy, TxTy};
@@ -12,7 +12,7 @@ use std::fmt::Debug;
 
 /// Helper trait to unify all provider traits for simplicity.
 pub trait FullProvider<N: NodeTypesWithDB>:
-    DatabaseProviderFactory<DB = N::DB, Provider: BlockReader>
+    DatabaseProviderFactory<DB = N::DB, Provider: BlockReader + TrieReader>
     + NodePrimitivesProvider<Primitives = N::Primitives>
     + StaticFileProviderFactory<Primitives = N::Primitives>
     + BlockReaderIdExt<
@@ -37,7 +37,7 @@ pub trait FullProvider<N: NodeTypesWithDB>:
 }
 
 impl<T, N: NodeTypesWithDB> FullProvider<N> for T where
-    T: DatabaseProviderFactory<DB = N::DB, Provider: BlockReader>
+    T: DatabaseProviderFactory<DB = N::DB, Provider: BlockReader + TrieReader>
         + NodePrimitivesProvider<Primitives = N::Primitives>
         + StaticFileProviderFactory<Primitives = N::Primitives>
         + BlockReaderIdExt<

--- a/crates/storage/storage-api/src/noop.rs
+++ b/crates/storage/storage-api/src/noop.rs
@@ -6,7 +6,7 @@ use crate::{
     HashedPostStateProvider, HeaderProvider, NodePrimitivesProvider, PruneCheckpointReader,
     ReceiptProvider, ReceiptProviderIdExt, StageCheckpointReader, StateProofProvider,
     StateProvider, StateProviderBox, StateProviderFactory, StateReader, StateRootProvider,
-    StorageRootProvider, TransactionVariant, TransactionsProvider,
+    StorageRootProvider, TransactionVariant, TransactionsProvider, TrieReader,
 };
 
 #[cfg(feature = "db-api")]
@@ -35,8 +35,9 @@ use reth_prune_types::{PruneCheckpoint, PruneSegment};
 use reth_stages_types::{StageCheckpoint, StageId};
 use reth_storage_errors::provider::{ProviderError, ProviderResult};
 use reth_trie_common::{
-    updates::TrieUpdates, AccountProof, HashedPostState, HashedStorage, MultiProof,
-    MultiProofTargets, StorageMultiProof, StorageProof, TrieInput,
+    updates::{TrieUpdates, TrieUpdatesSorted},
+    AccountProof, HashedPostState, HashedStorage, MultiProof, MultiProofTargets, StorageMultiProof,
+    StorageProof, TrieInput,
 };
 
 /// Supports various api interfaces for testing purposes.
@@ -635,6 +636,19 @@ impl<ChainSpec: Send + Sync, N: NodePrimitives> DBProvider for NoopProvider<Chai
         use reth_db_api::transaction::DbTx;
 
         Ok(self.tx.commit()?)
+    }
+}
+
+impl<C: Send + Sync, N: NodePrimitives> TrieReader for NoopProvider<C, N> {
+    fn trie_reverts(&self, _from: BlockNumber) -> ProviderResult<TrieUpdatesSorted> {
+        Ok(TrieUpdatesSorted::default())
+    }
+
+    fn get_block_trie_updates(
+        &self,
+        _block_number: BlockNumber,
+    ) -> ProviderResult<TrieUpdatesSorted> {
+        Ok(TrieUpdatesSorted::default())
     }
 }
 

--- a/crates/storage/storage-api/src/trie.rs
+++ b/crates/storage/storage-api/src/trie.rs
@@ -95,6 +95,12 @@ pub trait TrieReader: Send + Sync {
     /// Returns the [`TrieUpdatesSorted`] for reverting the trie database to its state prior to the
     /// given block and onwards having been processed.
     fn trie_reverts(&self, from: BlockNumber) -> ProviderResult<TrieUpdatesSorted>;
+
+    /// Returns the trie updates that were applied by the specified block.
+    fn get_block_trie_updates(
+        &self,
+        block_number: BlockNumber,
+    ) -> ProviderResult<TrieUpdatesSorted>;
 }
 
 /// Trie Writer

--- a/crates/trie/common/src/input.rs
+++ b/crates/trie/common/src/input.rs
@@ -34,7 +34,7 @@ impl TrieInput {
     /// Create new trie input from the provided blocks, from oldest to newest. See the documentation
     /// for [`Self::extend_with_blocks`] for details.
     pub fn from_blocks<'a>(
-        blocks: impl IntoIterator<Item = (&'a HashedPostState, Option<&'a TrieUpdates>)>,
+        blocks: impl IntoIterator<Item = (&'a HashedPostState, &'a TrieUpdates)>,
     ) -> Self {
         let mut input = Self::default();
         input.extend_with_blocks(blocks);
@@ -47,14 +47,10 @@ impl TrieInput {
     /// constructed from the state of this block and the state itself, **without** trie updates.
     pub fn extend_with_blocks<'a>(
         &mut self,
-        blocks: impl IntoIterator<Item = (&'a HashedPostState, Option<&'a TrieUpdates>)>,
+        blocks: impl IntoIterator<Item = (&'a HashedPostState, &'a TrieUpdates)>,
     ) {
         for (hashed_state, trie_updates) in blocks {
-            if let Some(nodes) = trie_updates.as_ref() {
-                self.append_cached_ref(nodes, hashed_state);
-            } else {
-                self.append_ref(hashed_state);
-            }
+            self.append_cached_ref(trie_updates, hashed_state);
         }
     }
 

--- a/crates/trie/common/src/updates.rs
+++ b/crates/trie/common/src/updates.rs
@@ -478,6 +478,29 @@ impl AsRef<Self> for TrieUpdatesSorted {
     }
 }
 
+impl From<TrieUpdatesSorted> for TrieUpdates {
+    fn from(sorted: TrieUpdatesSorted) -> Self {
+        let mut account_nodes = HashMap::default();
+        let mut removed_nodes = HashSet::default();
+
+        for (nibbles, node) in sorted.account_nodes {
+            if let Some(node) = node {
+                account_nodes.insert(nibbles, node);
+            } else {
+                removed_nodes.insert(nibbles);
+            }
+        }
+
+        let storage_tries = sorted
+            .storage_tries
+            .into_iter()
+            .map(|(address, storage)| (address, storage.into()))
+            .collect();
+
+        Self { account_nodes, removed_nodes, storage_tries }
+    }
+}
+
 /// Sorted storage trie updates reference used for serializing to file.
 #[derive(PartialEq, Eq, Clone, Default, Debug)]
 #[cfg_attr(any(test, feature = "serde"), derive(serde::Serialize))]
@@ -540,6 +563,23 @@ fn exclude_empty_from_pair<V>(
     iter: impl IntoIterator<Item = (Nibbles, V)>,
 ) -> impl Iterator<Item = (Nibbles, V)> {
     iter.into_iter().filter(|(n, _)| !n.is_empty())
+}
+
+impl From<StorageTrieUpdatesSorted> for StorageTrieUpdates {
+    fn from(sorted: StorageTrieUpdatesSorted) -> Self {
+        let mut storage_nodes = HashMap::default();
+        let mut removed_nodes = HashSet::default();
+
+        for (nibbles, node) in sorted.storage_nodes {
+            if let Some(node) = node {
+                storage_nodes.insert(nibbles, node);
+            } else {
+                removed_nodes.insert(nibbles);
+            }
+        }
+
+        Self { is_deleted: sorted.is_deleted, storage_nodes, removed_nodes }
+    }
 }
 
 #[cfg(test)]

--- a/examples/custom-node/src/engine.rs
+++ b/examples/custom-node/src/engine.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use alloy_eips::eip2718::WithEncoded;
 use op_alloy_rpc_types_engine::{OpExecutionData, OpExecutionPayload};
-use reth_chain_state::ExecutedBlockWithTrieUpdates;
+use reth_chain_state::ExecutedBlock;
 use reth_engine_primitives::EngineApiValidator;
 use reth_ethereum::{
     node::api::{
@@ -167,7 +167,7 @@ impl BuiltPayload for CustomBuiltPayload {
         self.0.fees()
     }
 
-    fn executed_block(&self) -> Option<ExecutedBlockWithTrieUpdates<Self::Primitives>> {
+    fn executed_block(&self) -> Option<ExecutedBlock<Self::Primitives>> {
         self.0.executed_block()
     }
 


### PR DESCRIPTION
This PR removes the type `ExecutedBlockWithTrieUpdates`, as well as the related `ExecutedTrieUpdates` type. Computation of the `TrieInput` is modified to take advantage of the trie changesets tables to generate reverts as necessary, the same as is done for hashed post state. This allows us to therefore always have valid `TrieUpdates` for a block. With this in place we can remove a lot of extraneous logic and types.

There is a new DB method added in this PR which was necessary to produce `ExecutedBlocks` for historical blocks without re-executing them. The new method calculates the `TrieUpdates` (not the reverts!) for a historical block based on the changesets.