### PR TITLE
fix: busy-wait in graceful shutdown loop

### DIFF
--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -247,7 +247,8 @@ impl TaskManager {
                 debug!("graceful shutdown timed out");
                 return false
             }
-            std::hint::spin_loop();
+            // Avoid busy-waiting; sleep briefly to reduce CPU usage during graceful shutdown loop.
+            std::thread::sleep(std::time::Duration::from_millis(1));
         }
 
         debug!("gracefully shut down");


### PR DESCRIPTION


**Description**

Replaced CPU-intensive `std::hint::spin_loop()` with a brief 1ms sleep in the `do_graceful_shutdown` method to reduce unnecessary CPU usage during graceful shutdown operations.

**Changes**
- Modified `TaskManager::do_graceful_shutdown` to use `std::thread::sleep(Duration::from_millis(1))` instead of busy-waiting
- Preserves existing timeout behavior and shutdown semantics

