### PR TITLE
fix(engine): always prune persisted trie updates

### DIFF
--- a/crates/engine/tree/src/tree/state.rs
+++ b/crates/engine/tree/src/tree/state.rs
@@ -274,8 +274,6 @@ impl<N: NodePrimitives> TreeState<N> {
             }
         }
 
-        self.prune_persisted_trie_updates();
-
         // The only block that should remain at the `finalized` number now, is the finalized
         // block, if it exists.
         //
@@ -340,6 +338,9 @@ impl<N: NodePrimitives> TreeState<N> {
         // * fetch the number of the finalized hash, removing any sidechains that are __below__ the
         // finalized block
         self.remove_canonical_until(upper_bound.number, last_persisted_hash);
+
+        // Always prune persisted trie updates to prevent unbounded memory growth during sync.
+        self.prune_persisted_trie_updates();
 
         // Now, we have removed canonical blocks (assuming the upper bound is above the finalized
         // block) and only have sidechains below the finalized block.


### PR DESCRIPTION
potentially closes https://github.com/paradigmxyz/reth/issues/18786 

The `persisted_trie_updates` in TreeState will prune the cached updates only if it receives a finalization status, https://github.com/paradigmxyz/reth/blob/250d5f4e2254e8a964f34285726dfb8820dc3640/crates/engine/tree/src/tree/state.rs#L50 

I think this may have caused the unbounded memory growth. So move the prune logic outside, run the removal always happens.


<img width="1612" height="821" alt="image" src="https://github.com/user-attachments/assets/0455ae5b-9c1f-46a1-baa1-24be8df52821" />


mark as draft, let reth run for a while and then see if it really fix the issue
