### PR TITLE
refactor: `HashedPostStateCursors`

### DIFF
--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -513,7 +513,7 @@ pub struct HashedAccountsSorted {
 impl HashedAccountsSorted {
     /// Returns a sorted iterator over updated accounts (Some) and destroyed accounts (None).
     pub fn accounts_sorted(&self) -> impl Iterator<Item = (B256, Option<Account>)> + '_ {
-        self.accounts.iter().cloned()
+        self.accounts.iter().copied()
     }
 }
 


### PR DESCRIPTION
Changes:

- `HashedPostStateSorted` structures: updated `HashedAccountsSorted` and HashedStorageSorted` to use a single `Vec<(B256, Option<...>)>` for accounts/storage, with sorted vectors and lookup via binary search algo.
- cursor refactors: modified `HashedPostStateAccountCursor` and `HashedPostStateStorageCursor` to iterate over the vectors, eliminating `HashSet` deps

Closes #18848 
