### PR TITLE
refactor(tree): remove unused Factory generic from multiproof system

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -192,8 +192,7 @@ where
     {
         let (to_sparse_trie, sparse_trie_rx) = channel();
         // spawn multiproof task, save the trie input
-        let (trie_input, state_root_config) =
-            MultiProofConfig::new_from_input(consistent_view, trie_input);
+        let (trie_input, state_root_config) = MultiProofConfig::from_input(trie_input);
         self.trie_input = Some(trie_input);
 
         // Create and spawn the storage proof task
@@ -207,7 +206,7 @@ where
         let max_proof_task_concurrency = config.max_proof_task_concurrency() as usize;
         let proof_task = match ProofTaskManager::new(
             self.executor.handle().clone(),
-            state_root_config.consistent_view.clone(),
+            consistent_view.clone(),
             task_ctx,
             storage_worker_count,
             account_worker_count,

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -206,7 +206,7 @@ where
         let max_proof_task_concurrency = config.max_proof_task_concurrency() as usize;
         let proof_task = match ProofTaskManager::new(
             self.executor.handle().clone(),
-            consistent_view.clone(),
+            consistent_view,
             task_ctx,
             storage_worker_count,
             account_worker_count,

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -323,7 +323,6 @@ mod tests {
         // after we compute the state root
         let join_handle = rt.spawn_blocking(move || proof_task.run());
 
-        type Factory = ProviderFactory<MockNodeTypesWithDB>;
         let parallel_result = ParallelProof::new(
             Default::default(),
             Default::default(),

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -240,9 +240,7 @@ mod tests {
     use rand::Rng;
     use reth_primitives_traits::{Account, StorageEntry};
     use reth_provider::{
-        providers::ConsistentDbView,
-        test_utils::{create_test_provider_factory, MockNodeTypesWithDB},
-        HashingWriter, ProviderFactory,
+        providers::ConsistentDbView, test_utils::create_test_provider_factory, HashingWriter,
     };
     use reth_trie::proof::Proof;
     use reth_trie_db::{DatabaseHashedCursorFactory, DatabaseTrieCursorFactory};

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -324,7 +324,7 @@ mod tests {
         let join_handle = rt.spawn_blocking(move || proof_task.run());
 
         type Factory = ProviderFactory<MockNodeTypesWithDB>;
-        let parallel_result = ParallelProof::<Factory>::new(
+        let parallel_result = ParallelProof::new(
             Default::default(),
             Default::default(),
             Default::default(),


### PR DESCRIPTION
Removes the unused `Factory` generic parameter from `ParallelProof`, `MultiProofConfig`, `MultiProofTask`, and related types. The generic only existed to carry `ConsistentDbView<Factory>` but was never accessed.

Closes #18932