### PR TITLE
refactor: remove needless collect() calls in trie tests

### DIFF
--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -4995,7 +4995,7 @@ mod tests {
                             state.clone(),
                             trie_cursor.account_trie_cursor().unwrap(),
                             Default::default(),
-                            state.keys().copied().collect::<Vec<_>>(),
+                            state.keys().copied(),
                         );
 
                     // Write trie updates to the database
@@ -5040,7 +5040,7 @@ mod tests {
                                 .iter()
                                 .map(|nibbles| B256::from_slice(&nibbles.pack()))
                                 .collect(),
-                            state.keys().copied().collect::<Vec<_>>(),
+                            state.keys().copied(),
                         );
 
                     // Write trie updates to the database

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -3031,7 +3031,7 @@ mod tests {
                             state.clone(),
                             trie_cursor.account_trie_cursor().unwrap(),
                             Default::default(),
-                            state.keys().copied().collect::<Vec<_>>(),
+                            state.keys().copied(),
                         );
 
                     // Write trie updates to the database
@@ -3073,7 +3073,7 @@ mod tests {
                                 .iter()
                                 .map(|nibbles| B256::from_slice(&nibbles.pack()))
                                 .collect(),
-                            state.keys().copied().collect::<Vec<_>>(),
+                            state.keys().copied(),
                         );
 
                     // Write trie updates to the database


### PR DESCRIPTION
Remove unnecessary `.collect::<Vec<_>>()` calls in trie test functions where iterators can be passed directly to `run_hash_builder()`.

The `run_hash_builder()` function accepts `impl IntoIterator<Item = Nibbles>` for the `proof_targets` parameter, making intermediate Vec collections unnecessary and less idiomatic.