### PR TITLE
fix(storage/libmdbx-rs): avoid panic in read tx monitor by using saturating_sub

### DIFF
--- a/crates/storage/libmdbx-rs/src/txn_manager.rs
+++ b/crates/storage/libmdbx-rs/src/txn_manager.rs
@@ -302,9 +302,8 @@ mod read_transactions {
                     // the closest deadline of an active read transaction
                     // Use saturating_sub to avoid panic when active duration exceeds max_duration
                     let sleep_duration = READ_TRANSACTIONS_CHECK_INTERVAL.min(
-                        self.max_duration.saturating_sub(
-                            max_active_transaction_duration.unwrap_or_default(),
-                        ),
+                        self.max_duration
+                            .saturating_sub(max_active_transaction_duration.unwrap_or_default()),
                     );
                     trace!(target: "libmdbx", ?sleep_duration, elapsed = ?now.elapsed(), "Putting transaction monitor to sleep");
                     std::thread::sleep(sleep_duration);

--- a/crates/storage/libmdbx-rs/src/txn_manager.rs
+++ b/crates/storage/libmdbx-rs/src/txn_manager.rs
@@ -300,8 +300,11 @@ mod read_transactions {
 
                     // Sleep not more than `READ_TRANSACTIONS_CHECK_INTERVAL`, but at least until
                     // the closest deadline of an active read transaction
+                    // Use saturating_sub to avoid panic when active duration exceeds max_duration
                     let sleep_duration = READ_TRANSACTIONS_CHECK_INTERVAL.min(
-                        self.max_duration - max_active_transaction_duration.unwrap_or_default(),
+                        self.max_duration.saturating_sub(
+                            max_active_transaction_duration.unwrap_or_default(),
+                        ),
                     );
                     trace!(target: "libmdbx", ?sleep_duration, elapsed = ?now.elapsed(), "Putting transaction monitor to sleep");
                     std::thread::sleep(sleep_duration);


### PR DESCRIPTION


### Description
- **What**: Replace potentially panicking `Duration` subtraction with `saturating_sub` when computing `sleep_duration`.
- **Why**: `Duration - Duration` panics on negative results; long‑lived read txs could crash the monitor thread.
- **How**: In `crates/storage/libmdbx-rs/src/txn_manager.rs` (`read_transactions::start_monitor`), compute:
  `READ_TRANSACTIONS_CHECK_INTERVAL.min(self.max_duration.saturating_sub(max_active_transaction_duration.unwrap_or_default()))`.
