### PR TITLE
fix(examples): change method to launch with debug capabilities

### DIFF
--- a/examples/custom-dev-node/src/main.rs
+++ b/examples/custom-dev-node/src/main.rs
@@ -33,7 +33,7 @@ async fn main() -> eyre::Result<()> {
     let NodeHandle { node, node_exit_future: _ } = NodeBuilder::new(node_config)
         .testing_node(tasks.executor())
         .node(EthereumNode::default())
-        .launch()
+        .launch_with_debug_capabilities()
         .await?;
 
     let mut notifications = node.provider.canonical_state_stream();


### PR DESCRIPTION
Without launching with debug capabilities, the example would be stuck waiting for the tx hash notification

```rust
    let head = notifications.next().await.unwrap();

    let tx = &head.tip().body().transactions().next().unwrap();
    assert_eq!(*tx.tx_hash(), hash);
    println!("mined transaction: {hash}");
```