### PR TITLE
fix(example): launch with debug capabilities

### DIFF
--- a/examples/node-custom-rpc/src/main.rs
+++ b/examples/node-custom-rpc/src/main.rs
@@ -53,7 +53,7 @@ fn main() {
                     Ok(())
                 })
                 // launch the node with custom rpc
-                .launch()
+                .launch_with_debug_capabilities()
                 .await?;
 
             handle.wait_for_node_exit().await


### PR DESCRIPTION
Without auto mining, cast command to create tx will just be stuck forever.
So it's better to launch_with_debug_capabilities

```
cast send 0x0000000000000000000000000000000000000000 \
  --value 0.1ether \
  --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 \
  --priority-gas-price 2gwei \
  --gas-price 20gwei
  --nonce 5
```