### PR TITLE
docs: improve documentation for history indexing utilities

### DIFF
--- a/crates/stages/stages/src/stages/utils.rs
+++ b/crates/stages/stages/src/stages/utils.rs
@@ -100,11 +100,48 @@ where
 /// Given a [`Collector`] created by [`collect_history_indices`] it iterates all entries, loading
 /// the indices into the database in shards.
 ///
-///  ## Process
-/// Iterates over elements, grouping indices by their partial keys (e.g., `Address` or
-/// `Address.StorageKey`). It flushes indices to disk when reaching a shard's max length
-/// (`NUM_OF_INDICES_IN_SHARD`) or when the partial key changes, ensuring the last previous partial
-/// key shard is stored.
+/// This function is the second phase of the history indexing process, taking the collected
+/// indices from the ETL collector and organizing them into properly sharded database entries.
+/// It handles the complex logic of merging existing shards with new data and managing
+/// shard boundaries.
+///
+/// ## Process
+///
+/// 1. **Iteration**: Processes all entries from the collector in order
+/// 2. **Partial Key Grouping**: Groups indices by their partial keys (e.g., `Address` or `Address.StorageKey`)
+/// 3. **Shard Management**: Flushes indices to disk when reaching shard limits or when partial key changes
+/// 4. **Existing Shard Merging**: For non-append-only mode, merges with existing database shards
+/// 5. **Final Flush**: Ensures the last shard is properly stored
+///
+/// ## Key Logic
+///
+/// - **Shard Boundaries**: Automatically flushes when `NUM_OF_INDICES_IN_SHARD` is reached or
+///   when the partial key changes
+/// - **Merge Strategy**: In non-append-only mode, loads existing shards from the database and
+///   merges them with new data before writing
+/// - **Memory Efficiency**: Processes data incrementally to avoid loading entire datasets into memory
+/// - **Progress Tracking**: Provides progress updates for long-running operations
+///
+/// ## Parameters
+///
+/// - `provider`: Database provider for read/write operations
+/// - `collector`: ETL collector containing the gathered history indices
+/// - `append_only`: If true, only appends new data; if false, merges with existing shards
+/// - `sharded_key_factory`: Function to create sharded keys from partial key and block number
+/// - `decode_key`: Function to decode raw key bytes into typed keys
+/// - `get_partial`: Function to extract partial key from a full sharded key
+///
+/// ## Returns
+///
+/// Returns `Ok(())` on success, or a [`StageError`] if database operations fail.
+///
+/// ## Example
+///
+/// For an address with indices `[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]` and `NUM_OF_INDICES_IN_SHARD = 3`:
+/// - Shard 1: `(address, 3)` → `[1, 2, 3]`
+/// - Shard 2: `(address, 6)` → `[4, 5, 6]`
+/// - Shard 3: `(address, 9)` → `[7, 8, 9]`
+/// - Shard 4: `(address, u64::MAX)` → `[10]` (final shard)
 pub(crate) fn load_history_indices<Provider, H, P>(
     provider: &Provider,
     mut collector: Collector<H::Key, H::Value>,
@@ -151,15 +188,18 @@ where
                 LoadMode::Flush,
             )?;
 
+            // Switch to the new partial key and reset the current list
             current_partial = partial_key;
             current_list.clear();
 
             // If it's not the first sync, there might an existing shard already, so we need to
-            // merge it with the one coming from the collector
+            // merge it with the one coming from the collector. This is crucial for incremental
+            // updates where we need to combine new data with existing database entries.
             if !append_only &&
                 let Some((_, last_database_shard)) =
                     write_cursor.seek_exact(sharded_key_factory(current_partial, u64::MAX))?
             {
+                // Load existing indices from the database and merge them with new data
                 current_list.extend(last_database_shard.iter());
             }
         }
@@ -189,6 +229,48 @@ where
 }
 
 /// Shard and insert the indices list according to [`LoadMode`] and its length.
+///
+/// This function handles the complex logic of sharding large index lists into smaller chunks
+/// that fit within the database's shard size limits. It's a critical component of the history
+/// indexing system that ensures efficient storage and retrieval of block number lists.
+///
+/// ## Process
+///
+/// 1. **Sharding Decision**: Only processes the list if it exceeds `NUM_OF_INDICES_IN_SHARD`
+///    or if the mode requires flushing all data
+/// 2. **Chunking**: Splits the list into chunks of maximum size `NUM_OF_INDICES_IN_SHARD`
+/// 3. **Key Generation**: Creates sharded keys using the highest block number in each chunk
+/// 4. **Storage Strategy**: Uses either append-only or upsert operations based on the `append_only` flag
+/// 5. **Last Chunk Handling**: Keeps the last chunk in memory if not flushing, otherwise stores it
+///
+/// ## Key Logic
+///
+/// - **Shard Key Strategy**: Uses the highest block number in each chunk as the shard key
+/// - **Last Shard Special Case**: The final shard uses `u64::MAX` as its key to ensure it's
+///   always the last shard for a given partial key
+/// - **Memory Management**: When not flushing, the last chunk is kept in the input `list` for
+///   potential future merging with additional data
+///
+/// ## Example
+///
+/// For a list `[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]` with `NUM_OF_INDICES_IN_SHARD = 3`:
+/// - Chunk 1: `[1, 2, 3]` → key: `(partial_key, 3)`
+/// - Chunk 2: `[4, 5, 6]` → key: `(partial_key, 6)`
+/// - Chunk 3: `[7, 8, 9]` → key: `(partial_key, 9)`
+/// - Chunk 4: `[10]` → key: `(partial_key, u64::MAX)` (if flushing)
+///
+/// ## Parameters
+///
+/// - `cursor`: Database cursor for read/write operations
+/// - `partial_key`: The base key (e.g., address or storage key) for this index set
+/// - `list`: Mutable reference to the block number list to be sharded
+/// - `sharded_key_factory`: Function to create sharded keys from partial key and block number
+/// - `append_only`: If true, uses append operations; otherwise uses upsert
+/// - `mode`: Controls whether to flush all chunks or keep the last one in memory
+///
+/// ## Returns
+///
+/// Returns `Ok(())` on success, or a [`StageError`] if database operations fail.
 pub(crate) fn load_indices<H, C, P>(
     cursor: &mut C,
     partial_key: P,
@@ -202,7 +284,9 @@ where
     H: Table<Value = BlockNumberList>,
     P: Copy,
 {
+    // Only process if the list exceeds shard size or we need to flush everything
     if list.len() > NUM_OF_INDICES_IN_SHARD || mode.is_flush() {
+        // Split the list into chunks of maximum shard size
         let chunks = list
             .chunks(NUM_OF_INDICES_IN_SHARD)
             .map(|chunks| chunks.to_vec())
@@ -212,12 +296,18 @@ where
         while let Some(chunk) = iter.next() {
             let mut highest = *chunk.last().expect("at least one index");
 
+            // Handle the last chunk specially based on flush mode
             if !mode.is_flush() && iter.peek().is_none() {
+                // Keep the last chunk in memory for potential future merging
                 *list = chunk;
             } else {
+                // For the final chunk when flushing, use u64::MAX as the key
+                // This ensures it's always the last shard for this partial key
                 if iter.peek().is_none() {
                     highest = u64::MAX;
                 }
+
+                // Create the sharded key and store the chunk
                 let key = sharded_key_factory(partial_key, highest);
                 let value = BlockNumberList::new_pre_sorted(chunk);
 
@@ -249,6 +339,51 @@ impl LoadMode {
 
 /// Called when database is ahead of static files. Attempts to find the first block we are missing
 /// transactions for.
+///
+/// This function handles the critical case where the database contains more transaction data than
+/// what's available in the static files. This can happen during sync operations when the database
+/// has been updated but the corresponding static files haven't been generated yet.
+///
+/// ## Process
+///
+/// 1. **Find Highest Static Block**: Gets the highest block number available in static files
+/// 2. **Validate Transaction Alignment**: Ensures the last transaction number in the static files
+///    doesn't exceed the expected `last_tx_num`
+/// 3. **Backtrack if Necessary**: If there's a mismatch, walks backwards through blocks to find
+///    the last valid block where transaction indices are consistent
+/// 4. **Identify Missing Block**: The missing block is the next block after the last valid one
+/// 5. **Create Error**: Returns a `MissingStaticFileData` error with the missing block information
+///
+/// ## Key Logic
+///
+/// - **Safety Check**: The function performs a safety validation to ensure transaction number
+///   consistency between the database and static files
+/// - **Backtracking Strategy**: If inconsistencies are found, it walks backwards block by block
+///   until it finds a block where `indices.last_tx_num() <= last_tx_num`
+/// - **Boundary Handling**: Stops at block 0 to prevent infinite loops
+/// - **Error Construction**: Creates a comprehensive error that includes both the missing block
+///   and the affected segment for proper error reporting
+///
+/// ## Parameters
+///
+/// - `last_tx_num`: The last transaction number expected in the database
+/// - `static_file_provider`: Provider for accessing static file data
+/// - `provider`: Main database provider for reading block and transaction data
+/// - `segment`: The static file segment that's missing data
+///
+/// ## Returns
+///
+/// Returns a [`StageError::MissingStaticFileData`] containing the missing block information,
+/// or a [`ProviderError`] if database operations fail.
+///
+/// ## Example
+///
+/// If the database has transactions up to tx_num 1000, but static files only contain data
+/// up to block 50 with tx_num 800, this function will:
+/// 1. Find block 50 as the highest static file block
+/// 2. Verify that block 50's last tx_num (800) <= 1000 ✓
+/// 3. Identify block 51 as the first missing block
+/// 4. Return an error indicating block 51 is missing from static files
 pub(crate) fn missing_static_data_error<Provider>(
     last_tx_num: TxNumber,
     static_file_provider: &StaticFileProvider<Provider::Primitives>,
@@ -258,23 +393,29 @@ pub(crate) fn missing_static_data_error<Provider>(
 where
     Provider: BlockReader + StaticFileProviderFactory,
 {
+    // Start with the highest block available in static files
     let mut last_block =
         static_file_provider.get_highest_static_file_block(segment).unwrap_or_default();
 
-    // To be extra safe, we make sure that the last tx num matches the last block from its indices.
-    // If not, get it.
+    // Safety check: ensure the last transaction number in static files doesn't exceed
+    // the expected last transaction number. If it does, we need to find the correct
+    // last block by walking backwards.
     loop {
         if let Some(indices) = provider.block_body_indices(last_block)? &&
             indices.last_tx_num() <= last_tx_num
         {
+            // Found a valid block where transaction indices are consistent
             break
         }
         if last_block == 0 {
+            // Reached the genesis block, stop to prevent infinite loop
             break
         }
+        // Walk backwards to find the last consistent block
         last_block -= 1;
     }
 
+    // The missing block is the next one after the last valid block
     let missing_block = Box::new(provider.sealed_header(last_block + 1)?.unwrap_or_default());
 
     Ok(StageError::MissingStaticFileData {

--- a/crates/stages/stages/src/stages/utils.rs
+++ b/crates/stages/stages/src/stages/utils.rs
@@ -382,10 +382,10 @@ impl LoadMode {
 ///
 /// ## Example
 ///
-/// If the database has transactions up to tx_num 1000, but static files only contain data
-/// up to block 50 with tx_num 800, this function will:
+/// If the database has transactions up to `tx_num` 1000, but static files only contain data
+/// up to block 50 with `tx_num` 800, this function will:
 /// 1. Find block 50 as the highest static file block
-/// 2. Verify that block 50's last tx_num (800) <= 1000 ✓
+/// 2. Verify that block 50's last `tx_num` (800) <= 1000 ✓
 /// 3. Identify block 51 as the first missing block
 /// 4. Return an error indicating block 51 is missing from static files
 pub(crate) fn missing_static_data_error<Provider>(

--- a/crates/stages/stages/src/stages/utils.rs
+++ b/crates/stages/stages/src/stages/utils.rs
@@ -108,18 +108,21 @@ where
 /// ## Process
 ///
 /// 1. **Iteration**: Processes all entries from the collector in order
-/// 2. **Partial Key Grouping**: Groups indices by their partial keys (e.g., `Address` or `Address.StorageKey`)
-/// 3. **Shard Management**: Flushes indices to disk when reaching shard limits or when partial key changes
+/// 2. **Partial Key Grouping**: Groups indices by their partial keys (e.g., `Address` or
+///    `Address.StorageKey`)
+/// 3. **Shard Management**: Flushes indices to disk when reaching shard limits or when partial key
+///    changes
 /// 4. **Existing Shard Merging**: For non-append-only mode, merges with existing database shards
 /// 5. **Final Flush**: Ensures the last shard is properly stored
 ///
 /// ## Key Logic
 ///
-/// - **Shard Boundaries**: Automatically flushes when `NUM_OF_INDICES_IN_SHARD` is reached or
-///   when the partial key changes
+/// - **Shard Boundaries**: Automatically flushes when `NUM_OF_INDICES_IN_SHARD` is reached or when
+///   the partial key changes
 /// - **Merge Strategy**: In non-append-only mode, loads existing shards from the database and
 ///   merges them with new data before writing
-/// - **Memory Efficiency**: Processes data incrementally to avoid loading entire datasets into memory
+/// - **Memory Efficiency**: Processes data incrementally to avoid loading entire datasets into
+///   memory
 /// - **Progress Tracking**: Provides progress updates for long-running operations
 ///
 /// ## Parameters
@@ -236,18 +239,19 @@ where
 ///
 /// ## Process
 ///
-/// 1. **Sharding Decision**: Only processes the list if it exceeds `NUM_OF_INDICES_IN_SHARD`
-///    or if the mode requires flushing all data
+/// 1. **Sharding Decision**: Only processes the list if it exceeds `NUM_OF_INDICES_IN_SHARD` or if
+///    the mode requires flushing all data
 /// 2. **Chunking**: Splits the list into chunks of maximum size `NUM_OF_INDICES_IN_SHARD`
 /// 3. **Key Generation**: Creates sharded keys using the highest block number in each chunk
-/// 4. **Storage Strategy**: Uses either append-only or upsert operations based on the `append_only` flag
+/// 4. **Storage Strategy**: Uses either append-only or upsert operations based on the `append_only`
+///    flag
 /// 5. **Last Chunk Handling**: Keeps the last chunk in memory if not flushing, otherwise stores it
 ///
 /// ## Key Logic
 ///
 /// - **Shard Key Strategy**: Uses the highest block number in each chunk as the shard key
-/// - **Last Shard Special Case**: The final shard uses `u64::MAX` as its key to ensure it's
-///   always the last shard for a given partial key
+/// - **Last Shard Special Case**: The final shard uses `u64::MAX` as its key to ensure it's always
+///   the last shard for a given partial key
 /// - **Memory Management**: When not flushing, the last chunk is kept in the input `list` for
 ///   potential future merging with additional data
 ///
@@ -349,8 +353,8 @@ impl LoadMode {
 /// 1. **Find Highest Static Block**: Gets the highest block number available in static files
 /// 2. **Validate Transaction Alignment**: Ensures the last transaction number in the static files
 ///    doesn't exceed the expected `last_tx_num`
-/// 3. **Backtrack if Necessary**: If there's a mismatch, walks backwards through blocks to find
-///    the last valid block where transaction indices are consistent
+/// 3. **Backtrack if Necessary**: If there's a mismatch, walks backwards through blocks to find the
+///    last valid block where transaction indices are consistent
 /// 4. **Identify Missing Block**: The missing block is the next block after the last valid one
 /// 5. **Create Error**: Returns a `MissingStaticFileData` error with the missing block information
 ///
@@ -361,8 +365,8 @@ impl LoadMode {
 /// - **Backtracking Strategy**: If inconsistencies are found, it walks backwards block by block
 ///   until it finds a block where `indices.last_tx_num() <= last_tx_num`
 /// - **Boundary Handling**: Stops at block 0 to prevent infinite loops
-/// - **Error Construction**: Creates a comprehensive error that includes both the missing block
-///   and the affected segment for proper error reporting
+/// - **Error Construction**: Creates a comprehensive error that includes both the missing block and
+///   the affected segment for proper error reporting
 ///
 /// ## Parameters
 ///


### PR DESCRIPTION
Enhanced documentation for complex history indexing functions in stages utils:

- Added comprehensive docs for `load_indices` with sharding logic explanation
- Documented `missing_static_data_error` error handling process  
- Improved `load_history_indices` with merge strategy details
- Added inline comments for complex branching logic
- Included examples and parameter descriptions
