### PR TITLE
fix(testsuite): Fix unused updates in e2e-test-utils

### DIFF
--- a/crates/e2e-test-utils/src/testsuite/actions/produce_blocks.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions/produce_blocks.rs
@@ -510,7 +510,7 @@ where
         Box::pin(async move {
             let mut accepted_check: bool = false;
 
-            let mut latest_block = env
+            let latest_block = env
                 .current_block_info()
                 .ok_or_else(|| eyre::eyre!("No latest block information available"))?;
 
@@ -603,10 +603,6 @@ where
                         rpc_latest_header.inner.timestamp;
                     env.active_node_state_mut()?.latest_fork_choice_state.head_block_hash =
                         rpc_latest_header.hash;
-
-                    // update local copy for any further usage in this scope
-                    latest_block.hash = rpc_latest_header.hash;
-                    latest_block.number = rpc_latest_header.inner.number;
                 }
             }
 


### PR DESCRIPTION
Fixes this error that we're seeing in CI:

```
warning: value assigned to `latest_block` is never read
   --> crates/e2e-test-utils/src/testsuite/actions/produce_blocks.rs:608:21
    |
608 |                     latest_block.hash = rpc_latest_header.hash;
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: maybe it is overwritten before being read?
    = note: `#[warn(unused_assignments)]` (part of `#[warn(unused)]`) on by default
```

https://github.com/paradigmxyz/reth/actions/runs/18459669041/job/52588015143