### PR TITLE
fix(payload): correct Debug label for PayloadTimestamp in PayloadServiceCommand

### DIFF
--- a/crates/payload/builder/src/service.rs
+++ b/crates/payload/builder/src/service.rs
@@ -512,7 +512,7 @@ where
                 f.debug_tuple("BestPayload").field(&f0).field(&f1).finish()
             }
             Self::PayloadTimestamp(f0, f1) => {
-                f.debug_tuple("PayloadAttributes").field(&f0).field(&f1).finish()
+                f.debug_tuple("PayloadTimestamp").field(&f0).field(&f1).finish()
             }
             Self::Resolve(f0, f1, _f2) => f.debug_tuple("Resolve").field(&f0).field(&f1).finish(),
             Self::Subscribe(f0) => f.debug_tuple("Subscribe").field(&f0).finish(),


### PR DESCRIPTION
The Debug impl for PayloadServiceCommand used the tuple label "PayloadAttributes" for the PayloadTimestamp variant, likely due to copy-paste. This produced misleading log output and hindered debugging/observability. Updated the label to "PayloadTimestamp" to accurately reflect the variant. No functional or API changes; improves log clarity.