### PR TITLE
refactor: replace println! with structured logging in test_vectors

### DIFF
--- a/crates/cli/commands/src/test_vectors/tables.rs
+++ b/crates/cli/commands/src/test_vectors/tables.rs
@@ -54,7 +54,7 @@ pub fn generate_vectors(mut tables: Vec<String>) -> Result<()> {
                 match table.as_str() {
                     $(
                         stringify!($table_type) => {
-                            println!("Generating test vectors for {} <{}>.", stringify!($table_or_dup), tables::$table_type$(::<$($generic),+>)?::NAME);
+                            tracing::info!(target: "reth::cli", "Generating test vectors for {} <{}>.", stringify!($table_or_dup), tables::$table_type$(::<$($generic),+>)?::NAME);
 
                             generate_vector!($table_type$(<$($generic),+>)?, $per_table, $table_or_dup);
                         },


### PR DESCRIPTION


## Description

This PR replaces the use of `println!` with structured logging using the `tracing` crate in the test vectors generation code.

## Changes
- Replaced `println!` with `tracing::info!(target: "reth::cli", ...)` in `crates/cli/commands/src/test_vectors/tables.rs`




