### PR TITLE
refactor(cli): use structured logging (tracing) in p2p command

### DIFF
--- a/crates/cli/commands/src/p2p/mod.rs
+++ b/crates/cli/commands/src/p2p/mod.rs
@@ -38,9 +38,9 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
 
                 let header = (move || get_single_header(fetch_client.clone(), id))
                     .retry(backoff)
-                    .notify(|err, _| println!("Error requesting header: {err}. Retrying..."))
+                    .notify(|err, _| tracing::warn!(target: "reth::cli", error = %err, "Error requesting header. Retrying..."))
                     .await?;
-                println!("Successfully downloaded header: {header:?}");
+                tracing::info!(target: "reth::cli", ?header, "Successfully downloaded header");
             }
 
             Subcommands::Body { args, id } => {
@@ -51,13 +51,13 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                 let hash = match id {
                     BlockHashOrNumber::Hash(hash) => hash,
                     BlockHashOrNumber::Number(number) => {
-                        println!("Block number provided. Downloading header first...");
+                        tracing::info!(target: "reth::cli", "Block number provided. Downloading header first...");
                         let client = fetch_client.clone();
                         let header = (move || {
                             get_single_header(client.clone(), BlockHashOrNumber::Number(number))
                         })
                         .retry(backoff)
-                        .notify(|err, _| println!("Error requesting header: {err}. Retrying..."))
+                        .notify(|err, _| tracing::warn!(target: "reth::cli", error = %err, "Error requesting header. Retrying..."))
                         .await?;
                         header.hash()
                     }
@@ -67,7 +67,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                     client.get_block_bodies(vec![hash])
                 })
                 .retry(backoff)
-                .notify(|err, _| println!("Error requesting block: {err}. Retrying..."))
+                .notify(|err, _| tracing::warn!(target: "reth::cli", error = %err, "Error requesting block. Retrying..."))
                 .await?
                 .split();
                 if result.len() != 1 {
@@ -77,7 +77,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                     )
                 }
                 let body = result.into_iter().next().unwrap();
-                println!("Successfully downloaded body: {body:?}")
+                tracing::info!(target: "reth::cli", ?body, "Successfully downloaded body")
             }
             Subcommands::Rlpx(command) => {
                 command.execute().await?;


### PR DESCRIPTION


### PR Description

Replace `println!`/`eprintln!` with structured logging via `tracing` in the p2p CLI command (`crates/cli/commands/src/p2p/mod.rs`).

## Changes
- Use `tracing::warn!(target: "reth::cli", ...)` in retry notifications.
- Use `tracing::info!(target: "reth::cli", ...)` for successful operations and info messages.


