### PR TITLE
ci: remove reproducible build from release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,6 @@ env:
   REPO_NAME: ${{ github.repository_owner }}/reth
   IMAGE_NAME: ${{ github.repository_owner }}/reth
   OP_IMAGE_NAME: ${{ github.repository_owner }}/op-reth
-  REPRODUCIBLE_IMAGE_NAME: ${{ github.repository_owner }}/reth-reproducible
   CARGO_TERM_COLOR: always
   DOCKER_IMAGE_NAME_URL: https://ghcr.io/${{ github.repository_owner }}/reth
   DOCKER_OP_IMAGE_NAME_URL: https://ghcr.io/${{ github.repository_owner }}/op-reth
@@ -74,10 +73,6 @@ jobs:
             os: ubuntu-24.04
             profile: maxperf
             allow_fail: false
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-24.04
-            profile: reproducible
-            allow_fail: false
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04
             profile: maxperf
@@ -124,13 +119,7 @@ jobs:
           echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx --show-sdk-platform-version)" >> $GITHUB_ENV
 
       - name: Build Reth
-        if: ${{ !(matrix.build.binary == 'op-reth' && matrix.configs.profile == 'reproducible') }}
-        run: |
-          if [[ "${{ matrix.build.binary }}" == "reth" && "${{ matrix.configs.profile }}" == "reproducible" ]]; then
-            make build-reth-reproducible
-          else
-            make PROFILE=${{ matrix.configs.profile }} ${{ matrix.build.command }}-${{ matrix.configs.target }}
-          fi
+        run: make PROFILE=${{ matrix.configs.profile }} ${{ matrix.build.command }}-${{ matrix.configs.target }}
 
       - name: Build Reth deb package
         if: ${{ matrix.build.binary == 'reth' && contains(env.DEB_SUPPORTED_TARGETS, matrix.configs.target) }}
@@ -140,13 +129,6 @@ jobs:
         run: |
           mkdir artifacts
           [[ "${{ matrix.configs.target }}" == *windows* ]] && ext=".exe"
-
-          # Handle reproducible builds which always target x86_64-unknown-linux-gnu
-          if [[ "${{ matrix.build.binary }}" == "reth" && "${{ matrix.configs.profile }}" == "reproducible" ]]; then
-            mv "target/x86_64-unknown-linux-gnu/${{ matrix.configs.profile }}/${{ matrix.build.binary }}${ext}" ./artifacts
-          else
-            mv "target/${{ matrix.configs.target }}/${{ matrix.configs.profile }}/${{ matrix.build.binary }}${ext}" ./artifacts
-          fi
 
           # Move deb packages if they exist
           if [[ "${{ matrix.build.binary }}" == "reth" && "${{ env.DEB_SUPPORTED_TARGETS }}" == *"${{ matrix.configs.target }}"* ]]; then


### PR DESCRIPTION
Removes reproducible build from `release.yml`, we have a specialized `release-reproducible.yml` workflow for that.