### PR TITLE
perf(tree): add elapsed time to parallel state root completion log

### DIFF
--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -492,13 +492,15 @@ where
                     ctx.state(),
                 ) {
                     Ok(result) => {
+                        let elapsed = root_time.elapsed();
                         info!(
                             target: "engine::tree",
                             block = ?block_num_hash,
                             regular_state_root = ?result.0,
+                            ?elapsed,
                             "Regular root task finished"
                         );
-                        maybe_state_root = Some((result.0, result.1, root_time.elapsed()));
+                        maybe_state_root = Some((result.0, result.1, elapsed));
                     }
                     Err(error) => {
                         debug!(target: "engine::tree", %error, "Parallel state root computation failed");


### PR DESCRIPTION
## Summary
- Add elapsed time tracking to the "Regular root task finished" log message in the parallel state root computation path

This change helps with performance analysis by providing elapsed time information consistently across all state root computation strategies. Previously, only the StateRootTask strategy logged elapsed time, but the Parallel strategy did not.