### PR TITLE
feat(cli): Reuse a single StaticFileProducer across file import chunks

### DIFF
--- a/crates/cli/commands/src/import_core.rs
+++ b/crates/cli/commands/src/import_core.rs
@@ -102,6 +102,10 @@ where
         .sealed_header(provider_factory.last_block_number()?)?
         .expect("should have genesis");
 
+    // Reuse a single StaticFileProducer across all chunks
+    let static_file_producer =
+        StaticFileProducer::new(provider_factory.clone(), PruneModes::default());
+
     while let Some(file_client) =
         reader.next_chunk::<BlockTy<N>>(consensus.clone(), Some(sealed_header)).await?
     {
@@ -121,7 +125,7 @@ where
             provider_factory.clone(),
             &consensus,
             Arc::new(file_client),
-            StaticFileProducer::new(provider_factory.clone(), PruneModes::default()),
+            static_file_producer.clone(),
             import_config.no_state,
             executor.clone(),
         )?;

--- a/crates/cli/commands/src/import_core.rs
+++ b/crates/cli/commands/src/import_core.rs
@@ -102,7 +102,6 @@ where
         .sealed_header(provider_factory.last_block_number()?)?
         .expect("should have genesis");
 
-    // Reuse a single StaticFileProducer across all chunks
     let static_file_producer =
         StaticFileProducer::new(provider_factory.clone(), PruneModes::default());
 

--- a/crates/optimism/cli/src/commands/import.rs
+++ b/crates/optimism/cli/src/commands/import.rs
@@ -71,6 +71,10 @@ impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> ImportOpCommand<C> {
             .sealed_header(provider_factory.last_block_number()?)?
             .expect("should have genesis");
 
+        // Reuse a single StaticFileProducer across all chunks
+        let static_file_producer =
+            StaticFileProducer::new(provider_factory.clone(), PruneModes::default());
+
         while let Some(mut file_client) =
             reader.next_chunk::<BlockTy<N>>(consensus.clone(), Some(sealed_header)).await?
         {
@@ -100,7 +104,7 @@ impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> ImportOpCommand<C> {
                 provider_factory.clone(),
                 &consensus,
                 Arc::new(file_client),
-                StaticFileProducer::new(provider_factory.clone(), PruneModes::default()),
+                static_file_producer.clone(),
                 true,
                 OpExecutorProvider::optimism(provider_factory.chain_spec()),
             )?;

--- a/crates/optimism/cli/src/commands/import.rs
+++ b/crates/optimism/cli/src/commands/import.rs
@@ -71,7 +71,6 @@ impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> ImportOpCommand<C> {
             .sealed_header(provider_factory.last_block_number()?)?
             .expect("should have genesis");
 
-        // Reuse a single StaticFileProducer across all chunks
         let static_file_producer =
             StaticFileProducer::new(provider_factory.clone(), PruneModes::default());
 


### PR DESCRIPTION
Previously, each file-import chunk created a new StaticFileProducer and passed it into a freshly built pipeline. StaticFileProducer is a lightweight Arc<Mutex<...>> wrapper with no chunk-specific state and is safe to clone and reuse. Creating it per chunk caused unnecessary allocations and event-channel setups without any functional benefit.
This change creates one StaticFileProducer before the import loop and passes static_file_producer.clone() into each pipeline build. It aligns the import path with the node’s engine lifecycle (where a single producer is reused), reduces overhead, and preserves behavior.