### PR TITLE
fix: overflow in BlockNumber range conversion at u64::MAX

### DIFF
--- a/crates/storage/db-api/src/models/accounts.rs
+++ b/crates/storage/db-api/src/models/accounts.rs
@@ -99,7 +99,14 @@ impl<R: RangeBounds<BlockNumber>> From<R> for BlockNumberAddressRange {
         };
 
         let end = match r.end_bound() {
-            Bound::Included(n) => Bound::Excluded(BlockNumberAddress((n + 1, Address::ZERO))),
+            // Avoid overflow if the inclusive end equals u64::MAX by treating it as unbounded.
+            Bound::Included(n) => {
+                if *n == u64::MAX {
+                    Bound::Unbounded
+                } else {
+                    Bound::Excluded(BlockNumberAddress((n + 1, Address::ZERO)))
+                }
+            }
             Bound::Excluded(n) => Bound::Excluded(BlockNumberAddress((*n, Address::ZERO))),
             Bound::Unbounded => Bound::Unbounded,
         };


### PR DESCRIPTION


### Description
- **Summary**: Prevent overflow when converting an inclusive end bound into an exclusive one for BlockNumber ranges by treating u64::MAX as unbounded.
- **Change**: In `crates/storage/db-api/src/models/accounts.rs`, `Bound::Included(n)` now checks `n == u64::MAX` and returns `Bound::Unbounded`; otherwise uses `n + 1` as before. 
- **Why**: Avoids debug panics and release wrap-around; ensures correct and predictable range semantics at the upper boundary.
