### PR TITLE
chore(rpc): Remove redundant U256::from in suggested_priority_fee

### DIFF
--- a/crates/optimism/rpc/src/eth/mod.rs
+++ b/crates/optimism/rpc/src/eth/mod.rs
@@ -290,8 +290,12 @@ where
     }
 
     async fn suggested_priority_fee(&self) -> Result<U256, Self::Error> {
-        let min_tip = U256::from(self.inner.min_suggested_priority_fee);
-        self.inner.eth_api.gas_oracle().op_suggest_tip_cap(min_tip).await.map_err(Into::into)
+        self.inner
+            .eth_api
+            .gas_oracle()
+            .op_suggest_tip_cap(self.inner.min_suggested_priority_fee)
+            .await
+            .map_err(Into::into)
     }
 }
 


### PR DESCRIPTION
Pass self.inner.min_suggested_priority_fee directly to op_suggest_tip_cap since it is already U256.