### PR TITLE
fix: overflow in inclusive range length calculation for static-file segments

### DIFF
--- a/crates/static-file/types/src/segment.rs
+++ b/crates/static-file/types/src/segment.rs
@@ -218,17 +218,13 @@ impl SegmentHeader {
     /// Number of transactions.
     pub fn tx_len(&self) -> Option<u64> {
         // Use saturating arithmetic to avoid overflow when end == u64::MAX.
-        self.tx_range
-            .as_ref()
-            .map(|r| r.end().saturating_sub(r.start()).saturating_add(1))
+        self.tx_range.as_ref().map(|r| r.end().saturating_sub(r.start()).saturating_add(1))
     }
 
     /// Number of blocks.
     pub fn block_len(&self) -> Option<u64> {
         // Use saturating arithmetic to avoid overflow when end == u64::MAX.
-        self.block_range
-            .as_ref()
-            .map(|r| r.end().saturating_sub(r.start()).saturating_add(1))
+        self.block_range.as_ref().map(|r| r.end().saturating_sub(r.start()).saturating_add(1))
     }
 
     /// Increments block end range depending on segment

--- a/crates/static-file/types/src/segment.rs
+++ b/crates/static-file/types/src/segment.rs
@@ -217,12 +217,18 @@ impl SegmentHeader {
 
     /// Number of transactions.
     pub fn tx_len(&self) -> Option<u64> {
-        self.tx_range.as_ref().map(|r| (r.end() + 1) - r.start())
+        // Use saturating arithmetic to avoid overflow when end == u64::MAX.
+        self.tx_range
+            .as_ref()
+            .map(|r| r.end().saturating_sub(r.start()).saturating_add(1))
     }
 
     /// Number of blocks.
     pub fn block_len(&self) -> Option<u64> {
-        self.block_range.as_ref().map(|r| (r.end() + 1) - r.start())
+        // Use saturating arithmetic to avoid overflow when end == u64::MAX.
+        self.block_range
+            .as_ref()
+            .map(|r| r.end().saturating_sub(r.start()).saturating_add(1))
     }
 
     /// Increments block end range depending on segment


### PR DESCRIPTION


### Description
- **Summary**: Use saturating arithmetic to compute inclusive range lengths without overflowing at u64::MAX.
- **Change**: In `crates/static-file/types/src/segment.rs`, replaced `(end + 1) - start` with `end.saturating_sub(start).saturating_add(1)` for both `tx_len` and `block_len`. 
- **Why**: Prevents debug panics and release wrap-around; ensures correct lengths at upper boundary.
