### PR TITLE
fix(trie): Fixes to pruning of MerkleChangeSets

### DIFF
--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -464,6 +464,7 @@ impl PruneConfig {
                     account_history,
                     storage_history,
                     bodies_history,
+                    merkle_changesets,
                     receipts_log_filter,
                 },
         } = other;
@@ -480,6 +481,8 @@ impl PruneConfig {
         self.segments.account_history = self.segments.account_history.or(account_history);
         self.segments.storage_history = self.segments.storage_history.or(storage_history);
         self.segments.bodies_history = self.segments.bodies_history.or(bodies_history);
+        // Merkle changesets is not optional, so we just replace it if provided
+        self.segments.merkle_changesets = merkle_changesets;
 
         if self.segments.receipts_log_filter.0.is_empty() && !receipts_log_filter.0.is_empty() {
             self.segments.receipts_log_filter = receipts_log_filter;

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -1004,6 +1004,7 @@ receipts = 'full'
                 account_history: None,
                 storage_history: Some(PruneMode::Before(5000)),
                 bodies_history: None,
+                merkle_changesets: PruneMode::Before(0),
                 receipts_log_filter: ReceiptsLogPruneConfig(BTreeMap::from([(
                     Address::random(),
                     PruneMode::Full,
@@ -1020,6 +1021,7 @@ receipts = 'full'
                 account_history: Some(PruneMode::Distance(2000)),
                 storage_history: Some(PruneMode::Distance(3000)),
                 bodies_history: None,
+                merkle_changesets: PruneMode::Distance(10000),
                 receipts_log_filter: ReceiptsLogPruneConfig(BTreeMap::from([
                     (Address::random(), PruneMode::Distance(1000)),
                     (Address::random(), PruneMode::Before(2000)),
@@ -1038,6 +1040,7 @@ receipts = 'full'
         assert_eq!(config1.segments.receipts, Some(PruneMode::Distance(1000)));
         assert_eq!(config1.segments.account_history, Some(PruneMode::Distance(2000)));
         assert_eq!(config1.segments.storage_history, Some(PruneMode::Before(5000)));
+        assert_eq!(config1.segments.merkle_changesets, PruneMode::Distance(10000));
         assert_eq!(config1.segments.receipts_log_filter, original_filter);
     }
 

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -440,7 +440,7 @@ pub struct PruneConfig {
 
 impl Default for PruneConfig {
     fn default() -> Self {
-        Self { block_interval: DEFAULT_BLOCK_INTERVAL, segments: PruneModes::none() }
+        Self { block_interval: DEFAULT_BLOCK_INTERVAL, segments: PruneModes::default() }
     }
 }
 

--- a/crates/exex/exex/src/backfill/factory.rs
+++ b/crates/exex/exex/src/backfill/factory.rs
@@ -24,7 +24,7 @@ impl<E, P> BackfillJobFactory<E, P> {
         Self {
             evm_config,
             provider,
-            prune_modes: PruneModes::none(),
+            prune_modes: PruneModes::default(),
             thresholds: ExecutionStageThresholds {
                 // Default duration for a database transaction to be considered long-lived is
                 // 60 seconds, so we limit the backfill job to the half of it to be sure we finish

--- a/crates/node/core/src/args/pruning.rs
+++ b/crates/node/core/src/args/pruning.rs
@@ -126,6 +126,7 @@ impl PruningArgs {
                     storage_history: Some(PruneMode::Distance(MINIMUM_PRUNING_DISTANCE)),
                     // TODO: set default to pre-merge block if available
                     bodies_history: None,
+                    merkle_changesets: PruneMode::Full,
                     receipts_log_filter: Default::default(),
                 },
             }

--- a/crates/node/core/src/args/pruning.rs
+++ b/crates/node/core/src/args/pruning.rs
@@ -126,7 +126,7 @@ impl PruningArgs {
                     storage_history: Some(PruneMode::Distance(MINIMUM_PRUNING_DISTANCE)),
                     // TODO: set default to pre-merge block if available
                     bodies_history: None,
-                    merkle_changesets: PruneMode::Full,
+                    merkle_changesets: PruneMode::Distance(MINIMUM_PRUNING_DISTANCE),
                     receipts_log_filter: Default::default(),
                 },
             }

--- a/crates/prune/prune/src/builder.rs
+++ b/crates/prune/prune/src/builder.rs
@@ -6,8 +6,8 @@ use reth_db_api::{table::Value, transaction::DbTxMut};
 use reth_exex_types::FinishedExExHeight;
 use reth_primitives_traits::NodePrimitives;
 use reth_provider::{
-    providers::StaticFileProvider, BlockReader, DBProvider, DatabaseProviderFactory,
-    NodePrimitivesProvider, PruneCheckpointReader, PruneCheckpointWriter,
+    providers::StaticFileProvider, BlockReader, ChainStateBlockReader, DBProvider,
+    DatabaseProviderFactory, NodePrimitivesProvider, PruneCheckpointReader, PruneCheckpointWriter,
     StaticFileProviderFactory,
 };
 use reth_prune_types::PruneModes;
@@ -83,6 +83,7 @@ impl PrunerBuilder {
                 ProviderRW: PruneCheckpointWriter
                                 + PruneCheckpointReader
                                 + BlockReader<Transaction: Encodable2718>
+                                + ChainStateBlockReader
                                 + StaticFileProviderFactory<
                     Primitives: NodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>,
                 >,
@@ -113,6 +114,7 @@ impl PrunerBuilder {
                 Primitives: NodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>,
             > + DBProvider<Tx: DbTxMut>
             + BlockReader<Transaction: Encodable2718>
+            + ChainStateBlockReader
             + PruneCheckpointWriter
             + PruneCheckpointReader,
     {

--- a/crates/prune/prune/src/builder.rs
+++ b/crates/prune/prune/src/builder.rs
@@ -134,7 +134,7 @@ impl Default for PrunerBuilder {
     fn default() -> Self {
         Self {
             block_interval: 5,
-            segments: PruneModes::none(),
+            segments: PruneModes::default(),
             delete_limit: MAINNET_PRUNE_DELETE_LIMIT,
             timeout: None,
             finished_exex_height: watch::channel(FinishedExExHeight::NoExExs).1,

--- a/crates/prune/prune/src/segments/set.rs
+++ b/crates/prune/prune/src/segments/set.rs
@@ -1,13 +1,13 @@
 use crate::segments::{
-    AccountHistory, ReceiptsByLogs, Segment, SenderRecovery, StorageHistory, TransactionLookup,
-    UserReceipts,
+    AccountHistory, MerkleChangeSets, ReceiptsByLogs, Segment, SenderRecovery, StorageHistory,
+    TransactionLookup, UserReceipts,
 };
 use alloy_eips::eip2718::Encodable2718;
 use reth_db_api::{table::Value, transaction::DbTxMut};
 use reth_primitives_traits::NodePrimitives;
 use reth_provider::{
-    providers::StaticFileProvider, BlockReader, DBProvider, PruneCheckpointReader,
-    PruneCheckpointWriter, StaticFileProviderFactory,
+    providers::StaticFileProvider, BlockReader, ChainStateBlockReader, DBProvider,
+    PruneCheckpointReader, PruneCheckpointWriter, StaticFileProviderFactory,
 };
 use reth_prune_types::PruneModes;
 
@@ -52,7 +52,8 @@ where
         > + DBProvider<Tx: DbTxMut>
         + PruneCheckpointWriter
         + PruneCheckpointReader
-        + BlockReader<Transaction: Encodable2718>,
+        + BlockReader<Transaction: Encodable2718>
+        + ChainStateBlockReader,
 {
     /// Creates a [`SegmentSet`] from an existing components, such as [`StaticFileProvider`] and
     /// [`PruneModes`].
@@ -67,6 +68,7 @@ where
             account_history,
             storage_history,
             bodies_history: _,
+            merkle_changesets,
             receipts_log_filter,
         } = prune_modes;
 
@@ -77,6 +79,8 @@ where
             .segment(StaticFileTransactions::new(static_file_provider.clone()))
             // Static file receipts
             .segment(StaticFileReceipts::new(static_file_provider))
+            // Merkle changesets
+            .segment(MerkleChangeSets::new(merkle_changesets))
             // Account history
             .segment_opt(account_history.map(AccountHistory::new))
             // Storage history

--- a/crates/prune/prune/src/segments/user/merkle_change_sets.rs
+++ b/crates/prune/prune/src/segments/user/merkle_change_sets.rs
@@ -15,14 +15,6 @@ use reth_prune_types::{
 };
 use tracing::{instrument, trace};
 
-/// Pruning segment for Merkle trie changesets (`AccountsTrieChangeSets` and
-/// `StoragesTrieChangeSets`).
-///
-/// The pruning behavior depends on the configured mode:
-/// - `PruneMode::Full`: Aggressively prunes all changesets up to the finalized block, keeping only
-///   changesets from the finalized block onwards (for potential reorgs)
-/// - `PruneMode::Distance(n)`: Keeps exactly the last `n` blocks of changesets, regardless of the
-///   finalized block position
 #[derive(Debug)]
 pub struct MerkleChangeSets {
     mode: PruneMode,
@@ -63,11 +55,6 @@ where
         };
 
         let block_range_end = *block_range.end();
-
-        trace!(target: "pruner",
-            ?block_range,
-            ?self.mode,
-            "Pruning merkle changesets based on configured mode");
         let mut limiter = input.limiter;
 
         // Create range for StoragesTrieChangeSets which uses BlockNumberHashedAddress as key

--- a/crates/prune/types/src/segment.rs
+++ b/crates/prune/types/src/segment.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 /// Segment of the data that can be pruned.
 ///
 /// NOTE new variants must be added to the end of this enum. The variant index is encoded directly
-/// when writing to the P`runeCheckpoint` table, so changing the order here will corrupt the table.
+/// when writing to the `PruneCheckpoint` table, so changing the order here will corrupt the table.
 #[derive(Debug, Display, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[cfg_attr(test, derive(arbitrary::Arbitrary))]
 #[cfg_attr(any(test, feature = "reth-codec"), derive(reth_codecs::Compact))]

--- a/crates/prune/types/src/segment.rs
+++ b/crates/prune/types/src/segment.rs
@@ -3,6 +3,9 @@ use derive_more::Display;
 use thiserror::Error;
 
 /// Segment of the data that can be pruned.
+///
+/// NOTE new variants must be added to the end of this enum. The variant index is encoded directly
+/// when writing to the P`runeCheckpoint` table, so changing the order here will corrupt the table.
 #[derive(Debug, Display, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[cfg_attr(test, derive(arbitrary::Arbitrary))]
 #[cfg_attr(any(test, feature = "reth-codec"), derive(reth_codecs::Compact))]
@@ -15,9 +18,6 @@ pub enum PruneSegment {
     TransactionLookup,
     /// Prune segment responsible for all rows in `Receipts` table.
     Receipts,
-    /// Prune segment responsible for all rows in `AccountsTrieChangeSets` and
-    /// `StoragesTrieChangeSets` table.
-    MerkleChangeSets,
     /// Prune segment responsible for some rows in `Receipts` table filtered by logs.
     ContractLogs,
     /// Prune segment responsible for the `AccountChangeSets` and `AccountsHistory` tables.
@@ -29,6 +29,9 @@ pub enum PruneSegment {
     Headers,
     /// Prune segment responsible for the `Transactions` table.
     Transactions,
+    /// Prune segment responsible for all rows in `AccountsTrieChangeSets` and
+    /// `StoragesTrieChangeSets` table.
+    MerkleChangeSets,
 }
 
 #[cfg(test)]

--- a/crates/prune/types/src/target.rs
+++ b/crates/prune/types/src/target.rs
@@ -36,7 +36,7 @@ pub enum HistoryType {
     StorageHistory,
 }
 
-/// Default pruning mode for merkle changesets - aggressively prune to finalized block
+/// Default pruning mode for merkle changesets
 const fn default_merkle_changesets_mode() -> PruneMode {
     PruneMode::Distance(MINIMUM_PRUNING_DISTANCE)
 }

--- a/crates/prune/types/src/target.rs
+++ b/crates/prune/types/src/target.rs
@@ -292,7 +292,7 @@ mod tests {
     #[test]
     fn test_unwind_target_unpruned() {
         // Test case 1: No pruning configured - should always succeed
-        let prune_modes = PruneModes::none();
+        let prune_modes = PruneModes::default();
         assert!(prune_modes.ensure_unwind_target_unpruned(1000, 500, &[]).is_ok());
         assert!(prune_modes.ensure_unwind_target_unpruned(1000, 0, &[]).is_ok());
 

--- a/crates/stages/stages/src/sets.rs
+++ b/crates/stages/stages/src/sets.rs
@@ -54,7 +54,7 @@ use reth_primitives_traits::{Block, NodePrimitives};
 use reth_provider::HeaderSyncGapProvider;
 use reth_prune_types::PruneModes;
 use reth_stages_api::Stage;
-use std::{ops::Not, sync::Arc};
+use std::sync::Arc;
 use tokio::sync::watch;
 
 /// A set containing all stages to run a fully syncing instance of reth.
@@ -337,12 +337,12 @@ where
                 stages_config: self.stages_config.clone(),
                 prune_modes: self.prune_modes.clone(),
             })
-            // If any prune modes are set, add the prune stage.
-            .add_stage_opt(self.prune_modes.is_empty().not().then(|| {
-                // Prune stage should be added after all hashing stages, because otherwise it will
-                // delete
-                PruneStage::new(self.prune_modes.clone(), self.stages_config.prune.commit_threshold)
-            }))
+            // Prune stage should be added after all hashing stages, because otherwise it will
+            // delete
+            .add_stage(PruneStage::new(
+                self.prune_modes.clone(),
+                self.stages_config.prune.commit_threshold,
+            ))
     }
 }
 

--- a/crates/stages/stages/src/stages/execution.rs
+++ b/crates/stages/stages/src/stages/execution.rs
@@ -896,7 +896,7 @@ mod tests {
 
         // If there is a pruning configuration, then it's forced to use the database.
         // This way we test both cases.
-        let modes = [None, Some(PruneModes::none())];
+        let modes = [None, Some(PruneModes::default())];
         let random_filter = ReceiptsLogPruneConfig(BTreeMap::from([(
             Address::random(),
             PruneMode::Distance(100000),
@@ -1033,7 +1033,7 @@ mod tests {
 
         // If there is a pruning configuration, then it's forced to use the database.
         // This way we test both cases.
-        let modes = [None, Some(PruneModes::none())];
+        let modes = [None, Some(PruneModes::default())];
         let random_filter = ReceiptsLogPruneConfig(BTreeMap::from([(
             Address::random(),
             PruneMode::Before(100000),

--- a/crates/stages/stages/src/stages/mod.rs
+++ b/crates/stages/stages/src/stages/mod.rs
@@ -228,7 +228,7 @@ mod tests {
 
         // In an unpruned configuration there is 1 receipt, 3 changed accounts and 1 changed
         // storage.
-        let mut prune = PruneModes::none();
+        let mut prune = PruneModes::default();
         check_pruning(test_db.factory.clone(), prune.clone(), 1, 3, 1).await;
 
         prune.receipts = Some(PruneMode::Full);

--- a/crates/stages/stages/src/stages/prune.rs
+++ b/crates/stages/stages/src/stages/prune.rs
@@ -122,7 +122,7 @@ impl PruneSenderRecoveryStage {
     /// Create new prune sender recovery stage with the given prune mode and commit threshold.
     pub fn new(prune_mode: PruneMode, commit_threshold: usize) -> Self {
         Self(PruneStage::new(
-            PruneModes { sender_recovery: Some(prune_mode), ..PruneModes::none() },
+            PruneModes { sender_recovery: Some(prune_mode), ..PruneModes::default() },
             commit_threshold,
         ))
     }

--- a/crates/stages/stages/src/stages/prune.rs
+++ b/crates/stages/stages/src/stages/prune.rs
@@ -1,7 +1,7 @@
 use reth_db_api::{table::Value, transaction::DbTxMut};
 use reth_primitives_traits::NodePrimitives;
 use reth_provider::{
-    BlockReader, DBProvider, PruneCheckpointReader, PruneCheckpointWriter,
+    BlockReader, ChainStateBlockReader, DBProvider, PruneCheckpointReader, PruneCheckpointWriter,
     StaticFileProviderFactory,
 };
 use reth_prune::{
@@ -42,6 +42,7 @@ where
         + PruneCheckpointReader
         + PruneCheckpointWriter
         + BlockReader
+        + ChainStateBlockReader
         + StaticFileProviderFactory<
             Primitives: NodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>,
         >,
@@ -133,6 +134,7 @@ where
         + PruneCheckpointReader
         + PruneCheckpointWriter
         + BlockReader
+        + ChainStateBlockReader
         + StaticFileProviderFactory<
             Primitives: NodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>,
         >,

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -665,7 +665,7 @@ mod tests {
             let prune_modes = PruneModes {
                 sender_recovery: Some(PruneMode::Full),
                 transaction_lookup: Some(PruneMode::Full),
-                ..PruneModes::none()
+                ..PruneModes::default()
             };
             let factory = create_test_provider_factory();
             let provider = factory.with_prune_modes(prune_modes).provider_rw().unwrap();

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -84,7 +84,7 @@ impl<N: NodeTypesWithDB> ProviderFactory<N> {
             db,
             chain_spec,
             static_file_provider,
-            prune_modes: PruneModes::none(),
+            prune_modes: PruneModes::default(),
             storage: Default::default(),
         }
     }
@@ -126,7 +126,7 @@ impl<N: NodeTypesWithDB<DB = Arc<DatabaseEnv>>> ProviderFactory<N> {
             db: Arc::new(init_db(path, args).map_err(RethError::msg)?),
             chain_spec,
             static_file_provider,
-            prune_modes: PruneModes::none(),
+            prune_modes: PruneModes::default(),
             storage: Default::default(),
         })
     }

--- a/crates/storage/storage-api/src/noop.rs
+++ b/crates/storage/storage-api/src/noop.rs
@@ -60,7 +60,7 @@ impl<ChainSpec, N> NoopProvider<ChainSpec, N> {
             #[cfg(feature = "db-api")]
             tx: TxMock::default(),
             #[cfg(feature = "db-api")]
-            prune_modes: PruneModes::none(),
+            prune_modes: PruneModes::default(),
             _phantom: Default::default(),
         }
     }
@@ -74,7 +74,7 @@ impl<ChainSpec> NoopProvider<ChainSpec> {
             #[cfg(feature = "db-api")]
             tx: TxMock::default(),
             #[cfg(feature = "db-api")]
-            prune_modes: PruneModes::none(),
+            prune_modes: PruneModes::default(),
             _phantom: Default::default(),
         }
     }


### PR DESCRIPTION
Closes #18950 

This PR contains a few related fixes:

* Adds MerkleChangeSets pruning segment to the default set (it wasn't previously present)

* Prune the StoragesTrieChangeSets table, not StoragesChangeSets

* Allows for configuration of the MerkleChangeSets PruneMode. The PruneMode _must_ be set for this segment, as we never want to keep the full history of trie changesets. The default is `Distance(10064)`. If someone really wanted to they could manually set it to `Before(0)` to keep all history.

* Because PruneModes now has a field which can't be None it doesn't make sense to have `none` or `is_empty` methods. These have been removed.