### PR TITLE
feat: support custom stages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8892,6 +8892,7 @@ dependencies = [
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
  "reth-provider",
+ "reth-stages-api",
  "reth-tasks",
  "reth-tokio-util",
  "reth-transaction-pool",

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -11,8 +11,10 @@ use reth_provider::{
     StageCheckpointWriter,
 };
 use reth_prune::{PrunerError, PrunerOutput, PrunerWithFactory};
-use reth_stages::{BoxedStage, ExecInput, ExecOutput, StageError, UnwindInput, UnwindOutput};
-use reth_stages_api::{MetricEvent, MetricEventsSender};
+use reth_stages_api::{
+    BoxedStage, ExecInput, ExecOutput, MetricEvent, MetricEventsSender, StageError, UnwindInput,
+    UnwindOutput,
+};
 use std::{
     sync::mpsc::{Receiver, SendError, Sender},
     time::Instant,

--- a/crates/node/api/Cargo.toml
+++ b/crates/node/api/Cargo.toml
@@ -26,6 +26,7 @@ reth-tasks.workspace = true
 reth-network-api.workspace = true
 reth-node-types.workspace = true
 reth-node-core.workspace = true
+reth-stages-api.workspace = true
 reth-tokio-util.workspace = true
 
 alloy-rpc-types-engine.workspace = true

--- a/crates/node/api/src/node.rs
+++ b/crates/node/api/src/node.rs
@@ -11,7 +11,8 @@ use reth_network_api::FullNetwork;
 use reth_node_core::node_config::NodeConfig;
 use reth_node_types::{NodeTypes, NodeTypesWithDBAdapter, TxTy};
 use reth_payload_builder::PayloadBuilderHandle;
-use reth_provider::FullProvider;
+use reth_provider::{DatabaseProviderFactory, FullProvider};
+use reth_stages_api::BoxedStage;
 use reth_tasks::TaskExecutor;
 use reth_tokio_util::EventSender;
 use reth_transaction_pool::{PoolTransaction, TransactionPool};
@@ -203,6 +204,13 @@ pub trait NodeAddOns<N: FullNodeComponents>: Send {
         self,
         ctx: AddOnsContext<'_, N>,
     ) -> impl Future<Output = eyre::Result<Self::Handle>> + Send;
+
+    /// Returns additional stages to be added to the pipeline.
+    fn extra_stages(
+        &self,
+    ) -> Vec<BoxedStage<<N::Provider as DatabaseProviderFactory>::ProviderRW>> {
+        Vec::new()
+    }
 }
 
 impl<N: FullNodeComponents> NodeAddOns<N> for () {

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -151,6 +151,7 @@ impl EngineNodeLauncher {
             ctx.components().evm_config().clone(),
             maybe_exex_manager_handle.clone().unwrap_or_else(ExExManagerHandle::empty),
             ctx.era_import_source(),
+            add_ons.extra_stages(),
         )?;
 
         // The new engine writes directly to static files. This ensures that they're up to the tip.
@@ -232,6 +233,7 @@ impl EngineNodeLauncher {
             engine_tree_config,
             ctx.sync_metrics_tx(),
             ctx.components().evm_config().clone(),
+            add_ons.extra_stages(),
         );
 
         info!(target: "reth::cli", "Consensus engine initialized");

--- a/crates/stages/api/src/pipeline/mod.rs
+++ b/crates/stages/api/src/pipeline/mod.rs
@@ -35,7 +35,7 @@ use reth_errors::{ProviderResult, RethResult};
 pub use set::*;
 
 /// A container for a queued stage.
-pub(crate) type BoxedStage<DB> = Box<dyn Stage<DB>>;
+pub type BoxedStage<Provider> = Box<dyn Stage<Provider>>;
 
 /// The future that returns the owned pipeline and the result of the pipeline run. See
 /// [`Pipeline::run_as_fut`].

--- a/crates/stages/api/src/pipeline/set.rs
+++ b/crates/stages/api/src/pipeline/set.rs
@@ -172,6 +172,24 @@ impl<Provider> StageSetBuilder<Provider> {
         self
     }
 
+    /// Adds given [`Stage`]s before the stage with the given [`StageId`].
+    ///
+    /// If the stage was already in the group, it is removed from its previous place.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the dependency stage is not in this set.
+    pub fn add_stages_before<S: Stage<Provider> + 'static>(
+        mut self,
+        stages: Vec<S>,
+        before: StageId,
+    ) -> Self {
+        for stage in stages {
+            self = self.add_before(stage, before);
+        }
+        self
+    }
+
     /// Adds the given [`Stage`] after the stage with the given [`StageId`].
     ///
     /// If the stage was already in the group, it is removed from its previous place.

--- a/crates/stages/stages/src/stages/headers.rs
+++ b/crates/stages/stages/src/stages/headers.rs
@@ -25,7 +25,10 @@ use reth_stages_api::{
 };
 use reth_static_file_types::StaticFileSegment;
 use reth_storage_errors::provider::ProviderError;
-use std::task::{ready, Context, Poll};
+use std::{
+    fmt::Debug,
+    task::{ready, Context, Poll},
+};
 
 use tokio::sync::watch;
 use tracing::*;
@@ -186,7 +189,7 @@ where
 
 impl<Provider, P, D> Stage<Provider> for HeaderStage<P, D>
 where
-    Provider: DBProvider<Tx: DbTxMut> + StaticFileProviderFactory,
+    Provider: DBProvider<Tx: DbTxMut> + StaticFileProviderFactory + Debug,
     P: HeaderSyncGapProvider<Header = <Provider::Primitives as NodePrimitives>::BlockHeader>,
     D: HeaderDownloader<Header = <Provider::Primitives as NodePrimitives>::BlockHeader>,
     <Provider::Primitives as NodePrimitives>::BlockHeader: FullBlockHeader + Value,


### PR DESCRIPTION
Based on #18955 

Allows defining custom stages on `NodeAddOns`. Those stages are added to pipeline and advanced in `PersistenceService`.

Open questions:
- Is there a better place for the `custom_stages` getter? Maybe `Node` trait?
- How appropriate is it to advance stages directly in the `PersistenceService`? This should work fine for most of the cases, especially for custom indexes. Another approach would be allowing to define custom hooks invoked when persisting but it feels like this might just lead to redundancy in custom stage impls