### PR TITLE
fix(discv5): get `fork_id` from `Enr` for all network stacks

### DIFF
--- a/crates/net/discv5/src/error.rs
+++ b/crates/net/discv5/src/error.rs
@@ -13,7 +13,7 @@ pub enum Error {
     #[error("network stack identifier is not configured")]
     NetworkStackIdNotConfigured,
     /// Missing key used to identify rlpx network.
-    #[error("fork missing on enr, with local network id '{id}', and 'eth' always accepted as fallback", id = String::from_utf8_lossy(.0))]
+    #[error("fork missing on enr, key {0:?} and key 'eth' missing")]
     ForkMissing(&'static [u8]),
     /// Failed to decode [`ForkId`](reth_ethereum_forks::ForkId) rlp value.
     #[error("failed to decode fork id, 'eth': {0:?}")]

--- a/crates/net/discv5/src/error.rs
+++ b/crates/net/discv5/src/error.rs
@@ -13,7 +13,7 @@ pub enum Error {
     #[error("network stack identifier is not configured")]
     NetworkStackIdNotConfigured,
     /// Missing key used to identify rlpx network.
-    #[error("fork missing on enr, key missing")]
+    #[error("fork missing on enr, with local network id '{id}', and 'eth' always accepted as fallback", id = String::from_utf8_lossy(.0))]
     ForkMissing(&'static [u8]),
     /// Failed to decode [`ForkId`](reth_ethereum_forks::ForkId) rlp value.
     #[error("failed to decode fork id, 'eth': {0:?}")]

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -924,7 +924,7 @@ mod test {
         let enr_with_opel = Enr::builder()
             .add_value_rlp(
                 NetworkStackId::OPEL,
-                alloy_rlp::encode(&EnrForkIdEntry::from(fork_id)).into(),
+                alloy_rlp::encode(EnrForkIdEntry::from(fork_id)).into(),
             )
             .build(&sk)
             .unwrap();
@@ -937,7 +937,7 @@ mod test {
         let enr_with_eth = Enr::builder()
             .add_value_rlp(
                 NetworkStackId::ETH,
-                alloy_rlp::encode(&EnrForkIdEntry::from(fork_id)).into(),
+                alloy_rlp::encode(EnrForkIdEntry::from(fork_id)).into(),
             )
             .build(&sk)
             .unwrap();

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -388,11 +388,7 @@ impl Discv5 {
                 (key != NetworkStackId::ETH)
                     .then(|| {
                         // Fallback: trying to get fork id from Enr with 'eth' as network stack id
-                        trace!(
-                            target: "net::discv5",
-                            "fork id not found for '{key}' network stack id, trying 'eth'",
-                            key = String::from_utf8_lossy(key),
-                        );
+                        trace!(target: "net::discv5", "Fork id not found for key, trying 'eth'...");
                         enr.get_decodable::<EnrForkIdEntry>(NetworkStackId::ETH)
                     })
                     .flatten()

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -384,7 +384,7 @@ impl Discv5 {
         let Some(key) = self.fork_key else { return Err(Error::NetworkStackIdNotConfigured) };
         let fork_id = enr
             .get_decodable::<EnrForkIdEntry>(key)
-            .or({
+            .or_else(|| {
                 (key != NetworkStackId::ETH)
                     .then(|| {
                         // Fallback: trying to get fork id from Enr with 'eth' as network stack id

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -681,6 +681,7 @@ mod test {
     use ::enr::{CombinedKey, EnrKey};
     use rand_08::thread_rng;
     use reth_chainspec::MAINNET;
+    use reth_tracing::init_test_tracing;
     use tracing::trace;
 
     fn discv5_noop() -> Discv5 {
@@ -916,6 +917,11 @@ mod test {
 
     #[test]
     fn get_fork_id_with_different_network_stack_ids() {
+        unsafe {
+            std::env::set_var("RUST_LOG", "net::discv5=trace");
+        }
+        init_test_tracing();
+
         let fork_id = MAINNET.latest_fork_id();
         let sk = SecretKey::new(&mut thread_rng());
 

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -682,6 +682,7 @@ mod test {
     use rand_08::thread_rng;
     use reth_chainspec::MAINNET;
     use reth_tracing::init_test_tracing;
+    use std::env;
     use tracing::trace;
 
     fn discv5_noop() -> Discv5 {
@@ -918,7 +919,7 @@ mod test {
     #[test]
     fn get_fork_id_with_different_network_stack_ids() {
         unsafe {
-            std::env::set_var("RUST_LOG", "net::discv5=trace");
+            env::set_var("RUST_LOG", "net::discv5=trace");
         }
         init_test_tracing();
 

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -389,8 +389,8 @@ impl Discv5 {
                     .then(|| {
                         // Fallback: trying to get fork id from Enr with 'eth' as network stack id
                         trace!(target: "net::discv5",
-                            "Fork id not found for '{key}' network stack id, trying 'eth'...",
-                            key = String::from_utf8_lossy(key)
+                            key = String::from_utf8_lossy(key),
+                            "Fork id not found for key, trying 'eth'..."
                         );
                         enr.get_decodable::<EnrForkIdEntry>(NetworkStackId::ETH)
                     })

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -320,10 +320,7 @@ impl Discv5 {
             return None
         }
 
-        // todo: extend for all network stacks in reth-network rlpx logic
-        let fork_id = (self.fork_key == Some(NetworkStackId::ETH))
-            .then(|| self.get_fork_id(enr).ok())
-            .flatten();
+        let fork_id = self.get_fork_id(enr).ok();
 
         trace!(target: "net::discv5",
             ?fork_id,

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -397,7 +397,7 @@ impl Discv5 {
                     .flatten()
             })
             .ok_or({
-                trace!(target: "net::discv5", "fork id not found for 'eth' network stack id");
+                trace!(target: "net::discv5", "Fork id not found for 'eth' network stack id");
                 Error::ForkMissing(key)
             })?
             .map(Into::into)?;

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -389,7 +389,7 @@ impl Discv5 {
                     .then(|| {
                         // Fallback: trying to get fork id from Enr with 'eth' as network stack id
                         trace!(target: "net::discv5",
-                            key = String::from_utf8_lossy(key),
+                            key = %String::from_utf8_lossy(key),
                             "Fork id not found for key, trying 'eth'..."
                         );
                         enr.get_decodable::<EnrForkIdEntry>(NetworkStackId::ETH)

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -388,7 +388,10 @@ impl Discv5 {
                 (key != NetworkStackId::ETH)
                     .then(|| {
                         // Fallback: trying to get fork id from Enr with 'eth' as network stack id
-                        trace!(target: "net::discv5", "Fork id not found for key, trying 'eth'...");
+                        trace!(target: "net::discv5",
+                            "Fork id not found for '{key}' network stack id, trying 'eth'...",
+                            key = String::from_utf8_lossy(key)
+                        );
                         enr.get_decodable::<EnrForkIdEntry>(NetworkStackId::ETH)
                     })
                     .flatten()


### PR DESCRIPTION
Fix #18924