### PR TITLE
ci(hive): use Go 1.24.x in hive workflow

### DIFF
--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "^1.13.1"
+          go-version: "^1.24.x"
       - run: go version
 
       - name: Restore hive assets cache


### PR DESCRIPTION
Update .github/workflows/hive.yml to install Go 1.24.x via actions/setup-go@v6.

- Replace "^1.13.1" with "1.24.x"
- Ensures compatibility with benchmarks using b.Loop()
- Improves consistency with the rest of CI jobs