### PR TITLE
refactor(tokio-util): use public API instead of direct field access in rate limit test

### DIFF
--- a/crates/tokio-util/src/ratelimit.rs
+++ b/crates/tokio-util/src/ratelimit.rs
@@ -150,7 +150,7 @@ mod tests {
         })
         .await;
 
-        tokio::time::sleep(limit.rate.duration).await;
+        time::sleep(limit.rate.duration()).await;
 
         poll_fn(|cx| {
             assert!(limit.poll_ready(cx).is_ready());


### PR DESCRIPTION

### Summary
Replaced direct field access to `Rate::duration` with the public `duration()` method in rate limit test for better encapsulation.

### Changes
- Updated test to use `limit.rate.duration()` instead of `limit.rate.duration`
- Consistent with existing test patterns in the same file

