### PR TITLE
refactor(storage): fix ChainStateKey enum variant name

### DIFF
--- a/crates/storage/db-api/src/tables/mod.rs
+++ b/crates/storage/db-api/src/tables/mod.rs
@@ -531,7 +531,7 @@ pub enum ChainStateKey {
     /// Last finalized block key
     LastFinalizedBlock,
     /// Last safe block key
-    LastSafeBlockBlock,
+     LastSafeBlock,
 }
 
 impl Encode for ChainStateKey {
@@ -540,7 +540,7 @@ impl Encode for ChainStateKey {
     fn encode(self) -> Self::Encoded {
         match self {
             Self::LastFinalizedBlock => [0],
-            Self::LastSafeBlockBlock => [1],
+            Self::LastSafeBlock => [1],
         }
     }
 }
@@ -549,7 +549,7 @@ impl Decode for ChainStateKey {
     fn decode(value: &[u8]) -> Result<Self, crate::DatabaseError> {
         match value {
             [0] => Ok(Self::LastFinalizedBlock),
-            [1] => Ok(Self::LastSafeBlockBlock),
+            [1] => Ok(Self::LastSafeBlock),
             _ => Err(crate::DatabaseError::Decode),
         }
     }

--- a/crates/storage/db-api/src/tables/mod.rs
+++ b/crates/storage/db-api/src/tables/mod.rs
@@ -531,7 +531,7 @@ pub enum ChainStateKey {
     /// Last finalized block key
     LastFinalizedBlock,
     /// Last safe block key
-     LastSafeBlock,
+    LastSafeBlock,
 }
 
 impl Encode for ChainStateKey {

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -2866,7 +2866,7 @@ impl<TX: DbTx + 'static, N: NodeTypes> ChainStateBlockReader for DatabaseProvide
         let mut finalized_blocks = self
             .tx
             .cursor_read::<tables::ChainState>()?
-            .walk(Some(tables::ChainStateKey::LastSafeBlockBlock))?
+            .walk(Some(tables::ChainStateKey::LastSafeBlock))?
             .take(1)
             .collect::<Result<BTreeMap<tables::ChainStateKey, BlockNumber>, _>>()?;
 
@@ -2885,7 +2885,7 @@ impl<TX: DbTxMut, N: NodeTypes> ChainStateBlockWriter for DatabaseProvider<TX, N
     fn save_safe_block_number(&self, block_number: BlockNumber) -> ProviderResult<()> {
         Ok(self
             .tx
-            .put::<tables::ChainState>(tables::ChainStateKey::LastSafeBlockBlock, block_number)?)
+            .put::<tables::ChainState>(tables::ChainStateKey::LastSafeBlock, block_number)?)
     }
 }
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -2883,9 +2883,7 @@ impl<TX: DbTxMut, N: NodeTypes> ChainStateBlockWriter for DatabaseProvider<TX, N
     }
 
     fn save_safe_block_number(&self, block_number: BlockNumber) -> ProviderResult<()> {
-        Ok(self
-            .tx
-            .put::<tables::ChainState>(tables::ChainStateKey::LastSafeBlock, block_number)?)
+        Ok(self.tx.put::<tables::ChainState>(tables::ChainStateKey::LastSafeBlock, block_number)?)
     }
 }
 


### PR DESCRIPTION


### Changes
- Renamed enum variant from `LastSafeBlockBlock` to `LastSafeBlock`
- Updated corresponding `Encode` and `Decode` implementations
- Updated all references in database provider

