### PR TITLE
refactor(storage/provider): remove redundant AsRef<Self> impl from DatabaseProvider

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -246,11 +246,7 @@ impl<TX: DbTxMut, N: NodeTypes> DatabaseProvider<TX, N> {
     }
 }
 
-impl<TX, N: NodeTypes> AsRef<Self> for DatabaseProvider<TX, N> {
-    fn as_ref(&self) -> &Self {
-        self
-    }
-}
+// NOTE: Removed redundant `AsRef<Self>` impl; borrowing `&DatabaseProvider` needs no trait.
 
 impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX, N> {
     /// Writes executed blocks and state to storage.


### PR DESCRIPTION

### Summary
Remove a no-op `AsRef<Self>` implementation for `DatabaseProvider`; borrowing `&DatabaseProvider` does not require a trait.

