### PR TITLE
fix: Set Era pipeline stage to last checkpoint when there is no target

### DIFF
--- a/crates/stages/stages/src/stages/era.rs
+++ b/crates/stages/stages/src/stages/era.rs
@@ -211,7 +211,7 @@ where
 
             height
         } else {
-            input.target()
+            input.checkpoint().block_number
         };
 
         Ok(ExecOutput { checkpoint: StageCheckpoint::new(height), done: height == input.target() })

--- a/crates/stages/stages/src/stages/era.rs
+++ b/crates/stages/stages/src/stages/era.rs
@@ -211,10 +211,16 @@ where
 
             height
         } else {
-            input.checkpoint().block_number
+            // It's possible for a pipeline sync to be executed with a None target, e.g. after a
+            // stage was manually dropped, and `reth node` is then called without a `--debug.tip`.
+            //
+            // In this case we don't want to simply default to zero, as that would overwrite the
+            // previously stored checkpoint block number. Instead we default to that previous
+            // checkpoint.
+            input.target.unwrap_or_else(|| input.checkpoint().block_number)
         };
 
-        Ok(ExecOutput { checkpoint: StageCheckpoint::new(height), done: height == input.target() })
+        Ok(ExecOutput { checkpoint: StageCheckpoint::new(height), done: height >= input.target() })
     }
 
     fn unwind(


### PR DESCRIPTION
I observed the following behavior on a node which was started without a `--debug.tip`, after having manually dropped a stage:

```
2025-10-14T12:17:32.267719Z  INFO Preparing stage pipeline_stages=1/16 stage=Era checkpoint=23575428 target=None
2025-10-14T12:17:32.267733Z  INFO Executing stage pipeline_stages=1/16 stage=Era checkpoint=23575428 target=None
2025-10-14T12:17:32.268088Z  INFO Finished stage pipeline_stages=1/16 stage=Era checkpoint=0 target=None
```

As shown, the Era stage was setting its checkpoint to zero. This was occurring because when the target has already been reached Era immediately returns ready from `poll_execute_ready`:

https://github.com/paradigmxyz/reth/blob/5065890823eb6358845218f5e0f3219c6544e63a/crates/stages/stages/src/stages/era.rs#L149-L151

(`target_reached` assumes a zero target block number if the target field is None.)

At this point `self.item` is None. When `execute` is then called Era has no work to do, but was returning the target (defaulting again to zero) rather than previous checkpoint:

https://github.com/paradigmxyz/reth/blob/5065890823eb6358845218f5e0f3219c6544e63a/crates/stages/stages/src/stages/era.rs#L214

If a stage was then manually dropped _again_ then both Era (the first stage) and Finish (the last stage) would be zero. This check in `check_pipeline_consistency` would never hit, and no pipeline sync would be reran:

https://github.com/paradigmxyz/reth/blob/cec30cd9f3f64b6ee5e3bf2135f984135632944a/crates/node/builder/src/launch/common.rs#L930-L942

Since the Finish stage is used to determine current block height generally, the node would then assume it has no blocks.

```
2025-10-14T13:59:36.340411Z  INFO Status connected_peers=0 latest_block=0
```