### PR TITLE
fix: Set node to idle if no initial backfill sync is performed

### DIFF
--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -268,7 +268,10 @@ impl EngineNodeLauncher {
         ctx.task_executor().spawn_critical("consensus engine", Box::pin(async move {
             if let Some(initial_target) = initial_target {
                 debug!(target: "reth::cli", %initial_target,  "start backfill sync");
+                // network_handle's sync state is already initialized at Syncing
                 engine_service.orchestrator_mut().start_backfill_sync(initial_target);
+            } else {
+                network_handle.update_sync_state(SyncState::Idle);
             }
 
             let mut res = Ok(());
@@ -291,6 +294,7 @@ impl EngineNodeLauncher {
                                     debug!(target: "reth::cli", "Terminating after initial backfill");
                                     break
                                 }
+                                network_handle.update_sync_state(SyncState::Idle);
                             }
                             ChainEvent::BackfillSyncStarted => {
                                 network_handle.update_sync_state(SyncState::Syncing);


### PR DESCRIPTION
The `eth_syncing` RPC call relies on the the NetworkHandle's sync state to decide whether or not the node is considered to be syncing.

At present the NetworkHandle is initialized in the Syncing state. This makes sense, as it prevents a race-condition where initially a node looks idle but then immediately goes into Syncing, possibly confusing clients.

The problem is that the node then remains in the Syncing state, even if no backfill sync is performed, up until after it has processed its first block. This makes `eth_syncing` not useful for determining if a node is ready for block processing or not.