### PR TITLE
chore(fs-util): remove redundant tmp_path clone

### DIFF
--- a/crates/fs-util/src/lib.rs
+++ b/crates/fs-util/src/lib.rs
@@ -332,10 +332,7 @@ where
         Err(err) => {
             // Clean up the temporary file before returning the error
             let _ = fs::remove_file(&tmp_path);
-            return Err(FsPathError::Write {
-                source: Error::other(err.into()),
-                path: tmp_path,
-            });
+            return Err(FsPathError::Write { source: Error::other(err.into()), path: tmp_path });
         }
     }
 

--- a/crates/fs-util/src/lib.rs
+++ b/crates/fs-util/src/lib.rs
@@ -334,7 +334,7 @@ where
             let _ = fs::remove_file(&tmp_path);
             return Err(FsPathError::Write {
                 source: Error::other(err.into()),
-                path: tmp_path.clone(),
+                path: tmp_path,
             });
         }
     }


### PR DESCRIPTION
The error branch of atomic_write_file returns immediately, so tmp_path never flows past that point; dropping the clone keeps behavior identical while avoiding an unnecessary PathBuf allocation.