### PR TITLE
chore: lower ecies instrument calls to trace

### DIFF
--- a/crates/net/ecies/src/algorithm.rs
+++ b/crates/net/ecies/src/algorithm.rs
@@ -499,7 +499,7 @@ impl ECIES {
     }
 
     /// Read and verify an auth message from the input data.
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn read_auth(&mut self, data: &mut [u8]) -> Result<(), ECIESError> {
         self.remote_init_msg = Some(Bytes::copy_from_slice(data));
         let unencrypted = self.decrypt_message(data)?;
@@ -571,7 +571,7 @@ impl ECIES {
     }
 
     /// Read and verify an ack message from the input data.
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn read_ack(&mut self, data: &mut [u8]) -> Result<(), ECIESError> {
         self.remote_init_msg = Some(Bytes::copy_from_slice(data));
         let unencrypted = self.decrypt_message(data)?;

--- a/crates/net/ecies/src/stream.rs
+++ b/crates/net/ecies/src/stream.rs
@@ -40,7 +40,7 @@ where
     Io: AsyncRead + AsyncWrite + Unpin,
 {
     /// Connect to an `ECIES` server
-    #[instrument(skip(transport, secret_key))]
+    #[instrument(level = "trace", skip(transport, secret_key))]
     pub async fn connect(
         transport: Io,
         secret_key: SecretKey,


### PR DESCRIPTION
It would be great to be able to filter / lower spans like we do logs, if we want to do this then these spans should definitely be at `trace`