### PR TITLE
fix: required optimism primitives features in db-api

### DIFF
--- a/crates/storage/db-api/Cargo.toml
+++ b/crates/storage/db-api/Cargo.toml
@@ -28,7 +28,7 @@ alloy-genesis.workspace = true
 alloy-consensus.workspace = true
 
 # optimism
-reth-optimism-primitives = { workspace = true, optional = true }
+reth-optimism-primitives = { workspace = true, optional = true, features = ["serde", "reth-codec"] }
 
 # codecs
 modular-bitfield.workspace = true


### PR DESCRIPTION
The `db-api` crate requires `reth-optimism-primitives`, but only works with `serde` and `reth-codec` enabled. Previously, this required importers of `db-api` to enable these features manually, but since this crate will only work with serde/codec features, we should mark these as required for this dependency. This matches `reth-ethereum-primitives` above.

Example error if not enabled:

```
error[E0277]: the trait bound `OpReceipt: serde::Serialize` is not satisfied
   --> crates/optimism/primitives/src/receipt.rs:424:25
    |
424 | impl DepositReceipt for OpReceipt {
    |                         ^^^^^^^^^ the trait `Serialize` is not implemented for `OpReceipt`
    |
    = note: for local types consider adding `#[derive(serde::Serialize)]` to your `OpReceipt` type
    = note: for types from other crates check whether the crate offers a `serde` feature flag
    = help: the following other types implement trait `Serialize`:
              &'a T
              &'a mut T
              ()
              (T,)
              (T0, T1)
              (T0, T1, T2)
              (T0, T1, T2, T3)
              (T0, T1, T2, T3, T4)
            and 288 others
    = note: required for `OpReceipt` to implement `MaybeSerde`
    = note: required for `OpReceipt` to implement `reth_primitives_traits::Receipt`
note: required by a bound in `DepositReceipt`
   --> crates/optimism/primitives/src/receipt.rs:416:27
    |
416 | pub trait DepositReceipt: reth_primitives_traits::Receipt {
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `DepositReceipt`
    ```