### PR TITLE
refactor(trie): rename queue_storage_proof to dispatch_proof for clarity

### DIFF
--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -113,7 +113,7 @@ where
     Factory: DatabaseProviderFactory<Provider: BlockReader> + Clone + 'static,
 {
     /// Queues a storage proof task and returns a receiver for the result.
-    fn queue_storage_proof(
+    fn dispatch_proof(
         &self,
         hashed_address: B256,
         prefix_set: PrefixSet,
@@ -150,7 +150,7 @@ where
             "Starting storage proof generation"
         );
 
-        let receiver = self.queue_storage_proof(hashed_address, prefix_set, target_slots);
+        let receiver = self.dispatch_proof(hashed_address, prefix_set, target_slots);
         let proof_result = receiver.recv().map_err(|_| {
             ParallelStateRootError::StorageRoot(StorageRootError::Database(DatabaseError::Other(
                 format!("channel closed for {hashed_address}"),
@@ -213,7 +213,7 @@ where
             storage_root_targets.into_iter().sorted_unstable_by_key(|(address, _)| *address)
         {
             let target_slots = targets.get(&hashed_address).cloned().unwrap_or_default();
-            let receiver = self.queue_storage_proof(hashed_address, prefix_set, target_slots);
+            let receiver = self.dispatch_proof(hashed_address, prefix_set, target_slots);
 
             // store the receiver for that result with the hashed address so we can await this in
             // place when we iterate over the trie


### PR DESCRIPTION
- spawn workers in the background and return the channel handle first. part of cleanup and micro optimisations of worker pool. 

closes: https://github.com/paradigmxyz/reth/issues/18995