### PR TITLE
perf: background init of workers

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -166,6 +166,7 @@ where
     ///
     /// This returns a handle to await the final state root and to interact with the tasks (e.g.
     /// canceling)
+    #[allow(clippy::type_complexity)]
     pub fn spawn<P, I: ExecutableTxIterator<Evm>>(
         &mut self,
         env: ExecutionEnv<Evm>,
@@ -174,7 +175,10 @@ where
         consistent_view: ConsistentDbView<P>,
         trie_input: TrieInput,
         config: &TreeConfig,
-    ) -> PayloadHandle<WithTxEnv<TxEnvFor<Evm>, I::Tx>, I::Error>
+    ) -> Result<
+        PayloadHandle<WithTxEnv<TxEnvFor<Evm>, I::Tx>, I::Error>,
+        (ParallelStateRootError, I, ExecutionEnv<Evm>, StateProviderBuilder<N, P>),
+    >
     where
         P: DatabaseProviderFactory<Provider: BlockReader>
             + BlockReader

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -166,9 +166,6 @@ where
     ///
     /// This returns a handle to await the final state root and to interact with the tasks (e.g.
     /// canceling)
-    ///
-    /// Returns an error with the original transactions iterator if proof worker spawning fails.
-    #[allow(clippy::type_complexity)]
     pub fn spawn<P, I: ExecutableTxIterator<Evm>>(
         &mut self,
         env: ExecutionEnv<Evm>,
@@ -177,10 +174,7 @@ where
         consistent_view: ConsistentDbView<P>,
         trie_input: TrieInput,
         config: &TreeConfig,
-    ) -> Result<
-        PayloadHandle<WithTxEnv<TxEnvFor<Evm>, I::Tx>, I::Error>,
-        (reth_provider::ProviderError, I, ExecutionEnv<Evm>, StateProviderBuilder<N, P>),
-    >
+    ) -> PayloadHandle<WithTxEnv<TxEnvFor<Evm>, I::Tx>, I::Error>
     where
         P: DatabaseProviderFactory<Provider: BlockReader>
             + BlockReader
@@ -203,18 +197,13 @@ where
         let storage_worker_count = config.storage_worker_count();
         let account_worker_count = config.account_worker_count();
         let max_proof_task_concurrency = config.max_proof_task_concurrency() as usize;
-        let proof_handle = match ProofWorkerHandle::new(
+        let proof_handle = ProofWorkerHandle::new(
             self.executor.handle().clone(),
             consistent_view,
             task_ctx,
             storage_worker_count,
             account_worker_count,
-        ) {
-            Ok(handle) => handle,
-            Err(error) => {
-                return Err((error, transactions, env, provider_builder));
-            }
-        };
+        );
 
         // We set it to half of the proof task concurrency, because often for each multiproof we
         // spawn one Tokio task for the account proof, and one Tokio task for the storage proof.

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -553,7 +553,7 @@ impl MultiproofManager {
 
             let proof_result: Result<DecodedMultiProof, ParallelStateRootError> = (|| {
                 let receiver = account_proof_worker_handle
-                    .queue_account_multiproof(input)
+                    .dispatch_account_multiproof(input)
                     .map_err(|e| ParallelStateRootError::Other(e.to_string()))?;
 
                 receiver

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -1228,8 +1228,7 @@ mod tests {
         );
         let consistent_view = ConsistentDbView::new(factory, None);
         let proof_handle =
-            ProofWorkerHandle::new(executor.handle().clone(), consistent_view, task_ctx, 1, 1)
-                .expect("Failed to spawn proof workers");
+            ProofWorkerHandle::new(executor.handle().clone(), consistent_view, task_ctx, 1, 1);
         let channel = channel();
 
         MultiProofTask::new(config, executor, proof_handle, channel.0, 1, None)

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -193,7 +193,7 @@ impl ParallelProof {
 
         let receiver = self
             .proof_worker_handle
-            .queue_account_multiproof(input)
+            .dispatch_account_multiproof(input)
             .map_err(|e| ParallelStateRootError::Other(e.to_string()))?;
 
         // Wait for account multiproof result from worker

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -307,7 +307,7 @@ mod tests {
         let task_ctx =
             ProofTaskCtx::new(Default::default(), Default::default(), Default::default());
         let proof_worker_handle =
-            ProofWorkerHandle::new(rt.handle().clone(), consistent_view, task_ctx, 1, 1).unwrap();
+            ProofWorkerHandle::new(rt.handle().clone(), consistent_view, task_ctx, 1, 1);
 
         let parallel_result = ParallelProof::new(
             Default::default(),

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -308,7 +308,7 @@ fn account_worker_loop<Tx>(
                 );
                 tracker.set_precomputed_storage_roots(storage_root_targets_len as u64);
 
-                let storage_proof_receivers = match queue_storage_proofs(
+                let storage_proof_receivers = match dispatch_storage_proofs(
                     &storage_work_tx,
                     &input.targets,
                     &mut storage_prefix_sets,
@@ -568,7 +568,7 @@ where
 /// computation. This enables interleaved parallelism for better performance.
 ///
 /// Propagates errors up if queuing fails. Receivers must be consumed by the caller.
-fn queue_storage_proofs(
+fn dispatch_storage_proofs(
     storage_work_tx: &CrossbeamSender<StorageWorkerJob>,
     targets: &MultiProofTargets,
     storage_prefix_sets: &mut B256Map<PrefixSet>,
@@ -963,7 +963,7 @@ impl ProofWorkerHandle {
     }
 
     /// Queue an account multiproof computation
-    pub fn queue_account_multiproof(
+    pub fn dispatch_account_multiproof(
         &self,
         input: AccountMultiproofInput,
     ) -> Result<Receiver<AccountMultiproofResult>, ProviderError> {

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -121,26 +121,9 @@ fn storage_worker_loop<Factory>(
     Factory: DatabaseProviderFactory<Provider: BlockReader>,
 {
     // Create db transaction before entering work loop
-    let proof_tx = match view.provider_ro() {
-        Ok(provider) => {
-            let tx = provider.into_tx();
-            tracing::debug!(
-                target: "trie::proof_task",
-                worker_id,
-                "Storage worker initialized transaction successfully"
-            );
-            ProofTaskTx::new(tx, task_ctx, worker_id)
-        }
-        Err(e) => {
-            tracing::error!(
-                target: "trie::proof_task",
-                worker_id,
-                error = %e,
-                "Storage worker failed to initialize transaction, exiting"
-            );
-            return;
-        }
-    };
+    let provider = view.provider_ro()
+        .expect("Storage worker failed to initialize: database unavailable");
+    let proof_tx = ProofTaskTx::new(provider.into_tx(), task_ctx, worker_id);
 
     tracing::debug!(
         target: "trie::proof_task",
@@ -291,26 +274,9 @@ fn account_worker_loop<Factory>(
     Factory: DatabaseProviderFactory<Provider: BlockReader>,
 {
     // Create db transaction before entering work loop
-    let proof_tx = match view.provider_ro() {
-        Ok(provider) => {
-            let tx = provider.into_tx();
-            tracing::debug!(
-                target: "trie::proof_task",
-                worker_id,
-                "Account worker initialized transaction successfully"
-            );
-            ProofTaskTx::new(tx, task_ctx, worker_id)
-        }
-        Err(e) => {
-            tracing::error!(
-                target: "trie::proof_task",
-                worker_id,
-                error = %e,
-                "Account worker failed to initialize transaction, exiting"
-            );
-            return;
-        }
-    };
+    let provider = view.provider_ro()
+        .expect("Account worker failed to initialize: database unavailable");
+    let proof_tx = ProofTaskTx::new(provider.into_tx(), task_ctx, worker_id);
 
     tracing::debug!(
         target: "trie::proof_task",

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -121,8 +121,8 @@ fn storage_worker_loop<Factory>(
     Factory: DatabaseProviderFactory<Provider: BlockReader>,
 {
     // Create db transaction before entering work loop
-    let provider = view.provider_ro()
-        .expect("Storage worker failed to initialize: database unavailable");
+    let provider =
+        view.provider_ro().expect("Storage worker failed to initialize: database unavailable");
     let proof_tx = ProofTaskTx::new(provider.into_tx(), task_ctx, worker_id);
 
     tracing::debug!(
@@ -274,8 +274,8 @@ fn account_worker_loop<Factory>(
     Factory: DatabaseProviderFactory<Provider: BlockReader>,
 {
     // Create db transaction before entering work loop
-    let provider = view.provider_ro()
-        .expect("Account worker failed to initialize: database unavailable");
+    let provider =
+        view.provider_ro().expect("Account worker failed to initialize: database unavailable");
     let proof_tx = ProofTaskTx::new(provider.into_tx(), task_ctx, worker_id);
 
     tracing::debug!(


### PR DESCRIPTION
- spawn workers in the background and return the channel handle first. part of cleanup and micro optimisations of worker pool. 

closes: https://github.com/paradigmxyz/reth/issues/18995