### PR TITLE
chore(privitives-traits): remove unused serde derives and camelCase attribute

### DIFF
--- a/crates/primitives-traits/src/transaction/access_list.rs
+++ b/crates/primitives-traits/src/transaction/access_list.rs
@@ -8,22 +8,11 @@ mod tests {
     use proptest::proptest;
     use proptest_arbitrary_interop::arb;
     use reth_codecs::{add_arbitrary_tests, Compact};
-    use serde::{Deserialize, Serialize};
 
     /// This type is kept for compatibility tests after the codec support was added to alloy-eips
     /// `AccessList` type natively
     #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        Default,
-        RlpDecodableWrapper,
-        RlpEncodableWrapper,
-        Serialize,
-        Deserialize,
-        Compact,
+        Clone, Debug, PartialEq, Eq, Default, RlpDecodableWrapper, RlpEncodableWrapper, Compact,
     )]
     #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
     #[add_arbitrary_tests(compact, rlp)]
@@ -36,22 +25,9 @@ mod tests {
     }
 
     // This
-    #[derive(
-        Clone,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        Default,
-        RlpDecodable,
-        RlpEncodable,
-        Serialize,
-        Deserialize,
-        Compact,
-    )]
+    #[derive(Clone, Debug, PartialEq, Eq, Default, RlpDecodable, RlpEncodable, Compact)]
     #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
     #[add_arbitrary_tests(compact, rlp)]
-    #[serde(rename_all = "camelCase")]
     struct RethAccessListItem {
         /// Account address that would be loaded at the start of execution
         address: Address,


### PR DESCRIPTION
- Removed Serialize/Deserialize derives and #[serde(rename_all = "camelCase")] from test-only types, as no JSON/bincode roundtrips occur in these tests.
- Dropped unused Hash derives and the now-unused serde import.
- This reduces test-only bloat and prevents confusion, aligning with repo conventions where serde is gated/used only when needed. No functional behavior changes.