### PR TITLE
chore: bump book timeout

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
I believe this started to time out:

<img width="928" height="555" alt="image" src="https://github.com/user-attachments/assets/b8d6449d-37db-4f91-993d-786b7dd38a93" />
