### PR TITLE
feat(engine): deprecate TestPipelineBuilder::with_executor_results

### DIFF
--- a/crates/engine/tree/src/test_utils.rs
+++ b/crates/engine/tree/src/test_utils.rs
@@ -3,9 +3,8 @@ use reth_chainspec::ChainSpec;
 use reth_ethereum_primitives::BlockBody;
 use reth_network_p2p::test_utils::TestFullBlockClient;
 use reth_primitives_traits::SealedHeader;
-use reth_provider::{
-    test_utils::{create_test_provider_factory_with_chain_spec, MockNodeTypesWithDB},
-    ExecutionOutcome,
+use reth_provider::test_utils::{
+    create_test_provider_factory_with_chain_spec, MockNodeTypesWithDB,
 };
 use reth_prune_types::PruneModes;
 use reth_stages::{test_utils::TestStages, ExecOutput, StageError};
@@ -18,13 +17,12 @@ use tokio::sync::watch;
 #[derive(Default, Debug)]
 pub struct TestPipelineBuilder {
     pipeline_exec_outputs: VecDeque<Result<ExecOutput, StageError>>,
-    executor_results: Vec<ExecutionOutcome>,
 }
 
 impl TestPipelineBuilder {
     /// Create a new [`TestPipelineBuilder`].
     pub const fn new() -> Self {
-        Self { pipeline_exec_outputs: VecDeque::new(), executor_results: Vec::new() }
+        Self { pipeline_exec_outputs: VecDeque::new() }
     }
 
     /// Set the pipeline execution outputs to use for the test consensus engine.
@@ -37,8 +35,14 @@ impl TestPipelineBuilder {
     }
 
     /// Set the executor results to use for the test consensus engine.
-    pub fn with_executor_results(mut self, executor_results: Vec<ExecutionOutcome>) -> Self {
-        self.executor_results = executor_results;
+    #[deprecated(
+        note = "no-op: executor results are not used and will be removed in a future release"
+    )]
+    pub fn with_executor_results(
+        self,
+        executor_results: Vec<reth_provider::ExecutionOutcome>,
+    ) -> Self {
+        let _ = executor_results;
         self
     }
 


### PR DESCRIPTION
Removed the unused executor_results field and its import because it was dead code: the pipeline never consumed these values, so calling with_executor_results had no effect. Leaving a no-op setter that looks functional is misleading for test authors and can hide configuration mistakes. To avoid a breaking change, kept with_executor_results as a deprecated no-op, making the intent explicit, maintaining source compatibility for external users who might call it, and clearly signaling future removal. This cleans up the API surface, prevents confusion in tests, and ensures there are no behavioral regressions since the method never influenced the pipeline in the first place.