### PR TITLE
fix(op): Optionally disable `op` feature for `reth-optimism-primitives` 

### DIFF
--- a/crates/optimism/bin/Cargo.toml
+++ b/crates/optimism/bin/Cargo.toml
@@ -17,7 +17,7 @@ reth-optimism-chainspec.workspace = true
 reth-optimism-consensus.workspace = true
 reth-optimism-evm.workspace = true
 reth-optimism-payload-builder.workspace = true
-reth-optimism-primitives.workspace = true
+reth-optimism-primitives = { workspace = true, features = ["reth-codec"] }
 reth-optimism-forks.workspace = true
 
 clap = { workspace = true, features = ["derive", "env"] }

--- a/crates/optimism/evm/Cargo.toml
+++ b/crates/optimism/evm/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 # Reth
 reth-chainspec.workspace = true
 reth-evm = { workspace = true, features = ["op"] }
-reth-primitives-traits.workspace = true
+reth-primitives-traits = { workspace = true, features = ["op"] }
 reth-execution-errors.workspace = true
 reth-execution-types.workspace = true
 reth-storage-errors.workspace = true
@@ -34,7 +34,7 @@ alloy-consensus.workspace = true
 reth-optimism-chainspec.workspace = true
 reth-optimism-consensus.workspace = true
 reth-optimism-forks.workspace = true
-reth-optimism-primitives.workspace = true
+reth-optimism-primitives = { workspace = true, features = ["op"] }
 
 # revm
 revm.workspace = true

--- a/crates/optimism/node/Cargo.toml
+++ b/crates/optimism/node/Cargo.toml
@@ -41,7 +41,7 @@ reth-optimism-txpool.workspace = true
 reth-optimism-chainspec.workspace = true
 reth-optimism-consensus = { workspace = true, features = ["std"] }
 reth-optimism-forks.workspace = true
-reth-optimism-primitives = { workspace = true, features = ["serde", "serde-bincode-compat", "reth-codec"] }
+reth-optimism-primitives = { workspace = true, features = ["serde", "serde-bincode-compat"] }
 
 # revm with required optimism features
 # Note: this must be kept to ensure all features are properly enabled/forwarded

--- a/crates/optimism/primitives/Cargo.toml
+++ b/crates/optimism/primitives/Cargo.toml
@@ -13,8 +13,8 @@ workspace = true
 
 [dependencies]
 # reth
-reth-primitives-traits = { workspace = true, features = ["op"] }
-reth-codecs = { workspace = true, optional = true, features = ["op"] }
+reth-primitives-traits.workspace = true
+reth-codecs = { workspace = true, optional = true }
 reth-zstd-compressors = { workspace = true, optional = true }
 
 # ethereum
@@ -37,6 +37,7 @@ arbitrary = { workspace = true, features = ["derive"], optional = true }
 
 [dev-dependencies]
 reth-codecs = { workspace = true, features = ["test-utils", "op"] }
+reth-primitives-traits = { workspace = true, features = ["op"] }
 
 rand.workspace = true
 arbitrary.workspace = true
@@ -70,6 +71,7 @@ alloy-compat = ["op-alloy-consensus/alloy-compat"]
 reth-codec = [
     "dep:reth-codecs",
     "std",
+    "op",
     "reth-primitives-traits/reth-codec",
     "reth-codecs?/op",
     "dep:bytes",
@@ -106,4 +108,8 @@ arbitrary = [
     "alloy-consensus/arbitrary",
     "alloy-primitives/arbitrary",
     "alloy-eips/arbitrary",
+]
+op = [
+    "reth-primitives-traits/op",
+    "reth-codecs?/op",
 ]

--- a/crates/optimism/primitives/src/lib.rs
+++ b/crates/optimism/primitives/src/lib.rs
@@ -33,6 +33,7 @@ pub type OpBlockBody = <OpBlock as reth_primitives_traits::Block>::Body;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OpPrimitives;
 
+#[cfg(feature = "op")]
 impl reth_primitives_traits::NodePrimitives for OpPrimitives {
     type Block = OpBlock;
     type BlockHeader = alloy_consensus::Header;

--- a/crates/rpc/rpc-convert/Cargo.toml
+++ b/crates/rpc/rpc-convert/Cargo.toml
@@ -51,13 +51,13 @@ serde_json.workspace = true
 [features]
 default = []
 op = [
-	"dep:op-alloy-consensus",
-	"dep:op-alloy-rpc-types",
-	"dep:op-alloy-network",
-	"dep:reth-optimism-primitives",
-	"dep:reth-storage-api",
-	"dep:op-revm",
-	"reth-evm/op",
-	"reth-primitives-traits/op",
-	"reth-optimism-primitives?/op"
+    "dep:op-alloy-consensus",
+    "dep:op-alloy-rpc-types",
+    "dep:op-alloy-network",
+    "dep:reth-optimism-primitives",
+    "dep:reth-storage-api",
+    "dep:op-revm",
+    "reth-evm/op",
+    "reth-primitives-traits/op",
+    "reth-optimism-primitives?/op",
 ]

--- a/crates/rpc/rpc-convert/Cargo.toml
+++ b/crates/rpc/rpc-convert/Cargo.toml
@@ -51,12 +51,13 @@ serde_json.workspace = true
 [features]
 default = []
 op = [
-    "dep:op-alloy-consensus",
-    "dep:op-alloy-rpc-types",
-    "dep:op-alloy-network",
-    "dep:reth-optimism-primitives",
-    "dep:reth-storage-api",
-    "dep:op-revm",
-    "reth-evm/op",
-    "reth-primitives-traits/op",
+	"dep:op-alloy-consensus",
+	"dep:op-alloy-rpc-types",
+	"dep:op-alloy-network",
+	"dep:reth-optimism-primitives",
+	"dep:reth-storage-api",
+	"dep:op-revm",
+	"reth-evm/op",
+	"reth-primitives-traits/op",
+	"reth-optimism-primitives?/op"
 ]

--- a/crates/storage/db-api/Cargo.toml
+++ b/crates/storage/db-api/Cargo.toml
@@ -86,9 +86,9 @@ arbitrary = [
     "reth-ethereum-primitives/arbitrary",
 ]
 op = [
-	"dep:reth-optimism-primitives",
-	"reth-codecs/op",
-	"reth-primitives-traits/op",
-	"reth-optimism-primitives?/op"
+    "dep:reth-optimism-primitives",
+    "reth-codecs/op",
+    "reth-primitives-traits/op",
+    "reth-optimism-primitives?/op",
 ]
 bench = []

--- a/crates/storage/db-api/Cargo.toml
+++ b/crates/storage/db-api/Cargo.toml
@@ -86,8 +86,9 @@ arbitrary = [
     "reth-ethereum-primitives/arbitrary",
 ]
 op = [
-    "dep:reth-optimism-primitives",
-    "reth-codecs/op",
-    "reth-primitives-traits/op",
+	"dep:reth-optimism-primitives",
+	"reth-codecs/op",
+	"reth-primitives-traits/op",
+	"reth-optimism-primitives?/op"
 ]
 bench = []


### PR DESCRIPTION
Makes it possible to disable `op` feature in crates that don't use implementations of following traits for `op-alloy` types:
- `Compact`
- `PayloadAttributesBuilder`
- `TransactionEnv`
- `ExecutionPayload`
- `PayloadAttributes`
- `SerdeBincodeCompat`
- `InMemorySize`
- `FromConsensusTx`
- `TryIntoTxEnv`
- `TryIntoSimTx`
- `TryFromReceiptResponse`
- `SignableTxRequest`
- `TryFromTransactionResponse`
- `Compress`
- `Decompress`

Currently most crates that use `reth-primitives-traits` don't have an `op` feature leading to failing lint for obscure reasons when adding optimism crates, hence would be good to have option to disable `op` feature.