### PR TITLE
chore: remove unused Args struct from exex-subscription example

### DIFF
--- a/examples/exex-subscription/src/main.rs
+++ b/examples/exex-subscription/src/main.rs
@@ -4,7 +4,6 @@
 //! requested address.
 #[allow(dead_code)]
 use alloy_primitives::{Address, U256};
-use clap::Parser;
 use futures::TryStreamExt;
 use jsonrpsee::{
     core::SubscriptionResult, proc_macros::rpc, tracing, PendingSubscriptionSink,
@@ -166,14 +165,8 @@ async fn my_exex<Node: FullNodeComponents>(
     Ok(())
 }
 
-#[derive(Parser, Debug)]
-struct Args {
-    #[arg(long)]
-    enable_ext: bool,
-}
-
 fn main() -> eyre::Result<()> {
-    reth_ethereum::cli::Cli::parse_args().run(|builder, _args| async move {
+    reth_ethereum::cli::Cli::parse_args().run(|builder, _| async move {
         let (subscriptions_tx, subscriptions_rx) = mpsc::unbounded_channel::<SubscriptionRequest>();
 
         let rpc = StorageWatcherRpc::new(subscriptions_tx.clone());


### PR DESCRIPTION
Removed dead code that was left over from copy-pasting from other examples. The Args struct and clap::Parser import were never used - just sitting there with #[allow(dead_code)] to silence compiler warnings.

Also cleaned up the unused _args parameter to just _ since we're not using the parsed arguments anyway.

This was probably copied from node-custom-rpc example originally but the enable_ext field was never actually used in the subscription logic.