### PR TITLE
fix: respect cli blob size setting

### DIFF
--- a/crates/node/builder/src/components/pool.rs
+++ b/crates/node/builder/src/components/pool.rs
@@ -1,5 +1,6 @@
 //! Pool component for the node builder.
 
+use crate::{BuilderContext, FullNodeTypes};
 use alloy_primitives::Address;
 use reth_chain_state::CanonStateSubscriptions;
 use reth_node_api::TxTy;
@@ -8,8 +9,6 @@ use reth_transaction_pool::{
     TransactionPool, TransactionValidationTaskExecutor, TransactionValidator,
 };
 use std::{collections::HashSet, future::Future};
-
-use crate::{BuilderContext, FullNodeTypes};
 
 /// A type that knows how to build the transaction pool.
 pub trait PoolBuilder<Node: FullNodeTypes>: Send {
@@ -166,14 +165,12 @@ where
 pub fn create_blob_store<Node: FullNodeTypes>(
     ctx: &BuilderContext<Node>,
 ) -> eyre::Result<DiskFileBlobStore> {
-    let data_dir = ctx.config().datadir();
-    Ok(reth_transaction_pool::blobstore::DiskFileBlobStore::open(
-        data_dir.blobstore(),
-        Default::default(),
-    )?)
+    let cache_size = Some(ctx.config().txpool.max_cached_entries);
+    create_blob_store_with_cache(ctx, cache_size)
 }
 
-/// Create blob store with custom cache size configuration.
+/// Create blob store with custom cache size configuration for how many blobs should be cached in
+/// memory.
 pub fn create_blob_store_with_cache<Node: FullNodeTypes>(
     ctx: &BuilderContext<Node>,
     cache_size: Option<u32>,


### PR DESCRIPTION
this CLI param wasn't used

https://github.com/paradigmxyz/reth/blob/ddd5c2efa2b2cd319a4764e0a25eaa6cc04c6645/crates/node/core/src/args/txpool.rs#L91-L92