### PR TITLE
fix: return ExitCode from main instead of calling process::exit

### DIFF
--- a/bin/reth/src/main.rs
+++ b/bin/reth/src/main.rs
@@ -18,25 +18,26 @@ fn main() -> std::process::ExitCode {
         unsafe { std::env::set_var("RUST_BACKTRACE", "1") };
     }
 
-    let result = Cli::<EthereumChainSpecParser, RessArgs>::parse().run(async move |builder, ress_args| {
-        info!(target: "reth::cli", "Launching node");
-        let NodeHandle { node, node_exit_future } =
-            builder.node(EthereumNode::default()).launch_with_debug_capabilities().await?;
+    let result =
+        Cli::<EthereumChainSpecParser, RessArgs>::parse().run(async move |builder, ress_args| {
+            info!(target: "reth::cli", "Launching node");
+            let NodeHandle { node, node_exit_future } =
+                builder.node(EthereumNode::default()).launch_with_debug_capabilities().await?;
 
-        // Install ress subprotocol.
-        if ress_args.enabled {
-            install_ress_subprotocol(
-                ress_args,
-                node.provider,
-                node.evm_config,
-                node.network,
-                node.task_executor,
-                node.add_ons_handle.engine_events.new_listener(),
-            )?;
-        }
+            // Install ress subprotocol.
+            if ress_args.enabled {
+                install_ress_subprotocol(
+                    ress_args,
+                    node.provider,
+                    node.evm_config,
+                    node.network,
+                    node.task_executor,
+                    node.add_ons_handle.engine_events.new_listener(),
+                )?;
+            }
 
-        node_exit_future.await
-    });
+            node_exit_future.await
+        });
 
     match result {
         Ok(()) => std::process::ExitCode::SUCCESS,


### PR DESCRIPTION


Description
- Summary: Replace direct std::process::exit(1) with returning std::process::ExitCode in bin/reth/src/main.rs for graceful shutdown.
- Why: Ensures destructors run, background tasks can finish, and logs/metrics flush; improves testability and maintainability.
