### PR TITLE
refactor(net): Deduplicate response handling in EthRequestHandler

### DIFF
--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -147,10 +147,15 @@ where
 
         headers
     }
-    
+
     /// Generic implementation for fetching response items.
     #[inline]
-    fn get_response_items<T, F>(&self, hashes: Vec<B256>, mut fetch_fn: F, max_items: usize) -> Vec<T>
+    fn get_response_items<T, F>(
+        &self,
+        hashes: Vec<B256>,
+        mut fetch_fn: F,
+        max_items: usize,
+    ) -> Vec<T>
     where
         F: FnMut(B256) -> Option<T>,
         T: Encodable,
@@ -195,10 +200,12 @@ where
         response: oneshot::Sender<RequestResult<BlockBodies<<C::Block as Block>::Body>>>,
     ) {
         self.metrics.eth_bodies_requests_received_total.increment(1);
-        
+
         let bodies = self.get_response_items(
             request.0,
-            |hash| self.client.block_by_hash(hash).unwrap_or_default().map(|block| block.into_body()),
+            |hash| {
+                self.client.block_by_hash(hash).unwrap_or_default().map(|block| block.into_body())
+            },
             MAX_BODIES_SERVE,
         );
 

--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -245,11 +245,11 @@ where
         response: oneshot::Sender<RequestResult<Receipts69<C::Receipt>>>,
     ) {
         self.metrics.eth_receipts_requests_received_total.increment(1);
-        
+
         let receipts = self.get_response_items(
             request.0,
             |hash| self.client.receipts_by_block(BlockHashOrNumber::Hash(hash)).unwrap_or_default(),
-            MAX_RECEIPTS_SERVE
+            MAX_RECEIPTS_SERVE,
         );
 
         let _ = response.send(Ok(Receipts69(receipts)));

--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -147,7 +147,6 @@ where
         headers
     }
     
-    /// Generic implementation for fetching items (bodies or receipts) based on hashes.
     #[inline]
     fn get_response_items<T, F>(&self, hashes: Vec<B256>, fetch_fn: F, max_items: usize) -> Vec<T>
     where
@@ -176,8 +175,6 @@ where
                     break;
                 }
             } else {
-                // If any hash is not found, we stop processing further hashes.
-                // This is consistent with the original logic.
                 break;
             }
         }


### PR DESCRIPTION


This PR refactors `EthRequestHandler` to eliminate duplicated code for handling p2p requests.

**Summary**

The logic for fetching data and enforcing response limits (`MAX_*_SERVE` and `SOFT_RESPONSE_LIMIT`) was repeated across multiple request handlers, particularly `on_bodies_request` and `get_receipts_response`.

This change introduces a single generic helper function, `get_response_items`, to encapsulate this shared logic. The existing handlers have been updated to use this new function, resulting in cleaner and more maintainable code.

**Changes**

- **Added** a new private generic function `get_response_items` in `eth_requests.rs`.
- **Refactored** `on_bodies_request` and `get_receipts_response` to delegate response fetching and limit checking to the new helper.

This improves maintainability by ensuring that any future changes to response limiting logic only need to be made in one place.