### PR TITLE
chore(ci): update expected failures

### DIFF
--- a/.github/assets/hive/expected_failures.yaml
+++ b/.github/assets/hive/expected_failures.yaml
@@ -41,11 +41,7 @@ engine-cancun:
 
 sync: []
 
-# https://github.com/ethereum/hive/issues/1277
-engine-auth:
-  - "JWT Authentication: No time drift, correct secret (Paris) (reth)"
-  - "JWT Authentication: Negative time drift, within limit, correct secret (Paris) (reth)"
-  - "JWT Authentication: Positive time drift, within limit, correct secret (Paris) (reth)"
+engine-auth: []
 
 # 7702 test - no fix: it’s too expensive to check whether the storage is empty on each creation
 # 6110 related tests - may start passing when fixtures improve


### PR DESCRIPTION
`engine-auth` tests started passing after this hive fix was committed https://github.com/ethereum/hive/commit/9b51302f28865fe916598dae355840092f9b677d

for instance here https://github.com/paradigmxyz/reth/actions/runs/18527239886/job/52802709583