### PR TITLE
fix(net): correct error messages for decrypt and header paths

### DIFF
--- a/crates/net/ecies/src/error.rs
+++ b/crates/net/ecies/src/error.rs
@@ -47,7 +47,7 @@ pub enum ECIESErrorImpl {
     /// Error when parsing ACK data
     #[error("invalid ack data")]
     InvalidAckData,
-    /// Error when reading/parsing the RLPx header
+    /// Error when reading/parsing the `RLPx` header
     #[error("invalid header")]
     InvalidHeader,
     /// Error when interacting with secp256k1

--- a/crates/net/ecies/src/error.rs
+++ b/crates/net/ecies/src/error.rs
@@ -33,7 +33,7 @@ pub enum ECIESErrorImpl {
     #[error(transparent)]
     IO(std::io::Error),
     /// Error when checking the HMAC tag against the tag on the message being decrypted
-    #[error("tag check failure in read_header")]
+    #[error("tag check failure in decrypt_message")]
     TagCheckDecryptFailed,
     /// Error when checking the HMAC tag against the tag on the header
     #[error("tag check failure in read_header")]
@@ -47,8 +47,8 @@ pub enum ECIESErrorImpl {
     /// Error when parsing ACK data
     #[error("invalid ack data")]
     InvalidAckData,
-    /// Error when reading the header if its length is <3
-    #[error("invalid body data")]
+    /// Error when reading/parsing the RLPx header
+    #[error("invalid header")]
     InvalidHeader,
     /// Error when interacting with secp256k1
     #[error(transparent)]


### PR DESCRIPTION

This change corrects two misleading ECIES error messages to match the actual failure sites and improve debugging clarity. TagCheckDecryptFailed was incorrectly worded as “tag check failure in read_header” despite only being raised in the ECIES decrypt path (EncryptedMessage::check_integrity during auth/ack payload decryption), and InvalidHeader was incorrectly worded as “invalid body data” although it is raised exclusively by read_header for malformed/undersized RLPx headers