### PR TITLE
fix: include serde-bincode-compat in db-api

### DIFF
--- a/crates/storage/db-api/Cargo.toml
+++ b/crates/storage/db-api/Cargo.toml
@@ -28,7 +28,7 @@ alloy-genesis.workspace = true
 alloy-consensus.workspace = true
 
 # optimism
-reth-optimism-primitives = { workspace = true, optional = true, features = ["serde", "reth-codec"] }
+reth-optimism-primitives = { workspace = true, optional = true, features = ["serde", "reth-codec", "serde-bincode-compat"] }
 
 # codecs
 modular-bitfield.workspace = true


### PR DESCRIPTION
There's another issue with compiling due to missing `serde-bincode-compat` feature in `reth-optimism-primitives`.

The dep chain is:
`reth-optimism-exex` requires
`reth-exex` requires (needs serde bincode compact impl here due to `ExExNotification` serialization/deserialization)
`reth-exex-types` requires
`reth-chain-state` requires
`reth-storage-api` requires
`reth-db-api` requires
`reth-optimism-primitives` but this doesn't have serde-bincode-compat by default

I think we should just enable `serde-bincode-compat` on `reth-db-api`'s dependency of `reth-optimism-primitives`. Otherwise, we'd have to add features to each of these crates to enable/disable the serde`-bincode-compat` feature.