### PR TITLE
fix: add revm-state to dev-dependencies of chain-state crate

### DIFF
--- a/crates/chain-state/Cargo.toml
+++ b/crates/chain-state/Cargo.toml
@@ -54,6 +54,7 @@ reth-testing-utils.workspace = true
 alloy-signer.workspace = true
 alloy-signer-local.workspace = true
 rand.workspace = true
+revm-state.workspace = true
 criterion.workspace = true
 
 [features]


### PR DESCRIPTION
Running the following command fails with compilation error:

cargo test -p reth-chain-state

```bash
error[E0432]: unresolved import `revm_state`
  --> crates/chain-state/src/test_utils.rs:28:5
   |
28 | use revm_state::AccountInfo;
   |     ^^^^^^^^^^ use of unresolved module or unlinked crate `revm_state`
```

This is a regression from commit 336c3d1fa (#14021) which migrated from `revm` to `revm-state`. The migration correctly:
- Updated dependencies: `revm` → `revm-database` + `revm-state = { optional = true }`
- Updated features: added `"revm-state"` to test-utils

But it accidentally removed `revm.workspace = true` from dev-dependencies without replacing it with `revm-state.workspace = true`. Add `revm-state.workspace = true` to dev-dependencies, following the pattern used in other crates like `reth-provider`, `reth-trie`, and `reth-primitives-traits`.
