### PR TITLE
chore(primitives-traits): relax SignerRecoverable bounds for Extended<B,T>

### DIFF
--- a/crates/primitives-traits/src/extended.rs
+++ b/crates/primitives-traits/src/extended.rs
@@ -142,8 +142,8 @@ where
 
 impl<B, T> SignerRecoverable for Extended<B, T>
 where
-    B: SignedTransaction + IsTyped2718,
-    T: SignedTransaction,
+    B: SignerRecoverable,
+    T: SignerRecoverable,
 {
     fn recover_signer(&self) -> Result<Address, RecoveryError> {
         delegate!(self => tx.recover_signer())


### PR DESCRIPTION
Replace asymmetric and unnecessary bounds B: SignedTransaction + IsTyped2718, T: SignedTransaction with B: SignerRecoverable, T: SignerRecoverable in impl SignerRecoverable for Extended<B,T>.

Reason: The impl only delegates recovery methods and does not require typed-2718 or full SignedTransaction capabilities. This makes bounds minimal, symmetric, and consistent with actual usage, while keeping impl SignedTransaction for Extended<B,T> unchanged where B: IsTyped2718 is required to satisfy the Decodable2718 supertrait.