### PR TITLE
feat: use env filter for otlp, respect otel env var

### DIFF
--- a/crates/ethereum/cli/src/app.rs
+++ b/crates/ethereum/cli/src/app.rs
@@ -119,7 +119,7 @@ where
                 layers.with_span_layer(
                     "reth".to_string(),
                     output_type.clone(),
-                    self.cli.traces.otlp_level,
+                    self.cli.traces.otlp_level.clone(),
                 )?;
             }
 

--- a/crates/node/core/Cargo.toml
+++ b/crates/node/core/Cargo.toml
@@ -45,7 +45,7 @@ alloy-eips.workspace = true
 
 # misc
 eyre.workspace = true
-clap = { workspace = true, features = ["derive"] }
+clap = { workspace = true, features = ["derive", "env"] }
 humantime.workspace = true
 rand.workspace = true
 derive_more.workspace = true

--- a/crates/node/core/src/args/trace.rs
+++ b/crates/node/core/src/args/trace.rs
@@ -2,19 +2,22 @@
 
 use clap::Parser;
 use eyre::{ensure, WrapErr};
-use tracing::Level;
+use reth_tracing::tracing_subscriber::EnvFilter;
 use url::Url;
 
 /// CLI arguments for configuring `Opentelemetry` trace and span export.
 #[derive(Debug, Clone, Parser)]
 pub struct TraceArgs {
-    /// Enable `Opentelemetry` tracing export to an OTLP endpoint.
+    /// Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently
+    /// only http exporting is supported.
     ///
     /// If no value provided, defaults to `http://localhost:4318/v1/traces`.
     ///
     /// Example: --tracing-otlp=http://collector:4318/v1/traces
     #[arg(
         long = "tracing-otlp",
+        // Per specification.
+        env = "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
         global = true,
         value_name = "URL",
         num_args = 0..=1,
@@ -25,30 +28,37 @@ pub struct TraceArgs {
     )]
     pub otlp: Option<Url>,
 
-    /// Set the minimum log level for OTLP traces.
+    /// Set a filter directive for the OTLP tracer. This controls the verbosity
+    /// of spans and events sent to the OTLP endpoint. It follows the same
+    /// syntax as the `RUST_LOG` environment variable.
     ///
-    /// Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+    /// Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
     ///
     /// Defaults to TRACE if not specified.
     #[arg(
         long = "tracing-otlp-level",
         global = true,
-        value_name = "LEVEL",
+        value_name = "FILTER",
         default_value = "TRACE",
         help_heading = "Tracing"
     )]
-    pub otlp_level: Level,
+    pub otlp_level: EnvFilter,
 }
 
 impl Default for TraceArgs {
     fn default() -> Self {
-        Self { otlp: None, otlp_level: Level::TRACE }
+        Self { otlp: None, otlp_level: EnvFilter::from_default_env() }
     }
 }
 
 // Parses and validates an OTLP endpoint url.
 fn parse_otlp_endpoint(arg: &str) -> eyre::Result<Url> {
-    let url = Url::parse(arg).wrap_err("Invalid URL for OTLP trace output")?;
+    let mut url = Url::parse(arg).wrap_err("Invalid URL for OTLP trace output")?;
+
+    // If the path is empty, we set the path.
+    if url.path() == "/" {
+        url.set_path("/v1/traces")
+    }
 
     // OTLP url must end with `/v1/traces` per the OTLP specification.
     ensure!(

--- a/crates/optimism/cli/src/app.rs
+++ b/crates/optimism/cli/src/app.rs
@@ -124,7 +124,7 @@ where
                 layers.with_span_layer(
                     "reth".to_string(),
                     output_type.clone(),
-                    self.cli.traces.otlp_level,
+                    self.cli.traces.otlp_level.clone(),
                 )?;
             }
 

--- a/crates/tracing/src/layers.rs
+++ b/crates/tracing/src/layers.rs
@@ -130,13 +130,13 @@ impl Layers {
         &mut self,
         service_name: String,
         endpoint_exporter: url::Url,
-        level: tracing::Level,
+        filter: EnvFilter,
     ) -> eyre::Result<()> {
         // Create the span provider
 
         let span_layer = span_layer(service_name, &endpoint_exporter)
             .map_err(|e| eyre::eyre!("Failed to build OTLP span exporter {}", e))?
-            .with_filter(tracing::level_filters::LevelFilter::from_level(level));
+            .with_filter(filter);
 
         self.add_layer(span_layer);
 

--- a/docs/vocs/docs/pages/cli/reth.mdx
+++ b/docs/vocs/docs/pages/cli/reth.mdx
@@ -116,16 +116,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/config.mdx
+++ b/docs/vocs/docs/pages/cli/reth/config.mdx
@@ -102,16 +102,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db.mdx
@@ -167,16 +167,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/checksum.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/checksum.mdx
@@ -119,16 +119,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/clear.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/clear.mdx
@@ -111,16 +111,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/clear/mdbx.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/clear/mdbx.mdx
@@ -110,16 +110,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/clear/static-file.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/clear/static-file.mdx
@@ -113,16 +113,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/diff.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/diff.mdx
@@ -146,16 +146,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/drop.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/drop.mdx
@@ -109,16 +109,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/get.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/get.mdx
@@ -111,16 +111,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/get/mdbx.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/get/mdbx.mdx
@@ -119,16 +119,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/get/static-file.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/get/static-file.mdx
@@ -119,16 +119,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/list.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/list.mdx
@@ -152,16 +152,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/path.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/path.mdx
@@ -106,16 +106,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/repair-trie.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/repair-trie.mdx
@@ -109,16 +109,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/stats.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/stats.mdx
@@ -119,16 +119,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/version.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/version.mdx
@@ -106,16 +106,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/download.mdx
+++ b/docs/vocs/docs/pages/cli/reth/download.mdx
@@ -164,16 +164,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/dump-genesis.mdx
+++ b/docs/vocs/docs/pages/cli/reth/dump-genesis.mdx
@@ -105,16 +105,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/export-era.mdx
+++ b/docs/vocs/docs/pages/cli/reth/export-era.mdx
@@ -170,16 +170,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/import-era.mdx
+++ b/docs/vocs/docs/pages/cli/reth/import-era.mdx
@@ -165,16 +165,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/import.mdx
+++ b/docs/vocs/docs/pages/cli/reth/import.mdx
@@ -166,16 +166,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/init-state.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init-state.mdx
@@ -189,16 +189,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/init.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init.mdx
@@ -154,16 +154,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -996,16 +996,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/p2p.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p.mdx
@@ -103,16 +103,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/p2p/body.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/body.mdx
@@ -323,16 +323,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/p2p/bootnode.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/bootnode.mdx
@@ -114,16 +114,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/p2p/header.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/header.mdx
@@ -323,16 +323,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/p2p/rlpx.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/rlpx.mdx
@@ -100,16 +100,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/p2p/rlpx/ping.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/rlpx/ping.mdx
@@ -100,16 +100,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/prune.mdx
+++ b/docs/vocs/docs/pages/cli/reth/prune.mdx
@@ -154,16 +154,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/re-execute.mdx
+++ b/docs/vocs/docs/pages/cli/reth/re-execute.mdx
@@ -167,16 +167,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/stage.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage.mdx
@@ -103,16 +103,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/drop.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/drop.mdx
@@ -168,16 +168,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/dump.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump.mdx
@@ -161,16 +161,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/dump/account-hashing.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump/account-hashing.mdx
@@ -118,16 +118,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/dump/execution.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump/execution.mdx
@@ -118,16 +118,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/dump/merkle.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump/merkle.mdx
@@ -118,16 +118,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/dump/storage-hashing.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump/storage-hashing.mdx
@@ -118,16 +118,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/run.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/run.mdx
@@ -389,16 +389,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/unwind.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/unwind.mdx
@@ -162,16 +162,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/unwind/num-blocks.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/unwind/num-blocks.mdx
@@ -110,16 +110,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/unwind/to-block.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/unwind/to-block.mdx
@@ -110,16 +110,18 @@ Display:
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
 
           If no value provided, defaults to `http://localhost:4318/v1/traces`.
 
           Example: --tracing-otlp=http://collector:4318/v1/traces
 
-      --tracing-otlp-level <LEVEL>
-          Set the minimum log level for OTLP traces.
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-          Valid values: ERROR, WARN, INFO, DEBUG, TRACE
+      --tracing-otlp-level <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 


### PR DESCRIPTION
- enhance the OTLP  args by allowing a full env filter
    - Note: this is backwards compatible, as all levels are also valid filter directives
- allow lazy url specification by setting the path if the path is unset
- respect [OTEL conventions](https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/) by allowing the url to be set via the standard env var for trace exporting
- improve documentation