### PR TITLE
fix(session): remove Clone derive from SessionCounter

### DIFF
--- a/crates/net/network/src/session/counter.rs
+++ b/crates/net/network/src/session/counter.rs
@@ -3,7 +3,7 @@ use reth_network_api::Direction;
 use reth_network_types::SessionLimits;
 
 /// Keeps track of all sessions.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct SessionCounter {
     /// Limits to enforce.
     limits: SessionLimits,


### PR DESCRIPTION
Remove Clone from SessionCounter to prevent accidental duplication of mutable state. SessionCounter tracks live counters within SessionManager and is not cloned anywhere; keeping Clone is a footgun that could lead to diverging metrics if copies are modified independently. For cloneable counters we use Arc-based wrappers (see DisconnectionsCounter); SessionCounter should remain non-clone to reflect its ownership and mutation model.