### PR TITLE
refactor(trie): restructure proof task worker

### DIFF
--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -429,14 +429,14 @@ impl ProofWorkerHandle {
 
         // Spawn storage workers
         for worker_id in 0..storage_worker_count {
-            let worker = StorageProofWorker::new(
+            let storage_worker = StorageProofWorker::new(
                 view.clone(),
                 task_ctx.clone(),
                 storage_work_rx.clone(),
                 worker_id,
             );
 
-            executor.spawn_blocking(move || worker.run());
+            executor.spawn_blocking(move || storage_worker.run());
 
             tracing::debug!(
                 target: "trie::proof_task",
@@ -447,7 +447,7 @@ impl ProofWorkerHandle {
 
         // Spawn account workers
         for worker_id in 0..account_worker_count {
-            let worker = AccountProofWorker::new(
+            let account_worker = AccountProofWorker::new(
                 view.clone(),
                 task_ctx.clone(),
                 account_work_rx.clone(),
@@ -455,7 +455,7 @@ impl ProofWorkerHandle {
                 worker_id,
             );
 
-            executor.spawn_blocking(move || worker.run());
+            executor.spawn_blocking(move || account_worker.run());
 
             tracing::debug!(
                 target: "trie::proof_task",

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -553,7 +553,15 @@ where
         }
     }
 
-    /// Runs the storage worker loop until all senders are dropped.
+    /// Worker loop for storage trie operations.
+    ///
+    /// # Lifecycle
+    ///
+    /// Each worker:
+    /// 1. Receives `StorageWorkerJob` from crossbeam unbounded channel
+    /// 2. Computes result using its dedicated long-lived transaction
+    /// 3. Sends result directly to original caller via `std::mpsc`
+    /// 4. Repeats until channel closes (graceful shutdown)
     fn run(self) {
         let Self {
             view,
@@ -690,7 +698,15 @@ where
         }
     }
 
-    /// Runs the account worker loop until all senders are dropped.
+    /// Worker loop for account trie operations.
+    ///
+    /// # Lifecycle
+    ///
+    /// Each worker:
+    /// 1. Receives `AccountWorkerJob` from crossbeam unbounded channel
+    /// 2. Computes result using its dedicated long-lived transaction
+    /// 3. Sends result directly to original caller via `std::mpsc`
+    /// 4. Repeats until channel closes (graceful shutdown)
     fn run(self) {
         let Self {
             view,

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -88,539 +88,6 @@ enum StorageWorkerJob {
     },
 }
 
-/// Worker loop for storage trie operations.
-///
-/// # Lifecycle
-///
-/// Each worker:
-/// 1. Receives `StorageWorkerJob` from crossbeam unbounded channel
-/// 2. Computes result using its dedicated long-lived transaction
-/// 3. Sends result directly to original caller via `std::mpsc`
-/// 4. Repeats until channel closes (graceful shutdown)
-///
-/// # Transaction Reuse
-///
-/// Reuses the same transaction and cursor factories across multiple operations
-/// to avoid transaction creation and cursor factory setup overhead.
-///
-/// # Panic Safety
-///
-/// If this function panics, the worker thread terminates but other workers
-/// continue operating and the system degrades gracefully.
-///
-/// # Shutdown
-///
-/// Worker shuts down when the crossbeam channel closes (all senders dropped).
-fn storage_worker_loop<Factory>(
-    view: ConsistentDbView<Factory>,
-    task_ctx: ProofTaskCtx,
-    work_rx: CrossbeamReceiver<StorageWorkerJob>,
-    worker_id: usize,
-    #[cfg(feature = "metrics")] metrics: ProofTaskTrieMetrics,
-) where
-    Factory: DatabaseProviderFactory<Provider: BlockReader>,
-{
-    // Create db transaction before entering work loop
-    let provider =
-        view.provider_ro().expect("Storage worker failed to initialize: database unavailable");
-    let proof_tx = ProofTaskTx::new(provider.into_tx(), task_ctx, worker_id);
-
-    tracing::debug!(
-        target: "trie::proof_task",
-        worker_id,
-        "Storage worker started"
-    );
-
-    // Create factories once at worker startup to avoid recreation overhead.
-    let (trie_cursor_factory, hashed_cursor_factory) = proof_tx.create_factories();
-
-    // Create blinded provider factory once for all blinded node requests
-    let blinded_provider_factory = ProofTrieNodeProviderFactory::new(
-        trie_cursor_factory.clone(),
-        hashed_cursor_factory.clone(),
-        proof_tx.task_ctx.prefix_sets.clone(),
-    );
-
-    let mut storage_proofs_processed = 0u64;
-    let mut storage_nodes_processed = 0u64;
-
-    while let Ok(job) = work_rx.recv() {
-        match job {
-            StorageWorkerJob::StorageProof { input, result_sender } => {
-                let hashed_address = input.hashed_address;
-
-                trace!(
-                    target: "trie::proof_task",
-                    worker_id,
-                    hashed_address = ?hashed_address,
-                    prefix_set_len = input.prefix_set.len(),
-                    target_slots = input.target_slots.len(),
-                    "Processing storage proof"
-                );
-
-                let proof_start = Instant::now();
-                let result = proof_tx.compute_storage_proof(
-                    input,
-                    trie_cursor_factory.clone(),
-                    hashed_cursor_factory.clone(),
-                );
-
-                let proof_elapsed = proof_start.elapsed();
-                storage_proofs_processed += 1;
-
-                if result_sender.send(result).is_err() {
-                    tracing::debug!(
-                        target: "trie::proof_task",
-                        worker_id,
-                        hashed_address = ?hashed_address,
-                        storage_proofs_processed,
-                        "Storage proof receiver dropped, discarding result"
-                    );
-                }
-
-                trace!(
-                    target: "trie::proof_task",
-                    worker_id,
-                    hashed_address = ?hashed_address,
-                    proof_time_us = proof_elapsed.as_micros(),
-                    total_processed = storage_proofs_processed,
-                    "Storage proof completed"
-                );
-            }
-
-            StorageWorkerJob::BlindedStorageNode { account, path, result_sender } => {
-                trace!(
-                    target: "trie::proof_task",
-                    worker_id,
-                    ?account,
-                    ?path,
-                    "Processing blinded storage node"
-                );
-
-                let start = Instant::now();
-                let result =
-                    blinded_provider_factory.storage_node_provider(account).trie_node(&path);
-                let elapsed = start.elapsed();
-
-                storage_nodes_processed += 1;
-
-                if result_sender.send(result).is_err() {
-                    tracing::debug!(
-                        target: "trie::proof_task",
-                        worker_id,
-                        ?account,
-                        ?path,
-                        storage_nodes_processed,
-                        "Blinded storage node receiver dropped, discarding result"
-                    );
-                }
-
-                trace!(
-                    target: "trie::proof_task",
-                    worker_id,
-                    ?account,
-                    ?path,
-                    elapsed_us = elapsed.as_micros(),
-                    total_processed = storage_nodes_processed,
-                    "Blinded storage node completed"
-                );
-            }
-        }
-    }
-
-    tracing::debug!(
-        target: "trie::proof_task",
-        worker_id,
-        storage_proofs_processed,
-        storage_nodes_processed,
-        "Storage worker shutting down"
-    );
-
-    #[cfg(feature = "metrics")]
-    metrics.record_storage_nodes(storage_nodes_processed as usize);
-}
-
-/// Worker loop for account trie operations.
-///
-/// # Lifecycle
-///
-/// Each worker:
-/// 1. Receives `AccountWorkerJob` from crossbeam unbounded channel
-/// 2. Computes result using its dedicated long-lived transaction
-/// 3. Sends result directly to original caller via `std::mpsc`
-/// 4. Repeats until channel closes (graceful shutdown)
-///
-/// # Transaction Reuse
-///
-/// Reuses the same transaction and cursor factories across multiple operations
-/// to avoid transaction creation and cursor factory setup overhead.
-///
-/// # Panic Safety
-///
-/// If this function panics, the worker thread terminates but other workers
-/// continue operating and the system degrades gracefully.
-///
-/// # Shutdown
-///
-/// Worker shuts down when the crossbeam channel closes (all senders dropped).
-fn account_worker_loop<Factory>(
-    view: ConsistentDbView<Factory>,
-    task_ctx: ProofTaskCtx,
-    work_rx: CrossbeamReceiver<AccountWorkerJob>,
-    storage_work_tx: CrossbeamSender<StorageWorkerJob>,
-    worker_id: usize,
-    #[cfg(feature = "metrics")] metrics: ProofTaskTrieMetrics,
-) where
-    Factory: DatabaseProviderFactory<Provider: BlockReader>,
-{
-    // Create db transaction before entering work loop
-    let provider =
-        view.provider_ro().expect("Account worker failed to initialize: database unavailable");
-    let proof_tx = ProofTaskTx::new(provider.into_tx(), task_ctx, worker_id);
-
-    tracing::debug!(
-        target: "trie::proof_task",
-        worker_id,
-        "Account worker started"
-    );
-
-    // Create factories once at worker startup to avoid recreation overhead.
-    let (trie_cursor_factory, hashed_cursor_factory) = proof_tx.create_factories();
-
-    // Create blinded provider factory once for all blinded node requests
-    let blinded_provider_factory = ProofTrieNodeProviderFactory::new(
-        trie_cursor_factory.clone(),
-        hashed_cursor_factory.clone(),
-        proof_tx.task_ctx.prefix_sets.clone(),
-    );
-
-    let mut account_proofs_processed = 0u64;
-    let mut account_nodes_processed = 0u64;
-
-    while let Ok(job) = work_rx.recv() {
-        match job {
-            AccountWorkerJob::AccountMultiproof { mut input, result_sender } => {
-                trace!(
-                    target: "trie::proof_task",
-                    worker_id,
-                    targets = input.targets.len(),
-                    "Processing account multiproof"
-                );
-
-                let proof_start = Instant::now();
-                let mut tracker = ParallelTrieTracker::default();
-
-                let mut storage_prefix_sets =
-                    std::mem::take(&mut input.prefix_sets.storage_prefix_sets);
-
-                let storage_root_targets_len = StorageRootTargets::count(
-                    &input.prefix_sets.account_prefix_set,
-                    &storage_prefix_sets,
-                );
-                tracker.set_precomputed_storage_roots(storage_root_targets_len as u64);
-
-                let storage_proof_receivers = match dispatch_storage_proofs(
-                    &storage_work_tx,
-                    &input.targets,
-                    &mut storage_prefix_sets,
-                    input.collect_branch_node_masks,
-                    input.multi_added_removed_keys.as_ref(),
-                ) {
-                    Ok(receivers) => receivers,
-                    Err(error) => {
-                        let _ = result_sender.send(Err(error));
-                        continue;
-                    }
-                };
-
-                // Use the missed leaves cache passed from the multiproof manager
-                let missed_leaves_storage_roots = &input.missed_leaves_storage_roots;
-
-                let account_prefix_set = std::mem::take(&mut input.prefix_sets.account_prefix_set);
-
-                let ctx = AccountMultiproofParams {
-                    targets: &input.targets,
-                    prefix_set: account_prefix_set,
-                    collect_branch_node_masks: input.collect_branch_node_masks,
-                    multi_added_removed_keys: input.multi_added_removed_keys.as_ref(),
-                    storage_proof_receivers,
-                    missed_leaves_storage_roots,
-                };
-
-                let result = build_account_multiproof_with_storage_roots(
-                    trie_cursor_factory.clone(),
-                    hashed_cursor_factory.clone(),
-                    ctx,
-                    &mut tracker,
-                );
-
-                let proof_elapsed = proof_start.elapsed();
-                let stats = tracker.finish();
-                let result = result.map(|proof| (proof, stats));
-                account_proofs_processed += 1;
-
-                if result_sender.send(result).is_err() {
-                    tracing::debug!(
-                        target: "trie::proof_task",
-                        worker_id,
-                        account_proofs_processed,
-                        "Account multiproof receiver dropped, discarding result"
-                    );
-                }
-
-                trace!(
-                    target: "trie::proof_task",
-                    worker_id,
-                    proof_time_us = proof_elapsed.as_micros(),
-                    total_processed = account_proofs_processed,
-                    "Account multiproof completed"
-                );
-            }
-
-            AccountWorkerJob::BlindedAccountNode { path, result_sender } => {
-                trace!(
-                    target: "trie::proof_task",
-                    worker_id,
-                    ?path,
-                    "Processing blinded account node"
-                );
-
-                let start = Instant::now();
-                let result = blinded_provider_factory.account_node_provider().trie_node(&path);
-                let elapsed = start.elapsed();
-
-                account_nodes_processed += 1;
-
-                if result_sender.send(result).is_err() {
-                    tracing::debug!(
-                        target: "trie::proof_task",
-                        worker_id,
-                        ?path,
-                        account_nodes_processed,
-                        "Blinded account node receiver dropped, discarding result"
-                    );
-                }
-
-                trace!(
-                    target: "trie::proof_task",
-                    worker_id,
-                    ?path,
-                    node_time_us = elapsed.as_micros(),
-                    total_processed = account_nodes_processed,
-                    "Blinded account node completed"
-                );
-            }
-        }
-    }
-
-    tracing::debug!(
-        target: "trie::proof_task",
-        worker_id,
-        account_proofs_processed,
-        account_nodes_processed,
-        "Account worker shutting down"
-    );
-
-    #[cfg(feature = "metrics")]
-    metrics.record_account_nodes(account_nodes_processed as usize);
-}
-
-/// Builds an account multiproof by consuming storage proof receivers lazily during trie walk.
-///
-/// This is a helper function used by account workers to build the account subtree proof
-/// while storage proofs are still being computed. Receivers are consumed only when needed,
-/// enabling interleaved parallelism between account trie traversal and storage proof computation.
-///
-/// Returns a `DecodedMultiProof` containing the account subtree and storage proofs.
-fn build_account_multiproof_with_storage_roots<C, H>(
-    trie_cursor_factory: C,
-    hashed_cursor_factory: H,
-    ctx: AccountMultiproofParams<'_>,
-    tracker: &mut ParallelTrieTracker,
-) -> Result<DecodedMultiProof, ParallelStateRootError>
-where
-    C: TrieCursorFactory + Clone,
-    H: HashedCursorFactory + Clone,
-{
-    let accounts_added_removed_keys =
-        ctx.multi_added_removed_keys.as_ref().map(|keys| keys.get_accounts());
-
-    // Create the walker.
-    let walker = TrieWalker::<_>::state_trie(
-        trie_cursor_factory.account_trie_cursor().map_err(ProviderError::Database)?,
-        ctx.prefix_set,
-    )
-    .with_added_removed_keys(accounts_added_removed_keys)
-    .with_deletions_retained(true);
-
-    // Create a hash builder to rebuild the root node since it is not available in the database.
-    let retainer = ctx
-        .targets
-        .keys()
-        .map(Nibbles::unpack)
-        .collect::<ProofRetainer>()
-        .with_added_removed_keys(accounts_added_removed_keys);
-    let mut hash_builder = HashBuilder::default()
-        .with_proof_retainer(retainer)
-        .with_updates(ctx.collect_branch_node_masks);
-
-    // Initialize storage multiproofs map with pre-allocated capacity.
-    // Proofs will be inserted as they're consumed from receivers during trie walk.
-    let mut collected_decoded_storages: B256Map<DecodedStorageMultiProof> =
-        B256Map::with_capacity_and_hasher(ctx.targets.len(), Default::default());
-    let mut account_rlp = Vec::with_capacity(TRIE_ACCOUNT_RLP_MAX_SIZE);
-    let mut account_node_iter = TrieNodeIter::state_trie(
-        walker,
-        hashed_cursor_factory.hashed_account_cursor().map_err(ProviderError::Database)?,
-    );
-
-    let mut storage_proof_receivers = ctx.storage_proof_receivers;
-
-    while let Some(account_node) = account_node_iter.try_next().map_err(ProviderError::Database)? {
-        match account_node {
-            TrieElement::Branch(node) => {
-                hash_builder.add_branch(node.key, node.value, node.children_are_in_trie);
-            }
-            TrieElement::Leaf(hashed_address, account) => {
-                let root = match storage_proof_receivers.remove(&hashed_address) {
-                    Some(receiver) => {
-                        // Block on this specific storage proof receiver - enables interleaved
-                        // parallelism
-                        let proof = receiver.recv().map_err(|_| {
-                            ParallelStateRootError::StorageRoot(
-                                reth_execution_errors::StorageRootError::Database(
-                                    DatabaseError::Other(format!(
-                                        "Storage proof channel closed for {hashed_address}"
-                                    )),
-                                ),
-                            )
-                        })??;
-                        let root = proof.root;
-                        collected_decoded_storages.insert(hashed_address, proof);
-                        root
-                    }
-                    // Since we do not store all intermediate nodes in the database, there might
-                    // be a possibility of re-adding a non-modified leaf to the hash builder.
-                    None => {
-                        tracker.inc_missed_leaves();
-
-                        match ctx.missed_leaves_storage_roots.entry(hashed_address) {
-                            dashmap::Entry::Occupied(occ) => *occ.get(),
-                            dashmap::Entry::Vacant(vac) => {
-                                let root = StorageProof::new_hashed(
-                                    trie_cursor_factory.clone(),
-                                    hashed_cursor_factory.clone(),
-                                    hashed_address,
-                                )
-                                .with_prefix_set_mut(Default::default())
-                                .storage_multiproof(
-                                    ctx.targets.get(&hashed_address).cloned().unwrap_or_default(),
-                                )
-                                .map_err(|e| {
-                                    ParallelStateRootError::StorageRoot(
-                                        reth_execution_errors::StorageRootError::Database(
-                                            DatabaseError::Other(e.to_string()),
-                                        ),
-                                    )
-                                })?
-                                .root;
-
-                                vac.insert(root);
-                                root
-                            }
-                        }
-                    }
-                };
-
-                // Encode account
-                account_rlp.clear();
-                let account = account.into_trie_account(root);
-                account.encode(&mut account_rlp as &mut dyn BufMut);
-
-                hash_builder.add_leaf(Nibbles::unpack(hashed_address), &account_rlp);
-            }
-        }
-    }
-
-    // Consume remaining storage proof receivers for accounts not encountered during trie walk.
-    for (hashed_address, receiver) in storage_proof_receivers {
-        if let Ok(Ok(proof)) = receiver.recv() {
-            collected_decoded_storages.insert(hashed_address, proof);
-        }
-    }
-
-    let _ = hash_builder.root();
-
-    let account_subtree_raw_nodes = hash_builder.take_proof_nodes();
-    let decoded_account_subtree = DecodedProofNodes::try_from(account_subtree_raw_nodes)?;
-
-    let (branch_node_hash_masks, branch_node_tree_masks) = if ctx.collect_branch_node_masks {
-        let updated_branch_nodes = hash_builder.updated_branch_nodes.unwrap_or_default();
-        (
-            updated_branch_nodes.iter().map(|(path, node)| (*path, node.hash_mask)).collect(),
-            updated_branch_nodes.into_iter().map(|(path, node)| (path, node.tree_mask)).collect(),
-        )
-    } else {
-        (Default::default(), Default::default())
-    };
-
-    Ok(DecodedMultiProof {
-        account_subtree: decoded_account_subtree,
-        branch_node_hash_masks,
-        branch_node_tree_masks,
-        storages: collected_decoded_storages,
-    })
-}
-
-/// Queues storage proofs for all accounts in the targets and returns receivers.
-///
-/// This function queues all storage proof tasks to the worker pool but returns immediately
-/// with receivers, allowing the account trie walk to proceed in parallel with storage proof
-/// computation. This enables interleaved parallelism for better performance.
-///
-/// Propagates errors up if queuing fails. Receivers must be consumed by the caller.
-fn dispatch_storage_proofs(
-    storage_work_tx: &CrossbeamSender<StorageWorkerJob>,
-    targets: &MultiProofTargets,
-    storage_prefix_sets: &mut B256Map<PrefixSet>,
-    with_branch_node_masks: bool,
-    multi_added_removed_keys: Option<&Arc<MultiAddedRemovedKeys>>,
-) -> Result<B256Map<Receiver<StorageProofResult>>, ParallelStateRootError> {
-    let mut storage_proof_receivers =
-        B256Map::with_capacity_and_hasher(targets.len(), Default::default());
-
-    // Queue all storage proofs to worker pool
-    for (hashed_address, target_slots) in targets.iter() {
-        let prefix_set = storage_prefix_sets.remove(hashed_address).unwrap_or_default();
-
-        // Always queue a storage proof so we obtain the storage root even when no slots are
-        // requested.
-        let input = StorageProofInput::new(
-            *hashed_address,
-            prefix_set,
-            target_slots.clone(),
-            with_branch_node_masks,
-            multi_added_removed_keys.cloned(),
-        );
-
-        let (sender, receiver) = channel();
-
-        // If queuing fails, propagate error up (no fallback)
-        storage_work_tx
-            .send(StorageWorkerJob::StorageProof { input, result_sender: sender })
-            .map_err(|_| {
-                ParallelStateRootError::Other(format!(
-                    "Failed to queue storage proof for {}: storage worker pool unavailable",
-                    hashed_address
-                ))
-            })?;
-
-        storage_proof_receivers.insert(*hashed_address, receiver);
-    }
-
-    Ok(storage_proof_receivers)
-}
-
 /// Type alias for the factory tuple returned by `create_factories`
 type ProofFactories<'a, Tx> = (
     InMemoryTrieCursorFactory<DatabaseTrieCursorFactory<&'a Tx>, &'a TrieUpdatesSorted>,
@@ -858,96 +325,6 @@ pub struct ProofWorkerHandle {
 }
 
 impl ProofWorkerHandle {
-    /// Spawns storage and account worker pools with dedicated database transactions.
-    ///
-    /// Returns a handle for submitting proof tasks to the worker pools.
-    /// Workers run until the last handle is dropped.
-    ///
-    /// # Parameters
-    /// - `executor`: Tokio runtime handle for spawning blocking tasks
-    /// - `view`: Consistent database view for creating transactions
-    /// - `task_ctx`: Shared context with trie updates and prefix sets
-    /// - `storage_worker_count`: Number of storage workers to spawn
-    /// - `account_worker_count`: Number of account workers to spawn
-    pub fn new<Factory>(
-        executor: Handle,
-        view: ConsistentDbView<Factory>,
-        task_ctx: ProofTaskCtx,
-        storage_worker_count: usize,
-        account_worker_count: usize,
-    ) -> Self
-    where
-        Factory: DatabaseProviderFactory<Provider: BlockReader> + Clone + 'static,
-    {
-        let (storage_work_tx, storage_work_rx) = unbounded::<StorageWorkerJob>();
-        let (account_work_tx, account_work_rx) = unbounded::<AccountWorkerJob>();
-
-        tracing::debug!(
-            target: "trie::proof_task",
-            storage_worker_count,
-            account_worker_count,
-            "Spawning proof worker pools"
-        );
-
-        // Spawn storage workers
-        for worker_id in 0..storage_worker_count {
-            let view_clone = view.clone();
-            let task_ctx_clone = task_ctx.clone();
-            let work_rx_clone = storage_work_rx.clone();
-
-            executor.spawn_blocking(move || {
-                #[cfg(feature = "metrics")]
-                let metrics = ProofTaskTrieMetrics::default();
-
-                storage_worker_loop(
-                    view_clone,
-                    task_ctx_clone,
-                    work_rx_clone,
-                    worker_id,
-                    #[cfg(feature = "metrics")]
-                    metrics,
-                )
-            });
-
-            tracing::debug!(
-                target: "trie::proof_task",
-                worker_id,
-                "Storage worker spawned successfully"
-            );
-        }
-
-        // Spawn account workers
-        for worker_id in 0..account_worker_count {
-            let view_clone = view.clone();
-            let task_ctx_clone = task_ctx.clone();
-            let work_rx_clone = account_work_rx.clone();
-            let storage_work_tx_clone = storage_work_tx.clone();
-
-            executor.spawn_blocking(move || {
-                #[cfg(feature = "metrics")]
-                let metrics = ProofTaskTrieMetrics::default();
-
-                account_worker_loop(
-                    view_clone,
-                    task_ctx_clone,
-                    work_rx_clone,
-                    storage_work_tx_clone,
-                    worker_id,
-                    #[cfg(feature = "metrics")]
-                    metrics,
-                )
-            });
-
-            tracing::debug!(
-                target: "trie::proof_task",
-                worker_id,
-                "Account worker spawned successfully"
-            );
-        }
-
-        Self::new_handle(storage_work_tx, account_work_tx)
-    }
-
     /// Creates a new [`ProofWorkerHandle`] with direct access to worker pools.
     ///
     /// This is an internal constructor used for creating handles.
@@ -1018,6 +395,77 @@ impl ProofWorkerHandle {
 
         Ok(rx)
     }
+
+    /// Spawns storage and account worker pools with dedicated database transactions.
+    ///
+    /// Returns a handle for submitting proof tasks to the worker pools.
+    /// Workers run until the last handle is dropped.
+    ///
+    /// # Parameters
+    /// - `executor`: Tokio runtime handle for spawning blocking tasks
+    /// - `view`: Consistent database view for creating transactions
+    /// - `task_ctx`: Shared context with trie updates and prefix sets
+    /// - `storage_worker_count`: Number of storage workers to spawn
+    /// - `account_worker_count`: Number of account workers to spawn
+    pub fn new<Factory>(
+        executor: Handle,
+        view: ConsistentDbView<Factory>,
+        task_ctx: ProofTaskCtx,
+        storage_worker_count: usize,
+        account_worker_count: usize,
+    ) -> Self
+    where
+        Factory: DatabaseProviderFactory<Provider: BlockReader> + Clone + 'static,
+    {
+        let (storage_work_tx, storage_work_rx) = unbounded::<StorageWorkerJob>();
+        let (account_work_tx, account_work_rx) = unbounded::<AccountWorkerJob>();
+
+        tracing::debug!(
+            target: "trie::proof_task",
+            storage_worker_count,
+            account_worker_count,
+            "Spawning proof worker pools"
+        );
+
+        // Spawn storage workers
+        for worker_id in 0..storage_worker_count {
+            let worker = StorageProofWorker::new(
+                view.clone(),
+                task_ctx.clone(),
+                storage_work_rx.clone(),
+                worker_id,
+            );
+
+            executor.spawn_blocking(move || worker.run());
+
+            tracing::debug!(
+                target: "trie::proof_task",
+                worker_id,
+                "Storage worker spawned successfully"
+            );
+        }
+
+        // Spawn account workers
+        for worker_id in 0..account_worker_count {
+            let worker = AccountProofWorker::new(
+                view.clone(),
+                task_ctx.clone(),
+                account_work_rx.clone(),
+                storage_work_tx.clone(),
+                worker_id,
+            );
+
+            executor.spawn_blocking(move || worker.run());
+
+            tracing::debug!(
+                target: "trie::proof_task",
+                worker_id,
+                "Account worker spawned successfully"
+            );
+        }
+
+        Self::new_handle(storage_work_tx, account_work_tx)
+    }
 }
 
 impl TrieNodeProviderFactory for ProofWorkerHandle {
@@ -1067,6 +515,563 @@ impl TrieNodeProvider for ProofTaskTrieNodeProvider {
             }
         }
     }
+}
+
+/// Worker responsible for storage trie operations.
+struct StorageProofWorker<Factory> {
+    view: ConsistentDbView<Factory>,
+    task_ctx: ProofTaskCtx,
+    work_rx: CrossbeamReceiver<StorageWorkerJob>,
+    worker_id: usize,
+    #[cfg(feature = "metrics")]
+    metrics: ProofTaskTrieMetrics,
+}
+
+impl<Factory> StorageProofWorker<Factory>
+where
+    Factory: DatabaseProviderFactory<Provider: BlockReader>,
+{
+    fn new(
+        view: ConsistentDbView<Factory>,
+        task_ctx: ProofTaskCtx,
+        work_rx: CrossbeamReceiver<StorageWorkerJob>,
+        worker_id: usize,
+    ) -> Self {
+        Self {
+            view,
+            task_ctx,
+            work_rx,
+            worker_id,
+            #[cfg(feature = "metrics")]
+            metrics: ProofTaskTrieMetrics::default(),
+        }
+    }
+
+    /// Runs the storage worker loop until all senders are dropped.
+    fn run(self) {
+        let Self {
+            view,
+            task_ctx,
+            work_rx,
+            worker_id,
+            #[cfg(feature = "metrics")]
+            metrics,
+        } = self;
+
+        // Create db transaction before entering work loop
+        let provider =
+            view.provider_ro().expect("Storage worker failed to initialize: database unavailable");
+        let proof_tx = ProofTaskTx::new(provider.into_tx(), task_ctx, worker_id);
+
+        tracing::debug!(
+            target: "trie::proof_task",
+            worker_id,
+            "Storage worker started"
+        );
+
+        // Create factories once at worker startup to avoid recreation overhead.
+        let (trie_cursor_factory, hashed_cursor_factory) = proof_tx.create_factories();
+
+        // Create blinded provider factory once for all blinded node requests
+        let blinded_provider_factory = ProofTrieNodeProviderFactory::new(
+            trie_cursor_factory.clone(),
+            hashed_cursor_factory.clone(),
+            proof_tx.task_ctx.prefix_sets.clone(),
+        );
+
+        let mut storage_proofs_processed = 0u64;
+        let mut storage_nodes_processed = 0u64;
+
+        while let Ok(job) = work_rx.recv() {
+            match job {
+                StorageWorkerJob::StorageProof { input, result_sender } => {
+                    let hashed_address = input.hashed_address;
+
+                    trace!(
+                        target: "trie::proof_task",
+                        worker_id,
+                        hashed_address = ?hashed_address,
+                        prefix_set_len = input.prefix_set.len(),
+                        target_slots = input.target_slots.len(),
+                        "Processing storage proof"
+                    );
+
+                    let proof_start = Instant::now();
+                    let result = proof_tx.compute_storage_proof(
+                        input,
+                        trie_cursor_factory.clone(),
+                        hashed_cursor_factory.clone(),
+                    );
+
+                    let proof_elapsed = proof_start.elapsed();
+                    storage_proofs_processed += 1;
+
+                    if result_sender.send(result).is_err() {
+                        tracing::debug!(
+                            target: "trie::proof_task",
+                            worker_id,
+                            hashed_address = ?hashed_address,
+                            storage_proofs_processed,
+                            "Storage proof receiver dropped, discarding result"
+                        );
+                    }
+
+                    trace!(
+                        target: "trie::proof_task",
+                        worker_id,
+                        hashed_address = ?hashed_address,
+                        proof_time_us = proof_elapsed.as_micros(),
+                        total_processed = storage_proofs_processed,
+                        "Storage proof completed"
+                    );
+                }
+
+                StorageWorkerJob::BlindedStorageNode { account, path, result_sender } => {
+                    trace!(
+                        target: "trie::proof_task",
+                        worker_id,
+                        ?account,
+                        ?path,
+                        "Processing blinded storage node"
+                    );
+
+                    let start = Instant::now();
+                    let result =
+                        blinded_provider_factory.storage_node_provider(account).trie_node(&path);
+                    let elapsed = start.elapsed();
+
+                    storage_nodes_processed += 1;
+
+                    if result_sender.send(result).is_err() {
+                        tracing::debug!(
+                            target: "trie::proof_task",
+                            worker_id,
+                            ?account,
+                            ?path,
+                            storage_nodes_processed,
+                            "Blinded storage node receiver dropped, discarding result"
+                        );
+                    }
+
+                    trace!(
+                        target: "trie::proof_task",
+                        worker_id,
+                        ?account,
+                        ?path,
+                        elapsed_us = elapsed.as_micros(),
+                        total_processed = storage_nodes_processed,
+                        "Blinded storage node completed"
+                    );
+                }
+            }
+        }
+
+        tracing::debug!(
+            target: "trie::proof_task",
+            worker_id,
+            storage_proofs_processed,
+            storage_nodes_processed,
+            "Storage worker shutting down"
+        );
+
+        #[cfg(feature = "metrics")]
+        metrics.record_storage_nodes(storage_nodes_processed as usize);
+    }
+}
+
+/// Worker responsible for account trie operations.
+struct AccountProofWorker<Factory> {
+    view: ConsistentDbView<Factory>,
+    task_ctx: ProofTaskCtx,
+    work_rx: CrossbeamReceiver<AccountWorkerJob>,
+    storage_work_tx: CrossbeamSender<StorageWorkerJob>,
+    worker_id: usize,
+    #[cfg(feature = "metrics")]
+    metrics: ProofTaskTrieMetrics,
+}
+
+impl<Factory> AccountProofWorker<Factory>
+where
+    Factory: DatabaseProviderFactory<Provider: BlockReader>,
+{
+    fn new(
+        view: ConsistentDbView<Factory>,
+        task_ctx: ProofTaskCtx,
+        work_rx: CrossbeamReceiver<AccountWorkerJob>,
+        storage_work_tx: CrossbeamSender<StorageWorkerJob>,
+        worker_id: usize,
+    ) -> Self {
+        Self {
+            view,
+            task_ctx,
+            work_rx,
+            storage_work_tx,
+            worker_id,
+            #[cfg(feature = "metrics")]
+            metrics: ProofTaskTrieMetrics::default(),
+        }
+    }
+
+    /// Runs the account worker loop until all senders are dropped.
+    fn run(self) {
+        let Self {
+            view,
+            task_ctx,
+            work_rx,
+            storage_work_tx,
+            worker_id,
+            #[cfg(feature = "metrics")]
+            metrics,
+        } = self;
+
+        // Create db transaction before entering work loop
+        let provider =
+            view.provider_ro().expect("Account worker failed to initialize: database unavailable");
+        let proof_tx = ProofTaskTx::new(provider.into_tx(), task_ctx, worker_id);
+
+        tracing::debug!(
+            target: "trie::proof_task",
+            worker_id,
+            "Account worker started"
+        );
+
+        // Create factories once at worker startup to avoid recreation overhead.
+        let (trie_cursor_factory, hashed_cursor_factory) = proof_tx.create_factories();
+
+        // Create blinded provider factory once for all blinded node requests
+        let blinded_provider_factory = ProofTrieNodeProviderFactory::new(
+            trie_cursor_factory.clone(),
+            hashed_cursor_factory.clone(),
+            proof_tx.task_ctx.prefix_sets.clone(),
+        );
+
+        let mut account_proofs_processed = 0u64;
+        let mut account_nodes_processed = 0u64;
+
+        while let Ok(job) = work_rx.recv() {
+            match job {
+                AccountWorkerJob::AccountMultiproof { mut input, result_sender } => {
+                    trace!(
+                        target: "trie::proof_task",
+                        worker_id,
+                        targets = input.targets.len(),
+                        "Processing account multiproof"
+                    );
+
+                    let proof_start = Instant::now();
+                    let mut tracker = ParallelTrieTracker::default();
+
+                    let mut storage_prefix_sets =
+                        std::mem::take(&mut input.prefix_sets.storage_prefix_sets);
+
+                    let storage_root_targets_len = StorageRootTargets::count(
+                        &input.prefix_sets.account_prefix_set,
+                        &storage_prefix_sets,
+                    );
+                    tracker.set_precomputed_storage_roots(storage_root_targets_len as u64);
+
+                    let storage_proof_receivers = match dispatch_storage_proofs(
+                        &storage_work_tx,
+                        &input.targets,
+                        &mut storage_prefix_sets,
+                        input.collect_branch_node_masks,
+                        input.multi_added_removed_keys.as_ref(),
+                    ) {
+                        Ok(receivers) => receivers,
+                        Err(error) => {
+                            let _ = result_sender.send(Err(error));
+                            continue;
+                        }
+                    };
+
+                    // Use the missed leaves cache passed from the multiproof manager
+                    let missed_leaves_storage_roots = &input.missed_leaves_storage_roots;
+
+                    let account_prefix_set =
+                        std::mem::take(&mut input.prefix_sets.account_prefix_set);
+
+                    let ctx = AccountMultiproofParams {
+                        targets: &input.targets,
+                        prefix_set: account_prefix_set,
+                        collect_branch_node_masks: input.collect_branch_node_masks,
+                        multi_added_removed_keys: input.multi_added_removed_keys.as_ref(),
+                        storage_proof_receivers,
+                        missed_leaves_storage_roots,
+                    };
+
+                    let result = build_account_multiproof_with_storage_roots(
+                        trie_cursor_factory.clone(),
+                        hashed_cursor_factory.clone(),
+                        ctx,
+                        &mut tracker,
+                    );
+
+                    let proof_elapsed = proof_start.elapsed();
+                    let stats = tracker.finish();
+                    let result = result.map(|proof| (proof, stats));
+                    account_proofs_processed += 1;
+
+                    if result_sender.send(result).is_err() {
+                        tracing::debug!(
+                            target: "trie::proof_task",
+                            worker_id,
+                            account_proofs_processed,
+                            "Account multiproof receiver dropped, discarding result"
+                        );
+                    }
+
+                    trace!(
+                        target: "trie::proof_task",
+                        worker_id,
+                        proof_time_us = proof_elapsed.as_micros(),
+                        total_processed = account_proofs_processed,
+                        "Account multiproof completed"
+                    );
+                }
+
+                AccountWorkerJob::BlindedAccountNode { path, result_sender } => {
+                    trace!(
+                        target: "trie::proof_task",
+                        worker_id,
+                        ?path,
+                        "Processing blinded account node"
+                    );
+
+                    let start = Instant::now();
+                    let result = blinded_provider_factory.account_node_provider().trie_node(&path);
+                    let elapsed = start.elapsed();
+
+                    account_nodes_processed += 1;
+
+                    if result_sender.send(result).is_err() {
+                        tracing::debug!(
+                            target: "trie::proof_task",
+                            worker_id,
+                            ?path,
+                            account_nodes_processed,
+                            "Blinded account node receiver dropped, discarding result"
+                        );
+                    }
+
+                    trace!(
+                        target: "trie::proof_task",
+                        worker_id,
+                        ?path,
+                        node_time_us = elapsed.as_micros(),
+                        total_processed = account_nodes_processed,
+                        "Blinded account node completed"
+                    );
+                }
+            }
+        }
+
+        tracing::debug!(
+            target: "trie::proof_task",
+            worker_id,
+            account_proofs_processed,
+            account_nodes_processed,
+            "Account worker shutting down"
+        );
+
+        #[cfg(feature = "metrics")]
+        metrics.record_account_nodes(account_nodes_processed as usize);
+    }
+}
+
+/// Builds an account multiproof by consuming storage proof receivers lazily during trie walk.
+///
+/// This is a helper function used by account workers to build the account subtree proof
+/// while storage proofs are still being computed. Receivers are consumed only when needed,
+/// enabling interleaved parallelism between account trie traversal and storage proof computation.
+///
+/// Returns a `DecodedMultiProof` containing the account subtree and storage proofs.
+fn build_account_multiproof_with_storage_roots<C, H>(
+    trie_cursor_factory: C,
+    hashed_cursor_factory: H,
+    ctx: AccountMultiproofParams<'_>,
+    tracker: &mut ParallelTrieTracker,
+) -> Result<DecodedMultiProof, ParallelStateRootError>
+where
+    C: TrieCursorFactory + Clone,
+    H: HashedCursorFactory + Clone,
+{
+    let accounts_added_removed_keys =
+        ctx.multi_added_removed_keys.as_ref().map(|keys| keys.get_accounts());
+
+    // Create the walker.
+    let walker = TrieWalker::<_>::state_trie(
+        trie_cursor_factory.account_trie_cursor().map_err(ProviderError::Database)?,
+        ctx.prefix_set,
+    )
+    .with_added_removed_keys(accounts_added_removed_keys)
+    .with_deletions_retained(true);
+
+    // Create a hash builder to rebuild the root node since it is not available in the database.
+    let retainer = ctx
+        .targets
+        .keys()
+        .map(Nibbles::unpack)
+        .collect::<ProofRetainer>()
+        .with_added_removed_keys(accounts_added_removed_keys);
+    let mut hash_builder = HashBuilder::default()
+        .with_proof_retainer(retainer)
+        .with_updates(ctx.collect_branch_node_masks);
+
+    // Initialize storage multiproofs map with pre-allocated capacity.
+    // Proofs will be inserted as they're consumed from receivers during trie walk.
+    let mut collected_decoded_storages: B256Map<DecodedStorageMultiProof> =
+        B256Map::with_capacity_and_hasher(ctx.targets.len(), Default::default());
+    let mut account_rlp = Vec::with_capacity(TRIE_ACCOUNT_RLP_MAX_SIZE);
+    let mut account_node_iter = TrieNodeIter::state_trie(
+        walker,
+        hashed_cursor_factory.hashed_account_cursor().map_err(ProviderError::Database)?,
+    );
+
+    let mut storage_proof_receivers = ctx.storage_proof_receivers;
+
+    while let Some(account_node) = account_node_iter.try_next().map_err(ProviderError::Database)? {
+        match account_node {
+            TrieElement::Branch(node) => {
+                hash_builder.add_branch(node.key, node.value, node.children_are_in_trie);
+            }
+            TrieElement::Leaf(hashed_address, account) => {
+                let root = match storage_proof_receivers.remove(&hashed_address) {
+                    Some(receiver) => {
+                        // Block on this specific storage proof receiver - enables interleaved
+                        // parallelism
+                        let proof = receiver.recv().map_err(|_| {
+                            ParallelStateRootError::StorageRoot(
+                                reth_execution_errors::StorageRootError::Database(
+                                    DatabaseError::Other(format!(
+                                        "Storage proof channel closed for {hashed_address}"
+                                    )),
+                                ),
+                            )
+                        })??;
+                        let root = proof.root;
+                        collected_decoded_storages.insert(hashed_address, proof);
+                        root
+                    }
+                    // Since we do not store all intermediate nodes in the database, there might
+                    // be a possibility of re-adding a non-modified leaf to the hash builder.
+                    None => {
+                        tracker.inc_missed_leaves();
+
+                        match ctx.missed_leaves_storage_roots.entry(hashed_address) {
+                            dashmap::Entry::Occupied(occ) => *occ.get(),
+                            dashmap::Entry::Vacant(vac) => {
+                                let root = StorageProof::new_hashed(
+                                    trie_cursor_factory.clone(),
+                                    hashed_cursor_factory.clone(),
+                                    hashed_address,
+                                )
+                                .with_prefix_set_mut(Default::default())
+                                .storage_multiproof(
+                                    ctx.targets.get(&hashed_address).cloned().unwrap_or_default(),
+                                )
+                                .map_err(|e| {
+                                    ParallelStateRootError::StorageRoot(
+                                        reth_execution_errors::StorageRootError::Database(
+                                            DatabaseError::Other(e.to_string()),
+                                        ),
+                                    )
+                                })?
+                                .root;
+
+                                vac.insert(root);
+                                root
+                            }
+                        }
+                    }
+                };
+
+                // Encode account
+                account_rlp.clear();
+                let account = account.into_trie_account(root);
+                account.encode(&mut account_rlp as &mut dyn BufMut);
+
+                hash_builder.add_leaf(Nibbles::unpack(hashed_address), &account_rlp);
+            }
+        }
+    }
+
+    // Consume remaining storage proof receivers for accounts not encountered during trie walk.
+    for (hashed_address, receiver) in storage_proof_receivers {
+        if let Ok(Ok(proof)) = receiver.recv() {
+            collected_decoded_storages.insert(hashed_address, proof);
+        }
+    }
+
+    let _ = hash_builder.root();
+
+    let account_subtree_raw_nodes = hash_builder.take_proof_nodes();
+    let decoded_account_subtree = DecodedProofNodes::try_from(account_subtree_raw_nodes)?;
+
+    let (branch_node_hash_masks, branch_node_tree_masks) = if ctx.collect_branch_node_masks {
+        let updated_branch_nodes = hash_builder.updated_branch_nodes.unwrap_or_default();
+        (
+            updated_branch_nodes.iter().map(|(path, node)| (*path, node.hash_mask)).collect(),
+            updated_branch_nodes.into_iter().map(|(path, node)| (path, node.tree_mask)).collect(),
+        )
+    } else {
+        (Default::default(), Default::default())
+    };
+
+    Ok(DecodedMultiProof {
+        account_subtree: decoded_account_subtree,
+        branch_node_hash_masks,
+        branch_node_tree_masks,
+        storages: collected_decoded_storages,
+    })
+}
+
+/// Queues storage proofs for all accounts in the targets and returns receivers.
+///
+/// This function queues all storage proof tasks to the worker pool but returns immediately
+/// with receivers, allowing the account trie walk to proceed in parallel with storage proof
+/// computation. This enables interleaved parallelism for better performance.
+///
+/// Propagates errors up if queuing fails. Receivers must be consumed by the caller.
+fn dispatch_storage_proofs(
+    storage_work_tx: &CrossbeamSender<StorageWorkerJob>,
+    targets: &MultiProofTargets,
+    storage_prefix_sets: &mut B256Map<PrefixSet>,
+    with_branch_node_masks: bool,
+    multi_added_removed_keys: Option<&Arc<MultiAddedRemovedKeys>>,
+) -> Result<B256Map<Receiver<StorageProofResult>>, ParallelStateRootError> {
+    let mut storage_proof_receivers =
+        B256Map::with_capacity_and_hasher(targets.len(), Default::default());
+
+    // Queue all storage proofs to worker pool
+    for (hashed_address, target_slots) in targets.iter() {
+        let prefix_set = storage_prefix_sets.remove(hashed_address).unwrap_or_default();
+
+        // Always queue a storage proof so we obtain the storage root even when no slots are
+        // requested.
+        let input = StorageProofInput::new(
+            *hashed_address,
+            prefix_set,
+            target_slots.clone(),
+            with_branch_node_masks,
+            multi_added_removed_keys.cloned(),
+        );
+
+        let (sender, receiver) = channel();
+
+        // If queuing fails, propagate error up (no fallback)
+        storage_work_tx
+            .send(StorageWorkerJob::StorageProof { input, result_sender: sender })
+            .map_err(|_| {
+                ParallelStateRootError::Other(format!(
+                    "Failed to queue storage proof for {}: storage worker pool unavailable",
+                    hashed_address
+                ))
+            })?;
+
+        storage_proof_receivers.insert(*hashed_address, receiver);
+    }
+
+    Ok(storage_proof_receivers)
 }
 
 #[cfg(test)]

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -523,7 +523,9 @@ impl TrieNodeProvider for ProofTaskTrieNodeProvider {
     }
 }
 
-/// Worker responsible for storage trie operations.
+/// Handles storage trie jobs: keeps a dedicated `ConsistentDbView`, consumes
+/// `StorageWorkerJob`s from the crossbeam queue, returns results through the
+/// caller's `std::mpsc` sender, and records per-worker metrics when enabled.
 struct StorageProofWorker<Factory> {
     view: ConsistentDbView<Factory>,
     task_ctx: ProofTaskCtx,
@@ -665,7 +667,10 @@ where
     }
 }
 
-/// Worker responsible for account trie operations.
+/// Handles account trie jobs: keeps a dedicated `ConsistentDbView`, consumes
+/// `AccountWorkerJob`s from the crossbeam queue, dispatches related storage work
+/// via `storage_work_tx`, returns results through the caller's `std::mpsc`
+/// sender, and records per-worker metrics when enabled.
 struct AccountProofWorker<Factory> {
     view: ConsistentDbView<Factory>,
     task_ctx: ProofTaskCtx,


### PR DESCRIPTION
Closes: https://github.com/paradigmxyz/reth/issues/19007

Changes:
- Turn function based loops that are stateful into structs
	- e.g `spawn_account_loop` -> `AccountProofWorker::run()`