### PR TITLE
chore: rename CLI argument `--tracing-otlp-level` to `--tracing-otlp.filter`

### DIFF
--- a/crates/ethereum/cli/src/app.rs
+++ b/crates/ethereum/cli/src/app.rs
@@ -119,7 +119,7 @@ where
                 layers.with_span_layer(
                     "reth".to_string(),
                     output_type.clone(),
-                    self.cli.traces.otlp_level.clone(),
+                    self.cli.traces.otlp_filter.clone(),
                 )?;
             }
 

--- a/crates/node/core/src/args/trace.rs
+++ b/crates/node/core/src/args/trace.rs
@@ -32,22 +32,22 @@ pub struct TraceArgs {
     /// of spans and events sent to the OTLP endpoint. It follows the same
     /// syntax as the `RUST_LOG` environment variable.
     ///
-    /// Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+    /// Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
     ///
     /// Defaults to TRACE if not specified.
     #[arg(
-        long = "tracing-otlp-level",
+        long = "tracing-otlp.filter",
         global = true,
         value_name = "FILTER",
         default_value = "TRACE",
         help_heading = "Tracing"
     )]
-    pub otlp_level: EnvFilter,
+    pub otlp_filter: EnvFilter,
 }
 
 impl Default for TraceArgs {
     fn default() -> Self {
-        Self { otlp: None, otlp_level: EnvFilter::from_default_env() }
+        Self { otlp: None, otlp_filter: EnvFilter::from_default_env() }
     }
 }
 

--- a/crates/optimism/cli/src/app.rs
+++ b/crates/optimism/cli/src/app.rs
@@ -124,7 +124,7 @@ where
                 layers.with_span_layer(
                     "reth".to_string(),
                     output_type.clone(),
-                    self.cli.traces.otlp_level.clone(),
+                    self.cli.traces.otlp_filter.clone(),
                 )?;
             }
 

--- a/docs/vocs/docs/pages/cli/reth.mdx
+++ b/docs/vocs/docs/pages/cli/reth.mdx
@@ -124,10 +124,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/config.mdx
+++ b/docs/vocs/docs/pages/cli/reth/config.mdx
@@ -110,10 +110,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db.mdx
@@ -175,10 +175,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/checksum.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/checksum.mdx
@@ -127,10 +127,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/clear.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/clear.mdx
@@ -119,10 +119,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/clear/mdbx.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/clear/mdbx.mdx
@@ -118,10 +118,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/clear/static-file.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/clear/static-file.mdx
@@ -121,10 +121,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/diff.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/diff.mdx
@@ -154,10 +154,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/drop.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/drop.mdx
@@ -117,10 +117,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/get.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/get.mdx
@@ -119,10 +119,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/get/mdbx.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/get/mdbx.mdx
@@ -127,10 +127,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/get/static-file.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/get/static-file.mdx
@@ -127,10 +127,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/list.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/list.mdx
@@ -160,10 +160,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/path.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/path.mdx
@@ -114,10 +114,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/repair-trie.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/repair-trie.mdx
@@ -117,10 +117,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/stats.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/stats.mdx
@@ -127,10 +127,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/version.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/version.mdx
@@ -114,10 +114,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/download.mdx
+++ b/docs/vocs/docs/pages/cli/reth/download.mdx
@@ -172,10 +172,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/dump-genesis.mdx
+++ b/docs/vocs/docs/pages/cli/reth/dump-genesis.mdx
@@ -113,10 +113,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/export-era.mdx
+++ b/docs/vocs/docs/pages/cli/reth/export-era.mdx
@@ -178,10 +178,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/import-era.mdx
+++ b/docs/vocs/docs/pages/cli/reth/import-era.mdx
@@ -173,10 +173,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/import.mdx
+++ b/docs/vocs/docs/pages/cli/reth/import.mdx
@@ -174,10 +174,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/init-state.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init-state.mdx
@@ -197,10 +197,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/init.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init.mdx
@@ -162,10 +162,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -999,10 +999,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/p2p.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p.mdx
@@ -111,10 +111,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/p2p/body.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/body.mdx
@@ -331,10 +331,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/p2p/bootnode.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/bootnode.mdx
@@ -122,10 +122,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/p2p/header.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/header.mdx
@@ -331,10 +331,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/p2p/rlpx.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/rlpx.mdx
@@ -108,10 +108,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/p2p/rlpx/ping.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/rlpx/ping.mdx
@@ -108,10 +108,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/prune.mdx
+++ b/docs/vocs/docs/pages/cli/reth/prune.mdx
@@ -162,10 +162,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/re-execute.mdx
+++ b/docs/vocs/docs/pages/cli/reth/re-execute.mdx
@@ -175,10 +175,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/stage.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage.mdx
@@ -111,10 +111,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/drop.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/drop.mdx
@@ -176,10 +176,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/dump.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump.mdx
@@ -169,10 +169,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/dump/account-hashing.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump/account-hashing.mdx
@@ -126,10 +126,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/dump/execution.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump/execution.mdx
@@ -126,10 +126,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/dump/merkle.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump/merkle.mdx
@@ -126,10 +126,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/dump/storage-hashing.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump/storage-hashing.mdx
@@ -126,10 +126,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/run.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/run.mdx
@@ -397,10 +397,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/unwind.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/unwind.mdx
@@ -170,10 +170,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/unwind/num-blocks.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/unwind/num-blocks.mdx
@@ -118,10 +118,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/unwind/to-block.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/unwind/to-block.mdx
@@ -118,10 +118,10 @@ Tracing:
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
-      --tracing-otlp-level <FILTER>
+      --tracing-otlp.filter <FILTER>
           Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp-level=info,reth=debug,hyper_util=off
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
           Defaults to TRACE if not specified.
 


### PR DESCRIPTION
Small followup to https://github.com/paradigmxyz/reth/pull/19050. It's fine to rename the CLI argument, because it's unreleased yet.