### PR TITLE
fix(net): Increment out_of_order_requests in BodiesDownloader on range reset

### DIFF
--- a/crates/net/downloaders/src/bodies/bodies.rs
+++ b/crates/net/downloaders/src/bodies/bodies.rs
@@ -347,6 +347,12 @@ where
         // written by external services (e.g. BlockchainTree).
         tracing::trace!(target: "downloaders::bodies", ?range, prev_range = ?self.download_range, "Download range reset");
         info!(target: "downloaders::bodies", count, ?range, "Downloading bodies");
+        // Increment out-of-order requests metric if the new start is below the last returned block
+        if let Some(last_returned) = self.latest_queued_block_number &&
+            *range.start() < last_returned
+        {
+            self.metrics.out_of_order_requests.increment(1);
+        }
         self.clear();
         self.download_range = range;
         Ok(())


### PR DESCRIPTION
This change increments the bodies downloader metric out_of_order_requests when the download range is reset and the new start block is below the last block returned by the stream. This matches the metric’s documented intent (“count out-of-order re-requests after unwind or external writes”) and aligns behavior with the headers downloader, which already increments its analogous metric on sync target changes. The change adds a simple check in BodiesDownloader::set_download_range before self.clear() to increment the counter when range.start() < latest_queued_block_number. No functional behavior is altered; this improves observability and monitoring accuracy for out-of-order body requests.