### PR TITLE
fix(era): remove unnecessary into() when constructing ReceiptWithBloom

### DIFF
--- a/crates/era/src/test_utils.rs
+++ b/crates/era/src/test_utils.rs
@@ -86,7 +86,7 @@ pub(crate) fn create_test_receipt_with_bloom(
     log_count: usize,
 ) -> ReceiptWithBloom {
     let receipt = create_test_receipt(tx_type, success, cumulative_gas_used, log_count);
-    ReceiptWithBloom { receipt: receipt.into(), logs_bloom: Default::default() }
+    ReceiptWithBloom { receipt, logs_bloom: Default::default() }
 }
 
 // Helper function to create a sample block tuple


### PR DESCRIPTION
Replaced ReceiptWithBloom initialization to pass the native reth Receipt directly instead of calling .into(). The .into() was implicitly converting to alloy_consensus::Receipt, creating an inconsistent inner type across the codebase and adding brittle coupling to From/Into impls. This change aligns with existing patterns (other modules set the reth Receipt directly), improves type consistency, and avoids fragile implicit conversions. No behavioral changes.