### PR TITLE
fix(rpc): correct highest_block value in eth_syncing response

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/spec.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/spec.rs
@@ -60,7 +60,7 @@ pub trait EthApiSpec: RpcNodeCore + EthApiTypes {
             SyncStatus::Info(Box::new(SyncInfo {
                 starting_block: self.starting_block(),
                 current_block,
-                highest_block: current_block,
+                highest_block: U256::ZERO, // Use 0 to indicate unknown network target during sync
                 warp_chunks_amount: None,
                 warp_chunks_processed: None,
                 stages: Some(stages),

--- a/crates/rpc/rpc/src/eth/pubsub.rs
+++ b/crates/rpc/rpc/src/eth/pubsub.rs
@@ -326,7 +326,7 @@ where
                 syncing: true,
                 starting_block: 0,
                 current_block,
-                highest_block: Some(current_block),
+                highest_block: None, // Set to None instead of current_block as we don't have peer network height info here
             })
         } else {
             PubSubSyncStatus::Simple(false)

--- a/crates/rpc/rpc/src/eth/pubsub.rs
+++ b/crates/rpc/rpc/src/eth/pubsub.rs
@@ -326,7 +326,8 @@ where
                 syncing: true,
                 starting_block: 0,
                 current_block,
-                highest_block: None, // Set to None instead of current_block as we don't have peer network height info here
+                highest_block: None, /* Set to None instead of current_block as we don't have
+                                      * peer network height info here */
             })
         } else {
             PubSubSyncStatus::Simple(false)


### PR DESCRIPTION
Fix logical inconsistency in eth_syncing RPC endpoint where highest_block was incorrectly set to current_block during synchronization.
When is_syncing() returns true, highest_block should represent the network's target height, not the current local block. Setting highest_block = current_block is misleading and contradicts Ethereum RPC specification.
This ensures honest reporting when the actual network target is unavailable, preventing misleading sync progress information.