### PR TITLE
chore(docker): remove apt-get upgrade to ensure reproducible and faster builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL org.opencontainers.image.source=https://github.com/paradigmxyz/reth
 LABEL org.opencontainers.image.licenses="MIT OR Apache-2.0"
 
 # Install system dependencies
-RUN apt-get update && apt-get -y upgrade && apt-get install -y libclang-dev pkg-config
+RUN apt-get update && apt-get install -y libclang-dev pkg-config
 
 # Builds a cargo-chef plan
 FROM chef AS planner


### PR DESCRIPTION


### Description
- **Summary**: Remove `apt-get -y upgrade` from the build stage in `Dockerfile`.
- **Why**: Avoid non-deterministic builds, reduce cache busting, and speed up image builds.
- **Change**: Replace `RUN apt-get update && apt-get -y upgrade && apt-get install -y ...` with `RUN apt-get update && apt-get install -y ...`.
