### PR TITLE
ci: verify geth tarball checksum before extraction

### DIFF
--- a/.github/assets/install_geth.sh
+++ b/.github/assets/install_geth.sh
@@ -10,6 +10,8 @@ name="geth-linux-amd64-$GETH_BUILD"
 
 mkdir -p "$HOME/bin"
 wget "https://gethstore.blob.core.windows.net/builds/$name.tar.gz"
+wget "https://gethstore.blob.core.windows.net/builds/$name.tar.gz.sha256"
+sha256sum -c "$name.tar.gz.sha256"
 tar -xvf "$name.tar.gz"
 rm "$name.tar.gz"
 mv "$name/geth" "$HOME/bin/geth"


### PR DESCRIPTION


### Description
- **Summary**: Add SHA256 verification to `.github/assets/install_geth.sh` before extracting the tarball.
- **Change**: Download `*.sha256` and run `sha256sum -c` prior to `tar -xvf`.
- **Why**: Reduce supply-chain risk and prevent corrupted/altered artifacts from running in CI.
