### PR TITLE
ci(check_wasm): enable set -e -o pipefail for reliable pipeline failures

### DIFF
--- a/.github/assets/check_wasm.sh
+++ b/.github/assets/check_wasm.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set +e  # Disable immediate exit on error
+set -e -o pipefail
 
 # Array of crates to compile
 crates=($(cargo metadata --format-version=1 --no-deps | jq -r '.packages[].name' | grep '^reth' | sort))


### PR DESCRIPTION


### Description
- **Summary**: Replace global `set +e` with `set -e -o pipefail` at the start of `.github/assets/check_wasm.sh`.
- **Why**: Prevent hidden failures in the `cargo | jq | grep | sort` pipeline; ensure early, accurate error reporting.
