### PR TITLE
fix(net): remove redundant remove of evicted hash in fetcher

### DIFF
--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -413,7 +413,6 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
             if let (_, Some(evicted_hash)) = self.hashes_pending_fetch.insert_and_get_evicted(hash)
             {
                 self.hashes_fetch_inflight_and_pending_fetch.remove(&evicted_hash);
-                self.hashes_pending_fetch.remove(&evicted_hash);
             }
         }
     }


### PR DESCRIPTION
Remove a redundant call to remove an already-evicted key from hashes_pending_fetch after insert_and_get_evicted. The LruCache::insert_and_get_evicted API guarantees the evicted entry is already removed from that cache, so calling remove again is a no-op. This avoids an unnecessary operation without changing behavior.