### PR TITLE
fix: Remove deprecated SealedBlockFor alias from primitives

### DIFF
--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -16,10 +16,6 @@ pub type BlockBody<T = TransactionSigned, H = Header> = alloy_consensus::BlockBo
 /// Ethereum sealed block type
 pub type SealedBlock<B = Block> = reth_primitives_traits::block::SealedBlock<B>;
 
-/// Helper type for constructing the block
-#[deprecated(note = "Use `RecoveredBlock` instead")]
-pub type SealedBlockFor<B = Block> = reth_primitives_traits::block::SealedBlock<B>;
-
 /// Ethereum recovered block
 #[deprecated(note = "Use `RecoveredBlock` instead")]
 pub type BlockWithSenders<B = Block> = reth_primitives_traits::block::RecoveredBlock<B>;

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -26,7 +26,7 @@ pub mod transaction;
 pub use block::{generate_valid_header, valid_header_strategy};
 pub use block::{Block, BlockBody, SealedBlock};
 #[expect(deprecated)]
-pub use block::{BlockWithSenders, SealedBlockFor, SealedBlockWithSenders};
+pub use block::{BlockWithSenders, SealedBlockWithSenders};
 
 pub use receipt::{gas_spent_by_transactions, Receipt};
 pub use reth_primitives_traits::{


### PR DESCRIPTION
Remove the deprecated SealedBlockFor type alias which duplicated SealedBlock.
The alias adds noise to the public API and may confuse users. It’s already deprecated in favor of RecoveredBlock.
