### PR TITLE
fix: Deduplicate hashed storage preparation in MemoryOverlayStateProvider

### DIFF
--- a/crates/chain-state/src/memory_overlay.rs
+++ b/crates/chain-state/src/memory_overlay.rs
@@ -62,11 +62,7 @@ impl<'a, N: NodePrimitives> MemoryOverlayStateProviderRef<'a, N> {
         })
     }
 
-    fn merged_hashed_storage(
-        &self,
-        address: Address,
-        storage: HashedStorage,
-    ) -> HashedStorage {
+    fn merged_hashed_storage(&self, address: Address, storage: HashedStorage) -> HashedStorage {
         let state = &self.trie_input().state;
         let mut hashed = state.storages.get(&keccak256(address)).cloned().unwrap_or_default();
         hashed.extend(&storage);

--- a/crates/chain-state/src/memory_overlay.rs
+++ b/crates/chain-state/src/memory_overlay.rs
@@ -61,6 +61,17 @@ impl<'a, N: NodePrimitives> MemoryOverlayStateProviderRef<'a, N> {
             )
         })
     }
+
+    fn merged_hashed_storage(
+        &self,
+        address: Address,
+        storage: HashedStorage,
+    ) -> HashedStorage {
+        let state = &self.trie_input().state;
+        let mut hashed = state.storages.get(&keccak256(address)).cloned().unwrap_or_default();
+        hashed.extend(&storage);
+        hashed
+    }
 }
 
 impl<N: NodePrimitives> BlockHashReader for MemoryOverlayStateProviderRef<'_, N> {
@@ -145,11 +156,8 @@ impl<N: NodePrimitives> StateRootProvider for MemoryOverlayStateProviderRef<'_, 
 impl<N: NodePrimitives> StorageRootProvider for MemoryOverlayStateProviderRef<'_, N> {
     // TODO: Currently this does not reuse available in-memory trie nodes.
     fn storage_root(&self, address: Address, storage: HashedStorage) -> ProviderResult<B256> {
-        let state = &self.trie_input().state;
-        let mut hashed_storage =
-            state.storages.get(&keccak256(address)).cloned().unwrap_or_default();
-        hashed_storage.extend(&storage);
-        self.historical.storage_root(address, hashed_storage)
+        let merged = self.merged_hashed_storage(address, storage);
+        self.historical.storage_root(address, merged)
     }
 
     // TODO: Currently this does not reuse available in-memory trie nodes.
@@ -159,11 +167,8 @@ impl<N: NodePrimitives> StorageRootProvider for MemoryOverlayStateProviderRef<'_
         slot: B256,
         storage: HashedStorage,
     ) -> ProviderResult<reth_trie::StorageProof> {
-        let state = &self.trie_input().state;
-        let mut hashed_storage =
-            state.storages.get(&keccak256(address)).cloned().unwrap_or_default();
-        hashed_storage.extend(&storage);
-        self.historical.storage_proof(address, slot, hashed_storage)
+        let merged = self.merged_hashed_storage(address, storage);
+        self.historical.storage_proof(address, slot, merged)
     }
 
     // TODO: Currently this does not reuse available in-memory trie nodes.
@@ -173,11 +178,8 @@ impl<N: NodePrimitives> StorageRootProvider for MemoryOverlayStateProviderRef<'_
         slots: &[B256],
         storage: HashedStorage,
     ) -> ProviderResult<StorageMultiProof> {
-        let state = &self.trie_input().state;
-        let mut hashed_storage =
-            state.storages.get(&keccak256(address)).cloned().unwrap_or_default();
-        hashed_storage.extend(&storage);
-        self.historical.storage_multiproof(address, slots, hashed_storage)
+        let merged = self.merged_hashed_storage(address, storage);
+        self.historical.storage_multiproof(address, slots, merged)
     }
 }
 


### PR DESCRIPTION


## Description:
- Summary: Extract a private helper to merge in-memory and overlay hashed storage, and use it across three methods.
- Motivation: Removes duplicated logic, improves readability and maintainability, and reduces the risk of divergence.
- Changes:
  - Add `merged_hashed_storage` helper in `crates/chain-state/src/memory_overlay.rs`.
  - Replace duplicated code in `storage_root`, `storage_proof`, and `storage_multiproof` with the helper.
