### PR TITLE
feat(cli): add method `CliRunner::block_on`

### DIFF
--- a/crates/cli/runner/src/lib.rs
+++ b/crates/cli/runner/src/lib.rs
@@ -36,11 +36,15 @@ impl CliRunner {
     pub const fn from_runtime(tokio_runtime: tokio::runtime::Runtime) -> Self {
         Self { tokio_runtime }
     }
-}
 
-// === impl CliRunner ===
+    /// Executes an async block on the runtime and blocks until completion.
+    pub fn block_on<F, T>(&self, fut: F) -> T
+    where
+        F: Future<Output = T>,
+    {
+        self.tokio_runtime.block_on(fut)
+    }
 
-impl CliRunner {
     /// Executes the given _async_ command on the tokio runtime until the command future resolves or
     /// until the process receives a `SIGINT` or `SIGTERM` signal.
     ///


### PR DESCRIPTION
Add method for `CliRunner::block_on`.

It is be useful for https://github.com/paradigmxyz/reth/pull/18985 to enable some asynchronous step.

