### PR TITLE
fix: support rlp hex in read_header_from_file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7481,6 +7481,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tar",
+ "tempfile",
  "tokio",
  "tokio-stream",
  "toml",

--- a/crates/cli/commands/Cargo.toml
+++ b/crates/cli/commands/Cargo.toml
@@ -99,6 +99,7 @@ proptest-arbitrary-interop = { workspace = true, optional = true }
 
 [dev-dependencies]
 reth-ethereum-cli.workspace = true
+tempfile.workspace = true
 
 [features]
 default = []

--- a/crates/cli/commands/src/init_state/mod.rs
+++ b/crates/cli/commands/src/init_state/mod.rs
@@ -88,7 +88,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> InitStateC
             let header = self.header.ok_or_else(|| eyre::eyre!("Header file must be provided"))?;
             let header = without_evm::read_header_from_file::<
                 <N::Primitives as NodePrimitives>::BlockHeader,
-            >(header)?;
+            >(&header)?;
 
             let header_hash =
                 self.header_hash.ok_or_else(|| eyre::eyre!("Header hash must be provided"))?;


### PR DESCRIPTION
this would fail if the file content is hex rlp

this now supports both variants