### PR TITLE
refactor: simplify GasCap conversion in EthApi

### DIFF
--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -366,7 +366,7 @@ where
             signers,
             eth_cache,
             gas_oracle,
-            gas_cap: gas_cap.into().into(),
+            gas_cap: gas_cap.into().0,
             max_simulate_blocks,
             eth_proof_window,
             starting_block,


### PR DESCRIPTION
Replace `gas_cap.into().into()` with `gas_cap.into().0` for direct field access instead of redundant double conversion. Improves code readability while maintaining identical functionality.