### PR TITLE
fix: accurately track account and code weighs

### DIFF
--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -476,7 +476,7 @@ impl ExecutionCacheBuilder {
         let account_cache = CacheBuilder::new(self.account_cache_entries)
             .weigher(|_key: &Address, _value: &Option<Account>| -> u32 {
                 // Account has a fixed size (none, balance,code_hash)
-                size_of::<Option<Account>>() as u32
+                20 + size_of::<Option<Account>>() as u32
             })
             .max_capacity(account_cache_size)
             .time_to_live(EXPIRY_TIME)
@@ -485,13 +485,19 @@ impl ExecutionCacheBuilder {
 
         let code_cache = CacheBuilder::new(self.code_cache_entries)
             .weigher(|_key: &B256, value: &Option<Bytecode>| -> u32 {
-                match value {
+                let code_size = match value {
                     Some(bytecode) => {
-                        // base weight + actual bytecode size
-                        (40 + bytecode.len()) as u32
+                        // base weight + actual (padded) bytecode size + size of the jump table
+                        (size_of_val(value) +
+                            bytecode.bytecode().len() +
+                            bytecode
+                                .legacy_jump_table()
+                                .map(|table| table.as_slice().len())
+                                .unwrap_or_default()) as u32
                     }
-                    None => 8, // size of None variant
-                }
+                    None => size_of_val(value) as u32,
+                };
+                32 + code_size
             })
             .max_capacity(code_cache_size)
             .time_to_live(EXPIRY_TIME)

--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -474,9 +474,9 @@ impl ExecutionCacheBuilder {
             .build_with_hasher(DefaultHashBuilder::default());
 
         let account_cache = CacheBuilder::new(self.account_cache_entries)
-            .weigher(|_key: &Address, _value: &Option<Account>| -> u32 {
+            .weigher(|_key: &Address, value: &Option<Account>| -> u32 {
                 // Account has a fixed size (none, balance,code_hash)
-                20 + size_of::<Option<Account>>() as u32
+                20 + size_of_val(&value) as u32
             })
             .max_capacity(account_cache_size)
             .time_to_live(EXPIRY_TIME)

--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -476,7 +476,7 @@ impl ExecutionCacheBuilder {
         let account_cache = CacheBuilder::new(self.account_cache_entries)
             .weigher(|_key: &Address, value: &Option<Account>| -> u32 {
                 // Account has a fixed size (none, balance,code_hash)
-                20 + size_of_val(&value) as u32
+                20 + size_of_val(value) as u32
             })
             .max_capacity(account_cache_size)
             .time_to_live(EXPIRY_TIME)


### PR DESCRIPTION
weigher should include k+v

we also didn't include the total size of the bytecode because the 7702 variant has more stack data and the legacy one the jumptable