### PR TITLE
refactor: naming fix for multiproof dispatch

### DIFF
--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -101,7 +101,7 @@ impl ParallelProof {
         );
 
         self.proof_worker_handle
-            .queue_storage_proof(input)
+            .dispatch_storage_proof(input)
             .map_err(|e| ParallelStateRootError::Other(e.to_string()))
     }
 

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -958,8 +958,8 @@ impl ProofWorkerHandle {
         Self { storage_work_tx, account_work_tx }
     }
 
-    /// Queue a storage proof computation
-    pub fn queue_storage_proof(
+    /// Dispatch a storage proof computation to storage worker pool
+    pub fn dispatch_storage_proof(
         &self,
         input: StorageProofInput,
     ) -> Result<Receiver<StorageProofResult>, ProviderError> {
@@ -988,8 +988,8 @@ impl ProofWorkerHandle {
         Ok(rx)
     }
 
-    /// Internal: Queue blinded storage node request
-    fn queue_blinded_storage_node(
+    /// Internal: Dispatch blinded storage node request to storage worker pool
+    fn dispatch_blinded_storage_node(
         &self,
         account: B256,
         path: Nibbles,
@@ -1004,8 +1004,8 @@ impl ProofWorkerHandle {
         Ok(rx)
     }
 
-    /// Internal: Queue blinded account node request
-    fn queue_blinded_account_node(
+    /// Internal: Dispatch blinded account node request to account worker pool
+    fn dispatch_blinded_account_node(
         &self,
         path: Nibbles,
     ) -> Result<Receiver<TrieNodeProviderResult>, ProviderError> {
@@ -1055,13 +1055,13 @@ impl TrieNodeProvider for ProofTaskTrieNodeProvider {
         match self {
             Self::AccountNode { handle } => {
                 let rx = handle
-                    .queue_blinded_account_node(*path)
+                    .dispatch_blinded_account_node(*path)
                     .map_err(|error| SparseTrieErrorKind::Other(Box::new(error)))?;
                 rx.recv().map_err(|error| SparseTrieErrorKind::Other(Box::new(error)))?
             }
             Self::StorageNode { handle, account } => {
                 let rx = handle
-                    .queue_blinded_storage_node(*account, *path)
+                    .dispatch_blinded_storage_node(*account, *path)
                     .map_err(|error| SparseTrieErrorKind::Other(Box::new(error)))?;
                 rx.recv().map_err(|error| SparseTrieErrorKind::Other(Box::new(error)))?
             }

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -988,8 +988,8 @@ impl ProofWorkerHandle {
         Ok(rx)
     }
 
-    /// Internal: Dispatch blinded storage node request to storage worker pool
-    fn dispatch_blinded_storage_node(
+    /// Dispatch blinded storage node request to storage worker pool
+    pub(crate) fn dispatch_blinded_storage_node(
         &self,
         account: B256,
         path: Nibbles,
@@ -1004,8 +1004,8 @@ impl ProofWorkerHandle {
         Ok(rx)
     }
 
-    /// Internal: Dispatch blinded account node request to account worker pool
-    fn dispatch_blinded_account_node(
+    /// Dispatch blinded account node request to account worker pool
+    pub(crate) fn dispatch_blinded_account_node(
         &self,
         path: Nibbles,
     ) -> Result<Receiver<TrieNodeProviderResult>, ProviderError> {


### PR DESCRIPTION
The methods now consistently use dispatch instead of queue, which better reflects that they're just sending messages to the workers rather than actually queuing work directly.