### PR TITLE
fix(cli): Remove duplicit static file header and transaction append

### DIFF
--- a/crates/cli/commands/Cargo.toml
+++ b/crates/cli/commands/Cargo.toml
@@ -99,6 +99,7 @@ proptest-arbitrary-interop = { workspace = true, optional = true }
 
 [dev-dependencies]
 reth-ethereum-cli.workspace = true
+reth-provider = { workspace = true, features = ["test-utils"] }
 tempfile.workspace = true
 
 [features]

--- a/crates/cli/commands/src/init_state/mod.rs
+++ b/crates/cli/commands/src/init_state/mod.rs
@@ -2,7 +2,7 @@
 
 use crate::common::{AccessRights, CliHeader, CliNodeTypes, Environment, EnvironmentArgs};
 use alloy_consensus::BlockHeader as AlloyBlockHeader;
-use alloy_primitives::{Sealable, B256, U256};
+use alloy_primitives::{Sealable, B256};
 use clap::Parser;
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_cli::chainspec::ChainSpecParser;
@@ -13,7 +13,7 @@ use reth_provider::{
     BlockNumReader, DBProvider, DatabaseProviderFactory, StaticFileProviderFactory,
     StaticFileWriter,
 };
-use std::{io::BufReader, path::PathBuf, str::FromStr, sync::Arc};
+use std::{io::BufReader, path::PathBuf, sync::Arc};
 use tracing::info;
 
 pub mod without_evm;
@@ -58,10 +58,6 @@ pub struct InitStateCommand<C: ChainSpecParser> {
     #[arg(long, value_name = "HEADER_FILE", verbatim_doc_comment)]
     pub header: Option<PathBuf>,
 
-    /// Total difficulty of the header.
-    #[arg(long, value_name = "TOTAL_DIFFICULTY", verbatim_doc_comment)]
-    pub total_difficulty: Option<String>,
-
     /// Hash of the header.
     #[arg(long, value_name = "HEADER_HASH", verbatim_doc_comment)]
     pub header_hash: Option<B256>,
@@ -92,18 +88,12 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> InitStateC
 
             let header_hash = self.header_hash.unwrap_or_else(|| header.hash_slow());
 
-            let total_difficulty = self
-                .total_difficulty
-                .ok_or_else(|| eyre::eyre!("Total difficulty must be provided"))?;
-            let total_difficulty = U256::from_str(&total_difficulty)?;
-
             let last_block_number = provider_rw.last_block_number()?;
 
             if last_block_number == 0 {
                 without_evm::setup_without_evm(
                     &provider_rw,
                     SealedHeader::new(header, header_hash),
-                    total_difficulty,
                     |number| {
                         let mut header =
                             <<N::Primitives as NodePrimitives>::BlockHeader>::default();
@@ -160,8 +150,6 @@ mod tests {
             "--without-evm",
             "--header",
             "header.rlp",
-            "--total-difficulty",
-            "12345",
             "--header-hash",
             "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
             "state.jsonl",
@@ -169,7 +157,6 @@ mod tests {
         assert_eq!(cmd.state.to_str().unwrap(), "state.jsonl");
         assert!(cmd.without_evm);
         assert_eq!(cmd.header.unwrap().to_str().unwrap(), "header.rlp");
-        assert_eq!(cmd.total_difficulty.unwrap(), "12345");
         assert_eq!(
             cmd.header_hash.unwrap(),
             b256!("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")

--- a/crates/cli/commands/src/init_state/without_evm.rs
+++ b/crates/cli/commands/src/init_state/without_evm.rs
@@ -36,7 +36,6 @@ where
 pub fn setup_without_evm<Provider, F>(
     provider_rw: &Provider,
     header: SealedHeader<<Provider::Primitives as NodePrimitives>::BlockHeader>,
-    total_difficulty: U256,
     header_factory: F,
 ) -> ProviderResult<()>
 where
@@ -56,7 +55,7 @@ where
 
     info!(target: "reth::cli", "Appending first valid block.");
 
-    append_first_block(provider_rw, &header, total_difficulty)?;
+    append_first_block(provider_rw, &header)?;
 
     for stage in StageId::ALL {
         provider_rw.save_stage_checkpoint(stage, StageCheckpoint::new(header.number()))?;
@@ -74,7 +73,6 @@ where
 fn append_first_block<Provider>(
     provider_rw: &Provider,
     header: &SealedHeaderFor<Provider::Primitives>,
-    total_difficulty: U256,
 ) -> ProviderResult<()>
 where
     Provider: BlockWriter<Block = <Provider::Primitives as NodePrimitives>::Block>
@@ -91,15 +89,7 @@ where
 
     let sf_provider = provider_rw.static_file_provider();
 
-    sf_provider.latest_writer(StaticFileSegment::Headers)?.append_header(
-        header,
-        total_difficulty,
-        &header.hash(),
-    )?;
-
     sf_provider.latest_writer(StaticFileSegment::Receipts)?.increment_block(header.number())?;
-
-    sf_provider.latest_writer(StaticFileSegment::Transactions)?.increment_block(header.number())?;
 
     Ok(())
 }
@@ -179,6 +169,8 @@ mod tests {
     use super::*;
     use alloy_consensus::Header;
     use alloy_primitives::{address, b256};
+    use reth_db_common::init::init_genesis;
+    use reth_provider::{test_utils::create_test_provider_factory, DatabaseProviderFactory};
     use std::io::Write;
     use tempfile::NamedTempFile;
 
@@ -218,5 +210,38 @@ mod tests {
             b256!("0d84d79f59fc384a1f6402609a5b7253b4bfe7a4ae12608ed107273e5422b6dd")
         );
         assert_eq!(header.beneficiary, address!("71562b71999873db5b286df957af199ec94617f7"));
+    }
+
+    #[test]
+    fn test_setup_without_evm_succeeds() {
+        let header_rlp = "0xf90212a00d84d79f59fc384a1f6402609a5b7253b4bfe7a4ae12608ed107273e5422b6dda01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d493479471562b71999873db5b286df957af199ec94617f7a0f496f3d199c51a1aaee67dac95f24d92ac13c60d25181e1eecd6eca5ddf32ac0a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b9010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000808206a4840365908a808468e975f09ad983011003846765746888676f312e32352e308664617277696ea06f485a167165ec12e0ab3e6ab59a7b88560b90306ac98a26eb294abf95a8c59b88000000000000000007";
+        let header_bytes =
+            alloy_primitives::hex::decode(header_rlp.trim_start_matches("0x")).unwrap();
+
+        let mut temp_file = NamedTempFile::new().unwrap();
+        temp_file.write_all(&header_bytes).unwrap();
+        temp_file.flush().unwrap();
+
+        let header: Header = read_header_from_file(temp_file.path()).unwrap();
+        let header_hash = b256!("4f05e4392969fc82e41f6d6a8cea379323b0b2d3ddf7def1a33eec03883e3a33");
+
+        let provider_factory = create_test_provider_factory();
+
+        init_genesis(&provider_factory).unwrap();
+
+        let provider_rw = provider_factory.database_provider_rw().unwrap();
+
+        setup_without_evm(&provider_rw, SealedHeader::new(header, header_hash), |number| Header {
+            number,
+            ..Default::default()
+        })
+        .unwrap();
+
+        let static_files = provider_factory.static_file_provider();
+        let writer = static_files.latest_writer(StaticFileSegment::Headers).unwrap();
+        let actual_next_height = writer.next_block_number();
+        let expected_next_height = 1701;
+
+        assert_eq!(actual_next_height, expected_next_height);
     }
 }

--- a/crates/optimism/cli/src/commands/init_state.rs
+++ b/crates/optimism/cli/src/commands/init_state.rs
@@ -7,7 +7,7 @@ use reth_cli_commands::common::{AccessRights, CliHeader, CliNodeTypes, Environme
 use reth_db_common::init::init_from_state_dump;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_primitives::{
-    bedrock::{BEDROCK_HEADER, BEDROCK_HEADER_HASH, BEDROCK_HEADER_TTD},
+    bedrock::{BEDROCK_HEADER, BEDROCK_HEADER_HASH},
     OpPrimitives,
 };
 use reth_primitives_traits::SealedHeader;
@@ -58,7 +58,6 @@ impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> InitStateCommandOp<C> {
                 reth_cli_commands::init_state::without_evm::setup_without_evm(
                     &provider_rw,
                     SealedHeader::new(BEDROCK_HEADER, BEDROCK_HEADER_HASH),
-                    BEDROCK_HEADER_TTD,
                     |number| {
                         let mut header = Header::default();
                         header.set_number(number);

--- a/docs/vocs/docs/pages/cli/reth/init-state.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init-state.mdx
@@ -80,9 +80,6 @@ Database:
       --header <HEADER_FILE>
           Header file containing the header in an RLP encoded format.
 
-      --total-difficulty <TOTAL_DIFFICULTY>
-          Total difficulty of the header.
-
       --header-hash <HEADER_HASH>
           Hash of the header.
 


### PR DESCRIPTION
Fixes an import bug, in which this command fails.

```
reth init-state ./dump.json --datadir=test --chain ./chainspec.json --header=./header.rlp --header-hash=0x4f05e4392969fc82e41f6d6a8cea379323b0b2d3ddf7def1a33eec03883e3a33 --total-difficulty=0 --without-evm
```

By reporting

```
2025-10-16T15:42:50.687043Z  INFO Appending first valid block.
Error: trying to append data to Headers as block #1700 but expected block #1701
```