### PR TITLE
fix(cli): remove redundant EthChainSpec bound in run_with_components

### DIFF
--- a/crates/ethereum/cli/src/app.rs
+++ b/crates/ethereum/cli/src/app.rs
@@ -84,7 +84,7 @@ where
     where
         N: CliNodeTypes<
             Primitives: NodePrimitives<BlockHeader: CliHeader>,
-            ChainSpec: Hardforks + EthChainSpec,
+            ChainSpec: Hardforks,
         >,
         C: ChainSpecParser<ChainSpec = N::ChainSpec>,
     {

--- a/crates/ethereum/cli/src/app.rs
+++ b/crates/ethereum/cli/src/app.rs
@@ -82,10 +82,7 @@ where
         ) -> Result<()>,
     ) -> Result<()>
     where
-        N: CliNodeTypes<
-            Primitives: NodePrimitives<BlockHeader: CliHeader>,
-            ChainSpec: Hardforks,
-        >,
+        N: CliNodeTypes<Primitives: NodePrimitives<BlockHeader: CliHeader>, ChainSpec: Hardforks>,
         C: ChainSpecParser<ChainSpec = N::ChainSpec>,
     {
         let runner = match self.runner.take() {


### PR DESCRIPTION
This change removes the unnecessary EthChainSpec constraint from CliApp::run_with_components. The EthChainSpec bound is already implied by N: CliNodeTypes via NodeTypes, so requiring it explicitly here was redundant and made the CliApp path stricter than the shared implementation and the public CLI API. Aligning the bounds with run_commands_with and Cli::run_with_components