### PR TITLE
docs: Polish wording, unify style, and fix minor typos

### DIFF
--- a/docs/vocs/docs/pages/cli/reth/p2p/rlpx/ping.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/rlpx/ping.mdx
@@ -10,77 +10,78 @@ Usage: reth p2p rlpx ping [OPTIONS] <NODE>
 
 Arguments:
   <NODE>
-          The node to ping
+          The node to ping.
 
 Options:
   -h, --help
-          Print help (see a summary with '-h')
+          Print help information (use '-h' for a short summary).
 
 Logging:
       --log.stdout.format <FORMAT>
-          The format to use for logs written to stdout
+          The format to use for logs written to stdout.
 
           Possible values:
-          - json:     Represents JSON formatting for logs. This format outputs log records as JSON objects, making it suitable for structured logging
-          - log-fmt:  Represents logfmt (key=value) formatting for logs. This format is concise and human-readable, typically used in command-line applications
-          - terminal: Represents terminal-friendly formatting for logs
+          - json:     Outputs log records as JSON objects. Suitable for structured logging.
+          - log-fmt:  Outputs logs in logfmt (key=value) format. Concise and human-readable, ideal for CLI applications.
+          - terminal: Outputs logs in a terminal-friendly format.
 
           [default: terminal]
 
       --log.stdout.filter <FILTER>
-          The filter to use for logs written to stdout
+          The filter to use for logs written to stdout.
 
           [default: ]
 
       --log.file.format <FORMAT>
-          The format to use for logs written to the log file
+          The format to use for logs written to the log file.
 
           Possible values:
-          - json:     Represents JSON formatting for logs. This format outputs log records as JSON objects, making it suitable for structured logging
-          - log-fmt:  Represents logfmt (key=value) formatting for logs. This format is concise and human-readable, typically used in command-line applications
-          - terminal: Represents terminal-friendly formatting for logs
+          - json:     Outputs log records as JSON objects. Suitable for structured logging.
+          - log-fmt:  Outputs logs in logfmt (key=value) format. Concise and human-readable, ideal for CLI applications.
+          - terminal: Outputs logs in a terminal-friendly format.
 
           [default: terminal]
 
       --log.file.filter <FILTER>
-          The filter to use for logs written to the log file
+          The filter to use for logs written to the log file.
 
           [default: debug]
 
       --log.file.directory <PATH>
-          The path to put log files in
+          The path where log files will be stored.
 
           [default: <CACHE_DIR>/logs]
 
       --log.file.name <NAME>
-          The prefix name of the log files
+          The prefix name of the log files.
 
           [default: reth.log]
 
       --log.file.max-size <SIZE>
-          The maximum size (in MB) of one log file
+          The maximum size (in MB) of a single log file.
 
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum number of log files that will be stored.  
+          If set to 0, background file logging is disabled.
 
           [default: 5]
 
       --log.journald
-          Write logs to journald
+          Write logs to journald.
 
       --log.journald.filter <FILTER>
-          The filter to use for logs written to journald
+          The filter to use for logs written to journald.
 
           [default: error]
 
       --color <COLOR>
-          Sets whether or not the formatter emits ANSI terminal escape codes for colors and other text formatting
+          Sets whether the formatter emits ANSI terminal escape codes for colors and text formatting.
 
           Possible values:
           - always: Colors on
-          - auto:   Colors on
+          - auto:   Colors on when supported
           - never:  Colors off
 
           [default: always]
@@ -89,31 +90,37 @@ Display:
   -v, --verbosity...
           Set the minimum log level.
 
-          -v      Errors
-          -vv     Warnings
-          -vvv    Info
-          -vvvv   Debug
-          -vvvvv  Traces (warning: very verbose!)
+          -v      Errors  
+          -vv     Warnings  
+          -vvv    Info  
+          -vvvv   Debug  
+          -vvvvv  Trace (very verbose)
 
   -q, --quiet
-          Silence all log output
+          Silence all log output.
 
 Tracing:
       --tracing-otlp[=<URL>]
-          Enable `Opentelemetry` tracing export to an OTLP endpoint. Currently only http exporting is supported.
+          Enable OpenTelemetry tracing export to an OTLP endpoint.  
+          Currently, only HTTP export is supported.
 
-          If no value provided, defaults to `http://localhost:4318/v1/traces`.
+          If no value is provided, defaults to `http://localhost:4318/v1/traces`.
 
-          Example: --tracing-otlp=http://collector:4318/v1/traces
+          Example:
+              --tracing-otlp=http://collector:4318/v1/traces
 
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp.filter <FILTER>
-          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+          Set a filter directive for the OTLP tracer.  
+          This controls the verbosity of spans and events sent to the OTLP endpoint.  
+          Follows the same syntax as the `RUST_LOG` environment variable.
 
-          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
+          Example:
+              --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
-          Defaults to TRACE if not specified.
+          Defaults to TRACE level if not specified.
 
           [default: TRACE]
+
 ```


### PR DESCRIPTION
**Description:**
I went through the text and fixed all language and grammar issues. Unified the phrasing and punctuation for consistency (“The format to use…”, periods at the end, commas where needed).
Replaced *amount* → *number* and corrected *Opentelemetry* → *OpenTelemetry*.
Also made the CLI help output consistent with the style of tools like `cargo help` and `git help`.
