### PR TITLE
chore(trie): Add lifetime to cursors returned from Trie/HashedCursorFactorys

### DIFF
--- a/crates/cli/commands/src/db/repair_trie.rs
+++ b/crates/cli/commands/src/db/repair_trie.rs
@@ -52,7 +52,7 @@ fn verify_only<N: NodeTypesWithDB>(provider_factory: ProviderFactory<N>) -> eyre
     // Create the verifier
     let hashed_cursor_factory = DatabaseHashedCursorFactory::new(&tx);
     let trie_cursor_factory = DatabaseTrieCursorFactory::new(&tx);
-    let verifier = Verifier::new(trie_cursor_factory, hashed_cursor_factory)?;
+    let verifier = Verifier::new(&trie_cursor_factory, hashed_cursor_factory)?;
 
     let mut inconsistent_nodes = 0;
     let start_time = Instant::now();
@@ -136,7 +136,7 @@ fn verify_and_repair<N: ProviderNodeTypes>(
     let trie_cursor_factory = DatabaseTrieCursorFactory::new(tx);
 
     // Create the verifier
-    let verifier = Verifier::new(trie_cursor_factory, hashed_cursor_factory)?;
+    let verifier = Verifier::new(&trie_cursor_factory, hashed_cursor_factory)?;
 
     let mut inconsistent_nodes = 0;
     let start_time = Instant::now();

--- a/crates/trie/db/src/hashed_cursor.rs
+++ b/crates/trie/db/src/hashed_cursor.rs
@@ -20,18 +20,23 @@ impl<T> DatabaseHashedCursorFactory<T> {
 }
 
 impl<TX: DbTx> HashedCursorFactory for DatabaseHashedCursorFactory<&TX> {
-    type AccountCursor = DatabaseHashedAccountCursor<<TX as DbTx>::Cursor<tables::HashedAccounts>>;
-    type StorageCursor =
-        DatabaseHashedStorageCursor<<TX as DbTx>::DupCursor<tables::HashedStorages>>;
+    type AccountCursor<'a>
+        = DatabaseHashedAccountCursor<<TX as DbTx>::Cursor<tables::HashedAccounts>>
+    where
+        Self: 'a;
+    type StorageCursor<'a>
+        = DatabaseHashedStorageCursor<<TX as DbTx>::DupCursor<tables::HashedStorages>>
+    where
+        Self: 'a;
 
-    fn hashed_account_cursor(&self) -> Result<Self::AccountCursor, DatabaseError> {
+    fn hashed_account_cursor(&self) -> Result<Self::AccountCursor<'_>, DatabaseError> {
         Ok(DatabaseHashedAccountCursor(self.0.cursor_read::<tables::HashedAccounts>()?))
     }
 
     fn hashed_storage_cursor(
         &self,
         hashed_address: B256,
-    ) -> Result<Self::StorageCursor, DatabaseError> {
+    ) -> Result<Self::StorageCursor<'_>, DatabaseError> {
         Ok(DatabaseHashedStorageCursor::new(
             self.0.cursor_dup_read::<tables::HashedStorages>()?,
             hashed_address,

--- a/crates/trie/db/src/trie_cursor.rs
+++ b/crates/trie/db/src/trie_cursor.rs
@@ -53,14 +53,12 @@ where
 
 /// A cursor over the account trie.
 #[derive(Debug)]
-pub struct DatabaseAccountTrieCursor<C> {
-    cursor: C,
-}
+pub struct DatabaseAccountTrieCursor<C>(pub(crate) C);
 
 impl<C> DatabaseAccountTrieCursor<C> {
     /// Create a new account trie cursor.
     pub const fn new(cursor: C) -> Self {
-        Self { cursor }
+        Self(cursor)
     }
 }
 
@@ -73,7 +71,7 @@ where
         &mut self,
         key: Nibbles,
     ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
-        Ok(self.cursor.seek_exact(StoredNibbles(key))?.map(|value| (value.0 .0, value.1)))
+        Ok(self.0.seek_exact(StoredNibbles(key))?.map(|value| (value.0 .0, value.1)))
     }
 
     /// Seeks a key in the account trie that matches or is greater than the provided key.
@@ -81,17 +79,17 @@ where
         &mut self,
         key: Nibbles,
     ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
-        Ok(self.cursor.seek(StoredNibbles(key))?.map(|value| (value.0 .0, value.1)))
+        Ok(self.0.seek(StoredNibbles(key))?.map(|value| (value.0 .0, value.1)))
     }
 
     /// Move the cursor to the next entry and return it.
     fn next(&mut self) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
-        Ok(self.cursor.next()?.map(|value| (value.0 .0, value.1)))
+        Ok(self.0.next()?.map(|value| (value.0 .0, value.1)))
     }
 
     /// Retrieves the current key in the cursor.
     fn current(&mut self) -> Result<Option<Nibbles>, DatabaseError> {
-        Ok(self.cursor.current()?.map(|(k, _)| k.0))
+        Ok(self.0.current()?.map(|(k, _)| k.0))
     }
 }
 

--- a/crates/trie/trie/src/hashed_cursor/mock.rs
+++ b/crates/trie/trie/src/hashed_cursor/mock.rs
@@ -55,17 +55,23 @@ impl MockHashedCursorFactory {
 }
 
 impl HashedCursorFactory for MockHashedCursorFactory {
-    type AccountCursor = MockHashedCursor<Account>;
-    type StorageCursor = MockHashedCursor<U256>;
+    type AccountCursor<'a>
+        = MockHashedCursor<Account>
+    where
+        Self: 'a;
+    type StorageCursor<'a>
+        = MockHashedCursor<U256>
+    where
+        Self: 'a;
 
-    fn hashed_account_cursor(&self) -> Result<Self::AccountCursor, DatabaseError> {
+    fn hashed_account_cursor(&self) -> Result<Self::AccountCursor<'_>, DatabaseError> {
         Ok(MockHashedCursor::new(self.hashed_accounts.clone(), self.visited_account_keys.clone()))
     }
 
     fn hashed_storage_cursor(
         &self,
         hashed_address: B256,
-    ) -> Result<Self::StorageCursor, DatabaseError> {
+    ) -> Result<Self::StorageCursor<'_>, DatabaseError> {
         Ok(MockHashedCursor::new(
             self.hashed_storage_tries
                 .get(&hashed_address)

--- a/crates/trie/trie/src/hashed_cursor/mod.rs
+++ b/crates/trie/trie/src/hashed_cursor/mod.rs
@@ -14,6 +14,7 @@ pub mod noop;
 pub mod mock;
 
 /// The factory trait for creating cursors over the hashed state.
+#[auto_impl::auto_impl(&)]
 pub trait HashedCursorFactory {
     /// The hashed account cursor type.
     type AccountCursor<'a>: HashedCursor<Value = Account>
@@ -35,6 +36,7 @@ pub trait HashedCursorFactory {
 }
 
 /// The cursor for iterating over hashed entries.
+#[auto_impl::auto_impl(&mut)]
 pub trait HashedCursor {
     /// Value returned by the cursor.
     type Value: std::fmt::Debug;
@@ -48,6 +50,7 @@ pub trait HashedCursor {
 }
 
 /// The cursor for iterating over hashed storage entries.
+#[auto_impl::auto_impl(&mut)]
 pub trait HashedStorageCursor: HashedCursor {
     /// Returns `true` if there are no entries for a given key.
     fn is_storage_empty(&mut self) -> Result<bool, DatabaseError>;

--- a/crates/trie/trie/src/hashed_cursor/mod.rs
+++ b/crates/trie/trie/src/hashed_cursor/mod.rs
@@ -16,18 +16,22 @@ pub mod mock;
 /// The factory trait for creating cursors over the hashed state.
 pub trait HashedCursorFactory {
     /// The hashed account cursor type.
-    type AccountCursor: HashedCursor<Value = Account>;
+    type AccountCursor<'a>: HashedCursor<Value = Account>
+    where
+        Self: 'a;
     /// The hashed storage cursor type.
-    type StorageCursor: HashedStorageCursor<Value = U256>;
+    type StorageCursor<'a>: HashedStorageCursor<Value = U256>
+    where
+        Self: 'a;
 
     /// Returns a cursor for iterating over all hashed accounts in the state.
-    fn hashed_account_cursor(&self) -> Result<Self::AccountCursor, DatabaseError>;
+    fn hashed_account_cursor(&self) -> Result<Self::AccountCursor<'_>, DatabaseError>;
 
     /// Returns a cursor for iterating over all hashed storage entries in the state.
     fn hashed_storage_cursor(
         &self,
         hashed_address: B256,
-    ) -> Result<Self::StorageCursor, DatabaseError>;
+    ) -> Result<Self::StorageCursor<'_>, DatabaseError>;
 }
 
 /// The cursor for iterating over hashed entries.

--- a/crates/trie/trie/src/hashed_cursor/noop.rs
+++ b/crates/trie/trie/src/hashed_cursor/noop.rs
@@ -9,17 +9,23 @@ use reth_storage_errors::db::DatabaseError;
 pub struct NoopHashedCursorFactory;
 
 impl HashedCursorFactory for NoopHashedCursorFactory {
-    type AccountCursor = NoopHashedAccountCursor;
-    type StorageCursor = NoopHashedStorageCursor;
+    type AccountCursor<'a>
+        = NoopHashedAccountCursor
+    where
+        Self: 'a;
+    type StorageCursor<'a>
+        = NoopHashedStorageCursor
+    where
+        Self: 'a;
 
-    fn hashed_account_cursor(&self) -> Result<Self::AccountCursor, DatabaseError> {
+    fn hashed_account_cursor(&self) -> Result<Self::AccountCursor<'_>, DatabaseError> {
         Ok(NoopHashedAccountCursor::default())
     }
 
     fn hashed_storage_cursor(
         &self,
         _hashed_address: B256,
-    ) -> Result<Self::StorageCursor, DatabaseError> {
+    ) -> Result<Self::StorageCursor<'_>, DatabaseError> {
         Ok(NoopHashedStorageCursor::default())
     }
 }

--- a/crates/trie/trie/src/hashed_cursor/post_state.rs
+++ b/crates/trie/trie/src/hashed_cursor/post_state.rs
@@ -19,19 +19,19 @@ impl<CF, T> HashedPostStateCursorFactory<CF, T> {
     }
 }
 
-impl<'a, CF, T> HashedCursorFactory for HashedPostStateCursorFactory<CF, &'a T>
+impl<'overlay, CF, T> HashedCursorFactory for HashedPostStateCursorFactory<CF, &'overlay T>
 where
     CF: HashedCursorFactory,
     T: AsRef<HashedPostStateSorted>,
 {
-    type AccountCursor<'b>
-        = HashedPostStateAccountCursor<'a, CF::AccountCursor<'b>>
+    type AccountCursor<'cursor>
+        = HashedPostStateAccountCursor<'overlay, CF::AccountCursor<'cursor>>
     where
-        Self: 'b;
-    type StorageCursor<'b>
-        = HashedPostStateStorageCursor<'a, CF::StorageCursor<'b>>
+        Self: 'cursor;
+    type StorageCursor<'cursor>
+        = HashedPostStateStorageCursor<'overlay, CF::StorageCursor<'cursor>>
     where
-        Self: 'b;
+        Self: 'cursor;
 
     fn hashed_account_cursor(&self) -> Result<Self::AccountCursor<'_>, DatabaseError> {
         let cursor = self.cursor_factory.hashed_account_cursor()?;

--- a/crates/trie/trie/src/hashed_cursor/post_state.rs
+++ b/crates/trie/trie/src/hashed_cursor/post_state.rs
@@ -24,10 +24,16 @@ where
     CF: HashedCursorFactory,
     T: AsRef<HashedPostStateSorted>,
 {
-    type AccountCursor = HashedPostStateAccountCursor<'a, CF::AccountCursor>;
-    type StorageCursor = HashedPostStateStorageCursor<'a, CF::StorageCursor>;
+    type AccountCursor<'b>
+        = HashedPostStateAccountCursor<'a, CF::AccountCursor<'b>>
+    where
+        Self: 'b;
+    type StorageCursor<'b>
+        = HashedPostStateStorageCursor<'a, CF::StorageCursor<'b>>
+    where
+        Self: 'b;
 
-    fn hashed_account_cursor(&self) -> Result<Self::AccountCursor, DatabaseError> {
+    fn hashed_account_cursor(&self) -> Result<Self::AccountCursor<'_>, DatabaseError> {
         let cursor = self.cursor_factory.hashed_account_cursor()?;
         Ok(HashedPostStateAccountCursor::new(cursor, &self.post_state.as_ref().accounts))
     }
@@ -35,7 +41,7 @@ where
     fn hashed_storage_cursor(
         &self,
         hashed_address: B256,
-    ) -> Result<Self::StorageCursor, DatabaseError> {
+    ) -> Result<Self::StorageCursor<'_>, DatabaseError> {
         let cursor = self.cursor_factory.hashed_storage_cursor(hashed_address)?;
         Ok(HashedPostStateStorageCursor::new(
             cursor,

--- a/crates/trie/trie/src/trie_cursor/in_memory.rs
+++ b/crates/trie/trie/src/trie_cursor/in_memory.rs
@@ -44,12 +44,21 @@ where
         &self,
         hashed_address: B256,
     ) -> Result<Self::StorageTrieCursor<'_>, DatabaseError> {
-        let cursor = self.cursor_factory.storage_trie_cursor(hashed_address)?;
-        Ok(InMemoryTrieCursor::new_storage(
-            Some(cursor),
-            self.trie_updates.as_ref(),
-            hashed_address,
-        ))
+        // if the storage trie has no updates then we use this as the in-memory overlay.
+        static EMPTY_UPDATES: Vec<(Nibbles, Option<BranchNodeCompact>)> = Vec::new();
+
+        let storage_trie_updates = self.trie_updates.as_ref().storage_tries.get(&hashed_address);
+        let (storage_nodes, cleared) = storage_trie_updates
+            .map(|u| (u.storage_nodes_ref(), u.is_deleted()))
+            .unwrap_or((&EMPTY_UPDATES, false));
+
+        let cursor = if cleared {
+            None
+        } else {
+            Some(self.cursor_factory.storage_trie_cursor(hashed_address)?)
+        };
+
+        Ok(InMemoryTrieCursor::new(cursor, storage_nodes))
     }
 }
 
@@ -74,24 +83,6 @@ impl<'a, C: TrieCursor> InMemoryTrieCursor<'a, C> {
     ) -> Self {
         let in_memory_cursor = ForwardInMemoryCursor::new(trie_updates);
         Self { cursor, in_memory_cursor, last_key: None }
-    }
-
-    /// Wraps [`Self::new`] to create new trie cursor for the storage trie of a particular account.
-    pub fn new_storage(
-        cursor: Option<C>,
-        trie_updates: &'a TrieUpdatesSorted,
-        hashed_address: B256,
-    ) -> Self {
-        // if the storage trie has no updates then we use this as the in-memory overlay.
-        static EMPTY_UPDATES: Vec<(Nibbles, Option<BranchNodeCompact>)> = Vec::new();
-
-        let storage_trie_updates = trie_updates.storage_tries.get(&hashed_address);
-        let (storage_nodes, cleared) = storage_trie_updates
-            .map(|u| (u.storage_nodes_ref(), u.is_deleted()))
-            .unwrap_or((&EMPTY_UPDATES, false));
-
-        let cursor = if cleared { None } else { cursor };
-        Self::new(cursor, storage_nodes)
     }
 
     fn seek_inner(

--- a/crates/trie/trie/src/trie_cursor/mock.rs
+++ b/crates/trie/trie/src/trie_cursor/mock.rs
@@ -52,8 +52,14 @@ impl MockTrieCursorFactory {
 }
 
 impl TrieCursorFactory for MockTrieCursorFactory {
-    type AccountTrieCursor<'a> = MockTrieCursor where Self: 'a;
-    type StorageTrieCursor<'a> = MockTrieCursor where Self: 'a;
+    type AccountTrieCursor<'a>
+        = MockTrieCursor
+    where
+        Self: 'a;
+    type StorageTrieCursor<'a>
+        = MockTrieCursor
+    where
+        Self: 'a;
 
     /// Generates a mock account trie cursor.
     fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor<'_>, DatabaseError> {

--- a/crates/trie/trie/src/trie_cursor/mock.rs
+++ b/crates/trie/trie/src/trie_cursor/mock.rs
@@ -52,11 +52,11 @@ impl MockTrieCursorFactory {
 }
 
 impl TrieCursorFactory for MockTrieCursorFactory {
-    type AccountTrieCursor = MockTrieCursor;
-    type StorageTrieCursor = MockTrieCursor;
+    type AccountTrieCursor<'a> = MockTrieCursor where Self: 'a;
+    type StorageTrieCursor<'a> = MockTrieCursor where Self: 'a;
 
     /// Generates a mock account trie cursor.
-    fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor, DatabaseError> {
+    fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor<'_>, DatabaseError> {
         Ok(MockTrieCursor::new(self.account_trie_nodes.clone(), self.visited_account_keys.clone()))
     }
 
@@ -64,7 +64,7 @@ impl TrieCursorFactory for MockTrieCursorFactory {
     fn storage_trie_cursor(
         &self,
         hashed_address: B256,
-    ) -> Result<Self::StorageTrieCursor, DatabaseError> {
+    ) -> Result<Self::StorageTrieCursor<'_>, DatabaseError> {
         Ok(MockTrieCursor::new(
             self.storage_tries
                 .get(&hashed_address)

--- a/crates/trie/trie/src/trie_cursor/mod.rs
+++ b/crates/trie/trie/src/trie_cursor/mod.rs
@@ -45,8 +45,8 @@ pub trait TrieCursorFactory {
 
 /// A cursor for traversing stored trie nodes. The cursor must iterate over keys in
 /// lexicographical order.
-#[auto_impl::auto_impl(&mut, Box)]
-pub trait TrieCursor: Send + Sync {
+#[auto_impl::auto_impl(&mut)]
+pub trait TrieCursor {
     /// Move the cursor to the key and return if it is an exact match.
     fn seek_exact(
         &mut self,

--- a/crates/trie/trie/src/trie_cursor/mod.rs
+++ b/crates/trie/trie/src/trie_cursor/mod.rs
@@ -24,18 +24,23 @@ pub use self::{depth_first::DepthFirstTrieIterator, in_memory::*, subnode::Curso
 #[auto_impl::auto_impl(&)]
 pub trait TrieCursorFactory {
     /// The account trie cursor type.
-    type AccountTrieCursor: TrieCursor;
+    type AccountTrieCursor<'a>: TrieCursor
+    where
+        Self: 'a;
+
     /// The storage trie cursor type.
-    type StorageTrieCursor: TrieCursor;
+    type StorageTrieCursor<'a>: TrieCursor
+    where
+        Self: 'a;
 
     /// Create an account trie cursor.
-    fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor, DatabaseError>;
+    fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor<'_>, DatabaseError>;
 
     /// Create a storage tries cursor.
     fn storage_trie_cursor(
         &self,
         hashed_address: B256,
-    ) -> Result<Self::StorageTrieCursor, DatabaseError>;
+    ) -> Result<Self::StorageTrieCursor<'_>, DatabaseError>;
 }
 
 /// A cursor for traversing stored trie nodes. The cursor must iterate over keys in

--- a/crates/trie/trie/src/trie_cursor/noop.rs
+++ b/crates/trie/trie/src/trie_cursor/noop.rs
@@ -9,11 +9,18 @@ use reth_storage_errors::db::DatabaseError;
 pub struct NoopTrieCursorFactory;
 
 impl TrieCursorFactory for NoopTrieCursorFactory {
-    type AccountTrieCursor = NoopAccountTrieCursor;
-    type StorageTrieCursor = NoopStorageTrieCursor;
+    type AccountTrieCursor<'a>
+        = NoopAccountTrieCursor
+    where
+        Self: 'a;
+
+    type StorageTrieCursor<'a>
+        = NoopStorageTrieCursor
+    where
+        Self: 'a;
 
     /// Generates a noop account trie cursor.
-    fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor, DatabaseError> {
+    fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor<'_>, DatabaseError> {
         Ok(NoopAccountTrieCursor::default())
     }
 
@@ -21,7 +28,7 @@ impl TrieCursorFactory for NoopTrieCursorFactory {
     fn storage_trie_cursor(
         &self,
         _hashed_address: B256,
-    ) -> Result<Self::StorageTrieCursor, DatabaseError> {
+    ) -> Result<Self::StorageTrieCursor<'_>, DatabaseError> {
         Ok(NoopStorageTrieCursor::default())
     }
 }


### PR DESCRIPTION
Towards #18906 

In the original implementation of OverlayStateProvider I assumed it would be possible to obtain a DBProvider with Clone by wrapping a DBProvider in an Arc. This turns out to not be true, because DBProvider is both `&mut self` and `self` methods.

Because of this it becomes necessary to refactor OverlayStateProvider such that the cursors it returns from its Trie/HashedCursorFactory are bound to its lifetime.

In order to accomplish this the factory traits themselves had to be modified such that the associated types now have lifetimes bound to `Self`. At a lower level our underlying cursor types are not bound to the txs which spawn them, but at an even lower level MDBX does not support using a cursor after its TX is committed/aborted, so this lifetime is actually correct anyway.

I've also added auto_impls for different references to the factorys/cursors that were missing them.

