### PR TITLE
feat(stateless): make UncompressedPublicKey serializable

### DIFF
--- a/crates/stateless/src/recover_block.rs
+++ b/crates/stateless/src/recover_block.rs
@@ -2,15 +2,28 @@ use crate::validation::StatelessValidationError;
 use alloc::vec::Vec;
 use alloy_consensus::BlockHeader;
 use alloy_primitives::{Address, Signature, B256};
+use core::ops::Deref;
 use reth_chainspec::EthereumHardforks;
 use reth_ethereum_primitives::{Block, TransactionSigned};
 use reth_primitives_traits::{Block as _, RecoveredBlock};
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, Bytes};
 
 #[cfg(all(feature = "k256", feature = "secp256k1"))]
 use k256 as _;
 
 /// Serialized uncompressed public key
-pub type UncompressedPublicKey = [u8; 65];
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UncompressedPublicKey(#[serde_as(as = "Bytes")] pub [u8; 65]);
+
+impl Deref for UncompressedPublicKey {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 /// Verifies all transactions in a block against a list of public keys and signatures.
 ///

--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -433,7 +433,11 @@ where
         .map(|(i, tx)| {
             tx.signature()
                 .recover_from_prehash(&tx.signature_hash())
-                .map(|keys| keys.to_encoded_point(false).as_bytes().try_into().unwrap())
+                .map(|keys| {
+                    UncompressedPublicKey(
+                        keys.to_encoded_point(false).as_bytes().try_into().unwrap(),
+                    )
+                })
                 .map_err(|e| format!("failed to recover signature for tx #{i}: {e}").into())
         })
         .collect::<Result<Vec<UncompressedPublicKey>, _>>()


### PR DESCRIPTION
After merging https://github.com/paradigmxyz/reth/pull/17841, it was noted that the new `UncompressedPublicKey`, which is an input to the stateless block validator function, wasn't bincode serializable.

zkVMs require the inputs to be serialized to be passed to the guest program (which in this case is the STF), same reason why `StatelessInput` is bincode serializable: https://github.com/paradigmxyz/reth/blob/a5618f57a8a8f80f13739cae640340dd3600b3c6/crates/stateless/src/lib.rs#L58-L70

This PR makes the new `UncompressedPublicKey` also bincode serializable, since arrays of length 65 aren't included in generic u8 array impl. (Open to other style if it sounds better!)