### PR TITLE
fix: hold trace/debug semaphore permits correctly

### DIFF
--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -1013,7 +1013,10 @@ where
         rlp_block: Bytes,
         opts: Option<GethDebugTracingOptions>,
     ) -> RpcResult<Vec<TraceResult>> {
-        let _permit = self.acquire_trace_permit().await;
+        let _permit = self
+            .acquire_trace_permit()
+            .await
+            .map_err(|err| internal_rpc_err(format!("failed to acquire trace permit: {err}")))?;
         Self::debug_trace_raw_block(self, rlp_block, opts.unwrap_or_default())
             .await
             .map_err(Into::into)
@@ -1025,7 +1028,10 @@ where
         block: B256,
         opts: Option<GethDebugTracingOptions>,
     ) -> RpcResult<Vec<TraceResult>> {
-        let _permit = self.acquire_trace_permit().await;
+        let _permit = self
+            .acquire_trace_permit()
+            .await
+            .map_err(|err| internal_rpc_err(format!("failed to acquire trace permit: {err}")))?;
         Self::debug_trace_block(self, block.into(), opts.unwrap_or_default())
             .await
             .map_err(Into::into)
@@ -1037,7 +1043,10 @@ where
         block: BlockNumberOrTag,
         opts: Option<GethDebugTracingOptions>,
     ) -> RpcResult<Vec<TraceResult>> {
-        let _permit = self.acquire_trace_permit().await;
+        let _permit = self
+            .acquire_trace_permit()
+            .await
+            .map_err(|err| internal_rpc_err(format!("failed to acquire trace permit: {err}")))?;
         Self::debug_trace_block(self, block.into(), opts.unwrap_or_default())
             .await
             .map_err(Into::into)
@@ -1049,7 +1058,10 @@ where
         tx_hash: B256,
         opts: Option<GethDebugTracingOptions>,
     ) -> RpcResult<GethTrace> {
-        let _permit = self.acquire_trace_permit().await;
+        let _permit = self
+            .acquire_trace_permit()
+            .await
+            .map_err(|err| internal_rpc_err(format!("failed to acquire trace permit: {err}")))?;
         Self::debug_trace_transaction(self, tx_hash, opts.unwrap_or_default())
             .await
             .map_err(Into::into)
@@ -1062,7 +1074,10 @@ where
         block_id: Option<BlockId>,
         opts: Option<GethDebugTracingCallOptions>,
     ) -> RpcResult<GethTrace> {
-        let _permit = self.acquire_trace_permit().await;
+        let _permit = self
+            .acquire_trace_permit()
+            .await
+            .map_err(|err| internal_rpc_err(format!("failed to acquire trace permit: {err}")))?;
         Self::debug_trace_call(self, request, block_id, opts.unwrap_or_default())
             .await
             .map_err(Into::into)
@@ -1074,7 +1089,10 @@ where
         state_context: Option<StateContext>,
         opts: Option<GethDebugTracingCallOptions>,
     ) -> RpcResult<Vec<Vec<GethTrace>>> {
-        let _permit = self.acquire_trace_permit().await;
+        let _permit = self
+            .acquire_trace_permit()
+            .await
+            .map_err(|err| internal_rpc_err(format!("failed to acquire trace permit: {err}")))?;
         Self::debug_trace_call_many(self, bundles, state_context, opts).await.map_err(Into::into)
     }
 
@@ -1083,7 +1101,10 @@ where
         &self,
         block: BlockNumberOrTag,
     ) -> RpcResult<ExecutionWitness> {
-        let _permit = self.acquire_trace_permit().await;
+        let _permit = self
+            .acquire_trace_permit()
+            .await
+            .map_err(|err| internal_rpc_err(format!("failed to acquire trace permit: {err}")))?;
         Self::debug_execution_witness(self, block).await.map_err(Into::into)
     }
 
@@ -1092,7 +1113,10 @@ where
         &self,
         hash: B256,
     ) -> RpcResult<ExecutionWitness> {
-        let _permit = self.acquire_trace_permit().await;
+        let _permit = self
+            .acquire_trace_permit()
+            .await
+            .map_err(|err| internal_rpc_err(format!("failed to acquire trace permit: {err}")))?;
         Self::debug_execution_witness_by_block_hash(self, hash).await.map_err(Into::into)
     }
 

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -28,6 +28,7 @@ use reth_rpc_eth_api::{
     FromEthApiError, RpcNodeCore,
 };
 use reth_rpc_eth_types::{error::EthApiError, utils::recover_raw_transaction, EthConfig};
+use reth_rpc_server_types::result::internal_rpc_err;
 use reth_storage_api::{BlockNumReader, BlockReader};
 use reth_tasks::pool::BlockingTaskGuard;
 use reth_transaction_pool::{PoolPooledTx, PoolTransaction, TransactionPool};
@@ -624,7 +625,10 @@ where
         state_overrides: Option<StateOverride>,
         block_overrides: Option<Box<BlockOverrides>>,
     ) -> RpcResult<TraceResults> {
-        let _permit = self.acquire_trace_permit().await;
+        let _permit = self
+            .acquire_trace_permit()
+            .await
+            .map_err(|err| internal_rpc_err(format!("failed to acquire trace permit: {err}")))?;
         let request =
             TraceCallRequest { call, trace_types, block_id, state_overrides, block_overrides };
         Ok(Self::trace_call(self, request).await.map_err(Into::into)?)
@@ -636,7 +640,10 @@ where
         calls: Vec<(RpcTxReq<Eth::NetworkTypes>, HashSet<TraceType>)>,
         block_id: Option<BlockId>,
     ) -> RpcResult<Vec<TraceResults>> {
-        let _permit = self.acquire_trace_permit().await;
+        let _permit = self
+            .acquire_trace_permit()
+            .await
+            .map_err(|err| internal_rpc_err(format!("failed to acquire trace permit: {err}")))?;
         Ok(Self::trace_call_many(self, calls, block_id).await.map_err(Into::into)?)
     }
 
@@ -647,7 +654,10 @@ where
         trace_types: HashSet<TraceType>,
         block_id: Option<BlockId>,
     ) -> RpcResult<TraceResults> {
-        let _permit = self.acquire_trace_permit().await;
+        let _permit = self
+            .acquire_trace_permit()
+            .await
+            .map_err(|err| internal_rpc_err(format!("failed to acquire trace permit: {err}")))?;
         Ok(Self::trace_raw_transaction(self, data, trace_types, block_id)
             .await
             .map_err(Into::into)?)
@@ -659,7 +669,10 @@ where
         block_id: BlockId,
         trace_types: HashSet<TraceType>,
     ) -> RpcResult<Option<Vec<TraceResultsWithTransactionHash>>> {
-        let _permit = self.acquire_trace_permit().await;
+        let _permit = self
+            .acquire_trace_permit()
+            .await
+            .map_err(|err| internal_rpc_err(format!("failed to acquire trace permit: {err}")))?;
         Ok(Self::replay_block_transactions(self, block_id, trace_types)
             .await
             .map_err(Into::into)?)
@@ -671,7 +684,10 @@ where
         transaction: B256,
         trace_types: HashSet<TraceType>,
     ) -> RpcResult<TraceResults> {
-        let _permit = self.acquire_trace_permit().await;
+        let _permit = self
+            .acquire_trace_permit()
+            .await
+            .map_err(|err| internal_rpc_err(format!("failed to acquire trace permit: {err}")))?;
         Ok(Self::replay_transaction(self, transaction, trace_types).await.map_err(Into::into)?)
     }
 
@@ -680,7 +696,10 @@ where
         &self,
         block_id: BlockId,
     ) -> RpcResult<Option<Vec<LocalizedTransactionTrace>>> {
-        let _permit = self.acquire_trace_permit().await;
+        let _permit = self
+            .acquire_trace_permit()
+            .await
+            .map_err(|err| internal_rpc_err(format!("failed to acquire trace permit: {err}")))?;
         Ok(Self::trace_block(self, block_id).await.map_err(Into::into)?)
     }
 
@@ -701,7 +720,10 @@ where
         hash: B256,
         indices: Vec<Index>,
     ) -> RpcResult<Option<LocalizedTransactionTrace>> {
-        let _permit = self.acquire_trace_permit().await;
+        let _permit = self
+            .acquire_trace_permit()
+            .await
+            .map_err(|err| internal_rpc_err(format!("failed to acquire trace permit: {err}")))?;
         Ok(Self::trace_get(self, hash, indices.into_iter().map(Into::into).collect())
             .await
             .map_err(Into::into)?)
@@ -712,7 +734,10 @@ where
         &self,
         hash: B256,
     ) -> RpcResult<Option<Vec<LocalizedTransactionTrace>>> {
-        let _permit = self.acquire_trace_permit().await;
+        let _permit = self
+            .acquire_trace_permit()
+            .await
+            .map_err(|err| internal_rpc_err(format!("failed to acquire trace permit: {err}")))?;
         Ok(Self::trace_transaction(self, hash).await.map_err(Into::into)?)
     }
 
@@ -721,13 +746,19 @@ where
         &self,
         tx_hash: B256,
     ) -> RpcResult<Option<TransactionOpcodeGas>> {
-        let _permit = self.acquire_trace_permit().await;
+        let _permit = self
+            .acquire_trace_permit()
+            .await
+            .map_err(|err| internal_rpc_err(format!("failed to acquire trace permit: {err}")))?;
         Ok(Self::trace_transaction_opcode_gas(self, tx_hash).await.map_err(Into::into)?)
     }
 
     /// Handler for `trace_blockOpcodeGas`
     async fn trace_block_opcode_gas(&self, block_id: BlockId) -> RpcResult<Option<BlockOpcodeGas>> {
-        let _permit = self.acquire_trace_permit().await;
+        let _permit = self
+            .acquire_trace_permit()
+            .await
+            .map_err(|err| internal_rpc_err(format!("failed to acquire trace permit: {err}")))?;
         Ok(Self::trace_block_opcode_gas(self, block_id).await.map_err(Into::into)?)
     }
 }


### PR DESCRIPTION
The trace/debug RPC handlers tried to rate-limit themselves with a semaphore, but the permit was never actually held: we stored the Result from acquire_trace_permit() and immediately dropped it, so the OwnedSemaphorePermit was released right away and AcquireError was silently ignored. This change unwraps the Result, retains the permit for the lifetime of each RPC call, and converts AcquireError into a JSON-RPC internal error. With that, tracing endpoints finally respect the configured concurrency limit instead of running unbounded in parallel.