### PR TITLE
docs: improve SealedBlockRecoveryError documentation

### DIFF
--- a/crates/primitives-traits/src/block/error.rs
+++ b/crates/primitives-traits/src/block/error.rs
@@ -13,7 +13,8 @@ use crate::transaction::signed::RecoveryError;
 ///
 /// ```rust
 /// use reth_primitives_traits::block::error::SealedBlockRecoveryError;
-/// use reth_primitives_traits::{SealedBlock, Block};
+/// use reth_primitives_traits::SealedBlock;
+/// use alloy_consensus::Block;
 ///
 /// // Simulate a block recovery operation that fails
 /// let sealed_block = SealedBlock::new_unchecked(Block::default(), Default::default());

--- a/crates/primitives-traits/src/block/error.rs
+++ b/crates/primitives-traits/src/block/error.rs
@@ -14,12 +14,12 @@ use crate::transaction::signed::RecoveryError;
 /// ```rust
 /// use reth_primitives_traits::block::error::SealedBlockRecoveryError;
 /// use reth_primitives_traits::SealedBlock;
-/// use alloy_consensus::{Block, Header, BlockBody};
+/// use alloy_consensus::{Block, Header, BlockBody, TxLegacy};
 /// use alloy_primitives::B256;
 ///
 /// // Create a simple block for demonstration
 /// let header = Header::default();
-/// let body: BlockBody<alloy_consensus::Transaction, Header> = BlockBody::default();
+/// let body: BlockBody<TxLegacy, Header> = BlockBody::default();
 /// let block = Block::new(header, body);
 /// let sealed_block = SealedBlock::new_unchecked(block, B256::ZERO);
 ///

--- a/crates/primitives-traits/src/block/error.rs
+++ b/crates/primitives-traits/src/block/error.rs
@@ -3,6 +3,22 @@
 use crate::transaction::signed::RecoveryError;
 
 /// Type alias for [`BlockRecoveryError`] with a [`SealedBlock`](crate::SealedBlock) value.
+///
+/// This error type is specifically used when recovering a sealed block fails.
+/// It contains the original sealed block that could not be recovered, allowing
+/// callers to inspect the problematic block or attempt recovery with different
+/// parameters.
+///
+/// # Example
+///
+/// ```rust
+/// use reth_primitives_traits::block::error::SealedBlockRecoveryError;
+///
+/// // When block recovery fails, you get the error with the original block
+/// let error: SealedBlockRecoveryError<Block> = block_recovery_result.unwrap_err();
+/// let failed_block = error.into_inner();
+/// // Now you can inspect the failed block or try recovery again
+/// ```
 pub type SealedBlockRecoveryError<B> = BlockRecoveryError<crate::SealedBlock<B>>;
 
 /// Error when recovering a block from [`SealedBlock`](crate::SealedBlock) to

--- a/crates/primitives-traits/src/block/error.rs
+++ b/crates/primitives-traits/src/block/error.rs
@@ -12,14 +12,16 @@ use crate::transaction::signed::RecoveryError;
 /// # Example
 ///
 /// ```rust
-/// use reth_primitives_traits::block::error::SealedBlockRecoveryError;
-/// use reth_primitives_traits::SealedBlock;
-/// use alloy_consensus::{Block, Header, BlockBody, TxLegacy};
-/// use alloy_primitives::B256;
+/// use alloy_consensus::{Block, BlockBody, EthereumTxEnvelope, Header, Signed, TxLegacy};
+/// use alloy_primitives::{Signature, B256};
+/// use reth_primitives_traits::{block::error::SealedBlockRecoveryError, SealedBlock};
 ///
 /// // Create a simple block for demonstration
 /// let header = Header::default();
-/// let body: BlockBody<TxLegacy, Header> = BlockBody::default();
+/// let tx = TxLegacy::default();
+/// let signed_tx = Signed::new_unchecked(tx, Signature::default());
+/// let envelope = EthereumTxEnvelope::Legacy(signed_tx);
+/// let body: BlockBody<EthereumTxEnvelope, Header> = BlockBody::new(vec![envelope], vec![]);
 /// let block = Block::new(header, body);
 /// let sealed_block = SealedBlock::new_unchecked(block, B256::ZERO);
 ///

--- a/crates/primitives-traits/src/block/error.rs
+++ b/crates/primitives-traits/src/block/error.rs
@@ -13,9 +13,15 @@ use crate::transaction::signed::RecoveryError;
 ///
 /// ```rust
 /// use reth_primitives_traits::block::error::SealedBlockRecoveryError;
+/// use reth_primitives_traits::{SealedBlock, Block};
+///
+/// // Simulate a block recovery operation that fails
+/// let sealed_block = SealedBlock::new_unchecked(Block::default(), Default::default());
+/// let block_recovery_result: Result<_, SealedBlockRecoveryError<_>> =
+///     Err(SealedBlockRecoveryError::new(sealed_block));
 ///
 /// // When block recovery fails, you get the error with the original block
-/// let error: SealedBlockRecoveryError<Block> = block_recovery_result.unwrap_err();
+/// let error = block_recovery_result.unwrap_err();
 /// let failed_block = error.into_inner();
 /// // Now you can inspect the failed block or try recovery again
 /// ```

--- a/crates/primitives-traits/src/block/error.rs
+++ b/crates/primitives-traits/src/block/error.rs
@@ -14,10 +14,16 @@ use crate::transaction::signed::RecoveryError;
 /// ```rust
 /// use reth_primitives_traits::block::error::SealedBlockRecoveryError;
 /// use reth_primitives_traits::SealedBlock;
-/// use alloy_consensus::Block;
+/// use alloy_consensus::{Block, Header};
+/// use alloy_primitives::B256;
+///
+/// // Create a simple block for demonstration
+/// let header = Header::default();
+/// let body = alloy_consensus::BlockBody::default();
+/// let block = Block::new(header, body);
+/// let sealed_block = SealedBlock::new_unchecked(block, B256::ZERO);
 ///
 /// // Simulate a block recovery operation that fails
-/// let sealed_block = SealedBlock::new_unchecked(Block::default(), Default::default());
 /// let block_recovery_result: Result<_, SealedBlockRecoveryError<_>> =
 ///     Err(SealedBlockRecoveryError::new(sealed_block));
 ///

--- a/crates/primitives-traits/src/block/error.rs
+++ b/crates/primitives-traits/src/block/error.rs
@@ -12,16 +12,16 @@ use crate::transaction::signed::RecoveryError;
 /// # Example
 ///
 /// ```rust
-/// use alloy_consensus::{Block, BlockBody, EthereumTxEnvelope, Header, Signed, TxLegacy};
+/// use alloy_consensus::{Block, BlockBody, Header, Signed, TxEnvelope, TxLegacy};
 /// use alloy_primitives::{Signature, B256};
 /// use reth_primitives_traits::{block::error::SealedBlockRecoveryError, SealedBlock};
 ///
 /// // Create a simple block for demonstration
 /// let header = Header::default();
 /// let tx = TxLegacy::default();
-/// let signed_tx = Signed::new_unchecked(tx, Signature::default());
-/// let envelope = EthereumTxEnvelope::Legacy(signed_tx);
-/// let body: BlockBody<EthereumTxEnvelope, Header> = BlockBody::new(vec![envelope], vec![]);
+/// let signed_tx = Signed::new_unchecked(tx, Signature::test_signature(), B256::ZERO);
+/// let envelope = TxEnvelope::Legacy(signed_tx);
+/// let body = BlockBody { transactions: vec![envelope], ommers: vec![], withdrawals: None };
 /// let block = Block::new(header, body);
 /// let sealed_block = SealedBlock::new_unchecked(block, B256::ZERO);
 ///

--- a/crates/primitives-traits/src/block/error.rs
+++ b/crates/primitives-traits/src/block/error.rs
@@ -14,12 +14,12 @@ use crate::transaction::signed::RecoveryError;
 /// ```rust
 /// use reth_primitives_traits::block::error::SealedBlockRecoveryError;
 /// use reth_primitives_traits::SealedBlock;
-/// use alloy_consensus::{Block, Header};
+/// use alloy_consensus::{Block, Header, BlockBody};
 /// use alloy_primitives::B256;
 ///
 /// // Create a simple block for demonstration
 /// let header = Header::default();
-/// let body = alloy_consensus::BlockBody::default();
+/// let body: BlockBody<alloy_consensus::Transaction, Header> = BlockBody::default();
 /// let block = Block::new(header, body);
 /// let sealed_block = SealedBlock::new_unchecked(block, B256::ZERO);
 ///

--- a/crates/primitives-traits/src/block/error.rs
+++ b/crates/primitives-traits/src/block/error.rs
@@ -26,7 +26,7 @@ use crate::transaction::signed::RecoveryError;
 /// let sealed_block = SealedBlock::new_unchecked(block, B256::ZERO);
 ///
 /// // Simulate a block recovery operation that fails
-/// let block_recovery_result: Result<_, SealedBlockRecoveryError<_>> =
+/// let block_recovery_result: Result<(), SealedBlockRecoveryError<_>> =
 ///     Err(SealedBlockRecoveryError::new(sealed_block));
 ///
 /// // When block recovery fails, you get the error with the original block


### PR DESCRIPTION
Added documentation for the `SealedBlockRecoveryError` type alias, including usage examples and explanation of its purpose in block recovery operations. 
