### PR TITLE
chore: remove redundant collect in debug trace

### DIFF
--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -169,8 +169,6 @@ where
                     .iter()
                     .map(|tx| tx.recover_signer().map_err(Eth::Error::from_eth_err))
                     .collect::<Result<Vec<_>, _>>()?
-                    .into_iter()
-                    .collect()
             } else {
                 block
                     .body()
@@ -178,8 +176,6 @@ where
                     .iter()
                     .map(|tx| tx.recover_signer_unchecked().map_err(Eth::Error::from_eth_err))
                     .collect::<Result<Vec<_>, _>>()?
-                    .into_iter()
-                    .collect()
             };
 
         self.trace_block(Arc::new(block.into_recovered_with_signers(senders)), evm_env, opts).await


### PR DESCRIPTION
Remove the redundant `.into_iter().collect()` in `debug_trace_raw_block`; the first `collect::<Result<Vec<_>, _>>()?` already returns the required `Vec` of signer addresses, so looping again only re-allocates the same data. Dropping it keeps the tracing logic untouched while trimming unnecessary work.