### PR TITLE
fix: accurate build features reporting in `reth --version`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -371,7 +371,7 @@ reth-era-utils = { path = "crates/era-utils" }
 reth-errors = { path = "crates/errors" }
 reth-eth-wire = { path = "crates/net/eth-wire" }
 reth-eth-wire-types = { path = "crates/net/eth-wire-types" }
-reth-ethereum-cli = { path = "crates/ethereum/cli" }
+reth-ethereum-cli = { path = "crates/ethereum/cli", default-features = false }
 reth-ethereum-consensus = { path = "crates/ethereum/consensus", default-features = false }
 reth-ethereum-engine-primitives = { path = "crates/ethereum/engine-primitives", default-features = false }
 reth-ethereum-forks = { path = "crates/ethereum/hardforks", default-features = false }
@@ -412,7 +412,7 @@ reth-optimism-node = { path = "crates/optimism/node" }
 reth-node-types = { path = "crates/node/types" }
 reth-op = { path = "crates/optimism/reth", default-features = false }
 reth-optimism-chainspec = { path = "crates/optimism/chainspec", default-features = false }
-reth-optimism-cli = { path = "crates/optimism/cli" }
+reth-optimism-cli = { path = "crates/optimism/cli", default-features = false }
 reth-optimism-consensus = { path = "crates/optimism/consensus", default-features = false }
 reth-optimism-forks = { path = "crates/optimism/hardforks", default-features = false }
 reth-optimism-payload-builder = { path = "crates/optimism/payload" }

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -28,7 +28,7 @@ workspace = true
 
 [dependencies]
 # reth
-reth-ethereum-cli = { workspace = true, default-features = false }
+reth-ethereum-cli.workspace = true
 reth-chainspec.workspace = true
 reth-primitives.workspace = true
 reth-db = { workspace = true, features = ["mdbx"] }

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -28,7 +28,7 @@ workspace = true
 
 [dependencies]
 # reth
-reth-ethereum-cli.workspace = true
+reth-ethereum-cli = { workspace = true, default-features = false }
 reth-chainspec.workspace = true
 reth-primitives.workspace = true
 reth-db = { workspace = true, features = ["mdbx"] }
@@ -81,7 +81,9 @@ backon.workspace = true
 tempfile.workspace = true
 
 [features]
-default = ["jemalloc", "reth-revm/portable"]
+default = ["jemalloc", "otlp", "reth-revm/portable"]
+
+otlp = ["reth-ethereum-cli/otlp"]
 
 dev = ["reth-ethereum-cli/dev"]
 

--- a/crates/ethereum/cli/Cargo.toml
+++ b/crates/ethereum/cli/Cargo.toml
@@ -35,7 +35,7 @@ tracing.workspace = true
 tempfile.workspace = true
 
 [features]
-default = ["jemalloc", "otlp"]
+default = []
 
 otlp = ["reth-tracing/otlp", "reth-node-core/otlp"]
 

--- a/crates/node/core/build.rs
+++ b/crates/node/core/build.rs
@@ -73,9 +73,29 @@ fn main() -> Result<(), Box<dyn Error>> {
         "cargo:rustc-env=RETH_LONG_VERSION_2=Build Timestamp: {}",
         env::var("VERGEN_BUILD_TIMESTAMP")?
     );
+    // Collect enabled features for this crate using CARGO_FEATURE_* env vars
+    // This is more accurate than VERGEN_CARGO_FEATURES for the actual build
+    let mut features = Vec::new();
+    
+    if env::var("CARGO_FEATURE_JEMALLOC").is_ok() {
+        features.push("jemalloc");
+    }
+    if env::var("CARGO_FEATURE_ASM_KECCAK").is_ok() {
+        features.push("asm-keccak");
+    }
+    if env::var("CARGO_FEATURE_OTLP").is_ok() {
+        features.push("otlp");
+    }
+    
+    let features_str = if features.is_empty() {
+        String::from("none")
+    } else {
+        features.join(",")
+    };
+    
     println!(
         "cargo:rustc-env=RETH_LONG_VERSION_3=Build Features: {}",
-        env::var("VERGEN_CARGO_FEATURES")?
+        features_str
     );
     println!("cargo:rustc-env=RETH_LONG_VERSION_4=Build Profile: {profile}");
 

--- a/crates/node/core/build.rs
+++ b/crates/node/core/build.rs
@@ -73,23 +73,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         "cargo:rustc-env=RETH_LONG_VERSION_2=Build Timestamp: {}",
         env::var("VERGEN_BUILD_TIMESTAMP")?
     );
-    // Collect enabled features for this crate using CARGO_FEATURE_* env vars
-    // This is more accurate than VERGEN_CARGO_FEATURES for the actual build
-    let mut features = Vec::new();
-
-    if env::var("CARGO_FEATURE_JEMALLOC").is_ok() {
-        features.push("jemalloc");
-    }
-    if env::var("CARGO_FEATURE_ASM_KECCAK").is_ok() {
-        features.push("asm-keccak");
-    }
-    if env::var("CARGO_FEATURE_OTLP").is_ok() {
-        features.push("otlp");
-    }
-
-    let features_str = if features.is_empty() { String::from("none") } else { features.join(",") };
-
-    println!("cargo:rustc-env=RETH_LONG_VERSION_3=Build Features: {}", features_str);
+    println!(
+        "cargo:rustc-env=RETH_LONG_VERSION_3=Build Features: {}",
+        env::var("VERGEN_CARGO_FEATURES")?
+    );
     println!("cargo:rustc-env=RETH_LONG_VERSION_4=Build Profile: {profile}");
 
     // The version information for reth formatted for P2P (devp2p).

--- a/crates/node/core/build.rs
+++ b/crates/node/core/build.rs
@@ -76,7 +76,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Collect enabled features for this crate using CARGO_FEATURE_* env vars
     // This is more accurate than VERGEN_CARGO_FEATURES for the actual build
     let mut features = Vec::new();
-    
+
     if env::var("CARGO_FEATURE_JEMALLOC").is_ok() {
         features.push("jemalloc");
     }
@@ -86,17 +86,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     if env::var("CARGO_FEATURE_OTLP").is_ok() {
         features.push("otlp");
     }
-    
-    let features_str = if features.is_empty() {
-        String::from("none")
-    } else {
-        features.join(",")
-    };
-    
-    println!(
-        "cargo:rustc-env=RETH_LONG_VERSION_3=Build Features: {}",
-        features_str
-    );
+
+    let features_str = if features.is_empty() { String::from("none") } else { features.join(",") };
+
+    println!("cargo:rustc-env=RETH_LONG_VERSION_3=Build Features: {}", features_str);
     println!("cargo:rustc-env=RETH_LONG_VERSION_4=Build Profile: {profile}");
 
     // The version information for reth formatted for P2P (devp2p).

--- a/crates/optimism/bin/Cargo.toml
+++ b/crates/optimism/bin/Cargo.toml
@@ -10,7 +10,7 @@ exclude.workspace = true
 
 [dependencies]
 reth-cli-util.workspace = true
-reth-optimism-cli.workspace = true
+reth-optimism-cli = { workspace = true, default-features = false }
 reth-optimism-rpc.workspace = true
 reth-optimism-node = { workspace = true, features = ["js-tracer"] }
 reth-optimism-chainspec.workspace = true
@@ -27,7 +27,9 @@ tracing.workspace = true
 workspace = true
 
 [features]
-default = ["jemalloc", "reth-optimism-evm/portable"]
+default = ["jemalloc", "otlp", "reth-optimism-evm/portable"]
+
+otlp = ["reth-optimism-cli/otlp"]
 
 jemalloc = ["reth-cli-util/jemalloc", "reth-optimism-cli/jemalloc"]
 jemalloc-prof = ["reth-cli-util/jemalloc-prof"]

--- a/crates/optimism/bin/Cargo.toml
+++ b/crates/optimism/bin/Cargo.toml
@@ -10,7 +10,7 @@ exclude.workspace = true
 
 [dependencies]
 reth-cli-util.workspace = true
-reth-optimism-cli = { workspace = true, default-features = false }
+reth-optimism-cli.workspace = true
 reth-optimism-rpc.workspace = true
 reth-optimism-node = { workspace = true, features = ["js-tracer"] }
 reth-optimism-chainspec.workspace = true

--- a/crates/optimism/cli/Cargo.toml
+++ b/crates/optimism/cli/Cargo.toml
@@ -74,7 +74,7 @@ reth-stages = { workspace = true, features = ["test-utils"] }
 reth-optimism-chainspec = { workspace = true, features = ["std", "superchain-configs"] }
 
 [features]
-default = ["otlp"]
+default = []
 
 # Opentelemtry feature to activate metrics export
 otlp = ["reth-tracing/otlp", "reth-node-core/otlp"]


### PR DESCRIPTION
Replace `VERGEN_CARGO_FEATURES` with direct checks of `CARGO_FEATURE_*` environment variables. Accurate reporting of features actually enabled for the crate being built.

Fixes #19123