### PR TITLE
perf(storage): optimize wiped storage entry collection to avoid Vec allocation

### DIFF
--- a/crates/storage/provider/src/changesets_utils/mod.rs
+++ b/crates/storage/provider/src/changesets_utils/mod.rs
@@ -1,7 +1,7 @@
 //! This module contains helpful utilities related to populating changesets tables.
 
 mod state_reverts;
-pub use state_reverts::StorageRevertsIter;
+pub use state_reverts::*;
 
 mod trie;
 pub use trie::*;


### PR DESCRIPTION
Resolves #19077

Refactored the implementation to use a streaming iterator approach that processes wiped storage entries directly from the database cursor without intermediate collection. Key changes:

Added `StorageWipedEntriesIter`: A new iterator that yields wiped storage entries on-demand from the database cursor

Integrated with `StorageRevertsIter`: Combined with existing reverts processing for efficient merging
