### PR TITLE
refactor: extract gas calculation logic in re-execute command

### DIFF
--- a/crates/cli/commands/src/re_execute.rs
+++ b/crates/cli/commands/src/re_execute.rs
@@ -114,14 +114,14 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                             .ok_or_else(|| eyre::eyre!("receipts for block {} not found", block.number()))?;
 
                         // Helper function to calculate gas used for a specific transaction
-                        let calculate_gas_used = |receipts: &[_], index: usize| -> u64 {
+                          fn calculate_gas_used(receipts: &[impl TxReceipt], index: usize) -> u64 {
                             let prev_gas = if index == 0 {
                                 0
                             } else {
                                 receipts[index - 1].cumulative_gas_used()
                             };
                             receipts[index].cumulative_gas_used() - prev_gas
-                        };
+                        }
                         
                         for (i, (receipt, correct_receipt)) in
                             result.receipts.iter().zip(correct_receipts.iter()).enumerate()

--- a/crates/cli/commands/src/re_execute.rs
+++ b/crates/cli/commands/src/re_execute.rs
@@ -106,12 +106,13 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                     let result = executor.execute_one(&block)?;
 
                     if let Err(err) = consensus
-                        .validate_block_post_execution(&block, &result)
+                        .validate_block_post_execution(&block, &result);
                         .wrap_err_with(|| format!("Failed to validate block {}", block.number()))
                     {
-                        let correct_receipts = provider_factory
-                            .receipts_by_block(block.number().into())?
-                            .ok_or_else(|| eyre::eyre!("receipts for block {} not found", block.number()))?;
+                        let correct_receipts =
+                            provider_factory.receipts_by_block(block.number().into())?.ok_or_else(
+                                || eyre::eyre!("receipts for block {} not found", block.number()),
+                            )?;
 
                         // Helper function to calculate gas used for a specific transaction
                         fn calculate_gas_used(receipts: &[impl TxReceipt], index: usize) -> u64 {

--- a/crates/cli/commands/src/re_execute.rs
+++ b/crates/cli/commands/src/re_execute.rs
@@ -109,9 +109,20 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                         .validate_block_post_execution(&block, &result)
                         .wrap_err_with(|| format!("Failed to validate block {}", block.number()))
                     {
-                        let correct_receipts =
-                            provider_factory.receipts_by_block(block.number().into())?.unwrap();
+                        let correct_receipts = provider_factory
+                            .receipts_by_block(block.number().into())?
+                            .ok_or_else(|| eyre::eyre!("receipts for block {} not found", block.number()))?;
 
+                        // Helper function to calculate gas used for a specific transaction
+                        let calculate_gas_used = |receipts: &[_], index: usize| -> u64 {
+                            let prev_gas = if index == 0 {
+                                0
+                            } else {
+                                receipts[index - 1].cumulative_gas_used()
+                            };
+                            receipts[index].cumulative_gas_used() - prev_gas
+                        };
+                        
                         for (i, (receipt, correct_receipt)) in
                             result.receipts.iter().zip(correct_receipts.iter()).enumerate()
                         {
@@ -124,18 +135,8 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                                     ?tx_hash,
                                     "Invalid receipt"
                                 );
-                                let expected_gas_used = correct_receipt.cumulative_gas_used() -
-                                    if i == 0 {
-                                        0
-                                    } else {
-                                        correct_receipts[i - 1].cumulative_gas_used()
-                                    };
-                                let got_gas_used = receipt.cumulative_gas_used() -
-                                    if i == 0 {
-                                        0
-                                    } else {
-                                        result.receipts[i - 1].cumulative_gas_used()
-                                    };
+                                let expected_gas_used = calculate_gas_used(&correct_receipts, i);
+                                let got_gas_used = calculate_gas_used(&result.receipts, i);
                                 if got_gas_used != expected_gas_used {
                                     let mismatch = GotExpected {
                                         expected: expected_gas_used,

--- a/crates/cli/commands/src/re_execute.rs
+++ b/crates/cli/commands/src/re_execute.rs
@@ -114,7 +114,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                             .ok_or_else(|| eyre::eyre!("receipts for block {} not found", block.number()))?;
 
                         // Helper function to calculate gas used for a specific transaction
-                          fn calculate_gas_used(receipts: &[impl TxReceipt], index: usize) -> u64 {
+                        fn calculate_gas_used(receipts: &[impl TxReceipt], index: usize) -> u64 {
                             let prev_gas = if index == 0 {
                                 0
                             } else {


### PR DESCRIPTION
## Overview

Refactors duplicated gas calculation logic in the `re-execute` command by extracting it into a reusable helper closure.

## Why?
  - Eliminates code duplication
  - Improves maintainability - single source for gas calculation