### PR TITLE
fix: Remove duplicate debug log in write_blocks_to_rlp

### DIFF
--- a/crates/e2e-test-utils/src/test_rlp_utils.rs
+++ b/crates/e2e-test-utils/src/test_rlp_utils.rs
@@ -157,7 +157,6 @@ pub fn write_blocks_to_rlp(blocks: &[SealedBlock], path: &Path) -> std::io::Resu
         );
 
         // Debug: check what's in the encoded data
-        debug!(target: "e2e::import", "Block {} encoded to {} bytes", i, buf.len());
         if buf.len() < 20 {
             debug!(target: "e2e::import", "  Raw bytes: {:?}", &buf);
         } else {


### PR DESCRIPTION

### Description
- **What**: Remove a redundant `debug!` line that re-logs the encoded buffer size already included in the previous message.
- **Why**: Reduce log noise and minor formatting overhead in a hot loop without losing information.
