### PR TITLE
fix(engine): Eliminates spurious warning logs in prewarm task

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -165,10 +165,9 @@ where
                 handles.push(ctx.spawn_worker(i, &executor, actions_tx.clone(), done_tx.clone()));
             }
 
-            let mut tx_index = 0usize;
-
             // Distribute transactions to workers
-            for tx in core::iter::from_fn(|| pending.recv().ok()) {
+            let mut tx_index = 0usize;
+            while let Ok(tx) = pending.recv() {
                 // Stop distributing if termination was requested
                 if ctx.terminate_execution.load(Ordering::Relaxed) {
                     trace!(


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/19101

## Changes made

1. Fixes spurious warning logs issue
2. Reworked tx distribution code to improve readability

## Problem

The prewarm cache task was logging frequent warnings:
level=warn target=engine::tree::prewarm message="Failed to send transaction to worker"
task_idx=10 error="sending on a closed channel"

These warnings occur when the main block execution completes before the prewarm distribution thread finishes
sending all transactions to workers. This is expected behavior: workers check the `terminate_execution` flag and
exit early as an optimization when they're no longer needed.

## Root Cause

When main execution completes, it sends `TerminateTransactionExecution` to set the `terminate_execution` atomic
flag. Workers polling this flag exit their receive loops, dropping their channel receivers. The distribution
thread continues draining the `pending` channel and attempts to send to workers that have already exited,
resulting in `SendError`.

This race condition is by design - it allows workers to exit immediately when signaled rather than waiting for
all transactions to be distributed.

## Solution

**Two-part fix:**

1. **Add early termination check** in the distribution loop (line 172) - stops distributing transactions
immediately when `terminate_execution` is set

3. **Remove warning logs** for `SendError` (lines 190-194, 199-203) - replaced with comments explaining that
workers listen to `terminate_execution` and may exit early when signaled


ref #18892