### PR TITLE
chore: rm generic array dep from discv4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4013,7 +4013,6 @@ version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
- "serde",
  "typenum",
  "version_check",
  "zeroize",
@@ -7739,7 +7738,6 @@ dependencies = [
  "assert_matches",
  "discv5",
  "enr",
- "generic-array",
  "itertools 0.14.0",
  "parking_lot",
  "rand 0.8.5",

--- a/crates/net/discv4/Cargo.toml
+++ b/crates/net/discv4/Cargo.toml
@@ -35,7 +35,6 @@ tracing.workspace = true
 thiserror.workspace = true
 parking_lot.workspace = true
 rand_08 = { workspace = true, optional = true }
-generic-array.workspace = true
 serde = { workspace = true, optional = true }
 itertools.workspace = true
 
@@ -53,7 +52,6 @@ serde = [
     "alloy-primitives/serde",
     "discv5/serde",
     "enr/serde",
-    "generic-array/serde",
     "parking_lot/serde",
     "rand_08?/serde",
     "secp256k1/serde",

--- a/crates/net/discv4/src/node.rs
+++ b/crates/net/discv4/src/node.rs
@@ -1,5 +1,4 @@
 use alloy_primitives::keccak256;
-use generic_array::GenericArray;
 use reth_network_peers::{NodeRecord, PeerId};
 
 /// The key type for the table.
@@ -15,8 +14,7 @@ impl From<PeerId> for NodeKey {
 impl From<NodeKey> for discv5::Key<NodeKey> {
     fn from(value: NodeKey) -> Self {
         let hash = keccak256(value.0.as_slice());
-        let hash = *GenericArray::from_slice(hash.as_slice());
-        Self::new_raw(value, hash)
+        Self::new_raw(value, hash.0.into())
     }
 }
 


### PR DESCRIPTION
genericarray 0.* is deprecated but we can only move to 1.0 once all other deps moved to it

however we can get rid of this import here and instead invoke the into conversion directly because

> Struct representing a generic array - GenericArray<T, N> works like [T; N]