### PR TITLE
fix(prune): Disable pruning limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9795,7 +9795,6 @@ dependencies = [
  "itertools 0.14.0",
  "metrics",
  "rayon",
- "reth-chainspec",
  "reth-config",
  "reth-db",
  "reth-db-api",

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -421,8 +421,6 @@ impl<R, ChainSpec: EthChainSpec> LaunchContextWith<Attached<WithConfigs<ChainSpe
         ChainSpec: reth_chainspec::EthereumHardforks,
     {
         PrunerBuilder::new(self.prune_config().unwrap_or_default())
-            .delete_limit(self.chain_spec().prune_delete_limit())
-            .timeout(PrunerBuilder::DEFAULT_TIMEOUT)
     }
 
     /// Loads the JWT secret for the engine API

--- a/crates/prune/prune/Cargo.toml
+++ b/crates/prune/prune/Cargo.toml
@@ -13,7 +13,6 @@ workspace = true
 
 [dependencies]
 # reth
-reth-chainspec.workspace = true
 reth-exex-types.workspace = true
 reth-db-api.workspace = true
 reth-errors.workspace = true

--- a/crates/prune/prune/src/builder.rs
+++ b/crates/prune/prune/src/builder.rs
@@ -1,6 +1,5 @@
 use crate::{segments::SegmentSet, Pruner};
 use alloy_eips::eip2718::Encodable2718;
-use reth_chainspec::MAINNET_PRUNE_DELETE_LIMIT;
 use reth_config::PruneConfig;
 use reth_db_api::{table::Value, transaction::DbTxMut};
 use reth_exex_types::FinishedExExHeight;
@@ -132,7 +131,7 @@ impl Default for PrunerBuilder {
         Self {
             block_interval: 5,
             segments: PruneModes::default(),
-            delete_limit: MAINNET_PRUNE_DELETE_LIMIT,
+            delete_limit: usize::MAX,
             timeout: None,
             finished_exex_height: watch::channel(FinishedExExHeight::NoExExs).1,
         }

--- a/crates/prune/prune/src/builder.rs
+++ b/crates/prune/prune/src/builder.rs
@@ -30,9 +30,6 @@ pub struct PrunerBuilder {
 }
 
 impl PrunerBuilder {
-    /// Default timeout for a prune run.
-    pub const DEFAULT_TIMEOUT: Duration = Duration::from_millis(100);
-
     /// Creates a new [`PrunerBuilder`] from the given [`PruneConfig`].
     pub fn new(pruner_config: PruneConfig) -> Self {
         Self::default()


### PR DESCRIPTION
This PR disables the limits imposed in the Engine API on the Pruner. With the new Accounts/StoragesChangeSets tables the pruner was no longer able to complete all work within the normal limits, so we would have had to raise them. In reality these limits are not really necessary anymore, as pruning happens asynchronously to block processing and so should always be let run to completion.