### PR TITLE
feat(e2e): add builder API for configuring test node setups

### DIFF
--- a/crates/e2e-test-utils/src/lib.rs
+++ b/crates/e2e-test-utils/src/lib.rs
@@ -57,15 +57,10 @@ where
     LocalPayloadAttributesBuilder<N::ChainSpec>:
         PayloadAttributesBuilder<<<N as NodeTypes>::Payload as PayloadTypes>::PayloadAttributes>,
 {
-    E2ETestSetupBuilder::new(
-        num_nodes,
-        chain_spec,
-        is_dev,
-        reth_node_api::TreeConfig::default(),
-        attributes_generator,
-    )
-    .build()
-    .await
+    E2ETestSetupBuilder::new(num_nodes, chain_spec, attributes_generator)
+        .with_node_config_modifier(move |config| config.set_dev(is_dev))
+        .build()
+        .await
 }
 
 /// Creates the initial setup with `num_nodes` started and interconnected.
@@ -114,7 +109,9 @@ where
     LocalPayloadAttributesBuilder<N::ChainSpec>:
         PayloadAttributesBuilder<<N::Payload as PayloadTypes>::PayloadAttributes>,
 {
-    E2ETestSetupBuilder::new(num_nodes, chain_spec, is_dev, tree_config, attributes_generator)
+    E2ETestSetupBuilder::new(num_nodes, chain_spec, attributes_generator)
+        .with_tree_config_modifier(move |_| tree_config.clone())
+        .with_node_config_modifier(move |config| config.set_dev(is_dev))
         .with_connect_nodes(connect_nodes)
         .build()
         .await

--- a/crates/e2e-test-utils/src/lib.rs
+++ b/crates/e2e-test-utils/src/lib.rs
@@ -1,23 +1,19 @@
 //! Utilities for end-to-end tests.
 
 use node::NodeTestContext;
-use reth_chainspec::{ChainSpec, EthChainSpec};
+use reth_chainspec::ChainSpec;
 use reth_db::{test_utils::TempDatabase, DatabaseEnv};
 use reth_engine_local::LocalPayloadAttributesBuilder;
 use reth_network_api::test_utils::PeersHandleProvider;
 use reth_node_builder::{
     components::NodeComponentsBuilder,
     rpc::{EngineValidatorAddOn, RethRpcAddOns},
-    EngineNodeLauncher, FullNodeTypesAdapter, Node, NodeAdapter, NodeBuilder, NodeComponents,
-    NodeConfig, NodeHandle, NodePrimitives, NodeTypes, NodeTypesWithDBAdapter,
-    PayloadAttributesBuilder, PayloadTypes,
+    FullNodeTypesAdapter, Node, NodeAdapter, NodeComponents, NodePrimitives, NodeTypes,
+    NodeTypesWithDBAdapter, PayloadAttributesBuilder, PayloadTypes,
 };
-use reth_node_core::args::{DiscoveryArgs, NetworkArgs, RpcServerArgs};
 use reth_provider::providers::{BlockchainProvider, NodeTypesForProvider};
-use reth_rpc_server_types::RpcModuleSelection;
 use reth_tasks::TaskManager;
 use std::sync::Arc;
-use tracing::{span, Level};
 use wallet::Wallet;
 
 /// Wrapper type to create test nodes
@@ -45,6 +41,10 @@ mod rpc;
 /// Utilities for creating and writing RLP test data
 pub mod test_rlp_utils;
 
+/// Builder for configuring test node setups
+mod setup_builder;
+pub use setup_builder::E2ETestSetupBuilder;
+
 /// Creates the initial setup with `num_nodes` started and interconnected.
 pub async fn setup<N>(
     num_nodes: usize,
@@ -53,60 +53,19 @@ pub async fn setup<N>(
     attributes_generator: impl Fn(u64) -> <<N as NodeTypes>::Payload as PayloadTypes>::PayloadBuilderAttributes + Send + Sync + Copy + 'static,
 ) -> eyre::Result<(Vec<NodeHelperType<N>>, TaskManager, Wallet)>
 where
-    N: Default + Node<TmpNodeAdapter<N>> + NodeTypesForProvider,
-    N::ComponentsBuilder: NodeComponentsBuilder<
-        TmpNodeAdapter<N>,
-        Components: NodeComponents<TmpNodeAdapter<N>, Network: PeersHandleProvider>,
-    >,
-    N::AddOns: RethRpcAddOns<Adapter<N>> + EngineValidatorAddOn<Adapter<N>>,
+    N: NodeBuilderHelper,
     LocalPayloadAttributesBuilder<N::ChainSpec>:
         PayloadAttributesBuilder<<<N as NodeTypes>::Payload as PayloadTypes>::PayloadAttributes>,
 {
-    let tasks = TaskManager::current();
-    let exec = tasks.executor();
-
-    let network_config = NetworkArgs {
-        discovery: DiscoveryArgs { disable_discovery: true, ..DiscoveryArgs::default() },
-        ..NetworkArgs::default()
-    };
-
-    // Create nodes and peer them
-    let mut nodes: Vec<NodeTestContext<_, _>> = Vec::with_capacity(num_nodes);
-
-    for idx in 0..num_nodes {
-        let node_config = NodeConfig::new(chain_spec.clone())
-            .with_network(network_config.clone())
-            .with_unused_ports()
-            .with_rpc(RpcServerArgs::default().with_unused_ports().with_http())
-            .set_dev(is_dev);
-
-        let span = span!(Level::INFO, "node", idx);
-        let _enter = span.enter();
-        let NodeHandle { node, node_exit_future: _ } = NodeBuilder::new(node_config.clone())
-            .testing_node(exec.clone())
-            .node(Default::default())
-            .launch()
-            .await?;
-
-        let mut node = NodeTestContext::new(node, attributes_generator).await?;
-
-        // Connect each node in a chain.
-        if let Some(previous_node) = nodes.last_mut() {
-            previous_node.connect(&mut node).await;
-        }
-
-        // Connect last node with the first if there are more than two
-        if idx + 1 == num_nodes &&
-            num_nodes > 2 &&
-            let Some(first_node) = nodes.first_mut()
-        {
-            node.connect(first_node).await;
-        }
-
-        nodes.push(node);
-    }
-
-    Ok((nodes, tasks, Wallet::default().with_chain_id(chain_spec.chain().into())))
+    E2ETestSetupBuilder::new(
+        num_nodes,
+        chain_spec,
+        is_dev,
+        reth_node_api::TreeConfig::default(),
+        attributes_generator,
+    )
+    .build()
+    .await
 }
 
 /// Creates the initial setup with `num_nodes` started and interconnected.
@@ -155,71 +114,10 @@ where
     LocalPayloadAttributesBuilder<N::ChainSpec>:
         PayloadAttributesBuilder<<N::Payload as PayloadTypes>::PayloadAttributes>,
 {
-    let tasks = TaskManager::current();
-    let exec = tasks.executor();
-
-    let network_config = NetworkArgs {
-        discovery: DiscoveryArgs { disable_discovery: true, ..DiscoveryArgs::default() },
-        ..NetworkArgs::default()
-    };
-
-    // Create nodes and peer them
-    let mut nodes: Vec<NodeTestContext<_, _>> = Vec::with_capacity(num_nodes);
-
-    for idx in 0..num_nodes {
-        let node_config = NodeConfig::new(chain_spec.clone())
-            .with_network(network_config.clone())
-            .with_unused_ports()
-            .with_rpc(
-                RpcServerArgs::default()
-                    .with_unused_ports()
-                    .with_http()
-                    .with_http_api(RpcModuleSelection::All),
-            )
-            .set_dev(is_dev);
-
-        let span = span!(Level::INFO, "node", idx);
-        let _enter = span.enter();
-        let node = N::default();
-        let NodeHandle { node, node_exit_future: _ } = NodeBuilder::new(node_config.clone())
-            .testing_node(exec.clone())
-            .with_types_and_provider::<N, BlockchainProvider<_>>()
-            .with_components(node.components_builder())
-            .with_add_ons(node.add_ons())
-            .launch_with_fn(|builder| {
-                let launcher = EngineNodeLauncher::new(
-                    builder.task_executor().clone(),
-                    builder.config().datadir(),
-                    tree_config.clone(),
-                );
-                builder.launch_with(launcher)
-            })
-            .await?;
-
-        let mut node = NodeTestContext::new(node, attributes_generator).await?;
-
-        let genesis = node.block_hash(0);
-        node.update_forkchoice(genesis, genesis).await?;
-
-        // Connect each node in a chain if requested.
-        if connect_nodes {
-            if let Some(previous_node) = nodes.last_mut() {
-                previous_node.connect(&mut node).await;
-            }
-
-            // Connect last node with the first if there are more than two
-            if idx + 1 == num_nodes &&
-                num_nodes > 2 &&
-                let Some(first_node) = nodes.first_mut()
-            {
-                node.connect(first_node).await;
-            }
-        }
-
-        nodes.push(node);
-    }
-
-    Ok((nodes, tasks, Wallet::default().with_chain_id(chain_spec.chain().into())))
+    E2ETestSetupBuilder::new(num_nodes, chain_spec, is_dev, tree_config, attributes_generator)
+        .with_connect_nodes(connect_nodes)
+        .build()
+        .await
 }
 
 // Type aliases

--- a/crates/e2e-test-utils/src/setup_builder.rs
+++ b/crates/e2e-test-utils/src/setup_builder.rs
@@ -42,8 +42,6 @@ where
 {
     num_nodes: usize,
     chain_spec: Arc<N::ChainSpec>,
-    is_dev: bool,
-    tree_config: reth_node_api::TreeConfig,
     attributes_generator: F,
     connect_nodes: bool,
     tree_config_modifier: Option<TreeConfigModifier>,
@@ -62,18 +60,10 @@ where
         PayloadAttributesBuilder<<N::Payload as PayloadTypes>::PayloadAttributes>,
 {
     /// Creates a new builder with the required parameters.
-    pub fn new(
-        num_nodes: usize,
-        chain_spec: Arc<N::ChainSpec>,
-        is_dev: bool,
-        tree_config: reth_node_api::TreeConfig,
-        attributes_generator: F,
-    ) -> Self {
+    pub fn new(num_nodes: usize, chain_spec: Arc<N::ChainSpec>, attributes_generator: F) -> Self {
         Self {
             num_nodes,
             chain_spec,
-            is_dev,
-            tree_config,
             attributes_generator,
             connect_nodes: true,
             tree_config_modifier: None,
@@ -127,9 +117,9 @@ where
 
         // Apply tree config modifier if present
         let tree_config = if let Some(modifier) = self.tree_config_modifier {
-            modifier(self.tree_config)
+            modifier(reth_node_api::TreeConfig::default())
         } else {
-            self.tree_config
+            reth_node_api::TreeConfig::default()
         };
 
         let mut nodes: Vec<NodeTestContext<_, _>> = Vec::with_capacity(self.num_nodes);
@@ -144,8 +134,7 @@ where
                         .with_unused_ports()
                         .with_http()
                         .with_http_api(RpcModuleSelection::All),
-                )
-                .set_dev(self.is_dev);
+                );
 
             // Apply node config modifier if present
             let node_config = if let Some(modifier) = &self.node_config_modifier {
@@ -213,7 +202,6 @@ where
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("E2ETestSetupBuilder")
             .field("num_nodes", &self.num_nodes)
-            .field("is_dev", &self.is_dev)
             .field("connect_nodes", &self.connect_nodes)
             .field("tree_config_modifier", &self.tree_config_modifier.as_ref().map(|_| "<closure>"))
             .field("node_config_modifier", &self.node_config_modifier.as_ref().map(|_| "<closure>"))

--- a/crates/e2e-test-utils/src/setup_builder.rs
+++ b/crates/e2e-test-utils/src/setup_builder.rs
@@ -1,0 +1,222 @@
+//! Builder for configuring and creating test node setups.
+//!
+//! This module provides a flexible builder API for setting up test nodes with custom
+//! configurations through closures that modify `NodeConfig` and `TreeConfig`.
+
+use crate::{node::NodeTestContext, wallet::Wallet, NodeBuilderHelper, NodeHelperType, TmpDB};
+use reth_chainspec::EthChainSpec;
+use reth_engine_local::LocalPayloadAttributesBuilder;
+use reth_node_builder::{
+    EngineNodeLauncher, NodeBuilder, NodeConfig, NodeHandle, NodeTypes, NodeTypesWithDBAdapter,
+    PayloadAttributesBuilder, PayloadTypes,
+};
+use reth_node_core::args::{DiscoveryArgs, NetworkArgs, RpcServerArgs};
+use reth_provider::providers::BlockchainProvider;
+use reth_rpc_server_types::RpcModuleSelection;
+use reth_tasks::TaskManager;
+use std::sync::Arc;
+use tracing::{span, Level};
+
+/// Type alias for tree config modifier closure
+type TreeConfigModifier =
+    Box<dyn Fn(reth_node_api::TreeConfig) -> reth_node_api::TreeConfig + Send + Sync>;
+
+/// Type alias for node config modifier closure
+type NodeConfigModifier<C> = Box<dyn Fn(NodeConfig<C>) -> NodeConfig<C> + Send + Sync>;
+
+/// Builder for configuring and creating test node setups.
+///
+/// This builder allows customizing test node configurations through closures that
+/// modify `NodeConfig` and `TreeConfig`. It avoids code duplication by centralizing
+/// the node creation logic.
+pub struct E2ETestSetupBuilder<N, F>
+where
+    N: NodeBuilderHelper,
+    F: Fn(u64) -> <<N as NodeTypes>::Payload as PayloadTypes>::PayloadBuilderAttributes
+        + Send
+        + Sync
+        + Copy
+        + 'static,
+    LocalPayloadAttributesBuilder<N::ChainSpec>:
+        PayloadAttributesBuilder<<N::Payload as PayloadTypes>::PayloadAttributes>,
+{
+    num_nodes: usize,
+    chain_spec: Arc<N::ChainSpec>,
+    is_dev: bool,
+    tree_config: reth_node_api::TreeConfig,
+    attributes_generator: F,
+    connect_nodes: bool,
+    tree_config_modifier: Option<TreeConfigModifier>,
+    node_config_modifier: Option<NodeConfigModifier<N::ChainSpec>>,
+}
+
+impl<N, F> E2ETestSetupBuilder<N, F>
+where
+    N: NodeBuilderHelper,
+    F: Fn(u64) -> <<N as NodeTypes>::Payload as PayloadTypes>::PayloadBuilderAttributes
+        + Send
+        + Sync
+        + Copy
+        + 'static,
+    LocalPayloadAttributesBuilder<N::ChainSpec>:
+        PayloadAttributesBuilder<<N::Payload as PayloadTypes>::PayloadAttributes>,
+{
+    /// Creates a new builder with the required parameters.
+    pub fn new(
+        num_nodes: usize,
+        chain_spec: Arc<N::ChainSpec>,
+        is_dev: bool,
+        tree_config: reth_node_api::TreeConfig,
+        attributes_generator: F,
+    ) -> Self {
+        Self {
+            num_nodes,
+            chain_spec,
+            is_dev,
+            tree_config,
+            attributes_generator,
+            connect_nodes: true,
+            tree_config_modifier: None,
+            node_config_modifier: None,
+        }
+    }
+
+    /// Sets whether nodes should be interconnected (default: true).
+    pub const fn with_connect_nodes(mut self, connect_nodes: bool) -> Self {
+        self.connect_nodes = connect_nodes;
+        self
+    }
+
+    /// Sets a modifier function for the tree configuration.
+    ///
+    /// The closure receives the base tree config and returns a modified version.
+    pub fn with_tree_config_modifier<G>(mut self, modifier: G) -> Self
+    where
+        G: Fn(reth_node_api::TreeConfig) -> reth_node_api::TreeConfig + Send + Sync + 'static,
+    {
+        self.tree_config_modifier = Some(Box::new(modifier));
+        self
+    }
+
+    /// Sets a modifier function for the node configuration.
+    ///
+    /// The closure receives the base node config and returns a modified version.
+    pub fn with_node_config_modifier<G>(mut self, modifier: G) -> Self
+    where
+        G: Fn(NodeConfig<N::ChainSpec>) -> NodeConfig<N::ChainSpec> + Send + Sync + 'static,
+    {
+        self.node_config_modifier = Some(Box::new(modifier));
+        self
+    }
+
+    /// Builds and launches the test nodes.
+    pub async fn build(
+        self,
+    ) -> eyre::Result<(
+        Vec<NodeHelperType<N, BlockchainProvider<NodeTypesWithDBAdapter<N, TmpDB>>>>,
+        TaskManager,
+        Wallet,
+    )> {
+        let tasks = TaskManager::current();
+        let exec = tasks.executor();
+
+        let network_config = NetworkArgs {
+            discovery: DiscoveryArgs { disable_discovery: true, ..DiscoveryArgs::default() },
+            ..NetworkArgs::default()
+        };
+
+        // Apply tree config modifier if present
+        let tree_config = if let Some(modifier) = self.tree_config_modifier {
+            modifier(self.tree_config)
+        } else {
+            self.tree_config
+        };
+
+        let mut nodes: Vec<NodeTestContext<_, _>> = Vec::with_capacity(self.num_nodes);
+
+        for idx in 0..self.num_nodes {
+            // Create base node config
+            let base_config = NodeConfig::new(self.chain_spec.clone())
+                .with_network(network_config.clone())
+                .with_unused_ports()
+                .with_rpc(
+                    RpcServerArgs::default()
+                        .with_unused_ports()
+                        .with_http()
+                        .with_http_api(RpcModuleSelection::All),
+                )
+                .set_dev(self.is_dev);
+
+            // Apply node config modifier if present
+            let node_config = if let Some(modifier) = &self.node_config_modifier {
+                modifier(base_config)
+            } else {
+                base_config
+            };
+
+            let span = span!(Level::INFO, "node", idx);
+            let _enter = span.enter();
+            let node = N::default();
+            let NodeHandle { node, node_exit_future: _ } = NodeBuilder::new(node_config)
+                .testing_node(exec.clone())
+                .with_types_and_provider::<N, BlockchainProvider<_>>()
+                .with_components(node.components_builder())
+                .with_add_ons(node.add_ons())
+                .launch_with_fn(|builder| {
+                    let launcher = EngineNodeLauncher::new(
+                        builder.task_executor().clone(),
+                        builder.config().datadir(),
+                        tree_config.clone(),
+                    );
+                    builder.launch_with(launcher)
+                })
+                .await?;
+
+            let mut node = NodeTestContext::new(node, self.attributes_generator).await?;
+
+            let genesis = node.block_hash(0);
+            node.update_forkchoice(genesis, genesis).await?;
+
+            // Connect nodes if requested
+            if self.connect_nodes {
+                if let Some(previous_node) = nodes.last_mut() {
+                    previous_node.connect(&mut node).await;
+                }
+
+                // Connect last node with the first if there are more than two
+                if idx + 1 == self.num_nodes &&
+                    self.num_nodes > 2 &&
+                    let Some(first_node) = nodes.first_mut()
+                {
+                    node.connect(first_node).await;
+                }
+            }
+
+            nodes.push(node);
+        }
+
+        Ok((nodes, tasks, Wallet::default().with_chain_id(self.chain_spec.chain().into())))
+    }
+}
+
+impl<N, F> std::fmt::Debug for E2ETestSetupBuilder<N, F>
+where
+    N: NodeBuilderHelper,
+    F: Fn(u64) -> <<N as NodeTypes>::Payload as PayloadTypes>::PayloadBuilderAttributes
+        + Send
+        + Sync
+        + Copy
+        + 'static,
+    LocalPayloadAttributesBuilder<N::ChainSpec>:
+        PayloadAttributesBuilder<<N::Payload as PayloadTypes>::PayloadAttributes>,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("E2ETestSetupBuilder")
+            .field("num_nodes", &self.num_nodes)
+            .field("is_dev", &self.is_dev)
+            .field("connect_nodes", &self.connect_nodes)
+            .field("tree_config_modifier", &self.tree_config_modifier.as_ref().map(|_| "<closure>"))
+            .field("node_config_modifier", &self.node_config_modifier.as_ref().map(|_| "<closure>"))
+            .finish_non_exhaustive()
+    }
+}

--- a/crates/e2e-test-utils/tests/e2e-testsuite/main.rs
+++ b/crates/e2e-test-utils/tests/e2e-testsuite/main.rs
@@ -369,18 +369,15 @@ async fn test_setup_builder_with_custom_tree_config() -> Result<()> {
             .build(),
     );
 
-    let (nodes, _tasks, _wallet) = E2ETestSetupBuilder::<EthereumNode, _>::new(
-        1,
-        chain_spec,
-        false,
-        TreeConfig::default(),
-        |_| EthPayloadBuilderAttributes::default(),
-    )
-    .with_tree_config_modifier(|config| {
-        config.with_persistence_threshold(0).with_memory_block_buffer_target(5)
-    })
-    .build()
-    .await?;
+    let (nodes, _tasks, _wallet) =
+        E2ETestSetupBuilder::<EthereumNode, _>::new(1, chain_spec, |_| {
+            EthPayloadBuilderAttributes::default()
+        })
+        .with_tree_config_modifier(|config| {
+            config.with_persistence_threshold(0).with_memory_block_buffer_target(5)
+        })
+        .build()
+        .await?;
 
     assert_eq!(nodes.len(), 1);
 


### PR DESCRIPTION
introduces a builder API that accepts closures to modify `TreeConfig` and `NodeConfig`, enabling configuration of settings like `persistence_threshold`. 

refactors `reth-e2e-test-utils` setup functions to use the builder internally, maintaining backward compatibility
