### PR TITLE
chore: rm high frequency otel-related debug logs

### DIFF
--- a/crates/tracing/src/layers.rs
+++ b/crates/tracing/src/layers.rs
@@ -20,12 +20,16 @@ pub(crate) type BoxedLayer<S> = Box<dyn Layer<S> + Send + Sync>;
 
 /// Default [directives](Directive) for [`EnvFilter`] which disables high-frequency debug logs from
 /// `hyper`, `hickory-resolver`, `jsonrpsee-server`, and `discv5`.
-const DEFAULT_ENV_FILTER_DIRECTIVES: [&str; 5] = [
+const DEFAULT_ENV_FILTER_DIRECTIVES: [&str; 9] = [
     "hyper::proto::h1=off",
     "hickory_resolver=off",
     "hickory_proto=off",
     "discv5=off",
     "jsonrpsee-server=off",
+    "opentelemetry-otlp=off",
+    "opentelemetry_sdk=off",
+    "opentelemetry-http=off",
+    "hyper_util::client::legacy::pool=off",
 ];
 
 /// Manages the collection of layers for a tracing subscriber.


### PR DESCRIPTION
This fills logs when using otlp:
```
2025-10-20T16:02:33.306994Z DEBUG hyper_util::client::legacy::pool: reuse idle connection for ("http", localhost:4318)
2025-10-20T16:02:33.307467Z DEBUG hyper_util::client::legacy::pool: pooling idle connection for ("http", localhost:4318)
2025-10-20T16:02:33.307529Z DEBUG opentelemetry-otlp:  name="HttpTracesClient.ExportSucceeded"
2025-10-20T16:02:33.490482Z DEBUG opentelemetry_sdk:  name="BatchSpanProcessor.ExportingDueToBatchSize"
2025-10-20T16:02:33.494964Z DEBUG opentelemetry-otlp:  name="HttpTracesClient.ExportStarted"
2025-10-20T16:02:33.494991Z DEBUG opentelemetry-http:  name="ReqwestBlockingClient.Send"
2025-10-20T16:02:33.495090Z DEBUG hyper_util::client::legacy::pool: reuse idle connection for ("http", localhost:4318)
2025-10-20T16:02:33.499093Z DEBUG hyper_util::client::legacy::pool: pooling idle connection for ("http", localhost:4318)
2025-10-20T16:02:33.499172Z DEBUG opentelemetry-otlp:  name="HttpTracesClient.ExportSucceeded"
2025-10-20T16:02:33.499441Z DEBUG opentelemetry-otlp:  name="HttpTracesClient.ExportStarted"
2025-10-20T16:02:33.499462Z DEBUG opentelemetry-http:  name="ReqwestBlockingClient.Send"
2025-10-20T16:02:33.499562Z DEBUG hyper_util::client::legacy::pool: reuse idle connection for ("http", localhost:4318)
2025-10-20T16:02:33.500366Z DEBUG hyper_util::client::legacy::pool: pooling idle connection for ("http", localhost:4318)
2025-10-20T16:02:33.500429Z DEBUG opentelemetry-otlp:  name="HttpTracesClient.ExportSucceeded"
2025-10-20T16:02:33.500455Z DEBUG opentelemetry_sdk:  name="BatchSpanProcessor.ExportingDueToBatchSize"
2025-10-20T16:02:33.500565Z DEBUG opentelemetry-otlp:  name="HttpTracesClient.ExportStarted"
2025-10-20T16:02:33.500580Z DEBUG opentelemetry-http:  name="ReqwestBlockingClient.Send"
2025-10-20T16:02:33.500638Z DEBUG hyper_util::client::legacy::pool: reuse idle connection for ("http", localhost:4318)
2025-10-20T16:02:33.501188Z DEBUG hyper_util::client::legacy::pool: pooling idle connection for ("http", localhost:4318)
2025-10-20T16:02:33.501246Z DEBUG opentelemetry-otlp:  name="HttpTracesClient.ExportSucceeded"
2025-10-20T16:02:33.700904Z DEBUG opentelemetry_sdk:  name="BatchSpanProcessor.ExportingDueToBatchSize"
2025-10-20T16:02:33.704963Z DEBUG opentelemetry-otlp:  name="HttpTracesClient.ExportStarted"
2025-10-20T16:02:33.704988Z DEBUG opentelemetry-http:  name="ReqwestBlockingClient.Send"
2025-10-20T16:02:33.705081Z DEBUG hyper_util::client::legacy::pool: reuse idle connection for ("http", localhost:4318)
2025-10-20T16:02:33.709150Z DEBUG hyper_util::client::legacy::pool: pooling idle connection for ("http", localhost:4318)
2025-10-20T16:02:33.709219Z DEBUG opentelemetry-otlp:  name="HttpTracesClient.ExportSucceeded"
2025-10-20T16:02:33.709475Z DEBUG opentelemetry-otlp:  name="HttpTracesClient.ExportStarted"
2025-10-20T16:02:33.709504Z DEBUG opentelemetry-http:  name="ReqwestBlockingClient.Send"
2025-10-20T16:02:33.709564Z DEBUG hyper_util::client::legacy::pool: reuse idle connection for ("http", localhost:4318)
2025-10-20T16:02:33.710317Z DEBUG hyper_util::client::legacy::pool: pooling idle connection for ("http", localhost:4318)
2025-10-20T16:02:33.710382Z DEBUG opentelemetry-otlp:  name="HttpTracesClient.ExportSucceeded"
2025-10-20T16:02:33.710412Z DEBUG opentelemetry_sdk:  name="BatchSpanProcessor.ExportingDueToBatchSize"
2025-10-20T16:02:33.710509Z DEBUG opentelemetry-otlp:  name="HttpTracesClient.ExportStarted"
2025-10-20T16:02:33.710524Z DEBUG opentelemetry-http:  name="ReqwestBlockingClient.Send"
2025-10-20T16:02:33.710579Z DEBUG hyper_util::client::legacy::pool: reuse idle connection for ("http", localhost:4318)
2025-10-20T16:02:33.711084Z DEBUG hyper_util::client::legacy::pool: pooling idle connection for ("http", localhost:4318)
```