### PR TITLE
fix(net): correct variable in test_peer_rotation assertion

### DIFF
--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -520,7 +520,7 @@ mod tests {
         fetcher.on_pending_disconnect(&first_peer);
         // first_peer now isn't idle, so we should get other peer
         let second_peer = fetcher.next_best_peer().unwrap();
-        assert!(first_peer == peer1 || first_peer == peer2);
+        assert!(second_peer == peer1 || second_peer == peer2);
         assert_ne!(first_peer, second_peer);
         // without idle peers, returns None
         fetcher.on_pending_disconnect(&second_peer);


### PR DESCRIPTION
Fix copy-paste bug in test_peer_rotation where second_peer assertion was incorrectly checking first_peer variable instead of second_peer. This test validates peer switching logic when one peer becomes unavailable, and the incorrect assertion could have masked real bugs in the peer selection algorithm.

https://github.com/paradigmxyz/reth/blob/main/crates/net/network/src/fetch/mod.rs#L518