### PR TITLE
chore: remove total difficulty from `HeaderProvider`

### DIFF
--- a/crates/cli/commands/src/init_state/without_evm.rs
+++ b/crates/cli/commands/src/init_state/without_evm.rs
@@ -133,7 +133,7 @@ where
             for block_num in 1..=target_height {
                 // TODO: should we fill with real parent_hash?
                 let header = header_factory(block_num);
-                writer.append_header(&header, U256::ZERO, &B256::ZERO)?;
+                writer.append_header(&header, &B256::ZERO)?;
             }
             Ok(())
         });

--- a/crates/cli/commands/src/init_state/without_evm.rs
+++ b/crates/cli/commands/src/init_state/without_evm.rs
@@ -1,5 +1,5 @@
 use alloy_consensus::BlockHeader;
-use alloy_primitives::{BlockNumber, B256, U256};
+use alloy_primitives::{BlockNumber, B256};
 use alloy_rlp::Decodable;
 use reth_codecs::Compact;
 use reth_node_builder::NodePrimitives;

--- a/crates/era-utils/src/export.rs
+++ b/crates/era-utils/src/export.rs
@@ -15,6 +15,7 @@ use reth_era::{
     },
 };
 use reth_fs_util as fs;
+use reth_provider::StaticFileProviderFactory;
 use reth_storage_api::{BlockNumReader, BlockReader, HeaderProvider};
 use std::{
     path::PathBuf,
@@ -80,7 +81,7 @@ impl ExportConfig {
 /// for a given number of blocks then writes them to disk.
 pub fn export<P>(provider: &P, config: &ExportConfig) -> Result<Vec<PathBuf>>
 where
-    P: BlockReader,
+    P: BlockReader + StaticFileProviderFactory,
 {
     config.validate()?;
     info!(
@@ -115,6 +116,7 @@ where
     let mut total_difficulty = if config.first_block_number > 0 {
         let prev_block_number = config.first_block_number - 1;
         provider
+            .static_file_provider()
             .header_td_by_number(prev_block_number)?
             .ok_or_else(|| eyre!("Total difficulty not found for block {prev_block_number}"))?
     } else {

--- a/crates/era-utils/src/history.rs
+++ b/crates/era-utils/src/history.rs
@@ -305,7 +305,7 @@ where
         last_header_number = number;
 
         // Append to Headers segment
-        writer.append_header(&header, U256::ZERO, &hash)?;
+        writer.append_header(&header, &hash)?;
 
         // Write bodies to database.
         provider.append_block_bodies(vec![(header.number(), Some(body))])?;

--- a/crates/era-utils/src/history.rs
+++ b/crates/era-utils/src/history.rs
@@ -19,15 +19,15 @@ use reth_etl::Collector;
 use reth_fs_util as fs;
 use reth_primitives_traits::{Block, FullBlockBody, FullBlockHeader, NodePrimitives};
 use reth_provider::{
-    providers::StaticFileProviderRWRefMut, BlockWriter, ProviderError, StaticFileProviderFactory,
+    providers::StaticFileProviderRWRefMut, BlockWriter, StaticFileProviderFactory,
     StaticFileSegment, StaticFileWriter,
 };
 use reth_stages_types::{
     CheckpointBlockRange, EntitiesCheckpoint, HeadersCheckpoint, StageCheckpoint, StageId,
 };
 use reth_storage_api::{
-    errors::ProviderResult, DBProvider, DatabaseProviderFactory, HeaderProvider,
-    NodePrimitivesProvider, StageCheckpointWriter,
+    errors::ProviderResult, DBProvider, DatabaseProviderFactory, NodePrimitivesProvider,
+    StageCheckpointWriter,
 };
 use std::{
     collections::Bound,
@@ -85,7 +85,7 @@ where
     // Find the latest total difficulty
     let mut td = static_file_provider
         .header_td_by_number(height)?
-        .ok_or(ProviderError::TotalDifficultyNotFound(height))?;
+        .ok_or_else(|| eyre::eyre!("Total difficulty not found for block {height}"))?;
 
     while let Some(meta) = rx.recv()? {
         let from = height;

--- a/crates/era-utils/src/history.rs
+++ b/crates/era-utils/src/history.rs
@@ -1,3 +1,4 @@
+use alloy_consensus::BlockHeader;
 use alloy_primitives::{BlockHash, BlockNumber, U256};
 use futures_util::{Stream, StreamExt};
 use reth_db_api::{
@@ -19,7 +20,7 @@ use reth_etl::Collector;
 use reth_fs_util as fs;
 use reth_primitives_traits::{Block, FullBlockBody, FullBlockHeader, NodePrimitives};
 use reth_provider::{
-    providers::StaticFileProviderRWRefMut, BlockWriter, StaticFileProviderFactory,
+    providers::StaticFileProviderRWRefMut, BlockReader, BlockWriter, StaticFileProviderFactory,
     StaticFileSegment, StaticFileWriter,
 };
 use reth_stages_types::{
@@ -82,11 +83,6 @@ where
         .get_highest_static_file_block(StaticFileSegment::Headers)
         .unwrap_or_default();
 
-    // Find the latest total difficulty
-    let mut td = static_file_provider
-        .header_td_by_number(height)?
-        .ok_or_else(|| eyre::eyre!("Total difficulty not found for block {height}"))?;
-
     while let Some(meta) = rx.recv()? {
         let from = height;
         let provider = provider_factory.database_provider_rw()?;
@@ -96,7 +92,6 @@ where
             &mut static_file_provider.latest_writer(StaticFileSegment::Headers)?,
             &provider,
             hash_collector,
-            &mut td,
             height..,
         )?;
 
@@ -146,7 +141,7 @@ where
 
 /// Extracts block headers and bodies from `meta` and appends them using `writer` and `provider`.
 ///
-/// Adds on to `total_difficulty` and collects hash to height using `hash_collector`.
+/// Collects hash to height using `hash_collector`.
 ///
 /// Skips all blocks below the [`start_bound`] of `block_numbers` and stops when reaching past the
 /// [`end_bound`] or the end of the file.
@@ -160,7 +155,6 @@ pub fn process<Era, P, B, BB, BH>(
     writer: &mut StaticFileProviderRWRefMut<'_, <P as NodePrimitivesProvider>::Primitives>,
     provider: &P,
     hash_collector: &mut Collector<BlockHash, BlockNumber>,
-    total_difficulty: &mut U256,
     block_numbers: impl RangeBounds<BlockNumber>,
 ) -> eyre::Result<BlockNumber>
 where
@@ -182,7 +176,7 @@ where
                 as Box<dyn Fn(Result<BlockTuple, E2sError>) -> eyre::Result<(BH, BB)>>);
     let iter = ProcessIter { iter, era: meta };
 
-    process_iter(iter, writer, provider, hash_collector, total_difficulty, block_numbers)
+    process_iter(iter, writer, provider, hash_collector, block_numbers)
 }
 
 type ProcessInnerIter<R, BH, BB> =
@@ -271,7 +265,6 @@ pub fn process_iter<P, B, BB, BH>(
     writer: &mut StaticFileProviderRWRefMut<'_, <P as NodePrimitivesProvider>::Primitives>,
     provider: &P,
     hash_collector: &mut Collector<BlockHash, BlockNumber>,
-    total_difficulty: &mut U256,
     block_numbers: impl RangeBounds<BlockNumber>,
 ) -> eyre::Result<BlockNumber>
 where
@@ -311,11 +304,8 @@ where
         let hash = header.hash_slow();
         last_header_number = number;
 
-        // Increase total difficulty
-        *total_difficulty += header.difficulty();
-
         // Append to Headers segment
-        writer.append_header(&header, *total_difficulty, &hash)?;
+        writer.append_header(&header, U256::ZERO, &hash)?;
 
         // Write bodies to database.
         provider.append_block_bodies(vec![(header.number(), Some(body))])?;
@@ -381,4 +371,29 @@ where
     }
 
     Ok(())
+}
+
+/// Calculates the total difficulty for a given block number by summing the difficulty
+/// of all blocks from genesis to the given block.
+///
+/// Very expensive - iterates through all blocks in batches of 1000.
+///
+/// Returns an error if any block is missing.
+pub fn calculate_td_by_number<P>(provider: &P, num: BlockNumber) -> eyre::Result<U256>
+where
+    P: BlockReader,
+{
+    let mut total_difficulty = U256::ZERO;
+    let mut start = 0;
+
+    while start <= num {
+        let end = (start + 1000 - 1).min(num);
+
+        total_difficulty +=
+            provider.headers_range(start..=end)?.iter().map(|h| h.difficulty()).sum::<U256>();
+
+        start = end + 1;
+    }
+
+    Ok(total_difficulty)
 }

--- a/crates/era-utils/src/lib.rs
+++ b/crates/era-utils/src/lib.rs
@@ -14,5 +14,6 @@ pub use export::{export, ExportConfig};
 
 /// Imports history from ERA files.
 pub use history::{
-    build_index, decode, import, open, process, process_iter, save_stage_checkpoints, ProcessIter,
+    build_index, calculate_td_by_number, decode, import, open, process, process_iter,
+    save_stage_checkpoints, ProcessIter,
 };

--- a/crates/net/downloaders/src/bodies/test_utils.rs
+++ b/crates/net/downloaders/src/bodies/test_utils.rs
@@ -3,7 +3,7 @@
 #![allow(dead_code)]
 
 use alloy_consensus::BlockHeader;
-use alloy_primitives::{B256, U256};
+use alloy_primitives::B256;
 use reth_ethereum_primitives::BlockBody;
 use reth_network_p2p::bodies::response::BlockResponse;
 use reth_primitives_traits::{Block, SealedBlock, SealedHeader};

--- a/crates/net/downloaders/src/bodies/test_utils.rs
+++ b/crates/net/downloaders/src/bodies/test_utils.rs
@@ -55,9 +55,7 @@ pub(crate) fn insert_headers(
         .expect("failed to create writer");
 
     for header in headers {
-        writer
-            .append_header(header.header(), U256::ZERO, &header.hash())
-            .expect("failed to append header");
+        writer.append_header(header.header(), &header.hash()).expect("failed to append header");
     }
     drop(writer);
     provider_rw.commit().expect("failed to commit");

--- a/crates/node/core/src/node_config.rs
+++ b/crates/node/core/src/node_config.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use alloy_consensus::BlockHeader;
 use alloy_eips::BlockHashOrNumber;
-use alloy_primitives::{BlockNumber, B256};
+use alloy_primitives::{BlockNumber, B256, U256};
 use eyre::eyre;
 use reth_chainspec::{ChainSpec, EthChainSpec, MAINNET};
 use reth_config::config::PruneConfig;

--- a/crates/node/core/src/node_config.rs
+++ b/crates/node/core/src/node_config.rs
@@ -330,12 +330,6 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
             .header_by_number(head)?
             .expect("the header for the latest block is missing, database is corrupt");
 
-        let total_difficulty = provider
-            .header_td_by_number(head)?
-            // total difficulty is effectively deprecated, but still required in some places, e.g.
-            // p2p
-            .unwrap_or_default();
-
         let hash = provider
             .block_hash(head)?
             .expect("the hash for the latest block is missing, database is corrupt");
@@ -344,7 +338,7 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
             number: head,
             hash,
             difficulty: header.difficulty(),
-            total_difficulty,
+            total_difficulty: U256::ZERO,
             timestamp: header.timestamp(),
         })
     }

--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -462,7 +462,6 @@ impl From<reth_errors::ProviderError> for EthApiError {
             }
             ProviderError::BestBlockNotFound => Self::HeaderNotFound(BlockId::latest()),
             ProviderError::BlockNumberForTransactionIndexNotFound => Self::UnknownBlockOrTxIndex,
-            ProviderError::TotalDifficultyNotFound(num) => Self::HeaderNotFound(num.into()),
             ProviderError::FinalizedBlockNotFound => Self::HeaderNotFound(BlockId::finalized()),
             ProviderError::SafeBlockNotFound => Self::HeaderNotFound(BlockId::safe()),
             err => Self::Internal(err.into()),

--- a/crates/stages/stages/src/stages/era.rs
+++ b/crates/stages/stages/src/stages/era.rs
@@ -335,7 +335,7 @@ mod tests {
         };
         use reth_ethereum_primitives::TransactionSigned;
         use reth_primitives_traits::{SealedBlock, SealedHeader};
-        use reth_provider::{BlockNumReader, TransactionsProvider};
+        use reth_provider::{BlockNumReader, HeaderProvider, TransactionsProvider};
         use reth_testing_utils::generators::{
             random_block_range, random_signed_tx, BlockRangeParams,
         };

--- a/crates/stages/stages/src/stages/headers.rs
+++ b/crates/stages/stages/src/stages/headers.rs
@@ -1,5 +1,5 @@
 use alloy_consensus::BlockHeader;
-use alloy_primitives::{BlockHash, BlockNumber, Bytes, B256};
+use alloy_primitives::{BlockHash, BlockNumber, Bytes, B256, U256};
 use futures_util::StreamExt;
 use reth_config::config::EtlConfig;
 use reth_db_api::{
@@ -129,7 +129,7 @@ where
             last_header_number = header.number();
 
             // Append to Headers segment
-            writer.append_header(header, alloy_primitives::U256::ZERO, header_hash)?;
+            writer.append_header(header, U256::ZERO, header_hash)?;
         }
 
         info!(target: "sync::stages::headers", total = total_headers, "Writing headers hash index");

--- a/crates/stages/stages/src/stages/headers.rs
+++ b/crates/stages/stages/src/stages/headers.rs
@@ -414,7 +414,7 @@ mod tests {
             ReverseHeadersDownloader, ReverseHeadersDownloaderBuilder,
         };
         use reth_network_p2p::test_utils::{TestHeaderDownloader, TestHeadersClient};
-        use reth_provider::{test_utils::MockNodeTypesWithDB, BlockNumReader};
+        use reth_provider::{test_utils::MockNodeTypesWithDB, BlockNumReader, HeaderProvider};
         use tokio::sync::watch;
 
         pub(crate) struct HeadersTestRunner<D: HeaderDownloader> {

--- a/crates/stages/stages/src/stages/headers.rs
+++ b/crates/stages/stages/src/stages/headers.rs
@@ -1,5 +1,5 @@
 use alloy_consensus::BlockHeader;
-use alloy_primitives::{BlockHash, BlockNumber, Bytes, B256, U256};
+use alloy_primitives::{BlockHash, BlockNumber, Bytes, B256};
 use futures_util::StreamExt;
 use reth_config::config::EtlConfig;
 use reth_db_api::{
@@ -390,7 +390,7 @@ mod tests {
     use crate::test_utils::{
         stage_test_suite, ExecuteStageTestRunner, StageTestRunner, UnwindStageTestRunner,
     };
-    use alloy_primitives::{B256, U256};
+    use alloy_primitives::B256;
     use assert_matches::assert_matches;
     use reth_provider::{DatabaseProviderFactory, ProviderFactory, StaticFileProviderFactory};
     use reth_stages_api::StageUnitCheckpoint;

--- a/crates/stages/stages/src/stages/headers.rs
+++ b/crates/stages/stages/src/stages/headers.rs
@@ -129,7 +129,7 @@ where
             last_header_number = header.number();
 
             // Append to Headers segment
-            writer.append_header(header, U256::ZERO, header_hash)?;
+            writer.append_header(header, header_hash)?;
         }
 
         info!(target: "sync::stages::headers", total = total_headers, "Writing headers hash index");
@@ -619,7 +619,7 @@ mod tests {
         let static_file_provider = provider.static_file_provider();
         let mut writer = static_file_provider.latest_writer(StaticFileSegment::Headers).unwrap();
         for header in sealed_headers {
-            writer.append_header(header.header(), U256::ZERO, &header.hash()).unwrap();
+            writer.append_header(header.header(), &header.hash()).unwrap();
         }
         drop(writer);
 

--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -738,7 +738,7 @@ mod tests {
             let hash = last_header.hash_slow();
             writer.prune_headers(1).unwrap();
             writer.commit().unwrap();
-            writer.append_header(&last_header, U256::ZERO, &hash).unwrap();
+            writer.append_header(&last_header, &hash).unwrap();
             writer.commit().unwrap();
 
             Ok(blocks)

--- a/crates/stages/stages/src/test_utils/test_db.rs
+++ b/crates/stages/stages/src/test_utils/test_db.rs
@@ -160,11 +160,11 @@ impl TestStageDB {
                 for block_number in 0..header.number {
                     let mut prev = header.clone_header();
                     prev.number = block_number;
-                    writer.append_header(&prev, U256::ZERO, &B256::ZERO)?;
+                    writer.append_header(&prev, &B256::ZERO)?;
                 }
             }
 
-            writer.append_header(header.header(), td, &header.hash())?;
+            writer.append_header(header.header(), &header.hash())?;
         } else {
             tx.put::<tables::CanonicalHeaders>(header.number, header.hash())?;
             tx.put::<tables::HeaderTerminalDifficulties>(header.number, td.into())?;

--- a/crates/static-file/static-file/src/segments/headers.rs
+++ b/crates/static-file/static-file/src/segments/headers.rs
@@ -54,7 +54,7 @@ where
             debug_assert_eq!(header_block, header_td_block);
             debug_assert_eq!(header_td_block, canonical_header_block);
 
-            static_file_writer.append_header(&header, header_td.0, &canonical_header)?;
+            static_file_writer.append_header(&header, &canonical_header)?;
         }
 
         Ok(())

--- a/crates/static-file/static-file/src/segments/headers.rs
+++ b/crates/static-file/static-file/src/segments/headers.rs
@@ -36,23 +36,15 @@ where
             )?;
         let headers_walker = headers_cursor.walk_range(block_range.clone())?;
 
-        let mut header_td_cursor =
-            provider.tx_ref().cursor_read::<tables::HeaderTerminalDifficulties>()?;
-        let header_td_walker = header_td_cursor.walk_range(block_range.clone())?;
-
         let mut canonical_headers_cursor =
             provider.tx_ref().cursor_read::<tables::CanonicalHeaders>()?;
         let canonical_headers_walker = canonical_headers_cursor.walk_range(block_range)?;
 
-        for ((header_entry, header_td_entry), canonical_header_entry) in
-            headers_walker.zip(header_td_walker).zip(canonical_headers_walker)
-        {
+        for (header_entry, canonical_header_entry) in headers_walker.zip(canonical_headers_walker) {
             let (header_block, header) = header_entry?;
-            let (header_td_block, header_td) = header_td_entry?;
             let (canonical_header_block, canonical_header) = canonical_header_entry?;
 
-            debug_assert_eq!(header_block, header_td_block);
-            debug_assert_eq!(header_td_block, canonical_header_block);
+            debug_assert_eq!(header_block, canonical_header_block);
 
             static_file_writer.append_header(&header, &canonical_header)?;
         }

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -349,7 +349,7 @@ where
         Ok(None) | Err(ProviderError::MissingStaticFileBlock(StaticFileSegment::Headers, 0)) => {
             let (difficulty, hash) = (header.difficulty(), block_hash);
             let mut writer = static_file_provider.latest_writer(StaticFileSegment::Headers)?;
-            writer.append_header(header, difficulty, &hash)?;
+            writer.append_header(header, &hash)?;
         }
         Ok(Some(_)) => {}
         Err(e) => return Err(e),

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -347,9 +347,8 @@ where
 
     match static_file_provider.block_hash(0) {
         Ok(None) | Err(ProviderError::MissingStaticFileBlock(StaticFileSegment::Headers, 0)) => {
-            let (difficulty, hash) = (header.difficulty(), block_hash);
             let mut writer = static_file_provider.latest_writer(StaticFileSegment::Headers)?;
-            writer.append_header(header, &hash)?;
+            writer.append_header(header, &block_hash)?;
         }
         Ok(Some(_)) => {}
         Err(e) => return Err(e),

--- a/crates/storage/errors/src/provider.rs
+++ b/crates/storage/errors/src/provider.rs
@@ -58,9 +58,6 @@ pub enum ProviderError {
         /// The account address.
         address: Address,
     },
-    /// The total difficulty for a block is missing.
-    #[error("total difficulty not found for block #{_0}")]
-    TotalDifficultyNotFound(BlockNumber),
     /// When required header related data was not found but was required.
     #[error("no header found for {_0:?}")]
     HeaderNotFound(BlockHashOrNumber),

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -1272,23 +1272,11 @@ mod tests {
             BlockRangeParams::default(),
         )?;
 
-        let database_block = database_blocks.first().unwrap().clone();
-        let in_memory_block = in_memory_blocks.last().unwrap().clone();
         // make sure that the finalized block is on db
         let finalized_block = database_blocks.get(database_blocks.len() - 3).unwrap();
         provider.set_finalized(finalized_block.clone_sealed_header());
 
         let blocks = [database_blocks, in_memory_blocks].concat();
-
-        assert_eq!(
-            provider.header_td_by_number(database_block.number)?,
-            Some(database_block.difficulty)
-        );
-
-        assert_eq!(
-            provider.header_td_by_number(in_memory_block.number)?,
-            Some(in_memory_block.difficulty)
-        );
 
         assert_eq!(
             provider.sealed_headers_while(0..=10, |header| header.number <= 8)?,

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use alloy_consensus::transaction::TransactionMeta;
 use alloy_eips::{BlockHashOrNumber, BlockId, BlockNumHash, BlockNumberOrTag};
-use alloy_primitives::{Address, BlockHash, BlockNumber, TxHash, TxNumber, B256, U256};
+use alloy_primitives::{Address, BlockHash, BlockNumber, TxHash, TxNumber, B256};
 use alloy_rpc_types_engine::ForkchoiceState;
 use reth_chain_state::{
     BlockState, CanonicalInMemoryState, ForkChoiceNotifications, ForkChoiceSubscriptions,
@@ -174,14 +174,6 @@ impl<N: ProviderNodeTypes> HeaderProvider for BlockchainProvider<N> {
 
     fn header_by_number(&self, num: BlockNumber) -> ProviderResult<Option<Self::Header>> {
         self.consistent_provider()?.header_by_number(num)
-    }
-
-    fn header_td(&self, hash: BlockHash) -> ProviderResult<Option<U256>> {
-        self.consistent_provider()?.header_td(hash)
-    }
-
-    fn header_td_by_number(&self, number: BlockNumber) -> ProviderResult<Option<U256>> {
-        self.consistent_provider()?.header_td_by_number(number)
     }
 
     fn headers_range(

--- a/crates/storage/provider/src/providers/database/metrics.rs
+++ b/crates/storage/provider/src/providers/database/metrics.rs
@@ -45,7 +45,6 @@ pub(crate) enum Action {
     InsertBlockBodyIndices,
     InsertTransactionBlocks,
     GetNextTxNum,
-    GetParentTD,
 }
 
 /// Database provider metrics
@@ -71,8 +70,6 @@ struct DatabaseProviderMetrics {
     insert_tx_blocks: Histogram,
     /// Duration of get next tx num
     get_next_tx_num: Histogram,
-    /// Duration of get parent TD
-    get_parent_td: Histogram,
 }
 
 impl DatabaseProviderMetrics {
@@ -88,7 +85,6 @@ impl DatabaseProviderMetrics {
             Action::InsertBlockBodyIndices => self.insert_block_body_indices.record(duration),
             Action::InsertTransactionBlocks => self.insert_tx_blocks.record(duration),
             Action::GetNextTxNum => self.get_next_tx_num.record(duration),
-            Action::GetParentTD => self.get_parent_td.record(duration),
         }
     }
 }

--- a/crates/storage/provider/src/providers/database/metrics.rs
+++ b/crates/storage/provider/src/providers/database/metrics.rs
@@ -45,6 +45,7 @@ pub(crate) enum Action {
     InsertBlockBodyIndices,
     InsertTransactionBlocks,
     GetNextTxNum,
+    GetParentTD,
 }
 
 /// Database provider metrics
@@ -70,6 +71,8 @@ struct DatabaseProviderMetrics {
     insert_tx_blocks: Histogram,
     /// Duration of get next tx num
     get_next_tx_num: Histogram,
+    /// Duration of get parent TD
+    get_parent_td: Histogram,
 }
 
 impl DatabaseProviderMetrics {
@@ -85,6 +88,7 @@ impl DatabaseProviderMetrics {
             Action::InsertBlockBodyIndices => self.insert_block_body_indices.record(duration),
             Action::InsertTransactionBlocks => self.insert_tx_blocks.record(duration),
             Action::GetNextTxNum => self.get_next_tx_num.record(duration),
+            Action::GetParentTD => self.get_parent_td.record(duration),
         }
     }
 }

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -582,7 +582,7 @@ mod tests {
         BlockHashReader, BlockNumReader, BlockWriter, DBProvider, HeaderSyncGapProvider,
         TransactionsProvider,
     };
-    use alloy_primitives::{TxNumber, B256, U256};
+    use alloy_primitives::{TxNumber, B256};
     use assert_matches::assert_matches;
     use reth_chainspec::ChainSpecBuilder;
     use reth_db::{

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -727,7 +727,7 @@ mod tests {
         let static_file_provider = provider.static_file_provider();
         let mut static_file_writer =
             static_file_provider.latest_writer(StaticFileSegment::Headers).unwrap();
-        static_file_writer.append_header(head.header(), U256::ZERO, &head.hash()).unwrap();
+        static_file_writer.append_header(head.header(), &head.hash()).unwrap();
         static_file_writer.commit().unwrap();
         drop(static_file_writer);
 

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use alloy_consensus::transaction::TransactionMeta;
 use alloy_eips::BlockHashOrNumber;
-use alloy_primitives::{Address, BlockHash, BlockNumber, TxHash, TxNumber, B256, U256};
+use alloy_primitives::{Address, BlockHash, BlockNumber, TxHash, TxNumber, B256};
 use core::fmt;
 use reth_chainspec::ChainInfo;
 use reth_db::{init_db, mdbx::DatabaseArguments, DatabaseEnv};
@@ -245,14 +245,6 @@ impl<N: ProviderNodeTypes> HeaderProvider for ProviderFactory<N> {
 
     fn header_by_number(&self, num: BlockNumber) -> ProviderResult<Option<Self::Header>> {
         self.static_file_provider.header_by_number(num)
-    }
-
-    fn header_td(&self, hash: BlockHash) -> ProviderResult<Option<U256>> {
-        self.provider()?.header_td(hash)
-    }
-
-    fn header_td_by_number(&self, number: BlockNumber) -> ProviderResult<Option<U256>> {
-        self.static_file_provider.header_td_by_number(number)
     }
 
     fn headers_range(

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -28,12 +28,12 @@ use alloy_eips::BlockHashOrNumber;
 use alloy_primitives::{
     keccak256,
     map::{hash_map, B256Map, HashMap, HashSet},
-    Address, BlockHash, BlockNumber, TxHash, TxNumber, B256, U256,
+    Address, BlockHash, BlockNumber, TxHash, TxNumber, B256,
 };
 use itertools::Itertools;
 use rayon::slice::ParallelSliceMut;
 use reth_chain_state::ExecutedBlock;
-use reth_chainspec::{ChainInfo, ChainSpecProvider, EthChainSpec, EthereumHardforks};
+use reth_chainspec::{ChainInfo, ChainSpecProvider, EthChainSpec};
 use reth_db_api::{
     cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO, DbDupCursorRW},
     database::Database,
@@ -969,26 +969,6 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> HeaderProvider for DatabasePro
 
     fn header_by_number(&self, num: BlockNumber) -> ProviderResult<Option<Self::Header>> {
         self.static_file_provider.header_by_number(num)
-    }
-
-    fn header_td(&self, block_hash: BlockHash) -> ProviderResult<Option<U256>> {
-        if let Some(num) = self.block_number(block_hash)? {
-            self.header_td_by_number(num)
-        } else {
-            Ok(None)
-        }
-    }
-
-    fn header_td_by_number(&self, number: BlockNumber) -> ProviderResult<Option<U256>> {
-        if self.chain_spec.is_paris_active_at_block(number) &&
-            let Some(td) = self.chain_spec.final_paris_total_difficulty()
-        {
-            // if this block is higher than the final paris(merge) block, return the final paris
-            // difficulty
-            return Ok(Some(td))
-        }
-
-        self.static_file_provider.header_td_by_number(number)
     }
 
     fn headers_range(
@@ -2834,14 +2814,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider + 'static> BlockWrite
         let mut durations_recorder = metrics::DurationsRecorder::default();
 
         // total difficulty
-        let ttd = if block_number == 0 {
-            block.header().difficulty()
-        } else {
-            let parent_block_number = block_number - 1;
-            let parent_ttd = self.header_td_by_number(parent_block_number)?.unwrap_or_default();
-            durations_recorder.record_relative(metrics::Action::GetParentTD);
-            parent_ttd + block.header().difficulty()
-        };
+        let ttd = self.chain_spec.final_paris_total_difficulty().unwrap_or_default();
 
         self.static_file_provider
             .get_writer(block_number, StaticFileSegment::Headers)?

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -28,7 +28,7 @@ use alloy_eips::BlockHashOrNumber;
 use alloy_primitives::{
     keccak256,
     map::{hash_map, B256Map, HashMap, HashSet},
-    Address, BlockHash, BlockNumber, TxHash, TxNumber, B256,
+    Address, BlockHash, BlockNumber, TxHash, TxNumber, B256, U256,
 };
 use itertools::Itertools;
 use rayon::slice::ParallelSliceMut;
@@ -2813,19 +2813,9 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider + 'static> BlockWrite
 
         let mut durations_recorder = metrics::DurationsRecorder::default();
 
-        // total difficulty
-        let ttd = if block_number == 0 {
-            block.header().difficulty()
-        } else {
-            let parent_block_number = block_number - 1;
-            let parent_ttd = self.static_file_provider.header_td_by_number(parent_block_number)?.unwrap_or_default();
-            durations_recorder.record_relative(metrics::Action::GetParentTD);
-            parent_ttd + block.header().difficulty()
-        };
-
         self.static_file_provider
             .get_writer(block_number, StaticFileSegment::Headers)?
-            .append_header(block.header(), ttd, &block.hash())?;
+            .append_header(block.header(), U256::ZERO, &block.hash())?;
 
         self.tx.put::<tables::HeaderNumbers>(block.hash(), block_number)?;
         durations_recorder.record_relative(metrics::Action::InsertHeaderNumbers);

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -28,7 +28,7 @@ use alloy_eips::BlockHashOrNumber;
 use alloy_primitives::{
     keccak256,
     map::{hash_map, B256Map, HashMap, HashSet},
-    Address, BlockHash, BlockNumber, TxHash, TxNumber, B256, U256,
+    Address, BlockHash, BlockNumber, TxHash, TxNumber, B256,
 };
 use itertools::Itertools;
 use rayon::slice::ParallelSliceMut;

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -2815,7 +2815,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider + 'static> BlockWrite
 
         self.static_file_provider
             .get_writer(block_number, StaticFileSegment::Headers)?
-            .append_header(block.header(), U256::ZERO, &block.hash())?;
+            .append_header(block.header(), &block.hash())?;
 
         self.tx.put::<tables::HeaderNumbers>(block.hash(), block_number)?;
         durations_recorder.record_relative(metrics::Action::InsertHeaderNumbers);

--- a/crates/storage/provider/src/providers/static_file/jar.rs
+++ b/crates/storage/provider/src/providers/static_file/jar.rs
@@ -8,11 +8,10 @@ use crate::{
 };
 use alloy_consensus::transaction::{SignerRecoverable, TransactionMeta};
 use alloy_eips::{eip2718::Encodable2718, BlockHashOrNumber};
-use alloy_primitives::{Address, BlockHash, BlockNumber, TxHash, TxNumber, B256, U256};
+use alloy_primitives::{Address, BlockHash, BlockNumber, TxHash, TxNumber, B256};
 use reth_chainspec::ChainInfo;
 use reth_db::static_file::{
-    BlockHashMask, HeaderMask, HeaderWithHashMask, ReceiptMask, StaticFileCursor, TDWithHashMask,
-    TotalDifficultyMask, TransactionMask,
+    BlockHashMask, HeaderMask, HeaderWithHashMask, ReceiptMask, StaticFileCursor, TransactionMask,
 };
 use reth_db_api::table::{Decompress, Value};
 use reth_node_types::NodePrimitives;
@@ -99,18 +98,6 @@ impl<N: NodePrimitives<BlockHeader: Value>> HeaderProvider for StaticFileJarProv
 
     fn header_by_number(&self, num: BlockNumber) -> ProviderResult<Option<Self::Header>> {
         self.cursor()?.get_one::<HeaderMask<Self::Header>>(num.into())
-    }
-
-    fn header_td(&self, block_hash: BlockHash) -> ProviderResult<Option<U256>> {
-        Ok(self
-            .cursor()?
-            .get_two::<TDWithHashMask>((&block_hash).into())?
-            .filter(|(_, hash)| hash == &block_hash)
-            .map(|(td, _)| td.into()))
-    }
-
-    fn header_td_by_number(&self, num: BlockNumber) -> ProviderResult<Option<U256>> {
-        Ok(self.cursor()?.get_one::<TotalDifficultyMask>(num.into())?.map(Into::into))
     }
 
     fn headers_range(

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -12,9 +12,7 @@ use alloy_consensus::{
     Header,
 };
 use alloy_eips::{eip2718::Encodable2718, BlockHashOrNumber};
-use alloy_primitives::{
-    b256, keccak256, Address, BlockHash, BlockNumber, TxHash, TxNumber, B256, U256,
-};
+use alloy_primitives::{b256, keccak256, Address, BlockHash, BlockNumber, TxHash, TxNumber, B256};
 use dashmap::DashMap;
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use parking_lot::RwLock;
@@ -1310,26 +1308,6 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
     #[cfg(any(test, feature = "test-utils"))]
     pub fn tx_index(&self) -> &RwLock<SegmentRanges> {
         &self.static_files_tx_index
-    }
-
-    /// Fetches the total difficulty for a given block number from static files.
-    ///
-    /// Returns `None` if the block is not found or if the static file is missing.
-    pub fn header_td_by_number(&self, num: BlockNumber) -> ProviderResult<Option<U256>> {
-        self.get_segment_provider_from_block(StaticFileSegment::Headers, num, None)
-            .and_then(|provider| {
-                Ok(provider
-                    .cursor()?
-                    .get_one::<reth_db::static_file::TotalDifficultyMask>(num.into())?
-                    .map(Into::into))
-            })
-            .or_else(|err| {
-                if let ProviderError::MissingStaticFileBlock(_, _) = err {
-                    Ok(None)
-                } else {
-                    Err(err)
-                }
-            })
     }
 }
 

--- a/crates/storage/provider/src/providers/static_file/mod.rs
+++ b/crates/storage/provider/src/providers/static_file/mod.rs
@@ -148,12 +148,6 @@ mod tests {
                 // Compare Header
                 assert_eq!(header, db_provider.header(header_hash).unwrap().unwrap());
                 assert_eq!(header, jar_provider.header_by_number(header.number).unwrap().unwrap());
-
-                // Compare HeaderTerminalDifficulties
-                assert_eq!(
-                    db_provider.header_td(header_hash).unwrap().unwrap(),
-                    jar_provider.header_td_by_number(header.number).unwrap().unwrap()
-                );
             }
         }
     }

--- a/crates/storage/provider/src/providers/static_file/mod.rs
+++ b/crates/storage/provider/src/providers/static_file/mod.rs
@@ -118,12 +118,10 @@ mod tests {
         {
             let manager = factory.static_file_provider();
             let mut writer = manager.latest_writer(StaticFileSegment::Headers).unwrap();
-            let mut td = U256::ZERO;
 
             for header in headers.clone() {
-                td += header.header().difficulty;
                 let hash = header.hash();
-                writer.append_header(&header.unseal(), td, &hash).unwrap();
+                writer.append_header(&header.unseal(), &hash).unwrap();
             }
             writer.commit().unwrap();
         }
@@ -174,9 +172,7 @@ mod tests {
             let mut header = Header::default();
             for num in 0..=tip {
                 header.number = num;
-                header_writer
-                    .append_header(&header, U256::default(), &BlockHash::default())
-                    .unwrap();
+                header_writer.append_header(&header, &BlockHash::default()).unwrap();
             }
             header_writer.commit().unwrap();
         }

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -531,12 +531,7 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
     /// blocks.
     ///
     /// Returns the current [`BlockNumber`] as seen in the static file.
-    pub fn append_header(
-        &mut self,
-        header: &N::BlockHeader,
-        total_difficulty: U256,
-        hash: &BlockHash,
-    ) -> ProviderResult<()>
+    pub fn append_header(&mut self, header: &N::BlockHeader, hash: &BlockHash) -> ProviderResult<()>
     where
         N::BlockHeader: Compact,
     {
@@ -548,7 +543,7 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
         self.increment_block(header.number())?;
 
         self.append_column(header)?;
-        self.append_column(CompactU256::from(total_difficulty))?;
+        self.append_column(CompactU256::from(U256::ZERO))?; // deprecated total difficulty
         self.append_column(hash)?;
 
         if let Some(metrics) = &self.metrics {

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -535,6 +535,24 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
     where
         N::BlockHeader: Compact,
     {
+        self.append_header_with_td(header, U256::ZERO, hash)
+    }
+
+    /// Appends header to static file with a specified total difficulty.
+    ///
+    /// It **CALLS** `increment_block()` since the number of headers is equal to the number of
+    /// blocks.
+    ///
+    /// Returns the current [`BlockNumber`] as seen in the static file.
+    pub fn append_header_with_td(
+        &mut self,
+        header: &N::BlockHeader,
+        total_difficulty: U256,
+        hash: &BlockHash,
+    ) -> ProviderResult<()>
+    where
+        N::BlockHeader: Compact,
+    {
         let start = Instant::now();
         self.ensure_no_queued_prune()?;
 
@@ -543,7 +561,7 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
         self.increment_block(header.number())?;
 
         self.append_column(header)?;
-        self.append_column(CompactU256::from(U256::ZERO))?; // deprecated total difficulty
+        self.append_column(CompactU256::from(total_difficulty))?;
         self.append_column(hash)?;
 
         if let Some(metrics) = &self.metrics {

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -292,24 +292,6 @@ impl<T: NodePrimitives, ChainSpec: EthChainSpec + Send + Sync + 'static> HeaderP
         Ok(lock.values().find(|h| h.number() == num).cloned())
     }
 
-    fn header_td(&self, hash: BlockHash) -> ProviderResult<Option<U256>> {
-        let lock = self.headers.lock();
-        Ok(lock.get(&hash).map(|target| {
-            lock.values()
-                .filter(|h| h.number() < target.number())
-                .fold(target.difficulty(), |td, h| td + h.difficulty())
-        }))
-    }
-
-    fn header_td_by_number(&self, number: BlockNumber) -> ProviderResult<Option<U256>> {
-        let lock = self.headers.lock();
-        let sum = lock
-            .values()
-            .filter(|h| h.number() <= number)
-            .fold(U256::ZERO, |td, h| td + h.difficulty());
-        Ok(Some(sum))
-    }
-
     fn headers_range(
         &self,
         range: impl RangeBounds<BlockNumber>,

--- a/crates/storage/rpc-provider/src/lib.rs
+++ b/crates/storage/rpc-provider/src/lib.rs
@@ -364,18 +364,6 @@ where
         Ok(Some(sealed_header.into_header()))
     }
 
-    fn header_td(&self, hash: BlockHash) -> ProviderResult<Option<U256>> {
-        let header = self.header(hash).map_err(ProviderError::other)?;
-
-        Ok(header.map(|b| b.difficulty()))
-    }
-
-    fn header_td_by_number(&self, number: BlockNumber) -> ProviderResult<Option<U256>> {
-        let header = self.header_by_number(number).map_err(ProviderError::other)?;
-
-        Ok(header.map(|b| b.difficulty()))
-    }
-
     fn headers_range(
         &self,
         _range: impl RangeBounds<BlockNumber>,
@@ -1671,14 +1659,6 @@ where
     }
 
     fn header_by_number(&self, _num: BlockNumber) -> Result<Option<Self::Header>, ProviderError> {
-        Err(ProviderError::UnsupportedProvider)
-    }
-
-    fn header_td(&self, _hash: BlockHash) -> Result<Option<U256>, ProviderError> {
-        Err(ProviderError::UnsupportedProvider)
-    }
-
-    fn header_td_by_number(&self, _number: BlockNumber) -> Result<Option<U256>, ProviderError> {
         Err(ProviderError::UnsupportedProvider)
     }
 

--- a/crates/storage/storage-api/src/header.rs
+++ b/crates/storage/storage-api/src/header.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 use alloy_eips::BlockHashOrNumber;
-use alloy_primitives::{BlockHash, BlockNumber, U256};
+use alloy_primitives::{BlockHash, BlockNumber};
 use core::ops::RangeBounds;
 use reth_primitives_traits::{BlockHeader, SealedHeader};
 use reth_storage_errors::provider::ProviderResult;
@@ -43,12 +43,6 @@ pub trait HeaderProvider: Send + Sync {
             BlockHashOrNumber::Number(num) => self.header_by_number(num),
         }
     }
-
-    /// Get total difficulty by block hash.
-    fn header_td(&self, hash: BlockHash) -> ProviderResult<Option<U256>>;
-
-    /// Get total difficulty by block number.
-    fn header_td_by_number(&self, number: BlockNumber) -> ProviderResult<Option<U256>>;
 
     /// Get headers in range of block numbers
     fn headers_range(

--- a/crates/storage/storage-api/src/noop.rs
+++ b/crates/storage/storage-api/src/noop.rs
@@ -15,7 +15,7 @@ use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
 use alloy_consensus::transaction::TransactionMeta;
 use alloy_eips::{BlockHashOrNumber, BlockId, BlockNumberOrTag};
 use alloy_primitives::{
-    Address, BlockHash, BlockNumber, Bytes, StorageKey, StorageValue, TxHash, TxNumber, B256, U256,
+    Address, BlockHash, BlockNumber, Bytes, StorageKey, StorageValue, TxHash, TxNumber, B256,
 };
 use core::{
     fmt::Debug,
@@ -353,14 +353,6 @@ impl<C: Send + Sync, N: NodePrimitives> HeaderProvider for NoopProvider<C, N> {
     }
 
     fn header_by_number(&self, _num: u64) -> ProviderResult<Option<Self::Header>> {
-        Ok(None)
-    }
-
-    fn header_td(&self, _hash: BlockHash) -> ProviderResult<Option<U256>> {
-        Ok(None)
-    }
-
-    fn header_td_by_number(&self, _number: BlockNumber) -> ProviderResult<Option<U256>> {
         Ok(None)
     }
 

--- a/examples/db-access/src/main.rs
+++ b/examples/db-access/src/main.rs
@@ -66,11 +66,6 @@ fn header_provider_example<T: HeaderProvider>(provider: T, number: u64) -> eyre:
         provider.header(sealed_header.hash())?.ok_or(eyre::eyre!("header by hash not found"))?;
     assert_eq!(sealed_header.header(), &header_by_hash);
 
-    // The header's total difficulty is stored in a separate table, so we have a separate call for
-    // it. This is not needed for post PoS transition chains.
-    let td = provider.header_td_by_number(number)?.ok_or(eyre::eyre!("header td not found"))?;
-    assert!(!td.is_zero());
-
     // Can query headers by range as well, already sealed!
     let headers = provider.sealed_headers_range(100..200)?;
     assert_eq!(headers.len(), 100);


### PR DESCRIPTION
* removes total difficulty provider methods from `StorageApi`
* adds `era_utils::calculate_td_by_number` so we are able to generate era files with the same checksums. slightly expensive, since it has to iterate through all headers up to num.
* `static_file_provider.append_header` now always sets TTD column to zero. This has the side-effect that static files will have a different checksum after this PR. 


closes #16586