### PR TITLE
feat(storage): replace unreachable todo!() with explicit unreachable!() in compact derive

### DIFF
--- a/crates/storage/codecs/derive/src/compact/structs.rs
+++ b/crates/storage/codecs/derive/src/compact/structs.rs
@@ -155,7 +155,7 @@ impl<'a> StructHandler<'a> {
                     let (#name, new_buf) = #ident_type::#from_compact_ident(buf, flags.#len() as usize);
                 });
             } else {
-                todo!()
+                unreachable!("flag-type fields are always compact in Compact derive")
             }
             self.lines.push(quote! {
                 buf = new_buf;


### PR DESCRIPTION
- The todo!() branch inside StructHandler::from for is_flag_type(ftype) && !is_compact is unreachable because is_compact is always set to true for flag-types in load_field_from_segments (is_flag_type(ftype) || #[maybe_zero]).
- codify the invariant by using unreachable!("flag-type fields are always compact in Compact derive").