### PR TITLE
fix: clarify helper name for receipt offsets 

### DIFF
--- a/crates/optimism/rpc/src/eth/transaction.rs
+++ b/crates/optimism/rpc/src/eth/transaction.rs
@@ -12,8 +12,8 @@ use reth_primitives_traits::{BlockBody, SignedTransaction, SignerRecoverable};
 use reth_rpc_convert::transaction::ConvertReceiptInput;
 use reth_rpc_eth_api::{
     helpers::{
-        receipt::compute_offsets_before_tx, spec::SignersForRpc, EthTransactions,
-        LoadReceipt, LoadTransaction,
+        receipt::compute_offsets_before_tx, spec::SignersForRpc, EthTransactions, LoadReceipt,
+        LoadTransaction,
     },
     try_into_op_tx_info, EthApiTypes as _, FromEthApiError, FromEvmError, RpcConvert, RpcNodeCore,
     RpcReceipt, TxInfoMapper,

--- a/crates/optimism/rpc/src/eth/transaction.rs
+++ b/crates/optimism/rpc/src/eth/transaction.rs
@@ -12,7 +12,7 @@ use reth_primitives_traits::{BlockBody, SignedTransaction, SignerRecoverable};
 use reth_rpc_convert::transaction::ConvertReceiptInput;
 use reth_rpc_eth_api::{
     helpers::{
-        receipt::calculate_gas_used_and_next_log_index, spec::SignersForRpc, EthTransactions,
+        receipt::compute_offsets_before_tx, spec::SignersForRpc, EthTransactions,
         LoadReceipt, LoadTransaction,
     },
     try_into_op_tx_info, EthApiTypes as _, FromEthApiError, FromEvmError, RpcConvert, RpcNodeCore,
@@ -181,7 +181,7 @@ where
                         let all_receipts = &block_and_receipts.receipts;
 
                         let (gas_used, next_log_index) =
-                            calculate_gas_used_and_next_log_index(meta.index, all_receipts);
+                            compute_offsets_before_tx(meta.index, all_receipts);
 
                         return Ok(Some(
                             this.tx_resp_builder()

--- a/crates/rpc/rpc-eth-api/src/helpers/receipt.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/receipt.rs
@@ -9,8 +9,8 @@ use reth_rpc_convert::{transaction::ConvertReceiptInput, RpcConvert};
 use reth_rpc_eth_types::{error::FromEthApiError, EthApiError};
 use reth_storage_api::{ProviderReceipt, ProviderTx};
 
-/// Calculates the gas used and next log index for a transaction at the given index
-pub fn calculate_gas_used_and_next_log_index(
+/// Computes the cumulative gas and next log index offsets before the transaction at `tx_index`.
+pub fn compute_offsets_before_tx(
     tx_index: u64,
     all_receipts: &[impl TxReceipt],
 ) -> (u64, usize) {
@@ -60,7 +60,7 @@ pub trait LoadReceipt:
                 .ok_or(EthApiError::HeaderNotFound(hash.into()))?;
 
             let (gas_used, next_log_index) =
-                calculate_gas_used_and_next_log_index(meta.index, &all_receipts);
+                compute_offsets_before_tx(meta.index, &all_receipts);
 
             Ok(self
                 .tx_resp_builder()

--- a/crates/rpc/rpc-eth-api/src/helpers/receipt.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/receipt.rs
@@ -10,10 +10,7 @@ use reth_rpc_eth_types::{error::FromEthApiError, EthApiError};
 use reth_storage_api::{ProviderReceipt, ProviderTx};
 
 /// Computes the cumulative gas and next log index offsets before the transaction at `tx_index`.
-pub fn compute_offsets_before_tx(
-    tx_index: u64,
-    all_receipts: &[impl TxReceipt],
-) -> (u64, usize) {
+pub fn compute_offsets_before_tx(tx_index: u64, all_receipts: &[impl TxReceipt]) -> (u64, usize) {
     let mut gas_used = 0;
     let mut next_log_index = 0;
 
@@ -59,8 +56,7 @@ pub trait LoadReceipt:
                 .map_err(Self::Error::from_eth_err)?
                 .ok_or(EthApiError::HeaderNotFound(hash.into()))?;
 
-            let (gas_used, next_log_index) =
-                compute_offsets_before_tx(meta.index, &all_receipts);
+            let (gas_used, next_log_index) = compute_offsets_before_tx(meta.index, &all_receipts);
 
             Ok(self
                 .tx_resp_builder()


### PR DESCRIPTION


### Description
- **Summary**: Rename a misleading helper to accurately describe its behavior and reduce cognitive load.
- **Rationale**: The previous name suggested computing per-tx gas used, but the function returns cumulative gas and log index offsets before the target tx. Clear naming helps prevent misuse.
- **Changes**:
  - Rename `calculate_gas_used_and_next_log_index` to `compute_offsets_before_tx`.
