### PR TITLE
fix: remove unnecessary trait bounds in extend_sorted_vec helper

### DIFF
--- a/crates/trie/common/src/utils.rs
+++ b/crates/trie/common/src/utils.rs
@@ -11,7 +11,7 @@ use alloc::vec::Vec;
 /// 5. Appending and re-sorting only if new items were added
 pub(crate) fn extend_sorted_vec<K, V>(target: &mut Vec<(K, V)>, other: &[(K, V)])
 where
-    K: Clone + Ord + core::hash::Hash + Eq,
+    K: Clone + Ord,
     V: Clone,
 {
     if other.is_empty() {


### PR DESCRIPTION


### Description
- **Summary**: Remove unused and redundant trait bounds to simplify the API and improve reusability.
- **Rationale**: The function doesn't use hashing, so `Hash` bound is unnecessary. `Eq` is redundant since `Ord` already implies `Eq`.
- **Changes**:
  - Remove `core::hash::Hash + Eq` bounds from key type `K`
  - Keep only `Clone + Ord` which are actually required for the merge logic
