### PR TITLE
feat(engine): improve payload validator tracing spans 2

### DIFF
--- a/crates/engine/tree/src/chain.rs
+++ b/crates/engine/tree/src/chain.rs
@@ -71,7 +71,7 @@ where
     /// Internal function used to advance the chain.
     ///
     /// Polls the `ChainOrchestrator` for the next event.
-    #[tracing::instrument(level = "debug", name = "ChainOrchestrator::poll", skip(self, cx))]
+    #[tracing::instrument(name = "ChainOrchestrator::poll", skip(self, cx))]
     fn poll_next_event(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<ChainEvent<T::Event>> {
         let this = self.get_mut();
 

--- a/crates/engine/tree/src/chain.rs
+++ b/crates/engine/tree/src/chain.rs
@@ -71,7 +71,7 @@ where
     /// Internal function used to advance the chain.
     ///
     /// Polls the `ChainOrchestrator` for the next event.
-    #[tracing::instrument(name = "ChainOrchestrator::poll", skip(self, cx))]
+    #[tracing::instrument(level = "debug", target = "engine::tree::chain_orchestrator", skip_all)]
     fn poll_next_event(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<ChainEvent<T::Event>> {
         let this = self.get_mut();
 

--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -18,7 +18,7 @@ use reth_trie::{
     MultiProofTargets, StorageMultiProof, StorageProof, TrieInput,
 };
 use std::{sync::Arc, time::Duration};
-use tracing::trace;
+use tracing::{debug_span, instrument, trace};
 
 pub(crate) type Cache<K, V> =
     mini_moka::sync::Cache<K, V, alloy_primitives::map::DefaultHashBuilder>;
@@ -354,6 +354,7 @@ impl ExecutionCache {
     }
 
     /// Invalidates the storage for all addresses in the set
+    #[instrument(level = "debug", target = "engine::tree", skip_all, fields(accounts = addresses.len()))]
     pub(crate) fn invalidate_storages(&self, addresses: HashSet<&Address>) {
         // NOTE: this must collect because the invalidate function should not be called while we
         // hold an iter for it
@@ -385,12 +386,25 @@ impl ExecutionCache {
     /// ## Error Handling
     ///
     /// Returns an error if the state updates are inconsistent and should be discarded.
+    #[instrument(level = "debug", target = "engine::tree", skip_all)]
     pub(crate) fn insert_state(&self, state_updates: &BundleState) -> Result<(), ()> {
+        let _enter =
+            debug_span!(target: "engine::tree", "contracts", len = state_updates.contracts.len())
+                .entered();
         // Insert bytecodes
         for (code_hash, bytecode) in &state_updates.contracts {
             self.code_cache.insert(*code_hash, Some(Bytecode(bytecode.clone())));
         }
+        drop(_enter);
 
+        let _enter = debug_span!(
+            target: "engine::tree",
+            "accounts",
+            accounts = state_updates.state.len(),
+            storages =
+                state_updates.state.values().map(|account| account.storage.len()).sum::<usize>()
+        )
+        .entered();
         let mut invalidated_accounts = HashSet::default();
         for (addr, account) in &state_updates.state {
             // If the account was not modified, as in not changed and not destroyed, then we have

--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -354,7 +354,7 @@ impl ExecutionCache {
     }
 
     /// Invalidates the storage for all addresses in the set
-    #[instrument(level = "debug", target = "engine::tree", skip_all, fields(accounts = addresses.len()))]
+    #[instrument(level = "debug", target = "engine::caching", skip_all, fields(accounts = addresses.len()))]
     pub(crate) fn invalidate_storages(&self, addresses: HashSet<&Address>) {
         // NOTE: this must collect because the invalidate function should not be called while we
         // hold an iter for it
@@ -386,7 +386,7 @@ impl ExecutionCache {
     /// ## Error Handling
     ///
     /// Returns an error if the state updates are inconsistent and should be discarded.
-    #[instrument(level = "debug", target = "engine::tree", skip_all)]
+    #[instrument(level = "debug", target = "engine::caching", skip_all)]
     pub(crate) fn insert_state(&self, state_updates: &BundleState) -> Result<(), ()> {
         let _enter =
             debug_span!(target: "engine::tree", "contracts", len = state_updates.contracts.len())

--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -79,7 +79,7 @@ impl EngineApiMetrics {
             for tx in transactions {
                 let tx = tx?;
                 let span =
-                    debug_span!(target: "engine::tree", "execute_tx", tx_hash=?tx.tx().tx_hash());
+                    debug_span!(target: "engine::tree", "execute tx", tx_hash=?tx.tx().tx_hash());
                 let _enter = span.enter();
                 trace!(target: "engine::tree", "Executing transaction");
                 executor.execute_transaction(tx)?;

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -496,7 +496,12 @@ where
     ///
     /// This returns a [`PayloadStatus`] that represents the outcome of a processed new payload and
     /// returns an error if an internal error occurred.
-    #[instrument(level = "trace", skip_all, fields(block_hash = %payload.block_hash(), block_num = %payload.block_number(),), target = "engine::tree")]
+    #[instrument(
+        level = "debug",
+        target = "engine::tree",
+        skip_all,
+        fields(block_hash = %payload.block_hash(), block_num = %payload.block_number()),
+    )]
     fn on_new_payload(
         &mut self,
         payload: T::ExecutionData,
@@ -577,6 +582,7 @@ where
     /// - `Valid`: Payload successfully validated and inserted
     /// - `Syncing`: Parent missing, payload buffered for later
     /// - Error status: Payload is invalid
+    #[instrument(level = "debug", target = "engine::tree", skip_all)]
     fn try_insert_payload(
         &mut self,
         payload: T::ExecutionData,
@@ -970,7 +976,7 @@ where
     /// `engine_forkchoiceUpdated`](https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md#specification-1).
     ///
     /// Returns an error if an internal error occurred like a database error.
-    #[instrument(level = "trace", skip_all, fields(head = % state.head_block_hash, safe = % state.safe_block_hash,finalized = % state.finalized_block_hash), target = "engine::tree")]
+    #[instrument(level = "debug", target = "engine::tree", skip_all, fields(head = % state.head_block_hash, safe = % state.safe_block_hash,finalized = % state.finalized_block_hash))]
     fn on_forkchoice_updated(
         &mut self,
         state: ForkchoiceState,
@@ -1972,7 +1978,7 @@ where
     }
 
     /// Attempts to connect any buffered blocks that are connected to the given parent hash.
-    #[instrument(level = "trace", skip(self), target = "engine::tree")]
+    #[instrument(level = "debug", target = "engine::tree", skip(self))]
     fn try_connect_buffered_blocks(
         &mut self,
         parent: BlockNumHash,
@@ -2281,7 +2287,7 @@ where
     /// Returns an event with the appropriate action to take, such as:
     ///  - download more missing blocks
     ///  - try to canonicalize the target if the `block` is the tracked target (head) block.
-    #[instrument(level = "trace", skip_all, fields(block_hash = %block.hash(), block_num = %block.number(),), target = "engine::tree")]
+    #[instrument(level = "debug", target = "engine::tree", skip_all, fields(block_hash = %block.hash(), block_num = %block.number()))]
     fn on_downloaded_block(
         &mut self,
         block: RecoveredBlock<N::Block>,
@@ -2387,6 +2393,7 @@ where
     /// Returns `InsertPayloadOk::Inserted(BlockStatus::Valid)` on successful execution,
     /// `InsertPayloadOk::AlreadySeen` if the block already exists, or
     /// `InsertPayloadOk::Inserted(BlockStatus::Disconnected)` if parent state is missing.
+    #[instrument(level = "debug", target = "engine::tree", skip_all, fields(block_id))]
     fn insert_block_or_payload<Input, Err>(
         &mut self,
         block_id: BlockWithParent,

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -45,7 +45,7 @@ use std::sync::{
     mpsc::{self, channel, Sender},
     Arc,
 };
-use tracing::{debug, instrument, warn};
+use tracing::{debug, debug_span, instrument, warn};
 
 mod configured_sparse_trie;
 pub mod executor;
@@ -167,6 +167,12 @@ where
     /// This returns a handle to await the final state root and to interact with the tasks (e.g.
     /// canceling)
     #[allow(clippy::type_complexity)]
+    #[instrument(
+        level = "debug",
+        target = "engine::tree::payload_processor",
+        name = "payload processor",
+        skip_all
+    )]
     pub fn spawn<P, I: ExecutableTxIterator<Evm>>(
         &mut self,
         env: ExecutionEnv<Evm>,
@@ -236,7 +242,9 @@ where
         );
 
         // spawn multi-proof task
+        let span = tracing::Span::current();
         self.executor.spawn_blocking(move || {
+            let _enter = span.entered();
             multi_proof_task.run();
         });
 
@@ -257,6 +265,7 @@ where
     /// Spawns a task that exclusively handles cache prewarming for transaction execution.
     ///
     /// Returns a [`PayloadHandle`] to communicate with the task.
+    #[instrument(level = "debug", target = "engine::tree::payload_processor", skip_all)]
     pub(super) fn spawn_cache_exclusive<P, I: ExecutableTxIterator<Evm>>(
         &self,
         env: ExecutionEnv<Evm>,
@@ -353,7 +362,9 @@ where
         // spawn pre-warm task
         {
             let to_prewarm_task = to_prewarm_task.clone();
+            let span = debug_span!(target: "engine::tree::payload_processor", "prewarm task");
             self.executor.spawn_blocking(move || {
+                let _enter = span.entered();
                 prewarm_task.run(transactions, to_prewarm_task);
             });
         }
@@ -370,7 +381,7 @@ where
     ///
     /// If the given hash is different then what is recently cached, then this will create a new
     /// instance.
-    #[instrument(target = "engine::caching", skip(self))]
+    #[instrument(level = "debug", target = "engine::caching", skip(self))]
     fn cache_for(&self, parent_hash: B256) -> SavedCache {
         if let Some(cache) = self.execution_cache.get_cache_for(parent_hash) {
             debug!("reusing execution cache");
@@ -383,6 +394,7 @@ where
     }
 
     /// Spawns the [`SparseTrieTask`] for this payload processor.
+    #[instrument(level = "debug", target = "engine::tree::payload_processor", skip_all)]
     fn spawn_sparse_trie_task<BPF>(
         &self,
         sparse_trie_rx: mpsc::Receiver<SparseTrieUpdate>,
@@ -421,13 +433,18 @@ where
                 sparse_state_trie,
             );
 
+        let span = tracing::Span::current();
         self.executor.spawn_blocking(move || {
+            let _enter = span.entered();
+
             let (result, trie) = task.run();
             // Send state root computation result
             let _ = state_root_tx.send(result);
 
-            // Clear the SparseStateTrie and replace it back into the mutex _after_ sending results
-            // to the next step, so that time spent clearing doesn't block the step after this one.
+            // Clear the SparseStateTrie and replace it back into the mutex _after_ sending
+            // results to the next step, so that time spent clearing doesn't block the step after
+            // this one.
+            let _enter = debug_span!(target: "engine::tree::payload_processor", "clear").entered();
             cleared_sparse_trie.lock().replace(ClearedSparseStateTrie::from_state_trie(trie));
         });
     }
@@ -452,6 +469,7 @@ impl<Tx, Err> PayloadHandle<Tx, Err> {
     /// # Panics
     ///
     /// If payload processing was started without background tasks.
+    #[instrument(level = "debug", target = "engine::tree::payload_processor", skip_all)]
     pub fn state_root(&mut self) -> Result<StateRootComputeOutcome, ParallelStateRootError> {
         self.state_root
             .take()

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -193,6 +193,7 @@ where
             + Clone
             + 'static,
     {
+        let span = tracing::Span::current();
         let (to_sparse_trie, sparse_trie_rx) = channel();
         // spawn multiproof task, save the trie input
         let (trie_input, state_root_config) = MultiProofConfig::from_input(trie_input);
@@ -242,7 +243,6 @@ where
         );
 
         // spawn multi-proof task
-        let span = tracing::Span::current();
         self.executor.spawn_blocking(move || {
             let _enter = span.entered();
             multi_proof_task.run();

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -780,7 +780,7 @@ impl MultiProofTask {
         let all_proofs_processed =
             proofs_processed >= state_update_proofs_requested + prefetch_proofs_requested;
         let no_pending = !self.proof_sequencer.has_pending();
-        debug!(
+        trace!(
             target: "engine::root",
             proofs_processed,
             state_update_proofs_requested,
@@ -1016,7 +1016,7 @@ impl MultiProofTask {
                         let storage_targets =
                             targets.values().map(|slots| slots.len()).sum::<usize>();
                         prefetch_proofs_requested += self.on_prefetch_proof(targets);
-                        debug!(
+                        trace!(
                             target: "engine::root",
                             account_targets,
                             storage_targets,
@@ -1037,7 +1037,7 @@ impl MultiProofTask {
 
                         let len = update.len();
                         state_update_proofs_requested += self.on_state_update(source, update);
-                        debug!(
+                        trace!(
                             target: "engine::root",
                             ?source,
                             len,
@@ -1099,7 +1099,7 @@ impl MultiProofTask {
                             .proof_calculation_duration_histogram
                             .record(proof_calculated.elapsed);
 
-                        debug!(
+                        trace!(
                             target: "engine::root",
                             sequence = proof_calculated.sequence_number,
                             total_proofs = proofs_processed,

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -1222,7 +1222,6 @@ mod tests {
     use reth_trie::{MultiProof, TrieInput};
     use reth_trie_parallel::proof_task::{ProofTaskCtx, ProofWorkerHandle};
     use revm_primitives::{B256, U256};
-    use tracing::Span;
 
     fn create_test_state_root_task<F>(factory: F) -> MultiProofTask
     where

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -975,7 +975,12 @@ impl MultiProofTask {
     ///      currently being calculated, or if there are any pending proofs in the proof sequencer
     ///      left to be revealed by checking the pending tasks.
     /// 6. This task exits after all pending proofs are processed.
-    #[instrument(level = "debug", target = "engine::tree::payload_processor::multiproof", skip_all)]
+    #[instrument(
+        level = "debug",
+        name = "MultiProofTask::run",
+        target = "engine::tree::payload_processor::multiproof",
+        skip_all
+    )]
     pub(crate) fn run(mut self) {
         // TODO convert those into fields
         let mut prefetch_proofs_requested = 0;

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -1217,6 +1217,7 @@ mod tests {
     use reth_trie::{MultiProof, TrieInput};
     use reth_trie_parallel::proof_task::{ProofTaskCtx, ProofWorkerHandle};
     use revm_primitives::{B256, U256};
+    use tracing::Span;
 
     fn create_test_state_root_task<F>(factory: F) -> MultiProofTask
     where

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -32,7 +32,7 @@ use std::{
     },
     time::{Duration, Instant},
 };
-use tracing::{debug, error, trace};
+use tracing::{debug, error, instrument, trace};
 
 /// A trie update that can be applied to sparse trie alongside the proofs for touched parts of the
 /// state.
@@ -718,6 +718,7 @@ impl MultiProofTask {
     /// Handles request for proof prefetch.
     ///
     /// Returns a number of proofs that were spawned.
+    #[instrument(level = "debug", target = "engine::tree::payload_processor::multiproof", skip_all, fields(accounts = targets.len()))]
     fn on_prefetch_proof(&mut self, targets: MultiProofTargets) -> u64 {
         let proof_targets = self.get_prefetch_proof_targets(targets);
         self.fetched_proof_targets.extend_ref(&proof_targets);
@@ -844,6 +845,7 @@ impl MultiProofTask {
     /// Handles state updates.
     ///
     /// Returns a number of proofs that were spawned.
+    #[instrument(level = "debug", target = "engine::tree::payload_processor::multiproof", skip(self, update), fields(accounts = update.len()))]
     fn on_state_update(&mut self, source: StateChangeSource, update: EvmState) -> u64 {
         let hashed_state_update = evm_state_to_hashed_post_state(update);
 
@@ -973,6 +975,7 @@ impl MultiProofTask {
     ///      currently being calculated, or if there are any pending proofs in the proof sequencer
     ///      left to be revealed by checking the pending tasks.
     /// 6. This task exits after all pending proofs are processed.
+    #[instrument(level = "debug", target = "engine::tree::payload_processor::multiproof", skip_all)]
     pub(crate) fn run(mut self) {
         // TODO convert those into fields
         let mut prefetch_proofs_requested = 0;

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -39,7 +39,7 @@ use std::{
     },
     time::Instant,
 };
-use tracing::{debug, trace, warn};
+use tracing::{debug, debug_span, instrument, trace, warn};
 
 /// A wrapper for transactions that includes their index in the block.
 #[derive(Clone)]
@@ -139,8 +139,11 @@ where
         let ctx = self.ctx.clone();
         let max_concurrency = self.max_concurrency;
         let transaction_count_hint = self.transaction_count_hint;
+        let span = tracing::Span::current();
 
         self.executor.spawn_blocking(move || {
+            let _enter = debug_span!(target: "engine::tree::payload_processor::prewarm", parent: span, "spawn_all").entered();
+
             let (done_tx, done_rx) = mpsc::channel();
             let mut executing = 0usize;
 
@@ -157,8 +160,8 @@ where
             };
 
             // Only spawn initial workers as needed
-            for _ in 0..workers_needed {
-                handles.push(ctx.spawn_worker(&executor, actions_tx.clone(), done_tx.clone()));
+            for i in 0..workers_needed {
+                handles.push(ctx.spawn_worker(i, &executor, actions_tx.clone(), done_tx.clone()));
             }
 
             let mut tx_index = 0usize;
@@ -248,6 +251,7 @@ where
     /// the new, warmed cache to be inserted.
     ///
     /// This method is called from `run()` only after all execution tasks are complete.
+    #[instrument(level = "debug", target = "engine::tree::payload_processor::prewarm", skip_all)]
     fn save_cache(self, state: BundleState) {
         let start = Instant::now();
 
@@ -284,6 +288,12 @@ where
     ///
     /// This will execute the transactions until all transactions have been processed or the task
     /// was cancelled.
+    #[instrument(
+        level = "debug",
+        target = "engine::tree::payload_processor::prewarm",
+        name = "prewarm",
+        skip_all
+    )]
     pub(super) fn run(
         self,
         pending: mpsc::Receiver<impl ExecutableTxFor<Evm> + Clone + Send + 'static>,
@@ -364,6 +374,7 @@ where
 {
     /// Splits this context into an evm, an evm config, metrics, and the atomic bool for terminating
     /// execution.
+    #[instrument(level = "debug", target = "engine::tree::payload_processor::prewarm", skip_all)]
     fn evm_for_ctx(self) -> Option<(EvmFor<Evm, impl Database>, PrewarmMetrics, Arc<AtomicBool>)> {
         let Self {
             env,
@@ -380,7 +391,7 @@ where
             Ok(provider) => provider,
             Err(err) => {
                 trace!(
-                    target: "engine::tree",
+                    target: "engine::tree::payload_processor::prewarm",
                     %err,
                     "Failed to build state provider in prewarm thread"
                 );
@@ -429,6 +440,7 @@ where
     ///
     /// Note: There are no ordering guarantees; this does not reflect the state produced by
     /// sequential execution.
+    #[instrument(level = "debug", target = "engine::tree::payload_processor::prewarm", skip_all)]
     fn transact_batch<Tx>(
         self,
         txs: mpsc::Receiver<IndexedTransaction<Tx>>,
@@ -439,7 +451,15 @@ where
     {
         let Some((mut evm, metrics, terminate_execution)) = self.evm_for_ctx() else { return };
 
-        while let Ok(IndexedTransaction { index, tx }) = txs.recv() {
+        while let Ok(IndexedTransaction { index, tx }) = {
+            let _enter = debug_span!(target: "engine::tree::payload_processor::prewarm", "recv tx")
+                .entered();
+            txs.recv()
+        } {
+            let _enter =
+                debug_span!(target: "engine::tree::payload_processor::prewarm", "prewarm tx", index, tx_hash=%tx.tx().tx_hash())
+                    .entered();
+
             // If the task was cancelled, stop execution, send an empty result to notify the task,
             // and exit.
             if terminate_execution.load(Ordering::Relaxed) {
@@ -467,12 +487,18 @@ where
             };
             metrics.execution_duration.record(start.elapsed());
 
+            drop(_enter);
+
             // Only send outcome for transactions after the first txn
             // as the main execution will be just as fast
             if index > 0 {
+                let _enter =
+                    debug_span!(target: "engine::tree::payload_processor::prewarm", "prewarm outcome", index, tx_hash=%tx.tx().tx_hash())
+                        .entered();
                 let (targets, storage_targets) = multiproof_targets_from_state(res.state);
                 metrics.prefetch_storage_targets.record(storage_targets as f64);
                 let _ = sender.send(PrewarmTaskEvent::Outcome { proof_targets: Some(targets) });
+                drop(_enter);
             }
 
             metrics.total_runtime.record(start.elapsed());
@@ -485,6 +511,7 @@ where
     /// Spawns a worker task for transaction execution and returns its sender channel.
     fn spawn_worker<Tx>(
         &self,
+        idx: usize,
         executor: &WorkloadExecutor,
         actions_tx: Sender<PrewarmTaskEvent>,
         done_tx: Sender<()>,
@@ -494,8 +521,11 @@ where
     {
         let (tx, rx) = mpsc::channel();
         let ctx = self.clone();
+        let span =
+            debug_span!(target: "engine::tree::payload_processor::prewarm", "prewarm worker", idx);
 
         executor.spawn_blocking(move || {
+            let _enter = span.entered();
             ctx.transact_batch(rx, actions_tx, done_tx);
         });
 

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -15,7 +15,7 @@ use std::{
     sync::mpsc,
     time::{Duration, Instant},
 };
-use tracing::{debug, trace, trace_span};
+use tracing::{debug, debug_span, instrument, trace};
 
 /// A task responsible for populating the sparse trie.
 pub(super) struct SparseTrieTask<BPF, A = SerialSparseTrie, S = SerialSparseTrie>
@@ -61,6 +61,11 @@ where
     ///
     /// - State root computation outcome.
     /// - `SparseStateTrie` that needs to be cleared and reused to avoid reallocations.
+    #[instrument(
+        level = "debug",
+        target = "engine::tree::payload_processor::sparse_trie",
+        skip_all
+    )]
     pub(super) fn run(
         mut self,
     ) -> (Result<StateRootComputeOutcome, ParallelStateRootError>, SparseStateTrie<A, S>) {
@@ -80,10 +85,14 @@ where
         while let Ok(mut update) = self.updates.recv() {
             num_iterations += 1;
             let mut num_updates = 1;
+            let _enter =
+                debug_span!(target: "engine::tree::payload_processor::sparse_trie", "drain updates")
+                    .entered();
             while let Ok(next) = self.updates.try_recv() {
                 update.extend(next);
                 num_updates += 1;
             }
+            drop(_enter);
 
             debug!(
                 target: "engine::root",
@@ -130,6 +139,7 @@ pub struct StateRootComputeOutcome {
 }
 
 /// Updates the sparse trie with the given proofs and state, and returns the elapsed time.
+#[instrument(level = "debug", target = "engine::tree::payload_processor::sparse_trie", skip_all)]
 pub(crate) fn update_sparse_trie<BPF, A, S>(
     trie: &mut SparseStateTrie<A, S>,
     SparseTrieUpdate { mut state, multiproof }: SparseTrieUpdate,
@@ -155,6 +165,7 @@ where
     );
 
     // Update storage slots with new values and calculate storage roots.
+    let span = tracing::Span::current();
     let (tx, rx) = mpsc::channel();
     state
         .storages
@@ -162,14 +173,16 @@ where
         .map(|(address, storage)| (address, storage, trie.take_storage_trie(&address)))
         .par_bridge()
         .map(|(address, storage, storage_trie)| {
-            let span = trace_span!(target: "engine::root::sparse", "Storage trie", ?address);
-            let _enter = span.enter();
-            trace!(target: "engine::root::sparse", "Updating storage");
+            let _enter =
+                debug_span!(target: "engine::tree::payload_processor::sparse_trie", parent: span.clone(), "storage trie", ?address)
+                    .entered();
+
+            trace!(target: "engine::tree::payload_processor::sparse_trie", "Updating storage");
             let storage_provider = blinded_provider_factory.storage_node_provider(address);
             let mut storage_trie = storage_trie.ok_or(SparseTrieErrorKind::Blind)?;
 
             if storage.wiped {
-                trace!(target: "engine::root::sparse", "Wiping storage");
+                trace!(target: "engine::tree::payload_processor::sparse_trie", "Wiping storage");
                 storage_trie.wipe()?;
             }
 
@@ -187,7 +200,7 @@ where
                     continue;
                 }
 
-                trace!(target: "engine::root::sparse", ?slot_nibbles, "Updating storage slot");
+                trace!(target: "engine::tree::payload_processor::sparse_trie", ?slot_nibbles, "Updating storage slot");
                 storage_trie.update_leaf(
                     slot_nibbles,
                     alloy_rlp::encode_fixed_size(&value).to_vec(),
@@ -219,6 +232,9 @@ where
     let mut removed_accounts = Vec::new();
 
     // Update account storage roots
+    let _enter =
+        tracing::debug_span!(target: "engine::tree::payload_processor::sparse_trie", "account trie")
+            .entered();
     for result in rx {
         let (address, storage_trie) = result?;
         trie.insert_storage_trie(address, storage_trie);

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -329,7 +329,7 @@ where
         skip_all,
         fields(
             parent = ?input.parent_hash(),
-            block_num_hash = ?input.num_hash()
+            type_name = ?input.type_name(),
         )
     )]
     pub fn validate_block_with_state<T: PayloadTypes<BuiltPayload: BuiltPayload<Primitives = N>>>(
@@ -1255,6 +1255,14 @@ impl<T: PayloadTypes> BlockOrPayload<T> {
         match self {
             Self::Payload(payload) => payload.block_with_parent(),
             Self::Block(block) => block.block_with_parent(),
+        }
+    }
+
+    /// Returns a string showing whether or not this is a block or payload.
+    pub const fn type_name(&self) -> &'static str {
+        match self {
+            Self::Payload(_) => "payload",
+            Self::Block(_) => "block",
         }
     }
 }

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -44,9 +44,8 @@ use reth_trie::{
 };
 use reth_trie_db::DatabaseHashedPostState;
 use reth_trie_parallel::root::{ParallelStateRoot, ParallelStateRootError};
-use revm::context::Block;
 use std::{collections::HashMap, sync::Arc, time::Instant};
-use tracing::{debug, debug_span, error, info, trace, warn};
+use tracing::{debug, debug_span, error, info, instrument, trace, warn};
 
 /// Context providing access to tree state during validation.
 ///
@@ -289,7 +288,7 @@ where
         V: PayloadValidator<T, Block = N::Block>,
     {
         debug!(
-            target: "engine::tree",
+            target: "engine::tree::payload_validator",
             ?execution_err,
             block = ?input.num_hash(),
             "Block execution failed, checking for header validation errors"
@@ -324,6 +323,15 @@ where
     /// - Block execution
     /// - State root computation
     /// - Fork detection
+    #[instrument(
+        level = "debug",
+        target = "engine::tree::payload_validator",
+        skip_all,
+        fields(
+            parent = ?input.parent_hash(),
+            block_num_hash = ?input.num_hash()
+        )
+    )]
     pub fn validate_block_with_state<T: PayloadTypes<BuiltPayload: BuiltPayload<Primitives = N>>>(
         &mut self,
         input: BlockOrPayload<T>,
@@ -366,7 +374,9 @@ where
         let parent_hash = input.parent_hash();
         let block_num_hash = input.num_hash();
 
-        trace!(target: "engine::tree", block=?block_num_hash, parent=?parent_hash, "Fetching block state provider");
+        trace!(target: "engine::tree::payload_validator", "Fetching block state provider");
+        let _enter =
+            debug_span!(target: "engine::tree::payload_validator", "state provider").entered();
         let Some(provider_builder) =
             ensure_ok!(self.state_provider_builder(parent_hash, ctx.state()))
         else {
@@ -377,8 +387,8 @@ where
             )
             .into())
         };
-
         let state_provider = ensure_ok!(provider_builder.build());
+        drop(_enter);
 
         // fetch parent block
         let Some(parent_block) = ensure_ok!(self.sealed_header_by_hash(parent_hash, ctx.state()))
@@ -390,7 +400,9 @@ where
             .into())
         };
 
-        let evm_env = self.evm_env_for(&input).map_err(NewPayloadError::other)?;
+        let evm_env = debug_span!(target: "engine::tree::payload_validator", "evm env")
+            .in_scope(|| self.evm_env_for(&input))
+            .map_err(NewPayloadError::other)?;
 
         let env = ExecutionEnv { evm_env, hash: input.hash(), parent_hash: input.parent_hash() };
 
@@ -400,8 +412,7 @@ where
         let strategy = state_root_plan.strategy;
 
         debug!(
-            target: "engine::tree",
-            block=?block_num_hash,
+            target: "engine::tree::payload_validator",
             ?strategy,
             "Deciding which state root algorithm to run"
         );
@@ -417,7 +428,6 @@ where
             persisting_kind,
             parent_hash,
             ctx.state(),
-            block_num_hash,
             strategy,
         ));
 
@@ -452,7 +462,7 @@ where
             block
         );
 
-        debug!(target: "engine::tree", block=?block_num_hash, "Calculating block state root");
+        debug!(target: "engine::tree::payload_validator", "Calculating block state root");
 
         let root_time = Instant::now();
 
@@ -460,17 +470,17 @@ where
 
         match strategy {
             StateRootStrategy::StateRootTask => {
-                debug!(target: "engine::tree", block=?block_num_hash, "Using sparse trie state root algorithm");
+                debug!(target: "engine::tree::payload_validator", "Using sparse trie state root algorithm");
                 match handle.state_root() {
                     Ok(StateRootComputeOutcome { state_root, trie_updates }) => {
                         let elapsed = root_time.elapsed();
-                        info!(target: "engine::tree", ?state_root, ?elapsed, "State root task finished");
+                        info!(target: "engine::tree::payload_validator", ?state_root, ?elapsed, "State root task finished");
                         // we double check the state root here for good measure
                         if state_root == block.header().state_root() {
                             maybe_state_root = Some((state_root, trie_updates, elapsed))
                         } else {
                             warn!(
-                                target: "engine::tree",
+                                target: "engine::tree::payload_validator",
                                 ?state_root,
                                 block_state_root = ?block.header().state_root(),
                                 "State root task returned incorrect state root"
@@ -478,12 +488,12 @@ where
                         }
                     }
                     Err(error) => {
-                        debug!(target: "engine::tree", %error, "State root task failed");
+                        debug!(target: "engine::tree::payload_validator", %error, "State root task failed");
                     }
                 }
             }
             StateRootStrategy::Parallel => {
-                debug!(target: "engine::tree", block=?block_num_hash, "Using parallel state root algorithm");
+                debug!(target: "engine::tree::payload_validator", "Using parallel state root algorithm");
                 match self.compute_state_root_parallel(
                     persisting_kind,
                     block.parent_hash(),
@@ -493,8 +503,7 @@ where
                     Ok(result) => {
                         let elapsed = root_time.elapsed();
                         info!(
-                            target: "engine::tree",
-                            block = ?block_num_hash,
+                            target: "engine::tree::payload_validator",
                             regular_state_root = ?result.0,
                             ?elapsed,
                             "Regular root task finished"
@@ -502,7 +511,7 @@ where
                         maybe_state_root = Some((result.0, result.1, elapsed));
                     }
                     Err(error) => {
-                        debug!(target: "engine::tree", %error, "Parallel state root computation failed");
+                        debug!(target: "engine::tree::payload_validator", %error, "Parallel state root computation failed");
                     }
                 }
             }
@@ -519,9 +528,9 @@ where
         } else {
             // fallback is to compute the state root regularly in sync
             if self.config.state_root_fallback() {
-                debug!(target: "engine::tree", block=?block_num_hash, "Using state root fallback for testing");
+                debug!(target: "engine::tree::payload_validator", "Using state root fallback for testing");
             } else {
-                warn!(target: "engine::tree", block=?block_num_hash, ?persisting_kind, "Failed to compute state root in parallel");
+                warn!(target: "engine::tree::payload_validator", ?persisting_kind, "Failed to compute state root in parallel");
                 self.metrics.block_validation.state_root_parallel_fallback_total.increment(1);
             }
 
@@ -533,7 +542,7 @@ where
         };
 
         self.metrics.block_validation.record_state_root(&trie_output, root_elapsed.as_secs_f64());
-        debug!(target: "engine::tree", ?root_elapsed, block=?block_num_hash, "Calculated state root");
+        debug!(target: "engine::tree::payload_validator", ?root_elapsed, "Calculated state root");
 
         // ensure state root matches
         if state_root != block.header().state_root() {
@@ -587,12 +596,12 @@ where
     /// and block body itself.
     fn validate_block_inner(&self, block: &RecoveredBlock<N::Block>) -> Result<(), ConsensusError> {
         if let Err(e) = self.consensus.validate_header(block.sealed_header()) {
-            error!(target: "engine::tree", ?block, "Failed to validate header {}: {e}", block.hash());
+            error!(target: "engine::tree::payload_validator", ?block, "Failed to validate header {}: {e}", block.hash());
             return Err(e)
         }
 
         if let Err(e) = self.consensus.validate_block_pre_execution(block.sealed_block()) {
-            error!(target: "engine::tree", ?block, "Failed to validate block {}: {e}", block.hash());
+            error!(target: "engine::tree::payload_validator", ?block, "Failed to validate block {}: {e}", block.hash());
             return Err(e)
         }
 
@@ -600,6 +609,7 @@ where
     }
 
     /// Executes a block with the given state provider
+    #[instrument(level = "debug", target = "engine::tree::payload_validator", skip_all)]
     fn execute_block<S, Err, T>(
         &mut self,
         state_provider: S,
@@ -614,11 +624,7 @@ where
         T: PayloadTypes<BuiltPayload: BuiltPayload<Primitives = N>>,
         Evm: ConfigureEngineEvm<T::ExecutionData, Primitives = N>,
     {
-        let num_hash = NumHash::new(env.evm_env.block_env.number().to(), env.hash);
-
-        let span = debug_span!(target: "engine::tree", "execute_block", num = ?num_hash.number, hash = ?num_hash.hash);
-        let _enter = span.enter();
-        debug!(target: "engine::tree", "Executing block");
+        debug!(target: "engine::tree::payload_validator", "Executing block");
 
         let mut db = State::builder()
             .with_database(StateProviderDatabase::new(&state_provider))
@@ -657,7 +663,7 @@ where
         )?;
         let execution_finish = Instant::now();
         let execution_time = execution_finish.duration_since(execution_start);
-        debug!(target: "engine::tree", elapsed = ?execution_time, number=?num_hash.number, "Executed block");
+        debug!(target: "engine::tree::payload_validator", elapsed = ?execution_time, "Executed block");
         Ok(output)
     }
 
@@ -669,6 +675,7 @@ where
     /// Returns `Err(_)` if error was encountered during computation.
     /// `Err(ProviderError::ConsistentView(_))` can be safely ignored and fallback computation
     /// should be used instead.
+    #[instrument(level = "debug", target = "engine::tree::payload_validator", skip_all)]
     fn compute_state_root_parallel(
         &self,
         persisting_kind: PersistingKind,
@@ -709,7 +716,7 @@ where
     {
         let start = Instant::now();
 
-        trace!(target: "engine::tree", block=?block.num_hash(), "Validating block consensus");
+        trace!(target: "engine::tree::payload_validator", block=?block.num_hash(), "Validating block consensus");
         // validate block consensus rules
         if let Err(e) = self.validate_block_inner(block) {
             return Err(e.into())
@@ -719,7 +726,7 @@ where
         if let Err(e) =
             self.consensus.validate_header_against_parent(block.sealed_header(), parent_block)
         {
-            warn!(target: "engine::tree", ?block, "Failed to validate header {} against parent: {e}", block.hash());
+            warn!(target: "engine::tree::payload_validator", ?block, "Failed to validate header {} against parent: {e}", block.hash());
             return Err(e.into())
         }
 
@@ -759,6 +766,12 @@ where
     /// The method handles strategy fallbacks if the preferred approach fails, ensuring
     /// block execution always completes with a valid state root.
     #[allow(clippy::too_many_arguments)]
+    #[instrument(
+        level = "debug",
+        target = "engine::tree::payload_validator",
+        skip_all,
+        fields(strategy)
+    )]
     fn spawn_payload_processor<T: ExecutableTxIterator<Evm>>(
         &mut self,
         env: ExecutionEnv<Evm>,
@@ -767,7 +780,6 @@ where
         persisting_kind: PersistingKind,
         parent_hash: B256,
         state: &EngineApiTreeState<N>,
-        block_num_hash: NumHash,
         strategy: StateRootStrategy,
     ) -> Result<
         (
@@ -821,8 +833,7 @@ where
                         Err((error, txs, env, provider_builder)) => {
                             // Failed to spawn proof workers, fallback to parallel state root
                             error!(
-                                target: "engine::tree",
-                                block=?block_num_hash,
+                                target: "engine::tree::payload_validator",
                                 ?error,
                                 "Failed to spawn proof workers, falling back to parallel state root"
                             );
@@ -840,8 +851,7 @@ where
                 // prewarming for transaction execution
                 } else {
                     debug!(
-                        target: "engine::tree",
-                        block=?block_num_hash,
+                        target: "engine::tree::payload_validator",
                         "Disabling state root task due to non-empty prefix sets"
                     );
                     (
@@ -884,7 +894,7 @@ where
         state: &EngineApiTreeState<N>,
     ) -> ProviderResult<Option<StateProviderBuilder<N, P>>> {
         if let Some((historical, blocks)) = state.tree_state.blocks_by_hash(hash) {
-            debug!(target: "engine::tree", %hash, %historical, "found canonical state for block in memory, creating provider builder");
+            debug!(target: "engine::tree::payload_validator", %hash, %historical, "found canonical state for block in memory, creating provider builder");
             // the block leads back to the canonical chain
             return Ok(Some(StateProviderBuilder::new(
                 self.provider.clone(),
@@ -895,17 +905,18 @@ where
 
         // Check if the block is persisted
         if let Some(header) = self.provider.header(hash)? {
-            debug!(target: "engine::tree", %hash, number = %header.number(), "found canonical state for block in database, creating provider builder");
+            debug!(target: "engine::tree::payload_validator", %hash, number = %header.number(), "found canonical state for block in database, creating provider builder");
             // For persisted blocks, we create a builder that will fetch state directly from the
             // database
             return Ok(Some(StateProviderBuilder::new(self.provider.clone(), hash, None)))
         }
 
-        debug!(target: "engine::tree", %hash, "no canonical state found for block");
+        debug!(target: "engine::tree::payload_validator", %hash, "no canonical state found for block");
         Ok(None)
     }
 
     /// Determines the state root computation strategy based on persistence state and configuration.
+    #[instrument(level = "debug", target = "engine::tree::payload_validator", skip_all)]
     fn plan_state_root_computation<T: PayloadTypes<BuiltPayload: BuiltPayload<Primitives = N>>>(
         &self,
         input: &BlockOrPayload<T>,
@@ -939,7 +950,7 @@ where
         };
 
         debug!(
-            target: "engine::tree",
+            target: "engine::tree::payload_validator",
             block=?input.num_hash(),
             ?strategy,
             "Planned state root computation strategy"
@@ -979,6 +990,12 @@ where
     ///    block.
     /// 3. Once in-memory blocks are collected and optionally filtered, we compute the
     ///    [`HashedPostState`] from them.
+    #[instrument(
+        level = "debug",
+        target = "engine::tree::payload_validator",
+        skip_all,
+        fields(persisting_kind, parent_hash)
+    )]
     fn compute_trie_input<TP: DBProvider + BlockNumReader + TrieReader>(
         &self,
         persisting_kind: PersistingKind,
@@ -999,6 +1016,9 @@ where
 
         // If the current block is a descendant of the currently persisting blocks, then we need to
         // filter in-memory blocks, so that none of them are already persisted in the database.
+        let _enter =
+            debug_span!(target: "engine::tree::payload_validator", "filter in-memory blocks", len = blocks.len())
+                .entered();
         if persisting_kind.is_descendant() {
             // Iterate over the blocks from oldest to newest.
             while let Some(block) = blocks.last() {
@@ -1023,11 +1043,13 @@ where
                 parent_hash.into()
             };
         }
+        drop(_enter);
 
-        if blocks.is_empty() {
-            debug!(target: "engine::tree", %parent_hash, "Parent found on disk");
+        let blocks_empty = blocks.is_empty();
+        if blocks_empty {
+            debug!(target: "engine::tree::payload_validator", "Parent found on disk");
         } else {
-            debug!(target: "engine::tree", %parent_hash, %historical, blocks = blocks.len(), "Parent found in memory");
+            debug!(target: "engine::tree::payload_validator", %historical, blocks = blocks.len(), "Parent found in memory");
         }
 
         // Convert the historical block to the block number.
@@ -1035,12 +1057,15 @@ where
             .convert_hash_or_number(historical)?
             .ok_or_else(|| ProviderError::BlockHashNotFound(historical.as_hash().unwrap()))?;
 
+        let _enter =
+            debug_span!(target: "engine::tree::payload_validator", "revert state", blocks_empty)
+                .entered();
         // Retrieve revert state for historical block.
         let (revert_state, revert_trie) = if block_number == best_block_number {
             // We do not check against the `last_block_number` here because
             // `HashedPostState::from_reverts` / `trie_reverts` only use the database tables, and
             // not static files.
-            debug!(target: "engine::tree", block_number, best_block_number, "Empty revert state");
+            debug!(target: "engine::tree::payload_validator", block_number, best_block_number, "Empty revert state");
             (HashedPostState::default(), TrieUpdatesSorted::default())
         } else {
             let revert_state = HashedPostState::from_reverts::<KeccakKeyHasher>(
@@ -1050,7 +1075,7 @@ where
             .map_err(ProviderError::from)?;
             let revert_trie = provider.trie_reverts(block_number + 1)?;
             debug!(
-                target: "engine::tree",
+                target: "engine::tree::payload_validator",
                 block_number,
                 best_block_number,
                 accounts = revert_state.accounts.len(),

--- a/crates/net/ecies/src/codec.rs
+++ b/crates/net/ecies/src/codec.rs
@@ -58,7 +58,7 @@ impl Decoder for ECIESCodec {
     type Item = IngressECIESValue;
     type Error = ECIESError;
 
-    #[instrument(skip_all, fields(peer=?self.ecies.remote_id, state=?self.state))]
+    #[instrument(level = "trace", skip_all, fields(peer=?self.ecies.remote_id, state=?self.state))]
     fn decode(&mut self, buf: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
         loop {
             match self.state {
@@ -150,7 +150,7 @@ impl Decoder for ECIESCodec {
 impl Encoder<EgressECIESValue> for ECIESCodec {
     type Error = io::Error;
 
-    #[instrument(skip(self, buf), fields(peer=?self.ecies.remote_id, state=?self.state))]
+    #[instrument(level = "trace", skip(self, buf), fields(peer=?self.ecies.remote_id, state=?self.state))]
     fn encode(&mut self, item: EgressECIESValue, buf: &mut BytesMut) -> Result<(), Self::Error> {
         match item {
             EgressECIESValue::Auth => {

--- a/crates/net/ecies/src/codec.rs
+++ b/crates/net/ecies/src/codec.rs
@@ -58,7 +58,7 @@ impl Decoder for ECIESCodec {
     type Item = IngressECIESValue;
     type Error = ECIESError;
 
-    #[instrument(level = "trace", skip_all, fields(peer=?self.ecies.remote_id, state=?self.state))]
+    #[instrument(skip_all, fields(peer=?self.ecies.remote_id, state=?self.state))]
     fn decode(&mut self, buf: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
         loop {
             match self.state {
@@ -150,7 +150,7 @@ impl Decoder for ECIESCodec {
 impl Encoder<EgressECIESValue> for ECIESCodec {
     type Error = io::Error;
 
-    #[instrument(level = "trace", skip(self, buf), fields(peer=?self.ecies.remote_id, state=?self.state))]
+    #[instrument(skip(self, buf), fields(peer=?self.ecies.remote_id, state=?self.state))]
     fn encode(&mut self, item: EgressECIESValue, buf: &mut BytesMut) -> Result<(), Self::Error> {
         match item {
             EgressECIESValue::Auth => {

--- a/crates/node/core/src/args/trace.rs
+++ b/crates/node/core/src/args/trace.rs
@@ -39,7 +39,7 @@ pub struct TraceArgs {
         long = "tracing-otlp.filter",
         global = true,
         value_name = "FILTER",
-        default_value = "reth=debug",
+        default_value = "debug",
         help_heading = "Tracing"
     )]
     pub otlp_filter: EnvFilter,

--- a/crates/node/core/src/args/trace.rs
+++ b/crates/node/core/src/args/trace.rs
@@ -39,7 +39,7 @@ pub struct TraceArgs {
         long = "tracing-otlp.filter",
         global = true,
         value_name = "FILTER",
-        default_value = "TRACE",
+        default_value = "reth=debug",
         help_heading = "Tracing"
     )]
     pub otlp_filter: EnvFilter,

--- a/crates/prune/prune/src/segments/user/account_history.rs
+++ b/crates/prune/prune/src/segments/user/account_history.rs
@@ -45,7 +45,7 @@ where
         PrunePurpose::User
     }
 
-    #[instrument(level = "trace", target = "pruner", skip(self, provider), ret)]
+    #[instrument(target = "pruner", skip(self, provider), ret(level = "trace"))]
     fn prune(&self, provider: &Provider, input: PruneInput) -> Result<SegmentOutput, PrunerError> {
         let range = match input.get_next_block_range() {
             Some(range) => range,

--- a/crates/prune/prune/src/segments/user/receipts.rs
+++ b/crates/prune/prune/src/segments/user/receipts.rs
@@ -42,7 +42,7 @@ where
         PrunePurpose::User
     }
 
-    #[instrument(level = "trace", target = "pruner", skip(self, provider), ret)]
+    #[instrument(target = "pruner", skip(self, provider), ret(level = "trace"))]
     fn prune(&self, provider: &Provider, input: PruneInput) -> Result<SegmentOutput, PrunerError> {
         crate::segments::receipts::prune(provider, input)
     }

--- a/crates/prune/prune/src/segments/user/receipts_by_logs.rs
+++ b/crates/prune/prune/src/segments/user/receipts_by_logs.rs
@@ -45,7 +45,7 @@ where
         PrunePurpose::User
     }
 
-    #[instrument(level = "trace", target = "pruner", skip(self, provider), ret)]
+    #[instrument(target = "pruner", skip(self, provider), ret(level = "trace"))]
     fn prune(&self, provider: &Provider, input: PruneInput) -> Result<SegmentOutput, PrunerError> {
         // Contract log filtering removes every receipt possible except the ones in the list. So,
         // for the other receipts it's as if they had a `PruneMode::Distance()` of

--- a/crates/prune/prune/src/segments/user/sender_recovery.rs
+++ b/crates/prune/prune/src/segments/user/sender_recovery.rs
@@ -37,7 +37,7 @@ where
         PrunePurpose::User
     }
 
-    #[instrument(level = "trace", target = "pruner", skip(self, provider), ret)]
+    #[instrument(target = "pruner", skip(self, provider), ret(level = "trace"))]
     fn prune(&self, provider: &Provider, input: PruneInput) -> Result<SegmentOutput, PrunerError> {
         let tx_range = match input.get_next_tx_num_range(provider)? {
             Some(range) => range,

--- a/crates/prune/prune/src/segments/user/storage_history.rs
+++ b/crates/prune/prune/src/segments/user/storage_history.rs
@@ -47,7 +47,7 @@ where
         PrunePurpose::User
     }
 
-    #[instrument(level = "trace", target = "pruner", skip(self, provider), ret)]
+    #[instrument(target = "pruner", skip(self, provider), ret(level = "trace"))]
     fn prune(&self, provider: &Provider, input: PruneInput) -> Result<SegmentOutput, PrunerError> {
         let range = match input.get_next_block_range() {
             Some(range) => range,

--- a/crates/prune/prune/src/segments/user/transaction_lookup.rs
+++ b/crates/prune/prune/src/segments/user/transaction_lookup.rs
@@ -38,7 +38,7 @@ where
         PrunePurpose::User
     }
 
-    #[instrument(level = "trace", target = "pruner", skip(self, provider), ret)]
+    #[instrument(target = "pruner", skip(self, provider), ret(level = "trace"))]
     fn prune(
         &self,
         provider: &Provider,

--- a/crates/rpc/ipc/src/server/ipc.rs
+++ b/crates/rpc/ipc/src/server/ipc.rs
@@ -27,7 +27,7 @@ pub(crate) struct Batch<S> {
 // Batch responses must be sent back as a single message so we read the results from each
 // request in the batch and read the results off of a new channel, `rx_batch`, and then send the
 // complete batch response back to the client over `tx`.
-#[instrument(name = "batch", skip(b), level = "TRACE")]
+#[instrument(name = "batch", skip(b))]
 pub(crate) async fn process_batch_request<S>(
     b: Batch<S>,
     max_response_body_size: usize,
@@ -98,7 +98,7 @@ where
     }
 }
 
-#[instrument(name = "method_call", fields(method = req.method.as_ref()), skip(req, rpc_service), level = "TRACE")]
+#[instrument(name = "method_call", fields(method = req.method.as_ref()), skip(req, rpc_service))]
 pub(crate) async fn execute_call_with_tracing<'a, S>(
     req: Request<'a>,
     rpc_service: &S,

--- a/crates/rpc/ipc/src/server/mod.rs
+++ b/crates/rpc/ipc/src/server/mod.rs
@@ -443,7 +443,7 @@ struct ProcessConnection<'a, HttpMiddleware, RpcMiddleware> {
 }
 
 /// Spawns the IPC connection onto a new task
-#[instrument(name = "connection", skip_all, fields(conn_id = %params.conn_id), level = "INFO")]
+#[instrument(name = "connection", skip_all, fields(conn_id = %params.conn_id))]
 fn process_connection<RpcMiddleware, HttpMiddleware>(
     params: ProcessConnection<'_, HttpMiddleware, RpcMiddleware>,
 ) where

--- a/crates/rpc/rpc/src/engine.rs
+++ b/crates/rpc/rpc/src/engine.rs
@@ -16,7 +16,7 @@ use tracing_futures::Instrument;
 
 macro_rules! engine_span {
     () => {
-        tracing::trace_span!(target: "rpc", "engine")
+        tracing::info_span!(target: "rpc", "engine")
     };
 }
 

--- a/crates/trie/db/src/state.rs
+++ b/crates/trie/db/src/state.rs
@@ -20,7 +20,7 @@ use std::{
     collections::HashMap,
     ops::{RangeBounds, RangeInclusive},
 };
-use tracing::debug;
+use tracing::{debug, instrument};
 
 /// Extends [`StateRoot`] with operations specific for working with a database transaction.
 pub trait DatabaseStateRoot<'a, TX>: Sized {
@@ -226,6 +226,7 @@ impl<'a, TX: DbTx> DatabaseStateRoot<'a, TX>
 }
 
 impl<TX: DbTx> DatabaseHashedPostState<TX> for HashedPostState {
+    #[instrument(target = "trie::db", skip(tx), fields(range))]
     fn from_reverts<KH: KeyHasher>(
         tx: &TX,
         range: impl RangeBounds<BlockNumber>,

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -238,6 +238,7 @@ mod tests {
     use reth_trie::proof::Proof;
     use reth_trie_db::{DatabaseHashedCursorFactory, DatabaseTrieCursorFactory};
     use tokio::runtime::Runtime;
+    use tracing::Span;
 
     #[test]
     fn random_parallel_proof() {

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -238,7 +238,6 @@ mod tests {
     use reth_trie::proof::Proof;
     use reth_trie_db::{DatabaseHashedCursorFactory, DatabaseTrieCursorFactory};
     use tokio::runtime::Runtime;
-    use tracing::Span;
 
     #[test]
     fn random_parallel_proof() {

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -889,6 +889,10 @@ impl ProofWorkerHandle {
             "Spawning proof worker pools"
         );
 
+        let storage_worker_parent =
+            debug_span!(target: "trie::proof_task", "Storage worker tasks", ?storage_worker_count);
+        let _guard = storage_worker_parent.enter();
+
         // Spawn storage workers
         for worker_id in 0..storage_worker_count {
             let parent_span = debug_span!(target: "trie::proof_task", "Storage worker", ?worker_id);
@@ -917,6 +921,12 @@ impl ProofWorkerHandle {
                 "Storage worker spawned successfully"
             );
         }
+
+        drop(_guard);
+
+        let account_worker_parent =
+            debug_span!(target: "trie::proof_task", "Account worker tasks", ?account_worker_count);
+        let _guard = account_worker_parent.enter();
 
         // Spawn account workers
         for worker_id in 0..account_worker_count {
@@ -948,6 +958,8 @@ impl ProofWorkerHandle {
                 "Account worker spawned successfully"
             );
         }
+
+        drop(_guard);
 
         Self::new_handle(storage_work_tx, account_work_tx)
     }

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -693,7 +693,7 @@ where
             multi_added_removed_keys.unwrap_or_else(|| Arc::new(MultiAddedRemovedKeys::new()));
         let added_removed_keys = multi_added_removed_keys.get_storage(&hashed_address);
 
-        let span = tracing::trace_span!(
+        let span = tracing::info_span!(
             target: "trie::proof_task",
             "Storage proof calculation",
             hashed_address = ?hashed_address,

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -693,7 +693,7 @@ where
             multi_added_removed_keys.unwrap_or_else(|| Arc::new(MultiAddedRemovedKeys::new()));
         let added_removed_keys = multi_added_removed_keys.get_storage(&hashed_address);
 
-        let span = tracing::info_span!(
+        let span = tracing::debug_span!(
             target: "trie::proof_task",
             "Storage proof calculation",
             hashed_address = ?hashed_address,

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -57,7 +57,7 @@ use std::{
     time::Instant,
 };
 use tokio::runtime::Handle;
-use tracing::trace;
+use tracing::{debug_span, trace};
 
 #[cfg(feature = "metrics")]
 use crate::proof_task_metrics::ProofTaskTrieMetrics;
@@ -891,6 +891,7 @@ impl ProofWorkerHandle {
 
         // Spawn storage workers
         for worker_id in 0..storage_worker_count {
+            let parent_span = debug_span!(target: "trie::proof_task", "Storage worker", ?worker_id);
             let view_clone = view.clone();
             let task_ctx_clone = task_ctx.clone();
             let work_rx_clone = storage_work_rx.clone();
@@ -899,6 +900,7 @@ impl ProofWorkerHandle {
                 #[cfg(feature = "metrics")]
                 let metrics = ProofTaskTrieMetrics::default();
 
+                let _guard = parent_span.enter();
                 storage_worker_loop(
                     view_clone,
                     task_ctx_clone,
@@ -918,6 +920,7 @@ impl ProofWorkerHandle {
 
         // Spawn account workers
         for worker_id in 0..account_worker_count {
+            let parent_span = debug_span!(target: "trie::proof_task", "Account worker", ?worker_id);
             let view_clone = view.clone();
             let task_ctx_clone = task_ctx.clone();
             let work_rx_clone = account_work_rx.clone();
@@ -927,6 +930,7 @@ impl ProofWorkerHandle {
                 #[cfg(feature = "metrics")]
                 let metrics = ProofTaskTrieMetrics::default();
 
+                let _guard = parent_span.enter();
                 account_worker_loop(
                     view_clone,
                     task_ctx_clone,

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -752,7 +752,7 @@ impl SparseTrieInterface for ParallelSparseTrie {
                 .into_par_iter()
                 .map(|mut changed_subtrie| {
                     let _enter = info_span!(
-                        target: "trie::sparse::parallel",
+                        target: "trie::parallel_sparse",
                         parent: span.clone(),
                         "subtrie",
                         index = changed_subtrie.index
@@ -1303,7 +1303,7 @@ impl ParallelSparseTrie {
 
     /// Drains any [`SparseTrieUpdatesAction`]s from the given subtrie, and applies each action to
     /// the given `updates` set. If the given set is None then this is a no-op.
-    #[instrument(target = "trie::sparse::parallel", skip_all)]
+    #[instrument(target = "trie::parallel_sparse", skip_all)]
     fn apply_subtrie_update_actions(
         &mut self,
         update_actions: impl Iterator<Item = SparseTrieUpdatesAction>,
@@ -1405,7 +1405,7 @@ impl ParallelSparseTrie {
     ///
     /// IMPORTANT: The method removes the subtries from `lower_subtries`, and the caller is
     /// responsible for returning them back into the array.
-    #[instrument(target = "trie::sparse::parallel", skip_all, fields(prefix_set_len = prefix_set.len()))]
+    #[instrument(target = "trie::parallel_sparse", skip_all, fields(prefix_set_len = prefix_set.len()))]
     fn take_changed_lower_subtries(
         &mut self,
         prefix_set: &mut PrefixSet,
@@ -1562,7 +1562,7 @@ impl ParallelSparseTrie {
 
     /// Return updated subtries back to the trie after executing any actions required on the
     /// top-level `SparseTrieUpdates`.
-    #[instrument(target = "trie::sparse::parallel", skip_all)]
+    #[instrument(target = "trie::parallel_sparse", skip_all)]
     fn insert_changed_subtries(
         &mut self,
         changed_subtries: impl IntoIterator<Item = ChangedSubtrie>,

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -741,7 +741,7 @@ impl SparseTrieInterface for ParallelSparseTrie {
         // Update subtrie hashes in parallel
         {
             use rayon::iter::{IntoParallelIterator, ParallelIterator};
-            use tracing::info_span;
+            use tracing::debug_span;
 
             let (tx, rx) = mpsc::channel();
 
@@ -751,7 +751,7 @@ impl SparseTrieInterface for ParallelSparseTrie {
             changed_subtries
                 .into_par_iter()
                 .map(|mut changed_subtrie| {
-                    let _enter = info_span!(
+                    let _enter = debug_span!(
                         target: "trie::parallel_sparse",
                         parent: span.clone(),
                         "subtrie",

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -741,13 +741,24 @@ impl SparseTrieInterface for ParallelSparseTrie {
         // Update subtrie hashes in parallel
         {
             use rayon::iter::{IntoParallelIterator, ParallelIterator};
+            use tracing::info_span;
+
             let (tx, rx) = mpsc::channel();
 
             let branch_node_tree_masks = &self.branch_node_tree_masks;
             let branch_node_hash_masks = &self.branch_node_hash_masks;
+            let span = tracing::Span::current();
             changed_subtries
                 .into_par_iter()
                 .map(|mut changed_subtrie| {
+                    let _enter = info_span!(
+                        target: "trie::sparse::parallel",
+                        parent: span.clone(),
+                        "subtrie",
+                        index = changed_subtrie.index
+                    )
+                    .entered();
+
                     #[cfg(feature = "metrics")]
                     let start = std::time::Instant::now();
                     changed_subtrie.subtrie.update_hashes(
@@ -1292,6 +1303,7 @@ impl ParallelSparseTrie {
 
     /// Drains any [`SparseTrieUpdatesAction`]s from the given subtrie, and applies each action to
     /// the given `updates` set. If the given set is None then this is a no-op.
+    #[instrument(target = "trie::sparse::parallel", skip_all)]
     fn apply_subtrie_update_actions(
         &mut self,
         update_actions: impl Iterator<Item = SparseTrieUpdatesAction>,
@@ -1315,7 +1327,7 @@ impl ParallelSparseTrie {
     }
 
     /// Updates hashes for the upper subtrie, using nodes from both upper and lower subtries.
-    #[instrument(level = "trace", target = "trie::parallel_sparse", skip_all, ret)]
+    #[instrument(target = "trie::parallel_sparse", skip_all, ret(level = "trace"))]
     fn update_upper_subtrie_hashes(&mut self, prefix_set: &mut PrefixSet) -> RlpNode {
         trace!(target: "trie::parallel_sparse", "Updating upper subtrie hashes");
 
@@ -1393,6 +1405,7 @@ impl ParallelSparseTrie {
     ///
     /// IMPORTANT: The method removes the subtries from `lower_subtries`, and the caller is
     /// responsible for returning them back into the array.
+    #[instrument(target = "trie::sparse::parallel", skip_all, fields(prefix_set_len = prefix_set.len()))]
     fn take_changed_lower_subtries(
         &mut self,
         prefix_set: &mut PrefixSet,
@@ -1549,6 +1562,7 @@ impl ParallelSparseTrie {
 
     /// Return updated subtries back to the trie after executing any actions required on the
     /// top-level `SparseTrieUpdates`.
+    #[instrument(target = "trie::sparse::parallel", skip_all)]
     fn insert_changed_subtries(
         &mut self,
         changed_subtries: impl IntoIterator<Item = ChangedSubtrie>,
@@ -2036,7 +2050,7 @@ impl SparseSubtrie {
     /// # Panics
     ///
     /// If the node at the root path does not exist.
-    #[instrument(level = "trace", target = "trie::parallel_sparse", skip_all, fields(root = ?self.path), ret)]
+    #[instrument(target = "trie::parallel_sparse", skip_all, fields(root = ?self.path), ret(level = "trace"))]
     fn update_hashes(
         &mut self,
         prefix_set: &mut PrefixSet,

--- a/crates/trie/sparse/Cargo.toml
+++ b/crates/trie/sparse/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 reth-primitives-traits.workspace = true
 reth-execution-errors.workspace = true
 reth-trie-common.workspace = true
-tracing.workspace = true
+tracing = { workspace = true, features = ["attributes"] }
 alloy-trie.workspace = true
 
 # alloy

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -24,7 +24,7 @@ use reth_trie_common::{
     TrieNode, CHILD_INDEX_RANGE, EMPTY_ROOT_HASH,
 };
 use smallvec::SmallVec;
-use tracing::{debug, trace};
+use tracing::{debug, instrument, trace};
 
 /// The level below which the sparse trie hashes are calculated in
 /// [`SerialSparseTrie::update_subtrie_hashes`].
@@ -175,6 +175,7 @@ impl<T: SparseTrieInterface> SparseTrie<T> {
     /// and resetting the trie to only contain an empty root node.
     ///
     /// Note: This method will error if the trie is blinded.
+    #[instrument(target = "trie::sparse", skip_all)]
     pub fn wipe(&mut self) -> SparseTrieResult<()> {
         let revealed = self.as_revealed_mut().ok_or(SparseTrieErrorKind::Blind)?;
         revealed.wipe();
@@ -191,6 +192,7 @@ impl<T: SparseTrieInterface> SparseTrie<T> {
     ///
     /// - `Some(B256)` with the calculated root hash if the trie is revealed.
     /// - `None` if the trie is still blind.
+    #[instrument(target = "trie::sparse", skip_all)]
     pub fn root(&mut self) -> Option<B256> {
         Some(self.as_revealed_mut()?.root())
     }
@@ -230,6 +232,7 @@ impl<T: SparseTrieInterface> SparseTrie<T> {
     /// # Errors
     ///
     /// Returns an error if the trie is still blind, or if the update fails.
+    #[instrument(target = "trie::sparse", skip_all)]
     pub fn update_leaf(
         &mut self,
         path: Nibbles,
@@ -246,6 +249,7 @@ impl<T: SparseTrieInterface> SparseTrie<T> {
     /// # Errors
     ///
     /// Returns an error if the trie is still blind, or if the leaf cannot be removed
+    #[instrument(target = "trie::sparse", skip_all)]
     pub fn remove_leaf(
         &mut self,
         path: &Nibbles,
@@ -589,14 +593,13 @@ impl SparseTrieInterface for SerialSparseTrie {
         Ok(())
     }
 
+    #[instrument(target = "trie::sparse::serial", skip(self, provider))]
     fn update_leaf<P: TrieNodeProvider>(
         &mut self,
         full_path: Nibbles,
         value: Vec<u8>,
         provider: P,
     ) -> SparseTrieResult<()> {
-        trace!(target: "trie::sparse", ?full_path, ?value, "update_leaf called");
-
         self.prefix_set.insert(full_path);
         let existing = self.values.insert(full_path, value);
         if existing.is_some() {
@@ -728,6 +731,7 @@ impl SparseTrieInterface for SerialSparseTrie {
         Ok(())
     }
 
+    #[instrument(target = "trie::sparse::serial", skip(self, provider))]
     fn remove_leaf<P: TrieNodeProvider>(
         &mut self,
         full_path: &Nibbles,
@@ -913,6 +917,7 @@ impl SparseTrieInterface for SerialSparseTrie {
         Ok(())
     }
 
+    #[instrument(target = "trie::sparse::serial", skip(self))]
     fn root(&mut self) -> B256 {
         // Take the current prefix set
         let mut prefix_set = core::mem::take(&mut self.prefix_set).freeze();
@@ -1348,6 +1353,7 @@ impl SerialSparseTrie {
     ///
     /// This function identifies all nodes that have changed (based on the prefix set) at the given
     /// depth and recalculates their RLP representation.
+    #[instrument(target = "trie::sparse::serial", skip(self))]
     pub fn update_rlp_node_level(&mut self, depth: usize) {
         // Take the current prefix set
         let mut prefix_set = core::mem::take(&mut self.prefix_set).freeze();
@@ -1393,6 +1399,7 @@ impl SerialSparseTrie {
     ///   specified depth.
     /// - A `PrefixSetMut` containing paths shallower than the specified depth that still need to be
     ///   tracked for future updates.
+    #[instrument(target = "trie::sparse::serial", skip(self))]
     fn get_changed_nodes_at_depth(
         &self,
         prefix_set: &mut PrefixSet,
@@ -1479,6 +1486,7 @@ impl SerialSparseTrie {
     /// # Panics
     ///
     /// If the node at provided path does not exist.
+    #[instrument(target = "trie::sparse::serial", skip_all, ret(level = "trace"))]
     pub fn rlp_node(
         &mut self,
         prefix_set: &mut PrefixSet,

--- a/crates/trie/trie/src/hashed_cursor/mock.rs
+++ b/crates/trie/trie/src/hashed_cursor/mock.rs
@@ -107,7 +107,7 @@ impl<T> MockHashedCursor<T> {
 impl<T: Debug + Clone> HashedCursor for MockHashedCursor<T> {
     type Value = T;
 
-    #[instrument(level = "trace", skip(self), ret)]
+    #[instrument(skip(self), ret(level = "trace"))]
     fn seek(&mut self, key: B256) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
         // Find the first key that is greater than or equal to the given key.
         let entry = self.values.iter().find_map(|(k, v)| (k >= &key).then(|| (*k, v.clone())));
@@ -121,7 +121,7 @@ impl<T: Debug + Clone> HashedCursor for MockHashedCursor<T> {
         Ok(entry)
     }
 
-    #[instrument(level = "trace", skip(self), ret)]
+    #[instrument(skip(self), ret(level = "trace"))]
     fn next(&mut self) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
         let mut iter = self.values.iter();
         // Jump to the first key that has a prefix of the current key if it's set, or to the first

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -191,10 +191,11 @@ where
     ///
     /// NOTE: The iteration will start from the key of the previous hashed entry if it was supplied.
     #[instrument(
+        level = "trace",
         target = "trie::node_iter",
         skip_all,
         fields(trie_type = ?self.trie_type),
-        ret(level = "trace")
+        ret
     )]
     pub fn try_next(
         &mut self,

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -191,11 +191,10 @@ where
     ///
     /// NOTE: The iteration will start from the key of the previous hashed entry if it was supplied.
     #[instrument(
-        level = "trace",
         target = "trie::node_iter",
         skip_all,
         fields(trie_type = ?self.trie_type),
-        ret
+        ret(level = "trace")
     )]
     pub fn try_next(
         &mut self,

--- a/crates/trie/trie/src/trie_cursor/mock.rs
+++ b/crates/trie/trie/src/trie_cursor/mock.rs
@@ -109,7 +109,7 @@ impl MockTrieCursor {
 }
 
 impl TrieCursor for MockTrieCursor {
-    #[instrument(level = "trace", skip(self), ret)]
+    #[instrument(skip(self), ret(level = "trace"))]
     fn seek_exact(
         &mut self,
         key: Nibbles,
@@ -125,7 +125,7 @@ impl TrieCursor for MockTrieCursor {
         Ok(entry)
     }
 
-    #[instrument(level = "trace", skip(self), ret)]
+    #[instrument(skip(self), ret(level = "trace"))]
     fn seek(
         &mut self,
         key: Nibbles,
@@ -142,7 +142,7 @@ impl TrieCursor for MockTrieCursor {
         Ok(entry)
     }
 
-    #[instrument(level = "trace", skip(self), ret)]
+    #[instrument(skip(self), ret(level = "trace"))]
     fn next(&mut self) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
         let mut iter = self.trie_nodes.iter();
         // Jump to the first key that has a prefix of the current key if it's set, or to the first
@@ -161,7 +161,7 @@ impl TrieCursor for MockTrieCursor {
         Ok(entry)
     }
 
-    #[instrument(level = "trace", skip(self), ret)]
+    #[instrument(skip(self), ret(level = "trace"))]
     fn current(&mut self) -> Result<Option<Nibbles>, DatabaseError> {
         Ok(self.current_key)
     }

--- a/crates/trie/trie/src/walker.rs
+++ b/crates/trie/trie/src/walker.rs
@@ -157,7 +157,7 @@ impl<C: TrieCursor, K: AsRef<AddedRemovedKeys>> TrieWalker<C, K> {
     }
 
     /// Returns the next unprocessed key in the trie along with its raw [`Nibbles`] representation.
-    #[instrument(skip(self), ret(level = "trace"))]
+    #[instrument(level = "trace", skip(self), ret)]
     pub fn next_unprocessed_key(&self) -> Option<(B256, Nibbles)> {
         self.key()
             .and_then(|key| if self.can_skip_current_node { key.increment() } else { Some(*key) })
@@ -297,7 +297,7 @@ impl<C: TrieCursor, K: AsRef<AddedRemovedKeys>> TrieWalker<C, K> {
     }
 
     /// Consumes the next node in the trie, updating the stack.
-    #[instrument(skip(self), ret(level = "trace"))]
+    #[instrument(level = "trace", skip(self), ret)]
     fn consume_node(&mut self) -> Result<(), DatabaseError> {
         let Some((key, node)) = self.node(false)? else {
             // If no next node is found, clear the stack.
@@ -343,7 +343,7 @@ impl<C: TrieCursor, K: AsRef<AddedRemovedKeys>> TrieWalker<C, K> {
     }
 
     /// Moves to the next sibling node in the trie, updating the stack.
-    #[instrument(skip(self), ret(level = "trace"))]
+    #[instrument(level = "trace", skip(self), ret)]
     fn move_to_next_sibling(
         &mut self,
         allow_root_to_child_nibble: bool,

--- a/crates/trie/trie/src/walker.rs
+++ b/crates/trie/trie/src/walker.rs
@@ -157,7 +157,7 @@ impl<C: TrieCursor, K: AsRef<AddedRemovedKeys>> TrieWalker<C, K> {
     }
 
     /// Returns the next unprocessed key in the trie along with its raw [`Nibbles`] representation.
-    #[instrument(level = "trace", skip(self), ret)]
+    #[instrument(skip(self), ret(level = "trace"))]
     pub fn next_unprocessed_key(&self) -> Option<(B256, Nibbles)> {
         self.key()
             .and_then(|key| if self.can_skip_current_node { key.increment() } else { Some(*key) })
@@ -297,7 +297,7 @@ impl<C: TrieCursor, K: AsRef<AddedRemovedKeys>> TrieWalker<C, K> {
     }
 
     /// Consumes the next node in the trie, updating the stack.
-    #[instrument(level = "trace", skip(self), ret)]
+    #[instrument(skip(self), ret(level = "trace"))]
     fn consume_node(&mut self) -> Result<(), DatabaseError> {
         let Some((key, node)) = self.node(false)? else {
             // If no next node is found, clear the stack.
@@ -343,7 +343,7 @@ impl<C: TrieCursor, K: AsRef<AddedRemovedKeys>> TrieWalker<C, K> {
     }
 
     /// Moves to the next sibling node in the trie, updating the stack.
-    #[instrument(level = "trace", skip(self), ret)]
+    #[instrument(skip(self), ret(level = "trace"))]
     fn move_to_next_sibling(
         &mut self,
         allow_root_to_child_nibble: bool,

--- a/docs/vocs/docs/pages/cli/reth.mdx
+++ b/docs/vocs/docs/pages/cli/reth.mdx
@@ -131,5 +131,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/config.mdx
+++ b/docs/vocs/docs/pages/cli/reth/config.mdx
@@ -117,5 +117,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/db.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db.mdx
@@ -182,5 +182,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/db/checksum.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/checksum.mdx
@@ -134,5 +134,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/db/clear.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/clear.mdx
@@ -126,5 +126,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/db/clear/mdbx.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/clear/mdbx.mdx
@@ -125,5 +125,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/db/clear/static-file.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/clear/static-file.mdx
@@ -128,5 +128,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/db/diff.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/diff.mdx
@@ -161,5 +161,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/db/drop.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/drop.mdx
@@ -124,5 +124,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/db/get.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/get.mdx
@@ -126,5 +126,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/db/get/mdbx.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/get/mdbx.mdx
@@ -134,5 +134,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/db/get/static-file.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/get/static-file.mdx
@@ -134,5 +134,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/db/list.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/list.mdx
@@ -167,5 +167,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/db/path.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/path.mdx
@@ -121,5 +121,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/db/repair-trie.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/repair-trie.mdx
@@ -124,5 +124,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/db/stats.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/stats.mdx
@@ -134,5 +134,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/db/version.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/version.mdx
@@ -121,5 +121,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/download.mdx
+++ b/docs/vocs/docs/pages/cli/reth/download.mdx
@@ -179,5 +179,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/dump-genesis.mdx
+++ b/docs/vocs/docs/pages/cli/reth/dump-genesis.mdx
@@ -120,5 +120,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/export-era.mdx
+++ b/docs/vocs/docs/pages/cli/reth/export-era.mdx
@@ -185,5 +185,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/import-era.mdx
+++ b/docs/vocs/docs/pages/cli/reth/import-era.mdx
@@ -180,5 +180,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/import.mdx
+++ b/docs/vocs/docs/pages/cli/reth/import.mdx
@@ -181,5 +181,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/init-state.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init-state.mdx
@@ -201,5 +201,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/init.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init.mdx
@@ -169,5 +169,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -1016,5 +1016,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/p2p.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p.mdx
@@ -118,5 +118,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/p2p/body.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/body.mdx
@@ -338,5 +338,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/p2p/bootnode.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/bootnode.mdx
@@ -129,5 +129,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/p2p/header.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/header.mdx
@@ -338,5 +338,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/p2p/rlpx.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/rlpx.mdx
@@ -115,5 +115,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/p2p/rlpx/ping.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/rlpx/ping.mdx
@@ -115,5 +115,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/prune.mdx
+++ b/docs/vocs/docs/pages/cli/reth/prune.mdx
@@ -169,5 +169,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/re-execute.mdx
+++ b/docs/vocs/docs/pages/cli/reth/re-execute.mdx
@@ -182,5 +182,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/stage.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage.mdx
@@ -118,5 +118,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/stage/drop.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/drop.mdx
@@ -184,5 +184,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/stage/dump.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump.mdx
@@ -176,5 +176,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/stage/dump/account-hashing.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump/account-hashing.mdx
@@ -133,5 +133,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/stage/dump/execution.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump/execution.mdx
@@ -133,5 +133,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/stage/dump/merkle.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump/merkle.mdx
@@ -133,5 +133,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/stage/dump/storage-hashing.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump/storage-hashing.mdx
@@ -133,5 +133,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/stage/run.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/run.mdx
@@ -405,5 +405,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/stage/unwind.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/unwind.mdx
@@ -177,5 +177,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/stage/unwind/num-blocks.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/unwind/num-blocks.mdx
@@ -125,5 +125,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```

--- a/docs/vocs/docs/pages/cli/reth/stage/unwind/to-block.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/unwind/to-block.mdx
@@ -125,5 +125,5 @@ Tracing:
 
           Defaults to TRACE if not specified.
 
-          [default: TRACE]
+          [default: debug]
 ```


### PR DESCRIPTION
This does a few main things over https://github.com/paradigmxyz/reth/pull/18960:

* First, the default level for otlp traces are set to `debug`. This is mainly to avoid a frequently called `trace` level span in `HashBuilder`: https://github.com/alloy-rs/trie/blob/3401e6e8a8a44594bca7694dccd44a0f2130f92a/src/hash_builder/mod.rs#L234

<img width="2559" height="844" alt="Screenshot 2025-10-20 at 2 07 16 PM" src="https://github.com/user-attachments/assets/8ef02f8f-65ea-4fde-aaf6-2e6856e40e68" />

* `TrieNodeIter`and `TrieWalker` spans are downgraded to trace, these were too frequent and hurt performance

<img width="5118" height="1688" alt="Screenshot 2025-10-20 at 12 32 30 PM" src="https://github.com/user-attachments/assets/4a2e0ed8-531e-463d-98f3-c2fa439b7beb" />

* Downgrades ecies `instrument` calls to `trace` (I just prefer these be opt-in even in otlp)

* Moves `ChainOrchestrator::poll` instrument call `name` to `target`.

* Make parallel sparse trie traces and spans consistent

* Add account and storage proof task spans linked to workers:

<img width="2559" height="497" alt="Screenshot 2025-10-20 at 4 27 11 PM" src="https://github.com/user-attachments/assets/634e389b-dad2-4915-9bb2-b1b670da550b" />
<img width="2559" height="273" alt="Screenshot 2025-10-20 at 4 27 27 PM" src="https://github.com/user-attachments/assets/202760fb-a2ad-48a2-a7bc-2991ee555cf0" />

* Lower multiproof task traces from `debug` to `trace`: [`698227f` (#19155)](https://github.com/paradigmxyz/reth/pull/19155/commits/698227f5e14459b0b093ab1cd7d6288e90d796c4) - these were causing lots of log volume


