### PR TITLE
chore: grammar tweak in comment

### DIFF
--- a/crates/evm/execution-errors/src/trie.rs
+++ b/crates/evm/execution-errors/src/trie.rs
@@ -184,7 +184,7 @@ pub enum SparseTrieErrorKind {
 /// Trie witness errors.
 #[derive(Error, Debug)]
 pub enum TrieWitnessError {
-    /// Error gather proofs.
+    /// Error gathering proofs.
     #[error(transparent)]
     Proof(#[from] StateProofError),
     /// RLP decoding error.


### PR DESCRIPTION
a grammatical mistake in the comment `/// Error gather proofs.` - it should be `/// Error gathering proofs.` to use the correct gerund form after “Error.”
