### PR TITLE
chore: remove deprecated code

### DIFF
--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -148,20 +148,6 @@ pub trait Executor<DB: Database>: Sized {
     fn size_hint(&self) -> usize;
 }
 
-/// Helper type for the output of executing a block.
-///
-/// Deprecated: this type is unused within reth and will be removed in the next
-/// major release. Use `reth_execution_types::BlockExecutionResult` or
-/// `reth_execution_types::BlockExecutionOutput`.
-#[deprecated(note = "Use reth_execution_types::BlockExecutionResult or BlockExecutionOutput")]
-#[derive(Debug, Clone)]
-pub struct ExecuteOutput<R> {
-    /// Receipts obtained after executing a block.
-    pub receipts: Vec<R>,
-    /// Cumulative gas used in the block execution.
-    pub gas_used: u64,
-}
-
 /// Input for block building. Consumed by [`BlockAssembler`].
 ///
 /// This struct contains all the data needed by the [`BlockAssembler`] to create


### PR DESCRIPTION
this part is not using in anywhere, I think we should remove this