### PR TITLE
fix(engine): shrink tries after clearing

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/configured_sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/configured_sparse_trie.rs
@@ -186,4 +186,18 @@ impl SparseTrieInterface for ConfiguredSparseTrie {
             Self::Parallel(trie) => trie.value_capacity(),
         }
     }
+
+    fn shrink_nodes_to(&mut self, size: usize) {
+        match self {
+            Self::Serial(trie) => trie.shrink_nodes_to(size),
+            Self::Parallel(trie) => trie.shrink_nodes_to(size),
+        }
+    }
+
+    fn shrink_values_to(&mut self, size: usize) {
+        match self {
+            Self::Serial(trie) => trie.shrink_values_to(size),
+            Self::Parallel(trie) => trie.shrink_values_to(size),
+        }
+    }
 }

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -66,10 +66,27 @@ use configured_sparse_trie::ConfiguredSparseTrie;
 pub const PARALLEL_SPARSE_TRIE_PARALLELISM_THRESHOLDS: ParallelismThresholds =
     ParallelismThresholds { min_revealed_nodes: 100, min_updated_nodes: 100 };
 
-/// Default node capacity for shrinking the sparse trie.
+/// Default node capacity for shrinking the sparse trie. This is used to limit the number of trie
+/// nodes in allocated sparse tries.
+///
+/// Node maps have a key of `Nibbles` and value of `SparseNode`.
+/// The `size_of::<Nibbles>` is 40, and `size_of::<SparseNode>` is 80.
+///
+/// If we have 4 million entries of 120 bytes each, this conservative estimate comes out at around
+/// 480MB.
 pub const SPARSE_TRIE_MAX_NODES_SHRINK_CAPACITY: usize = 4_000_000;
 
-/// Default value capacity for shrinking the sparse trie.
+/// Default value capacity for shrinking the sparse trie. This is used to limit the number of values
+/// in allocated sparse tries.
+///
+/// There are storage and account values, the largest of the two being account values, which are
+/// essentially `TrieAccount`s.
+///
+/// Account value maps have a key of `Nibbles` and value of `TrieAccount`.
+/// The `size_of::<Nibbles>` is 40, and `size_of::<TrieAccount>` is 104.
+///
+/// If we have 1 million entries of 144 bytes each, this conservative estimate comes out at around
+/// 144MB.
 pub const SPARSE_TRIE_MAX_VALUE_SHRINK_CAPACITY: usize = 1_000_000;
 
 /// Entrypoint for executing the payload.

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -72,9 +72,9 @@ pub const PARALLEL_SPARSE_TRIE_PARALLELISM_THRESHOLDS: ParallelismThresholds =
 /// Node maps have a key of `Nibbles` and value of `SparseNode`.
 /// The `size_of::<Nibbles>` is 40, and `size_of::<SparseNode>` is 80.
 ///
-/// If we have 4 million entries of 120 bytes each, this conservative estimate comes out at around
-/// 480MB.
-pub const SPARSE_TRIE_MAX_NODES_SHRINK_CAPACITY: usize = 4_000_000;
+/// If we have 2 million entries of 120 bytes each, this conservative estimate comes out at around
+/// 240MB.
+pub const SPARSE_TRIE_MAX_NODES_SHRINK_CAPACITY: usize = 2_000_000;
 
 /// Default value capacity for shrinking the sparse trie. This is used to limit the number of values
 /// in allocated sparse tries.
@@ -85,9 +85,9 @@ pub const SPARSE_TRIE_MAX_NODES_SHRINK_CAPACITY: usize = 4_000_000;
 /// Account value maps have a key of `Nibbles` and value of `TrieAccount`.
 /// The `size_of::<Nibbles>` is 40, and `size_of::<TrieAccount>` is 104.
 ///
-/// If we have 1 million entries of 144 bytes each, this conservative estimate comes out at around
-/// 144MB.
-pub const SPARSE_TRIE_MAX_VALUE_SHRINK_CAPACITY: usize = 1_000_000;
+/// If we have 100k entries of 144 bytes each, this conservative estimate comes out at around
+/// 14.4MB.
+pub const SPARSE_TRIE_MAX_VALUES_SHRINK_CAPACITY: usize = 100_000;
 
 /// Entrypoint for executing the payload.
 #[derive(Debug)]
@@ -471,7 +471,7 @@ where
             // Shrink the sparse trie so that we don't have ever increasing memory.
             cleared_trie.shrink_to(
                 SPARSE_TRIE_MAX_NODES_SHRINK_CAPACITY,
-                SPARSE_TRIE_MAX_NODES_SHRINK_CAPACITY,
+                SPARSE_TRIE_MAX_VALUES_SHRINK_CAPACITY,
             );
 
             cleared_sparse_trie.lock().replace(cleared_trie);

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -72,9 +72,9 @@ pub const PARALLEL_SPARSE_TRIE_PARALLELISM_THRESHOLDS: ParallelismThresholds =
 /// Node maps have a key of `Nibbles` and value of `SparseNode`.
 /// The `size_of::<Nibbles>` is 40, and `size_of::<SparseNode>` is 80.
 ///
-/// If we have 2 million entries of 120 bytes each, this conservative estimate comes out at around
-/// 240MB.
-pub const SPARSE_TRIE_MAX_NODES_SHRINK_CAPACITY: usize = 2_000_000;
+/// If we have 1 million entries of 120 bytes each, this conservative estimate comes out at around
+/// 120MB.
+pub const SPARSE_TRIE_MAX_NODES_SHRINK_CAPACITY: usize = 1_000_000;
 
 /// Default value capacity for shrinking the sparse trie. This is used to limit the number of values
 /// in allocated sparse tries.
@@ -85,9 +85,9 @@ pub const SPARSE_TRIE_MAX_NODES_SHRINK_CAPACITY: usize = 2_000_000;
 /// Account value maps have a key of `Nibbles` and value of `TrieAccount`.
 /// The `size_of::<Nibbles>` is 40, and `size_of::<TrieAccount>` is 104.
 ///
-/// If we have 100k entries of 144 bytes each, this conservative estimate comes out at around
-/// 14.4MB.
-pub const SPARSE_TRIE_MAX_VALUES_SHRINK_CAPACITY: usize = 100_000;
+/// If we have 1 million entries of 144 bytes each, this conservative estimate comes out at around
+/// 144MB.
+pub const SPARSE_TRIE_MAX_VALUES_SHRINK_CAPACITY: usize = 1_000_000;
 
 /// Entrypoint for executing the payload.
 #[derive(Debug)]

--- a/crates/trie/sparse-parallel/src/lower.rs
+++ b/crates/trie/sparse-parallel/src/lower.rs
@@ -122,4 +122,26 @@ impl LowerSparseSubtrie {
             Self::Blind(None) => 0,
         }
     }
+
+    /// Shrinks the capacity of the subtrie's node storage.
+    /// Works for both revealed and blind tries with allocated storage.
+    pub(crate) fn shrink_nodes_to(&mut self, size: usize) {
+        match self {
+            Self::Revealed(trie) | Self::Blind(Some(trie)) => {
+                trie.shrink_nodes_to(size);
+            }
+            Self::Blind(None) => {}
+        }
+    }
+
+    /// Shrinks the capacity of the subtrie's value storage.
+    /// Works for both revealed and blind tries with allocated storage.
+    pub(crate) fn shrink_values_to(&mut self, size: usize) {
+        match self {
+            Self::Revealed(trie) | Self::Blind(Some(trie)) => {
+                trie.shrink_values_to(size);
+            }
+            Self::Blind(None) => {}
+        }
+    }
 }

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -905,12 +905,9 @@ impl SparseTrieInterface for ParallelSparseTrie {
 
     fn shrink_values_to(&mut self, size: usize) {
         // Distribute the capacity across upper and lower subtries
-        // Count how many subtries have capacity (revealed or blind with allocation)
-        let lower_with_capacity =
-            self.lower_subtries.iter().filter(|s| s.value_capacity() > 0).count();
-
-        // Always include upper subtrie, plus any lower subtries with capacity
-        let total_subtries = 1 + lower_with_capacity;
+        //
+        // Always include upper subtrie, plus any lower subtries
+        let total_subtries = 1 + NUM_LOWER_SUBTRIES;
         let size_per_subtrie = size / total_subtries;
 
         // Shrink the upper subtrie

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -886,12 +886,9 @@ impl SparseTrieInterface for ParallelSparseTrie {
 
     fn shrink_nodes_to(&mut self, size: usize) {
         // Distribute the capacity across upper and lower subtries
-        // Count how many subtries have capacity (revealed or blind with allocation)
-        let lower_with_capacity =
-            self.lower_subtries.iter().filter(|s| s.node_capacity() > 0).count();
-
-        // Always include upper subtrie, plus any lower subtries with capacity
-        let total_subtries = 1 + lower_with_capacity;
+        //
+        // Always include upper subtrie, plus any lower subtries
+        let total_subtries = 1 + NUM_LOWER_SUBTRIES;
         let size_per_subtrie = size / total_subtries;
 
         // Shrink the upper subtrie

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -2617,10 +2617,19 @@ impl SparseSubtrieBuffers {
     /// Clears all buffers.
     fn clear(&mut self) {
         self.path_stack.clear();
+        self.path_stack.shrink_to_fit();
+
         self.rlp_node_stack.clear();
+        self.rlp_node_stack.shrink_to_fit();
+
         self.branch_child_buf.clear();
+        self.branch_child_buf.shrink_to_fit();
+
         self.branch_value_stack_buf.clear();
+        self.branch_value_stack_buf.shrink_to_fit();
+
         self.rlp_buf.clear();
+        self.rlp_buf.shrink_to_fit();
     }
 }
 

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -901,6 +901,10 @@ impl SparseTrieInterface for ParallelSparseTrie {
         for subtrie in &mut self.lower_subtries {
             subtrie.shrink_nodes_to(size_per_subtrie);
         }
+
+        // shrink masks maps
+        self.branch_node_hash_masks.shrink_to(size);
+        self.branch_node_tree_masks.shrink_to(size);
     }
 
     fn shrink_values_to(&mut self, size: usize) {

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -43,6 +43,32 @@ where
         Self(trie)
     }
 
+    /// Shrink the cleared sparse trie's capacity to the given node and value size.
+    /// This helps reduce memory usage when the trie has excess capacity.
+    /// The capacity is distributed equally across the account trie and all storage tries.
+    pub fn shrink_to(&mut self, node_size: usize, value_size: usize) {
+        // Count total number of storage tries (active + cleared + default)
+        let storage_tries_count = self.0.storage.tries.len() + self.0.storage.cleared_tries.len();
+
+        // Total tries = 1 account trie + all storage tries
+        let total_tries = 1 + storage_tries_count;
+
+        // Distribute capacity equally among all tries
+        let node_size_per_trie = node_size / total_tries;
+        let value_size_per_trie = value_size / total_tries;
+
+        // Shrink the account trie
+        self.0.state.shrink_nodes_to(node_size_per_trie);
+        self.0.state.shrink_values_to(value_size_per_trie);
+
+        // Give storage tries the remaining capacity after account trie allocation
+        let storage_node_size = node_size.saturating_sub(node_size_per_trie);
+        let storage_value_size = value_size.saturating_sub(value_size_per_trie);
+
+        // Shrink all storage tries (they will redistribute internally)
+        self.0.storage.shrink_to(storage_node_size, storage_value_size);
+    }
+
     /// Returns the cleared [`SparseStateTrie`], consuming this instance.
     pub fn into_inner(self) -> SparseStateTrie<A, S> {
         self.0
@@ -831,6 +857,30 @@ where
     pub fn value_capacity(&self) -> usize {
         self.state.value_capacity() + self.storage.total_value_capacity()
     }
+
+    /// Shrink the sparse trie's capacity to the given size.
+    /// This helps reduce memory usage when the trie has excess capacity.
+    /// The capacity is distributed equally across the account trie and all storage tries.
+    pub fn shrink_to(&mut self, size: usize) {
+        // Count total number of storage tries (active + cleared + default)
+        let storage_tries_count = self.storage.tries.len() + self.storage.cleared_tries.len();
+
+        // Total tries = 1 account trie + all storage tries
+        let total_tries = 1 + storage_tries_count;
+
+        // Distribute capacity equally among all tries
+        let size_per_trie = size / total_tries;
+
+        // Shrink the account trie
+        self.state.shrink_nodes_to(size_per_trie);
+        self.state.shrink_values_to(size_per_trie);
+
+        // Calculate total capacity for storage tries
+        let storage_size = size_per_trie * storage_tries_count;
+
+        // Shrink all storage tries (they will redistribute internally)
+        self.storage.shrink_to(storage_size, storage_size);
+    }
 }
 
 /// The fields of [`SparseStateTrie`] related to storage tries. This is kept separate from the rest
@@ -859,6 +909,35 @@ impl<S: SparseTrieInterface> StorageTries<S> {
             set.clear();
             set
         }));
+    }
+
+    /// Shrinks the capacity of all storage tries (active, cleared, and default) to the given sizes.
+    /// The capacity is distributed equally among all tries that have allocations.
+    fn shrink_to(&mut self, node_size: usize, value_size: usize) {
+        // Count total number of tries with capacity (active + cleared + default)
+        let active_count = self.tries.len();
+        let cleared_count = self.cleared_tries.len();
+        let total_tries = 1 + active_count + cleared_count;
+
+        // Distribute capacity equally among all tries
+        let node_size_per_trie = node_size / total_tries;
+        let value_size_per_trie = value_size / total_tries;
+
+        // Shrink active storage tries
+        for trie in self.tries.values_mut() {
+            trie.shrink_nodes_to(node_size_per_trie);
+            trie.shrink_values_to(value_size_per_trie);
+        }
+
+        // Shrink cleared storage tries
+        for trie in &mut self.cleared_tries {
+            trie.shrink_nodes_to(node_size_per_trie);
+            trie.shrink_values_to(value_size_per_trie);
+        }
+
+        // Shrink the default trie
+        self.default_trie.shrink_nodes_to(node_size_per_trie);
+        self.default_trie.shrink_values_to(value_size_per_trie);
     }
 }
 

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -910,10 +910,6 @@ impl<S: SparseTrieInterface> StorageTries<S> {
             trie.shrink_nodes_to(node_size_per_trie);
             trie.shrink_values_to(value_size_per_trie);
         }
-
-        // Shrink the default trie
-        self.default_trie.shrink_nodes_to(node_size_per_trie);
-        self.default_trie.shrink_values_to(value_size_per_trie);
     }
 }
 

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -857,30 +857,6 @@ where
     pub fn value_capacity(&self) -> usize {
         self.state.value_capacity() + self.storage.total_value_capacity()
     }
-
-    /// Shrink the sparse trie's capacity to the given size.
-    /// This helps reduce memory usage when the trie has excess capacity.
-    /// The capacity is distributed equally across the account trie and all storage tries.
-    pub fn shrink_to(&mut self, size: usize) {
-        // Count total number of storage tries (active + cleared + default)
-        let storage_tries_count = self.storage.tries.len() + self.storage.cleared_tries.len();
-
-        // Total tries = 1 account trie + all storage tries
-        let total_tries = 1 + storage_tries_count;
-
-        // Distribute capacity equally among all tries
-        let size_per_trie = size / total_tries;
-
-        // Shrink the account trie
-        self.state.shrink_nodes_to(size_per_trie);
-        self.state.shrink_values_to(size_per_trie);
-
-        // Calculate total capacity for storage tries
-        let storage_size = size_per_trie * storage_tries_count;
-
-        // Shrink all storage tries (they will redistribute internally)
-        self.storage.shrink_to(storage_size, storage_size);
-    }
 }
 
 /// The fields of [`SparseStateTrie`] related to storage tries. This is kept separate from the rest

--- a/crates/trie/sparse/src/traits.rs
+++ b/crates/trie/sparse/src/traits.rs
@@ -228,6 +228,14 @@ pub trait SparseTrieInterface: Sized + Debug + Send + Sync {
 
     /// This returns the capacity of any inner data structures which store leaf values.
     fn value_capacity(&self) -> usize;
+
+    /// Shrink the capacity of the sparse trie's node storage to the given size.
+    /// This will reduce memory usage if the current capacity is higher than the given size.
+    fn shrink_nodes_to(&mut self, size: usize);
+
+    /// Shrink the capacity of the sparse trie's value storage to the given size.
+    /// This will reduce memory usage if the current capacity is higher than the given size.
+    fn shrink_values_to(&mut self, size: usize);
 }
 
 /// Struct for passing around branch node mask information.

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -275,6 +275,28 @@ impl<T: SparseTrieInterface> SparseTrie<T> {
             _ => 0,
         }
     }
+
+    /// Shrinks the capacity of the sparse trie's node storage.
+    /// Works for both revealed and blind tries with allocated storage.
+    pub fn shrink_nodes_to(&mut self, size: usize) {
+        match self {
+            Self::Blind(Some(trie)) | Self::Revealed(trie) => {
+                trie.shrink_nodes_to(size);
+            }
+            _ => {}
+        }
+    }
+
+    /// Shrinks the capacity of the sparse trie's value storage.
+    /// Works for both revealed and blind tries with allocated storage.
+    pub fn shrink_values_to(&mut self, size: usize) {
+        match self {
+            Self::Blind(Some(trie)) | Self::Revealed(trie) => {
+                trie.shrink_values_to(size);
+            }
+            _ => {}
+        }
+    }
 }
 
 /// The representation of revealed sparse trie.
@@ -1087,6 +1109,14 @@ impl SparseTrieInterface for SerialSparseTrie {
 
     fn value_capacity(&self) -> usize {
         self.values.capacity()
+    }
+
+    fn shrink_nodes_to(&mut self, size: usize) {
+        self.nodes.shrink_to(size);
+    }
+
+    fn shrink_values_to(&mut self, size: usize) {
+        self.values.shrink_to(size);
     }
 }
 

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -1113,6 +1113,8 @@ impl SparseTrieInterface for SerialSparseTrie {
 
     fn shrink_nodes_to(&mut self, size: usize) {
         self.nodes.shrink_to(size);
+        self.branch_node_tree_masks.shrink_to(size);
+        self.branch_node_hash_masks.shrink_to(size);
     }
 
     fn shrink_values_to(&mut self, size: usize) {


### PR DESCRIPTION
This adds `shrink_nodes_to` and `shrink_values_to` methods to all sparse trie implementations. This allows us to manage memory after clearing the sparse trie, so that the sparse tries do not have unbounded memory growth.

This was previously possible because there were roughly 600 active storage tries, and 600 cleared storage tries. For example, we may fill a storage trie with many nodes because it corresponds to a large contract like XEN. We would then clear this trie, and keep it around for reuse.

It's unlikely that the allocated space would be effectively reused, because cleared tries that we reuse are picked indiscriminately. So this allocated space would stick around in a cleared or active trie, while we then allocate even more space in other storage tries, for other large contracts.

Now, we shrink allocated space in tries before saving the trie using these `shrink_to` methods.

## Memory Usage Impact

Previously there was a striking similarity between the capacity, and the allocated space, for example here is the memory usage after 3000 blocks:
<img width="2355" height="1238" alt="Screenshot 2025-10-22 at 7 24 45 PM" src="https://github.com/user-attachments/assets/69994037-3613-47f6-8aca-bf145c57c119" />



And here is the node capacity metric:
<img width="2355" height="1238" alt="Screenshot 2025-10-22 at 7 24 56 PM" src="https://github.com/user-attachments/assets/9bb4d1ae-7cb2-4723-b7e3-153770aee4b5" />



Here is the memory usage now:
<img width="2356" height="1269" alt="Screenshot 2025-10-22 at 7 04 36 PM" src="https://github.com/user-attachments/assets/b503f66c-f6a1-4eea-bff4-5fb53bd4d526" />


And the node capacity metric:
<img width="2356" height="1269" alt="Screenshot 2025-10-22 at 7 05 07 PM" src="https://github.com/user-attachments/assets/e95df5e0-59f4-493f-bc4f-72c31a681185" />
