### PR TITLE
perf: fix redundant Arc clone in file_client tests

### DIFF
--- a/crates/net/downloaders/src/file_client.rs
+++ b/crates/net/downloaders/src/file_client.rs
@@ -815,7 +815,7 @@ mod tests {
 
             // construct headers downloader and use first header
             let mut header_downloader = ReverseHeadersDownloaderBuilder::default()
-                .build(Arc::clone(&Arc::new(client)), Arc::new(TestConsensus::default()));
+                .build(Arc::new(client), Arc::new(TestConsensus::default()));
             header_downloader.update_local_head(local_header.clone());
             header_downloader.update_sync_target(SyncTarget::Tip(sync_target_hash));
 
@@ -890,7 +890,7 @@ mod tests {
 
             // construct headers downloader and use first header
             let mut header_downloader = ReverseHeadersDownloaderBuilder::default()
-                .build(Arc::clone(&Arc::new(client)), Arc::new(TestConsensus::default()));
+                .build(Arc::new(client), Arc::new(TestConsensus::default()));
             header_downloader.update_local_head(local_header.clone());
             header_downloader.update_sync_target(SyncTarget::Tip(sync_target_hash));
 


### PR DESCRIPTION
Found some redundant Arc::clone(&Arc::new(client)) calls in the file_client tests. This is basically creating an Arc and immediately cloning it which is unnecessary work. Changed it to just Arc::new(client). Small performance improvement for test runs and cleaner code overall. Two instances fixed on lines 818 and 893.