### PR TITLE
fix(cli): prune config saving to file

### DIFF
--- a/crates/cli/commands/src/common.rs
+++ b/crates/cli/commands/src/common.rs
@@ -126,9 +126,8 @@ impl<C: ChainSpecParser> EnvironmentArgs<C> {
     where
         C: ChainSpecParser<ChainSpec = N::ChainSpec>,
     {
-        let has_receipt_pruning = config.prune.as_ref().is_some_and(|a| a.has_receipts_pruning());
-        let prune_modes =
-            config.prune.as_ref().map(|prune| prune.segments.clone()).unwrap_or_default();
+        let has_receipt_pruning = config.prune.has_receipts_pruning();
+        let prune_modes = config.prune.segments.clone();
         let factory = ProviderFactory::<NodeTypesWithDBAdapter<N, Arc<DatabaseEnv>>>::new(
             db,
             self.chain.clone(),

--- a/crates/cli/commands/src/prune.rs
+++ b/crates/cli/commands/src/prune.rs
@@ -1,5 +1,5 @@
 //! Command that runs pruning without any limits.
-use crate::common::{AccessRights, CliNodeTypes, Environment, EnvironmentArgs};
+use crate::common::{AccessRights, CliNodeTypes, EnvironmentArgs};
 use clap::Parser;
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_cli::chainspec::ChainSpecParser;
@@ -18,22 +18,23 @@ pub struct PruneCommand<C: ChainSpecParser> {
 impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> PruneCommand<C> {
     /// Execute the `prune` command
     pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec>>(self) -> eyre::Result<()> {
-        let Environment { config, provider_factory, .. } = self.env.init::<N>(AccessRights::RW)?;
-        let prune_config = config.prune.unwrap_or_default();
+        let env = self.env.init::<N>(AccessRights::RW)?;
+        let provider_factory = env.provider_factory;
+        let config = env.config.prune;
 
         // Copy data from database to static files
         info!(target: "reth::cli", "Copying data from database to static files...");
         let static_file_producer =
-            StaticFileProducer::new(provider_factory.clone(), prune_config.segments.clone());
+            StaticFileProducer::new(provider_factory.clone(), config.segments.clone());
         let lowest_static_file_height =
             static_file_producer.lock().copy_to_static_files()?.min_block_num();
         info!(target: "reth::cli", ?lowest_static_file_height, "Copied data from database to static files");
 
         // Delete data which has been copied to static files.
         if let Some(prune_tip) = lowest_static_file_height {
-            info!(target: "reth::cli", ?prune_tip, ?prune_config, "Pruning data from database...");
+            info!(target: "reth::cli", ?prune_tip, ?config, "Pruning data from database...");
             // Run the pruner according to the configuration, and don't enforce any limits on it
-            let mut pruner = PrunerBuilder::new(prune_config)
+            let mut pruner = PrunerBuilder::new(config)
                 .delete_limit(usize::MAX)
                 .build_with_provider_factory(provider_factory);
 

--- a/crates/cli/commands/src/stage/run.rs
+++ b/crates/cli/commands/src/stage/run.rs
@@ -151,7 +151,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
         let batch_size = self.batch_size.unwrap_or(self.to.saturating_sub(self.from) + 1);
 
         let etl_config = config.stages.etl.clone();
-        let prune_modes = config.prune.clone().map(|prune| prune.segments).unwrap_or_default();
+        let prune_modes = config.prune.segments.clone();
 
         let (mut exec_stage, mut unwind_stage): (Box<dyn Stage<_>>, Option<Box<dyn Stage<_>>>) =
             match self.stage {

--- a/crates/cli/commands/src/stage/unwind.rs
+++ b/crates/cli/commands/src/stage/unwind.rs
@@ -85,7 +85,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
         evm_config: impl ConfigureEvm<Primitives = N::Primitives> + 'static,
     ) -> Result<Pipeline<N>, eyre::Error> {
         let stage_conf = &config.stages;
-        let prune_modes = config.prune.clone().map(|prune| prune.segments).unwrap_or_default();
+        let prune_modes = config.prune.segments.clone();
 
         let (tip_tx, tip_rx) = watch::channel(B256::ZERO);
 

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -23,6 +23,7 @@ pub struct Config {
     // TODO(onbjerg): Can we make this easier to maintain when we add/remove stages?
     pub stages: StageConfig,
     /// Configuration for pruning.
+    #[cfg_attr(feature = "serde", serde(default))]
     pub prune: PruneConfig,
     /// Configuration for the discovery service.
     pub peers: PeersConfig,

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -23,8 +23,7 @@ pub struct Config {
     // TODO(onbjerg): Can we make this easier to maintain when we add/remove stages?
     pub stages: StageConfig,
     /// Configuration for pruning.
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    pub prune: Option<PruneConfig>,
+    pub prune: PruneConfig,
     /// Configuration for the discovery service.
     pub peers: PeersConfig,
     /// Configuration for peer sessions.
@@ -33,8 +32,8 @@ pub struct Config {
 
 impl Config {
     /// Sets the pruning configuration.
-    pub fn update_prune_config(&mut self, prune_config: PruneConfig) {
-        self.prune = Some(prune_config);
+    pub fn set_prune_config(&mut self, prune_config: PruneConfig) {
+        self.prune = prune_config;
     }
 }
 
@@ -445,6 +444,11 @@ impl Default for PruneConfig {
 }
 
 impl PruneConfig {
+    /// Returns whether this configuration is the default one.
+    pub fn is_default(&self) -> bool {
+        self == &Self::default()
+    }
+
     /// Returns whether there is any kind of receipt pruning configuration.
     pub fn has_receipts_pruning(&self) -> bool {
         self.segments.receipts.is_some() || !self.segments.receipts_log_filter.is_empty()
@@ -452,8 +456,7 @@ impl PruneConfig {
 
     /// Merges another `PruneConfig` into this one, taking values from the other config if and only
     /// if the corresponding value in this config is not set.
-    pub fn merge(&mut self, other: Option<Self>) {
-        let Some(other) = other else { return };
+    pub fn merge(&mut self, other: Self) {
         let Self {
             block_interval,
             segments:
@@ -1030,7 +1033,7 @@ receipts = 'full'
         };
 
         let original_filter = config1.segments.receipts_log_filter.clone();
-        config1.merge(Some(config2));
+        config1.merge(config2);
 
         // Check that the configuration has been merged. Any configuration present in config1
         // should not be overwritten by config2

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -168,7 +168,7 @@ impl EngineNodeLauncher {
         }
         let pruner = pruner_builder.build_with_provider_factory(ctx.provider_factory().clone());
         let pruner_events = pruner.events();
-        info!(target: "reth::cli", prune_config=?ctx.prune_config().unwrap_or_default(), "Pruner initialized");
+        info!(target: "reth::cli", prune_config=?ctx.prune_config(), "Pruner initialized");
 
         let event_sender = EventSender::default();
 

--- a/crates/node/builder/src/setup.rs
+++ b/crates/node/builder/src/setup.rs
@@ -36,7 +36,7 @@ pub fn build_networked_pipeline<N, Client, Evm>(
     provider_factory: ProviderFactory<N>,
     task_executor: &TaskExecutor,
     metrics_tx: reth_stages::MetricEventsSender,
-    prune_config: Option<PruneConfig>,
+    prune_config: PruneConfig,
     max_block: Option<BlockNumber>,
     static_file_producer: StaticFileProducer<ProviderFactory<N>>,
     evm_config: Evm,
@@ -85,7 +85,7 @@ pub fn build_pipeline<N, H, B, Evm>(
     consensus: Arc<dyn FullConsensus<N::Primitives, Error = ConsensusError>>,
     max_block: Option<u64>,
     metrics_tx: reth_stages::MetricEventsSender,
-    prune_config: Option<PruneConfig>,
+    prune_config: PruneConfig,
     static_file_producer: StaticFileProducer<ProviderFactory<N>>,
     evm_config: Evm,
     exex_manager_handle: ExExManagerHandle<N::Primitives>,
@@ -106,8 +106,6 @@ where
 
     let (tip_tx, tip_rx) = watch::channel(B256::ZERO);
 
-    let prune_modes = prune_config.map(|prune| prune.segments).unwrap_or_default();
-
     let pipeline = builder
         .with_tip_sender(tip_tx)
         .with_metrics_tx(metrics_tx)
@@ -120,7 +118,7 @@ where
                 body_downloader,
                 evm_config.clone(),
                 stage_config.clone(),
-                prune_modes,
+                prune_config.segments,
                 era_import_source,
             )
             .set(ExecutionStage::new(

--- a/crates/node/core/src/args/pruning.rs
+++ b/crates/node/core/src/args/pruning.rs
@@ -6,7 +6,7 @@ use clap::{builder::RangedU64ValueParser, Args};
 use reth_chainspec::EthereumHardforks;
 use reth_config::config::PruneConfig;
 use reth_prune_types::{PruneMode, PruneModes, ReceiptsLogPruneConfig, MINIMUM_PRUNING_DISTANCE};
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, ops::Not};
 
 /// Parameters for pruning and full node
 #[derive(Debug, Clone, Args, PartialEq, Eq, Default)]
@@ -107,6 +107,9 @@ pub struct PruningArgs {
 
 impl PruningArgs {
     /// Returns pruning configuration.
+    ///
+    /// Returns [`None`] if no parameters are specified and default pruning configuration should be
+    /// used.
     pub fn prune_config<ChainSpec>(&self, chain_spec: &ChainSpec) -> Option<PruneConfig>
     where
         ChainSpec: EthereumHardforks,
@@ -163,7 +166,7 @@ impl PruningArgs {
             config.segments.receipts.take();
         }
 
-        Some(config)
+        config.is_default().not().then_some(config)
     }
 
     fn bodies_prune_mode<ChainSpec>(&self, chain_spec: &ChainSpec) -> Option<PruneMode>

--- a/crates/prune/types/src/target.rs
+++ b/crates/prune/types/src/target.rs
@@ -104,6 +104,10 @@ pub struct PruneModes {
     ///
     /// The [`BlockNumber`](`crate::BlockNumber`) represents the starting block from which point
     /// onwards the receipts are preserved.
+    #[cfg_attr(
+        any(test, feature = "serde"),
+        serde(skip_serializing_if = "ReceiptsLogPruneConfig::is_empty")
+    )]
     pub receipts_log_filter: ReceiptsLogPruneConfig,
 }
 


### PR DESCRIPTION
## Problem

Since https://github.com/paradigmxyz/reth/pull/7938 was merged, we had a bunch of changes to pruning configuration that made the initial PR useless.
1. `PruningArgs::prune_config()` [never](https://github.com/paradigmxyz/reth/blob/792b82d8956d91255c022abf7ea39a81781d0796/crates/node/core/src/args/pruning.rs#L109-L166) returns `None`, and because of that we never update the prune config in the file. https://github.com/paradigmxyz/reth/blob/792b82d8956d91255c022abf7ea39a81781d0796/crates/node/builder/src/launch/common.rs#L181-L186
2. For the same reason, we never logged the following warning. https://github.com/paradigmxyz/reth/blob/792b82d8956d91255c022abf7ea39a81781d0796/crates/node/builder/src/launch/common.rs#L187-L189

## Solution

This PR fixes this behaviour in the following way:
1. `PruningArgs::prune_config()` returns `None` if it has the default configuration. https://github.com/paradigmxyz/reth/blob/7478e900169c949fedfc6f0af4ae4bbbeb494a13/crates/node/core/src/args/pruning.rs#L169
2. If prune config in the file doesn't match the config from non-empty CLI arguments, the file is updated with the config from CLI. https://github.com/paradigmxyz/reth/blob/3553bea320cc40699ccd6f5268847f56e97bef9b/crates/node/builder/src/launch/common.rs#L183-L187

This is a backward-compatible change that has the following effect:
1. If you have an existing archive node datadir and you start a node with any pruning CLI arguments, the config file will be updated.
2. If you have an existing pruned (full / custom) node datadir and you start a node with no pruning CLI arguments, the warning log will be emitted, and the prune config from the file will be used.
3. If you have an existing pruned node datadir and you start a node with different pruning CLI arguments than what's in the config file, the config file will be updated.