### PR TITLE
fix: prevent accidental overwrite of existing era1 files

### DIFF
--- a/crates/era-utils/src/export.rs
+++ b/crates/era-utils/src/export.rs
@@ -149,6 +149,16 @@ where
 
         debug!("Final file name {}", era1_id.to_file_name());
         let file_path = config.dir.join(era1_id.to_file_name());
+
+        // Check if file already exists to prevent accidental overwrites
+        if file_path.exists() {
+            warn!(
+                target: "era::history::export",
+                "ERA1 file already exists: {file_path:?}, skipping to prevent data loss"
+            );
+            continue;
+        }
+
         let file = std::fs::File::create(&file_path)?;
         let mut writer = Era1Writer::new(file);
         writer.write_version()?;


### PR DESCRIPTION
Add file existence check before creating era1 files to prevent data loss. 

When a file already exists, the export process now logs a warning and skips that file instead of silently overwriting it.
