### PR TITLE
refactor(ipc): simplify RpcServiceCfg from enum to struct

### DIFF
--- a/crates/rpc/ipc/src/server/mod.rs
+++ b/crates/rpc/ipc/src/server/mod.rs
@@ -391,7 +391,7 @@ where
     fn call(&mut self, request: String) -> Self::Future {
         trace!("{:?}", request);
 
-        let cfg = RpcServiceCfg::CallsAndSubscriptions {
+        let cfg = RpcServiceCfg {
             bounded_subscriptions: BoundedSubscriptions::new(
                 self.inner.server_cfg.max_subscriptions_per_connection,
             ),


### PR DESCRIPTION
Converts RpcServiceCfg from an enum with two variants to a simple struct. 

The OnlyCalls variant was never used in practice (had #[allow(dead_code)] since creation) and only CallsAndSubscriptions was ever instantiated. This change removes the unnecessary complexity of pattern matching and error handling for subscriptions that would never occur.

The IPC server always needs full RPC functionality including subscriptions, so having a "calls only" mode was theoretical overhead without practical benefit.