### PR TITLE
feat: replace Payment todo!() with explicit unsupported error

### DIFF
--- a/examples/custom-node/src/evm/executor.rs
+++ b/examples/custom-node/src/evm/executor.rs
@@ -45,7 +45,9 @@ where
             CustomTransaction::Op(op_tx) => self
                 .inner
                 .execute_transaction_without_commit(Recovered::new_unchecked(op_tx, *tx.signer())),
-            CustomTransaction::Payment(..) => todo!(),
+            CustomTransaction::Payment(..) => Err(BlockExecutionError::msg(
+                "CustomTransaction::Payment is not supported by OpBlockExecutor",
+            )),
         }
     }
 
@@ -58,7 +60,9 @@ where
             CustomTransaction::Op(op_tx) => {
                 self.inner.commit_transaction(output, Recovered::new_unchecked(op_tx, *tx.signer()))
             }
-            CustomTransaction::Payment(..) => todo!(),
+            CustomTransaction::Payment(..) => Err(BlockExecutionError::msg(
+                "CustomTransaction::Payment is not supported by OpBlockExecutor",
+            )),
         }
     }
 


### PR DESCRIPTION
The previous todo!() for CustomTransaction::Payment in execute_transaction_without_commit and commit_transaction caused panics. Direct forwarding to the inner executor is not compatible due to trait bounds requiring RecoveredTx<OpTxEnvelope>. This change keeps Op handling as before and returns a clear BlockExecutionError for Payment instead of panicking. This avoids crashes while documenting that Payment execution is currently unsupported by OpBlockExecutor.