### PR TITLE
fix: add missing excess_blob_gas validation in EIP-4844 header validation

### DIFF
--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -237,6 +237,7 @@ pub fn validate_4844_header_standalone<H: BlockHeader>(
     blob_params: BlobParams,
 ) -> Result<(), ConsensusError> {
     let blob_gas_used = header.blob_gas_used().ok_or(ConsensusError::BlobGasUsedMissing)?;
+    let excess_blob_gas = header.excess_blob_gas().ok_or(ConsensusError::ExcessBlobGasMissing)?;
 
     if header.parent_beacon_block_root().is_none() {
         return Err(ConsensusError::ParentBeaconBlockRootMissing)
@@ -245,6 +246,13 @@ pub fn validate_4844_header_standalone<H: BlockHeader>(
     if !blob_gas_used.is_multiple_of(DATA_GAS_PER_BLOB) {
         return Err(ConsensusError::BlobGasUsedNotMultipleOfBlobGasPerBlob {
             blob_gas_used,
+            blob_gas_per_blob: DATA_GAS_PER_BLOB,
+        })
+    }
+
+    if !excess_blob_gas.is_multiple_of(DATA_GAS_PER_BLOB) {
+        return Err(ConsensusError::ExcessBlobGasNotMultipleOfBlobGasPerBlob {
+            excess_blob_gas,
             blob_gas_per_blob: DATA_GAS_PER_BLOB,
         })
     }

--- a/crates/consensus/consensus/src/lib.rs
+++ b/crates/consensus/consensus/src/lib.rs
@@ -321,6 +321,17 @@ pub enum ConsensusError {
         blob_gas_per_blob: u64,
     },
 
+    /// Error when excess blob gas is not a multiple of blob gas per blob.
+    #[error(
+        "excess blob gas {excess_blob_gas} is not a multiple of blob gas per blob {blob_gas_per_blob}"
+    )]
+    ExcessBlobGasNotMultipleOfBlobGasPerBlob {
+        /// The actual excess blob gas.
+        excess_blob_gas: u64,
+        /// The blob gas per blob.
+        blob_gas_per_blob: u64,
+    },
+
     /// Error when the blob gas used in the header does not match the expected blob gas used.
     #[error("blob gas used mismatch: {0}")]
     BlobGasUsedDiff(GotExpected<u64>),


### PR DESCRIPTION
Add validation for excess_blob_gas field presence and multiple-of-DATA_GAS_PER_BLOB check in validate_4844_header_standalone function. 

This ensures the function matches its documentation and provides complete EIP-4844 header field validation.
