### PR TITLE
perf: eliminate bounds check in PrefixSet::contains while loop

### DIFF
--- a/crates/trie/common/src/prefix_set.rs
+++ b/crates/trie/common/src/prefix_set.rs
@@ -205,9 +205,10 @@ impl PrefixSet {
             return true
         }
 
-        // Ensure index is within bounds to eliminate bound checks in the while loop
-        if self.index >= self.keys.len() && !self.keys.is_empty() {
-            self.index = self.keys.len() - 1;
+        // Early bounds check to help compiler eliminate redundant checks in the while loop
+        // If index is out of bounds, reset to 0 to avoid unnecessary backward scanning
+        if self.index >= self.keys.len() {
+            self.index = 0;
         }
 
         while self.index > 0 && &self.keys[self.index] > prefix {

--- a/crates/trie/common/src/prefix_set.rs
+++ b/crates/trie/common/src/prefix_set.rs
@@ -205,6 +205,11 @@ impl PrefixSet {
             return true
         }
 
+        // Ensure index is within bounds to eliminate bound checks in the while loop
+        if self.index >= self.keys.len() && !self.keys.is_empty() {
+            self.index = self.keys.len() - 1;
+        }
+
         while self.index > 0 && &self.keys[self.index] > prefix {
             self.index -= 1;
         }


### PR DESCRIPTION
Add an explicit bounds check before the while loop in `PrefixSet::contains` to help the compiler eliminate redundant per-iteration bounds checks.

Closes #19189