### PR TITLE
fix: add arrayvec to dev-dependencies in reth-trie-common

### DIFF
--- a/crates/trie/common/Cargo.toml
+++ b/crates/trie/common/Cargo.toml
@@ -53,6 +53,7 @@ alloy-genesis.workspace = true
 alloy-primitives = { workspace = true, features = ["getrandom"] }
 alloy-trie = { workspace = true, features = ["arbitrary", "serde"] }
 bytes.workspace = true
+arrayvec.workspace = true
 hash-db.workspace = true
 plain_hasher.workspace = true
 arbitrary = { workspace = true, features = ["derive"] }
@@ -75,6 +76,7 @@ std = [
     "alloy-rpc-types-eth?/std",
     "alloy-serde?/std",
     "alloy-trie/std",
+    "arrayvec?/std",
     "bytes?/std",
     "derive_more/std",
     "nybbles/std",
@@ -84,7 +86,6 @@ std = [
     "serde_json/std",
     "revm-database/std",
     "revm-state/std",
-    "arrayvec?/std",
 ]
 eip1186 = ["alloy-rpc-types-eth/serde", "dep:alloy-serde"]
 serde = [


### PR DESCRIPTION
Running `cargo test -p reth-trie-common --lib` was failing with "unresolved module arrayvec" error because arrayvec was marked as optional but the test code needed it.

Added arrayvec to dev-dependencies so tests can run without requiring the --features reth-codec flag. This matches the pattern used in other crates like reth-revm where optional dependencies are also included in dev-dependencies for testing.

Now developers can run tests with the standard command documented in CONTRIBUTING.md without needing to remember special flags.