### PR TITLE
fix(trie): correct comment in sparse_trie_reveal_node_1 test

### DIFF
--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -3139,7 +3139,7 @@ mod tests {
     }
 
     /// We have three leaves that share the same prefix: 0x00, 0x01 and 0x02. Hash builder trie has
-    /// only nodes 0x00 and 0x01, and we have proofs for them. Node B is new and inserted in the
+    /// only nodes 0x00 and 0x02, and we have proofs for them. Node 0x01 is new and inserted in the
     /// sparse trie first.
     ///
     /// 1. Reveal the hash builder proof to leaf 0x00 in the sparse trie.


### PR DESCRIPTION
Fixed incorrect comment in sparse_trie_reveal_node_1 test: changed "hash builder has nodes 0x00 and 0x01" to "0x00 and 0x02" to match the actual code implementation which uses key1() and key3().