### PR TITLE
perf: Eliminate spawn_blocking in multiproof manager

### DIFF
--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -65,6 +65,7 @@ rayon.workspace = true
 tracing.workspace = true
 derive_more.workspace = true
 parking_lot.workspace = true
+crossbeam-channel.workspace = true
 
 # optional deps for test-utils
 reth-prune-types = { workspace = true, optional = true }

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -241,7 +241,6 @@ where
 
         let multi_proof_task = MultiProofTask::new(
             state_root_config,
-            self.executor.clone(),
             proof_handle.clone(),
             to_sparse_trie,
             config.multiproof_chunking_enabled().then_some(config.multiproof_chunk_size()),

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -15,6 +15,7 @@ use crate::tree::{
 };
 use alloy_evm::{block::StateChangeSource, ToTxEnv};
 use alloy_primitives::B256;
+use crossbeam_channel::Sender as CrossbeamSender;
 use executor::WorkloadExecutor;
 use multiproof::{SparseTrieUpdate, *};
 use parking_lot::RwLock;
@@ -45,7 +46,6 @@ use std::sync::{
     mpsc::{self, channel},
     Arc,
 };
-use crossbeam_channel::Sender as CrossbeamSender;
 use tracing::{debug, instrument, warn};
 
 mod configured_sparse_trie;

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -40,15 +40,13 @@ use reth_trie_sparse::{
     ClearedSparseStateTrie, SparseStateTrie, SparseTrie,
 };
 use reth_trie_sparse_parallel::{ParallelSparseTrie, ParallelismThresholds};
-use std::{
-    sync::{
-        atomic::AtomicBool,
-        mpsc::{self, channel, Sender},
-        Arc,
-    },
-    time::Instant,
+use std::sync::{
+    atomic::AtomicBool,
+    mpsc::{self, channel},
+    Arc,
 };
-use tracing::{debug, debug_span, instrument, warn};
+use crossbeam_channel::Sender as CrossbeamSender;
+use tracing::{debug, instrument, warn};
 
 mod configured_sparse_trie;
 pub mod executor;
@@ -345,7 +343,7 @@ where
         mut transactions: mpsc::Receiver<impl ExecutableTxFor<Evm> + Clone + Send + 'static>,
         transaction_count_hint: usize,
         provider_builder: StateProviderBuilder<N, P>,
-        to_multi_proof: Option<Sender<MultiProofMessage>>,
+        to_multi_proof: Option<CrossbeamSender<MultiProofMessage>>,
     ) -> CacheTaskHandle
     where
         P: BlockReader + StateProviderFactory + StateReader + Clone + 'static,
@@ -483,7 +481,7 @@ where
 #[derive(Debug)]
 pub struct PayloadHandle<Tx, Err> {
     /// Channel for evm state updates
-    to_multi_proof: Option<Sender<MultiProofMessage>>,
+    to_multi_proof: Option<CrossbeamSender<MultiProofMessage>>,
     // must include the receiver of the state root wired to the sparse trie
     prewarm_handle: CacheTaskHandle,
     /// Receiver for the state root
@@ -561,7 +559,7 @@ pub(crate) struct CacheTaskHandle {
     /// Metrics for the caches
     cache_metrics: CachedStateMetrics,
     /// Channel to the spawned prewarm task if any
-    to_prewarm_task: Option<Sender<PrewarmTaskEvent>>,
+    to_prewarm_task: Option<std::sync::mpsc::Sender<PrewarmTaskEvent>>,
 }
 
 impl CacheTaskHandle {

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -41,12 +41,15 @@ use reth_trie_sparse::{
     ClearedSparseStateTrie, SparseStateTrie, SparseTrie,
 };
 use reth_trie_sparse_parallel::{ParallelSparseTrie, ParallelismThresholds};
-use std::sync::{
-    atomic::AtomicBool,
-    mpsc::{self, channel},
-    Arc,
+use std::{
+    sync::{
+        atomic::AtomicBool,
+        mpsc::{self, channel},
+        Arc,
+    },
+    time::Instant,
 };
-use tracing::{debug, instrument, warn};
+use tracing::{debug, debug_span, instrument, warn};
 
 mod configured_sparse_trie;
 pub mod executor;

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -21,12 +21,7 @@ use reth_trie_parallel::{
     proof::ParallelProof,
     proof_task::{AccountMultiproofInput, ProofResultMessage, ProofWorkerHandle},
 };
-use std::{
-    collections::BTreeMap,
-    ops::DerefMut,
-    sync::Arc,
-    time::Instant,
-};
+use std::{collections::{BTreeMap, VecDeque}, ops::DerefMut, sync::Arc, time::Instant};
 use tracing::{debug, error, instrument, trace};
 
 /// A trie update that can be applied to sparse trie alongside the proofs for touched parts of the

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -511,7 +511,7 @@ impl MultiproofManager {
                 account_targets,
                 storage_targets,
                 ?source,
-                "Starting multiproof calculation",
+            "Dispatching multiproof to workers"
             );
 
             let start = Instant::now();

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -1167,8 +1167,11 @@ impl MultiProofTask {
                             }
                         }
                         Err(_) => {
-                            error!(target: "engine::tree::payload_processor::multiproof", "Proof result channel closed unexpectedly");
-                            return
+                            // SAFETY: This is unreachable because `self.multiproof_manager` owns
+                            // `proof_result_tx` (the sender), which keeps the channel open for
+                            // the entire lifetime of this task. The channel cannot close while
+                            // `self` exists.
+                            unreachable!("proof result channel closed while multiproof manager still exists")
                         }
                     }
                 }

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -21,6 +21,7 @@ use reth_trie::{
 use reth_trie_parallel::{
     proof::ParallelProof,
     proof_task::{AccountMultiproofInput, ProofResultMessage, ProofWorkerHandle},
+    root::ParallelStateRootError,
     stats::ParallelTrieTracker,
 };
 use std::{

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -460,8 +460,8 @@ impl MultiproofManager {
             hashed_state_update,
             proof_targets,
             proof_sequence_number,
+            state_root_message_sender: _,
             multi_added_removed_keys,
-            ..
         } = multiproof_input;
 
         let missed_leaves_storage_roots = self.missed_leaves_storage_roots.clone();

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -425,7 +425,12 @@ impl MultiproofManager {
         // Dispatch to storage worker
         if let Err(e) = self.proof_worker_handle.dispatch_storage_proof(
             input,
-            (self.proof_result_tx.clone(), proof_sequence_number, hashed_state_update, start),
+            reth_trie_parallel::proof_task::ProofResultContext::new(
+                self.proof_result_tx.clone(),
+                proof_sequence_number,
+                hashed_state_update,
+                start,
+            ),
         ) {
             error!(target: "engine::tree::payload_processor::multiproof", ?e, "Failed to dispatch storage proof");
             return;
@@ -493,7 +498,7 @@ impl MultiproofManager {
             multi_added_removed_keys,
             missed_leaves_storage_roots,
             // Workers will send ProofResultMessage directly to proof_result_rx
-            proof_result_sender: (
+            proof_result_sender: reth_trie_parallel::proof_task::ProofResultContext::new(
                 self.proof_result_tx.clone(),
                 proof_sequence_number,
                 hashed_state_update,

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -390,11 +390,10 @@ impl MultiproofManager {
         let storage_targets = proof_targets.len();
 
         trace!(
-            target: "engine::root",
+            target: "engine::tree::payload_processor::multiproof",
             proof_sequence_number,
             ?proof_targets,
             storage_targets,
-            ?source,
             "Dispatching storage proof to workers"
         );
 
@@ -415,12 +414,12 @@ impl MultiproofManager {
             Some(multi_added_removed_keys),
         );
 
-        // Dispatch to storage worker - NO spawn_blocking!
+        // Dispatch to storage worker
         if let Err(e) = self.proof_worker_handle.dispatch_storage_proof(
             input,
             (self.proof_result_tx.clone(), proof_sequence_number, hashed_state_update, start),
         ) {
-            error!(target: "engine::root", ?e, "Failed to dispatch storage proof");
+            error!(target: "engine::tree::payload_processor::multiproof", ?e, "Failed to dispatch storage proof");
             return;
         }
 
@@ -463,7 +462,7 @@ impl MultiproofManager {
         let storage_targets = proof_targets.values().map(|slots| slots.len()).sum::<usize>();
 
         trace!(
-            target: "engine::root",
+            target: "engine::tree::payload_processor::multiproof",
             proof_sequence_number,
             ?proof_targets,
             account_targets,
@@ -939,7 +938,7 @@ impl MultiProofTask {
                                 targets.values().map(|slots| slots.len()).sum::<usize>();
                             prefetch_proofs_requested += self.on_prefetch_proof(targets);
                             debug!(
-                                target: "engine::root",
+                                target: "engine::tree::payload_processor::multiproof",
                                 account_targets,
                                 storage_targets,
                                 prefetch_proofs_requested,
@@ -960,7 +959,7 @@ impl MultiProofTask {
                             let len = update.len();
                             state_update_proofs_requested += self.on_state_update(source, update);
                             debug!(
-                                target: "engine::root",
+                                target: "engine::tree::payload_processor::multiproof",
                                 ?source,
                                 len,
                                 ?state_update_proofs_requested,
@@ -978,7 +977,7 @@ impl MultiProofTask {
                                 updates_finished,
                             ) {
                                 debug!(
-                                    target: "engine::root",
+                                    target: "engine::tree::payload_processor::multiproof",
                                     "State updates finished and all proofs processed, ending calculation"
                                 );
                                     break
@@ -1003,7 +1002,7 @@ impl MultiProofTask {
                                     updates_finished,
                                 ) {
                                     debug!(
-                                        target: "engine::root",
+                                        target: "engine::tree::payload_processor::multiproof",
                                         "State updates finished and all proofs processed, ending calculation"
                                     );
                                     break
@@ -1011,7 +1010,7 @@ impl MultiProofTask {
                             }
                         },
                         Err(_) => {
-                            error!(target: "engine::root", "State root related message channel closed unexpectedly");
+                            error!(target: "engine::tree::payload_processor::multiproof", "State root related message channel closed unexpectedly");
                             return
                         }
                     }
@@ -1032,7 +1031,7 @@ impl MultiProofTask {
                             match proof_result.result {
                                 Ok((multiproof, _stats)) => {
                                     debug!(
-                                        target: "engine::root",
+                                        target: "engine::tree::payload_processor::multiproof",
                                         sequence = proof_result.sequence_number,
                                         total_proofs = proofs_processed,
                                         "Processing calculated proof from worker"
@@ -1050,7 +1049,7 @@ impl MultiProofTask {
                                     }
                                 }
                                 Err(error) => {
-                                    error!(target: "engine::root", ?error, "proof calculation error from worker");
+                                    error!(target: "engine::tree::payload_processor::multiproof", ?error, "proof calculation error from worker");
                                     return
                                 }
                             }
@@ -1062,14 +1061,14 @@ impl MultiProofTask {
                                 updates_finished,
                             ) {
                                 debug!(
-                                    target: "engine::root",
+                                    target: "engine::tree::payload_processor::multiproof",
                                     "State updates finished and all proofs processed, ending calculation"
                                 );
                                 break
                             }
                         }
                         Err(_) => {
-                            error!(target: "engine::root", "Proof result channel closed unexpectedly");
+                            error!(target: "engine::tree::payload_processor::multiproof", "Proof result channel closed unexpectedly");
                             return
                         }
                     }

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -21,7 +21,7 @@ use reth_trie_parallel::{
     proof::ParallelProof,
     proof_task::{AccountMultiproofInput, ProofResultMessage, ProofWorkerHandle},
 };
-use std::{collections::{BTreeMap, VecDeque}, ops::DerefMut, sync::Arc, time::Instant};
+use std::{collections::BTreeMap, ops::DerefMut, sync::Arc, time::Instant};
 use tracing::{debug, error, instrument, trace};
 
 /// A trie update that can be applied to sparse trie alongside the proofs for touched parts of the

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -113,17 +113,6 @@ pub(super) enum MultiProofMessage {
     FinishedStateUpdates,
 }
 
-/// Message about completion of proof calculation for a specific state update
-#[derive(Debug)]
-pub(super) struct ProofCalculated {
-    /// The index of this proof in the sequence of state updates
-    sequence_number: u64,
-    /// Sparse trie update
-    update: SparseTrieUpdate,
-    /// The time taken to calculate the proof.
-    elapsed: Duration,
-}
-
 /// Handle to track proof calculation ordering.
 #[derive(Debug, Default)]
 struct ProofSequencer {

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -265,7 +265,6 @@ impl From<MultiproofInput> for PendingMultiproofTask {
 /// Input parameters for spawning a dedicated storage multiproof calculation.
 #[derive(Debug)]
 struct StorageMultiproofInput {
-    source: Option<StateChangeSource>,
     hashed_state_update: HashedPostState,
     hashed_address: B256,
     proof_targets: B256Set,
@@ -378,7 +377,6 @@ impl MultiproofManager {
     /// Spawns a single storage proof calculation task.
     fn spawn_storage_proof(&mut self, storage_multiproof_input: StorageMultiproofInput) {
         let StorageMultiproofInput {
-            source,
             hashed_state_update,
             hashed_address,
             proof_targets,

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -311,9 +311,8 @@ impl MultiproofInput {
 /// 1. `MultiProofTask` asks the manager to spawn either storage or account proof work.
 /// 2. The manager builds the request, clones `proof_result_tx`, and hands everything to
 ///    [`ProofWorkerHandle`].
-/// 3. A worker finishes the proof and sends a
-///    [`ProofResultMessage`](reth_trie_parallel::proof_task::ProofResultMessage) through the
-///    channel included in the job.
+/// 3. A worker finishes the proof and sends a [`ProofResultMessage`] through the channel included
+///    in the job.
 /// 4. `MultiProofTask` consumes the message from the same channel and sequences it with
 ///    `ProofSequencer`.
 #[derive(Debug)]

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -1023,6 +1023,7 @@ impl MultiProofTask {
                         Ok(msg) => match msg {
                             MultiProofMessage::PrefetchProofs(targets) => {
                                 trace!(target: "engine::tree::payload_processor::multiproof", "processing MultiProofMessage::PrefetchProofs");
+
                                 if first_update_time.is_none() {
                                     // record the wait time
                                     self.metrics
@@ -1046,6 +1047,7 @@ impl MultiProofTask {
                             }
                             MultiProofMessage::StateUpdate(source, update) => {
                                 trace!(target: "engine::tree::payload_processor::multiproof", "processing MultiProofMessage::StateUpdate");
+
                                 if first_update_time.is_none() {
                                     // record the wait time
                                     self.metrics
@@ -1067,8 +1069,10 @@ impl MultiProofTask {
                             }
                             MultiProofMessage::FinishedStateUpdates => {
                                 trace!(target: "engine::tree::payload_processor::multiproof", "processing MultiProofMessage::FinishedStateUpdates");
+
                                 updates_finished = true;
                                 updates_finished_time = Some(Instant::now());
+
                                 if self.is_done(
                                     proofs_processed,
                                     state_update_proofs_requested,

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -368,12 +368,6 @@ impl MultiproofManager {
             return
         }
 
-        self.dispatch_multiproof_task(input);
-    }
-
-    /// Dispatches a multiproof task to `dispatch_storage_proof` if the input is a storage
-    /// multiproof, and to `dispatch_multiproof` otherwise.
-    fn dispatch_multiproof_task(&mut self, input: PendingMultiproofTask) {
         match input {
             PendingMultiproofTask::Storage(storage_input) => {
                 self.dispatch_storage_proof(storage_input);

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -1210,9 +1210,9 @@ mod tests {
         let consistent_view = ConsistentDbView::new(factory, None);
         let proof_handle =
             ProofWorkerHandle::new(executor.handle().clone(), consistent_view, task_ctx, 1, 1);
-        let channel = std::sync::mpsc::channel();
+        let (to_sparse_trie, _receiver) = std::sync::mpsc::channel();
 
-        MultiProofTask::new(config, executor, proof_handle, channel.0, Some(1))
+        MultiProofTask::new(config, executor, proof_handle, to_sparse_trie, Some(1))
     }
 
     #[test]

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -368,12 +368,12 @@ impl MultiproofManager {
             return
         }
 
-        self.dispatch_task(input);
+        self.dispatch_multiproof_task(input);
     }
 
     /// Dispatches a multiproof task to `dispatch_storage_proof` if the input is a storage
     /// multiproof, and to `dispatch_multiproof` otherwise.
-    fn dispatch_task(&mut self, input: PendingMultiproofTask) {
+    fn dispatch_multiproof_task(&mut self, input: PendingMultiproofTask) {
         match input {
             PendingMultiproofTask::Storage(storage_input) => {
                 self.dispatch_storage_proof(storage_input);

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -973,7 +973,7 @@ impl MultiProofTask {
     ///      so that the proofs for accounts and storage slots that were already fetched are not
     ///      requested again.
     /// 2. Using the proof targets, a new multiproof is calculated using
-    ///    [`MultiproofManager::spawn`].
+    ///    [`MultiproofManager::dispatch`].
     ///    * If the list of proof targets is empty, the [`MultiProofMessage::EmptyProof`] message is
     ///      sent back to this task along with the original state update.
     ///    * Otherwise, the multiproof is dispatched to worker pools and results are sent directly

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -335,7 +335,7 @@ pub struct MultiproofManager {
     /// a big account change into different chunks, which may repeatedly
     /// revisit missed leaves.
     missed_leaves_storage_roots: Arc<DashMap<B256, B256>>,
-    /// Sender for proof results (passed directly to workers)
+    /// Channel sender for receiving computed multiproof results from worker pools.
     proof_result_tx: CrossbeamSender<ProofResultMessage>,
     /// Metrics
     metrics: MultiProofTaskMetrics,

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -40,7 +40,7 @@ use std::{
     },
     time::Instant,
 };
-use tracing::{debug, trace, warn};
+use tracing::{debug, debug_span, instrument, trace, warn};
 
 /// A wrapper for transactions that includes their index in the block.
 #[derive(Clone)]

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -39,7 +39,8 @@ use std::{
     },
     time::Instant,
 };
-use tracing::{debug, debug_span, instrument, trace, warn};
+use crossbeam_channel::Sender as CrossbeamSender;
+use tracing::{debug, trace, warn};
 
 /// A wrapper for transactions that includes their index in the block.
 #[derive(Clone)]
@@ -83,7 +84,7 @@ where
     /// The number of transactions to be processed
     transaction_count_hint: usize,
     /// Sender to emit evm state outcome messages, if any.
-    to_multi_proof: Option<Sender<MultiProofMessage>>,
+    to_multi_proof: Option<CrossbeamSender<MultiProofMessage>>,
     /// Receiver for events produced by tx execution
     actions_rx: Receiver<PrewarmTaskEvent>,
 }
@@ -99,7 +100,7 @@ where
         executor: WorkloadExecutor,
         execution_cache: PayloadExecutionCache,
         ctx: PrewarmContext<N, P, Evm>,
-        to_multi_proof: Option<Sender<MultiProofMessage>>,
+        to_multi_proof: Option<CrossbeamSender<MultiProofMessage>>,
         transaction_count_hint: usize,
         max_concurrency: usize,
     ) -> (Self, Sender<PrewarmTaskEvent>) {

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -24,6 +24,7 @@ use alloy_consensus::transaction::TxHashRef;
 use alloy_eips::Typed2718;
 use alloy_evm::Database;
 use alloy_primitives::{keccak256, map::B256Set, B256};
+use crossbeam_channel::Sender as CrossbeamSender;
 use metrics::{Counter, Gauge, Histogram};
 use reth_evm::{execute::ExecutableTxFor, ConfigureEvm, Evm, EvmFor, SpecFor};
 use reth_metrics::Metrics;
@@ -39,7 +40,6 @@ use std::{
     },
     time::Instant,
 };
-use crossbeam_channel::Sender as CrossbeamSender;
 use tracing::{debug, trace, warn};
 
 /// A wrapper for transactions that includes their index in the block.

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -1,7 +1,8 @@
 use crate::{
     metrics::ParallelTrieMetrics,
     proof_task::{
-        AccountMultiproofInput, ProofResultMessage, ProofWorkerHandle, StorageProofInput,
+        AccountMultiproofInput, ProofResultContext, ProofResultMessage, ProofWorkerHandle,
+        StorageProofInput,
     },
     root::ParallelStateRootError,
     StorageRootTargets,
@@ -105,7 +106,10 @@ impl ParallelProof {
         );
 
         self.proof_worker_handle
-            .dispatch_storage_proof(input, (result_tx, 0, HashedPostState::default(), start))
+            .dispatch_storage_proof(
+                input,
+                ProofResultContext::new(result_tx, 0, HashedPostState::default(), start),
+            )
             .map_err(|e| ParallelStateRootError::Other(e.to_string()))?;
 
         Ok(result_rx)
@@ -208,7 +212,7 @@ impl ParallelProof {
             collect_branch_node_masks: self.collect_branch_node_masks,
             multi_added_removed_keys: self.multi_added_removed_keys.clone(),
             missed_leaves_storage_roots: self.missed_leaves_storage_roots.clone(),
-            proof_result_sender: (
+            proof_result_sender: ProofResultContext::new(
                 result_tx,
                 0,
                 HashedPostState::default(),

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -220,7 +220,7 @@ impl ParallelProof {
             .dispatch_account_multiproof(input)
             .map_err(|e| ParallelStateRootError::Other(e.to_string()))?;
 
-        // Wait for account multiproof result from worker via ProofResultMessage
+        // Wait for account multiproof result from worker
         let proof_result_msg = result_rx.recv().map_err(|_| {
             ParallelStateRootError::Other(
                 "Account multiproof channel dropped: worker died or pool shutdown".to_string(),

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -103,22 +103,6 @@ enum StorageWorkerJob {
     },
 }
 
-/// Message containing a completed proof result with metadata for direct delivery to
-/// `MultiProofTask`.
-///
-/// This type enables workers to send proof results directly to the `MultiProofTask` event loop.
-#[derive(Debug)]
-pub struct ProofResultMessage {
-    /// Sequence number for ordering proofs
-    pub sequence_number: u64,
-    /// The proof calculation result
-    pub result: AccountMultiproofResult,
-    /// Time taken for the entire proof calculation (from dispatch to completion)
-    pub elapsed: Duration,
-    /// Original state update that triggered this proof
-    pub state: HashedPostState,
-}
-
 /// Worker loop for storage trie operations.
 ///
 /// # Lifecycle
@@ -877,7 +861,6 @@ pub struct AccountMultiproofInput {
     /// Cached storage proof roots for missed leaves encountered during account trie walk.
     pub missed_leaves_storage_roots: Arc<DashMap<B256, B256>>,
     /// Sender for proof results.
-    ///
     /// The worker sends the computed proof result via this channel.
     pub proof_result_sender: ProofResultContext,
 }

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -12,8 +12,8 @@
 //!
 //! # Message Flow
 //!
-//! 1. [`MultiProofTask`](reth_engine_tree::tree::payload_processor::multiproof::MultiProofTask)
-//!    prepares a storage or account job and hands it to [`ProofWorkerHandle`]. The job carries a
+//! 1. `MultiProofTask` prepares a storage or account job
+//!    and hands it to [`ProofWorkerHandle`]. The job carries a
 //!    [`ProofResultContext`] so the worker knows how to send the result back.
 //! 2. A worker receives the job, runs the proof, and sends a [`ProofResultMessage`] through the
 //!    provided [`ProofResultSender`].

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -82,6 +82,22 @@ pub type ProofResultSender = CrossbeamSender<ProofResultMessage>;
 /// - `Instant`: Calculation start time for measuring elapsed duration
 pub type ProofResultContext = (ProofResultSender, u64, HashedPostState, Instant);
 
+/// Message containing a completed proof result with metadata for direct delivery to
+/// `MultiProofTask`.
+///
+/// This type enables workers to send proof results directly to the `MultiProofTask` event loop.
+#[derive(Debug)]
+pub struct ProofResultMessage {
+    /// Sequence number for ordering proofs
+    pub sequence_number: u64,
+    /// The proof calculation result
+    pub result: AccountMultiproofResult,
+    /// Time taken for the entire proof calculation (from dispatch to completion)
+    pub elapsed: Duration,
+    /// Original state update that triggered this proof
+    pub state: HashedPostState,
+}
+
 /// Internal message for storage workers.
 #[derive(Debug)]
 enum StorageWorkerJob {

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -124,9 +124,9 @@ pub struct ProofResultMessage {
 enum StorageWorkerJob {
     /// Storage proof computation request
     StorageProof {
-        /// Storage proof input parameters (what to compute)
+        /// Storage proof input parameters
         input: StorageProofInput,
-        /// Channel to send result back (where to send)
+        /// Context for sending the proof result.
         proof_result_sender: ProofResultContext,
     },
     /// Blinded storage node retrieval request
@@ -937,8 +937,7 @@ pub struct AccountMultiproofInput {
     pub multi_added_removed_keys: Option<Arc<MultiAddedRemovedKeys>>,
     /// Cached storage proof roots for missed leaves encountered during account trie walk.
     pub missed_leaves_storage_roots: Arc<DashMap<B256, B256>>,
-    /// Sender for proof results.
-    /// The worker sends the computed proof result via this channel.
+    /// Context for sending the proof result.
     pub proof_result_sender: ProofResultContext,
 }
 

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -371,6 +371,8 @@ fn account_worker_loop<Factory>(
                     "Processing account multiproof"
                 );
 
+                let proof_start = Instant::now();
+
                 let mut tracker = ParallelTrieTracker::default();
 
                 let mut storage_prefix_sets = std::mem::take(&mut prefix_sets.storage_prefix_sets);
@@ -426,7 +428,7 @@ fn account_worker_loop<Factory>(
                     &mut tracker,
                 );
 
-                let proof_elapsed = start.elapsed();
+                let proof_elapsed = proof_start.elapsed();
                 let stats = tracker.finish();
                 let result = result.map(|proof| (proof, stats));
                 account_proofs_processed += 1;
@@ -451,7 +453,7 @@ fn account_worker_loop<Factory>(
 
                 trace!(
                     target: "trie::proof_task",
-                    proof_time_us = proof_elapsed.as_micros(),
+                    proof_time_us = proof_start.elapsed().as_micros(),
                     total_processed = account_proofs_processed,
                     "Account multiproof completed"
                 );

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -467,7 +467,7 @@ fn account_worker_loop<Factory>(
                         target: "trie::proof_task",
                         worker_id,
                         account_proofs_processed,
-                        "Proof result receiver dropped, discarding result"
+                        "Account multiproof receiver dropped, discarding result"
                     );
                 }
 

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -408,14 +408,12 @@ fn account_worker_loop<Factory>(
 
                 tracker.set_precomputed_storage_roots(storage_root_targets_len as u64);
 
-                let multi_added_removed_keys_ref = multi_added_removed_keys.as_ref();
-
                 let storage_proof_receivers = match dispatch_storage_proofs(
                     &storage_work_tx,
                     &targets,
                     &mut storage_prefix_sets,
                     collect_branch_node_masks,
-                    multi_added_removed_keys_ref,
+                    multi_added_removed_keys.as_ref(),
                 ) {
                     Ok(receivers) => receivers,
                     Err(error) => {
@@ -432,17 +430,15 @@ fn account_worker_loop<Factory>(
                 };
 
                 // Use the missed leaves cache passed from the multiproof manager
-                let missed_leaves_storage_roots_ref = missed_leaves_storage_roots.as_ref();
-
                 let account_prefix_set = std::mem::take(&mut prefix_sets.account_prefix_set);
 
                 let ctx = AccountMultiproofParams {
                     targets: &targets,
                     prefix_set: account_prefix_set,
                     collect_branch_node_masks,
-                    multi_added_removed_keys: multi_added_removed_keys_ref,
+                    multi_added_removed_keys: multi_added_removed_keys.as_ref(),
                     storage_proof_receivers,
-                    missed_leaves_storage_roots: missed_leaves_storage_roots_ref,
+                    missed_leaves_storage_roots: missed_leaves_storage_roots.as_ref(),
                 };
 
                 let result = build_account_multiproof_with_storage_roots(

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -12,9 +12,8 @@
 //!
 //! # Message Flow
 //!
-//! 1. `MultiProofTask` prepares a storage or account job
-//!    and hands it to [`ProofWorkerHandle`]. The job carries a
-//!    [`ProofResultContext`] so the worker knows how to send the result back.
+//! 1. `MultiProofTask` prepares a storage or account job and hands it to [`ProofWorkerHandle`]. The
+//!    job carries a [`ProofResultContext`] so the worker knows how to send the result back.
 //! 2. A worker receives the job, runs the proof, and sends a [`ProofResultMessage`] through the
 //!    provided [`ProofResultSender`].
 //! 3. `MultiProofTask` receives the message, uses `sequence_number` to keep proofs in order, and

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -868,11 +868,7 @@ where
     }
 }
 
-/// Storage proof computation parameters.
-///
-/// This struct contains only the data needed to compute a storage proof,
-/// without any communication channels. The communication channel is stored
-/// separately in the `StorageWorkerJob` envelope.
+/// Input parameters for account multiproof computation.
 #[derive(Debug)]
 pub struct StorageProofInput {
     /// The hashed address for which the proof is calculated.

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -862,7 +862,7 @@ enum AccountWorkerJob {
     /// Account multiproof computation request
     AccountMultiproof {
         /// Account multiproof input parameters
-        input: AccountMultiproofInput,
+        input: Box<AccountMultiproofInput>,
         /// Channel to send result back to original caller
         result_sender: Sender<AccountMultiproofResult>,
     },
@@ -1099,7 +1099,7 @@ impl ProofWorkerHandle {
     ) -> Result<Receiver<AccountMultiproofResult>, ProviderError> {
         let (tx, rx) = channel();
         self.account_work_tx
-            .send(AccountWorkerJob::AccountMultiproof { input, result_sender: tx })
+            .send(AccountWorkerJob::AccountMultiproof { input: Box::new(input), result_sender: tx })
             .map_err(|_| {
                 ProviderError::other(std::io::Error::other("account workers unavailable"))
             })?;

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -496,6 +496,7 @@ fn account_worker_loop<Factory>(
                 );
 
                 let proof_elapsed = proof_start.elapsed();
+                let total_elapsed = start.elapsed();
                 let stats = tracker.finish();
                 let result = result.map(|proof| (proof, stats));
                 account_proofs_processed += 1;
@@ -505,7 +506,7 @@ fn account_worker_loop<Factory>(
                     .send(ProofResultMessage {
                         sequence_number: seq,
                         result,
-                        elapsed: proof_elapsed,
+                        elapsed: total_elapsed,
                         state,
                     })
                     .is_err()
@@ -521,6 +522,7 @@ fn account_worker_loop<Factory>(
                 trace!(
                     target: "trie::proof_task",
                     proof_time_us = proof_elapsed.as_micros(),
+                    total_elapsed_us = total_elapsed.as_micros(),
                     total_processed = account_proofs_processed,
                     "Account multiproof completed"
                 );

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -718,7 +718,7 @@ fn dispatch_storage_proofs(
     let mut storage_proof_receivers =
         B256Map::with_capacity_and_hasher(targets.len(), Default::default());
 
-    // Queue all storage proofs to worker pool
+    // Dispatch all storage proofs to worker pool
     for (hashed_address, target_slots) in targets.iter() {
         let prefix_set = storage_prefix_sets.remove(hashed_address).unwrap_or_default();
 
@@ -735,7 +735,7 @@ fn dispatch_storage_proofs(
             multi_added_removed_keys.cloned(),
         );
 
-        // Always queue a storage proof so we obtain the storage root even when no slots are
+        // Always dispatch a storage proof so we obtain the storage root even when no slots are
         // requested.
         storage_work_tx
             .send(StorageWorkerJob::StorageProof {

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -39,8 +39,8 @@ use reth_trie::{
     trie_cursor::{InMemoryTrieCursorFactory, TrieCursorFactory},
     updates::TrieUpdatesSorted,
     walker::TrieWalker,
-    DecodedMultiProof, DecodedStorageMultiProof, HashBuilder, HashedPostStateSorted,
-    MultiProofTargets, Nibbles, TRIE_ACCOUNT_RLP_MAX_SIZE,
+    DecodedMultiProof, DecodedStorageMultiProof, HashBuilder, HashedPostState,
+    HashedPostStateSorted, MultiProofTargets, Nibbles, TRIE_ACCOUNT_RLP_MAX_SIZE,
 };
 use reth_trie_common::{
     added_removed_keys::MultiAddedRemovedKeys,
@@ -55,10 +55,10 @@ use std::{
         mpsc::{channel, Receiver, Sender},
         Arc,
     },
-    time::Instant,
+    time::{Duration, Instant},
 };
 use tokio::runtime::Handle;
-use tracing::{debug_span, trace};
+use tracing::{error, trace};
 
 #[cfg(feature = "metrics")]
 use crate::proof_task_metrics::ProofTaskTrieMetrics;

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -68,6 +68,26 @@ type TrieNodeProviderResult = Result<Option<RevealedNode>, SparseTrieError>;
 type AccountMultiproofResult =
     Result<(DecodedMultiProof, ParallelTrieStats), ParallelStateRootError>;
 
+/// Message containing a completed proof result with metadata for direct delivery to `MultiProofTask`.
+///
+/// This type enables workers to send proof results directly to the `MultiProofTask` event loop.
+#[derive(Debug)]
+pub struct ProofResultMessage {
+    /// Sequence number for ordering proofs
+    pub sequence_number: u64,
+    /// The proof calculation result
+    pub result: AccountMultiproofResult,
+    /// Time taken for the entire proof calculation (from dispatch to completion)
+    pub elapsed: Duration,
+    /// Original state update that triggered this proof
+    pub state: HashedPostState,
+}
+
+/// Type alias for the proof result sender channel.
+///
+/// Workers use this sender to deliver proof results directly to `MultiProofTask`.
+pub type ProofResultSender = CrossbeamSender<ProofResultMessage>;
+
 /// Internal message for storage workers.
 #[derive(Debug)]
 enum StorageWorkerJob {

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -94,6 +94,22 @@ type AccountMultiproofResult =
 /// Workers use this sender to deliver proof results directly to `MultiProofTask`.
 pub type ProofResultSender = CrossbeamSender<ProofResultMessage>;
 
+/// Message containing a completed proof result with metadata for direct delivery to
+/// `MultiProofTask`.
+///
+/// This type enables workers to send proof results directly to the `MultiProofTask` event loop.
+#[derive(Debug)]
+pub struct ProofResultMessage {
+    /// Sequence number for ordering proofs
+    pub sequence_number: u64,
+    /// The proof calculation result
+    pub result: AccountMultiproofResult,
+    /// Time taken for the entire proof calculation (from dispatch to completion)
+    pub elapsed: Duration,
+    /// Original state update that triggered this proof
+    pub state: HashedPostState,
+}
+
 /// Context for sending proof calculation results back to `MultiProofTask`.
 ///
 /// This struct contains all context needed to send and track proof calculation results.
@@ -120,22 +136,6 @@ impl ProofResultContext {
     ) -> Self {
         Self { sender, sequence_number, state, start_time }
     }
-}
-
-/// Message containing a completed proof result with metadata for direct delivery to
-/// `MultiProofTask`.
-///
-/// This type enables workers to send proof results directly to the `MultiProofTask` event loop.
-#[derive(Debug)]
-pub struct ProofResultMessage {
-    /// Sequence number for ordering proofs
-    pub sequence_number: u64,
-    /// The proof calculation result
-    pub result: AccountMultiproofResult,
-    /// Time taken for the entire proof calculation (from dispatch to completion)
-    pub elapsed: Duration,
-    /// Original state update that triggered this proof
-    pub state: HashedPostState,
 }
 
 /// Internal message for storage workers.

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -868,7 +868,7 @@ where
     }
 }
 
-/// Input parameters for account multiproof computation.
+/// Input parameters for storage proof computation.
 #[derive(Debug)]
 pub struct StorageProofInput {
     /// The hashed address for which the proof is calculated.

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -453,7 +453,7 @@ fn account_worker_loop<Factory>(
 
                 trace!(
                     target: "trie::proof_task",
-                    proof_time_us = proof_start.elapsed().as_micros(),
+                    proof_time_us = proof_elapsed.as_micros(),
                     total_processed = account_proofs_processed,
                     "Account multiproof completed"
                 );

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -261,7 +261,6 @@ fn storage_worker_loop<Factory>(
                     Err(e) => Err(e),
                 };
 
-                // Send result directly to MultiProofTask
                 if sender
                     .send(ProofResultMessage {
                         sequence_number: seq,


### PR DESCRIPTION
Closes: https://github.com/paradigmxyz/reth/issues/19183

This PR refactors the multiproof pipeline to improve performance and simplify its design by eliminating a `spawn_blocking` hop for handling proof results.

Previously, the `MultiproofManager` would spawn a blocking task to await the result of each proof calculation, which introduced unnecessary overhead and complexity.

The new implementation streamlines this process:
1.  Proof workers now send their results (`ProofResultMessage`) directly to the `MultiProofTask` event loop via a dedicated `crossbeam` channel.
2.  The `MultiProofTask` uses `crossbeam::select!` to concurrently handle both incoming control messages (like state updates) and the proof results from workers.

This change removes the intermediate blocking task, resulting in a more direct, efficient, and easier-to-understand data flow.

The updated message flow is as follows:
```text
MultiProofTask -> MultiproofManager -> ProofWorkerHandle -> Storage/Account Worker
       ^                                          |
       |                                          v
ProofResultMessage <-------- ProofResultSender ---
```