### PR TITLE
perf(net): convert Bytes to BytesMut to avoid reallocation

### DIFF
--- a/crates/net/eth-wire/src/multiplex.rs
+++ b/crates/net/eth-wire/src/multiplex.rs
@@ -332,9 +332,9 @@ impl ProtocolProxy {
             return Ok(msg);
         }
 
-        let mut masked = Vec::from(msg);
+        let mut masked: BytesMut = msg.into();
         masked[0] = masked[0].checked_add(offset).ok_or(io::ErrorKind::InvalidInput)?;
-        Ok(masked.into())
+        Ok(masked.freeze())
     }
 
     /// Unmasks the message ID of a message received from the wire.


### PR DESCRIPTION
If `Bytes` has only one reference to the data, `Into<BytesMut>` would avoid cloning the underlying buffer.