### PR TITLE
refactor(engine): remove deprecated CLI arguments

### DIFF
--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -24,11 +24,9 @@ pub struct EngineArgs {
     #[arg(long = "engine.legacy-state-root", default_value = "false")]
     pub legacy_state_root_task_enabled: bool,
 
-
     /// Disable parallel prewarming
     #[arg(long = "engine.disable-prewarming", alias = "engine.disable-caching-and-prewarming")]
     pub prewarming_disabled: bool,
-
 
     /// Disable the parallel sparse trie in the engine.
     #[arg(long = "engine.disable-parallel-sparse-trie", default_value = "false")]
@@ -64,7 +62,6 @@ pub struct EngineArgs {
     /// Configure the number of reserved CPU cores for non-reth processes
     #[arg(long = "engine.reserved-cpu-cores", default_value_t = DEFAULT_RESERVED_CPU_CORES)]
     pub reserved_cpu_cores: usize,
-
 
     /// Disable precompile cache
     #[arg(long = "engine.disable-precompile-cache", default_value = "false")]

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -24,21 +24,11 @@ pub struct EngineArgs {
     #[arg(long = "engine.legacy-state-root", default_value = "false")]
     pub legacy_state_root_task_enabled: bool,
 
-    /// CAUTION: This CLI flag has no effect anymore, use --engine.disable-caching-and-prewarming
-    /// if you want to disable caching and prewarming
-    #[arg(long = "engine.caching-and-prewarming", default_value = "true", hide = true)]
-    #[deprecated]
-    pub caching_and_prewarming_enabled: bool,
 
     /// Disable parallel prewarming
     #[arg(long = "engine.disable-prewarming", alias = "engine.disable-caching-and-prewarming")]
     pub prewarming_disabled: bool,
 
-    /// CAUTION: This CLI flag has no effect anymore, use --engine.disable-parallel-sparse-trie
-    /// if you want to disable usage of the `ParallelSparseTrie`.
-    #[deprecated]
-    #[arg(long = "engine.parallel-sparse-trie", default_value = "true", hide = true)]
-    pub parallel_sparse_trie_enabled: bool,
 
     /// Disable the parallel sparse trie in the engine.
     #[arg(long = "engine.disable-parallel-sparse-trie", default_value = "false")]
@@ -75,11 +65,6 @@ pub struct EngineArgs {
     #[arg(long = "engine.reserved-cpu-cores", default_value_t = DEFAULT_RESERVED_CPU_CORES)]
     pub reserved_cpu_cores: usize,
 
-    /// CAUTION: This CLI flag has no effect anymore, use --engine.disable-precompile-cache
-    /// if you want to disable precompile cache
-    #[arg(long = "engine.precompile-cache", default_value = "true", hide = true)]
-    #[deprecated]
-    pub precompile_cache_enabled: bool,
 
     /// Disable precompile cache
     #[arg(long = "engine.disable-precompile-cache", default_value = "false")]
@@ -116,7 +101,6 @@ pub struct EngineArgs {
     pub account_worker_count: Option<usize>,
 }
 
-#[allow(deprecated)]
 impl Default for EngineArgs {
     fn default() -> Self {
         Self {
@@ -124,9 +108,7 @@ impl Default for EngineArgs {
             memory_block_buffer_target: DEFAULT_MEMORY_BLOCK_BUFFER_TARGET,
             legacy_state_root_task_enabled: false,
             state_root_task_compare_updates: false,
-            caching_and_prewarming_enabled: true,
             prewarming_disabled: false,
-            parallel_sparse_trie_enabled: true,
             parallel_sparse_trie_disabled: false,
             state_provider_metrics: false,
             cross_block_cache_size: DEFAULT_CROSS_BLOCK_CACHE_SIZE_MB,
@@ -134,7 +116,6 @@ impl Default for EngineArgs {
             multiproof_chunking_enabled: true,
             multiproof_chunk_size: DEFAULT_MULTIPROOF_TASK_CHUNK_SIZE,
             reserved_cpu_cores: DEFAULT_RESERVED_CPU_CORES,
-            precompile_cache_enabled: true,
             precompile_cache_disabled: false,
             state_root_fallback: false,
             always_process_payload_attributes_on_canonical_head: false,


### PR DESCRIPTION
Removes three deprecated fields from EngineArgs that have been sitting as dead code for months. The caching_and_prewarming_enabled field was deprecated back in June 2025, while parallel_sparse_trie_enabled and precompile_cache_enabled were both marked deprecated since August. These fields were completely ignored in the tree_config() method where the actual configuration happens. The functionality was moved to new fields with inverted logic like prewarming_disabled, parallel_sparse_trie_disabled, and precompile_cache_disabled. CLI backward compatibility is still maintained through aliases defined on the working fields, so existing scripts won't break. 