### PR TITLE
fix(cli): prune CLI argument names

### DIFF
--- a/crates/node/core/src/args/pruning.rs
+++ b/crates/node/core/src/args/pruning.rs
@@ -18,33 +18,33 @@ pub struct PruningArgs {
     pub full: bool,
 
     /// Minimum pruning interval measured in blocks.
-    #[arg(long, value_parser = RangedU64ValueParser::<u64>::new().range(1..),)]
+    #[arg(long = "prune.block-interval", alias = "block-interval", value_parser = RangedU64ValueParser::<u64>::new().range(1..))]
     pub block_interval: Option<u64>,
 
     // Sender Recovery
     /// Prunes all sender recovery data.
-    #[arg(long = "prune.senderrecovery.full", conflicts_with_all = &["sender_recovery_distance", "sender_recovery_before"])]
+    #[arg(long = "prune.sender-recovery.full", alias = "prune.senderrecovery.full", conflicts_with_all = &["sender_recovery_distance", "sender_recovery_before"])]
     pub sender_recovery_full: bool,
     /// Prune sender recovery data before the `head-N` block number. In other words, keep last N +
     /// 1 blocks.
-    #[arg(long = "prune.senderrecovery.distance", value_name = "BLOCKS", conflicts_with_all = &["sender_recovery_full", "sender_recovery_before"])]
+    #[arg(long = "prune.sender-recovery.distance", alias = "prune.senderrecovery.distance", value_name = "BLOCKS", conflicts_with_all = &["sender_recovery_full", "sender_recovery_before"])]
     pub sender_recovery_distance: Option<u64>,
     /// Prune sender recovery data before the specified block number. The specified block number is
     /// not pruned.
-    #[arg(long = "prune.senderrecovery.before", value_name = "BLOCK_NUMBER", conflicts_with_all = &["sender_recovery_full", "sender_recovery_distance"])]
+    #[arg(long = "prune.sender-recovery.before", alias = "prune.senderrecovery.before", value_name = "BLOCK_NUMBER", conflicts_with_all = &["sender_recovery_full", "sender_recovery_distance"])]
     pub sender_recovery_before: Option<BlockNumber>,
 
     // Transaction Lookup
     /// Prunes all transaction lookup data.
-    #[arg(long = "prune.transactionlookup.full", conflicts_with_all = &["transaction_lookup_distance", "transaction_lookup_before"])]
+    #[arg(long = "prune.transaction-lookup.full", alias = "prune.transactionlookup.full", conflicts_with_all = &["transaction_lookup_distance", "transaction_lookup_before"])]
     pub transaction_lookup_full: bool,
     /// Prune transaction lookup data before the `head-N` block number. In other words, keep last N
     /// + 1 blocks.
-    #[arg(long = "prune.transactionlookup.distance", value_name = "BLOCKS", conflicts_with_all = &["transaction_lookup_full", "transaction_lookup_before"])]
+    #[arg(long = "prune.transaction-lookup.distance", alias = "prune.transactionlookup.distance", value_name = "BLOCKS", conflicts_with_all = &["transaction_lookup_full", "transaction_lookup_before"])]
     pub transaction_lookup_distance: Option<u64>,
     /// Prune transaction lookup data before the specified block number. The specified block number
     /// is not pruned.
-    #[arg(long = "prune.transactionlookup.before", value_name = "BLOCK_NUMBER", conflicts_with_all = &["transaction_lookup_full", "transaction_lookup_distance"])]
+    #[arg(long = "prune.transaction-lookup.before", alias = "prune.transactionlookup.before", value_name = "BLOCK_NUMBER", conflicts_with_all = &["transaction_lookup_full", "transaction_lookup_distance"])]
     pub transaction_lookup_before: Option<BlockNumber>,
 
     // Receipts
@@ -61,33 +61,38 @@ pub struct PruningArgs {
     #[arg(long = "prune.receipts.before", value_name = "BLOCK_NUMBER", conflicts_with_all = &["receipts_full", "receipts_pre_merge", "receipts_distance"])]
     pub receipts_before: Option<BlockNumber>,
     /// Receipts Log Filter
-    #[arg(long = "prune.receiptslogfilter", value_name = "FILTER_CONFIG", hide = true)]
+    #[arg(
+        long = "prune.receipts-log-filter",
+        alias = "prune.receiptslogfilter",
+        value_name = "FILTER_CONFIG",
+        hide = true
+    )]
     #[deprecated]
     pub receipts_log_filter: Option<String>,
 
     // Account History
     /// Prunes all account history.
-    #[arg(long = "prune.accounthistory.full", conflicts_with_all = &["account_history_distance", "account_history_before"])]
+    #[arg(long = "prune.account-history.full", alias = "prune.accounthistory.full", conflicts_with_all = &["account_history_distance", "account_history_before"])]
     pub account_history_full: bool,
     /// Prune account before the `head-N` block number. In other words, keep last N + 1 blocks.
-    #[arg(long = "prune.accounthistory.distance", value_name = "BLOCKS", conflicts_with_all = &["account_history_full", "account_history_before"])]
+    #[arg(long = "prune.account-history.distance", alias = "prune.accounthistory.distance", value_name = "BLOCKS", conflicts_with_all = &["account_history_full", "account_history_before"])]
     pub account_history_distance: Option<u64>,
     /// Prune account history before the specified block number. The specified block number is not
     /// pruned.
-    #[arg(long = "prune.accounthistory.before", value_name = "BLOCK_NUMBER", conflicts_with_all = &["account_history_full", "account_history_distance"])]
+    #[arg(long = "prune.account-history.before", alias = "prune.accounthistory.before", value_name = "BLOCK_NUMBER", conflicts_with_all = &["account_history_full", "account_history_distance"])]
     pub account_history_before: Option<BlockNumber>,
 
     // Storage History
     /// Prunes all storage history data.
-    #[arg(long = "prune.storagehistory.full", conflicts_with_all = &["storage_history_distance", "storage_history_before"])]
+    #[arg(long = "prune.storage-history.full", alias = "prune.storagehistory.full", conflicts_with_all = &["storage_history_distance", "storage_history_before"])]
     pub storage_history_full: bool,
     /// Prune storage history before the `head-N` block number. In other words, keep last N + 1
     /// blocks.
-    #[arg(long = "prune.storagehistory.distance", value_name = "BLOCKS", conflicts_with_all = &["storage_history_full", "storage_history_before"])]
+    #[arg(long = "prune.storage-history.distance", alias = "prune.storagehistory.distance", value_name = "BLOCKS", conflicts_with_all = &["storage_history_full", "storage_history_before"])]
     pub storage_history_distance: Option<u64>,
     /// Prune storage history before the specified block number. The specified block number is not
     /// pruned.
-    #[arg(long = "prune.storagehistory.before", value_name = "BLOCK_NUMBER", conflicts_with_all = &["storage_history_full", "storage_history_distance"])]
+    #[arg(long = "prune.storage-history.before", alias = "prune.storagehistory.before", value_name = "BLOCK_NUMBER", conflicts_with_all = &["storage_history_full", "storage_history_distance"])]
     pub storage_history_before: Option<BlockNumber>,
 
     // Bodies

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -743,25 +743,25 @@ Pruning:
       --full
           Run full node. Only the most recent [`MINIMUM_PRUNING_DISTANCE`] block states are stored
 
-      --block-interval <BLOCK_INTERVAL>
+      --prune.block-interval <BLOCK_INTERVAL>
           Minimum pruning interval measured in blocks
 
-      --prune.senderrecovery.full
+      --prune.sender-recovery.full
           Prunes all sender recovery data
 
-      --prune.senderrecovery.distance <BLOCKS>
+      --prune.sender-recovery.distance <BLOCKS>
           Prune sender recovery data before the `head-N` block number. In other words, keep last N + 1 blocks
 
-      --prune.senderrecovery.before <BLOCK_NUMBER>
+      --prune.sender-recovery.before <BLOCK_NUMBER>
           Prune sender recovery data before the specified block number. The specified block number is not pruned
 
-      --prune.transactionlookup.full
+      --prune.transaction-lookup.full
           Prunes all transaction lookup data
 
-      --prune.transactionlookup.distance <BLOCKS>
+      --prune.transaction-lookup.distance <BLOCKS>
           Prune transaction lookup data before the `head-N` block number. In other words, keep last N + 1 blocks
 
-      --prune.transactionlookup.before <BLOCK_NUMBER>
+      --prune.transaction-lookup.before <BLOCK_NUMBER>
           Prune transaction lookup data before the specified block number. The specified block number is not pruned
 
       --prune.receipts.full
@@ -776,22 +776,22 @@ Pruning:
       --prune.receipts.before <BLOCK_NUMBER>
           Prune receipts before the specified block number. The specified block number is not pruned
 
-      --prune.accounthistory.full
+      --prune.account-history.full
           Prunes all account history
 
-      --prune.accounthistory.distance <BLOCKS>
+      --prune.account-history.distance <BLOCKS>
           Prune account before the `head-N` block number. In other words, keep last N + 1 blocks
 
-      --prune.accounthistory.before <BLOCK_NUMBER>
+      --prune.account-history.before <BLOCK_NUMBER>
           Prune account history before the specified block number. The specified block number is not pruned
 
-      --prune.storagehistory.full
+      --prune.storage-history.full
           Prunes all storage history data
 
-      --prune.storagehistory.distance <BLOCKS>
+      --prune.storage-history.distance <BLOCKS>
           Prune storage history before the `head-N` block number. In other words, keep last N + 1 blocks
 
-      --prune.storagehistory.before <BLOCK_NUMBER>
+      --prune.storage-history.before <BLOCK_NUMBER>
           Prune storage history before the specified block number. The specified block number is not pruned
 
       --prune.bodies.pre-merge


### PR DESCRIPTION
1. `--block-interval` -> `--prune.block-interval`
2. Add missing hyphens (like `--prune.senderrecovery.full` -> `--prune.sender-recovery.full`)

Backward-compatible, I also added old names as aliases.