### PR TITLE
fix: captured impl trait lifetime

### DIFF
--- a/crates/node/builder/src/node.rs
+++ b/crates/node/builder/src/node.rs
@@ -179,14 +179,16 @@ where
     /// Returns the [`EngineApiClient`] interface for the authenticated engine API.
     ///
     /// This will send authenticated http requests to the node's auth server.
-    pub fn engine_http_client(&self) -> impl EngineApiClient<Engine> {
+    pub fn engine_http_client(&self) -> impl EngineApiClient<Engine> + use<Engine, Node, AddOns> {
         self.auth_server_handle().http_client()
     }
 
     /// Returns the [`EngineApiClient`] interface for the authenticated engine API.
     ///
     /// This will send authenticated ws requests to the node's auth server.
-    pub async fn engine_ws_client(&self) -> impl EngineApiClient<Engine> {
+    pub async fn engine_ws_client(
+        &self,
+    ) -> impl EngineApiClient<Engine> + use<Engine, Node, AddOns> {
         self.auth_server_handle().ws_client().await
     }
 
@@ -194,7 +196,9 @@ where
     ///
     /// This will send not authenticated IPC requests to the node's auth server.
     #[cfg(unix)]
-    pub async fn engine_ipc_client(&self) -> Option<impl EngineApiClient<Engine>> {
+    pub async fn engine_ipc_client(
+        &self,
+    ) -> Option<impl EngineApiClient<Engine> + use<Engine, Node, AddOns>> {
         self.auth_server_handle().ipc_client().await
     }
 }

--- a/crates/rpc/rpc-builder/src/auth.rs
+++ b/crates/rpc/rpc-builder/src/auth.rs
@@ -354,7 +354,9 @@ impl AuthServerHandle {
     /// Returns a http client connected to the server.
     ///
     /// This client uses the JWT token to authenticate requests.
-    pub fn http_client(&self) -> impl SubscriptionClientT + Clone + Send + Sync + Unpin + 'static {
+    pub fn http_client(
+        &self,
+    ) -> impl SubscriptionClientT + use<> + Clone + Send + Sync + Unpin + 'static {
         // Create a middleware that adds a new JWT token to every request.
         let secret_layer = AuthClientLayer::new(self.secret);
         let middleware = tower::ServiceBuilder::default().layer(secret_layer);


### PR DESCRIPTION
Add the `use<>` syntax in order to avoid capturing the lifetime of the caller.