### PR TITLE
chore: fix incorrect comment about `BlockReader` interface

### DIFF
--- a/examples/db-access/src/main.rs
+++ b/examples/db-access/src/main.rs
@@ -109,7 +109,7 @@ fn txs_provider_example<T: TransactionsProvider<Transaction = TransactionSigned>
     Ok(())
 }
 
-/// The `BlockReader` allows querying the headers-related tables.
+/// The `BlockReader` allows querying the blocks-related tables.
 fn block_provider_example<T: BlockReader<Block = reth_ethereum::Block>>(
     provider: T,
     number: u64,


### PR DESCRIPTION
noticed that the previous comment incorrectly described what `BlockReader` interacts with.
it actually deals with tables containing full blocks (not just headers), providing methods like `block`, `block_by_hash`, `sealed_block_with_senders`, etc.
