### PR TITLE
refactor(e2e): relax bound

### DIFF
--- a/crates/e2e-test-utils/src/testsuite/setup.rs
+++ b/crates/e2e-test-utils/src/testsuite/setup.rs
@@ -215,14 +215,11 @@ where
         let is_dev = self.is_dev;
         let node_count = self.network.node_count;
 
-        let attributes_generator = Self::create_static_attributes_generator::<N>();
-
         let result = setup_engine_with_connection::<N>(
             node_count,
             Arc::<N::ChainSpec>::new((*chain_spec).clone().into()),
             is_dev,
             self.tree_config.clone(),
-            attributes_generator,
             self.network.connect_nodes,
         )
         .await;
@@ -292,31 +289,6 @@ where
             attributes_generator,
         )
         .await
-    }
-
-    /// Create a static attributes generator that doesn't capture any instance data
-    fn create_static_attributes_generator<N>(
-    ) -> impl Fn(u64) -> <<N as NodeTypes>::Payload as PayloadTypes>::PayloadBuilderAttributes
-           + Copy
-           + use<N, I>
-    where
-        N: NodeBuilderHelper<Payload = I>,
-        LocalPayloadAttributesBuilder<N::ChainSpec>: PayloadAttributesBuilder<
-            <<N as NodeTypes>::Payload as PayloadTypes>::PayloadAttributes,
-        >,
-    {
-        move |timestamp| {
-            let attributes = PayloadAttributes {
-                timestamp,
-                prev_randao: B256::ZERO,
-                suggested_fee_recipient: alloy_primitives::Address::ZERO,
-                withdrawals: Some(vec![]),
-                parent_beacon_block_root: Some(B256::ZERO),
-            };
-            <<N as NodeTypes>::Payload as PayloadTypes>::PayloadBuilderAttributes::from(
-                EthPayloadBuilderAttributes::new(B256::ZERO, attributes),
-            )
-        }
     }
 
     /// Common finalization logic for both apply methods

--- a/crates/e2e-test-utils/tests/e2e-testsuite/main.rs
+++ b/crates/e2e-test-utils/tests/e2e-testsuite/main.rs
@@ -19,7 +19,6 @@ use reth_e2e_test_utils::{
 };
 use reth_node_api::TreeConfig;
 use reth_node_ethereum::{EthEngineTypes, EthereumNode};
-use reth_payload_builder::EthPayloadBuilderAttributes;
 use std::sync::Arc;
 use tempfile::TempDir;
 use tracing::debug;
@@ -369,10 +368,7 @@ async fn test_setup_builder_with_custom_tree_config() -> Result<()> {
             .build(),
     );
 
-    let (nodes, _tasks, _wallet) =
-        E2ETestSetupBuilder::<EthereumNode, _>::new(1, chain_spec, |_| {
-            EthPayloadBuilderAttributes::default()
-        })
+    let (nodes, _tasks, _wallet) = E2ETestSetupBuilder::<EthereumNode>::new(1, chain_spec)
         .with_tree_config_modifier(|config| {
             config.with_persistence_threshold(0).with_memory_block_buffer_target(5)
         })

--- a/crates/ethereum/node/tests/e2e/eth.rs
+++ b/crates/ethereum/node/tests/e2e/eth.rs
@@ -24,7 +24,6 @@ async fn can_run_eth_node() -> eyre::Result<()> {
                 .build(),
         ),
         false,
-        eth_payload_attributes,
     )
     .await?;
 

--- a/crates/ethereum/node/tests/e2e/p2p.rs
+++ b/crates/ethereum/node/tests/e2e/p2p.rs
@@ -1,4 +1,4 @@
-use crate::utils::{advance_with_random_transactions, eth_payload_attributes};
+use crate::utils::advance_with_random_transactions;
 use alloy_provider::{Provider, ProviderBuilder};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use reth_chainspec::{ChainSpecBuilder, MAINNET};
@@ -20,7 +20,6 @@ async fn can_sync() -> eyre::Result<()> {
                 .build(),
         ),
         false,
-        eth_payload_attributes,
     )
     .await?;
 
@@ -66,14 +65,8 @@ async fn e2e_test_send_transactions() -> eyre::Result<()> {
             .build(),
     );
 
-    let (mut nodes, _tasks, _) = setup_engine::<EthereumNode>(
-        2,
-        chain_spec.clone(),
-        false,
-        Default::default(),
-        eth_payload_attributes,
-    )
-    .await?;
+    let (mut nodes, _tasks, _) =
+        setup_engine::<EthereumNode>(2, chain_spec.clone(), false, Default::default()).await?;
     let mut node = nodes.pop().unwrap();
     let provider = ProviderBuilder::new().connect_http(node.rpc_url());
 
@@ -108,14 +101,8 @@ async fn test_long_reorg() -> eyre::Result<()> {
             .build(),
     );
 
-    let (mut nodes, _tasks, _) = setup_engine::<EthereumNode>(
-        2,
-        chain_spec.clone(),
-        false,
-        Default::default(),
-        eth_payload_attributes,
-    )
-    .await?;
+    let (mut nodes, _tasks, _) =
+        setup_engine::<EthereumNode>(2, chain_spec.clone(), false, Default::default()).await?;
 
     let mut first_node = nodes.pop().unwrap();
     let mut second_node = nodes.pop().unwrap();
@@ -164,14 +151,8 @@ async fn test_reorg_through_backfill() -> eyre::Result<()> {
             .build(),
     );
 
-    let (mut nodes, _tasks, _) = setup_engine::<EthereumNode>(
-        2,
-        chain_spec.clone(),
-        false,
-        Default::default(),
-        eth_payload_attributes,
-    )
-    .await?;
+    let (mut nodes, _tasks, _) =
+        setup_engine::<EthereumNode>(2, chain_spec.clone(), false, Default::default()).await?;
 
     let mut first_node = nodes.pop().unwrap();
     let mut second_node = nodes.pop().unwrap();

--- a/crates/ethereum/node/tests/e2e/rpc.rs
+++ b/crates/ethereum/node/tests/e2e/rpc.rs
@@ -1,4 +1,3 @@
-use crate::utils::eth_payload_attributes;
 use alloy_eips::{eip2718::Encodable2718, eip7910::EthConfig};
 use alloy_primitives::{Address, B256, U256};
 use alloy_provider::{network::EthereumWallet, Provider, ProviderBuilder, SendableTx};
@@ -48,14 +47,8 @@ async fn test_fee_history() -> eyre::Result<()> {
             .build(),
     );
 
-    let (mut nodes, _tasks, wallet) = setup_engine::<EthereumNode>(
-        1,
-        chain_spec.clone(),
-        false,
-        Default::default(),
-        eth_payload_attributes,
-    )
-    .await?;
+    let (mut nodes, _tasks, wallet) =
+        setup_engine::<EthereumNode>(1, chain_spec.clone(), false, Default::default()).await?;
     let mut node = nodes.pop().unwrap();
     let provider = ProviderBuilder::new()
         .wallet(EthereumWallet::new(wallet.wallet_gen().swap_remove(0)))
@@ -133,14 +126,8 @@ async fn test_flashbots_validate_v3() -> eyre::Result<()> {
             .build(),
     );
 
-    let (mut nodes, _tasks, wallet) = setup_engine::<EthereumNode>(
-        1,
-        chain_spec.clone(),
-        false,
-        Default::default(),
-        eth_payload_attributes,
-    )
-    .await?;
+    let (mut nodes, _tasks, wallet) =
+        setup_engine::<EthereumNode>(1, chain_spec.clone(), false, Default::default()).await?;
     let mut node = nodes.pop().unwrap();
     let provider = ProviderBuilder::new()
         .wallet(EthereumWallet::new(wallet.wallet_gen().swap_remove(0)))
@@ -215,14 +202,8 @@ async fn test_flashbots_validate_v4() -> eyre::Result<()> {
             .build(),
     );
 
-    let (mut nodes, _tasks, wallet) = setup_engine::<EthereumNode>(
-        1,
-        chain_spec.clone(),
-        false,
-        Default::default(),
-        eth_payload_attributes,
-    )
-    .await?;
+    let (mut nodes, _tasks, wallet) =
+        setup_engine::<EthereumNode>(1, chain_spec.clone(), false, Default::default()).await?;
     let mut node = nodes.pop().unwrap();
     let provider = ProviderBuilder::new()
         .wallet(EthereumWallet::new(wallet.wallet_gen().swap_remove(0)))
@@ -305,14 +286,8 @@ async fn test_eth_config() -> eyre::Result<()> {
             .build(),
     );
 
-    let (mut nodes, _tasks, wallet) = setup_engine::<EthereumNode>(
-        1,
-        chain_spec.clone(),
-        false,
-        Default::default(),
-        eth_payload_attributes,
-    )
-    .await?;
+    let (mut nodes, _tasks, wallet) =
+        setup_engine::<EthereumNode>(1, chain_spec.clone(), false, Default::default()).await?;
     let mut node = nodes.pop().unwrap();
     let provider = ProviderBuilder::new()
         .wallet(EthereumWallet::new(wallet.wallet_gen().swap_remove(0)))

--- a/crates/optimism/node/src/utils.rs
+++ b/crates/optimism/node/src/utils.rs
@@ -26,7 +26,6 @@ pub async fn setup(num_nodes: usize) -> eyre::Result<(Vec<OpNode>, TaskManager, 
         Arc::new(OpChainSpecBuilder::base_mainnet().genesis(genesis).ecotone_activated().build()),
         false,
         Default::default(),
-        optimism_payload_attributes,
     )
     .await
 }


### PR DESCRIPTION
Relaxes `PayloadBuilderAttributes: From<reth_payload_builder::EthPayloadBuilderAttributes>` on `NodeBuilderHelper`

We already impose `LocalPayloadAttributesBuilder` bound everywhere so we can just use it