### PR TITLE
fix: incorrect RPC namespace reference

### DIFF
--- a/examples/node-custom-rpc/src/main.rs
+++ b/examples/node-custom-rpc/src/main.rs
@@ -91,7 +91,7 @@ pub trait TxpoolExtApi {
     ) -> SubscriptionResult;
 }
 
-/// The type that implements the `txpool` rpc namespace trait
+/// The type that implements the `txpoolExt` rpc namespace trait
 pub struct TxpoolExt<Pool> {
     pool: Pool,
 }


### PR DESCRIPTION
Comment referred to `'txpool'`, but the actual implemented namespace in the code is `'txpoolExt'`.
Corrected