### PR TITLE
fix: rename consume-* test suite

### DIFF
--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -137,43 +137,43 @@ jobs:
               - debug_
 
           # consume-engine
-          - sim: ethereum/eest/consume-engine
+          - sim: ethereum/eels/consume-engine
             limit: .*tests/osaka.*
-          - sim: ethereum/eest/consume-engine
+          - sim: ethereum/eels/consume-engine
             limit: .*tests/prague.*
-          - sim: ethereum/eest/consume-engine
+          - sim: ethereum/eels/consume-engine
             limit: .*tests/cancun.*
-          - sim: ethereum/eest/consume-engine
+          - sim: ethereum/eels/consume-engine
             limit: .*tests/shanghai.*
-          - sim: ethereum/eest/consume-engine
+          - sim: ethereum/eels/consume-engine
             limit: .*tests/berlin.*
-          - sim: ethereum/eest/consume-engine
+          - sim: ethereum/eels/consume-engine
             limit: .*tests/istanbul.*
-          - sim: ethereum/eest/consume-engine
+          - sim: ethereum/eels/consume-engine
             limit: .*tests/homestead.*
-          - sim: ethereum/eest/consume-engine
+          - sim: ethereum/eels/consume-engine
             limit: .*tests/frontier.*
-          - sim: ethereum/eest/consume-engine
+          - sim: ethereum/eels/consume-engine
             limit: .*tests/paris.*
 
           # consume-rlp
-          - sim: ethereum/eest/consume-rlp
+          - sim: ethereum/eels/consume-rlp
             limit: .*tests/osaka.*
-          - sim: ethereum/eest/consume-rlp
+          - sim: ethereum/eels/consume-rlp
             limit: .*tests/prague.*
           - sim: ethereum/eest/consume-rlp
             limit: .*tests/cancun.*
-          - sim: ethereum/eest/consume-rlp
+          - sim: ethereum/eels/consume-rlp
             limit: .*tests/shanghai.*
-          - sim: ethereum/eest/consume-rlp
+          - sim: ethereum/eels/consume-rlp
             limit: .*tests/berlin.*
-          - sim: ethereum/eest/consume-rlp
+          - sim: ethereum/eels/consume-rlp
             limit: .*tests/istanbul.*
-          - sim: ethereum/eest/consume-rlp
+          - sim: ethereum/eels/consume-rlp
             limit: .*tests/homestead.*
-          - sim: ethereum/eest/consume-rlp
+          - sim: ethereum/eels/consume-rlp
             limit: .*tests/frontier.*
-          - sim: ethereum/eest/consume-rlp
+          - sim: ethereum/eels/consume-rlp
             limit: .*tests/paris.*
     needs:
       - prepare-reth


### PR DESCRIPTION
Updates hive.yml 

More context:
Hive test consume-engine and consume-rlp run tests from the EELS (Ethereum Execution Layer Specification) test suite. EELS was recently renamed from EEST in the hive repository (see steel discord).