### PR TITLE
feat(prune): Add an empty `reth-prune-db` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9812,6 +9812,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-prune-db"
+version = "1.8.2"
+
+[[package]]
 name = "reth-prune-types"
 version = "1.8.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ members = [
     "crates/payload/util/",
     "crates/primitives-traits/",
     "crates/primitives/",
+    "crates/prune/db",
     "crates/prune/prune",
     "crates/prune/types",
     "crates/ress/protocol",

--- a/crates/prune/db/Cargo.toml
+++ b/crates/prune/db/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "reth-prune-db"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+exclude.workspace = true
+description = "Database integration with prune implementation"
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/prune/db/src/lib.rs
+++ b/crates/prune/db/src/lib.rs
@@ -1,0 +1,1 @@
+//! An integration of `reth-prune` with `reth-db`.


### PR DESCRIPTION
Part of #18926

Adds a crate dedicated for the `reth-db` specific implementations of `reth-prune`. In this iteration, the crate is empty.
