### PR TITLE
chore(trie): Use Vec<Option<...>> in HashedPostStateCursors

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -28,7 +28,7 @@ use alloy_eips::BlockHashOrNumber;
 use alloy_primitives::{
     keccak256,
     map::{hash_map, B256Map, HashMap, HashSet},
-    Address, BlockHash, BlockNumber, TxHash, TxNumber, B256, U256,
+    Address, BlockHash, BlockNumber, TxHash, TxNumber, B256,
 };
 use itertools::Itertools;
 use rayon::slice::ParallelSliceMut;

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1813,8 +1813,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
             }
 
             for (hashed_slot, value) in storage.storage_slots_ref() {
-                let v = value.unwrap_or(U256::ZERO);
-                let entry = StorageEntry { key: *hashed_slot, value: v };
+                let entry = StorageEntry { key: *hashed_slot, value: *value };
 
                 if let Some(db_entry) =
                     hashed_storage_cursor.seek_by_key_subkey(*hashed_address, entry.key)? &&

--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -332,17 +332,8 @@ impl HashedPostState {
     }
 
     /// Converts hashed post state into [`HashedPostStateSorted`].
-    pub fn into_sorted(self) -> HashedPostStateSorted {
-        let mut accounts: Vec<_> = self.accounts.into_iter().collect();
-        accounts.sort_unstable_by_key(|(address, _)| *address);
-
-        let storages = self
-            .storages
-            .into_iter()
-            .map(|(hashed_address, storage)| (hashed_address, storage.into_sorted()))
-            .collect();
-
-        HashedPostStateSorted { accounts, storages }
+    pub fn into_sorted(mut self) -> HashedPostStateSorted {
+        self.drain_into_sorted()
     }
 
     /// Converts hashed post state into [`HashedPostStateSorted`], but keeping the maps allocated by

--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -425,10 +425,7 @@ impl HashedStorage {
 
     /// Converts hashed storage into [`HashedStorageSorted`].
     pub fn into_sorted(self) -> HashedStorageSorted {
-        let mut storage_slots: Vec<_> = self
-            .storage
-            .into_iter()
-            .collect();
+        let mut storage_slots: Vec<_> = self.storage.into_iter().collect();
         storage_slots.sort_unstable_by_key(|(key, _)| *key);
 
         HashedStorageSorted { storage_slots, wiped: self.wiped }

--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -468,9 +468,7 @@ impl HashedPostStateSorted {
 
     /// Returns `true` if there are no account or storage updates.
     pub fn is_empty(&self) -> bool {
-        self.accounts.accounts.is_empty() &&
-            self.accounts.destroyed_accounts.is_empty() &&
-            self.storages.is_empty()
+        self.accounts.is_empty() && self.storages.is_empty()
     }
 
     /// Returns the total number of updates including all accounts and storage updates.

--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -9,7 +9,7 @@ use crate::{
 use alloc::{borrow::Cow, vec::Vec};
 use alloy_primitives::{
     keccak256,
-    map::{hash_map, B256Map, B256Set, HashMap, HashSet},
+    map::{hash_map, B256Map, HashMap, HashSet},
     Address, B256, U256,
 };
 use itertools::Itertools;
@@ -333,17 +333,8 @@ impl HashedPostState {
 
     /// Converts hashed post state into [`HashedPostStateSorted`].
     pub fn into_sorted(self) -> HashedPostStateSorted {
-        let mut updated_accounts = Vec::new();
-        let mut destroyed_accounts = HashSet::default();
-        for (hashed_address, info) in self.accounts {
-            if let Some(info) = info {
-                updated_accounts.push((hashed_address, info));
-            } else {
-                destroyed_accounts.insert(hashed_address);
-            }
-        }
-        updated_accounts.sort_unstable_by_key(|(address, _)| *address);
-        let accounts = HashedAccountsSorted { accounts: updated_accounts, destroyed_accounts };
+        let mut accounts: Vec<_> = self.accounts.into_iter().collect();
+        accounts.sort_unstable_by_key(|(address, _)| *address);
 
         let storages = self
             .storages
@@ -362,17 +353,8 @@ impl HashedPostState {
     /// This allows us to reuse the allocated space. This allocates new space for the sorted hashed
     /// post state, like `into_sorted`.
     pub fn drain_into_sorted(&mut self) -> HashedPostStateSorted {
-        let mut updated_accounts = Vec::new();
-        let mut destroyed_accounts = HashSet::default();
-        for (hashed_address, info) in self.accounts.drain() {
-            if let Some(info) = info {
-                updated_accounts.push((hashed_address, info));
-            } else {
-                destroyed_accounts.insert(hashed_address);
-            }
-        }
-        updated_accounts.sort_unstable_by_key(|(address, _)| *address);
-        let accounts = HashedAccountsSorted { accounts: updated_accounts, destroyed_accounts };
+        let mut accounts: Vec<_> = self.accounts.drain().collect();
+        accounts.sort_unstable_by_key(|(address, _)| *address);
 
         let storages = self
             .storages
@@ -452,41 +434,43 @@ impl HashedStorage {
 
     /// Converts hashed storage into [`HashedStorageSorted`].
     pub fn into_sorted(self) -> HashedStorageSorted {
-        let mut non_zero_valued_slots = Vec::new();
-        let mut zero_valued_slots = HashSet::default();
-        for (hashed_slot, value) in self.storage {
-            if value.is_zero() {
-                zero_valued_slots.insert(hashed_slot);
-            } else {
-                non_zero_valued_slots.push((hashed_slot, value));
-            }
-        }
-        non_zero_valued_slots.sort_unstable_by_key(|(key, _)| *key);
+        let mut storage_slots: Vec<_> = self
+            .storage
+            .into_iter()
+            .map(|(hashed_slot, value)| (hashed_slot, (!value.is_zero()).then_some(value)))
+            .collect();
+        storage_slots.sort_unstable_by_key(|(key, _)| *key);
 
-        HashedStorageSorted { non_zero_valued_slots, zero_valued_slots, wiped: self.wiped }
+        HashedStorageSorted { storage_slots, wiped: self.wiped }
     }
 }
 
 /// Sorted hashed post state optimized for iterating during state trie calculation.
+///
+/// This structure represents account and storage updates in a sorted format suitable for
+/// efficient trie traversal. Both accounts and storage slots use `Option<T>` to distinguish
+/// between updates and deletions:
+/// - `Some(value)`: The account/slot was updated to this value
+/// - `None`: The account was destroyed or the storage slot was deleted (set to zero)
 #[derive(PartialEq, Eq, Clone, Default, Debug)]
 pub struct HashedPostStateSorted {
-    /// Updated state of accounts.
-    pub accounts: HashedAccountsSorted,
-    /// Map of hashed addresses to hashed storage.
+    /// Sorted collection of account updates. `None` indicates a destroyed account.
+    pub accounts: Vec<(B256, Option<Account>)>,
+    /// Map of hashed addresses to their sorted storage updates.
     pub storages: B256Map<HashedStorageSorted>,
 }
 
 impl HashedPostStateSorted {
     /// Create new instance of [`HashedPostStateSorted`]
     pub const fn new(
-        accounts: HashedAccountsSorted,
+        accounts: Vec<(B256, Option<Account>)>,
         storages: B256Map<HashedStorageSorted>,
     ) -> Self {
         Self { accounts, storages }
     }
 
     /// Returns reference to hashed accounts.
-    pub const fn accounts(&self) -> &HashedAccountsSorted {
+    pub const fn accounts(&self) -> &Vec<(B256, Option<Account>)> {
         &self.accounts
     }
 
@@ -504,16 +488,14 @@ impl HashedPostStateSorted {
 
     /// Returns the total number of updates including all accounts and storage updates.
     pub fn total_len(&self) -> usize {
-        self.accounts.accounts.len() +
-            self.accounts.destroyed_accounts.len() +
-            self.storages.values().map(|storage| storage.len()).sum::<usize>()
+        self.accounts.len() + self.storages.values().map(|s| s.len()).sum::<usize>()
     }
 
     /// Extends this state with contents of another sorted state.
     /// Entries in `other` take precedence for duplicate keys.
     pub fn extend_ref(&mut self, other: &Self) {
         // Extend accounts
-        self.accounts.extend_ref(&other.accounts);
+        extend_sorted_vec(&mut self.accounts, &other.accounts);
 
         // Extend storages
         for (hashed_address, other_storage) in &other.storages {
@@ -531,47 +513,11 @@ impl AsRef<Self> for HashedPostStateSorted {
     }
 }
 
-/// Sorted account state optimized for iterating during state trie calculation.
-#[derive(Clone, Eq, PartialEq, Default, Debug)]
-pub struct HashedAccountsSorted {
-    /// Sorted collection of hashed addresses and their account info.
-    pub accounts: Vec<(B256, Account)>,
-    /// Set of destroyed account keys.
-    pub destroyed_accounts: B256Set,
-}
-
-impl HashedAccountsSorted {
-    /// Returns a sorted iterator over updated accounts.
-    pub fn accounts_sorted(&self) -> impl Iterator<Item = (B256, Option<Account>)> {
-        self.accounts
-            .iter()
-            .map(|(address, account)| (*address, Some(*account)))
-            .chain(self.destroyed_accounts.iter().map(|address| (*address, None)))
-            .sorted_by_key(|entry| *entry.0)
-    }
-
-    /// Extends this collection with contents of another sorted collection.
-    /// Entries in `other` take precedence for duplicate keys.
-    pub fn extend_ref(&mut self, other: &Self) {
-        // Updates take precedence over removals, so we want removals from `other` to only apply to
-        // the previous accounts.
-        self.accounts.retain(|(addr, _)| !other.destroyed_accounts.contains(addr));
-
-        // Extend the sorted accounts vector
-        extend_sorted_vec(&mut self.accounts, &other.accounts);
-
-        // Merge destroyed accounts sets
-        self.destroyed_accounts.extend(&other.destroyed_accounts);
-    }
-}
-
 /// Sorted hashed storage optimized for iterating during state trie calculation.
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub struct HashedStorageSorted {
-    /// Sorted hashed storage slots with non-zero value.
-    pub non_zero_valued_slots: Vec<(B256, U256)>,
-    /// Slots that have been zero valued.
-    pub zero_valued_slots: B256Set,
+    /// Sorted collection of updated storage slots, None indicates zero valued.
+    pub storage_slots: Vec<(B256, Option<U256>)>,
     /// Flag indicating whether the storage was wiped or not.
     pub wiped: bool,
 }
@@ -582,45 +528,36 @@ impl HashedStorageSorted {
         self.wiped
     }
 
-    /// Returns a sorted iterator over updated storage slots.
-    pub fn storage_slots_sorted(&self) -> impl Iterator<Item = (B256, U256)> {
-        self.non_zero_valued_slots
-            .iter()
-            .map(|(hashed_slot, value)| (*hashed_slot, *value))
-            .chain(self.zero_valued_slots.iter().map(|hashed_slot| (*hashed_slot, U256::ZERO)))
-            .sorted_by_key(|entry| *entry.0)
+    /// Returns reference to updated storage slots.
+    pub fn storage_slots_ref(&self) -> &[(B256, Option<U256>)] {
+        &self.storage_slots
     }
 
     /// Returns the total number of storage slot updates.
-    pub fn len(&self) -> usize {
-        self.non_zero_valued_slots.len() + self.zero_valued_slots.len()
+    pub const fn len(&self) -> usize {
+        self.storage_slots.len()
     }
 
     /// Returns `true` if there are no storage slot updates.
-    pub fn is_empty(&self) -> bool {
-        self.non_zero_valued_slots.is_empty() && self.zero_valued_slots.is_empty()
+    pub const fn is_empty(&self) -> bool {
+        self.storage_slots.is_empty()
     }
 
-    /// Extends this storage with contents of another sorted storage.
-    /// Entries in `other` take precedence for duplicate keys.
+    /// Extends the storage slots updates with another set of sorted updates.
+    ///
+    /// If `other` is marked as deleted, this will be marked as deleted and all slots cleared.
+    /// Otherwise, nodes are merged with `other`'s values taking precedence for duplicates.
     pub fn extend_ref(&mut self, other: &Self) {
         if other.wiped {
             // If other is wiped, clear everything and copy from other
             self.wiped = true;
-            self.non_zero_valued_slots.clear();
-            self.zero_valued_slots.clear();
-            self.non_zero_valued_slots.extend_from_slice(&other.non_zero_valued_slots);
-            self.zero_valued_slots.extend(&other.zero_valued_slots);
+            self.storage_slots.clear();
+            self.storage_slots.extend(other.storage_slots.iter().copied());
             return;
         }
 
-        self.non_zero_valued_slots.retain(|(slot, _)| !other.zero_valued_slots.contains(slot));
-
         // Extend the sorted non-zero valued slots
-        extend_sorted_vec(&mut self.non_zero_valued_slots, &other.non_zero_valued_slots);
-
-        // Merge zero valued slots sets
-        self.zero_valued_slots.extend(&other.zero_valued_slots);
+        extend_sorted_vec(&mut self.storage_slots, &other.storage_slots);
     }
 }
 
@@ -1162,87 +1099,92 @@ mod tests {
     fn test_hashed_post_state_sorted_extend_ref() {
         // Test extending accounts
         let mut state1 = HashedPostStateSorted {
-            accounts: HashedAccountsSorted {
-                accounts: vec![
-                    (B256::from([1; 32]), Account::default()),
-                    (B256::from([3; 32]), Account::default()),
-                ],
-                destroyed_accounts: B256Set::from_iter([B256::from([5; 32])]),
-            },
+            accounts: vec![
+                (B256::from([1; 32]), Some(Account::default())),
+                (B256::from([3; 32]), Some(Account::default())),
+                (B256::from([5; 32]), None),
+            ],
             storages: B256Map::default(),
         };
 
         let state2 = HashedPostStateSorted {
-            accounts: HashedAccountsSorted {
-                accounts: vec![
-                    (B256::from([2; 32]), Account::default()),
-                    (B256::from([3; 32]), Account { nonce: 1, ..Default::default() }), // Override
-                    (B256::from([4; 32]), Account::default()),
-                ],
-                destroyed_accounts: B256Set::from_iter([B256::from([6; 32])]),
-            },
+            accounts: vec![
+                (B256::from([2; 32]), Some(Account::default())),
+                (B256::from([3; 32]), Some(Account { nonce: 1, ..Default::default() })), /* Override */
+                (B256::from([4; 32]), Some(Account::default())),
+                (B256::from([6; 32]), None),
+            ],
             storages: B256Map::default(),
         };
 
         state1.extend_ref(&state2);
 
         // Check accounts are merged and sorted
-        assert_eq!(state1.accounts.accounts.len(), 4);
-        assert_eq!(state1.accounts.accounts[0].0, B256::from([1; 32]));
-        assert_eq!(state1.accounts.accounts[1].0, B256::from([2; 32]));
-        assert_eq!(state1.accounts.accounts[2].0, B256::from([3; 32]));
-        assert_eq!(state1.accounts.accounts[2].1.nonce, 1); // Should have state2's value
-        assert_eq!(state1.accounts.accounts[3].0, B256::from([4; 32]));
-
-        // Check destroyed accounts are merged
-        assert!(state1.accounts.destroyed_accounts.contains(&B256::from([5; 32])));
-        assert!(state1.accounts.destroyed_accounts.contains(&B256::from([6; 32])));
+        assert_eq!(state1.accounts.len(), 6);
+        assert_eq!(state1.accounts[0].0, B256::from([1; 32]));
+        assert_eq!(state1.accounts[1].0, B256::from([2; 32]));
+        assert_eq!(state1.accounts[2].0, B256::from([3; 32]));
+        assert_eq!(state1.accounts[2].1.unwrap().nonce, 1); // Should have state2's value
+        assert_eq!(state1.accounts[3].0, B256::from([4; 32]));
+        assert_eq!(state1.accounts[4].0, B256::from([5; 32]));
+        assert_eq!(state1.accounts[4].1, None);
+        assert_eq!(state1.accounts[5].0, B256::from([6; 32]));
+        assert_eq!(state1.accounts[5].1, None);
     }
 
     #[test]
     fn test_hashed_storage_sorted_extend_ref() {
         // Test normal extension
         let mut storage1 = HashedStorageSorted {
-            non_zero_valued_slots: vec![
-                (B256::from([1; 32]), U256::from(10)),
-                (B256::from([3; 32]), U256::from(30)),
+            storage_slots: vec![
+                (B256::from([1; 32]), Some(U256::from(10))),
+                (B256::from([3; 32]), Some(U256::from(30))),
+                (B256::from([5; 32]), None),
             ],
-            zero_valued_slots: B256Set::from_iter([B256::from([5; 32])]),
             wiped: false,
         };
 
         let storage2 = HashedStorageSorted {
-            non_zero_valued_slots: vec![
-                (B256::from([2; 32]), U256::from(20)),
-                (B256::from([3; 32]), U256::from(300)), // Override
-                (B256::from([4; 32]), U256::from(40)),
+            storage_slots: vec![
+                (B256::from([2; 32]), Some(U256::from(20))),
+                (B256::from([3; 32]), Some(U256::from(300))), // Override
+                (B256::from([4; 32]), Some(U256::from(40))),
+                (B256::from([6; 32]), None),
             ],
-            zero_valued_slots: B256Set::from_iter([B256::from([6; 32])]),
             wiped: false,
         };
 
         storage1.extend_ref(&storage2);
 
-        assert_eq!(storage1.non_zero_valued_slots.len(), 4);
-        assert_eq!(storage1.non_zero_valued_slots[0].0, B256::from([1; 32]));
-        assert_eq!(storage1.non_zero_valued_slots[1].0, B256::from([2; 32]));
-        assert_eq!(storage1.non_zero_valued_slots[2].0, B256::from([3; 32]));
-        assert_eq!(storage1.non_zero_valued_slots[2].1, U256::from(300)); // Should have storage2's value
-        assert_eq!(storage1.non_zero_valued_slots[3].0, B256::from([4; 32]));
-        assert!(storage1.zero_valued_slots.contains(&B256::from([5; 32])));
-        assert!(storage1.zero_valued_slots.contains(&B256::from([6; 32])));
+        assert_eq!(storage1.storage_slots.len(), 6);
+        assert_eq!(storage1.storage_slots[0].0, B256::from([1; 32]));
+        assert_eq!(storage1.storage_slots[0].1, Some(U256::from(10)));
+        assert_eq!(storage1.storage_slots[1].0, B256::from([2; 32]));
+        assert_eq!(storage1.storage_slots[1].1, Some(U256::from(20)));
+        assert_eq!(storage1.storage_slots[2].0, B256::from([3; 32]));
+        assert_eq!(storage1.storage_slots[2].1, Some(U256::from(300))); // Should have storage2's value
+        assert_eq!(storage1.storage_slots[3].0, B256::from([4; 32]));
+        assert_eq!(storage1.storage_slots[3].1, Some(U256::from(40)));
+        assert_eq!(storage1.storage_slots[4].0, B256::from([5; 32]));
+        assert_eq!(storage1.storage_slots[4].1, None);
+        assert_eq!(storage1.storage_slots[5].0, B256::from([6; 32]));
+        assert_eq!(storage1.storage_slots[5].1, None);
         assert!(!storage1.wiped);
 
         // Test wiped storage
         let mut storage3 = HashedStorageSorted {
-            non_zero_valued_slots: vec![(B256::from([1; 32]), U256::from(10))],
-            zero_valued_slots: B256Set::from_iter([B256::from([2; 32])]),
+            storage_slots: vec![
+                (B256::from([1; 32]), Some(U256::from(10))),
+                (B256::from([2; 32]), None),
+            ],
             wiped: false,
         };
 
         let storage4 = HashedStorageSorted {
-            non_zero_valued_slots: vec![(B256::from([3; 32]), U256::from(30))],
-            zero_valued_slots: B256Set::from_iter([B256::from([4; 32])]),
+            storage_slots: vec![
+                (B256::from([3; 32]), Some(U256::from(30))),
+                (B256::from([4; 32]), None),
+            ],
             wiped: true,
         };
 
@@ -1250,10 +1192,11 @@ mod tests {
 
         assert!(storage3.wiped);
         // When wiped, should only have storage4's values
-        assert_eq!(storage3.non_zero_valued_slots.len(), 1);
-        assert_eq!(storage3.non_zero_valued_slots[0].0, B256::from([3; 32]));
-        assert_eq!(storage3.zero_valued_slots.len(), 1);
-        assert!(storage3.zero_valued_slots.contains(&B256::from([4; 32])));
+        assert_eq!(storage3.storage_slots.len(), 2);
+        assert_eq!(storage3.storage_slots[0].0, B256::from([3; 32]));
+        assert_eq!(storage3.storage_slots[0].1, Some(U256::from(30)));
+        assert_eq!(storage3.storage_slots[1].0, B256::from([4; 32]));
+        assert_eq!(storage3.storage_slots[1].1, None);
     }
 
     #[test]

--- a/crates/trie/db/tests/post_state.rs
+++ b/crates/trie/db/tests/post_state.rs
@@ -244,6 +244,23 @@ fn storage_is_empty() {
         assert!(!cursor.is_storage_empty().unwrap());
     }
 
+    // all zero values, but not wiped
+    {
+        let wiped = false;
+        let mut hashed_storage = HashedStorage::new(wiped);
+        hashed_storage.storage.insert(B256::with_last_byte(0), U256::ZERO);
+
+        let mut hashed_post_state = HashedPostState::default();
+        hashed_post_state.storages.insert(address, hashed_storage);
+
+        let sorted = hashed_post_state.into_sorted();
+        let tx = db.tx().unwrap();
+        let factory =
+            HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), &sorted);
+        let mut cursor = factory.hashed_storage_cursor(address).unwrap();
+        assert!(!cursor.is_storage_empty().unwrap());
+    }
+
     // wiped storage, must be empty
     {
         let wiped = true;
@@ -487,4 +504,82 @@ fn fuzz_hashed_storage_cursor() {
         let factory = HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), &sorted);
         assert_storage_cursor_order(&factory, expected.into_iter());
     });
+}
+
+#[test]
+fn all_storage_slots_deleted_not_wiped_exact_keys() {
+    // This test reproduces an edge case where:
+    // - wiped = false
+    // - All post state entries are deletions (None values)
+    // - Database has corresponding entries
+    // - Expected: NO leaves should be returned (all deleted)
+    let address = B256::random();
+
+    // Generate 42 storage entries with keys distributed across the keyspace
+    let db_entries: Vec<(B256, u64)> = (0..42)
+        .map(|i| {
+            let mut key_bytes = [0u8; 32];
+            key_bytes[0] = (i * 6) as u8; // Spread keys across keyspace
+            key_bytes[31] = i as u8; // Ensure uniqueness
+            (B256::from(key_bytes), i as u64 + 1)
+        })
+        .collect();
+
+    let db = create_test_rw_db();
+    db.update(|tx| {
+        for (key, value) in &db_entries {
+            tx.put::<tables::HashedStorages>(
+                address,
+                StorageEntry { key: *key, value: U256::from(*value) },
+            )
+            .unwrap();
+        }
+    })
+    .unwrap();
+
+    // Create post state with same keys but all Zero values (deletions)
+    let wiped = false;
+    let mut hashed_storage = HashedStorage::new(wiped);
+    for (key, _) in &db_entries {
+        hashed_storage.storage.insert(*key, U256::ZERO); // Zero value = deletion
+    }
+
+    let mut hashed_post_state = HashedPostState::default();
+    hashed_post_state.storages.insert(address, hashed_storage);
+
+    let sorted = hashed_post_state.into_sorted();
+    let tx = db.tx().unwrap();
+    let factory = HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), &sorted);
+
+    let mut cursor = factory.hashed_storage_cursor(address).unwrap();
+
+    // Seek to beginning should return None (all slots are deleted)
+    let result = cursor.seek(B256::ZERO).unwrap();
+    assert_eq!(
+        result, None,
+        "Expected no entries when all slots are deleted, but got {:?}",
+        result
+    );
+
+    // Test seek operations at various positions - all should return None
+    // Pattern: before all, early range, mid-early range, mid-late range, late range, near end
+    let seek_keys = vec![
+        B256::ZERO, // Before all entries
+        B256::right_padding_from(&[0x5d]),
+        B256::right_padding_from(&[0x5e]),
+        B256::right_padding_from(&[0x5f]),
+        B256::right_padding_from(&[0xc2]),
+        B256::right_padding_from(&[0xc5]),
+        B256::right_padding_from(&[0xc9]),
+        B256::right_padding_from(&[0xf0]),
+    ];
+
+    for seek_key in seek_keys {
+        let result = cursor.seek(seek_key).unwrap();
+        assert_eq!(result, None, "Expected None when seeking to {} but got {:?}", seek_key, result);
+    }
+
+    // next() should also always return None
+    let result = cursor.next().unwrap();
+    assert_eq!(result, None, "Expected None from next() but got {:?}", result);
 }

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -2678,7 +2678,7 @@ mod tests {
     use reth_primitives_traits::Account;
     use reth_provider::{test_utils::create_test_provider_factory, TrieWriter};
     use reth_trie::{
-        hashed_cursor::{noop::NoopHashedAccountCursor, HashedPostStateAccountCursor},
+        hashed_cursor::{noop::NoopHashedCursor, HashedPostStateCursor},
         node_iter::{TrieElement, TrieNodeIter},
         trie_cursor::{noop::NoopAccountTrieCursor, TrieCursor, TrieCursorFactory},
         walker::TrieWalker,
@@ -2990,8 +2990,8 @@ mod tests {
             .into_sorted();
         let mut node_iter = TrieNodeIter::state_trie(
             walker,
-            HashedPostStateAccountCursor::new(
-                NoopHashedAccountCursor::default(),
+            HashedPostStateCursor::new(
+                Option::<NoopHashedCursor<Account>>::None,
                 hashed_post_state.accounts(),
             ),
         );

--- a/crates/trie/sparse/benches/root.rs
+++ b/crates/trie/sparse/benches/root.rs
@@ -5,7 +5,7 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use itertools::Itertools;
 use proptest::{prelude::*, strategy::ValueTree, test_runner::TestRunner};
 use reth_trie::{
-    hashed_cursor::{noop::NoopHashedStorageCursor, HashedPostStateStorageCursor},
+    hashed_cursor::{noop::NoopHashedCursor, HashedPostStateCursor},
     node_iter::{TrieElement, TrieNodeIter},
     trie_cursor::{noop::NoopStorageTrieCursor, InMemoryTrieCursor},
     updates::StorageTrieUpdates,
@@ -142,9 +142,9 @@ fn calculate_root_from_leaves_repeated(c: &mut Criterion) {
                                 );
                                 let mut node_iter = TrieNodeIter::storage_trie(
                                     walker,
-                                    HashedPostStateStorageCursor::new(
-                                        NoopHashedStorageCursor::default(),
-                                        Some(&storage_sorted),
+                                    HashedPostStateCursor::new(
+                                        Option::<NoopHashedCursor<U256>>::None,
+                                        &storage_sorted.storage_slots,
                                     ),
                                 );
 

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -2356,7 +2356,7 @@ mod tests {
     use reth_primitives_traits::Account;
     use reth_provider::{test_utils::create_test_provider_factory, TrieWriter};
     use reth_trie::{
-        hashed_cursor::{noop::NoopHashedAccountCursor, HashedPostStateAccountCursor},
+        hashed_cursor::{noop::NoopHashedCursor, HashedPostStateCursor},
         node_iter::{TrieElement, TrieNodeIter},
         trie_cursor::{noop::NoopAccountTrieCursor, TrieCursor, TrieCursorFactory},
         walker::TrieWalker,
@@ -2416,8 +2416,8 @@ mod tests {
             .into_sorted();
         let mut node_iter = TrieNodeIter::state_trie(
             walker,
-            HashedPostStateAccountCursor::new(
-                NoopHashedAccountCursor::default(),
+            HashedPostStateCursor::new(
+                Option::<NoopHashedCursor<Account>>::None,
                 hashed_post_state.accounts(),
             ),
         );

--- a/crates/trie/trie/src/hashed_cursor/post_state.rs
+++ b/crates/trie/trie/src/hashed_cursor/post_state.rs
@@ -192,10 +192,8 @@ where
     /// Otherwise, retrieve the next entries that are greater than or equal to the key from the
     /// database and the post state. The two entries are compared and the lowest is returned.
     ///
-    /// The returned key is memoized and the cursor remains positioned at that key until
-    /// [`HashedCursor::next`] is called.
-    ///
-    /// Note: `seek` can be called multiple times by `TrieNodeIter`
+    /// The returned account key is memoized and the cursor remains positioned at that key until
+    /// [`HashedCursor::seek`] or [`HashedCursor::next`] are called.
     fn seek(&mut self, key: B256) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
         self.cursor_seek(key)?;
         self.post_state_cursor.seek(&key);

--- a/crates/trie/trie/src/hashed_cursor/post_state.rs
+++ b/crates/trie/trie/src/hashed_cursor/post_state.rs
@@ -1,9 +1,9 @@
 use super::{HashedCursor, HashedCursorFactory, HashedStorageCursor};
 use crate::forward_cursor::ForwardInMemoryCursor;
-use alloy_primitives::{map::B256Set, B256, U256};
+use alloy_primitives::{B256, U256};
 use reth_primitives_traits::Account;
 use reth_storage_errors::db::DatabaseError;
-use reth_trie_common::{HashedAccountsSorted, HashedPostStateSorted, HashedStorageSorted};
+use reth_trie_common::HashedPostStateSorted;
 
 /// The hashed cursor factory for the post state.
 #[derive(Clone, Debug)]
@@ -25,141 +25,184 @@ where
     T: AsRef<HashedPostStateSorted>,
 {
     type AccountCursor<'cursor>
-        = HashedPostStateAccountCursor<'overlay, CF::AccountCursor<'cursor>>
+        = HashedPostStateCursor<'overlay, CF::AccountCursor<'cursor>, Account>
     where
         Self: 'cursor;
     type StorageCursor<'cursor>
-        = HashedPostStateStorageCursor<'overlay, CF::StorageCursor<'cursor>>
+        = HashedPostStateCursor<'overlay, CF::StorageCursor<'cursor>, U256>
     where
         Self: 'cursor;
 
     fn hashed_account_cursor(&self) -> Result<Self::AccountCursor<'_>, DatabaseError> {
         let cursor = self.cursor_factory.hashed_account_cursor()?;
-        Ok(HashedPostStateAccountCursor::new(cursor, &self.post_state.as_ref().accounts))
+        Ok(HashedPostStateCursor::new(Some(cursor), &self.post_state.as_ref().accounts))
     }
 
+    /// Returns a `HashedPostStateCursor` for storage slots that merges:
+    /// 1. `post_state_cursor` - In-memory overlay of storage updates (None if address has no
+    ///    updates)
+    /// 2. `cursor` - DB cursor for existing storage (None if storage was wiped via `SELF-DESTRUCT`)
+    ///
+    /// When storage is wiped, the DB cursor is omitted since all previous storage is destroyed.
     fn hashed_storage_cursor(
         &self,
         hashed_address: B256,
     ) -> Result<Self::StorageCursor<'_>, DatabaseError> {
-        let cursor = self.cursor_factory.hashed_storage_cursor(hashed_address)?;
-        Ok(HashedPostStateStorageCursor::new(
-            cursor,
-            self.post_state.as_ref().storages.get(&hashed_address),
-        ))
-    }
-}
+        static EMPTY_UPDATES: Vec<(B256, Option<U256>)> = Vec::new();
 
-/// The cursor to iterate over post state hashed accounts and corresponding database entries.
-/// It will always give precedence to the data from the hashed post state.
-#[derive(Debug)]
-pub struct HashedPostStateAccountCursor<'a, C> {
-    /// The database cursor.
-    cursor: C,
-    /// Forward-only in-memory cursor over accounts.
-    post_state_cursor: ForwardInMemoryCursor<'a, B256, Account>,
-    /// Reference to the collection of account keys that were destroyed.
-    destroyed_accounts: &'a B256Set,
-    /// The last hashed account that was returned by the cursor.
-    /// De facto, this is a current cursor position.
-    last_account: Option<B256>,
-}
+        let post_state_storage = self.post_state.as_ref().storages.get(&hashed_address);
+        let (storage_slots, wiped) = post_state_storage
+            .map(|u| (u.storage_slots_ref(), u.is_wiped()))
+            .unwrap_or((&EMPTY_UPDATES, false));
 
-impl<'a, C> HashedPostStateAccountCursor<'a, C>
-where
-    C: HashedCursor<Value = Account>,
-{
-    /// Create new instance of [`HashedPostStateAccountCursor`].
-    pub fn new(cursor: C, post_state_accounts: &'a HashedAccountsSorted) -> Self {
-        let post_state_cursor = ForwardInMemoryCursor::new(&post_state_accounts.accounts);
-        let destroyed_accounts = &post_state_accounts.destroyed_accounts;
-        Self { cursor, post_state_cursor, destroyed_accounts, last_account: None }
-    }
-
-    /// Returns `true` if the account has been destroyed.
-    /// This check is used for evicting account keys from the state trie.
-    ///
-    /// This function only checks the post state, not the database, because the latter does not
-    /// store destroyed accounts.
-    fn is_account_cleared(&self, account: &B256) -> bool {
-        self.destroyed_accounts.contains(account)
-    }
-
-    fn seek_inner(&mut self, key: B256) -> Result<Option<(B256, Account)>, DatabaseError> {
-        // Take the next account from the post state with the key greater than or equal to the
-        // sought key.
-        let post_state_entry = self.post_state_cursor.seek(&key);
-
-        // It's an exact match, return the account from post state without looking up in the
-        // database.
-        if post_state_entry.is_some_and(|entry| entry.0 == key) {
-            return Ok(post_state_entry)
-        }
-
-        // It's not an exact match, reposition to the first greater or equal account that wasn't
-        // cleared.
-        let mut db_entry = self.cursor.seek(key)?;
-        while db_entry.as_ref().is_some_and(|(address, _)| self.is_account_cleared(address)) {
-            db_entry = self.cursor.next()?;
-        }
-
-        // Compare two entries and return the lowest.
-        Ok(Self::compare_entries(post_state_entry, db_entry))
-    }
-
-    fn next_inner(&mut self, last_account: B256) -> Result<Option<(B256, Account)>, DatabaseError> {
-        // Take the next account from the post state with the key greater than the last sought key.
-        let post_state_entry = self.post_state_cursor.first_after(&last_account);
-
-        // If post state was given precedence or account was cleared, move the cursor forward.
-        let mut db_entry = self.cursor.seek(last_account)?;
-        while db_entry.as_ref().is_some_and(|(address, _)| {
-            address <= &last_account || self.is_account_cleared(address)
-        }) {
-            db_entry = self.cursor.next()?;
-        }
-
-        // Compare two entries and return the lowest.
-        Ok(Self::compare_entries(post_state_entry, db_entry))
-    }
-
-    /// Return the account with the lowest hashed account key.
-    ///
-    /// Given the next post state and database entries, return the smallest of the two.
-    /// If the account keys are the same, the post state entry is given precedence.
-    fn compare_entries(
-        post_state_item: Option<(B256, Account)>,
-        db_item: Option<(B256, Account)>,
-    ) -> Option<(B256, Account)> {
-        if let Some((post_state_entry, db_entry)) = post_state_item.zip(db_item) {
-            // If both are not empty, return the smallest of the two
-            // Post state is given precedence if keys are equal
-            Some(if post_state_entry.0 <= db_entry.0 { post_state_entry } else { db_entry })
+        let cursor = if wiped {
+            None
         } else {
-            // Return either non-empty entry
-            db_item.or(post_state_item)
+            Some(self.cursor_factory.hashed_storage_cursor(hashed_address)?)
+        };
+
+        Ok(HashedPostStateCursor::new(cursor, storage_slots))
+    }
+}
+
+/// A cursor to iterate over state updates and corresponding database entries.
+/// It will always give precedence to the data from the post state updates.
+#[derive(Debug)]
+pub struct HashedPostStateCursor<'a, C, V> {
+    /// The underlying `database_cursor`. If None then it is assumed there is no DB data.
+    cursor: Option<C>,
+    /// Entry that `database_cursor` is currently pointing to.
+    cursor_entry: Option<(B256, V)>,
+    /// Forward-only in-memory cursor over underlying V.
+    post_state_cursor: ForwardInMemoryCursor<'a, B256, Option<V>>,
+    /// The last hashed key that was returned by the cursor.
+    /// De facto, this is a current cursor position.
+    last_key: Option<B256>,
+    /// Tracks whether `seek` has been called. Used to prevent re-seeking the DB cursor
+    /// when it has been exhausted by iteration.
+    seeked: bool,
+}
+
+impl<'a, C, V> HashedPostStateCursor<'a, C, V>
+where
+    C: HashedCursor<Value = V>,
+    V: Copy + Clone + std::fmt::Debug,
+{
+    /// Creates a new post state cursor which combines a DB cursor and in-memory post state updates.
+    ///
+    /// # Parameters
+    /// - `cursor`: The database cursor. Pass `None` to indicate:
+    ///   - For accounts: Empty database (no persisted accounts)
+    ///   - For storage: Wiped storage (e.g., via `SELFDESTRUCT` - all previous storage destroyed)
+    /// - `updates`: Pre-sorted post state updates where `Some(value)` indicates an update and
+    ///   `None` indicates a deletion (destroyed account or zero-valued storage slot)
+    pub const fn new(cursor: Option<C>, updates: &'a [(B256, Option<V>)]) -> Self {
+        Self {
+            cursor,
+            cursor_entry: None,
+            post_state_cursor: ForwardInMemoryCursor::new(updates),
+            last_key: None,
+            seeked: false,
+        }
+    }
+
+    /// Asserts that the next entry to be returned from the cursor is not previous to the last entry
+    /// returned.
+    fn set_last_key(&mut self, next_entry: &Option<(B256, V)>) {
+        self.last_key = next_entry.as_ref().map(|e| e.0);
+    }
+
+    /// Seeks the `cursor_entry` field of the struct using the cursor.
+    fn cursor_seek(&mut self, key: B256) -> Result<(), DatabaseError> {
+        // Only seek if:
+        // 1. We have a cursor entry and need to seek forward (entry.0 < key), OR
+        // 2. We have no cursor entry and haven't seeked yet (!self.seeked)
+        let should_seek = match self.cursor_entry.as_ref() {
+            Some(entry) => entry.0 < key,
+            None => !self.seeked,
+        };
+
+        if should_seek {
+            self.cursor_entry = self.cursor.as_mut().map(|c| c.seek(key)).transpose()?.flatten();
+        }
+
+        Ok(())
+    }
+
+    /// Seeks the `cursor_entry` field of the struct to the subsequent entry using the cursor.
+    fn cursor_next(&mut self) -> Result<(), DatabaseError> {
+        // If the previous entry is `None`, and we've done a seek previously, then the cursor is
+        // exhausted, and we shouldn't call `next` again.
+        if self.cursor_entry.is_some() {
+            self.cursor_entry = self.cursor.as_mut().map(|c| c.next()).transpose()?.flatten();
+        }
+
+        Ok(())
+    }
+
+    /// Compares the current in-memory entry with the current entry of the cursor, and applies the
+    /// in-memory entry to the cursor entry as an overlay.
+    ///
+    /// This may consume and move forward the current entries when the overlay indicates a removed
+    /// node.
+    fn choose_next_entry(&mut self) -> Result<Option<(B256, V)>, DatabaseError> {
+        loop {
+            match (self.post_state_cursor.current().copied(), &self.cursor_entry) {
+                (Some((mem_key, None)), _)
+                    if self.cursor_entry.as_ref().is_none_or(|(db_key, _)| &mem_key < db_key) =>
+                {
+                    // If overlay has a removed node but DB cursor is exhausted or ahead of the
+                    // in-memory cursor then move ahead in-memory, as there might be further
+                    // non-removed overlay nodes.
+                    self.post_state_cursor.first_after(&mem_key);
+                }
+                (Some((mem_key, None)), Some((db_key, _))) if &mem_key == db_key => {
+                    // If overlay has a removed node which is returned from DB then move both
+                    // cursors ahead to the next key.
+                    self.post_state_cursor.first_after(&mem_key);
+                    self.cursor_next()?;
+                }
+                (Some((mem_key, Some(node))), _)
+                    if self.cursor_entry.as_ref().is_none_or(|(db_key, _)| &mem_key <= db_key) =>
+                {
+                    // If overlay returns a node prior to the DB's node, or the DB is exhausted,
+                    // then we return the overlay's node.
+                    return Ok(Some((mem_key, node)))
+                }
+                // All other cases:
+                // - mem_key > db_key
+                // - overlay is exhausted
+                // Return the db_entry. If DB is also exhausted then this returns None.
+                _ => return Ok(self.cursor_entry),
+            }
         }
     }
 }
 
-impl<C> HashedCursor for HashedPostStateAccountCursor<'_, C>
+impl<C, V> HashedCursor for HashedPostStateCursor<'_, C, V>
 where
-    C: HashedCursor<Value = Account>,
+    C: HashedCursor<Value = V>,
+    V: Copy + Clone + std::fmt::Debug,
 {
-    type Value = Account;
+    type Value = V;
 
-    /// Seek the next entry for a given hashed account key.
+    /// Seek the next entry for a given hashed key.
     ///
     /// If the post state contains the exact match for the key, return it.
     /// Otherwise, retrieve the next entries that are greater than or equal to the key from the
     /// database and the post state. The two entries are compared and the lowest is returned.
     ///
-    /// The returned account key is memoized and the cursor remains positioned at that key until
-    /// [`HashedCursor::seek`] or [`HashedCursor::next`] are called.
+    /// The returned key is memoized and the cursor remains positioned at that key until
+    /// [`HashedCursor::next`] is called.
+    ///
+    /// Note: `seek` can be called multiple times by `TrieNodeIter`
     fn seek(&mut self, key: B256) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
-        // Find the closes account.
-        let entry = self.seek_inner(key)?;
-        self.last_account = entry.as_ref().map(|entry| entry.0);
+        self.cursor_seek(key)?;
+        self.post_state_cursor.seek(&key);
+
+        let entry = self.choose_next_entry()?;
+        self.set_last_key(&entry);
+        self.seeked = true;
         Ok(entry)
     }
 
@@ -168,170 +211,52 @@ where
     /// If the cursor is positioned at the entry, return the entry with next greater key.
     /// Returns [None] if the previous memoized or the next greater entries are missing.
     ///
-    /// NOTE: This function will not return any entry unless [`HashedCursor::seek`] has been
-    /// called.
+    /// NOTE: This function will not return any entry unless [`HashedCursor::seek`] has been called.
     fn next(&mut self) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
-        let next = match self.last_account {
-            Some(account) => {
-                let entry = self.next_inner(account)?;
-                self.last_account = entry.as_ref().map(|entry| entry.0);
-                entry
-            }
-            // no previous entry was found
-            None => None,
+        // A `last_key` of `None` indicates that the cursor is exhausted.
+        let Some(last_key) = self.last_key else {
+            return Ok(None);
         };
-        Ok(next)
-    }
-}
 
-/// The cursor to iterate over post state hashed storages and corresponding database entries.
-/// It will always give precedence to the data from the post state.
-#[derive(Debug)]
-pub struct HashedPostStateStorageCursor<'a, C> {
-    /// The database cursor.
-    cursor: C,
-    /// Forward-only in-memory cursor over non zero-valued account storage slots.
-    post_state_cursor: Option<ForwardInMemoryCursor<'a, B256, U256>>,
-    /// Reference to the collection of storage slot keys that were cleared.
-    cleared_slots: Option<&'a B256Set>,
-    /// Flag indicating whether database storage was wiped.
-    storage_wiped: bool,
-    /// The last slot that has been returned by the cursor.
-    /// De facto, this is the cursor's position for the given account key.
-    last_slot: Option<B256>,
-}
-
-impl<'a, C> HashedPostStateStorageCursor<'a, C>
-where
-    C: HashedStorageCursor<Value = U256>,
-{
-    /// Create new instance of [`HashedPostStateStorageCursor`] for the given hashed address.
-    pub fn new(cursor: C, post_state_storage: Option<&'a HashedStorageSorted>) -> Self {
-        let post_state_cursor =
-            post_state_storage.map(|s| ForwardInMemoryCursor::new(&s.non_zero_valued_slots));
-        let cleared_slots = post_state_storage.map(|s| &s.zero_valued_slots);
-        let storage_wiped = post_state_storage.is_some_and(|s| s.wiped);
-        Self { cursor, post_state_cursor, cleared_slots, storage_wiped, last_slot: None }
-    }
-
-    /// Check if the slot was zeroed out in the post state.
-    /// The database is not checked since it already has no zero-valued slots.
-    fn is_slot_zero_valued(&self, slot: &B256) -> bool {
-        self.cleared_slots.is_some_and(|s| s.contains(slot))
-    }
-
-    /// Find the storage entry in post state or database that's greater or equal to provided subkey.
-    fn seek_inner(&mut self, subkey: B256) -> Result<Option<(B256, U256)>, DatabaseError> {
-        // Attempt to find the account's storage in post state.
-        let post_state_entry = self.post_state_cursor.as_mut().and_then(|c| c.seek(&subkey));
-
-        // If database storage was wiped or it's an exact match,
-        // return the storage slot from post state without looking up in the database.
-        if self.storage_wiped || post_state_entry.is_some_and(|entry| entry.0 == subkey) {
-            return Ok(post_state_entry)
-        }
-
-        // It's not an exact match and storage was not wiped,
-        // reposition to the first greater or equal account.
-        let mut db_entry = self.cursor.seek(subkey)?;
-        while db_entry.as_ref().is_some_and(|entry| self.is_slot_zero_valued(&entry.0)) {
-            db_entry = self.cursor.next()?;
-        }
-
-        // Compare two entries and return the lowest.
-        Ok(Self::compare_entries(post_state_entry, db_entry))
-    }
-
-    /// Find the storage entry that is right after current cursor position.
-    fn next_inner(&mut self, last_slot: B256) -> Result<Option<(B256, U256)>, DatabaseError> {
-        // Attempt to find the account's storage in post state.
-        let post_state_entry =
-            self.post_state_cursor.as_mut().and_then(|c| c.first_after(&last_slot));
-
-        // Return post state entry immediately if database was wiped.
-        if self.storage_wiped {
-            return Ok(post_state_entry)
-        }
-
-        // If post state was given precedence, move the cursor forward.
-        // If the entry was already returned or is zero-valued, move to the next.
-        let mut db_entry = self.cursor.seek(last_slot)?;
-        while db_entry
-            .as_ref()
-            .is_some_and(|entry| entry.0 == last_slot || self.is_slot_zero_valued(&entry.0))
+        // If either cursor is currently pointing to the last entry which was returned then consume
+        // that entry so that `choose_next_entry` is looking at the subsequent one.
+        if let Some((key, _)) = self.post_state_cursor.current() &&
+            key == &last_key
         {
-            db_entry = self.cursor.next()?;
+            self.post_state_cursor.first_after(&last_key);
         }
 
-        // Compare two entries and return the lowest.
-        Ok(Self::compare_entries(post_state_entry, db_entry))
-    }
-
-    /// Return the storage entry with the lowest hashed storage key (hashed slot).
-    ///
-    /// Given the next post state and database entries, return the smallest of the two.
-    /// If the storage keys are the same, the post state entry is given precedence.
-    fn compare_entries(
-        post_state_item: Option<(B256, U256)>,
-        db_item: Option<(B256, U256)>,
-    ) -> Option<(B256, U256)> {
-        if let Some((post_state_entry, db_entry)) = post_state_item.zip(db_item) {
-            // If both are not empty, return the smallest of the two
-            // Post state is given precedence if keys are equal
-            Some(if post_state_entry.0 <= db_entry.0 { post_state_entry } else { db_entry })
-        } else {
-            // Return either non-empty entry
-            db_item.or(post_state_item)
+        if let Some((key, _)) = &self.cursor_entry &&
+            key == &last_key
+        {
+            self.cursor_next()?;
         }
-    }
-}
 
-impl<C> HashedCursor for HashedPostStateStorageCursor<'_, C>
-where
-    C: HashedStorageCursor<Value = U256>,
-{
-    type Value = U256;
-
-    /// Seek the next account storage entry for a given hashed key pair.
-    fn seek(&mut self, subkey: B256) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
-        let entry = self.seek_inner(subkey)?;
-        self.last_slot = entry.as_ref().map(|entry| entry.0);
+        let entry = self.choose_next_entry()?;
+        self.set_last_key(&entry);
         Ok(entry)
     }
-
-    /// Return the next account storage entry for the current account key.
-    fn next(&mut self) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
-        let next = match self.last_slot {
-            Some(last_slot) => {
-                let entry = self.next_inner(last_slot)?;
-                self.last_slot = entry.as_ref().map(|entry| entry.0);
-                entry
-            }
-            // no previous entry was found
-            None => None,
-        };
-        Ok(next)
-    }
 }
 
-impl<C> HashedStorageCursor for HashedPostStateStorageCursor<'_, C>
+/// The cursor to iterate over post state hashed values and corresponding database entries.
+/// It will always give precedence to the data from the post state.
+impl<C, V> HashedStorageCursor for HashedPostStateCursor<'_, C, V>
 where
-    C: HashedStorageCursor<Value = U256>,
+    C: HashedStorageCursor<Value = V>,
+    V: Copy + Clone + std::fmt::Debug,
 {
     /// Returns `true` if the account has no storage entries.
     ///
     /// This function should be called before attempting to call [`HashedCursor::seek`] or
     /// [`HashedCursor::next`].
     fn is_storage_empty(&mut self) -> Result<bool, DatabaseError> {
-        let is_empty = match &self.post_state_cursor {
-            Some(cursor) => {
-                // If the storage has been wiped at any point
-                self.storage_wiped &&
-                    // and the current storage does not contain any non-zero values
-                    cursor.is_empty()
-            }
-            None => self.cursor.is_storage_empty()?,
-        };
-        Ok(is_empty)
+        // Storage is not empty if it has non-zero slots.
+        if self.post_state_cursor.has_any(|(_, value)| value.is_some()) {
+            return Ok(false);
+        }
+
+        // If no non-zero slots in post state, check the database.
+        // Returns true if cursor is None (wiped storage or empty DB).
+        self.cursor.as_mut().map_or(Ok(true), |c| c.is_storage_empty())
     }
 }

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -306,10 +306,11 @@ where
 
 #[cfg(test)]
 mod tests {
+    use super::{TrieElement, TrieNodeIter};
     use crate::{
         hashed_cursor::{
-            mock::MockHashedCursorFactory, noop::NoopHashedAccountCursor, HashedCursorFactory,
-            HashedPostStateAccountCursor,
+            mock::MockHashedCursorFactory, noop::NoopHashedCursor, HashedCursorFactory,
+            HashedPostStateCursor,
         },
         mock::{KeyVisit, KeyVisitType},
         trie_cursor::{
@@ -332,8 +333,6 @@ mod tests {
     };
     use std::collections::BTreeMap;
 
-    use super::{TrieElement, TrieNodeIter};
-
     /// Calculate the branch node stored in the database by feeding the provided state to the hash
     /// builder and taking the trie updates.
     fn get_hash_builder_branch_nodes(
@@ -353,8 +352,8 @@ mod tests {
 
         let mut node_iter = TrieNodeIter::state_trie(
             walker,
-            HashedPostStateAccountCursor::new(
-                NoopHashedAccountCursor::default(),
+            HashedPostStateCursor::new(
+                Option::<NoopHashedCursor<Account>>::None,
                 hashed_post_state.accounts(),
             ),
         );

--- a/crates/trie/trie/src/trie_cursor/in_memory.rs
+++ b/crates/trie/trie/src/trie_cursor/in_memory.rs
@@ -83,7 +83,7 @@ pub struct InMemoryTrieCursor<'a, C> {
 impl<'a, C: TrieCursor> InMemoryTrieCursor<'a, C> {
     /// Create new trie cursor which combines a DB cursor (None to assume empty DB) and a set of
     /// in-memory trie nodes.
-    pub fn new(
+    pub const fn new(
         cursor: Option<C>,
         trie_updates: &'a [(Nibbles, Option<BranchNodeCompact>)],
     ) -> Self {


### PR DESCRIPTION
Fixes https://github.com/paradigmxyz/reth/issues/18848

## Summary

  This PR refactors and simplifies the `HashedPostStateCursor` implementation by removing redundant state tracking and unifying the cursor types. The changes reduce code complexity while maintaining the same functional behavior.

  ## Key Changes

  ### 1. Unified Cursor Implementation

  - **Merged cursor types**: Combined `HashedPostStateAccountCursor` and `HashedPostStateStorageCursor` into a single generic `HashedPostStateCursor<C, V>` type
  - **Removed redundant `wiped` field**: The `wiped` state had 1:1 correspondence with the cursor being `None`/`Some`, so the field was redundant
  - **Simplified cursor construction**: Changed from passing `Some(NoopHashedCursor::default())` to passing `None` directly when no database cursor is needed

  ### 2. Simplified `HashedPostStateSorted` Structure

  **Before:**
  ```rust
  pub struct HashedAccountsSorted {
      pub accounts: Vec<(B256, Account)>,
      pub destroyed_accounts: B256Set,
  }

  pub struct HashedStorageSorted {
      pub non_zero_valued_slots: Vec<(B256, U256)>,
      pub zero_valued_slots: B256Set,
      pub wiped: bool,
  }

  After:
  pub struct HashedPostStateSorted {
      pub accounts: Vec<(B256, Option<Account>)>,  // None = destroyed
      pub storages: B256Map<HashedStorageSorted>,
  }

  pub struct HashedStorageSorted {
      pub storage_slots: Vec<(B256, Option<U256>)>,  // None = zero-valued
      pub wiped: bool,
  }

  This change:
  - Uses Option<T> consistently to represent deletions/zero-values
  - Eliminates separate collections for tracking destroyed/zero-valued entries
  - Maintains sorted order in a single vector per type
  - Simplifies iteration logic by removing the need to merge and re-sort

  3. Improved ForwardInMemoryCursor

  - Changed from iterator-based to index-based traversal
  - Added has_any() method for checking if any entry satisfies a predicate
  - More efficient current() implementation that doesn't clone the iterator

  4. Simplified is_storage_empty() Logic

  Before:
  fn is_storage_empty(&mut self) -> Result<bool, DatabaseError> {
      let post_state_is_empty = /* complex logic checking if all are zero */;
      Ok(post_state_is_empty && self.cursor.as_mut().map_or(self.wiped == Some(true), |c| c.is_storage_empty()?))
  }

  After:
  fn is_storage_empty(&mut self) -> Result<bool, DatabaseError> {
      // Storage is not empty if it has non-zero slots
      if self.post_state_cursor.has_any(|(_, value)| value.is_some()) {
          return Ok(false);
      }

      // If no non-zero slots in post state, check the database
      // Returns true if cursor is None (wiped storage or empty DB)
      self.cursor.as_mut().map_or(Ok(true), |c| c.is_storage_empty())
  }

  5. Documentation Improvements

  - Added comprehensive documentation to HashedPostStateSorted explaining the Option<T> semantics
  - Clarified that Some(value) means update and None means deletion
  - Improved comments in critical sections

  6. Test Coverage

  - Added regression test all_storage_slots_deleted_not_wiped_exact_keys to cover edge case where all storage slots are deleted (zero-valued) but storage is not wiped
  - Test ensures repeated seek() operations correctly return None for all deleted slots
  - Added test case for non-wiped storage with all zero-value entries

  Testing

  All 177 trie-related tests pass:
  - reth-trie: 36 tests
  - reth-trie-db: 70 tests
  - reth-trie-sparse: 36 tests
  - reth-trie-sparse-parallel: 35 tests

  Benefits

  1. Less code: Reduced by ~30 net lines while adding comprehensive tests
  2. Simpler logic: Single generic cursor type instead of multiple specialized types
  3. Better performance: Index-based cursor traversal instead of iterator cloning
  4. Clearer semantics: Option<T> explicitly communicates update vs deletion
  5. Easier to maintain: Less duplicate code and clearer abstractions