### PR TITLE
fix(node): remove unused ConsensusLayerHealthEvent variants

### DIFF
--- a/crates/node/events/src/cl.rs
+++ b/crates/node/events/src/cl.rs
@@ -61,7 +61,7 @@ impl<H: Send + Sync> Stream for ConsensusLayerHealthEvents<H> {
                 ))
             }
 
-            // We never had both FCU and transition config exchange.
+            // We never received any forkchoice updates.
             return Poll::Ready(Some(ConsensusLayerHealthEvent::NeverSeen))
         }
     }
@@ -71,12 +71,8 @@ impl<H: Send + Sync> Stream for ConsensusLayerHealthEvents<H> {
 /// Execution Layer point of view.
 #[derive(Clone, Copy, Debug)]
 pub enum ConsensusLayerHealthEvent {
-    /// Consensus Layer client was never seen.
+    /// Consensus Layer client was never seen (no forkchoice updates received).
     NeverSeen,
-    /// Consensus Layer client has not been seen for a while.
-    HasNotBeenSeenForAWhile(Duration),
-    /// Updates from the Consensus Layer client were never received.
-    NeverReceivedUpdates,
-    /// Updates from the Consensus Layer client have not been received for a while.
+    /// Forkchoice updates from the Consensus Layer client have not been received for a while.
     HaveNotReceivedUpdatesForAWhile(Duration),
 }

--- a/crates/node/events/src/node.rs
+++ b/crates/node/events/src/node.rs
@@ -296,17 +296,6 @@ impl NodeState {
                         "Post-merge network, but never seen beacon client. Please launch one to follow the chain!"
                     )
                 }
-                ConsensusLayerHealthEvent::HasNotBeenSeenForAWhile(period) => {
-                    warn!(
-                        ?period,
-                        "Post-merge network, but no beacon client seen for a while. Please launch one to follow the chain!"
-                    )
-                }
-                ConsensusLayerHealthEvent::NeverReceivedUpdates => {
-                    warn!(
-                        "Beacon client online, but never received consensus updates. Please ensure your beacon client is operational to follow the chain!"
-                    )
-                }
                 ConsensusLayerHealthEvent::HaveNotReceivedUpdatesForAWhile(period) => {
                     warn!(
                         ?period,


### PR DESCRIPTION
Removed two enum variants that were never generated by the event stream:
  - HasNotBeenSeenForAWhile
  - NeverReceivedUpdates

  These variants were defined in the enum and had corresponding handlers
  in node.rs, but the poll_next implementation in cl.rs only generates
  NeverSeen and HaveNotReceivedUpdatesForAWhile events.

  The variants were likely remnants from an earlier implementation that
  tracked exchangeTransitionConfiguration (now deprecated post-merge) in
  addition to forkchoiceUpdated. Current implementation only tracks
  forkchoice updates via last_received_update_timestamp, making the
  additional variants unreachable dead code.

  Updated the outdated comment referencing "FCU and transition config
  exchange" to accurately reflect current behavior.