### PR TITLE
feat(metrics): add push gateway support for Prometheus metrics

### DIFF
--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -610,7 +610,7 @@ where
                         }
                     })
                     .build(),
-            ).with_pushgateway(self.node_config().metrics.push_gateway_url.clone(), self.node_config().metrics.push_gateway_interval.clone());
+            ).with_pushgateway(self.node_config().metrics.push_gateway_url.clone(), self.node_config().metrics.push_gateway_interval);
 
             MetricServer::new(config).serve().await?;
         }

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -610,7 +610,7 @@ where
                         }
                     })
                     .build(),
-            );
+            ).with_pushgateway(self.node_config().metrics.push_gateway_url.clone(), self.node_config().metrics.push_gateway_interval.clone());
 
             MetricServer::new(config).serve().await?;
         }

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -610,7 +610,7 @@ where
                         }
                     })
                     .build(),
-            ).with_pushgateway(self.node_config().metrics.push_gateway_url.clone(), self.node_config().metrics.push_gateway_interval);
+            ).with_push_gateway(self.node_config().metrics.push_gateway_url.clone(), self.node_config().metrics.push_gateway_interval);
 
             MetricServer::new(config).serve().await?;
         }

--- a/crates/node/core/src/args/metric.rs
+++ b/crates/node/core/src/args/metric.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
-use reth_cli_util::parse_socket_address;
-use std::net::SocketAddr;
+use reth_cli_util::{parse_duration_from_secs, parse_socket_address};
+use std::{net::SocketAddr, time::Duration};
 
 /// Metrics configuration.
 #[derive(Debug, Clone, Default, Parser)]
@@ -10,4 +10,22 @@ pub struct MetricArgs {
     /// The metrics will be served at the given interface and port.
     #[arg(long="metrics", alias = "metrics.prometheus", value_name = "PROMETHEUS", value_parser = parse_socket_address, help_heading = "Metrics")]
     pub prometheus: Option<SocketAddr>,
+
+    /// URL for pushing Prometheus metrics to a push gateway.
+    ///
+    /// If set, the node will periodically push metrics to the specified push gateway URL.
+    #[arg(long = "metrics.push.url", value_name = "PUSH_GATEWAY_URL", help_heading = "Metrics")]
+    pub push_gateway_url: Option<String>,
+
+    /// Interval in seconds for pushing metrics to push gateway.
+    ///
+    /// Default: 5 seconds
+    #[arg(
+        long = "metrics.push.interval",
+        default_value = "5",
+        value_parser = parse_duration_from_secs,
+        value_name = "SECONDS",
+        help_heading = "Metrics"
+    )]
+    pub push_gateway_interval: Duration,
 }

--- a/crates/node/core/src/args/metric.rs
+++ b/crates/node/core/src/args/metric.rs
@@ -14,14 +14,18 @@ pub struct MetricArgs {
     /// URL for pushing Prometheus metrics to a push gateway.
     ///
     /// If set, the node will periodically push metrics to the specified push gateway URL.
-    #[arg(long = "metrics.push.url", value_name = "PUSH_GATEWAY_URL", help_heading = "Metrics")]
+    #[arg(
+        long = "metrics.prometheus.push.url",
+        value_name = "PUSH_GATEWAY_URL",
+        help_heading = "Metrics"
+    )]
     pub push_gateway_url: Option<String>,
 
     /// Interval in seconds for pushing metrics to push gateway.
     ///
     /// Default: 5 seconds
     #[arg(
-        long = "metrics.push.interval",
+        long = "metrics.prometheus.push.interval",
         default_value = "5",
         value_parser = parse_duration_from_secs,
         value_name = "SECONDS",

--- a/crates/node/core/src/node_config.rs
+++ b/crates/node/core/src/node_config.rs
@@ -234,7 +234,7 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
     }
 
     /// Set the metrics address for the node
-    pub const fn with_metrics(mut self, metrics: MetricArgs) -> Self {
+    pub fn with_metrics(mut self, metrics: MetricArgs) -> Self {
         self.metrics = metrics;
         self
     }

--- a/crates/node/metrics/Cargo.toml
+++ b/crates/node/metrics/Cargo.toml
@@ -21,6 +21,7 @@ tokio.workspace = true
 jsonrpsee-server.workspace = true
 http.workspace = true
 tower.workspace = true
+reqwest.workspace = true
 
 tracing.workspace = true
 eyre.workspace = true

--- a/crates/node/metrics/src/server.rs
+++ b/crates/node/metrics/src/server.rs
@@ -44,8 +44,8 @@ impl MetricServerConfig {
         }
     }
 
-    /// Set the push gateway URL for pushing metrics
-    pub fn with_pushgateway(mut self, url: Option<String>, interval: Duration) -> Self {
+    /// Set the gateway URL and interval for pushing metrics
+    pub fn with_push_gateway(mut self, url: Option<String>, interval: Duration) -> Self {
         self.push_gateway_url = url;
         self.push_gateway_interval = interval;
         self
@@ -163,7 +163,7 @@ impl MetricServer {
         Ok(())
     }
 
-    /// Starts a background task to push metrics to a push gateway
+    /// Starts a background task to push metrics to a metrics gateway
     fn start_push_gateway_task(
         &self,
         url: String,
@@ -179,17 +179,17 @@ impl MetricServer {
                 let client = match client {
                     Ok(c) => c,
                     Err(err) => {
-                        tracing::error!(%err, "Failed to create HTTP client for PushGateway");
+                        tracing::error!(%err, "Failed to create HTTP client to push metrics to gateway");
                         return;
                     }
                 };
 
-                tracing::info!(url = %url, interval = ?interval, "Starting PushGateway metrics push task");
+                tracing::info!(url = %url, interval = ?interval, "Starting task to push metrics to gateway");
 
                 loop {
                     tokio::select! {
                         _ = &mut signal => {
-                            tracing::info!("Shutting down PushGateway push task");
+                            tracing::info!("Shutting down task to push metrics to gateway");
                             break;
                         }
                         _ = tokio::time::sleep(interval) => {
@@ -201,12 +201,12 @@ impl MetricServer {
                                     if !response.status().is_success() {
                                         tracing::warn!(
                                             status = %response.status(),
-                                            "Failed to push metrics to PushGateway"
+                                            "Failed to push metrics to gateway"
                                         );
                                     }
                                 }
                                 Err(err) => {
-                                    tracing::warn!(%err, "Failed to push metrics to PushGateway");
+                                    tracing::warn!(%err, "Failed to push metrics to gateway");
                                 }
                             }
                         }

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -44,6 +44,18 @@ Metrics:
 
           The metrics will be served at the given interface and port.
 
+      --metrics.push.url <PUSH_GATEWAY_URL>
+          URL for pushing Prometheus metrics to a push gateway.
+
+          If set, the node will periodically push metrics to the specified push gateway URL.
+
+      --metrics.push.interval <SECONDS>
+          Interval in seconds for pushing metrics to push gateway.
+
+          Default: 5 seconds
+
+          [default: 5]
+
 Datadir:
       --datadir <DATA_DIR>
           The path to the data dir for all reth files and subdirectories.

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -44,12 +44,12 @@ Metrics:
 
           The metrics will be served at the given interface and port.
 
-      --metrics.push.url <PUSH_GATEWAY_URL>
+      --metrics.prometheus.push.url <PUSH_GATEWAY_URL>
           URL for pushing Prometheus metrics to a push gateway.
 
           If set, the node will periodically push metrics to the specified push gateway URL.
 
-      --metrics.push.interval <SECONDS>
+      --metrics.prometheus.push.interval <SECONDS>
           Interval in seconds for pushing metrics to push gateway.
 
           Default: 5 seconds


### PR DESCRIPTION
Closes #19229

This spawns a task to push metrics to prometheus following configurable interval (default 5sec).
Added CLI flags for push gateway url and push interval.
