### PR TITLE
fix: return hashed peer key as id

### DIFF
--- a/crates/rpc/rpc/src/admin.rs
+++ b/crates/rpc/rpc/src/admin.rs
@@ -14,6 +14,7 @@ use reth_network_types::PeerKind;
 use reth_rpc_api::AdminApiServer;
 use reth_rpc_server_types::ToRpcResult;
 use reth_transaction_pool::TransactionPool;
+use revm_primitives::keccak256;
 
 /// `admin` API implementation.
 ///
@@ -74,34 +75,25 @@ where
         let mut infos = Vec::with_capacity(peers.len());
 
         for peer in peers {
-            if let Ok(pk) = id2pk(peer.remote_id) {
-                infos.push(PeerInfo {
-                    id: pk.to_string(),
-                    name: peer.client_version.to_string(),
-                    enode: peer.enode,
-                    enr: peer.enr,
-                    caps: peer
-                        .capabilities
-                        .capabilities()
-                        .iter()
-                        .map(|cap| cap.to_string())
-                        .collect(),
-                    network: PeerNetworkInfo {
-                        remote_address: peer.remote_addr,
-                        local_address: peer.local_addr.unwrap_or_else(|| self.network.local_addr()),
-                        inbound: peer.direction.is_incoming(),
-                        trusted: peer.kind.is_trusted(),
-                        static_node: peer.kind.is_static(),
-                    },
-                    protocols: PeerProtocolInfo {
-                        eth: Some(EthPeerInfo::Info(EthInfo {
-                            version: peer.status.version as u64,
-                        })),
-                        snap: None,
-                        other: Default::default(),
-                    },
-                })
-            }
+            infos.push(PeerInfo {
+                id: keccak256(peer.remote_id.as_slice()).to_string(),
+                name: peer.client_version.to_string(),
+                enode: peer.enode,
+                enr: peer.enr,
+                caps: peer.capabilities.capabilities().iter().map(|cap| cap.to_string()).collect(),
+                network: PeerNetworkInfo {
+                    remote_address: peer.remote_addr,
+                    local_address: peer.local_addr.unwrap_or_else(|| self.network.local_addr()),
+                    inbound: peer.direction.is_incoming(),
+                    trusted: peer.kind.is_trusted(),
+                    static_node: peer.kind.is_static(),
+                },
+                protocols: PeerProtocolInfo {
+                    eth: Some(EthPeerInfo::Info(EthInfo { version: peer.status.version as u64 })),
+                    snap: None,
+                    other: Default::default(),
+                },
+            })
         }
 
         Ok(infos)


### PR DESCRIPTION
Changes behavior to match Geth and return keccak of peer's public key (same as `PeerId`) in `admin_peers` endpoint