### PR TITLE
fix(net): reject invalid headers in full block range download

### DIFF
--- a/crates/net/p2p/src/full_block.rs
+++ b/crates/net/p2p/src/full_block.rs
@@ -466,6 +466,7 @@ where
                 if let Err(err) = self.consensus.validate_header_range(&headers_rising) {
                     debug!(target: "downloaders", %err, ?self.start_hash, "Received bad header response");
                     self.client.report_bad_message(peer);
+                    return;
                 }
 
                 // get the bodies request so it can be polled later

--- a/crates/net/p2p/src/full_block.rs
+++ b/crates/net/p2p/src/full_block.rs
@@ -466,7 +466,7 @@ where
                 if let Err(err) = self.consensus.validate_header_range(&headers_rising) {
                     debug!(target: "downloaders", %err, ?self.start_hash, "Received bad header response");
                     self.client.report_bad_message(peer);
-                    return;
+                    return
                 }
 
                 // get the bodies request so it can be polled later


### PR DESCRIPTION
Previously, when validate_header_range failed in 
FetchFullBlockRangeFuture::on_headers_response, the code would 
report the peer as bad but continue processing the invalid headers.
This caused:

1. Invalid headers to be stored and used for body requests
2. Broken retry mechanism (headers were set even when invalid)
3. Potential consensus violations (parent-child validation ignored)
4. Security risk (malicious peers could send forged header chains)

This fix adds an early return after reporting bad message, ensuring:
- Invalid headers are rejected at the networking layer
- Retry mechanism works correctly (headers remain None)
- Consistent error handling with body validation
- Alignment with ReverseHeadersDownloader pattern

The fix addresses a critical security issue where consensus validation
was being logged but not enforced, potentially allowing invalid block
chains to be accepted.