### PR TITLE
docs: correct Payment tx type from 0x7E to 0x2A

### DIFF
--- a/examples/custom-node/src/pool.rs
+++ b/examples/custom-node/src/pool.rs
@@ -17,7 +17,7 @@ pub enum CustomPooledTransaction {
     /// A regular Optimism transaction as defined by [`OpPooledTransaction`].
     #[envelope(flatten)]
     Op(OpPooledTransaction),
-    /// A [`TxPayment`] tagged with type 0x7E.
+    /// A [`TxPayment`] tagged with type 0x2A (decimal 42).
     #[envelope(ty = 42)]
     Payment(Signed<TxPayment>),
 }


### PR DESCRIPTION
The comment stated `0x7E` but the code uses `#[envelope(ty = 42)]`.Since 0x7E = 126 decimal (not 42), this was a documentation bug.Changed to `0x2A (decimal 42)` to match both the actual attribute value and the correct comment in primitives/tx.rs line 26.