### PR TITLE
chore: remove unnecessary Clone derive from DummyInspector

### DIFF
--- a/examples/custom-inspector/src/main.rs
+++ b/examples/custom-inspector/src/main.rs
@@ -120,7 +120,7 @@ impl RethCliTxpoolExt {
 
 /// A dummy inspector that logs the opcodes and their corresponding program counter for a
 /// transaction
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug)]
 struct DummyInspector {
     ret_val: Vec<String>,
 }


### PR DESCRIPTION
removed unused Clone derive from DummyInspector. The inspector is constructed and passed by mutable reference into the EVM and later returned by value; no code path clones it, and the relevant EVM helper trait bounds for this flow do not require Clone. Keeping an unnecessary Clone derive increases surface area and can hide accidental copies in future refactors without benefit here.