### PR TITLE
fix: use known paris activation blocks in genesis parsing

### DIFF
--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -702,8 +702,9 @@ impl From<Genesis> for ChainSpec {
                             // this is the case for perfnet testing for example
                             // at the time of this fix, only two networks transitioned: MAINNET +
                             // SEPOLIA and this parsing from genesis is used for shadowforking, so
-                            // we can reasoable assume that if the TTD and the chainid matches those
-                            // networks we use the activation blocks of those networks
+                            // we can reasonably assume that if the TTD and the chainid matches
+                            // those networks we use the activation
+                            // blocks of those networks
                             match genesis.config.chain_id {
                                 1 => {
                                     if ttd == MAINNET_PARIS_TTD {
@@ -2736,10 +2737,13 @@ Post-merge hard forks (timestamp based):
         let genesis = serde_json::from_str::<Genesis>(s).unwrap();
         let chainspec = ChainSpec::from_genesis(genesis);
         let activation = chainspec.hardforks.fork(EthereumHardfork::Paris);
-       assert_eq!(activation, ForkCondition::TTD {
-           activation_block_number: MAINNET_PARIS_BLOCK,
-           total_difficulty: MAINNET_PARIS_TTD,
-           fork_block: None,
-       })
+        assert_eq!(
+            activation,
+            ForkCondition::TTD {
+                activation_block_number: MAINNET_PARIS_BLOCK,
+                total_difficulty: MAINNET_PARIS_TTD,
+                fork_block: None,
+            }
+        )
     }
 }

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -3,7 +3,12 @@ use alloy_evm::eth::spec::EthExecutorSpec;
 
 use crate::{
     constants::{MAINNET_DEPOSIT_CONTRACT, MAINNET_PRUNE_DELETE_LIMIT},
-    holesky, hoodi, sepolia, EthChainSpec,
+    ethereum::SEPOLIA_PARIS_TTD,
+    holesky, hoodi,
+    mainnet::{MAINNET_PARIS_BLOCK, MAINNET_PARIS_TTD},
+    sepolia,
+    sepolia::SEPOLIA_PARIS_BLOCK,
+    EthChainSpec,
 };
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use alloy_chains::{Chain, NamedChain};
@@ -100,7 +105,7 @@ pub static MAINNET: LazyLock<Arc<ChainSpec>> = LazyLock::new(|| {
         genesis,
         // <https://etherscan.io/block/15537394>
         paris_block_and_final_difficulty: Some((
-            15537394,
+            MAINNET_PARIS_BLOCK,
             U256::from(58_750_003_716_598_352_816_469u128),
         )),
         hardforks,
@@ -127,7 +132,10 @@ pub static SEPOLIA: LazyLock<Arc<ChainSpec>> = LazyLock::new(|| {
         ),
         genesis,
         // <https://sepolia.etherscan.io/block/1450409>
-        paris_block_and_final_difficulty: Some((1450409, U256::from(17_000_018_015_853_232u128))),
+        paris_block_and_final_difficulty: Some((
+            SEPOLIA_PARIS_BLOCK,
+            U256::from(17_000_018_015_853_232u128),
+        )),
         hardforks,
         // https://sepolia.etherscan.io/tx/0x025ecbf81a2f1220da6285d1701dc89fb5a956b62562ee922e1a9efd73eb4b14
         deposit_contract: Some(DepositContract::new(
@@ -678,26 +686,49 @@ impl From<Genesis> for ChainSpec {
         // We expect no new networks to be configured with the merge, so we ignore the TTD field
         // and merge netsplit block from external genesis files. All existing networks that have
         // merged should have a static ChainSpec already (namely mainnet and sepolia).
-        let paris_block_and_final_difficulty =
-            if let Some(ttd) = genesis.config.terminal_total_difficulty {
-                hardforks.push((
-                    EthereumHardfork::Paris.boxed(),
-                    ForkCondition::TTD {
-                        // NOTE: this will not work properly if the merge is not activated at
-                        // genesis, and there is no merge netsplit block
-                        activation_block_number: genesis
-                            .config
-                            .merge_netsplit_block
-                            .unwrap_or_default(),
-                        total_difficulty: ttd,
-                        fork_block: genesis.config.merge_netsplit_block,
-                    },
-                ));
+        let paris_block_and_final_difficulty = if let Some(ttd) =
+            genesis.config.terminal_total_difficulty
+        {
+            hardforks.push((
+                EthereumHardfork::Paris.boxed(),
+                ForkCondition::TTD {
+                    // NOTE: this will not work properly if the merge is not activated at
+                    // genesis, and there is no merge netsplit block
+                    activation_block_number: genesis
+                        .config
+                        .merge_netsplit_block
+                        .or_else(|| {
+                            // due to this limitation we can't determine the merge block,
+                            // this is the case for perfnet testing for example
+                            // at the time of this fix, only two networks transitioned: MAINNET +
+                            // SEPOLIA and this parsing from genesis is used for shadowforking, so
+                            // we can reasoable assume that if the TTD and the chainid matches those
+                            // networks we use the activation blocks of those networks
+                            match genesis.config.chain_id {
+                                1 => {
+                                    if ttd == MAINNET_PARIS_TTD {
+                                        return Some(MAINNET_PARIS_BLOCK)
+                                    }
+                                }
+                                11155111 => {
+                                    if ttd == SEPOLIA_PARIS_TTD {
+                                        return Some(SEPOLIA_PARIS_BLOCK)
+                                    }
+                                }
+                                _ => {}
+                            };
+                            None
+                        })
+                        .unwrap_or_default(),
+                    total_difficulty: ttd,
+                    fork_block: genesis.config.merge_netsplit_block,
+                },
+            ));
 
-                genesis.config.merge_netsplit_block.map(|block| (block, ttd))
-            } else {
-                None
-            };
+            genesis.config.merge_netsplit_block.map(|block| (block, ttd))
+        } else {
+            None
+        };
 
         // Time-based hardforks
         let time_hardfork_opts = [
@@ -2646,5 +2677,69 @@ Post-merge hard forks (timestamp based):
             ..Default::default()
         };
         assert_eq!(hardfork_params, expected);
+    }
+
+    #[test]
+    fn parse_perf_net_genesis() {
+        let s = r#"{
+    "config": {
+        "chainId": 1,
+        "homesteadBlock": 1150000,
+        "daoForkBlock": 1920000,
+        "daoForkSupport": true,
+        "eip150Block": 2463000,
+        "eip150Hash": "0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0",
+        "eip155Block": 2675000,
+        "eip158Block": 2675000,
+        "byzantiumBlock": 4370000,
+        "constantinopleBlock": 7280000,
+        "petersburgBlock": 7280000,
+        "istanbulBlock": 9069000,
+        "muirGlacierBlock": 9200000,
+        "berlinBlock": 12244000,
+        "londonBlock": 12965000,
+        "arrowGlacierBlock": 13773000,
+        "grayGlacierBlock": 15050000,
+        "terminalTotalDifficulty": 58750000000000000000000,
+        "terminalTotalDifficultyPassed": true,
+        "shanghaiTime": 1681338455,
+        "cancunTime": 1710338135,
+        "pragueTime": 1746612311,
+        "ethash": {},
+        "depositContractAddress": "0x00000000219ab540356cBB839Cbe05303d7705Fa",
+        "blobSchedule": {
+            "cancun": {
+                "target": 3,
+                "max": 6,
+                "baseFeeUpdateFraction": 3338477
+            },
+            "prague": {
+                "target": 6,
+                "max": 9,
+                "baseFeeUpdateFraction": 5007716
+            }
+        }
+    },
+    "nonce": "0x42",
+    "timestamp": "0x0",
+    "extraData": "0x11bbe8db4e347b4e8c937c1c8370e4b5ed33adb3db69cbdb7a38e1e50b1b82fa",
+    "gasLimit": "0x1388",
+    "difficulty": "0x400000000",
+    "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "coinbase": "0x0000000000000000000000000000000000000000",
+    "number": "0x0",
+    "gasUsed": "0x0",
+    "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "baseFeePerGas": null
+}"#;
+
+        let genesis = serde_json::from_str::<Genesis>(s).unwrap();
+        let chainspec = ChainSpec::from_genesis(genesis);
+        let activation = chainspec.hardforks.fork(EthereumHardfork::Paris);
+       assert_eq!(activation, ForkCondition::TTD {
+           activation_block_number: MAINNET_PARIS_BLOCK,
+           total_difficulty: MAINNET_PARIS_TTD,
+           fork_block: None,
+       })
     }
 }


### PR DESCRIPTION
this is a bit cursed, we removed all of difficulty handling because kinda deprecated, however we still need it for consensus checks such as:

https://github.com/paradigmxyz/reth/blob/ba33f27d62402593563a52b9506d54b1a618ec85/crates/ethereum/consensus/src/lib.rs#L96-L101

this was causing issues on perfnet which uses a mainnet equivalent genesis file.

imo we can reasonable set the activationblock here if the chainid and TTD matches.
this isnt great but because the only usecase for this is the activationblock for networks that had the merge we should be able to do this