### PR TITLE
fix: infinite loop in eth_test_protocol_satellite test

### DIFF
--- a/crates/net/eth-wire/src/multiplex.rs
+++ b/crates/net/eth-wire/src/multiplex.rs
@@ -869,9 +869,7 @@ mod tests {
             })
             .unwrap();
 
-            loop {
-                let _ = st.next().await;
-            }
+            while st.next().await.is_some() {}
         });
 
         let conn = connect_passthrough(local_addr, test_hello().0).await;


### PR DESCRIPTION


**Problem:** The test contains an infinite loop that ignores stream termination, potentially causing CPU busy-looping when the stream ends.
**Solution:** Replace `loop { let _ = st.next().await; }` with `while st.next().await.is_some() {}` to properly exit when the stream terminates.
**Impact:** Prevents potential resource waste and improves test reliability by following proper `Stream` semantics.

