### PR TITLE
docs: add safety comment for unsafe env::set_var usage

### DIFF
--- a/crates/optimism/bin/src/main.rs
+++ b/crates/optimism/bin/src/main.rs
@@ -13,6 +13,9 @@ fn main() {
 
     // Enable backtraces unless a RUST_BACKTRACE value has already been explicitly provided.
     if std::env::var_os("RUST_BACKTRACE").is_none() {
+        // SAFETY: This is safe because we're in main() before any threads are spawned.
+        // std::env::set_var is unsafe due to potential race conditions in multi-threaded
+        // environments, but we're still single-threaded at this point.
         unsafe {
             std::env::set_var("RUST_BACKTRACE", "1");
         }


### PR DESCRIPTION
Adds a SAFETY comment explaining why the unsafe std::env::set_var call is safe in this context. The call happens in main() before any threads are spawned, making it safe despite the function being marked unsafe due to potential race conditions in multi-threaded environments.