### PR TITLE
fix(optimism): guard follow-up inserts by payload_id to prevent mixed sequences

### DIFF
--- a/crates/optimism/flashblocks/src/sequence.rs
+++ b/crates/optimism/flashblocks/src/sequence.rs
@@ -1,6 +1,7 @@
 use crate::{ExecutionPayloadBaseV1, FlashBlock, FlashBlockCompleteSequenceRx};
 use alloy_eips::eip2718::WithEncoded;
 use alloy_primitives::B256;
+use alloy_rpc_types_engine::PayloadId;
 use core::mem;
 use eyre::{bail, OptionExt};
 use reth_primitives_traits::{Recovered, SignedTransaction};
@@ -85,8 +86,7 @@ where
         // only insert if we previously received the same block and payload, assume we received
         // index 0
         let same_block = self.block_number() == Some(flashblock.metadata.block_number);
-        let same_payload =
-            self.inner.values().next().map(|b| b.block().payload_id) == Some(flashblock.payload_id);
+        let same_payload = self.payload_id() == Some(flashblock.payload_id);
 
         if same_block && same_payload {
             trace!(number=%flashblock.block_number(), index = %flashblock.index, block_count = self.inner.len()  ,"Received followup flashblock");
@@ -143,6 +143,10 @@ where
     /// Returns the current/latest flashblock index in the sequence
     pub fn index(&self) -> Option<u64> {
         Some(self.inner.values().last()?.block().index)
+    }
+    /// Returns the payload id of the first tracked flashblock in the current sequence.
+    pub fn payload_id(&self) -> Option<PayloadId> {
+        Some(self.inner.values().next()?.block().payload_id)
     }
 }
 

--- a/crates/optimism/flashblocks/src/sequence.rs
+++ b/crates/optimism/flashblocks/src/sequence.rs
@@ -82,8 +82,13 @@ where
             return Ok(())
         }
 
-        // only insert if we previously received the same block, assume we received index 0
-        if self.block_number() == Some(flashblock.metadata.block_number) {
+        // only insert if we previously received the same block and payload, assume we received
+        // index 0
+        let same_block = self.block_number() == Some(flashblock.metadata.block_number);
+        let same_payload =
+            self.inner.values().next().map(|b| b.block().payload_id) == Some(flashblock.payload_id);
+
+        if same_block && same_payload {
             trace!(number=%flashblock.block_number(), index = %flashblock.index, block_count = self.inner.len()  ,"Received followup flashblock");
             self.inner.insert(flashblock.index, PreparedFlashBlock::new(flashblock)?);
         } else {


### PR DESCRIPTION
This change adds a payload_id equality check to FlashBlockPendingSequence::insert() for non-zero indices so that follow-up flashblocks are only accepted when both block_number and payload_id match the first tracked flashblock. The protocol and FlashBlockCompleteSequence::new() already require stable payload_id across a sequence, but previously insert() could merge frames from different payloads sharing the same block number, allowing ready_transactions() and build_args() to be assembled from mixed data before final broadcast validation rejected the sequence. By enforcing the payload_id guard at insertion time while preserving the reset-on-index-0 behavior and existing trace semantics, we prevent mixed sequences from polluting pending builds and align earlier with the protocol invariants.