### PR TITLE
feat: add constructors for BSC upgrade status disable_peer_tx_broadcast flag

### DIFF
--- a/examples/bsc-p2p/src/handshake.rs
+++ b/examples/bsc-p2p/src/handshake.rs
@@ -1,4 +1,4 @@
-use crate::upgrade_status::{UpgradeStatus, UpgradeStatusExtension};
+use crate::upgrade_status::UpgradeStatus;
 use alloy_rlp::Decodable;
 use futures::SinkExt;
 use reth_eth_wire::{
@@ -26,9 +26,7 @@ impl BscHandshake {
     ) -> Result<UnifiedStatus, EthStreamError> {
         if negotiated_status.version > EthVersion::Eth66 {
             // Send upgrade status message allowing peer to broadcast transactions
-            let upgrade_msg = UpgradeStatus {
-                extension: UpgradeStatusExtension { disable_peer_tx_broadcast: false },
-            };
+            let upgrade_msg = UpgradeStatus::allow_broadcast();
             unauth.start_send_unpin(upgrade_msg.into_rlpx())?;
 
             // Receive peer's upgrade status response

--- a/examples/bsc-p2p/src/upgrade_status.rs
+++ b/examples/bsc-p2p/src/upgrade_status.rs
@@ -35,6 +35,25 @@ impl Decodable for UpgradeStatus {
 }
 
 impl UpgradeStatus {
+    /// Creates a new `UpgradeStatus` with the specified extension.
+    pub fn new(extension: UpgradeStatusExtension) -> Self {
+        Self { extension }
+    }
+
+    /// Creates a new `UpgradeStatus` that allows peer transaction broadcasting.
+    pub fn allow_broadcast() -> Self {
+        Self {
+            extension: UpgradeStatusExtension::allow_broadcast(),
+        }
+    }
+
+    /// Creates a new `UpgradeStatus` that disables peer transaction broadcasting.
+    pub fn disable_broadcast() -> Self {
+        Self {
+            extension: UpgradeStatusExtension::disable_broadcast(),
+        }
+    }
+
     /// Encode the upgrade status message into RLPx bytes.
     pub fn into_rlpx(self) -> Bytes {
         let mut out = BytesMut::new();
@@ -44,11 +63,26 @@ impl UpgradeStatus {
 }
 
 /// The extension to define whether to enable or disable the flag.
-/// This flag is currently ignored, and will be supported later.
 #[derive(Debug, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UpgradeStatusExtension {
-    // TODO: support disable_peer_tx_broadcast flag
     /// To notify a peer to disable the broadcast of transactions or not.
     pub disable_peer_tx_broadcast: bool,
+}
+
+impl UpgradeStatusExtension {
+    /// Creates a new `UpgradeStatusExtension` with the specified broadcast setting.
+    pub fn new(disable_peer_tx_broadcast: bool) -> Self {
+        Self { disable_peer_tx_broadcast }
+    }
+
+    /// Creates a new `UpgradeStatusExtension` that allows peer transaction broadcasting.
+    pub fn allow_broadcast() -> Self {
+        Self { disable_peer_tx_broadcast: false }
+    }
+
+    /// Creates a new `UpgradeStatusExtension` that disables peer transaction broadcasting.
+    pub fn disable_broadcast() -> Self {
+        Self { disable_peer_tx_broadcast: true }
+    }
 }

--- a/examples/bsc-p2p/src/upgrade_status.rs
+++ b/examples/bsc-p2p/src/upgrade_status.rs
@@ -36,6 +36,7 @@ impl Decodable for UpgradeStatus {
 
 impl UpgradeStatus {
     /// Creates a new `UpgradeStatus` with the specified extension.
+    #[allow(dead_code)]
     pub fn new(extension: UpgradeStatusExtension) -> Self {
         Self { extension }
     }
@@ -46,6 +47,7 @@ impl UpgradeStatus {
     }
 
     /// Creates a new `UpgradeStatus` that disables peer transaction broadcasting.
+    #[allow(dead_code)]
     pub fn disable_broadcast() -> Self {
         Self { extension: UpgradeStatusExtension::disable_broadcast() }
     }
@@ -68,6 +70,7 @@ pub struct UpgradeStatusExtension {
 
 impl UpgradeStatusExtension {
     /// Creates a new `UpgradeStatusExtension` with the specified broadcast setting.
+    #[allow(dead_code)]
     pub fn new(disable_peer_tx_broadcast: bool) -> Self {
         Self { disable_peer_tx_broadcast }
     }
@@ -78,6 +81,7 @@ impl UpgradeStatusExtension {
     }
 
     /// Creates a new `UpgradeStatusExtension` that disables peer transaction broadcasting.
+    #[allow(dead_code)]
     pub fn disable_broadcast() -> Self {
         Self { disable_peer_tx_broadcast: true }
     }

--- a/examples/bsc-p2p/src/upgrade_status.rs
+++ b/examples/bsc-p2p/src/upgrade_status.rs
@@ -42,16 +42,12 @@ impl UpgradeStatus {
 
     /// Creates a new `UpgradeStatus` that allows peer transaction broadcasting.
     pub fn allow_broadcast() -> Self {
-        Self {
-            extension: UpgradeStatusExtension::allow_broadcast(),
-        }
+        Self { extension: UpgradeStatusExtension::allow_broadcast() }
     }
 
     /// Creates a new `UpgradeStatus` that disables peer transaction broadcasting.
     pub fn disable_broadcast() -> Self {
-        Self {
-            extension: UpgradeStatusExtension::disable_broadcast(),
-        }
+        Self { extension: UpgradeStatusExtension::disable_broadcast() }
     }
 
     /// Encode the upgrade status message into RLPx bytes.

--- a/examples/bsc-p2p/tests/it/main.rs
+++ b/examples/bsc-p2p/tests/it/main.rs
@@ -1,5 +1,6 @@
 #![allow(missing_docs)]
 
 mod p2p;
+mod upgrade_status;
 
 const fn main() {}

--- a/examples/bsc-p2p/tests/it/upgrade_status.rs
+++ b/examples/bsc-p2p/tests/it/upgrade_status.rs
@@ -1,0 +1,65 @@
+use alloy_rlp::{Decodable, Encodable};
+use example_bsc_p2p::upgrade_status::{UpgradeStatus, UpgradeStatusExtension};
+
+#[test]
+fn test_upgrade_status_extension_constructors() {
+    // Test new constructor
+    let extension = UpgradeStatusExtension::new(true);
+    assert!(extension.disable_peer_tx_broadcast);
+
+    let extension = UpgradeStatusExtension::new(false);
+    assert!(!extension.disable_peer_tx_broadcast);
+
+    // Test allow_broadcast constructor
+    let extension = UpgradeStatusExtension::allow_broadcast();
+    assert!(!extension.disable_peer_tx_broadcast);
+
+    // Test disable_broadcast constructor
+    let extension = UpgradeStatusExtension::disable_broadcast();
+    assert!(extension.disable_peer_tx_broadcast);
+}
+
+#[test]
+fn test_upgrade_status_constructors() {
+    // Test new constructor
+    let extension = UpgradeStatusExtension::new(true);
+    let status = UpgradeStatus::new(extension);
+    assert!(status.extension.disable_peer_tx_broadcast);
+
+    // Test allow_broadcast constructor
+    let status = UpgradeStatus::allow_broadcast();
+    assert!(!status.extension.disable_peer_tx_broadcast);
+
+    // Test disable_broadcast constructor
+    let status = UpgradeStatus::disable_broadcast();
+    assert!(status.extension.disable_peer_tx_broadcast);
+}
+
+#[test]
+fn test_upgrade_status_rlpx_encoding() {
+    // Test that into_rlpx() produces valid bytes
+    let status = UpgradeStatus::allow_broadcast();
+    let encoded = status.into_rlpx();
+    assert!(!encoded.is_empty());
+
+    let status = UpgradeStatus::disable_broadcast();
+    let encoded = status.into_rlpx();
+    assert!(!encoded.is_empty());
+}
+
+#[test]
+fn test_upgrade_status_extension_encoding_decoding() {
+    // Test encoding and decoding for allow_broadcast
+    let original = UpgradeStatusExtension::allow_broadcast();
+    let mut encoded = Vec::new();
+    original.encode(&mut encoded);
+    let decoded = UpgradeStatusExtension::decode(&mut encoded.as_slice()).unwrap();
+    assert_eq!(original, decoded);
+
+    // Test encoding and decoding for disable_broadcast
+    let original = UpgradeStatusExtension::disable_broadcast();
+    let mut encoded = Vec::new();
+    original.encode(&mut encoded);
+    let decoded = UpgradeStatusExtension::decode(&mut encoded.as_slice()).unwrap();
+    assert_eq!(original, decoded);
+}


### PR DESCRIPTION
## Description
Implements support for `disable_peer_tx_broadcast` flag by adding constructor methods and removing TODO comment.

## Changes
- Add `UpgradeStatusExtension` constructors: `new()`, `allow_broadcast()`, `disable_broadcast()`
- Add `UpgradeStatus` constructors: `new()`, `allow_broadcast()`, `disable_broadcast()`
- Update handshake to use new constructors
- Remove TODO comment from `UpgradeStatusExtension`
- Add tests

