### PR TITLE
fix: no_std compatibility in reth-optimism-chainspec

### DIFF
--- a/crates/optimism/chainspec/src/basefee.rs
+++ b/crates/optimism/chainspec/src/basefee.rs
@@ -76,7 +76,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use alloc::sync::Arc;
 
     use op_alloy_consensus::encode_jovian_extra_data;
     use reth_chainspec::{ChainSpec, ForkCondition, Hardfork};

--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -517,7 +517,7 @@ pub fn make_op_genesis_header(genesis: &Genesis, hardforks: &ChainHardforks) -> 
 
 #[cfg(test)]
 mod tests {
-    use alloc::string::String;
+    use alloc::string::{String, ToString};
     use alloy_genesis::{ChainConfig, Genesis};
     use alloy_primitives::b256;
     use reth_chainspec::{test_fork_ids, BaseFeeParams, BaseFeeParamsKind};
@@ -529,7 +529,7 @@ mod tests {
     #[test]
     fn test_storage_root_consistency() {
         use alloy_primitives::{B256, U256};
-        use std::str::FromStr;
+        use core::str::FromStr;
 
         let k1 =
             B256::from_str("0x0000000000000000000000000000000000000000000000000000000000000001")


### PR DESCRIPTION
Fix compilation failures when building without default features (no_std environment). The crate was using std::sync::Arc and std::str::FromStr imports which aren't available in no_std builds, causing tests to fail with "unresolved module" errors. Replace these with their core/alloc equivalents: use alloc::sync::Arc in test code, core::str::FromStr for parsing, and add missing ToString import.