### PR TITLE
feat(trie): proof task tracing improvements

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -49,7 +49,7 @@ use std::{
     },
     time::Instant,
 };
-use tracing::{debug, debug_span, instrument, warn};
+use tracing::{debug, debug_span, instrument, span::EnteredSpan, warn};
 
 mod configured_sparse_trie;
 pub mod executor;
@@ -234,7 +234,7 @@ where
         );
         let storage_worker_count = config.storage_worker_count();
         let account_worker_count = config.account_worker_count();
-        let proof_handle = ProofWorkerHandle::new(
+        let (proof_handle, proof_workers_span) = ProofWorkerHandle::new(
             self.executor.handle().clone(),
             consistent_view,
             task_ctx,
@@ -280,6 +280,7 @@ where
             prewarm_handle,
             state_root: Some(state_root_rx),
             transactions: execution_rx,
+            _proof_workers_span: Some(proof_workers_span),
         })
     }
 
@@ -304,6 +305,7 @@ where
             prewarm_handle,
             state_root: None,
             transactions: execution_rx,
+            _proof_workers_span: None,
         }
     }
 
@@ -490,6 +492,7 @@ pub struct PayloadHandle<Tx, Err> {
     state_root: Option<mpsc::Receiver<Result<StateRootComputeOutcome, ParallelStateRootError>>>,
     /// Stream of block transactions
     transactions: mpsc::Receiver<Result<Tx, Err>>,
+    _proof_workers_span: Option<EnteredSpan>,
 }
 
 impl<Tx, Err> PayloadHandle<Tx, Err> {

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -1282,7 +1282,7 @@ mod tests {
             config.prefix_sets.clone(),
         );
         let consistent_view = ConsistentDbView::new(factory, None);
-        let proof_handle = ProofWorkerHandle::new(rt_handle, consistent_view, task_ctx, 1, 1);
+        let (proof_handle, _) = ProofWorkerHandle::new(rt_handle, consistent_view, task_ctx, 1, 1);
         let (to_sparse_trie, _receiver) = std::sync::mpsc::channel();
 
         MultiProofTask::new(config, proof_handle, to_sparse_trie, Some(1))

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -336,7 +336,7 @@ mod tests {
 
         let task_ctx =
             ProofTaskCtx::new(Default::default(), Default::default(), Default::default());
-        let proof_worker_handle =
+        let (proof_worker_handle, _) =
             ProofWorkerHandle::new(rt.handle().clone(), consistent_view, task_ctx, 1, 1);
 
         let parallel_result = ParallelProof::new(

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -77,7 +77,7 @@ use std::{
     time::{Duration, Instant},
 };
 use tokio::runtime::Handle;
-use tracing::{debug_span, error, trace};
+use tracing::{debug, debug_span, error, trace};
 
 #[cfg(feature = "metrics")]
 use crate::proof_task_metrics::ProofTaskTrieMetrics;
@@ -196,7 +196,7 @@ fn storage_worker_loop<Factory>(
         view.provider_ro().expect("Storage worker failed to initialize: database unavailable");
     let proof_tx = ProofTaskTx::new(provider.into_tx(), task_ctx, worker_id);
 
-    tracing::debug!(
+    trace!(
         target: "trie::proof_task",
         worker_id,
         "Storage worker started"
@@ -270,7 +270,7 @@ fn storage_worker_loop<Factory>(
                     })
                     .is_err()
                 {
-                    tracing::debug!(
+                    trace!(
                         target: "trie::proof_task",
                         worker_id,
                         hashed_address = ?hashed_address,
@@ -309,7 +309,7 @@ fn storage_worker_loop<Factory>(
                 storage_nodes_processed += 1;
 
                 if result_sender.send(result).is_err() {
-                    tracing::debug!(
+                    trace!(
                         target: "trie::proof_task",
                         worker_id,
                         ?account,
@@ -335,7 +335,7 @@ fn storage_worker_loop<Factory>(
         }
     }
 
-    tracing::debug!(
+    trace!(
         target: "trie::proof_task",
         worker_id,
         storage_proofs_processed,
@@ -384,7 +384,7 @@ fn account_worker_loop<Factory>(
         view.provider_ro().expect("Account worker failed to initialize: database unavailable");
     let proof_tx = ProofTaskTx::new(provider.into_tx(), task_ctx, worker_id);
 
-    tracing::debug!(
+    trace!(
         target: "trie::proof_task",
         worker_id,
         "Account worker started"
@@ -427,7 +427,7 @@ fn account_worker_loop<Factory>(
                         },
                 } = *input;
 
-                let span = tracing::debug_span!(
+                let span = debug_span!(
                     target: "trie::proof_task",
                     "Account multiproof calculation",
                     targets = targets.len(),
@@ -509,7 +509,7 @@ fn account_worker_loop<Factory>(
                     })
                     .is_err()
                 {
-                    tracing::debug!(
+                    trace!(
                         target: "trie::proof_task",
                         worker_id,
                         account_proofs_processed,
@@ -531,7 +531,7 @@ fn account_worker_loop<Factory>(
             }
 
             AccountWorkerJob::BlindedAccountNode { path, result_sender } => {
-                let span = tracing::debug_span!(
+                let span = debug_span!(
                     target: "trie::proof_task",
                     "Blinded account node calculation",
                     ?path,
@@ -551,7 +551,7 @@ fn account_worker_loop<Factory>(
                 account_nodes_processed += 1;
 
                 if result_sender.send(result).is_err() {
-                    tracing::debug!(
+                    trace!(
                         target: "trie::proof_task",
                         worker_id,
                         ?path,
@@ -574,7 +574,7 @@ fn account_worker_loop<Factory>(
         }
     }
 
-    tracing::debug!(
+    trace!(
         target: "trie::proof_task",
         worker_id,
         account_proofs_processed,
@@ -879,7 +879,7 @@ where
             multi_added_removed_keys.unwrap_or_else(|| Arc::new(MultiAddedRemovedKeys::new()));
         let added_removed_keys = multi_added_removed_keys.get_storage(&hashed_address);
 
-        let span = tracing::debug_span!(
+        let span = debug_span!(
             target: "trie::proof_task",
             "Storage proof calculation",
             hashed_address = ?hashed_address,
@@ -1079,7 +1079,7 @@ impl ProofWorkerHandle {
         let storage_available_workers = Arc::new(AtomicUsize::new(0));
         let account_available_workers = Arc::new(AtomicUsize::new(0));
 
-        tracing::debug!(
+        debug!(
             target: "trie::proof_task",
             storage_worker_count,
             account_worker_count,
@@ -1113,12 +1113,6 @@ impl ProofWorkerHandle {
                     metrics,
                 )
             });
-
-            tracing::debug!(
-                target: "trie::proof_task",
-                worker_id,
-                "Storage worker spawned successfully"
-            );
         }
 
         drop(_guard);
@@ -1152,12 +1146,6 @@ impl ProofWorkerHandle {
                     metrics,
                 )
             });
-
-            tracing::debug!(
-                target: "trie::proof_task",
-                worker_id,
-                "Account worker spawned successfully"
-            );
         }
 
         drop(_guard);


### PR DESCRIPTION
Debug is too verbose: for a machine with 64 cores, we will have 128 account and 128 storage workers, and each will emit multiple logs.

Additionally, keeps the proof workers entered span around, so that it's not getting exited when `ProofWorkerHandle::new` exits.

Before (see top span):
<img width="2444" height="732" alt="image" src="https://github.com/user-attachments/assets/d8b74b3c-acd4-4f55-9197-f8c30dd889bf" />

After (same top span, with a new name):
<img width="2430" height="731" alt="image" src="https://github.com/user-attachments/assets/8447f5a7-ac50-4c02-bdb9-3ad9803625bf" />

