### PR TITLE
fix(txpool): correct propagate field name in Debug output

### DIFF
--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -515,7 +515,7 @@ impl<T: PoolTransaction> fmt::Debug for ValidPoolTransaction<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ValidPoolTransaction")
             .field("id", &self.transaction_id)
-            .field("pragate", &self.propagate)
+            .field("propagate", &self.propagate)
             .field("origin", &self.origin)
             .field("hash", self.transaction.hash())
             .field("tx", &self.transaction)


### PR DESCRIPTION
Fixed field name in ValidPoolTransaction Debug implementation. 
The field was displayed as "pragate" instead of the correct "propagate".