### PR TITLE
chore(trie): do not create a parent span for proof worker handle

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -49,7 +49,7 @@ use std::{
     },
     time::Instant,
 };
-use tracing::{debug, debug_span, instrument, span::EnteredSpan, warn};
+use tracing::{debug, debug_span, instrument, warn};
 
 mod configured_sparse_trie;
 pub mod executor;
@@ -234,7 +234,7 @@ where
         );
         let storage_worker_count = config.storage_worker_count();
         let account_worker_count = config.account_worker_count();
-        let (proof_handle, proof_workers_span) = ProofWorkerHandle::new(
+        let proof_handle = ProofWorkerHandle::new(
             self.executor.handle().clone(),
             consistent_view,
             task_ctx,
@@ -280,7 +280,6 @@ where
             prewarm_handle,
             state_root: Some(state_root_rx),
             transactions: execution_rx,
-            _proof_workers_span: Some(proof_workers_span),
         })
     }
 
@@ -305,7 +304,6 @@ where
             prewarm_handle,
             state_root: None,
             transactions: execution_rx,
-            _proof_workers_span: None,
         }
     }
 
@@ -492,7 +490,6 @@ pub struct PayloadHandle<Tx, Err> {
     state_root: Option<mpsc::Receiver<Result<StateRootComputeOutcome, ParallelStateRootError>>>,
     /// Stream of block transactions
     transactions: mpsc::Receiver<Result<Tx, Err>>,
-    _proof_workers_span: Option<EnteredSpan>,
 }
 
 impl<Tx, Err> PayloadHandle<Tx, Err> {

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -1282,7 +1282,7 @@ mod tests {
             config.prefix_sets.clone(),
         );
         let consistent_view = ConsistentDbView::new(factory, None);
-        let (proof_handle, _) = ProofWorkerHandle::new(rt_handle, consistent_view, task_ctx, 1, 1);
+        let proof_handle = ProofWorkerHandle::new(rt_handle, consistent_view, task_ctx, 1, 1);
         let (to_sparse_trie, _receiver) = std::sync::mpsc::channel();
 
         MultiProofTask::new(config, proof_handle, to_sparse_trie, Some(1))

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -336,7 +336,7 @@ mod tests {
 
         let task_ctx =
             ProofTaskCtx::new(Default::default(), Default::default(), Default::default());
-        let (proof_worker_handle, _) =
+        let proof_worker_handle =
             ProofWorkerHandle::new(rt.handle().clone(), consistent_view, task_ctx, 1, 1);
 
         let parallel_result = ParallelProof::new(


### PR DESCRIPTION
Partly reverts https://github.com/paradigmxyz/reth/pull/19276, as it caused changing the current span inside `PayloadProcessor::spawn` to the span that's returned from `ProofWorkerHandle`, messing up the span hierarchy.

<img width="2557" height="664" alt="image" src="https://github.com/user-attachments/assets/72450135-c01c-4989-8b38-fce6bf6a734f" />
