### PR TITLE
feat(tracing): set default OTLP log level to WARN

### DIFF
--- a/crates/tracing/src/layers.rs
+++ b/crates/tracing/src/layers.rs
@@ -21,18 +21,19 @@ pub type FileWorkerGuard = tracing_appender::non_blocking::WorkerGuard;
 ///  A boxed tracing [Layer].
 pub(crate) type BoxedLayer<S> = Box<dyn Layer<S> + Send + Sync>;
 
-/// Default [directives](Directive) for [`EnvFilter`] which disable high-frequency debug logs from
-/// dependencies such as `hyper`, `hickory-resolver`, `hickory_proto`, `discv5`, `jsonrpsee-server`,
-/// the `opentelemetry_*` crates, and `hyper_util::client::legacy::pool`.
+/// Default [directives](Directive) for [`EnvFilter`] which:
+/// 1. Disable high-frequency debug logs from dependencies such as `hyper`, `hickory-resolver`,
+///    `hickory_proto`, `discv5`, `jsonrpsee-server`, and `hyper_util::client::legacy::pool`.
+/// 2. Set `opentelemetry_*` crates log level to `WARN`, as `DEBUG` is too noisy.
 const DEFAULT_ENV_FILTER_DIRECTIVES: [&str; 9] = [
     "hyper::proto::h1=off",
     "hickory_resolver=off",
     "hickory_proto=off",
     "discv5=off",
     "jsonrpsee-server=off",
-    "opentelemetry-otlp=off",
-    "opentelemetry_sdk=off",
-    "opentelemetry-http=off",
+    "opentelemetry-otlp=warn",
+    "opentelemetry_sdk=warn",
+    "opentelemetry-http=warn",
     "hyper_util::client::legacy::pool=off",
 ];
 


### PR DESCRIPTION
OTLP logs can be very useful for troubleshooting.