### PR TITLE
chore(codecs): replace todo with unimplemented in Compact derive

### DIFF
--- a/crates/storage/codecs/derive/src/compact/mod.rs
+++ b/crates/storage/codecs/derive/src/compact/mod.rs
@@ -82,7 +82,7 @@ pub fn get_fields(data: &Data) -> FieldList {
                 );
                 load_field(&data_fields.unnamed[0], &mut fields, false);
             }
-            syn::Fields::Unit => todo!(),
+            syn::Fields::Unit => unimplemented!("Compact does not support unit structs"),
         },
         Data::Enum(data) => {
             for variant in &data.variants {
@@ -106,7 +106,7 @@ pub fn get_fields(data: &Data) -> FieldList {
                 }
             }
         }
-        Data::Union(_) => todo!(),
+        Data::Union(_) => unimplemented!("Compact does not support union types"),
     }
 
     fields


### PR DESCRIPTION
Replaced `todo!()` with `unimplemented!()` for unit structs and unions in the Compact derive macro.

These aren't planned features - they're design limitations. Unit structs have no fields to serialize, and unions can't be safely handled by derive macros. Better semantics and clearer error messages for users who try to derive Compact on unsupported types.