### PR TITLE
fix(node): classify connect_async failures as WebSocket and use Url parse error

### DIFF
--- a/crates/node/ethstats/src/ethstats.rs
+++ b/crates/node/ethstats/src/ethstats.rs
@@ -109,10 +109,9 @@ where
             "Attempting to connect to EthStats server at {}", self.credentials.host
         );
         let full_url = format!("ws://{}/api", self.credentials.host);
-        let url = Url::parse(&full_url)
-            .map_err(|e| EthStatsError::InvalidUrl(format!("Invalid URL: {full_url} - {e}")))?;
+        let url = Url::parse(&full_url).map_err(EthStatsError::Url)?;
 
-        match timeout(CONNECT_TIMEOUT, connect_async(url.to_string())).await {
+        match timeout(CONNECT_TIMEOUT, connect_async(url.as_str())).await {
             Ok(Ok((ws_stream, _))) => {
                 debug!(
                     target: "ethstats",
@@ -123,7 +122,7 @@ where
                 self.login().await?;
                 Ok(())
             }
-            Ok(Err(e)) => Err(EthStatsError::InvalidUrl(e.to_string())),
+            Ok(Err(e)) => Err(EthStatsError::WebSocket(e)),
             Err(_) => {
                 debug!(target: "ethstats", "Connection to EthStats server timed out");
                 Err(EthStatsError::Timeout)


### PR DESCRIPTION
The connect() function incorrectly mapped websocket handshake/transport failures from tokio-tungstenite connect_async into EthStatsError::InvalidUrl, which conflated network errors with URL format issues. This patch reclassifies those errors to EthStatsError::WebSocket and uses the existing Url(ParseError) variant for Url::parse failures. It also avoids unnecessary URL string conversion by passing url.as_str() to connect_async. This ensures accurate error semantics consistent with the error enum design and improves debuggability.