### PR TITLE
refactor: remove unused prune_modes from backfill jobs

### DIFF
--- a/crates/exex/exex/Cargo.toml
+++ b/crates/exex/exex/Cargo.toml
@@ -25,7 +25,6 @@ reth-node-core.workspace = true
 reth-primitives-traits.workspace = true
 reth-ethereum-primitives.workspace = true
 reth-provider.workspace = true
-reth-prune-types.workspace = true
 reth-revm.workspace = true
 reth-stages-api.workspace = true
 reth-tasks.workspace = true
@@ -76,7 +75,6 @@ serde = [
     "rand/serde",
     "secp256k1/serde",
     "reth-primitives-traits/serde",
-    "reth-prune-types/serde",
     "reth-config/serde",
     "reth-ethereum-primitives/serde",
     "reth-chain-state/serde",

--- a/crates/exex/exex/src/backfill/factory.rs
+++ b/crates/exex/exex/src/backfill/factory.rs
@@ -3,7 +3,6 @@ use std::{ops::RangeInclusive, time::Duration};
 
 use alloy_primitives::BlockNumber;
 use reth_node_api::FullNodeComponents;
-use reth_prune_types::PruneModes;
 use reth_stages_api::ExecutionStageThresholds;
 
 use super::stream::DEFAULT_PARALLELISM;
@@ -13,7 +12,6 @@ use super::stream::DEFAULT_PARALLELISM;
 pub struct BackfillJobFactory<E, P> {
     evm_config: E,
     provider: P,
-    prune_modes: PruneModes,
     thresholds: ExecutionStageThresholds,
     stream_parallelism: usize,
 }
@@ -24,7 +22,6 @@ impl<E, P> BackfillJobFactory<E, P> {
         Self {
             evm_config,
             provider,
-            prune_modes: PruneModes::default(),
             thresholds: ExecutionStageThresholds {
                 // Default duration for a database transaction to be considered long-lived is
                 // 60 seconds, so we limit the backfill job to the half of it to be sure we finish
@@ -36,12 +33,6 @@ impl<E, P> BackfillJobFactory<E, P> {
             },
             stream_parallelism: DEFAULT_PARALLELISM,
         }
-    }
-
-    /// Sets the prune modes
-    pub const fn with_prune_modes(mut self, prune_modes: PruneModes) -> Self {
-        self.prune_modes = prune_modes;
-        self
     }
 
     /// Sets the thresholds
@@ -66,7 +57,6 @@ impl<E: Clone, P: Clone> BackfillJobFactory<E, P> {
         BackfillJob {
             evm_config: self.evm_config.clone(),
             provider: self.provider.clone(),
-            prune_modes: self.prune_modes.clone(),
             range,
             thresholds: self.thresholds.clone(),
             stream_parallelism: self.stream_parallelism,

--- a/crates/exex/exex/src/backfill/job.rs
+++ b/crates/exex/exex/src/backfill/job.rs
@@ -15,7 +15,6 @@ use reth_provider::{
     BlockReader, Chain, ExecutionOutcome, HeaderProvider, ProviderError, StateProviderFactory,
     TransactionVariant,
 };
-use reth_prune_types::PruneModes;
 use reth_revm::database::StateProviderDatabase;
 use reth_stages_api::ExecutionStageThresholds;
 use reth_tracing::tracing::{debug, trace};
@@ -31,7 +30,6 @@ pub(super) type BackfillJobResult<T> = Result<T, BlockExecutionError>;
 pub struct BackfillJob<E, P> {
     pub(crate) evm_config: E,
     pub(crate) provider: P,
-    pub(crate) prune_modes: PruneModes,
     pub(crate) thresholds: ExecutionStageThresholds,
     pub(crate) range: RangeInclusive<BlockNumber>,
     pub(crate) stream_parallelism: usize,

--- a/crates/exex/exex/src/backfill/stream.rs
+++ b/crates/exex/exex/src/backfill/stream.rs
@@ -13,7 +13,6 @@ use reth_evm::{
 use reth_node_api::NodePrimitives;
 use reth_primitives_traits::RecoveredBlock;
 use reth_provider::{BlockReader, Chain, StateProviderFactory};
-use reth_prune_types::PruneModes;
 use reth_stages_api::ExecutionStageThresholds;
 use reth_tracing::tracing::debug;
 use std::{
@@ -55,7 +54,6 @@ type BatchBlockStreamItem<N = EthPrimitives> = Chain<N>;
 pub struct StreamBackfillJob<E, P, T> {
     evm_config: E,
     provider: P,
-    prune_modes: PruneModes,
     range: RangeInclusive<BlockNumber>,
     tasks: BackfillTasks<T>,
     parallelism: usize,
@@ -178,7 +176,6 @@ where
                 let job = Box::new(BackfillJob {
                     evm_config: this.evm_config.clone(),
                     provider: this.provider.clone(),
-                    prune_modes: this.prune_modes.clone(),
                     thresholds: this.thresholds.clone(),
                     range,
                     stream_parallelism: this.parallelism,
@@ -205,7 +202,6 @@ impl<E, P> From<SingleBlockBackfillJob<E, P>> for StreamBackfillJob<E, P, Single
         Self {
             evm_config: job.evm_config,
             provider: job.provider,
-            prune_modes: PruneModes::default(),
             range: job.range,
             tasks: FuturesOrdered::new(),
             parallelism: job.stream_parallelism,
@@ -224,7 +220,6 @@ where
         Self {
             evm_config: job.evm_config,
             provider: job.provider,
-            prune_modes: job.prune_modes,
             range: job.range,
             tasks: FuturesOrdered::new(),
             parallelism: job.stream_parallelism,


### PR DESCRIPTION
Remove unused prune_modes field from BackfillJob, BackfillJobFactory, and StreamBackfillJob structs. 

The field was never used in the execution logic and was only passed around without any functional purpose. 

Backfill jobs are designed for block execution, not pruning operations.
