### PR TITLE
chore: remove unused deprecated type aliases

### DIFF
--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -41,16 +41,10 @@ pub use alloy_consensus::{
     ReceiptWithBloom,
 };
 
-/// Recovered transaction
-#[deprecated(note = "use `Recovered` instead")]
-pub type RecoveredTx<T> = Recovered<T>;
-
 pub use transaction::{
     util::secp256k1::{public_key_to_address, recover_signer_unchecked, sign_message},
     InvalidTransactionError, Transaction, TransactionSigned, TxType,
 };
-#[expect(deprecated)]
-pub use transaction::{PooledTransactionsElementEcRecovered, TransactionSignedEcRecovered};
 
 // Re-exports
 pub use reth_ethereum_forks::*;

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1,10 +1,7 @@
 //! Transaction types.
 
-use crate::Recovered;
 pub use alloy_consensus::transaction::PooledTransaction;
 use once_cell as _;
-#[expect(deprecated)]
-pub use pooled::PooledTransactionsElementEcRecovered;
 pub use reth_primitives_traits::{
     sync::{LazyLock, OnceLock},
     transaction::{
@@ -28,7 +25,3 @@ mod tx_type;
 
 /// Signed transaction.
 pub use reth_ethereum_primitives::{Transaction, TransactionSigned};
-
-/// Type alias kept for backward compatibility.
-#[deprecated(note = "Use `Recovered` instead")]
-pub type TransactionSignedEcRecovered<T = TransactionSigned> = Recovered<T>;

--- a/crates/primitives/src/transaction/pooled.rs
+++ b/crates/primitives/src/transaction/pooled.rs
@@ -1,9 +1,2 @@
 //! Defines the types for blob transactions, legacy, and other EIP-2718 transactions included in a
 //! response to `GetPooledTransactions`.
-
-use crate::Recovered;
-use alloy_consensus::transaction::PooledTransaction;
-
-/// A signed pooled transaction with recovered signer.
-#[deprecated(note = "use `Recovered` instead")]
-pub type PooledTransactionsElementEcRecovered<T = PooledTransaction> = Recovered<T>;


### PR DESCRIPTION
This removes three deprecated type aliases that are no longer used anywhere in the codebase:
- RecoveredTx<T>
- TransactionSignedEcRecovered<T>  
- PooledTransactionsElementEcRecovered<T>

These types were deprecated in #13882 (Jan 20) as part of the migration to alloy::Recovered. The last actual usage was removed back in #13690 (Jan 6), which even removed a "TODO: remove this foreign type" comment from the code. They've just been sitting around as dead exports since then.

Since everything now uses alloy::Recovered directly, keeping these deprecated aliases just adds noise and might confuse new contributors who could think they should still be using them.

Also removed an unused import of `Recovered` in transaction/mod.rs that was only needed for these type aliases.