### PR TITLE
fix(engine): module doc to reflect schnellru::LruMap backend

### DIFF
--- a/crates/engine/tree/src/tree/precompile_cache.rs
+++ b/crates/engine/tree/src/tree/precompile_cache.rs
@@ -1,4 +1,4 @@
-//! Contains a precompile cache that is backed by a moka cache.
+//! Contains a precompile cache backed by `schnellru::LruMap` (LRU by length).
 
 use alloy_primitives::Bytes;
 use parking_lot::Mutex;


### PR DESCRIPTION
- Replaced an outdated reference to “moka” with the correct schnellru::LruMap in the module-level documentation of 
crates/engine/tree/src/tree/precompile_cache.rs
- The implementation imports and uses schnellru::LruMap (with ByLength limiter) and parking_lot::Mutex; other comments in the file already describe LruMap semantics.
- This change ensures the documentation accurately reflects the current implementation. No functional code changes.