### PR TITLE
refactor: cleanup abstractions in multiproofs

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -1,11 +1,7 @@
 //! Multiproof task related functionality.
 
 use alloy_evm::block::StateChangeSource;
-use alloy_primitives::{
-    keccak256,
-    map::{B256Set, HashSet},
-    B256,
-};
+use alloy_primitives::{keccak256, map::HashSet, B256};
 use crossbeam_channel::{unbounded, Receiver as CrossbeamReceiver, Sender as CrossbeamSender};
 use dashmap::DashMap;
 use derive_more::derive::Deref;
@@ -23,287 +19,6 @@ use reth_trie_parallel::{
 };
 use std::{collections::BTreeMap, ops::DerefMut, sync::Arc, time::Instant};
 use tracing::{debug, error, instrument, trace};
-
-/// A trie update that can be applied to sparse trie alongside the proofs for touched parts of the
-/// state.
-#[derive(Default, Debug)]
-pub struct SparseTrieUpdate {
-    /// The state update that was used to calculate the proof
-    pub(crate) state: HashedPostState,
-    /// The calculated multiproof
-    pub(crate) multiproof: DecodedMultiProof,
-}
-
-impl SparseTrieUpdate {
-    /// Returns true if the update is empty.
-    pub(super) fn is_empty(&self) -> bool {
-        self.state.is_empty() && self.multiproof.is_empty()
-    }
-
-    /// Construct update from multiproof.
-    #[cfg(test)]
-    pub(super) fn from_multiproof(multiproof: reth_trie::MultiProof) -> alloy_rlp::Result<Self> {
-        Ok(Self { multiproof: multiproof.try_into()?, ..Default::default() })
-    }
-
-    /// Extend update with contents of the other.
-    pub(super) fn extend(&mut self, other: Self) {
-        self.state.extend(other.state);
-        self.multiproof.extend(other.multiproof);
-    }
-}
-
-/// Common configuration for multi proof tasks
-#[derive(Debug, Clone)]
-pub(super) struct MultiProofConfig {
-    /// The sorted collection of cached in-memory intermediate trie nodes that
-    /// can be reused for computation.
-    pub nodes_sorted: Arc<TrieUpdatesSorted>,
-    /// The sorted in-memory overlay hashed state.
-    pub state_sorted: Arc<HashedPostStateSorted>,
-    /// The collection of prefix sets for the computation. Since the prefix sets _always_
-    /// invalidate the in-memory nodes, not all keys from `state_sorted` might be present here,
-    /// if we have cached nodes for them.
-    pub prefix_sets: Arc<TriePrefixSetsMut>,
-}
-
-impl MultiProofConfig {
-    /// Creates a new state root config from the trie input.
-    ///
-    /// This returns a cleared [`TrieInput`] so that we can reuse any allocated space in the
-    /// [`TrieInput`].
-    pub(super) fn from_input(mut input: TrieInput) -> (TrieInput, Self) {
-        let config = Self {
-            nodes_sorted: Arc::new(input.nodes.drain_into_sorted()),
-            state_sorted: Arc::new(input.state.drain_into_sorted()),
-            prefix_sets: Arc::new(input.prefix_sets.clone()),
-        };
-        (input.cleared(), config)
-    }
-}
-
-/// Messages used internally by the multi proof task.
-#[derive(Debug)]
-pub(super) enum MultiProofMessage {
-    /// Prefetch proof targets
-    PrefetchProofs(MultiProofTargets),
-    /// New state update from transaction execution with its source
-    StateUpdate(StateChangeSource, EvmState),
-    /// State update that can be applied to the sparse trie without any new proofs.
-    ///
-    /// It can be the case when all accounts and storage slots from the state update were already
-    /// fetched and revealed.
-    EmptyProof {
-        /// The index of this proof in the sequence of state updates
-        sequence_number: u64,
-        /// The state update that was used to calculate the proof
-        state: HashedPostState,
-    },
-    /// Signals state update stream end.
-    ///
-    /// This is triggered by block execution, indicating that no additional state updates are
-    /// expected.
-    FinishedStateUpdates,
-}
-
-/// Handle to track proof calculation ordering.
-#[derive(Debug, Default)]
-struct ProofSequencer {
-    /// The next proof sequence number to be produced.
-    next_sequence: u64,
-    /// The next sequence number expected to be delivered.
-    next_to_deliver: u64,
-    /// Buffer for out-of-order proofs and corresponding state updates
-    pending_proofs: BTreeMap<u64, SparseTrieUpdate>,
-}
-
-impl ProofSequencer {
-    /// Gets the next sequence number and increments the counter
-    const fn next_sequence(&mut self) -> u64 {
-        let seq = self.next_sequence;
-        self.next_sequence += 1;
-        seq
-    }
-
-    /// Adds a proof with the corresponding state update and returns all sequential proofs and state
-    /// updates if we have a continuous sequence
-    fn add_proof(&mut self, sequence: u64, update: SparseTrieUpdate) -> Vec<SparseTrieUpdate> {
-        if sequence >= self.next_to_deliver {
-            self.pending_proofs.insert(sequence, update);
-        }
-
-        // return early if we don't have the next expected proof
-        if !self.pending_proofs.contains_key(&self.next_to_deliver) {
-            return Vec::new()
-        }
-
-        let mut consecutive_proofs = Vec::with_capacity(self.pending_proofs.len());
-        let mut current_sequence = self.next_to_deliver;
-
-        // keep collecting proofs and state updates as long as we have consecutive sequence numbers
-        while let Some(pending) = self.pending_proofs.remove(&current_sequence) {
-            consecutive_proofs.push(pending);
-            current_sequence += 1;
-
-            // if we don't have the next number, stop collecting
-            if !self.pending_proofs.contains_key(&current_sequence) {
-                break;
-            }
-        }
-
-        self.next_to_deliver += consecutive_proofs.len() as u64;
-
-        consecutive_proofs
-    }
-
-    /// Returns true if we still have pending proofs
-    pub(crate) fn has_pending(&self) -> bool {
-        !self.pending_proofs.is_empty()
-    }
-}
-
-/// A wrapper for the sender that signals completion when dropped.
-///
-/// This type is intended to be used in combination with the evm executor statehook.
-/// This should trigger once the block has been executed (after) the last state update has been
-/// sent. This triggers the exit condition of the multi proof task.
-#[derive(Deref, Debug)]
-pub(super) struct StateHookSender(CrossbeamSender<MultiProofMessage>);
-
-impl StateHookSender {
-    pub(crate) const fn new(inner: CrossbeamSender<MultiProofMessage>) -> Self {
-        Self(inner)
-    }
-}
-
-impl Drop for StateHookSender {
-    fn drop(&mut self) {
-        // Send completion signal when the sender is dropped
-        let _ = self.0.send(MultiProofMessage::FinishedStateUpdates);
-    }
-}
-
-pub(crate) fn evm_state_to_hashed_post_state(update: EvmState) -> HashedPostState {
-    let mut hashed_state = HashedPostState::with_capacity(update.len());
-
-    for (address, account) in update {
-        if account.is_touched() {
-            let hashed_address = keccak256(address);
-            trace!(target: "engine::tree::payload_processor::multiproof", ?address, ?hashed_address, "Adding account to state update");
-
-            let destroyed = account.is_selfdestructed();
-            let info = if destroyed { None } else { Some(account.info.into()) };
-            hashed_state.accounts.insert(hashed_address, info);
-
-            let mut changed_storage_iter = account
-                .storage
-                .into_iter()
-                .filter(|(_slot, value)| value.is_changed())
-                .map(|(slot, value)| (keccak256(B256::from(slot)), value.present_value))
-                .peekable();
-
-            if destroyed {
-                hashed_state.storages.insert(hashed_address, HashedStorage::new(true));
-            } else if changed_storage_iter.peek().is_some() {
-                hashed_state
-                    .storages
-                    .insert(hashed_address, HashedStorage::from_iter(false, changed_storage_iter));
-            }
-        }
-    }
-
-    hashed_state
-}
-
-/// A pending multiproof task, either [`StorageMultiproofInput`] or [`MultiproofInput`].
-#[derive(Debug)]
-enum PendingMultiproofTask {
-    /// A storage multiproof task input.
-    Storage(StorageMultiproofInput),
-    /// A regular multiproof task input.
-    Regular(MultiproofInput),
-}
-
-impl PendingMultiproofTask {
-    /// Returns the proof sequence number of the task.
-    const fn proof_sequence_number(&self) -> u64 {
-        match self {
-            Self::Storage(input) => input.proof_sequence_number,
-            Self::Regular(input) => input.proof_sequence_number,
-        }
-    }
-
-    /// Returns whether or not the proof targets are empty.
-    fn proof_targets_is_empty(&self) -> bool {
-        match self {
-            Self::Storage(input) => input.proof_targets.is_empty(),
-            Self::Regular(input) => input.proof_targets.is_empty(),
-        }
-    }
-
-    /// Destroys the input and sends a [`MultiProofMessage::EmptyProof`] message to the sender.
-    fn send_empty_proof(self) {
-        match self {
-            Self::Storage(input) => input.send_empty_proof(),
-            Self::Regular(input) => input.send_empty_proof(),
-        }
-    }
-}
-
-impl From<StorageMultiproofInput> for PendingMultiproofTask {
-    fn from(input: StorageMultiproofInput) -> Self {
-        Self::Storage(input)
-    }
-}
-
-impl From<MultiproofInput> for PendingMultiproofTask {
-    fn from(input: MultiproofInput) -> Self {
-        Self::Regular(input)
-    }
-}
-
-/// Input parameters for dispatching a dedicated storage multiproof calculation.
-#[derive(Debug)]
-struct StorageMultiproofInput {
-    hashed_state_update: HashedPostState,
-    hashed_address: B256,
-    proof_targets: B256Set,
-    proof_sequence_number: u64,
-    state_root_message_sender: CrossbeamSender<MultiProofMessage>,
-    multi_added_removed_keys: Arc<MultiAddedRemovedKeys>,
-}
-
-impl StorageMultiproofInput {
-    /// Destroys the input and sends a [`MultiProofMessage::EmptyProof`] message to the sender.
-    fn send_empty_proof(self) {
-        let _ = self.state_root_message_sender.send(MultiProofMessage::EmptyProof {
-            sequence_number: self.proof_sequence_number,
-            state: self.hashed_state_update,
-        });
-    }
-}
-
-/// Input parameters for dispatching a multiproof calculation.
-#[derive(Debug)]
-struct MultiproofInput {
-    config: MultiProofConfig,
-    source: Option<StateChangeSource>,
-    hashed_state_update: HashedPostState,
-    proof_targets: MultiProofTargets,
-    proof_sequence_number: u64,
-    state_root_message_sender: CrossbeamSender<MultiProofMessage>,
-    multi_added_removed_keys: Option<Arc<MultiAddedRemovedKeys>>,
-}
-
-impl MultiproofInput {
-    /// Destroys the input and sends a [`MultiProofMessage::EmptyProof`] message to the sender.
-    fn send_empty_proof(self) {
-        let _ = self.state_root_message_sender.send(MultiProofMessage::EmptyProof {
-            sequence_number: self.proof_sequence_number,
-            state: self.hashed_state_update,
-        });
-    }
-}
 
 /// Coordinates multiproof dispatch between `MultiProofTask` and the parallel trie workers.
 ///
@@ -514,52 +229,6 @@ impl MultiproofManager {
             .pending_account_multiproofs_histogram
             .record(self.proof_worker_handle.pending_account_tasks() as f64);
     }
-}
-
-#[derive(Metrics, Clone)]
-#[metrics(scope = "tree.root")]
-pub(crate) struct MultiProofTaskMetrics {
-    /// Histogram of inflight multiproofs.
-    pub inflight_multiproofs_histogram: Histogram,
-    /// Histogram of pending storage multiproofs in the queue.
-    pub pending_storage_multiproofs_histogram: Histogram,
-    /// Histogram of pending account multiproofs in the queue.
-    pub pending_account_multiproofs_histogram: Histogram,
-
-    /// Histogram of the number of prefetch proof target accounts.
-    pub prefetch_proof_targets_accounts_histogram: Histogram,
-    /// Histogram of the number of prefetch proof target storages.
-    pub prefetch_proof_targets_storages_histogram: Histogram,
-    /// Histogram of the number of prefetch proof target chunks.
-    pub prefetch_proof_chunks_histogram: Histogram,
-
-    /// Histogram of the number of state update proof target accounts.
-    pub state_update_proof_targets_accounts_histogram: Histogram,
-    /// Histogram of the number of state update proof target storages.
-    pub state_update_proof_targets_storages_histogram: Histogram,
-    /// Histogram of the number of state update proof target chunks.
-    pub state_update_proof_chunks_histogram: Histogram,
-
-    /// Histogram of proof calculation durations.
-    pub proof_calculation_duration_histogram: Histogram,
-
-    /// Histogram of sparse trie update durations.
-    pub sparse_trie_update_duration_histogram: Histogram,
-    /// Histogram of sparse trie final update durations.
-    pub sparse_trie_final_update_duration_histogram: Histogram,
-    /// Histogram of sparse trie total durations.
-    pub sparse_trie_total_duration_histogram: Histogram,
-
-    /// Histogram of state updates received.
-    pub state_updates_received_histogram: Histogram,
-    /// Histogram of proofs processed.
-    pub proofs_processed_histogram: Histogram,
-    /// Histogram of total time spent in the multiproof task.
-    pub multiproof_task_total_duration_histogram: Histogram,
-    /// Total time spent waiting for the first state update or prefetch request.
-    pub first_update_wait_time_histogram: Histogram,
-    /// Total time spent waiting for the last proof result.
-    pub last_proof_wait_time_histogram: Histogram,
 }
 
 /// Standalone task that receives a transaction state stream and updates relevant
@@ -784,7 +453,7 @@ impl MultiProofTask {
         chunks
     }
 
-    // Returns true if all state updates finished and all proofs processed.
+    /// Returns true if all state updates finished and all proofs processed.
     fn is_done(
         &self,
         proofs_processed: u64,
@@ -1199,6 +868,265 @@ impl MultiProofTask {
                 .last_proof_wait_time_histogram
                 .record(updates_finished_time.elapsed().as_secs_f64());
         }
+    }
+}
+
+#[derive(Metrics, Clone)]
+#[metrics(scope = "tree.root")]
+pub(crate) struct MultiProofTaskMetrics {
+    /// Histogram of inflight multiproofs.
+    pub inflight_multiproofs_histogram: Histogram,
+    /// Histogram of pending storage multiproofs in the queue.
+    pub pending_storage_multiproofs_histogram: Histogram,
+    /// Histogram of pending account multiproofs in the queue.
+    pub pending_account_multiproofs_histogram: Histogram,
+
+    /// Histogram of the number of prefetch proof target accounts.
+    pub prefetch_proof_targets_accounts_histogram: Histogram,
+    /// Histogram of the number of prefetch proof target storages.
+    pub prefetch_proof_targets_storages_histogram: Histogram,
+    /// Histogram of the number of prefetch proof target chunks.
+    pub prefetch_proof_chunks_histogram: Histogram,
+
+    /// Histogram of the number of state update proof target accounts.
+    pub state_update_proof_targets_accounts_histogram: Histogram,
+    /// Histogram of the number of state update proof target storages.
+    pub state_update_proof_targets_storages_histogram: Histogram,
+    /// Histogram of the number of state update proof target chunks.
+    pub state_update_proof_chunks_histogram: Histogram,
+
+    /// Histogram of proof calculation durations.
+    pub proof_calculation_duration_histogram: Histogram,
+
+    /// Histogram of sparse trie update durations.
+    pub sparse_trie_update_duration_histogram: Histogram,
+    /// Histogram of sparse trie final update durations.
+    pub sparse_trie_final_update_duration_histogram: Histogram,
+    /// Histogram of sparse trie total durations.
+    pub sparse_trie_total_duration_histogram: Histogram,
+
+    /// Histogram of state updates received.
+    pub state_updates_received_histogram: Histogram,
+    /// Histogram of proofs processed.
+    pub proofs_processed_histogram: Histogram,
+    /// Histogram of total time spent in the multiproof task.
+    pub multiproof_task_total_duration_histogram: Histogram,
+    /// Total time spent waiting for the first state update or prefetch request.
+    pub first_update_wait_time_histogram: Histogram,
+    /// Total time spent waiting for the last proof result.
+    pub last_proof_wait_time_histogram: Histogram,
+}
+
+/// A trie update that can be applied to sparse trie alongside the proofs for touched parts of the
+/// state.
+#[derive(Default, Debug)]
+pub struct SparseTrieUpdate {
+    /// The state update that was used to calculate the proof
+    pub(crate) state: HashedPostState,
+    /// The calculated multiproof
+    pub(crate) multiproof: DecodedMultiProof,
+}
+
+impl SparseTrieUpdate {
+    /// Returns true if the update is empty.
+    pub(super) fn is_empty(&self) -> bool {
+        self.state.is_empty() && self.multiproof.is_empty()
+    }
+
+    /// Construct update from multiproof.
+    #[cfg(test)]
+    pub(super) fn from_multiproof(multiproof: reth_trie::MultiProof) -> alloy_rlp::Result<Self> {
+        Ok(Self { multiproof: multiproof.try_into()?, ..Default::default() })
+    }
+
+    /// Extend update with contents of the other.
+    pub(super) fn extend(&mut self, other: Self) {
+        self.state.extend(other.state);
+        self.multiproof.extend(other.multiproof);
+    }
+}
+
+/// Common configuration for multi proof tasks
+#[derive(Debug, Clone)]
+pub(super) struct MultiProofConfig {
+    /// The sorted collection of cached in-memory intermediate trie nodes that
+    /// can be reused for computation.
+    pub nodes_sorted: Arc<TrieUpdatesSorted>,
+    /// The sorted in-memory overlay hashed state.
+    pub state_sorted: Arc<HashedPostStateSorted>,
+    /// The collection of prefix sets for the computation. Since the prefix sets _always_
+    /// invalidate the in-memory nodes, not all keys from `state_sorted` might be present here,
+    /// if we have cached nodes for them.
+    pub prefix_sets: Arc<TriePrefixSetsMut>,
+}
+
+impl MultiProofConfig {
+    /// Creates a new state root config from the trie input.
+    ///
+    /// This returns a cleared [`TrieInput`] so that we can reuse any allocated space in the
+    /// [`TrieInput`].
+    pub(super) fn from_input(mut input: TrieInput) -> (TrieInput, Self) {
+        let config = Self {
+            nodes_sorted: Arc::new(input.nodes.drain_into_sorted()),
+            state_sorted: Arc::new(input.state.drain_into_sorted()),
+            prefix_sets: Arc::new(input.prefix_sets.clone()),
+        };
+        (input.cleared(), config)
+    }
+}
+
+/// Messages used internally by the multi proof task.
+#[derive(Debug)]
+pub(super) enum MultiProofMessage {
+    /// Prefetch proof targets
+    PrefetchProofs(MultiProofTargets),
+    /// New state update from transaction execution with its source
+    StateUpdate(StateChangeSource, EvmState),
+    /// State update that can be applied to the sparse trie without any new proofs.
+    ///
+    /// It can be the case when all accounts and storage slots from the state update were already
+    /// fetched and revealed.
+    EmptyProof {
+        /// The index of this proof in the sequence of state updates
+        sequence_number: u64,
+        /// The state update that was used to calculate the proof
+        state: HashedPostState,
+    },
+    /// Signals state update stream end.
+    ///
+    /// This is triggered by block execution, indicating that no additional state updates are
+    /// expected.
+    FinishedStateUpdates,
+}
+
+/// A wrapper for the sender that signals completion when dropped.
+///
+/// This type is intended to be used in combination with the evm executor statehook.
+/// This should trigger once the block has been executed (after) the last state update has been
+/// sent. This triggers the exit condition of the multi proof task.
+#[derive(Deref, Debug)]
+pub(super) struct StateHookSender(CrossbeamSender<MultiProofMessage>);
+
+impl StateHookSender {
+    pub(crate) const fn new(inner: CrossbeamSender<MultiProofMessage>) -> Self {
+        Self(inner)
+    }
+}
+
+impl Drop for StateHookSender {
+    fn drop(&mut self) {
+        // Send completion signal when the sender is dropped
+        let _ = self.0.send(MultiProofMessage::FinishedStateUpdates);
+    }
+}
+
+/// Handle to track proof calculation ordering.
+#[derive(Debug, Default)]
+struct ProofSequencer {
+    /// The next proof sequence number to be produced.
+    next_sequence: u64,
+    /// The next sequence number expected to be delivered.
+    next_to_deliver: u64,
+    /// Buffer for out-of-order proofs and corresponding state updates
+    pending_proofs: BTreeMap<u64, SparseTrieUpdate>,
+}
+
+impl ProofSequencer {
+    /// Gets the next sequence number and increments the counter
+    const fn next_sequence(&mut self) -> u64 {
+        let seq = self.next_sequence;
+        self.next_sequence += 1;
+        seq
+    }
+
+    /// Adds a proof with the corresponding state update and returns all sequential proofs and state
+    /// updates if we have a continuous sequence
+    fn add_proof(&mut self, sequence: u64, update: SparseTrieUpdate) -> Vec<SparseTrieUpdate> {
+        if sequence >= self.next_to_deliver {
+            self.pending_proofs.insert(sequence, update);
+        }
+
+        // return early if we don't have the next expected proof
+        if !self.pending_proofs.contains_key(&self.next_to_deliver) {
+            return Vec::new()
+        }
+
+        let mut consecutive_proofs = Vec::with_capacity(self.pending_proofs.len());
+        let mut current_sequence = self.next_to_deliver;
+
+        // keep collecting proofs and state updates as long as we have consecutive sequence numbers
+        while let Some(pending) = self.pending_proofs.remove(&current_sequence) {
+            consecutive_proofs.push(pending);
+            current_sequence += 1;
+
+            // if we don't have the next number, stop collecting
+            if !self.pending_proofs.contains_key(&current_sequence) {
+                break;
+            }
+        }
+
+        self.next_to_deliver += consecutive_proofs.len() as u64;
+
+        consecutive_proofs
+    }
+
+    /// Returns true if we still have pending proofs
+    pub(crate) fn has_pending(&self) -> bool {
+        !self.pending_proofs.is_empty()
+    }
+}
+
+pub(crate) fn evm_state_to_hashed_post_state(update: EvmState) -> HashedPostState {
+    let mut hashed_state = HashedPostState::with_capacity(update.len());
+
+    for (address, account) in update {
+        if account.is_touched() {
+            let hashed_address = keccak256(address);
+            trace!(target: "engine::tree::payload_processor::multiproof", ?address, ?hashed_address, "Adding account to state update");
+
+            let destroyed = account.is_selfdestructed();
+            let info = if destroyed { None } else { Some(account.info.into()) };
+            hashed_state.accounts.insert(hashed_address, info);
+
+            let mut changed_storage_iter = account
+                .storage
+                .into_iter()
+                .filter(|(_slot, value)| value.is_changed())
+                .map(|(slot, value)| (keccak256(B256::from(slot)), value.present_value))
+                .peekable();
+
+            if destroyed {
+                hashed_state.storages.insert(hashed_address, HashedStorage::new(true));
+            } else if changed_storage_iter.peek().is_some() {
+                hashed_state
+                    .storages
+                    .insert(hashed_address, HashedStorage::from_iter(false, changed_storage_iter));
+            }
+        }
+    }
+
+    hashed_state
+}
+
+/// Input parameters for dispatching a multiproof calculation.
+#[derive(Debug)]
+struct MultiproofInput {
+    config: MultiProofConfig,
+    source: Option<StateChangeSource>,
+    hashed_state_update: HashedPostState,
+    proof_targets: MultiProofTargets,
+    proof_sequence_number: u64,
+    state_root_message_sender: CrossbeamSender<MultiProofMessage>,
+    multi_added_removed_keys: Option<Arc<MultiAddedRemovedKeys>>,
+}
+
+impl MultiproofInput {
+    /// Destroys the input and sends a [`MultiProofMessage::EmptyProof`] message to the sender.
+    fn send_empty_proof(self) {
+        let _ = self.state_root_message_sender.send(MultiProofMessage::EmptyProof {
+            sequence_number: self.proof_sequence_number,
+            state: self.hashed_state_update,
+        });
     }
 }
 

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -88,7 +88,7 @@ impl ParallelProof {
         self
     }
     /// Queues a storage proof task and returns a receiver for the result.
-    fn queue_storage_proof(
+    fn send_storage_proof(
         &self,
         hashed_address: B256,
         prefix_set: PrefixSet,
@@ -132,7 +132,7 @@ impl ParallelProof {
             "Starting storage proof generation"
         );
 
-        let receiver = self.queue_storage_proof(hashed_address, prefix_set, target_slots)?;
+        let receiver = self.send_storage_proof(hashed_address, prefix_set, target_slots)?;
         let proof_msg = receiver.recv().map_err(|_| {
             ParallelStateRootError::StorageRoot(StorageRootError::Database(DatabaseError::Other(
                 format!("channel closed for {hashed_address}"),

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -139,15 +139,20 @@ impl ParallelProof {
             )))
         })?;
 
-        // Extract the multiproof from the result
-        let (mut multiproof, _stats) = proof_msg.result?;
-
-        // Extract storage proof from the multiproof
-        let storage_proof = multiproof.storages.remove(&hashed_address).ok_or_else(|| {
-            ParallelStateRootError::StorageRoot(StorageRootError::Database(DatabaseError::Other(
-                format!("storage proof not found in multiproof for {hashed_address}"),
-            )))
-        })?;
+        // Extract storage proof directly from the result
+        let storage_proof = match proof_msg.result? {
+            crate::proof_task::ProofResult::StorageProof { hashed_address: addr, proof } => {
+                debug_assert_eq!(
+                    addr,
+                    hashed_address,
+                    "storage worker must return same address: expected {hashed_address}, got {addr}"
+                );
+                proof
+            }
+            crate::proof_task::ProofResult::AccountMultiproof(..) => {
+                unreachable!("storage worker only sends StorageProof variant")
+            }
+        };
 
         trace!(
             target: "trie::parallel_proof",
@@ -231,7 +236,14 @@ impl ParallelProof {
             )
         })?;
 
-        let (multiproof, stats) = proof_result_msg.result?;
+        let (multiproof, stats) = match proof_result_msg.result? {
+            crate::proof_task::ProofResult::AccountMultiproof(multiproof, stats) => {
+                (multiproof, stats)
+            }
+            crate::proof_task::ProofResult::StorageProof { .. } => {
+                unreachable!("account worker only sends AccountMultiproof variant")
+            }
+        };
 
         #[cfg(feature = "metrics")]
         self.metrics.record(stats);

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -143,7 +143,7 @@ impl ProofWorkerHandle {
 
         let storage_worker_parent =
             debug_span!(target: "trie::proof_task", "Storage worker tasks", ?storage_worker_count);
-        let _guard = storage_worker_parent.enter();
+        let _span_guard = storage_worker_parent.enter();
 
         // Spawn storage workers
         for worker_id in 0..storage_worker_count {
@@ -157,7 +157,7 @@ impl ProofWorkerHandle {
                 #[cfg(feature = "metrics")]
                 let metrics = ProofTaskTrieMetrics::default();
 
-                let _guard = parent_span.enter();
+                let _span_guard = parent_span.enter();
                 storage_worker_loop(
                     view_clone,
                     task_ctx_clone,
@@ -176,11 +176,11 @@ impl ProofWorkerHandle {
             );
         }
 
-        drop(_guard);
+        drop(_span_guard);
 
         let account_worker_parent =
             debug_span!(target: "trie::proof_task", "Account worker tasks", ?account_worker_count);
-        let _guard = account_worker_parent.enter();
+        let _span_guard = account_worker_parent.enter();
 
         // Spawn account workers
         for worker_id in 0..account_worker_count {
@@ -195,7 +195,7 @@ impl ProofWorkerHandle {
                 #[cfg(feature = "metrics")]
                 let metrics = ProofTaskTrieMetrics::default();
 
-                let _guard = parent_span.enter();
+                let _span_guard = parent_span.enter();
                 account_worker_loop(
                     view_clone,
                     task_ctx_clone,
@@ -215,7 +215,7 @@ impl ProofWorkerHandle {
             );
         }
 
-        drop(_guard);
+        drop(_span_guard);
 
         Self::new_handle(
             storage_work_tx,

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -564,6 +564,21 @@ pub enum ProofResult {
     },
 }
 
+impl ProofResult {
+    /// Convert this proof result into a `DecodedMultiProof`.
+    ///
+    /// For account multiproofs, returns the multiproof directly (discarding stats).
+    /// For storage proofs, wraps the storage proof into a minimal multiproof.
+    pub fn into_multiproof(self) -> DecodedMultiProof {
+        match self {
+            ProofResult::AccountMultiproof(multiproof, _stats) => multiproof,
+            ProofResult::StorageProof { hashed_address, proof } => {
+                DecodedMultiProof::from_storage_proof(hashed_address, proof)
+            }
+        }
+    }
+}
+
 /// Channel used by worker threads to deliver `ProofResultMessage` items back to
 /// `MultiProofTask`.
 ///

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -571,8 +571,8 @@ impl ProofResult {
     /// For storage proofs, wraps the storage proof into a minimal multiproof.
     pub fn into_multiproof(self) -> DecodedMultiProof {
         match self {
-            ProofResult::AccountMultiproof(multiproof, _stats) => multiproof,
-            ProofResult::StorageProof { hashed_address, proof } => {
+            Self::AccountMultiproof(multiproof, _stats) => multiproof,
+            Self::StorageProof { hashed_address, proof } => {
                 DecodedMultiProof::from_storage_proof(hashed_address, proof)
             }
         }
@@ -1146,17 +1146,15 @@ where
                         // Extract storage proof from the result
                         let proof = match proof_msg.result? {
                             ProofResult::StorageProof { hashed_address: addr, proof } => {
-                                if addr != hashed_address {
-                                    return Err(ParallelStateRootError::Other(format!(
-                                        "storage proof address mismatch: expected {hashed_address}, got {addr}"
-                                    )));
-                                }
+                                debug_assert_eq!(
+                                    addr,
+                                    hashed_address,
+                                    "storage worker must return same address: expected {hashed_address}, got {addr}"
+                                );
                                 proof
                             }
                             ProofResult::AccountMultiproof(..) => {
-                                return Err(ParallelStateRootError::Other(
-                                    "expected storage proof, got account multiproof".to_string(),
-                                ));
+                                unreachable!("storage worker only sends StorageProof variant")
                             }
                         };
 

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -939,6 +939,8 @@ fn account_worker_loop<Factory>(
                             elapsed: start.elapsed(),
                             state,
                         });
+                        // Mark worker as available again before skipping the job.
+                        available_workers.fetch_add(1, Ordering::Relaxed);
                         continue;
                     }
                 };

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -77,15 +77,492 @@ use std::{
     time::{Duration, Instant},
 };
 use tokio::runtime::Handle;
-use tracing::{debug, debug_span, error, trace};
+use tracing::{debug_span, error, trace};
 
 #[cfg(feature = "metrics")]
 use crate::proof_task_metrics::ProofTaskTrieMetrics;
 
 type StorageProofResult = Result<DecodedStorageMultiProof, ParallelStateRootError>;
 type TrieNodeProviderResult = Result<Option<RevealedNode>, SparseTrieError>;
-type AccountMultiproofResult =
-    Result<(DecodedMultiProof, ParallelTrieStats), ParallelStateRootError>;
+
+/// A handle that provides type-safe access to proof worker pools.
+///
+/// The handle stores direct senders to both storage and account worker pools,
+/// eliminating the need for a routing thread. All handles share reference-counted
+/// channels, and workers shut down gracefully when all handles are dropped.
+#[derive(Debug, Clone)]
+pub struct ProofWorkerHandle {
+    /// Direct sender to storage worker pool
+    storage_work_tx: CrossbeamSender<StorageWorkerJob>,
+    /// Direct sender to account worker pool
+    account_work_tx: CrossbeamSender<AccountWorkerJob>,
+    /// Counter tracking available storage workers. Workers decrement when starting work,
+    /// increment when finishing. Used to determine whether to chunk multiproofs.
+    storage_available_workers: Arc<AtomicUsize>,
+    /// Counter tracking available account workers. Workers decrement when starting work,
+    /// increment when finishing. Used to determine whether to chunk multiproofs.
+    account_available_workers: Arc<AtomicUsize>,
+}
+
+impl ProofWorkerHandle {
+    /// Spawns storage and account worker pools with dedicated database transactions.
+    ///
+    /// Returns a handle for submitting proof tasks to the worker pools.
+    /// Workers run until the last handle is dropped.
+    ///
+    /// # Parameters
+    /// - `executor`: Tokio runtime handle for spawning blocking tasks
+    /// - `view`: Consistent database view for creating transactions
+    /// - `task_ctx`: Shared context with trie updates and prefix sets
+    /// - `storage_worker_count`: Number of storage workers to spawn
+    /// - `account_worker_count`: Number of account workers to spawn
+    pub fn new<Factory>(
+        executor: Handle,
+        view: ConsistentDbView<Factory>,
+        task_ctx: ProofTaskCtx,
+        storage_worker_count: usize,
+        account_worker_count: usize,
+    ) -> Self
+    where
+        Factory: DatabaseProviderFactory<Provider: BlockReader> + Clone + 'static,
+    {
+        let (storage_work_tx, storage_work_rx) = unbounded::<StorageWorkerJob>();
+        let (account_work_tx, account_work_rx) = unbounded::<AccountWorkerJob>();
+
+        // Initialize availability counters at zero. Each worker will increment when it
+        // successfully initializes, ensuring only healthy workers are counted.
+        let storage_available_workers = Arc::new(AtomicUsize::new(0));
+        let account_available_workers = Arc::new(AtomicUsize::new(0));
+
+        tracing::debug!(
+            target: "trie::proof_task",
+            storage_worker_count,
+            account_worker_count,
+            "Spawning proof worker pools"
+        );
+
+        let storage_worker_parent =
+            debug_span!(target: "trie::proof_task", "Storage worker tasks", ?storage_worker_count);
+        let _guard = storage_worker_parent.enter();
+
+        // Spawn storage workers
+        for worker_id in 0..storage_worker_count {
+            let parent_span = debug_span!(target: "trie::proof_task", "Storage worker", ?worker_id);
+            let view_clone = view.clone();
+            let task_ctx_clone = task_ctx.clone();
+            let work_rx_clone = storage_work_rx.clone();
+            let storage_available_workers_clone = storage_available_workers.clone();
+
+            executor.spawn_blocking(move || {
+                #[cfg(feature = "metrics")]
+                let metrics = ProofTaskTrieMetrics::default();
+
+                let _guard = parent_span.enter();
+                storage_worker_loop(
+                    view_clone,
+                    task_ctx_clone,
+                    work_rx_clone,
+                    worker_id,
+                    storage_available_workers_clone,
+                    #[cfg(feature = "metrics")]
+                    metrics,
+                )
+            });
+
+            tracing::debug!(
+                target: "trie::proof_task",
+                worker_id,
+                "Storage worker spawned successfully"
+            );
+        }
+
+        drop(_guard);
+
+        let account_worker_parent =
+            debug_span!(target: "trie::proof_task", "Account worker tasks", ?account_worker_count);
+        let _guard = account_worker_parent.enter();
+
+        // Spawn account workers
+        for worker_id in 0..account_worker_count {
+            let parent_span = debug_span!(target: "trie::proof_task", "Account worker", ?worker_id);
+            let view_clone = view.clone();
+            let task_ctx_clone = task_ctx.clone();
+            let work_rx_clone = account_work_rx.clone();
+            let storage_work_tx_clone = storage_work_tx.clone();
+            let account_available_workers_clone = account_available_workers.clone();
+
+            executor.spawn_blocking(move || {
+                #[cfg(feature = "metrics")]
+                let metrics = ProofTaskTrieMetrics::default();
+
+                let _guard = parent_span.enter();
+                account_worker_loop(
+                    view_clone,
+                    task_ctx_clone,
+                    work_rx_clone,
+                    storage_work_tx_clone,
+                    worker_id,
+                    account_available_workers_clone,
+                    #[cfg(feature = "metrics")]
+                    metrics,
+                )
+            });
+
+            tracing::debug!(
+                target: "trie::proof_task",
+                worker_id,
+                "Account worker spawned successfully"
+            );
+        }
+
+        drop(_guard);
+
+        Self::new_handle(
+            storage_work_tx,
+            account_work_tx,
+            storage_available_workers,
+            account_available_workers,
+        )
+    }
+
+    /// Creates a new [`ProofWorkerHandle`] with direct access to worker pools.
+    ///
+    /// This is an internal constructor used for creating handles.
+    const fn new_handle(
+        storage_work_tx: CrossbeamSender<StorageWorkerJob>,
+        account_work_tx: CrossbeamSender<AccountWorkerJob>,
+        storage_available_workers: Arc<AtomicUsize>,
+        account_available_workers: Arc<AtomicUsize>,
+    ) -> Self {
+        Self {
+            storage_work_tx,
+            account_work_tx,
+            storage_available_workers,
+            account_available_workers,
+        }
+    }
+
+    /// Returns true if there are available storage workers to process tasks.
+    pub fn has_available_storage_workers(&self) -> bool {
+        self.storage_available_workers.load(Ordering::Relaxed) > 0
+    }
+
+    /// Returns true if there are available account workers to process tasks.
+    pub fn has_available_account_workers(&self) -> bool {
+        self.account_available_workers.load(Ordering::Relaxed) > 0
+    }
+
+    /// Returns the number of pending storage tasks in the queue.
+    pub fn pending_storage_tasks(&self) -> usize {
+        self.storage_work_tx.len()
+    }
+
+    /// Returns the number of pending account tasks in the queue.
+    pub fn pending_account_tasks(&self) -> usize {
+        self.account_work_tx.len()
+    }
+
+    /// Dispatch a storage proof computation to storage worker pool
+    ///
+    /// The result will be sent via the `proof_result_sender` channel.
+    pub fn dispatch_storage_proof(
+        &self,
+        input: StorageProofInput,
+        proof_result_sender: ProofResultContext,
+    ) -> Result<(), ProviderError> {
+        self.storage_work_tx
+            .send(StorageWorkerJob::StorageProof { input, proof_result_sender })
+            .map_err(|err| {
+                let error =
+                    ProviderError::other(std::io::Error::other("storage workers unavailable"));
+
+                if let StorageWorkerJob::StorageProof { proof_result_sender, .. } = err.0 {
+                    let ProofResultContext {
+                        sender: result_tx,
+                        sequence_number: seq,
+                        state,
+                        start_time: start,
+                    } = proof_result_sender;
+
+                    let _ = result_tx.send(ProofResultMessage {
+                        sequence_number: seq,
+                        result: Err(ParallelStateRootError::Provider(error.clone())),
+                        elapsed: start.elapsed(),
+                        state,
+                    });
+                }
+
+                error
+            })
+    }
+
+    /// Dispatch an account multiproof computation
+    ///
+    /// The result will be sent via the `result_sender` channel included in the input.
+    pub fn dispatch_account_multiproof(
+        &self,
+        input: AccountMultiproofInput,
+    ) -> Result<(), ProviderError> {
+        self.account_work_tx
+            .send(AccountWorkerJob::AccountMultiproof { input: Box::new(input) })
+            .map_err(|err| {
+                let error =
+                    ProviderError::other(std::io::Error::other("account workers unavailable"));
+
+                if let AccountWorkerJob::AccountMultiproof { input } = err.0 {
+                    let AccountMultiproofInput {
+                        proof_result_sender:
+                            ProofResultContext {
+                                sender: result_tx,
+                                sequence_number: seq,
+                                state,
+                                start_time: start,
+                            },
+                        ..
+                    } = *input;
+
+                    let _ = result_tx.send(ProofResultMessage {
+                        sequence_number: seq,
+                        result: Err(ParallelStateRootError::Provider(error.clone())),
+                        elapsed: start.elapsed(),
+                        state,
+                    });
+                }
+
+                error
+            })
+    }
+
+    /// Dispatch blinded storage node request to storage worker pool
+    pub(crate) fn dispatch_blinded_storage_node(
+        &self,
+        account: B256,
+        path: Nibbles,
+    ) -> Result<Receiver<TrieNodeProviderResult>, ProviderError> {
+        let (tx, rx) = channel();
+        self.storage_work_tx
+            .send(StorageWorkerJob::BlindedStorageNode { account, path, result_sender: tx })
+            .map_err(|_| {
+                ProviderError::other(std::io::Error::other("storage workers unavailable"))
+            })?;
+
+        Ok(rx)
+    }
+
+    /// Dispatch blinded account node request to account worker pool
+    pub(crate) fn dispatch_blinded_account_node(
+        &self,
+        path: Nibbles,
+    ) -> Result<Receiver<TrieNodeProviderResult>, ProviderError> {
+        let (tx, rx) = channel();
+        self.account_work_tx
+            .send(AccountWorkerJob::BlindedAccountNode { path, result_sender: tx })
+            .map_err(|_| {
+                ProviderError::other(std::io::Error::other("account workers unavailable"))
+            })?;
+
+        Ok(rx)
+    }
+}
+
+/// Data used for initializing cursor factories that is shared across all storage proof instances.
+#[derive(Debug, Clone)]
+pub struct ProofTaskCtx {
+    /// The sorted collection of cached in-memory intermediate trie nodes that can be reused for
+    /// computation.
+    nodes_sorted: Arc<TrieUpdatesSorted>,
+    /// The sorted in-memory overlay hashed state.
+    state_sorted: Arc<HashedPostStateSorted>,
+    /// The collection of prefix sets for the computation. Since the prefix sets _always_
+    /// invalidate the in-memory nodes, not all keys from `state_sorted` might be present here,
+    /// if we have cached nodes for them.
+    prefix_sets: Arc<TriePrefixSetsMut>,
+}
+
+impl ProofTaskCtx {
+    /// Creates a new [`ProofTaskCtx`] with the given sorted nodes and state.
+    pub const fn new(
+        nodes_sorted: Arc<TrieUpdatesSorted>,
+        state_sorted: Arc<HashedPostStateSorted>,
+        prefix_sets: Arc<TriePrefixSetsMut>,
+    ) -> Self {
+        Self { nodes_sorted, state_sorted, prefix_sets }
+    }
+}
+
+/// Type alias for the factory tuple returned by [`ProofTaskTx::create_factories`].
+type ProofFactories<'a, Tx> = (
+    InMemoryTrieCursorFactory<DatabaseTrieCursorFactory<&'a Tx>, &'a TrieUpdatesSorted>,
+    HashedPostStateCursorFactory<DatabaseHashedCursorFactory<&'a Tx>, &'a HashedPostStateSorted>,
+);
+
+/// This contains all information shared between all storage proof instances.
+#[derive(Debug)]
+pub struct ProofTaskTx<Tx> {
+    /// The tx that is reused for proof calculations.
+    tx: Tx,
+    /// Trie updates, prefix sets, and state updates
+    task_ctx: ProofTaskCtx,
+    /// Identifier for the worker within the worker pool, used only for tracing.
+    id: usize,
+}
+
+impl<Tx> ProofTaskTx<Tx> {
+    /// Initializes a [`ProofTaskTx`] using the given transaction and a [`ProofTaskCtx`]. The id is
+    /// used only for tracing.
+    const fn new(tx: Tx, task_ctx: ProofTaskCtx, id: usize) -> Self {
+        Self { tx, task_ctx, id }
+    }
+}
+
+impl<Tx> ProofTaskTx<Tx>
+where
+    Tx: DbTx,
+{
+    #[inline]
+    fn create_factories(&self) -> ProofFactories<'_, Tx> {
+        let trie_cursor_factory = InMemoryTrieCursorFactory::new(
+            DatabaseTrieCursorFactory::new(&self.tx),
+            self.task_ctx.nodes_sorted.as_ref(),
+        );
+
+        let hashed_cursor_factory = HashedPostStateCursorFactory::new(
+            DatabaseHashedCursorFactory::new(&self.tx),
+            self.task_ctx.state_sorted.as_ref(),
+        );
+
+        (trie_cursor_factory, hashed_cursor_factory)
+    }
+
+    /// Compute storage proof with pre-created factories.
+    ///
+    /// Accepts cursor factories as parameters to allow reuse across multiple proofs.
+    /// Used by storage workers in the worker pool to avoid factory recreation
+    /// overhead on each proof computation.
+    #[inline]
+    fn compute_storage_proof(
+        &self,
+        input: StorageProofInput,
+        trie_cursor_factory: impl TrieCursorFactory,
+        hashed_cursor_factory: impl HashedCursorFactory,
+    ) -> StorageProofResult {
+        // Consume the input so we can move large collections (e.g. target slots) without cloning.
+        let StorageProofInput {
+            hashed_address,
+            prefix_set,
+            target_slots,
+            with_branch_node_masks,
+            multi_added_removed_keys,
+        } = input;
+
+        // Get or create added/removed keys context
+        let multi_added_removed_keys =
+            multi_added_removed_keys.unwrap_or_else(|| Arc::new(MultiAddedRemovedKeys::new()));
+        let added_removed_keys = multi_added_removed_keys.get_storage(&hashed_address);
+
+        let span = tracing::debug_span!(
+            target: "trie::proof_task",
+            "Storage proof calculation",
+            hashed_address = ?hashed_address,
+            worker_id = self.id,
+        );
+        let _span_guard = span.enter();
+
+        let proof_start = Instant::now();
+
+        // Compute raw storage multiproof
+        let raw_proof_result =
+            StorageProof::new_hashed(trie_cursor_factory, hashed_cursor_factory, hashed_address)
+                .with_prefix_set_mut(PrefixSetMut::from(prefix_set.iter().copied()))
+                .with_branch_node_masks(with_branch_node_masks)
+                .with_added_removed_keys(added_removed_keys)
+                .storage_multiproof(target_slots)
+                .map_err(|e| ParallelStateRootError::Other(e.to_string()));
+
+        // Decode proof into DecodedStorageMultiProof
+        let decoded_result = raw_proof_result.and_then(|raw_proof| {
+            raw_proof.try_into().map_err(|e: alloy_rlp::Error| {
+                ParallelStateRootError::Other(format!(
+                    "Failed to decode storage proof for {}: {}",
+                    hashed_address, e
+                ))
+            })
+        });
+
+        trace!(
+            target: "trie::proof_task",
+            hashed_address = ?hashed_address,
+            proof_time_us = proof_start.elapsed().as_micros(),
+            worker_id = self.id,
+            "Completed storage proof calculation"
+        );
+
+        decoded_result
+    }
+}
+
+impl TrieNodeProviderFactory for ProofWorkerHandle {
+    type AccountNodeProvider = ProofTaskTrieNodeProvider;
+    type StorageNodeProvider = ProofTaskTrieNodeProvider;
+
+    fn account_node_provider(&self) -> Self::AccountNodeProvider {
+        ProofTaskTrieNodeProvider::AccountNode { handle: self.clone() }
+    }
+
+    fn storage_node_provider(&self, account: B256) -> Self::StorageNodeProvider {
+        ProofTaskTrieNodeProvider::StorageNode { account, handle: self.clone() }
+    }
+}
+
+/// Trie node provider for retrieving trie nodes by path.
+#[derive(Debug)]
+pub enum ProofTaskTrieNodeProvider {
+    /// Blinded account trie node provider.
+    AccountNode {
+        /// Handle to the proof worker pools.
+        handle: ProofWorkerHandle,
+    },
+    /// Blinded storage trie node provider.
+    StorageNode {
+        /// Target account.
+        account: B256,
+        /// Handle to the proof worker pools.
+        handle: ProofWorkerHandle,
+    },
+}
+
+impl TrieNodeProvider for ProofTaskTrieNodeProvider {
+    fn trie_node(&self, path: &Nibbles) -> Result<Option<RevealedNode>, SparseTrieError> {
+        match self {
+            Self::AccountNode { handle } => {
+                let rx = handle
+                    .dispatch_blinded_account_node(*path)
+                    .map_err(|error| SparseTrieErrorKind::Other(Box::new(error)))?;
+                rx.recv().map_err(|error| SparseTrieErrorKind::Other(Box::new(error)))?
+            }
+            Self::StorageNode { handle, account } => {
+                let rx = handle
+                    .dispatch_blinded_storage_node(*account, *path)
+                    .map_err(|error| SparseTrieErrorKind::Other(Box::new(error)))?;
+                rx.recv().map_err(|error| SparseTrieErrorKind::Other(Box::new(error)))?
+            }
+        }
+    }
+}
+
+/// Result of a proof calculation, which can be either an account multiproof or a storage proof.
+#[derive(Debug)]
+pub enum ProofResult {
+    /// Account multiproof with statistics
+    AccountMultiproof(DecodedMultiProof, ParallelTrieStats),
+    /// Storage proof for a specific account
+    StorageProof {
+        /// The hashed address this storage proof belongs to
+        hashed_address: B256,
+        /// The storage multiproof
+        proof: DecodedStorageMultiProof,
+    },
+}
 
 /// Channel used by worker threads to deliver `ProofResultMessage` items back to
 /// `MultiProofTask`.
@@ -101,8 +578,8 @@ pub type ProofResultSender = CrossbeamSender<ProofResultMessage>;
 pub struct ProofResultMessage {
     /// Sequence number for ordering proofs
     pub sequence_number: u64,
-    /// The proof calculation result
-    pub result: AccountMultiproofResult,
+    /// The proof calculation result (either account multiproof or storage proof)
+    pub result: Result<ProofResult, ParallelStateRootError>,
     /// Time taken for the entire proof calculation (from dispatch to completion)
     pub elapsed: Duration,
     /// Original state update that triggered this proof
@@ -248,18 +725,10 @@ fn storage_worker_loop<Factory>(
                 let proof_elapsed = proof_start.elapsed();
                 storage_proofs_processed += 1;
 
-                // Convert storage proof to account multiproof format
-                let result_msg = match result {
-                    Ok(storage_proof) => {
-                        let multiproof = reth_trie::DecodedMultiProof::from_storage_proof(
-                            hashed_address,
-                            storage_proof,
-                        );
-                        let stats = crate::stats::ParallelTrieTracker::default().finish();
-                        Ok((multiproof, stats))
-                    }
-                    Err(e) => Err(e),
-                };
+                let result_msg = result.map(|storage_proof| ProofResult::StorageProof {
+                    hashed_address,
+                    proof: storage_proof,
+                });
 
                 if sender
                     .send(ProofResultMessage {
@@ -496,7 +965,7 @@ fn account_worker_loop<Factory>(
                 let proof_elapsed = proof_start.elapsed();
                 let total_elapsed = start.elapsed();
                 let stats = tracker.finish();
-                let result = result.map(|proof| (proof, stats));
+                let result = result.map(|proof| ProofResult::AccountMultiproof(proof, stats));
                 account_proofs_processed += 1;
 
                 // Send result to MultiProofTask
@@ -716,9 +1185,9 @@ where
     // Consume remaining storage proof receivers for accounts not encountered during trie walk.
     for (hashed_address, receiver) in storage_proof_receivers {
         if let Ok(proof_msg) = receiver.recv() {
-            // Extract storage proof from the multiproof wrapper
-            if let Ok((mut multiproof, _stats)) = proof_msg.result &&
-                let Some(proof) = multiproof.storages.remove(&hashed_address)
+            // Extract storage proof from the result
+            if let Ok(ProofResult::StorageProof { hashed_address: addr, proof }) = proof_msg.result &&
+                addr == hashed_address
             {
                 collected_decoded_storages.insert(hashed_address, proof);
             }
@@ -807,119 +1276,6 @@ fn dispatch_storage_proofs(
     Ok(storage_proof_receivers)
 }
 
-/// Type alias for the factory tuple returned by `create_factories`
-type ProofFactories<'a, Tx> = (
-    InMemoryTrieCursorFactory<DatabaseTrieCursorFactory<&'a Tx>, &'a TrieUpdatesSorted>,
-    HashedPostStateCursorFactory<DatabaseHashedCursorFactory<&'a Tx>, &'a HashedPostStateSorted>,
-);
-
-/// This contains all information shared between all storage proof instances.
-#[derive(Debug)]
-pub struct ProofTaskTx<Tx> {
-    /// The tx that is reused for proof calculations.
-    tx: Tx,
-
-    /// Trie updates, prefix sets, and state updates
-    task_ctx: ProofTaskCtx,
-
-    /// Identifier for the worker within the worker pool, used only for tracing.
-    id: usize,
-}
-
-impl<Tx> ProofTaskTx<Tx> {
-    /// Initializes a [`ProofTaskTx`] using the given transaction and a [`ProofTaskCtx`]. The id is
-    /// used only for tracing.
-    const fn new(tx: Tx, task_ctx: ProofTaskCtx, id: usize) -> Self {
-        Self { tx, task_ctx, id }
-    }
-}
-
-impl<Tx> ProofTaskTx<Tx>
-where
-    Tx: DbTx,
-{
-    #[inline]
-    fn create_factories(&self) -> ProofFactories<'_, Tx> {
-        let trie_cursor_factory = InMemoryTrieCursorFactory::new(
-            DatabaseTrieCursorFactory::new(&self.tx),
-            self.task_ctx.nodes_sorted.as_ref(),
-        );
-
-        let hashed_cursor_factory = HashedPostStateCursorFactory::new(
-            DatabaseHashedCursorFactory::new(&self.tx),
-            self.task_ctx.state_sorted.as_ref(),
-        );
-
-        (trie_cursor_factory, hashed_cursor_factory)
-    }
-
-    /// Compute storage proof with pre-created factories.
-    ///
-    /// Accepts cursor factories as parameters to allow reuse across multiple proofs.
-    /// Used by storage workers in the worker pool to avoid factory recreation
-    /// overhead on each proof computation.
-    #[inline]
-    fn compute_storage_proof(
-        &self,
-        input: StorageProofInput,
-        trie_cursor_factory: impl TrieCursorFactory,
-        hashed_cursor_factory: impl HashedCursorFactory,
-    ) -> StorageProofResult {
-        // Consume the input so we can move large collections (e.g. target slots) without cloning.
-        let StorageProofInput {
-            hashed_address,
-            prefix_set,
-            target_slots,
-            with_branch_node_masks,
-            multi_added_removed_keys,
-        } = input;
-
-        // Get or create added/removed keys context
-        let multi_added_removed_keys =
-            multi_added_removed_keys.unwrap_or_else(|| Arc::new(MultiAddedRemovedKeys::new()));
-        let added_removed_keys = multi_added_removed_keys.get_storage(&hashed_address);
-
-        let span = debug_span!(
-            target: "trie::proof_task",
-            "Storage proof calculation",
-            hashed_address = ?hashed_address,
-            worker_id = self.id,
-        );
-        let _span_guard = span.enter();
-
-        let proof_start = Instant::now();
-
-        // Compute raw storage multiproof
-        let raw_proof_result =
-            StorageProof::new_hashed(trie_cursor_factory, hashed_cursor_factory, hashed_address)
-                .with_prefix_set_mut(PrefixSetMut::from(prefix_set.iter().copied()))
-                .with_branch_node_masks(with_branch_node_masks)
-                .with_added_removed_keys(added_removed_keys)
-                .storage_multiproof(target_slots)
-                .map_err(|e| ParallelStateRootError::Other(e.to_string()));
-
-        // Decode proof into DecodedStorageMultiProof
-        let decoded_result = raw_proof_result.and_then(|raw_proof| {
-            raw_proof.try_into().map_err(|e: alloy_rlp::Error| {
-                ParallelStateRootError::Other(format!(
-                    "Failed to decode storage proof for {}: {}",
-                    hashed_address, e
-                ))
-            })
-        });
-
-        trace!(
-            target: "trie::proof_task",
-            hashed_address = ?hashed_address,
-            proof_time_us = proof_start.elapsed().as_micros(),
-            worker_id = self.id,
-            "Completed storage proof calculation"
-        );
-
-        decoded_result
-    }
-}
-
 /// Input parameters for storage proof computation.
 #[derive(Debug)]
 pub struct StorageProofInput {
@@ -1003,327 +1359,6 @@ enum AccountWorkerJob {
         /// Channel to send result back to original caller
         result_sender: Sender<TrieNodeProviderResult>,
     },
-}
-
-/// Data used for initializing cursor factories that is shared across all storage proof instances.
-#[derive(Debug, Clone)]
-pub struct ProofTaskCtx {
-    /// The sorted collection of cached in-memory intermediate trie nodes that can be reused for
-    /// computation.
-    nodes_sorted: Arc<TrieUpdatesSorted>,
-    /// The sorted in-memory overlay hashed state.
-    state_sorted: Arc<HashedPostStateSorted>,
-    /// The collection of prefix sets for the computation. Since the prefix sets _always_
-    /// invalidate the in-memory nodes, not all keys from `state_sorted` might be present here,
-    /// if we have cached nodes for them.
-    prefix_sets: Arc<TriePrefixSetsMut>,
-}
-
-impl ProofTaskCtx {
-    /// Creates a new [`ProofTaskCtx`] with the given sorted nodes and state.
-    pub const fn new(
-        nodes_sorted: Arc<TrieUpdatesSorted>,
-        state_sorted: Arc<HashedPostStateSorted>,
-        prefix_sets: Arc<TriePrefixSetsMut>,
-    ) -> Self {
-        Self { nodes_sorted, state_sorted, prefix_sets }
-    }
-}
-
-/// A handle that provides type-safe access to proof worker pools.
-///
-/// The handle stores direct senders to both storage and account worker pools,
-/// eliminating the need for a routing thread. All handles share reference-counted
-/// channels, and workers shut down gracefully when all handles are dropped.
-#[derive(Debug, Clone)]
-pub struct ProofWorkerHandle {
-    /// Direct sender to storage worker pool
-    storage_work_tx: CrossbeamSender<StorageWorkerJob>,
-    /// Direct sender to account worker pool
-    account_work_tx: CrossbeamSender<AccountWorkerJob>,
-    /// Counter tracking available storage workers. Workers decrement when starting work,
-    /// increment when finishing. Used to determine whether to chunk multiproofs.
-    storage_available_workers: Arc<AtomicUsize>,
-    /// Counter tracking available account workers. Workers decrement when starting work,
-    /// increment when finishing. Used to determine whether to chunk multiproofs.
-    account_available_workers: Arc<AtomicUsize>,
-}
-
-impl ProofWorkerHandle {
-    /// Spawns storage and account worker pools with dedicated database transactions.
-    ///
-    /// Returns a handle for submitting proof tasks to the worker pools.
-    /// Workers run until the last handle is dropped.
-    ///
-    /// # Parameters
-    /// - `executor`: Tokio runtime handle for spawning blocking tasks
-    /// - `view`: Consistent database view for creating transactions
-    /// - `task_ctx`: Shared context with trie updates and prefix sets
-    /// - `storage_worker_count`: Number of storage workers to spawn
-    /// - `account_worker_count`: Number of account workers to spawn
-    pub fn new<Factory>(
-        executor: Handle,
-        view: ConsistentDbView<Factory>,
-        task_ctx: ProofTaskCtx,
-        storage_worker_count: usize,
-        account_worker_count: usize,
-    ) -> Self
-    where
-        Factory: DatabaseProviderFactory<Provider: BlockReader> + Clone + 'static,
-    {
-        let (storage_work_tx, storage_work_rx) = unbounded::<StorageWorkerJob>();
-        let (account_work_tx, account_work_rx) = unbounded::<AccountWorkerJob>();
-
-        // Initialize availability counters at zero. Each worker will increment when it
-        // successfully initializes, ensuring only healthy workers are counted.
-        let storage_available_workers = Arc::new(AtomicUsize::new(0));
-        let account_available_workers = Arc::new(AtomicUsize::new(0));
-
-        debug!(
-            target: "trie::proof_task",
-            storage_worker_count,
-            account_worker_count,
-            "Spawning proof worker pools"
-        );
-
-        let parent_span =
-            debug_span!(target: "trie::proof_task", "storage proof workers", ?storage_worker_count)
-                .entered();
-        // Spawn storage workers
-        for worker_id in 0..storage_worker_count {
-            let span = debug_span!(target: "trie::proof_task", "storage worker", ?worker_id);
-            let view_clone = view.clone();
-            let task_ctx_clone = task_ctx.clone();
-            let work_rx_clone = storage_work_rx.clone();
-            let storage_available_workers_clone = storage_available_workers.clone();
-
-            executor.spawn_blocking(move || {
-                #[cfg(feature = "metrics")]
-                let metrics = ProofTaskTrieMetrics::default();
-
-                let _guard = span.enter();
-                storage_worker_loop(
-                    view_clone,
-                    task_ctx_clone,
-                    work_rx_clone,
-                    worker_id,
-                    storage_available_workers_clone,
-                    #[cfg(feature = "metrics")]
-                    metrics,
-                )
-            });
-        }
-        drop(parent_span);
-
-        let parent_span =
-            debug_span!(target: "trie::proof_task", "account proof workers", ?storage_worker_count)
-                .entered();
-        // Spawn account workers
-        for worker_id in 0..account_worker_count {
-            let span = debug_span!(target: "trie::proof_task", "account worker", ?worker_id);
-            let view_clone = view.clone();
-            let task_ctx_clone = task_ctx.clone();
-            let work_rx_clone = account_work_rx.clone();
-            let storage_work_tx_clone = storage_work_tx.clone();
-            let account_available_workers_clone = account_available_workers.clone();
-
-            executor.spawn_blocking(move || {
-                #[cfg(feature = "metrics")]
-                let metrics = ProofTaskTrieMetrics::default();
-
-                let _guard = span.enter();
-                account_worker_loop(
-                    view_clone,
-                    task_ctx_clone,
-                    work_rx_clone,
-                    storage_work_tx_clone,
-                    worker_id,
-                    account_available_workers_clone,
-                    #[cfg(feature = "metrics")]
-                    metrics,
-                )
-            });
-        }
-        drop(parent_span);
-
-        Self {
-            storage_work_tx,
-            account_work_tx,
-            storage_available_workers,
-            account_available_workers,
-        }
-    }
-
-    /// Returns true if there are available storage workers to process tasks.
-    pub fn has_available_storage_workers(&self) -> bool {
-        self.storage_available_workers.load(Ordering::Relaxed) > 0
-    }
-
-    /// Returns true if there are available account workers to process tasks.
-    pub fn has_available_account_workers(&self) -> bool {
-        self.account_available_workers.load(Ordering::Relaxed) > 0
-    }
-
-    /// Returns the number of pending storage tasks in the queue.
-    pub fn pending_storage_tasks(&self) -> usize {
-        self.storage_work_tx.len()
-    }
-
-    /// Returns the number of pending account tasks in the queue.
-    pub fn pending_account_tasks(&self) -> usize {
-        self.account_work_tx.len()
-    }
-
-    /// Dispatch a storage proof computation to storage worker pool
-    ///
-    /// The result will be sent via the `proof_result_sender` channel.
-    pub fn dispatch_storage_proof(
-        &self,
-        input: StorageProofInput,
-        proof_result_sender: ProofResultContext,
-    ) -> Result<(), ProviderError> {
-        self.storage_work_tx
-            .send(StorageWorkerJob::StorageProof { input, proof_result_sender })
-            .map_err(|err| {
-                let error =
-                    ProviderError::other(std::io::Error::other("storage workers unavailable"));
-
-                if let StorageWorkerJob::StorageProof { proof_result_sender, .. } = err.0 {
-                    let ProofResultContext {
-                        sender: result_tx,
-                        sequence_number: seq,
-                        state,
-                        start_time: start,
-                    } = proof_result_sender;
-
-                    let _ = result_tx.send(ProofResultMessage {
-                        sequence_number: seq,
-                        result: Err(ParallelStateRootError::Provider(error.clone())),
-                        elapsed: start.elapsed(),
-                        state,
-                    });
-                }
-
-                error
-            })
-    }
-
-    /// Dispatch an account multiproof computation
-    ///
-    /// The result will be sent via the `result_sender` channel included in the input.
-    pub fn dispatch_account_multiproof(
-        &self,
-        input: AccountMultiproofInput,
-    ) -> Result<(), ProviderError> {
-        self.account_work_tx
-            .send(AccountWorkerJob::AccountMultiproof { input: Box::new(input) })
-            .map_err(|err| {
-                let error =
-                    ProviderError::other(std::io::Error::other("account workers unavailable"));
-
-                if let AccountWorkerJob::AccountMultiproof { input } = err.0 {
-                    let AccountMultiproofInput {
-                        proof_result_sender:
-                            ProofResultContext {
-                                sender: result_tx,
-                                sequence_number: seq,
-                                state,
-                                start_time: start,
-                            },
-                        ..
-                    } = *input;
-
-                    let _ = result_tx.send(ProofResultMessage {
-                        sequence_number: seq,
-                        result: Err(ParallelStateRootError::Provider(error.clone())),
-                        elapsed: start.elapsed(),
-                        state,
-                    });
-                }
-
-                error
-            })
-    }
-
-    /// Dispatch blinded storage node request to storage worker pool
-    pub(crate) fn dispatch_blinded_storage_node(
-        &self,
-        account: B256,
-        path: Nibbles,
-    ) -> Result<Receiver<TrieNodeProviderResult>, ProviderError> {
-        let (tx, rx) = channel();
-        self.storage_work_tx
-            .send(StorageWorkerJob::BlindedStorageNode { account, path, result_sender: tx })
-            .map_err(|_| {
-                ProviderError::other(std::io::Error::other("storage workers unavailable"))
-            })?;
-
-        Ok(rx)
-    }
-
-    /// Dispatch blinded account node request to account worker pool
-    pub(crate) fn dispatch_blinded_account_node(
-        &self,
-        path: Nibbles,
-    ) -> Result<Receiver<TrieNodeProviderResult>, ProviderError> {
-        let (tx, rx) = channel();
-        self.account_work_tx
-            .send(AccountWorkerJob::BlindedAccountNode { path, result_sender: tx })
-            .map_err(|_| {
-                ProviderError::other(std::io::Error::other("account workers unavailable"))
-            })?;
-
-        Ok(rx)
-    }
-}
-
-impl TrieNodeProviderFactory for ProofWorkerHandle {
-    type AccountNodeProvider = ProofTaskTrieNodeProvider;
-    type StorageNodeProvider = ProofTaskTrieNodeProvider;
-
-    fn account_node_provider(&self) -> Self::AccountNodeProvider {
-        ProofTaskTrieNodeProvider::AccountNode { handle: self.clone() }
-    }
-
-    fn storage_node_provider(&self, account: B256) -> Self::StorageNodeProvider {
-        ProofTaskTrieNodeProvider::StorageNode { account, handle: self.clone() }
-    }
-}
-
-/// Trie node provider for retrieving trie nodes by path.
-#[derive(Debug)]
-pub enum ProofTaskTrieNodeProvider {
-    /// Blinded account trie node provider.
-    AccountNode {
-        /// Handle to the proof worker pools.
-        handle: ProofWorkerHandle,
-    },
-    /// Blinded storage trie node provider.
-    StorageNode {
-        /// Target account.
-        account: B256,
-        /// Handle to the proof worker pools.
-        handle: ProofWorkerHandle,
-    },
-}
-
-impl TrieNodeProvider for ProofTaskTrieNodeProvider {
-    fn trie_node(&self, path: &Nibbles) -> Result<Option<RevealedNode>, SparseTrieError> {
-        match self {
-            Self::AccountNode { handle } => {
-                let rx = handle
-                    .dispatch_blinded_account_node(*path)
-                    .map_err(|error| SparseTrieErrorKind::Other(Box::new(error)))?;
-                rx.recv().map_err(|error| SparseTrieErrorKind::Other(Box::new(error)))?
-            }
-            Self::StorageNode { handle, account } => {
-                let rx = handle
-                    .dispatch_blinded_storage_node(*account, *path)
-                    .map_err(|error| SparseTrieErrorKind::Other(Box::new(error)))?;
-                rx.recv().map_err(|error| SparseTrieErrorKind::Other(Box::new(error)))?
-            }
-        }
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Refactors multiproof computation code to close #19182

### Changes

1. Optimize Storage Proof Hot Path
- Introduced `ProofResult` enum to eliminate unnecessary allocations when returning storage proofs
- Storage proofs now returned directly instead of being wrapped in full `DecodedMultiProof` structure

2. Remove Dead Code
- `StorageMultiproofInput` (never constructed)
- `PendingMultiproofTask` (unnecessary wrapper)
- `AccountMultiproofResult` (unused alias)

3. Replace Unreachable Error Handling
- Changed defensive error returns to `unreachable!()` and `debug_assert_eq!()` for impossible conditions with storage proofs. 

4. Code Organization
- Reorganized `proof_task.rs` and `multiproof.rs` for logical flow. i.e main types at the start


### Future PR
- I wanted to limit the scope of this PR to just these 3 files. I have noticed another issue which is wrapping and unwrapping of `DecodedMultiProof`. This is a redudant abstraction that we should remove. tracking:
https://github.com/paradigmxyz/reth/issues/19309


### Testing
- Running on reth4 to test the refactor