### PR TITLE
refactor(trie): Unify proof return types

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -360,8 +360,7 @@ impl MultiproofManager {
     }
 
     /// Dispatches a new multiproof calculation to worker pools.
-    fn dispatch(&mut self, input: impl Into<PendingMultiproofTask>) {
-        let input = input.into();
+    fn dispatch(&mut self, input: PendingMultiproofTask) {
         // If there are no proof targets, we can just send an empty multiproof back immediately
         if input.proof_targets_is_empty() {
             debug!(
@@ -760,7 +759,7 @@ impl MultiProofTask {
                 self.multiproof_manager.proof_worker_handle.has_available_storage_workers();
 
         let mut dispatch = |proof_targets| {
-            self.multiproof_manager.dispatch(MultiproofInput {
+            self.multiproof_manager.dispatch(PendingMultiproofTask::Regular(MultiproofInput {
                 config: self.config.clone(),
                 source: None,
                 hashed_state_update: Default::default(),
@@ -768,7 +767,7 @@ impl MultiProofTask {
                 proof_sequence_number: self.proof_sequencer.next_sequence(),
                 state_root_message_sender: self.tx.clone(),
                 multi_added_removed_keys: Some(multi_added_removed_keys.clone()),
-            });
+            }));
             chunks += 1;
         };
 
@@ -905,7 +904,7 @@ impl MultiProofTask {
             );
             spawned_proof_targets.extend_ref(&proof_targets);
 
-            self.multiproof_manager.dispatch(MultiproofInput {
+            self.multiproof_manager.dispatch(PendingMultiproofTask::Regular(MultiproofInput {
                 config: self.config.clone(),
                 source: Some(source),
                 hashed_state_update,
@@ -913,7 +912,7 @@ impl MultiProofTask {
                 proof_sequence_number: self.proof_sequencer.next_sequence(),
                 state_root_message_sender: self.tx.clone(),
                 multi_added_removed_keys: Some(multi_added_removed_keys.clone()),
-            });
+            }));
 
             chunks += 1;
         };

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -759,15 +759,18 @@ impl MultiProofTask {
                 self.multiproof_manager.proof_worker_handle.has_available_storage_workers();
 
         let mut dispatch = |proof_targets| {
-            self.multiproof_manager.dispatch(PendingMultiproofTask::Regular(MultiproofInput {
-                config: self.config.clone(),
-                source: None,
-                hashed_state_update: Default::default(),
-                proof_targets,
-                proof_sequence_number: self.proof_sequencer.next_sequence(),
-                state_root_message_sender: self.tx.clone(),
-                multi_added_removed_keys: Some(multi_added_removed_keys.clone()),
-            }));
+            self.multiproof_manager.dispatch(
+                MultiproofInput {
+                    config: self.config.clone(),
+                    source: None,
+                    hashed_state_update: Default::default(),
+                    proof_targets,
+                    proof_sequence_number: self.proof_sequencer.next_sequence(),
+                    state_root_message_sender: self.tx.clone(),
+                    multi_added_removed_keys: Some(multi_added_removed_keys.clone()),
+                }
+                .into(),
+            );
             chunks += 1;
         };
 
@@ -904,15 +907,18 @@ impl MultiProofTask {
             );
             spawned_proof_targets.extend_ref(&proof_targets);
 
-            self.multiproof_manager.dispatch(PendingMultiproofTask::Regular(MultiproofInput {
-                config: self.config.clone(),
-                source: Some(source),
-                hashed_state_update,
-                proof_targets,
-                proof_sequence_number: self.proof_sequencer.next_sequence(),
-                state_root_message_sender: self.tx.clone(),
-                multi_added_removed_keys: Some(multi_added_removed_keys.clone()),
-            }));
+            self.multiproof_manager.dispatch(
+                MultiproofInput {
+                    config: self.config.clone(),
+                    source: Some(source),
+                    hashed_state_update,
+                    proof_targets,
+                    proof_sequence_number: self.proof_sequencer.next_sequence(),
+                    state_root_message_sender: self.tx.clone(),
+                    multi_added_removed_keys: Some(multi_added_removed_keys.clone()),
+                }
+                .into(),
+            );
 
             chunks += 1;
         };

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -382,18 +382,6 @@ impl MultiproofManager {
         }
     }
 
-    /// Signals that a multiproof calculation has finished.
-    fn on_calculation_complete(&mut self) {
-        self.inflight = self.inflight.saturating_sub(1);
-        self.metrics.inflight_multiproofs_histogram.record(self.inflight as f64);
-        self.metrics
-            .pending_storage_multiproofs_histogram
-            .record(self.proof_worker_handle.pending_storage_tasks() as f64);
-        self.metrics
-            .pending_account_multiproofs_histogram
-            .record(self.proof_worker_handle.pending_account_tasks() as f64);
-    }
-
     /// Dispatches a single storage proof calculation to worker pool.
     fn dispatch_storage_proof(&mut self, storage_multiproof_input: StorageMultiproofInput) {
         let StorageMultiproofInput {
@@ -447,6 +435,18 @@ impl MultiproofManager {
         }
 
         self.inflight += 1;
+        self.metrics.inflight_multiproofs_histogram.record(self.inflight as f64);
+        self.metrics
+            .pending_storage_multiproofs_histogram
+            .record(self.proof_worker_handle.pending_storage_tasks() as f64);
+        self.metrics
+            .pending_account_multiproofs_histogram
+            .record(self.proof_worker_handle.pending_account_tasks() as f64);
+    }
+
+    /// Signals that a multiproof calculation has finished.
+    fn on_calculation_complete(&mut self) {
+        self.inflight = self.inflight.saturating_sub(1);
         self.metrics.inflight_multiproofs_histogram.record(self.inflight as f64);
         self.metrics
             .pending_storage_multiproofs_histogram

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -1,7 +1,11 @@
 //! Multiproof task related functionality.
 
 use alloy_evm::block::StateChangeSource;
-use alloy_primitives::{keccak256, map::HashSet, B256};
+use alloy_primitives::{
+    keccak256,
+    map::{B256Set, HashSet},
+    B256,
+};
 use crossbeam_channel::{unbounded, Receiver as CrossbeamReceiver, Sender as CrossbeamSender};
 use dashmap::DashMap;
 use derive_more::derive::Deref;
@@ -15,7 +19,10 @@ use reth_trie::{
 };
 use reth_trie_parallel::{
     proof::ParallelProof,
-    proof_task::{AccountMultiproofInput, ProofResultMessage, ProofWorkerHandle},
+    proof_task::{
+        AccountMultiproofInput, ProofResultContext, ProofResultMessage, ProofWorkerHandle,
+        StorageProofInput,
+    },
 };
 use std::{collections::BTreeMap, ops::DerefMut, sync::Arc, time::Instant};
 use tracing::{debug, error, instrument, trace};
@@ -211,6 +218,74 @@ pub(crate) fn evm_state_to_hashed_post_state(update: EvmState) -> HashedPostStat
     hashed_state
 }
 
+/// A pending multiproof task, either [`StorageMultiproofInput`] or [`MultiproofInput`].
+#[derive(Debug)]
+enum PendingMultiproofTask {
+    /// A storage multiproof task input.
+    Storage(StorageMultiproofInput),
+    /// A regular multiproof task input.
+    Regular(MultiproofInput),
+}
+
+impl PendingMultiproofTask {
+    /// Returns the proof sequence number of the task.
+    const fn proof_sequence_number(&self) -> u64 {
+        match self {
+            Self::Storage(input) => input.proof_sequence_number,
+            Self::Regular(input) => input.proof_sequence_number,
+        }
+    }
+
+    /// Returns whether or not the proof targets are empty.
+    fn proof_targets_is_empty(&self) -> bool {
+        match self {
+            Self::Storage(input) => input.proof_targets.is_empty(),
+            Self::Regular(input) => input.proof_targets.is_empty(),
+        }
+    }
+
+    /// Destroys the input and sends a [`MultiProofMessage::EmptyProof`] message to the sender.
+    fn send_empty_proof(self) {
+        match self {
+            Self::Storage(input) => input.send_empty_proof(),
+            Self::Regular(input) => input.send_empty_proof(),
+        }
+    }
+}
+
+impl From<StorageMultiproofInput> for PendingMultiproofTask {
+    fn from(input: StorageMultiproofInput) -> Self {
+        Self::Storage(input)
+    }
+}
+
+impl From<MultiproofInput> for PendingMultiproofTask {
+    fn from(input: MultiproofInput) -> Self {
+        Self::Regular(input)
+    }
+}
+
+/// Input parameters for dispatching a dedicated storage multiproof calculation.
+#[derive(Debug)]
+struct StorageMultiproofInput {
+    hashed_state_update: HashedPostState,
+    hashed_address: B256,
+    proof_targets: B256Set,
+    proof_sequence_number: u64,
+    state_root_message_sender: CrossbeamSender<MultiProofMessage>,
+    multi_added_removed_keys: Arc<MultiAddedRemovedKeys>,
+}
+
+impl StorageMultiproofInput {
+    /// Destroys the input and sends a [`MultiProofMessage::EmptyProof`] message to the sender.
+    fn send_empty_proof(self) {
+        let _ = self.state_root_message_sender.send(MultiProofMessage::EmptyProof {
+            sequence_number: self.proof_sequence_number,
+            state: self.hashed_state_update,
+        });
+    }
+}
+
 /// Input parameters for dispatching a multiproof calculation.
 #[derive(Debug)]
 struct MultiproofInput {
@@ -285,23 +360,93 @@ impl MultiproofManager {
     }
 
     /// Dispatches a new multiproof calculation to worker pools.
-    fn dispatch(&mut self, input: MultiproofInput) {
+    fn dispatch(&mut self, input: impl Into<PendingMultiproofTask>) {
+        let input = input.into();
         // If there are no proof targets, we can just send an empty multiproof back immediately
-        if input.proof_targets.is_empty() {
+        if input.proof_targets_is_empty() {
             debug!(
-                sequence_number = input.proof_sequence_number,
+                sequence_number = input.proof_sequence_number(),
                 "No proof targets, sending empty multiproof back immediately"
             );
             input.send_empty_proof();
             return
         }
 
-        self.dispatch_multiproof(input);
+        match input {
+            PendingMultiproofTask::Storage(storage_input) => {
+                self.dispatch_storage_proof(storage_input);
+            }
+            PendingMultiproofTask::Regular(multiproof_input) => {
+                self.dispatch_multiproof(multiproof_input);
+            }
+        }
     }
 
     /// Signals that a multiproof calculation has finished.
     fn on_calculation_complete(&mut self) {
         self.inflight = self.inflight.saturating_sub(1);
+        self.metrics.inflight_multiproofs_histogram.record(self.inflight as f64);
+        self.metrics
+            .pending_storage_multiproofs_histogram
+            .record(self.proof_worker_handle.pending_storage_tasks() as f64);
+        self.metrics
+            .pending_account_multiproofs_histogram
+            .record(self.proof_worker_handle.pending_account_tasks() as f64);
+    }
+
+    /// Dispatches a single storage proof calculation to worker pool.
+    fn dispatch_storage_proof(&mut self, storage_multiproof_input: StorageMultiproofInput) {
+        let StorageMultiproofInput {
+            hashed_state_update,
+            hashed_address,
+            proof_targets,
+            proof_sequence_number,
+            multi_added_removed_keys,
+            state_root_message_sender: _,
+        } = storage_multiproof_input;
+
+        let storage_targets = proof_targets.len();
+
+        trace!(
+            target: "engine::tree::payload_processor::multiproof",
+            proof_sequence_number,
+            ?proof_targets,
+            storage_targets,
+            "Dispatching storage proof to workers"
+        );
+
+        let start = Instant::now();
+
+        // Create prefix set from targets
+        let prefix_set = reth_trie::prefix_set::PrefixSetMut::from(
+            proof_targets.iter().map(reth_trie::Nibbles::unpack),
+        );
+        let prefix_set = prefix_set.freeze();
+
+        // Build computation input (data only)
+        let input = StorageProofInput::new(
+            hashed_address,
+            prefix_set,
+            proof_targets,
+            true, // with_branch_node_masks
+            Some(multi_added_removed_keys),
+        );
+
+        // Dispatch to storage worker
+        if let Err(e) = self.proof_worker_handle.dispatch_storage_proof(
+            input,
+            ProofResultContext::new(
+                self.proof_result_tx.clone(),
+                proof_sequence_number,
+                hashed_state_update,
+                start,
+            ),
+        ) {
+            error!(target: "engine::tree::payload_processor::multiproof", ?e, "Failed to dispatch storage proof");
+            return;
+        }
+
+        self.inflight += 1;
         self.metrics.inflight_multiproofs_histogram.record(self.inflight as f64);
         self.metrics
             .pending_storage_multiproofs_histogram
@@ -351,7 +496,7 @@ impl MultiproofManager {
             multi_added_removed_keys,
             missed_leaves_storage_roots,
             // Workers will send ProofResultMessage directly to proof_result_rx
-            proof_result_sender: reth_trie_parallel::proof_task::ProofResultContext::new(
+            proof_result_sender: ProofResultContext::new(
                 self.proof_result_tx.clone(),
                 proof_sequence_number,
                 hashed_state_update,

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -149,7 +149,7 @@ impl ParallelProof {
                 );
                 proof
             }
-            crate::proof_task::ProofResult::AccountMultiproof(..) => {
+            crate::proof_task::ProofResult::AccountMultiproof { .. } => {
                 unreachable!("storage worker only sends StorageProof variant")
             }
         };
@@ -237,9 +237,7 @@ impl ParallelProof {
         })?;
 
         let (multiproof, stats) = match proof_result_msg.result? {
-            crate::proof_task::ProofResult::AccountMultiproof(multiproof, stats) => {
-                (multiproof, stats)
-            }
+            crate::proof_task::ProofResult::AccountMultiproof { proof, stats } => (proof, stats),
             crate::proof_task::ProofResult::StorageProof { .. } => {
                 unreachable!("account worker only sends AccountMultiproof variant")
             }

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -139,15 +139,20 @@ impl ParallelProof {
             )))
         })?;
 
-        // Extract the multiproof from the result
-        let (mut multiproof, _stats) = proof_msg.result?;
-
-        // Extract storage proof from the multiproof
-        let storage_proof = multiproof.storages.remove(&hashed_address).ok_or_else(|| {
-            ParallelStateRootError::StorageRoot(StorageRootError::Database(DatabaseError::Other(
-                format!("storage proof not found in multiproof for {hashed_address}"),
-            )))
-        })?;
+        // Extract storage proof directly from the result
+        let storage_proof = match proof_msg.result? {
+            crate::proof_task::ProofResult::StorageProof { hashed_address: addr, proof } => {
+                debug_assert_eq!(
+                    addr,
+                    hashed_address,
+                    "storage worker must return same address: expected {hashed_address}, got {addr}"
+                );
+                proof
+            }
+            crate::proof_task::ProofResult::AccountMultiproof(..) => {
+                unreachable!("storage worker only sends StorageProof variant")
+            }
+        };
 
         trace!(
             target: "trie::parallel_proof",
@@ -231,7 +236,14 @@ impl ParallelProof {
             )
         })?;
 
-        let (multiproof, stats) = proof_result_msg.result?;
+        let (multiproof, stats) = match proof_result_msg.result? {
+            crate::proof_task::ProofResult::AccountMultiproof(multiproof, stats) => {
+                (multiproof, stats)
+            }
+            crate::proof_task::ProofResult::StorageProof { .. } => {
+                unreachable!("account worker only sends AccountMultiproof variant")
+            }
+        };
 
         #[cfg(feature = "metrics")]
         self.metrics.record(stats);

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -742,9 +742,7 @@ where
     for (hashed_address, receiver) in storage_proof_receivers {
         if let Ok(proof_msg) = receiver.recv() {
             // Extract storage proof from the result
-            if let Ok(ProofResult::StorageProof { hashed_address: addr, proof }) = proof_msg.result &&
-                addr == hashed_address
-            {
+            if let Ok(ProofResult::StorageProof { proof, .. }) = proof_msg.result {
                 collected_decoded_storages.insert(hashed_address, proof);
             }
         }


### PR DESCRIPTION
Part of #19182 cleanup effort - split into smaller PRs for easier review.

Introduces a new `ProofResult` enum that unifies the return types for proof calculations:

## Changes

- Introduced `ProofResult` enum with `AccountMultiproof` and `StorageProof` variants
- Added `into_multiproof()` helper method for conversion when needed
- Removed unused `AccountMultiproofResult` type alias
