### PR TITLE
chore(net): upgrade some noisy spans to TRACE

### DIFF
--- a/crates/net/ecies/src/codec.rs
+++ b/crates/net/ecies/src/codec.rs
@@ -58,7 +58,7 @@ impl Decoder for ECIESCodec {
     type Item = IngressECIESValue;
     type Error = ECIESError;
 
-    #[instrument(level = "trace", skip_all, fields(peer=?self.ecies.remote_id, state=?self.state))]
+    #[instrument(level = "trace", target = "net::ecies", skip_all, fields(peer=?self.ecies.remote_id, state=?self.state))]
     fn decode(&mut self, buf: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
         loop {
             match self.state {
@@ -150,7 +150,7 @@ impl Decoder for ECIESCodec {
 impl Encoder<EgressECIESValue> for ECIESCodec {
     type Error = io::Error;
 
-    #[instrument(level = "trace", skip(self, buf), fields(peer=?self.ecies.remote_id, state=?self.state))]
+    #[instrument(level = "trace", target = "net::ecies", skip(self, buf), fields(peer=?self.ecies.remote_id, state=?self.state))]
     fn encode(&mut self, item: EgressECIESValue, buf: &mut BytesMut) -> Result<(), Self::Error> {
         match item {
             EgressECIESValue::Auth => {

--- a/crates/net/ecies/src/stream.rs
+++ b/crates/net/ecies/src/stream.rs
@@ -40,7 +40,7 @@ where
     Io: AsyncRead + AsyncWrite + Unpin,
 {
     /// Connect to an `ECIES` server
-    #[instrument(level = "trace", skip(transport, secret_key))]
+    #[instrument(level = "trace", target = "net::ecies", skip(transport, secret_key))]
     pub async fn connect(
         transport: Io,
         secret_key: SecretKey,

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -905,7 +905,7 @@ pub(crate) async fn start_pending_incoming_session<N: NetworkPrimitives>(
 }
 
 /// Starts the authentication process for a connection initiated by a remote peer.
-#[instrument(skip_all, fields(%remote_addr, peer_id), target = "net")]
+#[instrument(level = "trace", target = "net::network", skip_all, fields(%remote_addr, peer_id))]
 #[expect(clippy::too_many_arguments)]
 async fn start_pending_outbound_session<N: NetworkPrimitives>(
     handshake: Arc<dyn EthRlpxHandshake>,


### PR DESCRIPTION
Upgrades the level for `start_pending_outbound_session` to TRACE and adds missing targets for `ecies` spans.