### PR TITLE
refactor(trie): reorder proof_task.rs for better code organization

### DIFF
--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -139,15 +139,20 @@ impl ParallelProof {
             )))
         })?;
 
-        // Extract the multiproof from the result
-        let (mut multiproof, _stats) = proof_msg.result?;
-
-        // Extract storage proof from the multiproof
-        let storage_proof = multiproof.storages.remove(&hashed_address).ok_or_else(|| {
-            ParallelStateRootError::StorageRoot(StorageRootError::Database(DatabaseError::Other(
-                format!("storage proof not found in multiproof for {hashed_address}"),
-            )))
-        })?;
+        // Extract storage proof directly from the result
+        let storage_proof = match proof_msg.result? {
+            crate::proof_task::ProofResult::StorageProof { hashed_address: addr, proof } => {
+                debug_assert_eq!(
+                    addr,
+                    hashed_address,
+                    "storage worker must return same address: expected {hashed_address}, got {addr}"
+                );
+                proof
+            }
+            crate::proof_task::ProofResult::AccountMultiproof(..) => {
+                unreachable!("storage worker only sends StorageProof variant")
+            }
+        };
 
         trace!(
             target: "trie::parallel_proof",
@@ -231,7 +236,14 @@ impl ParallelProof {
             )
         })?;
 
-        let (multiproof, stats) = proof_result_msg.result?;
+        let (multiproof, stats) = match proof_result_msg.result? {
+            crate::proof_task::ProofResult::AccountMultiproof(multiproof, stats) => {
+                (multiproof, stats)
+            }
+            crate::proof_task::ProofResult::StorageProof { .. } => {
+                unreachable!("account worker only sends AccountMultiproof variant")
+            }
+        };
 
         #[cfg(feature = "metrics")]
         self.metrics.record(stats);


### PR DESCRIPTION
Part of #19182 - Stack of PRs for easier review
**Depends on:** #19311


Reorganizes `proof_task.rs` to follow better flow. This module is organized in the order:

- Main Types: MultiproofManager, MultiProofTask
- Metrics: MultiProofTaskMetrics
- Supporting Types: SparseTrieUpdate, MultiProofConfig, MultiProofMessage, StateHookSender
- Internal Types: ProofSequencer, MultiProofTaskState, MultiproofInput
- Helper Functions: evm_state_to_hashed_post_state, get_proof_targets