### PR TITLE
ci: pin Bun to v1.2.23

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -20,6 +20,8 @@ jobs:
 
       - name: Install bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: v1.2.23
 
       - name: Install Playwright browsers
         # Required for rehype-mermaid to render Mermaid diagrams during build

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           cd docs/vocs/
           bun i
-          npx playwright install --with-deps chromium
+          npx playwright@1.54.1 install --with-deps chromium
 
       - name: Install Rust nightly
         uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           cd docs/vocs/
           bun i
-          npx playwright@1.54.1 install --with-deps chromium
+          npx playwright install --with-deps chromium
 
       - name: Install Rust nightly
         uses: dtolnay/rust-toolchain@nightly


### PR DESCRIPTION
Bun 1.3 has some regression that makes the `book / build` job timeout. This PR pins the version until the issue is resolved upstream. We can probably just wait until 1.4 and see if it fixes it.