### PR TITLE
chore: remove redundant PhantomData from NodeHooks

### DIFF
--- a/crates/node/builder/src/hooks.rs
+++ b/crates/node/builder/src/hooks.rs
@@ -10,7 +10,6 @@ pub struct NodeHooks<Node: FullNodeComponents, AddOns: NodeAddOns<Node>> {
     pub on_component_initialized: Box<dyn OnComponentInitializedHook<Node>>,
     /// Hook to run once the node is started.
     pub on_node_started: Box<dyn OnNodeStartedHook<Node, AddOns>>,
-    _marker: std::marker::PhantomData<Node>,
 }
 
 impl<Node, AddOns> NodeHooks<Node, AddOns>
@@ -23,7 +22,6 @@ where
         Self {
             on_component_initialized: Box::<()>::default(),
             on_node_started: Box::<()>::default(),
-            _marker: Default::default(),
         }
     }
 


### PR DESCRIPTION
- Removed _marker: PhantomData<Node> field and its initialization in NodeHooks::new() in crates/node/builder/src/hooks.rs

Rationale: 
Node and AddOns are already present in the trait object fields, so the marker was redundant and provided no additional dropck, variance, or auto-trait benefits. This simplifies the struct without functional changes.