### PR TITLE
chore(trie): reduce sparse trie tracing

### DIFF
--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -688,6 +688,7 @@ impl SparseTrieInterface for ParallelSparseTrie {
         Ok(())
     }
 
+    #[instrument(level = "trace", target = "trie::sparse::parallel", skip(self))]
     fn root(&mut self) -> B256 {
         trace!(target: "trie::parallel_sparse", "Calculating trie root hash");
 
@@ -703,6 +704,7 @@ impl SparseTrieInterface for ParallelSparseTrie {
         root_rlp.as_hash().unwrap_or(EMPTY_ROOT_HASH)
     }
 
+    #[instrument(level = "trace", target = "trie::sparse::parallel", skip(self))]
     fn update_subtrie_hashes(&mut self) {
         trace!(target: "trie::parallel_sparse", "Updating subtrie hashes");
 
@@ -1339,7 +1341,7 @@ impl ParallelSparseTrie {
 
     /// Drains any [`SparseTrieUpdatesAction`]s from the given subtrie, and applies each action to
     /// the given `updates` set. If the given set is None then this is a no-op.
-    #[instrument(target = "trie::parallel_sparse", skip_all)]
+    #[instrument(level = "trace", target = "trie::parallel_sparse", skip_all)]
     fn apply_subtrie_update_actions(
         &mut self,
         update_actions: impl Iterator<Item = SparseTrieUpdatesAction>,
@@ -1363,7 +1365,7 @@ impl ParallelSparseTrie {
     }
 
     /// Updates hashes for the upper subtrie, using nodes from both upper and lower subtries.
-    #[instrument(target = "trie::parallel_sparse", skip_all, ret(level = "trace"))]
+    #[instrument(level = "trace", target = "trie::parallel_sparse", skip_all, ret)]
     fn update_upper_subtrie_hashes(&mut self, prefix_set: &mut PrefixSet) -> RlpNode {
         trace!(target: "trie::parallel_sparse", "Updating upper subtrie hashes");
 
@@ -1441,7 +1443,7 @@ impl ParallelSparseTrie {
     ///
     /// IMPORTANT: The method removes the subtries from `lower_subtries`, and the caller is
     /// responsible for returning them back into the array.
-    #[instrument(target = "trie::parallel_sparse", skip_all, fields(prefix_set_len = prefix_set.len()))]
+    #[instrument(level = "trace", target = "trie::parallel_sparse", skip_all, fields(prefix_set_len = prefix_set.len()))]
     fn take_changed_lower_subtries(
         &mut self,
         prefix_set: &mut PrefixSet,
@@ -1598,7 +1600,7 @@ impl ParallelSparseTrie {
 
     /// Return updated subtries back to the trie after executing any actions required on the
     /// top-level `SparseTrieUpdates`.
-    #[instrument(target = "trie::parallel_sparse", skip_all)]
+    #[instrument(level = "trace", target = "trie::parallel_sparse", skip_all)]
     fn insert_changed_subtries(
         &mut self,
         changed_subtries: impl IntoIterator<Item = ChangedSubtrie>,
@@ -2086,7 +2088,7 @@ impl SparseSubtrie {
     /// # Panics
     ///
     /// If the node at the root path does not exist.
-    #[instrument(target = "trie::parallel_sparse", skip_all, fields(root = ?self.path), ret(level = "trace"))]
+    #[instrument(level = "trace", target = "trie::parallel_sparse", skip_all, fields(root = ?self.path), ret)]
     fn update_hashes(
         &mut self,
         prefix_set: &mut PrefixSet,

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -731,7 +731,7 @@ where
     ///
     /// Returns false if the new account info and storage trie are empty, indicating the account
     /// leaf should be removed.
-    #[instrument(target = "trie::sparse", skip_all)]
+    #[instrument(level = "trace", target = "trie::sparse", skip_all)]
     pub fn update_account(
         &mut self,
         address: B256,

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -175,7 +175,6 @@ impl<T: SparseTrieInterface> SparseTrie<T> {
     /// and resetting the trie to only contain an empty root node.
     ///
     /// Note: This method will error if the trie is blinded.
-    #[instrument(target = "trie::sparse", skip_all)]
     pub fn wipe(&mut self) -> SparseTrieResult<()> {
         let revealed = self.as_revealed_mut().ok_or(SparseTrieErrorKind::Blind)?;
         revealed.wipe();
@@ -192,7 +191,6 @@ impl<T: SparseTrieInterface> SparseTrie<T> {
     ///
     /// - `Some(B256)` with the calculated root hash if the trie is revealed.
     /// - `None` if the trie is still blind.
-    #[instrument(target = "trie::sparse", skip_all)]
     pub fn root(&mut self) -> Option<B256> {
         Some(self.as_revealed_mut()?.root())
     }
@@ -232,7 +230,7 @@ impl<T: SparseTrieInterface> SparseTrie<T> {
     /// # Errors
     ///
     /// Returns an error if the trie is still blind, or if the update fails.
-    #[instrument(target = "trie::sparse", skip_all)]
+    #[instrument(level = "trace", target = "trie::sparse", skip_all)]
     pub fn update_leaf(
         &mut self,
         path: Nibbles,
@@ -249,7 +247,7 @@ impl<T: SparseTrieInterface> SparseTrie<T> {
     /// # Errors
     ///
     /// Returns an error if the trie is still blind, or if the leaf cannot be removed
-    #[instrument(target = "trie::sparse", skip_all)]
+    #[instrument(level = "trace", target = "trie::sparse", skip_all)]
     pub fn remove_leaf(
         &mut self,
         path: &Nibbles,
@@ -615,7 +613,7 @@ impl SparseTrieInterface for SerialSparseTrie {
         Ok(())
     }
 
-    #[instrument(target = "trie::sparse::serial", skip(self, provider))]
+    #[instrument(level = "trace", target = "trie::sparse::serial", skip(self, provider))]
     fn update_leaf<P: TrieNodeProvider>(
         &mut self,
         full_path: Nibbles,
@@ -753,7 +751,7 @@ impl SparseTrieInterface for SerialSparseTrie {
         Ok(())
     }
 
-    #[instrument(target = "trie::sparse::serial", skip(self, provider))]
+    #[instrument(level = "trace", target = "trie::sparse::serial", skip(self, provider))]
     fn remove_leaf<P: TrieNodeProvider>(
         &mut self,
         full_path: &Nibbles,
@@ -1385,7 +1383,7 @@ impl SerialSparseTrie {
     ///
     /// This function identifies all nodes that have changed (based on the prefix set) at the given
     /// depth and recalculates their RLP representation.
-    #[instrument(target = "trie::sparse::serial", skip(self))]
+    #[instrument(level = "trace", target = "trie::sparse::serial", skip(self))]
     pub fn update_rlp_node_level(&mut self, depth: usize) {
         // Take the current prefix set
         let mut prefix_set = core::mem::take(&mut self.prefix_set).freeze();
@@ -1431,7 +1429,7 @@ impl SerialSparseTrie {
     ///   specified depth.
     /// - A `PrefixSetMut` containing paths shallower than the specified depth that still need to be
     ///   tracked for future updates.
-    #[instrument(target = "trie::sparse::serial", skip(self))]
+    #[instrument(level = "trace", target = "trie::sparse::serial", skip(self))]
     fn get_changed_nodes_at_depth(
         &self,
         prefix_set: &mut PrefixSet,
@@ -1518,7 +1516,7 @@ impl SerialSparseTrie {
     /// # Panics
     ///
     /// If the node at provided path does not exist.
-    #[instrument(target = "trie::sparse::serial", skip_all, ret(level = "trace"))]
+    #[instrument(level = "trace", target = "trie::sparse::serial", skip_all, ret(level = "trace"))]
     pub fn rlp_node(
         &mut self,
         prefix_set: &mut PrefixSet,


### PR DESCRIPTION
Having sparse trie method spans on `DEBUG` level that's default for our tracing gets too noisy when processing new payloads. This PR moves them to `TRACE` level.