### PR TITLE
fix: update section name in expected failures, add more concise comments

### DIFF
--- a/.github/assets/hive/expected_failures.yaml
+++ b/.github/assets/hive/expected_failures.yaml
@@ -43,15 +43,30 @@ sync: []
 
 engine-auth: []
 
-# 7702 test - no fix: it’s too expensive to check whether the storage is empty on each creation
-# 6110 related tests - may start passing when fixtures improve
-# 7002 related tests - post-fork test, should fix for spec compliance but not
-# realistic on mainnet
-# 7251 related tests - modified contract, not necessarily practical on mainnet,
-# 7594: https://github.com/paradigmxyz/reth/issues/18975
-# 7610: tests are related to empty account that has storage, close to impossible to trigger
-# worth re-visiting when more of these related tests are passing
-eest/consume-engine:
+# tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_non_empty_storage
+#   no fix: it's too expensive to check whether the storage is empty on each creation (? - need more context on WHY)
+#
+# tests/prague/eip7251_consolidations/test_contract_deployment.py::test_system_contract_deployment
+#   modified consolidation contract, not necessarily practical on mainnet (? - need more context)
+#
+# tests/prague/eip6110_deposits/test_modified_contract.py::test_invalid_layout and test_invalid_log_length
+#   system contract is already fixed and deployed; tests cover scenarios where contract is
+#   malformed which can't happen retroactively. No point in adding checks.
+#
+# tests/prague/eip7002_el_triggerable_withdrawals/test_contract_deployment.py::test_system_contract_deployment
+#   post-fork test contract deployment, should fix for spec compliance but not realistic on mainnet (? - need more context)
+#
+# tests/osaka/eip7594_peerdas/test_max_blob_per_tx.py::test_max_blobs_per_tx_fork_transition
+#   reth enforces 6 blob limit from EIP-7594, but EIP-7892 raises it to 9.
+#   Needs constant update in alloy. https://github.com/paradigmxyz/reth/issues/18975
+#
+# tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_*
+#   status (27th June 2024): was discussed in ACDT meeting, need to be raised in ACDE.
+#   tests require hash collision on already deployed accounts with storage - mathematically
+#   impossible to trigger on mainnet. ~20-30 such accounts exist from before the state-clear
+#   EIP, but creating new accounts targeting these requires hash collision.
+#   ref: https://github.com/ethereum/go-ethereum/pull/28666#issuecomment-1891997143
+eels/consume-engine:
   - tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_non_empty_storage[fork_Prague-blockchain_test_engine-zero_nonce]-reth
   - tests/prague/eip7251_consolidations/test_contract_deployment.py::test_system_contract_deployment[fork_CancunToPragueAtTime15k-blockchain_test_engine-deploy_after_fork-nonzero_balance]-reth
   - tests/prague/eip7251_consolidations/test_contract_deployment.py::test_system_contract_deployment[fork_CancunToPragueAtTime15k-blockchain_test_engine-deploy_after_fork-zero_balance]-reth
@@ -131,7 +146,7 @@ eest/consume-engine:
   - tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Prague-tx_type_1-blockchain_test_engine_from_state_test-non-empty-balance-revert-initcode]-reth
   - tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Prague-tx_type_2-blockchain_test_engine_from_state_test-non-empty-balance-revert-initcode]-reth
   - tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Shanghai-tx_type_0-blockchain_test_engine_from_state_test-non-empty-balance-correct-initcode]-reth
-eest/consume-rlp:
+eels/consume-rlp:
   - tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_non_empty_storage[fork_Prague-blockchain_test-zero_nonce]-reth
   - tests/prague/eip7251_consolidations/test_modified_consolidation_contract.py::test_system_contract_errors[fork_Prague-blockchain_test_engine-system_contract_reaches_gas_limit-system_contract_0x0000bbddc7ce488642fb579f8b00f3a590007251]-reth
   - tests/prague/eip7251_consolidations/test_contract_deployment.py::test_system_contract_deployment[fork_CancunToPragueAtTime15k-blockchain_test_engine-deploy_after_fork-nonzero_balance]-reth


### PR DESCRIPTION
follow up from https://github.com/paradigmxyz/reth/pull/19240 

includes
- with recent migration, need to rename `eest/consume-engine` -> `else/consume-engine`
- adding more concise comments on expected failures 