### PR TITLE
chore: update Grafana dashboard with split pending multiproof metrics

### DIFF
--- a/etc/grafana/dashboards/overview.json
+++ b/etc/grafana/dashboards/overview.json
@@ -4239,11 +4239,23 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "reth_tree_root_pending_multiproofs_histogram{$instance_label=\"$instance\",quantile=~\"(0|0.5|0.9|0.95|1)\"}",
+          "expr": "reth_tree_root_pending_storage_multiproofs_histogram{$instance_label=\"$instance\",quantile=~\"(0|0.5|0.9|0.95|1)\"}",
           "instant": false,
-          "legendFormat": "{{quantile}} percentile",
+          "legendFormat": "storage {{quantile}} percentile",
           "range": true,
-          "refId": "Branch Nodes"
+          "refId": "Storage"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "reth_tree_root_pending_account_multiproofs_histogram{$instance_label=\"$instance\",quantile=~\"(0|0.5|0.9|0.95|1)\"}",
+          "instant": false,
+          "legendFormat": "account {{quantile}} percentile",
+          "range": true,
+          "refId": "Account"
         }
       ],
       "title": "Pending MultiProof requests",


### PR DESCRIPTION
Updates Grafana dashboard to track pending storage and account multiproofs separately instead of a single combined metric.
Splits the `Pending MultiProof requests` panel into `Pending Storage MultiProof requests` and `Pending Account MultiProof requests` to match metrics changes in 4548209e7b00351a993779820b78db86b8628c9b.

It should look like:
<img width="1132" height="856" alt="image" src="https://github.com/user-attachments/assets/d16d7f99-fd1a-4d51-9e30-8a1ef8551d54" />

