### PR TITLE
refactor(trie): restructure proof task workers into structs

### DIFF
--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -665,7 +665,8 @@ where
             .factory
             .database_provider_ro()
             .expect("Storage worker failed to initialize: unable to create provider");
-        let proof_tx = ProofTaskTx::new(provider, self.task_ctx.prefix_sets.clone(), self.worker_id);
+        let proof_tx =
+            ProofTaskTx::new(provider, self.task_ctx.prefix_sets.clone(), self.worker_id);
 
         trace!(
             target: "trie::proof_task",
@@ -901,7 +902,8 @@ where
             .factory
             .database_provider_ro()
             .expect("Account worker failed to initialize: unable to create provider");
-        let proof_tx = ProofTaskTx::new(provider, self.task_ctx.prefix_sets.clone(), self.worker_id);
+        let proof_tx =
+            ProofTaskTx::new(provider, self.task_ctx.prefix_sets.clone(), self.worker_id);
 
         trace!(
             target: "trie::proof_task",

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -1282,6 +1282,7 @@ pub struct AccountMultiproofInput {
     pub proof_result_sender: ProofResultContext,
 }
 
+/// Parameters for building an account multiproof with pre-computed storage roots.
 struct AccountMultiproofParams<'a> {
     /// The targets for which to compute the multiproof.
     targets: &'a MultiProofTargets,
@@ -1297,6 +1298,7 @@ struct AccountMultiproofParams<'a> {
     missed_leaves_storage_roots: &'a DashMap<B256, B256>,
 }
 
+/// Internal message for account workers.
 #[derive(Debug)]
 enum AccountWorkerJob {
     /// Account multiproof computation request


### PR DESCRIPTION
Part of #19182

Converts function-based worker loops into struct-based designs:
- `storage_worker_loop` → `StorageProofWorker::run()`
- `account_worker_loop` → `AccountProofWorker::run()`
 
  
Closed  https://github.com/paradigmxyz/reth/pull/19060/files as there were way too many conflicts