### PR TITLE
fix(pipeline): ensure we dont pass an outdated target to header stage

### DIFF
--- a/crates/stages/stages/src/sets.rs
+++ b/crates/stages/stages/src/sets.rs
@@ -270,8 +270,14 @@ where
         Stage<Provider>,
 {
     fn builder(self) -> StageSetBuilder<Provider> {
-        StageSetBuilder::default()
-            .add_stage(EraStage::new(self.era_import_source, self.stages_config.etl.clone()))
+        let mut builder = StageSetBuilder::default();
+
+        if self.era_import_source.is_some() {
+            builder = builder
+                .add_stage(EraStage::new(self.era_import_source, self.stages_config.etl.clone()));
+        }
+
+        builder
             .add_stage(HeaderStage::new(
                 self.provider,
                 self.header_downloader,


### PR DESCRIPTION
When `EraStage` does not have any more era files to process, it currently never advances its checkpoint - resulting in  the `HeaderStage` having an outdated target every time the pipeline is spawned.
https://github.com/paradigmxyz/reth/blob/5091482dec7ccd7df03b349030eb1f0382a8f1d5/crates/stages/api/src/pipeline/mod.rs#L414-L421


The following logs come from a ethpandaops snapshot, which im guessing was initially synced with `--debug.tip` or `--debug.maxblock `
```bash
Preparing stage pipeline_stages=1/16 stage=Era checkpoint=1499999 target=None
Executing stage pipeline_stages=1/16 stage=Era checkpoint=1499999 target=None
Finished stage pipeline_stages=1/16 stage=Era checkpoint=1499999 target=None
Preparing stage pipeline_stages=2/16 stage=Headers checkpoint=1505285 target=1499999
```

It has never been a real issue, because we do not actually use `input.target()` in the header stage afaict. Still seems like a footgun, and all stages checkpoints should be equal or higher than the Finish one.

-- 

Additionally, only adds `EraStage` to the pipeline if there is an `era_source` available. I think it makes sense, but open to removing this.