### PR TITLE
perf(codecs): avoid String allocation in proc macro type checking

### DIFF
--- a/crates/storage/codecs/derive/src/compact/mod.rs
+++ b/crates/storage/codecs/derive/src/compact/mod.rs
@@ -176,7 +176,8 @@ fn should_use_alt_impl(ftype: &str, segment: &syn::PathSegment) -> bool {
         let Some(syn::GenericArgument::Type(syn::Type::Path(arg_path))) = args.args.last() &&
         let (Some(path), 1) = (arg_path.path.segments.first(), arg_path.path.segments.len()) &&
         ["B256", "Address", "Address", "Bloom", "TxHash", "BlockHash", "CompactPlaceholder"]
-            .iter().any(|&s| path.ident == s)
+            .iter()
+            .any(|&s| path.ident == s)
     {
         return true
     }

--- a/crates/storage/codecs/derive/src/compact/mod.rs
+++ b/crates/storage/codecs/derive/src/compact/mod.rs
@@ -176,7 +176,7 @@ fn should_use_alt_impl(ftype: &str, segment: &syn::PathSegment) -> bool {
         let Some(syn::GenericArgument::Type(syn::Type::Path(arg_path))) = args.args.last() &&
         let (Some(path), 1) = (arg_path.path.segments.first(), arg_path.path.segments.len()) &&
         ["B256", "Address", "Address", "Bloom", "TxHash", "BlockHash", "CompactPlaceholder"]
-            .contains(&path.ident.to_string().as_str())
+            .iter().any(|&s| path.ident == s)
     {
         return true
     }


### PR DESCRIPTION
While looking at the derive macro code, I noticed we're converting syn::Ident to String just to compare it with string literals in should_use_alt_impl(). This creates unnecessary heap allocations during macro expansion.

Since syn::Ident already implements PartialEq<&str>, we can compare directly without the .to_string().as_str() chain. This matches the pattern already used on line 155 in the same file for the "maybe_zero" check.

The change is semantically identical but skips the temporary String allocation on every type check, which should help compile times for projects with lots of Compact derives.