### PR TITLE
fix(docker): fix docker image builds for ubuntu

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,7 +1,7 @@
 [build]
 pre-build = [
     # Use HTTPS for package sources
-    "apt-get update && apt-get install --assume-yes --no-install-recommends ca-certificates",
+    "apt-get update && apt-get install --assume-yes --no-install-recommends ca-certificates apt-transport-https",
     "find /etc/apt/ -type f \\( -name '*.list' -o -name '*.sources' \\) -exec sed -i 's|http://|https://|g' {} +",
 
     # Configure APT retries and timeouts to handle network issues
@@ -12,7 +12,7 @@ pre-build = [
     # rust-bindgen dependencies: llvm-dev libclang-dev (>= 10) clang (>= 10)
     # See: https://github.com/cross-rs/cross/wiki/FAQ#using-clang--bindgen for
     # recommended clang versions for the given cross and bindgen version.
-    "apt-get update && apt-get install --assume-yes --no-install-recommends llvm-dev libclang-dev clang",
+    "apt-get update && apt-get install --assume-yes --no-install-recommends llvm-dev libclang-5.0-dev clang-5.0",
 ]
 
 [target.x86_64-pc-windows-gnu]


### PR DESCRIPTION
## Description

`make IMAGE_NAME=op-reth DOCKER_IMAGE_NAME=op-reth PROFILE=release op-docker-build-push-nightly` fails on Ubuntu 24.04.3 LTS. This should fix builds.