### PR TITLE
feat: display blob params alongside hardfork info

### DIFF
--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -1183,8 +1183,8 @@ Merge hard forks:
 - Paris                            @58750000000000000000000 (network is known to be merged)
 Post-merge hard forks (timestamp based):
 - Shanghai                         @1681338455
-- Cancun                           @1710338135
-- Prague                           @1746612311"
+- Cancun                           @1710338135          blob: (target: 3, max: 6, fraction: 3338477)
+- Prague                           @1746612311          blob: (target: 6, max: 9, fraction: 5007716)"
         );
     }
 

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -10,7 +10,7 @@ use crate::{
     sepolia::SEPOLIA_PARIS_BLOCK,
     EthChainSpec,
 };
-use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use alloc::{boxed::Box, format, sync::Arc, vec::Vec};
 use alloy_chains::{Chain, NamedChain};
 use alloy_consensus::{
     constants::{
@@ -448,8 +448,8 @@ impl<H: BlockHeader> ChainSpec<H> {
                     // Check if this hardfork has blob parameters
                     let fork_name = fork.name();
                     if fork_name == "Cancun" || fork_name == "Prague" || fork_name == "Osaka" {
-                        // Get blob params for this timestamp
-                        self.blob_params_at_timestamp(timestamp).map(|params| {
+                        // Get blob params for this timestamp via EthChainSpec trait
+                        EthChainSpec::blob_params_at_timestamp(self, timestamp).map(|params| {
                             format!(
                                 "blob: (target: {}, max: {}, fraction: {})",
                                 params.target_blob_count,

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -442,24 +442,17 @@ impl<H: BlockHeader> ChainSpec<H> {
     pub fn display_hardforks(&self) -> DisplayHardforks {
         // Create an iterator with hardfork, condition, and optional blob metadata
         let hardforks_with_meta = self.hardforks.forks_iter().map(|(fork, condition)| {
-            // Generate blob metadata for supported hardforks
+            // Generate blob metadata for timestamp-based hardforks that have blob params
             let metadata = match condition {
                 ForkCondition::Timestamp(timestamp) => {
-                    // Check if this hardfork has blob parameters
-                    let fork_name = fork.name();
-                    if fork_name == "Cancun" || fork_name == "Prague" || fork_name == "Osaka" {
-                        // Get blob params for this timestamp via EthChainSpec trait
-                        EthChainSpec::blob_params_at_timestamp(self, timestamp).map(|params| {
-                            format!(
-                                "blob: (target: {}, max: {}, fraction: {})",
-                                params.target_blob_count,
-                                params.max_blob_count,
-                                params.update_fraction
-                            )
-                        })
-                    } else {
-                        None
-                    }
+                    // Try to get blob params for this timestamp
+                    // This automatically handles all hardforks with blob support
+                    EthChainSpec::blob_params_at_timestamp(self, timestamp).map(|params| {
+                        format!(
+                            "blob: (target: {}, max: {}, fraction: {})",
+                            params.target_blob_count, params.max_blob_count, params.update_fraction
+                        )
+                    })
                 }
                 _ => None,
             };

--- a/crates/ethereum/hardforks/src/display.rs
+++ b/crates/ethereum/hardforks/src/display.rs
@@ -154,38 +154,8 @@ impl DisplayHardforks {
     where
         I: IntoIterator<Item = (&'a dyn Hardfork, ForkCondition)>,
     {
-        let mut pre_merge = Vec::new();
-        let mut with_merge = Vec::new();
-        let mut post_merge = Vec::new();
-
-        for (fork, condition) in hardforks {
-            let mut display_fork = DisplayFork {
-                name: fork.name().to_string(),
-                activated_at: condition,
-                eip: None,
-                metadata: None,
-            };
-
-            match condition {
-                ForkCondition::Block(_) => {
-                    pre_merge.push(display_fork);
-                }
-                ForkCondition::TTD { activation_block_number, total_difficulty, fork_block } => {
-                    display_fork.activated_at = ForkCondition::TTD {
-                        activation_block_number,
-                        fork_block,
-                        total_difficulty,
-                    };
-                    with_merge.push(display_fork);
-                }
-                ForkCondition::Timestamp(_) => {
-                    post_merge.push(display_fork);
-                }
-                ForkCondition::Never => {}
-            }
-        }
-
-        Self { pre_merge, with_merge, post_merge }
+        // Delegate to with_meta by mapping the iterator to include None for metadata
+        Self::with_meta(hardforks.into_iter().map(|(fork, condition)| (fork, condition, None)))
     }
 
     /// Creates a new [`DisplayHardforks`] from an iterator of hardforks with optional metadata.

--- a/crates/ethereum/hardforks/src/display.rs
+++ b/crates/ethereum/hardforks/src/display.rs
@@ -25,6 +25,8 @@ struct DisplayFork {
     activated_at: ForkCondition,
     /// An optional EIP (e.g. `EIP-1559`).
     eip: Option<String>,
+    /// Optional metadata to display alongside the fork (e.g. blob parameters)
+    metadata: Option<String>,
 }
 
 impl core::fmt::Display for DisplayFork {
@@ -38,6 +40,9 @@ impl core::fmt::Display for DisplayFork {
         match self.activated_at {
             ForkCondition::Block(at) | ForkCondition::Timestamp(at) => {
                 write!(f, "{name_with_eip:32} @{at}")?;
+                if let Some(metadata) = &self.metadata {
+                    write!(f, "          {metadata}")?;
+                }
             }
             ForkCondition::TTD { total_difficulty, .. } => {
                 // All networks that have merged are finalized.
@@ -45,6 +50,9 @@ impl core::fmt::Display for DisplayFork {
                     f,
                     "{name_with_eip:32} @{total_difficulty} (network is known to be merged)",
                 )?;
+                if let Some(metadata) = &self.metadata {
+                    write!(f, "          {metadata}")?;
+                }
             }
             ForkCondition::Never => unreachable!(),
         }
@@ -151,8 +159,51 @@ impl DisplayHardforks {
         let mut post_merge = Vec::new();
 
         for (fork, condition) in hardforks {
-            let mut display_fork =
-                DisplayFork { name: fork.name().to_string(), activated_at: condition, eip: None };
+            let mut display_fork = DisplayFork {
+                name: fork.name().to_string(),
+                activated_at: condition,
+                eip: None,
+                metadata: None,
+            };
+
+            match condition {
+                ForkCondition::Block(_) => {
+                    pre_merge.push(display_fork);
+                }
+                ForkCondition::TTD { activation_block_number, total_difficulty, fork_block } => {
+                    display_fork.activated_at = ForkCondition::TTD {
+                        activation_block_number,
+                        fork_block,
+                        total_difficulty,
+                    };
+                    with_merge.push(display_fork);
+                }
+                ForkCondition::Timestamp(_) => {
+                    post_merge.push(display_fork);
+                }
+                ForkCondition::Never => {}
+            }
+        }
+
+        Self { pre_merge, with_merge, post_merge }
+    }
+
+    /// Creates a new [`DisplayHardforks`] from an iterator of hardforks with optional metadata.
+    pub fn with_meta<'a, I>(hardforks: I) -> Self
+    where
+        I: IntoIterator<Item = (&'a dyn Hardfork, ForkCondition, Option<String>)>,
+    {
+        let mut pre_merge = Vec::new();
+        let mut with_merge = Vec::new();
+        let mut post_merge = Vec::new();
+
+        for (fork, condition, metadata) in hardforks {
+            let mut display_fork = DisplayFork {
+                name: fork.name().to_string(),
+                activated_at: condition,
+                eip: None,
+                metadata,
+            };
 
             match condition {
                 ForkCondition::Block(_) => {


### PR DESCRIPTION
Implements optional metadata in `DisplayHardforks` to show blob parameters for Cancun+ hardforks.

Example output:

```
Cancun @0 blob: (target: 3, max: 6, fraction: 3338477)
Prague @0 blob: (target: 6, max: 9, fraction: 5007716)
```

Closes #19345

BTW could https://github.com/paradigmxyz/reth/pull/18546 be reopened?