### PR TITLE
feat: Output the block execution outputs after validating (reth-stateless)

### DIFF
--- a/crates/stateless/src/validation.rs
+++ b/crates/stateless/src/validation.rs
@@ -17,8 +17,11 @@ use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_consensus::{Consensus, HeaderValidator};
 use reth_errors::ConsensusError;
 use reth_ethereum_consensus::{validate_block_post_execution, EthBeaconConsensus};
-use reth_ethereum_primitives::{Block, EthPrimitives};
-use reth_evm::{execute::Executor, ConfigureEvm};
+use reth_ethereum_primitives::{Block, EthPrimitives, EthereumReceipt};
+use reth_evm::{
+    execute::{BlockExecutionOutput, Executor},
+    ConfigureEvm,
+};
 use reth_primitives_traits::{RecoveredBlock, SealedHeader};
 use reth_trie_common::{HashedPostState, KeccakKeyHasher};
 
@@ -144,7 +147,7 @@ pub fn stateless_validation<ChainSpec, E>(
     witness: ExecutionWitness,
     chain_spec: Arc<ChainSpec>,
     evm_config: E,
-) -> Result<B256, StatelessValidationError>
+) -> Result<(B256, BlockExecutionOutput<EthereumReceipt>), StatelessValidationError>
 where
     ChainSpec: Send + Sync + EthChainSpec<Header = Header> + EthereumHardforks + Debug,
     E: ConfigureEvm<Primitives = EthPrimitives> + Clone + 'static,
@@ -170,7 +173,7 @@ pub fn stateless_validation_with_trie<T, ChainSpec, E>(
     witness: ExecutionWitness,
     chain_spec: Arc<ChainSpec>,
     evm_config: E,
-) -> Result<B256, StatelessValidationError>
+) -> Result<(B256, BlockExecutionOutput<EthereumReceipt>), StatelessValidationError>
 where
     T: StatelessTrie,
     ChainSpec: Send + Sync + EthChainSpec<Header = Header> + EthereumHardforks + Debug,
@@ -242,7 +245,7 @@ where
     }
 
     // Return block hash
-    Ok(current_block.hash_slow())
+    Ok((current_block.hash_slow(), output))
 }
 
 /// Performs consensus validation checks on a block without execution or state validation.


### PR DESCRIPTION
This changes the signature of `stateless_validation` and `stateless_validation_with_trie` to output the block execution output, which notably includes transaction receipts.
This makes it possible to check the status of a particular transaction or the logs of a particular transaction whilst also proving a block executed correctly.

Performance impact is likely negligible - with optimisations this _should_ just be RVO-d out. If this is a concern, we can potentially simply return receipts and/or requests instead.

Unfortunately this would be a breaking change - not sure if reth uses semver. Alternatively, new functions can be provided - I haven't done so because honestly I haven't found a good name. Some users of this crate I know are `zeth` and the ETH applied cryptography team (who I've quickly chatted about this PR with), but it's a pretty easy fix downstream.

Alternatives:
- There are several functions in `stateless_validation_with_trie` that are not public, making it impossible to construct custom versions of that functions from the bricks `reth-stateless` provides. I think it would be good to make those public regardless, but haven't done it here.
- We could also output the `current_block` instead of pre-hashing it, and leave it to the caller to hash or not, as needed.