### PR TITLE
feat: insert at timestamp

### DIFF
--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -883,7 +883,7 @@ impl ChainSpecBuilder {
 
     /// Remove the given fork from the spec.
     pub fn without_fork<H: Hardfork>(mut self, fork: H) -> Self {
-        self.hardforks.remove(fork);
+        self.hardforks.remove(&fork);
         self
     }
 


### PR DESCRIPTION
helper fn to insert a timestamp based fork at the correct position.

this is primarily useful for new forks that are added on top and we can assume those are always timestamp based