### PR TITLE
refactor(cli): rename `new_with_raw_values` to `new_with_raw` in TUI module

### DIFF
--- a/crates/cli/commands/src/db/tui.rs
+++ b/crates/cli/commands/src/db/tui.rs
@@ -47,10 +47,10 @@ enum Entries<T: Table> {
 }
 
 impl<T: Table> Entries<T> {
-    /// Creates new empty [Entries] as [`Entries::RawValues`] if `raw_values == true` and as
-    /// [`Entries::Values`] if `raw == false`.
-    const fn new_with_raw_values(raw_values: bool) -> Self {
-        if raw_values {
+    /// Creates a new empty [`Entries`]: [`Entries::RawValues`] if `raw` is `true`,
+    /// otherwise [`Entries::Values`].
+    const fn new_with_raw(raw: bool) -> Self {
+        if raw {
             Self::RawValues(Vec::new())
         } else {
             Self::Values(Vec::new())
@@ -148,7 +148,7 @@ where
             mode: ViewMode::Normal,
             input: String::new(),
             list_state: ListState::default(),
-            entries: Entries::new_with_raw_values(raw),
+            entries: Entries::new_with_raw(raw),
         }
     }
 


### PR DESCRIPTION

Simplifies function naming in the database TUI module by renaming `new_with_raw_values` to `new_with_raw` for better readability and consistency.

#### Changes

- **Renamed function**: `Entries::new_with_raw_values()` → `Entries::new_with_raw()`


