### PR TITLE
feat(jovian/rpc): update receipts to transmit over RPC with Jovian compatible fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9525,6 +9525,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-json-rpc",
+ "alloy-op-hardforks",
  "alloy-primitives",
  "alloy-rpc-client",
  "alloy-rpc-types-debug",

--- a/crates/optimism/rpc/Cargo.toml
+++ b/crates/optimism/rpc/Cargo.toml
@@ -84,6 +84,7 @@ metrics.workspace = true
 
 [dev-dependencies]
 reth-optimism-chainspec.workspace = true
+alloy-op-hardforks.workspace = true
 
 [features]
 client = [

--- a/crates/optimism/rpc/src/eth/receipt.rs
+++ b/crates/optimism/rpc/src/eth/receipt.rs
@@ -1,7 +1,7 @@
 //! Loads and formats OP receipt RPC response.
 
 use crate::{eth::RpcNodeCore, OpEthApi, OpEthApiError};
-use alloy_consensus::{transaction::TransactionMeta, BlockHeader, Receipt, TxReceipt};
+use alloy_consensus::{BlockHeader, Receipt, TxReceipt};
 use alloy_eips::eip2718::Encodable2718;
 use alloy_rpc_types_eth::{Log, TransactionReceipt};
 use op_alloy_consensus::{OpReceiptEnvelope, OpTransaction};
@@ -276,47 +276,6 @@ pub struct OpReceiptBuilder {
 }
 
 impl OpReceiptBuilder {
-    /// Builds an [`TransactionReceipt`] obtaining the inner receipt envelope from the given
-    /// closure.
-    pub fn build_op_receipt<N, E>(
-        chain_spec: &impl OpHardforks,
-        input: ConvertReceiptInput<'_, N>,
-        l1_block_info: &mut op_revm::L1BlockInfo,
-        build_rpc_receipt: impl FnOnce(N::Receipt, usize, TransactionMeta) -> E,
-    ) -> TransactionReceipt<E>
-    where
-        N: NodePrimitives,
-    {
-        // In jovian, we're using the blob gas used field to store the current da
-        // footprint's value.
-        // We're computing the jovian blob gas used before building the receipt since the inputs get
-        // consumed by the `build_receipt` function.
-        let jovian_blob_gas_used =
-            chain_spec.is_jovian_active_at_timestamp(input.meta.timestamp).then(|| {
-                let da_footprint_gas_scalar =
-                    l1_block_info.da_footprint_gas_scalar.unwrap_or_default();
-
-                // Estimate the size of the transaction in bytes and multiply by the DA
-                // footprint gas scalar.
-                // TODO(@theochap): Instead of recomputing the encoding of the tx, we could add
-                // a new field to the `TxReceipt` type to compute the cumulated
-                // `blob_gas_used`, a bit like `cumulative_gas_used` is
-                // computed.
-                // Jovian specs: `https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/jovian/exec-engine.md#da-footprint-block-limit`
-                estimate_tx_compressed_size(input.tx.encoded_2718().as_slice())
-                    .saturating_div(1_000_000)
-                    .saturating_mul(da_footprint_gas_scalar.into())
-            });
-
-        let mut tx_receipt = build_receipt(input, None, build_rpc_receipt);
-
-        if let Some(blob_gas_used) = jovian_blob_gas_used {
-            tx_receipt.blob_gas_used = Some(blob_gas_used);
-        }
-
-        tx_receipt
-    }
-
     /// Returns a new builder.
     pub fn new<N>(
         chain_spec: &impl OpHardforks,
@@ -329,35 +288,49 @@ impl OpReceiptBuilder {
         let timestamp = input.meta.timestamp;
         let block_number = input.meta.block_number;
         let tx_signed = *input.tx.inner();
-        let core_receipt = Self::build_op_receipt(
-            chain_spec,
-            input,
-            l1_block_info,
-            |receipt, next_log_index, meta| {
-                let map_logs = move |receipt: alloy_consensus::Receipt| {
-                    let Receipt { status, cumulative_gas_used, logs } = receipt;
-                    let logs = Log::collect_for_receipt(next_log_index, meta, logs);
-                    Receipt { status, cumulative_gas_used, logs }
-                };
-                match receipt {
-                    OpReceipt::Legacy(receipt) => {
-                        OpReceiptEnvelope::Legacy(map_logs(receipt).into_with_bloom())
-                    }
-                    OpReceipt::Eip2930(receipt) => {
-                        OpReceiptEnvelope::Eip2930(map_logs(receipt).into_with_bloom())
-                    }
-                    OpReceipt::Eip1559(receipt) => {
-                        OpReceiptEnvelope::Eip1559(map_logs(receipt).into_with_bloom())
-                    }
-                    OpReceipt::Eip7702(receipt) => {
-                        OpReceiptEnvelope::Eip7702(map_logs(receipt).into_with_bloom())
-                    }
-                    OpReceipt::Deposit(receipt) => {
-                        OpReceiptEnvelope::Deposit(receipt.map_inner(map_logs).into_with_bloom())
-                    }
+        let mut core_receipt = build_receipt(input, None, |receipt, next_log_index, meta| {
+            let map_logs = move |receipt: alloy_consensus::Receipt| {
+                let Receipt { status, cumulative_gas_used, logs } = receipt;
+                let logs = Log::collect_for_receipt(next_log_index, meta, logs);
+                Receipt { status, cumulative_gas_used, logs }
+            };
+            match receipt {
+                OpReceipt::Legacy(receipt) => {
+                    OpReceiptEnvelope::Legacy(map_logs(receipt).into_with_bloom())
                 }
-            },
-        );
+                OpReceipt::Eip2930(receipt) => {
+                    OpReceiptEnvelope::Eip2930(map_logs(receipt).into_with_bloom())
+                }
+                OpReceipt::Eip1559(receipt) => {
+                    OpReceiptEnvelope::Eip1559(map_logs(receipt).into_with_bloom())
+                }
+                OpReceipt::Eip7702(receipt) => {
+                    OpReceiptEnvelope::Eip7702(map_logs(receipt).into_with_bloom())
+                }
+
+                OpReceipt::Deposit(receipt) => {
+                    OpReceiptEnvelope::Deposit(receipt.map_inner(map_logs).into_with_bloom())
+                }
+            }
+        });
+
+        // In jovian, we're using the blob gas used field to store the current da
+        // footprint's value.
+        // We're computing the jovian blob gas used before building the receipt since the inputs get
+        // consumed by the `build_receipt` function.
+        chain_spec.is_jovian_active_at_timestamp(timestamp).then(|| {
+            // Estimate the size of the transaction in bytes and multiply by the DA
+            // footprint gas scalar.
+            // a new field to the `TxReceipt` type to compute the cumulated
+            // `blob_gas_used`, a bit like `cumulative_gas_used` is
+            // computed.
+            // Jovian specs: `https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/jovian/exec-engine.md#da-footprint-block-limit`
+            let da_size = estimate_tx_compressed_size(tx_signed.encoded_2718().as_slice())
+                .saturating_div(1_000_000)
+                .saturating_mul(l1_block_info.da_footprint_gas_scalar.unwrap_or_default().into());
+
+            core_receipt.blob_gas_used = Some(da_size);
+        });
 
         let op_receipt_fields = OpReceiptFieldsBuilder::new(timestamp, block_number)
             .l1_block_info(chain_spec, tx_signed, l1_block_info)?

--- a/crates/optimism/rpc/src/eth/receipt.rs
+++ b/crates/optimism/rpc/src/eth/receipt.rs
@@ -353,7 +353,7 @@ impl OpReceiptBuilder {
 #[cfg(test)]
 mod test {
     use super::*;
-    use alloy_consensus::{Block, BlockBody, Eip658Value, TxEip7702};
+    use alloy_consensus::{transaction::TransactionMeta, Block, BlockBody, Eip658Value, TxEip7702};
     use alloy_op_hardforks::{
         OpChainHardforks, OP_MAINNET_ISTHMUS_TIMESTAMP, OP_MAINNET_JOVIAN_TIMESTAMP,
     };

--- a/crates/optimism/rpc/src/eth/receipt.rs
+++ b/crates/optimism/rpc/src/eth/receipt.rs
@@ -321,9 +321,6 @@ impl OpReceiptBuilder {
         chain_spec.is_jovian_active_at_timestamp(timestamp).then(|| {
             // Estimate the size of the transaction in bytes and multiply by the DA
             // footprint gas scalar.
-            // a new field to the `TxReceipt` type to compute the cumulated
-            // `blob_gas_used`, a bit like `cumulative_gas_used` is
-            // computed.
             // Jovian specs: `https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/jovian/exec-engine.md#da-footprint-block-limit`
             let da_size = estimate_tx_compressed_size(tx_signed.encoded_2718().as_slice())
                 .saturating_div(1_000_000)


### PR DESCRIPTION
## Description

Updates the tx receipts to transmit over RPC to be consistent with Jovian updates. Ie, to contain the updated correct value of the `blob_base_fee`.

Added unit tests.