### PR TITLE
docs: improve RESS protocol module documentation

### DIFF
--- a/crates/ress/protocol/src/lib.rs
+++ b/crates/ress/protocol/src/lib.rs
@@ -1,5 +1,30 @@
-//! `ress` protocol is an `RLPx` subprotocol for stateless nodes.
-//! following [RLPx specs](https://github.com/ethereum/devp2p/blob/master/rlpx.md)
+//! RESS protocol for stateless Ethereum nodes.
+//!
+//! Enables stateless nodes to fetch execution witnesses, bytecode, and block data from
+//! stateful peers for minimal on-disk state with full execution capability.
+//!
+//! ## Node Types
+//!
+//! - **Stateless**: Minimal state, requests data on-demand
+//! - **Stateful**: Full Ethereum nodes providing state data
+//!
+//! Valid connections: Stateless ↔ Stateless ✅, Stateless ↔ Stateful ✅, Stateful ↔ Stateful ❌
+//!
+//! ## Messages
+//!
+//! - `NodeType (0x00)`: Handshake
+//! - `GetHeaders/Headers (0x01/0x02)`: Block headers
+//! - `GetBlockBodies/BlockBodies (0x03/0x04)`: Block bodies
+//! - `GetBytecode/Bytecode (0x05/0x06)`: Contract bytecode
+//! - `GetWitness/Witness (0x07/0x08)`: Execution witnesses
+//!
+//! ## Flow
+//!
+//! 1. Exchange `NodeType` for compatibility
+//! 2. Download ancestor blocks via headers/bodies
+//! 3. For new payloads: request witness → get missing bytecode → execute
+//!
+//! Protocol version: `ress/1`
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",


### PR DESCRIPTION
- Added detailed protocol overview explaining stateless vs stateful nodes
- Documented all message types with their IDs (0x00-0x08)
- Included connection rules and usage flow
- Specified protocol version (ress/1)

The documentation now provides clear understanding of the protocol's purpose, message types, and operational flow for developers working with stateless Ethereum nodes.