### PR TITLE
fix: remove duplicate debug log

### DIFF
--- a/crates/trie/db/src/state.rs
+++ b/crates/trie/db/src/state.rs
@@ -162,7 +162,6 @@ impl<'a, TX: DbTx> DatabaseStateRoot<'a, TX>
         tx: &'a TX,
         range: RangeInclusive<BlockNumber>,
     ) -> Result<(B256, TrieUpdates), StateRootError> {
-        debug!(target: "trie::loader", ?range, "incremental state root");
         Self::incremental_root_calculator(tx, range)?.root_with_updates()
     }
 


### PR DESCRIPTION
In `crates/trie/db/src/state.rs`, duplicate debug logging was removed to reduce log noise. Specifically, the `debug!` call was removed from the `incremental_root_with_updates()` method because it duplicated an identical message already logged by the `incremental_root()` method. This change eliminates redundant output that provided no unique context, while the debug log in `incremental_root()` has been retained for necessary observability.

