### PR TITLE
perf: optimize SyncHeight event handling to avoid recursive calls

### DIFF
--- a/crates/stages/api/src/metrics/listener.rs
+++ b/crates/stages/api/src/metrics/listener.rs
@@ -73,9 +73,7 @@ impl MetricsListener {
             }
         }
     }
-}
 
-impl MetricsListener {
     /// Updates all stage checkpoints to the given height efficiently.
     fn update_all_stages_height(&mut self, height: BlockNumber) {
         for stage_id in StageId::ALL {

--- a/crates/stages/api/src/metrics/sync_metrics.rs
+++ b/crates/stages/api/src/metrics/sync_metrics.rs
@@ -16,7 +16,6 @@ impl SyncMetrics {
             .entry(stage_id)
             .or_insert_with(|| StageMetrics::new_with_labels(&[("stage", stage_id.to_string())]))
     }
-
 }
 
 #[derive(Metrics)]

--- a/crates/stages/api/src/metrics/sync_metrics.rs
+++ b/crates/stages/api/src/metrics/sync_metrics.rs
@@ -17,16 +17,6 @@ impl SyncMetrics {
             .or_insert_with(|| StageMetrics::new_with_labels(&[("stage", stage_id.to_string())]))
     }
 
-    /// Updates all stage checkpoints to the given height efficiently.
-    /// This avoids creating multiple individual events when sync height changes.
-    pub(crate) fn update_all_stages_height(&mut self, height: u64) {
-        for stage_id in StageId::ALL {
-            let stage_metrics = self.get_stage_metrics(stage_id);
-            stage_metrics.checkpoint.set(height as f64);
-            stage_metrics.entities_processed.set(height as f64);
-            stage_metrics.entities_total.set(height as f64);
-        }
-    }
 }
 
 #[derive(Metrics)]

--- a/crates/stages/api/src/metrics/sync_metrics.rs
+++ b/crates/stages/api/src/metrics/sync_metrics.rs
@@ -16,6 +16,17 @@ impl SyncMetrics {
             .entry(stage_id)
             .or_insert_with(|| StageMetrics::new_with_labels(&[("stage", stage_id.to_string())]))
     }
+
+    /// Updates all stage checkpoints to the given height efficiently.
+    /// This avoids creating multiple individual events when sync height changes.
+    pub(crate) fn update_all_stages_height(&mut self, height: u64) {
+        for stage_id in StageId::ALL {
+            let stage_metrics = self.get_stage_metrics(stage_id);
+            stage_metrics.checkpoint.set(height as f64);
+            stage_metrics.entities_processed.set(height as f64);
+            stage_metrics.entities_total.set(height as f64);
+        }
+    }
 }
 
 #[derive(Metrics)]


### PR DESCRIPTION
Replaces recursive event creation with direct batch updates when sync height changes. 

Eliminates 16 redundant StageCheckpoint events per SyncHeight event, reducing computational overhead during blockchain synchronization.