### PR TITLE
feat: impl a function to create new instance of TransactionEvents

### DIFF
--- a/crates/transaction-pool/src/pool/listener.rs
+++ b/crates/transaction-pool/src/pool/listener.rs
@@ -30,7 +30,7 @@ pub struct TransactionEvents {
 
 impl TransactionEvents {
     /// Create a new instance of this stream.
-    pub fn new(hash: TxHash, events: UnboundedReceiver<TransactionEvent>) -> Self {
+    pub const fn new(hash: TxHash, events: UnboundedReceiver<TransactionEvent>) -> Self {
         Self { hash, events }
     }
 

--- a/crates/transaction-pool/src/pool/listener.rs
+++ b/crates/transaction-pool/src/pool/listener.rs
@@ -29,6 +29,11 @@ pub struct TransactionEvents {
 }
 
 impl TransactionEvents {
+    /// Create a new instance of this stream.
+    pub fn new(hash: TxHash, events: UnboundedReceiver<TransactionEvent>) -> Self {
+        Self { hash, events }
+    }
+
     /// The hash for this transaction
     pub const fn hash(&self) -> TxHash {
         self.hash


### PR DESCRIPTION
- The TransactionPool trait includes functions that return TransactionEvents, but currently, it’s not possible to initialize the TransactionEvents outside of Reth. This limitation makes it difficult to implement a custom transaction pool.