### PR TITLE
fix(engine): remove redundant parent_to_child cleanup in insert_executed

### DIFF
--- a/crates/engine/tree/src/tree/state.rs
+++ b/crates/engine/tree/src/tree/state.rs
@@ -107,10 +107,6 @@ impl<N: NodePrimitives> TreeState<N> {
         self.blocks_by_number.entry(block_number).or_default().push(executed);
 
         self.parent_to_child.entry(parent_hash).or_default().insert(hash);
-
-        for children in self.parent_to_child.values_mut() {
-            children.retain(|child| self.blocks_by_hash.contains_key(child));
-        }
     }
 
     /// Remove single executed block by its hash.


### PR DESCRIPTION
Drop unnecessary parent_to_child cleanup loop in TreeState::insert_executed. This method only inserts blocks, never removes them, so iterating through all parent-child relationships to clean up stale references is redundant. The proper cleanup already happens in remove_by_hash where it belongs.

Same pattern as #18648 but for TreeState instead of BlockBuffer.