### PR TITLE
refactor: extract ExecutionWitness construction into helper function

### DIFF
--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -40,6 +40,7 @@ reth-consensus.workspace = true
 reth-consensus-common.workspace = true
 reth-node-api.workspace = true
 reth-trie-common.workspace = true
+reth-stateless.workspace = true
 
 # ethereum
 alloy-evm = { workspace = true, features = ["overrides"] }

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -22,7 +22,6 @@ use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_errors::RethError;
 use reth_evm::{execute::Executor, ConfigureEvm, EvmEnvFor, TxEnvFor};
 use reth_primitives_traits::{Block as _, BlockBody, ReceiptWithBloom, RecoveredBlock};
-use reth_stateless::build_execution_witness;
 use reth_revm::{database::StateProviderDatabase, db::State, witness::ExecutionWitnessRecord};
 use reth_rpc_api::DebugApiServer;
 use reth_rpc_convert::RpcTxReq;
@@ -32,6 +31,7 @@ use reth_rpc_eth_api::{
 };
 use reth_rpc_eth_types::{EthApiError, StateCacheDb};
 use reth_rpc_server_types::{result::internal_rpc_err, ToRpcResult};
+use reth_stateless::build_execution_witness;
 use reth_storage_api::{
     BlockIdReader, BlockReaderIdExt, HeaderProvider, ProviderBlock, ReceiptProviderIdExt,
     StateProofProvider, StateProviderFactory, StateRootProvider, TransactionVariant,

--- a/crates/stateless/src/lib.rs
+++ b/crates/stateless/src/lib.rs
@@ -53,7 +53,9 @@ pub(crate) mod witness_db;
 #[doc(inline)]
 pub use alloy_rpc_types_debug::ExecutionWitness;
 
+use alloy_primitives::Bytes;
 use reth_ethereum_primitives::Block;
+use reth_revm::witness::ExecutionWitnessRecord;
 
 /// `StatelessInput` is a convenience structure for serializing the input needed
 /// for the stateless validation function.
@@ -67,4 +69,31 @@ pub struct StatelessInput {
     pub block: Block,
     /// `ExecutionWitness` for the stateless validation function
     pub witness: ExecutionWitness,
+}
+
+/// Builds an `ExecutionWitness` from an `ExecutionWitnessRecord`, state witness, and headers.
+///
+/// This helper function consolidates the common logic for creating an `ExecutionWitness`
+/// from execution data, avoiding code duplication.
+///
+/// # Arguments
+///
+/// * `witness_record` - The execution witness record containing execution state
+/// * `state_witness` - The state witness created from the state provider (`Vec<Bytes>`)
+/// * `headers` - Serialized headers for the ancestor blocks
+///
+/// # Returns
+///
+/// An `ExecutionWitness` ready for stateless validation
+pub fn build_execution_witness(
+    witness_record: ExecutionWitnessRecord,
+    state_witness: alloc::vec::Vec<Bytes>,
+    headers: alloc::vec::Vec<Bytes>,
+) -> ExecutionWitness {
+    ExecutionWitness {
+        state: state_witness,
+        codes: witness_record.codes,
+        keys: witness_record.keys,
+        headers,
+    }
 }

--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -21,7 +21,7 @@ use reth_provider::{
 };
 use reth_revm::{database::StateProviderDatabase, witness::ExecutionWitnessRecord, State};
 use reth_stateless::{
-    trie::StatelessSparseTrie, validation::stateless_validation_with_trie, build_execution_witness,
+    build_execution_witness, trie::StatelessSparseTrie, validation::stateless_validation_with_trie,
     ExecutionWitness, UncompressedPublicKey,
 };
 use reth_trie::{HashedPostState, KeccakKeyHasher, StateRoot};


### PR DESCRIPTION


Extracts duplicate logic for constructing `ExecutionWitness` from `ExecutionWitnessRecord` into a reusable helper function `build_execution_witness`.

### Changes

- Added `build_execution_witness` helper function in `reth-stateless` crate
- Updated `debug_execution_witness_for_block` in `reth-rpc` to use the helper
- Updated blockchain test case to use the helper instead of inline construction


### Motivation

The same logic for creating `ExecutionWitness` from `ExecutionWitnessRecord`, state witness, and headers was duplicated in two places:
1. `debug_execution_witness_for_block` method in `reth-rpc`
2. Blockchain test case in `ef-tests`

This refactoring centralizes the logic, making it easier to maintain and ensuring consistency across both usages.

