### PR TITLE
chore(primitives-traits): gate test-only modules

### DIFF
--- a/crates/primitives-traits/src/lib.rs
+++ b/crates/primitives-traits/src/lib.rs
@@ -148,6 +148,7 @@ pub use block::{
     Block, FullBlock, RecoveredBlock, SealedBlock,
 };
 
+#[cfg(test)]
 mod withdrawal;
 pub use alloy_eips::eip2718::WithEncoded;
 
@@ -156,6 +157,7 @@ pub mod crypto;
 mod error;
 pub use error::{GotExpected, GotExpectedBoxed};
 
+#[cfg(test)]
 mod log;
 pub use alloy_primitives::{logs_bloom, Log, LogData};
 


### PR DESCRIPTION
- Gate withdrawal and log modules with #[cfg(test)]
- These files contain only #[cfg(test)] test code and no public items, so compiling them in non-test builds is unnecessary.
- This change prevents empty private modules from being built outside tests and avoids internal namespace noise without impacting public API or downstream crates.