### PR TITLE
docs: fix otlp flag in monioring docs

### DIFF
--- a/docs/vocs/docs/pages/run/monitoring.mdx
+++ b/docs/vocs/docs/pages/run/monitoring.mdx
@@ -10,10 +10,10 @@ Reth exposes a number of metrics which can be enabled by adding the `--metrics` 
 reth node --metrics 127.0.0.1:9001
 ```
 
-Alternatively, you can export metrics to an OpenTelemetry collector using `--otlp-metrics`:
+Additionally, you can export spans to an OpenTelemetry collector using `--tracing-otlp`:
 
 ```bash
-reth node --otlp-metrics 127.0.0.1:4318
+reth node --tracing-otlp=http://localhost:4318/v1/traces
 ```
 
 Now, as the node is running, you can `curl` the endpoint you provided to the `--metrics` flag to get a text dump of the metrics at that time:


### PR DESCRIPTION
This flag doesn't exist, but it's worth mentioning `--tracing-otlp` in the monitoring section