### PR TITLE
chore: reuse gzip read buffer to avoid per-iteration allocation

### DIFF
--- a/crates/net/downloaders/src/file_client.rs
+++ b/crates/net/downloaders/src/file_client.rs
@@ -481,18 +481,16 @@ impl FileReader {
         chunk: &mut Vec<u8>,
         chunk_byte_len: u64,
     ) -> Result<bool, FileClientError> {
+        let mut buffer = vec![0u8; 64 * 1024];
         loop {
             if chunk.len() >= chunk_byte_len as usize {
                 return Ok(true)
             }
 
-            let mut buffer = vec![0u8; 64 * 1024];
-
             match self.read(&mut buffer).await {
                 Ok(0) => return Ok(!chunk.is_empty()),
                 Ok(n) => {
-                    buffer.truncate(n);
-                    chunk.extend_from_slice(&buffer);
+                    chunk.extend_from_slice(&buffer[..n]);
                 }
                 Err(e) => return Err(e.into()),
             }


### PR DESCRIPTION
Optimize gzip chunk reading by allocating the 64 KiB read buffer once per callto read_gzip_chunk() and reusing it across loop iterations. Previously, a newVec<u8> was allocated on each iteration, causing unnecessary allocations for large chunks. This change preserves behavior while reducing allocation pressure and aligning with standard AsyncRead buffering practices.