### PR TITLE
perf: box ForkId in Peer struct to reduce size

### DIFF
--- a/crates/net/network-types/src/peers/mod.rs
+++ b/crates/net/network-types/src/peers/mod.rs
@@ -25,7 +25,7 @@ pub struct Peer {
     /// The state of the connection, if any.
     pub state: PeerConnectionState,
     /// The [`ForkId`] that the peer announced via discovery.
-    pub fork_id: Option<ForkId>,
+    pub fork_id: Option<Box<ForkId>>,
     /// Whether the entry should be removed after an existing session was terminated.
     pub remove_after_disconnect: bool,
     /// The kind of peer


### PR DESCRIPTION
we have a bunch of those:

https://github.com/paradigmxyz/reth/blob/37d8b2300d5098dbc34add26b789420c59db1abd/crates/net/network/src/peers.rs#L50-L50

this makes the type a few bytes lighter, useful for discv4 peers without a forkid, and we dont access this field in the hotpath (peer selection)