### PR TITLE
chore(net): avoid cloning GetBlockBodies request

### DIFF
--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -29,7 +29,7 @@ use tokio::sync::{mpsc, mpsc::UnboundedSender, oneshot};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
 type InflightHeadersRequest<H> = Request<HeadersRequest, PeerRequestResult<Vec<H>>>;
-type InflightBodiesRequest<B> = Request<Vec<B256>, PeerRequestResult<Vec<B>>>;
+type InflightBodiesRequest<B> = Request<(), PeerRequestResult<Vec<B>>>;
 
 /// Manages data fetching operations.
 ///
@@ -237,7 +237,7 @@ impl<N: NetworkPrimitives> StateFetcher<N> {
                 })
             }
             DownloadRequest::GetBlockBodies { request, response, .. } => {
-                let inflight = Request { request: request.clone(), response };
+                let inflight = Request { request: (), response };
                 self.inflight_bodies_requests.insert(peer_id, inflight);
                 BlockRequest::GetBlockBodies(GetBlockBodies(request))
             }


### PR DESCRIPTION
- Replace InflightBodiesRequest payload from Vec<B256> to () and stop cloning the bodies request vector when inserting into inflight_bodies_requests in StateFetcher.
- The inflight request contents were not used for validation or retries; only the response channel is needed. This removes an unnecessary allocation/copy of potentially large vectors.