### PR TITLE
fix(cli): Metrics log when passed metrics port 0

### DIFF
--- a/crates/cli/commands/src/stage/run.rs
+++ b/crates/cli/commands/src/stage/run.rs
@@ -116,7 +116,6 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
         let components = components(provider_factory.chain_spec());
 
         if let Some(listen_addr) = self.metrics {
-            info!(target: "reth::cli", "Starting metrics endpoint at {}", listen_addr);
             let config = MetricServerConfig::new(
                 listen_addr,
                 VersionInfo {

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -582,7 +582,6 @@ where
 
         let listen_addr = self.node_config().metrics.prometheus;
         if let Some(addr) = listen_addr {
-            info!(target: "reth::cli", "Starting metrics endpoint at {}", addr);
             let config = MetricServerConfig::new(
                 addr,
                 VersionInfo {

--- a/crates/node/metrics/src/server.rs
+++ b/crates/node/metrics/src/server.rs
@@ -119,6 +119,8 @@ impl MetricServer {
             .await
             .wrap_err("Could not bind to address")?;
 
+        tracing::info!(target: "reth::cli", "Starting metrics endpoint at {}", listener.local_addr().unwrap());
+
         task_executor.spawn_with_graceful_shutdown_signal(|mut signal| {
             Box::pin(async move {
                 loop {


### PR DESCRIPTION
Upstreaming https://github.com/op-rs/op-reth/pull/334

Bug: When no value was passed to metrics flag, a random port was assigned, but port 0 was shown as metric port in logs
Fix: Log actual used metrics port