### PR TITLE
chore: Use move-based append in with_resolved_peers to avoid allocation and clones

### DIFF
--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -290,11 +290,10 @@ impl<ChainSpec> LaunchContextWith<WithConfigs<ChainSpec>> {
         if !self.attachment.config.network.trusted_peers.is_empty() {
             info!(target: "reth::cli", "Adding trusted nodes");
 
-            self.attachment
-                .toml_config
-                .peers
-                .trusted_nodes
-                .extend(self.attachment.config.network.trusted_peers.clone());
+            {
+                let mut peers = std::mem::take(&mut self.attachment.config.network.trusted_peers);
+                self.attachment.toml_config.peers.trusted_nodes.append(&mut peers);
+            }
         }
         Ok(self)
     }


### PR DESCRIPTION
Replace extend(...clone()) with a move-based transfer in with_resolved_peers():

- Use std::mem::take on NodeConfig.network.trusted_peers and append the  elements into Config.peers.trusted_nodes.
- Eliminates both the temporary Vec allocation and per-element cloning of  TrustedPeer (which may include domain strings).
- Semantics are preserved because the engine launch path does not read  NodeConfig.network.trusted_peers after with_resolved_peers(), and the  networking stack consumes the TOML-backed PeersConfig.trusted_nodes.
- CLI code paths that only have &self continue to clone by necessity.