### PR TITLE
fix(codecs): return remaining slice in EIP-1559 from_compact

### DIFF
--- a/crates/storage/codecs/src/alloy/transaction/eip1559.rs
+++ b/crates/storage/codecs/src/alloy/transaction/eip1559.rs
@@ -53,7 +53,8 @@ impl Compact for AlloyTxEip1559 {
     }
 
     fn from_compact(buf: &[u8], len: usize) -> (Self, &[u8]) {
-        let (tx, _) = TxEip1559::from_compact(buf, len);
+        // Return the remaining slice from the inner from_compact to advance the cursor correctly.
+        let (tx, remaining) = TxEip1559::from_compact(buf, len);
 
         let alloy_tx = Self {
             chain_id: tx.chain_id,
@@ -67,6 +68,6 @@ impl Compact for AlloyTxEip1559 {
             input: tx.input,
         };
 
-        (alloy_tx, buf)
+        (alloy_tx, remaining)
     }
 }

--- a/crates/storage/codecs/src/alloy/transaction/eip2930.rs
+++ b/crates/storage/codecs/src/alloy/transaction/eip2930.rs
@@ -52,7 +52,8 @@ impl Compact for AlloyTxEip2930 {
     }
 
     fn from_compact(buf: &[u8], len: usize) -> (Self, &[u8]) {
-        let (tx, _) = TxEip2930::from_compact(buf, len);
+        // Return the remaining slice from the inner from_compact to advance the cursor correctly.
+        let (tx, remaining) = TxEip2930::from_compact(buf, len);
         let alloy_tx = Self {
             chain_id: tx.chain_id,
             nonce: tx.nonce,
@@ -63,6 +64,6 @@ impl Compact for AlloyTxEip2930 {
             access_list: tx.access_list,
             input: tx.input,
         };
-        (alloy_tx, buf)
+        (alloy_tx, remaining)
     }
 }

--- a/crates/storage/codecs/src/alloy/transaction/eip4844.rs
+++ b/crates/storage/codecs/src/alloy/transaction/eip4844.rs
@@ -68,7 +68,8 @@ impl Compact for AlloyTxEip4844 {
     }
 
     fn from_compact(buf: &[u8], len: usize) -> (Self, &[u8]) {
-        let (tx, _) = TxEip4844::from_compact(buf, len);
+        // Return the remaining slice from the inner from_compact to advance the cursor correctly.
+        let (tx, remaining) = TxEip4844::from_compact(buf, len);
         let alloy_tx = Self {
             chain_id: tx.chain_id,
             nonce: tx.nonce,
@@ -82,7 +83,7 @@ impl Compact for AlloyTxEip4844 {
             max_fee_per_blob_gas: tx.max_fee_per_blob_gas,
             input: tx.input,
         };
-        (alloy_tx, buf)
+        (alloy_tx, remaining)
     }
 }
 

--- a/crates/storage/codecs/src/alloy/transaction/eip7702.rs
+++ b/crates/storage/codecs/src/alloy/transaction/eip7702.rs
@@ -57,7 +57,8 @@ impl Compact for AlloyTxEip7702 {
     }
 
     fn from_compact(buf: &[u8], len: usize) -> (Self, &[u8]) {
-        let (tx, _) = TxEip7702::from_compact(buf, len);
+        // Return the remaining slice from the inner from_compact to advance the cursor correctly.
+        let (tx, remaining) = TxEip7702::from_compact(buf, len);
         let alloy_tx = Self {
             chain_id: tx.chain_id,
             nonce: tx.nonce,
@@ -70,6 +71,6 @@ impl Compact for AlloyTxEip7702 {
             access_list: tx.access_list,
             authorization_list: tx.authorization_list,
         };
-        (alloy_tx, buf)
+        (alloy_tx, remaining)
     }
 }

--- a/crates/storage/codecs/src/alloy/transaction/legacy.rs
+++ b/crates/storage/codecs/src/alloy/transaction/legacy.rs
@@ -67,7 +67,8 @@ impl Compact for AlloyTxLegacy {
     }
 
     fn from_compact(buf: &[u8], len: usize) -> (Self, &[u8]) {
-        let (tx, _) = TxLegacy::from_compact(buf, len);
+        // Return the remaining slice from the inner from_compact to advance the cursor correctly.
+        let (tx, remaining) = TxLegacy::from_compact(buf, len);
 
         let alloy_tx = Self {
             chain_id: tx.chain_id,
@@ -79,6 +80,6 @@ impl Compact for AlloyTxLegacy {
             input: tx.input,
         };
 
-        (alloy_tx, buf)
+        (alloy_tx, remaining)
     }
 }

--- a/crates/storage/codecs/src/alloy/transaction/optimism.rs
+++ b/crates/storage/codecs/src/alloy/transaction/optimism.rs
@@ -66,7 +66,8 @@ impl Compact for AlloyTxDeposit {
     }
 
     fn from_compact(buf: &[u8], len: usize) -> (Self, &[u8]) {
-        let (tx, _) = TxDeposit::from_compact(buf, len);
+        // Return the remaining slice from the inner from_compact to advance the cursor correctly.
+        let (tx, remaining) = TxDeposit::from_compact(buf, len);
         let alloy_tx = Self {
             source_hash: tx.source_hash,
             from: tx.from,
@@ -77,7 +78,7 @@ impl Compact for AlloyTxDeposit {
             is_system_transaction: tx.is_system_transaction,
             input: tx.input,
         };
-        (alloy_tx, buf)
+        (alloy_tx, remaining)
     }
 }
 


### PR DESCRIPTION
Return the remaining buffer from inner TxEip1559::from_compact to maintain cursor advancement and fix chained deserialization.