### PR TITLE
chore: mark OpBuilderConfig::constrained_da_config as deprecated

### DIFF
--- a/crates/optimism/payload/src/config.rs
+++ b/crates/optimism/payload/src/config.rs
@@ -17,6 +17,9 @@ impl OpBuilderConfig {
 
     /// Returns the Data Availability configuration for the OP builder, if it has configured
     /// constraints.
+    #[deprecated(
+        note = "Use OpDAConfig::max_da_tx_size()/max_da_block_size() directly. This method is unused and will be removed in a future release."
+    )]
     pub fn constrained_da_config(&self) -> Option<&OpDAConfig> {
         if self.da_config.is_empty() {
             None

--- a/crates/optimism/payload/src/config.rs
+++ b/crates/optimism/payload/src/config.rs
@@ -120,6 +120,7 @@ mod tests {
         assert_eq!(da.max_da_block_size(), None);
     }
 
+    #[allow(deprecated)]
     #[test]
     fn test_da_constrained() {
         let config = OpBuilderConfig::default();


### PR DESCRIPTION
The method is unused across the repository and external code search.
It is redundant with OpDAConfig::max_da_tx_size() and max_da_block_size() which already return Option<u64> for “no limit.”
Builders and RPC paths directly use OpDAConfig and its per-limit getters.