### PR TITLE
chore: inline hardcoded filter name in segment filename

### DIFF
--- a/crates/static-file/types/src/segment.rs
+++ b/crates/static-file/types/src/segment.rs
@@ -1,8 +1,5 @@
 use crate::{BlockNumber, Compression};
-use alloc::{
-    format,
-    string::{String, ToString},
-};
+use alloc::{format, string::String};
 use alloy_primitives::TxNumber;
 use core::{ops::RangeInclusive, str::FromStr};
 use derive_more::Display;
@@ -83,11 +80,9 @@ impl StaticFileSegment {
     ) -> String {
         let prefix = self.filename(block_range);
 
-        let filters_name = "none".to_string();
-
         // ATTENTION: if changing the name format, be sure to reflect those changes in
         // [`Self::parse_filename`.]
-        format!("{prefix}_{}_{}", filters_name, compression.as_ref())
+        format!("{prefix}_none_{}", compression.as_ref())
     }
 
     /// Parses a filename into a `StaticFileSegment` and its expected block range.

--- a/crates/static-file/types/src/segment.rs
+++ b/crates/static-file/types/src/segment.rs
@@ -80,9 +80,11 @@ impl StaticFileSegment {
     ) -> String {
         let prefix = self.filename(block_range);
 
+        let filters_name = "none";
+
         // ATTENTION: if changing the name format, be sure to reflect those changes in
         // [`Self::parse_filename`.]
-        format!("{prefix}_none_{}", compression.as_ref())
+        format!("{prefix}_{}_{}", filters_name, compression.as_ref())
     }
 
     /// Parses a filename into a `StaticFileSegment` and its expected block range.


### PR DESCRIPTION
Removes unnecessary .to_string() call in filename_with_configuration.

After #10627 removed the Filters enum, filters_name became a hardcoded "none" literal but was still being converted to
String unnecessarily. This just inlines it directly into the format macro.

Also removes the now-unused ToString import.

