### PR TITLE
fix: Properly set MerkleChangeSets checkpoint in stage's fast-path

### DIFF
--- a/crates/stages/stages/src/stages/merkle_changesets.rs
+++ b/crates/stages/stages/src/stages/merkle_changesets.rs
@@ -312,6 +312,12 @@ where
         // Get the previously computed range. This will be updated to reflect the populating of the
         // target range.
         let mut computed_range = Self::computed_range(provider, input.checkpoint)?;
+        debug!(
+            target: "sync::stages::merkle_changesets",
+            ?computed_range,
+            ?target_range,
+            "Got computed and target ranges",
+        );
 
         // We want the target range to not include any data already computed previously, if
         // possible, so we start the target range from the end of the computed range if that is
@@ -335,9 +341,9 @@ where
         }
 
         // If target range is empty (target_start >= target_end), stage is already successfully
-        // executed
+        // executed.
         if target_range.start >= target_range.end {
-            return Ok(ExecOutput::done(input.checkpoint.unwrap_or_default()));
+            return Ok(ExecOutput::done(StageCheckpoint::new(target_range.end.saturating_sub(1))));
         }
 
         // If our target range is a continuation of the already computed range then we can keep the


### PR DESCRIPTION
When the Merkle checkpoint (aka the db tip) == last finalized block, and the previous MerkleChangeSets checkpoint was unset, then the MerkleChangeSets stage pipeline had a bug in its fast-path:

* `target_range.end` is set to Merkle checkpoint + 1 (because the range is exclusive)
* `target_range.start` is set to last finalized block + 1 (which is one more than the Merkle checkpoint)
* `target_range.start >= target_range.end`, triggering immediate return of previous MerkleChangeSets checkpoint. But this checkpoint was not set, so a checkpoint of zero would get stored.

Fix is to store `target_range.end - 1`, aka the Merkle checkpoint, as the MerkleChangeSets checkpoint.