### PR TITLE
feat: optimize ECIES body decode to avoid extra allocation/copy

### DIFF
--- a/crates/net/ecies/src/codec.rs
+++ b/crates/net/ecies/src/codec.rs
@@ -136,11 +136,14 @@ impl Decoder for ECIESCodec {
                     }
 
                     let mut data = buf.split_to(self.ecies.body_len());
-                    let mut ret = BytesMut::new();
-                    ret.extend_from_slice(self.ecies.read_body(&mut data)?);
+                    let size = {
+                        let slice = self.ecies.read_body(&mut data)?;
+                        slice.len()
+                    };
+                    data.truncate(size);
 
                     self.state = ECIESState::Header;
-                    return Ok(Some(IngressECIESValue::Message(ret)))
+                    return Ok(Some(IngressECIESValue::Message(data)))
                 }
             }
         }


### PR DESCRIPTION
- Replace creating a new BytesMut and copying plaintext with truncating the split buffer based on the slice length returned by read_body.
- This preserves in-place decryption semantics and eliminates unnecessary allocation and memcpy on every message body, reducing overhead under load.