### PR TITLE
fix(beacon-api-sidecar): use correct block metadata for reorged blobs

### DIFF
--- a/examples/beacon-api-sidecar-fetcher/src/mined_sidecar.rs
+++ b/examples/beacon-api-sidecar-fetcher/src/mined_sidecar.rs
@@ -202,9 +202,9 @@ where
                                     .map(|tx| {
                                         let transaction_hash = *tx.tx_hash();
                                         let block_metadata = BlockMetadata {
-                                            block_hash: new.tip().hash(),
-                                            block_number: new.tip().number(),
-                                            gas_used: new.tip().gas_used(),
+                                            block_hash: block.hash(),
+                                            block_number: block.number,
+                                            gas_used: block.gas_used,
                                         };
                                         BlobTransactionEvent::Reorged(ReorgedBlob {
                                             transaction_hash,

--- a/examples/beacon-api-sidecar-fetcher/src/mined_sidecar.rs
+++ b/examples/beacon-api-sidecar-fetcher/src/mined_sidecar.rs
@@ -1,5 +1,5 @@
 use crate::BeaconSidecarConfig;
-use alloy_consensus::{BlockHeader, Signed, Transaction as _, TxEip4844WithSidecar, Typed2718};
+use alloy_consensus::{Signed, Transaction as _, TxEip4844WithSidecar, Typed2718};
 use alloy_eips::eip7594::BlobTransactionSidecarVariant;
 use alloy_primitives::B256;
 use alloy_rpc_types_beacon::sidecar::{BeaconBlobBundle, SidecarIterator};


### PR DESCRIPTION
Use metadata from the actual reorged block instead of new.tip() when creating ReorgedBlob events. 
Previously, all reorged transactions from different blocks received the same metadata from the new chain tip, losing information about which block each transaction originally belonged to.