### PR TITLE
feat(node): CLI argument for sync state idle when backfill is idle

### DIFF
--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -261,12 +261,16 @@ impl EngineNodeLauncher {
         let provider = ctx.blockchain_db().clone();
         let (exit, rx) = oneshot::channel();
         let terminate_after_backfill = ctx.terminate_after_initial_backfill();
+        let backfill_sync_state_idle = ctx.node_config().debug.backfill_sync_state_idle;
 
         info!(target: "reth::cli", "Starting consensus engine");
         ctx.task_executor().spawn_critical("consensus engine", Box::pin(async move {
             if let Some(initial_target) = initial_target {
                 debug!(target: "reth::cli", %initial_target,  "start backfill sync");
+                // network_handle's sync state is already initialized at Syncing
                 engine_service.orchestrator_mut().start_backfill_sync(initial_target);
+            } else if backfill_sync_state_idle {
+                network_handle.update_sync_state(SyncState::Idle);
             }
 
             let mut res = Ok(());
@@ -288,6 +292,9 @@ impl EngineNodeLauncher {
                                 if terminate_after_backfill {
                                     debug!(target: "reth::cli", "Terminating after initial backfill");
                                     break
+                                }
+                                if backfill_sync_state_idle {
+                                    network_handle.update_sync_state(SyncState::Idle);
                                 }
                             }
                             ChainEvent::BackfillSyncStarted => {

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -261,7 +261,7 @@ impl EngineNodeLauncher {
         let provider = ctx.blockchain_db().clone();
         let (exit, rx) = oneshot::channel();
         let terminate_after_backfill = ctx.terminate_after_initial_backfill();
-        let backfill_sync_state_idle = ctx.node_config().debug.backfill_sync_state_idle;
+        let startup_sync_state_idle = ctx.node_config().debug.startup_sync_state_idle;
 
         info!(target: "reth::cli", "Starting consensus engine");
         ctx.task_executor().spawn_critical("consensus engine", Box::pin(async move {
@@ -269,7 +269,7 @@ impl EngineNodeLauncher {
                 debug!(target: "reth::cli", %initial_target,  "start backfill sync");
                 // network_handle's sync state is already initialized at Syncing
                 engine_service.orchestrator_mut().start_backfill_sync(initial_target);
-            } else if backfill_sync_state_idle {
+            } else if startup_sync_state_idle {
                 network_handle.update_sync_state(SyncState::Idle);
             }
 
@@ -293,7 +293,7 @@ impl EngineNodeLauncher {
                                     debug!(target: "reth::cli", "Terminating after initial backfill");
                                     break
                                 }
-                                if backfill_sync_state_idle {
+                                if startup_sync_state_idle {
                                     network_handle.update_sync_state(SyncState::Idle);
                                 }
                             }

--- a/crates/node/core/src/args/debug.rs
+++ b/crates/node/core/src/args/debug.rs
@@ -101,6 +101,13 @@ pub struct DebugArgs {
     /// Example: `nodename:secret@host:port`
     #[arg(long = "ethstats", help_heading = "Debug")]
     pub ethstats: Option<String>,
+
+    /// Set the node to idle state when the backfill is not running.
+    ///
+    /// This makes the `eth_syncing` RPC return "Idle" when the node has just started or finished
+    /// the backfill, but did not yet receive any new blocks.
+    #[arg(long = "debug.backfill-sync-state-idle", help_heading = "Debug")]
+    pub backfill_sync_state_idle: bool,
 }
 
 impl Default for DebugArgs {
@@ -119,6 +126,7 @@ impl Default for DebugArgs {
             invalid_block_hook: Some(InvalidBlockSelection::default()),
             healthy_node_rpc_url: None,
             ethstats: None,
+            backfill_sync_state_idle: false,
         }
     }
 }

--- a/crates/node/core/src/args/debug.rs
+++ b/crates/node/core/src/args/debug.rs
@@ -106,8 +106,8 @@ pub struct DebugArgs {
     ///
     /// This makes the `eth_syncing` RPC return "Idle" when the node has just started or finished
     /// the backfill, but did not yet receive any new blocks.
-    #[arg(long = "debug.backfill-sync-state-idle", help_heading = "Debug")]
-    pub backfill_sync_state_idle: bool,
+    #[arg(long = "debug.startup-sync-state-idle", help_heading = "Debug")]
+    pub startup_sync_state_idle: bool,
 }
 
 impl Default for DebugArgs {
@@ -126,7 +126,7 @@ impl Default for DebugArgs {
             invalid_block_hook: Some(InvalidBlockSelection::default()),
             healthy_node_rpc_url: None,
             ethstats: None,
-            backfill_sync_state_idle: false,
+            startup_sync_state_idle: false,
         }
     }
 }

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -701,6 +701,11 @@ Debug:
       --ethstats <ETHSTATS>
           The URL of the ethstats server to connect to. Example: `nodename:secret@host:port`
 
+      --debug.startup-sync-state-idle
+          Set the node to idle state when the backfill is not running.
+
+          This makes the `eth_syncing` RPC return "Idle" when the node has just started or finished the backfill, but did not yet receive any new blocks.
+
 Database:
       --db.log-level <LOG_LEVEL>
           Database logging level. Levels higher than "notice" require a debug build


### PR DESCRIPTION
Useful when running `reth-bench-compare` for correct syncing/idle detection https://github.com/shekhirin/reth-bench-compare/commit/3fbf28399ff11b66191ddd463aeb1c3685d4b3ff