### PR TITLE
chore: avoid allocating empty AccountStorageCache when no storage entries

### DIFF
--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -340,9 +340,16 @@ impl ExecutionCache {
     where
         I: IntoIterator<Item = (StorageKey, Option<StorageValue>)>,
     {
+        let mut iter = storage_entries.into_iter();
+
+        let Some((first_key, first_value)) = iter.next() else {
+            return;
+        };
+
         let account_cache = self.storage_cache.get(&address).unwrap_or_default();
 
-        for (key, value) in storage_entries {
+        account_cache.insert_storage(first_key, first_value);
+        for (key, value) in iter {
             account_cache.insert_storage(key, value);
         }
 


### PR DESCRIPTION
Avoid allocating and inserting an empty per-account storage cache when there are no storage entries to add.

Previously, insert_storage_bulk() always created and inserted an Arc<AccountStorageCache> even if the iterator was empty. This led to unnecessary allocations and capacity consumption.

The new logic early-returns on empty iterators and only re-inserts into storage_cache when at least one slot is actually inserted. This preserves behavior (get_storage semantics are unchanged) while eliminating waste and keeping weigher/TTL refreshes only when the cache genuinely changes.