### PR TITLE
fix(payload): emit events for Freeze payload outcomes

### DIFF
--- a/crates/payload/basic/src/better_payload_emitter.rs
+++ b/crates/payload/basic/src/better_payload_emitter.rs
@@ -42,6 +42,10 @@ where
                 let _ = self.better_payloads_tx.send(Arc::new(payload.clone()));
                 Ok(BuildOutcome::Better { payload, cached_reads })
             }
+            Ok(BuildOutcome::Freeze(payload)) => {
+                let _ = self.better_payloads_tx.send(Arc::new(payload.clone()));
+                Ok(BuildOutcome::Freeze(payload))
+            }
             res => res,
         }
     }

--- a/crates/payload/basic/src/better_payload_emitter.rs
+++ b/crates/payload/basic/src/better_payload_emitter.rs
@@ -38,13 +38,11 @@ where
         args: BuildArguments<Self::Attributes, Self::BuiltPayload>,
     ) -> Result<BuildOutcome<Self::BuiltPayload>, PayloadBuilderError> {
         match self.inner.try_build(args) {
-            Ok(BuildOutcome::Better { payload, cached_reads }) => {
-                let _ = self.better_payloads_tx.send(Arc::new(payload.clone()));
-                Ok(BuildOutcome::Better { payload, cached_reads })
-            }
-            Ok(BuildOutcome::Freeze(payload)) => {
-                let _ = self.better_payloads_tx.send(Arc::new(payload.clone()));
-                Ok(BuildOutcome::Freeze(payload))
+            Ok(res) => {
+                if let Some(payload) = res.payload().cloned() {
+                    let _ = self.better_payloads_tx.send(Arc::new(payload));
+                }
+                Ok(res)
             }
             res => res,
         }

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -706,8 +706,16 @@ pub enum BuildOutcome<Payload> {
 }
 
 impl<Payload> BuildOutcome<Payload> {
-    /// Consumes the type and returns the payload if the outcome is `Better`.
+    /// Consumes the type and returns the payload if the outcome is `Better` or `Freeze`.
     pub fn into_payload(self) -> Option<Payload> {
+        match self {
+            Self::Better { payload, .. } | Self::Freeze(payload) => Some(payload),
+            _ => None,
+        }
+    }
+
+    /// Consumes the type and returns the payload if the outcome is `Better` or `Freeze`.
+    pub const fn payload(&self) -> Option<&Payload> {
         match self {
             Self::Better { payload, .. } | Self::Freeze(payload) => Some(payload),
             _ => None,
@@ -717,6 +725,11 @@ impl<Payload> BuildOutcome<Payload> {
     /// Returns true if the outcome is `Better`.
     pub const fn is_better(&self) -> bool {
         matches!(self, Self::Better { .. })
+    }
+
+    /// Returns true if the outcome is `Freeze`.
+    pub const fn is_frozen(&self) -> bool {
+        matches!(self, Self::Freeze { .. })
     }
 
     /// Returns true if the outcome is `Aborted`.


### PR DESCRIPTION
Handle BuildOutcome::Freeze variant in BetterPayloadEmitter by sending frozen payloads to the broadcast channel, same as Better outcomes. 

This ensures subscribers receive all valid payload events, including final frozen payloads used in deterministic scenarios.