### PR TITLE
chore: add js-tracer feature to bins

### DIFF
--- a/.config/zepter.yaml
+++ b/.config/zepter.yaml
@@ -12,7 +12,7 @@ workflows:
         # Check that `A` activates the features of `B`.
         "propagate-feature",
         # These are the features to check:
-        "--features=std,op,dev,asm-keccak,jemalloc,jemalloc-prof,tracy-allocator,serde-bincode-compat,serde,test-utils,arbitrary,bench,alloy-compat,min-error-logs,min-warn-logs,min-info-logs,min-debug-logs,min-trace-logs,otlp",
+        "--features=std,op,dev,asm-keccak,jemalloc,jemalloc-prof,tracy-allocator,serde-bincode-compat,serde,test-utils,arbitrary,bench,alloy-compat,min-error-logs,min-warn-logs,min-info-logs,min-debug-logs,min-trace-logs,otlp,js-tracer",
         # Do not try to add a new section to `[features]` of `A` only because `B` exposes that feature. There are edge-cases where this is still needed, but we can add them manually.
         "--left-side-feature-missing=ignore",
         # Ignore the case that `A` it outside of the workspace. Otherwise it will report errors in external dependencies that we have no influence on.

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -40,7 +40,7 @@ reth-node-api.workspace = true
 reth-node-core.workspace = true
 reth-ethereum-payload-builder.workspace = true
 reth-ethereum-primitives.workspace = true
-reth-node-ethereum = { workspace = true, features = ["js-tracer"] }
+reth-node-ethereum.workspace = true
 reth-node-builder.workspace = true
 reth-node-metrics.workspace = true
 reth-consensus.workspace = true
@@ -67,11 +67,17 @@ backon.workspace = true
 tempfile.workspace = true
 
 [features]
-default = ["jemalloc", "otlp", "reth-revm/portable"]
+default = ["jemalloc", "otlp", "reth-revm/portable", "js-tracer"]
 
 otlp = [
     "reth-ethereum-cli/otlp",
     "reth-node-core/otlp",
+]
+js-tracer = [
+	"reth-node-builder/js-tracer",
+	"reth-node-ethereum/js-tracer",
+	"reth-rpc/js-tracer",
+	"reth-rpc-eth-types/js-tracer"
 ]
 
 dev = ["reth-ethereum-cli/dev"]

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -74,10 +74,10 @@ otlp = [
     "reth-node-core/otlp",
 ]
 js-tracer = [
-	"reth-node-builder/js-tracer",
-	"reth-node-ethereum/js-tracer",
-	"reth-rpc/js-tracer",
-	"reth-rpc-eth-types/js-tracer"
+    "reth-node-builder/js-tracer",
+    "reth-node-ethereum/js-tracer",
+    "reth-rpc/js-tracer",
+    "reth-rpc-eth-types/js-tracer",
 ]
 
 dev = ["reth-ethereum-cli/dev"]

--- a/crates/ethereum/node/Cargo.toml
+++ b/crates/ethereum/node/Cargo.toml
@@ -83,10 +83,10 @@ asm-keccak = [
     "revm/asm-keccak",
 ]
 js-tracer = [
-	"reth-node-builder/js-tracer",
-	"reth-rpc/js-tracer",
-	"reth-rpc-eth-api/js-tracer",
-	"reth-rpc-eth-types/js-tracer"
+    "reth-node-builder/js-tracer",
+    "reth-rpc/js-tracer",
+    "reth-rpc-eth-api/js-tracer",
+    "reth-rpc-eth-types/js-tracer",
 ]
 test-utils = [
     "reth-node-builder/test-utils",

--- a/crates/ethereum/node/Cargo.toml
+++ b/crates/ethereum/node/Cargo.toml
@@ -82,7 +82,12 @@ asm-keccak = [
     "reth-node-core/asm-keccak",
     "revm/asm-keccak",
 ]
-js-tracer = ["reth-node-builder/js-tracer"]
+js-tracer = [
+	"reth-node-builder/js-tracer",
+	"reth-rpc/js-tracer",
+	"reth-rpc-eth-api/js-tracer",
+	"reth-rpc-eth-types/js-tracer"
+]
 test-utils = [
     "reth-node-builder/test-utils",
     "reth-chainspec/test-utils",

--- a/crates/ethereum/reth/Cargo.toml
+++ b/crates/ethereum/reth/Cargo.toml
@@ -145,11 +145,11 @@ rpc = [
 ]
 tasks = ["dep:reth-tasks"]
 js-tracer = [
-	"rpc",
-	"reth-rpc/js-tracer",
-	"reth-node-builder?/js-tracer",
-	"reth-node-ethereum?/js-tracer",
-	"reth-rpc-eth-types?/js-tracer"
+    "rpc",
+    "reth-rpc/js-tracer",
+    "reth-node-builder?/js-tracer",
+    "reth-node-ethereum?/js-tracer",
+    "reth-rpc-eth-types?/js-tracer",
 ]
 network = ["dep:reth-network", "tasks", "dep:reth-network-api", "dep:reth-eth-wire"]
 provider = ["storage-api", "tasks", "dep:reth-provider", "dep:reth-db", "dep:reth-codecs"]

--- a/crates/ethereum/reth/Cargo.toml
+++ b/crates/ethereum/reth/Cargo.toml
@@ -144,7 +144,13 @@ rpc = [
     "dep:alloy-rpc-types-engine",
 ]
 tasks = ["dep:reth-tasks"]
-js-tracer = ["rpc", "reth-rpc/js-tracer"]
+js-tracer = [
+	"rpc",
+	"reth-rpc/js-tracer",
+	"reth-node-builder?/js-tracer",
+	"reth-node-ethereum?/js-tracer",
+	"reth-rpc-eth-types?/js-tracer"
+]
 network = ["dep:reth-network", "tasks", "dep:reth-network-api", "dep:reth-eth-wire"]
 provider = ["storage-api", "tasks", "dep:reth-provider", "dep:reth-db", "dep:reth-codecs"]
 storage-api = ["dep:reth-storage-api"]

--- a/crates/node/builder/Cargo.toml
+++ b/crates/node/builder/Cargo.toml
@@ -96,9 +96,9 @@ reth-evm-ethereum = { workspace = true, features = ["test-utils"] }
 [features]
 default = []
 js-tracer = [
-	"reth-rpc/js-tracer",
-	"reth-node-ethereum/js-tracer",
-	"reth-rpc-eth-types/js-tracer"
+    "reth-rpc/js-tracer",
+    "reth-node-ethereum/js-tracer",
+    "reth-rpc-eth-types/js-tracer",
 ]
 test-utils = [
     "reth-db/test-utils",

--- a/crates/node/builder/Cargo.toml
+++ b/crates/node/builder/Cargo.toml
@@ -95,7 +95,11 @@ reth-evm-ethereum = { workspace = true, features = ["test-utils"] }
 
 [features]
 default = []
-js-tracer = ["reth-rpc/js-tracer"]
+js-tracer = [
+	"reth-rpc/js-tracer",
+	"reth-node-ethereum/js-tracer",
+	"reth-rpc-eth-types/js-tracer"
+]
 test-utils = [
     "reth-db/test-utils",
     "reth-chain-state/test-utils",

--- a/crates/optimism/bin/Cargo.toml
+++ b/crates/optimism/bin/Cargo.toml
@@ -12,7 +12,7 @@ exclude.workspace = true
 reth-cli-util.workspace = true
 reth-optimism-cli.workspace = true
 reth-optimism-rpc.workspace = true
-reth-optimism-node = { workspace = true, features = ["js-tracer"] }
+reth-optimism-node.workspace = true
 reth-optimism-chainspec.workspace = true
 reth-optimism-consensus.workspace = true
 reth-optimism-evm.workspace = true
@@ -27,9 +27,13 @@ tracing.workspace = true
 workspace = true
 
 [features]
-default = ["jemalloc", "otlp", "reth-optimism-evm/portable"]
+default = ["jemalloc", "otlp", "reth-optimism-evm/portable", "js-tracer"]
 
 otlp = ["reth-optimism-cli/otlp"]
+
+js-tracer = [
+	"reth-optimism-node/js-tracer"
+]
 
 jemalloc = ["reth-cli-util/jemalloc", "reth-optimism-cli/jemalloc"]
 jemalloc-prof = ["reth-cli-util/jemalloc-prof"]

--- a/crates/optimism/bin/Cargo.toml
+++ b/crates/optimism/bin/Cargo.toml
@@ -32,7 +32,7 @@ default = ["jemalloc", "otlp", "reth-optimism-evm/portable", "js-tracer"]
 otlp = ["reth-optimism-cli/otlp"]
 
 js-tracer = [
-	"reth-optimism-node/js-tracer"
+    "reth-optimism-node/js-tracer",
 ]
 
 jemalloc = ["reth-cli-util/jemalloc", "reth-optimism-cli/jemalloc"]

--- a/crates/optimism/node/Cargo.toml
+++ b/crates/optimism/node/Cargo.toml
@@ -94,10 +94,10 @@ asm-keccak = [
     "revm/asm-keccak",
 ]
 js-tracer = [
-	"reth-node-builder/js-tracer",
-	"reth-optimism-node/js-tracer",
-	"reth-rpc/js-tracer",
-	"reth-rpc-eth-types/js-tracer"
+    "reth-node-builder/js-tracer",
+    "reth-optimism-node/js-tracer",
+    "reth-rpc/js-tracer",
+    "reth-rpc-eth-types/js-tracer",
 ]
 test-utils = [
     "reth-tasks",

--- a/crates/optimism/node/Cargo.toml
+++ b/crates/optimism/node/Cargo.toml
@@ -93,7 +93,12 @@ asm-keccak = [
     "reth-node-core/asm-keccak",
     "revm/asm-keccak",
 ]
-js-tracer = ["reth-node-builder/js-tracer"]
+js-tracer = [
+	"reth-node-builder/js-tracer",
+	"reth-optimism-node/js-tracer",
+	"reth-rpc/js-tracer",
+	"reth-rpc-eth-types/js-tracer"
+]
 test-utils = [
     "reth-tasks",
     "reth-e2e-test-utils",

--- a/crates/optimism/reth/Cargo.toml
+++ b/crates/optimism/reth/Cargo.toml
@@ -126,7 +126,13 @@ rpc = [
     "dep:reth-optimism-rpc",
 ]
 tasks = ["dep:reth-tasks"]
-js-tracer = ["rpc", "reth-rpc/js-tracer"]
+js-tracer = [
+	"rpc",
+	"reth-rpc/js-tracer",
+	"reth-node-builder?/js-tracer",
+	"reth-optimism-node?/js-tracer",
+	"reth-rpc-eth-types?/js-tracer"
+]
 network = ["dep:reth-network", "tasks", "dep:reth-network-api", "dep:reth-eth-wire"]
 provider = ["storage-api", "tasks", "dep:reth-provider", "dep:reth-db", "dep:reth-codecs"]
 pool = ["dep:reth-transaction-pool"]

--- a/crates/optimism/reth/Cargo.toml
+++ b/crates/optimism/reth/Cargo.toml
@@ -127,11 +127,11 @@ rpc = [
 ]
 tasks = ["dep:reth-tasks"]
 js-tracer = [
-	"rpc",
-	"reth-rpc/js-tracer",
-	"reth-node-builder?/js-tracer",
-	"reth-optimism-node?/js-tracer",
-	"reth-rpc-eth-types?/js-tracer"
+    "rpc",
+    "reth-rpc/js-tracer",
+    "reth-node-builder?/js-tracer",
+    "reth-optimism-node?/js-tracer",
+    "reth-rpc-eth-types?/js-tracer",
 ]
 network = ["dep:reth-network", "tasks", "dep:reth-network-api", "dep:reth-eth-wire"]
 provider = ["storage-api", "tasks", "dep:reth-provider", "dep:reth-db", "dep:reth-codecs"]

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -106,4 +106,8 @@ rand.workspace = true
 jsonrpsee = { workspace = true, features = ["client"] }
 
 [features]
-js-tracer = ["revm-inspectors/js-tracer", "reth-rpc-eth-types/js-tracer"]
+js-tracer = [
+	"revm-inspectors/js-tracer",
+	"reth-rpc-eth-types/js-tracer",
+	"reth-rpc-eth-api/js-tracer"
+]

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -107,7 +107,7 @@ jsonrpsee = { workspace = true, features = ["client"] }
 
 [features]
 js-tracer = [
-	"revm-inspectors/js-tracer",
-	"reth-rpc-eth-types/js-tracer",
-	"reth-rpc-eth-api/js-tracer"
+    "revm-inspectors/js-tracer",
+    "reth-rpc-eth-types/js-tracer",
+    "reth-rpc-eth-api/js-tracer",
 ]


### PR DESCRIPTION
make js-tracer support a feature in the binary crates, activated by default, so no functional changes

adds js-tracer to zepter forward features