### PR TITLE
fix: refocus txpool example description on pool validator

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -49,7 +49,7 @@ See examples in a [dedicated repository](https://github.com/paradigmxyz/reth-exe
 | Example                                        | Description                                                                                                                |
 | ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
 | [Trace pending transactions](./txpool-tracing) | Illustrates how to trace pending transactions as they arrive in the mempool                                                |
-| [Standalone txpool](./network-txpool)          | Illustrates how to use the network as a standalone component together with a transaction pool with a custom pool validator |
+| [Standalone txpool](./network-txpool)          | Illustrates how to use a transaction pool with a custom pool validator integrated with the network component |
 
 ## P2P
 


### PR DESCRIPTION
Refocuses txpool example description on the transaction pool with custom validator instead of network component to match the Mempool section focus.