### PR TITLE
fix: honor OpenDiskFileBlobStore and implement reindex

### DIFF
--- a/crates/transaction-pool/src/blobstore/disk.rs
+++ b/crates/transaction-pool/src/blobstore/disk.rs
@@ -939,7 +939,7 @@ mod tests {
 
         let blobs = rng_blobs(4);
         let txs: Vec<_> = blobs.iter().map(|(tx, _)| *tx).collect();
-        store.insert_all(blobs.clone()).unwrap();
+        store.insert_all(blobs).unwrap();
 
         // ensure we wrote something
         assert!(store.data_size_hint().unwrap() > 0);


### PR DESCRIPTION
- Wire OpenDiskFileBlobStore in DiskFileBlobStore::open() to support both Clear (delete+create) and ReIndex (create if missing and rebuild in-memory state).
- Implement DiskFileBlobStoreInner::reindex() to scan the blob directory, reconstruct size_tracker, and rebuild versioned_hashes_to_txhash from decoded sidecars.
- Add a unit test to verify reindex preserves visibility of on-disk blobs across restarts.
- This change fixes the previously ignored open option and ensures blobstore contents remain discoverable after process restarts, aligning implementation with the documented API.