### PR TITLE
refactor(witness): unify witness generation with DebugApi

### DIFF
--- a/crates/engine/invalid-block-hooks/Cargo.toml
+++ b/crates/engine/invalid-block-hooks/Cargo.toml
@@ -19,7 +19,8 @@ reth-engine-primitives.workspace = true
 reth-evm.workspace = true
 reth-primitives-traits.workspace = true
 reth-provider.workspace = true
-reth-revm = { workspace = true, features = ["serde"] }
+reth-revm = { workspace = true, features = ["serde", "witness"] }
+reth-storage-api.workspace = true
 reth-rpc-api = { workspace = true, features = ["client"] }
 reth-tracing.workspace = true
 reth-trie.workspace = true


### PR DESCRIPTION
Unifies witness generation logic in InvalidBlockWitnessHook with DebugApi::debug_execution_witness by using ExecutionWitnessRecord::from_executed_state() instead of manual data collection. 

Adds headers collection for BLOCKHASH opcode support and removes duplicate code. 

This ensures witness comparison with healthy nodes is accurate and prevents false mismatches.

The changes maintain backward compatibility while improving code reuse and consistency
across the codebase.