### PR TITLE
fix: compare execution witness codes/keys as sets

### DIFF
--- a/crates/engine/invalid-block-hooks/src/witness.rs
+++ b/crates/engine/invalid-block-hooks/src/witness.rs
@@ -250,7 +250,7 @@ where
             // Sort codes and keys in place to make comparison order-insensitive
             // These fields represent unordered sets of bytecode and preimages
             let mut normalized_witness = witness.clone();
-            let mut normalized_healthy_witness = healthy_node_witness.clone();
+            let mut normalized_healthy_witness = healthy_node_witness;
             normalized_witness.codes.sort();
             normalized_witness.keys.sort();
             normalized_healthy_witness.codes.sort();
@@ -260,7 +260,8 @@ where
 
             if !witness_matches {
                 let filename = format!("{}.witness.diff", block_prefix);
-                let diff_path = self.save_diff(filename, &normalized_witness, &normalized_healthy_witness)?;
+                let diff_path =
+                    self.save_diff(filename, &normalized_witness, &normalized_healthy_witness)?;
                 warn!(
                     target: "engine::invalid_block_hooks::witness",
                     diff_path = %diff_path.display(),

--- a/crates/engine/invalid-block-hooks/src/witness.rs
+++ b/crates/engine/invalid-block-hooks/src/witness.rs
@@ -20,18 +20,12 @@ use revm_database::{
     AccountStatus, RevertToSlot,
 };
 use serde::Serialize;
-use std::{
-    collections::BTreeMap,
-    fmt::Debug,
-    fs::File,
-    io::Write,
-    path::PathBuf,
-};
+use std::{collections::BTreeMap, fmt::Debug, fs::File, io::Write, path::PathBuf};
 
 type CollectionResult =
     (BTreeMap<B256, Bytes>, BTreeMap<B256, Bytes>, reth_trie::HashedPostState, BundleState);
 
-/// Extension trait for normalizing ExecutionWitness to ensure deterministic comparison
+/// Extension trait for normalizing [`ExecutionWitness`] to ensure deterministic comparison
 trait ExecutionWitnessExt {
     /// Normalizes the witness by sorting codes and keys vectors in place.
     /// This makes the witness comparison order-insensitive while preserving the same semantic


### PR DESCRIPTION
The comparison between re-executed and healthy node witnesses was failing due to order sensitivity in codes and keys vectors. ExecutionWitnessRecord may produce different ordering than our BTreeMap-based collection.

This change converts codes and keys to BTreeSets before comparison, making the comparison order-insensitive while preserving the same semantic meaning (since these fields represent unordered sets of bytecode and preimages).