### PR TITLE
chore: Remove unused jsonrpsee tracing import in exex subscription example

### DIFF
--- a/examples/exex-subscription/src/main.rs
+++ b/examples/exex-subscription/src/main.rs
@@ -6,8 +6,7 @@
 use alloy_primitives::{Address, U256};
 use futures::TryStreamExt;
 use jsonrpsee::{
-    core::SubscriptionResult, proc_macros::rpc, tracing, PendingSubscriptionSink,
-    SubscriptionMessage,
+    core::SubscriptionResult, proc_macros::rpc, PendingSubscriptionSink, SubscriptionMessage,
 };
 use reth_ethereum::{
     exex::{ExExContext, ExExEvent, ExExNotification},


### PR DESCRIPTION
drop the unused `jsonrpsee::tracing` import from the ExEx subscription example keep the example warning-free without changing runtime behavior
