### PR TITLE
fix: avoid unnecessary self.clone() in OpNetworkBuilder::network_config

### DIFF
--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -1169,7 +1169,8 @@ impl OpNetworkBuilder {
         Node: FullNodeTypes<Types: NodeTypes<ChainSpec: Hardforks>>,
         NetworkP: NetworkPrimitives,
     {
-        let Self { disable_txpool_gossip, disable_discovery_v4, .. } = self.clone();
+        let disable_txpool_gossip = self.disable_txpool_gossip;
+        let disable_discovery_v4 = self.disable_discovery_v4;
         let args = &ctx.config().network;
         let network_builder = ctx
             .network_config_builder()?


### PR DESCRIPTION
Replace self.clone() destructure with direct bool copies in OpNetworkBuilder::network_config. OpNetworkBuilder only holds bool fields, so cloning the builder to extract flags is redundant.
This change avoids an unnecessary allocation/copy of the struct, simplifies the code, and aligns with patterns used elsewhere in the codebase. No functional changes.