### PR TITLE
feat(node): remove unnecessary ConnWrapper clone in connect()

### DIFF
--- a/crates/node/ethstats/src/ethstats.rs
+++ b/crates/node/ethstats/src/ethstats.rs
@@ -118,7 +118,7 @@ where
                     "Successfully connected to EthStats server at {}", self.credentials.host
                 );
                 let conn: ConnWrapper = ConnWrapper::new(ws_stream);
-                *self.conn.write().await = Some(conn.clone());
+                *self.conn.write().await = Some(conn);
                 self.login().await?;
                 Ok(())
             }


### PR DESCRIPTION
ConnWrapper internally uses Arc<Mutex<...>> and is cheap to clone, but the extra clone in connect() was not needed because the local variable is not used after storing into self.conn
Removing the clone avoids a redundant Arc refcount inc/dec