### PR TITLE
refactor(rpc): remove redundant comment in bundle execution

### DIFF
--- a/crates/rpc/rpc/src/eth/bundle.rs
+++ b/crates/rpc/rpc/src/eth/bundle.rs
@@ -236,8 +236,6 @@ where
                     // need to apply the state changes of this call before executing the
                     // next call
                     if transactions.peek().is_some() {
-                        // need to apply the state changes of this call before executing
-                        // the next call
                         evm.db_mut().commit(state)
                     }
                 }


### PR DESCRIPTION
Remove redundant duplicate comment in bundle transaction processing. The comment "need to apply the state changes of this call before executing the next call" was duplicated both outside and inside the if block. Kept only the outer comment to improve code readability