### PR TITLE
feat: add broadcast channel for received flashblocks

### DIFF
--- a/crates/optimism/flashblocks/src/lib.rs
+++ b/crates/optimism/flashblocks/src/lib.rs
@@ -50,7 +50,7 @@ pub type InProgressFlashBlockRx = tokio::sync::watch::Receiver<Option<FlashBlock
 
 /// Container for all flashblocks-related listeners.
 ///
-/// Groups together the three receivers that provide flashblock-related updates.
+/// Groups together the channels for flashblock-related updates.
 #[derive(Debug)]
 pub struct FlashblocksListeners<N: NodePrimitives> {
     /// Receiver of the most recent executed [`PendingFlashBlock`] built out of [`FlashBlock`]s.

--- a/crates/optimism/flashblocks/src/lib.rs
+++ b/crates/optimism/flashblocks/src/lib.rs
@@ -9,6 +9,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 use reth_primitives_traits::NodePrimitives;
+use std::sync::Arc;
 
 pub use payload::{
     ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, FlashBlock, FlashBlockDecoder,
@@ -39,6 +40,11 @@ pub type PendingBlockRx<N> = tokio::sync::watch::Receiver<Option<PendingFlashBlo
 pub type FlashBlockCompleteSequenceRx =
     tokio::sync::broadcast::Receiver<FlashBlockCompleteSequence>;
 
+/// Receiver of received [`FlashBlock`]s from the (websocket) subscription.
+///
+/// [`FlashBlock`]: crate::FlashBlock
+pub type FlashBlockRx = tokio::sync::broadcast::Receiver<Arc<FlashBlock>>;
+
 /// Receiver that signals whether a [`FlashBlock`] is currently being built.
 pub type InProgressFlashBlockRx = tokio::sync::watch::Receiver<Option<FlashBlockBuildInfo>>;
 
@@ -47,31 +53,24 @@ pub type InProgressFlashBlockRx = tokio::sync::watch::Receiver<Option<FlashBlock
 /// Groups together the three receivers that provide flashblock-related updates.
 #[derive(Debug)]
 pub struct FlashblocksListeners<N: NodePrimitives> {
-    /// Receiver of the most recent [`PendingFlashBlock`] built out of [`FlashBlock`]s.
+    /// Receiver of the most recent executed [`PendingFlashBlock`] built out of [`FlashBlock`]s.
     pub pending_block_rx: PendingBlockRx<N>,
-    /// Receiver of the sequences of [`FlashBlock`]s built.
-    pub flashblock_rx: FlashBlockCompleteSequenceRx,
+    /// Subscription channel of the complete sequences of [`FlashBlock`]s built.
+    pub flashblocks_sequence: tokio::sync::broadcast::Sender<FlashBlockCompleteSequence>,
     /// Receiver that signals whether a [`FlashBlock`] is currently being built.
     pub in_progress_rx: InProgressFlashBlockRx,
+    /// Subscription channel for received flashblocks from the (websocket) connection.
+    pub received_flashblocks: tokio::sync::broadcast::Sender<Arc<FlashBlock>>,
 }
 
 impl<N: NodePrimitives> FlashblocksListeners<N> {
-    /// Creates a new [`FlashblocksListeners`] with the given receivers.
+    /// Creates a new [`FlashblocksListeners`] with the given channels.
     pub const fn new(
         pending_block_rx: PendingBlockRx<N>,
-        flashblock_rx: FlashBlockCompleteSequenceRx,
+        flashblocks_sequence: tokio::sync::broadcast::Sender<FlashBlockCompleteSequence>,
         in_progress_rx: InProgressFlashBlockRx,
+        received_flashblocks: tokio::sync::broadcast::Sender<Arc<FlashBlock>>,
     ) -> Self {
-        Self { pending_block_rx, flashblock_rx, in_progress_rx }
-    }
-}
-
-impl<N: NodePrimitives> Clone for FlashblocksListeners<N> {
-    fn clone(&self) -> Self {
-        Self {
-            pending_block_rx: self.pending_block_rx.clone(),
-            flashblock_rx: self.flashblock_rx.resubscribe(),
-            in_progress_rx: self.in_progress_rx.clone(),
-        }
+        Self { pending_block_rx, flashblocks_sequence, in_progress_rx, received_flashblocks }
     }
 }

--- a/crates/optimism/flashblocks/src/sequence.rs
+++ b/crates/optimism/flashblocks/src/sequence.rs
@@ -38,6 +38,11 @@ where
         Self { inner: BTreeMap::new(), block_broadcaster: tx, state_root: None }
     }
 
+    /// Returns the sender half of the [`FlashBlockCompleteSequence`] channel.
+    pub fn block_sequence_broadcaster(&self) -> &broadcast::Sender<FlashBlockCompleteSequence> {
+        &self.block_broadcaster
+    }
+
     /// Gets a subscriber to the flashblock sequences produced.
     pub fn subscribe_block_sequence(&self) -> FlashBlockCompleteSequenceRx {
         self.block_broadcaster.subscribe()
@@ -160,7 +165,10 @@ where
 }
 
 /// A complete sequence of flashblocks, often corresponding to a full block.
-/// Ensure invariants of a complete flashblocks sequence.
+///
+/// Ensures invariants of a complete flashblocks sequence.
+/// If this entire sequence of flashblocks was executed on top of latest block, this also includes
+/// the computed state root.
 #[derive(Debug, Clone)]
 pub struct FlashBlockCompleteSequence {
     inner: Vec<FlashBlock>,

--- a/crates/optimism/flashblocks/src/sequence.rs
+++ b/crates/optimism/flashblocks/src/sequence.rs
@@ -39,7 +39,9 @@ where
     }
 
     /// Returns the sender half of the [`FlashBlockCompleteSequence`] channel.
-    pub fn block_sequence_broadcaster(&self) -> &broadcast::Sender<FlashBlockCompleteSequence> {
+    pub const fn block_sequence_broadcaster(
+        &self,
+    ) -> &broadcast::Sender<FlashBlockCompleteSequence> {
         &self.block_broadcaster
     }
 

--- a/crates/optimism/flashblocks/src/service.rs
+++ b/crates/optimism/flashblocks/src/service.rs
@@ -144,7 +144,7 @@ where
     }
 
     /// Notifies all subscribers about the received flashblock
-    fn notifiy_received_flashblock(&self, flashblock: &FlashBlock) {
+    fn notify_received_flashblock(&self, flashblock: &FlashBlock) {
         if self.received_flashblocks_tx.receiver_count() > 0 {
             let _ = self.received_flashblocks_tx.send(Arc::new(flashblock.clone()));
         }
@@ -297,7 +297,7 @@ where
             while let Poll::Ready(Some(result)) = this.rx.poll_next_unpin(cx) {
                 match result {
                     Ok(flashblock) => {
-                        this.notifiy_received_flashblock(&flashblock);
+                        this.notify_received_flashblock(&flashblock);
                         if flashblock.index == 0 {
                             this.metrics.last_flashblock_length.record(this.blocks.count() as f64);
                         }

--- a/crates/optimism/flashblocks/src/service.rs
+++ b/crates/optimism/flashblocks/src/service.rs
@@ -109,12 +109,14 @@ where
     }
 
     /// Returns the sender half to the received flashblocks.
-    pub fn flashblocks_broadcaster(&self) -> &tokio::sync::broadcast::Sender<Arc<FlashBlock>> {
+    pub const fn flashblocks_broadcaster(
+        &self,
+    ) -> &tokio::sync::broadcast::Sender<Arc<FlashBlock>> {
         &self.received_flashblocks_tx
     }
 
     /// Returns the sender half to the flashblock sequence.
-    pub fn block_sequence_broadcaster(
+    pub const fn block_sequence_broadcaster(
         &self,
     ) -> &tokio::sync::broadcast::Sender<FlashBlockCompleteSequence> {
         self.blocks.block_sequence_broadcaster()

--- a/crates/optimism/flashblocks/src/service.rs
+++ b/crates/optimism/flashblocks/src/service.rs
@@ -1,8 +1,8 @@
 use crate::{
     sequence::FlashBlockPendingSequence,
     worker::{BuildArgs, FlashBlockBuilder},
-    ExecutionPayloadBaseV1, FlashBlock, FlashBlockCompleteSequenceRx, InProgressFlashBlockRx,
-    PendingFlashBlock,
+    ExecutionPayloadBaseV1, FlashBlock, FlashBlockCompleteSequence, FlashBlockCompleteSequenceRx,
+    InProgressFlashBlockRx, PendingFlashBlock,
 };
 use alloy_eips::eip2718::WithEncoded;
 use alloy_primitives::B256;
@@ -19,6 +19,7 @@ use reth_storage_api::{BlockReaderIdExt, StateProviderFactory};
 use reth_tasks::TaskExecutor;
 use std::{
     pin::Pin,
+    sync::Arc,
     task::{ready, Context, Poll},
     time::Instant,
 };
@@ -42,6 +43,8 @@ pub struct FlashBlockService<
     rx: S,
     current: Option<PendingFlashBlock<N>>,
     blocks: FlashBlockPendingSequence<N::SignedTx>,
+    /// Broadcast channel to forward received flashblocks from the subscription.
+    received_flashblocks_tx: tokio::sync::broadcast::Sender<Arc<FlashBlock>>,
     rebuild: bool,
     builder: FlashBlockBuilder<EvmConfig, Provider>,
     canon_receiver: CanonStateNotifications<N>,
@@ -58,17 +61,6 @@ pub struct FlashBlockService<
     metrics: FlashBlockServiceMetrics,
     /// Enable state root calculation from flashblock with index [`FB_STATE_ROOT_FROM_INDEX`]
     compute_state_root: bool,
-}
-
-/// Information for a flashblock currently built
-#[derive(Debug, Clone, Copy)]
-pub struct FlashBlockBuildInfo {
-    /// Parent block hash
-    pub parent_hash: B256,
-    /// Flashblock index within the current block's sequence
-    pub index: u64,
-    /// Block number of the flashblock being built.
-    pub block_number: u64,
 }
 
 impl<N, S, EvmConfig, Provider> FlashBlockService<N, S, EvmConfig, Provider>
@@ -92,10 +84,12 @@ where
     /// Constructs a new `FlashBlockService` that receives [`FlashBlock`]s from `rx` stream.
     pub fn new(rx: S, evm_config: EvmConfig, provider: Provider, spawner: TaskExecutor) -> Self {
         let (in_progress_tx, _) = watch::channel(None);
+        let (received_flashblocks_tx, _) = tokio::sync::broadcast::channel(128);
         Self {
             rx,
             current: None,
             blocks: FlashBlockPendingSequence::new(),
+            received_flashblocks_tx,
             canon_receiver: provider.subscribe_to_canonical_state(),
             builder: FlashBlockBuilder::new(evm_config, provider),
             rebuild: false,
@@ -112,6 +106,18 @@ where
     pub const fn compute_state_root(mut self, enable_state_root: bool) -> Self {
         self.compute_state_root = enable_state_root;
         self
+    }
+
+    /// Returns the sender half to the received flashblocks.
+    pub fn flashblocks_broadcaster(&self) -> &tokio::sync::broadcast::Sender<Arc<FlashBlock>> {
+        &self.received_flashblocks_tx
+    }
+
+    /// Returns the sender half to the flashblock sequence.
+    pub fn block_sequence_broadcaster(
+        &self,
+    ) -> &tokio::sync::broadcast::Sender<FlashBlockCompleteSequence> {
+        self.blocks.block_sequence_broadcaster()
     }
 
     /// Returns a subscriber to the flashblock sequence.
@@ -135,6 +141,13 @@ where
         }
 
         warn!("Flashblock service has stopped");
+    }
+
+    /// Notifies all subscribers about the received flashblock
+    fn notifiy_received_flashblock(&self, flashblock: &FlashBlock) {
+        if self.received_flashblocks_tx.receiver_count() > 0 {
+            let _ = self.received_flashblocks_tx.send(Arc::new(flashblock.clone()));
+        }
     }
 
     /// Returns the [`BuildArgs`] made purely out of [`FlashBlock`]s that were received earlier.
@@ -284,6 +297,7 @@ where
             while let Poll::Ready(Some(result)) = this.rx.poll_next_unpin(cx) {
                 match result {
                     Ok(flashblock) => {
+                        this.notifiy_received_flashblock(&flashblock);
                         if flashblock.index == 0 {
                             this.metrics.last_flashblock_length.record(this.blocks.count() as f64);
                         }
@@ -342,6 +356,17 @@ where
             return Poll::Pending
         }
     }
+}
+
+/// Information for a flashblock currently built
+#[derive(Debug, Clone, Copy)]
+pub struct FlashBlockBuildInfo {
+    /// Parent block hash
+    pub parent_hash: B256,
+    /// Flashblock index within the current block's sequence
+    pub index: u64,
+    /// Block number of the flashblock being built.
+    pub block_number: u64,
 }
 
 type BuildJob<N> =


### PR DESCRIPTION
more prep for https://github.com/paradigmxyz/reth/issues/19433

this introduces a new broadcast channel for received flashblocks

and changes the broadcast rx type to sender in the flashblockslistner, because otherwise this would always keep a subscription open and fully buffer the receiver