### PR TITLE
refactor: replace static worker pools with dynamic task spawning for proof computation

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -213,6 +213,7 @@ where
         F: DatabaseProviderROFactory<Provider: TrieCursorFactory + HashedCursorFactory>
             + Clone
             + Send
+            + Sync
             + 'static,
     {
         let span = tracing::Span::current();


### PR DESCRIPTION
closes #19298 
Replaced static worker pools with dynamic task spawning to potentially reduce memory usage
