### PR TITLE
chore: use name const for cli name

### DIFF
--- a/crates/ethereum/cli/src/interface.rs
+++ b/crates/ethereum/cli/src/interface.rs
@@ -32,7 +32,7 @@ use tracing::info;
 ///
 /// This is the entrypoint to the executable.
 #[derive(Debug, Parser)]
-#[command(author, version =version_metadata().short_version.as_ref(), long_version = version_metadata().long_version.as_ref(), about = "Reth", long_about = None)]
+#[command(author, name = version_metadata().name_client.as_ref(), version = version_metadata().short_version.as_ref(), long_version = version_metadata().long_version.as_ref(), about = "Reth", long_about = None)]
 pub struct Cli<
     C: ChainSpecParser = EthereumChainSpecParser,
     Ext: clap::Args + fmt::Debug = NoArgs,

--- a/crates/optimism/cli/src/lib.rs
+++ b/crates/optimism/cli/src/lib.rs
@@ -62,7 +62,7 @@ use reth_node_metrics as _;
 ///
 /// This is the entrypoint to the executable.
 #[derive(Debug, Parser)]
-#[command(author, version = version_metadata().short_version.as_ref(), long_version = version_metadata().long_version.as_ref(), about = "Reth", long_about = None)]
+#[command(author, name = version_metadata().name_client.as_ref(), version = version_metadata().short_version.as_ref(), long_version = version_metadata().long_version.as_ref(), about = "Reth", long_about = None)]
 pub struct Cli<
     Spec: ChainSpecParser = OpChainSpecParser,
     Ext: clap::Args + fmt::Debug = RollupArgs,


### PR DESCRIPTION
uses the name that is displayed for --version from the consts:


```
Reth Version: 1.8.3-dev
Commit SHA: 7905fba953e5d7c96e547bc8f3e0a0edc8af374a
Build Timestamp: 2025-11-03T15:15:19.209771000Z
Build Features: jemalloc,otlp
Build Profile: debug
```

