### PR TITLE
fix: update `min_block` on `StaticFileProvider::update_index`

### DIFF
--- a/crates/prune/prune/src/segments/user/bodies.rs
+++ b/crates/prune/prune/src/segments/user/bodies.rs
@@ -207,4 +207,121 @@ mod tests {
             run_prune_test(&factory, &finished_exex_height_rx, test_case, tip);
         }
     }
+
+    #[test]
+    fn min_block_updated_on_sync() {
+        // Regression test: update_index must update min_block to prevent stale values
+        // that can cause pruner to incorrectly delete static files when PruneMode::Before(0) is
+        // used.
+
+        struct MinBlockTestCase {
+            // Block range
+            initial_range: Option<SegmentRangeInclusive>,
+            updated_range: SegmentRangeInclusive,
+            // Min block
+            expected_before_update: Option<BlockNumber>,
+            expected_after_update: BlockNumber,
+            // Test delete_segment_below_block with this value
+            delete_below_block: BlockNumber,
+            // Expected number of deleted segments
+            expected_deleted: usize,
+        }
+
+        let test_cases = vec![
+            // Test 1: Empty initial state (None) -> syncs to block 100
+            MinBlockTestCase {
+                initial_range: None,
+                updated_range: SegmentRangeInclusive::new(0, 100),
+                expected_before_update: None,
+                expected_after_update: 100,
+                delete_below_block: 1,
+                expected_deleted: 0,
+            },
+            // Test 2: Genesis state [0..=0] -> syncs to block 100 (eg. op-reth node after op-reth
+            // init-state)
+            MinBlockTestCase {
+                initial_range: Some(SegmentRangeInclusive::new(0, 0)),
+                updated_range: SegmentRangeInclusive::new(0, 100),
+                expected_before_update: Some(0),
+                expected_after_update: 100,
+                delete_below_block: 1,
+                expected_deleted: 0,
+            },
+            // Test 3: Existing state [0..=50] -> syncs to block 200
+            MinBlockTestCase {
+                initial_range: Some(SegmentRangeInclusive::new(0, 50)),
+                updated_range: SegmentRangeInclusive::new(0, 200),
+                expected_before_update: Some(50),
+                expected_after_update: 200,
+                delete_below_block: 150,
+                expected_deleted: 0,
+            },
+        ];
+
+        for (
+            idx,
+            MinBlockTestCase {
+                initial_range,
+                updated_range,
+                expected_before_update,
+                expected_after_update,
+                delete_below_block,
+                expected_deleted,
+            },
+        ) in test_cases.into_iter().enumerate()
+        {
+            let factory = create_test_provider_factory();
+            let static_provider = factory.static_file_provider();
+
+            let mut writer =
+                static_provider.latest_writer(StaticFileSegment::Transactions).unwrap();
+
+            // Set up initial state if provided
+            if let Some(initial_range) = initial_range {
+                *writer.user_header_mut() = SegmentHeader::new(
+                    initial_range,
+                    Some(initial_range),
+                    Some(initial_range),
+                    StaticFileSegment::Transactions,
+                );
+                writer.inner().set_dirty();
+                writer.commit().unwrap();
+                static_provider.initialize_index().unwrap();
+            }
+
+            // Verify initial state
+            assert_eq!(
+                static_provider.get_lowest_static_file_block(StaticFileSegment::Transactions),
+                expected_before_update,
+                "Test case {}: Initial min_block mismatch",
+                idx
+            );
+
+            // Update to new range
+            *writer.user_header_mut() = SegmentHeader::new(
+                updated_range,
+                Some(updated_range),
+                Some(updated_range),
+                StaticFileSegment::Transactions,
+            );
+            writer.inner().set_dirty();
+            writer.commit().unwrap(); // update_index is called inside
+
+            // Verify min_block was updated (not stuck at stale value)
+            assert_eq!(
+                static_provider.get_lowest_static_file_block(StaticFileSegment::Transactions),
+                Some(expected_after_update),
+                "Test case {}: min_block should be updated to {} (not stuck at stale value)",
+                idx,
+                expected_after_update
+            );
+
+            // Verify delete_segment_below_block behaves correctly with updated min_block
+            let deleted = static_provider
+                .delete_segment_below_block(StaticFileSegment::Transactions, delete_below_block)
+                .unwrap();
+
+            assert_eq!(deleted.len(), expected_deleted);
+        }
+    }
 }

--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -200,6 +200,9 @@ impl<H: NippyJarHeader> NippyJar<H> {
         // Read [`Self`] located at the data file.
         let config_path = path.with_extension(CONFIG_FILE_EXTENSION);
         let config_file = File::open(&config_path)
+            .inspect_err(|e| {
+                warn!( ?path, %e, "Failed to load static file jar");
+            })
             .map_err(|err| reth_fs_util::FsPathError::open(err, config_path))?;
 
         let mut obj = Self::load_from_reader(config_file)?;

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -627,10 +627,9 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                 max_block.insert(segment, segment_max_block);
                 let fixed_range = self.find_fixed_range(segment_max_block);
 
-                let jar = NippyJar::<SegmentHeader>::load(
-                    &self.path.join(segment.filename(&fixed_range)),
-                )
-                .map_err(ProviderError::other)?;
+                let path = self.path.join(segment.filename(&fixed_range));
+                let jar = NippyJar::<SegmentHeader>::load(&path)
+                    .map_err(|e| ProviderError::other(format!("Failed to load {path:?}: {e}")))?;
 
                 // Update min_block to track the lowest block range of the segment.
                 // This is initially set by initialize_index() on node startup, but must be updated

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -530,6 +530,8 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         let header = jar.user_header().clone();
         jar.delete().map_err(ProviderError::other)?;
 
+        // SAFETY: this is currently necessary to ensure that certain indexes like
+        // `static_files_min_block` have the correct values after pruning.
         self.initialize_index()?;
 
         Ok(header)
@@ -649,6 +651,8 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                     min_block
                         .entry(segment)
                         .and_modify(|current_min| {
+                            // delete_jar WILL ALWAYS re-initialize all indexes, so we are always
+                            // sure that current_min is always the lowest.
                             if current_block_range.start() == current_min.start() {
                                 *current_min = current_block_range;
                             }

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -628,8 +628,9 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                 let fixed_range = self.find_fixed_range(segment_max_block);
 
                 let path = self.path.join(segment.filename(&fixed_range));
-                let jar = NippyJar::<SegmentHeader>::load(&path)
-                    .map_err(|e| ProviderError::other(format!("Failed to load {path:?}: {e}")))?;
+                let jar = NippyJar::<SegmentHeader>::load(&path).inspect_err(|e| {
+                    warn!(target: "provider::static_file", ?path, %e, "Failed to load static file jar");
+                }).map_err(ProviderError::other)?;
 
                 // Update min_block to track the lowest block range of the segment.
                 // This is initially set by initialize_index() on node startup, but must be updated


### PR DESCRIPTION
Ensures that `min_block` is updated when the node only has 1 static file of the segment.

Without this PR:
* If `reth node` is spawned completely from scratch, `get_lowest_static_file_block` would always report `None`. And we would never prune until a restart.
* If `reth node` is spawned after an initial `init_genesis` but without progressing the chain (eg. reth init-state), `min_block` would always report `[0,0]` and would report the wrong `block_height` below, leading to deleting the only static file prematurely https://github.com/paradigmxyz/reth/blob/846025545cb0d15f09a098d6a39f2f85d0559f40/crates/storage/provider/src/providers/static_file/manager.rs#L476-L483 