### PR TITLE
chore: remove unused TransactionBuilder import from txpool tracing example

### DIFF
--- a/examples/txpool-tracing/src/submit.rs
+++ b/examples/txpool-tracing/src/submit.rs
@@ -2,7 +2,7 @@
 #![allow(unused)]
 #![allow(clippy::too_many_arguments)]
 
-use alloy_network::{Ethereum, EthereumWallet, NetworkWallet, TransactionBuilder};
+use alloy_network::{Ethereum, EthereumWallet, NetworkWallet};
 use alloy_primitives::{Address, TxHash, U256};
 use futures_util::StreamExt;
 use reth_ethereum::{


### PR DESCRIPTION
Drop the unused `TransactionBuilder` import from `examples/txpool-tracing/src/submit.rs` keep the example clean by relying only on the imports it actually uses