### PR TITLE
fix(net): remove capacity inflation from buffered blocks size calculation

### DIFF
--- a/crates/net/downloaders/src/bodies/bodies.rs
+++ b/crates/net/downloaders/src/bodies/bodies.rs
@@ -21,7 +21,6 @@ use std::{
     cmp::Ordering,
     collections::BinaryHeap,
     fmt::Debug,
-    mem,
     ops::RangeInclusive,
     pin::Pin,
     sync::Arc,
@@ -215,9 +214,7 @@ where
 
     /// Adds a new response to the internal buffer
     fn buffer_bodies_response(&mut self, response: Vec<BlockResponse<B>>) {
-        // take into account capacity
-        let size = response.iter().map(BlockResponse::size).sum::<usize>() +
-            response.capacity() * mem::size_of::<BlockResponse<B>>();
+        let size = response.iter().map(BlockResponse::size).sum::<usize>();
 
         let response = OrderedBodiesResponse { resp: response, size };
         let response_len = response.len();


### PR DESCRIPTION
Fixes `buffered_blocks_size_bytes` in `BodiesDownloader::buffer_bodies_response` to reflect only actual block data by removing `response.capacity() * mem::size_of::<BlockResponse<B>>()`.