### PR TITLE
fix: extract helper for execution witness generation

### DIFF
--- a/crates/engine/invalid-block-hooks/src/witness.rs
+++ b/crates/engine/invalid-block-hooks/src/witness.rs
@@ -205,11 +205,6 @@ where
     N: NodePrimitives,
 {
     /// Generates an `ExecutionWitness` and returns it together with the `BundleState`.
-    ///
-    /// This is the core helper that performs block re-execution and collects all
-    /// artifacts necessary to build the execution witness. It is intentionally
-    /// kept small and self-contained to minimize drift and prepare for potential
-    /// reuse across subsystems.
     fn generate_execution_witness_core(
         &self,
         parent_header: &SealedHeader<N::BlockHeader>,


### PR DESCRIPTION
Factor out the core “re-execute and collect ExecutionWitness” logic into a small internal helper in `invalid-block-hooks` and document intended reuse.
The hook duplicates logic that exists in the Debug API; extracting the core makes behavior clearer and reduces future drift, preparing a clean path to unify both call sites.
