### PR TITLE
refactor: use `Url::as_str()` directly in era modules

### DIFF
--- a/crates/era-downloader/tests/it/checksums.rs
+++ b/crates/era-downloader/tests/it/checksums.rs
@@ -60,7 +60,7 @@ impl HttpClient for FailingClient {
     ) -> eyre::Result<impl Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin> {
         let url = url.into_url().unwrap();
 
-        Ok(futures::stream::iter(vec![Ok(match url.to_string().as_str() {
+        Ok(futures::stream::iter(vec![Ok(match url.as_str() {
             "https://mainnet.era1.nimbus.team/" => Bytes::from_static(crate::NIMBUS),
             "https://era1.ethportal.net/" => Bytes::from_static(crate::ETH_PORTAL),
             "https://era.ithaca.xyz/era1/index.html" => Bytes::from_static(crate::ITHACA),

--- a/crates/era-downloader/tests/it/main.rs
+++ b/crates/era-downloader/tests/it/main.rs
@@ -32,7 +32,7 @@ impl HttpClient for StubClient {
     ) -> eyre::Result<impl Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin> {
         let url = url.into_url().unwrap();
 
-        Ok(futures::stream::iter(vec![Ok(match url.to_string().as_str() {
+        Ok(futures::stream::iter(vec![Ok(match url.as_str() {
             "https://mainnet.era1.nimbus.team/" => Bytes::from_static(NIMBUS),
             "https://era1.ethportal.net/" => Bytes::from_static(ETH_PORTAL),
             "https://era.ithaca.xyz/era1/index.html" => Bytes::from_static(ITHACA),

--- a/crates/era-utils/tests/it/main.rs
+++ b/crates/era-utils/tests/it/main.rs
@@ -32,7 +32,7 @@ impl HttpClient for ClientWithFakeIndex {
     ) -> eyre::Result<impl Stream<Item = eyre::Result<Bytes>> + Send + Sync + Unpin> {
         let url = url.into_url()?;
 
-        match url.to_string().as_str() {
+        match url.as_str() {
             ITHACA_ERA_INDEX_URL => {
                 // Create a static stream without boxing
                 let stream =


### PR DESCRIPTION
Replace `url.to_string().as_str()` with `url.as_str()` to avoid unnecessary String allocation.

The Url type already provides `as_str()` method.