### PR TITLE
chore: Various cleanups after consistent DB view removal

### DIFF
--- a/crates/engine/tree/benches/state_root_task.rs
+++ b/crates/engine/tree/benches/state_root_task.rs
@@ -227,21 +227,15 @@ fn bench_state_root(c: &mut Criterion) {
                     },
                     |(genesis_hash, mut payload_processor, provider, state_updates)| {
                         black_box({
-                            let mut handle = payload_processor
-                                .spawn(
-                                    Default::default(),
-                                    core::iter::empty::<
-                                        Result<
-                                            Recovered<TransactionSigned>,
-                                            core::convert::Infallible,
-                                        >,
-                                    >(),
-                                    StateProviderBuilder::new(provider.clone(), genesis_hash, None),
-                                    OverlayStateProviderFactory::new(provider),
-                                    &TreeConfig::default(),
-                                )
-                                .map_err(|(err, ..)| err)
-                                .expect("failed to spawn payload processor");
+                            let mut handle = payload_processor.spawn(
+                                Default::default(),
+                                core::iter::empty::<
+                                    Result<Recovered<TransactionSigned>, core::convert::Infallible>,
+                                >(),
+                                StateProviderBuilder::new(provider.clone(), genesis_hash, None),
+                                OverlayStateProviderFactory::new(provider),
+                                &TreeConfig::default(),
+                            );
 
                             let mut state_hook = handle.state_hook();
 

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -28,9 +28,7 @@ use reth_evm::{
 use reth_primitives_traits::NodePrimitives;
 use reth_provider::{BlockReader, DatabaseProviderROFactory, StateProviderFactory, StateReader};
 use reth_revm::{db::BundleState, state::EvmState};
-use reth_trie::{
-    hashed_cursor::HashedCursorFactory, trie_cursor::TrieCursorFactory,
-};
+use reth_trie::{hashed_cursor::HashedCursorFactory, trie_cursor::TrieCursorFactory};
 use reth_trie_parallel::{
     proof_task::{ProofTaskCtx, ProofWorkerHandle},
     root::ParallelStateRootError,

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -29,8 +29,7 @@ use reth_primitives_traits::NodePrimitives;
 use reth_provider::{BlockReader, DatabaseProviderROFactory, StateProviderFactory, StateReader};
 use reth_revm::{db::BundleState, state::EvmState};
 use reth_trie::{
-    hashed_cursor::HashedCursorFactory, prefix_set::TriePrefixSetsMut,
-    trie_cursor::TrieCursorFactory,
+    hashed_cursor::HashedCursorFactory, trie_cursor::TrieCursorFactory,
 };
 use reth_trie_parallel::{
     proof_task::{ProofTaskCtx, ProofWorkerHandle},
@@ -891,19 +890,13 @@ mod tests {
 
         let provider_factory = BlockchainProvider::new(factory).unwrap();
 
-        let mut handle =
-            payload_processor
-                .spawn(
-                    Default::default(),
-                    core::iter::empty::<
-                        Result<Recovered<TransactionSigned>, core::convert::Infallible>,
-                    >(),
-                    StateProviderBuilder::new(provider_factory.clone(), genesis_hash, None),
-                    OverlayStateProviderFactory::new(provider_factory),
-                    &TreeConfig::default(),
-                )
-                .map_err(|(err, ..)| err)
-                .expect("failed to spawn payload processor");
+        let mut handle = payload_processor.spawn(
+            Default::default(),
+            core::iter::empty::<Result<Recovered<TransactionSigned>, core::convert::Infallible>>(),
+            StateProviderBuilder::new(provider_factory.clone(), genesis_hash, None),
+            OverlayStateProviderFactory::new(provider_factory),
+            &TreeConfig::default(),
+        );
 
         let mut state_hook = handle.state_hook();
 

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -1317,7 +1317,7 @@ mod tests {
     {
         let rt_handle = get_test_runtime_handle();
         let overlay_factory = OverlayStateProviderFactory::new(factory);
-        let task_ctx = ProofTaskCtx::new(overlay_factory, Default::default());
+        let task_ctx = ProofTaskCtx::new(overlay_factory);
         let proof_handle = ProofWorkerHandle::new(rt_handle, task_ctx, 1, 1);
         let (to_sparse_trie, _receiver) = std::sync::mpsc::channel();
 

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -370,8 +370,7 @@ where
         let env = ExecutionEnv { evm_env, hash: input.hash(), parent_hash: input.parent_hash() };
 
         // Plan the strategy used for state root computation.
-        let state_root_plan = self.plan_state_root_computation();
-        let strategy = state_root_plan.strategy;
+        let strategy = self.plan_state_root_computation();
 
         debug!(
             target: "engine::tree::payload_validator",
@@ -383,7 +382,7 @@ where
         let txs = self.tx_iterator_for(&input)?;
 
         // Spawn the appropriate processor based on strategy
-        let (mut handle, strategy) = ensure_ok!(self.spawn_payload_processor(
+        let mut handle = ensure_ok!(self.spawn_payload_processor(
             env.clone(),
             txs,
             provider_builder,
@@ -749,13 +748,10 @@ where
         state: &EngineApiTreeState<N>,
         strategy: StateRootStrategy,
     ) -> Result<
-        (
-            PayloadHandle<
-                impl ExecutableTxFor<Evm> + use<N, P, Evm, V, T>,
-                impl core::error::Error + Send + Sync + 'static + use<N, P, Evm, V, T>,
-            >,
-            StateRootStrategy,
-        ),
+        PayloadHandle<
+            impl ExecutableTxFor<Evm> + use<N, P, Evm, V, T>,
+            impl core::error::Error + Send + Sync + 'static + use<N, P, Evm, V, T>,
+        >,
         InsertBlockErrorKind,
     > {
         match strategy {
@@ -789,34 +785,13 @@ where
                 // Use state root task only if prefix sets are empty, otherwise proof generation is
                 // too expensive because it requires walking all paths in every proof.
                 let spawn_start = Instant::now();
-                let (handle, strategy) = match self.payload_processor.spawn(
+                let handle = self.payload_processor.spawn(
                     env,
                     txs,
                     provider_builder,
                     multiproof_provider_factory,
                     &self.config,
-                ) {
-                    Ok(handle) => {
-                        // Successfully spawned with state root task support
-                        (handle, StateRootStrategy::StateRootTask)
-                    }
-                    Err((error, txs, env, provider_builder)) => {
-                        // Failed to spawn proof workers, fallback to parallel state root
-                        error!(
-                            target: "engine::tree::payload_validator",
-                            ?error,
-                            "Failed to spawn proof workers, falling back to parallel state root"
-                        );
-                        (
-                            self.payload_processor.spawn_cache_exclusive(
-                                env,
-                                txs,
-                                provider_builder,
-                            ),
-                            StateRootStrategy::Parallel,
-                        )
-                    }
-                };
+                );
 
                 // record prewarming initialization duration
                 self.metrics
@@ -824,9 +799,9 @@ where
                     .spawn_payload_processor
                     .record(spawn_start.elapsed().as_secs_f64());
 
-                Ok((handle, strategy))
+                Ok(handle)
             }
-            strategy @ (StateRootStrategy::Parallel | StateRootStrategy::Synchronous) => {
+            StateRootStrategy::Parallel | StateRootStrategy::Synchronous => {
                 let start = Instant::now();
                 let handle =
                     self.payload_processor.spawn_cache_exclusive(env, txs, provider_builder);
@@ -837,7 +812,7 @@ where
                     .spawn_payload_processor
                     .record(start.elapsed().as_secs_f64());
 
-                Ok((handle, strategy))
+                Ok(handle)
             }
         }
     }
@@ -875,7 +850,7 @@ where
 
     /// Determines the state root computation strategy based on configuration.
     #[instrument(level = "debug", target = "engine::tree::payload_validator", skip_all)]
-    fn plan_state_root_computation(&self) -> StateRootPlan {
+    fn plan_state_root_computation(&self) -> StateRootStrategy {
         let strategy = if self.config.state_root_fallback() {
             StateRootStrategy::Synchronous
         } else if self.config.use_state_root_task() {
@@ -890,7 +865,7 @@ where
             "Planned state root computation strategy"
         );
 
-        StateRootPlan { strategy }
+        strategy
     }
 
     /// Called when an invalid block is encountered during validation.
@@ -967,12 +942,6 @@ enum StateRootStrategy {
     Parallel,
     /// Fall back to synchronous computation via the state provider.
     Synchronous,
-}
-
-/// State root computation plan that captures strategy and required data.
-struct StateRootPlan {
-    /// Strategy that should be attempted for computing the state root.
-    strategy: StateRootStrategy,
 }
 
 /// Type that validates the payloads processed by the engine.

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -329,7 +329,7 @@ mod tests {
         let rt = Runtime::new().unwrap();
 
         let factory = reth_provider::providers::OverlayStateProviderFactory::new(factory);
-        let task_ctx = ProofTaskCtx::new(factory, Default::default());
+        let task_ctx = ProofTaskCtx::new(factory);
         let proof_worker_handle = ProofWorkerHandle::new(rt.handle().clone(), task_ctx, 1, 1);
 
         let parallel_result =

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -42,12 +42,12 @@ use alloy_rlp::{BufMut, Encodable};
 use crossbeam_channel::{unbounded, Receiver as CrossbeamReceiver, Sender as CrossbeamSender};
 use dashmap::DashMap;
 use reth_execution_errors::{SparseTrieError, SparseTrieErrorKind};
-use reth_provider::{DatabaseProviderROFactory, ProviderError};
+use reth_provider::{DatabaseProviderROFactory, ProviderError, ProviderResult};
 use reth_storage_errors::db::DatabaseError;
 use reth_trie::{
     hashed_cursor::HashedCursorFactory,
     node_iter::{TrieElement, TrieNodeIter},
-    prefix_set::{TriePrefixSets, TriePrefixSetsMut},
+    prefix_set::TriePrefixSets,
     proof::{ProofBlindedAccountProvider, ProofBlindedStorageProvider, StorageProof},
     trie_cursor::TrieCursorFactory,
     walker::TrieWalker,
@@ -1474,8 +1474,6 @@ enum AccountWorkerJob {
 mod tests {
     use super::*;
     use reth_provider::test_utils::create_test_provider_factory;
-    use reth_trie_common::prefix_set::TriePrefixSetsMut;
-    use std::sync::Arc;
     use tokio::{runtime::Builder, task};
 
     fn test_ctx<Factory>(factory: Factory) -> ProofTaskCtx<Factory> {

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -161,7 +161,14 @@ impl ProofWorkerHandle {
                     #[cfg(feature = "metrics")]
                     metrics,
                 );
-                worker.run()
+                if let Err(error) = worker.run() {
+                    error!(
+                        target: "trie::proof_task",
+                        worker_id,
+                        ?error,
+                        "Storage worker failed"
+                    );
+                }
             });
         }
         drop(parent_span);
@@ -191,7 +198,14 @@ impl ProofWorkerHandle {
                     #[cfg(feature = "metrics")]
                     metrics,
                 );
-                worker.run()
+                if let Err(error) = worker.run() {
+                    error!(
+                        target: "trie::proof_task",
+                        worker_id,
+                        ?error,
+                        "Account worker failed"
+                    );
+                }
             });
         }
         drop(parent_span);
@@ -358,16 +372,12 @@ impl ProofWorkerHandle {
 pub struct ProofTaskCtx<Factory> {
     /// The factory for creating state providers.
     factory: Factory,
-    /// The collection of prefix sets for the computation. Since the prefix sets _always_
-    /// invalidate the in-memory nodes, not all keys from `state_sorted` might be present here,
-    /// if we have cached nodes for them.
-    prefix_sets: Arc<TriePrefixSetsMut>,
 }
 
 impl<Factory> ProofTaskCtx<Factory> {
-    /// Creates a new [`ProofTaskCtx`] with the given factory and prefix sets.
-    pub const fn new(factory: Factory, prefix_sets: Arc<TriePrefixSetsMut>) -> Self {
-        Self { factory, prefix_sets }
+    /// Creates a new [`ProofTaskCtx`] with the given factory.
+    pub const fn new(factory: Factory) -> Self {
+        Self { factory }
     }
 }
 
@@ -377,17 +387,14 @@ pub struct ProofTaskTx<Provider> {
     /// The provider that implements `TrieCursorFactory` and `HashedCursorFactory`.
     provider: Provider,
 
-    /// The prefix sets for the computation.
-    prefix_sets: Arc<TriePrefixSetsMut>,
-
     /// Identifier for the worker within the worker pool, used only for tracing.
     id: usize,
 }
 
 impl<Provider> ProofTaskTx<Provider> {
-    /// Initializes a [`ProofTaskTx`] with the given provider, prefix sets, and ID.
-    const fn new(provider: Provider, prefix_sets: Arc<TriePrefixSetsMut>, id: usize) -> Self {
-        Self { provider, prefix_sets, id }
+    /// Initializes a [`ProofTaskTx`] with the given provider and ID.
+    const fn new(provider: Provider, id: usize) -> Self {
+        Self { provider, id }
     }
 }
 
@@ -462,12 +469,8 @@ where
         account: B256,
         path: &Nibbles,
     ) -> TrieNodeProviderResult {
-        let storage_node_provider = ProofBlindedStorageProvider::new(
-            &self.provider,
-            &self.provider,
-            self.prefix_sets.clone(),
-            account,
-        );
+        let storage_node_provider =
+            ProofBlindedStorageProvider::new(&self.provider, &self.provider, account);
         storage_node_provider.trie_node(path)
     }
 
@@ -475,11 +478,8 @@ where
     ///
     /// Used by account workers to retrieve blinded account trie nodes for proof construction.
     fn process_blinded_account_node(&self, path: &Nibbles) -> TrieNodeProviderResult {
-        let account_node_provider = ProofBlindedAccountProvider::new(
-            &self.provider,
-            &self.provider,
-            self.prefix_sets.clone(),
-        );
+        let account_node_provider =
+            ProofBlindedAccountProvider::new(&self.provider, &self.provider);
         account_node_provider.trie_node(path)
     }
 }
@@ -691,7 +691,7 @@ where
     ///
     /// If this function panics, the worker thread terminates but other workers
     /// continue operating and the system degrades gracefully.
-    fn run(self) {
+    fn run(self) -> ProviderResult<()> {
         let Self {
             task_ctx,
             work_rx,
@@ -702,11 +702,8 @@ where
         } = self;
 
         // Create provider from factory
-        let provider = task_ctx
-            .factory
-            .database_provider_ro()
-            .expect("Storage worker failed to initialize: unable to create provider");
-        let proof_tx = ProofTaskTx::new(provider, task_ctx.prefix_sets, worker_id);
+        let provider = task_ctx.factory.database_provider_ro()?;
+        let proof_tx = ProofTaskTx::new(provider, worker_id);
 
         trace!(
             target: "trie::proof_task",
@@ -761,6 +758,8 @@ where
 
         #[cfg(feature = "metrics")]
         metrics.record_storage_nodes(storage_nodes_processed as usize);
+
+        Ok(())
     }
 
     /// Processes a storage proof request.
@@ -934,7 +933,7 @@ where
     ///
     /// If this function panics, the worker thread terminates but other workers
     /// continue operating and the system degrades gracefully.
-    fn run(self) {
+    fn run(self) -> ProviderResult<()> {
         let Self {
             task_ctx,
             work_rx,
@@ -946,11 +945,8 @@ where
         } = self;
 
         // Create provider from factory
-        let provider = task_ctx
-            .factory
-            .database_provider_ro()
-            .expect("Account worker failed to initialize: unable to create provider");
-        let proof_tx = ProofTaskTx::new(provider, task_ctx.prefix_sets, worker_id);
+        let provider = task_ctx.factory.database_provider_ro()?;
+        let proof_tx = ProofTaskTx::new(provider, worker_id);
 
         trace!(
             target: "trie::proof_task",
@@ -1004,6 +1000,8 @@ where
 
         #[cfg(feature = "metrics")]
         metrics.record_account_nodes(account_nodes_processed as usize);
+
+        Ok(())
     }
 
     /// Processes an account multiproof request.
@@ -1481,7 +1479,7 @@ mod tests {
     use tokio::{runtime::Builder, task};
 
     fn test_ctx<Factory>(factory: Factory) -> ProofTaskCtx<Factory> {
-        ProofTaskCtx::new(factory, Arc::new(TriePrefixSetsMut::default()))
+        ProofTaskCtx::new(factory)
     }
 
     /// Ensures `ProofWorkerHandle::new` spawns workers correctly.

--- a/crates/trie/trie/src/proof/trie_node.rs
+++ b/crates/trie/trie/src/proof/trie_node.rs
@@ -2,11 +2,11 @@ use super::{Proof, StorageProof};
 use crate::{hashed_cursor::HashedCursorFactory, trie_cursor::TrieCursorFactory};
 use alloy_primitives::{map::HashSet, B256};
 use reth_execution_errors::{SparseTrieError, SparseTrieErrorKind};
-use reth_trie_common::{prefix_set::TriePrefixSetsMut, MultiProofTargets, Nibbles};
+use reth_trie_common::{MultiProofTargets, Nibbles};
 use reth_trie_sparse::provider::{
     pad_path_to_key, RevealedNode, TrieNodeProvider, TrieNodeProviderFactory,
 };
-use std::{sync::Arc, time::Instant};
+use std::time::Instant;
 use tracing::{enabled, trace, Level};
 
 /// Factory for instantiating providers capable of retrieving blinded trie nodes via proofs.

--- a/crates/trie/trie/src/proof/trie_node.rs
+++ b/crates/trie/trie/src/proof/trie_node.rs
@@ -16,18 +16,12 @@ pub struct ProofTrieNodeProviderFactory<T, H> {
     trie_cursor_factory: T,
     /// The factory for hashed cursors.
     hashed_cursor_factory: H,
-    /// A set of prefix sets that have changes.
-    prefix_sets: Arc<TriePrefixSetsMut>,
 }
 
 impl<T, H> ProofTrieNodeProviderFactory<T, H> {
     /// Create new proof-based blinded provider factory.
-    pub const fn new(
-        trie_cursor_factory: T,
-        hashed_cursor_factory: H,
-        prefix_sets: Arc<TriePrefixSetsMut>,
-    ) -> Self {
-        Self { trie_cursor_factory, hashed_cursor_factory, prefix_sets }
+    pub const fn new(trie_cursor_factory: T, hashed_cursor_factory: H) -> Self {
+        Self { trie_cursor_factory, hashed_cursor_factory }
     }
 }
 
@@ -43,7 +37,6 @@ where
         ProofBlindedAccountProvider {
             trie_cursor_factory: self.trie_cursor_factory.clone(),
             hashed_cursor_factory: self.hashed_cursor_factory.clone(),
-            prefix_sets: self.prefix_sets.clone(),
         }
     }
 
@@ -51,7 +44,6 @@ where
         ProofBlindedStorageProvider {
             trie_cursor_factory: self.trie_cursor_factory.clone(),
             hashed_cursor_factory: self.hashed_cursor_factory.clone(),
-            prefix_sets: self.prefix_sets.clone(),
             account,
         }
     }
@@ -64,18 +56,12 @@ pub struct ProofBlindedAccountProvider<T, H> {
     trie_cursor_factory: T,
     /// The factory for hashed cursors.
     hashed_cursor_factory: H,
-    /// A set of prefix sets that have changes.
-    prefix_sets: Arc<TriePrefixSetsMut>,
 }
 
 impl<T, H> ProofBlindedAccountProvider<T, H> {
     /// Create new proof-based blinded account node provider.
-    pub const fn new(
-        trie_cursor_factory: T,
-        hashed_cursor_factory: H,
-        prefix_sets: Arc<TriePrefixSetsMut>,
-    ) -> Self {
-        Self { trie_cursor_factory, hashed_cursor_factory, prefix_sets }
+    pub const fn new(trie_cursor_factory: T, hashed_cursor_factory: H) -> Self {
+        Self { trie_cursor_factory, hashed_cursor_factory }
     }
 }
 
@@ -89,7 +75,6 @@ where
 
         let targets = MultiProofTargets::from_iter([(pad_path_to_key(path), HashSet::default())]);
         let mut proof = Proof::new(&self.trie_cursor_factory, &self.hashed_cursor_factory)
-            .with_prefix_sets_mut(self.prefix_sets.as_ref().clone())
             .with_branch_node_masks(true)
             .multiproof(targets)
             .map_err(|error| SparseTrieErrorKind::Other(Box::new(error)))?;
@@ -117,21 +102,14 @@ pub struct ProofBlindedStorageProvider<T, H> {
     trie_cursor_factory: T,
     /// The factory for hashed cursors.
     hashed_cursor_factory: H,
-    /// A set of prefix sets that have changes.
-    prefix_sets: Arc<TriePrefixSetsMut>,
     /// Target account.
     account: B256,
 }
 
 impl<T, H> ProofBlindedStorageProvider<T, H> {
     /// Create new proof-based blinded storage node provider.
-    pub const fn new(
-        trie_cursor_factory: T,
-        hashed_cursor_factory: H,
-        prefix_sets: Arc<TriePrefixSetsMut>,
-        account: B256,
-    ) -> Self {
-        Self { trie_cursor_factory, hashed_cursor_factory, prefix_sets, account }
+    pub const fn new(trie_cursor_factory: T, hashed_cursor_factory: H, account: B256) -> Self {
+        Self { trie_cursor_factory, hashed_cursor_factory, account }
     }
 }
 
@@ -144,14 +122,11 @@ where
         let start = enabled!(target: "trie::proof::blinded", Level::TRACE).then(Instant::now);
 
         let targets = HashSet::from_iter([pad_path_to_key(path)]);
-        let storage_prefix_set =
-            self.prefix_sets.storage_prefix_sets.get(&self.account).cloned().unwrap_or_default();
         let mut proof = StorageProof::new_hashed(
             &self.trie_cursor_factory,
             &self.hashed_cursor_factory,
             self.account,
         )
-        .with_prefix_set_mut(storage_prefix_set)
         .with_branch_node_masks(true)
         .storage_multiproof(targets)
         .map_err(|error| SparseTrieErrorKind::Other(Box::new(error)))?;

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -147,11 +147,7 @@ where
 
         let (tx, rx) = mpsc::channel();
         let blinded_provider_factory = WitnessTrieNodeProviderFactory::new(
-            ProofTrieNodeProviderFactory::new(
-                self.trie_cursor_factory,
-                self.hashed_cursor_factory,
-                Arc::new(self.prefix_sets),
-            ),
+            ProofTrieNodeProviderFactory::new(self.trie_cursor_factory, self.hashed_cursor_factory),
             tx,
         );
         let mut sparse_trie = SparseStateTrie::<SerialSparseTrie>::new();

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -24,7 +24,7 @@ use reth_trie_sparse::{
     provider::{RevealedNode, TrieNodeProvider, TrieNodeProviderFactory},
     SerialSparseTrie, SparseStateTrie,
 };
-use std::sync::{mpsc, Arc};
+use std::sync::mpsc;
 
 /// State transition witness for the trie.
 #[derive(Debug)]


### PR DESCRIPTION
Closes #19341

This implements various minor improvements which were pointed out during review of the ConsistentDbView removal PR.

* Remove prefix_sets from proof tasks. We no longer use prefix_sets at all during proof calculations.

* Spawning state root task can no longer fail, so we can simplify a bunch of logic around spawn_payload_validator, including no longer needing to fallback to a new strategy.

* Propagate errors from account/storage proof workers.