### PR TITLE
refactor(era): move to e2s module e2s types and file handling

### DIFF
--- a/crates/era-utils/src/export.rs
+++ b/crates/era-utils/src/export.rs
@@ -6,7 +6,7 @@ use alloy_consensus::BlockHeader;
 use alloy_primitives::{BlockNumber, B256, U256};
 use eyre::{eyre, Result};
 use reth_era::{
-    e2s_types::IndexEntry,
+    e2s::types::IndexEntry,
     era1_file::Era1Writer,
     era1_types::{BlockIndex, Era1Id},
     era_file_ops::{EraFileId, StreamWriter},

--- a/crates/era-utils/src/history.rs
+++ b/crates/era-utils/src/history.rs
@@ -9,7 +9,7 @@ use reth_db_api::{
     RawKey, RawTable, RawValue,
 };
 use reth_era::{
-    e2s_types::E2sError,
+    e2s::error::E2sError,
     era1_file::{BlockTupleIterator, Era1Reader},
     era_file_ops::StreamReader,
     execution_types::BlockTuple,

--- a/crates/era/src/consensus_types.rs
+++ b/crates/era/src/consensus_types.rs
@@ -1,7 +1,7 @@
 //! Consensus types for Era post-merge history files
 
 use crate::{
-    e2s_types::{E2sError, Entry},
+    e2s::{error::E2sError, types::Entry},
     DecodeCompressedSsz,
 };
 use snap::{read::FrameDecoder, write::FrameEncoder};

--- a/crates/era/src/e2s/error.rs
+++ b/crates/era/src/e2s/error.rs
@@ -1,0 +1,32 @@
+//! Error handling for e2s files operations
+
+use std::io;
+use thiserror::Error;
+
+/// Error types for e2s file operations
+#[derive(Error, Debug)]
+pub enum E2sError {
+    /// IO error during file operations
+    #[error("IO error: {0}")]
+    Io(#[from] io::Error),
+
+    /// Error during SSZ encoding/decoding
+    #[error("SSZ error: {0}")]
+    Ssz(String),
+
+    /// Reserved field in header not zero
+    #[error("Reserved field in header not zero")]
+    ReservedNotZero,
+
+    /// Error during snappy compression
+    #[error("Snappy compression error: {0}")]
+    SnappyCompression(String),
+
+    /// Error during snappy decompression
+    #[error("Snappy decompression error: {0}")]
+    SnappyDecompression(String),
+
+    /// Error during RLP encoding/decoding
+    #[error("RLP error: {0}")]
+    Rlp(String),
+}

--- a/crates/era/src/e2s/file.rs
+++ b/crates/era/src/e2s/file.rs
@@ -2,7 +2,10 @@
 //!
 //! See also <https://github.com/status-im/nimbus-eth2/blob/stable/docs/e2store.md>
 
-use crate::e2s_types::{E2sError, Entry, Version};
+use crate::e2s::{
+    error::E2sError,
+    types::{Entry, Version},
+};
 use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 
 /// A reader for `E2Store` files that wraps a [`BufReader`].
@@ -107,7 +110,7 @@ impl<W: Write> E2StoreWriter<W> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::e2s_types::{SLOT_INDEX, VERSION};
+    use crate::e2s::types::{SLOT_INDEX, VERSION};
     use std::io::Cursor;
 
     fn create_slot_index_data(starting_slot: u64, offsets: &[i64]) -> Vec<u8> {

--- a/crates/era/src/e2s/mod.rs
+++ b/crates/era/src/e2s/mod.rs
@@ -1,0 +1,5 @@
+//! Core e2store primitives and file handling.
+
+pub mod error;
+pub mod file;
+pub mod types;

--- a/crates/era/src/e2s/types.rs
+++ b/crates/era/src/e2s/types.rs
@@ -8,9 +8,9 @@
 //! An [`Entry`] is a complete record in the file, consisting of both a [`Header`] and its
 //! associated data
 
+use crate::e2s::error::E2sError;
 use ssz_derive::{Decode, Encode};
 use std::io::{self, Read, Write};
-use thiserror::Error;
 
 /// [`Version`] record: ['e', '2']
 pub const VERSION: [u8; 2] = [0x65, 0x32];
@@ -20,34 +20,6 @@ pub const EMPTY: [u8; 2] = [0x00, 0x00];
 
 /// `SlotIndex` record: ['i', '2']
 pub const SLOT_INDEX: [u8; 2] = [0x69, 0x32];
-
-/// Error types for e2s file operations
-#[derive(Error, Debug)]
-pub enum E2sError {
-    /// IO error during file operations
-    #[error("IO error: {0}")]
-    Io(#[from] io::Error),
-
-    /// Error during SSZ encoding/decoding
-    #[error("SSZ error: {0}")]
-    Ssz(String),
-
-    /// Reserved field in header not zero
-    #[error("Reserved field in header not zero")]
-    ReservedNotZero,
-
-    /// Error during snappy compression
-    #[error("Snappy compression error: {0}")]
-    SnappyCompression(String),
-
-    /// Error during snappy decompression
-    #[error("Snappy decompression error: {0}")]
-    SnappyDecompression(String),
-
-    /// Error during RLP encoding/decoding
-    #[error("RLP error: {0}")]
-    Rlp(String),
-}
 
 /// Header for TLV records in e2store files
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]

--- a/crates/era/src/era1_file.rs
+++ b/crates/era/src/era1_file.rs
@@ -6,8 +6,11 @@
 //! See also <https://github.com/eth-clients/e2store-format-specs/blob/main/formats/era1.md>.
 
 use crate::{
-    e2s_file::{E2StoreReader, E2StoreWriter},
-    e2s_types::{E2sError, Entry, IndexEntry, Version},
+    e2s::{
+        error::E2sError,
+        file::{E2StoreReader, E2StoreWriter},
+        types::{Entry, IndexEntry, Version},
+    },
     era1_types::{BlockIndex, Era1Group, Era1Id, BLOCK_INDEX},
     era_file_ops::{EraFileFormat, FileReader, StreamReader, StreamWriter},
     execution_types::{

--- a/crates/era/src/era1_types.rs
+++ b/crates/era/src/era1_types.rs
@@ -3,7 +3,7 @@
 //! See also <https://github.com/eth-clients/e2store-format-specs/blob/main/formats/era1.md>
 
 use crate::{
-    e2s_types::{Entry, IndexEntry},
+    e2s::types::{Entry, IndexEntry},
     era_file_ops::EraFileId,
     execution_types::{Accumulator, BlockTuple, MAX_BLOCKS_PER_ERA1},
 };

--- a/crates/era/src/era_file_ops.rs
+++ b/crates/era/src/era_file_ops.rs
@@ -1,6 +1,6 @@
 //! Represents reading and writing operations' era file
 
-use crate::{e2s_types::Version, E2sError};
+use crate::e2s::{error::E2sError, types::Version};
 use std::{
     fs::File,
     io::{Read, Seek, Write},

--- a/crates/era/src/era_types.rs
+++ b/crates/era/src/era_types.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     consensus_types::{CompressedBeaconState, CompressedSignedBeaconBlock},
-    e2s_types::{Entry, IndexEntry, SLOT_INDEX},
+    e2s::types::{Entry, IndexEntry, SLOT_INDEX},
 };
 
 /// Era file content group
@@ -126,7 +126,7 @@ impl IndexEntry for SlotIndex {
 mod tests {
     use super::*;
     use crate::{
-        e2s_types::{Entry, IndexEntry},
+        e2s::types::{Entry, IndexEntry},
         test_utils::{create_beacon_block, create_beacon_state},
     };
 

--- a/crates/era/src/execution_types.rs
+++ b/crates/era/src/execution_types.rs
@@ -72,7 +72,7 @@
 //! ``````
 
 use crate::{
-    e2s_types::{E2sError, Entry},
+    e2s::{error::E2sError, types::Entry},
     DecodeCompressed,
 };
 use alloy_consensus::{Block, BlockBody, Header};

--- a/crates/era/src/execution_types.rs
+++ b/crates/era/src/execution_types.rs
@@ -24,7 +24,7 @@
 //! // Decompressed and decode typed compressed header
 //! let decoded_header: Header = compressed.decode_header()?;
 //! assert_eq!(decoded_header.number, 100);
-//! # Ok::<(), reth_era::e2s_types::E2sError>(())
+//! # Ok::<(), reth_era::e2s::error::E2sError>(())
 //! ```
 //!
 //! ## [`CompressedBody`]
@@ -46,7 +46,7 @@
 //! let decoded_body: alloy_consensus::BlockBody<alloy_primitives::Bytes> =
 //!     compressed_body.decode()?;
 //! assert_eq!(decoded_body.transactions.len(), 1);
-//! # Ok::<(), reth_era::e2s_types::E2sError>(())
+//! # Ok::<(), reth_era::e2s::error::E2sError>(())
 //! ```
 //!
 //! ## [`CompressedReceipts`]
@@ -68,7 +68,7 @@
 //! // Get raw receipt by decoding and decompressing compressed and encoded receipt
 //! let decompressed_receipt = compressed_receipt_data.decode::<ReceiptWithBloom>()?;
 //! assert_eq!(decompressed_receipt.receipt.cumulative_gas_used, 21000);
-//! # Ok::<(), reth_era::e2s_types::E2sError>(())
+//! # Ok::<(), reth_era::e2s::error::E2sError>(())
 //! ``````
 
 use crate::{

--- a/crates/era/src/lib.rs
+++ b/crates/era/src/lib.rs
@@ -13,8 +13,7 @@
 //! - Era1 format: <https://github.com/eth-clients/e2store-format-specs/blob/main/formats/era1.md>
 
 pub mod consensus_types;
-pub mod e2s_file;
-pub mod e2s_types;
+pub mod e2s;
 pub mod era1_file;
 pub mod era1_types;
 pub mod era_file_ops;
@@ -23,7 +22,7 @@ pub mod execution_types;
 #[cfg(test)]
 pub(crate) mod test_utils;
 
-use crate::e2s_types::E2sError;
+use crate::e2s::error::E2sError;
 use alloy_rlp::Decodable;
 use ssz::Decode;
 

--- a/crates/era/tests/it/dd.rs
+++ b/crates/era/tests/it/dd.rs
@@ -4,7 +4,7 @@
 use alloy_consensus::{BlockBody, Header};
 use alloy_primitives::U256;
 use reth_era::{
-    e2s_types::IndexEntry,
+    e2s::types::IndexEntry,
     era1_file::{Era1Reader, Era1Writer},
     era_file_ops::{StreamReader, StreamWriter},
     execution_types::CompressedBody,

--- a/crates/era/tests/it/genesis.rs
+++ b/crates/era/tests/it/genesis.rs
@@ -7,7 +7,7 @@ use crate::{
     Era1TestDownloader, ERA1_MAINNET_FILES_NAMES, ERA1_SEPOLIA_FILES_NAMES, MAINNET, SEPOLIA,
 };
 use alloy_consensus::{BlockBody, Header};
-use reth_era::{e2s_types::IndexEntry, execution_types::CompressedBody};
+use reth_era::{e2s::types::IndexEntry, execution_types::CompressedBody};
 use reth_ethereum_primitives::TransactionSigned;
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/era/tests/it/main.rs
+++ b/crates/era/tests/it/main.rs
@@ -8,7 +8,7 @@
 
 use reqwest::{Client, Url};
 use reth_era::{
-    e2s_types::E2sError,
+    e2s::error::E2sError,
     era1_file::{Era1File, Era1Reader},
     era_file_ops::FileReader,
 };

--- a/crates/era/tests/it/roundtrip.rs
+++ b/crates/era/tests/it/roundtrip.rs
@@ -10,7 +10,7 @@
 use alloy_consensus::{BlockBody, BlockHeader, Header, ReceiptWithBloom};
 use rand::{prelude::IndexedRandom, rng};
 use reth_era::{
-    e2s_types::IndexEntry,
+    e2s::types::IndexEntry,
     era1_file::{Era1File, Era1Reader, Era1Writer},
     era1_types::{Era1Group, Era1Id},
     era_file_ops::{EraFileFormat, StreamReader, StreamWriter},


### PR DESCRIPTION
Part 1 for some refactor to make cleaner the files architecture of https://github.com/paradigmxyz/reth/tree/main/crates/era/src.

Right now, just the e2s types and file handling is moved to its own module.