### PR TITLE
docs(banlist): document timeout update behavior on re-ban

### DIFF
--- a/crates/net/banlist/src/lib.rs
+++ b/crates/net/banlist/src/lib.rs
@@ -125,11 +125,14 @@ impl BanList {
     /// Bans the IP until the timestamp.
     ///
     /// This does not ban non-global IPs.
+    /// If the IP is already banned, the timeout will be updated to the new value.
     pub fn ban_ip_until(&mut self, ip: IpAddr, until: Instant) {
         self.ban_ip_with(ip, Some(until));
     }
 
-    /// Bans the peer until the timestamp
+    /// Bans the peer until the timestamp.
+    ///
+    /// If the peer is already banned, the timeout will be updated to the new value.
     pub fn ban_peer_until(&mut self, node_id: PeerId, until: Instant) {
         self.ban_peer_with(node_id, Some(until));
     }
@@ -147,6 +150,8 @@ impl BanList {
     }
 
     /// Bans the peer indefinitely or until the given timeout.
+    ///
+    /// If the peer is already banned, the timeout will be updated to the new value.
     pub fn ban_peer_with(&mut self, node_id: PeerId, until: Option<Instant>) {
         self.banned_peers.insert(node_id, until);
     }
@@ -154,6 +159,7 @@ impl BanList {
     /// Bans the ip indefinitely or until the given timeout.
     ///
     /// This does not ban non-global IPs.
+    /// If the IP is already banned, the timeout will be updated to the new value.
     pub fn ban_ip_with(&mut self, ip: IpAddr, until: Option<Instant>) {
         if is_global(&ip) {
             self.banned_ips.insert(ip, until);
@@ -167,7 +173,7 @@ mod tests {
 
     #[test]
     fn can_ban_unban_peer() {
-        let peer = PeerId::random();
+        let peer = PeerId::new([1; 64]);
         let mut banlist = BanList::default();
         banlist.ban_peer(peer);
         assert!(banlist.is_banned_peer(&peer));


### PR DESCRIPTION
Adds documentation clarifying that banning an already banned peer or IP updates the timeout to the new value. 

Also fixes a test compilation error by replacing PeerId::random() with PeerId::new([1; 64]) since the random() method doesn't exist on FixedBytes<64>.