### PR TITLE
fix: validate negative count values in E2S index parsing

### DIFF
--- a/crates/era/src/e2s_types.rs
+++ b/crates/era/src/e2s_types.rs
@@ -219,11 +219,17 @@ pub trait IndexEntry: Sized {
 
         // Extract count from last 8 bytes
         let count_bytes = &entry.data[entry.data.len() - 8..];
-        let count = i64::from_le_bytes(
+        let count_i64 = i64::from_le_bytes(
             count_bytes
                 .try_into()
                 .map_err(|_| E2sError::Ssz("Failed to read count bytes".to_string()))?,
-        ) as usize;
+        );
+
+        // Validate that count is non-negative before converting to usize
+        if count_i64 < 0 {
+            return Err(E2sError::Ssz(format!("Invalid negative count value: {}", count_i64)));
+        }
+        let count = count_i64 as usize;
 
         // Verify entry has correct size
         let expected_len = 8 + count * 8 + 8;


### PR DESCRIPTION
Added validation for negative count values during E2S index parsing. Previously, the code read count as i64 and immediately cast it to usize without checking. If a malformed file contained a negative number (e.g., -1), it would wrap to a huge value like 18 quintillion, causing the subsequent Vec::with_capacity() to panic with OOM.

Now we validate that count is non-negative before the cast and return a clear error if the file is corrupted.