### PR TITLE
perf(trie): replace static Vec with const slice for empty updates

### DIFF
--- a/crates/trie/trie/src/trie_cursor/in_memory.rs
+++ b/crates/trie/trie/src/trie_cursor/in_memory.rs
@@ -45,13 +45,13 @@ where
         hashed_address: B256,
     ) -> Result<Self::StorageTrieCursor<'_>, DatabaseError> {
         // if the storage trie has no updates then we use this as the in-memory overlay.
-        static EMPTY_UPDATES: Vec<(Nibbles, Option<BranchNodeCompact>)> = Vec::new();
+        const EMPTY_UPDATES: &[(Nibbles, Option<BranchNodeCompact>)] = &[];
 
         let storage_trie_updates =
             self.trie_updates.as_ref().storage_tries_ref().get(&hashed_address);
         let (storage_nodes, cleared) = storage_trie_updates
             .map(|u| (u.storage_nodes_ref(), u.is_deleted()))
-            .unwrap_or((&EMPTY_UPDATES, false));
+            .unwrap_or((EMPTY_UPDATES, false));
 
         let cursor = if cleared {
             None


### PR DESCRIPTION
Replaced `static Vec::new()` with `const &[]` for EMPTY_UPDATES in InMemoryTrieCursorFactory::storage_trie_cursor.

The old version was creating a runtime-initialized static variable every time, which added unnecessary overhead. Since we just need an empty slice as a fallback when there are no storage trie updates, using a const reference to an empty array is more efficient and idiomatic.