### PR TITLE
fix(stages-types): resolve compilation errors in tests

### DIFF
--- a/crates/stages/types/Cargo.toml
+++ b/crates/stages/types/Cargo.toml
@@ -24,12 +24,14 @@ modular-bitfield = { workspace = true, optional = true }
 
 [dev-dependencies]
 reth-codecs.workspace = true
+reth-trie-common = { workspace = true, features = ["reth-codec"] }
 alloy-primitives = { workspace = true, features = ["arbitrary", "rand"] }
 arbitrary = { workspace = true, features = ["derive"] }
 proptest.workspace = true
 proptest-arbitrary-interop.workspace = true
 rand.workspace = true
 bytes.workspace = true
+modular-bitfield.workspace = true
 
 [features]
 default = ["std"]

--- a/crates/stages/types/src/checkpoints.rs
+++ b/crates/stages/types/src/checkpoints.rs
@@ -1,4 +1,6 @@
 use super::StageId;
+#[cfg(test)]
+use alloc::vec;
 use alloc::{format, string::String, vec::Vec};
 use alloy_primitives::{Address, BlockNumber, B256, U256};
 use core::ops::RangeInclusive;


### PR DESCRIPTION
Tests in reth-stages-types weren't compiling due to missing vec! macro import and some dev dependencies.

Fixed by:
- Adding #[cfg(test)] use alloc::vec for test builds
- Adding missing modular-bitfield and reth-trie-common[reth-codec] to dev-dependencies

cargo test -p reth-stages-types --lib now works properly