### PR TITLE
docs: fix license links in README.md

### DIFF
--- a/crates/storage/rpc-provider/README.md
+++ b/crates/storage/rpc-provider/README.md
@@ -65,7 +65,7 @@ This provider implements the same traits as the local `BlockchainProvider`, maki
 
 Licensed under either of:
 
-- Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+- Apache License, Version 2.0, ([LICENSE-APACHE](../../../LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](../../../LICENSE-MIT) or http://opensource.org/licenses/MIT)
 
 at your option.


### PR DESCRIPTION


Updated the license section to use correct relative paths for **Apache 2.0** and **MIT** licenses.

