### PR TITLE
feat(engine): record newPayload/forkchoiceUpdated metrics outside of RPC

### DIFF
--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -1,11 +1,13 @@
-use crate::tree::MeteredStateHook;
+use crate::tree::{error::InsertBlockFatalError, MeteredStateHook, TreeOutcome};
 use alloy_consensus::transaction::TxHashRef;
 use alloy_evm::{
     block::{BlockExecutor, ExecutableTx},
     Evm,
 };
+use alloy_rpc_types_engine::{PayloadStatus, PayloadStatusEnum};
 use core::borrow::BorrowMut;
-use reth_errors::BlockExecutionError;
+use reth_engine_primitives::{ForkchoiceStatus, OnForkChoiceUpdated};
+use reth_errors::{BlockExecutionError, ProviderError};
 use reth_evm::{metrics::ExecutorMetrics, OnStateHook};
 use reth_execution_types::BlockExecutionOutput;
 use reth_metrics::{
@@ -15,7 +17,7 @@ use reth_metrics::{
 use reth_primitives_traits::SignedTransaction;
 use reth_trie::updates::TrieUpdates;
 use revm::database::{states::bundle_state::BundleRetention, State};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tracing::{debug_span, trace};
 
 /// Metrics for the `EngineApi`.
@@ -132,20 +134,20 @@ pub(crate) struct TreeMetrics {
 #[derive(Metrics)]
 #[metrics(scope = "consensus.engine.beacon")]
 pub(crate) struct EngineMetrics {
+    /// Engine API forkchoiceUpdated response type metrics
+    #[metric(skip)]
+    pub(crate) forkchoice_updated: ForkchoiceUpdatedMetrics,
+    /// Engine API newPayload response type metrics
+    #[metric(skip)]
+    pub(crate) new_payload: NewPayloadStatusMetrics,
     /// How many executed blocks are currently stored.
     pub(crate) executed_blocks: Gauge,
     /// How many already executed blocks were directly inserted into the tree.
     pub(crate) inserted_already_executed_blocks: Counter,
     /// The number of times the pipeline was run.
     pub(crate) pipeline_runs: Counter,
-    /// The total count of forkchoice updated messages received.
-    pub(crate) forkchoice_updated_messages: Counter,
-    /// The total count of forkchoice updated messages with payload received.
-    pub(crate) forkchoice_with_attributes_updated_messages: Counter,
     /// Newly arriving block hash is not present in executed blocks cache storage
     pub(crate) executed_new_block_cache_miss: Counter,
-    /// The total count of new payload messages received.
-    pub(crate) new_payload_messages: Counter,
     /// Histogram of persistence operation durations (in seconds)
     pub(crate) persistence_duration: Histogram,
     /// Tracks the how often we failed to deliver a newPayload response.
@@ -158,6 +160,109 @@ pub(crate) struct EngineMetrics {
     pub(crate) failed_forkchoice_updated_response_deliveries: Counter,
     /// block insert duration
     pub(crate) block_insert_total_duration: Histogram,
+}
+
+/// Metrics for engine forkchoiceUpdated responses.
+#[derive(Metrics)]
+#[metrics(scope = "consensus.engine.beacon")]
+pub(crate) struct ForkchoiceUpdatedMetrics {
+    /// The total count of forkchoice updated messages received.
+    pub(crate) forkchoice_updated_messages: Counter,
+    /// The total count of forkchoice updated messages with payload received.
+    pub(crate) forkchoice_with_attributes_updated_messages: Counter,
+    /// The total count of forkchoice updated messages that we responded to with
+    /// [`Valid`](ForkchoiceStatus::Valid).
+    pub(crate) forkchoice_updated_valid: Counter,
+    /// The total count of forkchoice updated messages that we responded to with
+    /// [`Invalid`](ForkchoiceStatus::Invalid).
+    pub(crate) forkchoice_updated_invalid: Counter,
+    /// The total count of forkchoice updated messages that we responded to with
+    /// [`Syncing`](ForkchoiceStatus::Syncing).
+    pub(crate) forkchoice_updated_syncing: Counter,
+    /// The total count of forkchoice updated messages that were unsuccessful, i.e. we responded
+    /// with an error type that is not a [`PayloadStatusEnum`].
+    pub(crate) forkchoice_updated_error: Counter,
+    /// Latency for the last forkchoice updated call.
+    pub(crate) forkchoice_updated_last: Gauge,
+}
+
+impl ForkchoiceUpdatedMetrics {
+    /// Increment the forkchoiceUpdated counter based on the given result
+    pub(crate) fn update_response_metrics(
+        &self,
+        has_attrs: bool,
+        result: &Result<TreeOutcome<OnForkChoiceUpdated>, ProviderError>,
+        elapsed: Duration,
+    ) {
+        match result {
+            Ok(outcome) => match outcome.outcome.forkchoice_status() {
+                ForkchoiceStatus::Valid => self.forkchoice_updated_valid.increment(1),
+                ForkchoiceStatus::Invalid => self.forkchoice_updated_invalid.increment(1),
+                ForkchoiceStatus::Syncing => self.forkchoice_updated_syncing.increment(1),
+            },
+            Err(_) => self.forkchoice_updated_error.increment(1),
+        }
+        self.forkchoice_updated_messages.increment(1);
+        if has_attrs {
+            self.forkchoice_with_attributes_updated_messages.increment(1);
+        }
+        self.forkchoice_updated_last.set(elapsed);
+    }
+}
+
+/// Metrics for engine newPayload responses.
+#[derive(Metrics)]
+#[metrics(scope = "consensus.engine.beacon")]
+pub(crate) struct NewPayloadStatusMetrics {
+    /// The total count of new payload messages received.
+    pub(crate) new_payload_messages: Counter,
+    /// The total count of new payload messages that we responded to with
+    /// [Valid](PayloadStatusEnum::Valid).
+    pub(crate) new_payload_valid: Counter,
+    /// The total count of new payload messages that we responded to with
+    /// [Invalid](PayloadStatusEnum::Invalid).
+    pub(crate) new_payload_invalid: Counter,
+    /// The total count of new payload messages that we responded to with
+    /// [Syncing](PayloadStatusEnum::Syncing).
+    pub(crate) new_payload_syncing: Counter,
+    /// The total count of new payload messages that we responded to with
+    /// [Accepted](PayloadStatusEnum::Accepted).
+    pub(crate) new_payload_accepted: Counter,
+    /// The total count of new payload messages that were unsuccessful, i.e. we responded with an
+    /// error type that is not a [`PayloadStatusEnum`].
+    pub(crate) new_payload_error: Counter,
+    /// The total gas of valid new payload messages received.
+    pub(crate) new_payload_total_gas: Histogram,
+    /// The gas per second of valid new payload messages received.
+    pub(crate) new_payload_gas_per_second: Histogram,
+    /// Latency for the last new payload call.
+    pub(crate) new_payload_last: Gauge,
+}
+
+impl NewPayloadStatusMetrics {
+    /// Increment the newPayload counter based on the given result
+    pub(crate) fn update_response_metrics(
+        &self,
+        result: &Result<TreeOutcome<PayloadStatus>, InsertBlockFatalError>,
+        gas_used: u64,
+        elapsed: Duration,
+    ) {
+        match result {
+            Ok(outcome) => match outcome.outcome.status {
+                PayloadStatusEnum::Valid => {
+                    self.new_payload_valid.increment(1);
+                    self.new_payload_total_gas.record(gas_used as f64);
+                    self.new_payload_gas_per_second.record(gas_used as f64 / elapsed.as_secs_f64());
+                }
+                PayloadStatusEnum::Syncing => self.new_payload_syncing.increment(1),
+                PayloadStatusEnum::Accepted => self.new_payload_accepted.increment(1),
+                PayloadStatusEnum::Invalid { .. } => self.new_payload_invalid.increment(1),
+            },
+            Err(_) => self.new_payload_error.increment(1),
+        }
+        self.new_payload_messages.increment(1);
+        self.new_payload_last.set(elapsed);
+    }
 }
 
 /// Metrics for non-execution related block validation.

--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -182,6 +182,8 @@ pub(crate) struct ForkchoiceUpdatedMetrics {
     /// The total count of forkchoice updated messages that were unsuccessful, i.e. we responded
     /// with an error type that is not a [`PayloadStatusEnum`].
     pub(crate) forkchoice_updated_error: Counter,
+    /// Latency for the forkchoice updated calls.
+    pub(crate) forkchoice_updated_latency: Histogram,
     /// Latency for the last forkchoice updated call.
     pub(crate) forkchoice_updated_last: Gauge,
 }
@@ -206,6 +208,7 @@ impl ForkchoiceUpdatedMetrics {
         if has_attrs {
             self.forkchoice_with_attributes_updated_messages.increment(1);
         }
+        self.forkchoice_updated_latency.record(elapsed);
         self.forkchoice_updated_last.set(elapsed);
     }
 }
@@ -235,6 +238,8 @@ pub(crate) struct NewPayloadStatusMetrics {
     pub(crate) new_payload_total_gas: Histogram,
     /// The gas per second of valid new payload messages received.
     pub(crate) new_payload_gas_per_second: Histogram,
+    /// Latency for the new payload calls.
+    pub(crate) new_payload_latency: Histogram,
     /// Latency for the last new payload call.
     pub(crate) new_payload_last: Gauge,
 }
@@ -261,6 +266,7 @@ impl NewPayloadStatusMetrics {
             Err(_) => self.new_payload_error.increment(1),
         }
         self.new_payload_messages.increment(1);
+        self.new_payload_latency.record(elapsed);
         self.new_payload_last.set(elapsed);
     }
 }

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1393,11 +1393,6 @@ where
                                 let start = Instant::now();
                                 let mut output =
                                     self.on_forkchoice_updated(state, payload_attrs, version);
-                                let elapsed = start.elapsed();
-                                self.metrics
-                                    .engine
-                                    .forkchoice_updated
-                                    .update_response_metrics(has_attrs, &output, elapsed);
 
                                 if let Ok(res) = &mut output {
                                     // track last received forkchoice state
@@ -1414,6 +1409,12 @@ where
                                     // handle the event if any
                                     self.on_maybe_tree_event(res.event.take())?;
                                 }
+
+                                let elapsed = start.elapsed();
+                                self.metrics
+                                    .engine
+                                    .forkchoice_updated
+                                    .update_response_metrics(has_attrs, &output, elapsed);
 
                                 if let Err(err) =
                                     tx.send(output.map(|o| o.outcome).map_err(Into::into))

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -506,7 +506,6 @@ where
         payload: T::ExecutionData,
     ) -> Result<TreeOutcome<PayloadStatus>, InsertBlockFatalError> {
         trace!(target: "engine::tree", "invoked new payload");
-        self.metrics.engine.new_payload_messages.increment(1);
 
         // start timing for the new payload process
         let start = Instant::now();
@@ -985,7 +984,7 @@ where
         trace!(target: "engine::tree", ?attrs, "invoked forkchoice update");
 
         // Record metrics
-        self.record_forkchoice_metrics(&attrs);
+        self.record_forkchoice_metrics();
 
         // Pre-validation of forkchoice state
         if let Some(early_result) = self.validate_forkchoice_state(state)? {
@@ -1008,11 +1007,7 @@ where
     }
 
     /// Records metrics for forkchoice updated calls
-    fn record_forkchoice_metrics(&self, attrs: &Option<T::PayloadAttributes>) {
-        self.metrics.engine.forkchoice_updated_messages.increment(1);
-        if attrs.is_some() {
-            self.metrics.engine.forkchoice_with_attributes_updated_messages.increment(1);
-        }
+    fn record_forkchoice_metrics(&self) {
         self.canonical_in_memory_state.on_forkchoice_update_received();
     }
 
@@ -1393,8 +1388,16 @@ where
                                 tx,
                                 version,
                             } => {
+                                let has_attrs = payload_attrs.is_some();
+
+                                let start = Instant::now();
                                 let mut output =
                                     self.on_forkchoice_updated(state, payload_attrs, version);
+                                let elapsed = start.elapsed();
+                                self.metrics
+                                    .engine
+                                    .forkchoice_updated
+                                    .update_response_metrics(has_attrs, &output, elapsed);
 
                                 if let Ok(res) = &mut output {
                                     // track last received forkchoice state
@@ -1423,7 +1426,14 @@ where
                                 }
                             }
                             BeaconEngineMessage::NewPayload { payload, tx } => {
+                                let start = Instant::now();
+                                let gas_used = payload.gas_used();
                                 let mut output = self.on_new_payload(payload);
+                                let elapsed = start.elapsed();
+                                self.metrics
+                                    .engine
+                                    .new_payload
+                                    .update_response_metrics(&output, gas_used, elapsed);
 
                                 let maybe_event =
                                     output.as_mut().ok().and_then(|out| out.event.take());

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -1694,7 +1694,6 @@ mod payload_execution_tests {
 #[cfg(test)]
 mod forkchoice_updated_tests {
     use super::*;
-    use alloy_primitives::Address;
 
     /// Test that validates the forkchoice state pre-validation logic
     #[tokio::test]
@@ -1912,33 +1911,6 @@ mod forkchoice_updated_tests {
             .unwrap();
         let fcu_result = result.outcome.await.unwrap();
         assert!(fcu_result.payload_status.is_syncing(), "Should return syncing during backfill");
-    }
-
-    /// Test metrics recording in forkchoice updated
-    #[tokio::test]
-    async fn test_record_forkchoice_metrics() {
-        let chain_spec = MAINNET.clone();
-        let test_harness = TestHarness::new(chain_spec);
-
-        // Get initial metrics state by checking if metrics are recorded
-        // We can't directly get counter values, but we can verify the methods are called
-
-        // Test without attributes
-        let attrs_none = None;
-        test_harness.tree.record_forkchoice_metrics(&attrs_none);
-
-        // Test with attributes
-        let attrs_some = Some(alloy_rpc_types_engine::PayloadAttributes {
-            timestamp: 1000,
-            prev_randao: B256::random(),
-            suggested_fee_recipient: Address::random(),
-            withdrawals: None,
-            parent_beacon_block_root: None,
-        });
-        test_harness.tree.record_forkchoice_metrics(&attrs_some);
-
-        // We can't directly verify counter values since they're private metrics
-        // But we can verify the methods don't panic and execute successfully
     }
 
     /// Test edge case: FCU with invalid ancestor

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -21,8 +21,7 @@ use reth_chainspec::EthereumHardforks;
 use reth_engine_primitives::{ConsensusEngineHandle, EngineApiValidator, EngineTypes};
 use reth_payload_builder::PayloadStore;
 use reth_payload_primitives::{
-    validate_payload_timestamp, EngineApiMessageVersion, ExecutionPayload, PayloadOrAttributes,
-    PayloadTypes,
+    validate_payload_timestamp, EngineApiMessageVersion, PayloadOrAttributes, PayloadTypes,
 };
 use reth_primitives_traits::{Block, BlockBody};
 use reth_rpc_api::{EngineApiServer, IntoEngineApiRpcModule};
@@ -161,12 +160,9 @@ where
         payload: PayloadT::ExecutionData,
     ) -> EngineApiResult<PayloadStatus> {
         let start = Instant::now();
-        let gas_used = payload.gas_used();
-
         let res = Self::new_payload_v1(self, payload).await;
         let elapsed = start.elapsed();
         self.inner.metrics.latency.new_payload_v1.record(elapsed);
-        self.inner.metrics.new_payload_response.update_response_metrics(&res, gas_used, elapsed);
         res
     }
 
@@ -197,12 +193,9 @@ where
         payload: PayloadT::ExecutionData,
     ) -> EngineApiResult<PayloadStatus> {
         let start = Instant::now();
-        let gas_used = payload.gas_used();
-
         let res = Self::new_payload_v2(self, payload).await;
         let elapsed = start.elapsed();
         self.inner.metrics.latency.new_payload_v2.record(elapsed);
-        self.inner.metrics.new_payload_response.update_response_metrics(&res, gas_used, elapsed);
         res
     }
 
@@ -234,12 +227,10 @@ where
         payload: PayloadT::ExecutionData,
     ) -> RpcResult<PayloadStatus> {
         let start = Instant::now();
-        let gas_used = payload.gas_used();
 
         let res = Self::new_payload_v3(self, payload).await;
         let elapsed = start.elapsed();
         self.inner.metrics.latency.new_payload_v3.record(elapsed);
-        self.inner.metrics.new_payload_response.update_response_metrics(&res, gas_used, elapsed);
         Ok(res?)
     }
 
@@ -271,13 +262,10 @@ where
         payload: PayloadT::ExecutionData,
     ) -> RpcResult<PayloadStatus> {
         let start = Instant::now();
-        let gas_used = payload.gas_used();
-
         let res = Self::new_payload_v4(self, payload).await;
 
         let elapsed = start.elapsed();
         self.inner.metrics.latency.new_payload_v4.record(elapsed);
-        self.inner.metrics.new_payload_response.update_response_metrics(&res, gas_used, elapsed);
         Ok(res?)
     }
 
@@ -320,7 +308,6 @@ where
         let start = Instant::now();
         let res = Self::fork_choice_updated_v1(self, state, payload_attrs).await;
         self.inner.metrics.latency.fork_choice_updated_v1.record(start.elapsed());
-        self.inner.metrics.fcu_response.update_response_metrics(&res);
         res
     }
 
@@ -346,7 +333,6 @@ where
         let start = Instant::now();
         let res = Self::fork_choice_updated_v2(self, state, payload_attrs).await;
         self.inner.metrics.latency.fork_choice_updated_v2.record(start.elapsed());
-        self.inner.metrics.fcu_response.update_response_metrics(&res);
         res
     }
 
@@ -372,7 +358,6 @@ where
         let start = Instant::now();
         let res = Self::fork_choice_updated_v3(self, state, payload_attrs).await;
         self.inner.metrics.latency.fork_choice_updated_v3.record(start.elapsed());
-        self.inner.metrics.fcu_response.update_response_metrics(&res);
         res
     }
 

--- a/crates/rpc/rpc-engine-api/src/metrics.rs
+++ b/crates/rpc/rpc-engine-api/src/metrics.rs
@@ -1,8 +1,4 @@
-use std::time::Duration;
-
-use crate::EngineApiError;
-use alloy_rpc_types_engine::{ForkchoiceUpdated, PayloadStatus, PayloadStatusEnum};
-use metrics::{Counter, Gauge, Histogram};
+use metrics::{Counter, Histogram};
 use reth_metrics::Metrics;
 
 /// All beacon consensus engine metrics
@@ -10,10 +6,6 @@ use reth_metrics::Metrics;
 pub(crate) struct EngineApiMetrics {
     /// Engine API latency metrics
     pub(crate) latency: EngineApiLatencyMetrics,
-    /// Engine API forkchoiceUpdated response type metrics
-    pub(crate) fcu_response: ForkchoiceUpdatedResponseMetrics,
-    /// Engine API newPayload response type metrics
-    pub(crate) new_payload_response: NewPayloadStatusResponseMetrics,
     /// Blob-related metrics
     pub(crate) blob_metrics: BlobMetrics,
 }
@@ -58,58 +50,6 @@ pub(crate) struct EngineApiLatencyMetrics {
     pub(crate) get_blobs_v2: Histogram,
 }
 
-/// Metrics for engine API forkchoiceUpdated responses.
-#[derive(Metrics)]
-#[metrics(scope = "engine.rpc")]
-pub(crate) struct ForkchoiceUpdatedResponseMetrics {
-    /// The total count of forkchoice updated messages received.
-    pub(crate) forkchoice_updated_messages: Counter,
-    /// The total count of forkchoice updated messages that we responded to with
-    /// [`Invalid`](alloy_rpc_types_engine::PayloadStatusEnum#Invalid).
-    pub(crate) forkchoice_updated_invalid: Counter,
-    /// The total count of forkchoice updated messages that we responded to with
-    /// [`Valid`](alloy_rpc_types_engine::PayloadStatusEnum#Valid).
-    pub(crate) forkchoice_updated_valid: Counter,
-    /// The total count of forkchoice updated messages that we responded to with
-    /// [`Syncing`](alloy_rpc_types_engine::PayloadStatusEnum#Syncing).
-    pub(crate) forkchoice_updated_syncing: Counter,
-    /// The total count of forkchoice updated messages that we responded to with
-    /// [`Accepted`](alloy_rpc_types_engine::PayloadStatusEnum#Accepted).
-    pub(crate) forkchoice_updated_accepted: Counter,
-    /// The total count of forkchoice updated messages that were unsuccessful, i.e. we responded
-    /// with an error type that is not a [`PayloadStatusEnum`].
-    pub(crate) forkchoice_updated_error: Counter,
-}
-
-/// Metrics for engine API newPayload responses.
-#[derive(Metrics)]
-#[metrics(scope = "engine.rpc")]
-pub(crate) struct NewPayloadStatusResponseMetrics {
-    /// The total count of new payload messages received.
-    pub(crate) new_payload_messages: Counter,
-    /// The total count of new payload messages that we responded to with
-    /// [Invalid](alloy_rpc_types_engine::PayloadStatusEnum#Invalid).
-    pub(crate) new_payload_invalid: Counter,
-    /// The total count of new payload messages that we responded to with
-    /// [Valid](alloy_rpc_types_engine::PayloadStatusEnum#Valid).
-    pub(crate) new_payload_valid: Counter,
-    /// The total count of new payload messages that we responded to with
-    /// [Syncing](alloy_rpc_types_engine::PayloadStatusEnum#Syncing).
-    pub(crate) new_payload_syncing: Counter,
-    /// The total count of new payload messages that we responded to with
-    /// [Accepted](alloy_rpc_types_engine::PayloadStatusEnum#Accepted).
-    pub(crate) new_payload_accepted: Counter,
-    /// The total count of new payload messages that were unsuccessful, i.e. we responded with an
-    /// error type that is not a [`PayloadStatusEnum`].
-    pub(crate) new_payload_error: Counter,
-    /// The total gas of valid new payload messages received.
-    pub(crate) new_payload_total_gas: Histogram,
-    /// The gas per second of valid new payload messages received.
-    pub(crate) new_payload_gas_per_second: Histogram,
-    /// Latency for the last `engine_newPayloadV*` call
-    pub(crate) new_payload_last: Gauge,
-}
-
 #[derive(Metrics)]
 #[metrics(scope = "engine.rpc.blobs")]
 pub(crate) struct BlobMetrics {
@@ -125,49 +65,4 @@ pub(crate) struct BlobMetrics {
     pub(crate) get_blobs_requests_success_total: Counter,
     /// Number of times getBlobsV2 responded with “miss”
     pub(crate) get_blobs_requests_failure_total: Counter,
-}
-
-impl NewPayloadStatusResponseMetrics {
-    /// Increment the newPayload counter based on the given rpc result
-    pub(crate) fn update_response_metrics(
-        &self,
-        result: &Result<PayloadStatus, EngineApiError>,
-        gas_used: u64,
-        time: Duration,
-    ) {
-        self.new_payload_last.set(time);
-        match result {
-            Ok(status) => match status.status {
-                PayloadStatusEnum::Valid => {
-                    self.new_payload_valid.increment(1);
-                    self.new_payload_total_gas.record(gas_used as f64);
-                    self.new_payload_gas_per_second.record(gas_used as f64 / time.as_secs_f64());
-                }
-                PayloadStatusEnum::Syncing => self.new_payload_syncing.increment(1),
-                PayloadStatusEnum::Accepted => self.new_payload_accepted.increment(1),
-                PayloadStatusEnum::Invalid { .. } => self.new_payload_invalid.increment(1),
-            },
-            Err(_) => self.new_payload_error.increment(1),
-        }
-        self.new_payload_messages.increment(1);
-    }
-}
-
-impl ForkchoiceUpdatedResponseMetrics {
-    /// Increment the forkchoiceUpdated counter based on the given rpc result
-    pub(crate) fn update_response_metrics(
-        &self,
-        result: &Result<ForkchoiceUpdated, EngineApiError>,
-    ) {
-        match result {
-            Ok(status) => match status.payload_status.status {
-                PayloadStatusEnum::Valid => self.forkchoice_updated_valid.increment(1),
-                PayloadStatusEnum::Syncing => self.forkchoice_updated_syncing.increment(1),
-                PayloadStatusEnum::Accepted => self.forkchoice_updated_accepted.increment(1),
-                PayloadStatusEnum::Invalid { .. } => self.forkchoice_updated_invalid.increment(1),
-            },
-            Err(_) => self.forkchoice_updated_error.increment(1),
-        }
-        self.forkchoice_updated_messages.increment(1);
-    }
 }


### PR DESCRIPTION
Nodes building on top of Reth SDK and not using Engine API RPC directly, but via handle, don't have newPayload/forkchoiceUpdated metrics, because we record them in RPC layer.

This PR moves these metrics to `engine` crate and records them there.