### PR TITLE
docs(chainspec): improve fork_id and satisfy documentation

### DIFF
--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -514,8 +514,15 @@ impl<H: BlockHeader> ChainSpec<H> {
 
     /// Compute the [`ForkId`] for the given [`Head`] following eip-6122 spec.
     ///
-    /// Note: In case there are multiple hardforks activated at the same block or timestamp, only
-    /// the first gets applied.
+    /// The fork hash is computed by starting from the genesis hash and iteratively adding
+    /// block numbers (for block-based forks) or timestamps (for timestamp-based forks) of
+    /// active forks. The `next` field indicates the next fork activation point, or `0` if
+    /// all forks are active.
+    ///
+    /// Block-based forks are processed first, then timestamp-based forks. Multiple hardforks
+    /// activated at the same block or timestamp: only the first one is applied.
+    ///
+    /// See: <https://eips.ethereum.org/EIPS/eip-6122>
     pub fn fork_id(&self, head: &Head) -> ForkId {
         let mut forkhash = ForkHash::from(self.genesis_hash());
 
@@ -572,6 +579,10 @@ impl<H: BlockHeader> ChainSpec<H> {
     }
 
     /// An internal helper function that returns a head block that satisfies a given Fork condition.
+    ///
+    /// Creates a [`Head`] representation for a fork activation point, used by [`fork_id`] to
+    /// compute fork IDs. For timestamp-based forks, includes the last block-based fork number
+    /// before the merge (if any).
     pub(crate) fn satisfy(&self, cond: ForkCondition) -> Head {
         match cond {
             ForkCondition::Block(number) => Head { number, ..Default::default() },

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -580,7 +580,7 @@ impl<H: BlockHeader> ChainSpec<H> {
 
     /// An internal helper function that returns a head block that satisfies a given Fork condition.
     ///
-    /// Creates a [`Head`] representation for a fork activation point, used by [`fork_id`] to
+    /// Creates a [`Head`] representation for a fork activation point, used by [`Self::fork_id`] to
     /// compute fork IDs. For timestamp-based forks, includes the last block-based fork number
     /// before the merge (if any).
     pub(crate) fn satisfy(&self, cond: ForkCondition) -> Head {


### PR DESCRIPTION
Add algorithm overview and edge case notes to fork_id docs.
Clarify satisfy helper purpose and usage context.