### PR TITLE
Chore(testing-utils): remove redundant clones in generators

### DIFF
--- a/testing/testing-utils/src/generators.rs
+++ b/testing/testing-utils/src/generators.rs
@@ -269,11 +269,11 @@ pub fn random_block_range<R: Rng>(
     let mut blocks =
         Vec::with_capacity(block_numbers.end().saturating_sub(*block_numbers.start()) as usize);
     for idx in block_numbers {
-        let tx_count = block_range_params.tx_count.clone().sample_single(rng).unwrap();
+        let tx_count = block_range_params.tx_count.sample_single(rng).unwrap();
         let requests_count =
-            block_range_params.requests_count.clone().map(|r| r.sample_single(rng).unwrap());
+            block_range_params.requests_count.map(|r| r.sample_single(rng).unwrap());
         let withdrawals_count =
-            block_range_params.withdrawals_count.clone().map(|r| r.sample_single(rng).unwrap());
+            block_range_params.withdrawals_count.map(|r| r.sample_single(rng).unwrap());
         let parent = block_range_params.parent.unwrap_or_default();
         blocks.push(random_block(
             rng,
@@ -322,12 +322,8 @@ where
 
     for _block in blocks {
         let mut changeset = Vec::new();
-        let (from, to, mut transfer, new_entries) = random_account_change(
-            rng,
-            &valid_addresses,
-            n_storage_changes.clone(),
-            key_range.clone(),
-        );
+        let (from, to, mut transfer, new_entries) =
+            random_account_change(rng, &valid_addresses, n_storage_changes, key_range);
 
         // extract from sending account
         let (prev_from, _) = state.get_mut(&from).unwrap();
@@ -395,7 +391,7 @@ pub fn random_account_change<R: Rng>(
         Vec::new()
     } else {
         (0..n_storage_changes.sample_single(rng).unwrap())
-            .map(|_| random_storage_entry(rng, key_range.clone()))
+            .map(|_| random_storage_entry(rng, key_range))
             .collect()
     };
 


### PR DESCRIPTION
Context: BlockRangeParams and the Range arguments in random_account_change are Copy; cloning them per iteration added needless allocations. Changes: sample ranges directly without .clone() and pass range arguments through unchanged; behavior and signatures stay the same. Testing: cargo unavailable in the current environment, so no automated runs.