### PR TITLE
perf(era-utils): avoid unnecessary PathBuf clone in export

### DIFF
--- a/crates/era-utils/src/export.rs
+++ b/crates/era-utils/src/export.rs
@@ -219,12 +219,12 @@ where
             writer.write_accumulator(&accumulator)?;
             writer.write_block_index(&block_index)?;
             writer.flush()?;
-            created_files.push(file_path.clone());
 
             info!(
                 target: "era::history::export",
                 "Wrote ERA1 file: {file_path:?} with {blocks_written} blocks"
             );
+            created_files.push(file_path);
         }
     }
 


### PR DESCRIPTION
Move file_path into vector instead of cloning. Logging uses a reference before the move, eliminating unnecessary heap allocations when collecting exported file paths.