### PR TITLE
refactor: convert proof counters to MultiProofTask fields

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -1044,7 +1044,6 @@ impl MultiProofTask {
         skip_all
     )]
     pub(crate) fn run(mut self) {
-
         let mut updates_finished = false;
 
         // Timestamp before the first state update or prefetch was received
@@ -1229,7 +1228,9 @@ impl MultiProofTask {
         );
 
         // update total metrics on finish
-        self.metrics.state_updates_received_histogram.record(self.state_update_proofs_requested as f64);
+        self.metrics
+            .state_updates_received_histogram
+            .record(self.state_update_proofs_requested as f64);
         self.metrics.proofs_processed_histogram.record(self.proofs_processed as f64);
         if let Some(total_time) = first_update_time.map(|t| t.elapsed()) {
             self.metrics.multiproof_task_total_duration_histogram.record(total_time);


### PR DESCRIPTION
Convert `prefetch_proofs_requested`, `state_update_proofs_requested`, and `proofs_processed` from local variables in `run()` to fields of `MultiProofTask` struct.

- Add three new fields to `MultiProofTask` struct
- Initialize fields in `new()` constructor
- Update all usages in `run()` method to use `self.` prefix
- Remove TODO comment and local variable declarations