### PR TITLE
fix: replace unreachable libmdbx documentation URL

### DIFF
--- a/crates/storage/libmdbx-rs/README.md
+++ b/crates/storage/libmdbx-rs/README.md
@@ -1,7 +1,7 @@
 # libmdbx-rs
 
 
-Rust bindings for [libmdbx](https://libmdbx.dqdkfa.ru).
+Rust bindings for [libmdbx](https://github.com/erthink/libmdbx).
 
 Forked from an earlier Apache licenced version of the `libmdbx-rs` crate, before it changed licence to GPL.
 NOTE: Most of the repo came from [lmdb-rs bindings](https://github.com/mozilla/lmdb-rs).
@@ -9,7 +9,7 @@ NOTE: Most of the repo came from [lmdb-rs bindings](https://github.com/mozilla/l
 ## Updating the libmdbx Version
 
 To update the libmdbx version you must clone it and copy the `dist/` folder in `mdbx-sys/`.
-Make sure to follow the [building steps](https://libmdbx.dqdkfa.ru/usage.html#getting).
+Make sure to follow the [building steps](https://github.com/erthink/libmdbx#building).
 
 ```bash
 # clone libmdbx to a repository outside at specific tag

--- a/docs/repo/layout.md
+++ b/docs/repo/layout.md
@@ -40,7 +40,7 @@ All binaries are stored in [`bin`](../../bin).
 These crates are related to the database.
 
 - [`storage/codecs`](../../crates/storage/codecs): Different storage codecs.
-- [`storage/libmdbx-rs`](../../crates/storage/libmdbx-rs): Rust bindings for [libmdbx](https://libmdbx.dqdkfa.ru). A fork of an earlier Apache-licensed version of [libmdbx-rs][libmdbx-rs].
+- [`storage/libmdbx-rs`](../../crates/storage/libmdbx-rs): Rust bindings for [libmdbx](https://github.com/erthink/libmdbx). A fork of an earlier Apache-licensed version of [libmdbx-rs][libmdbx-rs].
 - [`storage/db`](../../crates/storage/db): Strongly typed Database abstractions (transactions, cursors, tables) over lower level database backends.
   - Implemented backends: mdbx
 - [`storage/provider`](../../crates/storage/provider): Traits which provide a higher level api over the database to access the Ethereum state and historical data (transactions, blocks etc.)


### PR DESCRIPTION

Updates libmdbx links from broken libmdbx.dqdkfa.ru domain to GitHub repository URL (github.com/erthink/libmdbx)