### PR TITLE
fix: remove redundant header insertion in extend_blocks and tests

### DIFF
--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -336,11 +336,9 @@ impl TestHarness {
 
     fn persist_blocks(&self, blocks: Vec<RecoveredBlock<reth_ethereum_primitives::Block>>) {
         let mut block_data: Vec<(B256, Block)> = Vec::with_capacity(blocks.len());
-        let mut headers_data: Vec<(B256, Header)> = Vec::with_capacity(blocks.len());
 
         for block in &blocks {
             block_data.push((block.hash(), block.clone_block()));
-            headers_data.push((block.hash(), block.header().clone()));
         }
 
         self.provider.extend_blocks(block_data);

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -7,7 +7,7 @@ use crate::{
         TreeConfig,
     },
 };
-use alloy_consensus::Header;
+
 use alloy_eips::eip1898::BlockWithParent;
 use alloy_primitives::{
     map::{HashMap, HashSet},

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -344,7 +344,6 @@ impl TestHarness {
         }
 
         self.provider.extend_blocks(block_data);
-        self.provider.extend_headers(headers_data);
     }
 }
 

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -118,7 +118,6 @@ impl<T: NodePrimitives, ChainSpec> MockEthProvider<T, ChainSpec> {
     /// Add multiple blocks to local block store
     pub fn extend_blocks(&self, iter: impl IntoIterator<Item = (B256, T::Block)>) {
         for (hash, block) in iter {
-            self.add_header(hash, block.header().clone());
             self.add_block(hash, block)
         }
     }


### PR DESCRIPTION
The mock provider’s extend_blocks() called add_header() and then add_block(), but add_block() already inserts the header. This resulted in redundant header insertions (double locking and duplicate HashMap inserts). In tests, persist_blocks() additionally called extend_headers(), effectively causing triple insertion.

Changes:
- test_utils/mock.rs: extend_blocks() now only calls add_block().
- engine/tree/tests.rs: removed extend_headers(...) in persist_blocks().

This keeps header insertion centralized in add_block(), aligns extend_* helper semantics with others, reduces unnecessary work, and preserves expected ordering.