### PR TITLE
fix: update docs and arg comments

### DIFF
--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -100,11 +100,11 @@ pub struct NetworkArgs {
     #[arg(long = "port", value_name = "PORT", default_value_t = DEFAULT_DISCOVERY_PORT)]
     pub port: u16,
 
-    /// Maximum number of outbound requests. default: 100
+    /// Maximum number of outbound peers. default: 100
     #[arg(long)]
     pub max_outbound_peers: Option<usize>,
 
-    /// Maximum number of inbound requests. default: 30
+    /// Maximum number of inbound peers. default: 30
     #[arg(long)]
     pub max_inbound_peers: Option<usize>,
 

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -179,10 +179,10 @@ Networking:
           [default: 30303]
 
       --max-outbound-peers <MAX_OUTBOUND_PEERS>
-          Maximum number of outbound requests. default: 100
+          Maximum number of outbound peers. default: 100
 
       --max-inbound-peers <MAX_INBOUND_PEERS>
-          Maximum number of inbound requests. default: 30
+          Maximum number of inbound peers. default: 30
 
       --max-tx-reqs <COUNT>
           Max concurrent `GetPooledTransactions` requests.

--- a/docs/vocs/docs/pages/cli/reth/p2p/body.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/body.mdx
@@ -125,10 +125,10 @@ Networking:
           [default: 30303]
 
       --max-outbound-peers <MAX_OUTBOUND_PEERS>
-          Maximum number of outbound requests. default: 100
+          Maximum number of outbound peers. default: 100
 
       --max-inbound-peers <MAX_INBOUND_PEERS>
-          Maximum number of inbound requests. default: 30
+          Maximum number of inbound peers. default: 30
 
       --max-tx-reqs <COUNT>
           Max concurrent `GetPooledTransactions` requests.

--- a/docs/vocs/docs/pages/cli/reth/p2p/header.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/header.mdx
@@ -125,10 +125,10 @@ Networking:
           [default: 30303]
 
       --max-outbound-peers <MAX_OUTBOUND_PEERS>
-          Maximum number of outbound requests. default: 100
+          Maximum number of outbound peers. default: 100
 
       --max-inbound-peers <MAX_INBOUND_PEERS>
-          Maximum number of inbound requests. default: 30
+          Maximum number of inbound peers. default: 30
 
       --max-tx-reqs <COUNT>
           Max concurrent `GetPooledTransactions` requests.

--- a/docs/vocs/docs/pages/cli/reth/stage/run.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/run.mdx
@@ -225,10 +225,10 @@ Networking:
           [default: 30303]
 
       --max-outbound-peers <MAX_OUTBOUND_PEERS>
-          Maximum number of outbound requests. default: 100
+          Maximum number of outbound peers. default: 100
 
       --max-inbound-peers <MAX_INBOUND_PEERS>
-          Maximum number of inbound requests. default: 30
+          Maximum number of inbound peers. default: 30
 
       --max-tx-reqs <COUNT>
           Max concurrent `GetPooledTransactions` requests.

--- a/docs/vocs/docs/pages/sdk/custom-node/transactions.mdx
+++ b/docs/vocs/docs/pages/sdk/custom-node/transactions.mdx
@@ -67,7 +67,7 @@ pub enum CustomTransaction {
     /// A regular Optimism transaction as defined by [`OpTxEnvelope`].
     #[envelope(flatten)]
     Op(OpTxEnvelope),
-    /// A [`TxPayment`] tagged with type 0x7E.
+    /// A [`TxPayment`] tagged with type 0x2A (decimal 42).
     #[envelope(ty = 42)]
     Payment(Signed<TxPayment>),
 }
@@ -178,7 +178,7 @@ pub enum CustomPooledTransaction {
     /// A regular Optimism transaction as defined by [`OpPooledTransaction`].
     #[envelope(flatten)]
     Op(OpPooledTransaction),
-    /// A [`TxPayment`] tagged with type 0x7E.
+    /// A [`TxPayment`] tagged with type 0x2A (decimal 42).
     #[envelope(ty = 42)]
     Payment(Signed<TxPayment>),
 }

--- a/testing/ef-tests/src/models.rs
+++ b/testing/ef-tests/src/models.rs
@@ -265,7 +265,7 @@ pub enum ForkSpec {
     FrontierToHomesteadAt5,
     /// Homestead
     Homestead,
-    /// Homestead to Tangerine
+    /// Homestead to DAO
     HomesteadToDaoAt5,
     /// Homestead to Tangerine
     HomesteadToEIP150At5,


### PR DESCRIPTION
`crates/node/core/src/args/network.rs:` these options configure peer counts rather than individual requests; the comments now describe the actual meaning of the parameters.

`docs/vocs/docs/pages/sdk/custom-node/transactions.mdx:` type 0x2A is hexadecimal 42, matching the #[envelope(ty = 42)] attribute, so the doc comment now accurately reflects the code.

`testing/ef-tests/src/models.rs:` the fork sequence jumps from Homestead to the DAO (the DAO hard fork preceded Tangerine Whistle), so the label now matches the historical transition.