### PR TITLE
fix: broken URL in download.mdx

### DIFF
--- a/docs/vocs/docs/pages/cli/reth/download.mdx
+++ b/docs/vocs/docs/pages/cli/reth/download.mdx
@@ -81,7 +81,7 @@ Database:
           - https://publicnode.com/snapshots (full nodes & testnets)
 
           If no URL is provided, the latest mainnet archive snapshot
-          will be proposed for download from https://downloads.merkle.io
+          will be proposed for download from https://www.merkle.io/snapshots
 
 Logging:
       --log.stdout.format <FORMAT>


### PR DESCRIPTION


**Description:**  
This PR updates the outdated download link in `download.mdx` to the correct Merkle snapshot URL.  

- Replaced `https://downloads.merkle.io` with `https://www.merkle.io/snapshots`  


