### PR TITLE
refactor(provider): introduce `EitherWriter`

### DIFF
--- a/crates/storage/provider/src/either_writer.rs
+++ b/crates/storage/provider/src/either_writer.rs
@@ -1,0 +1,43 @@
+//! Generic writer abstraction for writing to either database tables or static files.
+
+use crate::providers::StaticFileProviderRWRefMut;
+use alloy_primitives::{BlockNumber, TxNumber};
+use reth_db::table::Value;
+use reth_db_api::{cursor::DbCursorRW, tables};
+use reth_node_types::NodePrimitives;
+use reth_storage_errors::provider::ProviderResult;
+
+/// Represents a destination for writing data, either to database or static files.
+#[derive(Debug)]
+pub enum EitherWriter<'a, CURSOR, N> {
+    /// Write to database table via cursor
+    Database(CURSOR),
+    /// Write to static file
+    StaticFile(StaticFileProviderRWRefMut<'a, N>),
+}
+
+impl<'a, CURSOR, N: NodePrimitives> EitherWriter<'a, CURSOR, N> {
+    /// Increment the block number.
+    ///
+    /// Relevant only for [`Self::StaticFile`]. It is a no-op for [`Self::Database`].
+    pub fn increment_block(&mut self, expected_block_number: BlockNumber) -> ProviderResult<()> {
+        match self {
+            Self::Database(_) => Ok(()),
+            Self::StaticFile(writer) => writer.increment_block(expected_block_number),
+        }
+    }
+}
+
+impl<'a, CURSOR, N: NodePrimitives> EitherWriter<'a, CURSOR, N>
+where
+    N::Receipt: Value,
+    CURSOR: DbCursorRW<tables::Receipts<N::Receipt>>,
+{
+    /// Append a transaction receipt.
+    pub fn append_receipt(&mut self, tx_num: TxNumber, receipt: &N::Receipt) -> ProviderResult<()> {
+        match self {
+            Self::Database(cursor) => Ok(cursor.append(tx_num, receipt)?),
+            Self::StaticFile(writer) => writer.append_receipt(tx_num, receipt),
+        }
+    }
+}

--- a/crates/storage/provider/src/lib.rs
+++ b/crates/storage/provider/src/lib.rs
@@ -24,35 +24,31 @@ pub use providers::{
     StaticFileAccess, StaticFileProviderBuilder, StaticFileWriter,
 };
 
+pub mod changesets_utils;
+
 #[cfg(any(test, feature = "test-utils"))]
 /// Common test helpers for mocking the Provider.
 pub mod test_utils;
-/// Re-export provider error.
-pub use reth_storage_errors::provider::{ProviderError, ProviderResult};
 
-pub use reth_static_file_types as static_file;
-pub use static_file::StaticFileSegment;
-
-pub use reth_execution_types::*;
-
-pub mod changesets_utils;
-
-/// Re-export `OriginalValuesKnown`
-pub use revm_database::states::OriginalValuesKnown;
-
-/// Writer standalone type.
-pub mod writer;
+pub mod either_writer;
+pub use either_writer::*;
 
 pub use reth_chain_state::{
     CanonStateNotification, CanonStateNotificationSender, CanonStateNotificationStream,
     CanonStateNotifications, CanonStateSubscriptions,
 };
-
+pub use reth_execution_types::*;
+/// Re-export `OriginalValuesKnown`
+pub use revm_database::states::OriginalValuesKnown;
 // reexport traits to avoid breaking changes
+pub use reth_static_file_types as static_file;
 pub use reth_storage_api::{
     HistoryWriter, MetadataProvider, MetadataWriter, StatsReader, StorageSettings,
     StorageSettingsCache,
 };
+/// Re-export provider error.
+pub use reth_storage_errors::provider::{ProviderError, ProviderResult};
+pub use static_file::StaticFileSegment;
 
 pub(crate) fn to_range<R: std::ops::RangeBounds<u64>>(bounds: R) -> std::ops::Range<u64> {
     let start = match bounds.start_bound() {

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -13,12 +13,12 @@ use crate::{
     },
     AccountReader, BlockBodyWriter, BlockExecutionWriter, BlockHashReader, BlockNumReader,
     BlockReader, BlockWriter, BundleStateInit, ChainStateBlockReader, ChainStateBlockWriter,
-    DBProvider, HashingWriter, HeaderProvider, HeaderSyncGapProvider, HistoricalStateProvider,
-    HistoricalStateProviderRef, HistoryWriter, LatestStateProvider, LatestStateProviderRef,
-    OriginalValuesKnown, ProviderError, PruneCheckpointReader, PruneCheckpointWriter, RevertsInit,
-    StageCheckpointReader, StateProviderBox, StateWriter, StaticFileProviderFactory, StatsReader,
-    StorageReader, StorageTrieWriter, TransactionVariant, TransactionsProvider,
-    TransactionsProviderExt, TrieReader, TrieWriter,
+    DBProvider, EitherWriter, HashingWriter, HeaderProvider, HeaderSyncGapProvider,
+    HistoricalStateProvider, HistoricalStateProviderRef, HistoryWriter, LatestStateProvider,
+    LatestStateProviderRef, OriginalValuesKnown, ProviderError, PruneCheckpointReader,
+    PruneCheckpointWriter, RevertsInit, StageCheckpointReader, StateProviderBox, StateWriter,
+    StaticFileProviderFactory, StatsReader, StorageReader, StorageTrieWriter, TransactionVariant,
+    TransactionsProvider, TransactionsProviderExt, TrieReader, TrieWriter,
 };
 use alloy_consensus::{
     transaction::{SignerRecoverable, TransactionMeta, TxHashRef},
@@ -82,7 +82,7 @@ use std::{
     cmp::Ordering,
     collections::{BTreeMap, BTreeSet},
     fmt::Debug,
-    ops::{Deref, DerefMut, Not, Range, RangeBounds, RangeFrom, RangeInclusive},
+    ops::{Deref, DerefMut, Range, RangeBounds, RangeFrom, RangeInclusive},
     sync::Arc,
 };
 use tracing::{debug, trace};
@@ -1611,21 +1611,16 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
             ));
         }
 
-        let has_receipts_pruning = self.prune_modes.has_receipts_pruning();
-
-        // Prepare receipts cursor if we are going to write receipts to the database
-        //
-        // We are writing to database if requested or if there's any kind of receipt pruning
-        // configured
-        let mut receipts_cursor = self.tx.cursor_write::<tables::Receipts<Self::Receipt>>()?;
-
-        // Prepare receipts static writer if we are going to write receipts to static files
-        //
-        // We are writing to static files if requested and if there's no receipt pruning configured
-        let mut receipts_static_writer = has_receipts_pruning
-            .not()
-            .then(|| self.static_file_provider.get_writer(first_block, StaticFileSegment::Receipts))
-            .transpose()?;
+        // Write receipts to static files only if we don't have receipts pruning
+        let mut receipts_writer = if self.storage_settings.read().receipts_in_static_files ||
+            !self.prune_modes.has_receipts_pruning()
+        {
+            EitherWriter::StaticFile(
+                self.static_file_provider.get_writer(first_block, StaticFileSegment::Receipts)?,
+            )
+        } else {
+            EitherWriter::Database(self.tx.cursor_write::<tables::Receipts<Self::Receipt>>()?)
+        };
 
         // All receipts from the last 128 blocks are required for blockchain tree, even with
         // [`PruneSegment::ContractLogs`].
@@ -1638,9 +1633,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
             let block_number = first_block + idx as u64;
 
             // Increment block number for receipts static file writer
-            if let Some(writer) = receipts_static_writer.as_mut() {
-                writer.increment_block(block_number)?;
-            }
+            receipts_writer.increment_block(block_number)?;
 
             // Skip writing receipts if pruning configuration requires us to.
             if prunable_receipts &&
@@ -1654,11 +1647,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
             for (idx, receipt) in receipts.iter().enumerate() {
                 let receipt_idx = first_tx_index + idx as u64;
 
-                if let Some(writer) = &mut receipts_static_writer {
-                    writer.append_receipt(receipt_idx, receipt)?;
-                } else {
-                    receipts_cursor.append(receipt_idx, receipt)?;
-                }
+                receipts_writer.append_receipt(receipt_idx, receipt)?;
             }
         }
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1611,7 +1611,8 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
             ));
         }
 
-        // Write receipts to static files only if we don't have receipts pruning
+        // Write receipts to static files only if they're explicitly enabled or we don't have
+        // receipts pruning
         let mut receipts_writer = if self.storage_settings.read().receipts_in_static_files ||
             !self.prune_modes.has_receipts_pruning()
         {


### PR DESCRIPTION
With https://github.com/paradigmxyz/reth/issues/18682, we're doing a lot of conditional provider logic for new static files segments: old nodes should read and write from DB, new nodes from static files.

For that reason, we introduce such constructions https://github.com/paradigmxyz/reth/blob/a6c0ac8cf4ade4eafd38ea2d09457bb02ba0ed68/crates/storage/provider/src/providers/database/provider.rs#L1614-L1628

This PR simplifies it by introducing an `EitherWriter` that gets initialized with either a database cursor, or a static file writer.