### PR TITLE
chore: improve test database error messages

### DIFF
--- a/crates/storage/db/src/lib.rs
+++ b/crates/storage/db/src/lib.rs
@@ -185,12 +185,13 @@ pub mod test_utils {
     #[track_caller]
     pub fn create_test_rw_db_with_path<P: AsRef<Path>>(path: P) -> Arc<TempDatabase<DatabaseEnv>> {
         let path = path.as_ref().to_path_buf();
+        let emsg = format!("{ERROR_DB_CREATION}: {path:?}");
         let db = init_db(
             path.as_path(),
             DatabaseArguments::new(ClientVersion::default())
                 .with_max_read_transaction_duration(Some(MaxReadTransactionDuration::Unbounded)),
         )
-        .expect(ERROR_DB_CREATION);
+        .expect(&emsg);
         Arc::new(TempDatabase::new(db, path))
     }
 
@@ -201,8 +202,9 @@ pub mod test_utils {
             .with_max_read_transaction_duration(Some(MaxReadTransactionDuration::Unbounded));
 
         let path = tempdir_path();
+        let emsg = format!("{ERROR_DB_CREATION}: {path:?}");
         {
-            init_db(path.as_path(), args.clone()).expect(ERROR_DB_CREATION);
+            init_db(path.as_path(), args.clone()).expect(&emsg);
         }
         let db = open_db_read_only(path.as_path(), args).expect(ERROR_DB_OPEN);
         Arc::new(TempDatabase::new(db, path))


### PR DESCRIPTION
Test database creation functions now include the path in panic messages, making it easier to diagnose failures during test execution. Previously, panics only showed generic error constants without indicating which path failed.

Updated `create_test_rw_db_with_path` and `create_test_ro_db` to match the existing pattern in `create_test_rw_db`.