### PR TITLE
feat(cli): add cli flag `--txpool.disable-blobs-support` to disable blob support

### DIFF
--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -492,9 +492,11 @@ where
                 .with_minimum_priority_fee(ctx.config().txpool.minimum_priority_fee)
                 .with_additional_tasks(ctx.config().txpool.additional_validation_tasks);
 
-        if !blobs_disabled {
-            validator_builder = validator_builder.kzg_settings(ctx.kzg_settings()?);
-        }
+        validator_builder = if blobs_disabled {
+            validator_builder.no_eip4844()
+        } else {
+            validator_builder.kzg_settings(ctx.kzg_settings()?)
+        };
 
         let validator =
             validator_builder.build_with_tasks(ctx.task_executor().clone(), blob_store.clone());

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -488,7 +488,7 @@ where
             .with_additional_tasks(ctx.config().txpool.additional_validation_tasks)
             .build_with_tasks(ctx.task_executor().clone(), blob_store.clone());
 
-        if !blobs_disabled && validator.validator().eip4844() {
+        if validator.validator().eip4844() {
             // initializing the KZG settings can be expensive, this should be done upfront so that
             // it doesn't impact the first block or the first gossiped blob transaction, so we
             // initialize this in the background

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -456,10 +456,6 @@ where
         let blobs_disabled = ctx.config().txpool.disable_blobs_support ||
             ctx.config().txpool.blobpool_max_count == 0;
 
-        if blobs_disabled {
-            info!(target: "reth::cli", "Blob transaction support disabled");
-        }
-
         let blob_cache_size = if blobs_disabled {
             None
         } else if let Some(blob_cache_size) = pool_config.blob_cache_size {

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -476,18 +476,17 @@ where
         let blob_store =
             reth_node_builder::components::create_blob_store_with_cache(ctx, blob_cache_size)?;
 
-        let validator =
-            TransactionValidationTaskExecutor::eth_builder(ctx.provider().clone())
-                .with_head_timestamp(ctx.head().timestamp)
-                .with_max_tx_input_bytes(ctx.config().txpool.max_tx_input_bytes)
-                .with_local_transactions_config(pool_config.local_transactions_config.clone())
-                .set_tx_fee_cap(ctx.config().rpc.rpc_tx_fee_cap)
-                .with_max_tx_gas_limit(ctx.config().txpool.max_tx_gas_limit)
-                .with_minimum_priority_fee(ctx.config().txpool.minimum_priority_fee)
-                .with_additional_tasks(ctx.config().txpool.additional_validation_tasks)
-                .set_eip4844(!blobs_disabled)
-                .kzg_settings(ctx.kzg_settings()?)
-                .build_with_tasks(ctx.task_executor().clone(), blob_store.clone());
+        let validator = TransactionValidationTaskExecutor::eth_builder(ctx.provider().clone())
+            .with_head_timestamp(ctx.head().timestamp)
+            .with_max_tx_input_bytes(ctx.config().txpool.max_tx_input_bytes)
+            .with_local_transactions_config(pool_config.local_transactions_config.clone())
+            .set_tx_fee_cap(ctx.config().rpc.rpc_tx_fee_cap)
+            .with_max_tx_gas_limit(ctx.config().txpool.max_tx_gas_limit)
+            .with_minimum_priority_fee(ctx.config().txpool.minimum_priority_fee)
+            .with_additional_tasks(ctx.config().txpool.additional_validation_tasks)
+            .set_eip4844(!blobs_disabled)
+            .kzg_settings(ctx.kzg_settings()?)
+            .build_with_tasks(ctx.task_executor().clone(), blob_store.clone());
 
         if !blobs_disabled && validator.validator().eip4844() {
             // initializing the KZG settings can be expensive, this should be done upfront so that

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -478,14 +478,14 @@ where
 
         let validator = TransactionValidationTaskExecutor::eth_builder(ctx.provider().clone())
             .with_head_timestamp(ctx.head().timestamp)
+            .set_eip4844(!blobs_disabled)
+            .kzg_settings(ctx.kzg_settings()?)
             .with_max_tx_input_bytes(ctx.config().txpool.max_tx_input_bytes)
             .with_local_transactions_config(pool_config.local_transactions_config.clone())
             .set_tx_fee_cap(ctx.config().rpc.rpc_tx_fee_cap)
             .with_max_tx_gas_limit(ctx.config().txpool.max_tx_gas_limit)
             .with_minimum_priority_fee(ctx.config().txpool.minimum_priority_fee)
             .with_additional_tasks(ctx.config().txpool.additional_validation_tasks)
-            .set_eip4844(!blobs_disabled)
-            .kzg_settings(ctx.kzg_settings()?)
             .build_with_tasks(ctx.task_executor().clone(), blob_store.clone());
 
         if !blobs_disabled && validator.validator().eip4844() {

--- a/crates/node/core/src/args/txpool.rs
+++ b/crates/node/core/src/args/txpool.rs
@@ -49,13 +49,13 @@ pub struct TxPoolArgs {
     #[arg(long = "txpool.blobpool-max-size", alias = "txpool.blobpool_max_size", default_value_t = TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT)]
     pub blobpool_max_size: usize,
 
-    /// Disable EIP-4844 blob transaction support
-    #[arg(long = "txpool.disable-blobs-support", alias = "txpool.disable_blobs_support", default_value_t = false, conflicts_with_all = ["blobpool_max_count"])]
-    pub disable_blobs_support: bool,
-
     /// Max number of entries for the in memory cache of the blob store.
     #[arg(long = "txpool.blob-cache-size", alias = "txpool.blob_cache_size")]
     pub blob_cache_size: Option<u32>,
+
+    /// Disable EIP-4844 blob transaction support
+    #[arg(long = "txpool.disable-blobs-support", alias = "txpool.disable_blobs_support", default_value_t = false, conflicts_with_all = ["blobpool_max_count", "blobpool_max_size", "blob_cache_size", "blob_transaction_price_bump"])]
+    pub disable_blobs_support: bool,
 
     /// Max number of executable transaction slots guaranteed per account
     #[arg(long = "txpool.max-account-slots", alias = "txpool.max_account_slots", default_value_t = TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER)]
@@ -171,8 +171,8 @@ impl Default for TxPoolArgs {
             queued_max_size: TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT,
             blobpool_max_count: TXPOOL_SUBPOOL_MAX_TXS_DEFAULT,
             blobpool_max_size: TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT,
-            disable_blobs_support: false,
             blob_cache_size: None,
+            disable_blobs_support: false,
             max_account_slots: TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
             price_bump: DEFAULT_PRICE_BUMP,
             minimal_protocol_basefee: MIN_PROTOCOL_BASE_FEE,

--- a/crates/node/core/src/args/txpool.rs
+++ b/crates/node/core/src/args/txpool.rs
@@ -49,6 +49,10 @@ pub struct TxPoolArgs {
     #[arg(long = "txpool.blobpool-max-size", alias = "txpool.blobpool_max_size", default_value_t = TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT)]
     pub blobpool_max_size: usize,
 
+    /// Disable EIP-4844 blob transaction support
+    #[arg(long = "txpool.disable-blobs-support", alias = "txpool.disable_blobs_support", default_value_t = false, conflicts_with_all = ["blobpool_max_count"])]
+    pub disable_blobs_support: bool,
+
     /// Max number of entries for the in memory cache of the blob store.
     #[arg(long = "txpool.blob-cache-size", alias = "txpool.blob_cache_size")]
     pub blob_cache_size: Option<u32>,
@@ -167,6 +171,7 @@ impl Default for TxPoolArgs {
             queued_max_size: TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT,
             blobpool_max_count: TXPOOL_SUBPOOL_MAX_TXS_DEFAULT,
             blobpool_max_size: TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT,
+            disable_blobs_support: false,
             blob_cache_size: None,
             max_account_slots: TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
             price_bump: DEFAULT_PRICE_BUMP,

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -534,6 +534,9 @@ TxPool:
 
           [default: 20]
 
+      --txpool.disable-blobs-support
+          Disable EIP-4844 blob transaction support
+
       --txpool.blob-cache-size <BLOB_CACHE_SIZE>
           Max number of entries for the in memory cache of the blob store
 

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -534,11 +534,11 @@ TxPool:
 
           [default: 20]
 
-      --txpool.disable-blobs-support
-          Disable EIP-4844 blob transaction support
-
       --txpool.blob-cache-size <BLOB_CACHE_SIZE>
           Max number of entries for the in memory cache of the blob store
+
+      --txpool.disable-blobs-support
+          Disable EIP-4844 blob transaction support
 
       --txpool.max-account-slots <MAX_ACCOUNT_SLOTS>
           Max number of executable transaction slots guaranteed per account


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/19555.

Add cli flag `txpool.disable-blobs-support` to disable eip 4844 blob support.

How to test : 

```shell
cargo run --bin reth -- node --dev --txpool.disable-blobs-support
```
--
 
```shell
cargo run --bin reth -- node --dev \
  --txpool.disable-blobs-support \
  --txpool.blobpool-max-count 5000
```
should give `error: the argument '--txpool.disable-blobs-support' cannot be used with '--txpool.blobpool-max-count <BLOBPOOL_MAX_COUNT>'`
 
--

```shell
cargo run --bin reth -- node --dev \
  --txpool.blobpool-max-count 0
```