### PR TITLE
refactor: replace GenericArray with regular arrays in ECIES

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8005,7 +8005,6 @@ dependencies = [
  "ctr",
  "digest 0.10.7",
  "futures",
- "generic-array",
  "hmac",
  "pin-project",
  "rand 0.8.5",
@@ -8018,7 +8017,6 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
- "typenum",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -549,8 +549,6 @@ dirs-next = "2.0.0"
 dyn-clone = "1.0.17"
 eyre = "0.6"
 fdlimit = "0.3.0"
-# pinned until downstream crypto libs migrate to 1.0 because 0.14.8 marks all types as deprecated
-generic-array = "=0.14.7"
 humantime = "2.1"
 humantime-serde = "1.1"
 itertools = { version = "0.14", default-features = false }

--- a/crates/net/ecies/Cargo.toml
+++ b/crates/net/ecies/Cargo.toml
@@ -25,9 +25,6 @@ pin-project.workspace = true
 
 tracing = { workspace = true, features = ["attributes"] }
 
-# HeaderBytes
-generic-array.workspace = true
-typenum.workspace = true
 byteorder.workspace = true
 
 # crypto
@@ -42,3 +39,6 @@ aes.workspace = true
 hmac.workspace = true
 block-padding.workspace = true
 cipher = { workspace = true, features = ["block-padding"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["net", "rt", "macros"] }

--- a/crates/net/ecies/src/algorithm.rs
+++ b/crates/net/ecies/src/algorithm.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     error::ECIESErrorImpl,
-    mac::{HeaderBytes, MAC},
+    mac::MAC,
     util::{hmac_sha256, sha256},
     ECIESError,
 };
@@ -639,7 +639,6 @@ impl ECIES {
         header[..3].copy_from_slice(&buf[..3]);
         header[3..6].copy_from_slice(&[194, 128, 128]);
 
-        let mut header = HeaderBytes::from(header);
         self.egress_aes.as_mut().unwrap().apply_keystream(&mut header);
         self.egress_mac.as_mut().unwrap().update_header(&header);
         let tag = self.egress_mac.as_mut().unwrap().digest();
@@ -660,7 +659,7 @@ impl ECIES {
         }
 
         let (header_bytes, mac_bytes) = split_at_mut(data, 16)?;
-        let header = HeaderBytes::from_mut_slice(header_bytes);
+        let header: &mut [u8; 16] = header_bytes.try_into().unwrap();
         let mac = B128::from_slice(&mac_bytes[..16]);
 
         self.ingress_mac.as_mut().unwrap().update_header(header);
@@ -670,11 +669,11 @@ impl ECIES {
         }
 
         self.ingress_aes.as_mut().unwrap().apply_keystream(header);
-        if header.as_slice().len() < 3 {
+        if header.len() < 3 {
             return Err(ECIESErrorImpl::InvalidHeader.into())
         }
 
-        let body_size = usize::try_from(header.as_slice().read_uint::<BigEndian>(3)?)?;
+        let body_size = usize::try_from((&header[..]).read_uint::<BigEndian>(3)?)?;
 
         self.body_size = Some(body_size);
 

--- a/crates/net/ecies/src/mac.rs
+++ b/crates/net/ecies/src/mac.rs
@@ -14,16 +14,7 @@ use alloy_primitives::{B128, B256};
 use block_padding::NoPadding;
 use cipher::BlockEncrypt;
 use digest::KeyInit;
-use generic_array::GenericArray;
 use sha3::{Digest, Keccak256};
-use typenum::U16;
-
-/// Type alias for a fixed-size array of 16 bytes used as headers.
-///
-/// This type is defined as [`GenericArray<u8, U16>`] and is commonly employed in Ethereum `RLPx`
-/// protocol-related structures for headers. It represents 16 bytes of data used in various
-/// cryptographic operations, such as MAC (Message Authentication Code) computation.
-pub type HeaderBytes = GenericArray<u8, U16>;
 
 /// [`Ethereum MAC`](https://github.com/ethereum/devp2p/blob/master/rlpx.md#mac) state.
 ///
@@ -49,8 +40,8 @@ impl MAC {
         self.hasher.update(data)
     }
 
-    /// Accumulate the given [`HeaderBytes`] into the MAC's internal state.
-    pub fn update_header(&mut self, data: &HeaderBytes) {
+    /// Accumulate the given header bytes into the MAC's internal state.
+    pub fn update_header(&mut self, data: &[u8; 16]) {
         let aes = Aes256Enc::new_from_slice(self.secret.as_ref()).unwrap();
         let mut encrypted = self.digest().0;
 


### PR DESCRIPTION
The `HeaderBytes` type alias using `GenericArray<u8, U16>` has been replaced with standard Rust arrays `[u8; 16]`. This simplifies the code and removes unnecessary dependencies.

## Changes

- Removed `HeaderBytes` type alias from `mac.rs`
- Updated `MAC::update_header` to accept `&[u8; 16]` instead of `&GenericArray<u8, U16>`
- Updated call sites in `algorithm.rs` to use regular arrays
- Removed `generic-array` and `typenum` dependencies from `reth-ecies`
- Removed `generic-array` from root `Cargo.toml` (no longer needed by any crate)
- Added tokio dev-dependencies to fix test compilation

The functionality remains identical, just with simpler types and fewer dependencies.