### PR TITLE
feat: dynamic chunking instead of hardcoding 

### DIFF
--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -112,6 +112,10 @@ harness = false
 name = "state_root_task"
 harness = false
 
+[[bench]]
+name = "multiproof_chunking"
+harness = false
+
 [features]
 test-utils = [
     "reth-chain-state/test-utils",

--- a/crates/engine/tree/benches/multiproof_chunking.rs
+++ b/crates/engine/tree/benches/multiproof_chunking.rs
@@ -30,6 +30,7 @@ fn count_chunks(targets: &MultiProofTargets, chunk_size: usize) -> usize {
     targets.clone().chunks(chunk_size).count()
 }
 
+/// Benchmarks how many chunks the dynamic policy emits for different idle worker counts.
 fn bench_chunking(c: &mut Criterion) {
     let targets = make_targets(512, 4);
     let work_units = targets.chunking_length();

--- a/crates/engine/tree/benches/multiproof_chunking.rs
+++ b/crates/engine/tree/benches/multiproof_chunking.rs
@@ -20,7 +20,7 @@ fn simulate_processing(work_units: usize, chunk_size: usize, workers: usize) -> 
     while remaining > 0 {
         let current = min(remaining, chunk_size) as f64;
         remaining -= current as usize;
-        let duration = PER_CHUNK_OVERHEAD_NS + current * PER_TARGET_COST_NS;
+        let duration = current.mul_add(PER_TARGET_COST_NS, PER_CHUNK_OVERHEAD_NS);
         for _ in 0..PER_CHUNK_SPIN {
             spin = spin.wrapping_add(1);
         }

--- a/crates/engine/tree/benches/multiproof_chunking.rs
+++ b/crates/engine/tree/benches/multiproof_chunking.rs
@@ -1,0 +1,86 @@
+#![allow(missing_docs)]
+
+use alloy_primitives::{map::B256Set, B256};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use reth_engine_tree::tree::{select_dynamic_chunk_size, WorkerSnapshot};
+use reth_trie::MultiProofTargets;
+
+const DEFAULT_BASE_CHUNK: usize = 10;
+
+fn make_targets(accounts: usize, slots: usize) -> MultiProofTargets {
+    let mut targets = MultiProofTargets::default();
+    for account in 0..accounts {
+        let hashed = make_hash(account as u64);
+        let mut storage = B256Set::default();
+        for slot in 0..slots {
+            storage.insert(make_hash((account * slots + slot) as u64));
+        }
+        targets.insert(hashed, storage);
+    }
+    targets
+}
+
+fn make_hash(value: u64) -> B256 {
+    let mut bytes = [0u8; 32];
+    bytes[24..].copy_from_slice(&value.to_be_bytes());
+    B256::from(bytes)
+}
+
+fn count_chunks(targets: &MultiProofTargets, chunk_size: usize) -> usize {
+    targets.clone().chunks(chunk_size).count()
+}
+
+fn bench_chunking(c: &mut Criterion) {
+    let targets = make_targets(512, 4);
+    let work_units = targets.chunking_length();
+
+    let scenarios = [
+        ("static", None),
+        (
+            "dynamic_idle_8",
+            select_dynamic_chunk_size(
+                Some(DEFAULT_BASE_CHUNK),
+                work_units,
+                WorkerSnapshot {
+                    available_accounts: 8,
+                    available_storage: 6,
+                    pending_accounts: 0,
+                    pending_storage: 0,
+                },
+            ),
+        ),
+        (
+            "dynamic_idle_2",
+            select_dynamic_chunk_size(
+                Some(DEFAULT_BASE_CHUNK),
+                work_units,
+                WorkerSnapshot {
+                    available_accounts: 2,
+                    available_storage: 1,
+                    pending_accounts: 0,
+                    pending_storage: 0,
+                },
+            ),
+        ),
+    ];
+
+    let mut group = c.benchmark_group("multiproof_chunking");
+    for (label, dynamic_size) in scenarios {
+        match dynamic_size {
+            Some(size) => {
+                group.bench_with_input(BenchmarkId::new("dynamic", label), &size, |b, size| {
+                    b.iter(|| count_chunks(&targets, *size));
+                });
+            }
+            None => {
+                group.bench_function(BenchmarkId::new("static", label), |b| {
+                    b.iter(|| count_chunks(&targets, DEFAULT_BASE_CHUNK));
+                });
+            }
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(multiproof_chunking, bench_chunking);
+criterion_main!(multiproof_chunking);

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -69,7 +69,10 @@ mod trie_updates;
 use crate::tree::error::AdvancePersistenceError;
 pub use block_buffer::BlockBuffer;
 pub use invalid_headers::InvalidHeaderCache;
-pub use payload_processor::*;
+pub use payload_processor::{
+    multiproof::{select_dynamic_chunk_size, WorkerSnapshot},
+    *,
+};
 pub use payload_validator::{BasicEngineValidator, EngineValidator};
 pub use persistence_state::PersistenceState;
 pub use reth_engine_primitives::TreeConfig;

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -530,7 +530,7 @@ impl MultiproofManager {
     }
 }
 
-/// Snapshot of current worker pool utilization used by chunking logic.
+/// Snapshot of the worker pools used to size multiproof chunks.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
 pub struct WorkerSnapshot {
@@ -569,7 +569,7 @@ impl WorkerSnapshot {
     }
 }
 
-/// Selects an adaptive chunk size based on worker availability.
+/// Returns an adaptive chunk size driven by the latest worker snapshot.
 #[doc(hidden)]
 pub fn select_dynamic_chunk_size(
     configured_chunk_size: Option<usize>,


### PR DESCRIPTION
This is on #19256 @yongkangc  @mattsse  Please check if this behaviour is correct 

Short summary : 

Dynamic multiproof chunking now adapts to actual worker capacity instead of blindly slicing every target set. 
I added a WorkerSnapshot + select_dynamic_chunk_size helper in tree::payload_processor::multiproof that reads idle/pending counts from ProofWorkerHandle, and both on_prefetch_proof and on_state_update use it to limit fan-out to what can be consumed immediately. 

When no spare workers exist (or work size is below the baseline), we dispatch the batch as a single proof to avoid inflating queues—addressing the PST latency regression called out in the issue.