### PR TITLE
chore: drop unused PoolTransaction import in txpool tracing submit

### DIFF
--- a/examples/txpool-tracing/src/submit.rs
+++ b/examples/txpool-tracing/src/submit.rs
@@ -7,10 +7,7 @@ use alloy_primitives::{Address, TxHash, U256};
 use futures_util::StreamExt;
 use reth_ethereum::{
     node::api::{FullNodeComponents, NodeTypes},
-    pool::{
-        AddedTransactionOutcome, PoolTransaction, TransactionEvent, TransactionOrigin,
-        TransactionPool,
-    },
+    pool::{AddedTransactionOutcome, TransactionEvent, TransactionOrigin, TransactionPool},
     primitives::SignerRecoverable,
     rpc::eth::primitives::TransactionRequest,
     EthPrimitives, TransactionSigned,


### PR DESCRIPTION
PoolTransaction was only there when the example manually called try_from_consensus. Once we added add_consensus_transaction(_and_subscribe) in #17431/#17442 the conversion moved inside the pool API, so the import has been dead weight ever since.