### PR TITLE
chore: scope otlp deps to feature flag

### DIFF
--- a/crates/ethereum/cli/Cargo.toml
+++ b/crates/ethereum/cli/Cargo.toml
@@ -23,13 +23,13 @@ reth-node-ethereum.workspace = true
 reth-node-metrics.workspace = true
 reth-rpc-server-types.workspace = true
 reth-tracing.workspace = true
-reth-tracing-otlp.workspace = true
+reth-tracing-otlp = { workspace = true, optional = true }
 reth-node-api.workspace = true
 
 # misc
 clap.workspace = true
 eyre.workspace = true
-url.workspace = true
+url = { workspace = true, optional = true }
 tracing.workspace = true
 
 [dev-dependencies]
@@ -39,7 +39,7 @@ tempfile.workspace = true
 [features]
 default = []
 
-otlp = ["reth-tracing/otlp", "reth-node-core/otlp"]
+otlp = ["reth-tracing/otlp", "reth-node-core/otlp", "reth-tracing-otlp", "url"]
 
 dev = ["reth-cli-commands/arbitrary"]
 

--- a/crates/ethereum/cli/src/app.rs
+++ b/crates/ethereum/cli/src/app.rs
@@ -14,9 +14,11 @@ use reth_node_ethereum::{consensus::EthBeaconConsensus, EthEvmConfig, EthereumNo
 use reth_node_metrics::recorder::install_prometheus_recorder;
 use reth_rpc_server_types::RpcModuleValidator;
 use reth_tracing::{FileWorkerGuard, Layers};
+#[cfg(feature = "otlp")]
 use reth_tracing_otlp::OtlpProtocol;
 use std::{fmt, sync::Arc};
 use tracing::info;
+#[cfg(feature = "otlp")]
 use url::Url;
 
 /// A wrapper around a parsed CLI that handles command execution.
@@ -112,6 +114,10 @@ where
     /// For gRPC OTLP, it requires tokio runtime context.
     pub fn init_tracing(&mut self, runner: &CliRunner) -> Result<()> {
         if self.guard.is_none() {
+            #[cfg(not(feature = "otlp"))]
+            let _ = runner;
+
+            #[cfg_attr(not(feature = "otlp"), allow(unused_mut))]
             let mut layers = self.layers.take().unwrap_or_default();
 
             #[cfg(feature = "otlp")]


### PR DESCRIPTION
The Ethereum CLI was always pulling in `reth-tracing-otlp` and `url`, even when the OTLP feature was disabled. That not only triggered unused-dependency warnings but also forced extra crates into every build. This patch gates the imports and moves both dependencies under the `otlp` feature, matching how the rest of the codebase handles OTLP support. Builds without OTLP are now clean, and enabling the feature keeps the same behaviour as before.