### PR TITLE
fix(storage): propagate IO errors in parse_accounts to avoid silent partial imports

### DIFF
--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -489,7 +489,8 @@ fn parse_accounts(
     let mut line = String::new();
     let mut collector = Collector::new(etl_config.file_size, etl_config.dir);
 
-    while let Ok(n) = reader.read_line(&mut line) {
+    loop {
+        let n = reader.read_line(&mut line)?;
         if n == 0 {
             break
         }


### PR DESCRIPTION
Previously parse_accounts used a while-let Ok loop around read_line which swallowed I/O errors by exiting the loop and returning Ok(collector). This could cause a silent partial import of the state dump and lead to confusing follow-up failures like state root mismatches. This change replaces the loop with one that uses the ? operator on read_line, ensuring any I/O error is propagated to init_from_state_dump and ultimately to the CLI. This aligns error handling with parse_state_root and makes failure modes explicit, without introducing extra allocations or changing the successful path behavior.