### PR TITLE
chore(trie): add number of target slots to storage proof span

### DIFF
--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -424,7 +424,8 @@ where
         let span = debug_span!(
             target: "trie::proof_task",
             "Storage proof calculation",
-            hashed_address = ?hashed_address,
+            ?hashed_address,
+            target_slots = ?target_slots.len(),
             worker_id = self.id,
         );
         let _span_guard = span.enter();


### PR DESCRIPTION
Having the number of target slots in the span is useful when analyzing large spans, compared to just having the hashed address