### PR TITLE
chore: remove unused stop_handle from IPC ServiceData

### DIFF
--- a/crates/rpc/ipc/src/server/mod.rs
+++ b/crates/rpc/ipc/src/server/mod.rs
@@ -269,14 +269,11 @@ pub struct IpcServerStartError {
 
 /// Data required by the server to handle requests received via an IPC connection
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub(crate) struct ServiceData {
     /// Registered server methods.
     pub(crate) methods: Methods,
     /// Subscription ID provider.
     pub(crate) id_provider: Arc<dyn IdProvider>,
-    /// Stop handle.
-    pub(crate) stop_handle: StopHandle,
     /// Connection ID
     pub(crate) conn_id: u32,
     /// Connection Permit.
@@ -483,7 +480,6 @@ fn process_connection<RpcMiddleware, HttpMiddleware>(
         inner: ServiceData {
             methods,
             id_provider,
-            stop_handle: stop_handle.clone(),
             server_cfg: server_cfg.clone(),
             conn_id,
             conn_permit,


### PR DESCRIPTION
drop the unused stop_handle field from ServiceData, removing the #[allow(dead_code)] escape hatch stop cloning the handle at the sole initialization site