### PR TITLE
fix: disable update bench harness for codspeed

### DIFF
--- a/crates/trie/sparse/Cargo.toml
+++ b/crates/trie/sparse/Cargo.toml
@@ -90,3 +90,7 @@ harness = false
 [[bench]]
 name = "rlp_node"
 harness = false
+
+[[bench]]
+name = "update"
+harness = false


### PR DESCRIPTION
Fixed CodSpeed failure by restoring `harness = false` for the `update` benchmark (`reth/crates/trie/sparse/Cargo.toml`)
Reference run: https://github.com/paradigmxyz/reth/actions/runs/19176868644/job/54823778718