### PR TITLE
fix: extract common file writing logic

### DIFF
--- a/crates/engine/invalid-block-hooks/Cargo.toml
+++ b/crates/engine/invalid-block-hooks/Cargo.toml
@@ -23,6 +23,7 @@ reth-revm = { workspace = true, features = ["serde"] }
 reth-rpc-api = { workspace = true, features = ["client"] }
 reth-tracing.workspace = true
 reth-trie.workspace = true
+reth-fs-util.workspace = true
 
 # alloy
 alloy-primitives.workspace = true

--- a/crates/engine/invalid-block-hooks/Cargo.toml
+++ b/crates/engine/invalid-block-hooks/Cargo.toml
@@ -23,7 +23,6 @@ reth-revm = { workspace = true, features = ["serde"] }
 reth-rpc-api = { workspace = true, features = ["client"] }
 reth-tracing.workspace = true
 reth-trie.workspace = true
-reth-fs-util.workspace = true
 
 # alloy
 alloy-primitives.workspace = true

--- a/crates/engine/invalid-block-hooks/src/witness.rs
+++ b/crates/engine/invalid-block-hooks/src/witness.rs
@@ -21,7 +21,7 @@ use revm_database::{
     AccountStatus, RevertToSlot,
 };
 use serde::Serialize;
-use std::{collections::BTreeMap, fmt::Debug, fs::File, io::Write, path::PathBuf};
+use std::{collections::BTreeMap, fmt::Debug, io::Write, path::PathBuf};
 
 type CollectionResult =
     (BTreeMap<B256, Bytes>, BTreeMap<B256, Bytes>, reth_trie::HashedPostState, BundleState);
@@ -400,7 +400,8 @@ where
         let path = self.output_directory.join(filename);
         let diff = Comparison::new(original, new);
         let mut file = reth_fs_util::create_file(&path)?;
-        file.write_all(diff.to_string().as_bytes()).map_err(|err| FsPathError::write(err, &path))?;
+        file.write_all(diff.to_string().as_bytes())
+            .map_err(|err| FsPathError::write(err, &path))?;
 
         Ok(path)
     }
@@ -750,8 +751,8 @@ mod tests {
 
         // Modify the state to create a mismatch
         let addr = Address::from([1u8; 20]);
-        if let Some(account) = modified_state.state.get_mut(&addr)
-            && let Some(ref mut info) = account.info
+        if let Some(account) = modified_state.state.get_mut(&addr) &&
+            let Some(ref mut info) = account.info
         {
             info.balance = U256::from(999);
         }

--- a/crates/engine/invalid-block-hooks/src/witness.rs
+++ b/crates/engine/invalid-block-hooks/src/witness.rs
@@ -13,7 +13,6 @@ use reth_revm::{
 use reth_rpc_api::DebugApiClient;
 use reth_tracing::tracing::warn;
 use reth_trie::{updates::TrieUpdates, HashedStorage};
-use reth_fs_util::{self, FsPathError};
 use revm::state::AccountInfo;
 use revm_bytecode::Bytecode;
 use revm_database::{

--- a/crates/engine/invalid-block-hooks/src/witness.rs
+++ b/crates/engine/invalid-block-hooks/src/witness.rs
@@ -364,12 +364,15 @@ where
         Ok(())
     }
 
+    fn write_file(&self, filename: String, contents: &[u8]) -> eyre::Result<PathBuf> {
+        let path = self.output_directory.join(filename);
+        File::create(&path)?.write_all(contents)?;
+        Ok(path)
+    }
+
     /// Serializes and saves a value to a JSON file in the output directory
     fn save_file<T: Serialize>(&self, filename: String, value: &T) -> eyre::Result<PathBuf> {
-        let path = self.output_directory.join(filename);
-        File::create(&path)?.write_all(serde_json::to_string(value)?.as_bytes())?;
-
-        Ok(path)
+        self.write_file(filename, serde_json::to_string(value)?.as_bytes())
     }
 
     /// Compares two values and saves their diff to a file in the output directory
@@ -379,11 +382,8 @@ where
         original: &T,
         new: &T,
     ) -> eyre::Result<PathBuf> {
-        let path = self.output_directory.join(filename);
         let diff = Comparison::new(original, new);
-        File::create(&path)?.write_all(diff.to_string().as_bytes())?;
-
-        Ok(path)
+        self.write_file(filename, diff.to_string().as_bytes())
     }
 }
 

--- a/crates/engine/invalid-block-hooks/src/witness.rs
+++ b/crates/engine/invalid-block-hooks/src/witness.rs
@@ -4,7 +4,6 @@ use alloy_rpc_types_debug::ExecutionWitness;
 use pretty_assertions::Comparison;
 use reth_engine_primitives::InvalidBlockHook;
 use reth_evm::{execute::Executor, ConfigureEvm};
-use reth_fs_util::{create_file, FsPathError};
 use reth_primitives_traits::{NodePrimitives, RecoveredBlock, SealedHeader};
 use reth_provider::{BlockExecutionOutput, StateProvider, StateProviderFactory};
 use reth_revm::{


### PR DESCRIPTION


Eliminates code duplication by extracting common file writing logic from `save_file` and `save_diff` methods into a shared `write_file` helper method.

