### PR TITLE
perf: disable storage branch masks for non-target accounts

### DIFF
--- a/crates/trie/trie/src/proof/mod.rs
+++ b/crates/trie/trie/src/proof/mod.rs
@@ -144,6 +144,8 @@ where
                 TrieElement::Leaf(hashed_address, account) => {
                     let proof_targets = targets.remove(&hashed_address);
                     let leaf_is_proof_target = proof_targets.is_some();
+                    let collect_storage_masks =
+                        self.collect_branch_node_masks && leaf_is_proof_target;
                     let storage_prefix_set = self
                         .prefix_sets
                         .storage_prefix_sets
@@ -155,7 +157,7 @@ where
                         hashed_address,
                     )
                     .with_prefix_set_mut(storage_prefix_set)
-                    .with_branch_node_masks(self.collect_branch_node_masks)
+                    .with_branch_node_masks(collect_storage_masks)
                     .storage_multiproof(proof_targets.unwrap_or_default())?;
 
                     // Encode account


### PR DESCRIPTION
Disable collecting storage branch-node masks in Proof::multiproof() when the current account leaf is not a proof target. We only need the storage root for account RLP encoding in this case, so collecting masks is unnecessary overhead.

This reduces minor allocations and bookkeeping without changing correctness or public API. Storage masks remain collected for target accounts to support blinded trie node retrieval and proof introspection.