### PR TITLE
fix(codspeed): add harness = false for update benchmark in reth-trie-sparse

### DIFF
--- a/crates/trie/sparse/Cargo.toml
+++ b/crates/trie/sparse/Cargo.toml
@@ -90,3 +90,7 @@ harness = false
 [[bench]]
 name = "rlp_node"
 harness = false
+
+[[bench]]
+name = "update"
+harness = false


### PR DESCRIPTION
Fixes codspeed benchmark build failure.

## Error

The `update` benchmark file exists (`benches/update.rs`) but was not declared in `Cargo.toml`, causing CI failures:

```
Error: CodSpeed will not work with the following benchmark targets:
  - `update` in package `reth-trie-sparse`

CodSpeed requires benchmark targets to disable the default test harness because benchmark frameworks handle harnessing themselves.

Either disable the default harness by adding `harness = false` to the corresponding `[[bench]]` section in the Cargo.toml, or specify which targets to build by using `cargo codspeed build -p package_name --bench first_target --bench second_target`.
```

**Failed run**: https://github.com/paradigmxyz/reth/actions/runs/19193393926/job/54870891287

## Fix

Added the missing benchmark configuration to `Cargo.toml`:

```toml
[[bench]]
name = "update"
harness = false
```

**What this does**: The `harness = false` tells Cargo to let the benchmark framework (criterion) handle test execution instead of using Cargo's default test harness. This is required for all benchmarks to run properly. Without this declaration, the `update` benchmark couldn't be discovered or executed by codspeed, causing the build to fail.

**Impact**: The `update` benchmark will now run correctly in CI performance tests.