### PR TITLE
refactor(provider): introduce `EitherWriter::new_receipts`

### DIFF
--- a/crates/static-file/static-file/src/segments/receipts.rs
+++ b/crates/static-file/static-file/src/segments/receipts.rs
@@ -3,9 +3,7 @@ use alloy_primitives::BlockNumber;
 use reth_codecs::Compact;
 use reth_db_api::{cursor::DbCursorRO, table::Value, tables, transaction::DbTx};
 use reth_primitives_traits::NodePrimitives;
-use reth_provider::{
-    providers::StaticFileWriter, BlockReader, DBProvider, StaticFileProviderFactory,
-};
+use reth_provider::{BlockReader, DBProvider, StaticFileProviderFactory};
 use reth_static_file_types::StaticFileSegment;
 use reth_storage_errors::provider::{ProviderError, ProviderResult};
 use std::ops::RangeInclusive;
@@ -29,9 +27,8 @@ where
         provider: Provider,
         block_range: RangeInclusive<BlockNumber>,
     ) -> ProviderResult<()> {
-        let static_file_provider = provider.static_file_provider();
         let mut static_file_writer =
-            static_file_provider.get_writer(*block_range.start(), StaticFileSegment::Receipts)?;
+            provider.get_static_file_writer(*block_range.start(), StaticFileSegment::Receipts)?;
 
         for block in block_range {
             static_file_writer.increment_block(block)?;

--- a/crates/storage/db-api/src/transaction.rs
+++ b/crates/storage/db-api/src/transaction.rs
@@ -5,6 +5,9 @@ use crate::{
 };
 use std::fmt::Debug;
 
+/// Helper adapter type for accessing [`DbTxMut`] mutable cursor.
+pub type CursorMutTy<TX, T> = <TX as DbTxMut>::CursorMut<T>;
+
 /// Read only transaction
 pub trait DbTx: Debug + Send + Sync {
     /// Cursor type for this read-only transaction

--- a/crates/storage/provider/src/either_writer.rs
+++ b/crates/storage/provider/src/either_writer.rs
@@ -13,6 +13,13 @@ use reth_static_file_types::StaticFileSegment;
 use reth_storage_api::{DBProvider, NodePrimitivesProvider, StorageSettingsCache};
 use reth_storage_errors::provider::ProviderResult;
 
+/// Type alias for [`EitherWriter`] constructors.
+type EitherWriterTy<'a, P, T> = EitherWriter<
+    'a,
+    CursorMutTy<<P as DBProvider>::Tx, T>,
+    <P as NodePrimitivesProvider>::Primitives,
+>;
+
 /// Represents a destination for writing data, either to database or static files.
 #[derive(Debug)]
 pub enum EitherWriter<'a, CURSOR, N> {
@@ -27,13 +34,7 @@ impl<'a> EitherWriter<'a, (), ()> {
     pub fn new_receipts<P>(
         provider: &'a P,
         block_number: BlockNumber,
-    ) -> ProviderResult<
-        EitherWriter<
-            'a,
-            CursorMutTy<P::Tx, tables::Receipts<ReceiptTy<P::Primitives>>>,
-            P::Primitives,
-        >,
-    >
+    ) -> ProviderResult<EitherWriterTy<'a, P, tables::Receipts<ReceiptTy<P::Primitives>>>>
     where
         P: DBProvider + NodePrimitivesProvider + StorageSettingsCache + StaticFileProviderFactory,
         P::Tx: DbTxMut,

--- a/crates/storage/provider/src/either_writer.rs
+++ b/crates/storage/provider/src/either_writer.rs
@@ -1,10 +1,16 @@
 //! Generic writer abstraction for writing to either database tables or static files.
 
-use crate::providers::StaticFileProviderRWRefMut;
+use crate::{providers::StaticFileProviderRWRefMut, StaticFileProviderFactory};
 use alloy_primitives::{BlockNumber, TxNumber};
-use reth_db::table::Value;
+use reth_db::{
+    table::Value,
+    transaction::{CursorMutTy, DbTxMut},
+};
 use reth_db_api::{cursor::DbCursorRW, tables};
 use reth_node_types::NodePrimitives;
+use reth_primitives_traits::ReceiptTy;
+use reth_static_file_types::StaticFileSegment;
+use reth_storage_api::{DBProvider, NodePrimitivesProvider, StorageSettingsCache};
 use reth_storage_errors::provider::ProviderResult;
 
 /// Represents a destination for writing data, either to database or static files.
@@ -14,6 +20,39 @@ pub enum EitherWriter<'a, CURSOR, N> {
     Database(CURSOR),
     /// Write to static file
     StaticFile(StaticFileProviderRWRefMut<'a, N>),
+}
+
+impl<'a> EitherWriter<'a, (), ()> {
+    /// Creates a new [`EitherWriter`] for receipts based on storage settings and prune modes.
+    pub fn new_receipts<P>(
+        provider: &'a P,
+        block_number: BlockNumber,
+    ) -> ProviderResult<
+        EitherWriter<
+            'a,
+            CursorMutTy<P::Tx, tables::Receipts<ReceiptTy<P::Primitives>>>,
+            P::Primitives,
+        >,
+    >
+    where
+        P: DBProvider + NodePrimitivesProvider + StorageSettingsCache + StaticFileProviderFactory,
+        P::Tx: DbTxMut,
+        ReceiptTy<P::Primitives>: Value,
+    {
+        // Write receipts to static files only if they're explicitly enabled or we don't have
+        // receipts pruning
+        if provider.cached_storage_settings().receipts_in_static_files ||
+            !provider.prune_modes_ref().has_receipts_pruning()
+        {
+            Ok(EitherWriter::StaticFile(
+                provider.get_static_file_writer(block_number, StaticFileSegment::Receipts)?,
+            ))
+        } else {
+            Ok(EitherWriter::Database(
+                provider.tx_ref().cursor_write::<tables::Receipts<ReceiptTy<P::Primitives>>>()?,
+            ))
+        }
+    }
 }
 
 impl<'a, CURSOR, N: NodePrimitives> EitherWriter<'a, CURSOR, N> {

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -1,5 +1,7 @@
 use crate::{
-    providers::{ConsistentProvider, ProviderNodeTypes, StaticFileProvider},
+    providers::{
+        ConsistentProvider, ProviderNodeTypes, StaticFileProvider, StaticFileProviderRWRefMut,
+    },
     AccountReader, BlockHashReader, BlockIdReader, BlockNumReader, BlockReader, BlockReaderIdExt,
     BlockSource, CanonChainTracker, CanonStateNotifications, CanonStateSubscriptions,
     ChainSpecProvider, ChainStateBlockReader, ChangeSetReader, DatabaseProviderFactory,
@@ -23,6 +25,7 @@ use reth_node_types::{BlockTy, HeaderTy, NodeTypesWithDB, ReceiptTy, TxTy};
 use reth_primitives_traits::{Account, RecoveredBlock, SealedHeader, StorageEntry};
 use reth_prune_types::{PruneCheckpoint, PruneSegment};
 use reth_stages_types::{StageCheckpoint, StageId};
+use reth_static_file_types::StaticFileSegment;
 use reth_storage_api::{BlockBodyIndicesProvider, NodePrimitivesProvider, StorageChangeSetReader};
 use reth_storage_errors::provider::ProviderResult;
 use reth_trie::{updates::TrieUpdatesSorted, HashedPostState, KeccakKeyHasher};
@@ -162,6 +165,14 @@ impl<N: ProviderNodeTypes> DatabaseProviderFactory for BlockchainProvider<N> {
 impl<N: ProviderNodeTypes> StaticFileProviderFactory for BlockchainProvider<N> {
     fn static_file_provider(&self) -> StaticFileProvider<Self::Primitives> {
         self.database.static_file_provider()
+    }
+
+    fn get_static_file_writer(
+        &self,
+        block: BlockNumber,
+        segment: StaticFileSegment,
+    ) -> ProviderResult<StaticFileProviderRWRefMut<'_, Self::Primitives>> {
+        self.database.get_static_file_writer(block, segment)
     }
 }
 

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -1,10 +1,10 @@
 use super::{DatabaseProviderRO, ProviderFactory, ProviderNodeTypes};
 use crate::{
-    providers::StaticFileProvider, AccountReader, BlockHashReader, BlockIdReader, BlockNumReader,
-    BlockReader, BlockReaderIdExt, BlockSource, ChainSpecProvider, ChangeSetReader, HeaderProvider,
-    ProviderError, PruneCheckpointReader, ReceiptProvider, ReceiptProviderIdExt,
-    StageCheckpointReader, StateReader, StaticFileProviderFactory, TransactionVariant,
-    TransactionsProvider, TrieReader,
+    providers::{StaticFileProvider, StaticFileProviderRWRefMut},
+    AccountReader, BlockHashReader, BlockIdReader, BlockNumReader, BlockReader, BlockReaderIdExt,
+    BlockSource, ChainSpecProvider, ChangeSetReader, HeaderProvider, ProviderError,
+    PruneCheckpointReader, ReceiptProvider, ReceiptProviderIdExt, StageCheckpointReader,
+    StateReader, StaticFileProviderFactory, TransactionVariant, TransactionsProvider, TrieReader,
 };
 use alloy_consensus::{transaction::TransactionMeta, BlockHeader};
 use alloy_eips::{
@@ -23,6 +23,7 @@ use reth_node_types::{BlockTy, HeaderTy, ReceiptTy, TxTy};
 use reth_primitives_traits::{Account, BlockBody, RecoveredBlock, SealedHeader, StorageEntry};
 use reth_prune_types::{PruneCheckpoint, PruneSegment};
 use reth_stages_types::{StageCheckpoint, StageId};
+use reth_static_file_types::StaticFileSegment;
 use reth_storage_api::{
     BlockBodyIndicesProvider, DatabaseProviderFactory, NodePrimitivesProvider, StateProvider,
     StorageChangeSetReader, TryIntoHistoricalStateProvider,
@@ -641,6 +642,14 @@ impl<N: ProviderNodeTypes> NodePrimitivesProvider for ConsistentProvider<N> {
 impl<N: ProviderNodeTypes> StaticFileProviderFactory for ConsistentProvider<N> {
     fn static_file_provider(&self) -> StaticFileProvider<N::Primitives> {
         self.storage_provider.static_file_provider()
+    }
+
+    fn get_static_file_writer(
+        &self,
+        block: BlockNumber,
+        segment: StaticFileSegment,
+    ) -> ProviderResult<StaticFileProviderRWRefMut<'_, Self::Primitives>> {
+        self.storage_provider.get_static_file_writer(block, segment)
     }
 }
 

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -1,11 +1,14 @@
 use crate::{
-    providers::{state::latest::LatestStateProvider, NodeTypesForProvider, StaticFileProvider},
+    providers::{
+        state::latest::LatestStateProvider, NodeTypesForProvider, StaticFileProvider,
+        StaticFileProviderRWRefMut,
+    },
     to_range,
     traits::{BlockSource, ReceiptProvider},
     BlockHashReader, BlockNumReader, BlockReader, ChainSpecProvider, DatabaseProviderFactory,
     HashedPostStateProvider, HeaderProvider, HeaderSyncGapProvider, MetadataProvider,
     ProviderError, PruneCheckpointReader, StageCheckpointReader, StateProviderBox,
-    StaticFileProviderFactory, TransactionVariant, TransactionsProvider,
+    StaticFileProviderFactory, StaticFileWriter, TransactionVariant, TransactionsProvider,
 };
 use alloy_consensus::transaction::TransactionMeta;
 use alloy_eips::BlockHashOrNumber;
@@ -246,6 +249,14 @@ impl<N: NodeTypesWithDB> StaticFileProviderFactory for ProviderFactory<N> {
     /// Returns static file provider
     fn static_file_provider(&self) -> StaticFileProvider<Self::Primitives> {
         self.static_file_provider.clone()
+    }
+
+    fn get_static_file_writer(
+        &self,
+        block: BlockNumber,
+        segment: StaticFileSegment,
+    ) -> ProviderResult<StaticFileProviderRWRefMut<'_, Self::Primitives>> {
+        self.static_file_provider.get_writer(block, segment)
     }
 }
 

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -1,6 +1,10 @@
 //! Additional testing support for `NoopProvider`.
 
-use crate::{providers::StaticFileProvider, StaticFileProviderFactory};
+use crate::{
+    providers::{StaticFileProvider, StaticFileProviderRWRefMut},
+    StaticFileProviderFactory,
+};
+use reth_errors::{ProviderError, ProviderResult};
 use reth_primitives_traits::NodePrimitives;
 use std::path::PathBuf;
 
@@ -10,5 +14,13 @@ pub use reth_storage_api::noop::NoopProvider;
 impl<C: Send + Sync, N: NodePrimitives> StaticFileProviderFactory for NoopProvider<C, N> {
     fn static_file_provider(&self) -> StaticFileProvider<Self::Primitives> {
         StaticFileProvider::read_only(PathBuf::default(), false).unwrap()
+    }
+
+    fn get_static_file_writer(
+        &self,
+        _block: alloy_primitives::BlockNumber,
+        _segment: reth_static_file_types::StaticFileSegment,
+    ) -> ProviderResult<StaticFileProviderRWRefMut<'_, Self::Primitives>> {
+        Err(ProviderError::ReadOnlyStaticFileAccess)
     }
 }

--- a/crates/storage/provider/src/traits/static_file_provider.rs
+++ b/crates/storage/provider/src/traits/static_file_provider.rs
@@ -1,9 +1,19 @@
+use alloy_primitives::BlockNumber;
+use reth_errors::ProviderResult;
+use reth_static_file_types::StaticFileSegment;
 use reth_storage_api::NodePrimitivesProvider;
 
-use crate::providers::StaticFileProvider;
+use crate::providers::{StaticFileProvider, StaticFileProviderRWRefMut};
 
 /// Static file provider factory.
 pub trait StaticFileProviderFactory: NodePrimitivesProvider {
     /// Create new instance of static file provider.
     fn static_file_provider(&self) -> StaticFileProvider<Self::Primitives>;
+
+    /// Returns a mutable reference to a [`StaticFileProviderRW`] of a [`StaticFileSegment`].
+    fn get_static_file_writer(
+        &self,
+        block: BlockNumber,
+        segment: StaticFileSegment,
+    ) -> ProviderResult<StaticFileProviderRWRefMut<'_, Self::Primitives>>;
 }

--- a/crates/storage/provider/src/traits/static_file_provider.rs
+++ b/crates/storage/provider/src/traits/static_file_provider.rs
@@ -10,7 +10,9 @@ pub trait StaticFileProviderFactory: NodePrimitivesProvider {
     /// Create new instance of static file provider.
     fn static_file_provider(&self) -> StaticFileProvider<Self::Primitives>;
 
-    /// Returns a mutable reference to a [`StaticFileProviderRW`] of a [`StaticFileSegment`].
+    /// Returns a mutable reference to a
+    /// [`StaticFileProviderRW`](`crate::providers::StaticFileProviderRW`) of a
+    /// [`StaticFileSegment`].
     fn get_static_file_writer(
         &self,
         block: BlockNumber,


### PR DESCRIPTION
Hides the logic of choosing between database vs static files into `EitherWriter`. Will be especially useful for other segments where we need to do this conditional writer creation in many places, and it can all be abstracted away into one `EitherWriter::new_` function call.