### PR TITLE
fix engine_getPayloadV4 compliance

### DIFF
--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -464,6 +464,13 @@ where
         &self,
         payload_id: PayloadId,
     ) -> EngineApiResult<EngineT::ExecutionPayloadEnvelopeV4> {
+        let current_timestamp =
+            SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap_or_default().as_secs();
+        if self.inner.chain_spec.is_osaka_active_at_timestamp(current_timestamp) {
+            return Err(EngineApiError::EngineObjectValidationError(
+                reth_payload_primitives::EngineObjectValidationError::UnsupportedFork,
+            ));
+        }
         self.get_payload_inner(payload_id, EngineApiMessageVersion::V4).await
     }
 


### PR DESCRIPTION
Fix the issue on engine API: engine_getPayloadV4, to make it compliant with osaka engine API spec. 
According to issue listed in Fusaka contest: https://audits.sherlock.xyz/contests/1140/voting/156, the issue of API: engine_getPayloadV4 should also follow the spec restriction as the PR: https://github.com/paradigmxyz/reth/pull/18669 for API: getBlobsV1.  