### PR TITLE
fix: log correct account worker count

### DIFF
--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -174,7 +174,7 @@ impl ProofWorkerHandle {
         drop(parent_span);
 
         let parent_span =
-            debug_span!(target: "trie::proof_task", "account proof workers", ?storage_worker_count)
+            debug_span!(target: "trie::proof_task", "account proof workers", ?account_worker_count)
                 .entered();
         // Spawn account workers
         for worker_id in 0..account_worker_count {


### PR DESCRIPTION
The span for account proof workers was still logging storage_worker_count because of a copy/paste slip. Swapped it to account_worker_count so the tracing output matches the pool we actually spawn.