### PR TITLE
fix(net): fix update_root ENR/LINK handling

### DIFF
--- a/crates/net/dns/src/lib.rs
+++ b/crates/net/dns/src/lib.rs
@@ -583,8 +583,14 @@ mod tests {
         // await recheck timeout
         tokio::time::sleep(config.recheck_interval).await;
 
+        let mut new_root = root.clone();
+        new_root.sequence_number = new_root.sequence_number.saturating_add(1);
+        new_root.enr_root = "NEW_ENR_ROOT".to_string();
+        new_root.sign(&secret_key).unwrap();
+        resolver.insert(link.domain.clone(), new_root.to_string());
+
         let enr = Enr::empty(&secret_key).unwrap();
-        resolver.insert(format!("{}.{}", root.enr_root.clone(), link.domain), enr.to_base64());
+        resolver.insert(format!("{}.{}", new_root.enr_root.clone(), link.domain), enr.to_base64());
 
         let event = poll_fn(|cx| service.poll(cx)).await;
 

--- a/crates/net/dns/src/sync.rs
+++ b/crates/net/dns/src/sync.rs
@@ -102,29 +102,30 @@ impl<K: EnrKeyUnambiguous> SyncTree<K> {
 
     /// Updates the root and returns what changed
     pub(crate) fn update_root(&mut self, root: TreeRootEntry) {
-        let enr = root.enr_root == self.root.enr_root;
-        let link = root.link_root == self.root.link_root;
+        let enr_unchanged = root.enr_root == self.root.enr_root;
+        let link_unchanged = root.link_root == self.root.link_root;
 
         self.root = root;
         self.root_updated = Instant::now();
 
-        let state = match (enr, link) {
-            (true, true) => {
-                self.unresolved_nodes.clear();
-                self.unresolved_links.clear();
-                SyncState::Pending
-            }
-            (true, _) => {
+        let state = match (enr_unchanged, link_unchanged) {
+            // both unchanged — no resync needed
+            (true, true) => return,
+            // only ENR changed
+            (false, true) => {
                 self.unresolved_nodes.clear();
                 SyncState::Enr
             }
-            (_, true) => {
+            // only LINK changed
+            (true, false) => {
                 self.unresolved_links.clear();
                 SyncState::Link
             }
-            _ => {
-                // unchanged
-                return
+            // both changed
+            (false, false) => {
+                self.unresolved_nodes.clear();
+                self.unresolved_links.clear();
+                SyncState::Pending
             }
         };
         self.sync_state = state;
@@ -132,6 +133,7 @@ impl<K: EnrKeyUnambiguous> SyncTree<K> {
 }
 
 /// The action to perform by the service
+#[derive(Debug)]
 pub(crate) enum SyncAction {
     UpdateRoot,
     Enr(String),
@@ -158,5 +160,99 @@ pub(crate) enum ResolveKind {
 impl ResolveKind {
     pub(crate) const fn is_link(&self) -> bool {
         matches!(self, Self::Link)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use enr::EnrKey;
+    use secp256k1::rand::thread_rng;
+
+    fn base_root() -> TreeRootEntry {
+        // taken from existing tests to ensure valid formatting
+        let s = "enrtree-root:v1 e=QFT4PBCRX4XQCV3VUYJ6BTCEPU l=JGUFMSAGI7KZYB3P7IZW4S5Y3A seq=3 sig=3FmXuVwpa8Y7OstZTx9PIb1mt8FrW7VpDOFv4AaGCsZ2EIHmhraWhe4NxYhQDlw5MjeFXYMbJjsPeKlHzmJREQE";
+        s.parse::<TreeRootEntry>().unwrap()
+    }
+
+    fn make_tree() -> SyncTree {
+        let secret_key = SecretKey::new(&mut thread_rng());
+        let link =
+            LinkEntry { domain: "nodes.example.org".to_string(), pubkey: secret_key.public() };
+        SyncTree::new(base_root(), link)
+    }
+
+    fn advance_to_active(tree: &mut SyncTree) {
+        // Move Pending -> (emit Link) -> Enr, then Enr -> (emit Enr) -> Active
+        let now = Instant::now();
+        let timeout = Duration::from_secs(60 * 60 * 24);
+        let _ = tree.poll(now, timeout);
+        let _ = tree.poll(now, timeout);
+    }
+
+    #[test]
+    fn update_root_unchanged_no_action_from_active() {
+        let mut tree = make_tree();
+        let now = Instant::now();
+        let timeout = Duration::from_secs(60 * 60 * 24);
+        advance_to_active(&mut tree);
+
+        // same root -> no resync
+        let same = base_root();
+        tree.update_root(same);
+        assert!(tree.poll(now, timeout).is_none());
+    }
+
+    #[test]
+    fn update_root_only_enr_changed_triggers_enr() {
+        let mut tree = make_tree();
+        advance_to_active(&mut tree);
+        let mut new_root = base_root();
+        new_root.enr_root = "NEW_ENR_ROOT".to_string();
+        let now = Instant::now();
+        let timeout = Duration::from_secs(60 * 60 * 24);
+
+        tree.update_root(new_root.clone());
+        match tree.poll(now, timeout) {
+            Some(SyncAction::Enr(hash)) => assert_eq!(hash, new_root.enr_root),
+            other => panic!("expected Enr action, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn update_root_only_link_changed_triggers_link() {
+        let mut tree = make_tree();
+        advance_to_active(&mut tree);
+        let mut new_root = base_root();
+        new_root.link_root = "NEW_LINK_ROOT".to_string();
+        let now = Instant::now();
+        let timeout = Duration::from_secs(60 * 60 * 24);
+
+        tree.update_root(new_root.clone());
+        match tree.poll(now, timeout) {
+            Some(SyncAction::Link(hash)) => assert_eq!(hash, new_root.link_root),
+            other => panic!("expected Link action, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn update_root_both_changed_triggers_link_then_enr() {
+        let mut tree = make_tree();
+        advance_to_active(&mut tree);
+        let mut new_root = base_root();
+        new_root.enr_root = "NEW_ENR_ROOT".to_string();
+        new_root.link_root = "NEW_LINK_ROOT".to_string();
+        let now = Instant::now();
+        let timeout = Duration::from_secs(60 * 60 * 24);
+
+        tree.update_root(new_root.clone());
+        match tree.poll(now, timeout) {
+            Some(SyncAction::Link(hash)) => assert_eq!(hash, new_root.link_root),
+            other => panic!("expected first Link action, got {:?}", other),
+        }
+        match tree.poll(now, timeout) {
+            Some(SyncAction::Enr(hash)) => assert_eq!(hash, new_root.enr_root),
+            other => panic!("expected second Enr action, got {:?}", other),
+        }
     }
 }


### PR DESCRIPTION
update_root handled partial root changes inverted: when only link_root changed it set SyncState::Enr, and when only enr_root changed it set SyncState::Link. Additionally, the case where both roots changed was treated as “unchanged”, and the case where neither changed triggered a full resync (Pending). This contradicted EIP-1459 semantics (enr-root -> ENR subtree, link-root -> link subtree), caused incorrect query sequences, potential missed updates, and unnecessary DNS lookups, and led to “unexpected entry” logs during resolution.

Fixes:
- Renamed local flags to enr_unchanged/link_unchanged for clarity.

Corrected the state mapping:
- (true, true): early return (no resync).
- (false, true): clear unresolved_nodes, set SyncState::Enr (ENR changed).
- (true, false): clear unresolved_links, set SyncState::Link (LINK changed).
- (false, false): clear both, set SyncState::Pending (both changed).

Added unit tests covering all four scenarios and verifying emitted SyncAction ordering (Link then Enr when both changed).