### PR TITLE
feat(provider, prune): return receipts log filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9947,6 +9947,7 @@ dependencies = [
  "proptest",
  "proptest-arbitrary-interop",
  "reth-codecs",
+ "reth-tracing",
  "serde",
  "serde_json",
  "strum 0.27.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9118,6 +9118,7 @@ dependencies = [
  "serde",
  "shellexpand",
  "strum 0.27.2",
+ "thiserror 2.0.17",
  "tokio",
  "toml",
  "tracing",

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -1,6 +1,6 @@
 //! Configuration files.
 use reth_network_types::{PeersConfig, SessionsConfig};
-use reth_prune_types::PruneModes;
+use reth_prune_types::{PruneModes, PruneSegmentError};
 use reth_stages_types::ExecutionStageThresholds;
 use std::{
     path::{Path, PathBuf},
@@ -453,6 +453,11 @@ impl PruneConfig {
     /// Returns whether there is any kind of receipt pruning configuration.
     pub const fn has_receipts_pruning(&self) -> bool {
         self.segments.receipts.is_some()
+    }
+
+    /// Validates the configuration.
+    pub fn validate(&self) -> Result<(), PruneSegmentError> {
+        self.segments.receipts_log_filter.validate()
     }
 
     /// Merges another `PruneConfig` into this one, taking values from the other config if and only

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -33,7 +33,7 @@ pub struct Config {
 
 impl Config {
     /// Sets the pruning configuration.
-    pub const fn set_prune_config(&mut self, prune_config: PruneConfig) {
+    pub fn set_prune_config(&mut self, prune_config: PruneConfig) {
         self.prune = prune_config;
     }
 }
@@ -458,7 +458,6 @@ impl PruneConfig {
     /// Merges another `PruneConfig` into this one, taking values from the other config if and only
     /// if the corresponding value in this config is not set.
     pub fn merge(&mut self, other: Self) {
-        #[expect(deprecated)]
         let Self {
             block_interval,
             segments:
@@ -470,7 +469,7 @@ impl PruneConfig {
                     storage_history,
                     bodies_history,
                     merkle_changesets,
-                    receipts_log_filter: (),
+                    receipts_log_filter,
                 },
         } = other;
 
@@ -488,6 +487,9 @@ impl PruneConfig {
         self.segments.bodies_history = self.segments.bodies_history.or(bodies_history);
         // Merkle changesets is not optional, so we just replace it if provided
         self.segments.merkle_changesets = merkle_changesets;
+        if self.segments.receipts_log_filter.0.is_empty() && !receipts_log_filter.0.is_empty() {
+            self.segments.receipts_log_filter = receipts_log_filter;
+        }
     }
 }
 
@@ -514,9 +516,10 @@ where
 mod tests {
     use super::{Config, EXTENSION};
     use crate::PruneConfig;
+    use alloy_primitives::Address;
     use reth_network_peers::TrustedPeer;
     use reth_prune_types::{PruneMode, PruneModes};
-    use std::{path::Path, str::FromStr, time::Duration};
+    use std::{collections::BTreeMap, path::Path, str::FromStr, time::Duration};
 
     fn with_tempdir(filename: &str, proc: fn(&std::path::Path)) {
         let temp_dir = tempfile::tempdir().unwrap();
@@ -1005,8 +1008,7 @@ receipts = 'full'
                 storage_history: Some(PruneMode::Before(5000)),
                 bodies_history: None,
                 merkle_changesets: PruneMode::Before(0),
-                #[expect(deprecated)]
-                receipts_log_filter: (),
+                receipts_log_filter: BTreeMap::from([(Address::random(), PruneMode::Full)]).into(),
             },
         };
 
@@ -1020,11 +1022,15 @@ receipts = 'full'
                 storage_history: Some(PruneMode::Distance(3000)),
                 bodies_history: None,
                 merkle_changesets: PruneMode::Distance(10000),
-                #[expect(deprecated)]
-                receipts_log_filter: (),
+                receipts_log_filter: BTreeMap::from([
+                    (Address::random(), PruneMode::Distance(1000)),
+                    (Address::random(), PruneMode::Before(2000)),
+                ])
+                .into(),
             },
         };
 
+        let original_receipts_log_filter = config1.segments.receipts_log_filter.clone();
         config1.merge(config2);
 
         // Check that the configuration has been merged. Any configuration present in config1
@@ -1036,6 +1042,7 @@ receipts = 'full'
         assert_eq!(config1.segments.account_history, Some(PruneMode::Distance(2000)));
         assert_eq!(config1.segments.storage_history, Some(PruneMode::Before(5000)));
         assert_eq!(config1.segments.merkle_changesets, PruneMode::Distance(10000));
+        assert_eq!(config1.segments.receipts_log_filter, original_receipts_log_filter);
     }
 
     #[test]

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -1,6 +1,6 @@
 //! Configuration files.
 use reth_network_types::{PeersConfig, SessionsConfig};
-use reth_prune_types::{PruneModes, PruneSegmentError};
+use reth_prune_types::PruneModes;
 use reth_stages_types::ExecutionStageThresholds;
 use std::{
     path::{Path, PathBuf},
@@ -453,11 +453,6 @@ impl PruneConfig {
     /// Returns whether there is any kind of receipt pruning configuration.
     pub const fn has_receipts_pruning(&self) -> bool {
         self.segments.receipts.is_some()
-    }
-
-    /// Validates the configuration.
-    pub fn validate(&self) -> Result<(), PruneSegmentError> {
-        self.segments.receipts_log_filter.validate()
     }
 
     /// Merges another `PruneConfig` into this one, taking values from the other config if and only

--- a/crates/exex/exex/src/backfill/factory.rs
+++ b/crates/exex/exex/src/backfill/factory.rs
@@ -39,7 +39,7 @@ impl<E, P> BackfillJobFactory<E, P> {
     }
 
     /// Sets the prune modes
-    pub const fn with_prune_modes(mut self, prune_modes: PruneModes) -> Self {
+    pub fn with_prune_modes(mut self, prune_modes: PruneModes) -> Self {
         self.prune_modes = prune_modes;
         self
     }

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -1172,7 +1172,6 @@ mod tests {
                     storage_history_before: None,
                     bodies_pre_merge: false,
                     bodies_distance: None,
-                    #[expect(deprecated)]
                     receipts_log_filter: None,
                     bodies_before: None,
                 },

--- a/crates/node/core/Cargo.toml
+++ b/crates/node/core/Cargo.toml
@@ -44,14 +44,15 @@ alloy-consensus.workspace = true
 alloy-eips.workspace = true
 
 # misc
-eyre.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
+derive_more.workspace = true
+eyre.workspace = true
 humantime.workspace = true
 rand.workspace = true
-derive_more.workspace = true
-toml.workspace = true
 serde.workspace = true
 strum = { workspace = true, features = ["derive"] }
+thiserror.workspace = true
+toml.workspace = true
 url.workspace = true
 
 # io

--- a/crates/node/core/src/args/pruning.rs
+++ b/crates/node/core/src/args/pruning.rs
@@ -309,7 +309,11 @@ pub(crate) fn parse_receipts_log_filter(
         config.insert(address, prune_mode);
     }
 
-    config.validate()?;
+    let errors = config.validate_and_fix();
+    for error in errors {
+        reth_tracing::tracing::warn!("Receipt log pruning CLI arguments error: {}", error);
+    }
+
     Ok(config)
 }
 

--- a/crates/node/core/src/args/pruning.rs
+++ b/crates/node/core/src/args/pruning.rs
@@ -159,6 +159,14 @@ impl PruningArgs {
         if let Some(mode) = self.storage_history_prune_mode() {
             config.segments.storage_history = Some(mode);
         }
+        if let Some(receipt_logs) =
+            self.receipts_log_filter.as_ref().filter(|c| !c.is_empty()).cloned()
+        {
+            config.segments.receipts_log_filter = receipt_logs;
+            // need to remove the receipts segment filter entirely because that takes precedence
+            // over the logs filter
+            config.segments.receipts.take();
+        }
 
         config.is_default().not().then_some(config)
     }

--- a/crates/node/core/src/args/pruning.rs
+++ b/crates/node/core/src/args/pruning.rs
@@ -319,6 +319,8 @@ pub(crate) fn parse_receipts_log_filter(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use super::*;
     use alloy_primitives::address;
     use clap::Parser;
@@ -355,25 +357,27 @@ mod tests {
 
     #[test]
     fn test_parse_receipts_log_filter() {
-        let filter1 = "0x0000000000000000000000000000000000000001:full";
-        let filter2 = "0x0000000000000000000000000000000000000002:distance:1000";
-        let filter3 = "0x0000000000000000000000000000000000000003:before:5000000";
-        let filters = [filter1, filter2, filter3].join(",");
+        let addr1 = address!("0x0000000000000000000000000000000000000001");
+        let addr2 = address!("0x0000000000000000000000000000000000000002");
+        let addr3 = address!("0x0000000000000000000000000000000000000003");
+
+        let filters = [
+            format!("{addr1}:full"),
+            format!("{addr2}:distance:1000"),
+            format!("{addr3}:before:5000000"),
+        ]
+        .join(",");
 
         // Args can be parsed.
         let result = parse_receipts_log_filter(&filters);
         assert!(result.is_ok());
         let config = result.unwrap();
-        assert_eq!(config.len(), 3);
 
         // Check that the args were parsed correctly.
-        let addr1: Address = "0x0000000000000000000000000000000000000001".parse().unwrap();
-        let addr2: Address = "0x0000000000000000000000000000000000000002".parse().unwrap();
-        let addr3: Address = "0x0000000000000000000000000000000000000003".parse().unwrap();
-
-        assert_eq!(config.get(&addr1), Some(&PruneMode::Full));
-        assert_eq!(config.get(&addr2), Some(&PruneMode::Distance(1000)));
-        assert_eq!(config.get(&addr3), Some(&PruneMode::Before(5000000)));
+        assert_eq!(
+            config,
+            BTreeMap::from([(addr1, PruneMode::Full), (addr3, PruneMode::Before(5000000))]).into()
+        );
     }
 
     #[test]

--- a/crates/node/core/src/args/pruning.rs
+++ b/crates/node/core/src/args/pruning.rs
@@ -7,7 +7,7 @@ use alloy_primitives::BlockNumber;
 use clap::{builder::RangedU64ValueParser, Args};
 use reth_chainspec::EthereumHardforks;
 use reth_config::config::PruneConfig;
-use reth_prune_types::{PruneMode, PruneModes, MINIMUM_PRUNING_DISTANCE};
+use reth_prune_types::{PruneMode, PruneModes, ReceiptsLogPruneConfig, MINIMUM_PRUNING_DISTANCE};
 
 /// Parameters for pruning and full node
 #[derive(Debug, Clone, Args, PartialEq, Eq, Default)]
@@ -136,8 +136,7 @@ impl PruningArgs {
                         .block_number()
                         .map(PruneMode::Before),
                     merkle_changesets: PruneMode::Distance(MINIMUM_PRUNING_DISTANCE),
-                    #[expect(deprecated)]
-                    receipts_log_filter: (),
+                    receipts_log_filter: ReceiptsLogPruneConfig::empty(),
                 },
             }
         }

--- a/crates/prune/prune/src/builder.rs
+++ b/crates/prune/prune/src/builder.rs
@@ -43,7 +43,7 @@ impl PrunerBuilder {
     }
 
     /// Sets the configuration for every part of the data that can be pruned.
-    pub const fn segments(mut self, segments: PruneModes) -> Self {
+    pub fn segments(mut self, segments: PruneModes) -> Self {
         self.segments = segments;
         self
     }

--- a/crates/prune/prune/src/segments/set.rs
+++ b/crates/prune/prune/src/segments/set.rs
@@ -59,7 +59,6 @@ where
         _static_file_provider: StaticFileProvider<Provider::Primitives>,
         prune_modes: PruneModes,
     ) -> Self {
-        #[expect(deprecated)]
         let PruneModes {
             sender_recovery,
             transaction_lookup,
@@ -68,7 +67,7 @@ where
             storage_history,
             bodies_history,
             merkle_changesets,
-            receipts_log_filter: (),
+            receipts_log_filter: _,
         } = prune_modes;
 
         Self::default()

--- a/crates/prune/types/Cargo.toml
+++ b/crates/prune/types/Cargo.toml
@@ -45,7 +45,7 @@ std = [
     "serde_json/std",
     "thiserror/std",
     "strum/std",
-    "dep:reth-tracing"
+    "dep:reth-tracing",
 ]
 test-utils = [
     "std",

--- a/crates/prune/types/Cargo.toml
+++ b/crates/prune/types/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 reth-codecs = { workspace = true, optional = true }
+reth-tracing = { workspace = true, optional = true }
 
 alloy-primitives.workspace = true
 derive_more.workspace = true
@@ -44,6 +45,7 @@ std = [
     "serde_json/std",
     "thiserror/std",
     "strum/std",
+    "dep:reth-tracing"
 ]
 test-utils = [
     "std",

--- a/crates/prune/types/src/lib.rs
+++ b/crates/prune/types/src/lib.rs
@@ -18,7 +18,11 @@ mod pruner;
 mod segment;
 mod target;
 
+use std::collections::BTreeMap;
+
+use alloy_primitives::{Address, BlockNumber};
 pub use checkpoint::PruneCheckpoint;
+use derive_more::{Deref, From};
 pub use event::PrunerEvent;
 pub use mode::PruneMode;
 pub use pruner::{
@@ -26,4 +30,81 @@ pub use pruner::{
     SegmentOutputCheckpoint,
 };
 pub use segment::{PrunePurpose, PruneSegment, PruneSegmentError};
+use serde::Deserialize;
 pub use target::{PruneModes, UnwindTargetPrunedError, MINIMUM_PRUNING_DISTANCE};
+
+/// Configuration for pruning receipts not associated with logs emitted by the specified contracts.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Deref, From)]
+#[cfg_attr(any(test, feature = "serde"), derive(serde::Serialize, serde::Deserialize))]
+pub struct ReceiptsLogPruneConfig(pub BTreeMap<Address, PruneMode>);
+
+impl ReceiptsLogPruneConfig {
+    /// Creates an empty config.
+    pub const fn empty() -> Self {
+        Self(BTreeMap::new())
+    }
+
+    /// Returns `true` if the config is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub(crate) fn deserialize<'de, D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let map = BTreeMap::<Address, PruneMode>::deserialize(deserializer)?;
+        if let Some(address) =
+            map.iter().find_map(|(address, mode)| mode.is_distance().then_some(address))
+        {
+            return Err(serde::de::Error::custom(format!(
+                "address {} has a distance-based pruning mode which is no longer supported. Please either use `full` or `before`.",
+                address
+            )));
+        }
+        Ok(Self(map))
+    }
+
+    /// Given the `tip` block number, consolidates the structure so it can easily be queried for
+    /// filtering across a range of blocks.
+    ///
+    /// Example:
+    ///
+    /// `{ addrA: Before(872), addrB: Before(500), addrC: Distance(128) }`
+    ///
+    ///    for `tip: 1000`, gets transformed to a map such as:
+    ///
+    /// `{ 500: [addrB], 872: [addrA, addrC] }`
+    ///
+    /// The [`BlockNumber`] key of the new map should be viewed as `PruneMode::Before(block)`, which
+    /// makes the previous result equivalent to
+    ///
+    /// `{ Before(500): [addrB], Before(872): [addrA, addrC] }`
+    pub fn group_by_block(
+        &self,
+        tip: BlockNumber,
+        pruned_block: Option<BlockNumber>,
+    ) -> Result<BTreeMap<BlockNumber, Vec<Address>>, PruneSegmentError> {
+        let mut map = BTreeMap::new();
+        let base_block = pruned_block.unwrap_or_default() + 1;
+
+        for (address, mode) in &self.0 {
+            // Getting `None`, means that there is nothing to prune yet, so we need it to include in
+            // the BTreeMap (block = 0), otherwise it will be excluded.
+            // Reminder that this BTreeMap works as an inclusion list that excludes (prunes) all
+            // other receipts.
+            //
+            // Reminder, that we increment because the [`BlockNumber`] key of the new map should be
+            // viewed as `PruneMode::Before(block)`
+            let block = base_block.max(
+                mode.prune_target_block(tip, PruneSegment::ContractLogs, PrunePurpose::User)?
+                    .map(|(block, _)| block)
+                    .unwrap_or_default() +
+                    1,
+            );
+
+            map.entry(block).or_insert_with(Vec::new).push(*address)
+        }
+        Ok(map)
+    }
+}

--- a/crates/prune/types/src/lib.rs
+++ b/crates/prune/types/src/lib.rs
@@ -115,6 +115,7 @@ impl<'de> Deserialize<'de> for ReceiptsLogPruneConfig {
     {
         let mut config = Self(BTreeMap::deserialize(deserializer)?);
         let errors = config.validate_and_fix();
+        #[cfg(feature = "std")]
         for error in errors {
             reth_tracing::tracing::warn!("Receipt log pruning config error: {}", error);
         }

--- a/crates/prune/types/src/lib.rs
+++ b/crates/prune/types/src/lib.rs
@@ -67,9 +67,7 @@ impl ReceiptsLogPruneConfig {
         let mut errors = Vec::new();
         self.retain(|address, mode| {
             if mode.is_distance() {
-                errors.push(PruneSegmentError::UnsupportedReceiptsLogFilterPruneMode(
-                    *address, *mode,
-                ));
+                errors.push(PruneSegmentError::UnsupportedReceiptsLogFilterDistance(*address));
                 return false;
             }
 

--- a/crates/prune/types/src/lib.rs
+++ b/crates/prune/types/src/lib.rs
@@ -12,26 +12,26 @@
 extern crate alloc;
 
 mod checkpoint;
-mod event;
-mod mode;
-mod pruner;
-mod segment;
-mod target;
-
-use std::collections::BTreeMap;
-
-use alloy_primitives::{Address, BlockNumber};
 pub use checkpoint::PruneCheckpoint;
-use derive_more::{Deref, DerefMut, From};
+mod event;
 pub use event::PrunerEvent;
+mod mode;
 pub use mode::PruneMode;
+mod pruner;
 pub use pruner::{
     PruneInterruptReason, PruneProgress, PrunedSegmentInfo, PrunerOutput, SegmentOutput,
     SegmentOutputCheckpoint,
 };
+mod segment;
 pub use segment::{PrunePurpose, PruneSegment, PruneSegmentError};
-use serde::{de::Error, Deserialize, Deserializer};
+mod target;
 pub use target::{PruneModes, UnwindTargetPrunedError, MINIMUM_PRUNING_DISTANCE};
+
+use alloc::{collections::BTreeMap, vec::Vec};
+use alloy_primitives::{Address, BlockNumber};
+use derive_more::{Deref, DerefMut, From};
+#[cfg(feature = "serde")]
+use serde::{de::Error, Deserialize, Deserializer};
 
 /// Configuration for pruning receipts not associated with logs emitted by the specified contracts.
 #[derive(Debug, Clone, PartialEq, Eq, Default, Deref, DerefMut, From)]
@@ -49,6 +49,7 @@ impl ReceiptsLogPruneConfig {
         self.0.is_empty()
     }
 
+    #[cfg(feature = "serde")]
     pub(crate) fn deserialize<'de, D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,

--- a/crates/prune/types/src/segment.rs
+++ b/crates/prune/types/src/segment.rs
@@ -1,6 +1,7 @@
 #![allow(deprecated)] // necessary to all defining deprecated `PruneSegment` variants
 
-use crate::MINIMUM_PRUNING_DISTANCE;
+use crate::{PruneMode, MINIMUM_PRUNING_DISTANCE};
+use alloy_primitives::Address;
 use derive_more::Display;
 use strum::{EnumIter, IntoEnumIterator};
 use thiserror::Error;
@@ -115,6 +116,9 @@ pub enum PruneSegmentError {
     /// Invalid configuration of a prune segment.
     #[error("the configuration provided for {0} is invalid")]
     Configuration(PruneSegment),
+    /// Unsupported receipts log filter prune mode for address.
+    #[error("unsupported receipts log filter prune mode for address {0}: {1:?}")]
+    UnsupportedReceiptsLogFilterPruneMode(Address, PruneMode),
 }
 
 #[cfg(test)]

--- a/crates/prune/types/src/segment.rs
+++ b/crates/prune/types/src/segment.rs
@@ -117,7 +117,7 @@ pub enum PruneSegmentError {
     #[error("the configuration provided for {0} is invalid")]
     Configuration(PruneSegment),
     /// Unsupported receipts log filter prune mode for address.
-    #[error("distance prune mode is not supported for receipts log filter, check address {0}")]
+    #[error("receipts log filter for address {0} does not support distance prune mode")]
     UnsupportedReceiptsLogFilterDistance(Address),
 }
 

--- a/crates/prune/types/src/segment.rs
+++ b/crates/prune/types/src/segment.rs
@@ -1,6 +1,6 @@
 #![allow(deprecated)] // necessary to all defining deprecated `PruneSegment` variants
 
-use crate::{PruneMode, MINIMUM_PRUNING_DISTANCE};
+use crate::MINIMUM_PRUNING_DISTANCE;
 use alloy_primitives::Address;
 use derive_more::Display;
 use strum::{EnumIter, IntoEnumIterator};

--- a/crates/prune/types/src/segment.rs
+++ b/crates/prune/types/src/segment.rs
@@ -117,8 +117,8 @@ pub enum PruneSegmentError {
     #[error("the configuration provided for {0} is invalid")]
     Configuration(PruneSegment),
     /// Unsupported receipts log filter prune mode for address.
-    #[error("unsupported receipts log filter prune mode for address {0}: {1:?}")]
-    UnsupportedReceiptsLogFilterPruneMode(Address, PruneMode),
+    #[error("distance prune mode is not supported for receipts log filter, check address {0}")]
+    UnsupportedReceiptsLogFilterDistance(Address),
 }
 
 #[cfg(test)]

--- a/crates/prune/types/src/target.rs
+++ b/crates/prune/types/src/target.rs
@@ -99,7 +99,11 @@ pub struct PruneModes {
         )
     )]
     pub merkle_changesets: PruneMode,
-    /// Receipts log filtering has been deprecated and will be removed in a future release.
+    /// Receipts pruning configuration by retaining only those receipts that contain logs emitted
+    /// by the specified addresses, discarding others. This setting is overridden by `receipts`.
+    ///
+    /// The [`BlockNumber`](`crate::BlockNumber`) represents the starting block from which point
+    /// onwards the receipts are preserved.
     #[cfg_attr(
         any(test, feature = "serde"),
         serde(skip_serializing_if = "ReceiptsLogPruneConfig::is_empty",)

--- a/crates/prune/types/src/target.rs
+++ b/crates/prune/types/src/target.rs
@@ -102,10 +102,7 @@ pub struct PruneModes {
     /// Receipts log filtering has been deprecated and will be removed in a future release.
     #[cfg_attr(
         any(test, feature = "serde"),
-        serde(
-            skip_serializing_if = "ReceiptsLogPruneConfig::is_empty",
-            deserialize_with = "ReceiptsLogPruneConfig::deserialize"
-        )
+        serde(skip_serializing_if = "ReceiptsLogPruneConfig::is_empty",)
     )]
     pub receipts_log_filter: ReceiptsLogPruneConfig,
 }

--- a/crates/prune/types/src/target.rs
+++ b/crates/prune/types/src/target.rs
@@ -120,7 +120,7 @@ impl Default for PruneModes {
             storage_history: None,
             bodies_history: None,
             merkle_changesets: default_merkle_changesets_mode(),
-            receipts_log_filter: ReceiptsLogPruneConfig::empty(),
+            receipts_log_filter: ReceiptsLogPruneConfig::new(),
         }
     }
 }
@@ -136,7 +136,7 @@ impl PruneModes {
             storage_history: Some(PruneMode::Full),
             bodies_history: Some(PruneMode::Full),
             merkle_changesets: PruneMode::Full,
-            receipts_log_filter: ReceiptsLogPruneConfig::empty(),
+            receipts_log_filter: ReceiptsLogPruneConfig::new(),
         }
     }
 

--- a/crates/stages/stages/src/stages/execution.rs
+++ b/crates/stages/stages/src/stages/execution.rs
@@ -11,9 +11,9 @@ use reth_exex::{ExExManagerHandle, ExExNotification, ExExNotificationSource};
 use reth_primitives_traits::{format_gas_throughput, BlockBody, NodePrimitives};
 use reth_provider::{
     providers::{StaticFileProvider, StaticFileWriter},
-    BlockHashReader, BlockReader, DBProvider, ExecutionOutcome, HeaderProvider,
+    BlockHashReader, BlockReader, DBProvider, EitherWriter, ExecutionOutcome, HeaderProvider,
     LatestStateProviderRef, OriginalValuesKnown, ProviderError, StateWriter,
-    StaticFileProviderFactory, StatsReader, TransactionVariant,
+    StaticFileProviderFactory, StatsReader, StorageSettingsCache, TransactionVariant,
 };
 use reth_revm::database::StateProviderDatabase;
 use reth_stages_api::{
@@ -185,11 +185,15 @@ where
         unwind_to: Option<u64>,
     ) -> Result<(), StageError>
     where
-        Provider: StaticFileProviderFactory + DBProvider + BlockReader + HeaderProvider,
+        Provider: StaticFileProviderFactory
+            + DBProvider
+            + BlockReader
+            + HeaderProvider
+            + StorageSettingsCache,
     {
         // If there's any receipts pruning configured, receipts are written directly to database and
         // inconsistencies are expected.
-        if provider.prune_modes_ref().has_receipts_pruning() {
+        if EitherWriter::receipts_destination(provider).is_database() {
             return Ok(())
         }
 
@@ -259,7 +263,8 @@ where
             Primitives: NodePrimitives<BlockHeader: reth_db_api::table::Value>,
         > + StatsReader
         + BlockHashReader
-        + StateWriter<Receipt = <E::Primitives as NodePrimitives>::Receipt>,
+        + StateWriter<Receipt = <E::Primitives as NodePrimitives>::Receipt>
+        + StorageSettingsCache,
 {
     /// Return the id of the stage
     fn id(&self) -> StageId {

--- a/crates/static-file/static-file/src/static_file_producer.rs
+++ b/crates/static-file/static-file/src/static_file_producer.rs
@@ -194,7 +194,9 @@ where
 
         let targets = StaticFileTargets {
             // StaticFile receipts only if they're not pruned according to the user configuration
-            receipts: if self.prune_modes.receipts.is_none() {
+            receipts: if self.prune_modes.receipts.is_none() &&
+                self.prune_modes.receipts_log_filter.is_empty()
+            {
                 finalized_block_numbers.receipts.and_then(|finalized_block_number| {
                     self.get_static_file_target(
                         highest_static_files.receipts,

--- a/crates/storage/provider/src/either_writer.rs
+++ b/crates/storage/provider/src/either_writer.rs
@@ -18,15 +18,15 @@ pub enum EitherWriter<'a, CURSOR, N> {
     StaticFile(StaticFileProviderRWRefMut<'a, N>),
 }
 
-#[derive(Debug, EnumIs)]
-#[allow(missing_docs)]
-pub enum EitherWriterDestination {
-    Database,
-    StaticFile,
-}
-
 impl EitherWriter<'_, (), ()> {
     /// Returns the destination for writing receipts.
+    ///
+    /// The rules are as follows:
+    /// - If the node should not always write receipts to static files, and any receipt pruning is
+    ///   enabled, write to the database.
+    /// - If the node should always write receipts to static files, but receipt log filter pruning
+    ///   is enabled, write to the database.
+    /// - Otherwise, write to static files.
     pub fn receipts_destination<P: DBProvider + StorageSettingsCache>(
         provider: &P,
     ) -> EitherWriterDestination {
@@ -42,6 +42,13 @@ impl EitherWriter<'_, (), ()> {
             EitherWriterDestination::StaticFile
         }
     }
+}
+
+#[derive(Debug, EnumIs)]
+#[allow(missing_docs)]
+pub enum EitherWriterDestination {
+    Database,
+    StaticFile,
 }
 
 impl<'a, CURSOR, N: NodePrimitives> EitherWriter<'a, CURSOR, N> {

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -113,7 +113,7 @@ impl<N: ProviderNodeTypes> ProviderFactory<N> {
 
 impl<N: NodeTypesWithDB> ProviderFactory<N> {
     /// Sets the pruning configuration for an existing [`ProviderFactory`].
-    pub const fn with_prune_modes(mut self, prune_modes: PruneModes) -> Self {
+    pub fn with_prune_modes(mut self, prune_modes: PruneModes) -> Self {
         self.prune_modes = prune_modes;
         self
     }

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -264,7 +264,7 @@ impl<TX, N: NodeTypes> AsRef<Self> for DatabaseProvider<TX, N> {
     }
 }
 
-impl<TX: DbTx + DbTxMut + 'static, N: NodeTypes + NodeTypesForProvider> DatabaseProvider<TX, N> {
+impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX, N> {
     /// Writes executed blocks and state to storage.
     pub fn save_blocks(&self, blocks: Vec<ExecutedBlock<N::Primitives>>) -> ProviderResult<()> {
         if blocks.is_empty() {

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -808,6 +808,9 @@ Pruning:
       --prune.receipts.before <BLOCK_NUMBER>
           Prune receipts before the specified block number. The specified block number is not pruned
 
+      --prune.receiptslogfilter <FILTER_CONFIG>
+          Receipts Log Filter
+
       --prune.account-history.full
           Prunes all account history
 


### PR DESCRIPTION
Fixes https://github.com/paradigmxyz/reth/issues/19621

This PR returns the previously removed receipts log filter pruning, but makes it work only with `Full` and `Before` prune modes. Most of the changes are reverted from https://github.com/paradigmxyz/reth/pull/19184.

We're returning it, because some stakers depend on having receipts from certain staking protocols, and they don't want to store all 300GB+ of receipts on Mainnet.

We don't have `Distance` prune mode for this segment anymore because it's not useful for the type of pruning stakers do, and for us to support it, we would need to add a prune segment back. `Full` and `Before` modes work without a separate pruning segment, writing only specific receipts at the time of persisting.