### PR TITLE
fix: require config path when not using --default

### DIFF
--- a/crates/cli/commands/src/config_cmd.rs
+++ b/crates/cli/commands/src/config_cmd.rs
@@ -22,13 +22,14 @@ impl Command {
         let config = if self.default {
             Config::default()
         } else {
-            let path = self.config.clone().unwrap_or_default();
-            // Check if the file exists
+            let path = match self.config.as_ref() {
+                Some(path) => path,
+                None => bail!("No config file provided. Use --config <FILE> or pass --default"),
+            };
             if !path.exists() {
                 bail!("Config file does not exist: {}", path.display());
             }
-            // Read the configuration file
-            Config::from_path(&path)
+            Config::from_path(path)
                 .wrap_err_with(|| format!("Could not load config file: {}", path.display()))?
         };
         println!("{}", toml::to_string_pretty(&config)?);


### PR DESCRIPTION
Without this change `reth config` silently tried to read from an empty path whenever neither --default nor --config was provided, which produced a confusing “config file does not exist:” error; now the command explicitly asks for --config <FILE> or --default, so users immediately know how to proceed.