### PR TITLE
chore: remove unused latest_update_kind from TxPool

### DIFF
--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -116,8 +116,6 @@ pub struct TxPool<T: TransactionOrdering> {
     all_transactions: AllTransactions<T::Transaction>,
     /// Transaction pool metrics
     metrics: TxPoolMetrics,
-    /// The last update kind that was applied to the pool.
-    latest_update_kind: Option<PoolUpdateKind>,
 }
 
 // === impl TxPool ===
@@ -137,7 +135,6 @@ impl<T: TransactionOrdering> TxPool<T> {
             all_transactions: AllTransactions::new(&config),
             config,
             metrics: Default::default(),
-            latest_update_kind: None,
         }
     }
 
@@ -646,7 +643,7 @@ impl<T: TransactionOrdering> TxPool<T> {
         block_info: BlockInfo,
         mined_transactions: Vec<TxHash>,
         changed_senders: FxHashMap<SenderId, SenderInfo>,
-        update_kind: PoolUpdateKind,
+        _update_kind: PoolUpdateKind,
     ) -> OnNewCanonicalStateOutcome<T::Transaction> {
         // update block info
         let block_hash = block_info.last_seen_block_hash;
@@ -681,9 +678,6 @@ impl<T: TransactionOrdering> TxPool<T> {
 
         self.update_transaction_type_metrics();
         self.metrics.performed_state_updates.increment(1);
-
-        // Update the latest update kind
-        self.latest_update_kind = Some(update_kind);
 
         OnNewCanonicalStateOutcome {
             block_hash,


### PR DESCRIPTION
The latest_update_kind field in TxPool was write-only and never read by any component, tests, or metrics. PoolUpdateKind still flows through callers via CanonicalStateUpdate and into TxPool::on_canonical_state_change, but no consumer needs the last update kind persisted in TxPool. This removes the dead state, its initialization, and its only assignment, and renames the parameter to update_kind to avoid unused variable warnings. This keeps API behavior unchanged for callers and reduces unnecessary state.