### PR TITLE
fix(storage): validate blocks_per_file to prevent division by zero

### DIFF
--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -69,11 +69,9 @@ impl fmt::Display for InvalidBlocksPerFile {
                 "blocks_per_file must be greater than zero for segment {segment:?} (received {})",
                 self.value
             ),
-            None => write!(
-                f,
-                "blocks_per_file must be greater than zero (received {})",
-                self.value
-            ),
+            None => {
+                write!(f, "blocks_per_file must be greater than zero (received {})", self.value)
+            }
         }
     }
 }

--- a/crates/storage/provider/src/providers/static_file/mod.rs
+++ b/crates/storage/provider/src/providers/static_file/mod.rs
@@ -163,6 +163,7 @@ mod tests {
             let sf_rw = StaticFileProviderBuilder::<EthPrimitives>::read_write(&static_dir)
                 .expect("Failed to create static file provider builder")
                 .with_blocks_per_file(blocks_per_file)
+                .expect("blocks_per_file must be greater than zero")
                 .build()
                 .expect("Failed to build static file provider");
 
@@ -259,6 +260,7 @@ mod tests {
             let sf_rw = StaticFileProviderBuilder::read_write(&static_dir)
                 .expect("Failed to create static file provider builder")
                 .with_blocks_per_file(blocks_per_file)
+                .expect("blocks_per_file must be greater than zero")
                 .build()
                 .expect("Failed to build static file provider");
 
@@ -476,6 +478,7 @@ mod tests {
             let sf_rw = StaticFileProviderBuilder::read_write(&static_dir)
                 .expect("Failed to create static file provider builder")
                 .with_blocks_per_file(blocks_per_file)
+                .expect("blocks_per_file must be greater than zero")
                 .build()
                 .expect("Failed to build static file provider");
 
@@ -484,6 +487,7 @@ mod tests {
             let sf_rw = StaticFileProviderBuilder::read_write(&static_dir)
                 .expect("Failed to create static file provider builder")
                 .with_blocks_per_file(blocks_per_file)
+                .expect("blocks_per_file must be greater than zero")
                 .build()
                 .expect("Failed to build static file provider");
             let highest_tx = sf_rw.get_highest_static_file_tx(segment).unwrap();
@@ -565,7 +569,7 @@ mod tests {
 
         {
             let sf_rw = StaticFileProviderBuilder::<EthPrimitives>::read_write(&static_dir)?
-                .with_blocks_per_file(10)
+                .with_blocks_per_file(10)?
                 .build()?;
             let mut header_writer = sf_rw.latest_writer(StaticFileSegment::Headers)?;
 
@@ -591,7 +595,7 @@ mod tests {
 
         {
             let sf_rw = StaticFileProviderBuilder::<EthPrimitives>::read_write(&static_dir)?
-                .with_blocks_per_file(5)
+                .with_blocks_per_file(5)?
                 .build()?;
             let mut header_writer = sf_rw.latest_writer(StaticFileSegment::Headers)?;
 
@@ -618,7 +622,7 @@ mod tests {
 
         {
             let sf_rw = StaticFileProviderBuilder::<EthPrimitives>::read_write(&static_dir)?
-                .with_blocks_per_file(15)
+                .with_blocks_per_file(15)?
                 .build()?;
             let mut header_writer = sf_rw.latest_writer(StaticFileSegment::Headers)?;
 


### PR DESCRIPTION


The `StaticFileProviderBuilder` methods `with_blocks_per_file()` and `with_blocks_per_file_for_segment()` accepted `0` as a valid value, which could lead to division by zero panics when calculating block ranges in `find_fixed_range_with_block_index()`.

