### PR TITLE
refactor: capped `to` to `best_block`

### DIFF
--- a/crates/cli/commands/src/re_execute.rs
+++ b/crates/cli/commands/src/re_execute.rs
@@ -66,19 +66,17 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
 
         let min_block = self.from;
         let best_block = provider.best_block_number()?;
-        let max_block = if let Some(to) = self.to {
+        let mut max_block = best_block;
+        if let Some(to) = self.to {
             if to > best_block {
                 warn!(
                     requested = to,
                     best_block,
                     "Requested --to is beyond available chain head; clamping to best block"
                 );
-                best_block
             } else {
-                to
+                max_block = to;
             }
-        } else {
-            best_block
         };
 
         let total_blocks = max_block - min_block;

--- a/crates/cli/commands/src/re_execute.rs
+++ b/crates/cli/commands/src/re_execute.rs
@@ -65,7 +65,21 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
         let components = components(provider_factory.chain_spec());
 
         let min_block = self.from;
-        let max_block = self.to.unwrap_or(provider.best_block_number()?);
+        let best_block = provider.best_block_number()?;
+        let max_block = if let Some(to) = self.to {
+            if to > best_block {
+                warn!(
+                    requested = to,
+                    best_block,
+                    "Requested --to is beyond available chain head; clamping to best block"
+                );
+                best_block
+            } else {
+                to
+            }
+        } else {
+            best_block
+        };
 
         let total_blocks = max_block - min_block;
         let total_gas = calculate_gas_used_from_headers(


### PR DESCRIPTION
# Fixes #19636 
- Caps the requested `to` block at the current `best_block`.
- If the user requests a block higher than `best_block`, execution now emits a warning instead of silently proceeding.