### PR TITLE
chore: Remove unnecessary dead_code attributes from benchmark utils

### DIFF
--- a/crates/storage/db/benches/utils.rs
+++ b/crates/storage/db/benches/utils.rs
@@ -12,15 +12,12 @@ use reth_fs_util as fs;
 use std::{path::Path, sync::Arc};
 
 /// Path where the DB is initialized for benchmarks.
-#[allow(dead_code)]
 pub(crate) const BENCH_DB_PATH: &str = "/tmp/reth-benches";
 
 /// Used for `RandomRead` and `RandomWrite` benchmarks.
-#[allow(dead_code)]
 pub(crate) const RANDOM_INDEXES: [usize; 10] = [23, 2, 42, 5, 3, 99, 54, 0, 33, 64];
 
 /// Returns bench vectors in the format: `Vec<(Key, EncodedKey, Value, CompressedValue)>`.
-#[allow(dead_code)]
 pub(crate) fn load_vectors<T: Table>() -> Vec<(T::Key, Bytes, T::Value, Bytes)>
 where
     T::Key: Clone + for<'de> serde::Deserialize<'de>,
@@ -48,7 +45,6 @@ where
 
 /// Sets up a clear database at `bench_db_path`.
 #[expect(clippy::ptr_arg)]
-#[allow(dead_code)]
 pub(crate) fn set_up_db<T>(
     bench_db_path: &Path,
     pair: &Vec<(<T as Table>::Key, Bytes, <T as Table>::Value, Bytes)>,


### PR DESCRIPTION
Those constants and functions in are actively used across multiple benchmark files, so removed `#[allow(dead_code)]` attributes.