### PR TITLE
feat(cli): log warning if otlp feature is not enabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8413,10 +8413,8 @@ dependencies = [
  "reth-node-metrics",
  "reth-rpc-server-types",
  "reth-tracing",
- "reth-tracing-otlp",
  "tempfile",
  "tracing",
- "url",
 ]
 
 [[package]]
@@ -9369,13 +9367,11 @@ dependencies = [
  "reth-static-file",
  "reth-static-file-types",
  "reth-tracing",
- "reth-tracing-otlp",
  "serde",
  "tempfile",
  "tokio",
  "tokio-util",
  "tracing",
- "url",
 ]
 
 [[package]]

--- a/crates/ethereum/cli/Cargo.toml
+++ b/crates/ethereum/cli/Cargo.toml
@@ -23,13 +23,11 @@ reth-node-ethereum.workspace = true
 reth-node-metrics.workspace = true
 reth-rpc-server-types.workspace = true
 reth-tracing.workspace = true
-reth-tracing-otlp.workspace = true
 reth-node-api.workspace = true
 
 # misc
 clap.workspace = true
 eyre.workspace = true
-url.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]

--- a/crates/ethereum/cli/src/app.rs
+++ b/crates/ethereum/cli/src/app.rs
@@ -16,7 +16,7 @@ use reth_rpc_server_types::RpcModuleValidator;
 use reth_tracing::{FileWorkerGuard, Layers};
 use reth_tracing_otlp::OtlpProtocol;
 use std::{fmt, sync::Arc};
-use tracing::info;
+use tracing::{info, warn};
 use url::Url;
 
 /// A wrapper around a parsed CLI that handles command execution.
@@ -114,18 +114,40 @@ where
         if self.guard.is_none() {
             let mut layers = self.layers.take().unwrap_or_default();
 
-            #[cfg(feature = "otlp")]
-            {
-                self.cli.traces.validate()?;
-
-                if let Some(endpoint) = &self.cli.traces.otlp {
-                    info!(target: "reth::cli", "Starting OTLP tracing export to {:?}", endpoint);
-                    self.init_otlp_export(&mut layers, endpoint, runner)?;
-                }
+            #[allow(unused)]
+            enum OtlpStatus<'a> {
+                Started(&'a Url),
+                Disabled,
+                NoFeature,
             }
+
+            let otlp_status = if self.cli.traces.otlp.is_some() {
+                #[cfg(feature = "otlp")]
+                {
+                    self.cli.traces.validate()?;
+                    let endpoint = self.cli.traces.otlp.as_ref().unwrap();
+                    self.init_otlp_export(&mut layers, endpoint, runner)?;
+                    OtlpStatus::Started(endpoint)
+                }
+                #[cfg(not(feature = "otlp"))]
+                {
+                    OtlpStatus::NoFeature
+                }
+            } else {
+                OtlpStatus::Disabled
+            };
 
             self.guard = self.cli.logs.init_tracing_with_layers(layers)?;
             info!(target: "reth::cli", "Initialized tracing, debug log directory: {}", self.cli.logs.log_file_directory);
+            match otlp_status {
+                OtlpStatus::Started(endpoint) => {
+                    info!(target: "reth::cli", "Started OTLP {:?} tracing export to {endpoint}", self.cli.traces.protocol);
+                }
+                OtlpStatus::NoFeature => {
+                    warn!(target: "reth::cli", "Provided OTLP tracing arguments do not have effect, compile with the `otlp` feature")
+                }
+                OtlpStatus::Disabled => {}
+            }
         }
         Ok(())
     }

--- a/crates/ethereum/cli/src/app.rs
+++ b/crates/ethereum/cli/src/app.rs
@@ -10,14 +10,13 @@ use reth_cli_runner::CliRunner;
 use reth_db::DatabaseEnv;
 use reth_node_api::NodePrimitives;
 use reth_node_builder::{NodeBuilder, WithLaunchContext};
+use reth_node_core::args::OtlpInitStatus;
 use reth_node_ethereum::{consensus::EthBeaconConsensus, EthEvmConfig, EthereumNode};
 use reth_node_metrics::recorder::install_prometheus_recorder;
 use reth_rpc_server_types::RpcModuleValidator;
 use reth_tracing::{FileWorkerGuard, Layers};
-use reth_tracing_otlp::OtlpProtocol;
 use std::{fmt, sync::Arc};
 use tracing::{info, warn};
-use url::Url;
 
 /// A wrapper around a parsed CLI that handles command execution.
 #[derive(Debug)]
@@ -114,70 +113,20 @@ where
         if self.guard.is_none() {
             let mut layers = self.layers.take().unwrap_or_default();
 
-            #[allow(unused)]
-            enum OtlpStatus<'a> {
-                Started(&'a Url),
-                Disabled,
-                NoFeature,
-            }
-
-            let otlp_status = if self.cli.traces.otlp.is_some() {
-                #[cfg(feature = "otlp")]
-                {
-                    self.cli.traces.validate()?;
-                    let endpoint = self.cli.traces.otlp.as_ref().unwrap();
-                    self.init_otlp_export(&mut layers, endpoint, runner)?;
-                    OtlpStatus::Started(endpoint)
-                }
-                #[cfg(not(feature = "otlp"))]
-                {
-                    OtlpStatus::NoFeature
-                }
-            } else {
-                OtlpStatus::Disabled
-            };
+            let otlp_status = runner.block_on(self.cli.traces.init_otlp_tracing(&mut layers))?;
 
             self.guard = self.cli.logs.init_tracing_with_layers(layers)?;
             info!(target: "reth::cli", "Initialized tracing, debug log directory: {}", self.cli.logs.log_file_directory);
             match otlp_status {
-                OtlpStatus::Started(endpoint) => {
+                OtlpInitStatus::Started(endpoint) => {
                     info!(target: "reth::cli", "Started OTLP {:?} tracing export to {endpoint}", self.cli.traces.protocol);
                 }
-                OtlpStatus::NoFeature => {
+                OtlpInitStatus::NoFeature => {
                     warn!(target: "reth::cli", "Provided OTLP tracing arguments do not have effect, compile with the `otlp` feature")
                 }
-                OtlpStatus::Disabled => {}
+                OtlpInitStatus::Disabled => {}
             }
         }
-        Ok(())
-    }
-
-    /// Initialize OTLP tracing export based on protocol type.
-    ///
-    /// For gRPC, `block_on` is required because tonic's channel initialization needs
-    /// a tokio runtime context, even though `with_span_layer` itself is not async.
-    #[cfg(feature = "otlp")]
-    fn init_otlp_export(
-        &self,
-        layers: &mut Layers,
-        endpoint: &Url,
-        runner: &CliRunner,
-    ) -> Result<()> {
-        let endpoint = endpoint.clone();
-        let protocol = self.cli.traces.protocol;
-        let filter_level = self.cli.traces.otlp_filter.clone();
-
-        match protocol {
-            OtlpProtocol::Grpc => {
-                runner.block_on(async {
-                    layers.with_span_layer("reth".to_string(), endpoint, filter_level, protocol)
-                })?;
-            }
-            OtlpProtocol::Http => {
-                layers.with_span_layer("reth".to_string(), endpoint, filter_level, protocol)?;
-            }
-        }
-
         Ok(())
     }
 }

--- a/crates/node/core/src/args/mod.rs
+++ b/crates/node/core/src/args/mod.rs
@@ -26,7 +26,7 @@ pub use log::{ColorMode, LogArgs, Verbosity};
 
 /// `TraceArgs` for tracing and spans support
 mod trace;
-pub use trace::TraceArgs;
+pub use trace::{OtlpInitStatus, TraceArgs};
 
 /// `MetricArgs` to configure metrics.
 mod metric;

--- a/crates/node/core/src/args/trace.rs
+++ b/crates/node/core/src/args/trace.rs
@@ -2,7 +2,7 @@
 
 use clap::Parser;
 use eyre::WrapErr;
-use reth_tracing::tracing_subscriber::EnvFilter;
+use reth_tracing::{tracing_subscriber::EnvFilter, Layers};
 use reth_tracing_otlp::OtlpProtocol;
 use url::Url;
 
@@ -74,13 +74,52 @@ impl Default for TraceArgs {
 }
 
 impl TraceArgs {
-    /// Validate the configuration
-    pub fn validate(&mut self) -> eyre::Result<()> {
-        if let Some(url) = &mut self.otlp {
-            self.protocol.validate_endpoint(url)?;
+    /// Initialize OTLP tracing with the given layers and runner.
+    ///
+    /// This method handles OTLP tracing initialization based on the configured options,
+    /// including validation, protocol selection, and feature flag checking.
+    ///
+    /// Returns the initialization status to allow callers to log appropriate messages.
+    ///
+    /// Note: even though this function is async, it does not actually perform any async operations.
+    /// It's needed only to be able to initialize the gRPC transport of OTLP tracing that needs to
+    /// be called inside a tokio runtime context.
+    pub async fn init_otlp_tracing(
+        &mut self,
+        _layers: &mut Layers,
+    ) -> eyre::Result<OtlpInitStatus> {
+        if let Some(endpoint) = self.otlp.as_mut() {
+            self.protocol.validate_endpoint(endpoint)?;
+
+            #[cfg(feature = "otlp")]
+            {
+                _layers.with_span_layer(
+                    "reth".to_string(),
+                    endpoint.clone(),
+                    self.otlp_filter.clone(),
+                    self.protocol,
+                )?;
+                Ok(OtlpInitStatus::Started(endpoint.clone()))
+            }
+            #[cfg(not(feature = "otlp"))]
+            {
+                Ok(OtlpInitStatus::NoFeature)
+            }
+        } else {
+            Ok(OtlpInitStatus::Disabled)
         }
-        Ok(())
     }
+}
+
+/// Status of OTLP tracing initialization.
+#[derive(Debug)]
+pub enum OtlpInitStatus {
+    /// OTLP tracing was successfully started with the given endpoint.
+    Started(Url),
+    /// OTLP tracing is disabled (no endpoint configured).
+    Disabled,
+    /// OTLP arguments provided but feature is not compiled.
+    NoFeature,
 }
 
 // Parses an OTLP endpoint url.

--- a/crates/optimism/cli/Cargo.toml
+++ b/crates/optimism/cli/Cargo.toml
@@ -44,7 +44,6 @@ reth-optimism-evm.workspace = true
 reth-cli-runner.workspace = true
 reth-node-builder = { workspace = true, features = ["op"] }
 reth-tracing.workspace = true
-reth-tracing-otlp.workspace = true
 
 # eth
 alloy-eips.workspace = true
@@ -56,7 +55,6 @@ alloy-rlp.workspace = true
 futures-util.workspace = true
 derive_more.workspace = true
 serde.workspace = true
-url.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 
 tokio = { workspace = true, features = ["sync", "macros", "time", "rt-multi-thread"] }
@@ -107,5 +105,4 @@ serde = [
     "reth-optimism-primitives/serde",
     "reth-primitives-traits/serde",
     "reth-optimism-chainspec/serde",
-    "url/serde",
 ]

--- a/crates/optimism/cli/src/app.rs
+++ b/crates/optimism/cli/src/app.rs
@@ -11,7 +11,7 @@ use reth_rpc_server_types::RpcModuleValidator;
 use reth_tracing::{FileWorkerGuard, Layers};
 use reth_tracing_otlp::OtlpProtocol;
 use std::{fmt, sync::Arc};
-use tracing::info;
+use tracing::{info, warn};
 use url::Url;
 
 /// A wrapper around a parsed CLI that handles command execution.
@@ -122,17 +122,40 @@ where
         if self.guard.is_none() {
             let mut layers = self.layers.take().unwrap_or_default();
 
-            #[cfg(feature = "otlp")]
-            {
-                self.cli.traces.validate()?;
-                if let Some(endpoint) = &self.cli.traces.otlp {
-                    info!(target: "reth::cli", "Starting OTLP tracing export to {:?}", endpoint);
-                    self.init_otlp_export(&mut layers, endpoint, runner)?;
-                }
+            #[allow(unused)]
+            enum OtlpStatus<'a> {
+                Started(&'a Url),
+                Disabled,
+                NoFeature,
             }
+
+            let otlp_status = if self.cli.traces.otlp.is_some() {
+                #[cfg(feature = "otlp")]
+                {
+                    self.cli.traces.validate()?;
+                    let endpoint = self.cli.traces.otlp.as_ref().unwrap();
+                    self.init_otlp_export(&mut layers, endpoint, runner)?;
+                    OtlpStatus::Started(endpoint)
+                }
+                #[cfg(not(feature = "otlp"))]
+                {
+                    OtlpStatus::NoFeature
+                }
+            } else {
+                OtlpStatus::Disabled
+            };
 
             self.guard = self.cli.logs.init_tracing_with_layers(layers)?;
             info!(target: "reth::cli", "Initialized tracing, debug log directory: {}", self.cli.logs.log_file_directory);
+            match otlp_status {
+                OtlpStatus::Started(endpoint) => {
+                    info!(target: "reth::cli", "Started OTLP {:?} tracing export to {endpoint}", self.cli.traces.protocol);
+                }
+                OtlpStatus::NoFeature => {
+                    warn!(target: "reth::cli", "Provided OTLP tracing arguments do not have effect, compile with the `otlp` feature")
+                }
+                OtlpStatus::Disabled => {}
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
Addresses two issues:
1. OTLP initialization log wasn't printed to stdout, because trace layers initialization happened after we emitted that log.
2. When OTLP tracing arguments were provided but feature is not enabled, we silently didn't initialize the layer.

Additionally, deduplicates the OTLP tracing initialization logic between `reth-ethereum-cli` and `reth-optimism-cli` crates.

### Demonstration

```console
❯ cargo r --no-default-features --quiet node --chain hoodi --tracing-otlp
2025-11-11T16:03:09.066553Z  INFO Initialized tracing, debug log directory: /Users/shekhirin/Library/Caches/reth/logs/hoodi
2025-11-11T16:03:09.066680Z  WARN Provided OTLP tracing arguments do not have effect, compile with the `otlp` feature
```

```console
❯ cargo r --quiet node --chain hoodi --tracing-otlp
2025-11-11T16:03:37.324707Z  INFO Initialized tracing, debug log directory: /Users/shekhirin/Library/Caches/reth/logs/hoodi
2025-11-11T16:03:37.324869Z  INFO Started OTLP Http tracing export to http://localhost:4318/v1/traces
```