### PR TITLE
fix(metrics): move trie_input_duration recording to capture full setup

### DIFF
--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -764,11 +764,6 @@ where
                 let (trie_input, block_hash) =
                     self.compute_trie_input(parent_hash, state, allocated_trie_input)?;
 
-                self.metrics
-                    .block_validation
-                    .trie_input_duration
-                    .record(trie_input_start.elapsed().as_secs_f64());
-
                 // Convert the TrieInput into a MultProofConfig, since everything uses the sorted
                 // forms of the state/trie fields.
                 let (trie_input, multiproof_config) = MultiProofConfig::from_input(trie_input);
@@ -784,6 +779,11 @@ where
 
                 // Use state root task only if prefix sets are empty, otherwise proof generation is
                 // too expensive because it requires walking all paths in every proof.
+                self.metrics
+                    .block_validation
+                    .trie_input_duration
+                    .record(trie_input_start.elapsed().as_secs_f64());
+
                 let spawn_start = Instant::now();
                 let handle = self.payload_processor.spawn(
                     env,


### PR DESCRIPTION
## Summary

Moves the `trie_input_duration` metric recording to just before the spawn call to capture the complete trie input preparation time.