### PR TITLE
fix(stages): correct tip_tx field comment in PipelineBuilder

### DIFF
--- a/crates/stages/api/src/pipeline/builder.rs
+++ b/crates/stages/api/src/pipeline/builder.rs
@@ -11,7 +11,7 @@ pub struct PipelineBuilder<Provider> {
     stages: Vec<BoxedStage<Provider>>,
     /// The maximum block number to sync to.
     max_block: Option<BlockNumber>,
-    /// A receiver for the current chain tip to sync to.
+    /// A Sender for the current chain tip to sync to.
     tip_tx: Option<watch::Sender<B256>>,
     metrics_tx: Option<MetricEventsSender>,
     fail_on_unwind: bool,


### PR DESCRIPTION
Fix incorrect comment for tip_tx field in PipelineBuilder. 

The field is a  watch::Sender, not a receiver, which matches its usage in Pipeline::set_tip() and the corresponding comment in the Pipeline struct.