### PR TITLE
ci: use macos-14 runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
             profile: maxperf
             allow_fail: false
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-14
             profile: maxperf
             allow_fail: false
           - target: aarch64-apple-darwin


### PR DESCRIPTION
`macos-13` is deprecated https://github.com/actions/runner-images/issues/13046