### PR TITLE
Remove unused Tracer import from custom EVM example

### DIFF
--- a/examples/custom-evm/src/main.rs
+++ b/examples/custom-evm/src/main.rs
@@ -38,7 +38,7 @@ use reth_ethereum::{
     tasks::TaskManager,
     EthPrimitives,
 };
-use reth_tracing::{RethTracer, Tracer};
+use reth_tracing::RethTracer;
 use std::sync::OnceLock;
 
 /// Custom EVM configuration.


### PR DESCRIPTION
drop the unused Tracer import in examples/custom-evm/src/main.rs, keep the custom EVM sample free of dead code and compiler warnings