### PR TITLE
Remove unused SignerRecoverable import from txpool tracing example

### DIFF
--- a/examples/txpool-tracing/src/submit.rs
+++ b/examples/txpool-tracing/src/submit.rs
@@ -11,7 +11,6 @@ use reth_ethereum::{
         AddedTransactionOutcome, PoolTransaction, TransactionEvent, TransactionOrigin,
         TransactionPool,
     },
-    primitives::SignerRecoverable,
     rpc::eth::primitives::TransactionRequest,
     EthPrimitives, TransactionSigned,
 };


### PR DESCRIPTION
drop the stale SignerRecoverable import in examples/txpool-tracing/src/submit.rs keep the example free of dead code and avoid future unused-import warnings