### PR TITLE
chore(examples): trim unused imports in txpool tracing submit

### DIFF
--- a/examples/txpool-tracing/src/submit.rs
+++ b/examples/txpool-tracing/src/submit.rs
@@ -2,16 +2,12 @@
 #![allow(unused)]
 #![allow(clippy::too_many_arguments)]
 
-use alloy_network::{Ethereum, EthereumWallet, NetworkWallet, TransactionBuilder};
+use alloy_network::{Ethereum, EthereumWallet, NetworkWallet};
 use alloy_primitives::{Address, TxHash, U256};
 use futures_util::StreamExt;
 use reth_ethereum::{
     node::api::{FullNodeComponents, NodeTypes},
-    pool::{
-        AddedTransactionOutcome, PoolTransaction, TransactionEvent, TransactionOrigin,
-        TransactionPool,
-    },
-    primitives::SignerRecoverable,
+    pool::{AddedTransactionOutcome, TransactionEvent, TransactionOrigin},
     rpc::eth::primitives::TransactionRequest,
     EthPrimitives, TransactionSigned,
 };


### PR DESCRIPTION
remove unused alloy and reth transaction pool imports from the txpool tracing submit helper keep the example focused on the types it actually consumes