### PR TITLE
refactor(provider): explicit static file segment matches

### DIFF
--- a/crates/static-file/types/src/segment.rs
+++ b/crates/static-file/types/src/segment.rs
@@ -127,12 +127,18 @@ impl StaticFileSegment {
 
     /// Returns `true` if a segment row is linked to a transaction.
     pub const fn is_tx_based(&self) -> bool {
-        matches!(self, Self::Receipts | Self::Transactions)
+        match self {
+            Self::Receipts | Self::Transactions => true,
+            Self::Headers => false,
+        }
     }
 
     /// Returns `true` if a segment row is linked to a block.
     pub const fn is_block_based(&self) -> bool {
-        matches!(self, Self::Headers)
+        match self {
+            Self::Headers => true,
+            Self::Receipts | Self::Transactions => false,
+        }
     }
 }
 

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -1196,20 +1196,21 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                     // TODO(joshie): is_block_meta
                     writer.prune_headers(highest_static_file_block - checkpoint_block_number)?;
                 }
-                StaticFileSegment::Transactions => {
+                StaticFileSegment::Transactions | StaticFileSegment::Receipts => {
                     if let Some(block) = provider.block_body_indices(checkpoint_block_number)? {
                         // todo joshie: is querying block_body_indices a potential issue once bbi is
                         // moved to sf as well
                         let number = highest_static_file_entry - block.last_tx_num();
-                        writer.prune_transactions(number, checkpoint_block_number)?;
-                    }
-                }
-                StaticFileSegment::Receipts => {
-                    if let Some(block) = provider.block_body_indices(checkpoint_block_number)? {
-                        // todo joshie: is querying block_body_indices a potential issue once bbi is
-                        // moved to sf as well
-                        let number = highest_static_file_entry - block.last_tx_num();
-                        writer.prune_receipts(number, checkpoint_block_number)?;
+
+                        match segment {
+                            StaticFileSegment::Transactions => {
+                                writer.prune_transactions(number, checkpoint_block_number)?
+                            }
+                            StaticFileSegment::Receipts => {
+                                writer.prune_receipts(number, checkpoint_block_number)?
+                            }
+                            StaticFileSegment::Headers => unreachable!(),
+                        }
                     }
                 }
             }

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -1198,8 +1198,6 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                 }
                 StaticFileSegment::Transactions | StaticFileSegment::Receipts => {
                     if let Some(block) = provider.block_body_indices(checkpoint_block_number)? {
-                        // todo joshie: is querying block_body_indices a potential issue once bbi is
-                        // moved to sf as well
                         let number = highest_static_file_entry - block.last_tx_num();
 
                         match segment {

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -1191,17 +1191,26 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                 "Unwinding static file segment."
             );
             let mut writer = self.latest_writer(segment)?;
-            if segment.is_headers() {
-                // TODO(joshie): is_block_meta
-                writer.prune_headers(highest_static_file_block - checkpoint_block_number)?;
-            } else if let Some(block) = provider.block_body_indices(checkpoint_block_number)? {
-                // todo joshie: is querying block_body_indices a potential issue once bbi is moved
-                // to sf as well
-                let number = highest_static_file_entry - block.last_tx_num();
-                if segment.is_receipts() {
-                    writer.prune_receipts(number, checkpoint_block_number)?;
-                } else {
-                    writer.prune_transactions(number, checkpoint_block_number)?;
+            match segment {
+                StaticFileSegment::Headers => {
+                    // TODO(joshie): is_block_meta
+                    writer.prune_headers(highest_static_file_block - checkpoint_block_number)?;
+                }
+                StaticFileSegment::Transactions => {
+                    if let Some(block) = provider.block_body_indices(checkpoint_block_number)? {
+                        // todo joshie: is querying block_body_indices a potential issue once bbi is
+                        // moved to sf as well
+                        let number = highest_static_file_entry - block.last_tx_num();
+                        writer.prune_transactions(number, checkpoint_block_number)?;
+                    }
+                }
+                StaticFileSegment::Receipts => {
+                    if let Some(block) = provider.block_body_indices(checkpoint_block_number)? {
+                        // todo joshie: is querying block_body_indices a potential issue once bbi is
+                        // moved to sf as well
+                        let number = highest_static_file_entry - block.last_tx_num();
+                        writer.prune_receipts(number, checkpoint_block_number)?;
+                    }
                 }
             }
             writer.commit()?;


### PR DESCRIPTION
When adding new segments, it can be easy to miss these `if transactions { transaction } else { receipt }`, so I refactored them into an explicit matches over static file segment enum.