### PR TITLE
fix(stages): implement floor rounding for percentage in no_std mode

### DIFF
--- a/crates/stages/types/src/checkpoints.rs
+++ b/crates/stages/types/src/checkpoints.rs
@@ -328,7 +328,9 @@ impl EntitiesCheckpoint {
         // Truncate to 2 decimal places, rounding down so that 99.999% becomes 99.99% and not 100%.
         #[cfg(not(feature = "std"))]
         {
-            Some(format!("{:.2}%", (percentage * 100.0) / 100.0))
+            // Manual floor implementation using integer arithmetic for no_std
+            let scaled = (percentage * 100.0) as u64;
+            Some(format!("{:.2}%", scaled as f64 / 100.0))
         }
         #[cfg(feature = "std")]
         Some(format!("{:.2}%", (percentage * 100.0).floor() / 100.0))


### PR DESCRIPTION
The no_std implementation of fmt_percentage was missing floor rounding, causing values like 99.999% to display as 100.00% instead of 99.99%.

This adds integer-based floor rounding to match the std behavior.