### PR TITLE
fix: correct argument order in save_diff calls for invalid block hooks

### DIFF
--- a/crates/engine/invalid-block-hooks/src/witness.rs
+++ b/crates/engine/invalid-block-hooks/src/witness.rs
@@ -278,7 +278,7 @@ where
             let bundle_state_sorted = sort_bundle_state_for_comparison(re_executed_state);
             let output_state_sorted = sort_bundle_state_for_comparison(original_state);
             let filename = format!("{}.bundle_state.diff", block_prefix);
-            let diff_path = self.save_diff(filename, &bundle_state_sorted, &output_state_sorted)?;
+            let diff_path = self.save_diff(filename, &output_state_sorted, &bundle_state_sorted)?;
 
             warn!(
                 target: "engine::invalid_block_hooks::witness",
@@ -308,13 +308,13 @@ where
         if let Some((original_updates, original_root)) = trie_updates {
             if re_executed_root != original_root {
                 let filename = format!("{}.state_root.diff", block_prefix);
-                let diff_path = self.save_diff(filename, &re_executed_root, &original_root)?;
+                let diff_path = self.save_diff(filename, &original_root, &re_executed_root)?;
                 warn!(target: "engine::invalid_block_hooks::witness", ?original_root, ?re_executed_root, diff_path = %diff_path.display(), "State root mismatch after re-execution");
             }
 
             if re_executed_root != block.state_root() {
                 let filename = format!("{}.header_state_root.diff", block_prefix);
-                let diff_path = self.save_diff(filename, &re_executed_root, &block.state_root())?;
+                let diff_path = self.save_diff(filename, &block.state_root(), &re_executed_root)?;
                 warn!(target: "engine::invalid_block_hooks::witness", header_state_root=?block.state_root(), ?re_executed_root, diff_path = %diff_path.display(), "Re-executed state root does not match block state root");
             }
 


### PR DESCRIPTION
The save_diff function in witness.rs had its arguments backwards in 3 places.
The function signature expects (original, new) but we were passing (new, original).

This meant when debugging invalid blocks, the diff files would show changes going the wrong way - from the re-executed value back to the original, instead of from original to re-executed. Pretty confusing when you're trying to figure out what actually changed.

See lines 272-275 & 383: files named `.original.json` and `.re_executed.json` match their variables, but save_diff calls had them swapped.