### PR TITLE
feat(chains): add support for custom/ephemeral chains

### DIFF
--- a/bin/reth-bench-compare/src/cli.rs
+++ b/bin/reth-bench-compare/src/cli.rs
@@ -231,8 +231,8 @@ impl Args {
                 PathBuf::from(expanded.as_ref())
             }
             None => {
-                // Use the same logic as reth: <datadir>/<chain>/jwt.hex
-                let chain_path = self.datadir.clone().resolve_datadir(self.chain);
+                // Use chain-id/name based path (bench tool only has `Chain`)
+                let chain_path = self.datadir.clone().resolve_datadir_for_chain(self.chain);
                 chain_path.jwt()
             }
         }
@@ -240,7 +240,8 @@ impl Args {
 
     /// Get the resolved datadir path using the chain
     pub(crate) fn datadir_path(&self) -> PathBuf {
-        let chain_path = self.datadir.clone().resolve_datadir(self.chain);
+        // Use chain-id/name based path (bench tool only has `Chain`)
+        let chain_path = self.datadir.clone().resolve_datadir_for_chain(self.chain);
         chain_path.data_dir().to_path_buf()
     }
 

--- a/crates/chainspec/src/api.rs
+++ b/crates/chainspec/src/api.rs
@@ -1,5 +1,5 @@
 use crate::{ChainSpec, DepositContract};
-use alloc::{boxed::Box, vec::Vec};
+use alloc::{boxed::Box, string::String, vec::Vec};
 use alloy_chains::Chain;
 use alloy_eips::{calc_next_block_base_fee, eip1559::BaseFeeParams, eip7840::BlobParams};
 use alloy_genesis::Genesis;
@@ -17,6 +17,14 @@ pub trait EthChainSpec: Send + Sync + Unpin + Debug {
 
     /// Returns the [`Chain`] object this spec targets.
     fn chain(&self) -> Chain;
+
+    /// Returns the display name for this chain to be used in filesystem paths.
+    ///
+    /// Defaults to the chain's identifier or canonical name, e.g. "mainnet" or "17000".
+    /// Custom chain specs can override this to choose a stable, human-friendly name.
+    fn name(&self) -> String {
+        self.chain().to_string()
+    }
 
     /// Returns the chain id number
     fn chain_id(&self) -> u64 {

--- a/crates/cli/commands/src/common.rs
+++ b/crates/cli/commands/src/common.rs
@@ -66,7 +66,8 @@ impl<C: ChainSpecParser> EnvironmentArgs<C> {
     where
         C: ChainSpecParser<ChainSpec = N::ChainSpec>,
     {
-        let data_dir = self.datadir.clone().resolve_datadir(self.chain.chain());
+        // Use spec-aware naming for datadir (supports custom chain names)
+        let data_dir = self.datadir.clone().resolve_datadir(self.chain.as_ref());
         let db_path = data_dir.db();
         let sf_path = data_dir.static_files();
 

--- a/crates/cli/commands/src/db/mod.rs
+++ b/crates/cli/commands/src/db/mod.rs
@@ -70,7 +70,8 @@ macro_rules! db_ro_exec {
 impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C> {
     /// Execute `db` command
     pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec>>(self) -> eyre::Result<()> {
-        let data_dir = self.env.datadir.clone().resolve_datadir(self.env.chain.chain());
+        // Use spec-aware naming for db paths
+        let data_dir = self.env.datadir.clone().resolve_datadir(self.env.chain.as_ref());
         let db_path = data_dir.db();
         let static_files_path = data_dir.static_files();
         let exex_wal_path = data_dir.exex_wal();
@@ -191,6 +192,9 @@ mod tests {
             "stats",
         ])
         .unwrap();
-        assert_eq!(cmd.env.datadir.resolve_datadir(cmd.env.chain.chain).as_ref(), Path::new(&path));
+        assert_eq!(
+            cmd.env.datadir.resolve_datadir(cmd.env.chain.as_ref()).as_ref(),
+            Path::new(&path)
+        );
     }
 }

--- a/crates/cli/commands/src/download.rs
+++ b/crates/cli/commands/src/download.rs
@@ -131,7 +131,8 @@ pub struct DownloadCommand<C: ChainSpecParser> {
 
 impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> DownloadCommand<C> {
     pub async fn execute<N>(self) -> Result<()> {
-        let data_dir = self.env.datadir.resolve_datadir(self.env.chain.chain());
+        // Use spec-aware naming for snapshot download destination
+        let data_dir = self.env.datadir.resolve_datadir(self.env.chain.as_ref());
         fs::create_dir_all(&data_dir)?;
 
         let url = match self.url {

--- a/crates/cli/commands/src/export_era.rs
+++ b/crates/cli/commands/src/export_era.rs
@@ -56,7 +56,8 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> ExportEraC
             None => self
                 .env
                 .datadir
-                .resolve_datadir(self.env.chain.chain())
+                // Use spec-aware naming for default ERA1 export location
+                .resolve_datadir(self.env.chain.as_ref())
                 .data_dir()
                 .join(ERA1_EXPORT_FOLDER_NAME),
         };

--- a/crates/cli/commands/src/import_era.rs
+++ b/crates/cli/commands/src/import_era.rs
@@ -89,8 +89,9 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> ImportEraC
                 Some(url) => url,
                 None => self.env.chain.chain().kind().try_to_url()?,
             };
+            // Use spec-aware naming for default ERA import location
             let folder =
-                self.env.datadir.resolve_datadir(self.env.chain.chain()).data_dir().join("era");
+                self.env.datadir.resolve_datadir(self.env.chain.as_ref()).data_dir().join("era");
 
             fs::create_dir_all(&folder)?;
 

--- a/crates/cli/commands/src/node.rs
+++ b/crates/cli/commands/src/node.rs
@@ -314,7 +314,8 @@ mod tests {
         let cmd: NodeCommand<EthereumChainSpecParser> =
             NodeCommand::try_parse_args_from(["reth", "--config", "my/path/to/reth.toml"]).unwrap();
         // always store reth.toml in the data dir, not the chain specific data dir
-        let data_dir = cmd.datadir.resolve_datadir(cmd.chain.chain);
+        // Use spec-aware naming
+        let data_dir = cmd.datadir.resolve_datadir(cmd.chain.as_ref());
         let config_path = cmd.config.unwrap_or_else(|| data_dir.config());
         assert_eq!(config_path, Path::new("my/path/to/reth.toml"));
 
@@ -322,7 +323,8 @@ mod tests {
             NodeCommand::try_parse_args_from(["reth"]).unwrap();
 
         // always store reth.toml in the data dir, not the chain specific data dir
-        let data_dir = cmd.datadir.resolve_datadir(cmd.chain.chain);
+        // Use spec-aware naming
+        let data_dir = cmd.datadir.resolve_datadir(cmd.chain.as_ref());
         let config_path = cmd.config.clone().unwrap_or_else(|| data_dir.config());
         let end = format!("{}/reth.toml", SUPPORTED_CHAINS[0]);
         assert!(config_path.ends_with(end), "{:?}", cmd.config);
@@ -332,7 +334,8 @@ mod tests {
     fn parse_db_path() {
         let cmd: NodeCommand<EthereumChainSpecParser> =
             NodeCommand::try_parse_args_from(["reth"]).unwrap();
-        let data_dir = cmd.datadir.resolve_datadir(cmd.chain.chain);
+        // Use spec-aware naming
+        let data_dir = cmd.datadir.resolve_datadir(cmd.chain.as_ref());
 
         let db_path = data_dir.db();
         let end = format!("reth/{}/db", SUPPORTED_CHAINS[0]);
@@ -340,7 +343,8 @@ mod tests {
 
         let cmd: NodeCommand<EthereumChainSpecParser> =
             NodeCommand::try_parse_args_from(["reth", "--datadir", "my/custom/path"]).unwrap();
-        let data_dir = cmd.datadir.resolve_datadir(cmd.chain.chain);
+        // Use spec-aware naming
+        let data_dir = cmd.datadir.resolve_datadir(cmd.chain.as_ref());
 
         let db_path = data_dir.db();
         assert_eq!(db_path, Path::new("my/custom/path/db"));

--- a/crates/cli/commands/src/p2p/mod.rs
+++ b/crates/cli/commands/src/p2p/mod.rs
@@ -166,7 +166,8 @@ impl<C: ChainSpecParser> DownloadArgs<C> {
         C::ChainSpec: EthChainSpec + Hardforks + EthereumHardforks + Send + Sync + 'static,
         N: CliNodeTypes<ChainSpec = C::ChainSpec>,
     {
-        let data_dir = self.datadir.clone().resolve_datadir(self.chain.chain());
+        // Use spec-aware naming for default config location
+        let data_dir = self.datadir.clone().resolve_datadir(self.chain.as_ref());
         let config_path = self.config.clone().unwrap_or_else(|| data_dir.config());
 
         // Load configuration

--- a/crates/cli/commands/src/stage/dump/mod.rs
+++ b/crates/cli/commands/src/stage/dump/mod.rs
@@ -74,15 +74,17 @@ pub struct StageCommand {
 macro_rules! handle_stage {
     ($stage_fn:ident, $tool:expr, $command:expr) => {{
         let StageCommand { output_datadir, from, to, dry_run, .. } = $command;
+        // Use spec-aware naming for output datadir
         let output_datadir =
-            output_datadir.with_chain($tool.chain().chain(), DatadirArgs::default());
+            output_datadir.with_chain_spec($tool.chain().as_ref(), DatadirArgs::default());
         $stage_fn($tool, *from, *to, output_datadir, *dry_run).await?
     }};
 
     ($stage_fn:ident, $tool:expr, $command:expr, $executor:expr, $consensus:expr) => {{
         let StageCommand { output_datadir, from, to, dry_run, .. } = $command;
+        // Use spec-aware naming for output datadir
         let output_datadir =
-            output_datadir.with_chain($tool.chain().chain(), DatadirArgs::default());
+            output_datadir.with_chain_spec($tool.chain().as_ref(), DatadirArgs::default());
         $stage_fn($tool, *from, *to, output_datadir, *dry_run, $executor, $consensus).await?
     }};
 }

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -263,7 +263,7 @@ impl<DB, ChainSpec: EthChainSpec> NodeBuilder<DB, ChainSpec> {
         });
 
         let data_dir =
-            path.unwrap_or_chain_default(self.config.chain.chain(), self.config.datadir.clone());
+            path.unwrap_or_spec_default(self.config.chain.as_ref(), self.config.datadir.clone());
 
         let db = reth_db::test_utils::create_test_rw_db_with_path(data_dir.db());
 

--- a/crates/node/builder/src/launch/exex.rs
+++ b/crates/node/builder/src/launch/exex.rs
@@ -3,7 +3,6 @@
 use alloy_eips::{eip2124::Head, BlockNumHash};
 use futures::future;
 use reth_chain_state::ForkChoiceSubscriptions;
-use reth_chainspec::EthChainSpec;
 use reth_exex::{
     ExExContext, ExExHandle, ExExManager, ExExManagerHandle, ExExNotificationSource, Wal,
     DEFAULT_EXEX_MANAGER_CAPACITY,
@@ -51,12 +50,13 @@ impl<Node: FullNodeComponents + Clone> ExExLauncher<Node> {
         }
 
         info!(target: "reth::cli", "Loading ExEx Write-Ahead Log...");
+        // Use spec-aware naming for ExEx WAL location
         let exex_wal = Wal::new(
             config_container
                 .config
                 .datadir
                 .clone()
-                .resolve_datadir(config_container.config.chain.chain())
+                .resolve_datadir(config_container.config.chain.as_ref())
                 .exex_wal(),
         )?;
 

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -12,7 +12,7 @@ use alloy_rpc_types::engine::ClientVersionV1;
 use alloy_rpc_types_engine::ExecutionData;
 use jsonrpsee::{core::middleware::layer::Either, RpcModule};
 use reth_chain_state::CanonStateSubscriptions;
-use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks, Hardforks};
+use reth_chainspec::{ChainSpecProvider, EthereumHardforks, Hardforks};
 use reth_node_api::{
     AddOnsContext, BlockTy, EngineApiValidator, EngineTypes, FullNodeComponents, FullNodeTypes,
     NodeAddOns, NodeTypes, PayloadTypes, PayloadValidator, PrimitivesTy, TreeConfig,
@@ -1306,7 +1306,8 @@ where
         tree_config: TreeConfig,
     ) -> eyre::Result<Self::EngineValidator> {
         let validator = self.payload_validator_builder.build(ctx).await?;
-        let data_dir = ctx.config.datadir.clone().resolve_datadir(ctx.config.chain.chain());
+        // Use spec-aware naming for invalid block hook path
+        let data_dir = ctx.config.datadir.clone().resolve_datadir(ctx.config.chain.as_ref());
         let invalid_block_hook = ctx.create_invalid_block_hook(&data_dir).await?;
         Ok(BasicEngineValidator::new(
             ctx.node.provider().clone(),

--- a/crates/node/core/src/args/datadir_args.rs
+++ b/crates/node/core/src/args/datadir_args.rs
@@ -2,7 +2,7 @@
 
 use crate::dirs::{ChainPath, DataDirPath, MaybePlatformPath};
 use clap::Args;
-use reth_chainspec::Chain;
+use reth_chainspec::{Chain, EthChainSpec};
 use std::path::PathBuf;
 
 /// Parameters for datadir configuration
@@ -30,8 +30,18 @@ pub struct DatadirArgs {
 }
 
 impl DatadirArgs {
-    /// Resolves the final datadir path.
-    pub fn resolve_datadir(self, chain: Chain) -> ChainPath<DataDirPath> {
+    /// Resolves the final datadir path using the provided chainspec for naming.
+    ///
+    /// Honors `EthChainSpec::name()` for custom/ephemeral chains.
+    pub fn resolve_datadir<S: EthChainSpec + ?Sized>(self, spec: &S) -> ChainPath<DataDirPath> {
+        let datadir = self.datadir.clone();
+        datadir.unwrap_or_spec_default(spec, self)
+    }
+
+    /// Resolves the final datadir path for a chain identifier.
+    ///
+    /// Keeps behavior for callers that only have a `Chain`.
+    pub fn resolve_datadir_for_chain(self, chain: Chain) -> ChainPath<DataDirPath> {
         let datadir = self.datadir.clone();
         datadir.unwrap_or_chain_default(chain, self)
     }

--- a/crates/node/core/src/node_config.rs
+++ b/crates/node/core/src/node_config.rs
@@ -447,11 +447,14 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
     }
 
     /// Resolve the final datadir path.
+    ///
+    /// Uses chainspec-based naming (via `EthChainSpec::name()`), falling back to
+    /// the chain's canonical name or id for built-in chains.
     pub fn datadir(&self) -> ChainPath<DataDirPath>
     where
         ChainSpec: EthChainSpec,
     {
-        self.datadir.clone().resolve_datadir(self.chain.chain())
+        self.datadir.clone().resolve_datadir(self.chain.as_ref())
     }
 
     /// Load an application configuration from a specified path.

--- a/crates/optimism/node/tests/it/priority.rs
+++ b/crates/optimism/node/tests/it/priority.rs
@@ -128,7 +128,7 @@ async fn test_custom_block_priority_config() {
         config
             .datadir
             .datadir
-            .unwrap_or_chain_default(config.chain.chain(), config.datadir.clone())
+            .unwrap_or_spec_default(config.chain.as_ref(), config.datadir.clone())
             .db(),
     );
     let tasks = TaskManager::current();


### PR DESCRIPTION
### **Title**

Add spec-aware datadir naming via `EthChainSpec::name()`

### **Summary**

This PR introduces spec-aware datadir naming to support custom and ephemeral chains while preserving existing behavior for built-in chains.

* Adds `EthChainSpec::name()` with a default of `chain().to_string()` for human-friendly, stable directory naming.
* Updates `resolve_datadir` and related helpers to use `EthChainSpec` instead of plain `Chain`.
* Introduces `resolve_datadir_for_chain` for compatibility with existing chain-only call sites.
* Propagates spec-based naming across key modules and tests.

### **Why**

Allows custom or ephemeral networks not in `alloy-chains` to define meaningful datadir folder names instead of numeric chain IDs, improving clarity and usability.

### **Behavior**

* Built-in chains remain unchanged.
* Custom chains can override `name()` for stable folder naming.

### **Linked Issue**

Closes #19635