### PR TITLE
refactor(stages): use named structs for ExecInput returns

### DIFF
--- a/crates/stages/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/stages/src/stages/tx_lookup.rs
@@ -126,14 +126,14 @@ where
         );
 
         loop {
-            let (tx_range, block_range, is_final_range) =
+            let range_output =
                 input.next_block_range_with_transaction_threshold(provider, self.chunk_size)?;
 
-            let end_block = *block_range.end();
+            let end_block = *range_output.block_range.end();
 
-            info!(target: "sync::stages::transaction_lookup", ?tx_range, "Calculating transaction hashes");
+            info!(target: "sync::stages::transaction_lookup", tx_range = ?range_output.tx_range, "Calculating transaction hashes");
 
-            for (key, value) in provider.transaction_hashes_by_range(tx_range)? {
+            for (key, value) in provider.transaction_hashes_by_range(range_output.tx_range)? {
                 hash_collector.insert(key, value)?;
             }
 
@@ -142,7 +142,7 @@ where
                     .with_entities_stage_checkpoint(stage_checkpoint(provider)?),
             );
 
-            if is_final_range {
+            if range_output.is_final_range {
                 let append_only =
                     provider.count_entries::<tables::TransactionHashNumbers>()?.is_zero();
                 let mut txhash_cursor = provider


### PR DESCRIPTION
Introduces `BlockRangeOutput` and `TransactionRangeOutput` structs to replace confusing tuple return types in `ExecInput` methods.

Fixes #19684

cc @shekhirin