### PR TITLE
Clean up unused import in fs-util

### DIFF
--- a/crates/fs-util/src/lib.rs
+++ b/crates/fs-util/src/lib.rs
@@ -9,7 +9,7 @@
 use serde::{de::DeserializeOwned, Serialize};
 use std::{
     fs::{self, File, OpenOptions, ReadDir},
-    io::{self, BufWriter, Error, Write},
+    io::{self, BufWriter, Error},
     path::{Path, PathBuf},
 };
 


### PR DESCRIPTION
remove the unused std::io::Write import from crates/fs-util/src/lib.rs so the crate builds warning-free keep the remaining io, BufWriter, and Error imports that are still required