### PR TITLE
perf(ress): avoid unnecessary clone in on_block_bodies_request

### DIFF
--- a/crates/ress/protocol/src/connection.rs
+++ b/crates/ress/protocol/src/connection.rs
@@ -124,10 +124,11 @@ where
     }
 
     fn on_block_bodies_request(&self, request: Vec<B256>) -> Vec<BlockBody> {
-        match self.provider.block_bodies(request.clone()) {
+        let req_len = request.len();
+        match self.provider.block_bodies(request) {
             Ok(bodies) => bodies,
             Err(error) => {
-                trace!(target: "ress::net::connection", peer_id = %self.peer_id, ?request, %error, "error retrieving block bodies");
+                trace!(target: "ress::net::connection", peer_id = %self.peer_id, len = req_len, %error, "error retrieving block bodies");
                 Default::default()
             }
         }


### PR DESCRIPTION
This change removes the redundant clone in on_block_bodies_request by passing the owned Vec<B256> directly to provider.block_bodies, which already accepts ownership. This eliminates an avoidable allocation and copy on potentially large vectors without altering behavior. Since the request vector is moved into the provider call, the trace logging was adjusted to log only the request length rather than the moved value. No public API or protocol logic is affected, and the change is consistent with the provider’s signature and usage patterns elsewhere.