### PR TITLE
chore(cli): disable long read transaction for `db list` and pipeline

### DIFF
--- a/crates/cli/commands/src/db/list.rs
+++ b/crates/cli/commands/src/db/list.rs
@@ -3,7 +3,7 @@ use alloy_primitives::hex;
 use clap::Parser;
 use eyre::WrapErr;
 use reth_chainspec::EthereumHardforks;
-use reth_db::DatabaseEnv;
+use reth_db::{transaction::DbTx, DatabaseEnv};
 use reth_db_api::{database::Database, table::Table, RawValue, TableViewer, Tables};
 use reth_db_common::{DbTool, ListFilter};
 use reth_node_builder::{NodeTypes, NodeTypesWithDBAdapter};
@@ -96,6 +96,9 @@ impl<N: NodeTypes> TableViewer<()> for ListTableViewer<'_, N> {
 
     fn view<T: Table>(&self) -> Result<(), Self::Error> {
         self.tool.provider_factory.db_ref().view(|tx| {
+            // We may be using the tui for a long time
+            tx.disable_long_read_transaction_safety();
+
             let table_db = tx.inner.open_db(Some(self.args.table.name())).wrap_err("Could not open db.")?;
             let stats = tx.inner.db_stat(&table_db).wrap_err(format!("Could not find table: {}", self.args.table.name()))?;
             let total_entries = stats.entries();

--- a/crates/stages/api/src/pipeline/mod.rs
+++ b/crates/stages/api/src/pipeline/mod.rs
@@ -315,7 +315,8 @@ impl<N: ProviderNodeTypes> Pipeline<N> {
         // attempt to proceed with a finalized block which has been unwinded
         let _locked_sf_producer = self.static_file_producer.lock();
 
-        let mut provider_rw = self.provider_factory.database_provider_rw()?;
+        let mut provider_rw =
+            self.provider_factory.database_provider_rw()?.disable_long_read_transaction_safety();
 
         for stage in unwind_pipeline {
             let stage_id = stage.id();

--- a/crates/storage/db-api/src/database.rs
+++ b/crates/storage/db-api/src/database.rs
@@ -26,11 +26,11 @@ pub trait Database: Send + Sync + Debug {
     /// end of the execution.
     fn view<T, F>(&self, f: F) -> Result<T, DatabaseError>
     where
-        F: FnOnce(&Self::TX) -> T,
+        F: FnOnce(&mut Self::TX) -> T,
     {
-        let tx = self.tx()?;
+        let mut tx = self.tx()?;
 
-        let res = f(&tx);
+        let res = f(&mut tx);
         tx.commit()?;
 
         Ok(res)


### PR DESCRIPTION
Some of the stages (for example unwinding storage history) may hold a transaction for a long time, and `db list` currently times out in the middle of viewing, this disables long read tx safety for both 