### PR TITLE
chore(engine): add basic tx result information to execution spans

### DIFF
--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -82,9 +82,12 @@ impl EngineApiMetrics {
                 let tx = tx?;
                 let span =
                     debug_span!(target: "engine::tree", "execute tx", tx_hash=?tx.tx().tx_hash());
-                let _enter = span.enter();
+                let enter = span.entered();
                 trace!(target: "engine::tree", "Executing transaction");
-                executor.execute_transaction(tx)?;
+                let gas_used = executor.execute_transaction(tx)?;
+
+                // record the tx gas used
+                enter.record("gas_used", gas_used);
             }
             executor.finish().map(|(evm, result)| (evm.into_db(), result))
         };

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -452,7 +452,7 @@ where
                 .entered();
             txs.recv()
         } {
-            let _enter =
+            let enter =
                 debug_span!(target: "engine::tree::payload_processor::prewarm", "prewarm tx", index, tx_hash=%tx.tx().tx_hash())
                     .entered();
 
@@ -484,7 +484,11 @@ where
             };
             metrics.execution_duration.record(start.elapsed());
 
-            drop(_enter);
+            // record some basic information about the transactions
+            enter.record("gas_used", res.result.gas_used());
+            enter.record("is_success", res.result.is_success());
+
+            drop(enter);
 
             // If the task was cancelled, stop execution, send an empty result to notify the task,
             // and exit.


### PR DESCRIPTION
Adds result and gas used to prewarm tx spans, and adds gas used to the regular execution span