### PR TITLE
chore: remove redundant clone in exex subscription RPC setup

### DIFF
--- a/examples/exex-subscription/src/main.rs
+++ b/examples/exex-subscription/src/main.rs
@@ -1,8 +1,5 @@
-#![allow(dead_code)]
-
 //! An ExEx example that installs a new RPC subscription endpoint that emits storage changes for a
 //! requested address.
-#[allow(dead_code)]
 use alloy_primitives::{Address, U256};
 use futures::TryStreamExt;
 use jsonrpsee::{
@@ -167,8 +164,7 @@ async fn my_exex<Node: FullNodeComponents>(
 fn main() -> eyre::Result<()> {
     reth_ethereum::cli::Cli::parse_args().run(|builder, _| async move {
         let (subscriptions_tx, subscriptions_rx) = mpsc::unbounded_channel::<SubscriptionRequest>();
-
-        let rpc = StorageWatcherRpc::new(subscriptions_tx.clone());
+        let rpc = StorageWatcherRpc::new(subscriptions_tx);
 
         let handle: NodeHandleFor<EthereumNode> = builder
             .node(EthereumNode::default())


### PR DESCRIPTION
pass subscriptions_tx directly into StorageWatcherRpc::new instead of cloning behavior unchanged; avoids an extra UnboundedSender clone and keeps the example lean