### PR TITLE
fix(db-api): resolve test compilation errors

### DIFF
--- a/crates/storage/db-api/Cargo.toml
+++ b/crates/storage/db-api/Cargo.toml
@@ -51,6 +51,7 @@ proptest = { workspace = true, optional = true }
 # reth libs with arbitrary
 reth-codecs = { workspace = true, features = ["test-utils"] }
 
+alloy-primitives = { workspace = true, features = ["rand"] }
 rand.workspace = true
 
 test-fuzz.workspace = true

--- a/crates/storage/db-api/Cargo.toml
+++ b/crates/storage/db-api/Cargo.toml
@@ -50,6 +50,7 @@ proptest = { workspace = true, optional = true }
 [dev-dependencies]
 # reth libs with arbitrary
 reth-codecs = { workspace = true, features = ["test-utils"] }
+reth-db-models = { workspace = true, features = ["arbitrary"] }
 
 alloy-primitives = { workspace = true, features = ["rand"] }
 rand.workspace = true

--- a/crates/storage/db-api/src/models/mod.rs
+++ b/crates/storage/db-api/src/models/mod.rs
@@ -315,43 +315,7 @@ macro_rules! add_wrapper_struct {
 
 add_wrapper_struct!((U256, CompactU256));
 add_wrapper_struct!((u64, CompactU64));
-
-/// Wrapper struct for `ClientVersion` so it can use `StructFlags` from Compact, when used as pure
-/// table values.
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, Compact)]
-#[add_arbitrary_tests(compact)]
-pub struct CompactClientVersion(pub ClientVersion);
-
-impl From<ClientVersion> for CompactClientVersion {
-    fn from(value: ClientVersion) -> Self {
-        Self(value)
-    }
-}
-
-impl From<CompactClientVersion> for ClientVersion {
-    fn from(value: CompactClientVersion) -> Self {
-        value.0
-    }
-}
-
-impl std::ops::Deref for CompactClientVersion {
-    type Target = ClientVersion;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-#[cfg(any(test, feature = "arbitrary"))]
-impl<'a> arbitrary::Arbitrary<'a> for CompactClientVersion {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        Ok(Self(ClientVersion {
-            version: String::arbitrary(u)?,
-            git_sha: String::arbitrary(u)?,
-            build_timestamp: String::arbitrary(u)?,
-        }))
-    }
-}
+add_wrapper_struct!((ClientVersion, CompactClientVersion));
 
 #[cfg(test)]
 mod tests {

--- a/crates/storage/db-api/src/models/mod.rs
+++ b/crates/storage/db-api/src/models/mod.rs
@@ -315,7 +315,43 @@ macro_rules! add_wrapper_struct {
 
 add_wrapper_struct!((U256, CompactU256));
 add_wrapper_struct!((u64, CompactU64));
-add_wrapper_struct!((ClientVersion, CompactClientVersion));
+
+/// Wrapper struct for `ClientVersion` so it can use `StructFlags` from Compact, when used as pure
+/// table values.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, Compact)]
+#[add_arbitrary_tests(compact)]
+pub struct CompactClientVersion(pub ClientVersion);
+
+impl From<ClientVersion> for CompactClientVersion {
+    fn from(value: ClientVersion) -> Self {
+        Self(value)
+    }
+}
+
+impl From<CompactClientVersion> for ClientVersion {
+    fn from(value: CompactClientVersion) -> Self {
+        value.0
+    }
+}
+
+impl std::ops::Deref for CompactClientVersion {
+    type Target = ClientVersion;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[cfg(any(test, feature = "arbitrary"))]
+impl<'a> arbitrary::Arbitrary<'a> for CompactClientVersion {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Self(ClientVersion {
+            version: String::arbitrary(u)?,
+            git_sha: String::arbitrary(u)?,
+            build_timestamp: String::arbitrary(u)?,
+        }))
+    }
+}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Fixes compilation errors in reth-db-api tests by:

- Add alloy-primitives with "rand" feature to dev-dependencies to enable StorageKey::random() method in tests
- Implement manual Arbitrary trait for CompactClientVersion wrapper struct since ClientVersion has conditional Arbitrary implementation that canno be auto-derived through the wrapper macro

The errors were not caught by CI because unit tests in #[cfg(test)] modules are excluded from the test run configuration.