### PR TITLE
feat(trie): add worker availability metrics to proof tracing

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -417,6 +417,8 @@ impl MultiproofManager {
             proof_targets,
             true, // with_branch_node_masks
             Some(multi_added_removed_keys),
+            self.proof_worker_handle.available_storage_workers(),
+            self.proof_worker_handle.pending_storage_tasks(),
         );
 
         // Dispatch to storage worker
@@ -508,6 +510,8 @@ impl MultiproofManager {
                 hashed_state_update,
                 start,
             ),
+            available_account_workers: self.proof_worker_handle.available_account_workers(),
+            pending_account_tasks: self.proof_worker_handle.pending_account_tasks(),
         };
 
         if let Err(e) = self.proof_worker_handle.dispatch_account_multiproof(input) {

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -90,6 +90,8 @@ impl ParallelProof {
             target_slots,
             self.collect_branch_node_masks,
             self.multi_added_removed_keys.clone(),
+            self.proof_worker_handle.available_storage_workers(),
+            self.proof_worker_handle.pending_storage_tasks(),
         );
 
         self.proof_worker_handle
@@ -210,6 +212,8 @@ impl ParallelProof {
                 HashedPostState::default(),
                 account_multiproof_start_time,
             ),
+            available_account_workers: self.proof_worker_handle.available_account_workers(),
+            pending_account_tasks: self.proof_worker_handle.pending_account_tasks(),
         };
 
         self.proof_worker_handle


### PR DESCRIPTION
Adds `available_workers` and `pending_tasks` fields to storage and account proof trace spans to diagnose whether workers were idle during long-running proof tasks.