### PR TITLE
chore: remove redundant eth/68 NewPooledTransactionHashes length validation

### DIFF
--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -237,16 +237,6 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
                 self.try_emit_broadcast(PeerMessage::PooledTransactions(msg.into())).into()
             }
             EthMessage::NewPooledTransactionHashes68(msg) => {
-                if msg.hashes.len() != msg.types.len() || msg.hashes.len() != msg.sizes.len() {
-                    return OnIncomingMessageOutcome::BadMessage {
-                        error: EthStreamError::TransactionHashesInvalidLenOfFields {
-                            hashes_len: msg.hashes.len(),
-                            types_len: msg.types.len(),
-                            sizes_len: msg.sizes.len(),
-                        },
-                        message: EthMessage::NewPooledTransactionHashes68(msg),
-                    }
-                }
                 self.try_emit_broadcast(PeerMessage::PooledTransactions(msg.into())).into()
             }
             EthMessage::GetBlockHeaders(req) => {


### PR DESCRIPTION
This change removes a redundant and unreachable length validation for eth/68 NewPooledTransactionHashes in ActiveSession::on_incoming_message. Incoming messages are decoded via ProtocolMessage::decode_message which dispatches to NewPooledTransactionHashes68::decode; the decoder already enforces that hashes, types, and sizes vectors have equal lengths and returns an InvalidMessage error on mismatch. Because the stream yields either a decoded EthMessage or an EthStreamError, malformed payloads never reach on_incoming_message and are handled earlier by closing the connection. Removing the duplicate check simplifies the code path and avoids unnecessary work without changing behavior on invalid inputs.