### PR TITLE
docs: fixed dead Sentry link

### DIFF
--- a/docs/design/review.md
+++ b/docs/design/review.md
@@ -4,7 +4,7 @@ This document contains some of our research on how other codebases designed vari
 
 ## P2P
 
-* [`Sentry`](https://erigon.gitbook.io/docs/summary/fundamentals/modules/sentry), a pluggable p2p node following the [Erigon gRPC architecture](https://erigon.substack.com/p/current-status-of-silkworm-and-silkrpc):
+* [`Sentry`](https://docs.erigon.tech/fundamentals/modules/sentry), a pluggable p2p node following the [Erigon gRPC architecture](https://erigon.substack.com/p/current-status-of-silkworm-and-silkrpc):
     * [`vorot93`](https://github.com/vorot93/) first started by implementing a rust devp2p stack in [`devp2p`](https://github.com/vorot93/devp2p)
     * vorot93 then started work on sentry, using devp2p, to satisfy the erigon architecture of modular components connected with gRPC.
     * The code from rust-ethereum/devp2p was merged into sentry, and rust-ethereum/devp2p was archived


### PR DESCRIPTION
Hi! I fixed broken link in docs
<img width="761" height="415" alt="image" src="https://github.com/user-attachments/assets/9ad03dd2-dafe-4fce-b718-f72cc0020908" />
