### PR TITLE
chore(stateless): show wrapped error message

### DIFF
--- a/crates/stateless/src/validation.rs
+++ b/crates/stateless/src/validation.rs
@@ -52,7 +52,7 @@ pub enum StatelessValidationError {
     },
 
     /// Error during stateless block execution.
-    #[error("stateless block execution failed")]
+    #[error("stateless block execution failed: {0}")]
     StatelessExecutionFailed(String),
 
     /// Error during consensus validation of the block.


### PR DESCRIPTION
Long due error display format change to have more detailed reason why a stateless execution failed.