### PR TITLE
chore(stages): remove unused itertools import

### DIFF
--- a/crates/stages/stages/src/stages/index_account_history.rs
+++ b/crates/stages/stages/src/stages/index_account_history.rs
@@ -147,7 +147,6 @@ mod tests {
         TestStageDB, UnwindStageTestRunner,
     };
     use alloy_primitives::{address, BlockNumber, B256};
-    use itertools::Itertools;
     use reth_db_api::{
         cursor::DbCursorRO,
         models::{


### PR DESCRIPTION
drop the unused itertools import from the index_account_history test module