### PR TITLE
feat(bench): Disable log styling in reth-bench-compare sub-processes

### DIFF
--- a/bin/reth-bench-compare/src/benchmark.rs
+++ b/bin/reth-bench-compare/src/benchmark.rs
@@ -103,7 +103,8 @@ impl BenchmarkRunner {
             cmd.args(["--wait-time", wait_time]);
         }
 
-        cmd.stdout(std::process::Stdio::piped())
+        cmd.env("RUST_LOG_STYLE", "never")
+            .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
             .kill_on_drop(true);
 
@@ -190,7 +191,8 @@ impl BenchmarkRunner {
             cmd.args(["--wait-time", wait_time]);
         }
 
-        cmd.stdout(std::process::Stdio::piped())
+        cmd.env("RUST_LOG_STYLE", "never")
+            .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
             .kill_on_drop(true);
 

--- a/bin/reth-bench-compare/src/node.rs
+++ b/bin/reth-bench-compare/src/node.rs
@@ -203,6 +203,9 @@ impl NodeManager {
         cmd.arg("--");
         cmd.args(reth_args);
 
+        // Set environment variable to disable log styling
+        cmd.env("RUST_LOG_STYLE", "never");
+
         Ok(cmd)
     }
 
@@ -210,17 +213,22 @@ impl NodeManager {
     fn create_direct_command(&self, reth_args: &[String]) -> Command {
         let binary_path = &reth_args[0];
 
-        if self.use_sudo {
+        let mut cmd = if self.use_sudo {
             info!("Starting reth node with sudo...");
-            let mut cmd = Command::new("sudo");
-            cmd.args(reth_args);
-            cmd
+            let mut sudo_cmd = Command::new("sudo");
+            sudo_cmd.args(reth_args);
+            sudo_cmd
         } else {
             info!("Starting reth node...");
-            let mut cmd = Command::new(binary_path);
-            cmd.args(&reth_args[1..]); // Skip the binary path since it's the command
-            cmd
-        }
+            let mut reth_cmd = Command::new(binary_path);
+            reth_cmd.args(&reth_args[1..]); // Skip the binary path since it's the command
+            reth_cmd
+        };
+
+        // Set environment variable to disable log styling
+        cmd.env("RUST_LOG_STYLE", "never");
+
+        cmd
     }
 
     /// Start a reth node using the specified binary path and return the process handle
@@ -484,6 +492,9 @@ impl NodeManager {
         }
 
         cmd.args(["to-block", &block_number.to_string()]);
+
+        // Set environment variable to disable log styling
+        cmd.env("RUST_LOG_STYLE", "never");
 
         // Debug log the command
         debug!("Executing reth unwind command: {:?}", cmd);


### PR DESCRIPTION
When we spawn reth and reth-bench processes from reth-bench-compare the log styling gets mangled when passed through reth-bench-compare's logging. Better to just disable the styling.