### PR TITLE
feat: add more block meta to comparison

### DIFF
--- a/bin/reth-bench-compare/src/comparison.rs
+++ b/bin/reth-bench-compare/src/comparison.rs
@@ -38,6 +38,8 @@ pub(crate) struct CombinedLatencyRow {
     pub block_number: u64,
     pub gas_used: u64,
     pub new_payload_latency: u128,
+    pub block_gas_used: u64,
+    pub transaction_count: u64,
 }
 
 /// Total gas CSV row structure
@@ -92,6 +94,8 @@ pub(crate) struct ComparisonSummary {
 #[derive(Debug, Serialize)]
 pub(crate) struct BlockComparison {
     pub block_number: u64,
+    pub block_gas_used: u64,
+    pub block_transaction_count: u64,
     pub baseline_new_payload_latency: u128,
     pub feature_new_payload_latency: u128,
     pub new_payload_latency_change_percent: f64,
@@ -377,6 +381,8 @@ impl ComparisonGenerator {
                 };
 
                 let comparison = BlockComparison {
+                    block_gas_used: feature_row.block_gas_used,
+                    block_transaction_count: feature_row.transaction_count,
                     block_number: feature_row.block_number,
                     baseline_new_payload_latency: baseline_row.new_payload_latency,
                     feature_new_payload_latency: feature_row.new_payload_latency,

--- a/bin/reth-bench-compare/src/comparison.rs
+++ b/bin/reth-bench-compare/src/comparison.rs
@@ -36,10 +36,9 @@ pub(crate) struct BenchmarkResults {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub(crate) struct CombinedLatencyRow {
     pub block_number: u64,
+    pub transaction_count: u64,
     pub gas_used: u64,
     pub new_payload_latency: u128,
-    pub block_gas_used: u64,
-    pub transaction_count: u64,
 }
 
 /// Total gas CSV row structure
@@ -94,8 +93,8 @@ pub(crate) struct ComparisonSummary {
 #[derive(Debug, Serialize)]
 pub(crate) struct BlockComparison {
     pub block_number: u64,
-    pub block_gas_used: u64,
-    pub block_transaction_count: u64,
+    pub transaction_count: u64,
+    pub gas_used: u64,
     pub baseline_new_payload_latency: u128,
     pub feature_new_payload_latency: u128,
     pub new_payload_latency_change_percent: f64,
@@ -381,9 +380,9 @@ impl ComparisonGenerator {
                 };
 
                 let comparison = BlockComparison {
-                    block_gas_used: feature_row.block_gas_used,
-                    block_transaction_count: feature_row.transaction_count,
                     block_number: feature_row.block_number,
+                    transaction_count: feature_row.transaction_count,
+                    gas_used: feature_row.gas_used,
                     baseline_new_payload_latency: baseline_row.new_payload_latency,
                     feature_new_payload_latency: feature_row.new_payload_latency,
                     new_payload_latency_change_percent: calc_percent_change(

--- a/bin/reth-bench/src/bench/new_payload_only.rs
+++ b/bin/reth-bench/src/bench/new_payload_only.rs
@@ -72,19 +72,9 @@ impl Command {
                         break;
                     }
                 };
-                let header = block.header.clone();
-
-                let (version, params) = match block_to_new_payload(block, is_optimism) {
-                    Ok(result) => result,
-                    Err(e) => {
-                        tracing::error!("Failed to convert block to new payload: {e}");
-                        let _ = error_sender.send(e);
-                        break;
-                    }
-                };
 
                 next_block += 1;
-                if let Err(e) = sender.send((header, version, params)).await {
+                if let Err(e) = sender.send(block).await {
                     tracing::error!("Failed to send block data: {e}");
                     break;
                 }
@@ -96,22 +86,23 @@ impl Command {
         let total_benchmark_duration = Instant::now();
         let mut total_wait_time = Duration::ZERO;
 
-        while let Some((header, version, params)) = {
+        while let Some(block) = {
             let wait_start = Instant::now();
             let result = receiver.recv().await;
             total_wait_time += wait_start.elapsed();
             result
         } {
-            // just put gas used here
-            let gas_used = header.gas_used;
-
-            let block_number = header.number;
+            let block_number = block.header.number;
+            let transaction_count = block.transactions.len() as u64;
+            let gas_used = block.header.gas_used;
 
             debug!(
                 target: "reth-bench",
-                number=?header.number,
+                number=?block.header.number,
                 "Sending payload to engine",
             );
+
+            let (version, params) = block_to_new_payload(block, is_optimism)?;
 
             let start = Instant::now();
             call_new_payload(&auth_provider, version, params).await?;
@@ -124,7 +115,8 @@ impl Command {
             let current_duration = total_benchmark_duration.elapsed() - total_wait_time;
 
             // record the current result
-            let row = TotalGasRow { block_number, gas_used, time: current_duration };
+            let row =
+                TotalGasRow { block_number, transaction_count, gas_used, time: current_duration };
             results.push((row, new_payload_result));
         }
 


### PR DESCRIPTION
adds additional block context to comparison

```
{
  "timestamp": "20251113_183148",
  "baseline": {
    "ref_name": "main",
    "summary": {
      "total_blocks": 10,
      "total_gas_used": 319147680,
      "total_duration_ms": 2693,
      "avg_new_payload_latency_ms": 42.1011,
      "gas_per_second": 118510092.83327144,
      "blocks_per_second": 3.713330857779428,
      "min_block_number": 827446,
      "max_block_number": 827455
    },
    "start_timestamp": "2025-11-13T18:31:59.787119Z",
    "end_timestamp": "2025-11-13T18:32:03.386585Z"
  },
  "feature": {
    "ref_name": "main",
    "summary": {
      "total_blocks": 10,
      "total_gas_used": 319147680,
      "total_duration_ms": 2801,
      "avg_new_payload_latency_ms": 52.5659,
      "gas_per_second": 113940621.20671189,
      "blocks_per_second": 3.5701535166012137,
      "min_block_number": 827446,
      "max_block_number": 827455
    },
    "start_timestamp": "2025-11-13T18:32:11.278978Z",
    "end_timestamp": "2025-11-13T18:32:15.786110Z"
  },
  "comparison_summary": {
    "new_payload_latency_change_percent": 24.856357672364844,
    "gas_per_second_change_percent": -3.8557657979293105,
    "blocks_per_second_change_percent": -3.855765797929309
  },
  "per_block_comparisons": [
    {
      "block_number": 827446,
      "transaction_count": 7,
      "gas_used": 1579986,
      "baseline_new_payload_latency": 25975,
      "feature_new_payload_latency": 23100,
      "new_payload_latency_change_percent": -11.068334937439845
    },
...
```