### PR TITLE
fix(stateless): export stateless_validation function

### DIFF
--- a/crates/stateless/src/lib.rs
+++ b/crates/stateless/src/lib.rs
@@ -44,6 +44,8 @@ pub use recover_block::UncompressedPublicKey;
 #[doc(inline)]
 pub use trie::StatelessTrie;
 #[doc(inline)]
+pub use validation::stateless_validation;
+#[doc(inline)]
 pub use validation::stateless_validation_with_trie;
 
 /// Implementation of stateless validation


### PR DESCRIPTION
Export stateless_validation at crate level to match module documentation.

The documentation states that stateless_validation is the primary entry point, but it was only accessible via validation::stateless_validation. Now both stateless_validation and stateless_validation_with_trie are exported at the crate root for consistency.