### PR TITLE
docs: remove obsolete max_changesets documentation

### DIFF
--- a/crates/stages/types/src/execution.rs
+++ b/crates/stages/types/src/execution.rs
@@ -2,11 +2,8 @@ use core::time::Duration;
 
 /// The thresholds at which the execution stage writes state changes to the database.
 ///
-/// If either of the thresholds (`max_blocks` and `max_changes`) are hit, then the execution stage
-/// commits all pending changes to the database.
-///
-/// A third threshold, `max_changesets`, can be set to periodically write changesets to the
-/// current database transaction, which frees up memory.
+/// If any of the thresholds are hit, then the execution stage commits all pending changes
+/// to the database.
 #[derive(Debug, Clone)]
 pub struct ExecutionStageThresholds {
     /// The maximum number of blocks to execute before the execution stage commits.

--- a/crates/stages/types/src/execution.rs
+++ b/crates/stages/types/src/execution.rs
@@ -2,8 +2,8 @@ use core::time::Duration;
 
 /// The thresholds at which the execution stage writes state changes to the database.
 ///
-/// If any of the thresholds are hit, then the execution stage commits all pending changes
-/// to the database.
+/// If any of the thresholds (`max_blocks`, `max_changes`, `max_cumulative_gas`, or `max_duration`)
+/// are hit, then the execution stage commits all pending changes to the database.
 #[derive(Debug, Clone)]
 pub struct ExecutionStageThresholds {
     /// The maximum number of blocks to execute before the execution stage commits.


### PR DESCRIPTION
Remove outdated reference to max_changesets field from ExecutionStageThresholds docs.



The struct only has four thresholds: max_blocks, max_changes, max_cumulative_gas, and max_duration.