### PR TITLE
docs(stages): align stages.md with current pipeline and PoS semantics

### DIFF
--- a/docs/crates/stages.md
+++ b/docs/crates/stages.md
@@ -7,10 +7,10 @@ The `stages` lib plays a central role in syncing the node, maintaining state, up
 - SenderRecoveryStage
 - ExecutionStage
 - PruneSenderRecoveryStage (if pruning for sender recovery is enabled)
-- MerkleStage (Unwind)
+- MerkleUnwindStage
 - AccountHashingStage
 - StorageHashingStage
-- MerkleStage (Execution)
+- MerkleExecuteStage
 - MerkleChangeSets
 - TransactionLookupStage
 - IndexStorageHistoryStage
@@ -78,14 +78,13 @@ At the end of the `execute()` function, a familiar value is returned, `Ok(ExecOu
 
 <br>
 
-## MerkleStage
+## MerkleUnwindStage
 
-The `MerkleStage` handles the construction and updates of the Merkle Patricia trie, which is Ethereum's core data structure for storing state. This stage has two modes:
+The `MerkleUnwindStage` is responsible for unwinding the Merkle Patricia trie when reorgs occur or when there's a need to roll back state changes. This ensures the trie remains consistent with the chain's canonical history by reverting changes beyond the unwind point. It typically runs before the hashing stages to unwind trie state during reorgs or rollbacks.
 
-- Unwind (StageId::MerkleUnwind): runs before the hashing stages to unwind trie state during reorgs or rollbacks.
-- Execution (StageId::MerkleExecute): runs after `AccountHashingStage` and `StorageHashingStage` to build/update the state root.
+## MerkleExecuteStage
 
-It processes state changes from executed transactions and maintains the state root included in block headers.
+The `MerkleExecuteStage` runs after `AccountHashingStage` and `StorageHashingStage` and is responsible for constructing or updating the state root based on the latest hashed account and storage data. It processes state changes from executed transactions and maintains the state root included in block headers.
 
 <br>
 

--- a/docs/crates/stages.md
+++ b/docs/crates/stages.md
@@ -1,9 +1,25 @@
 # Stages
 
-The `stages` lib plays a central role in syncing the node, maintaining state, updating the database and more. The stages involved in the Reth pipeline are the `HeaderStage`, `BodyStage`, `SenderRecoveryStage`, and `ExecutionStage` (note that this list is non-exhaustive, and more pipeline stages will be added in the near future). Each of these stages is queued up and stored within the Reth pipeline.
+The `stages` lib plays a central role in syncing the node, maintaining state, updating the database and more. The stages involved in the Reth pipeline are queued up and stored within the Reth pipeline. In the default configuration, the pipeline runs the following stages in order:
+
+- HeaderStage
+- BodyStage
+- SenderRecoveryStage
+- ExecutionStage
+- PruneSenderRecoveryStage (if pruning for sender recovery is enabled)
+- MerkleStage (Unwind)
+- AccountHashingStage
+- StorageHashingStage
+- MerkleStage (Execution)
+- MerkleChangeSets
+- TransactionLookupStage
+- IndexStorageHistoryStage
+- IndexAccountHistoryStage
+- PruneStage (execute)
+- FinishStage
 
 
-When the node is first started, a new `Pipeline` is initialized and all of the stages are added into `Pipeline.stages`. Then, the `Pipeline::run` function is called, which starts the pipeline, executing all of the stages continuously in an infinite loop. This process syncs the chain, keeping everything up to date with the chain tip. 
+When the node is first started, a new `Pipeline` is initialized and all of the stages are added into `Pipeline.stages`. Then, the `Pipeline::run` function is called, which starts the pipeline, executing all of the stages continuously in an infinite loop. This process syncs the chain, keeping everything up to date with the chain tip.
 
 Each stage within the pipeline implements the `Stage` trait which provides function interfaces to get the stage id, execute the stage and unwind the changes to the database if there was an issue during the stage execution.
 
@@ -14,15 +30,13 @@ To get a better idea of what is happening at each part of the pipeline, let's wa
 
 ## HeaderStage
 
-<!-- TODO: Cross-link to eth/65 chapter when it's written -->
-The `HeaderStage` is responsible for syncing the block headers, validating the header integrity and writing the headers to the database. When the `execute()` function is called, the local head of the chain is updated to the most recent block height previously executed by the stage. At this point, the node status is also updated with that block's height, hash and total difficulty. These values are used during any new eth/65 handshakes. After updating the head, a stream is established with other peers in the network to sync the missing chain headers between the most recent state stored in the database and the chain tip. The `HeaderStage` contains a `downloader` attribute, which is a type that implements the `HeaderDownloader` trait. A `HeaderDownloader` is a `Stream` that returns batches of headers.
+The `HeaderStage` is responsible for syncing the block headers, validating the header integrity and writing the headers to storage. When the stage runs, it determines the sync gap between the local head and the tip, then downloads headers in reverse (from tip down to the local head) using a `HeaderDownloader` stream. Headers are buffered in ETL collectors and then written to static files and to `HeaderNumbers` in the database in a single step.
 
-The `HeaderStage` relies on the downloader stream to return the headers in descending order starting from the chain tip down to the latest block in the database. While other stages in the `Pipeline` start from the most recent block in the database up to the chain tip, the `HeaderStage` works in reverse to avoid [long-range attacks](https://messari.io/report/long-range-attack). When a node downloads headers in ascending order, it will not know if it is being subjected to a long-range attack until it reaches the most recent blocks. To combat this, the `HeaderStage` starts by getting the chain tip from the Consensus Layer, verifies the tip, and then walks backwards by the parent hash.
+The `HeaderStage` relies on the downloader stream to return the headers in descending order starting from the chain tip down to the latest block in the database. While other stages in the `Pipeline` start from the most recent block in the database up to the chain tip, the `HeaderStage` works in reverse to avoid [long-range attacks](https://messari.io/report/long-range-attack). When a node downloads headers in ascending order, it will not know if it is being subjected to a long-range attack until it reaches the most recent blocks. To combat this, the `HeaderStage` starts by getting the chain tip, verifies the tip, and then walks backwards by the parent hash.
 
-<!-- Not sure about this, how is it validated? -->
-Each header is then validated to ensure that it has the proper parent. Note that this is only a basic response validation, and the `HeaderDownloader` uses the `validate` method during the `stream`, so that each header is validated according to the consensus specification before the header is yielded from the stream. After this, each header is then written to the database. If a header is not valid or the stream encounters any other error, the error is propagated up through the stage execution, the changes to the database are unwound and the stage is resumed from the most recent valid state.
+Each header is validated to ensure it correctly attaches to its parent and conforms to consensus expectations by the downloader before it is yielded. After download, headers are written to storage. If a header is not valid or the stream encounters any other error, the error is propagated up through the stage execution, the changes to the database are unwound and the stage is resumed from the most recent valid state.
 
-This process continues until all of the headers have been downloaded and written to the database. Finally, the total difficulty of the chain's head is updated and the function returns `Ok(ExecOutput { stage_progress, done: true })`, signaling that the header sync has been completed successfully. 
+This process continues until all of the headers have been downloaded and written to storage. Finally, the function returns, for example: `Ok(ExecOutput { checkpoint: StageCheckpoint::new(last_header_number).with_headers_stage_checkpoint(...), done: true })`, signaling that the header sync has been completed successfully.
 
 <br>
 
@@ -36,9 +50,9 @@ The transactions root is a value that is calculated based on the transactions in
 
 When the `BodyStage` is looking at the headers to determine which block to download, it will skip the blocks where the `header.ommers_hash` and the `header.transaction_root` are empty, denoting that the block is empty as well.
 
-Once the `BodyStage` determines which block bodies to fetch, a new `bodies_stream` is created which downloads all of the bodies from the `starting_block`, up until the `target_block` is specified. Each time the `bodies_stream` yields a value, a `SealedBlock` is created using the block header, the ommers hash and the newly downloaded block body.
+Once the `BodyStage` determines which block bodies to fetch, a new `bodies_stream` is created which downloads all of the bodies from the `starting_block`, up until the `target_block` is specified. Each time the `bodies_stream` yields a value, a response is received indicating either an empty block or a full block body to be written.
 
-The new block is then pre-validated, checking that the ommers hash and transactions root in the block header are the same in the block body. Following a successful pre-validation, the `BodyStage` loops through each transaction in the `block.body`, adding the transaction to the database. This process is repeated for every downloaded block body, with the `BodyStage` returning `Ok(ExecOutput { stage_progress, done: true })` signaling it successfully completed. 
+The `BodyStage` writes the received block bodies to storage. Validation of block body correctness relative to headers is enforced by the downloader and later by execution/consensus. This process is repeated for every downloaded block body, with the `BodyStage` returning `Ok(ExecOutput { checkpoint: StageCheckpoint::new(highest_block).with_entities_stage_checkpoint(...), done: ... })` signaling progress/completion.
 
 <br>
 
@@ -50,7 +64,7 @@ In an [ECDSA (Elliptic Curve Digital Signature Algorithm) signature](https://wik
 
 The "r" is the x-coordinate of a point on the elliptic curve that is calculated as part of the signature process. The "s" is the s-value that is calculated during the signature process. It is derived from the private key and the message being signed. Lastly, the "v" is the "recovery value" that is used to recover the public key from the signature, which is derived from the signature and the message that was signed. Together, the "r", "s", and "v" values make up an ECDSA signature, and they are used to verify the authenticity of the signed transaction.
 
-Once the transaction signer has been recovered, the signer is then added to the database. This process is repeated for every transaction that was retrieved, and similarly to previous stages, `Ok(ExecOutput { stage_progress, done: true })` is returned to signal a successful completion of the stage.
+Once the transaction signer has been recovered, the signer is then added to the database. This process is repeated for every transaction that was retrieved, and similarly to previous stages, `Ok(ExecOutput { checkpoint: StageCheckpoint::new(end_block).with_entities_stage_checkpoint(...), done: ... })` is returned to signal a successful completion of the stage.
 
 <br>
 
@@ -58,15 +72,20 @@ Once the transaction signer has been recovered, the signer is then added to the 
 
 Finally, after all headers, bodies and senders are added to the database, the `ExecutionStage` starts to execute. This stage is responsible for executing all of the transactions and updating the state stored in the database.
 
-After all headers and their corresponding transactions have been executed, all of the resulting state changes are applied to the database, updating account balances, account bytecode and other state changes. After applying all of the execution state changes, if there was a block reward, it is applied to the validator's account. 
+After all headers and their corresponding transactions have been executed, all of the resulting state changes are applied to the database, updating account balances, account bytecode and other state changes. In post-Merge Ethereum, there is no inflationary block reward on the Execution Layer; fees/priority tips are handled within transaction execution.
 
-At the end of the `execute()` function, a familiar value is returned, `Ok(ExecOutput { stage_progress, done: true })` signaling a successful completion of the `ExecutionStage`.
+At the end of the `execute()` function, a familiar value is returned, `Ok(ExecOutput { checkpoint: StageCheckpoint::new(stage_progress).with_execution_stage_checkpoint(...), done: ... })` signaling a successful completion of the `ExecutionStage`.
 
 <br>
 
-## MerkleUnwindStage
+## MerkleStage
 
-The `MerkleUnwindStage` is responsible for unwinding the Merkle Patricia trie state when a reorg occurs or when there's a need to rollback state changes. This stage ensures that the state trie remains consistent with the chain's canonical history by reverting any state changes that need to be undone. It works closely with the `MerkleExecuteStage` to maintain state integrity.
+The `MerkleStage` handles the construction and updates of the Merkle Patricia trie, which is Ethereum's core data structure for storing state. This stage has two modes:
+
+- Unwind (StageId::MerkleUnwind): runs before the hashing stages to unwind trie state during reorgs or rollbacks.
+- Execution (StageId::MerkleExecute): runs after `AccountHashingStage` and `StorageHashingStage` to build/update the state root.
+
+It processes state changes from executed transactions and maintains the state root included in block headers.
 
 <br>
 
@@ -82,9 +101,9 @@ The `StorageHashingStage` is responsible for computing hashes of contract storag
 
 <br>
 
-## MerkleExecuteStage
+## MerkleChangeSets
 
-The `MerkleExecuteStage` handles the construction and updates of the Merkle Patricia trie, which is Ethereum's core data structure for storing state. This stage processes state changes from executed transactions and builds the corresponding branches in the state trie. It's responsible for maintaining the state root that's included in block headers.
+The `MerkleChangeSets` stage consolidates and finalizes Merkle-related change sets after the `MerkleStage` execution mode has run, ensuring consistent trie updates and checkpoints.
 
 <br>
 
@@ -106,6 +125,18 @@ The `IndexAccountHistoryStage` builds indices for account history, tracking how 
 
 <br>
 
+## PruneSenderRecoveryStage
+
+The `PruneSenderRecoveryStage` removes entries from `TransactionSenders` according to configured prune modes. It typically runs after `ExecutionStage` when pruning for sender recovery is enabled.
+
+<br>
+
+## PruneStage
+
+The `PruneStage` performs pruning for the configured segments (such as history tables) based on `PruneModes`. It runs after hashing/merkle and history indexing stages.
+
+<br>
+
 ## FinishStage
 
 The `FinishStage` is the final stage in the pipeline that performs cleanup and verification tasks. It ensures that all previous stages have been completed successfully and that the node's state is consistent. This stage may also update various metrics and status indicators to reflect the completion of a sync cycle.
@@ -116,4 +147,4 @@ The `FinishStage` is the final stage in the pipeline that performs cleanup and v
 
 Now that we have covered all of the stages that are currently included in the `Pipeline`, you know how the Reth client stays synced with the chain tip and updates the database with all of the new headers, bodies, senders and state changes. While this chapter provides an overview on how the pipeline stages work, the following chapters will dive deeper into the database, the networking stack and other exciting corners of the Reth codebase. Feel free to check out any parts of the codebase mentioned in this chapter, and when you are ready, the next chapter will dive into the `database`.
 
-[Next Chapter]()
+[Next Chapter](db.md)


### PR DESCRIPTION
- Unify Merkle docs to a single MerkleStage with modes (StageId::MerkleUnwind/StageId::MerkleExecute) instead of separate stages; add MerkleChangeSets.
- Add missing stages: PruneSenderRecoveryStage, PruneStage; clarify their placement and conditions (prune modes).
- Modernize HeaderStage section: remove eth/65 and total difficulty handshake text; describe reverse header download, ETL collectors, and single-step write.
- Correct BodyStage description: downloader provides BlockResponse; stage writes bodies; no explicit header/body root pre-validation here.
- Fix ExecutionStage for PoS: remove EL block reward statement; note post-exec consensus validation and state/receipts writes.
- Replace Ok(ExecOutput { stage_progress, … }) examples with checkpoint: StageCheckpoint { … } and appropriate unit checkpoints.
- Fix “Next Chapter” link to [Next Chapter](db.md).