### PR TITLE
perf: Optimize BatchTxProcessor buffer reuse to avoid repeated allocations

### DIFF
--- a/crates/transaction-pool/src/batcher.rs
+++ b/crates/transaction-pool/src/batcher.rs
@@ -60,7 +60,8 @@ where
     ) -> (Self, mpsc::UnboundedSender<BatchTxRequest<Pool::Transaction>>) {
         let (request_tx, request_rx) = mpsc::unbounded_channel();
 
-        let processor = Self { pool, max_batch_size, buf: Vec::with_capacity(1), request_rx };
+        let processor =
+            Self { pool, max_batch_size, buf: Vec::with_capacity(max_batch_size), request_rx };
 
         (processor, request_tx)
     }
@@ -103,12 +104,12 @@ where
             ready!(this.request_rx.poll_recv_many(cx, this.buf, *this.max_batch_size));
 
             if !this.buf.is_empty() {
-                let batch = std::mem::take(this.buf);
+                let mut batch = Vec::with_capacity(this.buf.len());
+                batch.extend(this.buf.drain(..));
                 let pool = this.pool.clone();
                 tokio::spawn(async move {
                     Self::process_batch(&pool, batch).await;
                 });
-                this.buf.reserve(1);
 
                 continue;
             }


### PR DESCRIPTION

Initialize the batcher’s receive buffer with max_batch_size and preserve its capacity across batches. Instead of taking and resetting the buffer each iteration, drain its contents into a temporary batch vector and spawn processing. This keeps the hot poll_recv_many path from reallocating repeatedly and aligns with high-throughput batching goals. Removed the ineffective reserve(1) which discouraged capacity reuse.