### PR TITLE
fix(rpc): debug_executionWitness can create incorrect outputs while node is syncing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10100,6 +10100,7 @@ dependencies = [
  "reth-db-api",
  "reth-engine-primitives",
  "reth-errors",
+ "reth-ethereum-consensus",
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-evm-ethereum",

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -40,6 +40,7 @@ reth-consensus.workspace = true
 reth-consensus-common.workspace = true
 reth-node-api.workspace = true
 reth-trie-common.workspace = true
+reth-ethereum-consensus.workspace = true
 
 # ethereum
 alloy-evm = { workspace = true, features = ["overrides"] }
@@ -63,7 +64,12 @@ alloy-rpc-types-txpool.workspace = true
 alloy-rpc-types-admin.workspace = true
 alloy-rpc-types-engine = { workspace = true, features = ["kzg"] }
 alloy-serde.workspace = true
-revm = { workspace = true, features = ["optional_block_gas_limit", "optional_eip3607", "optional_no_base_fee", "memory_limit"] }
+revm = { workspace = true, features = [
+    "optional_block_gas_limit",
+    "optional_eip3607",
+    "optional_no_base_fee",
+    "memory_limit",
+] }
 revm-primitives = { workspace = true, features = ["serde"] }
 
 # rpc


### PR DESCRIPTION
This PR adds an extra check to the `debug_executionWitness`-like RPCs to show that there seems to be currently a bug where the RPC returns invalid results while the node is syncing.

The coded added is simply checking the `output` from the block execution part against some basic consensus rules. As in, the re-execution of the block to generate the asked witness should clearly generate an `output` that checks against the `block`.

The way I found this problem was debuggin why some L1 block proving was failing which was very weird. It took me a while to figure out since I never expected the witness was wrong, but probably was in some other part of what I was doing.

The bug is quite easily reproducible with this change:
- Stop a synced node so gets behind or many blocks (say a couple of days, but prob also works with less)
- Spin up the node again so it starts syncing.
- Call the `debug_executionWitness` RPC every 5 seconds and at some point you'll see the RPC failing (thanks to the check that I added in this PR -- without the check it would simply return a wrong witness!)

Here are two outputs to show how things look like.

First, the failed curl call:
```
$ curl http://localhost:8545/rpc \
  -X POST -H "Accept-Encoding: gzip, deflate, br" \
  --compressed \
  -H "Content-Type: application/json" \
  --data '{"jsonrpc":"2.0","method":"debug_executionWitness","params":["latest"],"id":1}'
{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"block gas used mismatch: got 20073859, expected 21018836; gas spent by each transaction: [(0, 21000), (1, 241339), (2, 271219), (3, 301032), (4, 607976), (5, 691123), (6, 748087), (7, 805051), (8, 879127), (9, ...
```
This shows that the added `validate_block_post_execution` failed with a consensus mismatch with the used gas. This basically means that the block re-execution is acting in non-consistent data in the db.

At the same time these are the logs in the node when this happened:
```
2025-11-13T22:49:02.206392Z  INFO Received block from consensus engine number=23793363 hash=0x3a5b09feeadee3670c90f8edb871d142bcc359140aa1812b9b9a2c762d998aaa
2025-11-13T22:49:12.845125Z  INFO Received block from consensus engine number=23793364 hash=0x5a7fe54228254d11a075e41b20d062dc1dd0ad2b3531a949dbb838e9c968c83b
2025-11-13T22:49:17.551652Z  INFO Committed stage progress pipeline_stages=4/15 stage=Execution checkpoint=23761054 target=23793193 stage_progress=99.71%
2025-11-13T22:49:17.551688Z  INFO Preparing stage pipeline_stages=4/15 stage=Execution checkpoint=23761054 target=23793193
2025-11-13T22:49:17.551701Z  INFO Executing stage pipeline_stages=4/15 stage=Execution checkpoint=23761054 target=23793193
2025-11-13T22:49:24.032605Z  INFO Status connected_peers=12 stage=Execution checkpoint=23761054 target=23793193 stage_progress=99.71%
2025-11-13T22:49:24.698326Z  INFO Received block from consensus engine number=23793365 hash=0x7c7f1193d1690c45ad50125820c92a8c1eb866a0fef03c16a9a11d79f6874ec0
2025-11-13T22:49:27.601380Z  INFO Executed block range start=23761055 end=23761232 throughput="412.01Mgas/second"
2025-11-13T22:49:36.694123Z  INFO Received block from consensus engine number=23793366 hash=0x23fcfd68453fd2e4c574f35cb27124c46d3d78b2c66bd2ba90c15d5b4a5e1085
2025-11-13T22:49:37.636516Z  INFO Executed block range start=23761233 end=23761473 throughput="549.14Mgas/second"
2025-11-13T22:49:47.671481Z  INFO Executed block range start=23761474 end=23761681 throughput="489.54Mgas/second"
2025-11-13T22:49:49.032676Z  INFO Status connected_peers=12 stage=Execution checkpoint=23761054 target=23793193 stage_progress=99.71%
2025-11-13T22:49:49.892597Z  INFO Received block from consensus engine number=23793367 hash=0xc4e5949e1a28f875b4962b4a7bcc46b88e49ffcc7b128c5d8b88633af4e8fde9
2025-11-13T22:49:57.732353Z  INFO Executed block range start=23761682 end=23761915 throughput="524.73Mgas/second"
2025-11-13T22:50:00.459818Z  INFO Received block from consensus engine number=23793368 hash=0x6d46f32f14789f1e9b83ff801cfcee06d7933d4fbe6ccbf7ef4a001eb1562a64
2025-11-13T22:50:07.792780Z  INFO Executed block range start=23761916 end=23762142 throughput="521.34Mgas/second"
2025-11-13T22:50:14.033153Z  INFO Status connected_peers=12 stage=Execution checkpoint=23761054 target=23793193 stage_progress=99.71%
2025-11-13T22:50:14.240825Z  INFO Received block from consensus engine number=23793369 hash=0x9e67391d453796d4ea087a686328df3962e41898f0881a31b027ce9b6415fec1
2025-11-13T22:50:17.829410Z  INFO Executed block range start=23762143 end=23762354 throughput="524.64Mgas/second"
2025-11-13T22:50:24.910518Z  INFO Received block from consensus engine number=23793370 hash=0xba239e4184a7ba6f583f44ab82929cde96ffbb445d8c9d3aee40b8448680ebcd
2025-11-13T22:50:27.839883Z  INFO Executed block range start=23762355 end=23762609 throughput="555.43Mgas/second"
2025-11-13T22:50:37.733656Z  INFO Received block from consensus engine number=23793371 hash=0x27dcdf8c5ff9b859cba25113ad32e2b78349a6db6af4995681578e70cc1fe7ed
2025-11-13T22:50:37.867128Z  INFO Executed block range start=23762610 end=23762854 throughput="553.55Mgas/second"
2025-11-13T22:50:39.032593Z  INFO Status connected_peers=12 stage=Execution checkpoint=23761054 target=23793193 stage_progress=99.71%
2025-11-13T22:50:47.883933Z  INFO Executed block range start=23762855 end=23763086 throughput="530.24Mgas/second"
2025-11-13T22:50:49.981011Z  INFO Received block from consensus engine number=23793372 hash=0x655651de62cd4e076fd7611465c401a11a2ade4559a11488eb7822c38c7fc10c
2025-11-13T22:50:57.899575Z  INFO Executed block range start=23763087 end=23763311 throughput="517.24Mgas/second"
2025-11-13T22:51:00.918043Z  INFO Received block from consensus engine number=23793373 hash=0x7538e4ececadca0d81f57adf696f89eb913f53ed4499b588dc80f37191d761cb
2025-11-13T22:51:04.032846Z  INFO Status connected_peers=12 stage=Execution checkpoint=23761054 target=23793193 stage_progress=99.71%

```
_(Note: the logs are UTC and the other output is UTC-3)_
So this means that the problem seems to be happening while the node is in `stage pipeline_stages=4/15 stage=Execution`. Before this stage, the above curl was returning 200 without problem (mainly because `"latest"` had a fixed/consistent tip for the RPC).

What this PR is doing is just allowing the RPC to fail more safely under this situation -- clearly isn't targeting whatever underlying root of the problem is. Doing this check should be  pretty light, but worth saying can add a bit of (CPU) overhead. But honestly, I would feel much better the RPC failing than giving a wrong result which causes some cascading problems for L1 proving.

I'll leave this PR as draft mostly to get some feedback on how is the best way to proceed.  e.g. we could merge this PR and create a separate issue so the underlying problem can be further investigated. Also I think would be nice if someone can reproduce this problem with the steps I mentioned before.
