### PR TITLE
feat(bench-compare): add configurable OTLP trace queue size

### DIFF
--- a/bin/reth-bench-compare/src/cli.rs
+++ b/bin/reth-bench-compare/src/cli.rs
@@ -134,6 +134,16 @@ pub(crate) struct Args {
     #[command(flatten)]
     pub traces: TraceArgs,
 
+    /// Maximum queue size for OTLP Batch Span Processor (traces).
+    /// Higher values prevent trace drops when benchmarking many blocks.
+    #[arg(
+        long,
+        value_name = "OTLP_BUFFER_SIZE",
+        default_value = "32768",
+        help_heading = "Tracing"
+    )]
+    pub otlp_max_queue_size: usize,
+
     /// Additional arguments to pass to baseline reth node command
     ///
     /// Example: `--baseline-args "--debug.tip 0xabc..."`

--- a/bin/reth-bench-compare/src/node.rs
+++ b/bin/reth-bench-compare/src/node.rs
@@ -30,6 +30,7 @@ pub(crate) struct NodeManager {
     additional_reth_args: Vec<String>,
     comparison_dir: Option<PathBuf>,
     tracing_endpoint: Option<String>,
+    otlp_max_queue_size: usize,
 }
 
 impl NodeManager {
@@ -46,6 +47,7 @@ impl NodeManager {
             additional_reth_args: args.reth_args.clone(),
             comparison_dir: None,
             tracing_endpoint: args.traces.otlp.as_ref().map(|u| u.to_string()),
+            otlp_max_queue_size: args.otlp_max_queue_size,
         }
     }
 
@@ -259,8 +261,9 @@ impl NodeManager {
 
         // Set high queue size to prevent trace dropping during benchmarks
         if self.tracing_endpoint.is_some() {
-            cmd.env("OTEL_BLRP_MAX_QUEUE_SIZE", "10000");
-            // Set service name to differentiate baseline vs feature runs in Jaeger
+            cmd.env("OTEL_BSP_MAX_QUEUE_SIZE", self.otlp_max_queue_size.to_string()); // Traces
+            cmd.env("OTEL_BLRP_MAX_QUEUE_SIZE", "10000"); // Logs
+                                                          // Set service name to differentiate baseline vs feature runs in Jaeger
             cmd.env("OTEL_SERVICE_NAME", format!("reth-{}", ref_type));
         }
 

--- a/bin/reth-bench-compare/src/node.rs
+++ b/bin/reth-bench-compare/src/node.rs
@@ -263,6 +263,7 @@ impl NodeManager {
         if self.tracing_endpoint.is_some() {
             cmd.env("OTEL_BSP_MAX_QUEUE_SIZE", self.otlp_max_queue_size.to_string()); // Traces
             cmd.env("OTEL_BLRP_MAX_QUEUE_SIZE", "10000"); // Logs
+
             // Set service name to differentiate baseline vs feature runs in Jaeger
             cmd.env("OTEL_SERVICE_NAME", format!("reth-{}", ref_type));
         }

--- a/bin/reth-bench-compare/src/node.rs
+++ b/bin/reth-bench-compare/src/node.rs
@@ -263,7 +263,7 @@ impl NodeManager {
         if self.tracing_endpoint.is_some() {
             cmd.env("OTEL_BSP_MAX_QUEUE_SIZE", self.otlp_max_queue_size.to_string()); // Traces
             cmd.env("OTEL_BLRP_MAX_QUEUE_SIZE", "10000"); // Logs
-                                                          // Set service name to differentiate baseline vs feature runs in Jaeger
+            // Set service name to differentiate baseline vs feature runs in Jaeger
             cmd.env("OTEL_SERVICE_NAME", format!("reth-{}", ref_type));
         }
 


### PR DESCRIPTION
Motivation: trace loss issues observed where blocks were missing traces even for 10-30 block ranges.

**Summary**
- Fixes trace drops during benchmarks by setting `OTEL_BSP_MAX_QUEUE_SIZE` for spans as defaults (previously used `OTEL_BLRP_MAX_QUEUE_SIZE` which only affects logs).
- Adds `--otlp-max-queue-size` CLI flag with default 32768 to prevent span drops during intensive block processing.
