### PR TITLE
perf(persistence): improve write batch for HashedPostState & TrieUpdatesSorted

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -69,7 +69,8 @@ use reth_trie::{
         TrieCursorIter,
     },
     updates::{StorageTrieUpdatesSorted, TrieUpdatesSorted},
-    HashedPostState, HashedPostStateSorted, StoredNibbles, StoredNibblesSubKey, TrieChangeSetsEntry,
+    HashedPostState, HashedPostStateSorted, StoredNibbles, StoredNibblesSubKey,
+    TrieChangeSetsEntry,
 };
 use reth_trie_db::{
     DatabaseAccountTrieCursor, DatabaseStorageTrieCursor, DatabaseTrieCursorFactory,

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -335,7 +335,7 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
             self.write_trie_updates_sorted(&trie_updates_sorted)?;
         }
 
-        // batch insert hashes and intermediate merkle nodes
+        // batch insert hashes
         if !aggregated_hashed_state.is_empty() {
             self.write_hashed_state(&aggregated_hashed_state.into_sorted())?;
         }

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -307,6 +307,7 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
         debug!(target: "providers::db", block_count = %blocks.len(), "Writing blocks and execution data to storage");
 
         let mut aggregated_hashed_state = HashedPostState::default();
+        let mut aggregated_trie_updates_sorted = TrieUpdatesSorted::default();
 
         // TODO: Do performant / batched writes for each type of object
         // instead of a loop over all blocks,
@@ -314,7 +315,7 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
         //  * blocks
         //  * state
         //  * hashed state (already done)
-        //  * trie updates (cannot naively extend, need helper)
+        //  * trie updates sorted (already done)
         //  * indices (already done basically)
         // Insert the blocks
         for ExecutedBlock { recovered_block, execution_output, hashed_state, trie_updates } in
@@ -332,13 +333,16 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
             // sort trie updates and insert changesets
             let trie_updates_sorted = (*trie_updates).clone().into_sorted();
             self.write_trie_changesets(block_number, &trie_updates_sorted, None)?;
-            self.write_trie_updates_sorted(&trie_updates_sorted)?;
+            aggregated_trie_updates_sorted.extend_ref(&trie_updates_sorted);
         }
 
         // batch insert hashes
         if !aggregated_hashed_state.is_empty() {
             self.write_hashed_state(&aggregated_hashed_state.into_sorted())?;
         }
+
+        // batch write trie updates sorted
+        self.write_trie_updates_sorted(&aggregated_trie_updates_sorted)?;
 
         // update history indices
         self.update_history_indices(first_number..=last_block_number)?;


### PR DESCRIPTION
- Batch `HashedPostState` & `TrieUpdatesSorted`  in `save_blocks` to improve batch processing performance.

**Performance Results:**
- Tested on devnet with 60k TPS raw-transfer workload, with default config (engine.persistence-thresh-hold = 3):
  - Before: ~50ms per block → ~150ms total for 3 blocks
  - After: ~50ms total for 3 blocks (3x improvement)
Note: This assumes the number of accounts remains relatively stable across blocks, which aligns with typical production workloads.

Before: 
<img width="702" height="137" alt="image" src="https://github.com/user-attachments/assets/5e1bafe0-5d06-49f2-98a6-9297850fd391" />
*Note: p0.9 is sum of total time for all persist blocks, so it will be multiple by number of block need to persist 

After:

<img width="709" height="137" alt="image" src="https://github.com/user-attachments/assets/3e8b65bf-01a7-42d5-9bd9-38cda2050dae" />

Updated:

With --engine.persistence-threshold 6, so it need persist 7 blocks per interval:

For **TrieUpdatesSorted**:
<img width="1734" height="407" alt="Image" src="https://github.com/user-attachments/assets/aba342a2-db1c-4d14-b021-9347ea170a81" />

after:

<img width="1714" height="414" alt="Image" src="https://github.com/user-attachments/assets/712b5bc3-92e0-4aea-a1b4-c73dc31f1d73" />

- reduce from 125ms -> ~100ms

Note: If we use default config: flush 3 blocks interval, the diff is not much different
But this still a win if in case our persistence very slow, and it need persist tons of block to catch-up with the tip

