### PR TITLE
docs: add comprehensive documentation for NodeType enum

### DIFF
--- a/crates/ress/protocol/src/types.rs
+++ b/crates/ress/protocol/src/types.rs
@@ -1,7 +1,16 @@
 use alloy_primitives::bytes::{Buf, BufMut};
 use alloy_rlp::{Decodable, Encodable};
 
-/// Node type variant.
+/// Represents the type of node in the RESS protocol.
+///
+/// This enum is used during the handshake phase to identify whether a peer is a stateless
+/// or stateful node. The node type determines which connections are valid:
+/// - Stateless ↔ Stateless: valid
+/// - Stateless ↔ Stateful: valid
+/// - Stateful ↔ Stateful: invalid
+///
+/// Use [`is_valid_connection`](Self::is_valid_connection) to check if a connection between
+/// two node types is allowed.
 #[repr(u8)]
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]


### PR DESCRIPTION
Adds detailed documentation to the NodeType enum explaining its role in the RESS protocol handshake and connection validation rules. 
The documentation now matches the style used for other enums in the module and provides clear guidance on when to use is_valid_connection.