### PR TITLE
fix(bench-compare): fix CSV parser schema

### DIFF
--- a/bin/reth-bench-compare/src/comparison.rs
+++ b/bin/reth-bench-compare/src/comparison.rs
@@ -45,6 +45,7 @@ pub(crate) struct CombinedLatencyRow {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub(crate) struct TotalGasRow {
     pub block_number: u64,
+    pub transaction_count: u64,
     pub gas_used: u64,
     pub time: u128,
 }


### PR DESCRIPTION
Fixes CSV parsing errors when running reth bench compare

- Add missing transaction_count field to TotalGasRow
- Completes schema update from #19722

Error:
```
Failed to parse combined latency row in "./re│2025-11-14T00:22:44.149231Z  INFO Running benchmark u
th-bench-compare/results/20251114_055408/baseline/co│sing data from RPC URL: https://mainnet.base.org
mbined_latency.csv"
```