### PR TITLE
feat: Inline TransactionConditional in OpPooledTransaction to avoid heap allocation

### DIFF
--- a/crates/optimism/txpool/src/transaction.rs
+++ b/crates/optimism/txpool/src/transaction.rs
@@ -47,7 +47,7 @@ pub struct OpPooledTransaction<
     _pd: core::marker::PhantomData<Pooled>,
 
     /// Optional conditional attached to this transaction.
-    conditional: Option<Box<TransactionConditional>>,
+    conditional: Option<TransactionConditional>,
 
     /// Optional interop deadline attached to this transaction.
     interop: Arc<AtomicU64>,
@@ -86,18 +86,18 @@ impl<Cons: SignedTransaction, Pooled> OpPooledTransaction<Cons, Pooled> {
 
     /// Conditional setter.
     pub fn with_conditional(mut self, conditional: TransactionConditional) -> Self {
-        self.conditional = Some(Box::new(conditional));
+        self.conditional = Some(conditional);
         self
     }
 }
 
 impl<Cons, Pooled> MaybeConditionalTransaction for OpPooledTransaction<Cons, Pooled> {
     fn set_conditional(&mut self, conditional: TransactionConditional) {
-        self.conditional = Some(Box::new(conditional))
+        self.conditional = Some(conditional)
     }
 
     fn conditional(&self) -> Option<&TransactionConditional> {
-        self.conditional.as_deref()
+        self.conditional.as_ref()
     }
 }
 


### PR DESCRIPTION
Replace Option<Box<TransactionConditional>> with Option<TransactionConditional> in OpPooledTransaction and adjust setters/getters. Boxing was unnecessary because conditional is owned, accessed by &mut self on set, and read by reference for checks; no interior mutability or stable address is required. This removes a per-transaction heap allocation while preserving semantics and external API, contrasting with interop which intentionally uses Arc<AtomicU64> due to &self setter and shared state across clones.