### PR TITLE
docs: resolve broken intra-doc link in transactions module

### DIFF
--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -98,8 +98,6 @@ pub struct TransactionsHandle<N: NetworkPrimitives = EthNetworkPrimitives> {
     manager_tx: mpsc::UnboundedSender<TransactionsCommand<N>>,
 }
 
-/// Implementation of the `TransactionsHandle` API for use in testnet via type
-/// [`PeerHandle`](crate::test_utils::PeerHandle).
 impl<N: NetworkPrimitives> TransactionsHandle<N> {
     fn send(&self, cmd: TransactionsCommand<N>) {
         let _ = self.manager_tx.send(cmd);


### PR DESCRIPTION
Remove impl-level doc comment referencing test_utils module to maintainconsistency with other impl blocks in the file, which document individual methods rather than the impl block itself.

The comment also referenced feature-gated code (test_utils::PeerHandle),making it potentially confusing for users without the test-utils feature.