### PR TITLE
refactor(stages): empty transactions range

### DIFF
--- a/crates/stages/api/src/stage.rs
+++ b/crates/stages/api/src/stage.rs
@@ -355,11 +355,8 @@ mod tests {
 
             let range_output = exec_input
                 .next_block_range_with_transaction_threshold(&provider_factory, 10)
-                .unwrap()
                 .unwrap();
-            assert_eq!(range_output.tx_range, 0..0);
-            assert_eq!(range_output.block_range, 0..=0);
-            assert!(range_output.is_final_range);
+            assert!(range_output.is_none());
         }
 
         // With checkpoint at block 10, without transactions in static files
@@ -369,11 +366,8 @@ mod tests {
 
             let range_output = exec_input
                 .next_block_range_with_transaction_threshold(&provider_factory, 10)
-                .unwrap()
                 .unwrap();
-            assert_eq!(range_output.tx_range, 0..0);
-            assert_eq!(range_output.block_range, 0..=0);
-            assert!(range_output.is_final_range);
+            assert!(range_output.is_none());
         }
 
         // Without checkpoint, with transactions in static files starting from block 1

--- a/crates/stages/api/src/stage.rs
+++ b/crates/stages/api/src/stage.rs
@@ -86,6 +86,8 @@ impl ExecInput {
     /// Return the next block range determined the number of transactions within it.
     /// This function walks the block indices until either the end of the range is reached or
     /// the number of transactions exceeds the threshold.
+    ///
+    /// Returns [`None`] if no transactions are found for the current execution input.
     #[instrument(level = "debug", target = "sync::stages", skip(provider), ret)]
     pub fn next_block_range_with_transaction_threshold<Provider>(
         &self,

--- a/crates/stages/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/stages/src/stages/tx_lookup.rs
@@ -126,8 +126,15 @@ where
         );
 
         loop {
-            let range_output =
-                input.next_block_range_with_transaction_threshold(provider, self.chunk_size)?;
+            let Some(range_output) =
+                input.next_block_range_with_transaction_threshold(provider, self.chunk_size)?
+            else {
+                input.checkpoint = Some(
+                    StageCheckpoint::new(input.target())
+                        .with_entities_stage_checkpoint(stage_checkpoint(provider)?),
+                );
+                break;
+            };
 
             let end_block = *range_output.block_range.end();
 
@@ -143,41 +150,39 @@ where
             );
 
             if range_output.is_final_range {
-                let append_only =
-                    provider.count_entries::<tables::TransactionHashNumbers>()?.is_zero();
-                let mut txhash_cursor = provider
-                    .tx_ref()
-                    .cursor_write::<tables::RawTable<tables::TransactionHashNumbers>>()?;
-
-                let total_hashes = hash_collector.len();
-                let interval = (total_hashes / 10).max(1);
-                for (index, hash_to_number) in hash_collector.iter()?.enumerate() {
-                    let (hash, number) = hash_to_number?;
-                    if index > 0 && index.is_multiple_of(interval) {
-                        info!(
-                            target: "sync::stages::transaction_lookup",
-                            ?append_only,
-                            progress = %format!("{:.2}%", (index as f64 / total_hashes as f64) * 100.0),
-                            "Inserting hashes"
-                        );
-                    }
-
-                    let key = RawKey::<TxHash>::from_vec(hash);
-                    if append_only {
-                        txhash_cursor.append(key, &RawValue::<TxNumber>::from_vec(number))?
-                    } else {
-                        txhash_cursor.insert(key, &RawValue::<TxNumber>::from_vec(number))?
-                    }
-                }
-
-                trace!(target: "sync::stages::transaction_lookup",
-                    total_hashes,
-                    "Transaction hashes inserted"
-                );
-
                 break;
             }
         }
+
+        let append_only = provider.count_entries::<tables::TransactionHashNumbers>()?.is_zero();
+        let mut txhash_cursor =
+            provider.tx_ref().cursor_write::<tables::RawTable<tables::TransactionHashNumbers>>()?;
+
+        let total_hashes = hash_collector.len();
+        let interval = (total_hashes / 10).max(1);
+        for (index, hash_to_number) in hash_collector.iter()?.enumerate() {
+            let (hash, number) = hash_to_number?;
+            if index > 0 && index.is_multiple_of(interval) {
+                info!(
+                    target: "sync::stages::transaction_lookup",
+                    ?append_only,
+                    progress = %format!("{:.2}%", (index as f64 / total_hashes as f64) * 100.0),
+                    "Inserting hashes"
+                );
+            }
+
+            let key = RawKey::<TxHash>::from_vec(hash);
+            if append_only {
+                txhash_cursor.append(key, &RawValue::<TxNumber>::from_vec(number))?
+            } else {
+                txhash_cursor.insert(key, &RawValue::<TxNumber>::from_vec(number))?
+            }
+        }
+
+        trace!(target: "sync::stages::transaction_lookup",
+            total_hashes,
+            "Transaction hashes inserted"
+        );
 
         Ok(ExecOutput {
             checkpoint: StageCheckpoint::new(input.target())


### PR DESCRIPTION
Instead of relying on `tx_range.is_empty()`, return an explicit `None` that means that no tx range is available for the current input, and the checkpoint should be advanced all the way to the target block.