### PR TITLE
refactor(cli): db subcommands

### DIFF
--- a/crates/cli/commands/src/db/clear.rs
+++ b/crates/cli/commands/src/db/clear.rs
@@ -6,8 +6,9 @@ use reth_db_api::{
     transaction::{DbTx, DbTxMut},
     TableViewer, Tables,
 };
+use reth_db_common::DbTool;
 use reth_node_builder::NodeTypesWithDB;
-use reth_provider::{ProviderFactory, StaticFileProviderFactory};
+use reth_provider::StaticFileProviderFactory;
 use reth_static_file_types::StaticFileSegment;
 
 /// The arguments for the `reth db clear` command
@@ -19,16 +20,13 @@ pub struct Command {
 
 impl Command {
     /// Execute `db clear` command
-    pub fn execute<N: NodeTypesWithDB>(
-        self,
-        provider_factory: ProviderFactory<N>,
-    ) -> eyre::Result<()> {
+    pub fn execute<N: NodeTypesWithDB>(self, tool: &DbTool<N>) -> eyre::Result<()> {
         match self.subcommand {
             Subcommands::Mdbx { table } => {
-                table.view(&ClearViewer { db: provider_factory.db_ref() })?
+                table.view(&ClearViewer { db: tool.provider_factory.db_ref() })?
             }
             Subcommands::StaticFile { segment } => {
-                let static_file_provider = provider_factory.static_file_provider();
+                let static_file_provider = tool.provider_factory.static_file_provider();
                 let static_files = iter_static_files(static_file_provider.directory())?;
 
                 if let Some(segment_static_files) = static_files.get(&segment) {

--- a/crates/cli/commands/src/db/mod.rs
+++ b/crates/cli/commands/src/db/mod.rs
@@ -92,7 +92,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
         match self.command {
             // TODO: We'll need to add this on the DB trait.
             Subcommands::Stats(command) => {
-                let access_rights = if command.inconsistent {
+                let access_rights = if command.skip_consistency_checks {
                     AccessRights::RoInconsistent
                 } else {
                     AccessRights::RO

--- a/crates/cli/commands/src/db/mod.rs
+++ b/crates/cli/commands/src/db/mod.rs
@@ -60,10 +60,11 @@ pub enum Subcommands {
     Path,
 }
 
-/// `db_ro_exec` opens a database in read-only mode, and then execute with the provided command
-macro_rules! db_ro_exec {
-    ($env:expr, $tool:ident, $N:ident, $command:block) => {
-        let Environment { provider_factory, .. } = $env.init::<$N>(AccessRights::RO)?;
+/// Initializes a provider factory with specified access rights, and then execute with the provided
+/// command
+macro_rules! db_exec {
+    ($env:expr, $tool:ident, $N:ident, $access_rights:expr, $command:block) => {
+        let Environment { provider_factory, .. } = $env.init::<$N>($access_rights)?;
 
         let $tool = DbTool::new(provider_factory)?;
         $command;
@@ -91,27 +92,32 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
         match self.command {
             // TODO: We'll need to add this on the DB trait.
             Subcommands::Stats(command) => {
-                db_ro_exec!(self.env, tool, N, {
+                let access_rights = if command.inconsistent {
+                    AccessRights::RoInconsistent
+                } else {
+                    AccessRights::RO
+                };
+                db_exec!(self.env, tool, N, access_rights, {
                     command.execute(data_dir, &tool)?;
                 });
             }
             Subcommands::List(command) => {
-                db_ro_exec!(self.env, tool, N, {
+                db_exec!(self.env, tool, N, AccessRights::RO, {
                     command.execute(&tool)?;
                 });
             }
             Subcommands::Checksum(command) => {
-                db_ro_exec!(self.env, tool, N, {
+                db_exec!(self.env, tool, N, AccessRights::RO, {
                     command.execute(&tool)?;
                 });
             }
             Subcommands::Diff(command) => {
-                db_ro_exec!(self.env, tool, N, {
+                db_exec!(self.env, tool, N, AccessRights::RO, {
                     command.execute(&tool)?;
                 });
             }
             Subcommands::Get(command) => {
-                db_ro_exec!(self.env, tool, N, {
+                db_exec!(self.env, tool, N, AccessRights::RO, {
                     command.execute(&tool)?;
                 });
             }
@@ -133,21 +139,27 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
                     }
                 }
 
-                let Environment { provider_factory, .. } = self.env.init::<N>(AccessRights::RW)?;
-                let tool = DbTool::new(provider_factory)?;
-                tool.drop(db_path, static_files_path, exex_wal_path)?;
+                db_exec!(self.env, tool, N, AccessRights::RW, {
+                    tool.drop(db_path, static_files_path, exex_wal_path)?;
+                });
             }
             Subcommands::Clear(command) => {
-                let Environment { provider_factory, .. } = self.env.init::<N>(AccessRights::RW)?;
-                command.execute(provider_factory)?;
+                db_exec!(self.env, tool, N, AccessRights::RW, {
+                    command.execute(&tool)?;
+                });
             }
             Subcommands::RepairTrie(command) => {
                 let access_rights =
                     if command.dry_run { AccessRights::RO } else { AccessRights::RW };
-                let Environment { provider_factory, .. } = self.env.init::<N>(access_rights)?;
-                command.execute(provider_factory)?;
+                db_exec!(self.env, tool, N, access_rights, {
+                    command.execute(&tool)?;
+                });
             }
-            Subcommands::StaticFileHeader(command) => command.execute::<N, _>(self.env)?,
+            Subcommands::StaticFileHeader(command) => {
+                db_exec!(self.env, tool, N, AccessRights::RoInconsistent, {
+                    command.execute(&tool)?;
+                });
+            }
             Subcommands::Version => {
                 let local_db_version = match get_db_version(&db_path) {
                     Ok(version) => Some(version),

--- a/crates/cli/commands/src/db/stats.rs
+++ b/crates/cli/commands/src/db/stats.rs
@@ -20,7 +20,7 @@ use std::{sync::Arc, time::Duration};
 pub struct Command {
     /// Skip consistency checks for static files.
     #[arg(long, default_value_t = false)]
-    pub(crate) inconsistent: bool,
+    pub(crate) skip_consistency_checks: bool,
 
     /// Show only the total size for static files.
     #[arg(long, default_value_t = false)]

--- a/crates/cli/commands/src/db/stats.rs
+++ b/crates/cli/commands/src/db/stats.rs
@@ -18,6 +18,10 @@ use std::{sync::Arc, time::Duration};
 #[derive(Parser, Debug)]
 /// The arguments for the `reth db stats` command
 pub struct Command {
+    /// Skip consistency checks for static files.
+    #[arg(long, default_value_t = false)]
+    pub(crate) inconsistent: bool,
+
     /// Show only the total size for static files.
     #[arg(long, default_value_t = false)]
     detailed_sizes: bool,

--- a/docs/vocs/docs/pages/cli/reth/db/stats.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/stats.mdx
@@ -9,7 +9,7 @@ $ reth db stats --help
 Usage: reth db stats [OPTIONS]
 
 Options:
-      --inconsistent
+      --skip-consistency-checks
           Skip consistency checks for static files
 
       --detailed-sizes

--- a/docs/vocs/docs/pages/cli/reth/db/stats.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/stats.mdx
@@ -9,6 +9,9 @@ $ reth db stats --help
 Usage: reth db stats [OPTIONS]
 
 Options:
+      --inconsistent
+          Skip consistency checks for static files
+
       --detailed-sizes
           Show only the total size for static files
 


### PR DESCRIPTION
1. Uses `db_exec` macro for all types of `AccessRights`
2. Uses `AccessRights::RoInconsistent` in `reth db stats` if `--inconsistent` flag is provided.