### PR TITLE
chore: replace labels in Grafana dashboard for docker compose

### DIFF
--- a/etc/docker-compose.yml
+++ b/etc/docker-compose.yml
@@ -65,7 +65,8 @@ services:
     # 3. Run Grafana
     entrypoint: >
       sh -c "cp -r /etc/grafana/provisioning_temp/dashboards/. /etc/grafana/provisioning/dashboards &&
-             find /etc/grafana/provisioning/dashboards/ -name '*.json' -exec sed -i 's/$${DS_PROMETHEUS}/Prometheus/g' {} \+ &&
+             find /etc/grafana/provisioning/dashboards/ -name '*.json' -exec sed -i 's/$${datasource}/Prometheus/g' {} \+ &&
+             find /etc/grafana/provisioning/dashboards/ -name '*.json' -exec sed -i 's/$${VAR_INSTANCE_LABEL}/instance/g' {} \+ &&
              /run.sh"
 
 volumes:


### PR DESCRIPTION
We don't use `${DS_PROMETHEUS}` anymore, and instead rely on `${datasource}` that takes the datasource from selectable variable.

`VAR_INSTANCE_LABEL` needs to be replaced because it's a provisioned dashboard.