### PR TITLE
Remove dead_code allow from TrustedPeersResolver::set_interval

### DIFF
--- a/crates/net/network/src/trusted_peers_resolver.rs
+++ b/crates/net/network/src/trusted_peers_resolver.rs
@@ -28,7 +28,6 @@ impl TrustedPeersResolver {
     }
 
     /// Update the resolution interval (useful for testing purposes)
-    #[allow(dead_code)]
     pub fn set_interval(&mut self, interval: Interval) {
         self.interval = interval;
     }


### PR DESCRIPTION
drop the #[allow(dead_code)] attribute from TrustedPeersResolver::set_interval keep dead-code lint coverage intact while the method remains in use (e.g. resolver tests)