### PR TITLE
Update node_iter.rs

### DIFF
--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -336,12 +336,12 @@ mod tests {
     /// Calculate the branch node stored in the database by feeding the provided state to the hash
     /// builder and taking the trie updates.
     fn get_hash_builder_branch_nodes(
-        state: impl IntoIterator<Item = (Nibbles, Account)> + Clone,
+        state: impl IntoIterator<Item = (Nibbles, Account)>,
     ) -> HashMap<Nibbles, BranchNodeCompact> {
-        let mut hash_builder = HashBuilder::default().with_updates(true);
+        let state: Vec<_> = state.into_iter().collect();
 
         let mut prefix_set = PrefixSetMut::default();
-        prefix_set.extend_keys(state.clone().into_iter().map(|(nibbles, _)| nibbles));
+        prefix_set.extend_keys(state.iter().map(|(nibbles, _)| *nibbles));
         let walker = TrieWalker::<_>::state_trie(NoopAccountTrieCursor, prefix_set.freeze());
 
         let hashed_post_state = HashedPostState::default()


### PR DESCRIPTION
collect the state once inside get_hash_builder_branch_nodes, removing the unnecessary Clone constraint and avoiding repeated iteration/cloning, fix clippy’s clone_on_copy lint by dereferencing Nibbles instead of cloning
