### PR TITLE
fix(cli): always commit the unwind for stage run headers

### DIFF
--- a/crates/cli/commands/src/stage/run.rs
+++ b/crates/cli/commands/src/stage/run.rs
@@ -84,6 +84,9 @@ pub struct Command<C: ChainSpecParser> {
     /// Commits the changes in the database. WARNING: potentially destructive.
     ///
     /// Useful when you want to run diagnostics on the database.
+    ///
+    /// NOTE: This flag is currently required for the headers, bodies, and execution stages because
+    /// they use static files and must commit to properly unwind and run.
     // TODO: We should consider allowing to run hooks at the end of the stage run,
     // e.g. query the DB size, or any table data.
     #[arg(long, short)]
@@ -105,6 +108,14 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
         Comp: CliNodeComponents<N>,
         F: FnOnce(Arc<C::ChainSpec>) -> Comp,
     {
+        // Quit early if the stages requires a commit and `--commit` is not provided.
+        if self.requires_commit() && !self.commit {
+            return Err(eyre::eyre!(
+                "The stage {} requires overwriting existing static files and must commit, but `--commit` was not provided. Please pass `--commit` and try again.",
+                self.stage.to_string()
+            ));
+        }
+
         // Raise the fd limit of the process.
         // Does not do anything on windows.
         let _ = fdlimit::raise_fd_limit();
@@ -340,13 +351,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                     provider_rw.save_stage_checkpoint(unwind_stage.id(), checkpoint)?;
                 }
 
-                // NOTE: headers must be committed because headers cannot be written to if static
-                // file pruning is already queued.
-                //
-                // This also means that all `stage run header` commands commit for unwinding. This
-                // is because static files do not have transactions and we cannot change the view of
-                // headers without writing.
-                if self.commit || self.stage == StageEnum::Headers {
+                if self.commit {
                     provider_rw.commit()?;
                     provider_rw = provider_factory.database_provider_rw()?;
                 }
@@ -388,5 +393,14 @@ impl<C: ChainSpecParser> Command<C> {
     /// Returns the underlying chain being used to run this command
     pub fn chain_spec(&self) -> Option<&Arc<C::ChainSpec>> {
         Some(&self.env.chain)
+    }
+
+    /// Returns whether or not the configured stage requires committing.
+    ///
+    /// This is the case for stages that mainly modify static files, as there is no way to unwind
+    /// these stages without committing anyways. This is because static files do not have
+    /// transactions and we cannot change the view of headers without writing.
+    pub fn requires_commit(&self) -> bool {
+        matches!(self.stage, StageEnum::Headers | StageEnum::Bodies | StageEnum::Execution)
     }
 }

--- a/crates/cli/commands/src/stage/run.rs
+++ b/crates/cli/commands/src/stage/run.rs
@@ -340,7 +340,13 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                     provider_rw.save_stage_checkpoint(unwind_stage.id(), checkpoint)?;
                 }
 
-                if self.commit {
+                // NOTE: headers must be committed because headers cannot be written to if static
+                // file pruning is already queued.
+                //
+                // This also means that all `stage run header` commands commit for unwinding. This
+                // is because static files do not have transactions and we cannot change the view of
+                // headers without writing.
+                if self.commit || self.stage == StageEnum::Headers {
                     provider_rw.commit()?;
                     provider_rw = provider_factory.database_provider_rw()?;
                 }

--- a/docs/vocs/docs/pages/cli/reth/stage/run.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/run.mdx
@@ -127,6 +127,8 @@ Static Files:
 
           Useful when you want to run diagnostics on the database.
 
+          NOTE: This flag is currently required for the headers, bodies, and execution stages because they use static files and must commit to properly unwind and run.
+
       --checkpoints
           Save stage checkpoints
 


### PR DESCRIPTION
fixes https://github.com/paradigmxyz/reth/issues/19766

Static files do not have transactions and we cannot change our local view of headers in the provider without committing. This caused problems with `stage run headers` which first unwinds the headers stage, queueing a prune but not committing it. Then, when the stage tried to write headers, it noticed the queued prune, which caused `Pruning should be committed before appending or pruning more data`

This causes `stage run` to require `--commit` for the headers, bodies, and execution stage.