### PR TITLE
refactor: rename state_root span to await_state_root

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -478,7 +478,12 @@ impl<Tx, Err> PayloadHandle<Tx, Err> {
     /// # Panics
     ///
     /// If payload processing was started without background tasks.
-    #[instrument(level = "debug", target = "engine::tree::payload_processor", skip_all, name = "await_state_root")]
+    #[instrument(
+        level = "debug",
+        target = "engine::tree::payload_processor",
+        skip_all,
+        name = "await_state_root"
+    )]
     pub fn state_root(&mut self) -> Result<StateRootComputeOutcome, ParallelStateRootError> {
         self.state_root
             .take()

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -478,7 +478,7 @@ impl<Tx, Err> PayloadHandle<Tx, Err> {
     /// # Panics
     ///
     /// If payload processing was started without background tasks.
-    #[instrument(level = "debug", target = "engine::tree::payload_processor", skip_all)]
+    #[instrument(level = "debug", target = "engine::tree::payload_processor", skip_all, name = "await_state_root")]
     pub fn state_root(&mut self) -> Result<StateRootComputeOutcome, ParallelStateRootError> {
         self.state_root
             .take()


### PR DESCRIPTION
Small nit: It would be nice to rename the span to make it clear whats happening. 

<img width="573" height="488" alt="Screenshot 2025-11-14 at 08 11 32" src="https://github.com/user-attachments/assets/14b3254b-49b7-4023-897e-5979b21783f8" />
