### PR TITLE
fix(grafana): restore DS_PROMETHEUS placeholder replacement

### DIFF
--- a/etc/docker-compose.yml
+++ b/etc/docker-compose.yml
@@ -61,10 +61,11 @@ services:
       - ./grafana/datasources:/etc/grafana/provisioning/datasources
       - ./grafana/dashboards:/etc/grafana/provisioning_temp/dashboards
     # 1. Copy dashboards from temp directory to prevent modifying original host files
-    # 2. Replace Prometheus datasource placeholder with the actual name
+    # 2. Replace Prometheus datasource placeholders with the actual name
     # 3. Run Grafana
     entrypoint: >
       sh -c "cp -r /etc/grafana/provisioning_temp/dashboards/. /etc/grafana/provisioning/dashboards &&
+             find /etc/grafana/provisioning/dashboards/ -name '*.json' -exec sed -i 's/$${DS_PROMETHEUS}/Prometheus/g' {} \+ &&
              find /etc/grafana/provisioning/dashboards/ -name '*.json' -exec sed -i 's/$${datasource}/Prometheus/g' {} \+ &&
              find /etc/grafana/provisioning/dashboards/ -name '*.json' -exec sed -i 's/$${VAR_INSTANCE_LABEL}/instance/g' {} \+ &&
              /run.sh"


### PR DESCRIPTION
Adds back the `${DS_PROMETHEUS}` → `Prometheus` replacement that was removed in #19756. Four dashboard files (metrics-exporter, reth-discovery, reth-mempool, reth-state-growth) still use this placeholder and were broken without it.