### PR TITLE
refactor(stages): deduplicate stage validation in replace method

### DIFF
--- a/crates/stages/api/src/pipeline/set.rs
+++ b/crates/stages/api/src/pipeline/set.rs
@@ -110,10 +110,6 @@ impl<Provider> StageSetBuilder<Provider> {
     /// If the new stage has a different ID,
     /// it will maintain the original stage's position in the execution order.
     pub fn replace<S: Stage<Provider> + 'static>(mut self, stage_id: StageId, stage: S) -> Self {
-        self.stages
-            .get(&stage_id)
-            .unwrap_or_else(|| panic!("Stage does not exist in set: {stage_id}"));
-
         if stage.id() == stage_id {
             return self.set(stage);
         }


### PR DESCRIPTION
Found a redundant check in StageSetBuilder::replace that was validating stage existence twice.

The removed stages.get() check is unnecessary because when stage IDs match, the subsequent set() call does the exact same check again. When IDs differ, index_of() validates existence through the order vector, which is kept in sync with stages by design.
