### PR TITLE
fix(transaction-pool): mark TransactionEvent::Invalid as final

### DIFF
--- a/crates/transaction-pool/src/pool/events.rs
+++ b/crates/transaction-pool/src/pool/events.rs
@@ -83,7 +83,7 @@ impl TransactionEvent {
     /// Returns `true` if the event is final and no more events are expected for this transaction
     /// hash.
     pub const fn is_final(&self) -> bool {
-        matches!(self, Self::Replaced(_) | Self::Mined(_) | Self::Discarded)
+        matches!(self, Self::Replaced(_) | Self::Mined(_) | Self::Discarded | Self::Invalid)
     }
 }
 


### PR DESCRIPTION
This change updates TransactionEvent::is_final() to include Invalid as a terminal event. The transaction pool subscribes to per-hash events before validation in add_transaction_and_subscribe(), and when validation fails with Invalid, the per-hash broadcaster would stay in broadcasters_by_hash because Invalid was not considered final and no more events would follow. As a result, the sender entry could be retained indefinitely. Treating Invalid as final aligns with documentation that Invalid is “invalid indefinitely,” matches lifecycle expectations for transactions that never enter the pool, and ensures the per-hash broadcaster is cleaned up immediately after emitting Invalid, preventing resource leaks.