### PR TITLE
fix(net): use external ip for discv5 config

### DIFF
--- a/crates/cli/commands/src/p2p/bootnode.rs
+++ b/crates/cli/commands/src/p2p/bootnode.rs
@@ -60,7 +60,7 @@ impl Command {
         if self.v5 {
             info!("Starting discv5");
             let config = Config::builder(self.addr).build();
-            let (_discv5, updates, _local_enr_discv5) = Discv5::start(&sk, config).await?;
+            let (_discv5, updates) = Discv5::start(&sk, config).await?;
             discv5_updates = Some(updates);
         };
 

--- a/crates/ethereum/node/tests/e2e/rpc.rs
+++ b/crates/ethereum/node/tests/e2e/rpc.rs
@@ -24,7 +24,7 @@ use reth_rpc_api::servers::AdminApiServer;
 use reth_tasks::TaskManager;
 use std::{
     sync::Arc,
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 alloy_sol_types::sol! {
@@ -360,7 +360,7 @@ async fn test_admin_external_ip() -> eyre::Result<()> {
             NetworkArgs::default().with_nat_resolver(NatResolver::ExternalIp(external_ip)),
         )
         .with_unused_ports()
-        .with_rpc(RpcServerArgs::default().with_unused_ports().with_http().with_auth_ipc());
+        .with_rpc(RpcServerArgs::default().with_unused_ports().with_http());
 
     let NodeHandle { node, node_exit_future: _ } = NodeBuilder::new(node_config)
         .testing_node(exec)
@@ -369,8 +369,6 @@ async fn test_admin_external_ip() -> eyre::Result<()> {
         .await?;
 
     let api = node.add_ons_handle.admin_api();
-
-    tokio::time::sleep(Duration::from_secs(60)).await;
 
     let info = api.node_info().await.unwrap();
 

--- a/crates/ethereum/node/tests/e2e/rpc.rs
+++ b/crates/ethereum/node/tests/e2e/rpc.rs
@@ -1,5 +1,6 @@
 use crate::utils::eth_payload_attributes;
 use alloy_eips::{eip2718::Encodable2718, eip7910::EthConfig};
+use alloy_genesis::Genesis;
 use alloy_primitives::{Address, B256, U256};
 use alloy_provider::{network::EthereumWallet, Provider, ProviderBuilder, SendableTx};
 use alloy_rpc_types_beacon::relay::{
@@ -11,11 +12,19 @@ use alloy_rpc_types_eth::TransactionRequest;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use reth_chainspec::{ChainSpecBuilder, EthChainSpec, MAINNET};
 use reth_e2e_test_utils::setup_engine;
+use reth_network::types::NatResolver;
+use reth_node_builder::{NodeBuilder, NodeHandle};
+use reth_node_core::{
+    args::{NetworkArgs, RpcServerArgs},
+    node_config::NodeConfig,
+};
 use reth_node_ethereum::EthereumNode;
 use reth_payload_primitives::BuiltPayload;
+use reth_rpc_api::servers::AdminApiServer;
+use reth_tasks::TaskManager;
 use std::{
     sync::Arc,
-    time::{SystemTime, UNIX_EPOCH},
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 alloy_sol_types::sol! {
@@ -326,6 +335,46 @@ async fn test_eth_config() -> eyre::Result<()> {
     assert_eq!(config.last.unwrap().activation_time, osaka_timestamp);
     assert_eq!(config.current.activation_time, prague_timestamp);
     assert_eq!(config.next.unwrap().activation_time, osaka_timestamp);
+
+    Ok(())
+}
+
+// <https://github.com/paradigmxyz/reth/issues/19765>
+#[tokio::test]
+async fn test_admin_external_ip() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let exec = TaskManager::current();
+    let exec = exec.executor();
+
+    // Chain spec with test allocs
+    let genesis: Genesis = serde_json::from_str(include_str!("../assets/genesis.json")).unwrap();
+    let chain_spec =
+        Arc::new(ChainSpecBuilder::default().chain(MAINNET.chain).genesis(genesis).build());
+
+    let external_ip = "10.64.128.71".parse().unwrap();
+    // Node setup
+    let node_config = NodeConfig::test()
+        .with_chain(chain_spec)
+        .with_network(
+            NetworkArgs::default().with_nat_resolver(NatResolver::ExternalIp(external_ip)),
+        )
+        .with_unused_ports()
+        .with_rpc(RpcServerArgs::default().with_unused_ports().with_http().with_auth_ipc());
+
+    let NodeHandle { node, node_exit_future: _ } = NodeBuilder::new(node_config)
+        .testing_node(exec)
+        .node(EthereumNode::default())
+        .launch()
+        .await?;
+
+    let api = node.add_ons_handle.admin_api();
+
+    tokio::time::sleep(Duration::from_secs(60)).await;
+
+    let info = api.node_info().await.unwrap();
+
+    assert_eq!(info.ip, external_ip);
 
     Ok(())
 }

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -166,7 +166,7 @@ impl Discv5 {
     }
 
     /// The port the discv5 service is listening on.
-    pub fn local_port(&self) -> u16 {
+    pub const fn local_port(&self) -> u16 {
         self.local_node_record.udp_port
     }
 
@@ -717,12 +717,14 @@ mod test {
             fork_key: None,
             discovered_peer_filter: MustNotIncludeKeys::default(),
             metrics: Discv5Metrics::default(),
+            local_node_record: NodeRecord::new(
+                (Ipv4Addr::LOCALHOST, 30303).into(),
+                PeerId::random(),
+            ),
         }
     }
 
-    async fn start_discovery_node(
-        udp_port_discv5: u16,
-    ) -> (Discv5, mpsc::Receiver<discv5::Event>, NodeRecord) {
+    async fn start_discovery_node(udp_port_discv5: u16) -> (Discv5, mpsc::Receiver<discv5::Event>) {
         let secret_key = SecretKey::new(&mut thread_rng());
 
         let discv5_addr: SocketAddr = format!("127.0.0.1:{udp_port_discv5}").parse().unwrap();
@@ -743,11 +745,11 @@ mod test {
         // rig test
 
         // rig node_1
-        let (node_1, mut stream_1, _) = start_discovery_node(30344).await;
+        let (node_1, mut stream_1) = start_discovery_node(30344).await;
         let node_1_enr = node_1.with_discv5(|discv5| discv5.local_enr());
 
         // rig node_2
-        let (node_2, mut stream_2, _) = start_discovery_node(30355).await;
+        let (node_2, mut stream_2) = start_discovery_node(30355).await;
         let node_2_enr = node_2.with_discv5(|discv5| discv5.local_enr());
 
         trace!(target: "net::discv5::test",

--- a/crates/net/network/src/discovery.rs
+++ b/crates/net/network/src/discovery.rs
@@ -25,7 +25,7 @@ use std::{
 };
 use tokio::{sync::mpsc, task::JoinHandle};
 use tokio_stream::{wrappers::ReceiverStream, Stream};
-use tracing::trace;
+use tracing::{debug, trace};
 
 /// Default max capacity for cache of discovered peers.
 ///
@@ -95,12 +95,15 @@ impl Discovery {
             // spawn the service
             let discv4_service = discv4_service.spawn();
 
+            debug!(target:"net", ?discovery_v4_addr, "started discovery v4");
+
             Ok((Some(discv4), Some(discv4_updates), Some(discv4_service)))
         };
 
         let discv5_future = async {
             let Some(config) = discv5_config else { return Ok::<_, NetworkError>((None, None)) };
-            let (discv5, discv5_updates, _local_enr_discv5) = Discv5::start(&sk, config).await?;
+            let (discv5, discv5_updates) = Discv5::start(&sk, config).await?;
+            debug!(target:"net", discovery_v5_enr=? discv5.local_enr(), "started discovery v5");
             Ok((Some(discv5), Some(discv5_updates.into())))
         };
 

--- a/crates/net/network/src/lib.rs
+++ b/crates/net/network/src/lib.rs
@@ -175,6 +175,7 @@ pub use reth_network_p2p as p2p;
 
 /// re-export types crates
 pub mod types {
+    pub use reth_discv4::NatResolver;
     pub use reth_eth_wire_types::*;
     pub use reth_network_types::*;
 }

--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -238,16 +238,19 @@ impl<N: NetworkPrimitives> PeersInfo for NetworkHandle<N> {
         } else if let Some(discv5) = self.inner.discv5.as_ref() {
             // for disv5 we must check if we have an external ip configured
             if let Some(external) = self.inner.nat.and_then(|nat| nat.as_external_ip()) {
-                return NodeRecord::new((external, discv5.local_port()).into(), *self.peer_id());
+                NodeRecord::new((external, discv5.local_port()).into(), *self.peer_id())
+            } else {
+                // use the node record that discv5 tracks or use localhost
+                self.inner.discv5.as_ref().and_then(|d| d.node_record()).unwrap_or_else(|| {
+                    NodeRecord::new(
+                        (std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), discv5.local_port())
+                            .into(),
+                        *self.peer_id(),
+                    )
+                })
             }
-            // use the node record that discv5 tracks or use localhost
-            self.inner.discv5.as_ref().and_then(|d| d.node_record()).unwrap_or_else(|| {
-                NodeRecord::new(
-                    (std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), discv5.local_port())
-                        .into(),
-                    *self.peer_id(),
-                )
-            })
+            // also use the tcp port
+            .with_tcp_port(self.inner.listener_address.lock().port())
         } else {
             let external_ip = self.inner.nat.and_then(|nat| nat.as_external_ip());
 

--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -232,9 +232,22 @@ impl<N: NetworkPrimitives> PeersInfo for NetworkHandle<N> {
 
     fn local_node_record(&self) -> NodeRecord {
         if let Some(discv4) = &self.inner.discv4 {
+            // Note: the discv4 services uses the same `nat` so we can directly return the node
+            // record here
             discv4.node_record()
-        } else if let Some(record) = self.inner.discv5.as_ref().and_then(|d| d.node_record()) {
-            record
+        } else if let Some(discv5) = self.inner.discv5.as_ref() {
+            // for disv5 we must check if we have an external ip configured
+            if let Some(external) = self.inner.nat.and_then(|nat| nat.as_external_ip()) {
+                return NodeRecord::new((external, discv5.local_port()).into(), *self.peer_id());
+            }
+            // use the node record that discv5 tracks or use localhost
+            self.inner.discv5.as_ref().and_then(|d| d.node_record()).unwrap_or_else(|| {
+                NodeRecord::new(
+                    (std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), discv5.local_port())
+                        .into(),
+                    *self.peer_id(),
+                )
+            })
         } else {
             let external_ip = self.inner.nat.and_then(|nat| nat.as_external_ip());
 

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -23,7 +23,10 @@ use reth_node_core::{
     version::{version_metadata, CLIENT_CODE},
 };
 use reth_payload_builder::{PayloadBuilderHandle, PayloadStore};
-use reth_rpc::eth::{core::EthRpcConverterFor, DevSigner, EthApiTypes, FullEthApiServer};
+use reth_rpc::{
+    eth::{core::EthRpcConverterFor, DevSigner, EthApiTypes, FullEthApiServer},
+    AdminApi,
+};
 use reth_rpc_api::{eth::helpers::EthTransactions, IntoEngineApiRpcModule};
 use reth_rpc_builder::{
     auth::{AuthRpcModule, AuthServerHandle},
@@ -382,6 +385,21 @@ impl<Node: FullNodeComponents, EthApi: EthApiTypes> RpcHandle<Node, EthApi> {
         &self,
     ) -> &EventSender<ConsensusEngineEvent<<Node::Types as NodeTypes>::Primitives>> {
         &self.engine_events
+    }
+
+    /// Returns the `EthApi` instance of the rpc server.
+    pub fn eth_api(&self) -> &EthApi {
+        self.rpc_registry.registry.eth_api()
+    }
+
+    /// Returns an instance of the [`AdminApi`] for the rpc server.
+    pub fn admin_api(
+        &self,
+    ) -> AdminApi<Node::Network, <Node::Types as NodeTypes>::ChainSpec, Node::Pool>
+    where
+        <Node::Types as NodeTypes>::ChainSpec: EthereumHardforks,
+    {
+        self.rpc_registry.registry.admin_api()
     }
 }
 

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -388,7 +388,7 @@ impl<Node: FullNodeComponents, EthApi: EthApiTypes> RpcHandle<Node, EthApi> {
     }
 
     /// Returns the `EthApi` instance of the rpc server.
-    pub fn eth_api(&self) -> &EthApi {
+    pub const fn eth_api(&self) -> &EthApi {
         self.rpc_registry.registry.eth_api()
     }
 

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -354,6 +354,12 @@ impl NetworkArgs {
         self
     }
 
+    /// Configures the [`NatResolver`]
+    pub const fn with_nat_resolver(mut self, nat: NatResolver) -> Self {
+        self.nat = nat;
+        self
+    }
+
     /// Change networking port numbers based on the instance number, if provided.
     /// Ports are updated to `previous_value + instance - 1`
     ///

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -339,6 +339,12 @@ impl NetworkArgs {
         self.no_persist_peers.not().then_some(peers_file)
     }
 
+    /// Configures the [`DiscoveryArgs`].
+    pub const fn with_discovery(mut self, discovery: DiscoveryArgs) -> Self {
+        self.discovery = discovery;
+        self
+    }
+
     /// Sets the p2p port to zero, to allow the OS to assign a random unused port when
     /// the network components bind to a socket.
     pub const fn with_unused_p2p_port(mut self) -> Self {
@@ -608,6 +614,12 @@ impl DiscoveryArgs {
     /// discovery binds to the socket.
     pub const fn with_unused_discovery_port(mut self) -> Self {
         self.port = 0;
+        self
+    }
+
+    /// Set the discovery V5 port
+    pub const fn with_discv5_port(mut self, port: u16) -> Self {
+        self.discv5_port = port;
         self
     }
 

--- a/crates/node/core/src/node_config.rs
+++ b/crates/node/core/src/node_config.rs
@@ -237,6 +237,46 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
         self
     }
 
+    /// Set the [`ChainSpec`] for the node and converts the type to that chainid.
+    pub fn map_chain<C>(self, chain: impl Into<Arc<C>>) -> NodeConfig<C> {
+        let Self {
+            datadir,
+            config,
+            metrics,
+            instance,
+            network,
+            rpc,
+            txpool,
+            builder,
+            debug,
+            db,
+            dev,
+            pruning,
+            engine,
+            era,
+            static_files,
+            ..
+        } = self;
+        NodeConfig {
+            datadir,
+            config,
+            chain: chain.into(),
+            metrics,
+            instance,
+            network,
+            rpc,
+            txpool,
+            builder,
+            debug,
+            db,
+            dev,
+            pruning,
+            engine,
+            era,
+            static_files,
+        }
+    }
+
     /// Set the metrics address for the node
     pub fn with_metrics(mut self, metrics: MetricArgs) -> Self {
         self.metrics = metrics;

--- a/crates/optimism/node/tests/it/main.rs
+++ b/crates/optimism/node/tests/it/main.rs
@@ -4,4 +4,6 @@ mod builder;
 
 mod priority;
 
+mod rpc;
+
 const fn main() {}

--- a/crates/optimism/node/tests/it/rpc.rs
+++ b/crates/optimism/node/tests/it/rpc.rs
@@ -1,0 +1,41 @@
+//! RPC integration tests.
+
+use reth_network::types::NatResolver;
+use reth_node_builder::{NodeBuilder, NodeHandle};
+use reth_node_core::{
+    args::{NetworkArgs, RpcServerArgs},
+    node_config::NodeConfig,
+};
+use reth_optimism_chainspec::BASE_MAINNET;
+use reth_optimism_node::OpNode;
+use reth_rpc_api::servers::AdminApiServer;
+use reth_tasks::TaskManager;
+
+// <https://github.com/paradigmxyz/reth/issues/19765>
+#[tokio::test]
+async fn test_admin_external_ip() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let exec = TaskManager::current();
+    let exec = exec.executor();
+
+    let external_ip = "10.64.128.71".parse().unwrap();
+    // Node setup
+    let node_config = NodeConfig::test()
+        .map_chain(BASE_MAINNET.clone())
+        .with_network(
+            NetworkArgs::default().with_nat_resolver(NatResolver::ExternalIp(external_ip)),
+        )
+        .with_rpc(RpcServerArgs::default().with_unused_ports().with_http());
+
+    let NodeHandle { node, node_exit_future: _ } =
+        NodeBuilder::new(node_config).testing_node(exec).node(OpNode::default()).launch().await?;
+
+    let api = node.add_ons_handle.admin_api();
+
+    let info = api.node_info().await.unwrap();
+
+    assert_eq!(info.ip, external_ip);
+
+    Ok(())
+}


### PR DESCRIPTION
closes #19765

for discv5 we must check if there's an external ip configured

this also adds some additional functions that were useful for the tests