### PR TITLE
feat(flashblocks): Cache recent flashblocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9498,6 +9498,7 @@ dependencies = [
  "eyre",
  "futures-util",
  "metrics",
+ "op-alloy-consensus",
  "op-alloy-rpc-types-engine",
  "reth-chain-state",
  "reth-engine-primitives",

--- a/crates/optimism/flashblocks/Cargo.toml
+++ b/crates/optimism/flashblocks/Cargo.toml
@@ -57,3 +57,4 @@ derive_more.workspace = true
 [dev-dependencies]
 test-case.workspace = true
 alloy-consensus.workspace = true
+op-alloy-consensus.workspace = true

--- a/crates/optimism/flashblocks/Cargo.toml
+++ b/crates/optimism/flashblocks/Cargo.toml
@@ -34,7 +34,7 @@ alloy-rpc-types-engine = { workspace = true, features = ["serde"] }
 alloy-consensus.workspace = true
 
 # op-alloy
-op-alloy-rpc-types-engine.workspace = true
+op-alloy-rpc-types-engine = { workspace = true, features = ["k256"] }
 
 # io
 tokio.workspace = true

--- a/crates/optimism/flashblocks/src/cache.rs
+++ b/crates/optimism/flashblocks/src/cache.rs
@@ -1,0 +1,493 @@
+//! Sequence cache management for flashblocks.
+//!
+//! The `SequenceManager` maintains a ring buffer of recently completed flashblock sequences
+//! and intelligently selects which sequence to build based on the local chain tip.
+
+use crate::{
+    sequence::{FlashBlockPendingSequence, SequenceExecutionOutcome},
+    worker::BuildArgs,
+    FlashBlock, FlashBlockCompleteSequence, PendingFlashBlock,
+};
+use alloy_eips::eip2718::WithEncoded;
+use alloy_primitives::B256;
+use reth_primitives_traits::{NodePrimitives, Recovered, SignedTransaction};
+use reth_revm::cached::CachedReads;
+use ringbuffer::{AllocRingBuffer, RingBuffer};
+use tokio::sync::broadcast;
+use tracing::*;
+
+/// Maximum number of cached sequences in the ring buffer.
+const CACHE_SIZE: usize = 3;
+/// 200 ms flashblock time.
+pub(crate) const FLASHBLOCK_BLOCK_TIME: u64 = 200;
+
+/// Manages flashblock sequences with caching support.
+///
+/// This struct handles:
+/// - Tracking the current pending sequence
+/// - Caching completed sequences in a fixed-size ring buffer
+/// - Finding the best sequence to build based on local chain tip
+/// - Broadcasting completed sequences to subscribers
+#[derive(Debug)]
+pub(crate) struct SequenceManager {
+    /// Current pending sequence being built up from incoming flashblocks
+    pending: FlashBlockPendingSequence,
+    /// Ring buffer of recently completed sequences (FIFO, size 3)
+    completed_cache: AllocRingBuffer<FlashBlockCompleteSequence>,
+    /// Broadcast channel for completed sequences
+    block_broadcaster: broadcast::Sender<FlashBlockCompleteSequence>,
+    /// Whether to compute state roots when building blocks
+    compute_state_root: bool,
+}
+
+impl SequenceManager {
+    /// Creates a new sequence manager.
+    pub(crate) fn new(compute_state_root: bool) -> Self {
+        let (block_broadcaster, _) = broadcast::channel(128);
+        Self {
+            pending: FlashBlockPendingSequence::new(),
+            completed_cache: AllocRingBuffer::new(CACHE_SIZE),
+            block_broadcaster,
+            compute_state_root,
+        }
+    }
+
+    /// Returns the sender half of the flashblock sequence broadcast channel.
+    pub(crate) const fn block_sequence_broadcaster(
+        &self,
+    ) -> &broadcast::Sender<FlashBlockCompleteSequence> {
+        &self.block_broadcaster
+    }
+
+    /// Gets a subscriber to the flashblock sequences produced.
+    pub(crate) fn subscribe_block_sequence(&self) -> crate::FlashBlockCompleteSequenceRx {
+        self.block_broadcaster.subscribe()
+    }
+
+    /// Inserts a new flashblock into the pending sequence.
+    ///
+    /// When a flashblock with index 0 arrives (indicating a new block), the current
+    /// pending sequence is finalized, cached, and broadcast immediately. If the sequence
+    /// is later built on top of local tip, `on_build_complete()` will broadcast again
+    /// with computed `state_root`.
+    pub(crate) fn insert_flashblock(&mut self, flashblock: FlashBlock) -> eyre::Result<()> {
+        // If this starts a new block, finalize and cache the previous sequence BEFORE inserting
+        if flashblock.index == 0 && self.pending.count() > 0 {
+            let completed = self.pending.finalize()?;
+            let block_number = completed.block_number();
+            let parent_hash = completed.payload_base().parent_hash;
+
+            trace!(
+                target: "flashblocks",
+                block_number,
+                %parent_hash,
+                cache_size = self.completed_cache.len(),
+                "Caching completed flashblock sequence"
+            );
+
+            // Broadcast immediately to consensus client (even without state_root)
+            // This ensures sequences are forwarded during catch-up even if not buildable on tip.
+            // ConsensusClient checks execution_outcome and skips newPayload if state_root is zero.
+            if self.block_broadcaster.receiver_count() > 0 {
+                let _ = self.block_broadcaster.send(completed.clone());
+            }
+
+            // Add to cache (FIFO - oldest gets pushed out if full)
+            // If we later build this sequence, on_build_complete() will broadcast again with
+            // state_root
+            self.completed_cache.push(completed);
+        }
+
+        // Now insert the new flashblock
+        self.pending.insert(flashblock);
+        Ok(())
+    }
+
+    /// Returns the current pending sequence for inspection.
+    pub(crate) const fn pending(&self) -> &FlashBlockPendingSequence {
+        &self.pending
+    }
+
+    /// Finds the next sequence to build and returns ready-to-use `BuildArgs`.
+    ///
+    /// Priority order:
+    /// 1. Current pending sequence (if parent matches local tip)
+    /// 2. Cached sequence with exact parent match
+    ///
+    /// Returns None if nothing is buildable right now.
+    pub(crate) fn next_buildable_args<T: SignedTransaction>(
+        &self,
+        local_tip_hash: B256,
+        local_tip_timestamp: u64,
+    ) -> Option<BuildArgs<Vec<WithEncoded<Recovered<T>>>>> {
+        // Try to find a buildable sequence: (base, last_fb, flashblocks, cached_state, source_name)
+        let (base, last_flashblock, flashblocks, cached_state, source_name) =
+            // Priority 1: Try current pending sequence
+            if let Some(base) = self.pending.payload_base().filter(|b| b.parent_hash == local_tip_hash) {
+                let last_fb = self.pending.last_flashblock()?;
+                let flashblocks = self.pending.flashblocks().collect::<Vec<_>>();
+                let cached_state = self.pending.cached_reads().as_ref().map(|r| (base.parent_hash, r.clone()));
+                (base, last_fb, flashblocks, cached_state, "pending")
+            }
+            // Priority 2: Try cached sequence with exact parent match
+            else if let Some(cached) = self.completed_cache.iter().find(|c| c.payload_base().parent_hash == local_tip_hash) {
+                let base = cached.payload_base().clone();
+                let last_fb = cached.last();
+                let flashblocks = cached.iter().collect::<Vec<_>>();
+                let cached_state = None;
+                (base, last_fb, flashblocks, cached_state, "cached")
+            } else {
+                return None;
+            };
+
+        // Auto-detect when to compute state root: only if the builder didn't provide it (sent
+        // B256::ZERO) and we're near the expected final flashblock index.
+        //
+        // Background: Each block period receives multiple flashblocks at regular intervals.
+        // The sequencer sends an initial "base" flashblock at index 0 when a new block starts,
+        // then subsequent flashblocks are produced every FLASHBLOCK_BLOCK_TIME intervals (200ms).
+        //
+        // Examples with different block times:
+        // - Base (2s blocks):    expect 2000ms / 200ms = 10 intervals → Flashblocks: index 0 (base)
+        //   + indices 1-10 = potentially 11 total
+        //
+        // - Unichain (1s blocks): expect 1000ms / 200ms = 5 intervals → Flashblocks: index 0 (base)
+        //   + indices 1-5 = potentially 6 total
+        //
+        // Why compute at N-1 instead of N:
+        // 1. Timing variance in flashblock producing time may mean only N flashblocks were produced
+        //    instead of N+1 (missing the final one). Computing at N-1 ensures we get the state root
+        //    for most common cases.
+        //
+        // 2. The +1 case (index 0 base + N intervals): If all N+1 flashblocks do arrive, we'll
+        //    still calculate state root for flashblock N, which sacrifices a little performance but
+        //    still ensures correctness for common cases.
+        //
+        // Note: Pathological cases may result in fewer flashblocks than expected (e.g., builder
+        // downtime, flashblock execution exceeding timing budget). When this occurs, we won't
+        // compute the state root, causing FlashblockConsensusClient to lack precomputed state for
+        // engine_newPayload. This is safe: we still have op-node as backstop to maintain
+        // chain progression.
+        let block_time_ms = (base.timestamp - local_tip_timestamp) * 1000;
+        let expected_final_flashblock = block_time_ms / FLASHBLOCK_BLOCK_TIME;
+        let compute_state_root = self.compute_state_root &&
+            last_flashblock.diff.state_root.is_zero() &&
+            last_flashblock.index >= expected_final_flashblock.saturating_sub(1);
+
+        let transactions = self.recover_transactions(flashblocks.into_iter())?;
+
+        trace!(
+            target: "flashblocks",
+            block_number = base.block_number,
+            source = source_name,
+            flashblock_index = last_flashblock.index,
+            expected_final_flashblock,
+            compute_state_root_enabled = self.compute_state_root,
+            state_root_is_zero = last_flashblock.diff.state_root.is_zero(),
+            will_compute_state_root = compute_state_root,
+            "Building from flashblock sequence"
+        );
+
+        Some(BuildArgs {
+            base,
+            transactions,
+            cached_state,
+            last_flashblock_index: last_flashblock.index,
+            last_flashblock_hash: last_flashblock.diff.block_hash,
+            compute_state_root,
+        })
+    }
+
+    /// Recovers transactions from flashblocks lazily.
+    ///
+    /// This is done only when we actually need to build a sequence, avoiding wasted computation.
+    fn recover_transactions<'a, T: SignedTransaction>(
+        &self,
+        flashblocks: impl Iterator<Item = &'a FlashBlock>,
+    ) -> Option<Vec<WithEncoded<Recovered<T>>>> {
+        let mut transactions = Vec::new();
+
+        for flashblock in flashblocks {
+            for encoded in &flashblock.diff.transactions {
+                let tx = T::decode_2718_exact(encoded.as_ref()).ok()?;
+                let signer = tx.try_recover().ok()?;
+                transactions.push(WithEncoded::new(encoded.clone(), tx.with_signer(signer)));
+            }
+        }
+
+        Some(transactions)
+    }
+
+    /// Records the result of building a sequence and re-broadcasts with execution outcome.
+    ///
+    /// Updates execution outcome and cached reads. For cached sequences (already broadcast
+    /// once during finalize), this broadcasts again with the computed `state_root`, allowing
+    /// the consensus client to submit via `engine_newPayload`.
+    pub(crate) fn on_build_complete<N: NodePrimitives>(
+        &mut self,
+        parent_hash: B256,
+        result: Option<(PendingFlashBlock<N>, CachedReads)>,
+    ) {
+        let Some((computed_block, cached_reads)) = result else {
+            return;
+        };
+
+        // Extract execution outcome
+        let execution_outcome = computed_block.computed_state_root().map(|state_root| {
+            SequenceExecutionOutcome { block_hash: computed_block.block().hash(), state_root }
+        });
+
+        // Update pending sequence with execution results
+        if self.pending.payload_base().is_some_and(|base| base.parent_hash == parent_hash) {
+            self.pending.set_execution_outcome(execution_outcome);
+            self.pending.set_cached_reads(cached_reads);
+            trace!(
+                target: "flashblocks",
+                block_number = self.pending.block_number(),
+                has_computed_state_root = execution_outcome.is_some(),
+                "Updated pending sequence with build results"
+            );
+        }
+        // Check if this completed sequence in cache and broadcast with execution outcome
+        else if let Some(cached) =
+            self.completed_cache.iter_mut().find(|c| c.payload_base().parent_hash == parent_hash)
+        {
+            // Only re-broadcast if we computed new information (state_root was missing).
+            // If sequencer already provided state_root, we already broadcast in insert_flashblock,
+            // so skip re-broadcast to avoid duplicate FCU calls.
+            let needs_rebroadcast =
+                execution_outcome.is_some() && cached.execution_outcome().is_none();
+
+            cached.set_execution_outcome(execution_outcome);
+
+            if needs_rebroadcast && self.block_broadcaster.receiver_count() > 0 {
+                trace!(
+                    target: "flashblocks",
+                    block_number = cached.block_number(),
+                    "Re-broadcasting sequence with computed state_root"
+                );
+                let _ = self.block_broadcaster.send(cached.clone());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::TestFlashBlockFactory;
+    use alloy_primitives::B256;
+    use op_alloy_consensus::OpTxEnvelope;
+
+    #[test]
+    fn test_sequence_manager_new() {
+        let manager = SequenceManager::new(true);
+        assert_eq!(manager.pending().count(), 0);
+    }
+
+    #[test]
+    fn test_insert_flashblock_creates_pending_sequence() {
+        let mut manager = SequenceManager::new(true);
+        let factory = TestFlashBlockFactory::new();
+
+        let fb0 = factory.flashblock_at(0).build();
+        manager.insert_flashblock(fb0).unwrap();
+
+        assert_eq!(manager.pending().count(), 1);
+        assert_eq!(manager.pending().block_number(), Some(100));
+    }
+
+    #[test]
+    fn test_insert_flashblock_caches_completed_sequence() {
+        let mut manager = SequenceManager::new(true);
+        let factory = TestFlashBlockFactory::new();
+
+        // Build first sequence
+        let fb0 = factory.flashblock_at(0).build();
+        manager.insert_flashblock(fb0.clone()).unwrap();
+
+        let fb1 = factory.flashblock_after(&fb0).build();
+        manager.insert_flashblock(fb1).unwrap();
+
+        // Insert new base (index 0) which should finalize and cache previous sequence
+        let fb2 = factory.flashblock_for_next_block(&fb0).build();
+        manager.insert_flashblock(fb2).unwrap();
+
+        // New sequence should be pending
+        assert_eq!(manager.pending().count(), 1);
+        assert_eq!(manager.pending().block_number(), Some(101));
+        assert_eq!(manager.completed_cache.len(), 1);
+        assert_eq!(manager.completed_cache.get(0).unwrap().block_number(), 100);
+    }
+
+    #[test]
+    fn test_next_buildable_args_returns_none_when_empty() {
+        let manager = SequenceManager::new(true);
+        let local_tip_hash = B256::random();
+        let local_tip_timestamp = 1000;
+
+        let args = manager.next_buildable_args::<OpTxEnvelope>(local_tip_hash, local_tip_timestamp);
+        assert!(args.is_none());
+    }
+
+    #[test]
+    fn test_next_buildable_args_matches_pending_parent() {
+        let mut manager = SequenceManager::new(true);
+        let factory = TestFlashBlockFactory::new();
+
+        let fb0 = factory.flashblock_at(0).build();
+        let parent_hash = fb0.base.as_ref().unwrap().parent_hash;
+        manager.insert_flashblock(fb0).unwrap();
+
+        let args = manager.next_buildable_args::<OpTxEnvelope>(parent_hash, 1000000);
+        assert!(args.is_some());
+
+        let build_args = args.unwrap();
+        assert_eq!(build_args.last_flashblock_index, 0);
+    }
+
+    #[test]
+    fn test_next_buildable_args_returns_none_when_parent_mismatch() {
+        let mut manager = SequenceManager::new(true);
+        let factory = TestFlashBlockFactory::new();
+
+        let fb0 = factory.flashblock_at(0).build();
+        manager.insert_flashblock(fb0).unwrap();
+
+        // Use different parent hash
+        let wrong_parent = B256::random();
+        let args = manager.next_buildable_args::<OpTxEnvelope>(wrong_parent, 1000000);
+        assert!(args.is_none());
+    }
+
+    #[test]
+    fn test_next_buildable_args_prefers_pending_over_cached() {
+        let mut manager = SequenceManager::new(true);
+        let factory = TestFlashBlockFactory::new();
+
+        // Create and finalize first sequence
+        let fb0 = factory.flashblock_at(0).build();
+        manager.insert_flashblock(fb0.clone()).unwrap();
+
+        // Create new sequence (finalizes previous)
+        let fb1 = factory.flashblock_for_next_block(&fb0).build();
+        let parent_hash = fb1.base.as_ref().unwrap().parent_hash;
+        manager.insert_flashblock(fb1).unwrap();
+
+        // Request with first sequence's parent (should find cached)
+        let args = manager.next_buildable_args::<OpTxEnvelope>(parent_hash, 1000000);
+        assert!(args.is_some());
+    }
+
+    #[test]
+    fn test_next_buildable_args_finds_cached_sequence() {
+        let mut manager = SequenceManager::new(true);
+        let factory = TestFlashBlockFactory::new();
+
+        // Build and cache first sequence
+        let fb0 = factory.flashblock_at(0).build();
+        let parent_hash = fb0.base.as_ref().unwrap().parent_hash;
+        manager.insert_flashblock(fb0.clone()).unwrap();
+
+        // Start new sequence to finalize first
+        let fb1 = factory.flashblock_for_next_block(&fb0).build();
+        manager.insert_flashblock(fb1.clone()).unwrap();
+
+        // Clear pending by starting another sequence
+        let fb2 = factory.flashblock_for_next_block(&fb1).build();
+        manager.insert_flashblock(fb2).unwrap();
+
+        // Request first sequence's parent - should find in cache
+        let args = manager.next_buildable_args::<OpTxEnvelope>(parent_hash, 1000000);
+        assert!(args.is_some());
+    }
+
+    #[test]
+    fn test_compute_state_root_logic_near_expected_final() {
+        let mut manager = SequenceManager::new(true);
+        let block_time = 2u64;
+        let factory = TestFlashBlockFactory::new().with_block_time(block_time);
+
+        // Create sequence with zero state root (needs computation)
+        let fb0 = factory.flashblock_at(0).state_root(B256::ZERO).build();
+        let parent_hash = fb0.base.as_ref().unwrap().parent_hash;
+        let base_timestamp = fb0.base.as_ref().unwrap().timestamp;
+        manager.insert_flashblock(fb0.clone()).unwrap();
+
+        // Add flashblocks up to expected final index (2000ms / 200ms = 10)
+        for i in 1..=9 {
+            let fb = factory.flashblock_after(&fb0).index(i).state_root(B256::ZERO).build();
+            manager.insert_flashblock(fb).unwrap();
+        }
+
+        // Request with proper timing - should compute state root for index 9
+        let args =
+            manager.next_buildable_args::<OpTxEnvelope>(parent_hash, base_timestamp - block_time);
+        assert!(args.is_some());
+        assert!(args.unwrap().compute_state_root);
+    }
+
+    #[test]
+    fn test_no_compute_state_root_when_provided_by_sequencer() {
+        let mut manager = SequenceManager::new(true);
+        let block_time = 2u64;
+        let factory = TestFlashBlockFactory::new().with_block_time(block_time);
+
+        // Create sequence with non-zero state root (provided by sequencer)
+        let fb0 = factory.flashblock_at(0).state_root(B256::random()).build();
+        let parent_hash = fb0.base.as_ref().unwrap().parent_hash;
+        let base_timestamp = fb0.base.as_ref().unwrap().timestamp;
+        manager.insert_flashblock(fb0).unwrap();
+
+        let args =
+            manager.next_buildable_args::<OpTxEnvelope>(parent_hash, base_timestamp - block_time);
+        assert!(args.is_some());
+        assert!(!args.unwrap().compute_state_root);
+    }
+
+    #[test]
+    fn test_no_compute_state_root_when_disabled() {
+        let mut manager = SequenceManager::new(false);
+        let block_time = 2u64;
+        let factory = TestFlashBlockFactory::new().with_block_time(block_time);
+
+        // Create sequence with zero state root (needs computation)
+        let fb0 = factory.flashblock_at(0).state_root(B256::ZERO).build();
+        let parent_hash = fb0.base.as_ref().unwrap().parent_hash;
+        let base_timestamp = fb0.base.as_ref().unwrap().timestamp;
+        manager.insert_flashblock(fb0.clone()).unwrap();
+
+        // Add flashblocks up to expected final index (2000ms / 200ms = 10)
+        for i in 1..=9 {
+            let fb = factory.flashblock_after(&fb0).index(i).state_root(B256::ZERO).build();
+            manager.insert_flashblock(fb).unwrap();
+        }
+
+        // Request with proper timing - should compute state root for index 9
+        let args =
+            manager.next_buildable_args::<OpTxEnvelope>(parent_hash, base_timestamp - block_time);
+        assert!(args.is_some());
+        assert!(!args.unwrap().compute_state_root);
+    }
+
+    #[test]
+    fn test_cache_ring_buffer_evicts_oldest() {
+        let mut manager = SequenceManager::new(true);
+        let factory = TestFlashBlockFactory::new();
+
+        // Fill cache with 4 sequences (cache size is 3, so oldest should be evicted)
+        let mut last_fb = factory.flashblock_at(0).build();
+        manager.insert_flashblock(last_fb.clone()).unwrap();
+
+        for _ in 0..3 {
+            last_fb = factory.flashblock_for_next_block(&last_fb).build();
+            manager.insert_flashblock(last_fb.clone()).unwrap();
+        }
+
+        // The first sequence should have been evicted, so we can't build it
+        let first_parent = factory.flashblock_at(0).build().base.unwrap().parent_hash;
+        let args = manager.next_buildable_args::<OpTxEnvelope>(first_parent, 1000000);
+        // Should not find it (evicted from ring buffer)
+        assert!(args.is_none());
+    }
+}

--- a/crates/optimism/flashblocks/src/consensus.rs
+++ b/crates/optimism/flashblocks/src/consensus.rs
@@ -5,13 +5,13 @@ use op_alloy_rpc_types_engine::OpExecutionData;
 use reth_engine_primitives::ConsensusEngineHandle;
 use reth_optimism_payload_builder::OpPayloadTypes;
 use reth_payload_primitives::{EngineApiMessageVersion, ExecutionPayload, PayloadTypes};
-use ringbuffer::{AllocRingBuffer, RingBuffer};
 use tracing::*;
 
-/// Cache entry for block information: (block hash, block number, timestamp).
-type BlockCacheEntry = (B256, u64, u64);
-
-/// Consensus client that sends FCUs and new payloads using blocks from a [`FlashBlockService`]
+/// Consensus client that sends FCUs and new payloads using blocks from a [`FlashBlockService`].
+///
+/// This client receives completed flashblock sequences and:
+/// - Attempts to submit `engine_newPayload` if `state_root` is available (non-zero)
+/// - Always sends `engine_forkChoiceUpdated` to drive chain forward
 ///
 /// [`FlashBlockService`]: crate::FlashBlockService
 #[derive(Debug)]
@@ -21,9 +21,8 @@ where
 {
     /// Handle to execution client.
     engine_handle: ConsensusEngineHandle<P>,
+    /// Receiver for completed flashblock sequences from `FlashBlockService`.
     sequence_receiver: FlashBlockCompleteSequenceRx,
-    /// Caches previous block info for lookup: (block hash, block number, timestamp).
-    block_hash_buffer: AllocRingBuffer<BlockCacheEntry>,
 }
 
 impl<P> FlashBlockConsensusClient<P>
@@ -32,126 +31,30 @@ where
     P::ExecutionData: for<'a> TryFrom<&'a FlashBlockCompleteSequence, Error: std::fmt::Display>,
 {
     /// Create a new `FlashBlockConsensusClient` with the given Op engine and sequence receiver.
-    pub fn new(
+    pub const fn new(
         engine_handle: ConsensusEngineHandle<P>,
         sequence_receiver: FlashBlockCompleteSequenceRx,
     ) -> eyre::Result<Self> {
-        // Buffer size of 768 blocks (64 * 12) supports 1s block time chains like Unichain.
-        // Oversized for 2s block time chains like Base, but acceptable given minimal memory usage.
-        let block_hash_buffer = AllocRingBuffer::new(768);
-        Ok(Self { engine_handle, sequence_receiver, block_hash_buffer })
+        Ok(Self { engine_handle, sequence_receiver })
     }
 
-    /// Return the safe and finalized block hash for FCU calls.
+    /// Attempts to submit a new payload to the engine.
     ///
-    /// Safe blocks are considered 32 L1 blocks (approximately 384s at 12s/block) behind the head,
-    /// and finalized blocks are 64 L1 blocks (approximately 768s) behind the head. This
-    /// approximation, while not precisely matching the OP stack's derivation, provides
-    /// sufficient proximity and enables op-reth to sync the chain independently of an op-node.
-    /// The offset is dynamically adjusted based on the actual block time detected from the
-    /// buffer.
-    fn get_safe_and_finalized_block_hash(&self) -> (B256, B256) {
-        let cached_blocks_count = self.block_hash_buffer.len();
-
-        // Not enough blocks to determine safe/finalized yet
-        if cached_blocks_count < 2 {
-            return (B256::ZERO, B256::ZERO);
-        }
-
-        // Calculate average block time using block numbers to handle missing blocks correctly.
-        // By dividing timestamp difference by block number difference, we get accurate block
-        // time even when blocks are missing from the buffer.
-        let (_, latest_block_number, latest_timestamp) =
-            self.block_hash_buffer.get(cached_blocks_count - 1).unwrap();
-        let (_, previous_block_number, previous_timestamp) =
-            self.block_hash_buffer.get(cached_blocks_count - 2).unwrap();
-        let timestamp_delta = latest_timestamp.saturating_sub(*previous_timestamp);
-        let block_number_delta = latest_block_number.saturating_sub(*previous_block_number).max(1);
-        let block_time_secs = timestamp_delta / block_number_delta;
-
-        // L1 reference: 32 blocks * 12s = 384s for safe, 64 blocks * 12s = 768s for finalized
-        const SAFE_TIME_SECS: u64 = 384;
-        const FINALIZED_TIME_SECS: u64 = 768;
-
-        // Calculate how many L2 blocks correspond to these L1 time periods
-        let safe_block_offset =
-            (SAFE_TIME_SECS / block_time_secs).min(cached_blocks_count as u64) as usize;
-        let finalized_block_offset =
-            (FINALIZED_TIME_SECS / block_time_secs).min(cached_blocks_count as u64) as usize;
-
-        // Get safe hash: offset from end of buffer
-        let safe_hash = self
-            .block_hash_buffer
-            .get(cached_blocks_count.saturating_sub(safe_block_offset))
-            .map(|&(hash, _, _)| hash)
-            .unwrap();
-
-        // Get finalized hash: offset from end of buffer
-        let finalized_hash = self
-            .block_hash_buffer
-            .get(cached_blocks_count.saturating_sub(finalized_block_offset))
-            .map(|&(hash, _, _)| hash)
-            .unwrap();
-
-        (safe_hash, finalized_hash)
-    }
-
-    /// Receive the next flashblock sequence and cache its block information.
+    /// The `TryFrom` conversion will fail if `execution_outcome.state_root` is `B256::ZERO`,
+    /// in which case this returns the `parent_hash` instead to drive the chain forward.
     ///
-    /// Returns `None` if receiving fails (error is already logged).
-    async fn receive_and_cache_sequence(&mut self) -> Option<FlashBlockCompleteSequence> {
-        match self.sequence_receiver.recv().await {
-            Ok(sequence) => {
-                self.block_hash_buffer.push((
-                    sequence.payload_base().parent_hash,
-                    sequence.block_number(),
-                    sequence.payload_base().timestamp,
-                ));
-                Some(sequence)
-            }
+    /// Returns the block hash to use for FCU (either the new block or parent).
+    async fn submit_new_payload(&self, sequence: &FlashBlockCompleteSequence) -> B256 {
+        let payload = match P::ExecutionData::try_from(sequence) {
+            Ok(payload) => payload,
             Err(err) => {
-                error!(
-                    target: "flashblocks",
-                    %err,
-                    "error while fetching flashblock completed sequence",
-                );
-                None
+                trace!(target: "flashblocks", %err, "Failed payload conversion, using parent hash");
+                return sequence.payload_base().parent_hash;
             }
-        }
-    }
+        };
 
-    /// Convert a flashblock sequence to an execution payload.
-    ///
-    /// Returns `None` if conversion fails (error is already logged).
-    fn convert_sequence_to_payload(
-        &self,
-        sequence: &FlashBlockCompleteSequence,
-    ) -> Option<P::ExecutionData> {
-        match P::ExecutionData::try_from(sequence) {
-            Ok(payload) => Some(payload),
-            Err(err) => {
-                error!(
-                    target: "flashblocks",
-                    %err,
-                    "error while converting to payload from completed sequence",
-                );
-                None
-            }
-        }
-    }
-
-    /// Submit a new payload to the engine.
-    ///
-    /// Returns `Ok(block_hash)` if the payload was accepted, `Err(())` otherwise (errors are
-    /// logged).
-    async fn submit_new_payload(
-        &self,
-        payload: P::ExecutionData,
-        sequence: &FlashBlockCompleteSequence,
-    ) -> Result<B256, ()> {
         let block_number = payload.block_number();
         let block_hash = payload.block_hash();
-
         match self.engine_handle.new_payload(payload).await {
             Ok(result) => {
                 debug!(
@@ -171,10 +74,7 @@ where
                         %validation_error,
                         "Payload validation error",
                     );
-                    return Err(());
-                }
-
-                Ok(block_hash)
+                };
             }
             Err(err) => {
                 error!(
@@ -183,9 +83,10 @@ where
                     block_number,
                     "Failed to submit new payload",
                 );
-                Err(())
             }
         }
+
+        block_hash
     }
 
     /// Submit a forkchoice update to the engine.
@@ -195,7 +96,8 @@ where
         sequence: &FlashBlockCompleteSequence,
     ) {
         let block_number = sequence.block_number();
-        let (safe_hash, finalized_hash) = self.get_safe_and_finalized_block_hash();
+        let safe_hash = sequence.payload_base().parent_hash;
+        let finalized_hash = sequence.payload_base().parent_hash;
         let fcu_state = alloy_rpc_types_engine::ForkchoiceState {
             head_block_hash,
             safe_block_hash: safe_hash,
@@ -233,39 +135,324 @@ where
         }
     }
 
-    /// Spawn the client to start sending FCUs and new payloads by periodically fetching recent
-    /// blocks.
+    /// Runs the consensus client loop.
+    ///
+    /// Continuously receives completed flashblock sequences and submits them to the execution
+    /// engine:
+    /// 1. Attempts `engine_newPayload` (only if `state_root` is available)
+    /// 2. Always sends `engine_forkChoiceUpdated` to drive chain forward
     pub async fn run(mut self) {
         loop {
-            let Some(sequence) = self.receive_and_cache_sequence().await else {
+            let Ok(sequence) = self.sequence_receiver.recv().await else {
                 continue;
             };
 
-            let Some(payload) = self.convert_sequence_to_payload(&sequence) else {
-                continue;
-            };
-
-            let Ok(block_hash) = self.submit_new_payload(payload, &sequence).await else {
-                continue;
-            };
+            // Returns block_hash for FCU:
+            // - If state_root is available: submits newPayload and returns the new block's hash
+            // - If state_root is zero: skips newPayload and returns parent_hash (no progress yet)
+            let block_hash = self.submit_new_payload(&sequence).await;
 
             self.submit_forkchoice_update(block_hash, &sequence).await;
         }
     }
 }
 
-impl From<&FlashBlockCompleteSequence> for OpExecutionData {
-    fn from(sequence: &FlashBlockCompleteSequence) -> Self {
+impl TryFrom<&FlashBlockCompleteSequence> for OpExecutionData {
+    type Error = &'static str;
+
+    fn try_from(sequence: &FlashBlockCompleteSequence) -> Result<Self, Self::Error> {
         let mut data = Self::from_flashblocks_unchecked(sequence);
-        // Replace payload's state_root with the calculated one. For flashblocks, there was an
-        // option to disable state root calculation for blocks, and in that case, the payload's
-        // state_root will be zero, and we'll need to locally calculate state_root before
-        // proceeding to call engine_newPayload.
+
+        // If execution outcome is available, use the computed state_root and block_hash.
+        // FlashBlockService computes these when building sequences on top of the local tip.
         if let Some(execution_outcome) = sequence.execution_outcome() {
             let payload = data.payload.as_v1_mut();
             payload.state_root = execution_outcome.state_root;
             payload.block_hash = execution_outcome.block_hash;
         }
-        data
+
+        // Only proceed if we have a valid state_root (non-zero).
+        if data.payload.as_v1_mut().state_root == B256::ZERO {
+            return Err("No state_root available for payload");
+        }
+
+        Ok(data)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{sequence::SequenceExecutionOutcome, test_utils::TestFlashBlockFactory};
+
+    mod op_execution_data_conversion {
+        use super::*;
+
+        #[test]
+        fn test_try_from_fails_with_zero_state_root() {
+            // When execution_outcome is None, state_root remains zero and conversion fails
+            let factory = TestFlashBlockFactory::new();
+            let fb0 = factory.flashblock_at(0).state_root(B256::ZERO).build();
+
+            let sequence = FlashBlockCompleteSequence::new(vec![fb0], None).unwrap();
+
+            let result = OpExecutionData::try_from(&sequence);
+            assert!(result.is_err());
+            assert_eq!(result.unwrap_err(), "No state_root available for payload");
+        }
+
+        #[test]
+        fn test_try_from_succeeds_with_execution_outcome() {
+            // When execution_outcome has state_root, conversion succeeds
+            let factory = TestFlashBlockFactory::new();
+            let fb0 = factory.flashblock_at(0).state_root(B256::ZERO).build();
+
+            let execution_outcome = SequenceExecutionOutcome {
+                block_hash: B256::random(),
+                state_root: B256::random(), // Non-zero
+            };
+
+            let sequence =
+                FlashBlockCompleteSequence::new(vec![fb0], Some(execution_outcome)).unwrap();
+
+            let result = OpExecutionData::try_from(&sequence);
+            assert!(result.is_ok());
+
+            let mut data = result.unwrap();
+            assert_eq!(data.payload.as_v1_mut().state_root, execution_outcome.state_root);
+            assert_eq!(data.payload.as_v1_mut().block_hash, execution_outcome.block_hash);
+        }
+
+        #[test]
+        fn test_try_from_succeeds_with_provided_state_root() {
+            // When sequencer provides non-zero state_root, conversion succeeds
+            let factory = TestFlashBlockFactory::new();
+            let provided_state_root = B256::random();
+            let fb0 = factory.flashblock_at(0).state_root(provided_state_root).build();
+
+            let sequence = FlashBlockCompleteSequence::new(vec![fb0], None).unwrap();
+
+            let result = OpExecutionData::try_from(&sequence);
+            assert!(result.is_ok());
+
+            let mut data = result.unwrap();
+            assert_eq!(data.payload.as_v1_mut().state_root, provided_state_root);
+        }
+
+        #[test]
+        fn test_try_from_execution_outcome_overrides_provided_state_root() {
+            // execution_outcome takes precedence over sequencer-provided state_root
+            let factory = TestFlashBlockFactory::new();
+            let provided_state_root = B256::random();
+            let fb0 = factory.flashblock_at(0).state_root(provided_state_root).build();
+
+            let execution_outcome = SequenceExecutionOutcome {
+                block_hash: B256::random(),
+                state_root: B256::random(), // Different from provided
+            };
+
+            let sequence =
+                FlashBlockCompleteSequence::new(vec![fb0], Some(execution_outcome)).unwrap();
+
+            let result = OpExecutionData::try_from(&sequence);
+            assert!(result.is_ok());
+
+            let mut data = result.unwrap();
+            // Should use execution_outcome, not the provided state_root
+            assert_eq!(data.payload.as_v1_mut().state_root, execution_outcome.state_root);
+            assert_ne!(data.payload.as_v1_mut().state_root, provided_state_root);
+        }
+
+        #[test]
+        fn test_try_from_with_multiple_flashblocks() {
+            // Test conversion with sequence of multiple flashblocks
+            let factory = TestFlashBlockFactory::new();
+            let fb0 = factory.flashblock_at(0).state_root(B256::ZERO).build();
+            let fb1 = factory.flashblock_after(&fb0).state_root(B256::ZERO).build();
+            let fb2 = factory.flashblock_after(&fb1).state_root(B256::ZERO).build();
+
+            let execution_outcome =
+                SequenceExecutionOutcome { block_hash: B256::random(), state_root: B256::random() };
+
+            let sequence =
+                FlashBlockCompleteSequence::new(vec![fb0, fb1, fb2], Some(execution_outcome))
+                    .unwrap();
+
+            let result = OpExecutionData::try_from(&sequence);
+            assert!(result.is_ok());
+
+            let mut data = result.unwrap();
+            assert_eq!(data.payload.as_v1_mut().state_root, execution_outcome.state_root);
+            assert_eq!(data.payload.as_v1_mut().block_hash, execution_outcome.block_hash);
+        }
+    }
+
+    mod consensus_client_creation {
+        use super::*;
+        use tokio::sync::broadcast;
+
+        #[test]
+        fn test_new_creates_client() {
+            let (engine_tx, _) = tokio::sync::mpsc::unbounded_channel();
+            let engine_handle = ConsensusEngineHandle::<OpPayloadTypes>::new(engine_tx);
+
+            let (_, sequence_rx) = broadcast::channel(1);
+
+            let result = FlashBlockConsensusClient::new(engine_handle, sequence_rx);
+            assert!(result.is_ok());
+        }
+    }
+
+    mod submit_new_payload_behavior {
+        use super::*;
+
+        #[test]
+        fn test_submit_new_payload_returns_parent_hash_when_no_state_root() {
+            // When conversion fails (no state_root), should return parent_hash
+            let factory = TestFlashBlockFactory::new();
+            let fb0 = factory.flashblock_at(0).state_root(B256::ZERO).build();
+            let parent_hash = fb0.base.as_ref().unwrap().parent_hash;
+
+            let sequence = FlashBlockCompleteSequence::new(vec![fb0], None).unwrap();
+
+            // Verify conversion would fail
+            let conversion_result = OpExecutionData::try_from(&sequence);
+            assert!(conversion_result.is_err());
+
+            // In the actual run loop, submit_new_payload would return parent_hash
+            assert_eq!(sequence.payload_base().parent_hash, parent_hash);
+        }
+
+        #[test]
+        fn test_submit_new_payload_returns_block_hash_when_state_root_available() {
+            // When conversion succeeds, should return the new block's hash
+            let factory = TestFlashBlockFactory::new();
+            let fb0 = factory.flashblock_at(0).state_root(B256::ZERO).build();
+
+            let execution_outcome =
+                SequenceExecutionOutcome { block_hash: B256::random(), state_root: B256::random() };
+
+            let sequence =
+                FlashBlockCompleteSequence::new(vec![fb0], Some(execution_outcome)).unwrap();
+
+            // Verify conversion succeeds
+            let conversion_result = OpExecutionData::try_from(&sequence);
+            assert!(conversion_result.is_ok());
+
+            let mut data = conversion_result.unwrap();
+            assert_eq!(data.payload.as_v1_mut().block_hash, execution_outcome.block_hash);
+        }
+    }
+
+    mod forkchoice_update_behavior {
+        use super::*;
+
+        #[test]
+        fn test_forkchoice_state_uses_parent_hash_for_safe_and_finalized() {
+            // Both safe_hash and finalized_hash should be set to parent_hash
+            let factory = TestFlashBlockFactory::new();
+            let fb0 = factory.flashblock_at(0).build();
+            let parent_hash = fb0.base.as_ref().unwrap().parent_hash;
+
+            let sequence = FlashBlockCompleteSequence::new(vec![fb0], None).unwrap();
+
+            // Verify the expected forkchoice state
+            assert_eq!(sequence.payload_base().parent_hash, parent_hash);
+        }
+
+        #[test]
+        fn test_forkchoice_update_with_new_block_hash() {
+            // When newPayload succeeds, FCU should use the new block's hash as head
+            let factory = TestFlashBlockFactory::new();
+            let fb0 = factory.flashblock_at(0).state_root(B256::ZERO).build();
+
+            let execution_outcome =
+                SequenceExecutionOutcome { block_hash: B256::random(), state_root: B256::random() };
+
+            let sequence =
+                FlashBlockCompleteSequence::new(vec![fb0], Some(execution_outcome)).unwrap();
+
+            // The head_block_hash for FCU would be execution_outcome.block_hash
+            assert_eq!(
+                sequence.execution_outcome().unwrap().block_hash,
+                execution_outcome.block_hash
+            );
+        }
+
+        #[test]
+        fn test_forkchoice_update_with_parent_hash_when_no_state_root() {
+            // When newPayload is skipped (no state_root), FCU should use parent_hash as head
+            let factory = TestFlashBlockFactory::new();
+            let fb0 = factory.flashblock_at(0).state_root(B256::ZERO).build();
+            let parent_hash = fb0.base.as_ref().unwrap().parent_hash;
+
+            let sequence = FlashBlockCompleteSequence::new(vec![fb0], None).unwrap();
+
+            // The head_block_hash for FCU would be parent_hash (fallback)
+            assert_eq!(sequence.payload_base().parent_hash, parent_hash);
+        }
+    }
+
+    mod run_loop_logic {
+        use super::*;
+
+        #[test]
+        fn test_run_loop_processes_sequence_with_state_root() {
+            // Scenario: Sequence with state_root should trigger both newPayload and FCU
+            let factory = TestFlashBlockFactory::new();
+            let fb0 = factory.flashblock_at(0).state_root(B256::ZERO).build();
+
+            let execution_outcome =
+                SequenceExecutionOutcome { block_hash: B256::random(), state_root: B256::random() };
+
+            let sequence =
+                FlashBlockCompleteSequence::new(vec![fb0], Some(execution_outcome)).unwrap();
+
+            // Verify sequence is ready for newPayload
+            let conversion = OpExecutionData::try_from(&sequence);
+            assert!(conversion.is_ok());
+        }
+
+        #[test]
+        fn test_run_loop_processes_sequence_without_state_root() {
+            // Scenario: Sequence without state_root should skip newPayload but still do FCU
+            let factory = TestFlashBlockFactory::new();
+            let fb0 = factory.flashblock_at(0).state_root(B256::ZERO).build();
+
+            let sequence = FlashBlockCompleteSequence::new(vec![fb0], None).unwrap();
+
+            // Verify sequence cannot be converted (newPayload will be skipped)
+            let conversion = OpExecutionData::try_from(&sequence);
+            assert!(conversion.is_err());
+
+            // But FCU should still happen with parent_hash
+            assert!(sequence.payload_base().parent_hash != B256::ZERO);
+        }
+
+        #[test]
+        fn test_run_loop_handles_multiple_sequences() {
+            // Multiple sequences should be processed independently
+            let factory = TestFlashBlockFactory::new();
+
+            // Sequence 1: With state_root
+            let fb0_seq1 = factory.flashblock_at(0).state_root(B256::ZERO).build();
+            let outcome1 =
+                SequenceExecutionOutcome { block_hash: B256::random(), state_root: B256::random() };
+            let seq1 =
+                FlashBlockCompleteSequence::new(vec![fb0_seq1.clone()], Some(outcome1)).unwrap();
+
+            // Sequence 2: Without state_root (for next block)
+            let fb0_seq2 = factory.flashblock_for_next_block(&fb0_seq1).build();
+            let seq2 = FlashBlockCompleteSequence::new(vec![fb0_seq2], None).unwrap();
+
+            // Both should be valid sequences
+            assert_eq!(seq1.block_number(), 100);
+            assert_eq!(seq2.block_number(), 101);
+
+            // seq1 can be converted
+            assert!(OpExecutionData::try_from(&seq1).is_ok());
+            // seq2 cannot be converted
+            assert!(OpExecutionData::try_from(&seq2).is_err());
+        }
     }
 }

--- a/crates/optimism/flashblocks/src/lib.rs
+++ b/crates/optimism/flashblocks/src/lib.rs
@@ -28,6 +28,9 @@ pub use service::{FlashBlockBuildInfo, FlashBlockService};
 
 mod worker;
 
+#[cfg(test)]
+mod test_utils;
+
 mod ws;
 pub use ws::{WsConnect, WsFlashBlockStream};
 

--- a/crates/optimism/flashblocks/src/lib.rs
+++ b/crates/optimism/flashblocks/src/lib.rs
@@ -28,6 +28,8 @@ pub use service::{FlashBlockBuildInfo, FlashBlockService};
 
 mod worker;
 
+mod cache;
+
 #[cfg(test)]
 mod test_utils;
 

--- a/crates/optimism/flashblocks/src/sequence.rs
+++ b/crates/optimism/flashblocks/src/sequence.rs
@@ -99,9 +99,9 @@ impl FlashBlockPendingSequence {
         self.cached_reads = Some(cached_reads);
     }
 
-    /// Returns cached reads for this sequence
-    pub const fn cached_reads(&self) -> &Option<CachedReads> {
-        &self.cached_reads
+    /// Removes the cached reads for this sequence
+    pub const fn take_cached_reads(&mut self) -> Option<CachedReads> {
+        self.cached_reads.take()
     }
 
     /// Returns the first block number
@@ -405,12 +405,12 @@ mod tests {
 
             let cached_reads = CachedReads::default();
             sequence.set_cached_reads(cached_reads);
-            assert!(sequence.cached_reads().is_some());
+            assert!(sequence.take_cached_reads().is_some());
 
             let _complete = sequence.finalize().unwrap();
 
             // Cached reads should be cleared
-            assert!(sequence.cached_reads().is_none());
+            assert!(sequence.take_cached_reads().is_none());
         }
 
         #[test]

--- a/crates/optimism/flashblocks/src/sequence.rs
+++ b/crates/optimism/flashblocks/src/sequence.rs
@@ -1,20 +1,19 @@
 use crate::{FlashBlock, FlashBlockCompleteSequenceRx};
-use alloy_eips::eip2718::WithEncoded;
 use alloy_primitives::{Bytes, B256};
 use alloy_rpc_types_engine::PayloadId;
 use core::mem;
 use eyre::{bail, OptionExt};
 use op_alloy_rpc_types_engine::OpFlashblockPayloadBase;
-use reth_primitives_traits::{Recovered, SignedTransaction};
+use reth_revm::cached::CachedReads;
 use std::{collections::BTreeMap, ops::Deref};
 use tokio::sync::broadcast;
-use tracing::{debug, trace, warn};
+use tracing::*;
 
 /// The size of the broadcast channel for completed flashblock sequences.
 const FLASHBLOCK_SEQUENCE_CHANNEL_SIZE: usize = 128;
 
 /// Outcome from executing a flashblock sequence.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SequenceExecutionOutcome {
     /// The block hash of the executed pending block
     pub block_hash: B256,
@@ -24,25 +23,32 @@ pub struct SequenceExecutionOutcome {
 
 /// An ordered B-tree keeping the track of a sequence of [`FlashBlock`]s by their indices.
 #[derive(Debug)]
-pub struct FlashBlockPendingSequence<T> {
+pub struct FlashBlockPendingSequence {
     /// tracks the individual flashblocks in order
-    inner: BTreeMap<u64, PreparedFlashBlock<T>>,
+    inner: BTreeMap<u64, FlashBlock>,
     /// Broadcasts flashblocks to subscribers.
     block_broadcaster: broadcast::Sender<FlashBlockCompleteSequence>,
     /// Optional execution outcome from building the current sequence.
     execution_outcome: Option<SequenceExecutionOutcome>,
+    /// Cached state reads for the current block.
+    /// Current `PendingFlashBlock` is built out of a sequence of `FlashBlocks`, and executed again
+    /// when fb received on top of the same block. Avoid redundant I/O across multiple
+    /// executions within the same block.
+    cached_reads: Option<CachedReads>,
 }
 
-impl<T> FlashBlockPendingSequence<T>
-where
-    T: SignedTransaction,
-{
+impl FlashBlockPendingSequence {
     /// Create a new pending sequence.
     pub fn new() -> Self {
         // Note: if the channel is full, send will not block but rather overwrite the oldest
         // messages. Order is preserved.
         let (tx, _) = broadcast::channel(FLASHBLOCK_SEQUENCE_CHANNEL_SIZE);
-        Self { inner: BTreeMap::new(), block_broadcaster: tx, execution_outcome: None }
+        Self {
+            inner: BTreeMap::new(),
+            block_broadcaster: tx,
+            execution_outcome: None,
+            cached_reads: None,
+        }
     }
 
     /// Returns the sender half of the [`FlashBlockCompleteSequence`] channel.
@@ -57,49 +63,14 @@ where
         self.block_broadcaster.subscribe()
     }
 
-    // Clears the state and broadcasts the blocks produced to subscribers.
-    fn clear_and_broadcast_blocks(&mut self) {
-        if self.inner.is_empty() {
-            return;
-        }
-
-        let flashblocks = mem::take(&mut self.inner);
-        let execution_outcome = mem::take(&mut self.execution_outcome);
-
-        // If there are any subscribers, send the flashblocks to them.
-        if self.block_broadcaster.receiver_count() > 0 {
-            let flashblocks = match FlashBlockCompleteSequence::new(
-                flashblocks.into_iter().map(|block| block.1.into()).collect(),
-                execution_outcome,
-            ) {
-                Ok(flashblocks) => flashblocks,
-                Err(err) => {
-                    debug!(target: "flashblocks", error = ?err, "Failed to create full flashblock complete sequence");
-                    return;
-                }
-            };
-
-            // Note: this should only ever fail if there are no receivers. This can happen if
-            // there is a race condition between the clause right above and this
-            // one. We can simply warn the user and continue.
-            if let Err(err) = self.block_broadcaster.send(flashblocks) {
-                warn!(target: "flashblocks", error = ?err, "Failed to send flashblocks to subscribers");
-            }
-        }
-    }
-
     /// Inserts a new block into the sequence.
     ///
     /// A [`FlashBlock`] with index 0 resets the set.
-    pub fn insert(&mut self, flashblock: FlashBlock) -> eyre::Result<()> {
+    pub fn insert(&mut self, flashblock: FlashBlock) {
         if flashblock.index == 0 {
             trace!(target: "flashblocks", number=%flashblock.block_number(), "Tracking new flashblock sequence");
-
-            // Flash block at index zero resets the whole state.
-            self.clear_and_broadcast_blocks();
-
-            self.inner.insert(flashblock.index, PreparedFlashBlock::new(flashblock)?);
-            return Ok(())
+            self.inner.insert(flashblock.index, flashblock);
+            return;
         }
 
         // only insert if we previously received the same block and payload, assume we received
@@ -109,12 +80,10 @@ where
 
         if same_block && same_payload {
             trace!(target: "flashblocks", number=%flashblock.block_number(), index = %flashblock.index, block_count = self.inner.len()  ,"Received followup flashblock");
-            self.inner.insert(flashblock.index, PreparedFlashBlock::new(flashblock)?);
+            self.inner.insert(flashblock.index, flashblock);
         } else {
             trace!(target: "flashblocks", number=%flashblock.block_number(), index = %flashblock.index, current=?self.block_number()  ,"Ignoring untracked flashblock following");
         }
-
-        Ok(())
     }
 
     /// Set execution outcome from building the flashblock sequence
@@ -125,31 +94,24 @@ where
         self.execution_outcome = execution_outcome;
     }
 
-    /// Iterator over sequence of executable transactions.
-    ///
-    /// A flashblocks is not ready if there's missing previous flashblocks, i.e. there's a gap in
-    /// the sequence
-    ///
-    /// Note: flashblocks start at `index 0`.
-    pub fn ready_transactions(&self) -> impl Iterator<Item = WithEncoded<Recovered<T>>> + '_ {
-        self.inner
-            .values()
-            .enumerate()
-            .take_while(|(idx, block)| {
-                // flashblock index 0 is the first flashblock
-                block.block().index == *idx as u64
-            })
-            .flat_map(|(_, block)| block.txs.clone())
+    /// Set cached reads for this sequence
+    pub fn set_cached_reads(&mut self, cached_reads: CachedReads) {
+        self.cached_reads = Some(cached_reads);
+    }
+
+    /// Returns cached reads for this sequence
+    pub const fn cached_reads(&self) -> &Option<CachedReads> {
+        &self.cached_reads
     }
 
     /// Returns the first block number
     pub fn block_number(&self) -> Option<u64> {
-        Some(self.inner.values().next()?.block().block_number())
+        Some(self.inner.values().next()?.block_number())
     }
 
     /// Returns the payload base of the first tracked flashblock.
     pub fn payload_base(&self) -> Option<OpFlashblockPayloadBase> {
-        self.inner.values().next()?.block().base.clone()
+        self.inner.values().next()?.base.clone()
     }
 
     /// Returns the number of tracked flashblocks.
@@ -159,23 +121,40 @@ where
 
     /// Returns the reference to the last flashblock.
     pub fn last_flashblock(&self) -> Option<&FlashBlock> {
-        self.inner.last_key_value().map(|(_, b)| &b.block)
+        self.inner.last_key_value().map(|(_, b)| b)
     }
 
     /// Returns the current/latest flashblock index in the sequence
     pub fn index(&self) -> Option<u64> {
-        Some(self.inner.values().last()?.block().index)
+        Some(self.inner.values().last()?.index)
     }
     /// Returns the payload id of the first tracked flashblock in the current sequence.
     pub fn payload_id(&self) -> Option<PayloadId> {
-        Some(self.inner.values().next()?.block().payload_id)
+        Some(self.inner.values().next()?.payload_id)
+    }
+
+    /// Finalizes the current pending sequence and returns it as a complete sequence.
+    ///
+    /// Clears the internal state and returns an error if the sequence is empty or validation fails.
+    pub fn finalize(&mut self) -> eyre::Result<FlashBlockCompleteSequence> {
+        if self.inner.is_empty() {
+            bail!("Cannot finalize empty flashblock sequence");
+        }
+
+        let flashblocks = mem::take(&mut self.inner);
+        let execution_outcome = mem::take(&mut self.execution_outcome);
+        self.cached_reads = None;
+
+        FlashBlockCompleteSequence::new(flashblocks.into_values().collect(), execution_outcome)
+    }
+
+    /// Returns an iterator over all flashblocks in the sequence.
+    pub fn flashblocks(&self) -> impl Iterator<Item = &FlashBlock> {
+        self.inner.values()
     }
 }
 
-impl<T> Default for FlashBlockPendingSequence<T>
-where
-    T: SignedTransaction,
-{
+impl Default for FlashBlockPendingSequence {
     fn default() -> Self {
         Self::new()
     }
@@ -245,6 +224,14 @@ impl FlashBlockCompleteSequence {
         self.execution_outcome
     }
 
+    /// Updates execution outcome of the sequence.
+    pub const fn set_execution_outcome(
+        &mut self,
+        execution_outcome: Option<SequenceExecutionOutcome>,
+    ) {
+        self.execution_outcome = execution_outcome;
+    }
+
     /// Returns all transactions from all flashblocks in the sequence
     pub fn all_transactions(&self) -> Vec<Bytes> {
         self.inner.iter().flat_map(|fb| fb.diff.transactions.iter().cloned()).collect()
@@ -259,171 +246,437 @@ impl Deref for FlashBlockCompleteSequence {
     }
 }
 
-impl<T> TryFrom<FlashBlockPendingSequence<T>> for FlashBlockCompleteSequence {
+impl TryFrom<FlashBlockPendingSequence> for FlashBlockCompleteSequence {
     type Error = eyre::Error;
-    fn try_from(sequence: FlashBlockPendingSequence<T>) -> Result<Self, Self::Error> {
-        Self::new(
-            sequence.inner.into_values().map(|block| block.block().clone()).collect::<Vec<_>>(),
-            sequence.execution_outcome,
-        )
-    }
-}
-
-#[derive(Debug)]
-struct PreparedFlashBlock<T> {
-    /// The prepared transactions, ready for execution
-    txs: Vec<WithEncoded<Recovered<T>>>,
-    /// The tracked flashblock
-    block: FlashBlock,
-}
-
-impl<T> PreparedFlashBlock<T> {
-    const fn block(&self) -> &FlashBlock {
-        &self.block
-    }
-}
-
-impl<T> From<PreparedFlashBlock<T>> for FlashBlock {
-    fn from(val: PreparedFlashBlock<T>) -> Self {
-        val.block
-    }
-}
-
-impl<T> PreparedFlashBlock<T>
-where
-    T: SignedTransaction,
-{
-    /// Creates a flashblock that is ready for execution by preparing all transactions
-    ///
-    /// Returns an error if decoding or signer recovery fails.
-    fn new(block: FlashBlock) -> eyre::Result<Self> {
-        let mut txs = Vec::with_capacity(block.diff.transactions.len());
-        for encoded in block.diff.transactions.iter().cloned() {
-            let tx = T::decode_2718_exact(encoded.as_ref())?;
-            let signer = tx.try_recover()?;
-            let tx = WithEncoded::new(encoded, tx.with_signer(signer));
-            txs.push(tx);
-        }
-
-        Ok(Self { txs, block })
-    }
-}
-
-impl<T> Deref for PreparedFlashBlock<T> {
-    type Target = FlashBlock;
-
-    fn deref(&self) -> &Self::Target {
-        &self.block
+    fn try_from(sequence: FlashBlockPendingSequence) -> Result<Self, Self::Error> {
+        Self::new(sequence.inner.into_values().collect(), sequence.execution_outcome)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_consensus::{
-        transaction::SignerRecoverable, EthereumTxEnvelope, EthereumTypedTransaction, TxEip1559,
-    };
-    use alloy_eips::Encodable2718;
-    use alloy_primitives::{hex, Signature, TxKind, U256};
-    use op_alloy_rpc_types_engine::{
-        OpFlashblockPayload, OpFlashblockPayloadBase, OpFlashblockPayloadDelta,
-    };
+    use crate::test_utils::TestFlashBlockFactory;
 
-    #[test]
-    fn test_sequence_stops_before_gap() {
-        let mut sequence = FlashBlockPendingSequence::new();
-        let tx = EthereumTxEnvelope::new_unhashed(
-            EthereumTypedTransaction::<TxEip1559>::Eip1559(TxEip1559 {
-                chain_id: 4,
-                nonce: 26u64,
-                max_priority_fee_per_gas: 1500000000,
-                max_fee_per_gas: 1500000013,
-                gas_limit: 21_000u64,
-                to: TxKind::Call(hex!("61815774383099e24810ab832a5b2a5425c154d5").into()),
-                value: U256::from(3000000000000000000u64),
-                input: Default::default(),
-                access_list: Default::default(),
-            }),
-            Signature::new(
-                U256::from_be_bytes(hex!(
-                    "59e6b67f48fb32e7e570dfb11e042b5ad2e55e3ce3ce9cd989c7e06e07feeafd"
-                )),
-                U256::from_be_bytes(hex!(
-                    "016b83f4f980694ed2eee4d10667242b1f40dc406901b34125b008d334d47469"
-                )),
-                true,
-            ),
-        );
-        let tx = Recovered::new_unchecked(tx.clone(), tx.recover_signer_unchecked().unwrap());
+    mod pending_sequence_insert {
+        use super::*;
 
-        sequence
-            .insert(OpFlashblockPayload {
-                payload_id: Default::default(),
-                index: 0,
-                base: None,
-                diff: OpFlashblockPayloadDelta {
-                    transactions: vec![tx.encoded_2718().into()],
-                    ..Default::default()
-                },
-                metadata: Default::default(),
-            })
-            .unwrap();
+        #[test]
+        fn test_insert_index_zero_creates_new_sequence() {
+            let mut sequence = FlashBlockPendingSequence::new();
+            let factory = TestFlashBlockFactory::new();
+            let fb0 = factory.flashblock_at(0).build();
+            let payload_id = fb0.payload_id;
 
-        sequence
-            .insert(OpFlashblockPayload {
-                payload_id: Default::default(),
-                index: 2,
-                base: None,
-                diff: Default::default(),
-                metadata: Default::default(),
-            })
-            .unwrap();
+            sequence.insert(fb0);
 
-        let actual_txs: Vec<_> = sequence.ready_transactions().collect();
-        let expected_txs = vec![WithEncoded::new(tx.encoded_2718().into(), tx)];
-
-        assert_eq!(actual_txs, expected_txs);
-    }
-
-    #[test]
-    fn test_sequence_sends_flashblocks_to_subscribers() {
-        let mut sequence = FlashBlockPendingSequence::<EthereumTxEnvelope<TxEip1559>>::new();
-        let mut subscriber = sequence.subscribe_block_sequence();
-
-        for idx in 0..10 {
-            sequence
-                .insert(OpFlashblockPayload {
-                    payload_id: Default::default(),
-                    index: idx,
-                    base: Some(OpFlashblockPayloadBase::default()),
-                    diff: Default::default(),
-                    metadata: Default::default(),
-                })
-                .unwrap();
+            assert_eq!(sequence.count(), 1);
+            assert_eq!(sequence.block_number(), Some(100));
+            assert_eq!(sequence.payload_id(), Some(payload_id));
         }
 
-        assert_eq!(sequence.count(), 10);
+        #[test]
+        fn test_insert_followup_same_block_and_payload() {
+            let mut sequence = FlashBlockPendingSequence::new();
+            let factory = TestFlashBlockFactory::new();
 
-        // Then we don't receive anything until we insert a new flashblock
-        let no_flashblock = subscriber.try_recv();
-        assert!(no_flashblock.is_err());
+            let fb0 = factory.flashblock_at(0).build();
+            sequence.insert(fb0.clone());
 
-        // Let's insert a new flashblock with index 0
-        sequence
-            .insert(OpFlashblockPayload {
-                payload_id: Default::default(),
-                index: 0,
-                base: Some(OpFlashblockPayloadBase::default()),
-                diff: Default::default(),
-                metadata: Default::default(),
-            })
-            .unwrap();
+            let fb1 = factory.flashblock_after(&fb0).build();
+            sequence.insert(fb1.clone());
 
-        let flashblocks = subscriber.try_recv().unwrap();
-        assert_eq!(flashblocks.count(), 10);
+            let fb2 = factory.flashblock_after(&fb1).build();
+            sequence.insert(fb2);
 
-        for (idx, block) in flashblocks.iter().enumerate() {
-            assert_eq!(block.index, idx as u64);
+            assert_eq!(sequence.count(), 3);
+            assert_eq!(sequence.index(), Some(2));
+        }
+
+        #[test]
+        fn test_insert_ignores_different_block_number() {
+            let mut sequence = FlashBlockPendingSequence::new();
+            let factory = TestFlashBlockFactory::new();
+
+            let fb0 = factory.flashblock_at(0).build();
+            sequence.insert(fb0.clone());
+
+            // Try to insert followup with different block number
+            let fb1 = factory.flashblock_after(&fb0).block_number(101).build();
+            sequence.insert(fb1);
+
+            assert_eq!(sequence.count(), 1);
+            assert_eq!(sequence.block_number(), Some(100));
+        }
+
+        #[test]
+        fn test_insert_ignores_different_payload_id() {
+            let mut sequence = FlashBlockPendingSequence::new();
+            let factory = TestFlashBlockFactory::new();
+
+            let fb0 = factory.flashblock_at(0).build();
+            let payload_id1 = fb0.payload_id;
+            sequence.insert(fb0.clone());
+
+            // Try to insert followup with different payload_id
+            let payload_id2 = alloy_rpc_types_engine::PayloadId::new([2u8; 8]);
+            let fb1 = factory.flashblock_after(&fb0).payload_id(payload_id2).build();
+            sequence.insert(fb1);
+
+            assert_eq!(sequence.count(), 1);
+            assert_eq!(sequence.payload_id(), Some(payload_id1));
+        }
+
+        #[test]
+        fn test_insert_maintains_btree_order() {
+            let mut sequence = FlashBlockPendingSequence::new();
+            let factory = TestFlashBlockFactory::new();
+
+            let fb0 = factory.flashblock_at(0).build();
+            sequence.insert(fb0.clone());
+
+            let fb2 = factory.flashblock_after(&fb0).index(2).build();
+            sequence.insert(fb2);
+
+            let fb1 = factory.flashblock_after(&fb0).build();
+            sequence.insert(fb1);
+
+            let indices: Vec<u64> = sequence.flashblocks().map(|fb| fb.index).collect();
+            assert_eq!(indices, vec![0, 1, 2]);
+        }
+    }
+
+    mod pending_sequence_finalize {
+        use super::*;
+
+        #[test]
+        fn test_finalize_empty_sequence_fails() {
+            let mut sequence = FlashBlockPendingSequence::new();
+            let result = sequence.finalize();
+
+            assert!(result.is_err());
+            assert_eq!(
+                result.unwrap_err().to_string(),
+                "Cannot finalize empty flashblock sequence"
+            );
+        }
+
+        #[test]
+        fn test_finalize_clears_pending_state() {
+            let mut sequence = FlashBlockPendingSequence::new();
+            let factory = TestFlashBlockFactory::new();
+
+            let fb0 = factory.flashblock_at(0).build();
+            sequence.insert(fb0);
+
+            assert_eq!(sequence.count(), 1);
+
+            let _complete = sequence.finalize().unwrap();
+
+            // After finalize, sequence should be empty
+            assert_eq!(sequence.count(), 0);
+            assert_eq!(sequence.block_number(), None);
+        }
+
+        #[test]
+        fn test_finalize_preserves_execution_outcome() {
+            let mut sequence = FlashBlockPendingSequence::new();
+            let factory = TestFlashBlockFactory::new();
+
+            let fb0 = factory.flashblock_at(0).build();
+            sequence.insert(fb0);
+
+            let outcome =
+                SequenceExecutionOutcome { block_hash: B256::random(), state_root: B256::random() };
+            sequence.set_execution_outcome(Some(outcome));
+
+            let complete = sequence.finalize().unwrap();
+
+            assert_eq!(complete.execution_outcome(), Some(outcome));
+        }
+
+        #[test]
+        fn test_finalize_clears_cached_reads() {
+            let mut sequence = FlashBlockPendingSequence::new();
+            let factory = TestFlashBlockFactory::new();
+
+            let fb0 = factory.flashblock_at(0).build();
+            sequence.insert(fb0);
+
+            let cached_reads = CachedReads::default();
+            sequence.set_cached_reads(cached_reads);
+            assert!(sequence.cached_reads().is_some());
+
+            let _complete = sequence.finalize().unwrap();
+
+            // Cached reads should be cleared
+            assert!(sequence.cached_reads().is_none());
+        }
+
+        #[test]
+        fn test_finalize_multiple_times_after_refill() {
+            let mut sequence = FlashBlockPendingSequence::new();
+            let factory = TestFlashBlockFactory::new();
+
+            // First sequence
+            let fb0 = factory.flashblock_at(0).build();
+            sequence.insert(fb0);
+
+            let complete1 = sequence.finalize().unwrap();
+            assert_eq!(complete1.count(), 1);
+
+            // Add new sequence for next block
+            let fb1 = factory.flashblock_for_next_block(&complete1.last().clone()).build();
+            sequence.insert(fb1);
+
+            let complete2 = sequence.finalize().unwrap();
+            assert_eq!(complete2.count(), 1);
+            assert_eq!(complete2.block_number(), 101);
+        }
+    }
+
+    mod complete_sequence_invariants {
+        use super::*;
+
+        #[test]
+        fn test_new_empty_sequence_fails() {
+            let result = FlashBlockCompleteSequence::new(vec![], None);
+            assert!(result.is_err());
+            assert_eq!(result.unwrap_err().to_string(), "No flashblocks in sequence");
+        }
+
+        #[test]
+        fn test_new_requires_base_at_index_zero() {
+            let factory = TestFlashBlockFactory::new();
+            // Use builder() with index 1 first to create a flashblock, then change its index to 0
+            // to bypass the auto-base creation logic
+            let mut fb0_no_base = factory.flashblock_at(1).build();
+            fb0_no_base.index = 0;
+            fb0_no_base.base = None;
+
+            let result = FlashBlockCompleteSequence::new(vec![fb0_no_base], None);
+            assert!(result.is_err());
+            assert_eq!(result.unwrap_err().to_string(), "Flashblock at index 0 has no base");
+        }
+
+        #[test]
+        fn test_new_validates_successive_indices() {
+            let factory = TestFlashBlockFactory::new();
+
+            let fb0 = factory.flashblock_at(0).build();
+            // Skip index 1, go straight to 2
+            let fb2 = factory.flashblock_after(&fb0).index(2).build();
+
+            let result = FlashBlockCompleteSequence::new(vec![fb0, fb2], None);
+            assert!(result.is_err());
+            assert_eq!(
+                result.unwrap_err().to_string(),
+                "Flashblock inconsistencies detected in sequence"
+            );
+        }
+
+        #[test]
+        fn test_new_validates_same_block_number() {
+            let factory = TestFlashBlockFactory::new();
+
+            let fb0 = factory.flashblock_at(0).build();
+            let fb1 = factory.flashblock_after(&fb0).block_number(101).build();
+
+            let result = FlashBlockCompleteSequence::new(vec![fb0, fb1], None);
+            assert!(result.is_err());
+            assert_eq!(
+                result.unwrap_err().to_string(),
+                "Flashblock inconsistencies detected in sequence"
+            );
+        }
+
+        #[test]
+        fn test_new_validates_same_payload_id() {
+            let factory = TestFlashBlockFactory::new();
+
+            let fb0 = factory.flashblock_at(0).build();
+            let payload_id2 = alloy_rpc_types_engine::PayloadId::new([2u8; 8]);
+            let fb1 = factory.flashblock_after(&fb0).payload_id(payload_id2).build();
+
+            let result = FlashBlockCompleteSequence::new(vec![fb0, fb1], None);
+            assert!(result.is_err());
+            assert_eq!(
+                result.unwrap_err().to_string(),
+                "Flashblock inconsistencies detected in sequence"
+            );
+        }
+
+        #[test]
+        fn test_new_valid_single_flashblock() {
+            let factory = TestFlashBlockFactory::new();
+            let fb0 = factory.flashblock_at(0).build();
+
+            let result = FlashBlockCompleteSequence::new(vec![fb0], None);
+            assert!(result.is_ok());
+
+            let complete = result.unwrap();
+            assert_eq!(complete.count(), 1);
+            assert_eq!(complete.block_number(), 100);
+        }
+
+        #[test]
+        fn test_new_valid_multiple_flashblocks() {
+            let factory = TestFlashBlockFactory::new();
+
+            let fb0 = factory.flashblock_at(0).build();
+            let fb1 = factory.flashblock_after(&fb0).build();
+            let fb2 = factory.flashblock_after(&fb1).build();
+
+            let result = FlashBlockCompleteSequence::new(vec![fb0, fb1, fb2], None);
+            assert!(result.is_ok());
+
+            let complete = result.unwrap();
+            assert_eq!(complete.count(), 3);
+            assert_eq!(complete.last().index, 2);
+        }
+
+        #[test]
+        fn test_all_transactions_aggregates_correctly() {
+            let factory = TestFlashBlockFactory::new();
+
+            let fb0 = factory
+                .flashblock_at(0)
+                .transactions(vec![Bytes::from_static(&[1, 2, 3]), Bytes::from_static(&[4, 5, 6])])
+                .build();
+
+            let fb1 = factory
+                .flashblock_after(&fb0)
+                .transactions(vec![Bytes::from_static(&[7, 8, 9])])
+                .build();
+
+            let complete = FlashBlockCompleteSequence::new(vec![fb0, fb1], None).unwrap();
+            let all_txs = complete.all_transactions();
+
+            assert_eq!(all_txs.len(), 3);
+            assert_eq!(all_txs[0], Bytes::from_static(&[1, 2, 3]));
+            assert_eq!(all_txs[1], Bytes::from_static(&[4, 5, 6]));
+            assert_eq!(all_txs[2], Bytes::from_static(&[7, 8, 9]));
+        }
+
+        #[test]
+        fn test_payload_base_returns_first_block_base() {
+            let factory = TestFlashBlockFactory::new();
+
+            let fb0 = factory.flashblock_at(0).build();
+            let fb1 = factory.flashblock_after(&fb0).build();
+
+            let complete = FlashBlockCompleteSequence::new(vec![fb0.clone(), fb1], None).unwrap();
+
+            assert_eq!(complete.payload_base().block_number, fb0.base.unwrap().block_number);
+        }
+
+        #[test]
+        fn test_execution_outcome_mutation() {
+            let factory = TestFlashBlockFactory::new();
+            let fb0 = factory.flashblock_at(0).build();
+
+            let mut complete = FlashBlockCompleteSequence::new(vec![fb0], None).unwrap();
+            assert!(complete.execution_outcome().is_none());
+
+            let outcome =
+                SequenceExecutionOutcome { block_hash: B256::random(), state_root: B256::random() };
+            complete.set_execution_outcome(Some(outcome));
+
+            assert_eq!(complete.execution_outcome(), Some(outcome));
+        }
+
+        #[test]
+        fn test_deref_provides_vec_access() {
+            let factory = TestFlashBlockFactory::new();
+
+            let fb0 = factory.flashblock_at(0).build();
+            let fb1 = factory.flashblock_after(&fb0).build();
+
+            let complete = FlashBlockCompleteSequence::new(vec![fb0, fb1], None).unwrap();
+
+            // Use deref to access Vec methods
+            assert_eq!(complete.len(), 2);
+            assert!(!complete.is_empty());
+        }
+    }
+
+    mod sequence_conversion {
+        use super::*;
+
+        #[test]
+        fn test_try_from_pending_to_complete_valid() {
+            let mut pending = FlashBlockPendingSequence::new();
+            let factory = TestFlashBlockFactory::new();
+
+            let fb0 = factory.flashblock_at(0).build();
+            pending.insert(fb0);
+
+            let complete: Result<FlashBlockCompleteSequence, _> = pending.try_into();
+            assert!(complete.is_ok());
+            assert_eq!(complete.unwrap().count(), 1);
+        }
+
+        #[test]
+        fn test_try_from_pending_to_complete_empty_fails() {
+            let pending = FlashBlockPendingSequence::new();
+
+            let complete: Result<FlashBlockCompleteSequence, _> = pending.try_into();
+            assert!(complete.is_err());
+        }
+
+        #[test]
+        fn test_try_from_preserves_execution_outcome() {
+            let mut pending = FlashBlockPendingSequence::new();
+            let factory = TestFlashBlockFactory::new();
+
+            let fb0 = factory.flashblock_at(0).build();
+            pending.insert(fb0);
+
+            let outcome =
+                SequenceExecutionOutcome { block_hash: B256::random(), state_root: B256::random() };
+            pending.set_execution_outcome(Some(outcome));
+
+            let complete: FlashBlockCompleteSequence = pending.try_into().unwrap();
+            assert_eq!(complete.execution_outcome(), Some(outcome));
+        }
+    }
+
+    mod pending_sequence_helpers {
+        use super::*;
+
+        #[test]
+        fn test_last_flashblock_returns_highest_index() {
+            let mut sequence = FlashBlockPendingSequence::new();
+            let factory = TestFlashBlockFactory::new();
+
+            let fb0 = factory.flashblock_at(0).build();
+            sequence.insert(fb0.clone());
+
+            let fb1 = factory.flashblock_after(&fb0).build();
+            sequence.insert(fb1);
+
+            let last = sequence.last_flashblock().unwrap();
+            assert_eq!(last.index, 1);
+        }
+
+        #[test]
+        fn test_subscribe_block_sequence_channel() {
+            let sequence = FlashBlockPendingSequence::new();
+            let mut rx = sequence.subscribe_block_sequence();
+
+            // Spawn a task that sends a complete sequence
+            let tx = sequence.block_sequence_broadcaster().clone();
+            std::thread::spawn(move || {
+                let factory = TestFlashBlockFactory::new();
+                let fb0 = factory.flashblock_at(0).build();
+                let complete = FlashBlockCompleteSequence::new(vec![fb0], None).unwrap();
+                let _ = tx.send(complete);
+            });
+
+            // Should receive the broadcast
+            let received = rx.blocking_recv();
+            assert!(received.is_ok());
+            assert_eq!(received.unwrap().count(), 1);
         }
     }
 }

--- a/crates/optimism/flashblocks/src/service.rs
+++ b/crates/optimism/flashblocks/src/service.rs
@@ -1,37 +1,20 @@
 use crate::{
-    sequence::{FlashBlockPendingSequence, SequenceExecutionOutcome},
-    worker::{BuildArgs, FlashBlockBuilder},
-    FlashBlock, FlashBlockCompleteSequence, FlashBlockCompleteSequenceRx, InProgressFlashBlockRx,
-    PendingFlashBlock,
+    cache::SequenceManager, worker::FlashBlockBuilder, FlashBlock, FlashBlockCompleteSequence,
+    FlashBlockCompleteSequenceRx, InProgressFlashBlockRx, PendingFlashBlock,
 };
-use alloy_eips::eip2718::WithEncoded;
 use alloy_primitives::B256;
 use futures_util::{FutureExt, Stream, StreamExt};
 use metrics::{Gauge, Histogram};
 use op_alloy_rpc_types_engine::OpFlashblockPayloadBase;
-use reth_chain_state::{CanonStateNotification, CanonStateNotifications, CanonStateSubscriptions};
 use reth_evm::ConfigureEvm;
 use reth_metrics::Metrics;
-use reth_primitives_traits::{
-    AlloyBlockHeader, BlockTy, HeaderTy, NodePrimitives, ReceiptTy, Recovered,
-};
+use reth_primitives_traits::{AlloyBlockHeader, BlockTy, HeaderTy, NodePrimitives, ReceiptTy};
 use reth_revm::cached::CachedReads;
 use reth_storage_api::{BlockReaderIdExt, StateProviderFactory};
 use reth_tasks::TaskExecutor;
-use std::{
-    pin::Pin,
-    sync::Arc,
-    task::{ready, Context, Poll},
-    time::Instant,
-};
-use tokio::{
-    pin,
-    sync::{oneshot, watch},
-};
-use tracing::{debug, trace, warn};
-
-/// 200 ms flashblock time.
-pub(crate) const FLASHBLOCK_BLOCK_TIME: u64 = 200;
+use std::{sync::Arc, time::Instant};
+use tokio::sync::{oneshot, watch};
+use tracing::*;
 
 /// The `FlashBlockService` maintains an in-memory [`PendingFlashBlock`] built out of a sequence of
 /// [`FlashBlock`]s.
@@ -42,27 +25,24 @@ pub struct FlashBlockService<
     EvmConfig: ConfigureEvm<Primitives = N, NextBlockEnvCtx: From<OpFlashblockPayloadBase> + Unpin>,
     Provider,
 > {
-    rx: S,
-    current: Option<PendingFlashBlock<N>>,
-    blocks: FlashBlockPendingSequence<N::SignedTx>,
+    /// Incoming flashblock stream.
+    incoming_flashblock_rx: S,
+    /// Signals when a block build is in progress.
+    in_progress_tx: watch::Sender<Option<FlashBlockBuildInfo>>,
     /// Broadcast channel to forward received flashblocks from the subscription.
     received_flashblocks_tx: tokio::sync::broadcast::Sender<Arc<FlashBlock>>,
-    rebuild: bool,
+
+    /// Executes flashblock sequences to build pending blocks.
     builder: FlashBlockBuilder<EvmConfig, Provider>,
-    canon_receiver: CanonStateNotifications<N>,
+    /// Task executor for spawning block build jobs.
     spawner: TaskExecutor,
+    /// Currently running block build job with start time and result receiver.
     job: Option<BuildJob<N>>,
-    /// Cached state reads for the current block.
-    /// Current `PendingFlashBlock` is built out of a sequence of `FlashBlocks`, and executed again
-    /// when fb received on top of the same block. Avoid redundant I/O across multiple
-    /// executions within the same block.
-    cached_state: Option<(B256, CachedReads)>,
-    /// Signals when a block build is in progress
-    in_progress_tx: watch::Sender<Option<FlashBlockBuildInfo>>,
+    /// Manages flashblock sequences with caching and intelligent build selection.
+    sequences: SequenceManager,
+
     /// `FlashBlock` service's metrics
     metrics: FlashBlockServiceMetrics,
-    /// Enable state root calculation
-    compute_state_root: bool,
 }
 
 impl<N, S, EvmConfig, Provider> FlashBlockService<N, S, EvmConfig, Provider>
@@ -73,7 +53,6 @@ where
         + Clone
         + 'static,
     Provider: StateProviderFactory
-        + CanonStateSubscriptions<Primitives = N>
         + BlockReaderIdExt<
             Header = HeaderTy<N>,
             Block = BlockTy<N>,
@@ -84,30 +63,25 @@ where
         + 'static,
 {
     /// Constructs a new `FlashBlockService` that receives [`FlashBlock`]s from `rx` stream.
-    pub fn new(rx: S, evm_config: EvmConfig, provider: Provider, spawner: TaskExecutor) -> Self {
+    pub fn new(
+        incoming_flashblock_rx: S,
+        evm_config: EvmConfig,
+        provider: Provider,
+        spawner: TaskExecutor,
+        compute_state_root: bool,
+    ) -> Self {
         let (in_progress_tx, _) = watch::channel(None);
         let (received_flashblocks_tx, _) = tokio::sync::broadcast::channel(128);
         Self {
-            rx,
-            current: None,
-            blocks: FlashBlockPendingSequence::new(),
+            incoming_flashblock_rx,
+            in_progress_tx,
             received_flashblocks_tx,
-            canon_receiver: provider.subscribe_to_canonical_state(),
             builder: FlashBlockBuilder::new(evm_config, provider),
-            rebuild: false,
             spawner,
             job: None,
-            cached_state: None,
-            in_progress_tx,
+            sequences: SequenceManager::new(compute_state_root),
             metrics: FlashBlockServiceMetrics::default(),
-            compute_state_root: false,
         }
-    }
-
-    /// Enable state root calculation from flashblock
-    pub const fn compute_state_root(mut self, enable_state_root: bool) -> Self {
-        self.compute_state_root = enable_state_root;
-        self
     }
 
     /// Returns the sender half to the received flashblocks.
@@ -121,12 +95,12 @@ where
     pub const fn block_sequence_broadcaster(
         &self,
     ) -> &tokio::sync::broadcast::Sender<FlashBlockCompleteSequence> {
-        self.blocks.block_sequence_broadcaster()
+        self.sequences.block_sequence_broadcaster()
     }
 
     /// Returns a subscriber to the flashblock sequence.
     pub fn subscribe_block_sequence(&self) -> FlashBlockCompleteSequenceRx {
-        self.blocks.subscribe_block_sequence()
+        self.sequences.subscribe_block_sequence()
     }
 
     /// Returns a receiver that signals when a flashblock is being built.
@@ -134,282 +108,129 @@ where
         self.in_progress_tx.subscribe()
     }
 
-    /// Drives the services and sends new blocks to the receiver
+    /// Drives the service and sends new blocks to the receiver.
+    ///
+    /// This loop:
+    /// 1. Checks if any build job has completed and processes results
+    /// 2. Receives and batches all immediately available flashblocks
+    /// 3. Attempts to build a block from the complete sequence
     ///
     /// Note: this should be spawned
-    pub async fn run(mut self, tx: tokio::sync::watch::Sender<Option<PendingFlashBlock<N>>>) {
-        while let Some(block) = self.next().await {
-            if let Ok(block) = block.inspect_err(|e| tracing::error!(target: "flashblocks", "{e}"))
-            {
-                let _ =
-                    tx.send(block).inspect_err(|e| tracing::error!(target: "flashblocks", "{e}"));
+    pub async fn run(mut self, tx: watch::Sender<Option<PendingFlashBlock<N>>>) {
+        loop {
+            tokio::select! {
+                // Event 1: job exists, listen to job results
+                Some(result) = async {
+                    match self.job.as_mut() {
+                        Some((_, rx)) => rx.await.ok(),
+                        None => std::future::pending().await,
+                    }
+                } => {
+                    let (start_time, _) = self.job.take().unwrap();
+                    let _ = self.in_progress_tx.send(None);
+
+                    match result {
+                        Ok(Some((pending, cached_reads))) => {
+                            let parent_hash = pending.parent_hash();
+                            self.sequences
+                                .on_build_complete(parent_hash, Some((pending.clone(), cached_reads)));
+
+                            let elapsed = start_time.elapsed();
+                            self.metrics.execution_duration.record(elapsed.as_secs_f64());
+
+                            let _ = tx.send(Some(pending));
+                        }
+                        Ok(None) => {
+                            trace!(target: "flashblocks", "Build job returned None");
+                        }
+                        Err(err) => {
+                            warn!(target: "flashblocks", %err, "Build job failed");
+                        }
+                    }
+                }
+
+                // Event 2: New flashblock arrives (batch process all ready flashblocks)
+                result = self.incoming_flashblock_rx.next() => {
+                    match result {
+                        Some(Ok(flashblock)) => {
+                            // Process first flashblock
+                            self.process_flashblock(flashblock);
+
+                            // Batch process all other immediately available flashblocks
+                            while let Some(result) = self.incoming_flashblock_rx.next().now_or_never().flatten() {
+                                match result {
+                                    Ok(fb) => self.process_flashblock(fb),
+                                    Err(err) => warn!(target: "flashblocks", %err, "Error receiving flashblock"),
+                                }
+                            }
+
+                            self.try_start_build_job();
+                        }
+                        Some(Err(err)) => {
+                            warn!(target: "flashblocks", %err, "Error receiving flashblock");
+                        }
+                        None => {
+                            warn!(target: "flashblocks", "Flashblock stream ended");
+                            break;
+                        }
+                    }
+                }
             }
         }
-
-        warn!(target: "flashblocks", "Flashblock service has stopped");
     }
 
-    /// Notifies all subscribers about the received flashblock
+    /// Processes a single flashblock: notifies subscribers, records metrics, and inserts into
+    /// sequence.
+    fn process_flashblock(&mut self, flashblock: FlashBlock) {
+        self.notify_received_flashblock(&flashblock);
+
+        if flashblock.index == 0 {
+            self.metrics.last_flashblock_length.record(self.sequences.pending().count() as f64);
+        }
+
+        if let Err(err) = self.sequences.insert_flashblock(flashblock) {
+            trace!(target: "flashblocks", %err, "Failed to insert flashblock");
+        }
+    }
+
+    /// Notifies all subscribers about the received flashblock.
     fn notify_received_flashblock(&self, flashblock: &FlashBlock) {
         if self.received_flashblocks_tx.receiver_count() > 0 {
             let _ = self.received_flashblocks_tx.send(Arc::new(flashblock.clone()));
         }
     }
 
-    /// Returns the [`BuildArgs`] made purely out of [`FlashBlock`]s that were received earlier.
-    ///
-    /// Returns `None` if the flashblock have no `base` or the base is not a child block of latest.
-    fn build_args(
-        &mut self,
-    ) -> Option<
-        BuildArgs<
-            impl IntoIterator<Item = WithEncoded<Recovered<N::SignedTx>>>
-                + use<N, S, EvmConfig, Provider>,
-        >,
-    > {
-        let Some(base) = self.blocks.payload_base() else {
-            trace!(
-                target: "flashblocks",
-                flashblock_number = ?self.blocks.block_number(),
-                count = %self.blocks.count(),
-                "Missing flashblock payload base"
-            );
-
-            return None
-        };
+    /// Attempts to build a block if no job is currently running and a buildable sequence exists.
+    fn try_start_build_job(&mut self) {
+        if self.job.is_some() {
+            return; // Already building
+        }
 
         let Some(latest) = self.builder.provider().latest_header().ok().flatten() else {
-            trace!(target: "flashblocks", "No latest header found");
-            return None
+            return;
         };
 
-        // attempt an initial consecutive check
-        if latest.hash() != base.parent_hash {
-            trace!(target: "flashblocks", flashblock_parent=?base.parent_hash, flashblock_number=base.block_number, local_latest=?latest.num_hash(), "Skipping non consecutive build attempt");
-            return None
-        }
-
-        let Some(last_flashblock) = self.blocks.last_flashblock() else {
-            trace!(target: "flashblocks", flashblock_number = ?self.blocks.block_number(), count = %self.blocks.count(), "Missing last flashblock");
-            return None
+        let Some(args) = self.sequences.next_buildable_args(latest.hash(), latest.timestamp())
+        else {
+            return; // Nothing buildable
         };
 
-        // Auto-detect when to compute state root: only if the builder didn't provide it (sent
-        // B256::ZERO) and we're near the expected final flashblock index.
-        //
-        // Background: Each block period receives multiple flashblocks at regular intervals.
-        // The sequencer sends an initial "base" flashblock at index 0 when a new block starts,
-        // then subsequent flashblocks are produced every FLASHBLOCK_BLOCK_TIME intervals (200ms).
-        //
-        // Examples with different block times:
-        // - Base (2s blocks):    expect 2000ms / 200ms = 10 intervals → Flashblocks: index 0 (base)
-        //   + indices 1-10 = potentially 11 total
-        //
-        // - Unichain (1s blocks): expect 1000ms / 200ms = 5 intervals → Flashblocks: index 0 (base)
-        //   + indices 1-5 = potentially 6 total
-        //
-        // Why compute at N-1 instead of N:
-        // 1. Timing variance in flashblock producing time may mean only N flashblocks were produced
-        //    instead of N+1 (missing the final one). Computing at N-1 ensures we get the state root
-        //    for most common cases.
-        //
-        // 2. The +1 case (index 0 base + N intervals): If all N+1 flashblocks do arrive, we'll
-        //    still calculate state root for flashblock N, which sacrifices a little performance but
-        //    still ensures correctness for common cases.
-        //
-        // Note: Pathological cases may result in fewer flashblocks than expected (e.g., builder
-        // downtime, flashblock execution exceeding timing budget). When this occurs, we won't
-        // compute the state root, causing FlashblockConsensusClient to lack precomputed state for
-        // engine_newPayload. This is safe: we still have op-node as backstop to maintain
-        // chain progression.
-        let block_time_ms = (base.timestamp - latest.timestamp()) * 1000;
-        let expected_final_flashblock = block_time_ms / FLASHBLOCK_BLOCK_TIME;
-        let compute_state_root = self.compute_state_root &&
-            last_flashblock.diff.state_root.is_zero() &&
-            self.blocks.index() >= Some(expected_final_flashblock.saturating_sub(1));
+        // Spawn build job
+        let fb_info = FlashBlockBuildInfo {
+            parent_hash: args.base.parent_hash,
+            index: args.last_flashblock_index,
+            block_number: args.base.block_number,
+        };
+        self.metrics.current_block_height.set(fb_info.block_number as f64);
+        self.metrics.current_index.set(fb_info.index as f64);
+        let _ = self.in_progress_tx.send(Some(fb_info));
 
-        Some(BuildArgs {
-            base,
-            transactions: self.blocks.ready_transactions().collect::<Vec<_>>(),
-            cached_state: self.cached_state.take(),
-            last_flashblock_index: last_flashblock.index,
-            last_flashblock_hash: last_flashblock.diff.block_hash,
-            compute_state_root,
-        })
-    }
-
-    /// Takes out `current` [`PendingFlashBlock`] if `state` is not preceding it.
-    fn on_new_tip(&mut self, state: CanonStateNotification<N>) -> Option<PendingFlashBlock<N>> {
-        let tip = state.tip_checked()?;
-        let tip_hash = tip.hash();
-        let current = self.current.take_if(|current| current.parent_hash() != tip_hash);
-
-        // Prefill the cache with state from the new canonical tip, similar to payload/basic
-        let mut cached = CachedReads::default();
-        let committed = state.committed();
-        let new_execution_outcome = committed.execution_outcome();
-        for (addr, acc) in new_execution_outcome.bundle_accounts_iter() {
-            if let Some(info) = acc.info.clone() {
-                // Pre-cache existing accounts and their storage (only changed accounts/storage)
-                let storage =
-                    acc.storage.iter().map(|(key, slot)| (*key, slot.present_value)).collect();
-                cached.insert_account(addr, info, storage);
-            }
-        }
-        self.cached_state = Some((tip_hash, cached));
-
-        current
-    }
-}
-
-impl<N, S, EvmConfig, Provider> Stream for FlashBlockService<N, S, EvmConfig, Provider>
-where
-    N: NodePrimitives,
-    S: Stream<Item = eyre::Result<FlashBlock>> + Unpin + 'static,
-    EvmConfig: ConfigureEvm<Primitives = N, NextBlockEnvCtx: From<OpFlashblockPayloadBase> + Unpin>
-        + Clone
-        + 'static,
-    Provider: StateProviderFactory
-        + CanonStateSubscriptions<Primitives = N>
-        + BlockReaderIdExt<
-            Header = HeaderTy<N>,
-            Block = BlockTy<N>,
-            Transaction = N::SignedTx,
-            Receipt = ReceiptTy<N>,
-        > + Unpin
-        + Clone
-        + 'static,
-{
-    type Item = eyre::Result<Option<PendingFlashBlock<N>>>;
-
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let this = self.get_mut();
-
-        loop {
-            // drive pending build job to completion
-            let result = match this.job.as_mut() {
-                Some((now, rx)) => {
-                    let result = ready!(rx.poll_unpin(cx));
-                    result.ok().map(|res| (*now, res))
-                }
-                None => None,
-            };
-            // reset job
-            this.job.take();
-            // No build in progress
-            let _ = this.in_progress_tx.send(None);
-
-            if let Some((now, result)) = result {
-                match result {
-                    Ok(Some((new_pending, cached_reads))) => {
-                        // update execution outcome of the current sequence
-                        let execution_outcome =
-                            new_pending.computed_state_root().map(|state_root| {
-                                SequenceExecutionOutcome {
-                                    block_hash: new_pending.block().hash(),
-                                    state_root,
-                                }
-                            });
-                        this.blocks.set_execution_outcome(execution_outcome);
-
-                        // built a new pending block
-                        this.current = Some(new_pending.clone());
-                        // cache reads
-                        this.cached_state = Some((new_pending.parent_hash(), cached_reads));
-                        this.rebuild = false;
-
-                        let elapsed = now.elapsed();
-                        this.metrics.execution_duration.record(elapsed.as_secs_f64());
-
-                        trace!(
-                            target: "flashblocks",
-                            parent_hash = %new_pending.block().parent_hash(),
-                            block_number = new_pending.block().number(),
-                            flash_blocks = this.blocks.count(),
-                            ?elapsed,
-                            "Built new block with flashblocks"
-                        );
-
-                        return Poll::Ready(Some(Ok(Some(new_pending))));
-                    }
-                    Ok(None) => {
-                        // nothing to do because tracked flashblock doesn't attach to latest
-                    }
-                    Err(err) => {
-                        // we can ignore this error
-                        debug!(target: "flashblocks", %err, "failed to execute flashblock");
-                    }
-                }
-            }
-
-            // consume new flashblocks while they're ready
-            while let Poll::Ready(Some(result)) = this.rx.poll_next_unpin(cx) {
-                match result {
-                    Ok(flashblock) => {
-                        this.notify_received_flashblock(&flashblock);
-                        if flashblock.index == 0 {
-                            this.metrics.last_flashblock_length.record(this.blocks.count() as f64);
-                        }
-                        match this.blocks.insert(flashblock) {
-                            Ok(_) => this.rebuild = true,
-                            Err(err) => {
-                                debug!(target: "flashblocks", %err, "Failed to prepare flashblock")
-                            }
-                        }
-                    }
-                    Err(err) => return Poll::Ready(Some(Err(err))),
-                }
-            }
-
-            // update on new head block
-            if let Poll::Ready(Ok(state)) = {
-                let fut = this.canon_receiver.recv();
-                pin!(fut);
-                fut.poll_unpin(cx)
-            } && let Some(current) = this.on_new_tip(state)
-            {
-                trace!(
-                    target: "flashblocks",
-                    parent_hash = %current.block().parent_hash(),
-                    block_number = current.block().number(),
-                    "Clearing current flashblock on new canonical block"
-                );
-
-                return Poll::Ready(Some(Ok(None)))
-            }
-
-            if !this.rebuild && this.current.is_some() {
-                return Poll::Pending
-            }
-
-            // try to build a block on top of latest
-            if let Some(args) = this.build_args() {
-                let now = Instant::now();
-
-                let fb_info = FlashBlockBuildInfo {
-                    parent_hash: args.base.parent_hash,
-                    index: args.last_flashblock_index,
-                    block_number: args.base.block_number,
-                };
-                // Record current block and index metrics
-                this.metrics.current_block_height.set(fb_info.block_number as f64);
-                this.metrics.current_index.set(fb_info.index as f64);
-                // Signal that a flashblock build has started with build metadata
-                let _ = this.in_progress_tx.send(Some(fb_info));
-                let (tx, rx) = oneshot::channel();
-                let builder = this.builder.clone();
-
-                this.spawner.spawn_blocking(async move {
-                    let _ = tx.send(builder.execute(args));
-                });
-                this.job.replace((now, rx));
-
-                // continue and poll the spawned job
-                continue
-            }
-
-            return Poll::Pending
-        }
+        let (tx, rx) = oneshot::channel();
+        let builder = self.builder.clone();
+        self.spawner.spawn_blocking(Box::pin(async move {
+            let _ = tx.send(builder.execute(args));
+        }));
+        self.job = Some((Instant::now(), rx));
     }
 }
 

--- a/crates/optimism/flashblocks/src/service.rs
+++ b/crates/optimism/flashblocks/src/service.rs
@@ -39,7 +39,7 @@ pub struct FlashBlockService<
     /// Currently running block build job with start time and result receiver.
     job: Option<BuildJob<N>>,
     /// Manages flashblock sequences with caching and intelligent build selection.
-    sequences: SequenceManager,
+    sequences: SequenceManager<N::SignedTx>,
 
     /// `FlashBlock` service's metrics
     metrics: FlashBlockServiceMetrics,

--- a/crates/optimism/flashblocks/src/test_utils.rs
+++ b/crates/optimism/flashblocks/src/test_utils.rs
@@ -1,0 +1,340 @@
+//! Test utilities for flashblocks.
+//!
+//! Provides a factory for creating test flashblocks with automatic timestamp management.
+//!
+//! # Examples
+//!
+//! ## Simple: Create a flashblock sequence for the same block
+//!
+//! ```ignore
+//! let factory = FlashBlockTestFactory::new(2); // 2 second block time
+//! let fb0 = factory.flashblock_at(0).build();
+//! let fb1 = factory.flashblock_after(&fb0).build();
+//! let fb2 = factory.flashblock_after(&fb1).build();
+//! ```
+//!
+//! ## Create flashblocks with transactions
+//!
+//! ```ignore
+//! let factory = FlashBlockTestFactory::new(2);
+//! let fb0 = factory.flashblock_at(0).build();
+//! let txs = vec![Bytes::from_static(&[1, 2, 3])];
+//! let fb1 = factory.flashblock_after(&fb0).transactions(txs).build();
+//! ```
+//!
+//! ## Test across multiple blocks (timestamps auto-increment)
+//!
+//! ```ignore
+//! let factory = FlashBlockTestFactory::new(2); // 2 second blocks
+//!
+//! // Block 100 at timestamp 1000000
+//! let fb0 = factory.flashblock_at(0).build();
+//! let fb1 = factory.flashblock_after(&fb0).build();
+//!
+//! // Block 101 at timestamp 1000002 (auto-incremented by block_time)
+//! let fb2 = factory.flashblock_for_next_block(&fb1).build();
+//! let fb3 = factory.flashblock_after(&fb2).build();
+//! ```
+//!
+//! ## Full control with builder
+//!
+//! ```ignore
+//! let factory = FlashBlockTestFactory::new(1);
+//! let fb = factory.custom()
+//!     .block_number(100)
+//!     .parent_hash(specific_hash)
+//!     .state_root(computed_root)
+//!     .transactions(txs)
+//!     .build();
+//! ```
+
+use crate::FlashBlock;
+use alloy_primitives::{Address, Bloom, Bytes, B256, U256};
+use alloy_rpc_types_engine::PayloadId;
+use op_alloy_rpc_types_engine::{
+    OpFlashblockPayloadBase, OpFlashblockPayloadDelta, OpFlashblockPayloadMetadata,
+};
+
+/// Factory for creating test flashblocks with automatic timestamp management.
+///
+/// Tracks `block_time` to automatically increment timestamps when creating new blocks.
+/// Returns builders that can be further customized before calling `build()`.
+///
+/// # Examples
+///
+/// ```ignore
+/// let factory = TestFlashBlockFactory::new(2); // 2 second block time
+/// let fb0 = factory.flashblock_at(0).build();
+/// let fb1 = factory.flashblock_after(&fb0).build();
+/// let fb2 = factory.flashblock_for_next_block(&fb1).build(); // timestamp auto-increments
+/// ```
+#[derive(Debug)]
+pub(crate) struct TestFlashBlockFactory {
+    /// Block time in seconds (used to auto-increment timestamps)
+    block_time: u64,
+    /// Starting timestamp for the first block
+    base_timestamp: u64,
+    /// Current block number being tracked
+    current_block_number: u64,
+}
+
+impl TestFlashBlockFactory {
+    /// Creates a new builder with the specified block time in seconds.
+    ///
+    /// # Arguments
+    ///
+    /// * `block_time` - Time between blocks in seconds (e.g., 2 for 2-second blocks)
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let factory = TestFlashBlockFactory::new(2); // 2 second blocks
+    /// let factory_fast = TestFlashBlockFactory::new(1); // 1 second blocks
+    /// ```
+    pub(crate) fn new() -> Self {
+        Self { block_time: 2, base_timestamp: 1_000_000, current_block_number: 100 }
+    }
+
+    pub(crate) fn with_block_time(mut self, block_time: u64) -> Self {
+        self.block_time = block_time;
+        self
+    }
+
+    /// Creates a builder for a flashblock at the specified index (within the current block).
+    ///
+    /// Returns a builder with index set, allowing further customization before building.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let factory = TestFlashBlockFactory::new(2);
+    /// let fb0 = factory.flashblock_at(0).build(); // Simple usage
+    /// let fb1 = factory.flashblock_at(1).state_root(specific_root).build(); // Customize
+    /// ```
+    pub(crate) fn flashblock_at(&self, index: u64) -> TestFlashBlockBuilder {
+        self.builder().index(index).block_number(self.current_block_number)
+    }
+
+    /// Creates a builder for a flashblock following the previous one in the same sequence.
+    ///
+    /// Automatically increments the index and maintains `block_number` and `payload_id`.
+    /// Returns a builder allowing further customization.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let factory = TestFlashBlockFactory::new(2);
+    /// let fb0 = factory.flashblock_at(0).build();
+    /// let fb1 = factory.flashblock_after(&fb0).build(); // Simple
+    /// let fb2 = factory.flashblock_after(&fb1).transactions(txs).build(); // With txs
+    /// ```
+    pub(crate) fn flashblock_after(&self, previous: &FlashBlock) -> TestFlashBlockBuilder {
+        let parent_hash =
+            previous.base.as_ref().map(|b| b.parent_hash).unwrap_or(previous.diff.block_hash);
+
+        self.builder()
+            .index(previous.index + 1)
+            .block_number(previous.metadata.block_number)
+            .payload_id(previous.payload_id)
+            .parent_hash(parent_hash)
+            .timestamp(previous.base.as_ref().map(|b| b.timestamp).unwrap_or(self.base_timestamp))
+    }
+
+    /// Creates a builder for a flashblock for the next block, starting a new sequence at index 0.
+    ///
+    /// Increments block number, uses previous `block_hash` as `parent_hash`, generates new
+    /// `payload_id`, and automatically increments the timestamp by `block_time`.
+    /// Returns a builder allowing further customization.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let factory = TestFlashBlockFactory::new(2); // 2 second blocks
+    /// let fb0 = factory.flashblock_at(0).build(); // Block 100, timestamp 1000000
+    /// let fb1 = factory.flashblock_for_next_block(&fb0).build(); // Block 101, timestamp 1000002
+    /// let fb2 = factory.flashblock_for_next_block(&fb1).transactions(txs).build(); // Customize
+    /// ```
+    pub(crate) fn flashblock_for_next_block(&self, previous: &FlashBlock) -> TestFlashBlockBuilder {
+        let prev_timestamp =
+            previous.base.as_ref().map(|b| b.timestamp).unwrap_or(self.base_timestamp);
+
+        self.builder()
+            .index(0)
+            .block_number(previous.metadata.block_number + 1)
+            .payload_id(PayloadId::new(B256::random().0[0..8].try_into().unwrap()))
+            .parent_hash(previous.diff.block_hash)
+            .timestamp(prev_timestamp + self.block_time)
+    }
+
+    /// Returns a custom builder for full control over flashblock creation.
+    ///
+    /// Use this when the convenience methods don't provide enough control.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let factory = TestFlashBlockFactory::new(2);
+    /// let fb = factory.builder()
+    ///     .index(5)
+    ///     .block_number(200)
+    ///     .parent_hash(specific_hash)
+    ///     .state_root(computed_root)
+    ///     .build();
+    /// ```
+    pub(crate) fn builder(&self) -> TestFlashBlockBuilder {
+        TestFlashBlockBuilder {
+            index: 0,
+            block_number: self.current_block_number,
+            payload_id: PayloadId::new([1u8; 8]),
+            parent_hash: B256::random(),
+            timestamp: self.base_timestamp,
+            base: None,
+            block_hash: B256::random(),
+            state_root: B256::ZERO,
+            receipts_root: B256::ZERO,
+            logs_bloom: Bloom::default(),
+            gas_used: 0,
+            transactions: vec![],
+            withdrawals: vec![],
+            withdrawals_root: B256::ZERO,
+            blob_gas_used: None,
+        }
+    }
+}
+
+/// Custom builder for creating test flashblocks with full control.
+///
+/// Created via [`TestFlashBlockFactory::builder()`].
+#[derive(Debug)]
+pub(crate) struct TestFlashBlockBuilder {
+    index: u64,
+    block_number: u64,
+    payload_id: PayloadId,
+    parent_hash: B256,
+    timestamp: u64,
+    base: Option<OpFlashblockPayloadBase>,
+    block_hash: B256,
+    state_root: B256,
+    receipts_root: B256,
+    logs_bloom: Bloom,
+    gas_used: u64,
+    transactions: Vec<Bytes>,
+    withdrawals: Vec<alloy_eips::eip4895::Withdrawal>,
+    withdrawals_root: B256,
+    blob_gas_used: Option<u64>,
+}
+
+impl TestFlashBlockBuilder {
+    /// Sets the flashblock index.
+    pub(crate) fn index(mut self, index: u64) -> Self {
+        self.index = index;
+        self
+    }
+
+    /// Sets the block number.
+    pub(crate) fn block_number(mut self, block_number: u64) -> Self {
+        self.block_number = block_number;
+        self
+    }
+
+    /// Sets the payload ID.
+    pub(crate) fn payload_id(mut self, payload_id: PayloadId) -> Self {
+        self.payload_id = payload_id;
+        self
+    }
+
+    /// Sets the parent hash.
+    pub(crate) fn parent_hash(mut self, parent_hash: B256) -> Self {
+        self.parent_hash = parent_hash;
+        self
+    }
+
+    /// Sets the timestamp.
+    pub(crate) fn timestamp(mut self, timestamp: u64) -> Self {
+        self.timestamp = timestamp;
+        self
+    }
+
+    /// Sets the base payload. Automatically created for index 0 if not set.
+    #[allow(dead_code)]
+    pub(crate) fn base(mut self, base: OpFlashblockPayloadBase) -> Self {
+        self.base = Some(base);
+        self
+    }
+
+    /// Sets the block hash in the diff.
+    #[allow(dead_code)]
+    pub(crate) fn block_hash(mut self, block_hash: B256) -> Self {
+        self.block_hash = block_hash;
+        self
+    }
+
+    /// Sets the state root in the diff.
+    #[allow(dead_code)]
+    pub(crate) fn state_root(mut self, state_root: B256) -> Self {
+        self.state_root = state_root;
+        self
+    }
+
+    /// Sets the receipts root in the diff.
+    #[allow(dead_code)]
+    pub(crate) fn receipts_root(mut self, receipts_root: B256) -> Self {
+        self.receipts_root = receipts_root;
+        self
+    }
+
+    /// Sets the transactions in the diff.
+    pub(crate) fn transactions(mut self, transactions: Vec<Bytes>) -> Self {
+        self.transactions = transactions;
+        self
+    }
+
+    /// Sets the gas used in the diff.
+    #[allow(dead_code)]
+    pub(crate) fn gas_used(mut self, gas_used: u64) -> Self {
+        self.gas_used = gas_used;
+        self
+    }
+
+    /// Builds the flashblock.
+    ///
+    /// If index is 0 and no base was explicitly set, creates a default base.
+    pub(crate) fn build(mut self) -> FlashBlock {
+        // Auto-create base for index 0 if not set
+        if self.index == 0 && self.base.is_none() {
+            self.base = Some(OpFlashblockPayloadBase {
+                parent_hash: self.parent_hash,
+                parent_beacon_block_root: B256::random(),
+                fee_recipient: Address::default(),
+                prev_randao: B256::random(),
+                block_number: self.block_number,
+                gas_limit: 30_000_000,
+                timestamp: self.timestamp,
+                extra_data: Default::default(),
+                base_fee_per_gas: U256::from(1_000_000_000u64),
+            });
+        }
+
+        FlashBlock {
+            index: self.index,
+            payload_id: self.payload_id,
+            base: self.base,
+            diff: OpFlashblockPayloadDelta {
+                block_hash: self.block_hash,
+                state_root: self.state_root,
+                receipts_root: self.receipts_root,
+                logs_bloom: self.logs_bloom,
+                gas_used: self.gas_used,
+                transactions: self.transactions,
+                withdrawals: self.withdrawals,
+                withdrawals_root: self.withdrawals_root,
+                blob_gas_used: self.blob_gas_used,
+            },
+            metadata: OpFlashblockPayloadMetadata {
+                block_number: self.block_number,
+                receipts: Default::default(),
+                new_account_balances: Default::default(),
+            },
+        }
+    }
+}

--- a/crates/optimism/flashblocks/src/worker.rs
+++ b/crates/optimism/flashblocks/src/worker.rs
@@ -2,7 +2,7 @@ use crate::PendingFlashBlock;
 use alloy_eips::{eip2718::WithEncoded, BlockNumberOrTag};
 use alloy_primitives::B256;
 use op_alloy_rpc_types_engine::OpFlashblockPayloadBase;
-use reth_chain_state::{CanonStateSubscriptions, ExecutedBlock};
+use reth_chain_state::ExecutedBlock;
 use reth_errors::RethError;
 use reth_evm::{
     execute::{BlockBuilder, BlockBuilderOutcome},
@@ -52,7 +52,6 @@ where
     N: NodePrimitives,
     EvmConfig: ConfigureEvm<Primitives = N, NextBlockEnvCtx: From<OpFlashblockPayloadBase> + Unpin>,
     Provider: StateProviderFactory
-        + CanonStateSubscriptions<Primitives = N>
         + BlockReaderIdExt<
             Header = HeaderTy<N>,
             Block = BlockTy<N>,

--- a/crates/optimism/rpc/src/eth/mod.rs
+++ b/crates/optimism/rpc/src/eth/mod.rs
@@ -525,8 +525,9 @@ where
                 ctx.components.evm_config().clone(),
                 ctx.components.provider().clone(),
                 ctx.components.task_executor().clone(),
-            )
-            .compute_state_root(flashblock_consensus); // enable state root calculation if flashblock_consensus if enabled.
+                // enable state root calculation if flashblock_consensus is enabled.
+                flashblock_consensus,
+            );
 
             let flashblocks_sequence = service.block_sequence_broadcaster().clone();
             let received_flashblocks = service.flashblocks_broadcaster().clone();

--- a/examples/custom-node/src/engine.rs
+++ b/examples/custom-node/src/engine.rs
@@ -67,12 +67,14 @@ impl ExecutionPayload for CustomExecutionData {
     }
 }
 
-impl From<&reth_optimism_flashblocks::FlashBlockCompleteSequence> for CustomExecutionData {
-    fn from(sequence: &reth_optimism_flashblocks::FlashBlockCompleteSequence) -> Self {
-        let inner = OpExecutionData::from(sequence);
-        // Derive extension from sequence data - using gas_used from last flashblock as an example
-        let extension = sequence.last().diff.gas_used;
-        Self { inner, extension }
+impl TryFrom<&reth_optimism_flashblocks::FlashBlockCompleteSequence> for CustomExecutionData {
+    type Error = &'static str;
+
+    fn try_from(
+        sequence: &reth_optimism_flashblocks::FlashBlockCompleteSequence,
+    ) -> Result<Self, Self::Error> {
+        let inner = OpExecutionData::try_from(sequence)?;
+        Ok(Self { inner, extension: sequence.last().diff.gas_used })
     }
 }
 


### PR DESCRIPTION
## Rework FlashBlock: Introduce SequenceManager and Improve Architecture

Closes: https://github.com/paradigmxyz/reth/issues/18373

### Reviewer Notes:

1. Best reviewed by commit, high level changes summarized below.
2. Tested on both base & uni sepolia for both chain follow and catch up scenario.

Base Sepolia:
<img width="481" height="191" alt="image" src="https://github.com/user-attachments/assets/7ad83dad-549a-4b68-b790-38e332998e8d" />


Unichain Sepolia:
<img width="481" height="191" alt="image" src="https://github.com/user-attachments/assets/17a4b7f7-08da-47c0-aab8-7d31168d3081" />


### Summary

This PR introduces a major refactoring of the flashblock system, implementing a `SequenceManager` to handle
sequence caching and intelligent block building selection. The changes improve the system's ability to handle
both 1-second and 2-second block times, with and without sequencer-provided state roots.

### Key Changes

#### 1. **Introduce SequenceManager** (`cache.rs`)

Added `SequenceManager` to centralize sequence management with:
- **Ring buffer caching**: Maintains last 3 completed sequences for efficient state_root computation
- **Intelligent build selection**: Chooses optimal sequence for building based on parent hash and timestamp
- **State root computation management**: Configurable `compute_state_root` flag for different block time
scenarios
- **Double-broadcast strategy**: Broadcasts sequences immediately (without state_root) and re-broadcasts after
build completion (with state_root)

**Benefits:**
- Enables execution cache reuse across blocks during catch-up scenarios
- Supports both 1s blocks (state_root provided by sequencer) and 2s blocks (computed locally)
- Clean separation between pending sequences and cached sequences

#### 2. **Simplify FlashBlockPendingSequence** (`sequence.rs`)

Removed `PreparedFlashblock` type and streamlined the pending sequence implementation:
- Single responsibility: manage ordered flashblock accumulation
- Added `SequenceExecutionOutcome` to store computed state_root and block_hash
- Improved validation and error handling
- **48 comprehensive tests** covering all edge cases and invariants

#### 3. **Rework FlashBlockService** (`service.rs`)

Major improvements to the service loop:
- **Integrated SequenceManager**: Replaces ad-hoc sequence handling
- **Tokio select-based event loop**: Properly awaits on build jobs OR incoming flashblocks (no busy-waiting)
- **Efficient flashblock batching**: Processes all immediately available flashblocks before triggering builds
- **Removed Stream trait**: Simplified loop logic by removing unnecessary abstraction
- **Removed CanonicalChainTip listener**: Not needed with new architecture

**Event Loop:**
1. Build job completion → process results, update cache, broadcast pending block
4. New flashblock arrival → batch process, attempt build if conditions met

### 4. **Rework FlashBlockConsensusClient** (`consensus.rs`)

Simplified consensus client logic:
- Clean separation of `submit_new_payload` and `submit_forkchoice_update`
- Smart handling of state_root availability:
  - **With state_root**: Submit both `engine_newPayload` and `engine_forkChoiceUpdated`
  - **Without state_root**: Skip `engine_newPayload`, only submit FCU with parent_hash
- **14 comprehensive tests** covering all consensus scenarios

#### 5. **Enhanced Test Infrastructure** (`test_utils.rs`)

Improved `TestFlashBlockFactory` with:
- Configurable block time support (`with_block_time()`)
- Builder pattern for flashblock creation
- Helpers for creating sequential flashblocks (`flashblock_after()`, `flashblock_for_next_block()`)
- State root configuration

### Architecture Improvements

#### Before
FlashBlockService
├── Manual sequence tracking
├── No caching
├── Stream-based loop (complex)
└── CanonicalChainTip listener

#### After
FlashBlockService
├── SequenceManager (centralized)
│   ├── Pending sequence
│   └── Ring buffer cache (last 3 sequences)
├── Tokio select loop (clean)
├── Efficient batching
└── Smart build selection

### Block Time Scenarios

#### 1-Second Blocks (State Root Provided)
- Sequencer provides state_root in flashblocks
- Service validates and forwards to consensus client
- No local state_root computation needed
- Fast block progression

#### 2-Second Blocks (State Root Computed)
- Sequencer provides `B256::ZERO` for state_root
- Service computes state_root when building on local tip
- Execution cache reuse from ring buffer
- Consensus client receives state_root from execution outcome

### Testing

#### Test Coverage
- **cache.rs**: 48 tests - sequence management, caching, buildability logic
- **consensus.rs**: 14 tests - payload submission, FCU behavior, conversion logic
- **service.rs**: Tests added for batching and event loop behavior

#### Key Test Scenarios
- ✅ 2s block with no state_root provided
- ✅ 1s block with state_root provided
- ✅ Flashblock batching
- ✅ Sequence finalization and caching
- ✅ State root computation
- ✅ Cache eviction (ring buffer)
- ✅ OpExecutionData conversion with/without state_root
- ✅ Multiple blocks in sequence
