### PR TITLE
chore(rpc): clean up engine_api test helper

### DIFF
--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -1197,10 +1197,10 @@ mod tests {
             task_executor,
             client,
             EngineCapabilities::default(),
-            EthereumEngineValidator::new(chain_spec.clone()),
+            EthereumEngineValidator::new(chain_spec),
             false,
         );
-        let handle = EngineApiTestHandle { chain_spec, provider, from_api: engine_rx };
+        let handle = EngineApiTestHandle { provider, from_api: engine_rx };
         (handle, api)
     }
 
@@ -1218,8 +1218,6 @@ mod tests {
     }
 
     struct EngineApiTestHandle {
-        #[allow(dead_code)]
-        chain_spec: Arc<ChainSpec>,
         provider: Arc<MockEthProvider>,
         from_api: UnboundedReceiver<BeaconEngineMessage<EthEngineTypes>>,
     }


### PR DESCRIPTION
Remove unused `chain_spec` field and redundant clone in `EngineApiTestHandle`.

Tests pass, clippy clean.