### PR TITLE
fix(tasks): prevent infinite recursion in TaskSpawner implementation

### DIFF
--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -635,7 +635,7 @@ impl TaskExecutor {
 impl TaskSpawner for TaskExecutor {
     fn spawn(&self, fut: BoxFuture<'static, ()>) -> JoinHandle<()> {
         self.metrics.inc_regular_tasks();
-        self.spawn(fut)
+        Self::spawn(self, fut)
     }
 
     fn spawn_critical(&self, name: &'static str, fut: BoxFuture<'static, ()>) -> JoinHandle<()> {
@@ -645,7 +645,7 @@ impl TaskSpawner for TaskExecutor {
 
     fn spawn_blocking(&self, fut: BoxFuture<'static, ()>) -> JoinHandle<()> {
         self.metrics.inc_regular_blocking_tasks();
-        self.spawn_blocking(fut)
+        Self::spawn_blocking(self, fut)
     }
 
     fn spawn_critical_blocking(


### PR DESCRIPTION
Fix infinite recursion in TaskSpawner trait methods for TaskExecutor.

When TaskSpawner::spawn or TaskSpawner::spawn_blocking were called via the trait, they would recursively call themselves instead of delegating to the inherent TaskExecutor methods. 
Changed to use Self::spawn and Self::spawn_blocking to explicitly call the inherent methods, matching the pattern already used in spawn_critical methods.