### PR TITLE
docs: update rust version

### DIFF
--- a/docs/vocs/docs/pages/installation/source.mdx
+++ b/docs/vocs/docs/pages/installation/source.mdx
@@ -37,7 +37,7 @@ operating system:
 
 These are needed to build bindings for Reth's database.
 
-The Minimum Supported Rust Version (MSRV) of this project is 1.80.0. If you already have a version of Rust installed,
+The Minimum Supported Rust Version (MSRV) of this project is 1.88.0. If you already have a version of Rust installed,
 you can check your version by running `rustc --version`. To update your version of Rust, run `rustup update`.
 
 ## Build Reth


### PR DESCRIPTION
The Minimum Supported Rust Version for RETH is now 1.88.0 as most of the crates do not compile below 1.88.0 as shown in the screenshot below:


<img width="1220" height="971" alt="Screenshot 2025-11-16 at 1 00 48 PM" src="https://github.com/user-attachments/assets/d9e9a03b-dc6f-433b-b047-d3887d6b4651" />
 