### PR TITLE
chore(payload): remove redundant attr clone

### DIFF
--- a/crates/payload/builder/src/service.rs
+++ b/crates/payload/builder/src/service.rs
@@ -441,7 +441,7 @@ where
                                     this.metrics.inc_initiated_jobs();
                                     new_job = true;
                                     this.payload_jobs.push((job, id));
-                                    this.payload_events.send(Events::Attributes(attr.clone())).ok();
+                                    this.payload_events.send(Events::Attributes(attr)).ok();
                                 }
                                 Err(err) => {
                                     this.metrics.inc_failed_jobs();


### PR DESCRIPTION
The BuildNewPayload path in PayloadBuilderService::poll() cloned the received attributes twice: once to pass ownership into 
new_payload_job and again to emit Events::Attributes. Since Events::Attributes requires an owned value and the original attr is not used afterwards, we can move attr into the event and keep a single clone for new_payload_job. This preserves semantics (attributes event still reflects what was received from the CL), avoids an unnecessary allocation/copy for potentially heavy attributes, and keeps logging (id, parent) intact as they are read before moving.