### PR TITLE
chore(bench-compare): clarify percentage calculation method for final report

### DIFF
--- a/bin/reth-bench-compare/src/comparison.rs
+++ b/bin/reth-bench-compare/src/comparison.rs
@@ -45,6 +45,7 @@ pub(crate) struct CombinedLatencyRow {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub(crate) struct TotalGasRow {
     pub block_number: u64,
+    pub transaction_count: u64,
     pub gas_used: u64,
     pub time: u128,
 }

--- a/bin/reth-bench-compare/src/comparison.rs
+++ b/bin/reth-bench-compare/src/comparison.rs
@@ -449,9 +449,18 @@ impl ComparisonGenerator {
         let summary = &report.comparison_summary;
 
         println!("Performance Changes:");
-        println!("  NewPayload Latency: {:+.2}%", summary.new_payload_latency_change_percent);
-        println!("  Gas/Second:         {:+.2}%", summary.gas_per_second_change_percent);
-        println!("  Blocks/Second:      {:+.2}%", summary.blocks_per_second_change_percent);
+        println!(
+            "  NewPayload Latency: {:+.2}% (total avg change)",
+            summary.new_payload_latency_change_percent
+        );
+        println!(
+            "  Gas/Second:         {:+.2}% (total avg change)",
+            summary.gas_per_second_change_percent
+        );
+        println!(
+            "  Blocks/Second:      {:+.2}% (total avg change)",
+            summary.blocks_per_second_change_percent
+        );
         println!();
 
         println!("Baseline Summary:");


### PR DESCRIPTION
Users may be confused when comparing the newpayload latency percentage in the console output with the mean/median percentages shown in the --draw diagrams, as they use different calculation methods:

- Console output: compares overall averages (avg(feature) vs avg(baseline))
- Diagram output: averages per-block percentage differences

Adding "(total avg change)" to the performance metrics clarifies that the console shows total average comparison, helping users understand the difference from diagram statistics.