### PR TITLE
fix: add alloy-rlp dependency to testing-utils (test_sign_eip_155)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10709,6 +10709,7 @@ dependencies = [
  "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
+ "alloy-rlp",
  "rand 0.8.5",
  "rand 0.9.2",
  "reth-ethereum-primitives",

--- a/testing/testing-utils/Cargo.toml
+++ b/testing/testing-utils/Cargo.toml
@@ -19,6 +19,7 @@ alloy-genesis.workspace = true
 alloy-primitives = { workspace = true, features = ["rand"] }
 alloy-consensus.workspace = true
 alloy-eips.workspace = true
+alloy-rlp.workspace = true
 
 rand.workspace = true
 secp256k1 = { workspace = true, features = ["rand"] }

--- a/testing/testing-utils/Cargo.toml
+++ b/testing/testing-utils/Cargo.toml
@@ -14,13 +14,14 @@ workspace = true
 [dependencies]
 reth-ethereum-primitives = { workspace = true, features = ["arbitrary", "std"] }
 reth-primitives-traits = { workspace = true, features = ["secp256k1", "arbitrary"] }
-
 alloy-genesis.workspace = true
 alloy-primitives = { workspace = true, features = ["rand"] }
 alloy-consensus.workspace = true
 alloy-eips.workspace = true
-alloy-rlp.workspace = true
 
 rand.workspace = true
 secp256k1 = { workspace = true, features = ["rand"] }
 rand_08.workspace = true
+
+[dev-dependencies]
+alloy-rlp.workspace = true

--- a/testing/testing-utils/src/generators.rs
+++ b/testing/testing-utils/src/generators.rs
@@ -345,7 +345,7 @@ where
                 let old = if entry.value.is_zero() {
                     let old = storage.remove(&entry.key);
                     if matches!(old, Some(U256::ZERO)) {
-                        return None
+                        return None;
                     }
                     old
                 } else {
@@ -529,7 +529,7 @@ mod tests {
     #[test]
     fn test_sign_eip_155() {
         // reference: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md#example
-        let transaction = Transaction::Legacy(TxLegacy {
+        let tx = TxLegacy {
             chain_id: Some(1),
             nonce: 9,
             gas_price: 20 * 10_u128.pow(9),
@@ -537,12 +537,11 @@ mod tests {
             to: TxKind::Call(hex!("3535353535353535353535353535353535353535").into()),
             value: U256::from(10_u128.pow(18)),
             input: Bytes::default(),
-        });
+        };
+        let transaction = Transaction::Legacy(tx.clone());
 
-        // TODO resolve dependency issue
-        // let expected =
-        // hex!("ec098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a764000080018080");
-        // assert_eq!(expected, &alloy_rlp::encode(transaction));
+        let expected = hex!("ec098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a764000080018080");
+        assert_eq!(expected.to_vec(), alloy_rlp::encode(tx));
 
         let hash = transaction.signature_hash();
         let expected =

--- a/testing/testing-utils/src/generators.rs
+++ b/testing/testing-utils/src/generators.rs
@@ -345,7 +345,7 @@ where
                 let old = if entry.value.is_zero() {
                     let old = storage.remove(&entry.key);
                     if matches!(old, Some(U256::ZERO)) {
-                        return None;
+                        return None
                     }
                     old
                 } else {
@@ -541,7 +541,7 @@ mod tests {
         let transaction = Transaction::Legacy(tx.clone());
 
         let expected = hex!("ec098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a764000080018080");
-        assert_eq!(expected.to_vec(), alloy_rlp::encode(tx));
+        assert_eq!(expected.as_slice(), &alloy_rlp::encode(tx));
 
         let hash = transaction.signature_hash();
         let expected =


### PR DESCRIPTION
fixes TODO by adding missing `alloy-rlp` dependency