### PR TITLE
fix(rpc): clear_txpool returns actually removed transaction count

### DIFF
--- a/crates/rpc/rpc/src/admin.rs
+++ b/crates/rpc/rpc/src/admin.rs
@@ -189,9 +189,8 @@ where
     /// Handler for `admin_clearTxpool`
     async fn clear_txpool(&self) -> RpcResult<u64> {
         let all_hashes = self.pool.all_transaction_hashes();
-        let count = all_hashes.len() as u64;
-        let _ = self.pool.remove_transactions(all_hashes);
-        Ok(count)
+        let removed = self.pool.remove_transactions(all_hashes);
+        Ok(removed.len() as u64)
     }
 }
 


### PR DESCRIPTION
The Admin API docs require admin_clearTxpool to return the number of transactions that were removed from the pool. The previous implementation counted the number of hashes requested for removal, which could overstate the result in the presence of concurrent removals or races. This change uses the length of TransactionPool::remove_transactions(...) to report the number of transactions actually removed, aligning the behavior with the API contract and the pool’s semantics.