### PR TITLE
chore: use unwrap_or_default instead of unwrap_or_else

### DIFF
--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -199,7 +199,7 @@ where
 
     let blob_params = chain_spec.blob_params_at_timestamp(attributes.timestamp);
     let protocol_max_blob_count =
-        blob_params.as_ref().map(|params| params.max_blob_count).unwrap_or_else(Default::default);
+        blob_params.as_ref().map(|params| params.max_blob_count).unwrap_or_default();
 
     // Apply user-configured blob limit (EIP-7872)
     // Per EIP-7872: if the minimum is zero, set it to one


### PR DESCRIPTION

This is a simple refactoring that improves code readability and addresses the clippy or_fun_call lint.