### PR TITLE
fix: ensure that pruning all rows doesn't leave the offset file corrupted

### DIFF
--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -1041,10 +1041,10 @@ mod tests {
         assert_eq!(writer.rows(), 0);
         assert_eq!(writer.max_row_size(), 0);
         assert_eq!(File::open(writer.data_path()).unwrap().metadata().unwrap().len() as usize, 0);
-        // Only the byte that indicates how many bytes per offset should be left
+        // Offset size byte (1) + final offset (8) = 9 bytes
         assert_eq!(
             File::open(writer.offsets_path()).unwrap().metadata().unwrap().len() as usize,
-            1
+            9
         );
         writer.commit().unwrap();
         assert!(!writer.is_dirty());

--- a/crates/storage/nippy-jar/src/writer.rs
+++ b/crates/storage/nippy-jar/src/writer.rs
@@ -292,7 +292,11 @@ impl<H: NippyJarHeader> NippyJarWriter<H> {
                 // If all rows are to be pruned
                 if new_num_offsets <= 1 {
                     // <= 1 because the one offset would actually be the expected file data size
-                    self.offsets_file.get_mut().set_len(1)?;
+                    //
+                    // When no rows remain, keep the offset size byte and the final offset (data file size = 0).
+                    // This maintains the same structure as when a file is initially created.
+                    // See `NippyJarWriter::create_or_open_files` for the initial file format.
+                    self.offsets_file.get_mut().set_len(1 + OFFSET_SIZE_BYTES as u64)?;
                     self.data_file.get_mut().set_len(0)?;
                 } else {
                     // Calculate the new length for the on-disk offset list

--- a/crates/storage/nippy-jar/src/writer.rs
+++ b/crates/storage/nippy-jar/src/writer.rs
@@ -293,8 +293,9 @@ impl<H: NippyJarHeader> NippyJarWriter<H> {
                 if new_num_offsets <= 1 {
                     // <= 1 because the one offset would actually be the expected file data size
                     //
-                    // When no rows remain, keep the offset size byte and the final offset (data file size = 0).
-                    // This maintains the same structure as when a file is initially created.
+                    // When no rows remain, keep the offset size byte and the final offset (data
+                    // file size = 0). This maintains the same structure as when
+                    // a file is initially created.
                     // See `NippyJarWriter::create_or_open_files` for the initial file format.
                     self.offsets_file.get_mut().set_len(1 + OFFSET_SIZE_BYTES as u64)?;
                     self.data_file.get_mut().set_len(0)?;


### PR DESCRIPTION
Read-only commands (eg. `reth db stats`) were failing with inconsistent state after pruning all rows of a static file.

When pruning to 0 rows, the code truncated the offsets file to 1 byte. However, the nippy jar format requires 9 bytes even with 0 rows:

https://github.com/paradigmxyz/reth/blob/bef8256073020a0ad6e06e713c71d2934d6e6d49/crates/storage/nippy-jar/src/writer.rs#L146-L157

Expected structure: `[offset_size: 1 byte][final_offset: 8 bytes] = 9 bytes` where the `final_offset` represents the size of the data file (0) when we have 0 rows.

This hasn't really been an issue on a normal node startup, because on read-write mode, we don't throw an error and enter here instead which just sets the rows to 0 (`actual_offsets_file_size` is 1).
https://github.com/paradigmxyz/reth/blob/bef8256073020a0ad6e06e713c71d2934d6e6d49/crates/storage/nippy-jar/src/consistency.rs#L86-L97

And when we append new data, the following code (`self.offsets.is_empty()`) ensures we fix the format by writing the first `[0; 8]` which is missing.

https://github.com/paradigmxyz/reth/blob/bef8256073020a0ad6e06e713c71d2934d6e6d49/crates/storage/nippy-jar/src/writer.rs#L204-L213

