### PR TITLE
perf: remove redundant clone in `From<[RethRpcModule; N]>` implementation

### DIFF
--- a/crates/rpc/rpc-server-types/src/module.rs
+++ b/crates/rpc/rpc-server-types/src/module.rs
@@ -240,7 +240,7 @@ impl From<Vec<RethRpcModule>> for RpcModuleSelection {
 
 impl<const N: usize> From<[RethRpcModule; N]> for RpcModuleSelection {
     fn from(s: [RethRpcModule; N]) -> Self {
-        Self::Selection(s.iter().cloned().collect())
+        Self::Selection(s.into_iter().collect())
     }
 }
 


### PR DESCRIPTION
Removes unnecessary clone operation when converting an owned array to `RpcModuleSelection`.