### PR TITLE
fix: remove bad reset and cancel on drop

### DIFF
--- a/crates/cli/util/src/cancellation.rs
+++ b/crates/cli/util/src/cancellation.rs
@@ -1,0 +1,103 @@
+//! Thread-safe cancellation primitives for cooperative task cancellation.
+
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+
+/// A thread-safe cancellation token that can be shared across threads.
+///
+/// This token allows cooperative cancellation by providing a way to signal
+/// cancellation and check cancellation status. The token can be cloned and
+/// shared across multiple threads, with all clones sharing the same cancellation state.
+///
+/// # Example
+///
+/// ```
+/// use reth_cli_util::cancellation::CancellationToken;
+/// use std::{thread, time::Duration};
+///
+/// let token = CancellationToken::new();
+/// let worker_token = token.clone();
+///
+/// let handle = thread::spawn(move || {
+///     while !worker_token.is_cancelled() {
+///         // Do work...
+///         thread::sleep(Duration::from_millis(100));
+///     }
+/// });
+///
+/// // Cancel from main thread
+/// token.cancel();
+/// handle.join().unwrap();
+/// ```
+#[derive(Clone, Debug)]
+pub struct CancellationToken {
+    cancelled: Arc<AtomicBool>,
+}
+
+impl CancellationToken {
+    /// Creates a new cancellation token in the non-cancelled state.
+    pub fn new() -> Self {
+        Self { cancelled: Arc::new(AtomicBool::new(false)) }
+    }
+
+    /// Signals cancellation to all holders of this token and its clones.
+    ///
+    /// Once cancelled, the token cannot be reset. This operation is thread-safe
+    /// and can be called multiple times without issue.
+    pub fn cancel(&self) {
+        self.cancelled.store(true, Ordering::Release);
+    }
+
+    /// Checks whether cancellation has been requested.
+    ///
+    /// Returns `true` if [`cancel`](Self::cancel) has been called on this token
+    /// or any of its clones.
+    pub fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::Relaxed)
+    }
+
+    /// Creates a guard that automatically cancels this token when dropped.
+    ///
+    /// This is useful for ensuring cancellation happens when a scope exits,
+    /// either normally or via panic.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use reth_cli_util::cancellation::CancellationToken;
+    ///
+    /// let token = CancellationToken::new();
+    /// {
+    ///     let _guard = token.drop_guard();
+    ///     assert!(!token.is_cancelled());
+    ///     // Guard dropped here, triggering cancellation
+    /// }
+    /// assert!(token.is_cancelled());
+    /// ```
+    pub fn drop_guard(&self) -> CancellationGuard {
+        CancellationGuard { token: self.clone() }
+    }
+}
+
+impl Default for CancellationToken {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A guard that cancels its associated [`CancellationToken`] when dropped.
+///
+/// Created by calling [`CancellationToken::drop_guard`]. When this guard is dropped,
+/// it automatically calls [`cancel`](CancellationToken::cancel) on the token.
+#[derive(Debug)]
+pub struct CancellationGuard {
+    token: CancellationToken,
+}
+
+impl Drop for CancellationGuard {
+    fn drop(&mut self) {
+        self.token.cancel();
+    }
+}

--- a/crates/cli/util/src/lib.rs
+++ b/crates/cli/util/src/lib.rs
@@ -9,6 +9,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod allocator;
+pub mod cancellation;
 
 /// Helper function to load a secret key from a file.
 pub mod load_secret_key;


### PR DESCRIPTION
this fixes two things

a bad reset, that would just reset the interval again to now + 10s, effectively preventing any progress logging

itnroduces a util type that we can use to check for cancel on drop because I noticed ctrl-c didnt behave as expected, because for this command we dont force drop the runtime and by default blocking tasks are awaited on runtime::drop

https://github.com/paradigmxyz/reth/blob/1d4f31a3b6cef1ebe57d1ade2400069aa4b08d61/crates/ethereum/cli/src/app.rs#L183-L183

