### PR TITLE
fix(stages-types): ensure no_std compatibility for tests

### DIFF
--- a/crates/stages/types/src/checkpoints.rs
+++ b/crates/stages/types/src/checkpoints.rs
@@ -220,9 +220,12 @@ impl reth_codecs::Compact for StorageRootMerkleCheckpoint {
 
 /// Saves the progress of `AccountHashing` stage.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
-#[cfg_attr(any(test, feature = "test-utils"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(all(any(test, feature = "test-utils"), feature = "std"), derive(arbitrary::Arbitrary))]
 #[cfg_attr(any(test, feature = "reth-codec"), derive(reth_codecs::Compact))]
-#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(compact))]
+#[cfg_attr(
+    all(any(test, feature = "reth-codec"), feature = "std"),
+    reth_codecs::add_arbitrary_tests(compact)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AccountHashingCheckpoint {
     /// The next account to start hashing from.
@@ -235,9 +238,12 @@ pub struct AccountHashingCheckpoint {
 
 /// Saves the progress of `StorageHashing` stage.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
-#[cfg_attr(any(test, feature = "test-utils"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(all(any(test, feature = "test-utils"), feature = "std"), derive(arbitrary::Arbitrary))]
 #[cfg_attr(any(test, feature = "reth-codec"), derive(reth_codecs::Compact))]
-#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(compact))]
+#[cfg_attr(
+    all(any(test, feature = "reth-codec"), feature = "std"),
+    reth_codecs::add_arbitrary_tests(compact)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StorageHashingCheckpoint {
     /// The next account to start hashing from.
@@ -252,9 +258,12 @@ pub struct StorageHashingCheckpoint {
 
 /// Saves the progress of Execution stage.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
-#[cfg_attr(any(test, feature = "test-utils"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(all(any(test, feature = "test-utils"), feature = "std"), derive(arbitrary::Arbitrary))]
 #[cfg_attr(any(test, feature = "reth-codec"), derive(reth_codecs::Compact))]
-#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(compact))]
+#[cfg_attr(
+    all(any(test, feature = "reth-codec"), feature = "std"),
+    reth_codecs::add_arbitrary_tests(compact)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ExecutionCheckpoint {
     /// Block range which this checkpoint is valid for.
@@ -265,9 +274,12 @@ pub struct ExecutionCheckpoint {
 
 /// Saves the progress of Headers stage.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
-#[cfg_attr(any(test, feature = "test-utils"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(all(any(test, feature = "test-utils"), feature = "std"), derive(arbitrary::Arbitrary))]
 #[cfg_attr(any(test, feature = "reth-codec"), derive(reth_codecs::Compact))]
-#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(compact))]
+#[cfg_attr(
+    all(any(test, feature = "reth-codec"), feature = "std"),
+    reth_codecs::add_arbitrary_tests(compact)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HeadersCheckpoint {
     /// Block range which this checkpoint is valid for.
@@ -278,9 +290,12 @@ pub struct HeadersCheckpoint {
 
 /// Saves the progress of Index History stages.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
-#[cfg_attr(any(test, feature = "test-utils"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(all(any(test, feature = "test-utils"), feature = "std"), derive(arbitrary::Arbitrary))]
 #[cfg_attr(any(test, feature = "reth-codec"), derive(reth_codecs::Compact))]
-#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(compact))]
+#[cfg_attr(
+    all(any(test, feature = "reth-codec"), feature = "std"),
+    reth_codecs::add_arbitrary_tests(compact)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IndexHistoryCheckpoint {
     /// Block range which this checkpoint is valid for.
@@ -291,9 +306,12 @@ pub struct IndexHistoryCheckpoint {
 
 /// Saves the progress of `MerkleChangeSets` stage.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
-#[cfg_attr(any(test, feature = "test-utils"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(all(any(test, feature = "test-utils"), feature = "std"), derive(arbitrary::Arbitrary))]
 #[cfg_attr(any(test, feature = "reth-codec"), derive(reth_codecs::Compact))]
-#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(compact))]
+#[cfg_attr(
+    all(any(test, feature = "reth-codec"), feature = "std"),
+    reth_codecs::add_arbitrary_tests(compact)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MerkleChangeSetsCheckpoint {
     /// Block range which this checkpoint is valid for.
@@ -302,9 +320,12 @@ pub struct MerkleChangeSetsCheckpoint {
 
 /// Saves the progress of abstract stage iterating over or downloading entities.
 #[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
-#[cfg_attr(any(test, feature = "test-utils"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(all(any(test, feature = "test-utils"), feature = "std"), derive(arbitrary::Arbitrary))]
 #[cfg_attr(any(test, feature = "reth-codec"), derive(reth_codecs::Compact))]
-#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(compact))]
+#[cfg_attr(
+    all(any(test, feature = "reth-codec"), feature = "std"),
+    reth_codecs::add_arbitrary_tests(compact)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EntitiesCheckpoint {
     /// Number of entities already processed.
@@ -340,9 +361,12 @@ impl EntitiesCheckpoint {
 /// Saves the block range. Usually, it's used to check the validity of some stage checkpoint across
 /// multiple executions.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
-#[cfg_attr(any(test, feature = "test-utils"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(all(any(test, feature = "test-utils"), feature = "std"), derive(arbitrary::Arbitrary))]
 #[cfg_attr(any(test, feature = "reth-codec"), derive(reth_codecs::Compact))]
-#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(compact))]
+#[cfg_attr(
+    all(any(test, feature = "reth-codec"), feature = "std"),
+    reth_codecs::add_arbitrary_tests(compact)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CheckpointBlockRange {
     /// The first block of the range, inclusive.
@@ -365,9 +389,12 @@ impl From<&RangeInclusive<BlockNumber>> for CheckpointBlockRange {
 
 /// Saves the progress of a stage.
 #[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
-#[cfg_attr(any(test, feature = "test-utils"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(all(any(test, feature = "test-utils"), feature = "std"), derive(arbitrary::Arbitrary))]
 #[cfg_attr(any(test, feature = "reth-codec"), derive(reth_codecs::Compact))]
-#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(compact))]
+#[cfg_attr(
+    all(any(test, feature = "reth-codec"), feature = "std"),
+    reth_codecs::add_arbitrary_tests(compact)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StageCheckpoint {
     /// The maximum block processed by the stage.
@@ -438,9 +465,12 @@ impl StageCheckpoint {
 //  is not a Copy type.
 /// Stage-specific checkpoint metrics.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-#[cfg_attr(any(test, feature = "test-utils"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(all(any(test, feature = "test-utils"), feature = "std"), derive(arbitrary::Arbitrary))]
 #[cfg_attr(any(test, feature = "reth-codec"), derive(reth_codecs::Compact))]
-#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(compact))]
+#[cfg_attr(
+    all(any(test, feature = "reth-codec"), feature = "std"),
+    reth_codecs::add_arbitrary_tests(compact)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum StageUnitCheckpoint {
     /// Saves the progress of `AccountHashing` stage.

--- a/crates/stages/types/src/id.rs
+++ b/crates/stages/types/src/id.rs
@@ -141,6 +141,7 @@ impl core::fmt::Display for StageId {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::string::ToString;
 
     #[test]
     fn stage_id_as_string() {


### PR DESCRIPTION
Running `cargo test -p reth-stages-types --lib --no-default-features` fails with 44 compilation errors, even though the crate declares `no_std` support. The main issues are that `arbitrary::Arbitrary` derive requires std through its dependencies, the `add_arbitrary_tests` macro uses `vec!` without proper imports, and `ToString` isn't in scope for no_std tests.

This fix adds `feature = "std"` guards to arbitrary-related attributes, which is consistent with how other Reth crates handle this. The Cargo.toml already declares `arbitrary = ["std", ...]`, so this just extends that contract to the derive attributes. Also added the missing `ToString` import from alloc in the test module.

After the fix, basic tests pass in no_std mode (5 tests), and all tests including proptests work with std enabled (15 tests). This matches the project architecture where arbitrary/proptest functionality requires std.