### PR TITLE
fix(rpc): metered getPayloadBodiesByHash timing to await before recording

### DIFF
--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -657,9 +657,9 @@ where
         hashes: Vec<BlockHash>,
     ) -> EngineApiResult<ExecutionPayloadBodiesV1> {
         let start = Instant::now();
-        let res = Self::get_payload_bodies_by_hash_v1(self, hashes);
+        let res = Self::get_payload_bodies_by_hash_v1(self, hashes).await;
         self.inner.metrics.latency.get_payload_bodies_by_hash_v1.record(start.elapsed());
-        res.await
+        res
     }
 
     /// Validates the `engine_forkchoiceUpdated` payload attributes and executes the forkchoice


### PR DESCRIPTION
Recorded the latency before awaiting the async operation, which only measured the time to create the future and severely under-reported the actual RPC duration. All other metered methods in engine_api.rs consistently await the operation and then record the elapsed time, and a repository-wide search shows no other instance of pre-await recording. This change applies the same pattern here by awaiting get_payload_bodies_by_hash_v1 before recording the histogram and then returning the already-resolved result, restoring correct latency semantics for the engine_getPayloadBodiesByHashV1 metric and aligning behavior with the rest of the module and the Optimism RPC callers.