### PR TITLE
docs: align eth wire protocol description with supported versions

### DIFF
--- a/crates/net/eth-wire/Cargo.toml
+++ b/crates/net/eth-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-eth-wire"
-description = "Implements the eth/64 and eth/65 P2P protocols"
+description = "Implements the Ethereum eth wire protocol (eth/66-eth/69)"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
Updated the `reth-eth-wire` crate blurb so it accurately says we implement the eth wire protocol versions 66 through 69
