### PR TITLE
feat: `EthApiError::from_revert`

### DIFF
--- a/crates/optimism/rpc/src/error.rs
+++ b/crates/optimism/rpc/src/error.rs
@@ -1,6 +1,7 @@
 //! RPC errors specific to OP.
 
 use alloy_json_rpc::ErrorPayload;
+use alloy_primitives::Bytes;
 use alloy_rpc_types_eth::{error::EthRpcErrorCode, BlockError};
 use alloy_transport::{RpcError, TransportErrorKind};
 use jsonrpsee_types::error::{INTERNAL_ERROR_CODE, INVALID_PARAMS_CODE};
@@ -8,7 +9,10 @@ use op_revm::{OpHaltReason, OpTransactionError};
 use reth_evm::execute::ProviderError;
 use reth_optimism_evm::OpBlockExecutionError;
 use reth_rpc_eth_api::{AsEthApiError, EthTxEnvError, TransactionConversionError};
-use reth_rpc_eth_types::{error::api::FromEvmHalt, EthApiError};
+use reth_rpc_eth_types::{
+    error::api::{FromEvmHalt, FromRevert},
+    EthApiError,
+};
 use reth_rpc_server_types::result::{internal_rpc_err, rpc_err};
 use revm::context_interface::result::{EVMError, InvalidTransaction};
 use std::{convert::Infallible, fmt::Display};
@@ -191,6 +195,12 @@ impl FromEvmHalt<OpHaltReason> for OpEthApiError {
             }
             OpHaltReason::Base(halt) => EthApiError::from_evm_halt(halt, gas_limit).into(),
         }
+    }
+}
+
+impl FromRevert for OpEthApiError {
+    fn from_revert(output: Bytes) -> Self {
+        Self::Eth(EthApiError::from_revert(output))
     }
 }
 


### PR DESCRIPTION
Adds `FromRevert` trait that allows customizing how reverts are formatted for custom `EthApiError` implementations


closes #19835