### PR TITLE
fix(bench): exclude wait-time from gas/s calculation and enable OTLP gRPC tracing

### DIFF
--- a/bin/reth-bench-compare/src/main.rs
+++ b/bin/reth-bench-compare/src/main.rs
@@ -34,12 +34,14 @@ fn main() -> Result<()> {
         }
     }
 
-    let args = Args::parse();
+    let mut args = Args::parse();
 
-    // Initialize tracing
-    let _guard = args.init_tracing()?;
+    // Create runtime first (needed for OTLP gRPC initialization)
+    let runner = CliRunner::try_default_runtime()?;
+
+    // Initialize tracing (including OTLP if requested)
+    let _guard = args.init_tracing(&runner)?;
 
     // Run until either exit or sigint or sigterm
-    let runner = CliRunner::try_default_runtime()?;
     runner.run_command_until_exit(|ctx| run_comparison(args, ctx))
 }

--- a/bin/reth-bench/src/bench/new_payload_fcu.rs
+++ b/bin/reth-bench/src/bench/new_payload_fcu.rs
@@ -114,6 +114,7 @@ impl Command {
         let mut results = Vec::new();
         let total_benchmark_duration = Instant::now();
         let mut total_wait_time = Duration::ZERO;
+        let mut total_sleep_time = Duration::ZERO;
 
         while let Some((block, head, safe, finalized)) = {
             let wait_start = Instant::now();
@@ -155,14 +156,17 @@ impl Command {
             };
 
             // current duration since the start of the benchmark minus the time
-            // waiting for blocks
-            let current_duration = total_benchmark_duration.elapsed() - total_wait_time;
+            // waiting for blocks and the artificial sleep time
+            let current_duration =
+                total_benchmark_duration.elapsed() - total_wait_time - total_sleep_time;
 
             // convert gas used to gigagas, then compute gigagas per second
             info!(%combined_result);
 
             // wait before sending the next payload
+            let sleep_start = Instant::now();
             tokio::time::sleep(self.wait_time).await;
+            total_sleep_time += sleep_start.elapsed();
 
             // record the current result
             let gas_row =


### PR DESCRIPTION
**Problem:**
- Gas/s metric included artificial `--wait-time` delays, measuring sustained throughput instead of processing speed
- OTLP gRPC tracing failed because initialization happened before tokio runtime was created

**Solution:**
- Calculate gas/s based only on newPayload latency (pure processing speed)
- Initialize OTLP tracing after creating CliRunner with proper tokio runtime context

**Impact:**
Gas/s now correctly measures node processing throughput without artificial delays, and gRPC tracing works alongside HTTP.