### PR TITLE
fix(bench-compare): initialize OTLP tracing with tokio runtime for gRPC support

### DIFF
--- a/bin/reth-bench-compare/src/cli.rs
+++ b/bin/reth-bench-compare/src/cli.rs
@@ -182,7 +182,7 @@ pub(crate) struct Args {
 
 impl Args {
     /// Initializes tracing with the configured options, including OTLP if requested.
-    /// Requires a CliRunner for OTLP gRPC initialization (which needs tokio runtime).
+    /// Requires a `CliRunner` for OTLP gRPC initialization (which needs tokio runtime).
     pub(crate) fn init_tracing(&mut self, runner: &CliRunner) -> Result<Option<FileWorkerGuard>> {
         use reth_tracing::Layers;
 

--- a/bin/reth-bench-compare/src/main.rs
+++ b/bin/reth-bench-compare/src/main.rs
@@ -34,12 +34,14 @@ fn main() -> Result<()> {
         }
     }
 
-    let args = Args::parse();
+    let mut args = Args::parse();
 
-    // Initialize tracing
-    let _guard = args.init_tracing()?;
+    // Create runtime first (needed for OTLP gRPC initialization)
+    let runner = CliRunner::try_default_runtime()?;
+
+    // Initialize tracing (including OTLP if requested)
+    let _guard = args.init_tracing(&runner)?;
 
     // Run until either exit or sigint or sigterm
-    let runner = CliRunner::try_default_runtime()?;
     runner.run_command_until_exit(|ctx| run_comparison(args, ctx))
 }


### PR DESCRIPTION
Fixes OTLP gRPC tracing in reth-bench-compare by initializing it with proper tokio runtime context.

**Problem**: gRPC tracing failed because OTLP initialization happened before tokio runtime was created

**Solution**: 
- Create CliRunner first, then initialize OTLP with `runner.block_on()` for gRPC async context  
- Both HTTP and gRPC OTLP tracing now work correctly in reth-bench-compare

tldr, this command can now work
```
cargo run -p reth-bench-compare -- \
  --baseline-ref main \
  --feature-ref origin/yk/chunk_llmit_2 \
  --blocks 10 \
  --chain base \
  --datadir ~/.local/share/reth/base \
  --rpc-url \
  --wait-time 400ms \
  --draw \
  --metrics-port 5007 --tracing-otlp=http://localhost:4317 \
  --tracing-otlp-protocol=grpc
```