### PR TITLE
chore(era): move reth-ethereum-primitives to dev-dependencies

### DIFF
--- a/crates/era/Cargo.toml
+++ b/crates/era/Cargo.toml
@@ -18,8 +18,6 @@ alloy-eips.workspace = true
 alloy-primitives.workspace = true
 alloy-rlp.workspace = true
 
-reth-ethereum-primitives.workspace = true
-
 # compression and decompression
 snap.workspace = true
 
@@ -32,6 +30,7 @@ eyre.workspace = true
 rand.workspace = true
 reqwest.workspace = true
 reth-era-downloader.workspace = true
+reth-ethereum-primitives.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["sync", "macros", "time", "rt-multi-thread"] }
 test-case.workspace = true


### PR DESCRIPTION
This dependency is only used in tests - test_utils.rs, the test module in era1/types/execution.rs, and integration tests. Moving it to dev-dependencies so it doesn't get pulled in when other crates depend on reth-era.