### PR TITLE
chore(ethereum): avoid cloning requests in try_into_v4

### DIFF
--- a/crates/ethereum/engine-primitives/src/payload.rs
+++ b/crates/ethereum/engine-primitives/src/payload.rs
@@ -120,11 +120,11 @@ impl EthBuiltPayload {
     /// Try converting built payload into [`ExecutionPayloadEnvelopeV4`].
     ///
     /// Returns an error if the payload contains non EIP-4844 sidecar.
-    pub fn try_into_v4(self) -> Result<ExecutionPayloadEnvelopeV4, BuiltPayloadConversionError> {
-        Ok(ExecutionPayloadEnvelopeV4 {
-            execution_requests: self.requests.clone().unwrap_or_default(),
-            envelope_inner: self.try_into()?,
-        })
+    pub fn try_into_v4(
+        mut self,
+    ) -> Result<ExecutionPayloadEnvelopeV4, BuiltPayloadConversionError> {
+        let execution_requests = self.requests.take().unwrap_or_default();
+        Ok(ExecutionPayloadEnvelopeV4 { execution_requests, envelope_inner: self.try_into()? })
     }
 
     /// Try converting built payload into [`ExecutionPayloadEnvelopeV5`].


### PR DESCRIPTION
This change removes an unnecessary clone of the execution requests in EthBuiltPayload::try_into_v4 by switching to Option::take and passing ownership directly into ExecutionPayloadEnvelopeV4. The previous implementation cloned self.requests even though self is immediately consumed by try_into for the inner V3 envelope, leading to avoidable allocations and copies for potentially large alloy_eips::eip7685::Requests. The new approach mirrors try_into_v5 which already moves requests without cloning, keeps the conversion logic centralized by still delegating to try_into_v3 for envelope_inner, and preserves all semantics while improving performance.