### PR TITLE
fix(net): resolve external ip on startup

### DIFF
--- a/crates/net/discv4/src/config.rs
+++ b/crates/net/discv4/src/config.rs
@@ -346,7 +346,7 @@ mod tests {
 
         // Create a config with external IP resolver
         let mut builder = Discv4Config::builder();
-        builder.external_ip_resolver(Some(NatResolver::ExternalIp(ip_addr.clone())));
+        builder.external_ip_resolver(Some(NatResolver::ExternalIp(ip_addr)));
         builder.resolve_external_ip_interval(Some(Duration::from_secs(60 * 5)));
         let config = builder.build();
 

--- a/crates/net/discv4/src/config.rs
+++ b/crates/net/discv4/src/config.rs
@@ -101,7 +101,7 @@ impl Discv4Config {
     pub fn resolve_external_ip_interval(&self) -> Option<ResolveNatInterval> {
         let resolver = self.external_ip_resolver?;
         let interval = self.resolve_external_ip_interval?;
-        Some(ResolveNatInterval::interval(resolver, interval))
+        Some(ResolveNatInterval::interval_at(resolver, tokio::time::Instant::now(), interval))
     }
 }
 


### PR DESCRIPTION
## Background
+ Nodes behind NAT should advertise a correct external IP immediately to improve early connectivity.
+ Using interval(...) delayed the first resolution by one full interval.

## Changes
+ Discv4/NAT: switch from `interval(...)` to` interval_at(Instant::now(), …)` so the first tick happens at startup.
+ Tests: add unit test in discv4 config to assert immediate first tick and correct IP.

## Impact
+ No API changes: behavior applies only when `--rollup.discovery.v4` is set.
+ Faster external IP availability on boot: early peer discovery/inbound reachability.
+ Low risk: covered by unit test.