### PR TITLE
feat(rpc): warn when --ws.api is set but --ws is disabled

### DIFF
--- a/crates/rpc/rpc-builder/src/config.rs
+++ b/crates/rpc/rpc-builder/src/config.rs
@@ -190,6 +190,13 @@ impl RethRpcServerConfig for RpcServerArgs {
             );
         }
 
+        if self.ws_api.is_some() && !self.ws {
+            warn!(
+                target: "reth::cli",
+                "The --ws.api flag is set but --ws is not enabled. WS RPC API will not be exposed."
+            );
+        }
+
         if self.http {
             let socket_address = SocketAddr::new(self.http_addr, self.http_port);
             config = config


### PR DESCRIPTION
Add a symmetric warning in rpc_server_config() when --ws.api is supplied without enabling --ws. This mirrors the existing HTTP warning and prevents user confusion where WS module selections are silently ignored if the WS transport is disabled. The change consistent with the current UX for HTTP.