### PR TITLE
chore(engine, trie): cleanup traces

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -481,7 +481,12 @@ impl<Tx, Err> PayloadHandle<Tx, Err> {
     /// # Panics
     ///
     /// If payload processing was started without background tasks.
-    #[instrument(level = "debug", target = "engine::tree::payload_processor", skip_all)]
+    #[instrument(
+        level = "debug",
+        target = "engine::tree::payload_processor",
+        name = "await_state_root",
+        skip_all
+    )]
     pub fn state_root(&mut self) -> Result<StateRootComputeOutcome, ParallelStateRootError> {
         self.state_root
             .take()

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -368,9 +368,7 @@ where
         // spawn pre-warm task
         {
             let to_prewarm_task = to_prewarm_task.clone();
-            let span = debug_span!(target: "engine::tree::payload_processor", "prewarm task");
             self.executor.spawn_blocking(move || {
-                let _enter = span.entered();
                 prewarm_task.run(transactions, to_prewarm_task);
             });
         }

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -46,7 +46,7 @@ use std::{
     },
     time::Instant,
 };
-use tracing::{debug, debug_span, instrument, warn};
+use tracing::{debug, debug_span, instrument, warn, Span};
 
 mod configured_sparse_trie;
 pub mod executor;
@@ -209,7 +209,7 @@ where
             + Send
             + 'static,
     {
-        let span = tracing::Span::current();
+        let span = Span::current();
         let (to_sparse_trie, sparse_trie_rx) = channel();
 
         // We rely on the cursor factory to provide whatever DB overlay is necessary to see a
@@ -249,8 +249,9 @@ where
         );
 
         // spawn multi-proof task
+        let parent_span = span.clone();
         self.executor.spawn_blocking(move || {
-            let _enter = span.entered();
+            let _enter = parent_span.entered();
             multi_proof_task.run();
         });
 
@@ -265,6 +266,7 @@ where
             prewarm_handle,
             state_root: Some(state_root_rx),
             transactions: execution_rx,
+            _span: span,
         }
     }
 
@@ -289,6 +291,7 @@ where
             prewarm_handle,
             state_root: None,
             transactions: execution_rx,
+            _span: Span::current(),
         }
     }
 
@@ -432,7 +435,7 @@ where
                 sparse_state_trie,
             );
 
-        let span = tracing::Span::current();
+        let span = Span::current();
         self.executor.spawn_blocking(move || {
             let _enter = span.entered();
 
@@ -464,10 +467,12 @@ pub struct PayloadHandle<Tx, Err> {
     to_multi_proof: Option<CrossbeamSender<MultiProofMessage>>,
     // must include the receiver of the state root wired to the sparse trie
     prewarm_handle: CacheTaskHandle,
-    /// Receiver for the state root
-    state_root: Option<mpsc::Receiver<Result<StateRootComputeOutcome, ParallelStateRootError>>>,
     /// Stream of block transactions
     transactions: mpsc::Receiver<Result<Tx, Err>>,
+    /// Receiver for the state root
+    state_root: Option<mpsc::Receiver<Result<StateRootComputeOutcome, ParallelStateRootError>>>,
+    /// Span for tracing
+    _span: Span,
 }
 
 impl<Tx, Err> PayloadHandle<Tx, Err> {
@@ -476,12 +481,7 @@ impl<Tx, Err> PayloadHandle<Tx, Err> {
     /// # Panics
     ///
     /// If payload processing was started without background tasks.
-    #[instrument(
-        level = "debug",
-        target = "engine::tree::payload_processor",
-        skip_all,
-        name = "await_state_root"
-    )]
+    #[instrument(level = "debug", target = "engine::tree::payload_processor", skip_all)]
     pub fn state_root(&mut self) -> Result<StateRootComputeOutcome, ParallelStateRootError> {
         self.state_root
             .take()

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -290,7 +290,7 @@ where
         parent = &self.parent_span,
         level = "debug",
         target = "engine::tree::payload_processor::prewarm",
-        name = "prewarm",
+        name = "prewarm and caching",
         skip_all
     )]
     pub(super) fn run(

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -40,7 +40,7 @@ use std::{
     },
     time::Instant,
 };
-use tracing::{debug, debug_span, instrument, trace, warn};
+use tracing::{debug, debug_span, instrument, trace, warn, Span};
 
 /// A wrapper for transactions that includes their index in the block.
 #[derive(Clone)]
@@ -87,6 +87,8 @@ where
     to_multi_proof: Option<CrossbeamSender<MultiProofMessage>>,
     /// Receiver for events produced by tx execution
     actions_rx: Receiver<PrewarmTaskEvent>,
+    /// Parent span for tracing
+    parent_span: Span,
 }
 
 impl<N, P, Evm> PrewarmCacheTask<N, P, Evm>
@@ -122,6 +124,7 @@ where
                 transaction_count_hint,
                 to_multi_proof,
                 actions_rx,
+                parent_span: Span::current(),
             },
             actions_tx,
         )
@@ -140,7 +143,7 @@ where
         let ctx = self.ctx.clone();
         let max_concurrency = self.max_concurrency;
         let transaction_count_hint = self.transaction_count_hint;
-        let span = tracing::Span::current();
+        let span = Span::current();
 
         self.executor.spawn_blocking(move || {
             let _enter = debug_span!(target: "engine::tree::payload_processor::prewarm", parent: span, "spawn_all").entered();
@@ -284,6 +287,7 @@ where
     /// This will execute the transactions until all transactions have been processed or the task
     /// was cancelled.
     #[instrument(
+        parent = &self.parent_span,
         level = "debug",
         target = "engine::tree::payload_processor::prewarm",
         name = "prewarm",

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -849,16 +849,14 @@ where
     }
 
     /// Determines the state root computation strategy based on configuration.
-    fn plan_state_root_computation(&self) -> StateRootStrategy {
-        let strategy = if self.config.state_root_fallback() {
+    const fn plan_state_root_computation(&self) -> StateRootStrategy {
+        if self.config.state_root_fallback() {
             StateRootStrategy::Synchronous
         } else if self.config.use_state_root_task() {
             StateRootStrategy::StateRootTask
         } else {
             StateRootStrategy::Parallel
-        };
-
-        strategy
+        }
     }
 
     /// Called when an invalid block is encountered during validation.

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -375,7 +375,7 @@ where
         debug!(
             target: "engine::tree::payload_validator",
             ?strategy,
-            "Deciding which state root algorithm to run"
+            "Decided which state root algorithm to run"
         );
 
         // use prewarming background task
@@ -849,7 +849,6 @@ where
     }
 
     /// Determines the state root computation strategy based on configuration.
-    #[instrument(level = "debug", target = "engine::tree::payload_validator", skip_all)]
     fn plan_state_root_computation(&self) -> StateRootStrategy {
         let strategy = if self.config.state_root_fallback() {
             StateRootStrategy::Synchronous
@@ -858,12 +857,6 @@ where
         } else {
             StateRootStrategy::Parallel
         };
-
-        debug!(
-            target: "engine::tree::payload_validator",
-            ?strategy,
-            "Planned state root computation strategy"
-        );
 
         strategy
     }

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -171,6 +171,7 @@ where
     }
 
     /// Converts a [`BlockOrPayload`] to a recovered block.
+    #[instrument(level = "debug", target = "engine::tree::payload_validator", skip_all)]
     pub fn convert_to_block<T: PayloadTypes<BuiltPayload: BuiltPayload<Primitives = N>>>(
         &self,
         input: BlockOrPayload<T>,
@@ -412,7 +413,7 @@ where
             Err(err) => return self.handle_execution_error(input, err, &parent_block),
         };
 
-        // after executing the block we can stop executing transactions
+        // After executing the block we can stop prewarming transactions
         handle.stop_prewarming_execution();
 
         let block = self.convert_to_block(input)?;
@@ -422,10 +423,7 @@ where
             block
         );
 
-        debug!(target: "engine::tree::payload_validator", "Calculating block state root");
-
         let root_time = Instant::now();
-
         let mut maybe_state_root = None;
 
         match strategy {
@@ -553,6 +551,7 @@ where
 
     /// Validate if block is correct and satisfies all the consensus rules that concern the header
     /// and block body itself.
+    #[instrument(level = "debug", target = "engine::tree::payload_validator", skip_all)]
     fn validate_block_inner(&self, block: &RecoveredBlock<N::Block>) -> Result<(), ConsensusError> {
         if let Err(e) = self.consensus.validate_header(block.sealed_header()) {
             error!(target: "engine::tree::payload_validator", ?block, "Failed to validate header {}: {e}", block.hash());
@@ -671,6 +670,7 @@ where
     /// - parent header validation
     /// - post-execution consensus validation
     /// - state-root based post-execution validation
+    #[instrument(level = "debug", target = "engine::tree::payload_validator", skip_all)]
     fn validate_post_execution<T: PayloadTypes<BuiltPayload: BuiltPayload<Primitives = N>>>(
         &self,
         block: &RecoveredBlock<N::Block>,
@@ -690,21 +690,32 @@ where
         }
 
         // now validate against the parent
+        let _enter = debug_span!(target: "engine::tree::payload_validator", "validate_header_against_parent").entered();
         if let Err(e) =
             self.consensus.validate_header_against_parent(block.sealed_header(), parent_block)
         {
             warn!(target: "engine::tree::payload_validator", ?block, "Failed to validate header {} against parent: {e}", block.hash());
             return Err(e.into())
         }
+        drop(_enter);
 
+        // Validate block post-execution rules
+        let _enter =
+            debug_span!(target: "engine::tree::payload_validator", "validate_block_post_execution")
+                .entered();
         if let Err(err) = self.consensus.validate_block_post_execution(block, output) {
             // call post-block hook
             self.on_invalid_block(parent_block, block, output, None, ctx.state_mut());
             return Err(err.into())
         }
+        drop(_enter);
 
+        let _enter =
+            debug_span!(target: "engine::tree::payload_validator", "hashed_post_state").entered();
         let hashed_state = self.provider.hashed_post_state(&output.state);
+        drop(_enter);
 
+        let _enter = debug_span!(target: "engine::tree::payload_validator", "validate_block_post_execution_with_hashed_state").entered();
         if let Err(err) =
             self.validator.validate_block_post_execution_with_hashed_state(&hashed_state, block)
         {

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -753,14 +753,6 @@ impl SparseTrieInterface for ParallelSparseTrie {
             changed_subtries
                 .into_par_iter()
                 .map(|mut changed_subtrie| {
-                    let _enter = debug_span!(
-                        target: "trie::parallel_sparse",
-                        parent: span.clone(),
-                        "subtrie",
-                        index = changed_subtrie.index
-                    )
-                    .entered();
-
                     #[cfg(feature = "metrics")]
                     let start = std::time::Instant::now();
                     changed_subtrie.subtrie.update_hashes(

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -743,13 +743,11 @@ impl SparseTrieInterface for ParallelSparseTrie {
         // Update subtrie hashes in parallel
         {
             use rayon::iter::{IntoParallelIterator, ParallelIterator};
-            use tracing::debug_span;
 
             let (tx, rx) = mpsc::channel();
 
             let branch_node_tree_masks = &self.branch_node_tree_masks;
             let branch_node_hash_masks = &self.branch_node_hash_masks;
-            let span = tracing::Span::current();
             changed_subtries
                 .into_par_iter()
                 .map(|mut changed_subtrie| {


### PR DESCRIPTION
1. Remove `prewarm task` span that had only the `prewarm` span
2. Rename `prewarm` span into` prewarm and caching`
3. Remove `plan_state_root_computation` span
4. Remove `subtrie` span from parallel sparse trie, as it's too noisy and not very useful
5. Start `state root task` span when we start waiting for the state root
6. Add spans for post-execution validation before we wait for the state root