### PR TITLE
fix(primitives-traits): improve test by enforcing full equality

### DIFF
--- a/crates/primitives-traits/src/transaction/access_list.rs
+++ b/crates/primitives-traits/src/transaction/access_list.rs
@@ -20,7 +20,7 @@ mod tests {
 
     impl PartialEq<AccessList> for RethAccessList {
         fn eq(&self, other: &AccessList) -> bool {
-            self.0.iter().zip(other.iter()).all(|(a, b)| a == b)
+            self.0.iter().eq(other.iter())
         }
     }
 


### PR DESCRIPTION
This change fixes a logical bug in the test-only PartialEq<AccessList> implementation for RethAccessList. The previous implementation used zip-and-all, which truncates to the shorter iterator and incorrectly accepts proper prefixes as equal, potentially masking discrepancies between encoded and decoded access lists in roundtrip tests. The new implementation uses 
Iterator::eq, which checks both element-wise equality and that both iterators are exhausted, ensuring length equality as well