### PR TITLE
feat(trie): Implement set_hashed_address on mock trie cursors

### DIFF
--- a/crates/trie/trie/src/hashed_cursor/mock.rs
+++ b/crates/trie/trie/src/hashed_cursor/mock.rs
@@ -13,12 +13,12 @@ use tracing::instrument;
 #[derive(Clone, Default, Debug)]
 pub struct MockHashedCursorFactory {
     hashed_accounts: Arc<BTreeMap<B256, Account>>,
-    hashed_storage_tries: B256Map<Arc<BTreeMap<B256, U256>>>,
+    hashed_storage_tries: Arc<B256Map<BTreeMap<B256, U256>>>,
 
     /// List of keys that the hashed accounts cursor has visited.
     visited_account_keys: Arc<Mutex<Vec<KeyVisit<B256>>>>,
     /// List of keys that the hashed storages cursor has visited, per storage trie.
-    visited_storage_keys: B256Map<Arc<Mutex<Vec<KeyVisit<B256>>>>>,
+    visited_storage_keys: Arc<B256Map<Mutex<Vec<KeyVisit<B256>>>>>,
 }
 
 impl MockHashedCursorFactory {
@@ -31,12 +31,9 @@ impl MockHashedCursorFactory {
             hashed_storage_tries.keys().map(|k| (*k, Default::default())).collect();
         Self {
             hashed_accounts: Arc::new(hashed_accounts),
-            hashed_storage_tries: hashed_storage_tries
-                .into_iter()
-                .map(|(k, v)| (k, Arc::new(v)))
-                .collect(),
+            hashed_storage_tries: Arc::new(hashed_storage_tries),
             visited_account_keys: Default::default(),
-            visited_storage_keys,
+            visited_storage_keys: Arc::new(visited_storage_keys),
         }
     }
 
@@ -72,39 +69,93 @@ impl HashedCursorFactory for MockHashedCursorFactory {
         &self,
         hashed_address: B256,
     ) -> Result<Self::StorageCursor<'_>, DatabaseError> {
-        Ok(MockHashedCursor::new(
-            self.hashed_storage_tries
-                .get(&hashed_address)
-                .ok_or_else(|| {
-                    DatabaseError::Other(format!("storage trie for {hashed_address:?} not found"))
-                })?
-                .clone(),
-            self.visited_storage_keys
-                .get(&hashed_address)
-                .ok_or_else(|| {
-                    DatabaseError::Other(format!("storage trie for {hashed_address:?} not found"))
-                })?
-                .clone(),
-        ))
+        MockHashedCursor::new_storage(
+            self.hashed_storage_tries.clone(),
+            self.visited_storage_keys.clone(),
+            hashed_address,
+        )
     }
 }
 
+/// Mock hashed cursor type - determines whether this is an account or storage cursor.
+#[derive(Debug)]
+enum MockHashedCursorType<T> {
+    Account {
+        values: Arc<BTreeMap<B256, T>>,
+        visited_keys: Arc<Mutex<Vec<KeyVisit<B256>>>>,
+    },
+    Storage {
+        all_storage_values: Arc<B256Map<BTreeMap<B256, T>>>,
+        all_visited_storage_keys: Arc<B256Map<Mutex<Vec<KeyVisit<B256>>>>>,
+        current_hashed_address: B256,
+    },
+}
+
 /// Mock hashed cursor.
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub struct MockHashedCursor<T> {
     /// The current key. If set, it is guaranteed to exist in `values`.
     current_key: Option<B256>,
-    values: Arc<BTreeMap<B256, T>>,
-    visited_keys: Arc<Mutex<Vec<KeyVisit<B256>>>>,
+    cursor_type: MockHashedCursorType<T>,
 }
 
 impl<T> MockHashedCursor<T> {
-    /// Creates a new mock hashed cursor with the given values and key tracking.
+    /// Creates a new mock hashed cursor for accounts with the given values and key tracking.
     pub fn new(
         values: Arc<BTreeMap<B256, T>>,
         visited_keys: Arc<Mutex<Vec<KeyVisit<B256>>>>,
     ) -> Self {
-        Self { current_key: None, values, visited_keys }
+        Self {
+            current_key: None,
+            cursor_type: MockHashedCursorType::Account { values, visited_keys },
+        }
+    }
+
+    /// Creates a new mock hashed cursor for storage with access to all storage tries.
+    pub fn new_storage(
+        all_storage_values: Arc<B256Map<BTreeMap<B256, T>>>,
+        all_visited_storage_keys: Arc<B256Map<Mutex<Vec<KeyVisit<B256>>>>>,
+        hashed_address: B256,
+    ) -> Result<Self, DatabaseError> {
+        if !all_storage_values.contains_key(&hashed_address) {
+            return Err(DatabaseError::Other(format!(
+                "storage trie for {hashed_address:?} not found"
+            )));
+        }
+        Ok(Self {
+            current_key: None,
+            cursor_type: MockHashedCursorType::Storage {
+                all_storage_values,
+                all_visited_storage_keys,
+                current_hashed_address: hashed_address,
+            },
+        })
+    }
+
+    /// Returns the values map for the current cursor type.
+    fn values(&self) -> &BTreeMap<B256, T> {
+        match &self.cursor_type {
+            MockHashedCursorType::Account { values, .. } => values.as_ref(),
+            MockHashedCursorType::Storage {
+                all_storage_values, current_hashed_address, ..
+            } => all_storage_values
+                .get(current_hashed_address)
+                .expect("current_hashed_address should exist in all_storage_values"),
+        }
+    }
+
+    /// Returns the visited keys mutex for the current cursor type.
+    fn visited_keys(&self) -> &Mutex<Vec<KeyVisit<B256>>> {
+        match &self.cursor_type {
+            MockHashedCursorType::Account { visited_keys, .. } => visited_keys.as_ref(),
+            MockHashedCursorType::Storage {
+                all_visited_storage_keys,
+                current_hashed_address,
+                ..
+            } => all_visited_storage_keys
+                .get(current_hashed_address)
+                .expect("current_hashed_address should exist in all_visited_storage_keys"),
+        }
     }
 }
 
@@ -114,11 +165,11 @@ impl<T: Debug + Clone> HashedCursor for MockHashedCursor<T> {
     #[instrument(skip(self), ret(level = "trace"))]
     fn seek(&mut self, key: B256) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
         // Find the first key that is greater than or equal to the given key.
-        let entry = self.values.iter().find_map(|(k, v)| (k >= &key).then(|| (*k, v.clone())));
+        let entry = self.values().iter().find_map(|(k, v)| (k >= &key).then(|| (*k, v.clone())));
         if let Some((key, _)) = &entry {
             self.current_key = Some(*key);
         }
-        self.visited_keys.lock().push(KeyVisit {
+        self.visited_keys().lock().push(KeyVisit {
             visit_type: KeyVisitType::SeekNonExact(key),
             visited_key: entry.as_ref().map(|(k, _)| *k),
         });
@@ -127,7 +178,7 @@ impl<T: Debug + Clone> HashedCursor for MockHashedCursor<T> {
 
     #[instrument(skip(self), ret(level = "trace"))]
     fn next(&mut self) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
-        let mut iter = self.values.iter();
+        let mut iter = self.values().iter();
         // Jump to the first key that has a prefix of the current key if it's set, or to the first
         // key otherwise.
         iter.find(|(k, _)| {
@@ -139,7 +190,7 @@ impl<T: Debug + Clone> HashedCursor for MockHashedCursor<T> {
         if let Some((key, _)) = &entry {
             self.current_key = Some(*key);
         }
-        self.visited_keys.lock().push(KeyVisit {
+        self.visited_keys().lock().push(KeyVisit {
             visit_type: KeyVisitType::Next,
             visited_key: entry.as_ref().map(|(k, _)| *k),
         });
@@ -154,10 +205,18 @@ impl<T: Debug + Clone> HashedCursor for MockHashedCursor<T> {
 impl<T: Debug + Clone> HashedStorageCursor for MockHashedCursor<T> {
     #[instrument(level = "trace", skip(self), ret)]
     fn is_storage_empty(&mut self) -> Result<bool, DatabaseError> {
-        Ok(self.values.is_empty())
+        Ok(self.values().is_empty())
     }
 
-    fn set_hashed_address(&mut self, _hashed_address: B256) {
-        unimplemented!()
+    fn set_hashed_address(&mut self, hashed_address: B256) {
+        self.reset();
+        match &mut self.cursor_type {
+            MockHashedCursorType::Storage { current_hashed_address, .. } => {
+                *current_hashed_address = hashed_address;
+            }
+            MockHashedCursorType::Account { .. } => {
+                panic!("set_hashed_address called on account cursor")
+            }
+        }
     }
 }

--- a/crates/trie/trie/src/trie_cursor/mock.rs
+++ b/crates/trie/trie/src/trie_cursor/mock.rs
@@ -14,12 +14,12 @@ use reth_storage_errors::db::DatabaseError;
 #[derive(Clone, Default, Debug)]
 pub struct MockTrieCursorFactory {
     account_trie_nodes: Arc<BTreeMap<Nibbles, BranchNodeCompact>>,
-    storage_tries: B256Map<Arc<BTreeMap<Nibbles, BranchNodeCompact>>>,
+    storage_tries: Arc<B256Map<BTreeMap<Nibbles, BranchNodeCompact>>>,
 
     /// List of keys that the account trie cursor has visited.
     visited_account_keys: Arc<Mutex<Vec<KeyVisit<Nibbles>>>>,
     /// List of keys that the storage trie cursor has visited, per storage trie.
-    visited_storage_keys: B256Map<Arc<Mutex<Vec<KeyVisit<Nibbles>>>>>,
+    visited_storage_keys: Arc<B256Map<Mutex<Vec<KeyVisit<Nibbles>>>>>,
 }
 
 impl MockTrieCursorFactory {
@@ -31,9 +31,9 @@ impl MockTrieCursorFactory {
         let visited_storage_keys = storage_tries.keys().map(|k| (*k, Default::default())).collect();
         Self {
             account_trie_nodes: Arc::new(account_trie_nodes),
-            storage_tries: storage_tries.into_iter().map(|(k, v)| (k, Arc::new(v))).collect(),
+            storage_tries: Arc::new(storage_tries),
             visited_account_keys: Default::default(),
-            visited_storage_keys,
+            visited_storage_keys: Arc::new(visited_storage_keys),
         }
     }
 
@@ -71,40 +71,94 @@ impl TrieCursorFactory for MockTrieCursorFactory {
         &self,
         hashed_address: B256,
     ) -> Result<Self::StorageTrieCursor<'_>, DatabaseError> {
-        Ok(MockTrieCursor::new(
-            self.storage_tries
-                .get(&hashed_address)
-                .ok_or_else(|| {
-                    DatabaseError::Other(format!("storage trie for {hashed_address:?} not found"))
-                })?
-                .clone(),
-            self.visited_storage_keys
-                .get(&hashed_address)
-                .ok_or_else(|| {
-                    DatabaseError::Other(format!("storage trie for {hashed_address:?} not found"))
-                })?
-                .clone(),
-        ))
+        MockTrieCursor::new_storage(
+            self.storage_tries.clone(),
+            self.visited_storage_keys.clone(),
+            hashed_address,
+        )
     }
 }
 
+/// Mock trie cursor type - determines whether this is an account or storage cursor.
+#[derive(Debug)]
+enum MockTrieCursorType {
+    Account {
+        trie_nodes: Arc<BTreeMap<Nibbles, BranchNodeCompact>>,
+        visited_keys: Arc<Mutex<Vec<KeyVisit<Nibbles>>>>,
+    },
+    Storage {
+        all_storage_tries: Arc<B256Map<BTreeMap<Nibbles, BranchNodeCompact>>>,
+        all_visited_storage_keys: Arc<B256Map<Mutex<Vec<KeyVisit<Nibbles>>>>>,
+        current_hashed_address: B256,
+    },
+}
+
 /// Mock trie cursor.
-#[derive(Default, Debug)]
+#[derive(Debug)]
 #[non_exhaustive]
 pub struct MockTrieCursor {
     /// The current key. If set, it is guaranteed to exist in `trie_nodes`.
     current_key: Option<Nibbles>,
-    trie_nodes: Arc<BTreeMap<Nibbles, BranchNodeCompact>>,
-    visited_keys: Arc<Mutex<Vec<KeyVisit<Nibbles>>>>,
+    cursor_type: MockTrieCursorType,
 }
 
 impl MockTrieCursor {
-    /// Creates a new mock trie cursor with the given trie nodes and key tracking.
+    /// Creates a new mock trie cursor for accounts with the given trie nodes and key tracking.
     pub fn new(
         trie_nodes: Arc<BTreeMap<Nibbles, BranchNodeCompact>>,
         visited_keys: Arc<Mutex<Vec<KeyVisit<Nibbles>>>>,
     ) -> Self {
-        Self { current_key: None, trie_nodes, visited_keys }
+        Self {
+            current_key: None,
+            cursor_type: MockTrieCursorType::Account { trie_nodes, visited_keys },
+        }
+    }
+
+    /// Creates a new mock trie cursor for storage with access to all storage tries.
+    pub fn new_storage(
+        all_storage_tries: Arc<B256Map<BTreeMap<Nibbles, BranchNodeCompact>>>,
+        all_visited_storage_keys: Arc<B256Map<Mutex<Vec<KeyVisit<Nibbles>>>>>,
+        hashed_address: B256,
+    ) -> Result<Self, DatabaseError> {
+        if !all_storage_tries.contains_key(&hashed_address) {
+            return Err(DatabaseError::Other(format!(
+                "storage trie for {hashed_address:?} not found"
+            )));
+        }
+        Ok(Self {
+            current_key: None,
+            cursor_type: MockTrieCursorType::Storage {
+                all_storage_tries,
+                all_visited_storage_keys,
+                current_hashed_address: hashed_address,
+            },
+        })
+    }
+
+    /// Returns the trie nodes map for the current cursor type.
+    fn trie_nodes(&self) -> &BTreeMap<Nibbles, BranchNodeCompact> {
+        match &self.cursor_type {
+            MockTrieCursorType::Account { trie_nodes, .. } => trie_nodes.as_ref(),
+            MockTrieCursorType::Storage { all_storage_tries, current_hashed_address, .. } => {
+                all_storage_tries
+                    .get(current_hashed_address)
+                    .expect("current_hashed_address should exist in all_storage_tries")
+            }
+        }
+    }
+
+    /// Returns the visited keys mutex for the current cursor type.
+    fn visited_keys(&self) -> &Mutex<Vec<KeyVisit<Nibbles>>> {
+        match &self.cursor_type {
+            MockTrieCursorType::Account { visited_keys, .. } => visited_keys.as_ref(),
+            MockTrieCursorType::Storage {
+                all_visited_storage_keys,
+                current_hashed_address,
+                ..
+            } => all_visited_storage_keys
+                .get(current_hashed_address)
+                .expect("current_hashed_address should exist in all_visited_storage_keys"),
+        }
     }
 }
 
@@ -114,11 +168,11 @@ impl TrieCursor for MockTrieCursor {
         &mut self,
         key: Nibbles,
     ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
-        let entry = self.trie_nodes.get(&key).cloned().map(|value| (key, value));
+        let entry = self.trie_nodes().get(&key).cloned().map(|value| (key, value));
         if let Some((key, _)) = &entry {
             self.current_key = Some(*key);
         }
-        self.visited_keys.lock().push(KeyVisit {
+        self.visited_keys().lock().push(KeyVisit {
             visit_type: KeyVisitType::SeekExact(key),
             visited_key: entry.as_ref().map(|(k, _)| *k),
         });
@@ -131,11 +185,12 @@ impl TrieCursor for MockTrieCursor {
         key: Nibbles,
     ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
         // Find the first key that is greater than or equal to the given key.
-        let entry = self.trie_nodes.iter().find_map(|(k, v)| (k >= &key).then(|| (*k, v.clone())));
+        let entry =
+            self.trie_nodes().iter().find_map(|(k, v)| (k >= &key).then(|| (*k, v.clone())));
         if let Some((key, _)) = &entry {
             self.current_key = Some(*key);
         }
-        self.visited_keys.lock().push(KeyVisit {
+        self.visited_keys().lock().push(KeyVisit {
             visit_type: KeyVisitType::SeekNonExact(key),
             visited_key: entry.as_ref().map(|(k, _)| *k),
         });
@@ -144,7 +199,7 @@ impl TrieCursor for MockTrieCursor {
 
     #[instrument(skip(self), ret(level = "trace"))]
     fn next(&mut self) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
-        let mut iter = self.trie_nodes.iter();
+        let mut iter = self.trie_nodes().iter();
         // Jump to the first key that has a prefix of the current key if it's set, or to the first
         // key otherwise.
         iter.find(|(k, _)| self.current_key.as_ref().is_none_or(|current| k.starts_with(current)))
@@ -154,7 +209,7 @@ impl TrieCursor for MockTrieCursor {
         if let Some((key, _)) = &entry {
             self.current_key = Some(*key);
         }
-        self.visited_keys.lock().push(KeyVisit {
+        self.visited_keys().lock().push(KeyVisit {
             visit_type: KeyVisitType::Next,
             visited_key: entry.as_ref().map(|(k, _)| *k),
         });
@@ -172,7 +227,15 @@ impl TrieCursor for MockTrieCursor {
 }
 
 impl TrieStorageCursor for MockTrieCursor {
-    fn set_hashed_address(&mut self, _hashed_address: B256) {
-        unimplemented!()
+    fn set_hashed_address(&mut self, hashed_address: B256) {
+        self.reset();
+        match &mut self.cursor_type {
+            MockTrieCursorType::Storage { current_hashed_address, .. } => {
+                *current_hashed_address = hashed_address;
+            }
+            MockTrieCursorType::Account { .. } => {
+                panic!("set_hashed_address called on account cursor")
+            }
+        }
     }
 }


### PR DESCRIPTION
This properly implements the `set_hashed_address` method on the MockTrieCursor and MockHashedCursor. This method was previously left unimplemented, but will be necessary for an upcoming feature.

Implementing this method required changing the internals of the mock cursors a bit, such that they are able to hold onto the full set of storage tries in order to switch between them, similar to how the in-memory cursor overlays do.