### PR TITLE
fix: disable state root task when no changesets

### DIFF
--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -860,7 +860,7 @@ where
         let changeset_progress_exists =
             self.provider.get_stage_checkpoint(StageId::MerkleChangeSets)?.is_some();
 
-        let strategy = if self.config.state_root_fallback() || changeset_progress_exists {
+        let strategy = if self.config.state_root_fallback() || !changeset_progress_exists {
             StateRootStrategy::Synchronous
         } else if self.config.use_state_root_task() {
             StateRootStrategy::StateRootTask


### PR DESCRIPTION
It's not safe to run the state root task or parallel state root anyways if there are not merkle changesets, so we disable it when we have no merkle changesets