### PR TITLE
feat(cli): add metrics for download command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7608,6 +7608,7 @@ dependencies = [
  "reth-evm",
  "reth-exex",
  "reth-fs-util",
+ "reth-metrics",
  "reth-net-nat",
  "reth-network",
  "reth-network-p2p",

--- a/crates/cli/commands/Cargo.toml
+++ b/crates/cli/commands/Cargo.toml
@@ -31,6 +31,7 @@ reth-etl.workspace = true
 reth-evm.workspace = true
 reth-exex.workspace = true
 reth-fs-util.workspace = true
+reth-metrics.workspace = true
 reth-net-nat.workspace = true
 reth-network = { workspace = true, features = ["serde"] }
 reth-network-p2p.workspace = true

--- a/crates/ethereum/cli/src/app.rs
+++ b/crates/ethereum/cli/src/app.rs
@@ -171,7 +171,7 @@ where
         Commands::ExportEra(command) => runner.run_blocking_until_ctrl_c(command.execute::<N>()),
         Commands::DumpGenesis(command) => runner.run_blocking_until_ctrl_c(command.execute()),
         Commands::Db(command) => runner.run_blocking_until_ctrl_c(command.execute::<N>()),
-        Commands::Download(command) => runner.run_blocking_until_ctrl_c(command.execute::<N>()),
+        Commands::Download(command) => runner.run_command_until_exit(|ctx| command.execute(ctx)),
         Commands::Stage(command) => {
             runner.run_command_until_exit(|ctx| command.execute::<N, _>(ctx, components))
         }

--- a/docs/vocs/docs/pages/cli/reth/download.mdx
+++ b/docs/vocs/docs/pages/cli/reth/download.mdx
@@ -113,6 +113,11 @@ Static Files:
           If no URL is provided, the latest mainnet archive snapshot
           will be proposed for download from https://downloads.merkle.io
 
+      --metrics <SOCKET>
+          Enable Prometheus metrics.
+
+          The metrics will be served at the given interface and port.
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout


### PR DESCRIPTION
We're downloading 2TB+ mainnet snapshots that take 48+ hours but had zero visibility into what's happening. 

### Before:

`Downloading and extracting... 42.31% (904.23 GB / 2.08 TB)`

That's it. No way to track via Prometheus, no failure stats, nothing.

### After:
```rust
// Now exposed as Prometheus metrics:
cli_download_downloads_started_total: 3
cli_download_downloads_success_total: 2  
cli_download_downloads_failed_total: 1
cli_download_download_speed_bytes_per_second: 125829120  // ~120MB/s
cli_download_download_progress_percent: 42.31
.....
```

Can now properly monitor downloads:
- Track success rates across retries
- Alert on slow speeds (`rate(cli_download_downloaded_bytes_total[1m]) < 10MB`)
- Predict completion time
- Identify if extraction or download is the bottleneck