### PR TITLE
refactor: remove futures_util from exex test utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8702,7 +8702,6 @@ version = "1.9.3"
 dependencies = [
  "alloy-eips",
  "eyre",
- "futures-util",
  "reth-chainspec",
  "reth-config",
  "reth-consensus",

--- a/crates/exex/test-utils/Cargo.toml
+++ b/crates/exex/test-utils/Cargo.toml
@@ -36,7 +36,6 @@ reth-transaction-pool = { workspace = true, features = ["test-utils"] }
 alloy-eips.workspace = true
 
 ## async
-futures-util.workspace = true
 tokio.workspace = true
 
 ## misc


### PR DESCRIPTION
This removes the `futures_util` dependency from the Execution Extension test helpers. The crate only used it for the `FutureExt::poll_unpin` method in the `poll_once` helper. By switching to `Pin::new(&mut *self).poll(cx)` from the standard library, we achieve the same behavior without the external dependency, reducing build times and eliminating an unnecessary crate from the dependency tree.