### PR TITLE
chore(bench-compare): Add latency distribution stats to reth-bench-compare

### DIFF
--- a/bin/reth-bench-compare/src/comparison.rs
+++ b/bin/reth-bench-compare/src/comparison.rs
@@ -53,12 +53,12 @@ pub(crate) struct TotalGasRow {
 
 /// Summary statistics for a benchmark run.
 ///
-/// Latencies are in milliseconds and describe `engine_newPayloadV3` calls:
-/// - `total_new_payload_latency_ms`: sum across all processed blocks.
-/// - `avg_new_payload_latency_ms`: mean latency per block.
-/// - `median_new_payload_latency_ms`: p50 latency per block.
-/// - `p90_new_payload_latency_ms` / `p99_new_payload_latency_ms`: tail latencies per block.
-/// - Throughput numbers are computed using total duration.
+/// Latencies are derived from per-block `engine_newPayloadV3` timings (converted from µs to ms):
+/// - `total_new_payload_latency_ms`: sum of all blocks' latencies.
+/// - `avg_new_payload_latency_ms`: arithmetic mean latency across blocks.
+/// - `median_new_payload_latency_ms`: p50 latency across blocks.
+/// - `p90_new_payload_latency_ms` / `p99_new_payload_latency_ms`: tail latencies across blocks.
+/// `gas_per_second` and `blocks_per_second` use the total run duration from the gas trace.
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct BenchmarkSummary {
     pub total_blocks: u64,

--- a/bin/reth-bench-compare/src/comparison.rs
+++ b/bin/reth-bench-compare/src/comparison.rs
@@ -54,19 +54,14 @@ pub(crate) struct TotalGasRow {
 /// Summary statistics for a benchmark run.
 ///
 /// Latencies are derived from per-block `engine_newPayload` timings (converted from µs to ms):
-/// - `total_new_payload_latency_ms`: sum of all blocks' latencies. Used for calculating mean and
-///   provides total execution time spent in `engine_newPayload`.
 /// - `mean_new_payload_latency_ms`: arithmetic mean latency across blocks.
 /// - `median_new_payload_latency_ms`: p50 latency across blocks.
 /// - `p90_new_payload_latency_ms` / `p99_new_payload_latency_ms`: tail latencies across blocks.
-///
-/// `gas_per_second` and `blocks_per_second` use the total run duration from the benchmark.
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct BenchmarkSummary {
     pub total_blocks: u64,
     pub total_gas_used: u64,
     pub total_duration_ms: u128,
-    pub total_new_payload_latency_ms: f64,
     pub mean_new_payload_latency_ms: f64,
     pub median_new_payload_latency_ms: f64,
     pub p90_new_payload_latency_ms: f64,
@@ -322,8 +317,8 @@ impl ComparisonGenerator {
 
         let latencies_ms: Vec<f64> =
             combined_data.iter().map(|r| r.new_payload_latency as f64 / 1000.0).collect();
-        let total_new_payload_latency_ms: f64 = latencies_ms.iter().sum();
-        let mean_new_payload_latency_ms: f64 = total_new_payload_latency_ms / total_blocks as f64;
+        let mean_new_payload_latency_ms: f64 =
+            latencies_ms.iter().sum::<f64>() / total_blocks as f64;
 
         let mut sorted_latencies_ms = latencies_ms;
         sorted_latencies_ms.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal));
@@ -351,7 +346,6 @@ impl ComparisonGenerator {
             total_blocks,
             total_gas_used,
             total_duration_ms,
-            total_new_payload_latency_ms,
             mean_new_payload_latency_ms,
             median_new_payload_latency_ms,
             p90_new_payload_latency_ms,
@@ -531,8 +525,7 @@ impl ComparisonGenerator {
         );
         println!("  NewPayload latency (ms):");
         println!(
-            "    total: {:.2}, mean: {:.2}, p50: {:.2}, p90: {:.2}, p99: {:.2}",
-            baseline.total_new_payload_latency_ms,
+            "    mean: {:.2}, p50: {:.2}, p90: {:.2}, p99: {:.2}",
             baseline.mean_new_payload_latency_ms,
             baseline.median_new_payload_latency_ms,
             baseline.p90_new_payload_latency_ms,
@@ -561,8 +554,7 @@ impl ComparisonGenerator {
         );
         println!("  NewPayload latency (ms):");
         println!(
-            "    total: {:.2}, mean: {:.2}, p50: {:.2}, p90: {:.2}, p99: {:.2}",
-            feature.total_new_payload_latency_ms,
+            "    mean: {:.2}, p50: {:.2}, p90: {:.2}, p99: {:.2}",
             feature.mean_new_payload_latency_ms,
             feature.median_new_payload_latency_ms,
             feature.p90_new_payload_latency_ms,

--- a/bin/reth-bench-compare/src/comparison.rs
+++ b/bin/reth-bench-compare/src/comparison.rs
@@ -109,8 +109,7 @@ pub(crate) struct ComparisonSummary {
     pub blocks_per_second_change_percent: f64,
 }
 
-/// Per-block comparison data (raw latencies in µs; percent change is `(feature - baseline) /
-/// baseline * 100`).
+/// Per-block comparison data
 #[derive(Debug, Serialize)]
 pub(crate) struct BlockComparison {
     pub block_number: u64,

--- a/bin/reth-bench-compare/src/comparison.rs
+++ b/bin/reth-bench-compare/src/comparison.rs
@@ -109,7 +109,8 @@ pub(crate) struct ComparisonSummary {
     pub blocks_per_second_change_percent: f64,
 }
 
-/// Per-block comparison data
+/// Per-block comparison data (raw latencies in µs; percent change is `(feature - baseline) /
+/// baseline * 100`).
 #[derive(Debug, Serialize)]
 pub(crate) struct BlockComparison {
     pub block_number: u64,
@@ -300,7 +301,11 @@ impl ComparisonGenerator {
         Ok(rows)
     }
 
-    /// Calculate summary statistics for a benchmark run
+    /// Calculate summary statistics for a benchmark run.
+    ///
+    /// Computes latency statistics from per-block `new_payload_latency` values in `combined_data`
+    /// (converting from µs to ms), and throughput metrics using the total run duration from
+    /// `total_gas_data`. Percentiles (p50/p90/p99) use linear interpolation on sorted latencies.
     fn calculate_summary(
         &self,
         combined_data: &[CombinedLatencyRow],

--- a/bin/reth-bench-compare/src/comparison.rs
+++ b/bin/reth-bench-compare/src/comparison.rs
@@ -58,6 +58,7 @@ pub(crate) struct TotalGasRow {
 /// - `mean_new_payload_latency_ms`: arithmetic mean latency across blocks.
 /// - `median_new_payload_latency_ms`: p50 latency across blocks.
 /// - `p90_new_payload_latency_ms` / `p99_new_payload_latency_ms`: tail latencies across blocks.
+///
 /// `gas_per_second` and `blocks_per_second` use the total run duration from the gas trace.
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct BenchmarkSummary {

--- a/bin/reth-bench-compare/src/comparison.rs
+++ b/bin/reth-bench-compare/src/comparison.rs
@@ -55,7 +55,7 @@ pub(crate) struct TotalGasRow {
 ///
 /// Latencies are derived from per-block `engine_newPayloadV3` timings (converted from µs to ms):
 /// - `total_new_payload_latency_ms`: sum of all blocks' latencies.
-/// - `avg_new_payload_latency_ms`: arithmetic mean latency across blocks.
+/// - `mean_new_payload_latency_ms`: arithmetic mean latency across blocks.
 /// - `median_new_payload_latency_ms`: p50 latency across blocks.
 /// - `p90_new_payload_latency_ms` / `p99_new_payload_latency_ms`: tail latencies across blocks.
 /// `gas_per_second` and `blocks_per_second` use the total run duration from the gas trace.
@@ -65,7 +65,7 @@ pub(crate) struct BenchmarkSummary {
     pub total_gas_used: u64,
     pub total_duration_ms: u128,
     pub total_new_payload_latency_ms: f64,
-    pub avg_new_payload_latency_ms: f64,
+    pub mean_new_payload_latency_ms: f64,
     pub median_new_payload_latency_ms: f64,
     pub p90_new_payload_latency_ms: f64,
     pub p99_new_payload_latency_ms: f64,
@@ -316,7 +316,7 @@ impl ComparisonGenerator {
         let latencies_ms: Vec<f64> =
             combined_data.iter().map(|r| r.new_payload_latency as f64 / 1000.0).collect();
         let total_new_payload_latency_ms: f64 = latencies_ms.iter().sum();
-        let avg_new_payload_latency_ms: f64 = total_new_payload_latency_ms / total_blocks as f64;
+        let mean_new_payload_latency_ms: f64 = total_new_payload_latency_ms / total_blocks as f64;
 
         let mut sorted_latencies_ms = latencies_ms;
         sorted_latencies_ms.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal));
@@ -345,7 +345,7 @@ impl ComparisonGenerator {
             total_gas_used,
             total_duration_ms,
             total_new_payload_latency_ms,
-            avg_new_payload_latency_ms,
+            mean_new_payload_latency_ms,
             median_new_payload_latency_ms,
             p90_new_payload_latency_ms,
             p99_new_payload_latency_ms,
@@ -372,8 +372,8 @@ impl ComparisonGenerator {
 
         Ok(ComparisonSummary {
             new_payload_latency_change_percent: calc_percent_change(
-                baseline.avg_new_payload_latency_ms,
-                feature.avg_new_payload_latency_ms,
+                baseline.mean_new_payload_latency_ms,
+                feature.mean_new_payload_latency_ms,
             ),
             new_payload_latency_p50_change_percent: calc_percent_change(
                 baseline.median_new_payload_latency_ms,
@@ -490,7 +490,7 @@ impl ComparisonGenerator {
 
         println!("Performance Changes:");
         println!(
-            "  NewPayload Latency (avg per block): {:+.2}%",
+            "  NewPayload Latency (mean per block): {:+.2}%",
             summary.new_payload_latency_change_percent
         );
         println!(
@@ -527,9 +527,9 @@ impl ComparisonGenerator {
         );
         println!("  NewPayload latency (ms):");
         println!(
-            "    total: {:.2}, avg/block: {:.2}, p50: {:.2}, p90: {:.2}, p99: {:.2}",
+            "    total: {:.2}, mean/block: {:.2}, p50: {:.2}, p90: {:.2}, p99: {:.2}",
             baseline.total_new_payload_latency_ms,
-            baseline.avg_new_payload_latency_ms,
+            baseline.mean_new_payload_latency_ms,
             baseline.median_new_payload_latency_ms,
             baseline.p90_new_payload_latency_ms,
             baseline.p99_new_payload_latency_ms
@@ -557,9 +557,9 @@ impl ComparisonGenerator {
         );
         println!("  NewPayload latency (ms):");
         println!(
-            "    total: {:.2}, avg/block: {:.2}, p50: {:.2}, p90: {:.2}, p99: {:.2}",
+            "    total: {:.2}, mean/block: {:.2}, p50: {:.2}, p90: {:.2}, p99: {:.2}",
             feature.total_new_payload_latency_ms,
-            feature.avg_new_payload_latency_ms,
+            feature.mean_new_payload_latency_ms,
             feature.median_new_payload_latency_ms,
             feature.p90_new_payload_latency_ms,
             feature.p99_new_payload_latency_ms

--- a/bin/reth-bench-compare/src/comparison.rs
+++ b/bin/reth-bench-compare/src/comparison.rs
@@ -96,7 +96,8 @@ pub(crate) struct RefInfo {
 
 /// Summary of the comparison between references.
 ///
-/// Latency deltas are percent changes for per-block statistics relative to the baseline run.
+/// Percent deltas are `(feature - baseline) / baseline * 100`, so positive is slower/higher and
+/// negative is faster/lower.
 #[derive(Debug, Serialize)]
 pub(crate) struct ComparisonSummary {
     pub new_payload_latency_change_percent: f64,

--- a/bin/reth-bench-compare/src/comparison.rs
+++ b/bin/reth-bench-compare/src/comparison.rs
@@ -581,7 +581,11 @@ impl ComparisonGenerator {
 
 /// Calculate percentile using linear interpolation on a sorted slice.
 ///
-/// Returns 0.0 for empty input (should already be guarded upstream).
+/// Computes `rank = percentile × (n - 1)` where n is the array length. If the rank falls
+/// between two indices, linearly interpolates between those values. For example, with 100 values,
+/// p90 computes rank = 0.9 × 99 = 89.1, then returns `values[89] × 0.9 + values[90] × 0.1`.
+///
+/// Returns 0.0 for empty input.
 fn percentile(sorted_values: &[f64], percentile: f64) -> f64 {
     if sorted_values.is_empty() {
         return 0.0;

--- a/bin/reth-bench-compare/src/comparison.rs
+++ b/bin/reth-bench-compare/src/comparison.rs
@@ -53,13 +53,14 @@ pub(crate) struct TotalGasRow {
 
 /// Summary statistics for a benchmark run.
 ///
-/// Latencies are derived from per-block `engine_newPayloadV3` timings (converted from µs to ms):
-/// - `total_new_payload_latency_ms`: sum of all blocks' latencies.
+/// Latencies are derived from per-block `engine_newPayload` timings (converted from µs to ms):
+/// - `total_new_payload_latency_ms`: sum of all blocks' latencies. Used for calculating mean and
+///   provides total execution time spent in `engine_newPayload`.
 /// - `mean_new_payload_latency_ms`: arithmetic mean latency across blocks.
 /// - `median_new_payload_latency_ms`: p50 latency across blocks.
 /// - `p90_new_payload_latency_ms` / `p99_new_payload_latency_ms`: tail latencies across blocks.
 ///
-/// `gas_per_second` and `blocks_per_second` use the total run duration from the gas trace.
+/// `gas_per_second` and `blocks_per_second` use the total run duration from the benchmark.
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct BenchmarkSummary {
     pub total_blocks: u64,
@@ -97,8 +98,8 @@ pub(crate) struct RefInfo {
 
 /// Summary of the comparison between references.
 ///
-/// Percent deltas are `(feature - baseline) / baseline * 100`, so positive is slower/higher and
-/// negative is faster/lower.
+/// Percent deltas are `(feature - baseline) / baseline * 100`, so positive is slower and
+/// negative is faster.
 #[derive(Debug, Serialize)]
 pub(crate) struct ComparisonSummary {
     pub new_payload_latency_change_percent: f64,
@@ -495,10 +496,7 @@ impl ComparisonGenerator {
         let summary = &report.comparison_summary;
 
         println!("Performance Changes:");
-        println!(
-            "  NewPayload Latency (mean per block): {:+.2}%",
-            summary.new_payload_latency_change_percent
-        );
+        println!("  NewPayload Latency mean: {:+.2}%", summary.new_payload_latency_change_percent);
         println!(
             "  NewPayload Latency p50:           {:+.2}%",
             summary.new_payload_latency_p50_change_percent
@@ -533,7 +531,7 @@ impl ComparisonGenerator {
         );
         println!("  NewPayload latency (ms):");
         println!(
-            "    total: {:.2}, mean/block: {:.2}, p50: {:.2}, p90: {:.2}, p99: {:.2}",
+            "    total: {:.2}, mean: {:.2}, p50: {:.2}, p90: {:.2}, p99: {:.2}",
             baseline.total_new_payload_latency_ms,
             baseline.mean_new_payload_latency_ms,
             baseline.median_new_payload_latency_ms,
@@ -563,7 +561,7 @@ impl ComparisonGenerator {
         );
         println!("  NewPayload latency (ms):");
         println!(
-            "    total: {:.2}, mean/block: {:.2}, p50: {:.2}, p90: {:.2}, p99: {:.2}",
+            "    total: {:.2}, mean: {:.2}, p50: {:.2}, p90: {:.2}, p99: {:.2}",
             feature.total_new_payload_latency_ms,
             feature.mean_new_payload_latency_ms,
             feature.median_new_payload_latency_ms,

--- a/bin/reth-bench-compare/src/comparison.rs
+++ b/bin/reth-bench-compare/src/comparison.rs
@@ -97,7 +97,8 @@ pub(crate) struct RefInfo {
 /// - `new_payload_latency_p50_change_percent` / p90 / p99: percent changes of the respective
 ///   per-block percentiles.
 /// - `per_block_latency_change_mean_percent` / `per_block_latency_change_median_percent` are the
-///   mean and median of per-block percent deltas (feature vs baseline), capturing block-level drift.
+///   mean and median of per-block percent deltas (feature vs baseline), capturing block-level
+///   drift.
 /// - `new_payload_total_latency_change_percent` is the percent change of the total newPayload time
 ///   across the run.
 ///

--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -162,7 +162,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
             if let Some(inflight_count) = self.active_peers.get(peer_id) {
                 *inflight_count = inflight_count.saturating_sub(1);
                 if *inflight_count == 0 {
-                    return true;
+                    return true
                 }
             }
             false
@@ -178,7 +178,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
     pub fn is_idle(&self, peer_id: &PeerId) -> bool {
         let Some(inflight_count) = self.active_peers.peek(peer_id) else { return true };
         if *inflight_count < self.info.max_inflight_requests_per_peer {
-            return true;
+            return true
         }
         false
     }
@@ -188,7 +188,13 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
         let TxFetchMetadata { fallback_peers, .. } =
             self.hashes_fetch_inflight_and_pending_fetch.peek(&hash)?;
 
-        fallback_peers.iter().find(|peer_id| self.is_idle(peer_id))
+        for peer_id in fallback_peers.iter() {
+            if self.is_idle(peer_id) {
+                return Some(peer_id)
+            }
+        }
+
+        None
     }
 
     /// Returns any idle peer for any hash pending fetch. If one is found, the corresponding
@@ -210,13 +216,13 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
 
             if idle_peer.is_some() {
                 hashes_to_request.insert(hash);
-                break idle_peer.copied();
+                break idle_peer.copied()
             }
 
             if let Some(ref mut bud) = budget {
                 *bud = bud.saturating_sub(1);
                 if *bud == 0 {
-                    return None;
+                    return None
                 }
             }
         };
@@ -239,7 +245,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
         hashes_from_announcement: ValidAnnouncementData,
     ) -> RequestTxHashes {
         if hashes_from_announcement.msg_version().is_eth68() {
-            return self.pack_request_eth68(hashes_to_request, hashes_from_announcement);
+            return self.pack_request_eth68(hashes_to_request, hashes_from_announcement)
         }
         self.pack_request_eth66(hashes_to_request, hashes_from_announcement)
     }
@@ -269,7 +275,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
 
             // tx is really big, pack request with single tx
             if size >= self.info.soft_limit_byte_size_pooled_transactions_response_on_pack_request {
-                return hashes_from_announcement_iter.collect();
+                return hashes_from_announcement_iter.collect()
             }
             acc_size_response = size;
         }
@@ -285,8 +291,8 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
 
             let next_acc_size = acc_size_response + size;
 
-            if next_acc_size
-                <= self.info.soft_limit_byte_size_pooled_transactions_response_on_pack_request
+            if next_acc_size <=
+                self.info.soft_limit_byte_size_pooled_transactions_response_on_pack_request
             {
                 // only update accumulated size of tx response if tx will fit in without exceeding
                 // soft limit
@@ -297,11 +303,11 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
             }
 
             let free_space =
-                self.info.soft_limit_byte_size_pooled_transactions_response_on_pack_request
-                    - acc_size_response;
+                self.info.soft_limit_byte_size_pooled_transactions_response_on_pack_request -
+                    acc_size_response;
 
             if free_space < MEDIAN_BYTE_SIZE_SMALL_LEGACY_TX_ENCODED {
-                break;
+                break
             }
         }
 
@@ -348,7 +354,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
         hashes.retain(|hash| {
             if let Some(entry) = self.hashes_fetch_inflight_and_pending_fetch.get(hash) {
                 entry.fallback_peers_mut().remove(peer_failed_to_serve);
-                return true;
+                return true
             }
             // tx has been seen over broadcast in the time it took for the request to resolve
             false
@@ -375,13 +381,13 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
         for hash in hashes {
             // hash could have been evicted from bounded lru map
             if self.hashes_fetch_inflight_and_pending_fetch.peek(&hash).is_none() {
-                continue;
+                continue
             }
 
             let Some(TxFetchMetadata { retries, fallback_peers, .. }) =
                 self.hashes_fetch_inflight_and_pending_fetch.get(&hash)
             else {
-                return;
+                return
             };
 
             if let Some(peer_id) = fallback_peer {
@@ -397,7 +403,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
 
                     self.hashes_fetch_inflight_and_pending_fetch.remove(&hash);
                     self.hashes_pending_fetch.remove(&hash);
-                    continue;
+                    continue
                 }
                 *retries += 1;
             }
@@ -434,7 +440,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
                     budget_find_idle_fallback_peer,
                 ) else {
                     // no peers are idle or budget is depleted
-                    return;
+                    return
                 };
 
                 peer_id
@@ -592,7 +598,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
                 max_inflight_transaction_requests=self.info.max_inflight_requests,
                 "limit for concurrent `GetPooledTransactions` requests reached, dropping request for hashes to peer"
             );
-            return Some(new_announced_hashes);
+            return Some(new_announced_hashes)
         }
 
         let Some(inflight_count) = self.active_peers.get_or_insert(peer_id, || 0) else {
@@ -602,7 +608,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
                 conn_eth_version=%conn_eth_version,
                 "failed to cache active peer in schnellru::LruMap, dropping request to peer"
             );
-            return Some(new_announced_hashes);
+            return Some(new_announced_hashes)
         };
 
         if *inflight_count >= self.info.max_inflight_requests_per_peer {
@@ -613,7 +619,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
                 max_concurrent_tx_reqs_per_peer=self.info.max_inflight_requests_per_peer,
                 "limit for concurrent `GetPooledTransactions` requests per peer reached"
             );
-            return Some(new_announced_hashes);
+            return Some(new_announced_hashes)
         }
 
         #[cfg(debug_assertions)]
@@ -646,7 +652,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
                     self.metrics.egress_peer_channel_full.increment(1);
                     Some(new_announced_hashes)
                 }
-            };
+            }
         }
 
         *inflight_count += 1;
@@ -690,10 +696,10 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
             .unwrap_or(AVERAGE_BYTE_SIZE_TX_ENCODED);
 
         // if request full enough already, we're satisfied, send request for single tx
-        if acc_size_response
-            >= DEFAULT_SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESPONSE_ON_FETCH_PENDING_HASHES
+        if acc_size_response >=
+            DEFAULT_SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESPONSE_ON_FETCH_PENDING_HASHES
         {
-            return;
+            return
         }
 
         // try to fill request by checking if any other hashes pending fetch (in lru order) are
@@ -701,7 +707,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
         for hash in self.hashes_pending_fetch.iter() {
             // 1. Check if a hash pending fetch is seen by peer.
             if !seen_hashes.contains(hash) {
-                continue;
+                continue
             };
 
             // 2. Optimistically include the hash in the request.
@@ -730,7 +736,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
             if let Some(ref mut bud) = budget_fill_request {
                 *bud -= 1;
                 if *bud == 0 {
-                    break;
+                    break
                 }
             }
         }
@@ -766,8 +772,8 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
         let info = &self.info;
 
         let tx_fetcher_has_capacity = self.has_capacity(
-            info.max_inflight_requests
-                / DEFAULT_DIVISOR_MAX_COUNT_INFLIGHT_REQUESTS_ON_FIND_IDLE_PEER,
+            info.max_inflight_requests /
+                DEFAULT_DIVISOR_MAX_COUNT_INFLIGHT_REQUESTS_ON_FIND_IDLE_PEER,
         );
         let tx_pool_has_capacity = has_capacity_wrt_pending_pool_imports(
             DEFAULT_DIVISOR_MAX_COUNT_PENDING_POOL_IMPORTS_ON_FIND_IDLE_PEER,
@@ -805,8 +811,8 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
         let info = &self.info;
 
         let tx_fetcher_has_capacity = self.has_capacity(
-            info.max_inflight_requests
-                / DEFAULT_DIVISOR_MAX_COUNT_INFLIGHT_REQUESTS_ON_FIND_INTERSECTION,
+            info.max_inflight_requests /
+                DEFAULT_DIVISOR_MAX_COUNT_INFLIGHT_REQUESTS_ON_FIND_INTERSECTION,
         );
         let tx_pool_has_capacity = has_capacity_wrt_pending_pool_imports(
             DEFAULT_DIVISOR_MAX_COUNT_PENDING_POOL_IMPORTS_ON_FIND_INTERSECTION,
@@ -857,7 +863,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
                         "received empty `PooledTransactions` response from peer, peer failed to serve hashes it announced"
                     );
 
-                    return FetchEvent::EmptyResponse { peer_id };
+                    return FetchEvent::EmptyResponse { peer_id }
                 }
 
                 //
@@ -888,7 +894,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
 
                 // peer has only sent hashes that we didn't request
                 if verified_payload.is_empty() {
-                    return FetchEvent::FetchError { peer_id, error: RequestError::BadResponse };
+                    return FetchEvent::FetchError { peer_id, error: RequestError::BadResponse }
                 }
 
                 //
@@ -924,7 +930,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
                     if valid_payload.contains_key(requested_hash) {
                         // hash is now known, stop tracking
                         fetched.push(*requested_hash);
-                        return false;
+                        return false
                     }
                     true
                 });
@@ -970,11 +976,11 @@ impl<N: NetworkPrimitives> Stream for TransactionFetcher<N> {
         // `FuturesUnordered` doesn't close when `None` is returned. so just return pending.
         // <https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=815be2b6c8003303757c3ced135f363e>
         if self.inflight_requests.is_empty() {
-            return Poll::Pending;
+            return Poll::Pending
         }
 
         if let Some(resp) = ready!(self.inflight_requests.poll_next_unpin(cx)) {
-            return Poll::Ready(Some(self.on_resolved_get_pooled_transactions_request_fut(resp)));
+            return Poll::Ready(Some(self.on_resolved_get_pooled_transactions_request_fut(resp)))
         }
 
         Poll::Pending
@@ -1181,7 +1187,7 @@ impl<T: SignedTransaction> VerifyPooledTransactionsResponse for UnverifiedPooled
                     tx_hashes_not_requested_count += 1;
                 }
 
-                return false;
+                return false
             }
             true
         });

--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -162,7 +162,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
             if let Some(inflight_count) = self.active_peers.get(peer_id) {
                 *inflight_count = inflight_count.saturating_sub(1);
                 if *inflight_count == 0 {
-                    return true
+                    return true;
                 }
             }
             false
@@ -178,7 +178,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
     pub fn is_idle(&self, peer_id: &PeerId) -> bool {
         let Some(inflight_count) = self.active_peers.peek(peer_id) else { return true };
         if *inflight_count < self.info.max_inflight_requests_per_peer {
-            return true
+            return true;
         }
         false
     }
@@ -188,13 +188,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
         let TxFetchMetadata { fallback_peers, .. } =
             self.hashes_fetch_inflight_and_pending_fetch.peek(&hash)?;
 
-        for peer_id in fallback_peers.iter() {
-            if self.is_idle(peer_id) {
-                return Some(peer_id)
-            }
-        }
-
-        None
+        fallback_peers.iter().find(|peer_id| self.is_idle(peer_id))
     }
 
     /// Returns any idle peer for any hash pending fetch. If one is found, the corresponding
@@ -216,13 +210,13 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
 
             if idle_peer.is_some() {
                 hashes_to_request.insert(hash);
-                break idle_peer.copied()
+                break idle_peer.copied();
             }
 
             if let Some(ref mut bud) = budget {
                 *bud = bud.saturating_sub(1);
                 if *bud == 0 {
-                    return None
+                    return None;
                 }
             }
         };
@@ -245,7 +239,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
         hashes_from_announcement: ValidAnnouncementData,
     ) -> RequestTxHashes {
         if hashes_from_announcement.msg_version().is_eth68() {
-            return self.pack_request_eth68(hashes_to_request, hashes_from_announcement)
+            return self.pack_request_eth68(hashes_to_request, hashes_from_announcement);
         }
         self.pack_request_eth66(hashes_to_request, hashes_from_announcement)
     }
@@ -275,7 +269,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
 
             // tx is really big, pack request with single tx
             if size >= self.info.soft_limit_byte_size_pooled_transactions_response_on_pack_request {
-                return hashes_from_announcement_iter.collect()
+                return hashes_from_announcement_iter.collect();
             }
             acc_size_response = size;
         }
@@ -291,8 +285,8 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
 
             let next_acc_size = acc_size_response + size;
 
-            if next_acc_size <=
-                self.info.soft_limit_byte_size_pooled_transactions_response_on_pack_request
+            if next_acc_size
+                <= self.info.soft_limit_byte_size_pooled_transactions_response_on_pack_request
             {
                 // only update accumulated size of tx response if tx will fit in without exceeding
                 // soft limit
@@ -303,11 +297,11 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
             }
 
             let free_space =
-                self.info.soft_limit_byte_size_pooled_transactions_response_on_pack_request -
-                    acc_size_response;
+                self.info.soft_limit_byte_size_pooled_transactions_response_on_pack_request
+                    - acc_size_response;
 
             if free_space < MEDIAN_BYTE_SIZE_SMALL_LEGACY_TX_ENCODED {
-                break
+                break;
             }
         }
 
@@ -354,7 +348,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
         hashes.retain(|hash| {
             if let Some(entry) = self.hashes_fetch_inflight_and_pending_fetch.get(hash) {
                 entry.fallback_peers_mut().remove(peer_failed_to_serve);
-                return true
+                return true;
             }
             // tx has been seen over broadcast in the time it took for the request to resolve
             false
@@ -381,13 +375,13 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
         for hash in hashes {
             // hash could have been evicted from bounded lru map
             if self.hashes_fetch_inflight_and_pending_fetch.peek(&hash).is_none() {
-                continue
+                continue;
             }
 
             let Some(TxFetchMetadata { retries, fallback_peers, .. }) =
                 self.hashes_fetch_inflight_and_pending_fetch.get(&hash)
             else {
-                return
+                return;
             };
 
             if let Some(peer_id) = fallback_peer {
@@ -403,7 +397,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
 
                     self.hashes_fetch_inflight_and_pending_fetch.remove(&hash);
                     self.hashes_pending_fetch.remove(&hash);
-                    continue
+                    continue;
                 }
                 *retries += 1;
             }
@@ -440,7 +434,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
                     budget_find_idle_fallback_peer,
                 ) else {
                     // no peers are idle or budget is depleted
-                    return
+                    return;
                 };
 
                 peer_id
@@ -598,7 +592,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
                 max_inflight_transaction_requests=self.info.max_inflight_requests,
                 "limit for concurrent `GetPooledTransactions` requests reached, dropping request for hashes to peer"
             );
-            return Some(new_announced_hashes)
+            return Some(new_announced_hashes);
         }
 
         let Some(inflight_count) = self.active_peers.get_or_insert(peer_id, || 0) else {
@@ -608,7 +602,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
                 conn_eth_version=%conn_eth_version,
                 "failed to cache active peer in schnellru::LruMap, dropping request to peer"
             );
-            return Some(new_announced_hashes)
+            return Some(new_announced_hashes);
         };
 
         if *inflight_count >= self.info.max_inflight_requests_per_peer {
@@ -619,7 +613,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
                 max_concurrent_tx_reqs_per_peer=self.info.max_inflight_requests_per_peer,
                 "limit for concurrent `GetPooledTransactions` requests per peer reached"
             );
-            return Some(new_announced_hashes)
+            return Some(new_announced_hashes);
         }
 
         #[cfg(debug_assertions)]
@@ -652,7 +646,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
                     self.metrics.egress_peer_channel_full.increment(1);
                     Some(new_announced_hashes)
                 }
-            }
+            };
         }
 
         *inflight_count += 1;
@@ -696,10 +690,10 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
             .unwrap_or(AVERAGE_BYTE_SIZE_TX_ENCODED);
 
         // if request full enough already, we're satisfied, send request for single tx
-        if acc_size_response >=
-            DEFAULT_SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESPONSE_ON_FETCH_PENDING_HASHES
+        if acc_size_response
+            >= DEFAULT_SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESPONSE_ON_FETCH_PENDING_HASHES
         {
-            return
+            return;
         }
 
         // try to fill request by checking if any other hashes pending fetch (in lru order) are
@@ -707,7 +701,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
         for hash in self.hashes_pending_fetch.iter() {
             // 1. Check if a hash pending fetch is seen by peer.
             if !seen_hashes.contains(hash) {
-                continue
+                continue;
             };
 
             // 2. Optimistically include the hash in the request.
@@ -736,7 +730,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
             if let Some(ref mut bud) = budget_fill_request {
                 *bud -= 1;
                 if *bud == 0 {
-                    break
+                    break;
                 }
             }
         }
@@ -772,8 +766,8 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
         let info = &self.info;
 
         let tx_fetcher_has_capacity = self.has_capacity(
-            info.max_inflight_requests /
-                DEFAULT_DIVISOR_MAX_COUNT_INFLIGHT_REQUESTS_ON_FIND_IDLE_PEER,
+            info.max_inflight_requests
+                / DEFAULT_DIVISOR_MAX_COUNT_INFLIGHT_REQUESTS_ON_FIND_IDLE_PEER,
         );
         let tx_pool_has_capacity = has_capacity_wrt_pending_pool_imports(
             DEFAULT_DIVISOR_MAX_COUNT_PENDING_POOL_IMPORTS_ON_FIND_IDLE_PEER,
@@ -811,8 +805,8 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
         let info = &self.info;
 
         let tx_fetcher_has_capacity = self.has_capacity(
-            info.max_inflight_requests /
-                DEFAULT_DIVISOR_MAX_COUNT_INFLIGHT_REQUESTS_ON_FIND_INTERSECTION,
+            info.max_inflight_requests
+                / DEFAULT_DIVISOR_MAX_COUNT_INFLIGHT_REQUESTS_ON_FIND_INTERSECTION,
         );
         let tx_pool_has_capacity = has_capacity_wrt_pending_pool_imports(
             DEFAULT_DIVISOR_MAX_COUNT_PENDING_POOL_IMPORTS_ON_FIND_INTERSECTION,
@@ -863,7 +857,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
                         "received empty `PooledTransactions` response from peer, peer failed to serve hashes it announced"
                     );
 
-                    return FetchEvent::EmptyResponse { peer_id }
+                    return FetchEvent::EmptyResponse { peer_id };
                 }
 
                 //
@@ -894,7 +888,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
 
                 // peer has only sent hashes that we didn't request
                 if verified_payload.is_empty() {
-                    return FetchEvent::FetchError { peer_id, error: RequestError::BadResponse }
+                    return FetchEvent::FetchError { peer_id, error: RequestError::BadResponse };
                 }
 
                 //
@@ -930,7 +924,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
                     if valid_payload.contains_key(requested_hash) {
                         // hash is now known, stop tracking
                         fetched.push(*requested_hash);
-                        return false
+                        return false;
                     }
                     true
                 });
@@ -976,11 +970,11 @@ impl<N: NetworkPrimitives> Stream for TransactionFetcher<N> {
         // `FuturesUnordered` doesn't close when `None` is returned. so just return pending.
         // <https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=815be2b6c8003303757c3ced135f363e>
         if self.inflight_requests.is_empty() {
-            return Poll::Pending
+            return Poll::Pending;
         }
 
         if let Some(resp) = ready!(self.inflight_requests.poll_next_unpin(cx)) {
-            return Poll::Ready(Some(self.on_resolved_get_pooled_transactions_request_fut(resp)))
+            return Poll::Ready(Some(self.on_resolved_get_pooled_transactions_request_fut(resp)));
         }
 
         Poll::Pending
@@ -1187,7 +1181,7 @@ impl<T: SignedTransaction> VerifyPooledTransactionsResponse for UnverifiedPooled
                     tx_hashes_not_requested_count += 1;
                 }
 
-                return false
+                return false;
             }
             true
         });


### PR DESCRIPTION
Add percentile-based latency statistics (p50, p90, p99) to provide a better overview of latency. Rename "avg" to "mean" for statistical precision.