### PR TITLE
chore(deps): clean up unused imports and dependencies in reth-downloaders

### DIFF
--- a/crates/net/downloaders/Cargo.toml
+++ b/crates/net/downloaders/Cargo.toml
@@ -67,6 +67,8 @@ assert_matches.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 rand.workspace = true
 tempfile.workspace = true
+alloy-rlp.workspace = true
+itertools.workspace = true
 
 [features]
 default = []

--- a/crates/net/downloaders/src/lib.rs
+++ b/crates/net/downloaders/src/lib.rs
@@ -13,6 +13,9 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+#[cfg(any(test, feature = "test-utils"))]
+use tempfile as _;
+
 /// The collection of algorithms for downloading block bodies.
 pub mod bodies;
 

--- a/crates/net/downloaders/src/test_utils/mod.rs
+++ b/crates/net/downloaders/src/test_utils/mod.rs
@@ -5,17 +5,9 @@
 #[cfg(any(test, feature = "file-client"))]
 use crate::{bodies::test_utils::create_raw_bodies, file_codec::BlockFileCodec};
 use alloy_primitives::B256;
-#[cfg(any(test, feature = "file-client"))]
-use futures::SinkExt;
 use reth_ethereum_primitives::BlockBody;
 use reth_testing_utils::generators::{self, random_block_range, BlockRangeParams};
-#[cfg(any(test, feature = "file-client"))]
-use std::io::SeekFrom;
 use std::{collections::HashMap, ops::RangeInclusive};
-#[cfg(any(test, feature = "file-client"))]
-use tokio::{fs::File, io::AsyncSeekExt};
-#[cfg(any(test, feature = "file-client"))]
-use tokio_util::codec::FramedWrite;
 
 mod bodies_client;
 pub use bodies_client::TestBodiesClient;
@@ -47,6 +39,11 @@ pub(crate) fn generate_bodies(
 pub(crate) async fn generate_bodies_file(
     range: RangeInclusive<u64>,
 ) -> (tokio::fs::File, Vec<SealedHeader>, HashMap<B256, BlockBody>) {
+    use futures::SinkExt;
+    use std::io::SeekFrom;
+    use tokio::{fs::File, io::AsyncSeekExt};
+    use tokio_util::codec::FramedWrite;
+
     let (headers, bodies) = generate_bodies(range);
     let raw_block_bodies = create_raw_bodies(headers.iter().cloned(), &mut bodies.clone());
 

--- a/crates/net/downloaders/src/test_utils/mod.rs
+++ b/crates/net/downloaders/src/test_utils/mod.rs
@@ -5,11 +5,16 @@
 #[cfg(any(test, feature = "file-client"))]
 use crate::{bodies::test_utils::create_raw_bodies, file_codec::BlockFileCodec};
 use alloy_primitives::B256;
+#[cfg(any(test, feature = "file-client"))]
 use futures::SinkExt;
 use reth_ethereum_primitives::BlockBody;
 use reth_testing_utils::generators::{self, random_block_range, BlockRangeParams};
-use std::{collections::HashMap, io::SeekFrom, ops::RangeInclusive};
+#[cfg(any(test, feature = "file-client"))]
+use std::io::SeekFrom;
+use std::{collections::HashMap, ops::RangeInclusive};
+#[cfg(any(test, feature = "file-client"))]
 use tokio::{fs::File, io::AsyncSeekExt};
+#[cfg(any(test, feature = "file-client"))]
 use tokio_util::codec::FramedWrite;
 
 mod bodies_client;


### PR DESCRIPTION
Some imports in test_utils/mod.rs were unconditionally imported but only used when the "file-client" feature is enabled or during testing. This adds proper cfg gates to ensure they're only compiled when actually needed.

Changes:
1. Added cfg attributes for feature-gated imports (futures, tokio, std::io)
2. Added explicit tempfile crate usage to satisfy unused_crate_dependencies lint
3. Added alloy-rlp and itertools to dev-dependencies for test compilation