### PR TITLE
refactor: tx policy traits

### DIFF
--- a/crates/ethereum/primitives/src/transaction.rs
+++ b/crates/ethereum/primitives/src/transaction.rs
@@ -8,7 +8,7 @@ use alloy_consensus::{
     TxLegacy, TxType, Typed2718,
 };
 use alloy_eips::{
-    eip2718::{Decodable2718, Eip2718Error, Eip2718Result, Encodable2718},
+    eip2718::{Decodable2718, Eip2718Error, Eip2718Result, Encodable2718, IsTyped2718},
     eip2930::AccessList,
     eip7702::SignedAuthorization,
 };
@@ -661,6 +661,12 @@ impl SignerRecoverable for TransactionSigned {
 impl TxHashRef for TransactionSigned {
     fn tx_hash(&self) -> &TxHash {
         self.hash.get_or_init(|| self.recalculate_hash())
+    }
+}
+
+impl IsTyped2718 for TransactionSigned {
+    fn is_type(type_id: u8) -> bool {
+        <alloy_consensus::TxEnvelope as IsTyped2718>::is_type(type_id)
     }
 }
 

--- a/crates/net/network/src/builder.rs
+++ b/crates/net/network/src/builder.rs
@@ -1,7 +1,5 @@
 //! Builder support for configuring the entire setup.
 
-use std::fmt::Debug;
-
 use crate::{
     eth_requests::EthRequestHandler,
     transactions::{
@@ -77,15 +75,7 @@ impl<Tx, Eth, N: NetworkPrimitives> NetworkBuilder<Tx, Eth, N> {
         self,
         pool: Pool,
         transactions_manager_config: TransactionsManagerConfig,
-    ) -> NetworkBuilder<
-        TransactionsManager<
-            Pool,
-            N,
-            NetworkPolicies<TransactionPropagationKind, StrictEthAnnouncementFilter>,
-        >,
-        Eth,
-        N,
-    > {
+    ) -> NetworkBuilder<TransactionsManager<Pool, N>, Eth, N> {
         self.transactions_with_policy(
             pool,
             transactions_manager_config,
@@ -94,19 +84,12 @@ impl<Tx, Eth, N: NetworkPrimitives> NetworkBuilder<Tx, Eth, N> {
     }
 
     /// Creates a new [`TransactionsManager`] and wires it to the network.
-    pub fn transactions_with_policy<
-        Pool: TransactionPool,
-        P: TransactionPropagationPolicy + Debug,
-    >(
+    pub fn transactions_with_policy<Pool: TransactionPool>(
         self,
         pool: Pool,
         transactions_manager_config: TransactionsManagerConfig,
-        propagation_policy: P,
-    ) -> NetworkBuilder<
-        TransactionsManager<Pool, N, NetworkPolicies<P, StrictEthAnnouncementFilter>>,
-        Eth,
-        N,
-    > {
+        propagation_policy: impl TransactionPropagationPolicy<N>,
+    ) -> NetworkBuilder<TransactionsManager<Pool, N>, Eth, N> {
         let Self { mut network, request_handler, .. } = self;
         let (tx, rx) = mpsc::unbounded_channel();
         network.set_transactions(tx);

--- a/crates/net/network/src/test_utils/testnet.rs
+++ b/crates/net/network/src/test_utils/testnet.rs
@@ -399,13 +399,7 @@ pub struct Peer<C, Pool = TestPool> {
     #[pin]
     request_handler: Option<EthRequestHandler<C, EthNetworkPrimitives>>,
     #[pin]
-    transactions_manager: Option<
-        TransactionsManager<
-            Pool,
-            EthNetworkPrimitives,
-            NetworkPolicies<TransactionPropagationKind, StrictEthAnnouncementFilter>,
-        >,
-    >,
+    transactions_manager: Option<TransactionsManager<Pool, EthNetworkPrimitives>>,
     pool: Option<Pool>,
     client: C,
     secret_key: SecretKey,

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -15,12 +15,12 @@ pub use self::constants::{
     tx_fetcher::DEFAULT_SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESP_ON_PACK_GET_POOLED_TRANSACTIONS_REQ,
     SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESPONSE,
 };
-use config::{AnnouncementAcceptance, StrictEthAnnouncementFilter, TransactionPropagationKind};
+use config::AnnouncementAcceptance;
 pub use config::{
     AnnouncementFilteringPolicy, TransactionFetcherConfig, TransactionIngressPolicy,
     TransactionPropagationMode, TransactionPropagationPolicy, TransactionsManagerConfig,
 };
-use policy::{NetworkPolicies, TransactionPolicies};
+use policy::NetworkPolicies;
 
 pub(crate) use fetcher::{FetchEvent, TransactionFetcher};
 
@@ -35,6 +35,7 @@ use crate::{
     metrics::{
         AnnouncedTxTypesMetrics, TransactionsManagerMetrics, NETWORK_POOL_TRANSACTIONS_SCOPE,
     },
+    transactions::config::{StrictEthAnnouncementFilter, TransactionPropagationKind},
     NetworkHandle, TxTypesCounter,
 };
 use alloy_primitives::{TxHash, B256};
@@ -278,14 +279,7 @@ impl<N: NetworkPrimitives> TransactionsHandle<N> {
 /// Rate limiting via reputation, bad transaction isolation, peer scoring.
 #[derive(Debug)]
 #[must_use = "Manager does nothing unless polled."]
-pub struct TransactionsManager<
-    Pool,
-    N: NetworkPrimitives = EthNetworkPrimitives,
-    PBundle: TransactionPolicies = NetworkPolicies<
-        TransactionPropagationKind,
-        StrictEthAnnouncementFilter,
-    >,
-> {
+pub struct TransactionsManager<Pool, N: NetworkPrimitives = EthNetworkPrimitives> {
     /// Access to the transaction pool.
     pool: Pool,
     /// Network access.
@@ -342,20 +336,14 @@ pub struct TransactionsManager<
     /// How the `TransactionsManager` is configured.
     config: TransactionsManagerConfig,
     /// Network Policies
-    policies: PBundle,
+    policies: NetworkPolicies<N>,
     /// `TransactionsManager` metrics
     metrics: TransactionsManagerMetrics,
     /// `AnnouncedTxTypes` metrics
     announced_tx_types_metrics: AnnouncedTxTypesMetrics,
 }
 
-impl<Pool: TransactionPool, N: NetworkPrimitives>
-    TransactionsManager<
-        Pool,
-        N,
-        NetworkPolicies<TransactionPropagationKind, StrictEthAnnouncementFilter>,
-    >
-{
+impl<Pool: TransactionPool, N: NetworkPrimitives> TransactionsManager<Pool, N> {
     /// Sets up a new instance.
     ///
     /// Note: This expects an existing [`NetworkManager`](crate::NetworkManager) instance.
@@ -370,14 +358,15 @@ impl<Pool: TransactionPool, N: NetworkPrimitives>
             pool,
             from_network,
             transactions_manager_config,
-            NetworkPolicies::default(),
+            NetworkPolicies::new(
+                TransactionPropagationKind::default(),
+                StrictEthAnnouncementFilter::default(),
+            ),
         )
     }
 }
 
-impl<Pool: TransactionPool, N: NetworkPrimitives, PBundle: TransactionPolicies>
-    TransactionsManager<Pool, N, PBundle>
-{
+impl<Pool: TransactionPool, N: NetworkPrimitives> TransactionsManager<Pool, N> {
     /// Sets up a new instance with given the settings.
     ///
     /// Note: This expects an existing [`NetworkManager`](crate::NetworkManager) instance.
@@ -386,7 +375,7 @@ impl<Pool: TransactionPool, N: NetworkPrimitives, PBundle: TransactionPolicies>
         pool: Pool,
         from_network: mpsc::UnboundedReceiver<NetworkTransactionEvent<N>>,
         transactions_manager_config: TransactionsManagerConfig,
-        policies: PBundle,
+        policies: NetworkPolicies<N>,
     ) -> Self {
         let network_events = network.event_listener();
 
@@ -557,9 +546,7 @@ impl<Pool: TransactionPool, N: NetworkPrimitives, PBundle: TransactionPolicies>
     }
 }
 
-impl<Pool: TransactionPool, N: NetworkPrimitives, PBundle: TransactionPolicies>
-    TransactionsManager<Pool, N, PBundle>
-{
+impl<Pool: TransactionPool, N: NetworkPrimitives> TransactionsManager<Pool, N> {
     /// Processes a batch import results.
     fn on_batch_import_result(&mut self, batch_results: Vec<PoolResult<AddedTransactionOutcome>>) {
         for res in batch_results {
@@ -826,16 +813,13 @@ impl<Pool: TransactionPool, N: NetworkPrimitives, PBundle: TransactionPolicies>
     }
 }
 
-impl<Pool, N, PBundle> TransactionsManager<Pool, N, PBundle>
+impl<Pool, N> TransactionsManager<Pool, N>
 where
     Pool: TransactionPool + Unpin + 'static,
-
     N: NetworkPrimitives<
             BroadcastedTransaction: SignedTransaction,
             PooledTransaction: SignedTransaction,
         > + Unpin,
-
-    PBundle: TransactionPolicies,
     Pool::Transaction:
         PoolTransaction<Consensus = N::BroadcastedTransaction, Pooled = N::PooledTransaction>,
 {
@@ -1508,8 +1492,7 @@ impl<
                 BroadcastedTransaction: SignedTransaction,
                 PooledTransaction: SignedTransaction,
             > + Unpin,
-        PBundle: TransactionPolicies + Unpin,
-    > Future for TransactionsManager<Pool, N, PBundle>
+    > Future for TransactionsManager<Pool, N>
 where
     Pool::Transaction:
         PoolTransaction<Consensus = N::BroadcastedTransaction, Pooled = N::PooledTransaction>,
@@ -2925,11 +2908,7 @@ mod tests {
         let network_handle = network_manager.handle().clone();
         let network_service_handle = tokio::spawn(network_manager);
 
-        let mut tx_manager = TransactionsManager::<
-            TestPool,
-            EthNetworkPrimitives,
-            NetworkPolicies<TransactionPropagationKind, RelaxedEthAnnouncementFilter>,
-        >::with_policy(
+        let mut tx_manager = TransactionsManager::<TestPool, EthNetworkPrimitives>::with_policy(
             network_handle.clone(),
             pool.clone(),
             from_network_rx,

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -8,7 +8,7 @@ pub mod config;
 pub mod constants;
 /// Component responsible for fetching transactions from [`NewPooledTransactionHashes`].
 pub mod fetcher;
-/// Defines the [`TransactionPolicies`] trait for aggregating transaction-related policies.
+/// Defines the traits for transaction-related policies.
 pub mod policy;
 
 pub use self::constants::{
@@ -242,7 +242,7 @@ impl<N: NetworkPrimitives> TransactionsHandle<N> {
 /// propagate new transactions over the network.
 ///
 /// It can be configured with different policies for transaction propagation and announcement
-/// filtering. See [`NetworkPolicies`] and [`TransactionPolicies`] for more details.
+/// filtering. See [`NetworkPolicies`] for more details.
 ///
 /// ## Network Transaction Processing
 ///

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -35,7 +35,7 @@ use reth_provider::{
 use reth_tasks::TaskExecutor;
 use reth_transaction_pool::{PoolConfig, PoolTransaction, TransactionPool};
 use secp256k1::SecretKey;
-use std::{fmt::Debug, sync::Arc};
+use std::sync::Arc;
 use tracing::{info, trace, warn};
 
 pub mod add_ons;
@@ -831,7 +831,7 @@ impl<Node: FullNodeTypes> BuilderContext<Node> {
             > + Unpin
             + 'static,
         Node::Provider: BlockReaderFor<N>,
-        Policy: TransactionPropagationPolicy + Debug,
+        Policy: TransactionPropagationPolicy<N>,
     {
         let (handle, network, txpool, eth) = builder
             .transactions_with_policy(pool, tx_config, propagation_policy)

--- a/crates/optimism/primitives/src/transaction/signed.rs
+++ b/crates/optimism/primitives/src/transaction/signed.rs
@@ -9,7 +9,7 @@ use alloy_consensus::{
     Typed2718,
 };
 use alloy_eips::{
-    eip2718::{Decodable2718, Eip2718Error, Eip2718Result, Encodable2718},
+    eip2718::{Decodable2718, Eip2718Error, Eip2718Result, Encodable2718, IsTyped2718},
     eip2930::AccessList,
     eip7702::SignedAuthorization,
 };
@@ -145,6 +145,12 @@ impl SignerRecoverable for OpTransactionSigned {
 impl TxHashRef for OpTransactionSigned {
     fn tx_hash(&self) -> &TxHash {
         self.hash.get_or_init(|| self.recalculate_hash())
+    }
+}
+
+impl IsTyped2718 for OpTransactionSigned {
+    fn is_type(type_id: u8) -> bool {
+        <op_alloy_consensus::OpTxEnvelope as IsTyped2718>::is_type(type_id)
     }
 }
 

--- a/crates/primitives-traits/src/transaction/signed.rs
+++ b/crates/primitives-traits/src/transaction/signed.rs
@@ -6,7 +6,7 @@ use alloy_consensus::{
     transaction::{Recovered, RlpEcdsaEncodableTx, SignerRecoverable, TxHashRef},
     EthereumTxEnvelope, SignableTransaction,
 };
-use alloy_eips::eip2718::{Decodable2718, Encodable2718};
+use alloy_eips::eip2718::{Decodable2718, Encodable2718, IsTyped2718};
 use alloy_primitives::{keccak256, Address, Signature, B256};
 use alloy_rlp::{Decodable, Encodable};
 use core::hash::Hash;
@@ -46,6 +46,7 @@ pub trait SignedTransaction:
     + InMemorySize
     + SignerRecoverable
     + TxHashRef
+    + IsTyped2718
 {
     /// Returns whether this transaction type can be __broadcasted__ as full transaction over the
     /// network.


### PR DESCRIPTION
This refactors transaction policy traits and makes them dyn-compatible which allowed to remove an extra generic from `TransactionsManager`

More importantly, this changes `SignedTransaction` trait to enforce `IsTyped2718` supertrait, and changes `AnnouncementFilteringPolicy` implementations so that txtype validity checks are done by checking `N::PooledTransaction::is_type` instead of a hardcoded Ethereum `TxType`

This allows to properly handle networking for chains with custom txtypes