### PR TITLE
chore(payload): remove redundant Debug bounds

### DIFF
--- a/crates/payload/builder/src/traits.rs
+++ b/crates/payload/builder/src/traits.rs
@@ -19,13 +19,13 @@ use std::future::Future;
 /// Note: A `PayloadJob` need to be cancel safe because it might be dropped after the CL has requested the payload via `engine_getPayloadV1` (see also [engine API docs](https://github.com/ethereum/execution-apis/blob/6709c2a795b707202e93c4f2867fa0bf2640a84f/src/engine/paris.md#engine_getpayloadv1))
 pub trait PayloadJob: Future<Output = Result<(), PayloadBuilderError>> {
     /// Represents the payload attributes type that is used to spawn this payload job.
-    type PayloadAttributes: PayloadBuilderAttributes + std::fmt::Debug;
+    type PayloadAttributes: PayloadBuilderAttributes;
     /// Represents the future that resolves the block that's returned to the CL.
     type ResolvePayloadFuture: Future<Output = Result<Self::BuiltPayload, PayloadBuilderError>>
         + Send
         + 'static;
     /// Represents the built payload type that is returned to the CL.
-    type BuiltPayload: BuiltPayload + Clone + std::fmt::Debug;
+    type BuiltPayload: BuiltPayload + Clone;
 
     /// Returns the best payload that has been built so far.
     ///


### PR DESCRIPTION
Remove explicit + Debug bounds from PayloadJob::PayloadAttributes and PayloadJob::BuiltPayload in crates/payload/builder/src/traits.rs because BuiltPayload and PayloadBuilderAttributes already require fmt::Debug per crates/payload/primitives/src/traits.rs. This duplication provides no additional guarantees, may trigger clippy redundancy lints, and slightly increases API noise.