### PR TITLE
fix: remove noisy storage proof spans

### DIFF
--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -1365,11 +1365,6 @@ where
                         match ctx.missed_leaves_storage_roots.entry(hashed_address) {
                             dashmap::Entry::Occupied(occ) => *occ.get(),
                             dashmap::Entry::Vacant(vac) => {
-                                let _guard = debug_span!(
-                                    target: "trie::proof_task",
-                                    "Waiting on missed leaf storage proof computation",
-                                    ?hashed_address,
-                                );
                                 let root =
                                     StorageProof::new_hashed(provider, provider, hashed_address)
                                         .with_prefix_set_mut(Default::default())
@@ -1413,11 +1408,6 @@ where
 
     // Consume remaining storage proof receivers for accounts not encountered during trie walk.
     for (hashed_address, receiver) in storage_proof_receivers {
-        let _guard = debug_span!(
-            target: "trie::proof_task",
-            "Blocking on final storage proof",
-            ?hashed_address,
-        );
         if let Ok(proof_msg) = receiver.recv() {
             // Extract storage proof from the result
             if let Ok(ProofResult::StorageProof { proof, .. }) = proof_msg.result {


### PR DESCRIPTION
This removes noisy spans, we should see if we still have too many spans because this keeps the `Waiting for storage proof` span