### PR TITLE
ci: partition cargo-checks job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -92,7 +92,12 @@ jobs:
         run: .github/assets/check_rv32imac.sh
 
   crate-checks:
+    name: crate-checks (${{ matrix.partition }}/${{ matrix.total_partitions }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        partition: [1, 2]
+        total_partitions: [2]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
@@ -102,7 +107,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-      - run: cargo hack check --workspace
+      - run: cargo hack check --workspace --partition ${{ matrix.partition }}/${{ matrix.total_partitions }}
 
   msrv:
     name: MSRV


### PR DESCRIPTION
It takes up to 30 minutes and is the longest job out of all in `lint` workflow

<img width="231" height="441" alt="image" src="https://github.com/user-attachments/assets/7836afca-e00f-4b1c-b132-eb648b6f54cc" />

This PR reduces the time to 15-20 minutes per partition.
