### PR TITLE
refactor(cli): deduplicate ethereum init_tracing implementations

### DIFF
--- a/crates/ethereum/cli/src/app.rs
+++ b/crates/ethereum/cli/src/app.rs
@@ -14,7 +14,7 @@ use reth_node_core::args::OtlpInitStatus;
 use reth_node_ethereum::{consensus::EthBeaconConsensus, EthEvmConfig, EthereumNode};
 use reth_node_metrics::recorder::install_prometheus_recorder;
 use reth_rpc_server_types::RpcModuleValidator;
-use reth_tracing::{FileWorkerGuard, Layers};
+use reth_tracing::{tracing_appender::non_blocking::WorkerGuard, FileWorkerGuard, Layers};
 use std::{fmt, sync::Arc};
 use tracing::{info, warn};
 
@@ -97,37 +97,14 @@ where
                 self.cli.logs.log_file_directory.join(chain_spec.chain().to_string());
         }
 
-        self.init_tracing(&runner)?;
+        if self.guard.is_none() {
+            self.guard = self.cli.init_tracing(&runner, self.layers.take().unwrap_or_default())?;
+        }
 
         // Install the prometheus recorder to be sure to record all metrics
         let _ = install_prometheus_recorder();
 
         run_commands_with::<C, Ext, Rpc, N>(self.cli, runner, components, launcher)
-    }
-
-    /// Initializes tracing with the configured options.
-    ///
-    /// If file logging is enabled, this function stores guard to the struct.
-    /// For gRPC OTLP, it requires tokio runtime context.
-    pub fn init_tracing(&mut self, runner: &CliRunner) -> Result<()> {
-        if self.guard.is_none() {
-            let mut layers = self.layers.take().unwrap_or_default();
-
-            let otlp_status = runner.block_on(self.cli.traces.init_otlp_tracing(&mut layers))?;
-
-            self.guard = self.cli.logs.init_tracing_with_layers(layers)?;
-            info!(target: "reth::cli", "Initialized tracing, debug log directory: {}", self.cli.logs.log_file_directory);
-            match otlp_status {
-                OtlpInitStatus::Started(endpoint) => {
-                    info!(target: "reth::cli", "Started OTLP {:?} tracing export to {endpoint}", self.cli.traces.protocol);
-                }
-                OtlpInitStatus::NoFeature => {
-                    warn!(target: "reth::cli", "Provided OTLP tracing arguments do not have effect, compile with the `otlp` feature")
-                }
-                OtlpInitStatus::Disabled => {}
-            }
-        }
-        Ok(())
     }
 }
 

--- a/crates/ethereum/cli/src/app.rs
+++ b/crates/ethereum/cli/src/app.rs
@@ -10,13 +10,11 @@ use reth_cli_runner::CliRunner;
 use reth_db::DatabaseEnv;
 use reth_node_api::NodePrimitives;
 use reth_node_builder::{NodeBuilder, WithLaunchContext};
-use reth_node_core::args::OtlpInitStatus;
 use reth_node_ethereum::{consensus::EthBeaconConsensus, EthEvmConfig, EthereumNode};
 use reth_node_metrics::recorder::install_prometheus_recorder;
 use reth_rpc_server_types::RpcModuleValidator;
-use reth_tracing::{tracing_appender::non_blocking::WorkerGuard, FileWorkerGuard, Layers};
+use reth_tracing::{FileWorkerGuard, Layers};
 use std::{fmt, sync::Arc};
-use tracing::{info, warn};
 
 /// A wrapper around a parsed CLI that handles command execution.
 #[derive(Debug)]

--- a/crates/ethereum/cli/src/app.rs
+++ b/crates/ethereum/cli/src/app.rs
@@ -95,14 +95,21 @@ where
                 self.cli.logs.log_file_directory.join(chain_spec.chain().to_string());
         }
 
-        if self.guard.is_none() {
-            self.guard = self.cli.init_tracing(&runner, self.layers.take().unwrap_or_default())?;
-        }
+        self.init_tracing(runner)?;
 
         // Install the prometheus recorder to be sure to record all metrics
         let _ = install_prometheus_recorder();
 
         run_commands_with::<C, Ext, Rpc, N>(self.cli, runner, components, launcher)
+    }
+
+    /// Initializes tracing with the configured options.
+    ///
+    /// See [`Cli::init_tracing`] for more information.
+    pub fn init_tracing(&mut self, runner: &CliRunner) -> Result<()> {
+        if self.guard.is_none() {
+            self.guard = self.cli.init_tracing(&runner, self.layers.take().unwrap_or_default())?;
+        }
     }
 }
 

--- a/crates/ethereum/cli/src/app.rs
+++ b/crates/ethereum/cli/src/app.rs
@@ -95,7 +95,7 @@ where
                 self.cli.logs.log_file_directory.join(chain_spec.chain().to_string());
         }
 
-        self.init_tracing(runner)?;
+        self.init_tracing(&runner)?;
 
         // Install the prometheus recorder to be sure to record all metrics
         let _ = install_prometheus_recorder();
@@ -108,8 +108,10 @@ where
     /// See [`Cli::init_tracing`] for more information.
     pub fn init_tracing(&mut self, runner: &CliRunner) -> Result<()> {
         if self.guard.is_none() {
-            self.guard = self.cli.init_tracing(&runner, self.layers.take().unwrap_or_default())?;
+            self.guard = self.cli.init_tracing(runner, self.layers.take().unwrap_or_default())?;
         }
+
+        Ok(())
     }
 }
 

--- a/crates/ethereum/cli/src/interface.rs
+++ b/crates/ethereum/cli/src/interface.rs
@@ -218,6 +218,7 @@ impl<C: ChainSpecParser, Ext: clap::Args + fmt::Debug, Rpc: RpcModuleValidator> 
     ///
     /// If file logging is enabled, this function returns a guard that must be kept alive to ensure
     /// that all logs are flushed to disk.
+    ///
     /// If an OTLP endpoint is specified, it will export metrics to the configured collector.
     pub fn init_tracing(
         &mut self,

--- a/crates/ethereum/cli/src/interface.rs
+++ b/crates/ethereum/cli/src/interface.rs
@@ -19,14 +19,14 @@ use reth_db::DatabaseEnv;
 use reth_node_api::NodePrimitives;
 use reth_node_builder::{NodeBuilder, WithLaunchContext};
 use reth_node_core::{
-    args::{LogArgs, TraceArgs},
+    args::{LogArgs, OtlpInitStatus, TraceArgs},
     version::version_metadata,
 };
 use reth_node_metrics::recorder::install_prometheus_recorder;
 use reth_rpc_server_types::{DefaultRpcModuleValidator, RpcModuleValidator};
-use reth_tracing::FileWorkerGuard;
+use reth_tracing::{FileWorkerGuard, Layers};
 use std::{ffi::OsString, fmt, future::Future, marker::PhantomData, sync::Arc};
-use tracing::info;
+use tracing::{info, warn};
 
 /// The main reth cli interface.
 ///
@@ -205,8 +205,7 @@ impl<C: ChainSpecParser, Ext: clap::Args + fmt::Debug, Rpc: RpcModuleValidator> 
             self.logs.log_file_directory =
                 self.logs.log_file_directory.join(chain_spec.chain().to_string());
         }
-        let _guard = self.init_tracing()?;
-        info!(target: "reth::cli", "Initialized tracing, debug log directory: {}", self.logs.log_file_directory);
+        let _guard = self.init_tracing(&runner, Layers::new())?;
 
         // Install the prometheus recorder to be sure to record all metrics
         let _ = install_prometheus_recorder();
@@ -220,10 +219,25 @@ impl<C: ChainSpecParser, Ext: clap::Args + fmt::Debug, Rpc: RpcModuleValidator> 
     /// If file logging is enabled, this function returns a guard that must be kept alive to ensure
     /// that all logs are flushed to disk.
     /// If an OTLP endpoint is specified, it will export metrics to the configured collector.
-    pub fn init_tracing(&self) -> eyre::Result<Option<FileWorkerGuard>> {
-        let layers = reth_tracing::Layers::new();
+    pub fn init_tracing(
+        &mut self,
+        runner: &CliRunner,
+        mut layers: Layers,
+    ) -> eyre::Result<Option<FileWorkerGuard>> {
+        let otlp_status = runner.block_on(self.traces.init_otlp_tracing(&mut layers))?;
 
         let guard = self.logs.init_tracing_with_layers(layers)?;
+        info!(target: "reth::cli", "Initialized tracing, debug log directory: {}", self.logs.log_file_directory);
+        match otlp_status {
+            OtlpInitStatus::Started(endpoint) => {
+                info!(target: "reth::cli", "Started OTLP {:?} tracing export to {endpoint}", self.traces.protocol);
+            }
+            OtlpInitStatus::NoFeature => {
+                warn!(target: "reth::cli", "Provided OTLP tracing arguments do not have effect, compile with the `otlp` feature")
+            }
+            OtlpInitStatus::Disabled => {}
+        }
+
         Ok(guard)
     }
 }


### PR DESCRIPTION
Projects building on SDK and using `ethereum::Cli` didn't have OTLP tracing initialized, because `Cli::init_tracing` method wasn't modified to do it.

To solve this, we additionally deduplicate the `init_tracing` method and have it only in `ethereum::Cli`, calling into it from `ethereum::CliApp`