### PR TITLE
fix(storage): buffer advancement in Compact::from_compact for alloy wrappers

### DIFF
--- a/crates/storage/codecs/src/alloy/genesis_account.rs
+++ b/crates/storage/codecs/src/alloy/genesis_account.rs
@@ -92,7 +92,7 @@ impl Compact for AlloyGenesisAccount {
     }
 
     fn from_compact(buf: &[u8], len: usize) -> (Self, &[u8]) {
-        let (account, _) = GenesisAccount::from_compact(buf, len);
+        let (account, new_buf) = GenesisAccount::from_compact(buf, len);
         let alloy_account = Self {
             nonce: account.nonce,
             balance: account.balance,
@@ -102,6 +102,6 @@ impl Compact for AlloyGenesisAccount {
                 .map(|s| s.entries.into_iter().map(|entry| (entry.key, entry.value)).collect()),
             private_key: account.private_key,
         };
-        (alloy_account, buf)
+        (alloy_account, new_buf)
     }
 }

--- a/crates/storage/codecs/src/alloy/header.rs
+++ b/crates/storage/codecs/src/alloy/header.rs
@@ -110,7 +110,7 @@ impl Compact for AlloyHeader {
     }
 
     fn from_compact(buf: &[u8], len: usize) -> (Self, &[u8]) {
-        let (header, _) = Header::from_compact(buf, len);
+        let (header, new_buf) = Header::from_compact(buf, len);
         let alloy_header = Self {
             parent_hash: header.parent_hash,
             ommers_hash: header.ommers_hash,
@@ -134,7 +134,7 @@ impl Compact for AlloyHeader {
             requests_hash: header.extra_fields.as_ref().and_then(|h| h.requests_hash),
             extra_data: header.extra_data,
         };
-        (alloy_header, buf)
+        (alloy_header, new_buf)
     }
 }
 

--- a/crates/storage/codecs/src/alloy/withdrawal.rs
+++ b/crates/storage/codecs/src/alloy/withdrawal.rs
@@ -43,14 +43,14 @@ impl Compact for AlloyWithdrawal {
     }
 
     fn from_compact(buf: &[u8], len: usize) -> (Self, &[u8]) {
-        let (withdrawal, _) = Withdrawal::from_compact(buf, len);
+        let (withdrawal, new_buf) = Withdrawal::from_compact(buf, len);
         let alloy_withdrawal = Self {
             index: withdrawal.index,
             validator_index: withdrawal.validator_index,
             address: withdrawal.address,
             amount: withdrawal.amount,
         };
-        (alloy_withdrawal, buf)
+        (alloy_withdrawal, new_buf)
     }
 }
 


### PR DESCRIPTION
This change corrects the remainder handling in Compact::from_compact implementations for AlloyWithdrawal, AlloyHeader, and AlloyGenesisAccount by returning the advanced buffer slice produced by the inner helper’s from_compact rather than the original input slice. The Compact trait contract in storage/codecs/src/lib.rs explicitly requires from_compact to return the object and the buffer advanced past the consumed bytes; the previous code violated this by discarding the advanced slice. While vector decoding masks this behavior in some contexts by ignoring the inner remainder and manually advancing, these wrappers still broke the contract and could lead to subtle parsing errors in composed decoders that rely on the returned remainder. The fix is minimal and consistent with other alloy implementations (e.g., authorization_list and all transaction wrappers) that already propagate the advanced buffer correctly, ensuring correctness and future-proofing without changing encoding layouts or introducing allocations.