### PR TITLE
fix: correctly poll tx fetcher

### DIFF
--- a/crates/e2e-test-utils/src/setup_builder.rs
+++ b/crates/e2e-test-utils/src/setup_builder.rs
@@ -4,6 +4,7 @@
 //! configurations through closures that modify `NodeConfig` and `TreeConfig`.
 
 use crate::{node::NodeTestContext, wallet::Wallet, NodeBuilderHelper, NodeHelperType, TmpDB};
+use futures_util::future::TryJoinAll;
 use reth_chainspec::EthChainSpec;
 use reth_engine_local::LocalPayloadAttributesBuilder;
 use reth_node_builder::{
@@ -15,7 +16,7 @@ use reth_provider::providers::BlockchainProvider;
 use reth_rpc_server_types::RpcModuleSelection;
 use reth_tasks::TaskManager;
 use std::sync::Arc;
-use tracing::{span, Level};
+use tracing::{span, Instrument, Level};
 
 /// Type alias for tree config modifier closure
 type TreeConfigModifier =
@@ -122,66 +123,71 @@ where
             reth_node_api::TreeConfig::default()
         };
 
-        let mut nodes: Vec<NodeTestContext<_, _>> = Vec::with_capacity(self.num_nodes);
+        let mut nodes = (0..self.num_nodes)
+            .map(async |idx| {
+                // Create base node config
+                let base_config = NodeConfig::new(self.chain_spec.clone())
+                    .with_network(network_config.clone())
+                    .with_unused_ports()
+                    .with_rpc(
+                        RpcServerArgs::default()
+                            .with_unused_ports()
+                            .with_http()
+                            .with_http_api(RpcModuleSelection::All),
+                    );
+
+                // Apply node config modifier if present
+                let node_config = if let Some(modifier) = &self.node_config_modifier {
+                    modifier(base_config)
+                } else {
+                    base_config
+                };
+
+                let span = span!(Level::INFO, "node", idx);
+                let node = N::default();
+                let NodeHandle { node, node_exit_future: _ } = NodeBuilder::new(node_config)
+                    .testing_node(exec.clone())
+                    .with_types_and_provider::<N, BlockchainProvider<_>>()
+                    .with_components(node.components_builder())
+                    .with_add_ons(node.add_ons())
+                    .launch_with_fn(|builder| {
+                        let launcher = EngineNodeLauncher::new(
+                            builder.task_executor().clone(),
+                            builder.config().datadir(),
+                            tree_config.clone(),
+                        );
+                        builder.launch_with(launcher)
+                    })
+                    .instrument(span)
+                    .await?;
+
+                let node = NodeTestContext::new(node, self.attributes_generator).await?;
+
+                let genesis = node.block_hash(0);
+                node.update_forkchoice(genesis, genesis).await?;
+
+                eyre::Ok(node)
+            })
+            .collect::<TryJoinAll<_>>()
+            .await?;
 
         for idx in 0..self.num_nodes {
-            // Create base node config
-            let base_config = NodeConfig::new(self.chain_spec.clone())
-                .with_network(network_config.clone())
-                .with_unused_ports()
-                .with_rpc(
-                    RpcServerArgs::default()
-                        .with_unused_ports()
-                        .with_http()
-                        .with_http_api(RpcModuleSelection::All),
-                );
-
-            // Apply node config modifier if present
-            let node_config = if let Some(modifier) = &self.node_config_modifier {
-                modifier(base_config)
-            } else {
-                base_config
-            };
-
-            let span = span!(Level::INFO, "node", idx);
-            let _enter = span.enter();
-            let node = N::default();
-            let NodeHandle { node, node_exit_future: _ } = NodeBuilder::new(node_config)
-                .testing_node(exec.clone())
-                .with_types_and_provider::<N, BlockchainProvider<_>>()
-                .with_components(node.components_builder())
-                .with_add_ons(node.add_ons())
-                .launch_with_fn(|builder| {
-                    let launcher = EngineNodeLauncher::new(
-                        builder.task_executor().clone(),
-                        builder.config().datadir(),
-                        tree_config.clone(),
-                    );
-                    builder.launch_with(launcher)
-                })
-                .await?;
-
-            let mut node = NodeTestContext::new(node, self.attributes_generator).await?;
-
-            let genesis = node.block_hash(0);
-            node.update_forkchoice(genesis, genesis).await?;
-
+            let (prev, current) = nodes.split_at_mut(idx);
+            let current = current.first_mut().unwrap();
             // Connect nodes if requested
             if self.connect_nodes {
-                if let Some(previous_node) = nodes.last_mut() {
-                    previous_node.connect(&mut node).await;
+                if let Some(prev_idx) = idx.checked_sub(1) {
+                    prev[prev_idx].connect(current).await;
                 }
 
                 // Connect last node with the first if there are more than two
                 if idx + 1 == self.num_nodes &&
                     self.num_nodes > 2 &&
-                    let Some(first_node) = nodes.first_mut()
+                    let Some(first) = prev.first_mut()
                 {
-                    node.connect(first_node).await;
+                    current.connect(first).await;
                 }
             }
-
-            nodes.push(node);
         }
 
         Ok((nodes, tasks, Wallet::default().with_chain_id(self.chain_spec.chain().into())))

--- a/crates/ethereum/node/tests/e2e/p2p.rs
+++ b/crates/ethereum/node/tests/e2e/p2p.rs
@@ -1,10 +1,18 @@
 use crate::utils::{advance_with_random_transactions, eth_payload_attributes};
+use alloy_consensus::{SignableTransaction, TxEip1559, TxEnvelope};
+use alloy_eips::Encodable2718;
+use alloy_network::TxSignerSync;
 use alloy_provider::{Provider, ProviderBuilder};
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use futures::future::JoinAll;
+use rand::{rngs::StdRng, seq::IndexedRandom, Rng, SeedableRng};
 use reth_chainspec::{ChainSpecBuilder, MAINNET};
-use reth_e2e_test_utils::{setup, setup_engine, transaction::TransactionTestContext};
+use reth_e2e_test_utils::{
+    setup, setup_engine, setup_engine_with_connection, transaction::TransactionTestContext,
+    wallet::Wallet,
+};
 use reth_node_ethereum::EthereumNode;
-use std::sync::Arc;
+use reth_rpc_api::EthApiServer;
+use std::{sync::Arc, time::Duration};
 
 #[tokio::test]
 async fn can_sync() -> eyre::Result<()> {
@@ -192,6 +200,97 @@ async fn test_reorg_through_backfill() -> eyre::Result<()> {
     // Now reorg second node to the finalized canonical head
     let head = first_provider.get_block_by_number(100.into()).await?.unwrap();
     second_node.sync_to(head.header.hash).await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_tx_propagation() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let chain_spec = Arc::new(
+        ChainSpecBuilder::default()
+            .chain(MAINNET.chain)
+            .genesis(serde_json::from_str(include_str!("../assets/genesis.json")).unwrap())
+            .cancun_activated()
+            .prague_activated()
+            .build(),
+    );
+
+    // Setup wallet
+    let chain_id = chain_spec.chain().into();
+    let wallet = Wallet::new(1).inner;
+    let mut nonce = 0;
+    let mut build_tx = || {
+        let mut tx = TxEip1559 {
+            chain_id,
+            max_priority_fee_per_gas: 1_000_000_000,
+            max_fee_per_gas: 1_000_000_000,
+            gas_limit: 100_000,
+            nonce,
+            ..Default::default()
+        };
+        nonce += 1;
+        let signature = wallet.sign_transaction_sync(&mut tx).unwrap();
+        TxEnvelope::Eip1559(tx.into_signed(signature))
+    };
+
+    // Setup 10 nodes
+    let (mut nodes, _tasks, _) = setup_engine_with_connection::<EthereumNode>(
+        10,
+        chain_spec.clone(),
+        false,
+        Default::default(),
+        eth_payload_attributes,
+        false,
+    )
+    .await?;
+
+    // Connect all nodes to the first one
+    let (first, rest) = nodes.split_at_mut(1);
+    for node in rest {
+        node.connect(&mut first[0]).await;
+    }
+
+    // Advance all nodes for 1 block so that they don't consider themselves unsynced
+    let tx = build_tx();
+    nodes[0].rpc.inject_tx(tx.encoded_2718().into()).await?;
+    let payload = nodes[0].advance_block().await?;
+    nodes[1..]
+        .iter_mut()
+        .map(|node| async {
+            node.submit_payload(payload.clone()).await.unwrap();
+            node.sync_to(payload.block().hash()).await.unwrap();
+        })
+        .collect::<JoinAll<_>>()
+        .await;
+
+    // Build and send transaction to first node
+    let tx = build_tx();
+    let tx_hash = *tx.tx_hash();
+    let _ = nodes[0].rpc.inject_tx(tx.encoded_2718().into()).await?;
+
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    // Assert that all nodes have the transaction
+    for (i, node) in nodes.iter().enumerate() {
+        assert!(
+            node.rpc.inner.eth_api().transaction_by_hash(tx_hash).await?.is_some(),
+            "Node {i} should have the transaction"
+        );
+    }
+
+    // Build and send one more transaction to a random node, assert t
+    let tx = build_tx();
+    let tx_hash = *tx.tx_hash();
+    let _ = nodes.choose(&mut rand::rng()).unwrap().rpc.inject_tx(tx.encoded_2718().into()).await?;
+
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    // Assert that all nodes have the transaction
+    for node in nodes {
+        assert!(node.rpc.inner.eth_api().transaction_by_hash(tx_hash).await?.is_some());
+    }
 
     Ok(())
 }

--- a/crates/ethereum/node/tests/e2e/p2p.rs
+++ b/crates/ethereum/node/tests/e2e/p2p.rs
@@ -270,7 +270,7 @@ async fn test_tx_propagation() -> eyre::Result<()> {
     let tx_hash = *tx.tx_hash();
     let _ = nodes[0].rpc.inject_tx(tx.encoded_2718().into()).await?;
 
-    tokio::time::sleep(Duration::from_millis(10)).await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
 
     // Assert that all nodes have the transaction
     for (i, node) in nodes.iter().enumerate() {
@@ -285,7 +285,7 @@ async fn test_tx_propagation() -> eyre::Result<()> {
     let tx_hash = *tx.tx_hash();
     let _ = nodes.choose(&mut rand::rng()).unwrap().rpc.inject_tx(tx.encoded_2718().into()).await?;
 
-    tokio::time::sleep(Duration::from_millis(10)).await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
 
     // Assert that all nodes have the transaction
     for node in nodes {

--- a/crates/ethereum/node/tests/e2e/p2p.rs
+++ b/crates/ethereum/node/tests/e2e/p2p.rs
@@ -280,7 +280,7 @@ async fn test_tx_propagation() -> eyre::Result<()> {
         );
     }
 
-    // Build and send one more transaction to a random node, assert t
+    // Build and send one more transaction to a random node
     let tx = build_tx();
     let tx_hash = *tx.tx_hash();
     let _ = nodes.choose(&mut rand::rng()).unwrap().rpc.inject_tx(tx.encoded_2718().into()).await?;


### PR DESCRIPTION
Both `on_network_tx_event` and `on_fetch_hashes_pending_fetch` might result in new futures being pushed to `transaction_fetcher.inflight_requests`

However, right now, `transaction_fetcher` is polled before both of those, meaning that waker is never registered with new futures.

This PR fixes this and also adds a tx propagation test that spins up a network of 10 nodes and asserts that txs are propagated within 10ms.

Also did a drive-by change with parallelizing the e2e nodes setup