### PR TITLE
chore(examples): complete state_provider_example

### DIFF
--- a/examples/db-access/src/main.rs
+++ b/examples/db-access/src/main.rs
@@ -40,7 +40,7 @@ fn main() -> eyre::Result<()> {
     receipts_provider_example(&provider)?;
 
     state_provider_example(factory.latest()?, &provider, provider.best_block_number()?)?;
-    state_provider_example(factory.history_by_block_number(block_num)?, &provider, block_num)?; 
+    state_provider_example(factory.history_by_block_number(block_num)?, &provider, block_num)?;
 
     // Closes the RO transaction opened in the `factory.provider()` call. This is optional and
     // would happen anyway at the end of the function scope.
@@ -208,8 +208,11 @@ fn receipts_provider_example<
 }
 
 /// The `StateProvider` allows querying the state tables.
-fn state_provider_example<T: StateProvider + AccountReader, H: HeaderProvider>(provider: T, headers: &H, number: u64) -> eyre::Result<()>
-{    
+fn state_provider_example<T: StateProvider + AccountReader, H: HeaderProvider>(
+    provider: T,
+    headers: &H,
+    number: u64,
+) -> eyre::Result<()> {
     let address = Address::random();
     let storage_key = B256::random();
     let slots = [storage_key];
@@ -223,7 +226,7 @@ fn state_provider_example<T: StateProvider + AccountReader, H: HeaderProvider>(p
     let storage_value = provider.storage(address, storage_key)?;
 
     println!(
-        "State at block #{number}: addr={address:?}, nonce={}, balance={}, storage[{:?}]={:?}, has_code={}",
+        "state at block #{number}: addr={address:?}, nonce={}, balance={}, storage[{:?}]={:?}, has_code={}",
         account.as_ref().map(|acc| acc.nonce).unwrap_or_default(),
         account.as_ref().map(|acc| acc.balance).unwrap_or_default(),
         storage_key,
@@ -234,7 +237,7 @@ fn state_provider_example<T: StateProvider + AccountReader, H: HeaderProvider>(p
     // Returns a bundled proof with the account's info
     let proof = provider.proof(Default::default(), address, &slots)?;
 
-
+    // Can verify the returned proof against the state root
     proof.verify(state_root)?;
     println!("account proof verified against state root {state_root:?}");
 

--- a/examples/db-access/src/main.rs
+++ b/examples/db-access/src/main.rs
@@ -6,8 +6,8 @@ use reth_ethereum::{
     node::EthereumNode,
     primitives::{AlloyBlockHeader, SealedBlock, SealedHeader},
     provider::{
-        providers::ReadOnlyConfig, AccountReader, BlockReader, BlockSource, HeaderProvider,
-        ReceiptProvider, StateProvider, TransactionVariant, TransactionsProvider,
+        providers::ReadOnlyConfig, AccountReader, BlockNumReader, BlockReader, BlockSource,
+        HeaderProvider, ReceiptProvider, StateProvider, TransactionVariant, TransactionsProvider,
     },
     rpc::eth::primitives::Filter,
     TransactionSigned,
@@ -33,13 +33,13 @@ fn main() -> eyre::Result<()> {
     let provider = factory.provider()?;
 
     // Run basic queries against the DB
-    let block_num = 11184524;
+    let block_num = 100;
     header_provider_example(&provider, block_num)?;
     block_provider_example(&provider, block_num)?;
     txs_provider_example(&provider)?;
     receipts_provider_example(&provider)?;
 
-    state_provider_example(factory.latest()?, &provider, block_num)?;
+    state_provider_example(factory.latest()?, &provider, provider.best_block_number()?)?;
     state_provider_example(factory.history_by_block_number(block_num)?, &provider, block_num)?; 
 
     // Closes the RO transaction opened in the `factory.provider()` call. This is optional and


### PR DESCRIPTION
example runs successfully both for `.latest()` and `.history_by_block_number()`

```
State at block #1667055: addr=0x747167c4a008be4deb897f0503d5d05705f1b73c, nonce=0, balance=0, storage[0x192a608bfda3f37a1dfe4de594c7afa1a7ae390bf5f72c2da7c93eb24114ec3
4]=None, has_code=false
account proof verified against state root 0x062bf31d04eb0293cec133218e01c0eccd26443341061eb04f07d7e8e0a6b516
State at block #1667045: addr=0x288ad1652fe4ea2b2e014e5b32bbba2414c7b36a, nonce=0, balance=0, storage[0x1e8637cdb4cb675d2ccc75a9ebc534aba77b85c8286e8f75f94820efeafec56
9]=Some(0), has_code=false
account proof verified against state root 0x2cff92a6bb670ee376e8b48cbdd714e38eadf6912a9f88d35c81cb7f76ff1841
```
