### PR TITLE
feat: allow customizing dev block timestamp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8101,6 +8101,7 @@ dependencies = [
  "reth-optimism-chainspec",
  "reth-payload-builder",
  "reth-payload-primitives",
+ "reth-primitives-traits",
  "reth-storage-api",
  "reth-transaction-pool",
  "tokio",
@@ -9801,6 +9802,7 @@ dependencies = [
 name = "reth-payload-primitives"
 version = "1.9.3"
 dependencies = [
+ "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",

--- a/crates/engine/local/Cargo.toml
+++ b/crates/engine/local/Cargo.toml
@@ -44,4 +44,5 @@ op = [
     "dep:op-alloy-rpc-types-engine",
     "dep:reth-optimism-chainspec",
     "reth-payload-primitives/op",
+    "reth-primitives-traits/op",
 ]

--- a/crates/engine/local/Cargo.toml
+++ b/crates/engine/local/Cargo.toml
@@ -15,6 +15,7 @@ reth-engine-primitives = { workspace = true, features = ["std"] }
 reth-ethereum-engine-primitives.workspace = true
 reth-payload-builder.workspace = true
 reth-payload-primitives.workspace = true
+reth-primitives-traits.workspace = true
 reth-storage-api.workspace = true
 reth-transaction-pool.workspace = true
 

--- a/crates/engine/local/src/miner.rs
+++ b/crates/engine/local/src/miner.rs
@@ -106,7 +106,7 @@ pub struct LocalMiner<T: PayloadTypes, B, Pool: TransactionPool + Unpin> {
     mode: MiningMode<Pool>,
     /// The payload builder for the engine
     payload_builder: PayloadBuilderHandle<T>,
-    /// Timestamp for the next block.
+    /// Latest block in the chain so far.
     last_header: SealedHeaderFor<<T::BuiltPayload as BuiltPayload>::Primitives>,
     /// Stores latest mined blocks.
     last_block_hashes: VecDeque<B256>,

--- a/crates/engine/local/src/miner.rs
+++ b/crates/engine/local/src/miner.rs
@@ -1,6 +1,5 @@
 //! Contains the implementation of the mining mode for the local engine.
 
-use alloy_consensus::BlockHeader;
 use alloy_primitives::{TxHash, B256};
 use alloy_rpc_types_engine::ForkchoiceState;
 use eyre::OptionExt;
@@ -10,6 +9,7 @@ use reth_payload_builder::PayloadBuilderHandle;
 use reth_payload_primitives::{
     BuiltPayload, EngineApiMessageVersion, PayloadAttributesBuilder, PayloadKind, PayloadTypes,
 };
+use reth_primitives_traits::{HeaderTy, SealedHeaderFor};
 use reth_storage_api::BlockReader;
 use reth_transaction_pool::TransactionPool;
 use std::{
@@ -17,7 +17,7 @@ use std::{
     future::Future,
     pin::Pin,
     task::{Context, Poll},
-    time::{Duration, UNIX_EPOCH},
+    time::Duration,
 };
 use tokio::time::Interval;
 use tokio_stream::wrappers::ReceiverStream;
@@ -107,7 +107,7 @@ pub struct LocalMiner<T: PayloadTypes, B, Pool: TransactionPool + Unpin> {
     /// The payload builder for the engine
     payload_builder: PayloadBuilderHandle<T>,
     /// Timestamp for the next block.
-    last_timestamp: u64,
+    last_header: SealedHeaderFor<<T::BuiltPayload as BuiltPayload>::Primitives>,
     /// Stores latest mined blocks.
     last_block_hashes: VecDeque<B256>,
 }
@@ -115,18 +115,21 @@ pub struct LocalMiner<T: PayloadTypes, B, Pool: TransactionPool + Unpin> {
 impl<T, B, Pool> LocalMiner<T, B, Pool>
 where
     T: PayloadTypes,
-    B: PayloadAttributesBuilder<<T as PayloadTypes>::PayloadAttributes>,
+    B: PayloadAttributesBuilder<
+        T::PayloadAttributes,
+        HeaderTy<<T::BuiltPayload as BuiltPayload>::Primitives>,
+    >,
     Pool: TransactionPool + Unpin,
 {
     /// Spawns a new [`LocalMiner`] with the given parameters.
     pub fn new(
-        provider: impl BlockReader,
+        provider: impl BlockReader<Header = HeaderTy<<T::BuiltPayload as BuiltPayload>::Primitives>>,
         payload_attributes_builder: B,
         to_engine: ConsensusEngineHandle<T>,
         mode: MiningMode<Pool>,
         payload_builder: PayloadBuilderHandle<T>,
     ) -> Self {
-        let latest_header =
+        let last_header =
             provider.sealed_header(provider.best_block_number().unwrap()).unwrap().unwrap();
 
         Self {
@@ -134,8 +137,8 @@ where
             to_engine,
             mode,
             payload_builder,
-            last_timestamp: latest_header.timestamp(),
-            last_block_hashes: VecDeque::from([latest_header.hash()]),
+            last_block_hashes: VecDeque::from([last_header.hash()]),
+            last_header,
         }
     }
 
@@ -193,19 +196,11 @@ where
     /// Generates payload attributes for a new block, passes them to FCU and inserts built payload
     /// through newPayload.
     async fn advance(&mut self) -> eyre::Result<()> {
-        let timestamp = std::cmp::max(
-            self.last_timestamp.saturating_add(1),
-            std::time::SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("cannot be earlier than UNIX_EPOCH")
-                .as_secs(),
-        );
-
         let res = self
             .to_engine
             .fork_choice_updated(
                 self.forkchoice_state(),
-                Some(self.payload_attributes_builder.build(timestamp)),
+                Some(self.payload_attributes_builder.build(&self.last_header)),
                 EngineApiMessageVersion::default(),
             )
             .await?;
@@ -222,8 +217,7 @@ where
             eyre::bail!("No payload")
         };
 
-        let block = payload.block();
-
+        let header = payload.block().sealed_header().clone();
         let payload = T::block_to_payload(payload.block().clone());
         let res = self.to_engine.new_payload(payload).await?;
 
@@ -231,8 +225,8 @@ where
             eyre::bail!("Invalid payload")
         }
 
-        self.last_timestamp = timestamp;
-        self.last_block_hashes.push_back(block.hash());
+        self.last_block_hashes.push_back(header.hash());
+        self.last_header = header;
         // ensure we keep at most 64 blocks
         if self.last_block_hashes.len() > 64 {
             self.last_block_hashes.pop_front();

--- a/crates/engine/local/src/payload.rs
+++ b/crates/engine/local/src/payload.rs
@@ -1,10 +1,12 @@
 //! The implementation of the [`PayloadAttributesBuilder`] for the
 //! [`LocalMiner`](super::LocalMiner).
 
+use alloy_consensus::BlockHeader;
 use alloy_primitives::{Address, B256};
-use reth_chainspec::EthereumHardforks;
+use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_ethereum_engine_primitives::EthPayloadAttributes;
 use reth_payload_primitives::PayloadAttributesBuilder;
+use reth_primitives_traits::SealedHeader;
 use std::sync::Arc;
 
 /// The attributes builder for local Ethereum payload.
@@ -13,21 +15,36 @@ use std::sync::Arc;
 pub struct LocalPayloadAttributesBuilder<ChainSpec> {
     /// The chainspec
     pub chain_spec: Arc<ChainSpec>,
+
+    /// Whether to enforce increasing timestamp.
+    pub enforce_increasing_timestamp: bool,
 }
 
 impl<ChainSpec> LocalPayloadAttributesBuilder<ChainSpec> {
     /// Creates a new instance of the builder.
     pub const fn new(chain_spec: Arc<ChainSpec>) -> Self {
-        Self { chain_spec }
+        Self { chain_spec, enforce_increasing_timestamp: true }
+    }
+
+    /// Creates a new instance of the builder without enforcing increasing timestamps.
+    pub fn without_increasing_timestamp(self) -> Self {
+        Self { enforce_increasing_timestamp: false, ..self }
     }
 }
 
-impl<ChainSpec> PayloadAttributesBuilder<EthPayloadAttributes>
+impl<ChainSpec> PayloadAttributesBuilder<EthPayloadAttributes, ChainSpec::Header>
     for LocalPayloadAttributesBuilder<ChainSpec>
 where
-    ChainSpec: Send + Sync + EthereumHardforks + 'static,
+    ChainSpec: EthChainSpec + EthereumHardforks + 'static,
 {
-    fn build(&self, timestamp: u64) -> EthPayloadAttributes {
+    fn build(&self, parent: &SealedHeader<ChainSpec::Header>) -> EthPayloadAttributes {
+        let mut timestamp =
+            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
+
+        if self.enforce_increasing_timestamp {
+            timestamp = std::cmp::max(parent.timestamp().saturating_add(1), timestamp);
+        }
+
         EthPayloadAttributes {
             timestamp,
             prev_randao: B256::random(),
@@ -45,14 +62,18 @@ where
 }
 
 #[cfg(feature = "op")]
-impl<ChainSpec> PayloadAttributesBuilder<op_alloy_rpc_types_engine::OpPayloadAttributes>
+impl<ChainSpec>
+    PayloadAttributesBuilder<op_alloy_rpc_types_engine::OpPayloadAttributes, ChainSpec::Header>
     for LocalPayloadAttributesBuilder<ChainSpec>
 where
-    ChainSpec: Send + Sync + EthereumHardforks + 'static,
+    ChainSpec: EthChainSpec + EthereumHardforks + 'static,
 {
-    fn build(&self, timestamp: u64) -> op_alloy_rpc_types_engine::OpPayloadAttributes {
+    fn build(
+        &self,
+        parent: &SealedHeader<ChainSpec::Header>,
+    ) -> op_alloy_rpc_types_engine::OpPayloadAttributes {
         op_alloy_rpc_types_engine::OpPayloadAttributes {
-            payload_attributes: self.build(timestamp),
+            payload_attributes: self.build(parent),
             // Add dummy system transaction
             transactions: Some(vec![
                 reth_optimism_chainspec::constants::TX_SET_L1_BLOCK_OP_MAINNET_BLOCK_124665056

--- a/crates/payload/primitives/Cargo.toml
+++ b/crates/payload/primitives/Cargo.toml
@@ -21,6 +21,7 @@ reth-execution-types.workspace = true
 reth-trie-common.workspace = true
 
 # alloy
+alloy-consensus.workspace = true
 alloy-eips.workspace = true
 alloy-primitives.workspace = true
 alloy-rpc-types-engine = { workspace = true, features = ["serde"] }

--- a/crates/payload/primitives/Cargo.toml
+++ b/crates/payload/primitives/Cargo.toml
@@ -51,6 +51,7 @@ std = [
     "thiserror/std",
     "reth-primitives-traits/std",
     "either/std",
+    "alloy-consensus/std",
 ]
 op = [
     "dep:op-alloy-rpc-types-engine",


### PR DESCRIPTION
Right now `LocalMiner` always enforces that block timestamp is always increasing https://github.com/paradigmxyz/reth/blob/9f3949cd35626f2685073103ccde4a759df72832/crates/engine/local/src/miner.rs#L196-L202

However, in cases when mining is instant or a low block time configured, this causes block time to drift into the future.

This PR moves the timestamp choosing logic into `PayloadAttributesBuilder`, allowing to customize this behavior. This required passing `Header` generic into `PayloadAttributesBuilder`

This is sdk breaking but only for chains with custom headers