### PR TITLE
refactor(engine): store hashes in blocks_by_number instead of ExecutedBlock

### DIFF
--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -242,7 +242,7 @@ impl TestHarness {
             let hash = sealed_block.hash();
             let number = sealed_block.number;
             blocks_by_hash.insert(hash, block.clone());
-            blocks_by_number.entry(number).or_insert_with(Vec::new).push(block.clone());
+            blocks_by_number.entry(number).or_insert_with(Vec::new).push(hash);
             state_by_hash.insert(hash, Arc::new(BlockState::new(block.clone())));
             hash_by_number.insert(number, hash);
             parent_to_child.entry(parent_hash).or_default().insert(hash);


### PR DESCRIPTION
This change replaces the per-height index blocks_by_number from a Vec<ExecutedBlock<N>> to a Vec<B256>, removing duplicated storage of full blocks. All code paths using this index only require block hashes for pruning and membership operations; the authoritative block data remains in blocks_by_hash. This reduces memory overhead and avoids unnecessary cloning in insert_executed, while preserving existing behavior in canonical removal and finalized sidechain pruning. Tests are updated accordingly to initialize the index with hashes.