### PR TITLE
Fix Clippy regressions across trie, storage, and ethereum e2e tests

### DIFF
--- a/crates/cli/util/src/lib.rs
+++ b/crates/cli/util/src/lib.rs
@@ -31,5 +31,5 @@ pub mod sigsegv_handler;
 #[cfg(not(all(unix, any(target_env = "gnu", target_os = "macos"))))]
 pub mod sigsegv_handler {
     /// No-op function.
-    pub fn install() {}
+    pub const fn install() {}
 }

--- a/crates/ethereum/node/tests/e2e/eth.rs
+++ b/crates/ethereum/node/tests/e2e/eth.rs
@@ -1,12 +1,18 @@
 use crate::utils::eth_payload_attributes;
+#[cfg(unix)]
 use alloy_genesis::Genesis;
 use reth_chainspec::{ChainSpecBuilder, MAINNET};
-use reth_e2e_test_utils::{
-    node::NodeTestContext, setup, transaction::TransactionTestContext, wallet::Wallet,
-};
+use reth_e2e_test_utils::{setup, transaction::TransactionTestContext};
+#[cfg(unix)]
+use reth_e2e_test_utils::wallet::Wallet;
+#[cfg(unix)]
+use reth_e2e_test_utils::node::NodeTestContext;
+#[cfg(unix)]
 use reth_node_builder::{NodeBuilder, NodeHandle};
+#[cfg(unix)]
 use reth_node_core::{args::RpcServerArgs, node_config::NodeConfig};
 use reth_node_ethereum::EthereumNode;
+#[cfg(unix)]
 use reth_tasks::TaskManager;
 use std::sync::Arc;
 

--- a/crates/ethereum/node/tests/e2e/utils.rs
+++ b/crates/ethereum/node/tests/e2e/utils.rs
@@ -70,7 +70,7 @@ where
                 tx = tx.into_create().with_input(dummy_bytecode.clone());
             } else {
                 tx = tx.with_to(*call_destinations.choose(rng).unwrap()).with_input(
-                    (0..rng.random_range(0..10000)).map(|_| rng.random()).collect::<Vec<u8>>(),
+                    (0..rng.random_range(0..10000)).map(|_| rng.random::<u8>()).collect::<Vec<u8>>()
                 );
             }
 
@@ -82,7 +82,9 @@ where
                 tx = tx.with_access_list(
                     vec![AccessListItem {
                         address: *call_destinations.choose(rng).unwrap(),
-                        storage_keys: (0..rng.random_range(0..100)).map(|_| rng.random()).collect(),
+                        storage_keys: (0..rng.random_range(0..100))
+                            .map(|_| rng.random::<B256>())
+                            .collect(),
                     }]
                     .into(),
                 );

--- a/crates/rpc/rpc-server-types/src/constants.rs
+++ b/crates/rpc/rpc-server-types/src/constants.rs
@@ -40,7 +40,7 @@ pub const DEFAULT_IPC_ENDPOINT: &str = r"\\.\pipe\reth.ipc";
 #[cfg(not(windows))]
 pub const DEFAULT_IPC_ENDPOINT: &str = "/tmp/reth.ipc";
 
-/// The engine_api IPC endpoint
+/// The `engine_api` IPC endpoint
 #[cfg(windows)]
 pub const DEFAULT_ENGINE_API_IPC_ENDPOINT: &str = r"\\.\pipe\reth_engine_api.ipc";
 

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -397,7 +397,7 @@ impl DatabaseEnv {
             retry: std::ffi::c_int,
         ) -> HandleSlowReadersReturnCode {
             if space > MAX_SAFE_READER_SPACE {
-                let message = if is_current_process(process_id as u32) {
+                let message = if is_current_process(process_id) {
                     "Current process has a long-lived database transaction that grows the database file."
                 } else {
                     "External process has a long-lived database transaction that grows the database file. \

--- a/crates/trie/trie/src/proof/mod.rs
+++ b/crates/trie/trie/src/proof/mod.rs
@@ -365,7 +365,7 @@ where
 
         let target_nibbles = targets.into_iter().map(Nibbles::unpack).collect::<Vec<_>>();
         let mut prefix_set = self.prefix_set;
-        prefix_set.extend_keys(target_nibbles.clone());
+        prefix_set.extend_keys(target_nibbles.iter().copied());
 
         let trie_cursor = self.trie_cursor_factory.storage_trie_cursor(self.hashed_address)?;
 


### PR DESCRIPTION
Quote the engine_api IPC doc string and drop a redundant MDBX cast to appease Clippy. Switch trie prefix extension to iter().copied() and mark the sigsegv handler stub as const fn. Scope unix-only e2e imports and pin RNG outputs to u8/B256 to resolve type inference failures