### PR TITLE
feat(op): pull chain config from superchain-registry github

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9364,6 +9364,7 @@ dependencies = [
  "op-alloy-consensus",
  "op-alloy-rpc-types",
  "paste",
+ "reqwest",
  "reth-chainspec",
  "reth-ethereum-forks",
  "reth-network-peers",
@@ -9374,6 +9375,7 @@ dependencies = [
  "serde_json",
  "tar-no-std",
  "thiserror 2.0.17",
+ "toml",
 ]
 
 [[package]]

--- a/crates/optimism/chainspec/Cargo.toml
+++ b/crates/optimism/chainspec/Cargo.toml
@@ -45,6 +45,8 @@ derive_more.workspace = true
 paste = { workspace = true, optional = true }
 thiserror = { workspace = true, optional = true }
 op-alloy-consensus.workspace = true
+reqwest = { workspace = true, features = ["rustls-tls-native-roots", "blocking"], optional = true }
+toml = { workspace = true, optional = true }
 
 [dev-dependencies]
 reth-chainspec = { workspace = true, features = ["test-utils"] }
@@ -52,7 +54,13 @@ alloy-op-hardforks.workspace = true
 
 [features]
 default = ["std"]
-superchain-configs = ["miniz_oxide", "paste", "tar-no-std", "thiserror", "thiserror", "dep:serde"]
+superchain-configs = ["miniz_oxide", "paste", "tar-no-std", "thiserror", "dep:serde"]
+pull-superchain-configs = [
+    "std",
+    "superchain-configs",
+    "dep:reqwest",
+    "dep:toml",
+]
 std = [
     "alloy-chains/std",
     "alloy-genesis/std",

--- a/crates/optimism/cli/Cargo.toml
+++ b/crates/optimism/cli/Cargo.toml
@@ -35,7 +35,7 @@ reth-node-metrics.workspace = true
 
 ## optimism
 reth-optimism-primitives.workspace = true
-reth-optimism-chainspec = { workspace = true, features = ["superchain-configs"] }
+reth-optimism-chainspec = { workspace = true, features = ["pull-superchain-configs"] }
 reth-optimism-consensus.workspace = true
 
 reth-chainspec.workspace = true
@@ -71,7 +71,7 @@ tempfile.workspace = true
 reth-stages = { workspace = true, features = ["test-utils"] }
 
 [build-dependencies]
-reth-optimism-chainspec = { workspace = true, features = ["std", "superchain-configs"] }
+reth-optimism-chainspec = { workspace = true, features = ["std", "pull-superchain-configs"] }
 
 [features]
 default = []


### PR DESCRIPTION
Updates the `reth-optimism-chainspec` crate, adding functionality to pull the latest chain configuration directly from the superchain registry. If the superchain registry is unreachable, it will fall back to the local chain configurations and follow the existing behavior.

This means that op-reth doesn't need to cut a new release to reflect updates to the superchain registry; rather, the node operator simply needs to restart op-reth and it will pull the latest config.