### PR TITLE
feat(engine): remove chunks shadowing and unify span recording

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -773,10 +773,8 @@ impl MultiProofTask {
             let Some(chunk_size) = self.chunk_size &&
             proof_targets.chunking_length() > chunk_size
         {
-            let mut chunks = 0usize;
             for proof_targets_chunk in proof_targets.chunks(chunk_size) {
                 dispatch(proof_targets_chunk);
-                chunks += 1;
             }
             tracing::Span::current().record("chunks", chunks);
         } else {
@@ -937,10 +935,8 @@ impl MultiProofTask {
             let Some(chunk_size) = self.chunk_size &&
             not_fetched_state_update.chunking_length() > chunk_size
         {
-            let mut chunks = 0usize;
             for chunk in not_fetched_state_update.chunks(chunk_size) {
                 dispatch(chunk);
-                chunks += 1;
             }
             tracing::Span::current().record("chunks", chunks);
         } else {


### PR DESCRIPTION
Removed the inner shadowed chunks counters in on_prefetch_proof and on_state_update and records the tracing span’s chunks field using the outer counter that is already used for metrics and return values. The previous pattern introduced two independent counters with identical intended semantics, which is unnecessary and risky for maintenance if future edits diverge their behavior. The new approach keeps a single source of truth, ensuring tracing, metrics, and logic remain aligned without changing runtime behavior.