### PR TITLE
chore(stages): fix naming and simplify add_stages implementation

### DIFF
--- a/crates/stages/api/src/pipeline/builder.rs
+++ b/crates/stages/api/src/pipeline/builder.rs
@@ -35,11 +35,9 @@ impl<Provider> PipelineBuilder<Provider> {
     /// [`builder`][StageSet::builder] on the set which will convert it to a
     /// [`StageSetBuilder`][crate::StageSetBuilder].
     pub fn add_stages<Set: StageSet<Provider>>(mut self, set: Set) -> Self {
-        let states = set.builder().build();
-        self.stages.reserve_exact(states.len());
-        for stage in states {
-            self.stages.push(stage);
-        }
+        let stages = set.builder().build();
+        self.stages.reserve(stages.len());
+        self.stages.extend(stages);
         self
     }
 


### PR DESCRIPTION
 #  **Description**

This PR introduces a small cleanup in `PipelineBuilder::add_stages`:

The previous implementation used:

```rust
let states = set.builder().build();
```

However, the value represents **stages**, not “states”.

### Simplifies vector operations

Replaces:

* `reserve_exact` → `reserve`
* manual `for` loop with `.push()` → `extend`

New implementation:

```rust
let stages = set.builder().build();
self.stages.reserve(stages.len());
self.stages.extend(stages);
```