### PR TITLE
chore: remove unused lifetime from map_internal_err impl

### DIFF
--- a/crates/rpc/rpc-server-types/src/result.rs
+++ b/crates/rpc/rpc-server-types/src/result.rs
@@ -65,7 +65,7 @@ macro_rules! impl_to_rpc_result {
             }
 
             #[inline]
-            fn map_internal_err<'a, F, M>(self, op: F) -> jsonrpsee_core::RpcResult<Ok>
+            fn map_internal_err<F, M>(self, op: F) -> jsonrpsee_core::RpcResult<Ok>
             where
                 F: FnOnce($err) -> M,
                 M: Into<String>,


### PR DESCRIPTION
The impl generated by impl_to_rpc_result! for map_internal_err declared an extra lifetime parameter 'a that is not present in the ToRpcResult trait method and is not used by the function signature or bounds. This was a copy-paste artifact from the methods that legitimately accept borrowed data and could trigger the unused_lifetimes lint. The change removes the redundant lifetime so the impl matches the trait and avoids misleading generics without altering behavior.