### PR TITLE
refactor(tracing): introduce `DebugInspector`

### DIFF
--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -12,15 +12,15 @@ use alloy_rpc_types_eth::{
     state::EvmOverrides, Block as RpcBlock, BlockError, Bundle, StateContext, TransactionInfo,
 };
 use alloy_rpc_types_trace::geth::{
-    call::FlatCallFrame, BlockTraceResult, FourByteFrame, GethDebugBuiltInTracerType,
-    GethDebugTracerType, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace,
-    NoopFrame, TraceResult,
+    mux::MuxConfig, BlockTraceResult, CallConfig, FourByteFrame, GethDebugBuiltInTracerType,
+    GethDebugTracerType, GethDebugTracingCallOptions, GethDebugTracingOptions,
+    GethDefaultTracingOptions, GethTrace, NoopFrame, PreStateConfig, TraceResult,
 };
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_errors::RethError;
-use reth_evm::{execute::Executor, ConfigureEvm, EvmEnvFor, TxEnvFor};
+use reth_evm::{execute::Executor, ConfigureEvm, EvmEnvFor};
 use reth_primitives_traits::{Block as _, BlockBody, ReceiptWithBloom, RecoveredBlock};
 use reth_revm::{db::State, witness::ExecutionWitnessRecord};
 use reth_rpc_api::DebugApiServer;
@@ -37,10 +37,19 @@ use reth_storage_api::{
 };
 use reth_tasks::pool::BlockingTaskGuard;
 use reth_trie_common::{updates::TrieUpdates, HashedPostState};
-use revm::{context::Block, context_interface::Transaction, state::EvmState, DatabaseCommit};
+use revm::{
+    context::{
+        result::{HaltReasonTr, ResultAndState},
+        ContextTr,
+    },
+    inspector::{JournalExt, NoOpInspector},
+    interpreter::{CallInputs, CallOutcome, CreateInputs, CreateOutcome, Interpreter},
+    DatabaseCommit, DatabaseRef, Inspector,
+};
 use revm_inspectors::tracing::{
     FourByteInspector, MuxInspector, TracingInspector, TracingInspectorConfig, TransactionContext,
 };
+use revm_primitives::{Log, U256};
 use std::sync::Arc;
 use tokio::sync::{AcquireError, OwnedSemaphorePermit};
 
@@ -91,8 +100,6 @@ where
         evm_env: EvmEnvFor<Eth::Evm>,
         opts: GethDebugTracingOptions,
     ) -> Result<Vec<TraceResult>, Eth::Error> {
-        let this = self.clone();
-        // replay all transactions of the block
         self.eth_api()
             .spawn_with_state_at_block(block.parent_hash(), move |eth_api, mut db| {
                 let mut results = Vec::with_capacity(block.body().transactions().len());
@@ -100,32 +107,31 @@ where
                 eth_api.apply_pre_execution_changes(&block, &mut db, &evm_env)?;
 
                 let mut transactions = block.transactions_recovered().enumerate().peekable();
-                let mut inspector = None;
+                let mut inspector = DebugInspector::new(opts)?;
                 while let Some((index, tx)) = transactions.next() {
                     let tx_hash = *tx.tx_hash();
-
                     let tx_env = eth_api.evm_config().tx_env(tx);
+                    let tx_ctx = Some(TransactionContext {
+                        block_hash: Some(block.hash()),
+                        tx_hash: Some(tx_hash),
+                        tx_index: Some(index),
+                    });
+                    inspector.before_tx(tx_ctx)?;
 
-                    let (result, state_changes) = this.trace_transaction(
-                        &opts,
-                        evm_env.clone(),
-                        tx_env,
+                    let res = eth_api.inspect(
                         &mut db,
-                        Some(TransactionContext {
-                            block_hash: Some(block.hash()),
-                            tx_hash: Some(tx_hash),
-                            tx_index: Some(index),
-                        }),
+                        evm_env.clone(),
+                        tx_env.clone(),
                         &mut inspector,
                     )?;
-
-                    inspector = inspector.map(|insp| insp.fused());
+                    let result =
+                        inspector.after_tx(tx_ctx, &tx_env, &evm_env.block_env, &res, &mut db)?;
 
                     results.push(TraceResult::Success { result, tx_hash: Some(tx_hash) });
                     if transactions.peek().is_some() {
                         // need to apply the state changes of this transaction before executing the
                         // next transaction
-                        db.commit(state_changes)
+                        db.commit(res.state)
                     }
                 }
 
@@ -217,7 +223,6 @@ where
         let state_at: BlockId = block.parent_hash().into();
         let block_hash = block.hash();
 
-        let this = self.clone();
         self.eth_api()
             .spawn_with_state_at_block(state_at, move |eth_api, mut db| {
                 let block_txs = block.transactions_recovered();
@@ -237,19 +242,19 @@ where
 
                 let tx_env = eth_api.evm_config().tx_env(&tx);
 
-                this.trace_transaction(
-                    &opts,
-                    evm_env,
-                    tx_env,
-                    &mut db,
-                    Some(TransactionContext {
-                        block_hash: Some(block_hash),
-                        tx_index: Some(index),
-                        tx_hash: Some(*tx.tx_hash()),
-                    }),
-                    &mut None,
-                )
-                .map(|(trace, _)| trace)
+                let mut inspector = DebugInspector::new(opts)?;
+                let tx_ctx = Some(TransactionContext {
+                    block_hash: Some(block_hash),
+                    tx_index: Some(index),
+                    tx_hash: Some(*tx.tx_hash()),
+                });
+                inspector.before_tx(tx_ctx)?;
+                let res =
+                    eth_api.inspect(&mut db, evm_env.clone(), tx_env.clone(), &mut inspector)?;
+                let trace =
+                    inspector.after_tx(tx_ctx, &tx_env, &evm_env.block_env, &res, &mut db)?;
+
+                Ok(trace)
             })
             .await
     }
@@ -285,202 +290,21 @@ where
                 .await;
         }
 
-        let GethDebugTracingOptions { config, tracer, tracer_config, .. } = tracing_options;
-
         let this = self.clone();
-        if let Some(tracer) = tracer {
-            #[allow(unreachable_patterns)]
-            return match tracer {
-                GethDebugTracerType::BuiltInTracer(tracer) => match tracer {
-                    GethDebugBuiltInTracerType::FourByteTracer => {
-                        let mut inspector = FourByteInspector::default();
-                        let inspector = self
-                            .eth_api()
-                            .spawn_with_call_at(call, at, overrides, move |db, evm_env, tx_env| {
-                                this.eth_api().inspect(db, evm_env, tx_env, &mut inspector)?;
-                                Ok(inspector)
-                            })
-                            .await?;
-                        Ok(FourByteFrame::from(&inspector).into())
-                    }
-                    GethDebugBuiltInTracerType::CallTracer => {
-                        let call_config = tracer_config
-                            .into_call_config()
-                            .map_err(|_| EthApiError::InvalidTracerConfig)?;
-
-                        let mut inspector = TracingInspector::new(
-                            TracingInspectorConfig::from_geth_call_config(&call_config),
-                        );
-
-                        let frame = self
-                            .eth_api()
-                            .spawn_with_call_at(call, at, overrides, move |db, evm_env, tx_env| {
-                                let gas_limit = tx_env.gas_limit();
-                                let res =
-                                    this.eth_api().inspect(db, evm_env, tx_env, &mut inspector)?;
-                                let frame = inspector
-                                    .with_transaction_gas_limit(gas_limit)
-                                    .into_geth_builder()
-                                    .geth_call_traces(call_config, res.result.gas_used());
-                                Ok(frame.into())
-                            })
-                            .await?;
-                        Ok(frame)
-                    }
-                    GethDebugBuiltInTracerType::PreStateTracer => {
-                        let prestate_config = tracer_config
-                            .into_pre_state_config()
-                            .map_err(|_| EthApiError::InvalidTracerConfig)?;
-                        let mut inspector = TracingInspector::new(
-                            TracingInspectorConfig::from_geth_prestate_config(&prestate_config),
-                        );
-
-                        let frame = self
-                            .eth_api()
-                            .spawn_with_call_at(call, at, overrides, move |db, evm_env, tx_env| {
-                                let gas_limit = tx_env.gas_limit();
-                                let res = this.eth_api().inspect(
-                                    &mut *db,
-                                    evm_env,
-                                    tx_env,
-                                    &mut inspector,
-                                )?;
-                                let frame = inspector
-                                    .with_transaction_gas_limit(gas_limit)
-                                    .into_geth_builder()
-                                    .geth_prestate_traces(&res, &prestate_config, db)
-                                    .map_err(Eth::Error::from_eth_err)?;
-                                Ok(frame)
-                            })
-                            .await?;
-                        Ok(frame.into())
-                    }
-                    GethDebugBuiltInTracerType::NoopTracer => Ok(NoopFrame::default().into()),
-                    GethDebugBuiltInTracerType::MuxTracer => {
-                        let mux_config = tracer_config
-                            .into_mux_config()
-                            .map_err(|_| EthApiError::InvalidTracerConfig)?;
-
-                        let mut inspector = MuxInspector::try_from_config(mux_config)
-                            .map_err(Eth::Error::from_eth_err)?;
-
-                        let frame = self
-                            .inner
-                            .eth_api
-                            .spawn_with_call_at(call, at, overrides, move |db, evm_env, tx_env| {
-                                let tx_info = TransactionInfo {
-                                    block_number: Some(evm_env.block_env.number().saturating_to()),
-                                    base_fee: Some(evm_env.block_env.basefee()),
-                                    hash: None,
-                                    block_hash: None,
-                                    index: None,
-                                };
-
-                                let res = this.eth_api().inspect(
-                                    &mut *db,
-                                    evm_env,
-                                    tx_env,
-                                    &mut inspector,
-                                )?;
-                                let frame = inspector
-                                    .try_into_mux_frame(&res, db, tx_info)
-                                    .map_err(Eth::Error::from_eth_err)?;
-                                Ok(frame.into())
-                            })
-                            .await?;
-                        Ok(frame)
-                    }
-                    GethDebugBuiltInTracerType::FlatCallTracer => {
-                        let flat_call_config = tracer_config
-                            .into_flat_call_config()
-                            .map_err(|_| EthApiError::InvalidTracerConfig)?;
-
-                        let mut inspector = TracingInspector::new(
-                            TracingInspectorConfig::from_flat_call_config(&flat_call_config),
-                        );
-
-                        let frame: FlatCallFrame = self
-                            .inner
-                            .eth_api
-                            .spawn_with_call_at(call, at, overrides, move |db, evm_env, tx_env| {
-                                let gas_limit = tx_env.gas_limit();
-                                this.eth_api().inspect(db, evm_env, tx_env, &mut inspector)?;
-                                let tx_info = TransactionInfo::default();
-                                let frame: FlatCallFrame = inspector
-                                    .with_transaction_gas_limit(gas_limit)
-                                    .into_parity_builder()
-                                    .into_localized_transaction_traces(tx_info);
-                                Ok(frame)
-                            })
-                            .await?;
-
-                        Ok(frame.into())
-                    }
-                    _ => {
-                        // Note: this match is non-exhaustive in case we need to add support for
-                        // additional tracers
-                        Err(EthApiError::Unsupported("unsupported tracer").into())
-                    }
-                },
-                #[cfg(not(feature = "js-tracer"))]
-                GethDebugTracerType::JsTracer(_) => {
-                    Err(EthApiError::Unsupported("JS Tracer is not enabled").into())
-                }
-                #[cfg(feature = "js-tracer")]
-                GethDebugTracerType::JsTracer(code) => {
-                    let config = tracer_config.into_json();
-
-                    let (_, at) = self.eth_api().evm_env_at(at).await?;
-
-                    let res = self
-                        .eth_api()
-                        .spawn_with_call_at(call, at, overrides, move |db, evm_env, tx_env| {
-                            let mut inspector =
-                                revm_inspectors::tracing::js::JsInspector::new(code, config)
-                                    .map_err(Eth::Error::from_eth_err)?;
-                            let res = this.eth_api().inspect(
-                                &mut *db,
-                                evm_env.clone(),
-                                tx_env.clone(),
-                                &mut inspector,
-                            )?;
-                            inspector
-                                .json_result(res, &tx_env, &evm_env.block_env, db)
-                                .map_err(Eth::Error::from_eth_err)
-                        })
-                        .await?;
-
-                    Ok(GethTrace::JS(res))
-                }
-                _ => {
-                    // Note: this match is non-exhaustive in case we need to add support for
-                    // additional tracers
-                    Err(EthApiError::Unsupported("unsupported tracer").into())
-                }
-            }
-        }
-
-        // default structlog tracer
-        let inspector_config = TracingInspectorConfig::from_geth_config(&config);
-
-        let mut inspector = TracingInspector::new(inspector_config);
-
-        let (res, tx_gas_limit, inspector) = self
-            .eth_api()
+        self.eth_api()
             .spawn_with_call_at(call, at, overrides, move |db, evm_env, tx_env| {
-                let gas_limit = tx_env.gas_limit();
-                let res = this.eth_api().inspect(db, evm_env, tx_env, &mut inspector)?;
-                Ok((res, gas_limit, inspector))
+                let mut inspector = DebugInspector::new(tracing_options)?;
+                inspector.before_tx(None)?;
+                let res = this.eth_api().inspect(
+                    &mut *db,
+                    evm_env.clone(),
+                    tx_env.clone(),
+                    &mut inspector,
+                )?;
+                let trace = inspector.after_tx(None, &tx_env, &evm_env.block_env, &res, db)?;
+                Ok(trace)
             })
-            .await?;
-        let gas_used = res.result.gas_used();
-        let return_value = res.result.into_output().unwrap_or_default();
-        let frame = inspector
-            .with_transaction_gas_limit(tx_gas_limit)
-            .into_geth_builder()
-            .geth_traces(gas_used, return_value, config);
-
-        Ok(frame.into())
+            .await
     }
 
     /// Helper method to execute `debug_trace_call` at a specific transaction index within a block.
@@ -516,7 +340,6 @@ where
         // execute after the parent block, replaying `tx_index` transactions
         let state_at = block.parent_hash();
 
-        let this = self.clone();
         self.eth_api()
             .spawn_with_state_at_block(state_at, move |eth_api, mut db| {
                 // 1. apply pre-execution changes
@@ -530,18 +353,14 @@ where
                 }
 
                 // 3. now execute the trace call on this state
-                let (call_evm_env, call_tx_env) =
+                let (evm_env, tx_env) =
                     eth_api.prepare_call_env(evm_env, call, &mut db, overrides)?;
 
-                // Execute the trace call using trace_transaction
-                let (trace, _) = this.trace_transaction(
-                    &tracing_options,
-                    call_evm_env,
-                    call_tx_env,
-                    &mut db,
-                    None, // No transaction context for call tracing
-                    &mut None,
-                )?;
+                let mut inspector = DebugInspector::new(tracing_options)?;
+                inspector.before_tx(None)?;
+                let res =
+                    eth_api.inspect(&mut db, evm_env.clone(), tx_env.clone(), &mut inspector)?;
+                let trace = inspector.after_tx(None, &tx_env, &evm_env.block_env, &res, &mut db)?;
 
                 Ok(trace)
             })
@@ -590,8 +409,6 @@ where
             replay_block_txs = false;
         }
 
-        let this = self.clone();
-
         self.eth_api()
             .spawn_with_state_at_block(at, move |eth_api, mut db| {
                 // the outer vec for the bundles
@@ -617,7 +434,7 @@ where
                     let Bundle { transactions, block_override } = bundle;
 
                     let block_overrides = block_override.map(Box::new);
-                    let mut inspector = None;
+                    let mut inspector = DebugInspector::new(tracing_options.clone())?;
 
                     let mut transactions = transactions.into_iter().peekable();
                     while let Some(tx) = transactions.next() {
@@ -628,21 +445,20 @@ where
                         let (evm_env, tx_env) =
                             eth_api.prepare_call_env(evm_env.clone(), tx, &mut db, overrides)?;
 
-                        let (trace, state) = this.trace_transaction(
-                            &tracing_options,
-                            evm_env,
-                            tx_env,
+                        inspector.before_tx(None)?;
+                        let res = eth_api.inspect(
                             &mut db,
-                            None,
+                            evm_env.clone(),
+                            tx_env.clone(),
                             &mut inspector,
                         )?;
-
-                        inspector = inspector.map(|insp| insp.fused());
+                        let trace =
+                            inspector.after_tx(None, &tx_env, &evm_env.block_env, &res, &mut db)?;
 
                         // If there is more transactions, commit the database
                         // If there is no transactions, but more bundles, commit to the database too
                         if transactions.peek().is_some() || bundles.peek().is_some() {
-                            db.commit(state);
+                            db.commit(res.state);
                         }
                         results.push(trace);
                     }
@@ -765,191 +581,6 @@ where
             .bytecode_by_hash(&hash)
             .map_err(Eth::Error::from_eth_err)?
             .map(|b| b.original_bytes()))
-    }
-
-    /// Executes the configured transaction with the environment on the given database.
-    ///
-    /// It optionally takes fused inspector ([`TracingInspector::fused`]) to avoid re-creating the
-    /// inspector for each transaction. This is useful when tracing multiple transactions in a
-    /// block. This is only useful for block tracing which uses the same tracer for all transactions
-    /// in the block.
-    ///
-    /// Caution: If the inspector is provided then `opts.tracer_config` is ignored.
-    ///
-    /// Returns the trace frame and the state that got updated after executing the transaction.
-    ///
-    /// Note: this does not apply any state overrides if they're configured in the `opts`.
-    ///
-    /// Caution: this is blocking and should be performed on a blocking task.
-    fn trace_transaction(
-        &self,
-        opts: &GethDebugTracingOptions,
-        evm_env: EvmEnvFor<Eth::Evm>,
-        tx_env: TxEnvFor<Eth::Evm>,
-        db: &mut StateCacheDb,
-        transaction_context: Option<TransactionContext>,
-        fused_inspector: &mut Option<TracingInspector>,
-    ) -> Result<(GethTrace, EvmState), Eth::Error> {
-        let GethDebugTracingOptions { config, tracer, tracer_config, .. } = opts;
-
-        let tx_info = TransactionInfo {
-            hash: transaction_context.as_ref().map(|c| c.tx_hash).unwrap_or_default(),
-            index: transaction_context
-                .as_ref()
-                .map(|c| c.tx_index.map(|i| i as u64))
-                .unwrap_or_default(),
-            block_hash: transaction_context.as_ref().map(|c| c.block_hash).unwrap_or_default(),
-            block_number: Some(evm_env.block_env.number().saturating_to()),
-            base_fee: Some(evm_env.block_env.basefee()),
-        };
-
-        if let Some(tracer) = tracer {
-            #[allow(unreachable_patterns)]
-            return match tracer {
-                GethDebugTracerType::BuiltInTracer(tracer) => match tracer {
-                    GethDebugBuiltInTracerType::FourByteTracer => {
-                        let mut inspector = FourByteInspector::default();
-                        let res = self.eth_api().inspect(db, evm_env, tx_env, &mut inspector)?;
-                        return Ok((FourByteFrame::from(&inspector).into(), res.state))
-                    }
-                    GethDebugBuiltInTracerType::CallTracer => {
-                        let call_config = tracer_config
-                            .clone()
-                            .into_call_config()
-                            .map_err(|_| EthApiError::InvalidTracerConfig)?;
-
-                        let mut inspector = fused_inspector.get_or_insert_with(|| {
-                            TracingInspector::new(TracingInspectorConfig::from_geth_call_config(
-                                &call_config,
-                            ))
-                        });
-
-                        let gas_limit = tx_env.gas_limit();
-                        let res = self.eth_api().inspect(db, evm_env, tx_env, &mut inspector)?;
-
-                        inspector.set_transaction_gas_limit(gas_limit);
-
-                        let frame = inspector
-                            .geth_builder()
-                            .geth_call_traces(call_config, res.result.gas_used());
-
-                        return Ok((frame.into(), res.state))
-                    }
-                    GethDebugBuiltInTracerType::PreStateTracer => {
-                        let prestate_config = tracer_config
-                            .clone()
-                            .into_pre_state_config()
-                            .map_err(|_| EthApiError::InvalidTracerConfig)?;
-
-                        let mut inspector = fused_inspector.get_or_insert_with(|| {
-                            TracingInspector::new(
-                                TracingInspectorConfig::from_geth_prestate_config(&prestate_config),
-                            )
-                        });
-                        let gas_limit = tx_env.gas_limit();
-                        let res =
-                            self.eth_api().inspect(&mut *db, evm_env, tx_env, &mut inspector)?;
-
-                        inspector.set_transaction_gas_limit(gas_limit);
-                        let frame = inspector
-                            .geth_builder()
-                            .geth_prestate_traces(&res, &prestate_config, db)
-                            .map_err(Eth::Error::from_eth_err)?;
-
-                        return Ok((frame.into(), res.state))
-                    }
-                    GethDebugBuiltInTracerType::NoopTracer => {
-                        Ok((NoopFrame::default().into(), Default::default()))
-                    }
-                    GethDebugBuiltInTracerType::MuxTracer => {
-                        let mux_config = tracer_config
-                            .clone()
-                            .into_mux_config()
-                            .map_err(|_| EthApiError::InvalidTracerConfig)?;
-
-                        let mut inspector = MuxInspector::try_from_config(mux_config)
-                            .map_err(Eth::Error::from_eth_err)?;
-
-                        let res =
-                            self.eth_api().inspect(&mut *db, evm_env, tx_env, &mut inspector)?;
-                        let frame = inspector
-                            .try_into_mux_frame(&res, db, tx_info)
-                            .map_err(Eth::Error::from_eth_err)?;
-                        return Ok((frame.into(), res.state))
-                    }
-                    GethDebugBuiltInTracerType::FlatCallTracer => {
-                        let flat_call_config = tracer_config
-                            .clone()
-                            .into_flat_call_config()
-                            .map_err(|_| EthApiError::InvalidTracerConfig)?;
-
-                        let mut inspector = TracingInspector::new(
-                            TracingInspectorConfig::from_flat_call_config(&flat_call_config),
-                        );
-
-                        let gas_limit = tx_env.gas_limit();
-                        let res = self.eth_api().inspect(db, evm_env, tx_env, &mut inspector)?;
-                        let frame: FlatCallFrame = inspector
-                            .with_transaction_gas_limit(gas_limit)
-                            .into_parity_builder()
-                            .into_localized_transaction_traces(tx_info);
-
-                        return Ok((frame.into(), res.state));
-                    }
-                    _ => {
-                        // Note: this match is non-exhaustive in case we need to add support for
-                        // additional tracers
-                        Err(EthApiError::Unsupported("unsupported tracer").into())
-                    }
-                },
-                #[cfg(not(feature = "js-tracer"))]
-                GethDebugTracerType::JsTracer(_) => {
-                    Err(EthApiError::Unsupported("JS Tracer is not enabled").into())
-                }
-                #[cfg(feature = "js-tracer")]
-                GethDebugTracerType::JsTracer(code) => {
-                    let config = tracer_config.clone().into_json();
-                    let mut inspector =
-                        revm_inspectors::tracing::js::JsInspector::with_transaction_context(
-                            code.clone(),
-                            config,
-                            transaction_context.unwrap_or_default(),
-                        )
-                        .map_err(Eth::Error::from_eth_err)?;
-                    let res = self.eth_api().inspect(
-                        &mut *db,
-                        evm_env.clone(),
-                        tx_env.clone(),
-                        &mut inspector,
-                    )?;
-
-                    let state = res.state.clone();
-                    let result = inspector
-                        .json_result(res, &tx_env, &evm_env.block_env, db)
-                        .map_err(Eth::Error::from_eth_err)?;
-                    Ok((GethTrace::JS(result), state))
-                }
-                _ => {
-                    // Note: this match is non-exhaustive in case we need to add support for
-                    // additional tracers
-                    Err(EthApiError::Unsupported("unsupported tracer").into())
-                }
-            }
-        }
-
-        // default structlog tracer
-        let mut inspector = fused_inspector.get_or_insert_with(|| {
-            let inspector_config = TracingInspectorConfig::from_geth_config(config);
-            TracingInspector::new(inspector_config)
-        });
-        let gas_limit = tx_env.gas_limit();
-        let res = self.eth_api().inspect(db, evm_env, tx_env, &mut inspector)?;
-        let gas_used = res.result.gas_used();
-        let return_value = res.result.into_output().unwrap_or_default();
-        inspector.set_transaction_gas_limit(gas_limit);
-        let frame = inspector.geth_builder().geth_traces(gas_used, return_value, *config);
-
-        Ok((frame.into(), res.state))
     }
 
     /// Returns the state root of the `HashedPostState` on top of the state for the given block with
@@ -1427,4 +1058,275 @@ struct DebugApiInner<Eth> {
     eth_api: Eth,
     // restrict the number of concurrent calls to blocking calls
     blocking_task_guard: BlockingTaskGuard,
+}
+
+/// Inspector for the `debug` API
+///
+/// This inspector is used to trace the execution of a transaction or call and supports all variants
+/// of [`GethDebugTracerType`].
+///
+/// This inspector can be re-used for tracing multiple transactions. This is supported by
+/// requiring caller to invoke [`DebugInspector::before_tx`] before each transaction. See method
+/// documentation for more details.
+enum DebugInspector {
+    FourByte(FourByteInspector),
+    CallTracer(TracingInspector, CallConfig),
+    PreStateTracer(TracingInspector, PreStateConfig),
+    Noop(NoOpInspector),
+    Mux(MuxInspector, MuxConfig),
+    FlatCallTracer(TracingInspector),
+    Default(TracingInspector, GethDefaultTracingOptions),
+    #[cfg(feature = "js-tracer")]
+    Js(Option<revm_inspectors::tracing::js::JsInspector>, String, serde_json::Value),
+}
+
+impl DebugInspector {
+    /// Create a new `DebugInspector` from the given tracing options.
+    fn new(opts: GethDebugTracingOptions) -> Result<Self, EthApiError> {
+        let GethDebugTracingOptions { config, tracer, tracer_config, .. } = opts;
+
+        let this = if let Some(tracer) = tracer {
+            #[allow(unreachable_patterns)]
+            match tracer {
+                GethDebugTracerType::BuiltInTracer(tracer) => match tracer {
+                    GethDebugBuiltInTracerType::FourByteTracer => {
+                        Self::FourByte(FourByteInspector::default())
+                    }
+                    GethDebugBuiltInTracerType::CallTracer => {
+                        let config = tracer_config
+                            .into_call_config()
+                            .map_err(|_| EthApiError::InvalidTracerConfig)?;
+
+                        Self::CallTracer(
+                            TracingInspector::new(TracingInspectorConfig::from_geth_call_config(
+                                &config,
+                            )),
+                            config,
+                        )
+                    }
+                    GethDebugBuiltInTracerType::PreStateTracer => {
+                        let config = tracer_config
+                            .into_pre_state_config()
+                            .map_err(|_| EthApiError::InvalidTracerConfig)?;
+
+                        Self::PreStateTracer(
+                            TracingInspector::new(
+                                TracingInspectorConfig::from_geth_prestate_config(&config),
+                            ),
+                            config,
+                        )
+                    }
+                    GethDebugBuiltInTracerType::NoopTracer => Self::Noop(NoOpInspector),
+                    GethDebugBuiltInTracerType::MuxTracer => {
+                        let config = tracer_config
+                            .into_mux_config()
+                            .map_err(|_| EthApiError::InvalidTracerConfig)?;
+
+                        Self::Mux(MuxInspector::try_from_config(config.clone())?, config)
+                    }
+                    GethDebugBuiltInTracerType::FlatCallTracer => {
+                        let flat_call_config = tracer_config
+                            .into_flat_call_config()
+                            .map_err(|_| EthApiError::InvalidTracerConfig)?;
+
+                        Self::FlatCallTracer(TracingInspector::new(
+                            TracingInspectorConfig::from_flat_call_config(&flat_call_config),
+                        ))
+                    }
+                    _ => {
+                        // Note: this match is non-exhaustive in case we need to add support for
+                        // additional tracers
+                        return Err(EthApiError::Unsupported("unsupported tracer"))
+                    }
+                },
+                #[cfg(not(feature = "js-tracer"))]
+                GethDebugTracerType::JsTracer(_) => {
+                    return Err(EthApiError::Unsupported("JS Tracer is not enabled").into())
+                }
+                #[cfg(feature = "js-tracer")]
+                GethDebugTracerType::JsTracer(code) => {
+                    let config = tracer_config.into_json();
+                    Self::Js(None, code, config)
+                }
+                _ => {
+                    // Note: this match is non-exhaustive in case we need to add support for
+                    // additional tracers
+                    return Err(EthApiError::Unsupported("unsupported tracer"))
+                }
+            }
+        } else {
+            Self::Default(
+                TracingInspector::new(TracingInspectorConfig::from_geth_config(&config)),
+                config,
+            )
+        };
+
+        Ok(this)
+    }
+
+    /// Preapres inspector for executing the next transaction.
+    ///
+    /// This will set the [`TransactionContext`] (only for JS tracer) and more importantly, fuse
+    /// the inspector and remove any remaining state from previous transactions.
+    fn before_tx(
+        &mut self,
+        transaction_context: Option<TransactionContext>,
+    ) -> Result<(), EthApiError> {
+        match self {
+            Self::FourByte(inspector) => {
+                std::mem::take(inspector);
+            }
+            Self::CallTracer(inspector, _) |
+            Self::PreStateTracer(inspector, _) |
+            Self::FlatCallTracer(inspector) |
+            Self::Default(inspector, _) => inspector.fuse(),
+            Self::Noop(_) => {}
+            Self::Mux(inspector, config) => {
+                *inspector = MuxInspector::try_from_config(config.clone())?
+            }
+            #[cfg(feature = "js-tracer")]
+            Self::Js(inspector, code, config) => {
+                *inspector =
+                    Some(revm_inspectors::tracing::js::JsInspector::with_transaction_context(
+                        code.clone(),
+                        config.clone(),
+                        transaction_context.unwrap_or_default(),
+                    )?);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Should be invoked after each transaction to obtain the resulting [`GethTrace`].
+    fn after_tx(
+        &mut self,
+        tx_context: Option<TransactionContext>,
+        tx_env: &impl revm::context::Transaction,
+        block_env: &impl revm::context::Block,
+        res: &ResultAndState<impl HaltReasonTr>,
+        db: &mut StateCacheDb,
+    ) -> Result<GethTrace, EthApiError> {
+        let tx_info = TransactionInfo {
+            hash: tx_context.as_ref().map(|c| c.tx_hash).unwrap_or_default(),
+            index: tx_context.as_ref().map(|c| c.tx_index.map(|i| i as u64)).unwrap_or_default(),
+            block_hash: tx_context.as_ref().map(|c| c.block_hash).unwrap_or_default(),
+            block_number: Some(block_env.number().saturating_to()),
+            base_fee: Some(block_env.basefee()),
+        };
+
+        let res = match self {
+            Self::FourByte(inspector) => FourByteFrame::from(&*inspector).into(),
+            Self::CallTracer(inspector, config) => {
+                inspector.set_transaction_gas_limit(tx_env.gas_limit());
+                inspector.geth_builder().geth_call_traces(*config, res.result.gas_used()).into()
+            }
+            Self::PreStateTracer(inspector, config) => {
+                inspector.set_transaction_gas_limit(tx_env.gas_limit());
+                inspector.geth_builder().geth_prestate_traces(res, config, db)?.into()
+            }
+            Self::Noop(_) => NoopFrame::default().into(),
+            Self::Mux(inspector, _) => inspector.try_into_mux_frame(res, db, tx_info)?.into(),
+            Self::FlatCallTracer(inspector) => {
+                inspector.set_transaction_gas_limit(tx_env.gas_limit());
+                inspector
+                    .clone()
+                    .into_parity_builder()
+                    .into_localized_transaction_traces(tx_info)
+                    .into()
+            }
+            Self::Default(inspector, config) => {
+                inspector.set_transaction_gas_limit(tx_env.gas_limit());
+                inspector
+                    .geth_builder()
+                    .geth_traces(
+                        res.result.gas_used(),
+                        res.result.output().unwrap_or_default().clone(),
+                        *config,
+                    )
+                    .into()
+            }
+            #[cfg(feature = "js-tracer")]
+            Self::Js(inspector, _, _) => {
+                let res = if let Some(inspector) = inspector {
+                    inspector.json_result(res.clone(), tx_env, block_env, db)?
+                } else {
+                    Default::default()
+                };
+
+                GethTrace::JS(res)
+            }
+        };
+
+        Ok(res)
+    }
+}
+
+macro_rules! delegate {
+    ($self:expr => $insp:ident.$method:ident($($arg:expr),*)) => {
+        match $self {
+            Self::FourByte($insp) => Inspector::<CTX>::$method($insp, $($arg),*),
+            Self::CallTracer($insp, _) => Inspector::<CTX>::$method($insp, $($arg),*),
+            Self::PreStateTracer($insp, _) => Inspector::<CTX>::$method($insp, $($arg),*),
+            Self::FlatCallTracer($insp) => Inspector::<CTX>::$method($insp, $($arg),*),
+            Self::Default($insp, _) => Inspector::<CTX>::$method($insp, $($arg),*),
+            Self::Noop($insp) => Inspector::<CTX>::$method($insp, $($arg),*),
+            Self::Mux($insp, _) => Inspector::<CTX>::$method($insp, $($arg),*),
+            #[cfg(feature = "js-tracer")]
+            Self::Js(Some($insp), _, _) => Inspector::<CTX>::$method($insp, $($arg),*),
+            #[cfg(feature = "js-tracer")]
+            // should be unreachable
+            Self::Js(None, _, _) => Inspector::<CTX>::$method(&mut NoOpInspector, $($arg),*),
+        }
+    };
+}
+
+impl<CTX> Inspector<CTX> for DebugInspector
+where
+    CTX: ContextTr<Journal: JournalExt, Db: DatabaseRef>,
+{
+    fn initialize_interp(&mut self, interp: &mut Interpreter, context: &mut CTX) {
+        delegate!(self => inspector.initialize_interp(interp, context))
+    }
+
+    fn step(&mut self, interp: &mut Interpreter, context: &mut CTX) {
+        delegate!(self => inspector.step(interp, context))
+    }
+
+    fn step_end(&mut self, interp: &mut Interpreter, context: &mut CTX) {
+        delegate!(self => inspector.step_end(interp, context))
+    }
+
+    fn log(&mut self, context: &mut CTX, log: Log) {
+        delegate!(self => inspector.log(context, log))
+    }
+
+    fn log_full(&mut self, interp: &mut Interpreter, context: &mut CTX, log: Log) {
+        delegate!(self => inspector.log_full(interp, context, log))
+    }
+
+    fn call(&mut self, context: &mut CTX, inputs: &mut CallInputs) -> Option<CallOutcome> {
+        delegate!(self => inspector.call(context, inputs))
+    }
+
+    fn call_end(&mut self, context: &mut CTX, inputs: &CallInputs, outcome: &mut CallOutcome) {
+        delegate!(self => inspector.call_end(context, inputs, outcome))
+    }
+
+    fn create(&mut self, context: &mut CTX, inputs: &mut CreateInputs) -> Option<CreateOutcome> {
+        delegate!(self => inspector.create(context, inputs))
+    }
+
+    fn create_end(
+        &mut self,
+        context: &mut CTX,
+        inputs: &CreateInputs,
+        outcome: &mut CreateOutcome,
+    ) {
+        delegate!(self => inspector.create_end(context, inputs, outcome))
+    }
+
+    fn selfdestruct(&mut self, contract: Address, target: Address, value: U256) {
+        delegate!(self => inspector.selfdestruct(contract, target, value))
+    }
 }


### PR DESCRIPTION
This PR refactors `DebugApi` and encapsulates the tracing logic in a `DebugInspector` enum.

This gives more control to the tracing callsite as it now knows has control over inspector type, allowing to rewrite those APIs logic to use `BlockExecutor`s and potentially reuse more existing helpers