### PR TITLE
Use execute_block_with_transaction_closure for metrics

### DIFF
--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -75,8 +75,6 @@ impl EngineApiMetrics {
         let wrapper = MeteredStateHook { metrics: self.executor.clone(), inner_hook: state_hook };
         let executor = executor.with_state_hook(Some(Box::new(wrapper)));
 
-        let transactions = transactions.collect::<Result<Vec<_>, _>>()?;
-
         let execute_block = || {
             executor.execute_block_with_transaction_closure(
                 transactions,


### PR DESCRIPTION
Let the `BlockExecutor` own its execution.

[Alloy-EVM PR.](https://github.com/alloy-rs/evm/pull/232)