### PR TITLE
chore(test): Increase timeout for ethereum e2e tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -19,3 +19,8 @@ slow-timeout = { period = "2m", terminate-after = 3 }
 [[profile.default.overrides]]
 filter = "package(reth-era) and binary(it)"
 slow-timeout = { period = "2m", terminate-after = 10 }
+
+# Allow slower ethereum node e2e tests (p2p + blobs) to run up to 5 minutes.
+[[profile.default.overrides]]
+filter = "package(reth-node-ethereum) and binary(e2e)"
+slow-timeout = { period = "1m", terminate-after = 5 }


### PR DESCRIPTION
## Summary
- raise the nextest slow-timeout for reth-node-ethereum e2e binary to ~5 minutes so long-running p2p/blob e2e tests stop hitting the 120s cap
- motivated by repeated timeouts in the integration job: https://github.com/paradigmxyz/reth/actions/runs/19631439252/job/56211995794?pr=19894