### PR TITLE
chore: avoid needless clone in module array conversion

### DIFF
--- a/crates/rpc/rpc-server-types/src/module.rs
+++ b/crates/rpc/rpc-server-types/src/module.rs
@@ -240,7 +240,7 @@ impl From<Vec<RethRpcModule>> for RpcModuleSelection {
 
 impl<const N: usize> From<[RethRpcModule; N]> for RpcModuleSelection {
     fn from(s: [RethRpcModule; N]) -> Self {
-        Self::Selection(s.iter().cloned().collect())
+        Self::Selection(s.into_iter().collect())
     }
 }
 


### PR DESCRIPTION
Swapped iter().cloned() for into_iter() when turning fixed-size module arrays into a set, so we consume the array by value and skip redundant cloning while keeping the exact same semantics.