### PR TITLE
feat(trie): Proof V2: retain proof nodes which match targets

### DIFF
--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -55,6 +55,13 @@ pub struct ProofCalculator<TC, HC, VE: LeafValueEncoder> {
     /// The children for the bottom branch in `branch_stack` are found at the bottom of this stack,
     /// and so on. When a branch is removed from `branch_stack` its children are removed from this
     /// one, and the branch is pushed onto this stack in their place (see [`Self::pop_branch`].
+    ///
+    /// Children on the `child_stack` are converted to [`ProofTrieBranchChild::RlpNode`]s via the
+    /// [`Self::commit_child`] method. Committing a child indicates that no further changes are
+    /// expected to happen to it (e.g. splitting its short key when inserting a new branch). Given
+    /// that keys are consumed in lexicographical order, only the most last child on the stack can
+    /// ever be modified, and therefore all children besides the last are expected to be
+    /// [`ProofTrieBranchChild::RlpNode`]s.
     child_stack: Vec<ProofTrieBranchChild<VE::DeferredEncoder>>,
     /// The proofs which will be returned from the calculation. This gets taken at the end of every
     /// proof call.
@@ -110,6 +117,38 @@ where
 
     /// Returns true if the proof of a node at the given path should be retained. This may move the
     /// `targets` iterator forward if the given path comes after the current target.
+    ///
+    /// This method takes advantage of the [`WindowIter`] component of [`TargetsIter`] to only check
+    /// a single target at a time. The [`WindowIter`] allows us to look at a current target and the
+    /// next target simultaneously, forming an end-exclusive range.
+    ///
+    /// ```
+    /// * targets: [ 0x012, 0x045, 0x678 ]
+    /// * targets.next() returns:
+    ///     - (0x012, Some(0x045)): covers (0x012..0x045)
+    ///     - (0x045, Some(0x678)): covers (0x045..0x678)
+    ///     - (0x678, None): covers (0x678..)
+    /// ```
+    ///
+    /// As long as the path which is passed in lies within that range we can continue to use the
+    /// current target. Once the path goes beyond that range (ie path >= next target) then we can be
+    /// sure that no further paths will be in the range, and we can iterate forward.
+    ///
+    /// ```
+    /// * Given:
+    ///     - path: 0x04
+    ///     - targets returns (0x012, Some(0x045))
+    ///
+    /// * 0x04 comes _after_ 0x045 in depth-first order, so (0x012..0x045) does not contain 0x04.
+    ///
+    /// * targets.next() is called.
+    /// * targets.peek() now returns (0x045, Some(0x678)). This does contain 0x04.
+    /// * 0x04 is a prefix of 0x045, and so is retained.
+    /// ```
+    ///
+    /// Because paths in the trie are visited in depth-first order, it's imperative that targets are
+    /// given in depth-first order as well. If the targets where generated off of B256s, which is
+    /// the common-case, then this is equivalent to lexicographical order.
     fn should_retain(
         &self,
         targets: &mut TargetsIter<impl Iterator<Item = Nibbles>>,
@@ -125,7 +164,8 @@ where
             self.retained_proofs.last().map(|n| n.path),
         );
 
-        // TODO docs
+        // If the path isn't in the current range then iterate forward until it is (or until there
+        // is no upper bound, indicating unbounded).
         while let Some((_, Some(upper))) = targets.peek() &&
             depth_first::cmp(path, upper) != Ordering::Less
         {
@@ -243,7 +283,8 @@ where
         Ok(())
     }
 
-    /// Pushes a new leaf node onto a branch, setting its `state_mask` bit.
+    /// Creates a new leaf node on a branch, setting its `state_mask` bit and pushing the leaf onto
+    /// the `child_stack`.
     ///
     /// # Panics
     ///
@@ -540,8 +581,8 @@ where
             targets.into_iter().inspect(move |target| {
                 if let Some(prev) = prev {
                     debug_assert!(
-                        prev <= *target,
-                        "targets must be sorted lexicographically: {:?} > {:?}",
+                        depth_first::cmp(&prev, target) != Ordering::Greater,
+                        "targets must be sorted depth-first, instead {:?} > {:?}",
                         prev,
                         target
                     );
@@ -643,8 +684,8 @@ where
 {
     /// Generate a proof for the given targets.
     ///
-    /// Given lexicographically sorted targets, returns nodes whose paths are a prefix of any
-    /// target. The returned nodes will be sorted lexicographically by path.
+    /// Given depth-first sorted targets, returns nodes whose paths are a prefix of any target. The
+    /// returned nodes will be sorted lexicographically by path.
     ///
     /// # Panics
     ///
@@ -676,8 +717,8 @@ where
 
     /// Generate a proof for a storage trie at the given hashed address.
     ///
-    /// Given lexicographically sorted targets, returns nodes whose paths are a prefix of any
-    /// target. The returned nodes will be sorted lexicographically by path.
+    /// Given depth-first sorted targets, returns nodes whose paths are a prefix of any target. The
+    /// returned nodes will be sorted lexicographically by path.
     ///
     /// # Panics
     ///
@@ -935,7 +976,7 @@ mod tests {
 
         /// Generate a strategy for `HashedPostState` with random accounts
         fn hashed_post_state_strategy() -> impl Strategy<Value = HashedPostState> {
-            prop::collection::vec((any::<[u8; 32]>(), account_strategy()), 0..20).prop_map(
+            prop::collection::vec((any::<[u8; 32]>(), account_strategy()), 0..40).prop_map(
                 |accounts| {
                     let account_map = accounts
                         .into_iter()
@@ -980,7 +1021,7 @@ mod tests {
         }
 
         proptest! {
-            #![proptest_config(ProptestConfig::with_cases(5000))]
+            #![proptest_config(ProptestConfig::with_cases(8000))]
 
             /// Tests that ProofCalculator produces valid proofs for randomly generated
             /// HashedPostState with proof targets.

--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -122,8 +122,8 @@ where
     /// a single target at a time. The [`WindowIter`] allows us to look at a current target and the
     /// next target simultaneously, forming an end-exclusive range.
     ///
-    /// ```
-    /// * targets: [ 0x012, 0x045, 0x678 ]
+    /// ```text
+    /// * Given targets: [ 0x012, 0x045, 0x678 ]
     /// * targets.next() returns:
     ///     - (0x012, Some(0x045)): covers (0x012..0x045)
     ///     - (0x045, Some(0x678)): covers (0x045..0x678)
@@ -134,15 +134,17 @@ where
     /// current target. Once the path goes beyond that range (ie path >= next target) then we can be
     /// sure that no further paths will be in the range, and we can iterate forward.
     ///
-    /// ```
+    /// ```text
     /// * Given:
     ///     - path: 0x04
-    ///     - targets returns (0x012, Some(0x045))
+    ///     - targets.peek() returns (0x012, Some(0x045))
     ///
     /// * 0x04 comes _after_ 0x045 in depth-first order, so (0x012..0x045) does not contain 0x04.
     ///
     /// * targets.next() is called.
+    ///
     /// * targets.peek() now returns (0x045, Some(0x678)). This does contain 0x04.
+    ///
     /// * 0x04 is a prefix of 0x045, and so is retained.
     /// ```
     ///
@@ -239,7 +241,6 @@ where
         };
 
         debug_assert_ne!(branch.state_mask.get(), 0, "branch.state_mask can never be zero");
-        // TODO export BITS off of `TrieMask`.
         let last_nibble = u16::BITS - branch.state_mask.leading_zeros() - 1;
 
         let mut child_path = self.branch_path;

--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -780,15 +780,16 @@ impl<I: Iterator<Item: Copy>> Iterator for WindowIter<I> {
     type Item = (I::Item, Option<I::Item>);
 
     fn next(&mut self) -> Option<Self::Item> {
-        match (self.prev, self.iter.next()) {
-            (None, None) => None,
-            (None, Some(v)) => {
-                self.prev = Some(v);
-                self.next()
-            }
-            (Some(v), next) => {
-                self.prev = next;
-                Some((v, next))
+        loop {
+            match (self.prev, self.iter.next()) {
+                (None, None) => return None,
+                (None, Some(v)) => {
+                    self.prev = Some(v);
+                }
+                (Some(v), next) => {
+                    self.prev = next;
+                    return Some((v, next))
+                }
             }
         }
     }

--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -59,7 +59,7 @@ pub struct ProofCalculator<TC, HC, VE: LeafValueEncoder> {
     /// Children on the `child_stack` are converted to [`ProofTrieBranchChild::RlpNode`]s via the
     /// [`Self::commit_child`] method. Committing a child indicates that no further changes are
     /// expected to happen to it (e.g. splitting its short key when inserting a new branch). Given
-    /// that keys are consumed in lexicographical order, only the most last child on the stack can
+    /// that keys are consumed in lexicographical order, only the last child on the stack can
     /// ever be modified, and therefore all children besides the last are expected to be
     /// [`ProofTrieBranchChild::RlpNode`]s.
     child_stack: Vec<ProofTrieBranchChild<VE::DeferredEncoder>>,
@@ -115,7 +115,9 @@ where
             .unwrap_or_else(|| Vec::with_capacity(16))
     }
 
-    /// Returns true if the proof of a node at the given path should be retained. This may move the
+    /// Returns true if the proof of a node at the given path should be retained. 
+    /// A node is retained if its path is a prefix of any target.
+    /// This may move the
     /// `targets` iterator forward if the given path comes after the current target.
     ///
     /// This method takes advantage of the [`WindowIter`] component of [`TargetsIter`] to only check
@@ -149,7 +151,7 @@ where
     /// ```
     ///
     /// Because paths in the trie are visited in depth-first order, it's imperative that targets are
-    /// given in depth-first order as well. If the targets where generated off of B256s, which is
+    /// given in depth-first order as well. If the targets were generated off of B256s, which is
     /// the common-case, then this is equivalent to lexicographical order.
     fn should_retain(
         &self,

--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -115,7 +115,7 @@ where
             .unwrap_or_else(|| Vec::with_capacity(16))
     }
 
-    /// Returns true if the proof of a node at the given path should be retained. 
+    /// Returns true if the proof of a node at the given path should be retained.
     /// A node is retained if its path is a prefix of any target.
     /// This may move the
     /// `targets` iterator forward if the given path comes after the current target.
@@ -168,17 +168,19 @@ where
             self.retained_proofs.last().map(|n| n.path),
         );
 
+        let &(mut lower, mut upper) = targets.peek().expect("targets is never exhausted");
+
         // If the path isn't in the current range then iterate forward until it is (or until there
         // is no upper bound, indicating unbounded).
-        while let Some((_, Some(upper))) = targets.peek() &&
-            depth_first::cmp(path, upper) != Ordering::Less
-        {
+        while upper.is_some_and(|upper| depth_first::cmp(path, &upper) != Ordering::Less) {
             targets.next();
             trace!(target: TRACE_TARGET, target = ?targets.peek(), "upper target <= path, next target");
+            let &(l, u) = targets.peek().expect("targets is never exhausted");
+            (lower, upper) = (l, u);
         }
 
         // If the node in question is a prefix of the target then we retain
-        targets.peek().is_some_and(|(lower, _)| lower.starts_with(path))
+        lower.starts_with(path)
     }
 
     /// Takes a child which has been removed from the `child_stack` and converts it to an

--- a/crates/trie/trie/src/proof_v2/node.rs
+++ b/crates/trie/trie/src/proof_v2/node.rs
@@ -17,15 +17,17 @@ pub(crate) enum ProofTrieBranchChild<RF> {
         /// The [`DeferredValueEncoder`] which will encode the leaf's value.
         value: RF,
     },
-    /// An extension node whose child branch has not yet been converted to an [`RlpNode`]
+    /// An extension node whose child branch has been converted to an [`RlpNode`]
     Extension {
         /// The short key of the leaf.
         short_key: Nibbles,
-        /// The node of the child branch.
-        child: BranchNode,
+        /// The [`RlpNode`] of the child branch.
+        child: RlpNode,
     },
     /// A branch node whose children have already been flattened into [`RlpNode`]s.
     Branch(BranchNode),
+    // A node whose type is not known, as it has already been converted to an [`RlpNode`].
+    RlpNode(RlpNode),
 }
 
 impl<RF: DeferredValueEncoder> ProofTrieBranchChild<RF> {
@@ -59,20 +61,22 @@ impl<RF: DeferredValueEncoder> ProofTrieBranchChild<RF> {
                 Ok((RlpNode::from_rlp(&buf[value_enc_len..]), None))
             }
             Self::Extension { short_key, child } => {
-                let (branch_rlp, rlp_buf) = Self::Branch(child).into_rlp(buf)?;
-                buf.clear();
-
-                ExtensionNodeRef::new(&short_key, branch_rlp.as_slice()).encode(buf);
-                Ok((RlpNode::from_rlp(buf), rlp_buf))
+                ExtensionNodeRef::new(&short_key, child.as_slice()).encode(buf);
+                Ok((RlpNode::from_rlp(buf), None))
             }
             Self::Branch(branch_node) => {
                 branch_node.encode(buf);
                 Ok((RlpNode::from_rlp(buf), Some(branch_node.stack)))
             }
+            Self::RlpNode(rlp_node) => Ok((rlp_node, None)),
         }
     }
 
     /// Converts this child into a [`ProofTrieNode`] having the given path.
+    ///
+    /// # Panics
+    ///
+    /// If called on a [`Self::RlpNode`].
     pub(crate) fn into_proof_trie_node(
         self,
         path: Nibbles,
@@ -84,15 +88,11 @@ impl<RF: DeferredValueEncoder> ProofTrieBranchChild<RF> {
                 (TrieNode::Leaf(LeafNode::new(short_key, core::mem::take(buf))), TrieMasks::none())
             }
             Self::Extension { short_key, child } => {
-                child.encode(buf);
-                let child_rlp_node = RlpNode::from_rlp(buf);
-                (
-                    TrieNode::Extension(ExtensionNode { key: short_key, child: child_rlp_node }),
-                    TrieMasks::none(),
-                )
+                (TrieNode::Extension(ExtensionNode { key: short_key, child }), TrieMasks::none())
             }
             // TODO store trie masks on branch
             Self::Branch(branch_node) => (TrieNode::Branch(branch_node), TrieMasks::none()),
+            Self::RlpNode(_) => panic!("Cannot call `into_proof_trie_node` on RlpNode"),
         };
 
         // Encode the `TrieNode` to the buffer, so we can return the `RlpNode` for it at the end.
@@ -103,11 +103,11 @@ impl<RF: DeferredValueEncoder> ProofTrieBranchChild<RF> {
     }
 
     /// Returns the short key of the child, if it is a leaf or extension, or empty if its a
-    /// [`Self::Branch`].
+    /// [`Self::Branch`] or [`Self::RlpNode`].
     pub(crate) fn short_key(&self) -> &Nibbles {
         match self {
             Self::Leaf { short_key, .. } | Self::Extension { short_key, .. } => short_key,
-            Self::Branch(_) => {
+            Self::Branch(_) | Self::RlpNode(_) => {
                 static EMPTY_NIBBLES: Nibbles = Nibbles::new();
                 &EMPTY_NIBBLES
             }
@@ -123,17 +123,17 @@ impl<RF: DeferredValueEncoder> ProofTrieBranchChild<RF> {
     ///
     /// - If the given len is longer than the short key
     /// - If the given len is the same as the length of a leaf's short key
-    /// - If the node is a [`Self::Branch`]
+    /// - If the node is a [`Self::Branch`] or [`Self::RlpNode`]
     pub(crate) fn trim_short_key_prefix(&mut self, len: usize) {
         match self {
             Self::Extension { short_key, child } if short_key.len() == len => {
-                *self = Self::Branch(core::mem::take(child));
+                *self = Self::RlpNode(core::mem::take(child));
             }
             Self::Leaf { short_key, .. } | Self::Extension { short_key, .. } => {
                 *short_key = trim_nibbles_prefix(short_key, len);
             }
-            Self::Branch(_) => {
-                panic!("Cannot call `trim_short_key_prefix` on Branch")
+            Self::Branch(_) | Self::RlpNode(_) => {
+                panic!("Cannot call `trim_short_key_prefix` on Branch or RlpNode")
             }
         }
     }

--- a/crates/trie/trie/src/proof_v2/node.rs
+++ b/crates/trie/trie/src/proof_v2/node.rs
@@ -26,7 +26,7 @@ pub(crate) enum ProofTrieBranchChild<RF> {
     },
     /// A branch node whose children have already been flattened into [`RlpNode`]s.
     Branch(BranchNode),
-    // A node whose type is not known, as it has already been converted to an [`RlpNode`].
+    /// A node whose type is not known, as it has already been converted to an [`RlpNode`].
     RlpNode(RlpNode),
 }
 


### PR DESCRIPTION
Closes #19512

This PR gives the new `proof_v2::ProofCalculator` the ability to retain the `ProofTrieNode`s for all nodes in the trie which match the given proof targets. The legacy proof calculator retains proofs by checking each node against all targets, whereas V2 checks each node against only a single target. See the [`should_retain`](https://github.com/paradigmxyz/reth/pull/19941/files#diff-0f5e4d1b41c9f7f212a9fb1ec319846f1489e692499d00bbd356c3a2022b1131R154-R159) method for details on how this works.

To support proof retention the idea of "committing" a child is introduced. A child is "committed" to when there can be no further changes to it, such as an extension or a leaf being split to insert a new branch. When a child is committed it is converted to an RlpNode, checked to see if its proof should be retained, and pushed back onto the child stack as a `ProofTrieBranchChild::RlpNode`. This is done all as one step in order to best reuse buffers during RLP-encoding.