### PR TITLE
docs(cli): remove reference to engine experimental

### DIFF
--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -12,7 +12,12 @@ use crate::node_config::{
 #[derive(Debug, Clone, Args, PartialEq, Eq)]
 #[command(next_help_heading = "Engine")]
 pub struct EngineArgs {
-    /// Configure persistence threshold for engine experimental.
+    /// Configure persistence threshold for the engine. This determines how many canonical blocks
+    /// must be in-memory, ahead of the last persisted block, before flushing canonical blocks to
+    /// disk again.
+    ///
+    /// To persist blocks as fast as the node receives them, set this value to zero. This will cause
+    /// more frequent DB writes.
     #[arg(long = "engine.persistence-threshold", default_value_t = DEFAULT_PERSISTENCE_THRESHOLD)]
     pub persistence_threshold: u64,
 

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -16,8 +16,8 @@ pub struct EngineArgs {
     /// must be in-memory, ahead of the last persisted block, before flushing canonical blocks to
     /// disk again.
     ///
-    /// To persist blocks as fast as the node receives them, set this value to zero. This will cause
-    /// more frequent DB writes.
+    /// To persist blocks as fast as the node receives them, set this value to zero. This will
+    /// cause more frequent DB writes.
     #[arg(long = "engine.persistence-threshold", default_value_t = DEFAULT_PERSISTENCE_THRESHOLD)]
     pub persistence_threshold: u64,
 

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -871,7 +871,9 @@ Pruning:
 
 Engine:
       --engine.persistence-threshold <PERSISTENCE_THRESHOLD>
-          Configure persistence threshold for engine experimental
+          Configure persistence threshold for the engine. This determines how many canonical blocks must be in-memory, ahead of the last persisted block, before flushing canonical blocks to disk again.
+
+          To persist blocks as fast as the node receives them, set this value to zero. This will cause more frequent DB writes.
 
           [default: 2]
 


### PR DESCRIPTION
ref https://github.com/paradigmxyz/reth/issues/19926

Removes reference to experimental engine and improves the docs for `--engine.persistence-threshold`.