### PR TITLE
remove redundant code and fix clippy warnings

### DIFF
--- a/crates/cli/util/src/lib.rs
+++ b/crates/cli/util/src/lib.rs
@@ -31,5 +31,5 @@ pub mod sigsegv_handler;
 #[cfg(not(all(unix, any(target_env = "gnu", target_os = "macos"))))]
 pub mod sigsegv_handler {
     /// No-op function.
-    pub fn install() {}
+    pub const fn install() {}
 }

--- a/crates/ethereum/node/tests/e2e/eth.rs
+++ b/crates/ethereum/node/tests/e2e/eth.rs
@@ -1,13 +1,7 @@
 use crate::utils::eth_payload_attributes;
-use alloy_genesis::Genesis;
 use reth_chainspec::{ChainSpecBuilder, MAINNET};
-use reth_e2e_test_utils::{
-    node::NodeTestContext, setup, transaction::TransactionTestContext, wallet::Wallet,
-};
-use reth_node_builder::{NodeBuilder, NodeHandle};
-use reth_node_core::{args::RpcServerArgs, node_config::NodeConfig};
+use reth_e2e_test_utils::{setup, transaction::TransactionTestContext};
 use reth_node_ethereum::EthereumNode;
-use reth_tasks::TaskManager;
 use std::sync::Arc;
 
 #[tokio::test]

--- a/crates/ethereum/node/tests/e2e/utils.rs
+++ b/crates/ethereum/node/tests/e2e/utils.rs
@@ -70,7 +70,7 @@ where
                 tx = tx.into_create().with_input(dummy_bytecode.clone());
             } else {
                 tx = tx.with_to(*call_destinations.choose(rng).unwrap()).with_input(
-                    (0..rng.random_range(0..10000)).map(|_| rng.random()).collect::<Vec<u8>>(),
+                    (0..rng.random_range(0..10000)).map(|_| rng.random::<u8>()).collect::<Vec<u8>>()
                 );
             }
 

--- a/crates/fs-util/src/lib.rs
+++ b/crates/fs-util/src/lib.rs
@@ -9,7 +9,7 @@
 use serde::{de::DeserializeOwned, Serialize};
 use std::{
     fs::{self, File, OpenOptions, ReadDir},
-    io::{self, BufWriter, Error, Write},
+    io::{self, BufWriter, Write},
     path::{Path, PathBuf},
 };
 
@@ -338,7 +338,7 @@ where
         Err(err) => {
             // Clean up the temporary file before returning the error
             let _ = fs::remove_file(&tmp_path);
-            return Err(FsPathError::Write { source: Error::other(err.into()), path: tmp_path });
+            return Err(FsPathError::Write { source: io::Error::other(err.into()), path: tmp_path });
         }
     }
 

--- a/crates/rpc/rpc-server-types/src/constants.rs
+++ b/crates/rpc/rpc-server-types/src/constants.rs
@@ -40,7 +40,7 @@ pub const DEFAULT_IPC_ENDPOINT: &str = r"\\.\pipe\reth.ipc";
 #[cfg(not(windows))]
 pub const DEFAULT_IPC_ENDPOINT: &str = "/tmp/reth.ipc";
 
-/// The engine_api IPC endpoint
+/// The `engine_api` IPC endpoint
 #[cfg(windows)]
 pub const DEFAULT_ENGINE_API_IPC_ENDPOINT: &str = r"\\.\pipe\reth_engine_api.ipc";
 

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -397,7 +397,7 @@ impl DatabaseEnv {
             retry: std::ffi::c_int,
         ) -> HandleSlowReadersReturnCode {
             if space > MAX_SAFE_READER_SPACE {
-                let message = if is_current_process(process_id as u32) {
+                let message = if is_current_process(process_id) {
                     "Current process has a long-lived database transaction that grows the database file."
                 } else {
                     "External process has a long-lived database transaction that grows the database file. \


### PR DESCRIPTION
This PR addresses several clippy warnings and removes redundant code across the codebase:
- Unused imports
- Redundant type casts
- Missing const qualifiers
- Documentation formatting issues
- Type inference errors