### PR TITLE
feat(cli): add db account-storage command

### DIFF
--- a/crates/cli/commands/src/db/account_storage.rs
+++ b/crates/cli/commands/src/db/account_storage.rs
@@ -1,0 +1,74 @@
+use alloy_primitives::{keccak256, Address};
+use clap::Parser;
+use human_bytes::human_bytes;
+use reth_codecs::Compact;
+use reth_db_api::{cursor::DbDupCursorRO, database::Database, tables, transaction::DbTx};
+use reth_db_common::DbTool;
+use reth_node_builder::NodeTypesWithDB;
+
+/// The arguments for the `reth db account-storage` command
+#[derive(Parser, Debug)]
+pub struct Command {
+    /// The account address to check storage for
+    address: Address,
+}
+
+impl Command {
+    /// Execute `db account-storage` command
+    pub fn execute<N: NodeTypesWithDB>(self, tool: &DbTool<N>) -> eyre::Result<()> {
+        let (slot_count, plain_size) = tool.provider_factory.db_ref().view(|tx| {
+            let mut cursor = tx.cursor_dup_read::<tables::PlainStorageState>()?;
+            let mut count = 0usize;
+            let mut total_value_bytes = 0usize;
+
+            // Walk all storage entries for this address
+            let walker = cursor.walk_dup(Some(self.address), None)?;
+            for entry in walker {
+                let (_, storage_entry) = entry?;
+                count += 1;
+                // StorageEntry encodes as: 32 bytes (key/subkey uncompressed) + compressed U256
+                let mut buf = Vec::new();
+                let entry_len = storage_entry.to_compact(&mut buf);
+                total_value_bytes += entry_len;
+            }
+
+            // Add 20 bytes for the Address key (stored once per account in dupsort)
+            let total_size = if count > 0 { 20 + total_value_bytes } else { 0 };
+
+            Ok::<_, eyre::Report>((count, total_size))
+        })??;
+
+        // Estimate hashed storage size: 32-byte B256 key instead of 20-byte Address
+        let hashed_size_estimate = if slot_count > 0 { plain_size + 12 } else { 0 };
+        let total_estimate = plain_size + hashed_size_estimate;
+
+        let hashed_address = keccak256(self.address);
+
+        println!("Account: {}", self.address);
+        println!("Hashed address: {hashed_address}");
+        println!("Storage slots: {slot_count}");
+        println!("Plain storage size: {} (estimated)", human_bytes(plain_size as f64));
+        println!("Hashed storage size: {} (estimated)", human_bytes(hashed_size_estimate as f64));
+        println!("Total estimated size: {}", human_bytes(total_estimate as f64));
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_address_arg() {
+        let cmd = Command::try_parse_from([
+            "account-storage",
+            "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+        ])
+        .unwrap();
+        assert_eq!(
+            cmd.address,
+            "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045".parse::<Address>().unwrap()
+        );
+    }
+}

--- a/crates/cli/commands/src/db/mod.rs
+++ b/crates/cli/commands/src/db/mod.rs
@@ -8,6 +8,7 @@ use std::{
     io::{self, Write},
     sync::Arc,
 };
+mod account_storage;
 mod checksum;
 mod clear;
 mod diff;
@@ -61,6 +62,8 @@ pub enum Subcommands {
     Path,
     /// Manage storage settings
     Settings(settings::Command),
+    /// Gets storage size information for an account
+    AccountStorage(account_storage::Command),
 }
 
 /// Initializes a provider factory with specified access rights, and then execute with the provided
@@ -183,6 +186,11 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
             }
             Subcommands::Settings(command) => {
                 db_exec!(self.env, tool, N, command.access_rights(), {
+                    command.execute(&tool)?;
+                });
+            }
+            Subcommands::AccountStorage(command) => {
+                db_exec!(self.env, tool, N, AccessRights::RO, {
                     command.execute(&tool)?;
                 });
             }

--- a/docs/vocs/docs/pages/cli/SUMMARY.mdx
+++ b/docs/vocs/docs/pages/cli/SUMMARY.mdx
@@ -29,6 +29,7 @@
         - [`reth db settings set`](../cli/reth/db/settings/set.mdx)
           - [`reth db settings set receipts_in_static_files`](../cli/reth/db/settings/set/receipts_in_static_files.mdx)
           - [`reth db settings set transaction_senders_in_static_files`](../cli/reth/db/settings/set/transaction_senders_in_static_files.mdx)
+      - [`reth db account-storage`](../cli/reth/db/account-storage.mdx)
     - [`reth download`](../cli/reth/download.mdx)
     - [`reth stage`](../cli/reth/stage.mdx)
       - [`reth stage run`](../cli/reth/stage/run.mdx)

--- a/docs/vocs/docs/pages/cli/reth/db.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db.mdx
@@ -21,6 +21,7 @@ Commands:
   version             Lists current and local database versions
   path                Returns the full database path
   settings            Manage storage settings
+  account-storage     Gets storage size information for an account
   help                Print this message or the help of the given subcommand(s)
 
 Options:

--- a/docs/vocs/docs/pages/cli/reth/db/account-storage.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/account-storage.mdx
@@ -1,0 +1,152 @@
+# reth db account-storage
+
+Gets storage size information for an account
+
+```bash
+$ reth db account-storage --help
+```
+```txt
+Usage: reth db account-storage [OPTIONS] <ADDRESS>
+
+Arguments:
+  <ADDRESS>
+          The account address to check storage for
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
+
+Datadir:
+      --chain <CHAIN_OR_PATH>
+          The chain this node is running.
+          Possible values are either a built-in chain or the path to a chain specification file.
+
+          Built-in chains:
+              mainnet, sepolia, holesky, hoodi, dev
+
+          [default: mainnet]
+
+Logging:
+      --log.stdout.format <FORMAT>
+          The format to use for logs written to stdout
+
+          Possible values:
+          - json:     Represents JSON formatting for logs. This format outputs log records as JSON objects, making it suitable for structured logging
+          - log-fmt:  Represents logfmt (key=value) formatting for logs. This format is concise and human-readable, typically used in command-line applications
+          - terminal: Represents terminal-friendly formatting for logs
+
+          [default: terminal]
+
+      --log.stdout.filter <FILTER>
+          The filter to use for logs written to stdout
+
+          [default: ]
+
+      --log.file.format <FORMAT>
+          The format to use for logs written to the log file
+
+          Possible values:
+          - json:     Represents JSON formatting for logs. This format outputs log records as JSON objects, making it suitable for structured logging
+          - log-fmt:  Represents logfmt (key=value) formatting for logs. This format is concise and human-readable, typically used in command-line applications
+          - terminal: Represents terminal-friendly formatting for logs
+
+          [default: terminal]
+
+      --log.file.filter <FILTER>
+          The filter to use for logs written to the log file
+
+          [default: debug]
+
+      --log.file.directory <PATH>
+          The path to put log files in
+
+          [default: <CACHE_DIR>/logs]
+
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
+      --log.file.max-size <SIZE>
+          The maximum size (in MB) of one log file
+
+          [default: 200]
+
+      --log.file.max-files <COUNT>
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+
+          [default: 5]
+
+      --log.journald
+          Write logs to journald
+
+      --log.journald.filter <FILTER>
+          The filter to use for logs written to journald
+
+          [default: error]
+
+      --color <COLOR>
+          Sets whether or not the formatter emits ANSI terminal escape codes for colors and other text formatting
+
+          Possible values:
+          - always: Colors on
+          - auto:   Auto-detect
+          - never:  Colors off
+
+          [default: always]
+
+Display:
+  -v, --verbosity...
+          Set the minimum log level.
+
+          -v      Errors
+          -vv     Warnings
+          -vvv    Info
+          -vvvv   Debug
+          -vvvvv  Traces (warning: very verbose!)
+
+  -q, --quiet
+          Silence all log output
+
+Tracing:
+      --tracing-otlp[=<URL>]
+          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/traces` - gRPC: `http://localhost:4317`
+
+          Example: --tracing-otlp=http://collector:4318/v1/traces
+
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
+
+      --tracing-otlp-protocol <PROTOCOL>
+          OTLP transport protocol to use for exporting traces.
+
+          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+
+          Defaults to HTTP if not specified.
+
+          Possible values:
+          - http: HTTP/Protobuf transport, port 4318, requires `/v1/traces` path
+          - grpc: gRPC transport, port 4317
+
+          [env: OTEL_EXPORTER_OTLP_PROTOCOL=]
+          [default: http]
+
+      --tracing-otlp.filter <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
+
+          Defaults to TRACE if not specified.
+
+          [default: debug]
+
+      --tracing-otlp.sample-ratio <RATIO>
+          Trace sampling ratio to control the percentage of traces to export.
+
+          Valid range: 0.0 to 1.0 - 1.0, default: Sample all traces - 0.01: Sample 1% of traces - 0.0: Disable sampling
+
+          Example: --tracing-otlp.sample-ratio=0.0.
+
+          [env: OTEL_TRACES_SAMPLER_ARG=]
+```


### PR DESCRIPTION
Adds a new db subcommand that reports storage slot count and estimated byte sizes for a given account address.

```
reth db account-storage 0xffcbf84650ce02dafe96926b37a0ac5e34932fa5
```

This will give an overview of the number of slots and the estimated space the plain + hashed state take up in the DB.