### PR TITLE
docs(cli): enhance documentation for memory block buffer target configuration

### DIFF
--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -22,6 +22,11 @@ pub struct EngineArgs {
     pub persistence_threshold: u64,
 
     /// Configure the target number of blocks to keep in memory.
+    ///
+    /// This represents the number of most recent blocks to keep in memory for quick access and reorgs.
+    ///
+    /// This target is maintained after flushing canonical blocks to disk (controlled by
+    /// --engine.persistence-threshold).
     #[arg(long = "engine.memory-block-buffer-target", default_value_t = DEFAULT_MEMORY_BLOCK_BUFFER_TARGET)]
     pub memory_block_buffer_target: u64,
 

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -880,6 +880,10 @@ Engine:
       --engine.memory-block-buffer-target <MEMORY_BLOCK_BUFFER_TARGET>
           Configure the target number of blocks to keep in memory
 
+          This represents the number of most recent blocks to keep in memory for quick access and reorgs.
+
+          This target is maintained after flushing canonical blocks to disk (controlled by --engine.persistence-threshold).
+
           [default: 0]
 
       --engine.legacy-state-root


### PR DESCRIPTION
closes #19946 

Updated the documentation for the `--memory-block-buffer-target` flag.