### PR TITLE
feat: `PoolTransaction::requres_nonce_check`

### DIFF
--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -1215,6 +1215,11 @@ pub trait PoolTransaction:
             Ok(())
         }
     }
+
+    /// Allows to communicate to the pool that the transaction doesn't require a nonce check.
+    fn requires_nonce_check(&self) -> bool {
+        true
+    }
 }
 
 /// Super trait for transactions that can be converted to and from Eth transactions intended for the

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -531,7 +531,9 @@ where
         };
 
         // Checks for nonce
-        if let Err(err) = self.validate_sender_nonce(&transaction, &account) {
+        if transaction.requires_nonce_check() &&
+            let Err(err) = self.validate_sender_nonce(&transaction, &account)
+        {
             return TransactionValidationOutcome::Invalid(transaction, err)
         }
 


### PR DESCRIPTION
Allows pool transactions to communicate if they want nonce check to be skipped