### PR TITLE
chore: avoid redundant factory construction in witness/proof overlay init

### DIFF
--- a/crates/trie/db/src/proof.rs
+++ b/crates/trie/db/src/proof.rs
@@ -119,13 +119,13 @@ impl<'a, TX: DbTx> DatabaseStorageProof<'a, TX>
             Default::default(),
             HashMap::from_iter([(hashed_address, storage.into_sorted())]),
         );
-        Self::from_tx(tx, address)
-            .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(
-                DatabaseHashedCursorFactory::new(tx),
-                &state_sorted,
-            ))
-            .with_prefix_set_mut(prefix_set)
-            .storage_proof(slot)
+        StorageProof::new(
+            DatabaseTrieCursorFactory::new(tx),
+            HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(tx), &state_sorted),
+            address,
+        )
+        .with_prefix_set_mut(prefix_set)
+        .storage_proof(slot)
     }
 
     fn overlay_storage_multiproof(
@@ -141,12 +141,12 @@ impl<'a, TX: DbTx> DatabaseStorageProof<'a, TX>
             Default::default(),
             HashMap::from_iter([(hashed_address, storage.into_sorted())]),
         );
-        Self::from_tx(tx, address)
-            .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(
-                DatabaseHashedCursorFactory::new(tx),
-                &state_sorted,
-            ))
-            .with_prefix_set_mut(prefix_set)
-            .storage_multiproof(targets)
+        StorageProof::new(
+            DatabaseTrieCursorFactory::new(tx),
+            HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(tx), &state_sorted),
+            address,
+        )
+        .with_prefix_set_mut(prefix_set)
+        .storage_multiproof(targets)
     }
 }

--- a/crates/trie/db/src/witness.rs
+++ b/crates/trie/db/src/witness.rs
@@ -34,17 +34,12 @@ impl<'a, TX: DbTx> DatabaseTrieWitness<'a, TX>
     ) -> Result<B256Map<Bytes>, TrieWitnessError> {
         let nodes_sorted = input.nodes.into_sorted();
         let state_sorted = input.state.into_sorted();
-        Self::from_tx(tx)
-            .with_trie_cursor_factory(InMemoryTrieCursorFactory::new(
-                DatabaseTrieCursorFactory::new(tx),
-                &nodes_sorted,
-            ))
-            .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(
-                DatabaseHashedCursorFactory::new(tx),
-                &state_sorted,
-            ))
-            .with_prefix_sets_mut(input.prefix_sets)
-            .always_include_root_node()
-            .compute(target)
+        TrieWitness::new(
+            InMemoryTrieCursorFactory::new(DatabaseTrieCursorFactory::new(tx), &nodes_sorted),
+            HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(tx), &state_sorted),
+        )
+        .with_prefix_sets_mut(input.prefix_sets)
+        .always_include_root_node()
+        .compute(target)
     }
 }


### PR DESCRIPTION
Refactor TrieWitness::overlay_witness and DatabaseStorageProof overlay methods to initialize directly with InMemoryTrieCursorFactory and HashedPostStateCursorFactory instead of creating base factories and immediately replacing them, eliminating redundant instantiations without changing behavior; this mirrors the established pattern used in Proof overlay paths, maintains lifetime and API correctness, and slightly reduces overhead while improving consistency across trie db integration code