### PR TITLE
fix: better `RpcConvert` bounds

### DIFF
--- a/crates/optimism/rpc/src/eth/mod.rs
+++ b/crates/optimism/rpc/src/eth/mod.rs
@@ -188,7 +188,7 @@ impl<N: RpcNodeCore, Rpc: RpcConvert> OpEthApi<N, Rpc> {
 impl<N, Rpc> EthApiTypes for OpEthApi<N, Rpc>
 where
     N: RpcNodeCore,
-    Rpc: RpcConvert<Primitives = N::Primitives>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError>,
 {
     type Error = OpEthApiError;
     type NetworkTypes = Rpc::Network;
@@ -245,7 +245,7 @@ where
 impl<N, Rpc> EthApiSpec for OpEthApi<N, Rpc>
 where
     N: RpcNodeCore,
-    Rpc: RpcConvert<Primitives = N::Primitives>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError>,
 {
     #[inline]
     fn starting_block(&self) -> U256 {
@@ -256,7 +256,7 @@ where
 impl<N, Rpc> SpawnBlocking for OpEthApi<N, Rpc>
 where
     N: RpcNodeCore,
-    Rpc: RpcConvert<Primitives = N::Primitives>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError>,
 {
     #[inline]
     fn io_task_spawner(&self) -> impl TaskSpawner {
@@ -311,7 +311,7 @@ where
 impl<N, Rpc> EthState for OpEthApi<N, Rpc>
 where
     N: RpcNodeCore,
-    Rpc: RpcConvert<Primitives = N::Primitives>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError>,
     Self: LoadPendingBlock,
 {
     #[inline]

--- a/crates/optimism/rpc/src/eth/pending_block.rs
+++ b/crates/optimism/rpc/src/eth/pending_block.rs
@@ -18,7 +18,7 @@ impl<N, Rpc> LoadPendingBlock for OpEthApi<N, Rpc>
 where
     N: RpcNodeCore,
     OpEthApiError: FromEvmError<N::Evm>,
-    Rpc: RpcConvert<Primitives = N::Primitives>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError>,
 {
     #[inline]
     fn pending_block(&self) -> &tokio::sync::Mutex<Option<PendingBlock<N::Primitives>>> {

--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -551,7 +551,8 @@ where
         Ok(EthTransactions::transaction_by_hash(self, hash)
             .await?
             .map(|tx| tx.into_transaction(self.tx_resp_builder()))
-            .transpose()?)
+            .transpose()
+            .map_err(T::Error::from)?)
     }
 
     /// Handler for: `eth_getRawTransactionByBlockHashAndIndex`

--- a/crates/rpc/rpc-eth-api/src/helpers/block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/block.rs
@@ -30,9 +30,7 @@ pub type BlockAndReceiptsResult<Eth> = Result<
 
 /// Block related functions for the [`EthApiServer`](crate::EthApiServer) trait in the
 /// `eth_` namespace.
-pub trait EthBlocks:
-    LoadBlock<RpcConvert: RpcConvert<Primitives = Self::Primitives, Error = Self::Error>>
-{
+pub trait EthBlocks: LoadBlock<RpcConvert: RpcConvert<Primitives = Self::Primitives>> {
     /// Returns the block header for the given block id.
     fn rpc_block_header(
         &self,
@@ -156,10 +154,10 @@ pub trait EthBlocks:
                     })
                     .collect::<Vec<_>>();
 
-                return self
+                return Ok(self
                     .tx_resp_builder()
                     .convert_receipts_with_block(inputs, block.sealed_block())
-                    .map(Some)
+                    .map(Some)?)
             }
 
             Ok(None)

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -188,7 +188,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
 
                     parent = result.block.clone_sealed_header();
 
-                    let block = simulate::build_simulated_block(
+                    let block = simulate::build_simulated_block::<Self::Error, _>(
                         result.block,
                         results,
                         return_full_transactions.into(),

--- a/crates/rpc/rpc-eth-api/src/helpers/receipt.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/receipt.rs
@@ -15,16 +15,7 @@ use reth_storage_api::{ProviderReceipt, ProviderTx};
 ///
 /// Behaviour shared by several `eth_` RPC methods, not exclusive to `eth_` receipts RPC methods.
 pub trait LoadReceipt:
-    EthApiTypes<
-        RpcConvert: RpcConvert<
-            Primitives = Self::Primitives,
-            Error = Self::Error,
-            Network = Self::NetworkTypes,
-        >,
-        Error: FromEthApiError,
-    > + RpcNodeCoreExt
-    + Send
-    + Sync
+    EthApiTypes<RpcConvert: RpcConvert<Primitives = Self::Primitives>> + RpcNodeCoreExt + Send + Sync
 {
     /// Helper method for `eth_getBlockReceipts` and `eth_getTransactionReceipt`.
     fn build_transaction_receipt(

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -364,7 +364,9 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
                                 base_fee: base_fee_per_gas,
                                 index: Some(index as u64),
                             };
-                            self.tx_resp_builder().fill(tx.clone().with_signer(*signer), tx_info)
+                            Ok(self
+                                .tx_resp_builder()
+                                .fill(tx.clone().with_signer(*signer), tx_info)?)
                         })
                 })
                 .ok_or(EthApiError::HeaderNotFound(block_id))?

--- a/crates/rpc/rpc-eth-api/src/types.rs
+++ b/crates/rpc/rpc-eth-api/src/types.rs
@@ -53,11 +53,7 @@ where
             NetworkTypes: RpcTypes<
                 TransactionRequest: SignableTxRequest<ProviderTx<Self::Provider>>,
             >,
-            RpcConvert: RpcConvert<
-                Primitives = Self::Primitives,
-                Network = Self::NetworkTypes,
-                Error = RpcError<Self>,
-            >,
+            RpcConvert: RpcConvert<Primitives = Self::Primitives>,
         >,
 {
 }
@@ -68,11 +64,7 @@ impl<T> FullEthApiTypes for T where
             NetworkTypes: RpcTypes<
                 TransactionRequest: SignableTxRequest<ProviderTx<Self::Provider>>,
             >,
-            RpcConvert: RpcConvert<
-                Primitives = <Self as RpcNodeCore>::Primitives,
-                Network = Self::NetworkTypes,
-                Error = RpcError<T>,
-            >,
+            RpcConvert: RpcConvert<Primitives = Self::Primitives>,
         >
 {
 }

--- a/crates/rpc/rpc-eth-api/src/types.rs
+++ b/crates/rpc/rpc-eth-api/src/types.rs
@@ -5,10 +5,7 @@ use alloy_rpc_types_eth::Block;
 use reth_rpc_convert::{RpcConvert, SignableTxRequest};
 pub use reth_rpc_convert::{RpcTransaction, RpcTxReq, RpcTypes};
 use reth_storage_api::ProviderTx;
-use std::{
-    error::Error,
-    fmt::{self},
-};
+use std::error::Error;
 
 /// Network specific `eth` API types.
 ///
@@ -23,13 +20,14 @@ pub trait EthApiTypes: Send + Sync + Clone {
     type Error: Into<jsonrpsee_types::error::ErrorObject<'static>>
         + FromEthApiError
         + AsEthApiError
+        + From<<Self::RpcConvert as RpcConvert>::Error>
         + Error
         + Send
         + Sync;
     /// Blockchain primitive types, specific to network, e.g. block and transaction.
     type NetworkTypes: RpcTypes;
     /// Conversion methods for transaction RPC type.
-    type RpcConvert: Send + Sync + fmt::Debug;
+    type RpcConvert: RpcConvert<Network = Self::NetworkTypes>;
 
     /// Returns reference to transaction response builder.
     fn tx_resp_builder(&self) -> &Self::RpcConvert;

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -184,7 +184,7 @@ where
 impl<N, Rpc> EthApiTypes for EthApi<N, Rpc>
 where
     N: RpcNodeCore,
-    Rpc: RpcConvert,
+    Rpc: RpcConvert<Error = EthApiError>,
 {
     type Error = EthApiError;
     type NetworkTypes = Rpc::Network;
@@ -247,7 +247,7 @@ where
 impl<N, Rpc> SpawnBlocking for EthApi<N, Rpc>
 where
     N: RpcNodeCore,
-    Rpc: RpcConvert,
+    Rpc: RpcConvert<Error = EthApiError>,
 {
     #[inline]
     fn io_task_spawner(&self) -> impl TaskSpawner {

--- a/crates/rpc/rpc/src/eth/helpers/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/pending_block.rs
@@ -12,7 +12,7 @@ impl<N, Rpc> LoadPendingBlock for EthApi<N, Rpc>
 where
     N: RpcNodeCore,
     EthApiError: FromEvmError<N::Evm>,
-    Rpc: RpcConvert<Primitives = N::Primitives>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError>,
 {
     #[inline]
     fn pending_block(&self) -> &tokio::sync::Mutex<Option<PendingBlock<Self::Primitives>>> {

--- a/crates/rpc/rpc/src/eth/helpers/spec.rs
+++ b/crates/rpc/rpc/src/eth/helpers/spec.rs
@@ -1,13 +1,14 @@
 use alloy_primitives::U256;
 use reth_rpc_convert::RpcConvert;
 use reth_rpc_eth_api::{helpers::EthApiSpec, RpcNodeCore};
+use reth_rpc_eth_types::EthApiError;
 
 use crate::EthApi;
 
 impl<N, Rpc> EthApiSpec for EthApi<N, Rpc>
 where
     N: RpcNodeCore,
-    Rpc: RpcConvert<Primitives = N::Primitives>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError>,
 {
     fn starting_block(&self) -> U256 {
         self.inner.starting_block()

--- a/crates/rpc/rpc/src/eth/helpers/state.rs
+++ b/crates/rpc/rpc/src/eth/helpers/state.rs
@@ -6,11 +6,12 @@ use reth_rpc_eth_api::{
     helpers::{EthState, LoadPendingBlock, LoadState},
     RpcNodeCore,
 };
+use reth_rpc_eth_types::EthApiError;
 
 impl<N, Rpc> EthState for EthApi<N, Rpc>
 where
     N: RpcNodeCore,
-    Rpc: RpcConvert<Primitives = N::Primitives>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError>,
     Self: LoadPendingBlock,
 {
     fn max_proof_window(&self) -> u64 {


### PR DESCRIPTION
removes the requirement of `Self::Error = RpcConvert::Error` on RPC side