### PR TITLE
fix(era-utils): validate export range and error on post-clamp invalid ranges

### DIFF
--- a/crates/era-utils/src/export.rs
+++ b/crates/era-utils/src/export.rs
@@ -76,6 +76,14 @@ impl ExportConfig {
             return Err(eyre!("Max blocks per file cannot be zero"));
         }
 
+        if self.first_block_number > self.last_block_number {
+            return Err(eyre!(
+                "First block ({}) must be less than or equal to last block ({})",
+                self.first_block_number,
+                self.last_block_number
+            ));
+        }
+
         Ok(())
     }
 }
@@ -96,6 +104,14 @@ where
     // Determine the actual last block to export
     // best_block_number() might be outdated, so check actual block availability
     let last_block_number = determine_export_range(provider, config)?;
+
+    if config.first_block_number > last_block_number {
+        return Err(eyre!(
+            "First block ({}) is greater than the highest available block ({}) after clamping to head. Reduce --first-block-number or sync further.",
+            config.first_block_number,
+            last_block_number
+        ));
+    }
 
     info!(
         target: "era::history::export",


### PR DESCRIPTION
This change addresses a UX issue in export-era where an invalid range could lead to a silent no-op. Previously, 
ExportConfig::validate() did not check that first_block_number <= last_block_number, and after clamping the last block to the chain head in export(), the effective range could still become invalid, resulting in no files being produced while the command reported success. We now validate the range in two places: in ExportConfig::validate() to catch obvious misconfiguration early, and in export() immediately after clamping to ensure the effective range remains valid. If the first block exceeds the effective last block, we return a clear error suggesting to lower --first-block-number or sync further. This aligns the behavior with other CLI tools that enforce range correctness (e.g., dump-stage), prevents user confusion, retains support for single-block exports (first == last), and keeps defaults intact.