### PR TITLE
feat(persistence): batch write hashed_state

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -339,10 +339,8 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
             // Must be written after blocks because of the receipt lookup.
             self.write_state(&execution_output, OriginalValuesKnown::No)?;
 
-            // insert hashes and intermediate merkle nodes
-            self.write_hashed_state(&trie_data.hashed_state)?;
             // aggregate hashed post states for batch insert
-            aggregated_hashed_post_state_sorted.extend_ref(&hashed_state);
+            aggregated_hashed_post_state_sorted.extend_ref(&trie_data.hashed_state);
 
             self.write_trie_changesets(block_number, &trie_data.trie_updates, None)?;
             self.write_trie_updates_sorted(&trie_data.trie_updates)?;

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -318,6 +318,8 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
 
         debug!(target: "providers::db", block_count = %blocks.len(), "Writing blocks and execution data to storage");
 
+        let mut aggregated_hashed_post_state_sorted = HashedPostStateSorted::default();
+
         // TODO: Do performant / batched writes for each type of object
         // instead of a loop over all blocks,
         // meaning:
@@ -339,10 +341,15 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
 
             // insert hashes and intermediate merkle nodes
             self.write_hashed_state(&trie_data.hashed_state)?;
+            // aggregate hashed post states for batch insert
+            aggregated_hashed_post_state_sorted.extend_ref(&hashed_state);
 
             self.write_trie_changesets(block_number, &trie_data.trie_updates, None)?;
             self.write_trie_updates_sorted(&trie_data.trie_updates)?;
         }
+
+        // batch insert hash post states
+        self.write_hashed_state(&aggregated_hashed_post_state_sorted)?;
 
         // update history indices
         self.update_history_indices(first_number..=last_block_number)?;
@@ -1725,7 +1732,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
     ) -> ProviderResult<()> {
         // Write storage changes
         tracing::trace!("Writing storage changes");
-        let mut storages_cursor = self.tx_ref().cursor_dup_write::<tables::PlainStorageState>()?;
+        let mut storages_cursor = self.tx_ref().cursor_dup_read::<tables::PlainStorageState>()?;
         let mut storage_changeset_cursor =
             self.tx_ref().cursor_dup_write::<tables::StorageChangeSets>()?;
         for (block_index, mut storage_changes) in reverts.storage.into_iter().enumerate() {

--- a/crates/trie/common/src/utils.rs
+++ b/crates/trie/common/src/utils.rs
@@ -89,3 +89,111 @@ mod tests {
         assert_eq!(target, vec![(1, "a"), (2, "b"), (3, "c_new")]);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extend_sorted_vec_empty_other() {
+        let mut target = vec![(1, "a"), (2, "b"), (3, "c")];
+        let other: Vec<(i32, &str)> = vec![];
+        extend_sorted_vec(&mut target, &other);
+        assert_eq!(target, vec![(1, "a"), (2, "b"), (3, "c")]);
+    }
+
+    #[test]
+    fn test_extend_sorted_vec_empty_target() {
+        let mut target: Vec<(i32, &str)> = vec![];
+        let other = vec![(1, "a"), (2, "b"), (3, "c")];
+        extend_sorted_vec(&mut target, &other);
+        assert_eq!(target, vec![(1, "a"), (2, "b"), (3, "c")]);
+    }
+
+    #[test]
+    fn test_extend_sorted_vec_no_overlap() {
+        let mut target = vec![(1, "a"), (3, "c"), (5, "e")];
+        let other = vec![(2, "b"), (4, "d"), (6, "f")];
+        extend_sorted_vec(&mut target, &other);
+        assert_eq!(target, vec![(1, "a"), (2, "b"), (3, "c"), (4, "d"), (5, "e"), (6, "f")]);
+    }
+
+    #[test]
+    fn test_extend_sorted_vec_with_duplicates_other_precedence() {
+        let mut target = vec![(1, "a"), (2, "target"), (3, "c")];
+        let other = vec![(2, "other"), (4, "d")];
+        extend_sorted_vec(&mut target, &other);
+        // other's value should take precedence for key 2
+        assert_eq!(target, vec![(1, "a"), (2, "other"), (3, "c"), (4, "d")]);
+    }
+
+    #[test]
+    fn test_extend_sorted_vec_all_other_before_target() {
+        let mut target = vec![(5, "e"), (6, "f")];
+        let other = vec![(1, "a"), (2, "b"), (3, "c")];
+        extend_sorted_vec(&mut target, &other);
+        assert_eq!(target, vec![(1, "a"), (2, "b"), (3, "c"), (5, "e"), (6, "f")]);
+    }
+
+    #[test]
+    fn test_extend_sorted_vec_all_other_after_target() {
+        let mut target = vec![(1, "a"), (2, "b")];
+        let other = vec![(5, "e"), (6, "f"), (7, "g")];
+        extend_sorted_vec(&mut target, &other);
+        assert_eq!(target, vec![(1, "a"), (2, "b"), (5, "e"), (6, "f"), (7, "g")]);
+    }
+
+    #[test]
+    fn test_extend_sorted_vec_interleaved() {
+        let mut target = vec![(1, "a"), (3, "c"), (5, "e"), (7, "g")];
+        let other = vec![(2, "b"), (4, "d"), (6, "f")];
+        extend_sorted_vec(&mut target, &other);
+        assert_eq!(
+            target,
+            vec![(1, "a"), (2, "b"), (3, "c"), (4, "d"), (5, "e"), (6, "f"), (7, "g")]
+        );
+    }
+
+    #[test]
+    fn test_extend_sorted_vec_multiple_duplicates() {
+        let mut target = vec![(1, "target1"), (2, "target2"), (3, "target3")];
+        let other = vec![(1, "other1"), (2, "other2"), (3, "other3")];
+        extend_sorted_vec(&mut target, &other);
+        // All other values should take precedence
+        assert_eq!(target, vec![(1, "other1"), (2, "other2"), (3, "other3")]);
+    }
+
+    #[test]
+    fn test_extend_sorted_vec_single_element_each() {
+        let mut target = vec![(5, "target")];
+        let other = vec![(3, "other")];
+        extend_sorted_vec(&mut target, &other);
+        assert_eq!(target, vec![(3, "other"), (5, "target")]);
+    }
+
+    #[test]
+    fn test_extend_sorted_vec_same_key_different_values() {
+        let mut target = vec![(1, "original")];
+        let other = vec![(1, "override")];
+        extend_sorted_vec(&mut target, &other);
+        assert_eq!(target, vec![(1, "override")]);
+    }
+
+    #[test]
+    fn test_extend_sorted_vec_large_merge() {
+        let mut target: Vec<(i32, i32)> = (0..100).step_by(2).map(|i| (i, i)).collect();
+        let other: Vec<(i32, i32)> = (1..100).step_by(2).map(|i| (i, i * 10)).collect();
+        extend_sorted_vec(&mut target, &other);
+
+        // Verify sorted order
+        for i in 0..(target.len() - 1) {
+            assert!(target[i].0 < target[i + 1].0);
+        }
+
+        // Verify all keys are present
+        assert_eq!(target.len(), 100);
+
+        // Verify other values took precedence for odd numbers
+        assert_eq!(target[1].1, 10); // key 1 should have value 10 from other
+    }
+}

--- a/crates/trie/common/src/utils.rs
+++ b/crates/trie/common/src/utils.rs
@@ -5,11 +5,10 @@ use core::cmp::Ordering;
 /// Values from `other` take precedence for duplicate keys.
 ///
 /// This function efficiently merges two sorted vectors by:
-/// 1. Iterating through the target vector with mutable references
-/// 2. Using a peekable iterator for the other vector
-/// 3. For each target item, processing other items that come before or equal to it
-/// 4. Collecting items from other that need to be inserted
-/// 5. Appending and re-sorting only if new items were added
+/// 1. Using peekable iterators for both vectors to compare without consuming
+/// 2. Merging in one pass (O(n+m)) by always choosing the smaller element
+/// 3. Building the result in a pre-allocated vector
+/// 4. Replacing target with the merged result
 pub(crate) fn extend_sorted_vec<K, V>(target: &mut Vec<(K, V)>, other: &[(K, V)])
 where
     K: Clone + Ord,
@@ -19,8 +18,9 @@ where
         return;
     }
 
+    let mut result = Vec::with_capacity(target.len() + other.len());
+    let mut target_iter = target.iter().peekable();
     let mut other_iter = other.iter().peekable();
-    let mut to_insert = Vec::new();
 
     // Iterate through target and update/collect items from other
     for target_item in target.iter_mut() {
@@ -39,17 +39,42 @@ where
                     // Other item comes after current target item, keep target unchanged
                     break;
                 }
+    loop {
+        match (target_iter.peek(), other_iter.peek()) {
+            (Some(target_item), Some(other_item)) => {
+                use core::cmp::Ordering;
+                match other_item.0.cmp(&target_item.0) {
+                    Ordering::Less => {
+                        result.push(other_iter.next().unwrap().clone());
+                    }
+                    Ordering::Equal => {
+                        // duplicate key, use other's value (takes precedence)
+                        result.push(other_iter.next().unwrap().clone());
+                        target_iter.next();
+                    }
+                    Ordering::Greater => {
+                        result.push(target_iter.next().unwrap().clone());
+                    }
+                }
+            }
+            (Some(_), None) => {
+                // Only target items remaining
+                result.extend(target_iter.cloned());
+                break;
+            }
+            (None, Some(_)) => {
+                // Only other items remaining
+                result.extend(other_iter.cloned());
+                break;
+            }
+            (None, None) => {
+                // Both exhausted
+                break;
             }
         }
     }
 
-    // Append collected new items, as well as any remaining from `other` which are necessarily also
-    // new, and sort if needed
-    if !to_insert.is_empty() || other_iter.peek().is_some() {
-        target.extend(to_insert);
-        target.extend(other_iter.cloned());
-        target.sort_unstable_by(|a, b| a.0.cmp(&b.0));
-    }
+    *target = result;
 }
 
 #[cfg(test)]

--- a/crates/trie/common/src/utils.rs
+++ b/crates/trie/common/src/utils.rs
@@ -5,10 +5,11 @@ use core::cmp::Ordering;
 /// Values from `other` take precedence for duplicate keys.
 ///
 /// This function efficiently merges two sorted vectors by:
-/// 1. Using peekable iterators for both vectors to compare without consuming
-/// 2. Merging in one pass (O(n+m)) by always choosing the smaller element
-/// 3. Building the result in a pre-allocated vector
-/// 4. Replacing target with the merged result
+/// 1. Iterating through the target vector with mutable references
+/// 2. Using a peekable iterator for the other vector
+/// 3. For each target item, processing other items that come before or equal to it
+/// 4. Collecting items from other that need to be inserted
+/// 5. Appending and re-sorting only if new items were added
 pub(crate) fn extend_sorted_vec<K, V>(target: &mut Vec<(K, V)>, other: &[(K, V)])
 where
     K: Clone + Ord,
@@ -18,9 +19,8 @@ where
         return;
     }
 
-    let mut result = Vec::with_capacity(target.len() + other.len());
-    let mut target_iter = target.iter().peekable();
     let mut other_iter = other.iter().peekable();
+    let mut to_insert = Vec::new();
 
     // Iterate through target and update/collect items from other
     for target_item in target.iter_mut() {
@@ -39,42 +39,17 @@ where
                     // Other item comes after current target item, keep target unchanged
                     break;
                 }
-    loop {
-        match (target_iter.peek(), other_iter.peek()) {
-            (Some(target_item), Some(other_item)) => {
-                use core::cmp::Ordering;
-                match other_item.0.cmp(&target_item.0) {
-                    Ordering::Less => {
-                        result.push(other_iter.next().unwrap().clone());
-                    }
-                    Ordering::Equal => {
-                        // duplicate key, use other's value (takes precedence)
-                        result.push(other_iter.next().unwrap().clone());
-                        target_iter.next();
-                    }
-                    Ordering::Greater => {
-                        result.push(target_iter.next().unwrap().clone());
-                    }
-                }
-            }
-            (Some(_), None) => {
-                // Only target items remaining
-                result.extend(target_iter.cloned());
-                break;
-            }
-            (None, Some(_)) => {
-                // Only other items remaining
-                result.extend(other_iter.cloned());
-                break;
-            }
-            (None, None) => {
-                // Both exhausted
-                break;
             }
         }
     }
 
-    *target = result;
+    // Append collected new items, as well as any remaining from `other` which are necessarily also
+    // new, and sort if needed
+    if !to_insert.is_empty() || other_iter.peek().is_some() {
+        target.extend(to_insert);
+        target.extend(other_iter.cloned());
+        target.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+    }
 }
 
 #[cfg(test)]
@@ -87,113 +62,5 @@ mod tests {
         let other = vec![(2, "b"), (3, "c_new")];
         extend_sorted_vec(&mut target, &other);
         assert_eq!(target, vec![(1, "a"), (2, "b"), (3, "c_new")]);
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_extend_sorted_vec_empty_other() {
-        let mut target = vec![(1, "a"), (2, "b"), (3, "c")];
-        let other: Vec<(i32, &str)> = vec![];
-        extend_sorted_vec(&mut target, &other);
-        assert_eq!(target, vec![(1, "a"), (2, "b"), (3, "c")]);
-    }
-
-    #[test]
-    fn test_extend_sorted_vec_empty_target() {
-        let mut target: Vec<(i32, &str)> = vec![];
-        let other = vec![(1, "a"), (2, "b"), (3, "c")];
-        extend_sorted_vec(&mut target, &other);
-        assert_eq!(target, vec![(1, "a"), (2, "b"), (3, "c")]);
-    }
-
-    #[test]
-    fn test_extend_sorted_vec_no_overlap() {
-        let mut target = vec![(1, "a"), (3, "c"), (5, "e")];
-        let other = vec![(2, "b"), (4, "d"), (6, "f")];
-        extend_sorted_vec(&mut target, &other);
-        assert_eq!(target, vec![(1, "a"), (2, "b"), (3, "c"), (4, "d"), (5, "e"), (6, "f")]);
-    }
-
-    #[test]
-    fn test_extend_sorted_vec_with_duplicates_other_precedence() {
-        let mut target = vec![(1, "a"), (2, "target"), (3, "c")];
-        let other = vec![(2, "other"), (4, "d")];
-        extend_sorted_vec(&mut target, &other);
-        // other's value should take precedence for key 2
-        assert_eq!(target, vec![(1, "a"), (2, "other"), (3, "c"), (4, "d")]);
-    }
-
-    #[test]
-    fn test_extend_sorted_vec_all_other_before_target() {
-        let mut target = vec![(5, "e"), (6, "f")];
-        let other = vec![(1, "a"), (2, "b"), (3, "c")];
-        extend_sorted_vec(&mut target, &other);
-        assert_eq!(target, vec![(1, "a"), (2, "b"), (3, "c"), (5, "e"), (6, "f")]);
-    }
-
-    #[test]
-    fn test_extend_sorted_vec_all_other_after_target() {
-        let mut target = vec![(1, "a"), (2, "b")];
-        let other = vec![(5, "e"), (6, "f"), (7, "g")];
-        extend_sorted_vec(&mut target, &other);
-        assert_eq!(target, vec![(1, "a"), (2, "b"), (5, "e"), (6, "f"), (7, "g")]);
-    }
-
-    #[test]
-    fn test_extend_sorted_vec_interleaved() {
-        let mut target = vec![(1, "a"), (3, "c"), (5, "e"), (7, "g")];
-        let other = vec![(2, "b"), (4, "d"), (6, "f")];
-        extend_sorted_vec(&mut target, &other);
-        assert_eq!(
-            target,
-            vec![(1, "a"), (2, "b"), (3, "c"), (4, "d"), (5, "e"), (6, "f"), (7, "g")]
-        );
-    }
-
-    #[test]
-    fn test_extend_sorted_vec_multiple_duplicates() {
-        let mut target = vec![(1, "target1"), (2, "target2"), (3, "target3")];
-        let other = vec![(1, "other1"), (2, "other2"), (3, "other3")];
-        extend_sorted_vec(&mut target, &other);
-        // All other values should take precedence
-        assert_eq!(target, vec![(1, "other1"), (2, "other2"), (3, "other3")]);
-    }
-
-    #[test]
-    fn test_extend_sorted_vec_single_element_each() {
-        let mut target = vec![(5, "target")];
-        let other = vec![(3, "other")];
-        extend_sorted_vec(&mut target, &other);
-        assert_eq!(target, vec![(3, "other"), (5, "target")]);
-    }
-
-    #[test]
-    fn test_extend_sorted_vec_same_key_different_values() {
-        let mut target = vec![(1, "original")];
-        let other = vec![(1, "override")];
-        extend_sorted_vec(&mut target, &other);
-        assert_eq!(target, vec![(1, "override")]);
-    }
-
-    #[test]
-    fn test_extend_sorted_vec_large_merge() {
-        let mut target: Vec<(i32, i32)> = (0..100).step_by(2).map(|i| (i, i)).collect();
-        let other: Vec<(i32, i32)> = (1..100).step_by(2).map(|i| (i, i * 10)).collect();
-        extend_sorted_vec(&mut target, &other);
-
-        // Verify sorted order
-        for i in 0..(target.len() - 1) {
-            assert!(target[i].0 < target[i + 1].0);
-        }
-
-        // Verify all keys are present
-        assert_eq!(target.len(), 100);
-
-        // Verify other values took precedence for odd numbers
-        assert_eq!(target[1].1, 10); // key 1 should have value 10 from other
     }
 }


### PR DESCRIPTION
As discussed https://github.com/paradigmxyz/reth/pull/19739#issuecomment-3563008832
Batch write of `hashed_state` is safe, so I created this PR to cherry-pick old reverted commit

### Changes
- batch write hashed_state

*Note: The after result here is after we improve extend_sorted_vec, which is upcoming PR


### before

#### erc20 transfers spam: ~100ms

<img width="1650" height="927" alt="image" src="https://github.com/user-attachments/assets/514d5f99-d480-4ab8-adf9-e0872219fd80" />

#### native transfers spam: ~50ms

<img width="1644" height="449" alt="image" src="https://github.com/user-attachments/assets/fe90eb18-6915-4396-9fd9-06143e2ae2cb" />


### after

#### erc20 transfers spam: ~80ms

<img width="1640" height="434" alt="image" src="https://github.com/user-attachments/assets/db440656-8dd4-41f5-a423-f72afcb2925c" />

#### native transfers spam: ~30ms

<img width="1674" height="909" alt="image" src="https://github.com/user-attachments/assets/10906deb-74be-455e-9156-928684022d79" />