### PR TITLE
fix(mev): correct refund calculation in sim_bundle

### DIFF
--- a/crates/rpc/rpc/src/eth/sim_bundle.rs
+++ b/crates/rpc/rpc/src/eth/sim_bundle.rs
@@ -340,6 +340,8 @@ where
                 }
 
                 // After processing all transactions, process refunds
+                // Store the original refundable value to calculate all payouts correctly
+                let original_refundable_value = refundable_value;
                 for item in &flattened_bundle {
                     if let Some(refund_percent) = item.refund_percent {
                         // Get refund configurations
@@ -355,9 +357,11 @@ where
                         // Add gas used for payout transactions
                         total_gas_used += SBUNDLE_PAYOUT_MAX_COST * refund_configs.len() as u64;
 
-                        // Calculate allocated refundable value (payout value)
-                        let payout_value =
-                            refundable_value * U256::from(refund_percent) / U256::from(100);
+                        // Calculate allocated refundable value (payout value) based on ORIGINAL
+                        // refundable value This ensures all refund_percent
+                        // values are calculated from the same base
+                        let payout_value = original_refundable_value * U256::from(refund_percent) /
+                            U256::from(100);
 
                         if payout_tx_fee > payout_value {
                             return Err(EthApiError::InvalidParams(


### PR DESCRIPTION
Fixed a bug where multiple transactions with refund_percent in a bundle were getting incorrect refund amounts.

The problem was that each transaction calculated its refund from the already-reduced refundable_value instead of the original amount. This caused later transactions to receive progressively smaller payouts.

For example, with two txs requesting 50% refund each from 1000 wei:
- First tx: got 500 wei (correct)
- Second tx: got 250 wei (50% of remaining 500, wrong - should be 500)

The fix stores the original refundable_value before the loop and uses that for all calculations. This matches the validation logic that ensures the sum of all refund percentages doesn't exceed 100%.