### PR TITLE
fix: deduplicate blocking task pool spawn helpers

### DIFF
--- a/crates/tasks/src/pool.rs
+++ b/crates/tasks/src/pool.rs
@@ -76,10 +76,7 @@ impl BlockingTaskPool {
         Self::builder().build().map(Self::new)
     }
 
-    fn prepare_task<F, R>(
-        &self,
-        func: F,
-    ) -> (BlockingTaskHandle<R>, impl FnOnce() + Send + 'static)
+    fn prepare_task<F, R>(&self, func: F) -> (BlockingTaskHandle<R>, impl FnOnce() + Send + 'static)
     where
         F: FnOnce() -> R + Send + 'static,
         R: Send + 'static,


### PR DESCRIPTION


Refactor `BlockingTaskPool::spawn` and `BlockingTaskPool::spawn_fifo` to share a common helper that prepares the oneshot channel and panic-catching job closure.

