### PR TITLE
feat: add helper for is nonce too low

### DIFF
--- a/crates/primitives-traits/src/transaction/error.rs
+++ b/crates/primitives-traits/src/transaction/error.rs
@@ -66,6 +66,17 @@ pub enum InvalidTransactionError {
     GasLimitTooHigh,
 }
 
+impl InvalidTransactionError {
+    /// Returns true if this is [`InvalidTransactionError::NonceNotConsistent`] and the
+    /// transaction's nonce is lower than the state's.
+    pub fn is_nonce_too_low(&self) -> bool {
+        match self {
+            Self::NonceNotConsistent { tx, state } => tx < state,
+            _ => false,
+        }
+    }
+}
+
 /// Represents error variants that can happen when trying to convert a transaction to pooled
 /// transaction.
 #[derive(Debug, Clone, Eq, PartialEq, derive_more::Display, derive_more::Error)]

--- a/crates/transaction-pool/src/error.rs
+++ b/crates/transaction-pool/src/error.rs
@@ -396,6 +396,23 @@ impl InvalidPoolTransactionError {
         }
     }
 
+    /// Returns true if this is a [`Self::Consensus`] variant.
+    pub const fn as_consensus(&self) -> Option<&InvalidTransactionError> {
+        match self {
+            Self::Consensus(err) => Some(err),
+            _ => None,
+        }
+    }
+
+    /// Returns true if this is [`InvalidTransactionError::NonceNotConsistent`] and the
+    /// transaction's nonce is lower than the state's.
+    pub fn is_nonce_too_low(&self) -> bool {
+        match self {
+            Self::Consensus(err) => err.is_nonce_too_low(),
+            _ => false,
+        }
+    }
+
     /// Returns `true` if an import failed due to an oversized transaction
     pub const fn is_oversized(&self) -> bool {
         matches!(self, Self::OversizedData { .. })


### PR DESCRIPTION
this can be used to skip marking txs as invalid because this means we can still try to include descendant nonces