### PR TITLE
perf(payload): move parent_header in PayloadBuilderStack::build_empty_payload

### DIFF
--- a/crates/payload/basic/src/stack.rs
+++ b/crates/payload/basic/src/stack.rs
@@ -240,19 +240,13 @@ where
         &self,
         config: PayloadConfig<Self::Attributes, HeaderForPayload<Self::BuiltPayload>>,
     ) -> Result<Self::BuiltPayload, PayloadBuilderError> {
-        match config.attributes {
-            Either::Left(left_attr) => {
-                let left_config = PayloadConfig {
-                    parent_header: config.parent_header.clone(),
-                    attributes: left_attr,
-                };
+        match config {
+            PayloadConfig { parent_header, attributes: Either::Left(left_attr) } => {
+                let left_config = PayloadConfig { parent_header, attributes: left_attr };
                 self.left.build_empty_payload(left_config).map(Either::Left)
             }
-            Either::Right(right_attr) => {
-                let right_config = PayloadConfig {
-                    parent_header: config.parent_header.clone(),
-                    attributes: right_attr,
-                };
+            PayloadConfig { parent_header, attributes: Either::Right(right_attr) } => {
+                let right_config = PayloadConfig { parent_header, attributes: right_attr };
                 self.right.build_empty_payload(right_config).map(Either::Right)
             }
         }


### PR DESCRIPTION
This change removes two unnecessary Arc clones of the parent header in PayloadBuilderStack::build_empty_payload by destructuring the owned PayloadConfig and moving parent_header directly into the branch-specific PayloadConfig. Since PayloadConfig::parent_header is an Arc<SealedHeader<...>> and the function takes config by value, cloning the Arc only increments and later decrements the refcount without any semantic benefit. The refactoring preserves behavior and type safety, as the impl requires both sides to share the same Primitives, ensuring the header type matches between branches. The result is slightly reduced refcount churn with no API changes or logic alterations.