### PR TITLE
docs: document missing config sections and fields

### DIFF
--- a/docs/vocs/docs/pages/run/configuration.mdx
+++ b/docs/vocs/docs/pages/run/configuration.mdx
@@ -15,6 +15,7 @@ The default data directory is platform dependent:
 The configuration file contains the following sections:
 
 -   [`[stages]`](#the-stages-section) -- Configuration of the individual sync stages
+    -   [`era`](#era)
     -   [`headers`](#headers)
     -   [`bodies`](#bodies)
     -   [`sender_recovery`](#sender_recovery)
@@ -25,18 +26,35 @@ The configuration file contains the following sections:
     -   [`transaction_lookup`](#transaction_lookup)
     -   [`index_account_history`](#index_account_history)
     -   [`index_storage_history`](#index_storage_history)
+    -   [`etl`](#etl)
+    -   [`prune`](#prune)
 -   [`[peers]`](#the-peers-section)
     -   [`connection_info`](#connection_info)
     -   [`reputation_weights`](#reputation_weights)
     -   [`backoff_durations`](#backoff_durations)
 -   [`[sessions]`](#the-sessions-section)
 -   [`[prune]`](#the-prune-section)
+-   [`[static_files]`](#the-static_files-section)
 
 ## The `[stages]` section
 
 The stages section is used to configure how individual stages in reth behave, which has a direct impact on resource utilization and sync speed.
 
 The defaults shipped with Reth try to be relatively reasonable, but may not be optimal for your specific set of hardware.
+
+### `era`
+
+The ERA stage configures pre-synced ERA1 data ingestion, either from a local directory or a remote host.
+
+```toml
+[stages.era]
+# Use a local directory containing ERA1 files (conflicts with `url`)
+path = "/path/to/era1"
+# Or download ERA1 files from a host (conflicts with `path`)
+# url = "https://example.com/era1/"
+# When using `url`, specify a temporary download folder
+# folder = "/path/to/reth/era"
+```
 
 ### `headers`
 
@@ -138,6 +156,16 @@ For all thresholds specified, the first to be hit will determine when the result
 
 Lower values correspond to more frequent disk writes, but also lower memory consumption. A lower value also negatively impacts sync speed, since reth keeps a cache around for the entire duration of blocks executed in the same range.
 
+### `prune`
+
+Controls how frequently the prune stage commits its progress.
+
+```toml
+[stages.prune]
+# The maximum number of entries to prune before committing progress to the database.
+commit_threshold = 1_000_000
+```
+
 ### `account_hashing`
 
 The account hashing stage builds a secondary table of accounts, where the key is the hash of the address instead of the raw address.
@@ -234,6 +262,8 @@ An ETL (extract, transform, load) data collector. Used mainly to insert data int
 
 ```toml
 [stages.etl]
+# Optional directory for temporary files used by ETL. Defaults to `datadir/etl-tmp` when unset.
+# dir = "/path/to/reth/etl-tmp"
 # The maximum size in bytes of data held in memory before being flushed to disk as a file.
 #
 # Lower threshold corresponds to more frequent flushes,
@@ -257,8 +287,14 @@ trusted_nodes = []
 # Whether reth will only attempt to connect to the peers specified above,
 # or if it will connect to other peers in the network
 connect_trusted_nodes_only = false
+# Maximum number of backoff attempts before we drop a non-trusted peer
+max_backoff_count = 5
+# DNS resolution refresh interval for trusted nodes
+trusted_nodes_resolution_interval = '1h'
 # The duration for which a badly behaving peer is banned
 ban_duration = '12h'
+# Temporary per-IP throttle for inbound connection attempts
+incoming_ip_throttle_duration = '30s'
 ```
 
 ### `connection_info`
@@ -271,6 +307,8 @@ This section configures how many peers reth will connect to.
 max_outbound = 100
 # The maximum number of inbound peers (peers that connect to us)
 max_inbound = 30
+# The maximum number of concurrent outbound dials performed at once
+max_concurrent_outbound_dials = 15
 ```
 
 ### `reputation_weights`
@@ -291,6 +329,7 @@ timeout = -4096
 bad_protocol = -2147483648
 failed_to_connect = -25600
 dropped = -4096
+bad_announcement = -1024
 ```
 
 ### `backoff_durations`
@@ -333,6 +372,22 @@ nanos = 0
 [sessions.protocol_breach_request_timeout]
 secs = 120
 nanos = 0
+```
+
+Additionally, you can configure when pending sessions time out, and enforce optional per-state limits.
+
+```toml
+# Timeout after which a pending session attempt is considered failed
+[sessions.pending_session_timeout]
+secs = 20
+nanos = 0
+
+# Optional limits (no limits are enforced by default when unset)
+[sessions.limits]
+max_pending_inbound = 100
+max_pending_outbound = 50
+max_established_inbound = 100
+max_established_outbound = 50
 ```
 
 ## The `[prune]` section
@@ -388,6 +443,20 @@ We can also prune receipts more granular, using the logs filtering:
 # - Contain logs from address `0xdac17f958d2ee523a2206206994597c13d831ec7` in the last 1001 blocks
 "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48" = { before = 17000000 }
 "0xdac17f958d2ee523a2206206994597c13d831ec7" = { distance = 1000 }
+```
+
+## The `[static_files]` section
+
+Configure static file segmentation.
+
+```toml
+[static_files.blocks_per_file]
+# Number of blocks per file for each segment (optional)
+# Values must be greater than 0 if set
+headers = 8192
+transactions = 8192
+receipts = 8192
+transaction_senders = 8192
 ```
 
 [TOML]: https://toml.io/


### PR DESCRIPTION
This change updates the configuration reference to align with the current configuration schema in code. It adds missing sections for the stages.era and stages.prune configurations, includes the optional dir field for stages.etl, extends the sessions section with pending_session_timeout and the limits subtable, and documents additional peers options including max_backoff_count, trusted_nodes_resolution_interval, incoming_ip_throttle_duration, and connection_info.max_concurrent_outbound_dials, as well as reputation_weights.bad_announcement. It also introduces the static_files section for per-segment block partitioning. These updates are grounded in the definitions in 
crates/config/src/config.rs
crates/net/network-types/src/peers/config.rs
crates/net/network-types/src/session/config.rs
crates/net/network-types/src/peers/reputation.rs
ensuring flag names and defaults match the implementation. The ip_filter field in PeersConfig is intentionally omitted because it is not deserializable from TOML (#[serde(skip)]) and therefore cannot be configured via reth.toml.