### PR TITLE
chore: refactor `pooled_transaction_hashes_max` for early termination

### DIFF
--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -532,7 +532,7 @@ where
     }
 
     fn pooled_transaction_hashes_max(&self, max: usize) -> Vec<TxHash> {
-        self.pooled_transaction_hashes().into_iter().take(max).collect()
+        self.pool.pooled_transactions_hashes_max(max)
     }
 
     fn pooled_transactions(&self) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -313,6 +313,20 @@ where
             .collect()
     }
 
+    /// Returns only the first `max` hashes of transactions in the pool that can be propagated.
+    pub fn pooled_transactions_hashes_max(&self, max: usize) -> Vec<TxHash> {
+        if max == 0 {
+            return Vec::new();
+        }
+        self.get_pool_data()
+            .all()
+            .transactions_iter()
+            .filter(|tx| tx.propagate)
+            .take(max)
+            .map(|tx| *tx.hash())
+            .collect()
+    }
+
     /// Converts the internally tracked transaction to the pooled format.
     ///
     /// If the transaction is an EIP-4844 transaction, the blob sidecar is fetched from the blob

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -1712,7 +1712,7 @@ mod tests {
             ExtendedAccount::new(transaction.nonce(), alloy_primitives::U256::ZERO),
         );
 
-        // Valdiate with balance check enabled
+        // Validate with balance check enabled
         let validator = EthTransactionValidatorBuilder::new(provider.clone())
             .build(InMemoryBlobStore::default());
 
@@ -1728,7 +1728,7 @@ mod tests {
             panic!("Expected Invalid outcome with InsufficientFunds error");
         }
 
-        // Valdiate with balance check disabled
+        // Validate with balance check disabled
         let validator = EthTransactionValidatorBuilder::new(provider)
             .disable_balance_check() // This should allow the transaction through despite zero balance
             .build(InMemoryBlobStore::default());


### PR DESCRIPTION
closes #19972

cc @mattsse 