### PR TITLE
chore: simplify sync listener test network status setup

### DIFF
--- a/crates/rpc/rpc/src/eth/helpers/sync_listener.rs
+++ b/crates/rpc/rpc/src/eth/helpers/sync_listener.rs
@@ -80,17 +80,10 @@ mod tests {
         }
 
         async fn network_status(&self) -> Result<NetworkStatus, NetworkError> {
-            #[allow(deprecated)]
             Ok(NetworkStatus {
                 client_version: "test".to_string(),
                 protocol_version: 5,
-                eth_protocol_info: EthProtocolInfo {
-                    network: 1,
-                    difficulty: None,
-                    genesis: Default::default(),
-                    config: Default::default(),
-                    head: Default::default(),
-                },
+                eth_protocol_info: EthProtocolInfo { network: 1, ..Default::default() },
                 capabilities: vec![],
             })
         }


### PR DESCRIPTION
drop the deprecated allowance around the mocked network_status, rely on EthProtocolInfo defaults while overriding the network id