### PR TITLE
chore: remove unused stream item generic from SyncListener future impl

### DIFF
--- a/crates/rpc/rpc/src/eth/helpers/sync_listener.rs
+++ b/crates/rpc/rpc/src/eth/helpers/sync_listener.rs
@@ -26,10 +26,10 @@ impl<N, St> SyncListener<N, St> {
     }
 }
 
-impl<N, St, Out> Future for SyncListener<N, St>
+impl<N, St> Future for SyncListener<N, St>
 where
     N: NetworkInfo,
-    St: Stream<Item = Out> + Unpin,
+    St: Stream + Unpin,
 {
     type Output = ();
 


### PR DESCRIPTION
drop the unused Out type parameter from SyncListener’s Future impl, rely directly on Stream to keep the signature minimal and easier to read