### PR TITLE
fix: propagate-only pending listener dropping promoted txs

### DIFF
--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -604,16 +604,8 @@ where
     /// [`TransactionPool`](crate::TransactionPool) trait for a custom pool implementation
     /// [`TransactionPool::pending_transactions_listener_for`](crate::TransactionPool).
     pub fn on_new_pending_transaction(&self, pending: &AddedPendingTransaction<T::Transaction>) {
-        let propagate_allowed = pending.is_propagate_allowed();
-
         let mut transaction_listeners = self.pending_transaction_listener.lock();
         transaction_listeners.retain_mut(|listener| {
-            if listener.kind.is_propagate_only() && !propagate_allowed {
-                // only emit this hash to listeners that are only allowed to receive propagate only
-                // transactions, such as network
-                return !listener.sender.is_closed()
-            }
-
             // broadcast all pending transactions to the listener
             listener.send_all(pending.pending_transactions(listener.kind))
         });

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -1117,11 +1117,6 @@ impl<T: PoolTransaction> AddedPendingTransaction<T> {
         let iter = std::iter::once(&self.transaction).chain(self.promoted.iter());
         PendingTransactionIter { kind, iter }
     }
-
-    /// Returns if the transaction should be propagated.
-    pub(crate) fn is_propagate_allowed(&self) -> bool {
-        self.transaction.propagate
-    }
 }
 
 pub(crate) struct PendingTransactionIter<Iter> {

--- a/crates/transaction-pool/tests/it/listeners.rs
+++ b/crates/transaction-pool/tests/it/listeners.rs
@@ -29,6 +29,52 @@ async fn txpool_listener_by_hash() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn txpool_listener_pending_promotions_propagate_only() {
+    let txpool =
+        TestPoolBuilder::default().with_validator(MockTransactionValidator::no_propagate_local());
+    let mut mock_tx_factory = MockTransactionFactory::default();
+
+    // Create two transactions from the same sender with nonces 0 (local, non-propagatable) and 1
+    let mut tx_local = mock_tx_factory.create_eip1559();
+    let mut tx_external = mock_tx_factory.create_eip1559();
+
+    // Ensure same sender
+    let sender = *tx_local.transaction.get_sender();
+    tx_external.transaction.set_sender(sender);
+
+    // Set explicit nonces to create a nonce gap scenario
+    tx_local.transaction.set_nonce(0);
+    tx_external.transaction.set_nonce(1);
+
+    let hash_local = *tx_local.transaction.hash();
+    let hash_external = *tx_external.transaction.hash();
+
+    // Listeners: propagate-only and all
+    let mut listener_network = txpool.pending_transactions_listener();
+    let mut listener_all = txpool.pending_transactions_listener_for(TransactionListenerKind::All);
+
+    // Insert the higher-nonce external tx first; it should be queued due to nonce gap
+    let res =
+        txpool.add_transaction(TransactionOrigin::External, tx_external.transaction.clone()).await;
+    assert!(res.is_ok());
+
+    // Now insert the local tx with nonce 0; it becomes pending and should promote the external tx
+    let res = txpool.add_transaction(TransactionOrigin::Local, tx_local.transaction.clone()).await;
+    assert!(res.is_ok());
+
+    // All-listener should receive both pending hashes in order: inserted local first, then promoted
+    // external
+    let inserted_all_first = listener_all.recv().await.unwrap();
+    let inserted_all_second = listener_all.recv().await.unwrap();
+    assert_eq!(inserted_all_first, hash_local);
+    assert_eq!(inserted_all_second, hash_external);
+
+    // Propagate-only listener should receive only the external tx (local is non-propagatable)
+    let inserted_network = listener_network.recv().await.unwrap();
+    assert_eq!(inserted_network, hash_external);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn txpool_listener_replace_event() {
     let txpool = TestPoolBuilder::default();
     let mut mock_tx_factory = MockTransactionFactory::default();


### PR DESCRIPTION
Remove the batch-level early-return in on_new_pending_transaction that suppressed propagate-only notifications when the inserted transaction itself was non-propagatable; the underlying iter already enforces per-item filtering, so the pre-check incorrectly prevented promotions from being announced to network listeners; added an integration test that creates a nonce-gap scenario with a local non-propagatable tx unblocking an external tx and verify that All listeners receive both pending hashes while PropagateOnly listeners receive only the promotable external hash, ensuring promotions are visible to the network as intended.