### PR TITLE
fix(cli): always attempt graceful shutdown in run_command_until_exit 

### DIFF
--- a/crates/cli/runner/src/lib.rs
+++ b/crates/cli/runner/src/lib.rs
@@ -74,8 +74,9 @@ impl CliRunner {
             // after the command has finished or exit signal was received we shutdown the task
             // manager which fires the shutdown signal to all tasks spawned via the task
             // executor and awaiting on tasks spawned with graceful shutdown
-            task_manager.graceful_shutdown_with_timeout(Duration::from_secs(5));
         }
+
+        task_manager.graceful_shutdown_with_timeout(Duration::from_secs(5));
 
         // `drop(tokio_runtime)` would block the current thread until its pools
         // (including blocking pool) are shutdown. Since we want to exit as soon as possible, drop


### PR DESCRIPTION
Previously, `CliRunner::run_command_until_exit()` only invoked `task_manager.graceful_shutdown_with_timeout(5s)` on successful command completion, while the error path skipped it and relied on TaskManager drop to propagate shutdown. This caused graceful tasks to be signaled but not awaited in error scenarios, leading to abrupt termination under load and risking incomplete cleanup. This change moves the graceful shutdown call out of the success branch so it runs unconditionally, ensuring graceful tasks get a bounded window to finish regardless of whether the command exited cleanly or with an error. The behavior remains consistent with the success path, preserves the existing 5s cap, and aligns with the TaskManager’s semantics without altering public APIs.