### PR TITLE
fix: keep peer status unchanged on new discovered updates

### DIFF
--- a/crates/net/network-api/src/lib.rs
+++ b/crates/net/network-api/src/lib.rs
@@ -112,11 +112,15 @@ pub trait PeersInfo: Send + Sync {
 #[auto_impl::auto_impl(&, Arc)]
 pub trait Peers: PeersInfo {
     /// Adds a peer to the peer set with TCP `SocketAddr`.
+    ///
+    /// If the peer already exists, then this will update its tracked info.
     fn add_peer(&self, peer: PeerId, tcp_addr: SocketAddr) {
         self.add_peer_kind(peer, PeerKind::Static, tcp_addr, None);
     }
 
     /// Adds a peer to the peer set with TCP and UDP `SocketAddr`.
+    ///
+    /// If the peer already exists, then this will update its tracked info.
     fn add_peer_with_udp(&self, peer: PeerId, tcp_addr: SocketAddr, udp_addr: SocketAddr) {
         self.add_peer_kind(peer, PeerKind::Static, tcp_addr, Some(udp_addr));
     }
@@ -137,6 +141,8 @@ pub trait Peers: PeersInfo {
     }
 
     /// Adds a peer to the known peer set, with the given kind.
+    ///
+    /// If the peer already exists, then this will update its tracked info.
     fn add_peer_kind(
         &self,
         peer: PeerId,

--- a/crates/net/network-api/src/test_utils/peers_manager.rs
+++ b/crates/net/network-api/src/test_utils/peers_manager.rs
@@ -32,6 +32,9 @@ impl PeersHandle {
     }
 
     /// Adds a peer to the set.
+    ///
+    /// If the peer already exists, then this will update only the provided address, this is
+    /// equivalent to discovering a peer.
     pub fn add_peer(&self, peer_id: PeerId, addr: SocketAddr) {
         self.send(PeerCommand::Add(peer_id, addr));
     }

--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -349,7 +349,7 @@ impl<N: NetworkPrimitives> Peers for NetworkHandle<N> {
     /// Sends a message to the [`NetworkManager`](crate::NetworkManager) to connect to the given
     /// peer.
     ///
-    /// This will add a new entry foor the given peer if it isn't tracked yet.
+    /// This will add a new entry for the given peer if it isn't tracked yet.
     /// If it is tracked then the peer is updated with the given information.
     fn connect_peer_kind(
         &self,

--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -348,6 +348,9 @@ impl<N: NetworkPrimitives> Peers for NetworkHandle<N> {
 
     /// Sends a message to the [`NetworkManager`](crate::NetworkManager) to connect to the given
     /// peer.
+    ///
+    /// This will add a new entry foor the given peer if it isn't tracked yet.
+    /// If it is tracked then the peer is updated with the given information.
     fn connect_peer_kind(
         &self,
         peer_id: PeerId,

--- a/crates/net/network/src/state.rs
+++ b/crates/net/network/src/state.rs
@@ -306,7 +306,7 @@ impl<N: NetworkPrimitives> NetworkState<N> {
 
     /// Adds a peer and its address with the given kind to the peerset.
     pub(crate) fn add_peer_kind(&mut self, peer_id: PeerId, kind: PeerKind, addr: PeerAddr) {
-        self.peers_manager.add_peer_kind(peer_id, kind, addr, None)
+        self.peers_manager.add_peer_kind(peer_id, Some(kind), addr, None)
     }
 
     /// Connects a peer and its address with the given kind


### PR DESCRIPTION
retains peer status for existing peers on discovery level updates.

admin level operations are allowed to modify peer status