### PR TITLE
chore(trie): drop redundant counters in storage shrink_to

### DIFF
--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -866,9 +866,7 @@ impl<S: SparseTrieInterface> StorageTries<S> {
     /// The capacity is distributed equally among all tries that have allocations.
     fn shrink_to(&mut self, node_size: usize, value_size: usize) {
         // Count total number of tries with capacity (active + cleared + default)
-        let active_count = self.tries.len();
-        let cleared_count = self.cleared_tries.len();
-        let total_tries = 1 + active_count + cleared_count;
+        let total_tries = 1 + self.tries.len() + self.cleared_tries.len();
 
         // Distribute capacity equally among all tries
         let node_size_per_trie = node_size / total_tries;


### PR DESCRIPTION
compute `total_tries` directly from the active and cleared collections, remove two unused temporary counters without changing behaviour