### PR TITLE
fix: remove dead resolved_links state from SyncTree and its usage

### DIFF
--- a/crates/net/dns/src/lib.rs
+++ b/crates/net/dns/src/lib.rs
@@ -268,9 +268,6 @@ impl<R: Resolver> DnsDiscoveryService<R> {
                     }
                     DnsEntry::Link(link_entry) => {
                         if kind.is_link() {
-                            if let Some(tree) = self.trees.get_mut(&link) {
-                                tree.resolved_links_mut().insert(hash, link_entry.clone());
-                            }
                             self.sync_tree_with_link(link_entry)
                         } else {
                             debug!(target: "disc::dns",%link_entry, domain=%link.domain, ?hash, "resolved unexpected Link entry");

--- a/crates/net/dns/src/sync.rs
+++ b/crates/net/dns/src/sync.rs
@@ -2,10 +2,7 @@ use crate::tree::{LinkEntry, TreeRootEntry};
 use enr::EnrKeyUnambiguous;
 use linked_hash_set::LinkedHashSet;
 use secp256k1::SecretKey;
-use std::{
-    collections::HashMap,
-    time::{Duration, Instant},
-};
+use std::time::{Duration, Instant};
 
 /// A sync-able tree
 pub(crate) struct SyncTree<K: EnrKeyUnambiguous = SecretKey> {
@@ -17,8 +14,6 @@ pub(crate) struct SyncTree<K: EnrKeyUnambiguous = SecretKey> {
     root_updated: Instant,
     /// The state of the tree sync progress.
     sync_state: SyncState,
-    /// Links contained in this tree
-    resolved_links: HashMap<String, LinkEntry<K>>,
     /// Unresolved links of the tree
     unresolved_links: LinkedHashSet<String>,
     /// Unresolved nodes of the tree
@@ -34,7 +29,6 @@ impl<K: EnrKeyUnambiguous> SyncTree<K> {
             link,
             root_updated: Instant::now(),
             sync_state: SyncState::Pending,
-            resolved_links: Default::default(),
             unresolved_links: Default::default(),
             unresolved_nodes: Default::default(),
         }
@@ -47,10 +41,6 @@ impl<K: EnrKeyUnambiguous> SyncTree<K> {
 
     pub(crate) const fn link(&self) -> &LinkEntry<K> {
         &self.link
-    }
-
-    pub(crate) const fn resolved_links_mut(&mut self) -> &mut HashMap<String, LinkEntry<K>> {
-        &mut self.resolved_links
     }
 
     pub(crate) fn extend_children(


### PR DESCRIPTION
The resolved_links map in SyncTree was a dead state: it was only written to in DnsDiscoveryService::on_resolved_entry() and never read or cleared. This caused unnecessary allocations and clones of LinkEntry while providing no functional value. Deduplication of trees is already ensured by DnsDiscoveryService’s trees HashMap keyed by LinkEntry, and DNS entry results are cached by dns_record_cache. Removing resolved_links eliminates the redundant memory growth and avoids needless cloning without changing behavior. The change removes the field, its accessor, and the single write site, and cleans up an unused import.