### PR TITLE
fix(rpc): unify EthFilterConfig TTL default with constant

### DIFF
--- a/crates/rpc/rpc-eth-types/src/builder/config.rs
+++ b/crates/rpc/rpc-eth-types/src/builder/config.rs
@@ -272,7 +272,7 @@ impl Default for EthFilterConfig {
             max_blocks_per_filter: None,
             max_logs_per_response: None,
             // 5min
-            stale_filter_ttl: Duration::from_secs(5 * 60),
+            stale_filter_ttl: DEFAULT_STALE_FILTER_TTL,
         }
     }
 }


### PR DESCRIPTION
Replaced the hardcoded 5-minute TTL in EthFilterConfig::default() with DEFAULT_STALE_FILTER_TTL in crates/rpc/rpc-eth-types/src/builder/config.rs to eliminate duplicate sources of truth and prevent future drift. EthConfig::default() already uses this constant, and EthFilterConfig::default() is used directly in some call sites (e.g., EthFilter::new examples), so aligning both ensures consistent behavior across construction paths without changing the effective default