### PR TITLE
docs: correct profiling feature name and jemalloc env var

### DIFF
--- a/docs/vocs/docs/pages/run/faq/profiling.mdx
+++ b/docs/vocs/docs/pages/run/faq/profiling.mdx
@@ -33,7 +33,7 @@ Reth includes a `jemalloc` feature to explicitly use jemalloc instead of the sys
 cargo build --features jemalloc
 ```
 
-While the `jemalloc` feature does enable jemalloc, reth has an additional feature, `profiling`, that must be used to enable heap profiling. This feature implicitly enables the `jemalloc`
+While the `jemalloc` feature does enable jemalloc, reth has an additional feature, `jemalloc-prof`, that must be used to enable heap profiling. This feature implicitly enables the `jemalloc`
 feature as well:
 
 ```
@@ -139,17 +139,17 @@ cgexec -g memory:rethMemory reth node
 
 ### Understanding allocation with jeprof
 
-When reth is built with the `jemalloc-prof` feature and debug symbols, the profiling still needs to be configured and enabled at runtime. This is done with the `_RJEM_MALLOC_CONF` environment variable. Take the following
+When reth is built with the `jemalloc-prof` feature and debug symbols, the profiling still needs to be configured and enabled at runtime. This is done with the `MALLOC_CONF` environment variable. Take the following
 command to launch reth with jemalloc profiling enabled:
 
 ```
-_RJEM_MALLOC_CONF=prof:true,lg_prof_interval:32,lg_prof_sample:19 reth node
+MALLOC_CONF=prof:true,lg_prof_interval:32,lg_prof_sample:19 reth node
 ```
 
 If reth is not built properly, you will see this when you try to run reth:
 
 ```
-~/p/reth (dan/managing-memory)> _RJEM_MALLOC_CONF=prof:true,lg_prof_interval:32,lg_prof_sample:19 reth node
+~/p/reth (dan/managing-memory)> MALLOC_CONF=prof:true,lg_prof_interval:32,lg_prof_sample:19 reth node
 <jemalloc>: Invalid conf pair: prof:true
 <jemalloc>: Invalid conf pair: lg_prof_interval:32
 <jemalloc>: Invalid conf pair: lg_prof_sample:19

--- a/docs/vocs/docs/pages/run/faq/profiling.mdx
+++ b/docs/vocs/docs/pages/run/faq/profiling.mdx
@@ -139,17 +139,17 @@ cgexec -g memory:rethMemory reth node
 
 ### Understanding allocation with jeprof
 
-When reth is built with the `jemalloc-prof` feature and debug symbols, the profiling still needs to be configured and enabled at runtime. This is done with the `MALLOC_CONF` environment variable. Take the following
+When reth is built with the `jemalloc-prof` feature and debug symbols, the profiling still needs to be configured and enabled at runtime. This is done with the `_RJEM_MALLOC_CONF` environment variable. Take the following
 command to launch reth with jemalloc profiling enabled:
 
 ```
-MALLOC_CONF=prof:true,lg_prof_interval:32,lg_prof_sample:19 reth node
+_RJEM_MALLOC_CONF=prof:true,lg_prof_interval:32,lg_prof_sample:19 reth node
 ```
 
 If reth is not built properly, you will see this when you try to run reth:
 
 ```
-~/p/reth (dan/managing-memory)> MALLOC_CONF=prof:true,lg_prof_interval:32,lg_prof_sample:19 reth node
+~/p/reth (dan/managing-memory)> _RJEM_MALLOC_CONF=prof:true,lg_prof_interval:32,lg_prof_sample:19 reth node
 <jemalloc>: Invalid conf pair: prof:true
 <jemalloc>: Invalid conf pair: lg_prof_interval:32
 <jemalloc>: Invalid conf pair: lg_prof_sample:19


### PR DESCRIPTION
Updated the profiling documentation in docs/vocs/docs/pages/run/faq/profiling.mdx to replace the incorrect reference to an “additional feature, profiling” with the correct jemalloc-prof feature, which is what actually enables jemalloc heap profiling in 
bin/reth/Cargo.toml, and replaces the outdated _RJEM_MALLOC_CONF environment variable with the standard MALLOC_CONF used by tikv-jemallocator. This aligns the docs with the repository’s current feature flags and allocator configuration, avoids confusion between the Cargo build profile named profiling and the jemalloc-prof feature, and ensures the provided commands work on modern builds.