### PR TITLE
chore(node): gate otlp-only code and silence unused warnings

### DIFF
--- a/crates/node/core/src/args/trace.rs
+++ b/crates/node/core/src/args/trace.rs
@@ -4,6 +4,8 @@ use clap::Parser;
 use eyre::WrapErr;
 use reth_tracing::{tracing_subscriber::EnvFilter, Layers};
 use reth_tracing_otlp::OtlpProtocol;
+#[cfg(feature = "otlp")]
+use reth_tracing_otlp::OtlpConfig;
 use url::Url;
 
 /// CLI arguments for configuring `Opentelemetry` trace and span export.
@@ -120,10 +122,10 @@ impl TraceArgs {
     /// Note: even though this function is async, it does not actually perform any async operations.
     /// It's needed only to be able to initialize the gRPC transport of OTLP tracing that needs to
     /// be called inside a tokio runtime context.
-    pub async fn init_otlp_tracing(
-        &mut self,
-        _layers: &mut Layers,
-    ) -> eyre::Result<OtlpInitStatus> {
+    pub async fn init_otlp_tracing(&mut self, layers: &mut Layers) -> eyre::Result<OtlpInitStatus> {
+        #[cfg(not(feature = "otlp"))]
+        let _ = layers;
+        
         if let Some(endpoint) = self.otlp.as_mut() {
             self.protocol.validate_endpoint(endpoint)?;
 

--- a/crates/node/core/src/args/trace.rs
+++ b/crates/node/core/src/args/trace.rs
@@ -4,8 +4,6 @@ use clap::Parser;
 use eyre::WrapErr;
 use reth_tracing::{tracing_subscriber::EnvFilter, Layers};
 use reth_tracing_otlp::OtlpProtocol;
-#[cfg(feature = "otlp")]
-use reth_tracing_otlp::OtlpConfig;
 use url::Url;
 
 /// CLI arguments for configuring `Opentelemetry` trace and span export.


### PR DESCRIPTION
move OtlpConfig behind #[cfg(feature = "otlp")] so it only compiles when the feature is enabled
silence the unused layers parameter for builds without otlp by explicitly binding it under the same cfg guard
keeps the tracing logic untouched when the feature is on while removing noise for minimal builds
