### PR TITLE
fix(ipc): make IpcServer Debug impl generic

### DIFF
--- a/crates/rpc/ipc/src/server/mod.rs
+++ b/crates/rpc/ipc/src/server/mod.rs
@@ -248,7 +248,7 @@ where
     }
 }
 
-impl std::fmt::Debug for IpcServer {
+impl<HttpMiddleware, RpcMiddleware> std::fmt::Debug for IpcServer<HttpMiddleware, RpcMiddleware> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("IpcServer")
             .field("endpoint", &self.endpoint)


### PR DESCRIPTION
Made this change to provide Debug for all IpcServer generic instantiations because it aligns with upstream patterns, satisfies workspace lint for missing debug, and avoids restricting Debug to default middleware without introducing extra bounds.