### PR TITLE
feat: add [TransactionPoolExt::filter_pooled_txs] for efficient transaction filtering

### DIFF
--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -814,6 +814,24 @@ where
     }
 }
 
+impl<V, T, S> TransactionPoolExtExt for Pool<V, T, S>
+where
+    V: TransactionValidator,
+    <V as TransactionValidator>::Transaction: EthPoolTransaction,
+    T: TransactionOrdering<Transaction = <V as TransactionValidator>::Transaction>,
+    S: BlobStore,
+{
+    fn filter_pooled_txs<F>(
+        &self,
+        predicate: F,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>
+    where
+        F: FnMut(&Arc<ValidPoolTransaction<Self::Transaction>>) -> bool,
+    {
+        self.pool.filter_pooled_txs(predicate)
+    }
+}
+
 impl<V, T: TransactionOrdering, S> Clone for Pool<V, T, S> {
     fn clone(&self) -> Self {
         Self { pool: Arc::clone(&self.pool) }

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -312,6 +312,26 @@ where
             .collect()
     }
 
+    /// Returns transactions in the pool that can be propagated and match the given predicate.
+    ///
+    /// This is more efficient than [`Self::pooled_transactions`] when you need to filter
+    /// transactions, as it applies the predicate during iteration rather than collecting all
+    /// transactions first.
+    pub fn filter_pooled_txs<F>(
+        &self,
+        mut predicate: F,
+    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>>
+    where
+        F: FnMut(&Arc<ValidPoolTransaction<T::Transaction>>) -> bool,
+    {
+        self.get_pool_data()
+            .all()
+            .transactions_iter()
+            .filter(|tx| tx.propagate && predicate(tx))
+            .cloned()
+            .collect()
+    }
+
     /// Converts the internally tracked transaction to the pooled format.
     ///
     /// If the transaction is an EIP-4844 transaction, the blob sidecar is fetched from the blob


### PR DESCRIPTION
### Summary
Adds filter_pooled_txs method to efficiently filter pooled transactions using a predicate, avoiding the need to collect all transactions before filtering.

Changes
- Added  TransactionPoolExtExt trait with filter_pooled_txsmethod
- Implemented efficient filtering in Pool that applies predicate during iteration
- Updated maintain_transaction_pool_conditional
 to use the new method
 
 This closes #19919 