### PR TITLE
docs(trace): fix trace_callMany params structure and formatting inconsistencies

### DIFF
--- a/docs/vocs/docs/pages/jsonrpc/trace.mdx
+++ b/docs/vocs/docs/pages/jsonrpc/trace.mdx
@@ -222,7 +222,7 @@ The second and optional parameter is a block number, block hash, or a block tag 
 
 | Client | Method invocation                                          |
 | ------ | ---------------------------------------------------------- |
-| RPC    | `{"method": "trace_callMany", "params": [trace[], block]}` |
+| RPC    | `{"method": "trace_callMany", "params": [[[tx, type[]], ...], block]}` |
 
 ### Example
 
@@ -502,7 +502,7 @@ Returns trace at given position.
 
 | Client | Method invocation                                        |
 | ------ | -------------------------------------------------------- |
-| RPC    | `{"method": "trace_get", "params": [tx_hash,indices[]]}` |
+| RPC    | `{"method": "trace_get", "params": [tx_hash, indices[]]}` |
 
 ### Example
 
@@ -521,13 +521,13 @@ Returns trace at given position.
             "value": "0x0"
         },
         "blockHash": "0x7eb25504e4c202cf3d62fd585d3e238f592c780cca82dacb2ed3cb5b38883add",
-            "blockNumber": 3068185,
-            "result": {
+        "blockNumber": 3068185,
+        "result": {
             "gasUsed": "0x183",
             "output": "0x0000000000000000000000000000000000000000000000000000000000000001"
         },
         "subtraces": 0,
-            "traceAddress": [
+        "traceAddress": [
             0
         ],
         "transactionHash": "0x17104ac9d3312d8c136b7f44d4b8b47852618065ebfa534bd2d3b5ef218ca1f3",


### PR DESCRIPTION
Fixed trace_callMany method invocation table to show correct nested array  structure `[[[tx, type[]], ...], block]` instead of misleading `[trace[], block]`, added missing space after comma in trace_get params, and corrected JSON indentation in trace_get example.