### PR TITLE
fix(rpc): check correct variable for division by zero in blob gas ratio

### DIFF
--- a/crates/rpc/rpc-eth-types/src/utils.rs
+++ b/crates/rpc/rpc-eth-types/src/utils.rs
@@ -83,10 +83,10 @@ where
 /// Calculates the blob gas used ratio for a block, accounting for the case where
 /// `max_blob_gas_per_block` is zero.
 ///
-/// Returns `0.0` if `blob_gas_used` is `0`, otherwise returns the ratio
+/// Returns `0.0` if `max_blob_gas_per_block` is `0`, otherwise returns the ratio
 /// `blob_gas_used/max_blob_gas_per_block`.
 pub fn checked_blob_gas_used_ratio(blob_gas_used: u64, max_blob_gas_per_block: u64) -> f64 {
-    if blob_gas_used == 0 {
+    if max_blob_gas_per_block == 0 {
         0.0
     } else {
         blob_gas_used as f64 / max_blob_gas_per_block as f64
@@ -124,6 +124,8 @@ mod tests {
     fn test_checked_blob_gas_used_ratio() {
         // No blob gas used, max blob gas per block is 0
         assert_eq!(checked_blob_gas_used_ratio(0, 0), 0.0);
+        // Blob gas used is non-zero, max blob gas per block is 0 (division by zero protection)
+        assert_eq!(checked_blob_gas_used_ratio(50, 0), 0.0);
         // Blob gas used is zero, max blob gas per block is non-zero
         assert_eq!(checked_blob_gas_used_ratio(0, 100), 0.0);
         // Blob gas used is non-zero, max blob gas per block is non-zero


### PR DESCRIPTION
The `checked_blob_gas_used_ratio` function was checking the wrong variable.
It checked `blob_gas_used == 0` but should check `max_blob_gas_per_block == 0`to prevent division by zero.

The doc comment even says "accounting for the case where max_blob_gas_per_block is zero" but the code was checking blob_gas_used instead. This caused the function to return `inf` when called with non-zero blob_gas_used and zero max_blob_gas_per_block.
