### PR TITLE
docs: set tracing-otlp.filter default text to DEBUG

### DIFF
--- a/docs/vocs/docs/pages/cli/reth/config.mdx
+++ b/docs/vocs/docs/pages/cli/reth/config.mdx
@@ -129,7 +129,7 @@ Tracing:
 
           Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
-          Defaults to TRACE if not specified.
+          Defaults to DEBUG if not specified.
 
           [default: debug]
 

--- a/docs/vocs/docs/pages/cli/reth/db.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db.mdx
@@ -240,7 +240,7 @@ Tracing:
 
           Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
-          Defaults to TRACE if not specified.
+          Defaults to DEBUG if not specified.
 
           [default: debug]
 

--- a/docs/vocs/docs/pages/cli/reth/db/account-storage.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/account-storage.mdx
@@ -137,7 +137,7 @@ Tracing:
 
           Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
-          Defaults to TRACE if not specified.
+          Defaults to DEBUG if not specified.
 
           [default: debug]
 

--- a/docs/vocs/docs/pages/cli/reth/db/checksum.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/checksum.mdx
@@ -146,7 +146,7 @@ Tracing:
 
           Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
-          Defaults to TRACE if not specified.
+          Defaults to DEBUG if not specified.
 
           [default: debug]
 

--- a/docs/vocs/docs/pages/cli/reth/db/clear.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/clear.mdx
@@ -138,7 +138,7 @@ Tracing:
 
           Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
-          Defaults to TRACE if not specified.
+          Defaults to DEBUG if not specified.
 
           [default: debug]
 

--- a/docs/vocs/docs/pages/cli/reth/db/clear/mdbx.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/clear/mdbx.mdx
@@ -137,7 +137,7 @@ Tracing:
 
           Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
-          Defaults to TRACE if not specified.
+          Defaults to DEBUG if not specified.
 
           [default: debug]
 

--- a/docs/vocs/docs/pages/cli/reth/db/clear/static-file.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/clear/static-file.mdx
@@ -141,7 +141,7 @@ Tracing:
 
           Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
-          Defaults to TRACE if not specified.
+          Defaults to DEBUG if not specified.
 
           [default: debug]
 

--- a/docs/vocs/docs/pages/cli/reth/db/diff.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/diff.mdx
@@ -189,7 +189,7 @@ Tracing:
 
           Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
-          Defaults to TRACE if not specified.
+          Defaults to DEBUG if not specified.
 
           [default: debug]
 

--- a/docs/vocs/docs/pages/cli/reth/db/drop.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/drop.mdx
@@ -136,7 +136,7 @@ Tracing:
 
           Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
-          Defaults to TRACE if not specified.
+          Defaults to DEBUG if not specified.
 
           [default: debug]
 

--- a/docs/vocs/docs/pages/cli/reth/db/get.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/get.mdx
@@ -138,7 +138,7 @@ Tracing:
 
           Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
-          Defaults to TRACE if not specified.
+          Defaults to DEBUG if not specified.
 
           [default: debug]
 

--- a/docs/vocs/docs/pages/cli/reth/db/get/mdbx.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/get/mdbx.mdx
@@ -146,7 +146,7 @@ Tracing:
 
           Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
-          Defaults to TRACE if not specified.
+          Defaults to DEBUG if not specified.
 
           [default: debug]
 

--- a/docs/vocs/docs/pages/cli/reth/db/get/static-file.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/get/static-file.mdx
@@ -147,7 +147,7 @@ Tracing:
 
           Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
-          Defaults to TRACE if not specified.
+          Defaults to DEBUG if not specified.
 
           [default: debug]
 

--- a/docs/vocs/docs/pages/cli/reth/db/list.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/list.mdx
@@ -179,7 +179,7 @@ Tracing:
 
           Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
-          Defaults to TRACE if not specified.
+          Defaults to DEBUG if not specified.
 
           [default: debug]
 

--- a/docs/vocs/docs/pages/cli/reth/db/path.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/path.mdx
@@ -133,7 +133,7 @@ Tracing:
 
           Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
-          Defaults to TRACE if not specified.
+          Defaults to DEBUG if not specified.
 
           [default: debug]
 

--- a/docs/vocs/docs/pages/cli/reth/db/repair-trie.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/repair-trie.mdx
@@ -136,7 +136,7 @@ Tracing:
 
           Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
-          Defaults to TRACE if not specified.
+          Defaults to DEBUG if not specified.
 
           [default: debug]
 

--- a/docs/vocs/docs/pages/cli/reth/db/settings.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/settings.mdx
@@ -138,7 +138,7 @@ Tracing:
 
           Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
-          Defaults to TRACE if not specified.
+          Defaults to DEBUG if not specified.
 
           [default: debug]
 

--- a/docs/vocs/docs/pages/cli/reth/db/settings/get.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/settings/get.mdx
@@ -133,7 +133,7 @@ Tracing:
 
           Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
-          Defaults to TRACE if not specified.
+          Defaults to DEBUG if not specified.
 
           [default: debug]
 

--- a/docs/vocs/docs/pages/cli/reth/db/settings/set.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/settings/set.mdx
@@ -138,7 +138,7 @@ Tracing:
 
           Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
-          Defaults to TRACE if not specified.
+          Defaults to DEBUG if not specified.
 
           [default: debug]
 

--- a/docs/vocs/docs/pages/cli/reth/db/static-file-header.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/static-file-header.mdx
@@ -138,7 +138,7 @@ Tracing:
 
           Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
-          Defaults to TRACE if not specified.
+          Defaults to DEBUG if not specified.
 
           [default: debug]
 

--- a/docs/vocs/docs/pages/cli/reth/db/static-file-header/block.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/static-file-header/block.mdx
@@ -146,7 +146,7 @@ Tracing:
 
           Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
-          Defaults to TRACE if not specified.
+          Defaults to DEBUG if not specified.
 
           [default: debug]
 

--- a/docs/vocs/docs/pages/cli/reth/db/stats.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/stats.mdx
@@ -149,7 +149,7 @@ Tracing:
 
           Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
-          Defaults to TRACE if not specified.
+          Defaults to DEBUG if not specified.
 
           [default: debug]
 

--- a/docs/vocs/docs/pages/cli/reth/db/version.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/version.mdx
@@ -133,7 +133,7 @@ Tracing:
 
           Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
-          Defaults to TRACE if not specified.
+          Defaults to DEBUG if not specified.
 
           [default: debug]
 

--- a/docs/vocs/docs/pages/cli/reth/download.mdx
+++ b/docs/vocs/docs/pages/cli/reth/download.mdx
@@ -234,7 +234,7 @@ Tracing:
 
           Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
-          Defaults to TRACE if not specified.
+          Defaults to DEBUG if not specified.
 
           [default: debug]
 

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -1115,7 +1115,7 @@ Tracing:
 
           Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
-          Defaults to TRACE if not specified.
+          Defaults to DEBUG if not specified.
 
           [default: debug]
 

--- a/docs/vocs/docs/pages/cli/reth/p2p.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p.mdx
@@ -130,7 +130,7 @@ Tracing:
 
           Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
-          Defaults to TRACE if not specified.
+          Defaults to DEBUG if not specified.
 
           [default: debug]
 

--- a/docs/vocs/docs/pages/cli/reth/p2p/header.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/header.mdx
@@ -369,7 +369,7 @@ Tracing:
 
           Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
 
-          Defaults to TRACE if not specified.
+          Defaults to DEBUG if not specified.
 
           [default: debug]
 


### PR DESCRIPTION
The CLI’s --tracing-otlp.filter default is “debug” (see TraceArgs), but many docs stated “Defaults to TRACE if not specified.” I updated that sentence to “Defaults to DEBUG if not specified.” across docs/vocs/docs/pages/cli/reth/ to match the actual default and avoid confusion