### PR TITLE
fix(provider): correct capacity calculation for inclusive block range

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -622,7 +622,7 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> DatabaseProvider<TX, N> {
             return Ok(Vec::new())
         }
 
-        let len = range.end().saturating_sub(*range.start()) as usize;
+        let len = range.end().saturating_sub(*range.start()).saturating_add(1) as usize;
         let mut blocks = Vec::with_capacity(len);
 
         let headers = headers_range(range.clone())?;


### PR DESCRIPTION
Capacity for RangeInclusive should be `end - start + 1`.
Matches the pattern already used in consistent.rs and bodies.rs.