### PR TITLE
fix: ensure `MerkleChangeSets` pruner only runs if pipeline stage has finished

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9969,6 +9969,7 @@ dependencies = [
  "reth-provider",
  "reth-prune-types",
  "reth-stages",
+ "reth-stages-types",
  "reth-static-file-types",
  "reth-testing-utils",
  "reth-tokio-util",

--- a/crates/prune/prune/Cargo.toml
+++ b/crates/prune/prune/Cargo.toml
@@ -21,6 +21,7 @@ reth-tokio-util.workspace = true
 reth-config.workspace = true
 reth-prune-types.workspace = true
 reth-primitives-traits.workspace = true
+reth-stages-types.workspace = true
 reth-static-file-types.workspace = true
 
 # ethereum

--- a/crates/prune/prune/src/builder.rs
+++ b/crates/prune/prune/src/builder.rs
@@ -7,7 +7,7 @@ use reth_primitives_traits::NodePrimitives;
 use reth_provider::{
     providers::StaticFileProvider, BlockReader, ChainStateBlockReader, DBProvider,
     DatabaseProviderFactory, NodePrimitivesProvider, PruneCheckpointReader, PruneCheckpointWriter,
-    StaticFileProviderFactory, StorageSettingsCache,
+    StageCheckpointReader, StaticFileProviderFactory, StorageSettingsCache,
 };
 use reth_prune_types::PruneModes;
 use std::time::Duration;
@@ -81,6 +81,7 @@ impl PrunerBuilder {
                                 + BlockReader<Transaction: Encodable2718>
                                 + ChainStateBlockReader
                                 + StorageSettingsCache
+                                + StageCheckpointReader
                                 + StaticFileProviderFactory<
                     Primitives: NodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>,
                 >,
@@ -114,7 +115,8 @@ impl PrunerBuilder {
             + ChainStateBlockReader
             + PruneCheckpointWriter
             + PruneCheckpointReader
-            + StorageSettingsCache,
+            + StorageSettingsCache
+            + StageCheckpointReader,
     {
         let segments = SegmentSet::<Provider>::from_components(static_file_provider, self.segments);
 

--- a/crates/prune/prune/src/pruner.rs
+++ b/crates/prune/prune/src/pruner.rs
@@ -202,14 +202,6 @@ where
                 .transpose()?
                 .flatten()
             {
-                debug!(
-                    target: "pruner",
-                    segment = ?segment.segment(),
-                    purpose = ?segment.purpose(),
-                    %to_block,
-                    ?prune_mode,
-                    "Segment pruning started"
-                );
 
                 // Check if segment has a required stage that must be finished first
                 if let Some(required_stage) = segment.required_stage() &&
@@ -223,6 +215,15 @@ where
                     );
                     continue
                 }
+
+                debug!(
+                    target: "pruner",
+                    segment = ?segment.segment(),
+                    purpose = ?segment.purpose(),
+                    %to_block,
+                    ?prune_mode,
+                    "Segment pruning started"
+                );
 
                 let segment_start = Instant::now();
                 let previous_checkpoint = provider.get_prune_checkpoint(segment.segment())?;

--- a/crates/prune/prune/src/pruner.rs
+++ b/crates/prune/prune/src/pruner.rs
@@ -8,8 +8,10 @@ use alloy_primitives::BlockNumber;
 use reth_exex_types::FinishedExExHeight;
 use reth_provider::{
     DBProvider, DatabaseProviderFactory, PruneCheckpointReader, PruneCheckpointWriter,
+    StageCheckpointReader,
 };
 use reth_prune_types::{PruneProgress, PrunedSegmentInfo, PrunerOutput};
+use reth_stages_types::StageId;
 use reth_tokio_util::{EventSender, EventStream};
 use std::time::{Duration, Instant};
 use tokio::sync::watch;
@@ -100,7 +102,7 @@ where
 
 impl<Provider, S> Pruner<Provider, S>
 where
-    Provider: PruneCheckpointReader + PruneCheckpointWriter,
+    Provider: PruneCheckpointReader + PruneCheckpointWriter + StageCheckpointReader,
 {
     /// Listen for events on the pruner.
     pub fn events(&self) -> EventStream<PrunerEvent> {
@@ -208,6 +210,19 @@ where
                     ?prune_mode,
                     "Segment pruning started"
                 );
+
+                // Check if segment has a required stage that must be finished first
+                if let Some(required_stage) = segment.required_stage() &&
+                    !is_stage_finished(provider, required_stage)?
+                {
+                    debug!(
+                        target: "pruner",
+                        segment = ?segment.segment(),
+                        ?required_stage,
+                        "Segment's required stage not finished, skipping"
+                    );
+                    continue
+                }
 
                 let segment_start = Instant::now();
                 let previous_checkpoint = provider.get_prune_checkpoint(segment.segment())?;
@@ -318,7 +333,9 @@ where
 
 impl<PF> Pruner<PF::ProviderRW, PF>
 where
-    PF: DatabaseProviderFactory<ProviderRW: PruneCheckpointWriter + PruneCheckpointReader>,
+    PF: DatabaseProviderFactory<
+        ProviderRW: PruneCheckpointWriter + PruneCheckpointReader + StageCheckpointReader,
+    >,
 {
     /// Run the pruner. This will only prune data up to the highest finished ExEx height, if there
     /// are no ExExes.
@@ -331,6 +348,19 @@ where
         provider.commit()?;
         result
     }
+}
+
+/// Checks if the given stage has caught up with the `Finish` stage.
+///
+/// Returns `true` if the stage checkpoint is >= the Finish stage checkpoint.
+fn is_stage_finished<Provider: StageCheckpointReader>(
+    provider: &Provider,
+    stage_id: StageId,
+) -> Result<bool, PrunerError> {
+    let stage_checkpoint = provider.get_stage_checkpoint(stage_id)?.map(|c| c.block_number);
+    let finish_checkpoint = provider.get_stage_checkpoint(StageId::Finish)?.map(|c| c.block_number);
+
+    Ok(stage_checkpoint >= finish_checkpoint)
 }
 
 #[cfg(test)]

--- a/crates/prune/prune/src/pruner.rs
+++ b/crates/prune/prune/src/pruner.rs
@@ -202,7 +202,6 @@ where
                 .transpose()?
                 .flatten()
             {
-
                 // Check if segment has a required stage that must be finished first
                 if let Some(required_stage) = segment.required_stage() &&
                     !is_stage_finished(provider, required_stage)?

--- a/crates/prune/prune/src/segments/mod.rs
+++ b/crates/prune/prune/src/segments/mod.rs
@@ -11,6 +11,7 @@ use reth_prune_types::{
     PruneCheckpoint, PruneMode, PruneProgress, PrunePurpose, PruneSegment, SegmentOutput,
     SegmentOutputCheckpoint,
 };
+use reth_stages_types::StageId;
 use reth_static_file_types::StaticFileSegment;
 pub use set::SegmentSet;
 use std::{fmt::Debug, ops::RangeInclusive};
@@ -83,6 +84,14 @@ pub trait Segment<Provider>: Debug + Send + Sync {
         Provider: PruneCheckpointWriter,
     {
         provider.save_prune_checkpoint(self.segment(), checkpoint)
+    }
+
+    /// Returns the stage this segment depends on, if any.
+    ///
+    /// If this returns `Some(stage_id)`, the pruner will skip this segment if the stage
+    /// has not yet caught up with the `Finish` stage checkpoint.
+    fn required_stage(&self) -> Option<StageId> {
+        None
     }
 }
 

--- a/crates/prune/prune/src/segments/user/merkle_change_sets.rs
+++ b/crates/prune/prune/src/segments/user/merkle_change_sets.rs
@@ -13,6 +13,7 @@ use reth_provider::{
 use reth_prune_types::{
     PruneCheckpoint, PruneMode, PrunePurpose, PruneSegment, SegmentOutput, SegmentOutputCheckpoint,
 };
+use reth_stages_types::StageId;
 use tracing::{instrument, trace};
 
 #[derive(Debug)]
@@ -45,6 +46,10 @@ where
 
     fn purpose(&self) -> PrunePurpose {
         PrunePurpose::User
+    }
+
+    fn required_stage(&self) -> Option<StageId> {
+        Some(StageId::MerkleChangeSets)
     }
 
     #[instrument(level = "trace", target = "pruner", skip(self, provider), ret)]

--- a/crates/stages/stages/src/stages/prune.rs
+++ b/crates/stages/stages/src/stages/prune.rs
@@ -2,7 +2,7 @@ use reth_db_api::{table::Value, transaction::DbTxMut};
 use reth_primitives_traits::NodePrimitives;
 use reth_provider::{
     BlockReader, ChainStateBlockReader, DBProvider, PruneCheckpointReader, PruneCheckpointWriter,
-    StaticFileProviderFactory, StorageSettingsCache,
+    StageCheckpointReader, StaticFileProviderFactory, StorageSettingsCache,
 };
 use reth_prune::{
     PruneMode, PruneModes, PruneSegment, PrunerBuilder, SegmentOutput, SegmentOutputCheckpoint,
@@ -43,6 +43,7 @@ where
         + PruneCheckpointWriter
         + BlockReader
         + ChainStateBlockReader
+        + StageCheckpointReader
         + StaticFileProviderFactory<
             Primitives: NodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>,
         > + StorageSettingsCache,
@@ -144,6 +145,7 @@ where
         + PruneCheckpointWriter
         + BlockReader
         + ChainStateBlockReader
+        + StageCheckpointReader
         + StaticFileProviderFactory<
             Primitives: NodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>,
         > + StorageSettingsCache,


### PR DESCRIPTION
When upgrading from v1.8.x to v1.9.x, a new `MerkleChangeSets` stage is introduced. On the first boot after upgrade, this stage's checkpoint will be behind the `Finish` stage checkpoint. This is kinda unusual since all stages should be >= Finish stage usually. The node will then spawn the pipeline to bring it up to the tiup.

Context:
The `MerkleChangeSets` stage uses `tx.clear()` to wipe rows in bulk, but if the pruner runs first (which does when booting the node), it will iterate and delete rows one by one from the table, which takes way more time and may make it seem like the node is stuck.

The PR solves the following edge case (or any similar):
* user upgrades to v1.9
* node runs without any issue
* user downgrades back to v1.8 (stage checkpoint for MerkleChangeSets will not be incremented anymore)
* node runs without any issue
* user upgrades back to v1.9
* pruner runs first and attempts to delete rows one by one (MerkleChangeSets stage checkpoint is way behind the finish stage checkpoint)

This PR adds a `required_stage()` method to the `Segment` trait, allowing segments to declare a stage dependency. The pruner now skips any segment whose required stage hasn't caught up with the `Finish` stage checkpoint.
