### PR TITLE
fix(cli): correct BlockBodyIndices import range in setup()

### DIFF
--- a/crates/cli/commands/src/stage/dump/mod.rs
+++ b/crates/cli/commands/src/stage/dump/mod.rs
@@ -140,8 +140,8 @@ pub(crate) fn setup<N: NodeTypesWithDB>(
     output_datadir.update(|tx| {
         tx.import_table_with_range::<tables::BlockBodyIndices, _>(
             &db_tool.provider_factory.db_ref().tx()?,
-            Some(from - 1),
-            to + 1,
+            Some(from),
+            to,
         )
     })??;
 


### PR DESCRIPTION
import_table_with_range expects an inclusive end bound. Using from - 1 and to + 1 could underflow/overflow for edge inputs (from == 0 or to == u64::MAX) and was inconsistent with other stage imports. Switch to Some(from), to to precisely copy [from..=to] and avoid numeric wraparounds.