### PR TITLE
refactor(merkle): prevent overlapping chunk ranges in incremental trie updates

### DIFF
--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -300,7 +300,8 @@ where
         } else {
             debug!(target: "sync::stages::merkle::exec", current = ?current_block_number, target = ?to_block, "Updating trie in chunks");
             let mut final_root = None;
-            for start_block in range.step_by(incremental_threshold as usize) {
+            let mut start_block = from_block;
+            while start_block <= to_block {
                 let chunk_to = std::cmp::min(start_block + incremental_threshold, to_block);
                 let chunk_range = start_block..=chunk_to;
                 debug!(
@@ -319,6 +320,7 @@ where
                     })?;
                 provider.write_trie_updates(updates)?;
                 final_root = Some(root);
+                start_block = chunk_to + 1;
             }
 
             // if we had no final root, we must have not looped above, which should not be possible


### PR DESCRIPTION
# Description
## Problem
The incremental merkle update loop uses range.step_by(incremental_threshold) combined with inclusive range start_block..=chunk_to, which causes boundary blocks to be processed twice.
Before (log / overlapping):
```
2025-12-03T03:48:20.240579Z  DEBUG Processing chunk current=50000 target=90000 incremental_threshold=7000 chunk_range=50001..=57001
2025-12-03T03:48:20.270721Z  DEBUG Processing chunk current=50000 target=90000 incremental_threshold=7000 chunk_range=57001..=64001
2025-12-03T03:48:20.290994Z  DEBUG Processing chunk current=50000 target=90000 incremental_threshold=7000 chunk_range=64001..=71001
2025-12-03T03:48:20.331801Z  DEBUG Processing chunk current=50000 target=90000 incremental_threshold=7000 chunk_range=71001..=78001
...
```

## Solution
Replace step_by iterator with a while loop that advances start_block to chunk_to + 1, ensuring non-overlapping ranges.
After (log / non-overlapping):
```
2025-12-03T03:51:54.325227Z  DEBUG Processing chunk current=90000 target=150000 incremental_threshold=7000 chunk_range=90001..=97001
2025-12-03T03:51:54.356900Z  DEBUG Processing chunk current=90000 target=150000 incremental_threshold=7000 chunk_range=97002..=104002
2025-12-03T03:51:54.384736Z  DEBUG Processing chunk current=90000 target=150000 incremental_threshold=7000 chunk_range=104003..=111003
2025-12-03T03:51:54.414019Z  DEBUG Processing chunk current=90000 target=150000 incremental_threshold=7000 chunk_range=111004..=118004
...
```

## Note
The current merkle algorithm is idempotent, so correctness is unaffected. This fix eliminates redundant computation and ensures correctness if the implementation ever becomes non-idempotent.