### PR TITLE
fix(txpool): derive accurate queued reason for SubPool::Blob

### DIFF
--- a/crates/transaction-pool/src/pool/state.rs
+++ b/crates/transaction-pool/src/pool/state.rs
@@ -330,7 +330,7 @@ mod tests {
     #[test]
     fn test_blob_reason_insufficient_base_fee() {
         // Blob tx with all structural bits set and blob fee sufficient, but base fee insufficient
-        let mut state = TxState::NO_PARKED_ANCESTORS |
+        let state = TxState::NO_PARKED_ANCESTORS |
             TxState::NO_NONCE_GAPS |
             TxState::ENOUGH_BALANCE |
             TxState::NOT_TOO_MUCH_GAS |
@@ -346,7 +346,7 @@ mod tests {
     #[test]
     fn test_blob_reason_insufficient_blob_fee() {
         // Blob tx with all structural bits set and base fee sufficient, but blob fee insufficient
-        let mut state = TxState::NO_PARKED_ANCESTORS |
+        let state = TxState::NO_PARKED_ANCESTORS |
             TxState::NO_NONCE_GAPS |
             TxState::ENOUGH_BALANCE |
             TxState::NOT_TOO_MUCH_GAS |
@@ -378,7 +378,7 @@ mod tests {
     #[test]
     fn test_blob_reason_insufficient_balance() {
         // Blob tx with insufficient balance
-        let mut state = TxState::NO_PARKED_ANCESTORS |
+        let state = TxState::NO_PARKED_ANCESTORS |
             TxState::NO_NONCE_GAPS |
             TxState::NOT_TOO_MUCH_GAS |
             TxState::ENOUGH_FEE_CAP_BLOCK |


### PR DESCRIPTION
Blob subpool aggregates all non-pending blob transactions, not just those missing the blob fee. The previous implementation always reported InsufficientBlobFee, misclassifying cases such as nonce gaps, insufficient balance, too much gas, parked ancestors, or insufficient base fee. This change derives the queued reason for blob transactions from TxState flags in a consistent order (structural first, then fees), and adds unit tests to cover the major combinations. Sub-pool routing is unchanged; only the reported reason is corrected.