### PR TITLE
chore(storage): Add trait object error variant to `DatabaseError`

### DIFF
--- a/crates/evm/execution-errors/src/trie.rs
+++ b/crates/evm/execution-errors/src/trie.rs
@@ -7,7 +7,7 @@ use reth_storage_errors::{db::DatabaseError, provider::ProviderError};
 use thiserror::Error;
 
 /// State root errors.
-#[derive(Error, PartialEq, Eq, Clone, Debug)]
+#[derive(Error, Clone, Debug)]
 pub enum StateRootError {
     /// Internal database error.
     #[error(transparent)]
@@ -27,7 +27,7 @@ impl From<StateRootError> for DatabaseError {
 }
 
 /// Storage root error.
-#[derive(Error, PartialEq, Eq, Clone, Debug)]
+#[derive(Error, Clone, Debug)]
 pub enum StorageRootError {
     /// Internal database error.
     #[error(transparent)]
@@ -43,7 +43,7 @@ impl From<StorageRootError> for DatabaseError {
 }
 
 /// State proof errors.
-#[derive(Error, PartialEq, Eq, Clone, Debug)]
+#[derive(Error, Clone, Debug)]
 pub enum StateProofError {
     /// Internal database error.
     #[error(transparent)]

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -679,14 +679,14 @@ mod tests {
         dup_cursor.upsert(Address::with_last_byte(1), &entry_1).expect(ERROR_UPSERT);
 
         assert_eq!(
-            dup_cursor.walk(None).unwrap().collect::<Result<Vec<_>, _>>(),
-            Ok(vec![(Address::with_last_byte(1), entry_0), (Address::with_last_byte(1), entry_1),])
+            dup_cursor.walk(None).unwrap().collect::<Result<Vec<_>, _>>().unwrap(),
+            vec![(Address::with_last_byte(1), entry_0), (Address::with_last_byte(1), entry_1),]
         );
 
         let mut walker = dup_cursor.walk(None).unwrap();
         walker.delete_current().expect(ERROR_DEL);
 
-        assert_eq!(walker.next(), Some(Ok((Address::with_last_byte(1), entry_1))));
+        assert_eq!(walker.next().unwrap().unwrap(), (Address::with_last_byte(1), entry_1));
 
         // Check the tx view - it correctly holds entry_1
         assert_eq!(
@@ -694,14 +694,15 @@ mod tests {
                 .unwrap()
                 .walk(None)
                 .unwrap()
-                .collect::<Result<Vec<_>, _>>(),
-            Ok(vec![
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap(),
+            vec![
                 (Address::with_last_byte(1), entry_1), // This is ok - we removed entry_0
-            ])
+            ]
         );
 
         // Check the remainder of walker
-        assert_eq!(walker.next(), None);
+        assert!(walker.next().is_none());
     }
 
     #[test]
@@ -746,51 +747,51 @@ mod tests {
 
         // [1, 3)
         let mut walker = cursor.walk_range(1..3).unwrap();
-        assert_eq!(walker.next(), Some(Ok((1, B256::ZERO))));
-        assert_eq!(walker.next(), Some(Ok((2, B256::ZERO))));
-        assert_eq!(walker.next(), None);
+        assert_eq!(walker.next().unwrap().unwrap(), (1, B256::ZERO));
+        assert_eq!(walker.next().unwrap().unwrap(), (2, B256::ZERO));
+        assert!(walker.next().is_none());
         // next() returns None after walker is done
-        assert_eq!(walker.next(), None);
+        assert!(walker.next().is_none());
 
         // [1, 2]
         let mut walker = cursor.walk_range(1..=2).unwrap();
-        assert_eq!(walker.next(), Some(Ok((1, B256::ZERO))));
-        assert_eq!(walker.next(), Some(Ok((2, B256::ZERO))));
+        assert_eq!(walker.next().unwrap().unwrap(), (1, B256::ZERO));
+        assert_eq!(walker.next().unwrap().unwrap(), (2, B256::ZERO));
         // next() returns None after walker is done
-        assert_eq!(walker.next(), None);
+        assert!(walker.next().is_none());
 
         // [1, ∞)
         let mut walker = cursor.walk_range(1..).unwrap();
-        assert_eq!(walker.next(), Some(Ok((1, B256::ZERO))));
-        assert_eq!(walker.next(), Some(Ok((2, B256::ZERO))));
-        assert_eq!(walker.next(), Some(Ok((3, B256::ZERO))));
+        assert_eq!(walker.next().unwrap().unwrap(), (1, B256::ZERO));
+        assert_eq!(walker.next().unwrap().unwrap(), (2, B256::ZERO));
+        assert_eq!(walker.next().unwrap().unwrap(), (3, B256::ZERO));
         // next() returns None after walker is done
-        assert_eq!(walker.next(), None);
+        assert!(walker.next().is_none());
 
         // [2, 4)
         let mut walker = cursor.walk_range(2..4).unwrap();
-        assert_eq!(walker.next(), Some(Ok((2, B256::ZERO))));
-        assert_eq!(walker.next(), Some(Ok((3, B256::ZERO))));
-        assert_eq!(walker.next(), None);
+        assert_eq!(walker.next().unwrap().unwrap(), (2, B256::ZERO));
+        assert_eq!(walker.next().unwrap().unwrap(), (3, B256::ZERO));
+        assert!(walker.next().is_none());
         // next() returns None after walker is done
-        assert_eq!(walker.next(), None);
+        assert!(walker.next().is_none());
 
         // (∞, 3)
         let mut walker = cursor.walk_range(..3).unwrap();
-        assert_eq!(walker.next(), Some(Ok((0, B256::ZERO))));
-        assert_eq!(walker.next(), Some(Ok((1, B256::ZERO))));
-        assert_eq!(walker.next(), Some(Ok((2, B256::ZERO))));
+        assert_eq!(walker.next().unwrap().unwrap(), (0, B256::ZERO));
+        assert_eq!(walker.next().unwrap().unwrap(), (1, B256::ZERO));
+        assert_eq!(walker.next().unwrap().unwrap(), (2, B256::ZERO));
         // next() returns None after walker is done
-        assert_eq!(walker.next(), None);
+        assert!(walker.next().is_none());
 
         // (∞, ∞)
         let mut walker = cursor.walk_range(..).unwrap();
-        assert_eq!(walker.next(), Some(Ok((0, B256::ZERO))));
-        assert_eq!(walker.next(), Some(Ok((1, B256::ZERO))));
-        assert_eq!(walker.next(), Some(Ok((2, B256::ZERO))));
-        assert_eq!(walker.next(), Some(Ok((3, B256::ZERO))));
+        assert_eq!(walker.next().unwrap().unwrap(), (0, B256::ZERO));
+        assert_eq!(walker.next().unwrap().unwrap(), (1, B256::ZERO));
+        assert_eq!(walker.next().unwrap().unwrap(), (2, B256::ZERO));
+        assert_eq!(walker.next().unwrap().unwrap(), (3, B256::ZERO));
         // next() returns None after walker is done
-        assert_eq!(walker.next(), None);
+        assert!(walker.next().is_none());
     }
 
     #[test]
@@ -825,13 +826,31 @@ mod tests {
         assert_eq!(entries.len(), 7);
 
         let mut walker = cursor.walk_range(0..=1).unwrap();
-        assert_eq!(walker.next(), Some(Ok((0, AccountBeforeTx { address: address0, info: None }))));
-        assert_eq!(walker.next(), Some(Ok((0, AccountBeforeTx { address: address1, info: None }))));
-        assert_eq!(walker.next(), Some(Ok((0, AccountBeforeTx { address: address2, info: None }))));
-        assert_eq!(walker.next(), Some(Ok((1, AccountBeforeTx { address: address0, info: None }))));
-        assert_eq!(walker.next(), Some(Ok((1, AccountBeforeTx { address: address1, info: None }))));
-        assert_eq!(walker.next(), Some(Ok((1, AccountBeforeTx { address: address2, info: None }))));
-        assert_eq!(walker.next(), None);
+        assert_eq!(
+            walker.next().unwrap().unwrap(),
+            (0, AccountBeforeTx { address: address0, info: None })
+        );
+        assert_eq!(
+            walker.next().unwrap().unwrap(),
+            (0, AccountBeforeTx { address: address1, info: None })
+        );
+        assert_eq!(
+            walker.next().unwrap().unwrap(),
+            (0, AccountBeforeTx { address: address2, info: None })
+        );
+        assert_eq!(
+            walker.next().unwrap().unwrap(),
+            (1, AccountBeforeTx { address: address0, info: None })
+        );
+        assert_eq!(
+            walker.next().unwrap().unwrap(),
+            (1, AccountBeforeTx { address: address1, info: None })
+        );
+        assert_eq!(
+            walker.next().unwrap().unwrap(),
+            (1, AccountBeforeTx { address: address2, info: None })
+        );
+        assert!(walker.next().is_none());
     }
 
     #[expect(clippy::reversed_empty_ranges)]
@@ -852,15 +871,15 @@ mod tests {
 
         // start bound greater than end bound
         let mut res = cursor.walk_range(3..1).unwrap();
-        assert_eq!(res.next(), None);
+        assert!(res.next().is_none());
 
         // start bound greater than end bound
         let mut res = cursor.walk_range(15..=2).unwrap();
-        assert_eq!(res.next(), None);
+        assert!(res.next().is_none());
 
         // returning nothing
         let mut walker = cursor.walk_range(1..1).unwrap();
-        assert_eq!(walker.next(), None);
+        assert!(walker.next().is_none());
     }
 
     #[test]
@@ -880,17 +899,17 @@ mod tests {
 
         let mut walker = Walker::new(&mut cursor, None);
 
-        assert_eq!(walker.next(), Some(Ok((0, B256::ZERO))));
-        assert_eq!(walker.next(), Some(Ok((1, B256::ZERO))));
-        assert_eq!(walker.next(), Some(Ok((3, B256::ZERO))));
-        assert_eq!(walker.next(), None);
+        assert_eq!(walker.next().unwrap().unwrap(), (0, B256::ZERO));
+        assert_eq!(walker.next().unwrap().unwrap(), (1, B256::ZERO));
+        assert_eq!(walker.next().unwrap().unwrap(), (3, B256::ZERO));
+        assert!(walker.next().is_none());
 
         // transform to ReverseWalker
         let mut reverse_walker = walker.rev();
-        assert_eq!(reverse_walker.next(), Some(Ok((3, B256::ZERO))));
-        assert_eq!(reverse_walker.next(), Some(Ok((1, B256::ZERO))));
-        assert_eq!(reverse_walker.next(), Some(Ok((0, B256::ZERO))));
-        assert_eq!(reverse_walker.next(), None);
+        assert_eq!(reverse_walker.next().unwrap().unwrap(), (3, B256::ZERO));
+        assert_eq!(reverse_walker.next().unwrap().unwrap(), (1, B256::ZERO));
+        assert_eq!(reverse_walker.next().unwrap().unwrap(), (0, B256::ZERO));
+        assert!(reverse_walker.next().is_none());
     }
 
     #[test]
@@ -910,17 +929,17 @@ mod tests {
 
         let mut reverse_walker = ReverseWalker::new(&mut cursor, None);
 
-        assert_eq!(reverse_walker.next(), Some(Ok((3, B256::ZERO))));
-        assert_eq!(reverse_walker.next(), Some(Ok((1, B256::ZERO))));
-        assert_eq!(reverse_walker.next(), Some(Ok((0, B256::ZERO))));
-        assert_eq!(reverse_walker.next(), None);
+        assert_eq!(reverse_walker.next().unwrap().unwrap(), (3, B256::ZERO));
+        assert_eq!(reverse_walker.next().unwrap().unwrap(), (1, B256::ZERO));
+        assert_eq!(reverse_walker.next().unwrap().unwrap(), (0, B256::ZERO));
+        assert!(reverse_walker.next().is_none());
 
         // transform to Walker
         let mut walker = reverse_walker.forward();
-        assert_eq!(walker.next(), Some(Ok((0, B256::ZERO))));
-        assert_eq!(walker.next(), Some(Ok((1, B256::ZERO))));
-        assert_eq!(walker.next(), Some(Ok((3, B256::ZERO))));
-        assert_eq!(walker.next(), None);
+        assert_eq!(walker.next().unwrap().unwrap(), (0, B256::ZERO));
+        assert_eq!(walker.next().unwrap().unwrap(), (1, B256::ZERO));
+        assert_eq!(walker.next().unwrap().unwrap(), (3, B256::ZERO));
+        assert!(walker.next().is_none());
     }
 
     #[test]
@@ -939,27 +958,27 @@ mod tests {
         let mut cursor = tx.cursor_read::<CanonicalHeaders>().unwrap();
 
         let mut reverse_walker = cursor.walk_back(Some(1)).unwrap();
-        assert_eq!(reverse_walker.next(), Some(Ok((1, B256::ZERO))));
-        assert_eq!(reverse_walker.next(), Some(Ok((0, B256::ZERO))));
-        assert_eq!(reverse_walker.next(), None);
+        assert_eq!(reverse_walker.next().unwrap().unwrap(), (1, B256::ZERO));
+        assert_eq!(reverse_walker.next().unwrap().unwrap(), (0, B256::ZERO));
+        assert!(reverse_walker.next().is_none());
 
         let mut reverse_walker = cursor.walk_back(Some(2)).unwrap();
-        assert_eq!(reverse_walker.next(), Some(Ok((3, B256::ZERO))));
-        assert_eq!(reverse_walker.next(), Some(Ok((1, B256::ZERO))));
-        assert_eq!(reverse_walker.next(), Some(Ok((0, B256::ZERO))));
-        assert_eq!(reverse_walker.next(), None);
+        assert_eq!(reverse_walker.next().unwrap().unwrap(), (3, B256::ZERO));
+        assert_eq!(reverse_walker.next().unwrap().unwrap(), (1, B256::ZERO));
+        assert_eq!(reverse_walker.next().unwrap().unwrap(), (0, B256::ZERO));
+        assert!(reverse_walker.next().is_none());
 
         let mut reverse_walker = cursor.walk_back(Some(4)).unwrap();
-        assert_eq!(reverse_walker.next(), Some(Ok((3, B256::ZERO))));
-        assert_eq!(reverse_walker.next(), Some(Ok((1, B256::ZERO))));
-        assert_eq!(reverse_walker.next(), Some(Ok((0, B256::ZERO))));
-        assert_eq!(reverse_walker.next(), None);
+        assert_eq!(reverse_walker.next().unwrap().unwrap(), (3, B256::ZERO));
+        assert_eq!(reverse_walker.next().unwrap().unwrap(), (1, B256::ZERO));
+        assert_eq!(reverse_walker.next().unwrap().unwrap(), (0, B256::ZERO));
+        assert!(reverse_walker.next().is_none());
 
         let mut reverse_walker = cursor.walk_back(None).unwrap();
-        assert_eq!(reverse_walker.next(), Some(Ok((3, B256::ZERO))));
-        assert_eq!(reverse_walker.next(), Some(Ok((1, B256::ZERO))));
-        assert_eq!(reverse_walker.next(), Some(Ok((0, B256::ZERO))));
-        assert_eq!(reverse_walker.next(), None);
+        assert_eq!(reverse_walker.next().unwrap().unwrap(), (3, B256::ZERO));
+        assert_eq!(reverse_walker.next().unwrap().unwrap(), (1, B256::ZERO));
+        assert_eq!(reverse_walker.next().unwrap().unwrap(), (0, B256::ZERO));
+        assert!(reverse_walker.next().is_none());
     }
 
     #[test]
@@ -978,12 +997,12 @@ mod tests {
         let missing_key = 2;
         let tx = db.tx().expect(ERROR_INIT_TX);
         let mut cursor = tx.cursor_read::<CanonicalHeaders>().unwrap();
-        assert_eq!(cursor.current(), Ok(None));
+        assert!(cursor.current().unwrap().is_none());
 
         // Seek exact
         let exact = cursor.seek_exact(missing_key).unwrap();
         assert_eq!(exact, None);
-        assert_eq!(cursor.current(), Ok(None));
+        assert!(cursor.current().unwrap().is_none());
     }
 
     #[test]
@@ -1003,21 +1022,18 @@ mod tests {
         let mut cursor = tx.cursor_write::<CanonicalHeaders>().unwrap();
 
         // INSERT
-        assert_eq!(cursor.insert(key_to_insert, &B256::ZERO), Ok(()));
-        assert_eq!(cursor.current(), Ok(Some((key_to_insert, B256::ZERO))));
-
+        assert!(cursor.insert(key_to_insert, &B256::ZERO).is_ok());
+        assert_eq!(cursor.current().unwrap(), Some((key_to_insert, B256::ZERO)));
         // INSERT (failure)
-        assert_eq!(
-            cursor.insert(key_to_insert, &B256::ZERO),
-            Err(DatabaseWriteError {
-                info: Error::KeyExist.into(),
-                operation: DatabaseWriteOperation::CursorInsert,
-                table_name: CanonicalHeaders::NAME,
-                key: key_to_insert.encode().into(),
-            }
-            .into())
-        );
-        assert_eq!(cursor.current(), Ok(Some((key_to_insert, B256::ZERO))));
+        assert!(matches!(
+        cursor.insert(key_to_insert, &B256::ZERO).unwrap_err(),
+        DatabaseError::Write(err) if *err == DatabaseWriteError {
+            info: Error::KeyExist.into(),
+            operation: DatabaseWriteOperation::CursorInsert,
+            table_name: CanonicalHeaders::NAME,
+            key: key_to_insert.encode().into(),
+        }));
+        assert_eq!(cursor.current().unwrap(), Some((key_to_insert, B256::ZERO)));
 
         tx.commit().expect(ERROR_COMMIT);
 
@@ -1063,19 +1079,18 @@ mod tests {
 
         // Seek & delete key2
         cursor.seek_exact(key2).unwrap();
-        assert_eq!(cursor.delete_current(), Ok(()));
-        assert_eq!(cursor.seek_exact(key2), Ok(None));
+        assert!(cursor.delete_current().is_ok());
+        assert!(cursor.seek_exact(key2).unwrap().is_none());
 
         // Seek & delete key2 again
-        assert_eq!(cursor.seek_exact(key2), Ok(None));
-        assert_eq!(
-            cursor.delete_current(),
-            Err(DatabaseError::Delete(reth_libmdbx::Error::NoData.into()))
-        );
+        assert!(cursor.seek_exact(key2).unwrap().is_none());
+        assert!(matches!(
+            cursor.delete_current().unwrap_err(),
+            DatabaseError::Delete(err) if err == reth_libmdbx::Error::NoData.into()));
         // Assert that key1 is still there
-        assert_eq!(cursor.seek_exact(key1), Ok(Some((key1, Account::default()))));
+        assert_eq!(cursor.seek_exact(key1).unwrap(), Some((key1, Account::default())));
         // Assert that key3 is still there
-        assert_eq!(cursor.seek_exact(key3), Ok(Some((key3, Account::default()))));
+        assert_eq!(cursor.seek_exact(key3).unwrap(), Some((key3, Account::default())));
     }
 
     #[test]
@@ -1095,11 +1110,11 @@ mod tests {
 
         // INSERT (cursor starts at last)
         cursor.last().unwrap();
-        assert_eq!(cursor.current(), Ok(Some((9, B256::ZERO))));
+        assert_eq!(cursor.current().unwrap(), Some((9, B256::ZERO)));
 
         for pos in (2..=8).step_by(2) {
-            assert_eq!(cursor.insert(pos, &B256::ZERO), Ok(()));
-            assert_eq!(cursor.current(), Ok(Some((pos, B256::ZERO))));
+            assert!(cursor.insert(pos, &B256::ZERO).is_ok());
+            assert_eq!(cursor.current().unwrap(), Some((pos, B256::ZERO)));
         }
         tx.commit().expect(ERROR_COMMIT);
 
@@ -1127,7 +1142,7 @@ mod tests {
         let key_to_append = 5;
         let tx = db.tx_mut().expect(ERROR_INIT_TX);
         let mut cursor = tx.cursor_write::<CanonicalHeaders>().unwrap();
-        assert_eq!(cursor.append(key_to_append, &B256::ZERO), Ok(()));
+        assert!(cursor.append(key_to_append, &B256::ZERO).is_ok());
         tx.commit().expect(ERROR_COMMIT);
 
         // Confirm the result
@@ -1154,17 +1169,15 @@ mod tests {
         let key_to_append = 2;
         let tx = db.tx_mut().expect(ERROR_INIT_TX);
         let mut cursor = tx.cursor_write::<CanonicalHeaders>().unwrap();
-        assert_eq!(
-            cursor.append(key_to_append, &B256::ZERO),
-            Err(DatabaseWriteError {
-                info: Error::KeyMismatch.into(),
-                operation: DatabaseWriteOperation::CursorAppend,
-                table_name: CanonicalHeaders::NAME,
-                key: key_to_append.encode().into(),
-            }
-            .into())
-        );
-        assert_eq!(cursor.current(), Ok(Some((5, B256::ZERO)))); // the end of table
+        assert!(matches!(
+        cursor.append(key_to_append, &B256::ZERO).unwrap_err(),
+        DatabaseError::Write(err) if *err == DatabaseWriteError {
+            info: Error::KeyMismatch.into(),
+            operation: DatabaseWriteOperation::CursorAppend,
+            table_name: CanonicalHeaders::NAME,
+            key: key_to_append.encode().into(),
+        }));
+        assert_eq!(cursor.current().unwrap(), Some((5, B256::ZERO))); // the end of table
         tx.commit().expect(ERROR_COMMIT);
 
         // Confirm the result
@@ -1185,15 +1198,15 @@ mod tests {
 
         let account = Account::default();
         cursor.upsert(key, &account).expect(ERROR_UPSERT);
-        assert_eq!(cursor.seek_exact(key), Ok(Some((key, account))));
+        assert_eq!(cursor.seek_exact(key).unwrap(), Some((key, account)));
 
         let account = Account { nonce: 1, ..Default::default() };
         cursor.upsert(key, &account).expect(ERROR_UPSERT);
-        assert_eq!(cursor.seek_exact(key), Ok(Some((key, account))));
+        assert_eq!(cursor.seek_exact(key).unwrap(), Some((key, account)));
 
         let account = Account { nonce: 2, ..Default::default() };
         cursor.upsert(key, &account).expect(ERROR_UPSERT);
-        assert_eq!(cursor.seek_exact(key), Ok(Some((key, account))));
+        assert_eq!(cursor.seek_exact(key).unwrap(), Some((key, account)));
 
         let mut dup_cursor = tx.cursor_dup_write::<PlainStorageState>().unwrap();
         let subkey = B256::random();
@@ -1201,13 +1214,13 @@ mod tests {
         let value = U256::from(1);
         let entry1 = StorageEntry { key: subkey, value };
         dup_cursor.upsert(key, &entry1).expect(ERROR_UPSERT);
-        assert_eq!(dup_cursor.seek_by_key_subkey(key, subkey), Ok(Some(entry1)));
+        assert_eq!(dup_cursor.seek_by_key_subkey(key, subkey).unwrap(), Some(entry1));
 
         let value = U256::from(2);
         let entry2 = StorageEntry { key: subkey, value };
         dup_cursor.upsert(key, &entry2).expect(ERROR_UPSERT);
-        assert_eq!(dup_cursor.seek_by_key_subkey(key, subkey), Ok(Some(entry1)));
-        assert_eq!(dup_cursor.next_dup_val(), Ok(Some(entry2)));
+        assert_eq!(dup_cursor.seek_by_key_subkey(key, subkey).unwrap(), Some(entry1));
+        assert_eq!(dup_cursor.next_dup_val().unwrap(), Some(entry2));
     }
 
     #[test]
@@ -1233,39 +1246,45 @@ mod tests {
         let subkey_to_append = 2;
         let tx = db.tx_mut().expect(ERROR_INIT_TX);
         let mut cursor = tx.cursor_write::<AccountChangeSets>().unwrap();
-        assert_eq!(
-            cursor.append_dup(
+        assert!(matches!(
+        cursor
+            .append_dup(
                 transition_id,
-                AccountBeforeTx { address: Address::with_last_byte(subkey_to_append), info: None }
-            ),
-            Err(DatabaseWriteError {
-                info: Error::KeyMismatch.into(),
-                operation: DatabaseWriteOperation::CursorAppendDup,
-                table_name: AccountChangeSets::NAME,
-                key: transition_id.encode().into(),
-            }
-            .into())
-        );
-        assert_eq!(
-            cursor.append(
-                transition_id - 1,
-                &AccountBeforeTx { address: Address::with_last_byte(subkey_to_append), info: None }
-            ),
-            Err(DatabaseWriteError {
+                AccountBeforeTx {
+                    address: Address::with_last_byte(subkey_to_append),
+                    info: None
+                }
+            )
+            .unwrap_err(),
+        DatabaseError::Write(err) if *err == DatabaseWriteError {
+            info: Error::KeyMismatch.into(),
+            operation: DatabaseWriteOperation::CursorAppendDup,
+            table_name: AccountChangeSets::NAME,
+            key: transition_id.encode().into(),
+        }));
+        assert!(matches!(
+            cursor
+                .append(
+                    transition_id - 1,
+                    &AccountBeforeTx {
+                        address: Address::with_last_byte(subkey_to_append),
+                        info: None
+                    }
+                )
+                .unwrap_err(),
+            DatabaseError::Write(err) if *err == DatabaseWriteError {
                 info: Error::KeyMismatch.into(),
                 operation: DatabaseWriteOperation::CursorAppend,
                 table_name: AccountChangeSets::NAME,
                 key: (transition_id - 1).encode().into(),
             }
-            .into())
-        );
-        assert_eq!(
-            cursor.append(
+        ));
+        assert!(cursor
+            .append(
                 transition_id,
                 &AccountBeforeTx { address: Address::with_last_byte(subkey_to_append), info: None }
-            ),
-            Ok(())
-        );
+            )
+            .is_ok());
     }
 
     #[test]
@@ -1373,7 +1392,7 @@ mod tests {
             let mut cursor = tx.cursor_dup_read::<PlainStorageState>().unwrap();
             let not_existing_key = Address::ZERO;
             let mut walker = cursor.walk_dup(Some(not_existing_key), None).unwrap();
-            assert_eq!(walker.next(), None);
+            assert!(walker.next().is_none());
         }
     }
 
@@ -1404,11 +1423,11 @@ mod tests {
             let mut walker = cursor.walk_dup(None, None).unwrap();
 
             // Notice that value11 and value22 have been ordered in the DB.
-            assert_eq!(Some(Ok((key1, value00))), walker.next());
-            assert_eq!(Some(Ok((key1, value11))), walker.next());
+            assert_eq!((key1, value00), walker.next().unwrap().unwrap());
+            assert_eq!((key1, value11), walker.next().unwrap().unwrap());
             // NOTE: Dup cursor does NOT iterates on all values but only on duplicated values of the
             // same key. assert_eq!(Ok(Some(value22.clone())), walker.next());
-            assert_eq!(None, walker.next());
+            assert!(walker.next().is_none());
         }
 
         // Iterate by using `walk`
@@ -1417,9 +1436,9 @@ mod tests {
             let mut cursor = tx.cursor_dup_read::<PlainStorageState>().unwrap();
             let first = cursor.first().unwrap().unwrap();
             let mut walker = cursor.walk(Some(first.0)).unwrap();
-            assert_eq!(Some(Ok((key1, value00))), walker.next());
-            assert_eq!(Some(Ok((key1, value11))), walker.next());
-            assert_eq!(Some(Ok((key2, value22))), walker.next());
+            assert_eq!((key1, value00), walker.next().unwrap().unwrap());
+            assert_eq!((key1, value11), walker.next().unwrap().unwrap());
+            assert_eq!((key2, value22), walker.next().unwrap().unwrap());
         }
     }
 
@@ -1449,9 +1468,9 @@ mod tests {
             let mut walker = cursor.walk(Some(first.0)).unwrap();
 
             // NOTE: Both values are present
-            assert_eq!(Some(Ok((key1, value00))), walker.next());
-            assert_eq!(Some(Ok((key1, value01))), walker.next());
-            assert_eq!(Some(Ok((key2, value22))), walker.next());
+            assert_eq!((key1, value00), walker.next().unwrap().unwrap());
+            assert_eq!((key1, value01), walker.next().unwrap().unwrap());
+            assert_eq!((key2, value22), walker.next().unwrap().unwrap());
         }
 
         // seek_by_key_subkey
@@ -1460,9 +1479,9 @@ mod tests {
             let mut cursor = tx.cursor_dup_read::<PlainStorageState>().unwrap();
 
             // NOTE: There are two values with same SubKey but only first one is shown
-            assert_eq!(Ok(Some(value00)), cursor.seek_by_key_subkey(key1, value00.key));
+            assert_eq!(value00, cursor.seek_by_key_subkey(key1, value00.key).unwrap().unwrap());
             // key1 but value is greater than the one in the DB
-            assert_eq!(Ok(None), cursor.seek_by_key_subkey(key1, value22.key));
+            assert_eq!(None, cursor.seek_by_key_subkey(key1, value22.key).unwrap());
         }
     }
 

--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -460,10 +460,9 @@ mod tests {
         sleep(MAX_DURATION + Duration::from_millis(100));
 
         // Transaction has not timed out.
-        assert_eq!(
-            tx.get::<tables::Transactions>(0),
-            Err(DatabaseError::Open(reth_libmdbx::Error::NotFound.into()))
-        );
+        assert!(matches!(
+            tx.get::<tables::Transactions>(0).unwrap_err(),
+            DatabaseError::Open(err) if err == reth_libmdbx::Error::NotFound.into()));
         // Backtrace is not recorded.
         assert!(!tx.metrics_handler.unwrap().backtrace_recorded.load(Ordering::Relaxed));
     }
@@ -485,10 +484,9 @@ mod tests {
         sleep(MAX_DURATION + Duration::from_millis(100));
 
         // Transaction has timed out.
-        assert_eq!(
-            tx.get::<tables::Transactions>(0),
-            Err(DatabaseError::Open(reth_libmdbx::Error::ReadTransactionTimeout.into()))
-        );
+        assert!(matches!(
+            tx.get::<tables::Transactions>(0).unwrap_err(),
+            DatabaseError::Open(err) if err == reth_libmdbx::Error::ReadTransactionTimeout.into()));
         // Backtrace is recorded.
         assert!(tx.metrics_handler.unwrap().backtrace_recorded.load(Ordering::Relaxed));
     }

--- a/crates/storage/errors/src/db.rs
+++ b/crates/storage/errors/src/db.rs
@@ -2,15 +2,17 @@ use alloc::{
     boxed::Box,
     format,
     string::{String, ToString},
+    sync::Arc,
     vec::Vec,
 };
 use core::{
+    error::Error,
     fmt::{Debug, Display},
     str::FromStr,
 };
 
 /// Database error type.
-#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+#[derive(Clone, Debug, thiserror::Error)]
 pub enum DatabaseError {
     /// Failed to open the database.
     #[error("failed to open the database: {_0}")]
@@ -48,6 +50,9 @@ pub enum DatabaseError {
     /// Other unspecified error.
     #[error("{_0}")]
     Other(String),
+    /// Other unspecified error.
+    #[error(transparent)]
+    Custom(#[from] Arc<dyn Error + Send + Sync>),
 }
 
 /// Common error struct to propagate implementation-specific error information.

--- a/crates/storage/provider/src/changesets_utils/trie.rs
+++ b/crates/storage/provider/src/changesets_utils/trie.rs
@@ -140,7 +140,7 @@ pub fn storage_trie_wiped_changeset_iter(
             // Due to the ordering closure passed to `merge_join_by` it's not possible for either
             // value to be an error here.
             debug_assert!(changed.is_ok(), "unreachable error condition: {changed:?}");
-            debug_assert_eq!(changed, _wiped);
+            debug_assert_eq!(*changed.as_ref().unwrap(), _wiped.unwrap());
             changed
         }
     }))

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -736,16 +736,16 @@ mod tests {
 
             assert_matches!(provider.insert_block(block.clone().try_recover().unwrap()), Ok(_));
 
-            let senders = provider.take::<tables::TransactionSenders>(range.clone());
+            let senders = provider.take::<tables::TransactionSenders>(range.clone()).unwrap();
             assert_eq!(
                 senders,
-                Ok(range
+                range
                     .clone()
                     .map(|tx_number| (
                         tx_number,
                         block.body().transactions[tx_number as usize].recover_signer().unwrap()
                     ))
-                    .collect())
+                    .collect::<Vec<_>>()
             );
 
             let db_senders = provider.senders_by_tx_range(range);


### PR DESCRIPTION
This PR contains one of the bindings which is needed to use `DatabaseError` in a type safe way in l2 code, for example in the OP historical proofs workstream. This allows downcast to OP error enum as opposed to adding additional wrapper cursor traits to be able to propagate OP errors in a type safe way (matching on error strings out ruled).

- Adds variant wrapping trait object error to `DatabaseError`
- Removes redundant `PartialEq` impl for `DatabaseError`, this was almost exclusively used in tests
- Updates tests to match on errors or compare the error variant data instead or relying on `PartialEq`

Ref https://github.com/op-rs/op-reth/pull/388