### PR TITLE
docs(engine): fix transact_batch comment

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -435,8 +435,9 @@ where
     /// Accepts an [`mpsc::Receiver`] of transactions and a handle to prewarm task. Executes
     /// transactions and streams [`PrewarmTaskEvent::Outcome`] messages for each transaction.
     ///
-    /// Returns `None` if executing the transactions failed to a non Revert error.
-    /// Returns the touched+modified state of the transaction.
+    /// This function processes transactions sequentially from the receiver and emits outcome events
+    /// via the provided sender. Execution errors are logged and tracked but do not stop the batch
+    /// processing unless the task is explicitly cancelled.
     ///
     /// Note: There are no ordering guarantees; this does not reflect the state produced by
     /// sequential execution.


### PR DESCRIPTION
Corrects the documentation for the `transact_batch` function in the engine's prewarming component. The previous comments incorrectly described function return values, while the function actually communicates outcomes via a sender channel.