### PR TITLE
feat(rpc): handle dedicated eth_simulate errors

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -29,7 +29,7 @@ use reth_revm::{database::StateProviderDatabase, db::State};
 use reth_rpc_convert::{RpcConvert, RpcTxReq};
 use reth_rpc_eth_types::{
     cache::db::StateProviderTraitObjWrapper,
-    error::FromEthApiError,
+    error::{AsEthApiError, FromEthApiError},
     simulate::{self, EthSimulateError},
     EthApiError, StateCacheDb,
 };
@@ -159,6 +159,13 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                         .context_for_next_block(&parent, this.next_env_attributes(&parent)?)
                         .map_err(RethError::other)
                         .map_err(Self::Error::from_eth_err)?;
+                    let map_err = |e: EthApiError| -> Self::Error {
+                        match e.as_simulate_error() {
+                            Some(sim_err) => Self::Error::from_eth_err(EthApiError::other(sim_err)),
+                            None => Self::Error::from_eth_err(e),
+                        }
+                    };
+
                     let (result, results) = if trace_transfers {
                         // prepare inspector to capture transfer inside the evm so they are recorded
                         // and included in logs
@@ -173,7 +180,8 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                             default_gas_limit,
                             chain_id,
                             this.converter(),
-                        )?
+                        )
+                        .map_err(map_err)?
                     } else {
                         let evm = this.evm_config().evm_with_env(&mut db, evm_env);
                         let builder = this.evm_config().create_block_builder(evm, &parent, ctx);
@@ -183,7 +191,8 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                             default_gas_limit,
                             chain_id,
                             this.converter(),
-                        )?
+                        )
+                        .map_err(map_err)?
                     };
 
                     parent = result.block.clone_sealed_header();

--- a/crates/rpc/rpc-eth-types/src/error/api.rs
+++ b/crates/rpc/rpc-eth-types/src/error/api.rs
@@ -80,16 +80,21 @@ pub trait AsEthApiError {
         let err = self.as_err()?;
         match err {
             EthApiError::InvalidTransaction(tx_err) => match tx_err {
-                RpcInvalidTransactionError::NonceTooLow { tx, state } => 
-                    Some(EthSimulateError::NonceTooLow { tx: *tx, state: *state }),
+                RpcInvalidTransactionError::NonceTooLow { tx, state } => {
+                    Some(EthSimulateError::NonceTooLow { tx: *tx, state: *state })
+                }
                 RpcInvalidTransactionError::NonceTooHigh => Some(EthSimulateError::NonceTooHigh),
-                RpcInvalidTransactionError::FeeCapTooLow => Some(EthSimulateError::BaseFeePerGasTooLow),
+                RpcInvalidTransactionError::FeeCapTooLow => {
+                    Some(EthSimulateError::BaseFeePerGasTooLow)
+                }
                 RpcInvalidTransactionError::GasTooLow => Some(EthSimulateError::IntrinsicGasTooLow),
-                RpcInvalidTransactionError::InsufficientFunds { cost, balance } => 
-                    Some(EthSimulateError::InsufficientFunds { cost: *cost, balance: *balance }),
+                RpcInvalidTransactionError::InsufficientFunds { cost, balance } => {
+                    Some(EthSimulateError::InsufficientFunds { cost: *cost, balance: *balance })
+                }
                 RpcInvalidTransactionError::SenderNoEOA => Some(EthSimulateError::SenderNotEOA),
-                RpcInvalidTransactionError::MaxInitCodeSizeExceeded => 
-                    Some(EthSimulateError::MaxInitCodeSizeExceeded),
+                RpcInvalidTransactionError::MaxInitCodeSizeExceeded => {
+                    Some(EthSimulateError::MaxInitCodeSizeExceeded)
+                }
                 _ => None,
             },
             _ => None,

--- a/crates/rpc/rpc-eth-types/src/error/api.rs
+++ b/crates/rpc/rpc-eth-types/src/error/api.rs
@@ -1,7 +1,7 @@
 //! Helper traits to wrap generic l1 errors, in network specific error type configured in
 //! `reth_rpc_eth_api::EthApiTypes`.
 
-use crate::{EthApiError, RevertError};
+use crate::{simulate::EthSimulateError, EthApiError, RevertError};
 use alloy_primitives::Bytes;
 use reth_errors::ProviderError;
 use reth_evm::{ConfigureEvm, EvmErrorFor, HaltReasonFor};
@@ -73,6 +73,27 @@ pub trait AsEthApiError {
         }
 
         false
+    }
+
+    /// Returns [`EthSimulateError`] if this error maps to a simulate-specific error code.
+    fn as_simulate_error(&self) -> Option<EthSimulateError> {
+        let err = self.as_err()?;
+        match err {
+            EthApiError::InvalidTransaction(tx_err) => match tx_err {
+                RpcInvalidTransactionError::NonceTooLow { tx, state } => 
+                    Some(EthSimulateError::NonceTooLow { tx: *tx, state: *state }),
+                RpcInvalidTransactionError::NonceTooHigh => Some(EthSimulateError::NonceTooHigh),
+                RpcInvalidTransactionError::FeeCapTooLow => Some(EthSimulateError::BaseFeePerGasTooLow),
+                RpcInvalidTransactionError::GasTooLow => Some(EthSimulateError::IntrinsicGasTooLow),
+                RpcInvalidTransactionError::InsufficientFunds { cost, balance } => 
+                    Some(EthSimulateError::InsufficientFunds { cost: *cost, balance: *balance }),
+                RpcInvalidTransactionError::SenderNoEOA => Some(EthSimulateError::SenderNotEOA),
+                RpcInvalidTransactionError::MaxInitCodeSizeExceeded => 
+                    Some(EthSimulateError::MaxInitCodeSizeExceeded),
+                _ => None,
+            },
+            _ => None,
+        }
     }
 }
 

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -82,10 +82,9 @@ pub enum EthSimulateError {
 }
 
 impl EthSimulateError {
-    /// Returns the JSON-RPC error code for this error.
+    /// Returns the JSON-RPC error code for a `eth_simulateV1` error.
     pub const fn error_code(&self) -> i32 {
         match self {
-            // Transaction errors
             Self::NonceTooLow { .. } => -38010,
             Self::NonceTooHigh => -38011,
             Self::BaseFeePerGasTooLow => -38012,


### PR DESCRIPTION
solves #20054 by:
- extending `EthSimulateError` following [execution-apis](https://github.com/ethereum/execution-apis/blob/f910189261255eb0ebc49ee0e6f10f48562a41c3/src/eth/execute.yaml#L129) and [geth/ethapi/errors](https://github.com/ethereum/go-ethereum/blob/6f2cbb7a27ba7e62b0bdb2090755ef0d271714be/internal/ethapi/errors.go#L102-L118)
- extending the trait `AsEthApiError` with as_simulate_error() to match RpcInvalidTransactionError counterparts
- small refactor at `simulate_v1` using this new method