### PR TITLE
fix: set minimum pruning distance to 64 blocks for trie changesets

### DIFF
--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -172,7 +172,7 @@ impl LaunchContext {
     }
 
     /// Save prune config to the toml file if node is a full node or has custom pruning CLI
-    /// arguments.
+    /// arguments. Also migrates deprecated prune config values to new defaults.
     fn save_pruning_config<ChainSpec>(
         reth_config: &mut reth_config::Config,
         config: &NodeConfig<ChainSpec>,
@@ -181,15 +181,22 @@ impl LaunchContext {
     where
         ChainSpec: EthChainSpec + reth_chainspec::EthereumHardforks,
     {
+        let mut should_save = reth_config.prune.segments.migrate();
+
         if let Some(prune_config) = config.prune_config() {
             if reth_config.prune != prune_config {
                 reth_config.set_prune_config(prune_config);
-                info!(target: "reth::cli", "Saving prune config to toml file");
-                reth_config.save(config_path.as_ref())?;
+                should_save = true;
             }
         } else if !reth_config.prune.is_default() {
             warn!(target: "reth::cli", "Pruning configuration is present in the config file, but no CLI arguments are provided. Using config from file.");
         }
+
+        if should_save {
+            info!(target: "reth::cli", "Saving prune config to toml file");
+            reth_config.save(config_path.as_ref())?;
+        }
+
         Ok(())
     }
 

--- a/crates/node/core/src/args/pruning.rs
+++ b/crates/node/core/src/args/pruning.rs
@@ -5,7 +5,10 @@ use alloy_primitives::{Address, BlockNumber};
 use clap::{builder::RangedU64ValueParser, Args};
 use reth_chainspec::EthereumHardforks;
 use reth_config::config::PruneConfig;
-use reth_prune_types::{PruneMode, PruneModes, ReceiptsLogPruneConfig, MINIMUM_PRUNING_DISTANCE};
+use reth_prune_types::{
+    PruneMode, PruneModes, ReceiptsLogPruneConfig, MERKLE_CHANGESETS_RETENTION_BLOCKS,
+    MINIMUM_PRUNING_DISTANCE,
+};
 use std::{collections::BTreeMap, ops::Not};
 
 /// Parameters for pruning and full node
@@ -131,7 +134,7 @@ impl PruningArgs {
                         .ethereum_fork_activation(EthereumHardfork::Paris)
                         .block_number()
                         .map(PruneMode::Before),
-                    merkle_changesets: PruneMode::Distance(MINIMUM_PRUNING_DISTANCE),
+                    merkle_changesets: PruneMode::Distance(MERKLE_CHANGESETS_RETENTION_BLOCKS),
                     receipts_log_filter: Default::default(),
                 },
             }

--- a/crates/prune/types/src/lib.rs
+++ b/crates/prune/types/src/lib.rs
@@ -30,7 +30,10 @@ pub use pruner::{
     SegmentOutputCheckpoint,
 };
 pub use segment::{PrunePurpose, PruneSegment, PruneSegmentError};
-pub use target::{PruneModes, UnwindTargetPrunedError, MINIMUM_PRUNING_DISTANCE};
+pub use target::{
+    PruneModes, UnwindTargetPrunedError, MERKLE_CHANGESETS_RETENTION_BLOCKS,
+    MINIMUM_PRUNING_DISTANCE,
+};
 
 /// Configuration for pruning receipts not associated with logs emitted by the specified contracts.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]

--- a/crates/prune/types/src/segment.rs
+++ b/crates/prune/types/src/segment.rs
@@ -1,6 +1,6 @@
 #![allow(deprecated)] // necessary to all defining deprecated `PruneSegment` variants
 
-use crate::MINIMUM_PRUNING_DISTANCE;
+use crate::{MERKLE_CHANGESETS_RETENTION_BLOCKS, MINIMUM_PRUNING_DISTANCE};
 use derive_more::Display;
 use strum::{EnumIter, IntoEnumIterator};
 use thiserror::Error;
@@ -68,9 +68,9 @@ impl PruneSegment {
             Self::ContractLogs |
             Self::AccountHistory |
             Self::StorageHistory |
-            Self::MerkleChangeSets |
             Self::Bodies |
             Self::Receipts => MINIMUM_PRUNING_DISTANCE,
+            Self::MerkleChangeSets => MERKLE_CHANGESETS_RETENTION_BLOCKS,
             #[expect(deprecated)]
             #[expect(clippy::match_same_arms)]
             Self::Headers | Self::Transactions => 0,

--- a/crates/prune/types/src/target.rs
+++ b/crates/prune/types/src/target.rs
@@ -150,6 +150,23 @@ impl PruneModes {
         self.receipts.is_some() || !self.receipts_log_filter.is_empty()
     }
 
+    /// Migrates deprecated prune mode values to their new defaults.
+    ///
+    /// Returns `true` if any migration was performed.
+    ///
+    /// Currently migrates:
+    /// - `merkle_changesets`: `Distance(10064)` -> `Distance(64)`
+    pub fn migrate(&mut self) -> bool {
+        let mut migrated = false;
+
+        if self.merkle_changesets == PruneMode::Distance(MINIMUM_PRUNING_DISTANCE) {
+            self.merkle_changesets = PruneMode::Distance(MERKLE_CHANGESETS_RETENTION_BLOCKS);
+            migrated = true;
+        }
+
+        migrated
+    }
+
     /// Returns an error if we can't unwind to the targeted block because the target block is
     /// outside the range.
     ///

--- a/crates/prune/types/src/target.rs
+++ b/crates/prune/types/src/target.rs
@@ -36,9 +36,13 @@ pub enum HistoryType {
     StorageHistory,
 }
 
+/// Default number of blocks to retain for merkle changesets.
+/// This is used by both the `MerkleChangeSets` stage and the pruner segment.
+pub const MERKLE_CHANGESETS_RETENTION_BLOCKS: u64 = 64;
+
 /// Default pruning mode for merkle changesets
 const fn default_merkle_changesets_mode() -> PruneMode {
-    PruneMode::Distance(MINIMUM_PRUNING_DISTANCE)
+    PruneMode::Distance(MERKLE_CHANGESETS_RETENTION_BLOCKS)
 }
 
 /// Pruning configuration for every segment of the data that can be pruned.
@@ -95,7 +99,7 @@ pub struct PruneModes {
         any(test, feature = "serde"),
         serde(
             default = "default_merkle_changesets_mode",
-            deserialize_with = "deserialize_prune_mode_with_min_blocks::<MINIMUM_PRUNING_DISTANCE, _>"
+            deserialize_with = "deserialize_prune_mode_with_min_blocks::<MERKLE_CHANGESETS_RETENTION_BLOCKS, _>"
         )
     )]
     pub merkle_changesets: PruneMode,

--- a/crates/prune/types/src/target.rs
+++ b/crates/prune/types/src/target.rs
@@ -157,14 +157,12 @@ impl PruneModes {
     /// Currently migrates:
     /// - `merkle_changesets`: `Distance(10064)` -> `Distance(64)`
     pub fn migrate(&mut self) -> bool {
-        let mut migrated = false;
-
         if self.merkle_changesets == PruneMode::Distance(MINIMUM_PRUNING_DISTANCE) {
             self.merkle_changesets = PruneMode::Distance(MERKLE_CHANGESETS_RETENTION_BLOCKS);
-            migrated = true;
+            true
+        } else {
+            false
         }
-
-        migrated
     }
 
     /// Returns an error if we can't unwind to the targeted block because the target block is

--- a/crates/stages/stages/src/stages/merkle_changesets.rs
+++ b/crates/stages/stages/src/stages/merkle_changesets.rs
@@ -27,7 +27,8 @@ use tracing::{debug, error};
 #[derive(Debug, Clone)]
 pub struct MerkleChangeSets {
     /// The number of blocks to retain changesets for, used as a fallback when the finalized block
-    /// is not found. Defaults to [`MERKLE_CHANGESETS_RETENTION_BLOCKS`] (2 epochs in beacon chain).
+    /// is not found. Defaults to [`MERKLE_CHANGESETS_RETENTION_BLOCKS`] (2 epochs in beacon
+    /// chain).
     retention_blocks: u64,
 }
 

--- a/crates/stages/stages/src/stages/merkle_changesets.rs
+++ b/crates/stages/stages/src/stages/merkle_changesets.rs
@@ -7,7 +7,9 @@ use reth_provider::{
     ChainStateBlockReader, DBProvider, HeaderProvider, ProviderError, PruneCheckpointReader,
     PruneCheckpointWriter, StageCheckpointReader, TrieWriter,
 };
-use reth_prune_types::{PruneCheckpoint, PruneMode, PruneSegment};
+use reth_prune_types::{
+    PruneCheckpoint, PruneMode, PruneSegment, MERKLE_CHANGESETS_RETENTION_BLOCKS,
+};
 use reth_stages_api::{
     BlockErrorKind, ExecInput, ExecOutput, Stage, StageCheckpoint, StageError, StageId,
     UnwindInput, UnwindOutput,
@@ -25,14 +27,14 @@ use tracing::{debug, error};
 #[derive(Debug, Clone)]
 pub struct MerkleChangeSets {
     /// The number of blocks to retain changesets for, used as a fallback when the finalized block
-    /// is not found. Defaults to 64 (2 epochs in beacon chain).
+    /// is not found. Defaults to [`MERKLE_CHANGESETS_RETENTION_BLOCKS`] (2 epochs in beacon chain).
     retention_blocks: u64,
 }
 
 impl MerkleChangeSets {
-    /// Creates a new `MerkleChangeSets` stage with default retention blocks of 64.
+    /// Creates a new `MerkleChangeSets` stage with the default retention blocks.
     pub const fn new() -> Self {
-        Self { retention_blocks: 64 }
+        Self { retention_blocks: MERKLE_CHANGESETS_RETENTION_BLOCKS }
     }
 
     /// Creates a new `MerkleChangeSets` stage with a custom finalized block height.


### PR DESCRIPTION
Right now 10k is too much, leading to big tables. And the pipeline stage trims them to 64 blocks anyway, resulting in a potential big freelist.