### PR TITLE
chore(docker): upgrade lighthouse image to version 8.0.1

### DIFF
--- a/etc/lighthouse.yml
+++ b/etc/lighthouse.yml
@@ -3,7 +3,7 @@ name: reth
 services:
   lighthouse:
     restart: unless-stopped
-    image: sigp/lighthouse:v7.0.1
+    image: sigp/lighthouse:v8.0.1
     depends_on:
       - reth
     ports:


### PR DESCRIPTION
from [https://github.com/sigp/lighthouse/releases/tag/v8.0.1](https://github.com/sigp/lighthouse/releases/tag/v8.0.1)

"As a reminder, all mainnet users must upgrade to either v8.0.0 or v8.0.1 prior to the Fulu fork at epoch 411,392 (2025-12-03, 21:49 UTC)."