### PR TITLE
chore(rpc): protect gas_used_ratio from div by zero

### DIFF
--- a/crates/rpc/rpc-eth-types/src/fee_history.rs
+++ b/crates/rpc/rpc-eth-types/src/fee_history.rs
@@ -374,7 +374,11 @@ where
         let header = block.header();
         Self {
             header: block.header().clone(),
-            gas_used_ratio: header.gas_used() as f64 / header.gas_limit() as f64,
+            gas_used_ratio: if header.gas_limit() == 0 {
+                0.0
+            } else {
+                header.gas_used() as f64 / header.gas_limit() as f64
+            },
             base_fee_per_blob_gas: header
                 .excess_blob_gas()
                 .and_then(|excess_blob_gas| Some(blob_params?.calc_blob_fee(excess_blob_gas))),


### PR DESCRIPTION
Adds a division-by-zero check for `gas_used_ratio` calculation in `FeeHistoryEntry::new`, this prevents `NaN` or `Infinity` results if `gas_limit` is zero.