### PR TITLE
feat: transition from `&mut State<DB>` -> StateDB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,7 +267,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.24.2"
-source = "git+https://github.com/0xforerunner/evm?rev=f5a7b28#f5a7b28c7e025de9dd532ab5481bfa306419650b"
+source = "git+https://github.com/0xforerunner/evm?rev=9de0fb0#9de0fb0c4440b1dfbffa6abca2aad66483d09c07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -383,7 +383,7 @@ dependencies = [
 [[package]]
 name = "alloy-op-evm"
 version = "0.24.2"
-source = "git+https://github.com/0xforerunner/evm?rev=f5a7b28#f5a7b28c7e025de9dd532ab5481bfa306419650b"
+source = "git+https://github.com/0xforerunner/evm?rev=9de0fb0#9de0fb0c4440b1dfbffa6abca2aad66483d09c07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,7 +267,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.24.2"
-source = "git+https://github.com/0xforerunner/evm?rev=30b6df1#30b6df18b2a3c5e23ad190cc96e5bd15ecd53aa1"
+source = "git+https://github.com/0xforerunner/evm?rev=f5a7b28#f5a7b28c7e025de9dd532ab5481bfa306419650b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -383,7 +383,7 @@ dependencies = [
 [[package]]
 name = "alloy-op-evm"
 version = "0.24.2"
-source = "git+https://github.com/0xforerunner/evm?rev=30b6df1#30b6df18b2a3c5e23ad190cc96e5bd15ecd53aa1"
+source = "git+https://github.com/0xforerunner/evm?rev=f5a7b28#f5a7b28c7e025de9dd532ab5481bfa306419650b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,9 +97,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bc32535569185cbcb6ad5fa64d989a47bccb9a08e27284b1f2a3ccf16e6d010"
+checksum = "1b9ebac8ff9c2f07667e1803dc777304337e160ce5153335beb45e8ec0751808"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -267,8 +267,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01be36ba6f5e6e62563b369e03ca529eac46aea50677f84655084b4750816574"
+source = "git+https://github.com/0xforerunner/evm?rev=30b6df1#30b6df18b2a3c5e23ad190cc96e5bd15ecd53aa1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -384,8 +383,7 @@ dependencies = [
 [[package]]
 name = "alloy-op-evm"
 version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "231262d7e06000f3fb642d32d38ca75e09e78e04977c10be0a07a5ee2c869cfd"
+source = "git+https://github.com/0xforerunner/evm?rev=30b6df1#30b6df18b2a3c5e23ad190cc96e5bd15ecd53aa1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -1627,15 +1625,15 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitcoin-io"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
+checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
+checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
 dependencies = [
  "bitcoin-io",
  "hex-conservative",
@@ -2461,9 +2459,9 @@ dependencies = [
 
 [[package]]
 name = "convert_case"
-version = "0.7.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -2968,22 +2966,23 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+checksum = "10b768e943bed7bf2cab53df09f4bc34bfd217cdb57d971e769874c9a6710618"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+checksum = "6d286bfdaf75e988b4a78e013ecd79c581e06399ab53fbacd2d916c2f904f30b"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
+ "rustc_version 0.4.1",
  "syn 2.0.111",
  "unicode-xid",
 ]
@@ -4694,9 +4693,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
+checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5406,9 +5405,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "libgit2-sys"
@@ -5543,9 +5542,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "loom"
@@ -6302,8 +6301,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "14.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1475a779c73999fc803778524042319691b31f3d6699d2b560c4ed8be1db802a"
+source = "git+https://github.com/0xforerunner/revm?rev=195c8e9#195c8e90138c17488dc56aae023903684ec87c73"
 dependencies = [
  "auto_impl",
  "revm",
@@ -11006,8 +11004,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "33.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c85ed0028f043f87b3c88d4a4cb6f0a76440085523b6a8afe5ff003cf418054"
+source = "git+https://github.com/0xforerunner/revm?rev=195c8e9#195c8e90138c17488dc56aae023903684ec87c73"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -11025,8 +11022,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "7.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2c6b5e6e8dd1e28a4a60e5f46615d4ef0809111c9e63208e55b5c7058200fb0"
+source = "git+https://github.com/0xforerunner/revm?rev=195c8e9#195c8e90138c17488dc56aae023903684ec87c73"
 dependencies = [
  "bitvec",
  "phf",
@@ -11037,8 +11033,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "12.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f038f0c9c723393ac897a5df9140b21cfa98f5753a2cb7d0f28fa430c4118abf"
+source = "git+https://github.com/0xforerunner/revm?rev=195c8e9#195c8e90138c17488dc56aae023903684ec87c73"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -11054,8 +11049,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "13.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "431c9a14e4ef1be41ae503708fd02d974f80ef1f2b6b23b5e402e8d854d1b225"
+source = "git+https://github.com/0xforerunner/revm?rev=195c8e9#195c8e90138c17488dc56aae023903684ec87c73"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -11070,8 +11064,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "9.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "980d8d6bba78c5dd35b83abbb6585b0b902eb25ea4448ed7bfba6283b0337191"
+source = "git+https://github.com/0xforerunner/revm?rev=195c8e9#195c8e90138c17488dc56aae023903684ec87c73"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -11084,21 +11077,20 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "8.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cce03e3780287b07abe58faf4a7f5d8be7e81321f93ccf3343c8f7755602bae"
+source = "git+https://github.com/0xforerunner/revm?rev=195c8e9#195c8e90138c17488dc56aae023903684ec87c73"
 dependencies = [
  "auto_impl",
  "either",
  "revm-primitives",
  "revm-state",
  "serde",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "revm-handler"
 version = "14.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d44f8f6dbeec3fecf9fe55f78ef0a758bdd92ea46cd4f1ca6e2a946b32c367f3"
+source = "git+https://github.com/0xforerunner/revm?rev=195c8e9#195c8e90138c17488dc56aae023903684ec87c73"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -11116,8 +11108,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "14.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5617e49216ce1ca6c8826bcead0386bc84f49359ef67cde6d189961735659f93"
+source = "git+https://github.com/0xforerunner/revm?rev=195c8e9#195c8e90138c17488dc56aae023903684ec87c73"
 dependencies = [
  "auto_impl",
  "either",
@@ -11154,8 +11145,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "31.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ec36405f7477b9dccdc6caa3be19adf5662a7a0dffa6270cdb13a090c077e5"
+source = "git+https://github.com/0xforerunner/revm?rev=195c8e9#195c8e90138c17488dc56aae023903684ec87c73"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -11167,8 +11157,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "31.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a62958af953cc4043e93b5be9b8497df84cc3bd612b865c49a7a7dfa26a84e2"
+source = "git+https://github.com/0xforerunner/revm?rev=195c8e9#195c8e90138c17488dc56aae023903684ec87c73"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -11192,8 +11181,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "21.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29e161db429d465c09ba9cbff0df49e31049fe6b549e28eb0b7bd642fcbd4412"
+source = "git+https://github.com/0xforerunner/revm?rev=195c8e9#195c8e90138c17488dc56aae023903684ec87c73"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -11204,8 +11192,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "8.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d8be953b7e374dbdea0773cf360debed8df394ea8d82a8b240a6b5da37592fc"
+source = "git+https://github.com/0xforerunner/revm?rev=195c8e9#195c8e90138c17488dc56aae023903684ec87c73"
 dependencies = [
  "bitflags 2.10.0",
  "revm-bytecode",
@@ -13263,9 +13250,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.18.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",
@@ -14242,18 +14229,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.30"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea879c944afe8a2b25fef16bb4ba234f47c694565e97383b36f3a878219065c"
+checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.30"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf955aa904d6040f70dc8e9384444cb1030aed272ba3cb09bbc4ab9e7c1f34f5"
+checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -487,8 +487,12 @@ alloy-chains = { version = "0.2.5", default-features = false }
 alloy-dyn-abi = "1.4.1"
 alloy-eip2124 = { version = "0.2.0", default-features = false }
 alloy-evm = { version = "0.24.1", default-features = false }
-alloy-primitives = { version = "1.4.1", default-features = false, features = ["map-foldhash"] }
-alloy-rlp = { version = "0.3.10", default-features = false, features = ["core-net"] }
+alloy-primitives = { version = "1.4.1", default-features = false, features = [
+    "map-foldhash",
+] }
+alloy-rlp = { version = "0.3.10", default-features = false, features = [
+    "core-net",
+] }
 alloy-sol-macro = "1.4.1"
 alloy-sol-types = { version = "1.4.1", default-features = false }
 alloy-trie = { version = "0.9.1", default-features = false }
@@ -502,10 +506,15 @@ alloy-genesis = { version = "1.1.2", default-features = false }
 alloy-json-rpc = { version = "1.1.2", default-features = false }
 alloy-network = { version = "1.1.2", default-features = false }
 alloy-network-primitives = { version = "1.1.2", default-features = false }
-alloy-provider = { version = "1.1.2", features = ["reqwest", "debug-api"], default-features = false }
+alloy-provider = { version = "1.1.2", features = [
+    "reqwest",
+    "debug-api",
+], default-features = false }
 alloy-pubsub = { version = "1.1.2", default-features = false }
 alloy-rpc-client = { version = "1.1.2", default-features = false }
-alloy-rpc-types = { version = "1.1.2", features = ["eth"], default-features = false }
+alloy-rpc-types = { version = "1.1.2", features = [
+    "eth",
+], default-features = false }
 alloy-rpc-types-admin = { version = "1.1.2", default-features = false }
 alloy-rpc-types-anvil = { version = "1.1.2", default-features = false }
 alloy-rpc-types-beacon = { version = "1.1.2", default-features = false }
@@ -519,7 +528,9 @@ alloy-serde = { version = "1.1.2", default-features = false }
 alloy-signer = { version = "1.1.2", default-features = false }
 alloy-signer-local = { version = "1.1.2", default-features = false }
 alloy-transport = { version = "1.1.2" }
-alloy-transport-http = { version = "1.1.2", features = ["reqwest-rustls-tls"], default-features = false }
+alloy-transport-http = { version = "1.1.2", features = [
+    "reqwest-rustls-tls",
+], default-features = false }
 alloy-transport-ipc = { version = "1.1.2", default-features = false }
 alloy-transport-ws = { version = "1.1.2", default-features = false }
 
@@ -538,7 +549,10 @@ either = { version = "1.15.0", default-features = false }
 arrayvec = { version = "0.7.6", default-features = false }
 aquamarine = "0.6"
 auto_impl = "1"
-backon = { version = "1.2", default-features = false, features = ["std-blocking-sleep", "tokio-sleep"] }
+backon = { version = "1.2", default-features = false, features = [
+    "std-blocking-sleep",
+    "tokio-sleep",
+] }
 bincode = "1.3"
 bitflags = "2.4"
 boyer-moore-magiclen = "0.2.16"
@@ -558,9 +572,13 @@ itertools = { version = "0.14", default-features = false }
 linked_hash_set = "0.1"
 lz4 = "1.28.1"
 modular-bitfield = "0.11.2"
-notify = { version = "8.0.0", default-features = false, features = ["macos_fsevent"] }
+notify = { version = "8.0.0", default-features = false, features = [
+    "macos_fsevent",
+] }
 nybbles = { version = "0.4.2", default-features = false }
-once_cell = { version = "1.19", default-features = false, features = ["critical-section"] }
+once_cell = { version = "1.19", default-features = false, features = [
+    "critical-section",
+] }
 parking_lot = "0.12"
 paste = "1.0"
 rand = "0.9"
@@ -642,7 +660,10 @@ proptest-arbitrary-interop = "0.1.0"
 # crypto
 enr = { version = "0.13", default-features = false }
 k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
-secp256k1 = { version = "0.30", default-features = false, features = ["global-context", "recovery"] }
+secp256k1 = { version = "0.30", default-features = false, features = [
+    "global-context",
+    "recovery",
+] }
 # rand 8 for secp256k1
 rand_08 = { package = "rand", version = "0.8" }
 
@@ -735,7 +756,20 @@ vergen-git2 = "1.0.5"
 # networking
 ipnet = "2.11"
 
-# [patch.crates-io]
+[patch.crates-io]
+# TODO: Remove once new versions is published
+revm = { git = "https://github.com/0xforerunner/revm", rev = "195c8e9" }
+revm-bytecode = { git = "https://github.com/0xforerunner/revm", rev = "195c8e9" }
+revm-database = { git = "https://github.com/0xforerunner/revm", rev = "195c8e9" }
+revm-state = { git = "https://github.com/0xforerunner/revm", rev = "195c8e9" }
+revm-primitives = { git = "https://github.com/0xforerunner/revm", rev = "195c8e9" }
+revm-interpreter = { git = "https://github.com/0xforerunner/revm", rev = "195c8e9" }
+revm-database-interface = { git = "https://github.com/0xforerunner/revm", rev = "195c8e9" }
+op-revm = { git = "https://github.com/0xforerunner/revm", rev = "195c8e9" }
+# revm-inspectors = { git = "https://github.com/0xforerunner/revm", rev = "195c8e9" }
+
+alloy-op-evm = { git = "https://github.com/0xforerunner/evm", rev = "30b6df1" }
+alloy-evm = { git = "https://github.com/0xforerunner/evm", rev = "30b6df1" }
 # alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
 # alloy-contract = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
 # alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -768,8 +768,8 @@ revm-database-interface = { git = "https://github.com/0xforerunner/revm", rev = 
 op-revm = { git = "https://github.com/0xforerunner/revm", rev = "195c8e9" }
 # revm-inspectors = { git = "https://github.com/0xforerunner/revm", rev = "195c8e9" }
 
-alloy-op-evm = { git = "https://github.com/0xforerunner/evm", rev = "f5a7b28" }
-alloy-evm = { git = "https://github.com/0xforerunner/evm", rev = "f5a7b28" }
+alloy-op-evm = { git = "https://github.com/0xforerunner/evm", rev = "9de0fb0" }
+alloy-evm = { git = "https://github.com/0xforerunner/evm", rev = "9de0fb0" }
 # alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
 # alloy-contract = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
 # alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -768,8 +768,8 @@ revm-database-interface = { git = "https://github.com/0xforerunner/revm", rev = 
 op-revm = { git = "https://github.com/0xforerunner/revm", rev = "195c8e9" }
 # revm-inspectors = { git = "https://github.com/0xforerunner/revm", rev = "195c8e9" }
 
-alloy-op-evm = { git = "https://github.com/0xforerunner/evm", rev = "30b6df1" }
-alloy-evm = { git = "https://github.com/0xforerunner/evm", rev = "30b6df1" }
+alloy-op-evm = { git = "https://github.com/0xforerunner/evm", rev = "f5a7b28" }
+alloy-evm = { git = "https://github.com/0xforerunner/evm", rev = "f5a7b28" }
 # alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
 # alloy-contract = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
 # alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }

--- a/crates/ethereum/evm/src/test_utils.rs
+++ b/crates/ethereum/evm/src/test_utils.rs
@@ -77,7 +77,7 @@ pub struct MockExecutor<DB: Database, I> {
     hook: Option<Box<dyn reth_evm::OnStateHook>>,
 }
 
-impl<'a, DB: StateDB + Database, I: Inspector<EthEvmContext<DB>>> BlockExecutor
+impl<DB: StateDB + Database, I: Inspector<EthEvmContext<DB>>> BlockExecutor
     for MockExecutor<DB, I>
 {
     type Evm = EthEvm<DB, I, PrecompilesMap>;

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -1,6 +1,6 @@
 //! Traits for execution.
 
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 
 use crate::{ConfigureEvm, Database, OnStateHook, TxEnvFor};
 use alloc::{boxed::Box, sync::Arc, vec::Vec};

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -6,7 +6,7 @@ use alloy_consensus::{BlockHeader, Header};
 use alloy_eips::eip2718::WithEncoded;
 pub use alloy_evm::block::{BlockExecutor, BlockExecutorFactory};
 use alloy_evm::{
-    block::{CommitChanges, ExecutableTx},
+    block::{CommitChanges, ExecutableTx, StateDB},
     Evm, EvmEnv, EvmFactory, RecoveredTx, ToTxEnv,
 };
 use alloy_primitives::{Address, B256};
@@ -461,7 +461,7 @@ where
     }
 }
 
-impl<'a, F, DB, Executor, Builder, N> BlockBuilder
+impl<'a, DB, F, Executor, Builder, N> BlockBuilder
     for BasicBlockBuilder<'a, F, Executor, Builder, N>
 where
     F: BlockExecutorFactory<Transaction = N::SignedTx, Receipt = N::Receipt>,
@@ -470,12 +470,12 @@ where
             Spec = <F::EvmFactory as EvmFactory>::Spec,
             HaltReason = <F::EvmFactory as EvmFactory>::HaltReason,
             BlockEnv = <F::EvmFactory as EvmFactory>::BlockEnv,
-            DB = &'a mut State<DB>,
+            DB = &'a mut DB,
         >,
         Transaction = N::SignedTx,
         Receipt = N::Receipt,
     >,
-    DB: Database + 'a,
+    DB: StateDB + 'a,
     Builder: BlockAssembler<F, Block = N::Block>,
     N: NodePrimitives,
 {
@@ -514,7 +514,7 @@ where
         db.merge_transitions(BundleRetention::Reverts);
 
         // calculate the state root
-        let hashed_state = state.hashed_post_state(&db.bundle_state);
+        let hashed_state = state.hashed_post_state(db.bundle_state());
         let (state_root, trie_updates) = state
             .state_root_with_updates(hashed_state.clone())
             .map_err(BlockExecutionError::other)?;
@@ -528,7 +528,7 @@ where
             parent: self.parent,
             transactions,
             output: &result,
-            bundle_state: &db.bundle_state,
+            bundle_state: db.bundle_state(),
             state_provider: &state,
             state_root,
         })?;

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -528,7 +528,7 @@ where
             parent: self.parent,
             transactions,
             output: &result,
-            bundle_state: db.bundle_state(),
+            bundle_state: (*db).bundle_state(),
             state_provider: &state,
             state_root,
         })?;

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -1,5 +1,7 @@
 //! Traits for execution.
 
+use std::borrow::Cow;
+
 use crate::{ConfigureEvm, Database, OnStateHook, TxEnvFor};
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use alloy_consensus::{BlockHeader, Header};
@@ -214,7 +216,7 @@ pub struct BlockAssemblerInput<'a, 'b, F: BlockExecutorFactory, H = Header> {
     /// Output of block execution.
     pub output: &'b BlockExecutionResult<F::Receipt>,
     /// [`BundleState`] after the block execution.
-    pub bundle_state: &'a BundleState,
+    pub bundle_state: Cow<'a, BundleState>,
     /// Provider with access to state.
     #[debug(skip)]
     pub state_provider: &'b dyn StateProvider,
@@ -234,7 +236,7 @@ impl<'a, 'b, F: BlockExecutorFactory, H> BlockAssemblerInput<'a, 'b, F, H> {
         parent: &'a SealedHeader<H>,
         transactions: Vec<F::Transaction>,
         output: &'b BlockExecutionResult<F::Receipt>,
-        bundle_state: &'a BundleState,
+        bundle_state: impl Into<Cow<'a, BundleState>>,
         state_provider: &'b dyn StateProvider,
         state_root: B256,
     ) -> Self {
@@ -244,7 +246,7 @@ impl<'a, 'b, F: BlockExecutorFactory, H> BlockAssemblerInput<'a, 'b, F, H> {
             parent,
             transactions,
             output,
-            bundle_state,
+            bundle_state: bundle_state.into(),
             state_provider,
             state_root,
         }
@@ -461,8 +463,7 @@ where
     }
 }
 
-impl<'a, DB, F, Executor, Builder, N> BlockBuilder
-    for BasicBlockBuilder<'a, F, Executor, Builder, N>
+impl<'a, F, Executor, Builder, N> BlockBuilder for BasicBlockBuilder<'a, F, Executor, Builder, N>
 where
     F: BlockExecutorFactory<Transaction = N::SignedTx, Receipt = N::Receipt>,
     Executor: BlockExecutor<
@@ -470,12 +471,11 @@ where
             Spec = <F::EvmFactory as EvmFactory>::Spec,
             HaltReason = <F::EvmFactory as EvmFactory>::HaltReason,
             BlockEnv = <F::EvmFactory as EvmFactory>::BlockEnv,
-            DB = &'a mut DB,
+            DB: StateDB + 'a,
         >,
         Transaction = N::SignedTx,
         Receipt = N::Receipt,
     >,
-    DB: StateDB + 'a,
     Builder: BlockAssembler<F, Block = N::Block>,
     N: NodePrimitives,
 {
@@ -508,7 +508,7 @@ where
         state: impl StateProvider,
     ) -> Result<BlockBuilderOutcome<N>, BlockExecutionError> {
         let (evm, result) = self.executor.finish()?;
-        let (db, evm_env) = evm.finish();
+        let (mut db, evm_env) = evm.finish();
 
         // merge all transitions into bundle state
         db.merge_transitions(BundleRetention::Reverts);
@@ -528,7 +528,7 @@ where
             parent: self.parent,
             transactions,
             output: &result,
-            bundle_state: (*db).bundle_state(),
+            bundle_state: Cow::Owned(db.take_bundle()),
             state_provider: &state,
             state_root,
         })?;

--- a/crates/optimism/evm/src/build.rs
+++ b/crates/optimism/evm/src/build.rs
@@ -70,7 +70,7 @@ impl<ChainSpec: OpHardforks> OpBlockAssembler<ChainSpec> {
             // withdrawals root field in block header is used for storage root of L2 predeploy
             // `l2tol1-message-passer`
             Some(
-                isthmus::withdrawals_root(bundle_state, state_provider)
+                isthmus::withdrawals_root(&bundle_state, state_provider)
                     .map_err(BlockExecutionError::other)?,
             )
         } else if self.chain_spec.is_canyon_active_at_timestamp(timestamp) {

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -11,7 +11,7 @@ use alloy_rpc_types_engine::PayloadId;
 use reth_basic_payload_builder::*;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_evm::{
-    block::BlockExecutorFor,
+    block::{BlockExecutorFor, StateDB},
     execute::{
         BlockBuilder, BlockBuilderOutcome, BlockExecutionError, BlockExecutor, BlockValidationError,
     },
@@ -38,7 +38,10 @@ use reth_revm::{
 };
 use reth_storage_api::{errors::ProviderError, StateProvider, StateProviderFactory};
 use reth_transaction_pool::{BestTransactionsAttributes, PoolTransaction, TransactionPool};
-use revm::context::{Block, BlockEnv};
+use revm::{
+    context::{Block, BlockEnv},
+    DatabaseCommit,
+};
 use std::{marker::PhantomData, sync::Arc};
 use tracing::{debug, trace, warn};
 
@@ -598,9 +601,9 @@ where
     }
 
     /// Prepares a [`BlockBuilder`] for the next block.
-    pub fn block_builder<'a, DB: Database>(
+    pub fn block_builder<'a, DB: StateDB + DatabaseCommit + Database + 'a>(
         &'a self,
-        db: &'a mut State<DB>,
+        db: DB,
     ) -> Result<
         impl BlockBuilder<
                 Primitives = Evm::Primitives,

--- a/examples/custom-beacon-withdrawals/src/main.rs
+++ b/examples/custom-beacon-withdrawals/src/main.rs
@@ -5,7 +5,7 @@
 
 use alloy_eips::eip4895::Withdrawal;
 use alloy_evm::{
-    block::{BlockExecutorFactory, BlockExecutorFor, ExecutableTx},
+    block::{BlockExecutorFactory, BlockExecutorFor, ExecutableTx, StateDB},
     eth::{EthBlockExecutionCtx, EthBlockExecutor},
     precompiles::PrecompilesMap,
     revm::context::{result::ResultAndState, Block as _},
@@ -188,10 +188,9 @@ pub struct CustomBlockExecutor<'a, Evm> {
     inner: EthBlockExecutor<'a, Evm, &'a Arc<ChainSpec>, &'a RethReceiptBuilder>,
 }
 
-impl<'db, DB, E> BlockExecutor for CustomBlockExecutor<'_, E>
+impl<E> BlockExecutor for CustomBlockExecutor<'_, E>
 where
-    DB: Database + 'db,
-    E: Evm<DB = &'db mut State<DB>, Tx = TxEnv>,
+    E: Evm<DB: StateDB, Tx = TxEnv>,
 {
     type Transaction = TransactionSigned;
     type Receipt = Receipt;

--- a/examples/custom-beacon-withdrawals/src/main.rs
+++ b/examples/custom-beacon-withdrawals/src/main.rs
@@ -24,7 +24,6 @@ use reth_ethereum::{
         },
         revm::{
             context::TxEnv,
-            db::State,
             primitives::{address, hardfork::SpecId, Address},
             DatabaseCommit,
         },
@@ -102,12 +101,12 @@ impl BlockExecutorFactory for CustomEvmConfig {
 
     fn create_executor<'a, DB, I>(
         &'a self,
-        evm: EthEvm<&'a mut State<DB>, I, PrecompilesMap>,
+        evm: EthEvm<DB, I, PrecompilesMap>,
         ctx: EthBlockExecutionCtx<'a>,
     ) -> impl BlockExecutorFor<'a, Self, DB, I>
     where
-        DB: Database + 'a,
-        I: InspectorFor<Self, &'a mut State<DB>> + 'a,
+        DB: StateDB + DatabaseCommit + Database + 'a,
+        I: InspectorFor<Self, DB> + 'a,
     {
         CustomBlockExecutor {
             inner: EthBlockExecutor::new(
@@ -190,7 +189,7 @@ pub struct CustomBlockExecutor<'a, Evm> {
 
 impl<E> BlockExecutor for CustomBlockExecutor<'_, E>
 where
-    E: Evm<DB: StateDB, Tx = TxEnv>,
+    E: Evm<DB: StateDB + DatabaseCommit + Database, Tx = TxEnv>,
 {
     type Transaction = TransactionSigned;
     type Receipt = Receipt;

--- a/examples/custom-node/src/evm/executor.rs
+++ b/examples/custom-node/src/evm/executor.rs
@@ -9,7 +9,7 @@ use alloy_consensus::transaction::Recovered;
 use alloy_evm::{
     block::{
         BlockExecutionError, BlockExecutionResult, BlockExecutor, BlockExecutorFactory,
-        BlockExecutorFor, ExecutableTx, OnStateHook,
+        BlockExecutorFor, ExecutableTx, OnStateHook, StateDB,
     },
     precompiles::PrecompilesMap,
     Database, Evm,
@@ -24,10 +24,9 @@ pub struct CustomBlockExecutor<Evm> {
     inner: OpBlockExecutor<Evm, OpRethReceiptBuilder, Arc<OpChainSpec>>,
 }
 
-impl<'db, DB, E> BlockExecutor for CustomBlockExecutor<E>
+impl<E> BlockExecutor for CustomBlockExecutor<E>
 where
-    DB: Database + 'db,
-    E: Evm<DB = &'db mut State<DB>, Tx = CustomTxEnv>,
+    E: Evm<DB: StateDB, Tx = CustomTxEnv>,
 {
     type Transaction = CustomTransaction;
     type Receipt = OpReceipt;


### PR DESCRIPTION
This PR moves reth traits from using the concrete `State<DB>` to relying on a new `StateDB` trait. This allows trait implementations to be much more flexible, and allows for greater code reuse.

In particular, we're implementing Flashblock based block access lists, and we need a DB wrapper around `State` that can construct the access lists. This will allow us to build something like `BalBuilderDB<&mut State>`, and then impl `StateDB` for this type.

This PR is marked as a draft because it depends on these upstream PRs.
- [feat: Clean up StateDB methods, bump revm](https://github.com/alloy-rs/evm/pull/238)
- [feat: DatabaseCommitExt::drain_balances](https://github.com/bluealloy/revm/pull/3205)