### PR TITLE
perf(sparse): move-encode account RLP into trie to avoid clone

### DIFF
--- a/crates/stateless/src/trie.rs
+++ b/crates/stateless/src/trie.rs
@@ -280,7 +280,6 @@ fn calculate_state_root(
     // 2. Apply account‑level updates and (re)encode the account nodes
     // Update accounts with new values
     // TODO: upstream changes into reth so that `SparseStateTrie::update_account` handles this
-    let mut account_rlp_buf = Vec::with_capacity(TRIE_ACCOUNT_RLP_MAX_SIZE);
 
     for (hashed_address, account) in
         state.accounts.into_iter().sorted_unstable_by_key(|(addr, _)| *addr)
@@ -298,9 +297,9 @@ fn calculate_state_root(
 
         // Decide whether to remove or update the account leaf
         if let Some(account) = account {
-            account_rlp_buf.clear();
-            account.into_trie_account(storage_root).encode(&mut account_rlp_buf);
-            trie.update_account_leaf(nibbles, account_rlp_buf.clone(), &provider_factory)?;
+            let mut buf = Vec::with_capacity(TRIE_ACCOUNT_RLP_MAX_SIZE);
+            account.into_trie_account(storage_root).encode(&mut buf);
+            trie.update_account_leaf(nibbles, buf, &provider_factory)?;
         } else {
             trie.remove_account_leaf(&nibbles, &provider_factory)?;
         }

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -40,7 +40,6 @@ where
         trie.state = trie.state.clear();
         trie.revealed_account_paths.clear();
         trie.storage.clear();
-        trie.account_rlp_buf.clear();
         Self(trie)
     }
 
@@ -90,8 +89,6 @@ pub struct SparseStateTrie<
     storage: StorageTries<S>,
     /// Flag indicating whether trie updates should be retained.
     retain_updates: bool,
-    /// Reusable buffer for RLP encoding of trie accounts.
-    account_rlp_buf: Vec<u8>,
     /// Metrics for the sparse state trie.
     #[cfg(feature = "metrics")]
     metrics: crate::metrics::SparseStateTrieMetrics,
@@ -108,7 +105,6 @@ where
             revealed_account_paths: Default::default(),
             storage: Default::default(),
             retain_updates: false,
-            account_rlp_buf: Vec::with_capacity(TRIE_ACCOUNT_RLP_MAX_SIZE),
             #[cfg(feature = "metrics")]
             metrics: Default::default(),
         }
@@ -746,9 +742,9 @@ where
 
         trace!(target: "trie::sparse", ?address, "Updating account");
         let nibbles = Nibbles::unpack(address);
-        self.account_rlp_buf.clear();
-        account.into_trie_account(storage_root).encode(&mut self.account_rlp_buf);
-        self.update_account_leaf(nibbles, self.account_rlp_buf.clone(), provider_factory)?;
+        let mut buf = Vec::with_capacity(TRIE_ACCOUNT_RLP_MAX_SIZE);
+        account.into_trie_account(storage_root).encode(&mut buf);
+        self.update_account_leaf(nibbles, buf, provider_factory)?;
 
         Ok(true)
     }
@@ -799,9 +795,9 @@ where
         // Otherwise, update the account leaf.
         trace!(target: "trie::sparse", ?address, "Updating account with the new storage root");
         let nibbles = Nibbles::unpack(address);
-        self.account_rlp_buf.clear();
-        trie_account.encode(&mut self.account_rlp_buf);
-        self.update_account_leaf(nibbles, self.account_rlp_buf.clone(), provider_factory)?;
+        let mut buf = Vec::with_capacity(TRIE_ACCOUNT_RLP_MAX_SIZE);
+        trie_account.encode(&mut buf);
+        self.update_account_leaf(nibbles, buf, provider_factory)?;
 
         Ok(true)
     }


### PR DESCRIPTION
Encode account RLP into a fresh Vec and move it into the trie instead of cloning a reusable buffer. This removes one allocation and memcpy per account update. The persistent buffer in SparseStateTrie was removed since the trie must own the bytes; keeping it yielded no benefit and forced a clone. Mirrored the same change in the stateless path for consistency. Only allocation and copy reductions.