### PR TITLE
perf(engine): only recover senders once

### DIFF
--- a/crates/chain-state/src/test_utils.rs
+++ b/crates/chain-state/src/test_utils.rs
@@ -92,7 +92,7 @@ impl<N: NodePrimitives> TestBlockBuilder<N> {
         &mut self,
         number: BlockNumber,
         parent_hash: B256,
-    ) -> RecoveredBlock<reth_ethereum_primitives::Block> {
+    ) -> SealedBlock<reth_ethereum_primitives::Block> {
         let mut rng = rand::rng();
 
         let mock_tx = |nonce: u64| -> Recovered<_> {
@@ -167,17 +167,14 @@ impl<N: NodePrimitives> TestBlockBuilder<N> {
             ..Default::default()
         };
 
-        let block = SealedBlock::from_sealed_parts(
+        SealedBlock::from_sealed_parts(
             SealedHeader::seal_slow(header),
             BlockBody {
                 transactions: transactions.into_iter().map(|tx| tx.into_inner()).collect(),
                 ommers: Vec::new(),
                 withdrawals: Some(vec![].into()),
             },
-        );
-
-        RecoveredBlock::try_recover_sealed_with_senders(block, vec![self.signer; num_txs as usize])
-            .unwrap()
+        )
     }
 
     /// Creates a fork chain with the given base block.
@@ -191,7 +188,9 @@ impl<N: NodePrimitives> TestBlockBuilder<N> {
 
         for _ in 0..length {
             let block = self.generate_random_block(parent.number + 1, parent.hash());
-            parent = block.clone_sealed_block();
+            parent = block.clone();
+            let senders = vec![self.signer; block.body().transactions.len()];
+            let block = block.with_senders(senders);
             fork.push(block);
         }
 
@@ -205,9 +204,8 @@ impl<N: NodePrimitives> TestBlockBuilder<N> {
         receipts: Vec<Vec<Receipt>>,
         parent_hash: B256,
     ) -> ExecutedBlock {
-        let block_with_senders = self.generate_random_block(block_number, parent_hash);
-
-        let (block, senders) = block_with_senders.split_sealed();
+        let block = self.generate_random_block(block_number, parent_hash);
+        let senders = vec![self.signer; block.body().transactions.len()];
         let trie_data = ComputedTrieData::default();
         ExecutedBlock::new(
             Arc::new(RecoveredBlock::new_sealed(block, senders)),

--- a/crates/engine/tree/src/download.rs
+++ b/crates/engine/tree/src/download.rs
@@ -9,7 +9,7 @@ use reth_network_p2p::{
     full_block::{FetchFullBlockFuture, FetchFullBlockRangeFuture, FullBlockClient},
     BlockClient,
 };
-use reth_primitives_traits::{Block, RecoveredBlock, SealedBlock};
+use reth_primitives_traits::{Block, SealedBlock};
 use std::{
     cmp::{Ordering, Reverse},
     collections::{binary_heap::PeekMut, BinaryHeap, HashSet, VecDeque},
@@ -44,7 +44,7 @@ pub enum DownloadAction {
 #[derive(Debug)]
 pub enum DownloadOutcome<B: Block> {
     /// Downloaded blocks.
-    Blocks(Vec<RecoveredBlock<B>>),
+    Blocks(Vec<SealedBlock<B>>),
     /// New download started.
     NewDownloadStarted {
         /// How many blocks are pending in this download.
@@ -68,7 +68,7 @@ where
     inflight_block_range_requests: Vec<FetchFullBlockRangeFuture<Client>>,
     /// Buffered blocks from downloads - this is a min-heap of blocks, using the block number for
     /// ordering. This means the blocks will be popped from the heap with ascending block numbers.
-    set_buffered_blocks: BinaryHeap<Reverse<OrderedRecoveredBlock<B>>>,
+    set_buffered_blocks: BinaryHeap<Reverse<OrderedSealedBlock<B>>>,
     /// Engine download metrics.
     metrics: BlockDownloaderMetrics,
     /// Pending events to be emitted.
@@ -226,15 +226,8 @@ where
             let mut request = self.inflight_block_range_requests.swap_remove(idx);
             if let Poll::Ready(blocks) = request.poll_unpin(cx) {
                 trace!(target: "engine::download", len=?blocks.len(), first=?blocks.first().map(|b| b.num_hash()), last=?blocks.last().map(|b| b.num_hash()), "Received full block range, buffering");
-                self.set_buffered_blocks.extend(
-                    blocks
-                        .into_iter()
-                        .map(|b| {
-                            let senders = b.senders().unwrap_or_default();
-                            OrderedRecoveredBlock(RecoveredBlock::new_sealed(b, senders))
-                        })
-                        .map(Reverse),
-                );
+                self.set_buffered_blocks
+                    .extend(blocks.into_iter().map(OrderedSealedBlock).map(Reverse));
             } else {
                 // still pending
                 self.inflight_block_range_requests.push(request);
@@ -248,8 +241,7 @@ where
         }
 
         // drain all unique element of the block buffer if there are any
-        let mut downloaded_blocks: Vec<RecoveredBlock<B>> =
-            Vec::with_capacity(self.set_buffered_blocks.len());
+        let mut downloaded_blocks = Vec::with_capacity(self.set_buffered_blocks.len());
         while let Some(block) = self.set_buffered_blocks.pop() {
             // peek ahead and pop duplicates
             while let Some(peek) = self.set_buffered_blocks.peek_mut() {
@@ -265,32 +257,31 @@ where
     }
 }
 
-/// A wrapper type around [`RecoveredBlock`] that implements the [Ord]
+/// A wrapper type around [`SealedBlock`] that implements the [Ord]
 /// trait by block number.
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct OrderedRecoveredBlock<B: Block>(RecoveredBlock<B>);
+struct OrderedSealedBlock<B: Block>(SealedBlock<B>);
 
-impl<B: Block> PartialOrd for OrderedRecoveredBlock<B> {
+impl<B: Block> PartialOrd for OrderedSealedBlock<B> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl<B: Block> Ord for OrderedRecoveredBlock<B> {
+impl<B: Block> Ord for OrderedSealedBlock<B> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.0.number().cmp(&other.0.number())
     }
 }
 
-impl<B: Block> From<SealedBlock<B>> for OrderedRecoveredBlock<B> {
+impl<B: Block> From<SealedBlock<B>> for OrderedSealedBlock<B> {
     fn from(block: SealedBlock<B>) -> Self {
-        let senders = block.senders().unwrap_or_default();
-        Self(RecoveredBlock::new_sealed(block, senders))
+        Self(block)
     }
 }
 
-impl<B: Block> From<OrderedRecoveredBlock<B>> for RecoveredBlock<B> {
-    fn from(value: OrderedRecoveredBlock<B>) -> Self {
+impl<B: Block> From<OrderedSealedBlock<B>> for SealedBlock<B> {
+    fn from(value: OrderedSealedBlock<B>) -> Self {
         value.0
     }
 }

--- a/crates/engine/tree/src/engine.rs
+++ b/crates/engine/tree/src/engine.rs
@@ -11,7 +11,7 @@ use reth_chain_state::ExecutedBlock;
 use reth_engine_primitives::{BeaconEngineMessage, ConsensusEngineEvent};
 use reth_ethereum_primitives::EthPrimitives;
 use reth_payload_primitives::PayloadTypes;
-use reth_primitives_traits::{Block, NodePrimitives, RecoveredBlock};
+use reth_primitives_traits::{Block, NodePrimitives, SealedBlock};
 use std::{
     collections::HashSet,
     fmt::Display,
@@ -307,7 +307,7 @@ pub enum FromEngine<Req, B: Block> {
     /// Request from the engine.
     Request(Req),
     /// Downloaded blocks from the network.
-    DownloadedBlocks(Vec<RecoveredBlock<B>>),
+    DownloadedBlocks(Vec<SealedBlock<B>>),
 }
 
 impl<Req: Display, B: Block> Display for FromEngine<Req, B> {

--- a/crates/engine/tree/src/tree/block_buffer.rs
+++ b/crates/engine/tree/src/tree/block_buffer.rs
@@ -1,7 +1,7 @@
 use crate::tree::metrics::BlockBufferMetrics;
 use alloy_consensus::BlockHeader;
 use alloy_primitives::{BlockHash, BlockNumber};
-use reth_primitives_traits::{Block, RecoveredBlock};
+use reth_primitives_traits::{Block, SealedBlock};
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 
 /// Contains the tree of pending blocks that cannot be executed due to missing parent.
@@ -18,7 +18,7 @@ use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 #[derive(Debug)]
 pub struct BlockBuffer<B: Block> {
     /// All blocks in the buffer stored by their block hash.
-    pub(crate) blocks: HashMap<BlockHash, RecoveredBlock<B>>,
+    pub(crate) blocks: HashMap<BlockHash, SealedBlock<B>>,
     /// Map of any parent block hash (even the ones not currently in the buffer)
     /// to the buffered children.
     /// Allows connecting buffered blocks by parent.
@@ -49,12 +49,12 @@ impl<B: Block> BlockBuffer<B> {
     }
 
     /// Return reference to the requested block.
-    pub fn block(&self, hash: &BlockHash) -> Option<&RecoveredBlock<B>> {
+    pub fn block(&self, hash: &BlockHash) -> Option<&SealedBlock<B>> {
         self.blocks.get(hash)
     }
 
     /// Return a reference to the lowest ancestor of the given block in the buffer.
-    pub fn lowest_ancestor(&self, hash: &BlockHash) -> Option<&RecoveredBlock<B>> {
+    pub fn lowest_ancestor(&self, hash: &BlockHash) -> Option<&SealedBlock<B>> {
         let mut current_block = self.blocks.get(hash)?;
         while let Some(parent) = self.blocks.get(&current_block.parent_hash()) {
             current_block = parent;
@@ -63,7 +63,7 @@ impl<B: Block> BlockBuffer<B> {
     }
 
     /// Insert a correct block inside the buffer.
-    pub fn insert_block(&mut self, block: RecoveredBlock<B>) {
+    pub fn insert_block(&mut self, block: SealedBlock<B>) {
         let hash = block.hash();
 
         self.parent_to_child.entry(block.parent_hash()).or_default().insert(hash);
@@ -87,10 +87,7 @@ impl<B: Block> BlockBuffer<B> {
     ///
     /// Note: that order of returned blocks is important and the blocks with lower block number
     /// in the chain will come first so that they can be executed in the correct order.
-    pub fn remove_block_with_children(
-        &mut self,
-        parent_hash: &BlockHash,
-    ) -> Vec<RecoveredBlock<B>> {
+    pub fn remove_block_with_children(&mut self, parent_hash: &BlockHash) -> Vec<SealedBlock<B>> {
         let removed = self
             .remove_block(parent_hash)
             .into_iter()
@@ -149,7 +146,7 @@ impl<B: Block> BlockBuffer<B> {
     /// This method will only remove the block if it's present inside `self.blocks`.
     /// The block might be missing from other collections, the method will only ensure that it has
     /// been removed.
-    fn remove_block(&mut self, hash: &BlockHash) -> Option<RecoveredBlock<B>> {
+    fn remove_block(&mut self, hash: &BlockHash) -> Option<SealedBlock<B>> {
         let block = self.blocks.remove(hash)?;
         self.remove_from_earliest_blocks(block.number(), hash);
         self.remove_from_parent(block.parent_hash(), hash);
@@ -158,7 +155,7 @@ impl<B: Block> BlockBuffer<B> {
     }
 
     /// Remove all children and their descendants for the given blocks and return them.
-    fn remove_children(&mut self, parent_hashes: Vec<BlockHash>) -> Vec<RecoveredBlock<B>> {
+    fn remove_children(&mut self, parent_hashes: Vec<BlockHash>) -> Vec<SealedBlock<B>> {
         // remove all parent child connection and all the child children blocks that are connected
         // to the discarded parent blocks.
         let mut remove_parent_children = parent_hashes;
@@ -184,7 +181,6 @@ mod tests {
     use super::*;
     use alloy_eips::BlockNumHash;
     use alloy_primitives::BlockHash;
-    use reth_primitives_traits::RecoveredBlock;
     use reth_testing_utils::generators::{self, random_block, BlockParams, Rng};
     use std::collections::HashMap;
 
@@ -193,10 +189,8 @@ mod tests {
         rng: &mut R,
         number: u64,
         parent: BlockHash,
-    ) -> RecoveredBlock<reth_ethereum_primitives::Block> {
-        let block =
-            random_block(rng, number, BlockParams { parent: Some(parent), ..Default::default() });
-        block.try_recover().unwrap()
+    ) -> SealedBlock<reth_ethereum_primitives::Block> {
+        random_block(rng, number, BlockParams { parent: Some(parent), ..Default::default() })
     }
 
     /// Assert that all buffer collections have the same data length.
@@ -216,7 +210,7 @@ mod tests {
     /// Assert that the block was removed from all buffer collections.
     fn assert_block_removal<B: Block>(
         buffer: &BlockBuffer<B>,
-        block: &RecoveredBlock<reth_ethereum_primitives::Block>,
+        block: &SealedBlock<reth_ethereum_primitives::Block>,
     ) {
         assert!(!buffer.blocks.contains_key(&block.hash()));
         assert!(buffer

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -28,7 +28,8 @@ use reth_payload_primitives::{
     BuiltPayload, InvalidPayloadAttributesError, NewPayloadError, PayloadTypes,
 };
 use reth_primitives_traits::{
-    AlloyBlockHeader, BlockTy, GotExpected, NodePrimitives, RecoveredBlock, SealedHeader,
+    AlloyBlockHeader, BlockBody, BlockTy, GotExpected, NodePrimitives, RecoveredBlock, SealedBlock,
+    SealedHeader, SignerRecoverable,
 };
 use reth_provider::{
     providers::OverlayStateProviderFactory, BlockExecutionOutput, BlockReader,
@@ -39,6 +40,7 @@ use reth_provider::{
 use reth_revm::db::State;
 use reth_trie::{updates::TrieUpdates, HashedPostState, TrieInputSorted};
 use reth_trie_parallel::root::{ParallelStateRoot, ParallelStateRootError};
+use revm_primitives::Address;
 use std::{
     collections::HashMap,
     panic::{self, AssertUnwindSafe},
@@ -176,12 +178,12 @@ where
     pub fn convert_to_block<T: PayloadTypes<BuiltPayload: BuiltPayload<Primitives = N>>>(
         &self,
         input: BlockOrPayload<T>,
-    ) -> Result<RecoveredBlock<N::Block>, NewPayloadError>
+    ) -> Result<SealedBlock<N::Block>, NewPayloadError>
     where
         V: PayloadValidator<T, Block = N::Block>,
     {
         match input {
-            BlockOrPayload::Payload(payload) => self.validator.ensure_well_formed_payload(payload),
+            BlockOrPayload::Payload(payload) => self.validator.convert_payload_to_block(payload),
             BlockOrPayload::Block(block) => Ok(block),
         }
     }
@@ -205,7 +207,7 @@ where
     pub fn tx_iterator_for<'a, T: PayloadTypes<BuiltPayload: BuiltPayload<Primitives = N>>>(
         &'a self,
         input: &'a BlockOrPayload<T>,
-    ) -> Result<impl ExecutableTxIterator<Evm> + 'a, NewPayloadError>
+    ) -> Result<impl ExecutableTxIterator<Evm>, NewPayloadError>
     where
         V: PayloadValidator<T, Block = N::Block>,
         Evm: ConfigureEngineEvm<T::ExecutionData, Primitives = N>,
@@ -215,11 +217,12 @@ where
                 self.evm_config
                     .tx_iterator_for_payload(payload)
                     .map_err(NewPayloadError::other)?
-                    .map(|res| res.map(Either::Left)),
+                    .map(|res| res.map(Either::Left).map_err(NewPayloadError::other)),
             )),
             BlockOrPayload::Block(block) => {
-                let transactions = block.clone_transactions_recovered().collect::<Vec<_>>();
-                Ok(Either::Right(transactions.into_iter().map(|tx| Ok(Either::Right(tx)))))
+                Ok(Either::Right(block.body().clone_transactions().into_iter().map(|tx| {
+                    Ok(Either::Right(tx.try_into_recovered().map_err(NewPayloadError::other)?))
+                })))
             }
         }
     }
@@ -266,7 +269,7 @@ where
         // Validate block consensus rules which includes header validation
         if let Err(consensus_err) = self.validate_block_inner(&block) {
             // Header validation error takes precedence over execution error
-            return Err(InsertBlockError::new(block.into_sealed_block(), consensus_err.into()).into())
+            return Err(InsertBlockError::new(block, consensus_err.into()).into())
         }
 
         // Also validate against the parent
@@ -274,11 +277,11 @@ where
             self.consensus.validate_header_against_parent(block.sealed_header(), parent_block)
         {
             // Parent validation error takes precedence over execution error
-            return Err(InsertBlockError::new(block.into_sealed_block(), consensus_err.into()).into())
+            return Err(InsertBlockError::new(block, consensus_err.into()).into())
         }
 
         // No header validation errors, return the original execution error
-        Err(InsertBlockError::new(block.into_sealed_block(), execution_err).into())
+        Err(InsertBlockError::new(block, execution_err).into())
     }
 
     /// Validates a block that has already been converted from a payload.
@@ -314,9 +317,7 @@ where
                     Ok(val) => val,
                     Err(e) => {
                         let block = self.convert_to_block(input)?;
-                        return Err(
-                            InsertBlockError::new(block.into_sealed_block(), e.into()).into()
-                        )
+                        return Err(InsertBlockError::new(block, e.into()).into())
                     }
                 }
             };
@@ -347,7 +348,7 @@ where
         else {
             // this is pre-validated in the tree
             return Err(InsertBlockError::new(
-                self.convert_to_block(input)?.into_sealed_block(),
+                self.convert_to_block(input)?,
                 ProviderError::HeaderNotFound(parent_hash.into()).into(),
             )
             .into())
@@ -359,7 +360,7 @@ where
         let Some(parent_block) = ensure_ok!(self.sealed_header_by_hash(parent_hash, ctx.state()))
         else {
             return Err(InsertBlockError::new(
-                self.convert_to_block(input)?.into_sealed_block(),
+                self.convert_to_block(input)?,
                 ProviderError::HeaderNotFound(parent_hash.into()).into(),
             )
             .into())
@@ -402,7 +403,7 @@ where
         );
 
         // Execute the block and handle any execution errors
-        let output = match if self.config.state_provider_metrics() {
+        let (output, senders) = match if self.config.state_provider_metrics() {
             let state_provider = InstrumentedStateProvider::from_state_provider(&state_provider);
             let result = self.execute_block(&state_provider, env, &input, &mut handle);
             state_provider.record_total_latency();
@@ -417,7 +418,7 @@ where
         // After executing the block we can stop prewarming transactions
         handle.stop_prewarming_execution();
 
-        let block = self.convert_to_block(input)?;
+        let block = self.convert_to_block(input)?.with_senders(senders);
 
         let hashed_state = ensure_ok_post_block!(
             self.validate_post_execution(&block, &parent_block, &output, &mut ctx),
@@ -555,13 +556,13 @@ where
     /// Validate if block is correct and satisfies all the consensus rules that concern the header
     /// and block body itself.
     #[instrument(level = "debug", target = "engine::tree::payload_validator", skip_all)]
-    fn validate_block_inner(&self, block: &RecoveredBlock<N::Block>) -> Result<(), ConsensusError> {
+    fn validate_block_inner(&self, block: &SealedBlock<N::Block>) -> Result<(), ConsensusError> {
         if let Err(e) = self.consensus.validate_header(block.sealed_header()) {
             error!(target: "engine::tree::payload_validator", ?block, "Failed to validate header {}: {e}", block.hash());
             return Err(e)
         }
 
-        if let Err(e) = self.consensus.validate_block_pre_execution(block.sealed_block()) {
+        if let Err(e) = self.consensus.validate_block_pre_execution(block) {
             error!(target: "engine::tree::payload_validator", ?block, "Failed to validate block {}: {e}", block.hash());
             return Err(e)
         }
@@ -577,7 +578,7 @@ where
         env: ExecutionEnv<Evm>,
         input: &BlockOrPayload<T>,
         handle: &mut PayloadHandle<impl ExecutableTxFor<Evm>, Err>,
-    ) -> Result<BlockExecutionOutput<N::Receipt>, InsertBlockErrorKind>
+    ) -> Result<(BlockExecutionOutput<N::Receipt>, Vec<Address>), InsertBlockErrorKind>
     where
         S: StateProvider,
         Err: core::error::Error + Send + Sync + 'static,
@@ -617,7 +618,7 @@ where
 
         let execution_start = Instant::now();
         let state_hook = Box::new(handle.state_hook());
-        let output = self.metrics.execute_metered(
+        let (output, senders) = self.metrics.execute_metered(
             executor,
             handle.iter_transactions().map(|res| res.map_err(BlockExecutionError::other)),
             state_hook,
@@ -625,7 +626,7 @@ where
         let execution_finish = Instant::now();
         let execution_time = execution_finish.duration_since(execution_start);
         debug!(target: "engine::tree::payload_validator", elapsed = ?execution_time, "Executed block");
-        Ok(output)
+        Ok((output, senders))
     }
 
     /// Compute state root for the given hashed post state in parallel.
@@ -1097,10 +1098,10 @@ pub trait EngineValidator<
     ///
     /// Implementers should ensure that the checks are done in the order that conforms with the
     /// engine-API specification.
-    fn ensure_well_formed_payload(
+    fn convert_payload_to_block(
         &self,
         payload: Types::ExecutionData,
-    ) -> Result<RecoveredBlock<N::Block>, NewPayloadError>;
+    ) -> Result<SealedBlock<N::Block>, NewPayloadError>;
 
     /// Validates a payload received from engine API.
     fn validate_payload(
@@ -1112,7 +1113,7 @@ pub trait EngineValidator<
     /// Validates a block downloaded from the network.
     fn validate_block(
         &mut self,
-        block: RecoveredBlock<N::Block>,
+        block: SealedBlock<N::Block>,
         ctx: TreeCtx<'_, N>,
     ) -> ValidationOutcome<N>;
 
@@ -1146,11 +1147,11 @@ where
         self.validator.validate_payload_attributes_against_header(attr, header)
     }
 
-    fn ensure_well_formed_payload(
+    fn convert_payload_to_block(
         &self,
         payload: Types::ExecutionData,
-    ) -> Result<RecoveredBlock<N::Block>, NewPayloadError> {
-        let block = self.validator.ensure_well_formed_payload(payload)?;
+    ) -> Result<SealedBlock<N::Block>, NewPayloadError> {
+        let block = self.validator.convert_payload_to_block(payload)?;
         Ok(block)
     }
 
@@ -1164,7 +1165,7 @@ where
 
     fn validate_block(
         &mut self,
-        block: RecoveredBlock<N::Block>,
+        block: SealedBlock<N::Block>,
         ctx: TreeCtx<'_, N>,
     ) -> ValidationOutcome<N> {
         self.validate_block_with_state(BlockOrPayload::Block(block), ctx)
@@ -1184,7 +1185,7 @@ pub enum BlockOrPayload<T: PayloadTypes> {
     /// Payload.
     Payload(T::ExecutionData),
     /// Block.
-    Block(RecoveredBlock<BlockTy<<T::BuiltPayload as BuiltPayload>::Primitives>>),
+    Block(SealedBlock<BlockTy<<T::BuiltPayload as BuiltPayload>::Primitives>>),
 }
 
 impl<T: PayloadTypes> BlockOrPayload<T> {

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -421,7 +421,7 @@ impl ValidatorTestHarness {
     /// Call `validate_block_with_state` directly with block
     fn validate_block_direct(
         &mut self,
-        block: RecoveredBlock<Block>,
+        block: SealedBlock<Block>,
     ) -> ValidationOutcome<EthPrimitives> {
         let ctx = TreeCtx::new(
             &mut self.harness.tree.state,
@@ -449,30 +449,30 @@ impl TestBlockFactory {
     }
 
     /// Create block that triggers consensus violation by corrupting state root
-    fn create_invalid_consensus_block(&mut self, parent_hash: B256) -> RecoveredBlock<Block> {
+    fn create_invalid_consensus_block(&mut self, parent_hash: B256) -> SealedBlock<Block> {
         let mut block = self.builder.generate_random_block(1, parent_hash).into_block();
 
         // Corrupt state root to trigger consensus violation
         block.header.state_root = B256::random();
 
-        block.seal_slow().try_recover().unwrap()
+        block.seal_slow()
     }
 
     /// Create block that triggers execution failure
-    fn create_invalid_execution_block(&mut self, parent_hash: B256) -> RecoveredBlock<Block> {
+    fn create_invalid_execution_block(&mut self, parent_hash: B256) -> SealedBlock<Block> {
         let mut block = self.builder.generate_random_block(1, parent_hash).into_block();
 
         // Create transaction that will fail execution
         // This is simplified - in practice we'd create a transaction with insufficient gas, etc.
         block.header.gas_used = block.header.gas_limit + 1; // Gas used exceeds limit
 
-        block.seal_slow().try_recover().unwrap()
+        block.seal_slow()
     }
 
     /// Create valid block
-    fn create_valid_block(&mut self, parent_hash: B256) -> RecoveredBlock<Block> {
+    fn create_valid_block(&mut self, parent_hash: B256) -> SealedBlock<Block> {
         let block = self.builder.generate_random_block(1, parent_hash).into_block();
-        block.seal_slow().try_recover().unwrap()
+        block.seal_slow()
     }
 }
 
@@ -622,7 +622,7 @@ fn test_disconnected_payload() {
 
     // ensure block is buffered
     let buffered = test_harness.tree.state.buffer.block(&hash).unwrap();
-    assert_eq!(buffered.clone_sealed_block(), sealed_clone);
+    assert_eq!(*buffered, sealed_clone);
 }
 
 #[test]
@@ -630,7 +630,7 @@ fn test_disconnected_block() {
     let s = include_str!("../../test-data/holesky/2.rlp");
     let data = Bytes::from_str(s).unwrap();
     let block = Block::decode(&mut data.as_ref()).unwrap();
-    let sealed = block.seal_slow().try_recover().unwrap();
+    let sealed = block.seal_slow();
 
     let mut test_harness = TestHarness::new(HOLESKY.clone());
 
@@ -993,7 +993,10 @@ async fn test_engine_tree_live_sync_transition_required_blocks_requested() {
 
     test_harness
         .tree
-        .on_engine_message(FromEngine::DownloadedBlocks(vec![main_chain.last().unwrap().clone()]))
+        .on_engine_message(FromEngine::DownloadedBlocks(vec![main_chain
+            .last()
+            .unwrap()
+            .clone_sealed_block()]))
         .unwrap();
 
     let event = test_harness.from_tree_rx.recv().await.unwrap();
@@ -1125,7 +1128,7 @@ fn test_on_new_payload_canonical_insertion() {
 
     // Ensure block is buffered (like test_disconnected_payload)
     let buffered = test_harness.tree.state.buffer.block(&hash1).unwrap();
-    assert_eq!(buffered.clone_sealed_block(), sealed1_clone, "Block should be buffered");
+    assert_eq!(buffered.clone(), sealed1_clone, "Block should be buffered");
 }
 
 /// Test that ensures payloads are rejected when linking to a known-invalid ancestor
@@ -1232,11 +1235,7 @@ fn test_on_new_payload_backfill_buffering() {
         .expect("Block should be buffered during backfill sync");
 
     // Verify the buffered block matches what we submitted
-    assert_eq!(
-        buffered_block.clone_sealed_block(),
-        sealed,
-        "Buffered block should match submitted payload"
-    );
+    assert_eq!(*buffered_block, sealed, "Buffered block should match submitted payload");
 }
 
 /// Test that captures the Engine-API rule where malformed payloads report latestValidHash = None
@@ -1509,11 +1508,10 @@ mod check_invalid_ancestors_tests {
         // Create a genesis-like payload with parent_hash = B256::ZERO
         let mut test_block_builder = TestBlockBuilder::eth();
         let genesis_block = test_block_builder.generate_random_block(0, B256::ZERO);
-        let (sealed_genesis, _) = genesis_block.split_sealed();
         let genesis_payload = ExecutionData {
             payload: ExecutionPayloadV1::from_block_unchecked(
-                sealed_genesis.hash(),
-                &sealed_genesis.into_block(),
+                genesis_block.hash(),
+                &genesis_block.into_block(),
             )
             .into(),
             sidecar: ExecutionPayloadSidecar::none(),
@@ -1563,8 +1561,7 @@ mod check_invalid_ancestors_tests {
 
         // Intentionally corrupt the block to make it malformed
         // Modify the block after creation to make validation fail
-        let (sealed_block, _senders) = block.split_sealed();
-        let unsealed_block = sealed_block.unseal();
+        let unsealed_block = block.unseal();
 
         // Create payload with wrong hash (this makes it malformed)
         let wrong_hash = B256::from([0xff; 32]);
@@ -1592,13 +1589,9 @@ mod payload_execution_tests {
         // Create a valid payload
         let mut test_block_builder = TestBlockBuilder::eth();
         let block = test_block_builder.generate_random_block(1, B256::ZERO);
-        let (sealed_block, _) = block.split_sealed();
         let payload = ExecutionData {
-            payload: ExecutionPayloadV1::from_block_unchecked(
-                sealed_block.hash(),
-                &sealed_block.into_block(),
-            )
-            .into(),
+            payload: ExecutionPayloadV1::from_block_unchecked(block.hash(), &block.into_block())
+                .into(),
             sidecar: ExecutionPayloadSidecar::none(),
         };
 
@@ -1638,13 +1631,9 @@ mod payload_execution_tests {
         // Create a valid payload
         let mut test_block_builder = TestBlockBuilder::eth();
         let block = test_block_builder.generate_random_block(1, B256::ZERO);
-        let (sealed_block, _) = block.split_sealed();
         let payload = ExecutionData {
-            payload: ExecutionPayloadV1::from_block_unchecked(
-                sealed_block.hash(),
-                &sealed_block.into_block(),
-            )
-            .into(),
+            payload: ExecutionPayloadV1::from_block_unchecked(block.hash(), &block.into_block())
+                .into(),
             sidecar: ExecutionPayloadSidecar::none(),
         };
 
@@ -1666,8 +1655,7 @@ mod payload_execution_tests {
         let block = test_block_builder.generate_random_block(1, B256::ZERO);
 
         // Modify the block to make it malformed
-        let (sealed_block, _senders) = block.split_sealed();
-        let mut unsealed_block = sealed_block.unseal();
+        let mut unsealed_block = block.unseal();
 
         // Corrupt the block by setting an invalid gas limit
         unsealed_block.header.gas_limit = 0;

--- a/crates/engine/util/src/reorg.rs
+++ b/crates/engine/util/src/reorg.rs
@@ -253,7 +253,7 @@ where
 {
     // Ensure next payload is valid.
     let next_block =
-        payload_validator.ensure_well_formed_payload(next_payload).map_err(RethError::msg)?;
+        payload_validator.convert_payload_to_block(next_payload).map_err(RethError::msg)?;
 
     // Fetch reorg target block depending on its depth and its parent.
     let mut previous_hash = next_block.parent_hash();

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -1303,7 +1303,7 @@ mod tests {
 
         // Generate a random block to initialize the blockchain provider.
         let mut test_block_builder = TestBlockBuilder::eth();
-        let block_1 = test_block_builder.generate_random_block(0, B256::ZERO);
+        let block_1 = test_block_builder.generate_random_block(0, B256::ZERO).try_recover()?;
         let block_hash_1 = block_1.hash();
 
         // Insert and commit the block.
@@ -1319,7 +1319,7 @@ mod tests {
         let mut rx_2 = provider.subscribe_to_canonical_state();
 
         // Send and receive commit notifications.
-        let block_2 = test_block_builder.generate_random_block(1, block_hash_1);
+        let block_2 = test_block_builder.generate_random_block(1, block_hash_1).try_recover()?;
         let chain = Chain::new(vec![block_2], ExecutionOutcome::default(), None);
         let commit = CanonStateNotification::Commit { new: Arc::new(chain.clone()) };
         in_memory_state.notify_canon_state(commit.clone());
@@ -1328,8 +1328,8 @@ mod tests {
         assert_eq!(notification_2, Ok(commit.clone()));
 
         // Send and receive re-org notifications.
-        let block_3 = test_block_builder.generate_random_block(1, block_hash_1);
-        let block_4 = test_block_builder.generate_random_block(2, block_3.hash());
+        let block_3 = test_block_builder.generate_random_block(1, block_hash_1).try_recover()?;
+        let block_4 = test_block_builder.generate_random_block(2, block_3.hash()).try_recover()?;
         let new_chain = Chain::new(vec![block_3, block_4], ExecutionOutcome::default(), None);
         let re_org =
             CanonStateNotification::Reorg { old: Arc::new(chain), new: Arc::new(new_chain) };


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/20115

Right now we recover senders in 3 places across the engine — on every downloaded block, when converting a payload to block, and when advancing the tx iterator on a separate thread.

Only the latter is necessary and the rest can simply reuse its outputs instead of doing extra work.

This PR changes engine to operate on `SealedBlock` for un-executed blocks and only construct `RecoveredBlock` once all transactions were executed