### PR TITLE
feat: add inbound & outbound peer counts to network metrics & logs

### DIFF
--- a/crates/net/network-api/src/lib.rs
+++ b/crates/net/network-api/src/lib.rs
@@ -101,6 +101,20 @@ pub trait PeersInfo: Send + Sync {
     /// Note: this should only include established connections and _not_ ongoing attempts.
     fn num_connected_peers(&self) -> usize;
 
+    /// Returns the number of currently connected inbound peers.
+    ///
+    /// Defaults to 0 for no-op/mock implementations, override to return the actual count.
+    fn num_inbound_peers(&self) -> usize {
+        0
+    }
+
+    /// Returns the number of currently connected outbound peers.
+    ///
+    /// Defaults to 0 for no-op/mock implementations, override to return the actual count.
+    fn num_outbound_peers(&self) -> usize {
+        0
+    }
+
     /// Returns the Ethereum Node Record of the node.
     fn local_node_record(&self) -> NodeRecord;
 

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -135,6 +135,12 @@ pub struct NetworkManager<N: NetworkPrimitives = EthNetworkPrimitives> {
     /// This is updated via internal events and shared via `Arc` with the [`NetworkHandle`]
     /// Updated by the `NetworkWorker` and loaded by the `NetworkService`.
     num_active_peers: Arc<AtomicUsize>,
+    /// Tracks the number of inbound peer connections.
+    /// Shared via `Arc` with the [`NetworkHandle`]
+    num_inbound_peers: Arc<AtomicUsize>,
+    /// Tracks the number of outbound peer connections.
+    /// Shared via `Arc` with the [`NetworkHandle`]
+    num_outbound_peers: Arc<AtomicUsize>,
     /// Metrics for the Network
     metrics: NetworkMetrics,
     /// Disconnect metrics for the Network
@@ -296,6 +302,8 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
         let discv5 = discovery.discv5();
 
         let num_active_peers = Arc::new(AtomicUsize::new(0));
+        let num_inbound_peers = Arc::new(AtomicUsize::new(0));
+        let num_outbound_peers = Arc::new(AtomicUsize::new(0));
 
         let sessions = SessionManager::new(
             secret_key,
@@ -323,6 +331,8 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
 
         let handle = NetworkHandle::new(
             Arc::clone(&num_active_peers),
+            Arc::clone(&num_inbound_peers),
+            Arc::clone(&num_outbound_peers),
             Arc::new(Mutex::new(listener_addr)),
             to_manager_tx,
             secret_key,
@@ -352,6 +362,8 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
             to_transactions_manager: None,
             to_eth_request_handler: None,
             num_active_peers,
+            num_inbound_peers,
+            num_outbound_peers,
             metrics: Default::default(),
             disconnect_metrics: Default::default(),
         })
@@ -1029,12 +1041,16 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
     /// Updates the metrics for active,established connections
     #[inline]
     fn update_active_connection_metrics(&self) {
-        self.metrics
-            .incoming_connections
-            .set(self.swarm.state().peers().num_inbound_connections() as f64);
-        self.metrics
-            .outgoing_connections
-            .set(self.swarm.state().peers().num_outbound_connections() as f64);
+        let inbound = self.swarm.state().peers().num_inbound_connections();
+        let outbound = self.swarm.state().peers().num_outbound_connections();
+
+        // Update Prometheus metrics
+        self.metrics.incoming_connections.set(inbound as f64);
+        self.metrics.outgoing_connections.set(outbound as f64);
+
+        // Update atomic counters for NetworkHandle
+        self.num_inbound_peers.store(inbound, Ordering::Relaxed);
+        self.num_outbound_peers.store(outbound, Ordering::Relaxed);
     }
 
     /// Updates the metrics for pending connections

--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -54,6 +54,8 @@ impl<N: NetworkPrimitives> NetworkHandle<N> {
     #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
         num_active_peers: Arc<AtomicUsize>,
+        num_inbound_peers: Arc<AtomicUsize>,
+        num_outbound_peers: Arc<AtomicUsize>,
         listener_address: Arc<Mutex<SocketAddr>>,
         to_manager_tx: UnboundedSender<NetworkHandleMessage<N>>,
         secret_key: SecretKey,
@@ -69,6 +71,8 @@ impl<N: NetworkPrimitives> NetworkHandle<N> {
     ) -> Self {
         let inner = NetworkInner {
             num_active_peers,
+            num_inbound_peers,
+            num_outbound_peers,
             to_manager_tx,
             listener_address,
             secret_key,
@@ -228,6 +232,14 @@ impl<N: NetworkPrimitives> NetworkProtocols for NetworkHandle<N> {
 impl<N: NetworkPrimitives> PeersInfo for NetworkHandle<N> {
     fn num_connected_peers(&self) -> usize {
         self.inner.num_active_peers.load(Ordering::Relaxed)
+    }
+
+    fn num_inbound_peers(&self) -> usize {
+        self.inner.num_inbound_peers.load(Ordering::Relaxed)
+    }
+
+    fn num_outbound_peers(&self) -> usize {
+        self.inner.num_outbound_peers.load(Ordering::Relaxed)
     }
 
     fn local_node_record(&self) -> NodeRecord {
@@ -455,6 +467,10 @@ impl<N: NetworkPrimitives> BlockDownloaderProvider for NetworkHandle<N> {
 struct NetworkInner<N: NetworkPrimitives = EthNetworkPrimitives> {
     /// Number of active peer sessions the node's currently handling.
     num_active_peers: Arc<AtomicUsize>,
+    /// Number of active inbound peer connections.
+    num_inbound_peers: Arc<AtomicUsize>,
+    /// Number of active outbound peer connections.
+    num_outbound_peers: Arc<AtomicUsize>,
     /// Sender half of the message channel to the [`crate::NetworkManager`].
     to_manager_tx: UnboundedSender<NetworkHandleMessage<N>>,
     /// The local address that accepts incoming connections.

--- a/crates/node/events/src/node.rs
+++ b/crates/node/events/src/node.rs
@@ -65,6 +65,14 @@ impl NodeState {
         self.peers_info.as_ref().map(|info| info.num_connected_peers()).unwrap_or_default()
     }
 
+    fn num_inbound_peers(&self) -> usize {
+        self.peers_info.as_ref().map(|info| info.num_inbound_peers()).unwrap_or_default()
+    }
+
+    fn num_outbound_peers(&self) -> usize {
+        self.peers_info.as_ref().map(|info| info.num_outbound_peers()).unwrap_or_default()
+    }
+
     fn build_current_stage(
         &self,
         stage_id: StageId,
@@ -413,6 +421,8 @@ where
                         info!(
                             target: "reth::cli",
                             connected_peers = this.state.num_connected_peers(),
+                            inbound = this.state.num_inbound_peers(),
+                            outbound = this.state.num_outbound_peers(),
                             stage = %stage_id,
                             checkpoint = checkpoint.block_number,
                             target = %OptionalField(*target),
@@ -425,6 +435,8 @@ where
                         info!(
                             target: "reth::cli",
                             connected_peers = this.state.num_connected_peers(),
+                            inbound = this.state.num_inbound_peers(),
+                            outbound = this.state.num_outbound_peers(),
                             stage = %stage_id,
                             checkpoint = checkpoint.block_number,
                             target = %OptionalField(*target),
@@ -436,6 +448,8 @@ where
                         info!(
                             target: "reth::cli",
                             connected_peers = this.state.num_connected_peers(),
+                            inbound = this.state.num_inbound_peers(),
+                            outbound = this.state.num_outbound_peers(),
                             stage = %stage_id,
                             checkpoint = checkpoint.block_number,
                             target = %OptionalField(*target),
@@ -447,6 +461,8 @@ where
                         info!(
                             target: "reth::cli",
                             connected_peers = this.state.num_connected_peers(),
+                            inbound = this.state.num_inbound_peers(),
+                            outbound = this.state.num_outbound_peers(),
                             stage = %stage_id,
                             checkpoint = checkpoint.block_number,
                             target = %OptionalField(*target),
@@ -464,6 +480,8 @@ where
                         info!(
                             target: "reth::cli",
                             connected_peers = this.state.num_connected_peers(),
+                            inbound = this.state.num_inbound_peers(),
+                            outbound = this.state.num_outbound_peers(),
                             %latest_block,
                             "Status"
                         );
@@ -471,6 +489,8 @@ where
                         info!(
                             target: "reth::cli",
                             connected_peers = this.state.num_connected_peers(),
+                            inbound = this.state.num_inbound_peers(),
+                            outbound = this.state.num_outbound_peers(),
                             "Status"
                         );
                     }


### PR DESCRIPTION
This PR adds inbound & outbound peer counts to network metrics & logs. Logs now display: `connected_peers=X inbound=Y outbound=Z .....`

Partially cover: [6100](https://github.com/paradigmxyz/reth/issues/6100)