### PR TITLE
feat(tests): add Osaka fork specification to ForkSpec enum

### DIFF
--- a/testing/ef-tests/src/models.rs
+++ b/testing/ef-tests/src/models.rs
@@ -317,6 +317,8 @@ pub enum ForkSpec {
     CancunToPragueAtTime15k,
     /// Prague
     Prague,
+    /// Osaka
+    Osaka,
 }
 
 impl From<ForkSpec> for ChainSpec {
@@ -371,6 +373,7 @@ impl From<ForkSpec> for ChainSpec {
                 .cancun_activated()
                 .with_fork(EthereumHardfork::Prague, ForkCondition::Timestamp(15_000)),
             ForkSpec::Prague => spec_builder.prague_activated(),
+            ForkSpec::Osaka => spec_builder.osaka_activated(),
         }
         .build()
     }


### PR DESCRIPTION
Add Osaka to the list of supported forks for EEST tests.

This is required to run EEST tests targeting Osaka without Hive but directly, but also to generate witnesses for EEST benchmark tests for L1 proving benchmarking (which is was my motivation for the PR).