### PR TITLE
feat(engine): run sync state root if not enough parallelism

### DIFF
--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -97,7 +97,7 @@ pub struct TreeConfig {
     state_provider_metrics: bool,
     /// Cross-block cache size in bytes.
     cross_block_cache_size: u64,
-    /// Whether the host has enough parallelism to run state root task.
+    /// Whether the host has enough parallelism to run state root in parallel.
     has_enough_parallelism: bool,
     /// Whether multiproof task should chunk proof targets.
     multiproof_chunking_enabled: bool,
@@ -385,10 +385,15 @@ impl TreeConfig {
         self
     }
 
-    /// Setter for has enough parallelism.
+    /// Setter for whether or not the host has enough parallelism to run state root in parallel.
     pub const fn with_has_enough_parallelism(mut self, has_enough_parallelism: bool) -> Self {
         self.has_enough_parallelism = has_enough_parallelism;
         self
+    }
+
+    /// Whether or not the host has enough parallelism to run state root in parallel.
+    pub const fn has_enough_parallelism(&self) -> bool {
+        self.has_enough_parallelism
     }
 
     /// Setter for state provider metrics.

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -856,7 +856,7 @@ where
     /// Note: Use state root task only if prefix sets are empty, otherwise proof generation is
     /// too expensive because it requires walking all paths in every proof.
     const fn plan_state_root_computation(&self) -> StateRootStrategy {
-        if self.config.state_root_fallback() {
+        if self.config.state_root_fallback() || !self.config.has_enough_parallelism() {
             StateRootStrategy::Synchronous
         } else if self.config.use_state_root_task() {
             StateRootStrategy::StateRootTask


### PR DESCRIPTION
Do not run state root task or parallel state root if the host has less than 5 cores.

ref #20110