### PR TITLE
fix(engine/tree): gate persistence on max(threshold, buffer-target)

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1695,8 +1695,13 @@ where
         }
 
         let min_block = self.persistence_state.last_persisted_block.number;
-        self.state.tree_state.canonical_block_number().saturating_sub(min_block) >
+        let gate = if self.config.persistence_threshold() > self.config.memory_block_buffer_target()
+        {
             self.config.persistence_threshold()
+        } else {
+            self.config.memory_block_buffer_target()
+        };
+        self.state.tree_state.canonical_block_number().saturating_sub(min_block) > gate
     }
 
     /// Returns a batch of consecutive canonical blocks to persist in the range


### PR DESCRIPTION
Persistence gating only considered persistence_threshold, while the selection of blocks to persist was capped by memory_block_buffer_target. When the buffer target exceeded the threshold, the engine could repeatedly attempt persistence with an empty set. This change updates should_persist() to use the maximum of the two, ensuring persistence starts only when there are blocks eligible to persist and matching the documented expectation that the buffer target should not exceed the threshold.