### PR TITLE
fix(rpc): remove redundant blob_gas_used calculation in eth_callBundle

### DIFF
--- a/crates/rpc/rpc/src/eth/bundle.rs
+++ b/crates/rpc/rpc/src/eth/bundle.rs
@@ -113,9 +113,7 @@ where
                 .chain_spec()
                 .blob_params_at_timestamp(evm_env.block_env.timestamp().saturating_to())
                 .unwrap_or_else(BlobParams::cancun);
-            if transactions.iter().filter_map(|tx| tx.blob_gas_used()).sum::<u64>() >
-                blob_params.max_blob_gas_per_block()
-            {
+            if blob_gas_used > blob_params.max_blob_gas_per_block() {
                 return Err(EthApiError::InvalidParams(
                     EthBundleError::Eip4844BlobGasExceeded(blob_params.max_blob_gas_per_block())
                         .to_string(),


### PR DESCRIPTION
blob_gas_used was already computed on line 108 but the same sum was recalculated on line 116 instead of reusing the variable. This was introduced during the alloy 0.15.5 bump refactor.