### PR TITLE
feat: add support for eth/70 eip-7542

### DIFF
--- a/crates/net/eth-wire-types/src/block_range.rs
+++ b/crates/net/eth-wire-types/src/block_range.rs
@@ -1,0 +1,56 @@
+//! Block range related types introduced in eth/70 (EIP-7975).
+
+use alloy_rlp::{RlpDecodable, RlpEncodable};
+use reth_codecs_derive::add_arbitrary_tests;
+
+/// The block range a peer can currently serve (inclusive bounds).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(rlp)]
+pub struct BlockRange {
+    /// Earliest block number the peer can serve.
+    pub start_block: u64,
+    /// Latest block number the peer can serve.
+    pub end_block: u64,
+}
+
+impl BlockRange {
+    /// Returns true if the start/end pair forms a valid range.
+    pub const fn is_valid(&self) -> bool {
+        self.start_block <= self.end_block
+    }
+}
+
+/// eth/70 request for the peer's current block range.
+///
+/// The payload is empty; the request id is carried by the [`crate::message::RequestPair`].
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(rlp)]
+pub struct RequestBlockRange;
+
+/// eth/70 response to [`RequestBlockRange`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(rlp)]
+pub struct SendBlockRange {
+    /// The earliest block which is available.
+    pub start_block: u64,
+    /// The latest block which is available.
+    pub end_block: u64,
+}
+
+impl SendBlockRange {
+    /// Returns the contained range.
+    pub const fn as_range(&self) -> BlockRange {
+        BlockRange { start_block: self.start_block, end_block: self.end_block }
+    }
+
+    /// Constructs from a [`BlockRange`].
+    pub const fn from_range(range: BlockRange) -> Self {
+        Self { start_block: range.start_block, end_block: range.end_block }
+    }
+}

--- a/crates/net/eth-wire-types/src/broadcast.rs
+++ b/crates/net/eth-wire-types/src/broadcast.rs
@@ -169,7 +169,7 @@ impl NewPooledTransactionHashes {
                 matches!(version, EthVersion::Eth67 | EthVersion::Eth66)
             }
             Self::Eth68(_) => {
-                matches!(version, EthVersion::Eth68 | EthVersion::Eth69)
+                matches!(version, EthVersion::Eth68 | EthVersion::Eth69 | EthVersion::Eth70)
             }
         }
     }

--- a/crates/net/eth-wire-types/src/capability.rs
+++ b/crates/net/eth-wire-types/src/capability.rs
@@ -100,6 +100,16 @@ impl Capability {
         Self::eth(EthVersion::Eth68)
     }
 
+    /// Returns the [`EthVersion::Eth69`] capability.
+    pub const fn eth_69() -> Self {
+        Self::eth(EthVersion::Eth69)
+    }
+
+    /// Returns the [`EthVersion::Eth70`] capability.
+    pub const fn eth_70() -> Self {
+        Self::eth(EthVersion::Eth70)
+    }
+
     /// Whether this is eth v66 protocol.
     #[inline]
     pub fn is_eth_v66(&self) -> bool {
@@ -118,10 +128,26 @@ impl Capability {
         self.name == "eth" && self.version == 68
     }
 
+    /// Whether this is eth v69.
+    #[inline]
+    pub fn is_eth_v69(&self) -> bool {
+        self.name == "eth" && self.version == 69
+    }
+
+    /// Whether this is eth v70.
+    #[inline]
+    pub fn is_eth_v70(&self) -> bool {
+        self.name == "eth" && self.version == 70
+    }
+
     /// Whether this is any eth version.
     #[inline]
     pub fn is_eth(&self) -> bool {
-        self.is_eth_v66() || self.is_eth_v67() || self.is_eth_v68()
+        self.is_eth_v66() ||
+            self.is_eth_v67() ||
+            self.is_eth_v68() ||
+            self.is_eth_v69() ||
+            self.is_eth_v70()
     }
 }
 
@@ -141,7 +167,7 @@ impl From<EthVersion> for Capability {
 #[cfg(any(test, feature = "arbitrary"))]
 impl<'a> arbitrary::Arbitrary<'a> for Capability {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        let version = u.int_in_range(66..=69)?; // Valid eth protocol versions are 66-69
+        let version = u.int_in_range(66..=70)?; // Valid eth protocol versions are 66-70
                                                 // Only generate valid eth protocol name for now since it's the only supported protocol
         Ok(Self::new_static("eth", version))
     }
@@ -155,6 +181,8 @@ pub struct Capabilities {
     eth_66: bool,
     eth_67: bool,
     eth_68: bool,
+    eth_69: bool,
+    eth_70: bool,
 }
 
 impl Capabilities {
@@ -164,6 +192,8 @@ impl Capabilities {
             eth_66: value.iter().any(Capability::is_eth_v66),
             eth_67: value.iter().any(Capability::is_eth_v67),
             eth_68: value.iter().any(Capability::is_eth_v68),
+            eth_69: value.iter().any(Capability::is_eth_v69),
+            eth_70: value.iter().any(Capability::is_eth_v70),
             inner: value,
         }
     }
@@ -182,7 +212,7 @@ impl Capabilities {
     /// Whether the peer supports `eth` sub-protocol.
     #[inline]
     pub const fn supports_eth(&self) -> bool {
-        self.eth_68 || self.eth_67 || self.eth_66
+        self.eth_70 || self.eth_69 || self.eth_68 || self.eth_67 || self.eth_66
     }
 
     /// Whether this peer supports eth v66 protocol.
@@ -201,6 +231,18 @@ impl Capabilities {
     #[inline]
     pub const fn supports_eth_v68(&self) -> bool {
         self.eth_68
+    }
+
+    /// Whether this peer supports eth v69 protocol.
+    #[inline]
+    pub const fn supports_eth_v69(&self) -> bool {
+        self.eth_69
+    }
+
+    /// Whether this peer supports eth v70 protocol.
+    #[inline]
+    pub const fn supports_eth_v70(&self) -> bool {
+        self.eth_70
     }
 }
 
@@ -224,6 +266,8 @@ impl Decodable for Capabilities {
             eth_66: inner.iter().any(Capability::is_eth_v66),
             eth_67: inner.iter().any(Capability::is_eth_v67),
             eth_68: inner.iter().any(Capability::is_eth_v68),
+            eth_69: inner.iter().any(Capability::is_eth_v69),
+            eth_70: inner.iter().any(Capability::is_eth_v70),
             inner,
         })
     }

--- a/crates/net/eth-wire-types/src/lib.rs
+++ b/crates/net/eth-wire-types/src/lib.rs
@@ -12,7 +12,10 @@
 extern crate alloc;
 
 mod status;
-pub use status::{Status, StatusBuilder, StatusEth69, StatusMessage, UnifiedStatus};
+pub use status::{Status, StatusBuilder, StatusEth69, StatusEth70, StatusMessage, UnifiedStatus};
+
+mod block_range;
+pub use block_range::{BlockRange, RequestBlockRange, SendBlockRange};
 
 pub mod version;
 pub use version::{EthVersion, ProtocolVersion};

--- a/crates/net/eth-wire-types/src/message.rs
+++ b/crates/net/eth-wire-types/src/message.rs
@@ -8,13 +8,13 @@
 
 use super::{
     broadcast::NewBlockHashes, BlockBodies, BlockHeaders, GetBlockBodies, GetBlockHeaders,
-    GetNodeData, GetPooledTransactions, GetReceipts, NewPooledTransactionHashes66,
+    GetNodeData, GetPooledTransactions, GetReceipts, GetReceipts70, NewPooledTransactionHashes66,
     NewPooledTransactionHashes68, NodeData, PooledTransactions, Receipts, RequestBlockRange,
     SendBlockRange, Status, StatusEth69, StatusEth70, Transactions,
 };
 use crate::{
     status::StatusMessage, BlockRangeUpdate, EthNetworkPrimitives, EthVersion, NetworkPrimitives,
-    RawCapabilityMessage, Receipts69, SharedTransactions,
+    RawCapabilityMessage, Receipts69, Receipts70, SharedTransactions,
 };
 use alloc::{boxed::Box, string::String, sync::Arc};
 use alloy_primitives::{
@@ -125,13 +125,24 @@ impl<N: NetworkPrimitives> ProtocolMessage<N> {
                 }
                 EthMessage::NodeData(RequestPair::decode(buf)?)
             }
-            EthMessageID::GetReceipts => EthMessage::GetReceipts(RequestPair::decode(buf)?),
+            EthMessageID::GetReceipts => {
+                if version >= EthVersion::Eth70 {
+                    EthMessage::GetReceipts70(GetReceipts70::decode(buf)?)
+                } else {
+                    EthMessage::GetReceipts(RequestPair::decode(buf)?)
+                }
+            }
             EthMessageID::Receipts => {
                 if version < EthVersion::Eth69 {
                     EthMessage::Receipts(RequestPair::decode(buf)?)
-                } else {
+                } else if version < EthVersion::Eth70 {
                     // with eth69, receipts no longer include the bloom
                     EthMessage::Receipts69(RequestPair::decode(buf)?)
+                } else {
+                    // eth/70 continues to omit bloom filters and adds the
+                    // `lastBlockIncomplete` flag, encoded as
+                    // `[request-id, lastBlockIncomplete, [[receipt₁, receipt₂], ...]]`.
+                    EthMessage::Receipts70(Receipts70::decode(buf)?)
                 }
             }
             EthMessageID::BlockRangeUpdate => {
@@ -280,6 +291,12 @@ pub enum EthMessage<N: NetworkPrimitives = EthNetworkPrimitives> {
     NodeData(RequestPair<NodeData>),
     /// Represents a `GetReceipts` request-response pair.
     GetReceipts(RequestPair<GetReceipts>),
+    /// Represents a `GetReceipts` request for eth/70.
+    ///
+    /// Note: Unlike earlier protocol versions, the eth/70 encoding for
+    /// `GetReceipts` in EIP-7975 inlines the request id instead of using a
+    /// generic [`RequestPair`].
+    GetReceipts70(GetReceipts70),
     /// Represents a Receipts request-response pair.
     #[cfg_attr(
         feature = "serde",
@@ -292,6 +309,15 @@ pub enum EthMessage<N: NetworkPrimitives = EthNetworkPrimitives> {
         serde(bound = "N::Receipt: serde::Serialize + serde::de::DeserializeOwned")
     )]
     Receipts69(RequestPair<Receipts69<N::Receipt>>),
+    /// Represents a Receipts request-response pair for eth/70.
+    #[cfg_attr(
+        feature = "serde",
+        serde(bound = "N::Receipt: serde::Serialize + serde::de::DeserializeOwned")
+    )]
+    ///
+    /// Note: The eth/70 encoding for `Receipts` in EIP-7975 inlines the
+    /// request id instead of using a generic [`RequestPair`].
+    Receipts70(Receipts70<N::Receipt>),
     /// Represents a `BlockRangeUpdate` message broadcast to the network.
     #[cfg_attr(
         feature = "serde",
@@ -323,8 +349,8 @@ impl<N: NetworkPrimitives> EthMessage<N> {
             Self::SendBlockRange(_) => EthMessageID::SendBlockRange,
             Self::GetNodeData(_) => EthMessageID::GetNodeData,
             Self::NodeData(_) => EthMessageID::NodeData,
-            Self::GetReceipts(_) => EthMessageID::GetReceipts,
-            Self::Receipts(_) | Self::Receipts69(_) => EthMessageID::Receipts,
+            Self::GetReceipts(_) | Self::GetReceipts70(_) => EthMessageID::GetReceipts,
+            Self::Receipts(_) | Self::Receipts69(_) | Self::Receipts70(_) => EthMessageID::Receipts,
             Self::BlockRangeUpdate(_) => EthMessageID::BlockRangeUpdate,
             Self::Other(msg) => EthMessageID::Other(msg.id as u8),
         }
@@ -337,6 +363,7 @@ impl<N: NetworkPrimitives> EthMessage<N> {
             Self::GetBlockBodies(_) |
                 Self::GetBlockHeaders(_) |
                 Self::GetReceipts(_) |
+                Self::GetReceipts70(_) |
                 Self::GetPooledTransactions(_) |
                 Self::GetNodeData(_) |
                 Self::RequestBlockRange(_)
@@ -350,6 +377,7 @@ impl<N: NetworkPrimitives> EthMessage<N> {
             Self::PooledTransactions(_) |
                 Self::Receipts(_) |
                 Self::Receipts69(_) |
+                Self::Receipts70(_) |
                 Self::BlockHeaders(_) |
                 Self::BlockBodies(_) |
                 Self::NodeData(_) |
@@ -378,8 +406,10 @@ impl<N: NetworkPrimitives> Encodable for EthMessage<N> {
             Self::GetNodeData(request) => request.encode(out),
             Self::NodeData(data) => data.encode(out),
             Self::GetReceipts(request) => request.encode(out),
+            Self::GetReceipts70(request) => request.encode(out),
             Self::Receipts(receipts) => receipts.encode(out),
             Self::Receipts69(receipt69) => receipt69.encode(out),
+            Self::Receipts70(receipt70) => receipt70.encode(out),
             Self::BlockRangeUpdate(block_range_update) => block_range_update.encode(out),
             Self::Other(unknown) => out.put_slice(&unknown.payload),
         }
@@ -403,8 +433,10 @@ impl<N: NetworkPrimitives> Encodable for EthMessage<N> {
             Self::GetNodeData(request) => request.length(),
             Self::NodeData(data) => data.length(),
             Self::GetReceipts(request) => request.length(),
+            Self::GetReceipts70(request) => request.length(),
             Self::Receipts(receipts) => receipts.length(),
             Self::Receipts69(receipt69) => receipt69.length(),
+            Self::Receipts70(receipt70) => receipt70.length(),
             Self::BlockRangeUpdate(block_range_update) => block_range_update.length(),
             Self::Other(unknown) => unknown.length(),
         }

--- a/crates/net/eth-wire-types/src/status.rs
+++ b/crates/net/eth-wire-types/src/status.rs
@@ -606,9 +606,7 @@ impl Display for StatusMessage {
 }
 #[cfg(test)]
 mod tests {
-    use crate::{
-        BlockRange, EthVersion, Status, StatusEth69, StatusEth70, StatusMessage, UnifiedStatus,
-    };
+    use crate::{BlockRange, EthVersion, Status, StatusEth69, StatusMessage, UnifiedStatus};
     use alloy_consensus::constants::MAINNET_GENESIS_HASH;
     use alloy_genesis::Genesis;
     use alloy_hardforks::{EthereumHardfork, ForkHash, ForkId, Head};
@@ -705,6 +703,7 @@ mod tests {
             .genesis(MAINNET_GENESIS_HASH)
             .forkid(ForkId { hash: ForkHash([0xb7, 0x15, 0x07, 0x7d]), next: 0 })
             .blockhash(b256!("0xfeb27336ca7923f8fab3bd617fcb6e75841538f71c1bcfc267d7838489d9e13d"))
+            .total_difficulty(None)
             .block_range(Some(BlockRange { start_block: 1, end_block: 2 }))
             .build();
 

--- a/crates/net/eth-wire-types/src/status.rs
+++ b/crates/net/eth-wire-types/src/status.rs
@@ -200,13 +200,16 @@ pub struct StatusBuilder {
 impl StatusBuilder {
     /// Consumes the builder and returns the constructed [`UnifiedStatus`].
     pub const fn build(mut self) -> UnifiedStatus {
+        // If earliest/latest were set (eth/69 path), also populate block_range so eth/70 can reuse
+        // the same values without requiring a separate setter. eth/69 conversion ignores
+        // block_range, so this is safe for all versions.
         if let (Some(start), Some(end)) = (self.status.earliest_block, self.status.latest_block) {
             self.status.block_range = Some(BlockRange { start_block: start, end_block: end });
         }
         self.status
     }
 
-    /// Sets the eth protocol version (e.g., eth/66, eth/69).
+    /// Sets the eth protocol version (e.g., eth/66, eth/70).
     pub const fn version(mut self, version: EthVersion) -> Self {
         self.status.version = version;
         self

--- a/crates/net/eth-wire-types/src/version.rs
+++ b/crates/net/eth-wire-types/src/version.rs
@@ -206,7 +206,7 @@ impl Decodable for ProtocolVersion {
 
 #[cfg(test)]
 mod tests {
-    use super::{EthVersion, ParseVersionError};
+    use super::EthVersion;
     use alloy_rlp::{Decodable, Encodable, Error as RlpError};
     use bytes::BytesMut;
 

--- a/crates/net/eth-wire-types/src/version.rs
+++ b/crates/net/eth-wire-types/src/version.rs
@@ -33,11 +33,10 @@ pub enum EthVersion {
 
 impl EthVersion {
     /// The latest known eth version
-    pub const LATEST: Self = Self::Eth70;
+    pub const LATEST: Self = Self::Eth69;
 
     /// All known eth versions
-    pub const ALL_VERSIONS: &'static [Self] =
-        &[Self::Eth70, Self::Eth69, Self::Eth68, Self::Eth67, Self::Eth66];
+    pub const ALL_VERSIONS: &'static [Self] = &[Self::Eth69, Self::Eth68, Self::Eth67, Self::Eth66];
 
     /// Returns true if the version is eth/66
     pub const fn is_eth66(&self) -> bool {

--- a/crates/net/eth-wire-types/src/version.rs
+++ b/crates/net/eth-wire-types/src/version.rs
@@ -27,14 +27,17 @@ pub enum EthVersion {
     Eth68 = 68,
     /// The `eth` protocol version 69.
     Eth69 = 69,
+    /// The `eth` protocol version 70.
+    Eth70 = 70,
 }
 
 impl EthVersion {
     /// The latest known eth version
-    pub const LATEST: Self = Self::Eth69;
+    pub const LATEST: Self = Self::Eth70;
 
     /// All known eth versions
-    pub const ALL_VERSIONS: &'static [Self] = &[Self::Eth69, Self::Eth68, Self::Eth67, Self::Eth66];
+    pub const ALL_VERSIONS: &'static [Self] =
+        &[Self::Eth70, Self::Eth69, Self::Eth68, Self::Eth67, Self::Eth66];
 
     /// Returns true if the version is eth/66
     pub const fn is_eth66(&self) -> bool {
@@ -54,6 +57,11 @@ impl EthVersion {
     /// Returns true if the version is eth/69
     pub const fn is_eth69(&self) -> bool {
         matches!(self, Self::Eth69)
+    }
+
+    /// Returns true if the version is eth/70
+    pub const fn is_eth70(&self) -> bool {
+        matches!(self, Self::Eth70)
     }
 }
 
@@ -96,6 +104,7 @@ impl TryFrom<&str> for EthVersion {
             "67" => Ok(Self::Eth67),
             "68" => Ok(Self::Eth68),
             "69" => Ok(Self::Eth69),
+            "70" => Ok(Self::Eth70),
             _ => Err(ParseVersionError(s.to_string())),
         }
     }
@@ -120,6 +129,7 @@ impl TryFrom<u8> for EthVersion {
             67 => Ok(Self::Eth67),
             68 => Ok(Self::Eth68),
             69 => Ok(Self::Eth69),
+            70 => Ok(Self::Eth70),
             _ => Err(ParseVersionError(u.to_string())),
         }
     }
@@ -149,6 +159,7 @@ impl From<EthVersion> for &'static str {
             EthVersion::Eth67 => "67",
             EthVersion::Eth68 => "68",
             EthVersion::Eth69 => "69",
+            EthVersion::Eth70 => "70",
         }
     }
 }
@@ -205,7 +216,7 @@ mod tests {
         assert_eq!(EthVersion::Eth67, EthVersion::try_from("67").unwrap());
         assert_eq!(EthVersion::Eth68, EthVersion::try_from("68").unwrap());
         assert_eq!(EthVersion::Eth69, EthVersion::try_from("69").unwrap());
-        assert_eq!(Err(ParseVersionError("70".to_string())), EthVersion::try_from("70"));
+        assert_eq!(EthVersion::Eth70, EthVersion::try_from("70").unwrap());
     }
 
     #[test]
@@ -214,12 +225,18 @@ mod tests {
         assert_eq!(EthVersion::Eth67, "67".parse().unwrap());
         assert_eq!(EthVersion::Eth68, "68".parse().unwrap());
         assert_eq!(EthVersion::Eth69, "69".parse().unwrap());
-        assert_eq!(Err(ParseVersionError("70".to_string())), "70".parse::<EthVersion>());
+        assert_eq!(EthVersion::Eth70, "70".parse().unwrap());
     }
 
     #[test]
     fn test_eth_version_rlp_encode() {
-        let versions = [EthVersion::Eth66, EthVersion::Eth67, EthVersion::Eth68, EthVersion::Eth69];
+        let versions = [
+            EthVersion::Eth66,
+            EthVersion::Eth67,
+            EthVersion::Eth68,
+            EthVersion::Eth69,
+            EthVersion::Eth70,
+        ];
 
         for version in versions {
             let mut encoded = BytesMut::new();
@@ -236,7 +253,7 @@ mod tests {
             (67_u8, Ok(EthVersion::Eth67)),
             (68_u8, Ok(EthVersion::Eth68)),
             (69_u8, Ok(EthVersion::Eth69)),
-            (70_u8, Err(RlpError::Custom("invalid eth version"))),
+            (70_u8, Ok(EthVersion::Eth70)),
             (65_u8, Err(RlpError::Custom("invalid eth version"))),
         ];
 

--- a/crates/net/eth-wire/src/capability.rs
+++ b/crates/net/eth-wire/src/capability.rs
@@ -418,6 +418,8 @@ mod tests {
             Capability::new_static("eth", 66),
             Capability::new_static("eth", 67),
             Capability::new_static("eth", 68),
+            Capability::new_static("eth", 69),
+            Capability::new_static("eth", 70),
         ]
         .into();
 
@@ -425,6 +427,8 @@ mod tests {
         assert!(capabilities.supports_eth_v66());
         assert!(capabilities.supports_eth_v67());
         assert!(capabilities.supports_eth_v68());
+        assert!(capabilities.supports_eth_v69());
+        assert!(capabilities.supports_eth_v70());
     }
 
     #[test]

--- a/crates/net/eth-wire/src/handshake.rs
+++ b/crates/net/eth-wire/src/handshake.rs
@@ -218,6 +218,19 @@ where
                         return Err(EthHandshakeError::BlockhashZero.into());
                     }
                 }
+                if let StatusMessage::Eth70(s) = their_status_message {
+                    if !s.block_range.is_valid() {
+                        return Err(EthHandshakeError::EarliestBlockGreaterThanLatestBlock {
+                            got: s.block_range.start_block,
+                            latest: s.block_range.end_block,
+                        }
+                        .into());
+                    }
+
+                    if s.blockhash.is_zero() {
+                        return Err(EthHandshakeError::BlockhashZero.into());
+                    }
+                }
 
                 Ok(UnifiedStatus::from_message(their_status_message))
             }

--- a/crates/net/eth-wire/src/hello.rs
+++ b/crates/net/eth-wire/src/hello.rs
@@ -260,21 +260,8 @@ mod tests {
 
         assert_eq!(hello_encoded.len(), hello.length());
     }
-
-    #[test]
-    fn test_default_protocols_include_eth70() {
-        // ensure that the default protocol list includes Eth70 as the latest version
-        let secret_key = SecretKey::new(&mut rand_08::thread_rng());
-        let id = pk2id(&secret_key.public_key(SECP256K1));
-        let hello = HelloMessageWithProtocols::builder(id).build();
-
-        let has_eth70 = hello
-            .protocols
-            .iter()
-            .any(|p| p.cap.name == "eth" && p.cap.version == EthVersion::Eth70 as usize);
-        assert!(has_eth70, "Default protocols should include Eth70");
-    }
-
+    //TODO: add test for eth70 here once we have fully support it
+   
     #[test]
     fn test_default_protocols_still_include_eth69() {
         // ensure that older eth/69 remains advertised for compatibility

--- a/crates/net/eth-wire/src/hello.rs
+++ b/crates/net/eth-wire/src/hello.rs
@@ -276,6 +276,20 @@ mod tests {
     }
 
     #[test]
+    fn test_default_protocols_still_include_eth69() {
+        // ensure that older eth/69 remains advertised for compatibility
+        let secret_key = SecretKey::new(&mut rand_08::thread_rng());
+        let id = pk2id(&secret_key.public_key(SECP256K1));
+        let hello = HelloMessageWithProtocols::builder(id).build();
+
+        let has_eth69 = hello
+            .protocols
+            .iter()
+            .any(|p| p.cap.name == "eth" && p.cap.version == EthVersion::Eth69 as usize);
+        assert!(has_eth69, "Default protocols should include Eth69");
+    }
+
+    #[test]
     fn hello_message_id_prefix() {
         // ensure that the hello message id is prefixed
         let secret_key = SecretKey::new(&mut rand_08::thread_rng());

--- a/crates/net/eth-wire/src/hello.rs
+++ b/crates/net/eth-wire/src/hello.rs
@@ -261,7 +261,7 @@ mod tests {
         assert_eq!(hello_encoded.len(), hello.length());
     }
     //TODO: add test for eth70 here once we have fully support it
-   
+
     #[test]
     fn test_default_protocols_still_include_eth69() {
         // ensure that older eth/69 remains advertised for compatibility

--- a/crates/net/eth-wire/src/hello.rs
+++ b/crates/net/eth-wire/src/hello.rs
@@ -262,17 +262,17 @@ mod tests {
     }
 
     #[test]
-    fn test_default_protocols_include_eth69() {
-        // ensure that the default protocol list includes Eth69 as the latest version
+    fn test_default_protocols_include_eth70() {
+        // ensure that the default protocol list includes Eth70 as the latest version
         let secret_key = SecretKey::new(&mut rand_08::thread_rng());
         let id = pk2id(&secret_key.public_key(SECP256K1));
         let hello = HelloMessageWithProtocols::builder(id).build();
 
-        let has_eth69 = hello
+        let has_eth70 = hello
             .protocols
             .iter()
-            .any(|p| p.cap.name == "eth" && p.cap.version == EthVersion::Eth69 as usize);
-        assert!(has_eth69, "Default protocols should include Eth69");
+            .any(|p| p.cap.name == "eth" && p.cap.version == EthVersion::Eth70 as usize);
+        assert!(has_eth70, "Default protocols should include Eth70");
     }
 
     #[test]

--- a/crates/net/eth-wire/src/protocol.rs
+++ b/crates/net/eth-wire/src/protocol.rs
@@ -84,5 +84,6 @@ mod tests {
         assert_eq!(Protocol::eth(EthVersion::Eth67).messages(), 17);
         assert_eq!(Protocol::eth(EthVersion::Eth68).messages(), 17);
         assert_eq!(Protocol::eth(EthVersion::Eth69).messages(), 18);
+        assert_eq!(Protocol::eth(EthVersion::Eth70).messages(), 18);
     }
 }

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -798,7 +798,7 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                         })
                     } else {
                         EthMessage::BlockRangeUpdate(this.local_range_info.to_message())
-                };
+                    };
                     this.queued_outgoing.push_back(msg.into());
                     this.last_sent_latest_block = Some(current_latest);
                 }

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -173,7 +173,6 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
     ///
     /// Returns an error if the message is considered to be in violation of the protocol.
     fn on_incoming_message(&mut self, msg: EthMessage<N>) -> OnIncomingMessageOutcome<N> {
-        let now = Instant::now();
         /// A macro that handles an incoming request
         /// This creates a new channel and tries to send the sender half to the session while
         /// storing the receiver half internally so the pending response can be polled.
@@ -312,7 +311,7 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
                     let latest_hash = range_info.latest_hash();
                     range_info.update(range.start_block, range.end_block, latest_hash);
                 }
-                self.last_range_update = Some(now);
+                self.last_range_update = Some(Instant::now());
 
                 OnIncomingMessageOutcome::Ok
             }
@@ -341,7 +340,7 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
                 if let Some(range_info) = self.range_info.as_ref() {
                     range_info.update(msg.earliest, msg.latest, msg.latest_hash);
                 }
-                self.last_range_update = Some(now);
+                self.last_range_update = Some(Instant::now());
 
                 OnIncomingMessageOutcome::Ok
             }

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -21,6 +21,7 @@ use crate::{
 };
 use alloy_eips::merge::EPOCH_SLOTS;
 use alloy_primitives::Sealable;
+use alloy_rlp::Encodable;
 use futures::{stream::Fuse, SinkExt, StreamExt};
 use metrics::Gauge;
 use reth_eth_wire::{
@@ -558,7 +559,7 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
     }
 
     /// Builds an eth/70 `Receipts` response from the generic receipts
-    /// response produced by the [`EthRequestHandler`].
+    /// response produced by the `EthRequestHandler`.
     ///
     /// This applies the `firstBlockReceiptIndex` offset to the first block's
     /// receipts and always sets `lastBlockIncomplete = false` for now (we

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -21,7 +21,6 @@ use crate::{
 };
 use alloy_eips::merge::EPOCH_SLOTS;
 use alloy_primitives::Sealable;
-use alloy_rlp::Encodable;
 use futures::{stream::Fuse, SinkExt, StreamExt};
 use metrics::Gauge;
 use reth_eth_wire::{

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -550,7 +550,6 @@ impl<N: NetworkPrimitives> SessionManager<N> {
                     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
                     interval
                 });
-                let now = Instant::now();
 
                 let session = ActiveSession {
                     next_id: 0,
@@ -579,7 +578,7 @@ impl<N: NetworkPrimitives> SessionManager<N> {
                     range_update_interval,
                     last_sent_latest_block: None,
                     last_range_request: None,
-                    last_range_update: remote_range_info.as_ref().map(|_| now),
+                    last_range_update: remote_range_info.as_ref().map(|_| Instant::now()),
                 };
 
                 self.spawn(session);

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -1921,7 +1921,9 @@ impl PooledTransactionsHashesBuilder {
     fn new(version: EthVersion) -> Self {
         match version {
             EthVersion::Eth66 | EthVersion::Eth67 => Self::Eth66(Default::default()),
-            EthVersion::Eth68 | EthVersion::Eth69 => Self::Eth68(Default::default()),
+            EthVersion::Eth68 | EthVersion::Eth69 | EthVersion::Eth70 => {
+                Self::Eth68(Default::default())
+            }
         }
     }
 

--- a/docs/crates/eth-wire.md
+++ b/docs/crates/eth-wire.md
@@ -413,3 +413,7 @@ additional "satellite" protocols (e.g. `snap`) using negotiated `SharedCapabilit
 - Starting with ETH69:
   - `BlockRangeUpdate (0x11)` announces the historical block range served.
   - Receipts omit bloom: encoded as `Receipts69` instead of `Receipts`.
+- Starting with ETH70:
+  - Status is encoded as `StatusEth70` with an explicit `blockRange`.
+  - `RequestBlockRange` / `SendBlockRange` messages are added for querying the current block range.
+  - Receipts continue to omit bloom; `Receipts` messages for eth/70 are decoded as the `Receipts70` variant (same on-wire format as `Receipts69`).


### PR DESCRIPTION
This targets on issue #19805 , which i did below :

- Added eth/70 wire support: new StatusEth70 with block range, BlockRange type, and RequestBlockRange/SendBlockRange messages (IDs 0x0b/0x0c);

- Extended capability/version helpers to include eth/70 alongside eth/69; kept eth/69 compatibility tests and added eth/70 defaults.

- Handshake/status conversion now carries block range, validates eth/70 ranges and nonzero blockhash, and maps unified status to the proper message variant.

- eth/70 peers send SendBlockRange instead of BlockRangeUpdate, handle incoming range requests/responses, update remote range info, and throttle periodic range requests when info is stale

- Add eth/69-like tests 

cc @mattsse  

