### PR TITLE
feat: add support for debug_getBadblock

### DIFF
--- a/crates/e2e-test-utils/src/node.rs
+++ b/crates/e2e-test-utils/src/node.rs
@@ -90,7 +90,8 @@ where
     where
         AddOns::EthApi: EthApiSpec<Provider: BlockReader<Block = BlockTy<Node::Types>>>
             + EthTransactions
-            + TraceExt,
+            + TraceExt
+            + reth_rpc_eth_api::RpcNodeCore<Provider = Node::Provider>,
     {
         let mut chain = Vec::with_capacity(length as usize);
         for i in 0..length {

--- a/crates/e2e-test-utils/src/rpc.rs
+++ b/crates/e2e-test-utils/src/rpc.rs
@@ -22,7 +22,8 @@ where
     Node: FullNodeComponents<Types: NodeTypes<ChainSpec: EthereumHardforks>>,
     EthApi: EthApiSpec<Provider: BlockReader<Block = BlockTy<Node::Types>>>
         + EthTransactions
-        + TraceExt,
+        + TraceExt
+        + reth_rpc_eth_api::RpcNodeCore<Provider = Node::Provider>,
 {
     /// Injects a raw transaction into the node tx pool via RPC server
     pub async fn inject_tx(&self, raw_tx: Bytes) -> Result<B256, EthApi::Error> {

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -1027,8 +1027,8 @@ where
             "collect bad blocks",
             Box::pin(async move {
                 while let Some(event) = engine_events_stream.next().await {
-                    if let ConsensusEngineEvent::InvalidBlock(block) = event
-                        && let Ok(recovered) =
+                    if let ConsensusEngineEvent::InvalidBlock(block) = event &&
+                        let Ok(recovered) =
                             RecoveredBlock::try_recover_sealed(block.as_ref().clone())
                     {
                         bad_block_store.insert(recovered);

--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -3,7 +3,7 @@ use alloy_genesis::ChainConfig;
 use alloy_json_rpc::RpcObject;
 use alloy_primitives::{Address, Bytes, B256};
 use alloy_rpc_types_debug::ExecutionWitness;
-use alloy_rpc_types_eth::{Block, Bundle, StateContext};
+use alloy_rpc_types_eth::{BadBlock, Bundle, StateContext};
 use alloy_rpc_types_trace::geth::{
     BlockTraceResult, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
 };
@@ -38,7 +38,7 @@ pub trait DebugApi<TxReq: RpcObject> {
 
     /// Returns an array of recent bad blocks that the client has seen on the network.
     #[method(name = "getBadBlocks")]
-    async fn bad_blocks(&self) -> RpcResult<Vec<Block>>;
+    async fn bad_blocks(&self) -> RpcResult<Vec<BadBlock>>;
 
     /// Returns the structured logs created during the execution of EVM between two blocks
     /// (excluding start) as a JSON object.

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -90,7 +90,6 @@ impl<B: BlockTrait> Default for BadBlockStore<B> {
     }
 }
 
-// === impl DebugApi ===
 
 impl<Eth> DebugApi<Eth>
 where

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -12,8 +12,7 @@ use alloy_rpc_types_eth::{
     state::EvmOverrides, BadBlock, BlockError, BlockTransactionsKind, Bundle, StateContext,
 };
 use alloy_rpc_types_trace::geth::{
-    BlockTraceResult, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace,
-    TraceResult,
+    BlockTraceResult, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
 };
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -10,12 +10,10 @@ use alloy_rlp::{Decodable, Encodable};
 use alloy_rpc_types_debug::ExecutionWitness;
 use alloy_rpc_types_eth::{
     state::EvmOverrides, BadBlock, BlockError, BlockTransactionsKind, Bundle, StateContext,
-    TransactionInfo,
 };
 use alloy_rpc_types_trace::geth::{
-    mux::MuxConfig, BlockTraceResult, CallConfig, FourByteFrame, GethDebugBuiltInTracerType,
-    GethDebugTracerType, GethDebugTracingCallOptions, GethDebugTracingOptions,
-    GethDefaultTracingOptions, GethTrace, NoopFrame, PreStateConfig, TraceResult,
+    BlockTraceResult, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace,
+    TraceResult,
 };
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
@@ -39,19 +37,8 @@ use reth_storage_api::{
 };
 use reth_tasks::pool::BlockingTaskGuard;
 use reth_trie_common::{updates::TrieUpdates, HashedPostState};
-use revm::{
-    context::{
-        result::{HaltReasonTr, ResultAndState},
-        ContextTr,
-    },
-    inspector::{JournalExt, NoOpInspector},
-    interpreter::{CallInputs, CallOutcome, CreateInputs, CreateOutcome, Interpreter},
-    DatabaseCommit, DatabaseRef, Inspector,
-};
-use revm_inspectors::tracing::{
-    FourByteInspector, MuxInspector, TracingInspector, TracingInspectorConfig, TransactionContext,
-};
-use revm_primitives::{Log, U256};
+use revm::DatabaseCommit;
+use revm_inspectors::tracing::{DebugInspector, TransactionContext};
 use serde::{Deserialize, Serialize};
 use std::{collections::VecDeque, sync::Arc};
 use tokio::sync::{AcquireError, OwnedSemaphorePermit};

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -90,7 +90,6 @@ impl<B: BlockTrait> Default for BadBlockStore<B> {
     }
 }
 
-
 impl<Eth> DebugApi<Eth>
 where
     Eth: RpcNodeCore,

--- a/crates/rpc/rpc/src/lib.rs
+++ b/crates/rpc/rpc/src/lib.rs
@@ -49,7 +49,7 @@ mod web3;
 
 pub use admin::AdminApi;
 pub use aliases::*;
-pub use debug::DebugApi;
+pub use debug::{BadBlockStore, DebugApi};
 pub use engine::{EngineApi, EngineEthApi};
 pub use eth::{helpers::SyncListener, EthApi, EthApiBuilder, EthBundle, EthFilter, EthPubSub};
 pub use miner::MinerApi;

--- a/examples/exex-hello-world/src/main.rs
+++ b/examples/exex-hello-world/src/main.rs
@@ -66,7 +66,7 @@ async fn ethapi_exex<Node, EthApi>(
 ) -> eyre::Result<()>
 where
     Node: FullNodeComponents<Types: NodeTypes<ChainSpec: EthereumHardforks>>,
-    EthApi: FullEthApi,
+    EthApi: FullEthApi + reth_ethereum::rpc::eth::RpcNodeCore<Provider = Node::Provider>,
 {
     // Wait for the ethapi to be sent from the main function
     let rpc_handle = rpc_handle.await?;


### PR DESCRIPTION
This targets on issue #20123 , as below :

- Add a shared BadBlockStore (bounded, deduped, newest-first) and wire it into DebugApi
-  Implement debug_getBadBlocks to expose recent invalid blocks with full transactions, hash, and RLP
- Listen for ConsensusEngineEvent::InvalidBlock, recover the sealed block with senders, and cache it for the debug API

cc @mattsse  @klkvr @Rjected 