### PR TITLE
refactor(net): remove unused enable_packet_filter and ban_duration from config

### DIFF
--- a/crates/net/discv4/src/config.rs
+++ b/crates/net/discv4/src/config.rs
@@ -17,8 +17,6 @@ use std::{
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Discv4Config {
-    /// Whether to enable the incoming packet filter. Default: false.
-    pub enable_packet_filter: bool,
     /// Size of the channel buffer for outgoing messages.
     pub udp_egress_message_buffer: usize,
     /// Size of the channel buffer for incoming messages.
@@ -41,10 +39,6 @@ pub struct Discv4Config {
     /// Provides a way to ban peers and ips.
     #[cfg_attr(feature = "serde", serde(skip))]
     pub ban_list: BanList,
-    /// Set the default duration for which nodes are banned for. This timeouts are checked every 5
-    /// minutes, so the precision will be to the nearest 5 minutes. If set to `None`, bans from
-    /// the filter will last indefinitely. Default is 1 hour.
-    pub ban_duration: Option<Duration>,
     /// Nodes to boot from.
     pub bootstrap_nodes: HashSet<NodeRecord>,
     /// Whether to randomly discover new peers.
@@ -108,7 +102,6 @@ impl Discv4Config {
 impl Default for Discv4Config {
     fn default() -> Self {
         Self {
-            enable_packet_filter: false,
             // This should be high enough to cover an entire recursive FindNode lookup which is
             // includes sending FindNode to nodes it discovered in the rounds using the concurrency
             // factor ALPHA
@@ -126,7 +119,6 @@ impl Default for Discv4Config {
 
             lookup_interval: Duration::from_secs(20),
             ban_list: Default::default(),
-            ban_duration: Some(Duration::from_secs(60 * 60)), // 1 hour
             bootstrap_nodes: Default::default(),
             enable_dht_random_walk: true,
             enable_lookup: true,
@@ -148,12 +140,6 @@ pub struct Discv4ConfigBuilder {
 }
 
 impl Discv4ConfigBuilder {
-    /// Whether to enable the incoming packet filter.
-    pub const fn enable_packet_filter(&mut self) -> &mut Self {
-        self.config.enable_packet_filter = true;
-        self
-    }
-
     /// Sets the channel size for incoming messages
     pub const fn udp_ingress_message_buffer(
         &mut self,
@@ -276,14 +262,6 @@ impl Discv4ConfigBuilder {
         self
     }
 
-    /// Set the default duration for which nodes are banned for. This timeouts are checked every 5
-    /// minutes, so the precision will be to the nearest 5 minutes. If set to `None`, bans from
-    /// the filter will last indefinitely. Default is 1 hour.
-    pub const fn ban_duration(&mut self, ban_duration: Option<Duration>) -> &mut Self {
-        self.config.ban_duration = ban_duration;
-        self
-    }
-
     /// Adds a boot node
     pub fn add_boot_node(&mut self, node: NodeRecord) -> &mut Self {
         self.config.bootstrap_nodes.insert(node);
@@ -331,7 +309,6 @@ mod tests {
             .enable_lookup(true)
             .enable_dht_random_walk(true)
             .add_boot_nodes(HashSet::new())
-            .ban_duration(None)
             .lookup_interval(Duration::from_secs(3))
             .enable_lookup(true)
             .build();


### PR DESCRIPTION
Removed enable_packet_filter and ban_duration from Discv4Config and their builder methods. These fields were not used by the discv4 service: inbound packet filtering is always applied in receive_loop, and ban duration is managed at the peers manager layer, not in discv4. Updated defaults and tests accordingly. 