### PR TITLE
fix(node): Added missing trait bound on RethRpcAddOns for EthereumAddOns

### DIFF
--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -319,7 +319,8 @@ where
     }
 }
 
-impl<N, EthB, PVB, EB, EVB> RethRpcAddOns<N> for EthereumAddOns<N, EthB, PVB, EB, EVB>
+impl<N, EthB, PVB, EB, EVB, RpcMiddleware> RethRpcAddOns<N>
+    for EthereumAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>
 where
     N: FullNodeComponents<
         Types: NodeTypes<
@@ -335,6 +336,7 @@ where
     EVB: EngineValidatorBuilder<N>,
     EthApiError: FromEvmError<N::Evm>,
     EvmFactoryFor<N::Evm>: EvmFactory<Tx = TxEnv>,
+    RpcMiddleware: RethRpcMiddleware,
 {
     type EthApi = EthB::EthApi;
 


### PR DESCRIPTION
  ### Summary
  - add the missing `RpcMiddleware: RethRpcMiddleware` bound on `impl RethRpcAddOns for EthereumAddOns` so `with_rpc_middleware` works with custom middleware types
  - no behavior changes - fixes a compile-time regression when using non-Identity middleware
  
 ### Future Work
  - plan to add example code of launching a node with custom rpc middleware