### PR TITLE
docs: add architecture diagram for EVM node component

### DIFF
--- a/docs/vocs/docs/pages/sdk/node-components/evm.mdx
+++ b/docs/vocs/docs/pages/sdk/node-components/evm.mdx
@@ -13,7 +13,18 @@ The EVM component manages:
 - State management and caching
 
 ## Architecture
+```mermaid
+graph TD
+    Config[EVM Configuration] --> Env[EVM Environment]
+    Config --> Executor[Block Executor]
+    Config --> Builder[Block Builder]
 
+    Executor --> State[(State Database)]
+    Builder --> State
+
+    Builder --> Assembler[Block Assembler]
+    Assembler --> State
+```
 
 ## Key Concepts
 


### PR DESCRIPTION
Fill the previously empty Architecture section of the EVM node component docs with a mermaid diagram.

The diagram documents the main EVM building blocks (configuration, environment, block executor, block builder, block assembler and state database) and how they interact, matching the style used by other node-components docs (network, pool). This makes the EVM documentation more complete and easier to understand