### PR TITLE
fix: prevent `TransactionLookup::prune` from panicking

### DIFF
--- a/crates/prune/prune/src/segments/user/transaction_lookup.rs
+++ b/crates/prune/prune/src/segments/user/transaction_lookup.rs
@@ -82,9 +82,14 @@ where
             }
         }
         .into_inner();
-        let tx_range = start..=
-            Some(end)
-                .min(input.limiter.deleted_entries_limit_left().map(|left| start + left as u64 - 1))
+        let tx_range = start
+            ..=Some(end)
+                .min(
+                    input
+                        .limiter
+                        .deleted_entries_limit_left()
+                        .map(|left| start.wrapping_add(left as u64).wrapping_sub(1)),
+                )
                 .unwrap();
         let tx_range_end = *tx_range.end();
 


### PR DESCRIPTION
This PR resolves #20161.
This is done by ensuring that the debug profile behaves like release by wrapping arithmetic.