### PR TITLE
deps: remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3859,7 +3859,6 @@ name = "exex-subscription"
 version = "1.9.3"
 dependencies = [
  "alloy-primitives",
- "clap",
  "eyre",
  "futures",
  "jsonrpsee",
@@ -8052,7 +8051,6 @@ dependencies = [
  "reth-consensus",
  "reth-db",
  "reth-db-common",
- "reth-engine-local",
  "reth-engine-primitives",
  "reth-ethereum-primitives",
  "reth-network-api",
@@ -8960,10 +8958,8 @@ dependencies = [
 name = "reth-network-api"
 version = "1.9.3"
 dependencies = [
- "alloy-consensus",
  "alloy-primitives",
  "alloy-rpc-types-admin",
- "alloy-rpc-types-eth",
  "auto_impl",
  "derive_more",
  "enr",

--- a/crates/e2e-test-utils/Cargo.toml
+++ b/crates/e2e-test-utils/Cargo.toml
@@ -30,7 +30,6 @@ reth-node-builder = { workspace = true, features = ["test-utils"] }
 reth-tokio-util.workspace = true
 reth-stages-types.workspace = true
 reth-network-peers.workspace = true
-reth-engine-local.workspace = true
 reth-engine-primitives.workspace = true
 reth-tasks.workspace = true
 reth-node-ethereum.workspace = true

--- a/crates/net/network-api/Cargo.toml
+++ b/crates/net/network-api/Cargo.toml
@@ -21,8 +21,6 @@ reth-tokio-util.workspace = true
 reth-ethereum-forks.workspace = true
 
 # ethereum
-alloy-consensus.workspace = true
-alloy-rpc-types-eth.workspace = true
 alloy-primitives = { workspace = true, features = ["getrandom"] }
 alloy-rpc-types-admin.workspace = true
 enr = { workspace = true, default-features = false, features = ["rust-secp256k1"] }
@@ -46,6 +44,4 @@ serde = [
     "alloy-primitives/serde",
     "enr/serde",
     "reth-ethereum-forks/serde",
-    "alloy-consensus/serde",
-    "alloy-rpc-types-eth/serde",
 ]

--- a/crates/primitives-traits/Cargo.toml
+++ b/crates/primitives-traits/Cargo.toml
@@ -132,6 +132,7 @@ serde = [
     "revm-primitives/serde",
     "revm-primitives/serde",
     "op-alloy-consensus?/serde",
+    "secp256k1?/serde",
     "alloy-trie/serde",
     "revm-bytecode/serde",
     "revm-state/serde",

--- a/crates/primitives-traits/Cargo.toml
+++ b/crates/primitives-traits/Cargo.toml
@@ -132,7 +132,6 @@ serde = [
     "revm-primitives/serde",
     "revm-primitives/serde",
     "op-alloy-consensus?/serde",
-    "secp256k1?/serde",
     "alloy-trie/serde",
     "revm-bytecode/serde",
     "revm-state/serde",

--- a/crates/primitives-traits/Cargo.toml
+++ b/crates/primitives-traits/Cargo.toml
@@ -29,9 +29,6 @@ revm-state.workspace = true
 # op
 op-alloy-consensus = { workspace = true, optional = true, features = ["k256"] }
 
-# crypto
-secp256k1 = { workspace = true, features = ["recovery"], optional = true }
-
 # misc
 auto_impl.workspace = true
 byteorder = { workspace = true, optional = true }
@@ -84,7 +81,6 @@ std = [
     "bytes/std",
     "derive_more/std",
     "once_cell/std",
-    "secp256k1?/std",
     "thiserror/std",
     "alloy-trie/std",
     "op-alloy-consensus?/std",
@@ -110,8 +106,6 @@ arbitrary = [
     "alloy-eips/arbitrary",
     "revm-primitives/arbitrary",
     "reth-codecs?/arbitrary",
-    "secp256k1?/global-context",
-    "secp256k1?/rand",
     "op-alloy-consensus?/arbitrary",
     "alloy-trie/arbitrary",
     "reth-chainspec/arbitrary",
@@ -138,7 +132,6 @@ serde = [
     "revm-primitives/serde",
     "revm-primitives/serde",
     "op-alloy-consensus?/serde",
-    "secp256k1?/serde",
     "alloy-trie/serde",
     "revm-bytecode/serde",
     "revm-state/serde",

--- a/crates/stages/types/Cargo.toml
+++ b/crates/stages/types/Cargo.toml
@@ -31,7 +31,6 @@ proptest.workspace = true
 proptest-arbitrary-interop.workspace = true
 rand.workspace = true
 bytes.workspace = true
-modular-bitfield.workspace = true
 
 [features]
 default = ["std"]

--- a/docs/vocs/docs/snippets/sources/exex/remote/Cargo.toml
+++ b/docs/vocs/docs/snippets/sources/exex/remote/Cargo.toml
@@ -18,7 +18,6 @@ futures-util = "0.3"
 
 # grpc
 tonic = "0.11"
-prost = "0.12"
 bincode = "1"
 
 # misc

--- a/examples/exex-subscription/Cargo.toml
+++ b/examples/exex-subscription/Cargo.toml
@@ -16,7 +16,6 @@ alloy-primitives.workspace = true
 
 eyre.workspace = true
 futures.workspace = true
-clap = { workspace = true, features = ["derive"] }
 jsonrpsee = { workspace = true, features = ["server", "macros"] }
 tokio.workspace = true
 serde.workspace = true


### PR DESCRIPTION
```console
❯ cargo machete
Analyzing dependencies of crates in this directory...
cargo-machete found the following unused dependencies in this directory:
reth-network-types -- ./crates/net/network-types/Cargo.toml:
        humantime-serde
reth-network-api -- ./crates/net/network-api/Cargo.toml:
        alloy-consensus
        alloy-rpc-types-eth
reth-stages-types -- ./crates/stages/types/Cargo.toml:
        modular-bitfield
reth-e2e-test-utils -- ./crates/e2e-test-utils/Cargo.toml:
        reth-engine-local
reth-era -- ./crates/era/Cargo.toml:
        ethereum_ssz
        ethereum_ssz_derive
reth-db-models -- ./crates/storage/db-models/Cargo.toml:
        modular-bitfield
reth-db-api -- ./crates/storage/db-api/Cargo.toml:
        modular-bitfield
reth-prune-types -- ./crates/prune/types/Cargo.toml:
        modular-bitfield
reth-primitives-traits -- ./crates/primitives-traits/Cargo.toml:
        modular-bitfield
        secp256k1
remote-exex -- ./docs/vocs/docs/snippets/sources/exex/remote/Cargo.toml:
        prost
exex-subscription -- ./examples/exex-subscription/Cargo.toml:
        clap
example-custom-node -- ./examples/custom-node/Cargo.toml:
        modular-bitfield
```

Some of these were actually false positives