### PR TITLE
docs: remove hardcoded values from prune segment comments

### DIFF
--- a/crates/prune/prune/src/segments/user/account_history.rs
+++ b/crates/prune/prune/src/segments/user/account_history.rs
@@ -72,11 +72,13 @@ where
         // Deleted account changeset keys (account addresses) with the highest block number deleted
         // for that key.
         //
-        // The size of this map it's limited by `prune_delete_limit * blocks_since_last_run /
-        // ACCOUNT_HISTORY_TABLES_TO_PRUNE`, and with current default it's usually `3500 * 5
-        // / 2`, so 8750 entries. Each entry is `160 bit + 256 bit + 64 bit`, so the total
-        // size should be up to 0.5MB + some hashmap overhead. `blocks_since_last_run` is
-        // additionally limited by the `max_reorg_depth`, so no OOM is expected here.
+        // The size of this map is limited by `prune_delete_limit * blocks_since_last_run /
+        // ACCOUNT_HISTORY_TABLES_TO_PRUNE`. With typical defaults (e.g., `prune_delete_limit` from
+        // chain spec, `blocks_since_last_run` limited by `min_block_interval`), this results in
+        // approximately `(prune_delete_limit / 2) * min_block_interval` entries. Each entry is
+        // `160 bit + 256 bit + 64 bit`, so the total size should be up to ~0.5MB + some hashmap
+        // overhead for typical configurations. `blocks_since_last_run` is additionally limited by
+        // reorg protection mechanisms, so no OOM is expected here.
         let mut highest_deleted_accounts = FxHashMap::default();
         let (pruned_changesets, done) =
             provider.tx_ref().prune_table_with_range::<tables::AccountChangeSets>(


### PR DESCRIPTION
Replace hardcoded configuration values (3500, 5, 8750) in account_history and storage_history prune segment comments with generic formulas. 
This prevents the comments from becoming outdated when default values change. 
Also fixes incorrect  constant reference in storage_history.rs comment.