### PR TITLE
fix: fail fast on config file read/parse errors

### DIFF
--- a/crates/cli/commands/src/common.rs
+++ b/crates/cli/commands/src/common.rs
@@ -83,11 +83,9 @@ impl<C: ChainSpecParser> EnvironmentArgs<C> {
 
         let config_path = self.config.clone().unwrap_or_else(|| data_dir.config());
 
-        let mut config = Config::from_path(config_path)
-            .inspect_err(
-                |err| warn!(target: "reth::cli", %err, "Failed to load config file, using default"),
-            )
-            .unwrap_or_default();
+        let mut config = Config::from_path(config_path).inspect_err(|err| {
+            warn!(target: "reth::cli", %err, "Failed to load config file");
+        })?;
 
         // Make sure ETL doesn't default to /tmp/, but to whatever datadir is set to
         if config.stages.etl.dir.is_none() {


### PR DESCRIPTION


Replaced `unwrap_or_default()` with proper error propagation using `?` operator. This ensures that configuration errors are surfaced immediately, preventing silent failures.

