### PR TITLE
Avoid recomputing block RLP length in validation

### DIFF
--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -457,11 +457,12 @@ where
 
         // Check block size as per EIP-7934 (only applies when Osaka hardfork is active)
         let chain_spec = self.provider.chain_spec();
+        let rlp_length = block.rlp_length();
         if chain_spec.is_osaka_active_at_timestamp(block.timestamp()) &&
-            block.rlp_length() > MAX_RLP_BLOCK_SIZE
+            rlp_length > MAX_RLP_BLOCK_SIZE
         {
             return Err(ValidationApiError::Consensus(ConsensusError::BlockTooLarge {
-                rlp_length: block.rlp_length(),
+                rlp_length,
                 max_rlp_length: MAX_RLP_BLOCK_SIZE,
             }));
         }


### PR DESCRIPTION
cache the block RLP length before the Osaka size check, reuse the cached value when constructing the oversized-block error