### PR TITLE
fix(trie): correctly populate prefix_sets when building TrieInput from blocks

### DIFF
--- a/crates/trie/common/src/input.rs
+++ b/crates/trie/common/src/input.rs
@@ -53,9 +53,11 @@ impl TrieInput {
     ) -> Self {
         let mut input = Self::default();
         for (hashed_state, trie_updates) in blocks {
-            // Extend directly from sorted types, avoiding intermediate HashMap allocations
             input.nodes.extend_from_sorted(trie_updates);
             input.state.extend_from_sorted(hashed_state);
+            if trie_updates.is_empty() {
+                input.prefix_sets.extend(hashed_state.construct_prefix_sets());
+            }
         }
         input
     }
@@ -69,7 +71,11 @@ impl TrieInput {
         blocks: impl IntoIterator<Item = (&'a HashedPostState, &'a TrieUpdates)>,
     ) {
         for (hashed_state, trie_updates) in blocks {
-            self.append_cached_ref(trie_updates, hashed_state);
+            if trie_updates.is_empty() {
+                self.append_ref(hashed_state);
+            } else {
+                self.append_cached_ref(trie_updates, hashed_state);
+            }
         }
     }
 


### PR DESCRIPTION
Previously, TrieInput built from blocks ignored prefix_sets entirely and extend_with_blocks always appended cached refs. This contradicted the docs and caused incomplete traversal when computing state root from nodes. Now, if a block has no trie updates, we extend prefix_sets from its state (append_ref); otherwise we only append cached nodes/state (append_cached_ref). The same logic is applied to from_blocks_sorted. This aligns behavior with the documented contract and ensures correct walker coverage during state root and proof generation.