### PR TITLE
feat(primitives-traits): add recover_transactions_ref to avoid cloning

### DIFF
--- a/crates/primitives-traits/src/block/body.rs
+++ b/crates/primitives-traits/src/block/body.rs
@@ -202,7 +202,8 @@ pub trait BlockBody:
     /// Returns an iterator over `Recovered<&Transaction>` for all transactions in the block body.
     ///
     /// This method recovers signers and returns an iterator without cloning transactions,
-    /// making it more efficient than [`BlockBody::recover_transactions`] when owned values are not required.
+    /// making it more efficient than [`BlockBody::recover_transactions`] when owned values are not
+    /// required.
     ///
     /// # Errors
     ///

--- a/crates/primitives-traits/src/block/body.rs
+++ b/crates/primitives-traits/src/block/body.rs
@@ -202,7 +202,7 @@ pub trait BlockBody:
     /// Returns an iterator over `Recovered<&Transaction>` for all transactions in the block body.
     ///
     /// This method recovers signers and returns an iterator without cloning transactions,
-    /// making it more efficient than [`recover_transactions`] when owned values are not required.
+    /// making it more efficient than [`BlockBody::recover_transactions`] when owned values are not required.
     ///
     /// # Errors
     ///

--- a/crates/primitives-traits/src/block/body.rs
+++ b/crates/primitives-traits/src/block/body.rs
@@ -198,6 +198,25 @@ pub trait BlockBody:
                 .collect()
         })
     }
+
+    /// Returns an iterator over `Recovered<&Transaction>` for all transactions in the block body.
+    ///
+    /// This method recovers signers and returns an iterator without cloning transactions,
+    /// making it more efficient than [`recover_transactions`] when owned values are not required.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any transaction's signature is invalid.
+    fn recover_transactions_ref(
+        &self,
+    ) -> Result<impl Iterator<Item = Recovered<&Self::Transaction>> + '_, RecoveryError> {
+        let signers = self.recover_signers()?;
+        Ok(self
+            .transactions()
+            .iter()
+            .zip(signers)
+            .map(|(tx, signer)| Recovered::new_unchecked(tx, signer)))
+    }
 }
 
 impl<T, H> BlockBody for alloy_consensus::BlockBody<T, H>


### PR DESCRIPTION
### Fix
Adds recover_transactions_ref() to BlockBody to avoid cloning transactions when owned values aren't needed. recover_transactions() clones all transactions, which is expensive for large blocks.
### Changes
- Added recover_transactions_ref() returning Result<impl Iterator<Item = Recovered<&Transaction>>, RecoveryError>
- Uses Recovered::new_unchecked() with references instead of cloning
- Matches the pattern used in RecoveredBlock::transactions_recovered()
- Keeps recover_transactions() unchanged for backward compatibility