### PR TITLE
fix(rpc): validate fee history reward percentiles

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/fee.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/fee.rs
@@ -110,7 +110,8 @@ pub trait EthFees:
             // increasing and 0 <= p <= 100
             // Note: The types used ensure that the percentiles are never < 0
             if let Some(percentiles) = &reward_percentiles &&
-                percentiles.windows(2).any(|w| w[0] > w[1] || w[0] > 100.)
+                (percentiles.iter().any(|p| *p < 0.0 || *p > 100.0) ||
+                    percentiles.windows(2).any(|w| w[0] > w[1]))
             {
                 return Err(EthApiError::InvalidRewardPercentiles.into())
             }


### PR DESCRIPTION
Ensure eth_feeHistory reward_percentiles are fully validated against the [0, 100] range and checked for monotonicity for all entries, including single-element vectors and the last percentile. This prevents invalid user-supplied percentiles from slipping through RPC input and keeps the implementation aligned with the API expectations.