### PR TITLE
fix: set merkle changesets distance minimum to 128

### DIFF
--- a/crates/prune/types/src/target.rs
+++ b/crates/prune/types/src/target.rs
@@ -38,7 +38,7 @@ pub enum HistoryType {
 
 /// Default number of blocks to retain for merkle changesets.
 /// This is used by both the `MerkleChangeSets` stage and the pruner segment.
-pub const MERKLE_CHANGESETS_RETENTION_BLOCKS: u64 = 64;
+pub const MERKLE_CHANGESETS_RETENTION_BLOCKS: u64 = 128;
 
 /// Default pruning mode for merkle changesets
 const fn default_merkle_changesets_mode() -> PruneMode {
@@ -95,13 +95,7 @@ pub struct PruneModes {
     pub bodies_history: Option<PruneMode>,
     /// Merkle Changesets pruning configuration for `AccountsTrieChangeSets` and
     /// `StoragesTrieChangeSets`.
-    #[cfg_attr(
-        any(test, feature = "serde"),
-        serde(
-            default = "default_merkle_changesets_mode",
-            deserialize_with = "deserialize_prune_mode_with_min_blocks::<MERKLE_CHANGESETS_RETENTION_BLOCKS, _>"
-        )
-    )]
+    #[cfg_attr(any(test, feature = "serde"), serde(default = "default_merkle_changesets_mode"))]
     pub merkle_changesets: PruneMode,
     /// Receipts pruning configuration by retaining only those receipts that contain logs emitted
     /// by the specified addresses, discarding others. This setting is overridden by `receipts`.
@@ -155,14 +149,15 @@ impl PruneModes {
     /// Returns `true` if any migration was performed.
     ///
     /// Currently migrates:
-    /// - `merkle_changesets`: `Distance(10064)` -> `Distance(64)`
-    pub fn migrate(&mut self) -> bool {
-        if self.merkle_changesets == PruneMode::Distance(MINIMUM_PRUNING_DISTANCE) {
+    /// - `merkle_changesets`: `Distance(n)` where `n < 128` or `n == 10064` -> `Distance(128)`
+    pub const fn migrate(&mut self) -> bool {
+        if let PruneMode::Distance(d) = self.merkle_changesets &&
+            (d < MERKLE_CHANGESETS_RETENTION_BLOCKS || d == MINIMUM_PRUNING_DISTANCE)
+        {
             self.merkle_changesets = PruneMode::Distance(MERKLE_CHANGESETS_RETENTION_BLOCKS);
-            true
-        } else {
-            false
+            return true;
         }
+        false
     }
 
     /// Returns an error if we can't unwind to the targeted block because the target block is
@@ -212,28 +207,6 @@ impl PruneModes {
         }
         Ok(())
     }
-}
-
-/// Deserializes [`PruneMode`] and validates that the value is not less than the const
-/// generic parameter `MIN_BLOCKS`. This parameter represents the number of blocks that needs to be
-/// left in database after the pruning.
-///
-/// 1. For [`PruneMode::Full`], it fails if `MIN_BLOCKS > 0`.
-/// 2. For [`PruneMode::Distance`], it fails if `distance < MIN_BLOCKS + 1`. `+ 1` is needed because
-///    `PruneMode::Distance(0)` means that we leave zero blocks from the latest, meaning we have one
-///    block in the database.
-#[cfg(any(test, feature = "serde"))]
-fn deserialize_prune_mode_with_min_blocks<
-    'de,
-    const MIN_BLOCKS: u64,
-    D: serde::Deserializer<'de>,
->(
-    deserializer: D,
-) -> Result<PruneMode, D::Error> {
-    use serde::Deserialize;
-    let prune_mode = PruneMode::deserialize(deserializer)?;
-    serde_deserialize_validate::<MIN_BLOCKS, D>(&prune_mode)?;
-    Ok(prune_mode)
 }
 
 /// Deserializes [`Option<PruneMode>`] and validates that the value is not less than the const


### PR DESCRIPTION
64 can result in some transition edge cases. This PR:
* sets the minimum to 128
* ensures we migrate the old 10k default to 128
* automatically migrates any value lower than 128 to 128. 