### PR TITLE
docs: document state and block overrides for trace_call

### DIFF
--- a/docs/vocs/docs/pages/jsonrpc/trace.mdx
+++ b/docs/vocs/docs/pages/jsonrpc/trace.mdx
@@ -176,9 +176,13 @@ The second parameter is an array of one or more trace types (`vmTrace`, `trace`,
 
 The third and optional parameter is a block number, block hash, or a block tag (`latest`, `finalized`, `safe`, `earliest`, `pending`).
 
-| Client | Method invocation                                              |
-| ------ | -------------------------------------------------------------- |
-| RPC    | `{"method": "trace_call", "params": [tx, trace[], block]}` |
+The fourth and optional parameter is a `stateOverrides` object that temporarily overrides account state used for the trace (balances, nonces, code, storage).
+
+The fifth and optional parameter is a `blockOverrides` object that temporarily overrides block fields used for the trace (for example `timestamp`, `baseFee`, `number`).
+
+| Client | Method invocation                                                                    |
+| ------ | ------------------------------------------------------------------------------------ |
+| RPC    | `{"method": "trace_call", "params": [tx, trace[], block, stateOverrides, blockOverrides]}` |
 
 ### Example
 


### PR DESCRIPTION
`trace_call` accepts optional `stateOverrides` and `blockOverrides` parameters, but the JSON-RPC docs only showed three arguments. This updates the `trace_call` section to describe both override objects and reflects them in the example method invocation so that the documentation matches the actual RPC interface.