### PR TITLE
fix(cli): reference correct --without-evm flag in init-state error

### DIFF
--- a/crates/cli/commands/src/init_state/mod.rs
+++ b/crates/cli/commands/src/init_state/mod.rs
@@ -110,7 +110,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> InitStateC
                 static_file_provider.commit()?;
             } else if last_block_number > 0 && last_block_number < header.number() {
                 return Err(eyre::eyre!(
-                    "Data directory should be empty when calling init-state with --without-evm-history."
+                    "Data directory should be empty when calling init-state with --without-evm."
                 ));
             }
         }


### PR DESCRIPTION
The init-state command error message referred to a non-existent --without-evm-history flag, while the actual CLI option and documentation use --without-evm. This mismatch is confusing for users who rely on the help text and docs.

Updated the error string to reference --without-evm so that the runtime error, CLI help, and documentation are consistent.