### PR TITLE
docs: remove incorrect total_difficulty mention from process_iter

### DIFF
--- a/crates/era-utils/src/history.rs
+++ b/crates/era-utils/src/history.rs
@@ -252,7 +252,7 @@ where
 
 /// Extracts block headers and bodies from `iter` and appends them using `writer` and `provider`.
 ///
-/// Adds on to `total_difficulty` and collects hash to height using `hash_collector`.
+/// Collects hash to height using `hash_collector`.
 ///
 /// Skips all blocks below the [`start_bound`] of `block_numbers` and stops when reaching past the
 /// [`end_bound`] or the end of the file.


### PR DESCRIPTION
### Fix
Removed incorrect documentation claim that process_iter updates total_difficulty. 
The function only processes headers and bodies; total_difficulty is not part of its implementation.
### Changes
Removed "Adds on to total_difficulty and" from process_iter documentation in crates/era-utils/src/history.rs