### PR TITLE
docs: add missing documentation for serde_bincode_compat::ExExNotification

### DIFF
--- a/crates/exex/types/src/notification.rs
+++ b/crates/exex/types/src/notification.rs
@@ -95,17 +95,33 @@ pub(super) mod serde_bincode_compat {
     ///     notification: ExExNotification<N>,
     /// }
     /// ```
+    ///
+    /// This enum mirrors [`super::ExExNotification`] but uses borrowed [`Chain`] types
+    /// instead of `Arc<Chain>` for bincode compatibility.
     #[derive(Debug, Serialize, Deserialize)]
-    #[expect(missing_docs)]
     #[serde(bound = "")]
     #[expect(clippy::large_enum_variant)]
     pub enum ExExNotification<'a, N>
     where
         N: NodePrimitives,
     {
-        ChainCommitted { new: Chain<'a, N> },
-        ChainReorged { old: Chain<'a, N>, new: Chain<'a, N> },
-        ChainReverted { old: Chain<'a, N> },
+        /// Chain got committed without a reorg, and only the new chain is returned.
+        ChainCommitted {
+            /// The new chain after commit.
+            new: Chain<'a, N>,
+        },
+        /// Chain got reorged, and both the old and the new chains are returned.
+        ChainReorged {
+            /// The old chain before reorg.
+            old: Chain<'a, N>,
+            /// The new chain after reorg.
+            new: Chain<'a, N>,
+        },
+        /// Chain got reverted, and only the old chain is returned.
+        ChainReverted {
+            /// The old chain before reversion.
+            old: Chain<'a, N>,
+        },
     }
 
     impl<'a, N> From<&'a super::ExExNotification<N>> for ExExNotification<'a, N>


### PR DESCRIPTION
## What

Adds missing documentation for `ExExNotification` enum in `serde_bincode_compat` module and removes `#[expect(missing_docs)]` attribute.

## Why

The enum is part of the public API (exported via `pub mod serde_bincode_compat`) but lacked documentation, which is inconsistent with other `serde_bincode_compat` types in the codebase. This improves API discoverability and follows the project's documentation standards.