### PR TITLE
docs(txpool): fix PoolSize total field comment to include blob pool

### DIFF
--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -1593,7 +1593,7 @@ pub struct PoolSize {
     pub queued_size: usize,
     /// Number of all transactions of all sub-pools
     ///
-    /// Note: this is the sum of ```pending + basefee + queued```
+    /// Note: this is the sum of ```pending + basefee + queued + blob```
     pub total: usize,
 }
 


### PR DESCRIPTION
The comment incorrectly stated `total = pending + basefee + queued`, missing the blob pool component that was added in EIP-4844 support.