### PR TITLE
Eng 458/pycckuu/slow engineget payload v4 on warm start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9972,6 +9972,7 @@ dependencies = [
  "revm-database-interface",
  "revm-state",
  "rocksdb",
+ "schnellru",
  "strum 0.27.2",
  "tempfile",
  "tokio",

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -52,6 +52,7 @@ itertools.workspace = true
 notify = { workspace = true, default-features = false, features = ["macos_fsevent"] }
 parking_lot.workspace = true
 dashmap = { workspace = true, features = ["inline"] }
+schnellru.workspace = true
 strum.workspace = true
 eyre.workspace = true
 


### PR DESCRIPTION
When building blocks after deep reorgs, engine_getPayloadV4 was slow (~82ms per block) 
because revert_state() scanned all changesets from target block to DB tip for every block.
Building 4,477 blocks triggered 367 seconds of redundant changeset scanning.

This adds a 16-entry LRU cache to revert_state() with key (block_number, db_tip).
The db_tip in the cache key ensures automatic invalidation when the database changes.

Changes:
- Add schnellru dependency to reth-provider
- Implement global LRU cache using LazyLock<RwLock<LruMap>>
- Cache HashedPostStateSorted results wrapped in Arc for efficient sharing
- Cache size of 16 entries is sufficient for typical block building patterns