### PR TITLE
docs: add missing `bodies_history` and `merkle_changesets` prune config fields

### DIFF
--- a/docs/vocs/docs/pages/run/configuration.mdx
+++ b/docs/vocs/docs/pages/run/configuration.mdx
@@ -406,9 +406,10 @@ No pruning, run as archive node.
 This configuration will:
 
 -   Run pruning every 5 blocks
--   Continuously prune all transaction senders, account history and storage history before the block `head-100_000`,
+-   Continuously prune all transaction senders, account history, storage history and bodies history before the block `head-100_000`,
     i.e. keep the data for the last `100_000` blocks
 -   Prune all receipts before the block 1920000, i.e. keep receipts from the block 1920000
+-   Keep the last 128 blocks of merkle changesets (default behavior)
 
 ```toml
 [prune]
@@ -430,6 +431,14 @@ account_history = { distance = 100_000 } # Prune all historical account states b
 
 # Storage History pruning configuration
 storage_history = { distance = 100_000 } # Prune all historical storage states before the block `head-100000`
+
+# Bodies History pruning configuration
+bodies_history = { distance = 100_000 } # Prune all historical block bodies before the block `head-100000`
+
+# Merkle Changesets pruning configuration
+# Controls pruning of AccountsTrieChangeSets and StoragesTrieChangeSets.
+# Default: { distance = 128 } - keeps the last 128 blocks of merkle changesets
+merkle_changesets = { distance = 128 }
 ```
 
 We can also prune receipts more granular, using the logs filtering:


### PR DESCRIPTION
Added documentation for two prune configuration fields that exist in `PruneModes` struct but were missing from the configuration guide:

- `bodies_history` - prune historical block bodies
- `merkle_changesets` - prune trie changesets (default: distance 128)

Ref: `crates/prune/types/src/target.rs` lines 87-99