### PR TITLE
fix(consensus): swap got/expected in validate_cancun_gas error

### DIFF
--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -82,8 +82,8 @@ pub fn validate_cancun_gas<B: Block>(block: &SealedBlock<B>) -> Result<(), Conse
     let total_blob_gas = block.body().blob_gas_used();
     if total_blob_gas != header_blob_gas_used {
         return Err(ConsensusError::BlobGasUsedDiff(GotExpected {
-            got: header_blob_gas_used,
-            expected: total_blob_gas,
+            got: total_blob_gas,
+            expected: header_blob_gas_used,
         }));
     }
     Ok(())
@@ -495,8 +495,8 @@ mod tests {
         assert_eq!(
             validate_block_pre_execution(&block, &chain_spec),
             Err(ConsensusError::BlobGasUsedDiff(GotExpected {
-                got: 1,
-                expected: expected_blob_gas_used
+                got: expected_blob_gas_used,
+                expected: 1
             }))
         );
     }


### PR DESCRIPTION
The GotExpected fields in validate_cancun_gas were swapped, making error messages confusing.

When validating blob gas, we compute the total from transactions and compare it against the header value. The error should report what we computed (got) vs what the header claims (expected), not the other way around.

This aligns with how other body-vs-header validations work in the same file (tx_root, ommers_hash, withdrawals_root).