### PR TITLE
docs: fix timestamp validation comment

### DIFF
--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -327,7 +327,7 @@ pub fn validate_against_parent_eip1559_base_fee<ChainSpec: EthChainSpec + Ethere
     Ok(())
 }
 
-/// Validates the timestamp against the parent to make sure it is in the past.
+/// Validates that the block timestamp is greater than the parent block timestamp.
 #[inline]
 pub fn validate_against_parent_timestamp<H: BlockHeader>(
     header: &H,


### PR DESCRIPTION
## Fix

Corrects misleading doc comment for `validate_against_parent_timestamp` function.

## Changes

- Updated function doc comment to accurately state that it validates the block timestamp is greater than the parent timestamp, not that it's in the past
- The previous comment contradicted the actual validation logic which requires `header.timestamp() > parent.timestamp()`