### PR TITLE
docs: improve map_add_ons method documentation

### DIFF
--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -533,6 +533,27 @@ where
     }
 
     /// Modifies the addons with the given closure.
+    ///
+    /// This method provides access to methods on the addons type that don't have
+    /// direct builder methods. It's useful for advanced configuration scenarios
+    /// where you need to call addon-specific methods.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use tower::layer::util::Identity;
+    ///
+    /// let builder = NodeBuilder::new(config)
+    ///     .with_types::<EthereumNode>()
+    ///     .with_components(EthereumNode::components())
+    ///     .with_add_ons(EthereumAddOns::default())
+    ///     .map_add_ons(|addons| addons.with_rpc_middleware(Identity::default()));
+    /// ```
+    ///
+    /// # See also
+    ///
+    /// - [`NodeAddOns`] trait for available addon types
+    /// - [`extend_rpc_modules`] for RPC module configuration
     pub fn map_add_ons<F>(self, f: F) -> Self
     where
         F: FnOnce(AO) -> AO,

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -553,7 +553,7 @@ where
     /// # See also
     ///
     /// - [`NodeAddOns`] trait for available addon types
-    /// - [`extend_rpc_modules`] for RPC module configuration
+    /// - [`NodeBuilderWithComponents::extend_rpc_modules`] for RPC module configuration
     pub fn map_add_ons<F>(self, f: F) -> Self
     where
         F: FnOnce(AO) -> AO,

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -553,8 +553,7 @@ where
     /// # See also
     ///
     /// - [`NodeAddOns`] trait for available addon types
-    /// - [`reth_node_builder::NodeBuilderWithComponents::extend_rpc_modules`] for RPC module
-    ///   configuration
+    /// - [`crate::NodeBuilderWithComponents::extend_rpc_modules`] for RPC module configuration
     pub fn map_add_ons<F>(self, f: F) -> Self
     where
         F: FnOnce(AO) -> AO,

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -553,7 +553,8 @@ where
     /// # See also
     ///
     /// - [`NodeAddOns`] trait for available addon types
-    /// - [`NodeBuilderWithComponents::extend_rpc_modules`] for RPC module configuration
+    /// - [`reth_node_builder::NodeBuilderWithComponents::extend_rpc_modules`] for RPC module
+    ///   configuration
     pub fn map_add_ons<F>(self, f: F) -> Self
     where
         F: FnOnce(AO) -> AO,
@@ -600,10 +601,10 @@ where
     ///     .extend_rpc_modules(|ctx| {
     ///         // Access node components, so they can used by the CustomApi
     ///         let pool = ctx.pool().clone();
-    ///         
+    ///
     ///         // Add custom RPC namespace
     ///         ctx.modules.merge_configured(CustomApi { pool }.into_rpc())?;
-    ///         
+    ///
     ///         Ok(())
     ///     })
     ///     .build()?;

--- a/crates/node/builder/src/builder/states.rs
+++ b/crates/node/builder/src/builder/states.rs
@@ -255,8 +255,7 @@ where
     /// # See also
     ///
     /// - [`NodeAddOns`] trait for available addon types
-    /// - [`reth_node_builder::NodeBuilderWithComponents::extend_rpc_modules`] for RPC module
-    ///   configuration
+    /// - [`crate::NodeBuilderWithComponents::extend_rpc_modules`] for RPC module configuration
     pub fn map_add_ons<F>(mut self, f: F) -> Self
     where
         F: FnOnce(AO) -> AO,

--- a/crates/node/builder/src/builder/states.rs
+++ b/crates/node/builder/src/builder/states.rs
@@ -255,7 +255,8 @@ where
     /// # See also
     ///
     /// - [`NodeAddOns`] trait for available addon types
-    /// - [`extend_rpc_modules`] for RPC module configuration
+    /// - [`reth_node_builder::NodeBuilderWithComponents::extend_rpc_modules`] for RPC module
+    ///   configuration
     pub fn map_add_ons<F>(mut self, f: F) -> Self
     where
         F: FnOnce(AO) -> AO,

--- a/crates/node/builder/src/builder/states.rs
+++ b/crates/node/builder/src/builder/states.rs
@@ -235,6 +235,27 @@ where
     }
 
     /// Modifies the addons with the given closure.
+    ///
+    /// This method provides access to methods on the addons type that don't have
+    /// direct builder methods. It's useful for advanced configuration scenarios
+    /// where you need to call addon-specific methods.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use tower::layer::util::Identity;
+    ///
+    /// let builder = NodeBuilder::new(config)
+    ///     .with_types::<EthereumNode>()
+    ///     .with_components(EthereumNode::components())
+    ///     .with_add_ons(EthereumAddOns::default())
+    ///     .map_add_ons(|addons| addons.with_rpc_middleware(Identity::default()));
+    /// ```
+    ///
+    /// # See also
+    ///
+    /// - [`NodeAddOns`] trait for available addon types
+    /// - [`extend_rpc_modules`] for RPC module configuration
     pub fn map_add_ons<F>(mut self, f: F) -> Self
     where
         F: FnOnce(AO) -> AO,


### PR DESCRIPTION
## What

Improves documentation for `map_add_ons` method in `NodeBuilderWithComponents` and `WithLaunchContext` by adding usage examples, purpose description, and cross-references to related types.

## Why

The method serves as an escape hatch for accessing addon-specific configuration methods (like `with_rpc_middleware`) that don't have direct builder API equivalents. The previous minimal documentation made it unclear when and how to use this method, especially for advanced configuration scenarios.