### PR TITLE
docs(reth-bench): fix incorrect authrpc.jwtsecret flag

### DIFF
--- a/bin/reth-bench/README.md
+++ b/bin/reth-bench/README.md
@@ -80,7 +80,7 @@ RUSTFLAGS="-C target-cpu=native" cargo build --profile profiling --no-default-fe
 ### Run the Benchmark:
 First, start the reth node. Here is an example that runs `reth` compiled with the `profiling` profile, runs `samply`, and configures `reth` to run with metrics enabled:
 ```bash
-samply record -p 3001 target/profiling/reth node --metrics localhost:9001 --authrpc.jwt-secret <jwt_file_path>
+samply record -p 3001 target/profiling/reth node --metrics localhost:9001 --authrpc.jwtsecret <jwt_file_path>
 ```
 
 ```bash


### PR DESCRIPTION
The flag was documented as --authrpc.jwt-secret (with hyphen), the correct flag is --authrpc.jwtsecret.