### PR TITLE
fix(db): add metrics for clear operation

### DIFF
--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -419,9 +419,9 @@ impl DbTxMut for Tx<RW> {
     }
 
     fn clear<T: Table>(&self) -> Result<(), DatabaseError> {
-        self.inner.clear_db(self.get_dbi::<T>()?).map_err(|e| DatabaseError::Delete(e.into()))?;
-
-        Ok(())
+        self.execute_with_operation_metric::<T, _>(Operation::Clear, None, |tx| {
+            tx.clear_db(self.get_dbi::<T>()?).map_err(|e| DatabaseError::Delete(e.into()))
+        })
     }
 
     fn cursor_write<T: Table>(&self) -> Result<Self::CursorMut<T>, DatabaseError> {

--- a/crates/storage/db/src/metrics.rs
+++ b/crates/storage/db/src/metrics.rs
@@ -203,6 +203,8 @@ pub(crate) enum Operation {
     PutAppend,
     /// Database delete operation.
     Delete,
+    /// Database clear operation.
+    Clear,
     /// Database cursor upsert operation.
     CursorUpsert,
     /// Database cursor insert operation.
@@ -225,6 +227,7 @@ impl Operation {
             Self::PutUpsert => "put-upsert",
             Self::PutAppend => "put-append",
             Self::Delete => "delete",
+            Self::Clear => "clear",
             Self::CursorUpsert => "cursor-upsert",
             Self::CursorInsert => "cursor-insert",
             Self::CursorAppend => "cursor-append",


### PR DESCRIPTION
Add Operation::Clear variant and wrap clear() method with operation metrics to match the pattern used by other write operations (put, delete). 
This ensures consistent metrics tracking for table clearing operations.