### PR TITLE
feat(storage): add rocksdb provider into database provider

### DIFF
--- a/crates/cli/commands/src/stage/dump/execution.rs
+++ b/crates/cli/commands/src/stage/dump/execution.rs
@@ -9,7 +9,7 @@ use reth_evm::ConfigureEvm;
 use reth_node_builder::NodeTypesWithDB;
 use reth_node_core::dirs::{ChainPath, DataDirPath};
 use reth_provider::{
-    providers::{ProviderNodeTypes, StaticFileProvider},
+    providers::{ProviderNodeTypes, RocksDBProvider, StaticFileProvider},
     DatabaseProviderFactory, ProviderFactory,
 };
 use reth_stages::{stages::ExecutionStage, Stage, StageCheckpoint, UnwindInput};
@@ -42,6 +42,7 @@ where
                 Arc::new(output_db),
                 db_tool.chain(),
                 StaticFileProvider::read_write(output_datadir.static_files())?,
+                RocksDBProvider::builder(output_datadir.rocksdb()).build()?,
             )?,
             to,
             from,

--- a/crates/cli/commands/src/stage/dump/hashing_account.rs
+++ b/crates/cli/commands/src/stage/dump/hashing_account.rs
@@ -6,7 +6,7 @@ use reth_db_api::{database::Database, table::TableImporter, tables};
 use reth_db_common::DbTool;
 use reth_node_core::dirs::{ChainPath, DataDirPath};
 use reth_provider::{
-    providers::{ProviderNodeTypes, StaticFileProvider},
+    providers::{ProviderNodeTypes, RocksDBProvider, StaticFileProvider},
     DatabaseProviderFactory, ProviderFactory,
 };
 use reth_stages::{stages::AccountHashingStage, Stage, StageCheckpoint, UnwindInput};
@@ -39,6 +39,7 @@ pub(crate) async fn dump_hashing_account_stage<N: ProviderNodeTypes<DB = Arc<Dat
                 Arc::new(output_db),
                 db_tool.chain(),
                 StaticFileProvider::read_write(output_datadir.static_files())?,
+                RocksDBProvider::builder(output_datadir.rocksdb()).build()?,
             )?,
             to,
             from,

--- a/crates/cli/commands/src/stage/dump/hashing_storage.rs
+++ b/crates/cli/commands/src/stage/dump/hashing_storage.rs
@@ -5,7 +5,7 @@ use reth_db_api::{database::Database, table::TableImporter, tables};
 use reth_db_common::DbTool;
 use reth_node_core::dirs::{ChainPath, DataDirPath};
 use reth_provider::{
-    providers::{ProviderNodeTypes, StaticFileProvider},
+    providers::{ProviderNodeTypes, RocksDBProvider, StaticFileProvider},
     DatabaseProviderFactory, ProviderFactory,
 };
 use reth_stages::{stages::StorageHashingStage, Stage, StageCheckpoint, UnwindInput};
@@ -29,6 +29,7 @@ pub(crate) async fn dump_hashing_storage_stage<N: ProviderNodeTypes<DB = Arc<Dat
                 Arc::new(output_db),
                 db_tool.chain(),
                 StaticFileProvider::read_write(output_datadir.static_files())?,
+                RocksDBProvider::builder(output_datadir.rocksdb()).build()?,
             )?,
             to,
             from,

--- a/crates/cli/commands/src/stage/dump/merkle.rs
+++ b/crates/cli/commands/src/stage/dump/merkle.rs
@@ -12,7 +12,7 @@ use reth_evm::ConfigureEvm;
 use reth_exex::ExExManagerHandle;
 use reth_node_core::dirs::{ChainPath, DataDirPath};
 use reth_provider::{
-    providers::{ProviderNodeTypes, StaticFileProvider},
+    providers::{ProviderNodeTypes, RocksDBProvider, StaticFileProvider},
     DatabaseProviderFactory, ProviderFactory,
 };
 use reth_stages::{
@@ -62,6 +62,7 @@ where
                 Arc::new(output_db),
                 db_tool.chain(),
                 StaticFileProvider::read_write(output_datadir.static_files())?,
+                RocksDBProvider::builder(output_datadir.rocksdb()).build()?,
             )?,
             to,
             from,

--- a/crates/e2e-test-utils/src/setup_import.rs
+++ b/crates/e2e-test-utils/src/setup_import.rs
@@ -110,6 +110,7 @@ pub async fn setup_engine_with_chain_import(
         // Create database path and static files path
         let db_path = datadir.join("db");
         let static_files_path = datadir.join("static_files");
+        let rocksdb_dir_path = datadir.join("rocksdb");
 
         // Initialize the database using init_db (same as CLI import command)
         // Use the same database arguments as the node will use
@@ -125,6 +126,7 @@ pub async fn setup_engine_with_chain_import(
             db.clone(),
             chain_spec.clone(),
             reth_provider::providers::StaticFileProvider::read_write(static_files_path.clone())?,
+            reth_provider::providers::RocksDBProvider::builder(rocksdb_dir_path).build().unwrap(),
         )?;
 
         // Initialize genesis if needed
@@ -311,6 +313,7 @@ mod tests {
         std::fs::create_dir_all(&datadir).unwrap();
         let db_path = datadir.join("db");
         let static_files_path = datadir.join("static_files");
+        let rocksdb_dir_path = datadir.join("rocksdb");
 
         // Import the chain
         {
@@ -323,6 +326,9 @@ mod tests {
                 db.clone(),
                 chain_spec.clone(),
                 reth_provider::providers::StaticFileProvider::read_write(static_files_path.clone())
+                    .unwrap(),
+                reth_provider::providers::RocksDBProvider::builder(rocksdb_dir_path.clone())
+                    .build()
                     .unwrap(),
             )
             .expect("failed to create provider factory");
@@ -384,6 +390,9 @@ mod tests {
                 db,
                 chain_spec.clone(),
                 reth_provider::providers::StaticFileProvider::read_only(static_files_path, false)
+                    .unwrap(),
+                reth_provider::providers::RocksDBProvider::builder(rocksdb_dir_path)
+                    .build()
                     .unwrap(),
             )
             .expect("failed to create provider factory");
@@ -472,11 +481,15 @@ mod tests {
         // Create static files path
         let static_files_path = datadir.join("static_files");
 
+        // Create rocksdb path
+        let rocksdb_dir_path = datadir.join("rocksdb");
+
         // Create a provider factory
         let provider_factory: ProviderFactory<MockNodeTypesWithDB> = ProviderFactory::new(
             db.clone(),
             chain_spec.clone(),
             reth_provider::providers::StaticFileProvider::read_write(static_files_path).unwrap(),
+            reth_provider::providers::RocksDBProvider::builder(rocksdb_dir_path).build().unwrap(),
         )
         .expect("failed to create provider factory");
 

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -118,13 +118,14 @@ impl EthereumNode {
     /// use reth_chainspec::ChainSpecBuilder;
     /// use reth_db::open_db_read_only;
     /// use reth_node_ethereum::EthereumNode;
-    /// use reth_provider::providers::StaticFileProvider;
+    /// use reth_provider::providers::{RocksDBProvider, StaticFileProvider};
     /// use std::sync::Arc;
     ///
     /// let factory = EthereumNode::provider_factory_builder()
     ///     .db(Arc::new(open_db_read_only("db", Default::default()).unwrap()))
     ///     .chainspec(ChainSpecBuilder::mainnet().build().into())
     ///     .static_file(StaticFileProvider::read_only("db/static_files", false).unwrap())
+    ///     .rocksdb_provider(RocksDBProvider::builder("db/rocksdb").build().unwrap())
     ///     .build_provider_factory();
     /// ```
     pub fn provider_factory_builder() -> ProviderFactoryBuilder<Self> {

--- a/crates/ethereum/node/tests/it/testing.rs
+++ b/crates/ethereum/node/tests/it/testing.rs
@@ -28,6 +28,7 @@ async fn testing_rpc_build_block_works() -> eyre::Result<()> {
         datadir: MaybePlatformPath::<DataDirPath>::from_str(tempdir.path().to_str().unwrap())
             .expect("valid datadir"),
         static_files_path: Some(tempdir.path().join("static")),
+        rocksdb_path: Some(tempdir.path().join("rocksdb")),
     };
     let config = NodeConfig::test().with_datadir_args(datadir_args).with_rpc(rpc_args);
     let db = create_test_rw_db();

--- a/crates/exex/test-utils/src/lib.rs
+++ b/crates/exex/test-utils/src/lib.rs
@@ -20,7 +20,9 @@ use futures_util::FutureExt;
 use reth_chainspec::{ChainSpec, MAINNET};
 use reth_consensus::test_utils::TestConsensus;
 use reth_db::{
-    test_utils::{create_test_rw_db, create_test_static_files_dir, TempDatabase},
+    test_utils::{
+        create_test_rocksdb_dir, create_test_rw_db, create_test_static_files_dir, TempDatabase,
+    },
     DatabaseEnv,
 };
 use reth_db_common::init::init_genesis;
@@ -50,7 +52,7 @@ use reth_node_ethereum::{
 use reth_payload_builder::noop::NoopPayloadBuilderService;
 use reth_primitives_traits::{Block as _, RecoveredBlock};
 use reth_provider::{
-    providers::{BlockchainProvider, StaticFileProvider},
+    providers::{BlockchainProvider, RocksDBProvider, StaticFileProvider},
     BlockReader, EthStorage, ProviderFactory,
 };
 use reth_tasks::TaskManager;
@@ -239,11 +241,13 @@ pub async fn test_exex_context_with_chain_spec(
     let consensus = Arc::new(TestConsensus::default());
 
     let (static_dir, _) = create_test_static_files_dir();
+    let (rocksdb_dir, _) = create_test_rocksdb_dir();
     let db = create_test_rw_db();
     let provider_factory = ProviderFactory::<NodeTypesWithDBAdapter<TestNode, _>>::new(
         db,
         chain_spec.clone(),
         StaticFileProvider::read_write(static_dir.keep()).expect("static file provider"),
+        RocksDBProvider::builder(rocksdb_dir.keep()).build().unwrap(),
     )?;
 
     let genesis_hash = init_genesis(&provider_factory)?;

--- a/crates/node/core/src/args/datadir_args.rs
+++ b/crates/node/core/src/args/datadir_args.rs
@@ -27,6 +27,10 @@ pub struct DatadirArgs {
         verbatim_doc_comment
     )]
     pub static_files_path: Option<PathBuf>,
+
+    /// The absolute path to store `RocksDB` database in.
+    #[arg(long = "datadir.rocksdb", value_name = "PATH", verbatim_doc_comment)]
+    pub rocksdb_path: Option<PathBuf>,
 }
 
 impl DatadirArgs {

--- a/crates/node/core/src/dirs.rs
+++ b/crates/node/core/src/dirs.rs
@@ -301,6 +301,18 @@ impl<D> ChainPath<D> {
         }
     }
 
+    /// Returns the path to the `RocksDB` database directory for this chain.
+    ///
+    /// `<DIR>/<CHAIN_ID>/rocksdb`
+    pub fn rocksdb(&self) -> PathBuf {
+        let datadir_args = &self.2;
+        if let Some(rocksdb_path) = &datadir_args.rocksdb_path {
+            rocksdb_path.clone()
+        } else {
+            self.data_dir().join("rocksdb")
+        }
+    }
+
     /// Returns the path to the reth p2p secret key for this chain.
     ///
     /// `<DIR>/<CHAIN_ID>/discovery-secret`

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -218,13 +218,14 @@ impl OpNode {
     /// use reth_db::open_db_read_only;
     /// use reth_optimism_chainspec::OpChainSpecBuilder;
     /// use reth_optimism_node::OpNode;
-    /// use reth_provider::providers::StaticFileProvider;
+    /// use reth_provider::providers::{RocksDBProvider, StaticFileProvider};
     /// use std::sync::Arc;
     ///
     /// let factory = OpNode::provider_factory_builder()
     ///     .db(Arc::new(open_db_read_only("db", Default::default()).unwrap()))
     ///     .chainspec(OpChainSpecBuilder::base_mainnet().build().into())
     ///     .static_file(StaticFileProvider::read_only("db/static_files", false).unwrap())
+    ///     .rocksdb_provider(RocksDBProvider::builder("db/rocksdb").build().unwrap())
     ///     .build_provider_factory();
     /// ```
     pub fn provider_factory_builder() -> ProviderFactoryBuilder<Self> {

--- a/crates/stages/api/src/stage.rs
+++ b/crates/stages/api/src/stage.rs
@@ -324,11 +324,13 @@ impl<Provider, S: Stage<Provider> + ?Sized> StageExt<Provider> for S {}
 #[cfg(test)]
 mod tests {
     use reth_chainspec::MAINNET;
-    use reth_db::test_utils::{create_test_rw_db, create_test_static_files_dir};
+    use reth_db::test_utils::{
+        create_test_rocksdb_dir, create_test_rw_db, create_test_static_files_dir,
+    };
     use reth_db_api::{models::StoredBlockBodyIndices, tables, transaction::DbTxMut};
     use reth_provider::{
-        test_utils::MockNodeTypesWithDB, ProviderFactory, StaticFileProviderBuilder,
-        StaticFileProviderFactory, StaticFileSegment,
+        providers::RocksDBProvider, test_utils::MockNodeTypesWithDB, ProviderFactory,
+        StaticFileProviderBuilder, StaticFileProviderFactory, StaticFileSegment,
     };
     use reth_stages_types::StageCheckpoint;
     use reth_testing_utils::generators::{self, random_signed_tx};
@@ -346,6 +348,7 @@ mod tests {
                 .with_blocks_per_file(1)
                 .build()
                 .unwrap(),
+            RocksDBProvider::builder(create_test_rocksdb_dir().0.keep()).build().unwrap(),
         )
         .unwrap();
 

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -762,10 +762,10 @@ mod tests {
         // Try to init db with a different genesis block
         let genesis_hash = init_genesis(
             &ProviderFactory::<MockNodeTypesWithDB>::new(
-                factory.clone().into_db(),
+                factory.into_db(),
                 MAINNET.clone(),
                 static_file_provider,
-                rocksdb_provider.clone(),
+                rocksdb_provider,
             )
             .unwrap(),
         );

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -711,7 +711,7 @@ mod tests {
     };
     use reth_provider::{
         test_utils::{create_test_provider_factory_with_chain_spec, MockNodeTypesWithDB},
-        ProviderFactory,
+        ProviderFactory, RocksDBProviderFactory,
     };
     use std::{collections::BTreeMap, sync::Arc};
 
@@ -756,14 +756,16 @@ mod tests {
     fn fail_init_inconsistent_db() {
         let factory = create_test_provider_factory_with_chain_spec(SEPOLIA.clone());
         let static_file_provider = factory.static_file_provider();
+        let rocksdb_provider = factory.rocksdb_provider();
         init_genesis(&factory).unwrap();
 
         // Try to init db with a different genesis block
         let genesis_hash = init_genesis(
             &ProviderFactory::<MockNodeTypesWithDB>::new(
-                factory.into_db(),
+                factory.clone().into_db(),
                 MAINNET.clone(),
                 static_file_provider,
+                rocksdb_provider.clone(),
             )
             .unwrap(),
         );

--- a/crates/storage/db/src/lib.rs
+++ b/crates/storage/db/src/lib.rs
@@ -159,6 +159,14 @@ pub mod test_utils {
         (temp_dir, path)
     }
 
+    /// Create `rocksdb` path for testing
+    #[track_caller]
+    pub fn create_test_rocksdb_dir() -> (TempDir, PathBuf) {
+        let temp_dir = TempDir::with_prefix("reth-test-rocksdb-").expect(ERROR_TEMPDIR);
+        let path = temp_dir.path().to_path_buf();
+        (temp_dir, path)
+    }
+
     /// Get a temporary directory path to use for the database
     pub fn tempdir_path() -> PathBuf {
         let builder = tempfile::Builder::new().prefix("reth-test-").rand_bytes(8).tempdir();

--- a/crates/storage/errors/src/provider.rs
+++ b/crates/storage/errors/src/provider.rs
@@ -126,9 +126,6 @@ pub enum ProviderError {
     /// Static File Provider was initialized as read-only.
     #[error("cannot get a writer on a read-only environment.")]
     ReadOnlyStaticFileAccess,
-    /// `RocksDB` was opened in read-only mode.
-    #[error("cannot perform write operations on a read-only RocksDB instance.")]
-    ReadOnlyRocksDBAccess,
     /// Consistent view error.
     #[error("failed to initialize consistent view: {_0}")]
     ConsistentView(Box<ConsistentViewError>),

--- a/crates/storage/errors/src/provider.rs
+++ b/crates/storage/errors/src/provider.rs
@@ -126,6 +126,9 @@ pub enum ProviderError {
     /// Static File Provider was initialized as read-only.
     #[error("cannot get a writer on a read-only environment.")]
     ReadOnlyStaticFileAccess,
+    /// `RocksDB` was opened in read-only mode.
+    #[error("cannot perform write operations on a read-only RocksDB instance.")]
+    ReadOnlyRocksDBAccess,
     /// Consistent view error.
     #[error("failed to initialize consistent view: {_0}")]
     ConsistentView(Box<ConsistentViewError>),

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -1,14 +1,15 @@
 use crate::{
     providers::{
-        ConsistentProvider, ProviderNodeTypes, StaticFileProvider, StaticFileProviderRWRefMut,
+        ConsistentProvider, ProviderNodeTypes, RocksDBProvider, StaticFileProvider,
+        StaticFileProviderRWRefMut,
     },
     AccountReader, BlockHashReader, BlockIdReader, BlockNumReader, BlockReader, BlockReaderIdExt,
     BlockSource, CanonChainTracker, CanonStateNotifications, CanonStateSubscriptions,
     ChainSpecProvider, ChainStateBlockReader, ChangeSetReader, DatabaseProviderFactory,
     HashedPostStateProvider, HeaderProvider, ProviderError, ProviderFactory, PruneCheckpointReader,
-    ReceiptProvider, ReceiptProviderIdExt, StageCheckpointReader, StateProviderBox,
-    StateProviderFactory, StateReader, StaticFileProviderFactory, TransactionVariant,
-    TransactionsProvider, TrieReader,
+    ReceiptProvider, ReceiptProviderIdExt, RocksDBProviderFactory, StageCheckpointReader,
+    StateProviderBox, StateProviderFactory, StateReader, StaticFileProviderFactory,
+    TransactionVariant, TransactionsProvider, TrieReader,
 };
 use alloy_consensus::transaction::TransactionMeta;
 use alloy_eips::{BlockHashOrNumber, BlockId, BlockNumHash, BlockNumberOrTag};
@@ -173,6 +174,12 @@ impl<N: ProviderNodeTypes> StaticFileProviderFactory for BlockchainProvider<N> {
         segment: StaticFileSegment,
     ) -> ProviderResult<StaticFileProviderRWRefMut<'_, Self::Primitives>> {
         self.database.get_static_file_writer(block, segment)
+    }
+}
+
+impl<N: ProviderNodeTypes> RocksDBProviderFactory for BlockchainProvider<N> {
+    fn rocksdb_provider(&self) -> RocksDBProvider {
+        self.database.rocksdb_provider()
     }
 }
 

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -150,8 +150,8 @@ impl<N: NodeTypesWithDB> StorageSettingsCache for ProviderFactory<N> {
 }
 
 impl<N: NodeTypesWithDB> RocksDBProviderFactory for ProviderFactory<N> {
-    fn rocksdb_provider(&self) -> &RocksDBProvider {
-        &self.rocksdb_provider
+    fn rocksdb_provider(&self) -> RocksDBProvider {
+        self.rocksdb_provider.clone()
     }
 }
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -255,9 +255,9 @@ impl<TX, N: NodeTypes> StaticFileProviderFactory for DatabaseProvider<TX, N> {
 }
 
 impl<TX, N: NodeTypes> RocksDBProviderFactory for DatabaseProvider<TX, N> {
-    /// Returns a reference to the `RocksDB` provider.
-    fn rocksdb_provider(&self) -> &RocksDBProvider {
-        &self.rocksdb_provider
+    /// Returns the `RocksDB` provider.
+    fn rocksdb_provider(&self) -> RocksDBProvider {
+        self.rocksdb_provider.clone()
     }
 }
 

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -31,9 +31,10 @@ pub use consistent::ConsistentProvider;
 
 // RocksDB currently only supported on Unix platforms
 // Windows support is planned for future releases
-#[cfg(all(unix, feature = "rocksdb"))]
+#[cfg_attr(all(unix, feature = "rocksdb"), path = "rocksdb/mod.rs")]
+#[cfg_attr(not(all(unix, feature = "rocksdb")), path = "rocksdb_stub.rs")]
 pub(crate) mod rocksdb;
-#[cfg(all(unix, feature = "rocksdb"))]
+
 pub use rocksdb::{RocksDBBuilder, RocksDBProvider, RocksTx};
 
 /// Helper trait to bound [`NodeTypes`] so that combined with database they satisfy

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -151,8 +151,10 @@ impl RocksDBBuilder {
     }
 
     /// Sets the log level from `DatabaseArgs` configuration.
-    pub const fn with_database_log_level(mut self, log_level: LogLevel) -> Self {
-        self.log_level = convert_log_level(log_level);
+    pub const fn with_database_log_level(mut self, log_level: Option<LogLevel>) -> Self {
+        if let Some(level) = log_level {
+            self.log_level = convert_log_level(level);
+        }
         self
     }
 

--- a/crates/storage/provider/src/providers/rocksdb_stub.rs
+++ b/crates/storage/provider/src/providers/rocksdb_stub.rs
@@ -4,7 +4,7 @@
 //! available (either on non-Unix platforms or when the `rocksdb` feature is not enabled).
 //! Operations will produce errors if actually attempted.
 
-use reth_db_api::table::{Decompress, Table};
+use reth_db_api::table::{Encode, Table};
 use reth_storage_errors::{
     db::LogLevel,
     provider::{ProviderError::UnsupportedProvider, ProviderResult},
@@ -24,37 +24,44 @@ impl RocksDBProvider {
     /// Creates a new stub `RocksDB` provider.
     ///
     /// On non-Unix platforms, this returns an error indicating `RocksDB` is not supported.
-    pub fn new<P: AsRef<Path>>(_path: P) -> ProviderResult<Self> {
+    pub fn new(_path: impl AsRef<Path>) -> ProviderResult<Self> {
         Ok(Self)
     }
 
     /// Creates a new stub `RocksDB` provider builder.
-    pub fn builder<P: AsRef<Path>>(path: P) -> RocksDBBuilder {
+    pub fn builder(path: impl AsRef<Path>) -> RocksDBBuilder {
         RocksDBBuilder::new(path)
     }
 
     /// Get a value from `RocksDB` (stub implementation).
-    pub fn get<T>(&self, _key: T::Key) -> ProviderResult<Option<T::Value>>
-    where
-        T: Table,
-        T::Value: Decompress,
-    {
+    pub fn get<T: Table>(&self, _key: T::Key) -> ProviderResult<Option<T::Value>> {
+        Err(UnsupportedProvider)
+    }
+
+    /// Get a value from `RocksDB` using pre-encoded key (stub implementation).
+    pub const fn get_encoded<T: Table>(
+        &self,
+        _key: &<T::Key as Encode>::Encoded,
+    ) -> ProviderResult<Option<T::Value>> {
         Err(UnsupportedProvider)
     }
 
     /// Put a value into `RocksDB` (stub implementation).
-    pub fn put<T>(&self, _key: T::Key, _value: T::Value) -> ProviderResult<()>
-    where
-        T: Table,
-    {
+    pub fn put<T: Table>(&self, _key: T::Key, _value: &T::Value) -> ProviderResult<()> {
+        Err(UnsupportedProvider)
+    }
+
+    /// Put a value into `RocksDB` using pre-encoded key (stub implementation).
+    pub const fn put_encoded<T: Table>(
+        &self,
+        _key: &<T::Key as Encode>::Encoded,
+        _value: &T::Value,
+    ) -> ProviderResult<()> {
         Err(UnsupportedProvider)
     }
 
     /// Delete a value from `RocksDB` (stub implementation).
-    pub fn delete<T>(&self, _key: T::Key) -> ProviderResult<()>
-    where
-        T: Table,
-    {
+    pub fn delete<T: Table>(&self, _key: T::Key) -> ProviderResult<()> {
         Err(UnsupportedProvider)
     }
 
@@ -72,11 +79,22 @@ impl RocksDBProvider {
 pub struct RocksDBBatch;
 
 impl RocksDBBatch {
-    /// Put a value into the batch (stub implementation).
-    pub fn put<T>(&self, _key: T::Key, _value: T::Value) -> ProviderResult<()>
-    where
-        T: Table,
-    {
+    /// Puts a value into the batch (stub implementation).
+    pub fn put<T: Table>(&self, _key: T::Key, _value: &T::Value) -> ProviderResult<()> {
+        Err(UnsupportedProvider)
+    }
+
+    /// Puts a value into the batch using pre-encoded key (stub implementation).
+    pub const fn put_encoded<T: Table>(
+        &self,
+        _key: &<T::Key as Encode>::Encoded,
+        _value: &T::Value,
+    ) -> ProviderResult<()> {
+        Err(UnsupportedProvider)
+    }
+
+    /// Deletes a value from the batch (stub implementation).
+    pub fn delete<T: Table>(&self, _key: T::Key) -> ProviderResult<()> {
         Err(UnsupportedProvider)
     }
 }

--- a/crates/storage/provider/src/providers/rocksdb_stub.rs
+++ b/crates/storage/provider/src/providers/rocksdb_stub.rs
@@ -1,0 +1,128 @@
+//! Stub implementation of `RocksDB` provider.
+//!
+//! This module provides placeholder types that allow the code to compile when `RocksDB` is not
+//! available (either on non-Unix platforms or when the `rocksdb` feature is not enabled).
+//! Operations will produce errors if actually attempted.
+
+use reth_db_api::table::{Decompress, Table};
+use reth_storage_errors::{
+    db::LogLevel,
+    provider::{ProviderError::UnsupportedProvider, ProviderResult},
+};
+use std::path::Path;
+
+/// A stub `RocksDB` provider.
+///
+/// This type exists to allow code to compile when `RocksDB` is not available (either on non-Unix
+/// platforms or when the `rocksdb` feature is not enabled). When using this stub, the
+/// `transaction_hash_numbers_in_rocksdb` flag should be set to `false` to ensure all operations
+/// route to MDBX instead.
+#[derive(Debug, Clone)]
+pub struct RocksDBProvider;
+
+impl RocksDBProvider {
+    /// Creates a new stub `RocksDB` provider.
+    ///
+    /// On non-Unix platforms, this returns an error indicating `RocksDB` is not supported.
+    pub fn new<P: AsRef<Path>>(_path: P) -> ProviderResult<Self> {
+        Ok(Self)
+    }
+
+    /// Creates a new stub `RocksDB` provider builder.
+    pub fn builder<P: AsRef<Path>>(path: P) -> RocksDBBuilder {
+        RocksDBBuilder::new(path)
+    }
+
+    /// Get a value from `RocksDB` (stub implementation).
+    pub fn get<T>(&self, _key: T::Key) -> ProviderResult<Option<T::Value>>
+    where
+        T: Table,
+        T::Value: Decompress,
+    {
+        Err(UnsupportedProvider)
+    }
+
+    /// Put a value into `RocksDB` (stub implementation).
+    pub fn put<T>(&self, _key: T::Key, _value: T::Value) -> ProviderResult<()>
+    where
+        T: Table,
+    {
+        Err(UnsupportedProvider)
+    }
+
+    /// Delete a value from `RocksDB` (stub implementation).
+    pub fn delete<T>(&self, _key: T::Key) -> ProviderResult<()>
+    where
+        T: Table,
+    {
+        Err(UnsupportedProvider)
+    }
+
+    /// Write a batch of operations (stub implementation).
+    pub fn write_batch<F>(&self, _f: F) -> ProviderResult<()>
+    where
+        F: FnOnce(&mut RocksDBBatch) -> ProviderResult<()>,
+    {
+        Err(UnsupportedProvider)
+    }
+}
+
+/// A stub batch writer for `RocksDB` on non-Unix platforms.
+#[derive(Debug)]
+pub struct RocksDBBatch;
+
+impl RocksDBBatch {
+    /// Put a value into the batch (stub implementation).
+    pub fn put<T>(&self, _key: T::Key, _value: T::Value) -> ProviderResult<()>
+    where
+        T: Table,
+    {
+        Err(UnsupportedProvider)
+    }
+}
+
+/// A stub builder for `RocksDB` on non-Unix platforms.
+#[derive(Debug)]
+pub struct RocksDBBuilder;
+
+impl RocksDBBuilder {
+    /// Creates a new stub builder.
+    pub fn new<P: AsRef<Path>>(_path: P) -> Self {
+        Self
+    }
+
+    /// Adds a column family for a specific table type (stub implementation).
+    pub const fn with_table<T: Table>(self) -> Self {
+        self
+    }
+
+    /// Enables metrics (stub implementation).
+    pub const fn with_metrics(self) -> Self {
+        self
+    }
+
+    /// Enables `RocksDB` internal statistics collection (stub implementation).
+    pub const fn with_statistics(self) -> Self {
+        self
+    }
+
+    /// Sets the log level from `DatabaseArgs` configuration (stub implementation).
+    pub const fn with_database_log_level(self, _log_level: Option<LogLevel>) -> Self {
+        self
+    }
+
+    /// Sets a custom block cache size (stub implementation).
+    pub const fn with_block_cache_size(self, _capacity_bytes: usize) -> Self {
+        self
+    }
+
+    /// Opens the database in read-only mode (stub implementation).
+    pub const fn read_only(self) -> Self {
+        self
+    }
+
+    /// Build the `RocksDB` provider (stub implementation).
+    pub const fn build(self) -> ProviderResult<RocksDBProvider> {
+        Ok(RocksDBProvider)
+    }
+}

--- a/crates/storage/provider/src/providers/rocksdb_stub.rs
+++ b/crates/storage/provider/src/providers/rocksdb_stub.rs
@@ -72,6 +72,11 @@ impl RocksDBProvider {
     {
         Err(UnsupportedProvider)
     }
+
+    /// Creates a new transaction (stub implementation).
+    pub const fn tx(&self) -> RocksTx {
+        RocksTx
+    }
 }
 
 /// A stub batch writer for `RocksDB` on non-Unix platforms.
@@ -134,13 +139,72 @@ impl RocksDBBuilder {
         self
     }
 
-    /// Opens the database in read-only mode (stub implementation).
-    pub const fn read_only(self) -> Self {
-        self
-    }
-
     /// Build the `RocksDB` provider (stub implementation).
     pub const fn build(self) -> ProviderResult<RocksDBProvider> {
         Ok(RocksDBProvider)
     }
+}
+
+/// A stub transaction for `RocksDB`.
+#[derive(Debug)]
+pub struct RocksTx;
+
+impl RocksTx {
+    /// Gets a value from the specified table (stub implementation).
+    pub fn get<T: Table>(&self, _key: T::Key) -> ProviderResult<Option<T::Value>> {
+        Err(UnsupportedProvider)
+    }
+
+    /// Gets a value using pre-encoded key (stub implementation).
+    pub const fn get_encoded<T: Table>(
+        &self,
+        _key: &<T::Key as Encode>::Encoded,
+    ) -> ProviderResult<Option<T::Value>> {
+        Err(UnsupportedProvider)
+    }
+
+    /// Puts a value into the specified table (stub implementation).
+    pub fn put<T: Table>(&self, _key: T::Key, _value: &T::Value) -> ProviderResult<()> {
+        Err(UnsupportedProvider)
+    }
+
+    /// Puts a value using pre-encoded key (stub implementation).
+    pub const fn put_encoded<T: Table>(
+        &self,
+        _key: &<T::Key as Encode>::Encoded,
+        _value: &T::Value,
+    ) -> ProviderResult<()> {
+        Err(UnsupportedProvider)
+    }
+
+    /// Deletes a value from the specified table (stub implementation).
+    pub fn delete<T: Table>(&self, _key: T::Key) -> ProviderResult<()> {
+        Err(UnsupportedProvider)
+    }
+
+    /// Creates an iterator for the specified table (stub implementation).
+    pub const fn iter<T: Table>(&self) -> ProviderResult<RocksTxIter<'_, T>> {
+        Err(UnsupportedProvider)
+    }
+
+    /// Creates an iterator starting from the given key (stub implementation).
+    pub fn iter_from<T: Table>(&self, _key: T::Key) -> ProviderResult<RocksTxIter<'_, T>> {
+        Err(UnsupportedProvider)
+    }
+
+    /// Commits the transaction (stub implementation).
+    pub const fn commit(self) -> ProviderResult<()> {
+        Err(UnsupportedProvider)
+    }
+
+    /// Rolls back the transaction (stub implementation).
+    pub const fn rollback(self) -> ProviderResult<()> {
+        Err(UnsupportedProvider)
+    }
+}
+
+/// A stub iterator for `RocksDB` transactions.
+#[derive(Debug)]
+pub struct RocksTxIter<'a, T> {
+    _marker: std::marker::PhantomData<(&'a (), T)>,
 }

--- a/crates/storage/provider/src/test_utils/mod.rs
+++ b/crates/storage/provider/src/test_utils/mod.rs
@@ -1,11 +1,13 @@
 use crate::{
-    providers::{NodeTypesForProvider, ProviderNodeTypes, StaticFileProvider},
+    providers::{NodeTypesForProvider, ProviderNodeTypes, RocksDBProvider, StaticFileProvider},
     HashingWriter, ProviderFactory, TrieWriter,
 };
 use alloy_primitives::B256;
 use reth_chainspec::{ChainSpec, MAINNET};
 use reth_db::{
-    test_utils::{create_test_rw_db, create_test_static_files_dir, TempDatabase},
+    test_utils::{
+        create_test_rocksdb_dir, create_test_rw_db, create_test_static_files_dir, TempDatabase,
+    },
     DatabaseEnv,
 };
 use reth_errors::ProviderResult;
@@ -54,11 +56,13 @@ pub fn create_test_provider_factory_with_node_types<N: NodeTypesForProvider>(
     chain_spec: Arc<N::ChainSpec>,
 ) -> ProviderFactory<NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>> {
     let (static_dir, _) = create_test_static_files_dir();
+    let (rocksdb_dir, _) = create_test_rocksdb_dir();
     let db = create_test_rw_db();
     ProviderFactory::new(
         db,
         chain_spec,
         StaticFileProvider::read_write(static_dir.keep()).expect("static file provider"),
+        RocksDBProvider::new(&rocksdb_dir).expect("failed to create test RocksDB provider"),
     )
     .expect("failed to create test provider factory")
 }

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -27,6 +27,6 @@ impl<C: Send + Sync, N: NodePrimitives> StaticFileProviderFactory for NoopProvid
 
 impl<C: Send + Sync, N: NodePrimitives> RocksDBProviderFactory for NoopProvider<C, N> {
     fn rocksdb_provider(&self) -> RocksDBProvider {
-        RocksDBProvider::builder(PathBuf::default()).read_only().build().unwrap()
+        RocksDBProvider::builder(PathBuf::default()).build().unwrap()
     }
 }

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -1,8 +1,8 @@
 //! Additional testing support for `NoopProvider`.
 
 use crate::{
-    providers::{StaticFileProvider, StaticFileProviderRWRefMut},
-    StaticFileProviderFactory,
+    providers::{RocksDBProvider, StaticFileProvider, StaticFileProviderRWRefMut},
+    RocksDBProviderFactory, StaticFileProviderFactory,
 };
 use reth_errors::{ProviderError, ProviderResult};
 use reth_primitives_traits::NodePrimitives;
@@ -22,5 +22,11 @@ impl<C: Send + Sync, N: NodePrimitives> StaticFileProviderFactory for NoopProvid
         _segment: reth_static_file_types::StaticFileSegment,
     ) -> ProviderResult<StaticFileProviderRWRefMut<'_, Self::Primitives>> {
         Err(ProviderError::ReadOnlyStaticFileAccess)
+    }
+}
+
+impl<C: Send + Sync, N: NodePrimitives> RocksDBProviderFactory for NoopProvider<C, N> {
+    fn rocksdb_provider(&self) -> RocksDBProvider {
+        RocksDBProvider::builder(PathBuf::default()).read_only().build().unwrap()
     }
 }

--- a/crates/storage/provider/src/traits/full.rs
+++ b/crates/storage/provider/src/traits/full.rs
@@ -2,8 +2,9 @@
 
 use crate::{
     AccountReader, BlockReader, BlockReaderIdExt, ChainSpecProvider, ChangeSetReader,
-    DatabaseProviderFactory, HashedPostStateProvider, PruneCheckpointReader, StageCheckpointReader,
-    StateProviderFactory, StateReader, StaticFileProviderFactory, TrieReader,
+    DatabaseProviderFactory, HashedPostStateProvider, PruneCheckpointReader,
+    RocksDBProviderFactory, StageCheckpointReader, StateProviderFactory, StateReader,
+    StaticFileProviderFactory, TrieReader,
 };
 use reth_chain_state::{CanonStateSubscriptions, ForkChoiceSubscriptions};
 use reth_node_types::{BlockTy, HeaderTy, NodeTypesWithDB, ReceiptTy, TxTy};
@@ -17,6 +18,7 @@ pub trait FullProvider<N: NodeTypesWithDB>:
         Provider: BlockReader + TrieReader + StageCheckpointReader + PruneCheckpointReader,
     > + NodePrimitivesProvider<Primitives = N::Primitives>
     + StaticFileProviderFactory<Primitives = N::Primitives>
+    + RocksDBProviderFactory
     + BlockReaderIdExt<
         Transaction = TxTy<N>,
         Block = BlockTy<N>,
@@ -44,6 +46,7 @@ impl<T, N: NodeTypesWithDB> FullProvider<N> for T where
             Provider: BlockReader + TrieReader + StageCheckpointReader + PruneCheckpointReader,
         > + NodePrimitivesProvider<Primitives = N::Primitives>
         + StaticFileProviderFactory<Primitives = N::Primitives>
+        + RocksDBProviderFactory
         + BlockReaderIdExt<
             Transaction = TxTy<N>,
             Block = BlockTy<N>,

--- a/crates/storage/provider/src/traits/mod.rs
+++ b/crates/storage/provider/src/traits/mod.rs
@@ -8,5 +8,8 @@ pub use reth_chainspec::ChainSpecProvider;
 mod static_file_provider;
 pub use static_file_provider::StaticFileProviderFactory;
 
+mod rocksdb_provider;
+pub use rocksdb_provider::RocksDBProviderFactory;
+
 mod full;
 pub use full::FullProvider;

--- a/crates/storage/provider/src/traits/rocksdb_provider.rs
+++ b/crates/storage/provider/src/traits/rocksdb_provider.rs
@@ -1,0 +1,9 @@
+use crate::providers::RocksDBProvider;
+
+/// `RocksDB` provider factory.
+///
+/// This trait provides access to the `RocksDB` provider
+pub trait RocksDBProviderFactory {
+    /// Returns a reference to the `RocksDB` provider.
+    fn rocksdb_provider(&self) -> &RocksDBProvider;
+}

--- a/crates/storage/provider/src/traits/rocksdb_provider.rs
+++ b/crates/storage/provider/src/traits/rocksdb_provider.rs
@@ -4,6 +4,6 @@ use crate::providers::RocksDBProvider;
 ///
 /// This trait provides access to the `RocksDB` provider
 pub trait RocksDBProviderFactory {
-    /// Returns a reference to the `RocksDB` provider.
-    fn rocksdb_provider(&self) -> &RocksDBProvider;
+    /// Returns the `RocksDB` provider.
+    fn rocksdb_provider(&self) -> RocksDBProvider;
 }

--- a/docs/vocs/docs/pages/cli/op-reth/db.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/db.mdx
@@ -43,6 +43,9 @@ Datadir:
       --datadir.static-files <PATH>
           The absolute path to store static files in.
 
+      --datadir.rocksdb <PATH>
+          The absolute path to store `RocksDB` database in.
+
       --config <FILE>
           The path to the configuration file to use
 

--- a/docs/vocs/docs/pages/cli/op-reth/import-op.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/import-op.mdx
@@ -27,6 +27,9 @@ Datadir:
       --datadir.static-files <PATH>
           The absolute path to store static files in.
 
+      --datadir.rocksdb <PATH>
+          The absolute path to store `RocksDB` database in.
+
       --config <FILE>
           The path to the configuration file to use
 

--- a/docs/vocs/docs/pages/cli/op-reth/import-receipts-op.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/import-receipts-op.mdx
@@ -27,6 +27,9 @@ Datadir:
       --datadir.static-files <PATH>
           The absolute path to store static files in.
 
+      --datadir.rocksdb <PATH>
+          The absolute path to store `RocksDB` database in.
+
       --config <FILE>
           The path to the configuration file to use
 

--- a/docs/vocs/docs/pages/cli/op-reth/init-state.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/init-state.mdx
@@ -27,6 +27,9 @@ Datadir:
       --datadir.static-files <PATH>
           The absolute path to store static files in.
 
+      --datadir.rocksdb <PATH>
+          The absolute path to store `RocksDB` database in.
+
       --config <FILE>
           The path to the configuration file to use
 

--- a/docs/vocs/docs/pages/cli/op-reth/init.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/init.mdx
@@ -27,6 +27,9 @@ Datadir:
       --datadir.static-files <PATH>
           The absolute path to store static files in.
 
+      --datadir.rocksdb <PATH>
+          The absolute path to store `RocksDB` database in.
+
       --config <FILE>
           The path to the configuration file to use
 

--- a/docs/vocs/docs/pages/cli/op-reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/node.mdx
@@ -71,6 +71,9 @@ Datadir:
       --datadir.static-files <PATH>
           The absolute path to store static files in.
 
+      --datadir.rocksdb <PATH>
+          The absolute path to store `RocksDB` database in.
+
 Networking:
   -d, --disable-discovery
           Disable the discovery service

--- a/docs/vocs/docs/pages/cli/op-reth/p2p/body.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/p2p/body.mdx
@@ -248,6 +248,9 @@ Datadir:
       --datadir.static-files <PATH>
           The absolute path to store static files in.
 
+      --datadir.rocksdb <PATH>
+          The absolute path to store `RocksDB` database in.
+
       --config <FILE>
           The path to the configuration file to use.
 

--- a/docs/vocs/docs/pages/cli/op-reth/p2p/header.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/p2p/header.mdx
@@ -248,6 +248,9 @@ Datadir:
       --datadir.static-files <PATH>
           The absolute path to store static files in.
 
+      --datadir.rocksdb <PATH>
+          The absolute path to store `RocksDB` database in.
+
       --config <FILE>
           The path to the configuration file to use.
 

--- a/docs/vocs/docs/pages/cli/op-reth/prune.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/prune.mdx
@@ -27,6 +27,9 @@ Datadir:
       --datadir.static-files <PATH>
           The absolute path to store static files in.
 
+      --datadir.rocksdb <PATH>
+          The absolute path to store `RocksDB` database in.
+
       --config <FILE>
           The path to the configuration file to use
 

--- a/docs/vocs/docs/pages/cli/op-reth/re-execute.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/re-execute.mdx
@@ -27,6 +27,9 @@ Datadir:
       --datadir.static-files <PATH>
           The absolute path to store static files in.
 
+      --datadir.rocksdb <PATH>
+          The absolute path to store `RocksDB` database in.
+
       --config <FILE>
           The path to the configuration file to use
 

--- a/docs/vocs/docs/pages/cli/op-reth/stage/drop.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/stage/drop.mdx
@@ -27,6 +27,9 @@ Datadir:
       --datadir.static-files <PATH>
           The absolute path to store static files in.
 
+      --datadir.rocksdb <PATH>
+          The absolute path to store `RocksDB` database in.
+
       --config <FILE>
           The path to the configuration file to use
 

--- a/docs/vocs/docs/pages/cli/op-reth/stage/dump.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/stage/dump.mdx
@@ -34,6 +34,9 @@ Datadir:
       --datadir.static-files <PATH>
           The absolute path to store static files in.
 
+      --datadir.rocksdb <PATH>
+          The absolute path to store `RocksDB` database in.
+
       --config <FILE>
           The path to the configuration file to use
 

--- a/docs/vocs/docs/pages/cli/op-reth/stage/run.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/stage/run.mdx
@@ -27,6 +27,9 @@ Datadir:
       --datadir.static-files <PATH>
           The absolute path to store static files in.
 
+      --datadir.rocksdb <PATH>
+          The absolute path to store `RocksDB` database in.
+
       --config <FILE>
           The path to the configuration file to use
 

--- a/docs/vocs/docs/pages/cli/op-reth/stage/unwind.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/stage/unwind.mdx
@@ -32,6 +32,9 @@ Datadir:
       --datadir.static-files <PATH>
           The absolute path to store static files in.
 
+      --datadir.rocksdb <PATH>
+          The absolute path to store `RocksDB` database in.
+
       --config <FILE>
           The path to the configuration file to use
 

--- a/docs/vocs/docs/pages/cli/reth/db.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db.mdx
@@ -43,6 +43,9 @@ Datadir:
       --datadir.static-files <PATH>
           The absolute path to store static files in.
 
+      --datadir.rocksdb <PATH>
+          The absolute path to store `RocksDB` database in.
+
       --config <FILE>
           The path to the configuration file to use
 

--- a/docs/vocs/docs/pages/cli/reth/download.mdx
+++ b/docs/vocs/docs/pages/cli/reth/download.mdx
@@ -27,6 +27,9 @@ Datadir:
       --datadir.static-files <PATH>
           The absolute path to store static files in.
 
+      --datadir.rocksdb <PATH>
+          The absolute path to store `RocksDB` database in.
+
       --config <FILE>
           The path to the configuration file to use
 

--- a/docs/vocs/docs/pages/cli/reth/export-era.mdx
+++ b/docs/vocs/docs/pages/cli/reth/export-era.mdx
@@ -27,6 +27,9 @@ Datadir:
       --datadir.static-files <PATH>
           The absolute path to store static files in.
 
+      --datadir.rocksdb <PATH>
+          The absolute path to store `RocksDB` database in.
+
       --config <FILE>
           The path to the configuration file to use
 

--- a/docs/vocs/docs/pages/cli/reth/import-era.mdx
+++ b/docs/vocs/docs/pages/cli/reth/import-era.mdx
@@ -27,6 +27,9 @@ Datadir:
       --datadir.static-files <PATH>
           The absolute path to store static files in.
 
+      --datadir.rocksdb <PATH>
+          The absolute path to store `RocksDB` database in.
+
       --config <FILE>
           The path to the configuration file to use
 

--- a/docs/vocs/docs/pages/cli/reth/import.mdx
+++ b/docs/vocs/docs/pages/cli/reth/import.mdx
@@ -27,6 +27,9 @@ Datadir:
       --datadir.static-files <PATH>
           The absolute path to store static files in.
 
+      --datadir.rocksdb <PATH>
+          The absolute path to store `RocksDB` database in.
+
       --config <FILE>
           The path to the configuration file to use
 

--- a/docs/vocs/docs/pages/cli/reth/init-state.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init-state.mdx
@@ -27,6 +27,9 @@ Datadir:
       --datadir.static-files <PATH>
           The absolute path to store static files in.
 
+      --datadir.rocksdb <PATH>
+          The absolute path to store `RocksDB` database in.
+
       --config <FILE>
           The path to the configuration file to use
 

--- a/docs/vocs/docs/pages/cli/reth/init.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init.mdx
@@ -27,6 +27,9 @@ Datadir:
       --datadir.static-files <PATH>
           The absolute path to store static files in.
 
+      --datadir.rocksdb <PATH>
+          The absolute path to store `RocksDB` database in.
+
       --config <FILE>
           The path to the configuration file to use
 

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -71,6 +71,9 @@ Datadir:
       --datadir.static-files <PATH>
           The absolute path to store static files in.
 
+      --datadir.rocksdb <PATH>
+          The absolute path to store `RocksDB` database in.
+
 Networking:
   -d, --disable-discovery
           Disable the discovery service

--- a/docs/vocs/docs/pages/cli/reth/p2p/body.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/body.mdx
@@ -248,6 +248,9 @@ Datadir:
       --datadir.static-files <PATH>
           The absolute path to store static files in.
 
+      --datadir.rocksdb <PATH>
+          The absolute path to store `RocksDB` database in.
+
       --config <FILE>
           The path to the configuration file to use.
 

--- a/docs/vocs/docs/pages/cli/reth/p2p/header.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/header.mdx
@@ -248,6 +248,9 @@ Datadir:
       --datadir.static-files <PATH>
           The absolute path to store static files in.
 
+      --datadir.rocksdb <PATH>
+          The absolute path to store `RocksDB` database in.
+
       --config <FILE>
           The path to the configuration file to use.
 

--- a/docs/vocs/docs/pages/cli/reth/prune.mdx
+++ b/docs/vocs/docs/pages/cli/reth/prune.mdx
@@ -27,6 +27,9 @@ Datadir:
       --datadir.static-files <PATH>
           The absolute path to store static files in.
 
+      --datadir.rocksdb <PATH>
+          The absolute path to store `RocksDB` database in.
+
       --config <FILE>
           The path to the configuration file to use
 

--- a/docs/vocs/docs/pages/cli/reth/re-execute.mdx
+++ b/docs/vocs/docs/pages/cli/reth/re-execute.mdx
@@ -27,6 +27,9 @@ Datadir:
       --datadir.static-files <PATH>
           The absolute path to store static files in.
 
+      --datadir.rocksdb <PATH>
+          The absolute path to store `RocksDB` database in.
+
       --config <FILE>
           The path to the configuration file to use
 

--- a/docs/vocs/docs/pages/cli/reth/stage/drop.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/drop.mdx
@@ -27,6 +27,9 @@ Datadir:
       --datadir.static-files <PATH>
           The absolute path to store static files in.
 
+      --datadir.rocksdb <PATH>
+          The absolute path to store `RocksDB` database in.
+
       --config <FILE>
           The path to the configuration file to use
 

--- a/docs/vocs/docs/pages/cli/reth/stage/dump.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump.mdx
@@ -34,6 +34,9 @@ Datadir:
       --datadir.static-files <PATH>
           The absolute path to store static files in.
 
+      --datadir.rocksdb <PATH>
+          The absolute path to store `RocksDB` database in.
+
       --config <FILE>
           The path to the configuration file to use
 

--- a/docs/vocs/docs/pages/cli/reth/stage/run.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/run.mdx
@@ -27,6 +27,9 @@ Datadir:
       --datadir.static-files <PATH>
           The absolute path to store static files in.
 
+      --datadir.rocksdb <PATH>
+          The absolute path to store `RocksDB` database in.
+
       --config <FILE>
           The path to the configuration file to use
 

--- a/docs/vocs/docs/pages/cli/reth/stage/unwind.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/unwind.mdx
@@ -32,6 +32,9 @@ Datadir:
       --datadir.static-files <PATH>
           The absolute path to store static files in.
 
+      --datadir.rocksdb <PATH>
+          The absolute path to store `RocksDB` database in.
+
       --config <FILE>
           The path to the configuration file to use
 

--- a/examples/rpc-db/src/main.rs
+++ b/examples/rpc-db/src/main.rs
@@ -24,7 +24,7 @@ use reth_ethereum::{
     pool::noop::NoopTransactionPool,
     provider::{
         db::{mdbx::DatabaseArguments, open_db_read_only, ClientVersion, DatabaseEnv},
-        providers::{BlockchainProvider, StaticFileProvider},
+        providers::{BlockchainProvider, RocksDBProvider, StaticFileProvider},
         ProviderFactory,
     },
     rpc::{
@@ -53,6 +53,7 @@ async fn main() -> eyre::Result<()> {
         db.clone(),
         spec.clone(),
         StaticFileProvider::read_only(db_path.join("static_files"), true)?,
+        RocksDBProvider::builder(db_path.join("rocksdb")).build().unwrap(),
     )?;
 
     // 2. Set up the blockchain provider using only the database provider and a noop for the tree to


### PR DESCRIPTION
Resolve #20152

Changes:
- `rocksdb_stub.rs` (stub for non-Unix, no feature), `rocksdb_provider.rs` (for unix, enabled rocksdb feature)
- Added `RocksDBProvider` to `ProviderFactory` with builder pattern
- Added `/rocksdb` directory alongside `/db` and `/static_files`
- Integration: Updated provider factory builder, node launch, CLI commands, and test utilities
