### PR TITLE
fix(rpc): avoid signing Optimism deposit transactions

### DIFF
--- a/crates/rpc/rpc-convert/src/rpc.rs
+++ b/crates/rpc/rpc-convert/src/rpc.rs
@@ -90,12 +90,13 @@ impl SignableTxRequest<op_alloy_consensus::OpTxEnvelope>
     ) -> Result<op_alloy_consensus::OpTxEnvelope, SignTxRequestError> {
         let mut tx =
             self.build_typed_tx().map_err(|_| SignTxRequestError::InvalidTransactionRequest)?;
-        let signature = signer.sign_transaction(&mut tx).await?;
 
-        // sanity check
+        // sanity check: deposit transactions must not be signed by the user
         if tx.is_deposit() {
             return Err(SignTxRequestError::InvalidTransactionRequest);
         }
+
+        let signature = signer.sign_transaction(&mut tx).await?;
 
         Ok(tx.into_signed(signature).into())
     }


### PR DESCRIPTION
SignableTxRequest for OpTransactionRequest was calling the signer before checking is_deposit(), even though Optimism deposit transactions are not supposed to be user-signed. This caused unnecessary signer calls (including potential hardware wallet prompts) for requests that are ultimately rejected as invalid. Reorder the logic to build the typed transaction, immediately reject deposits, and only then sign non-deposit transactions, aligning the RPC signing path with the Optimism deposit semantics.