### PR TITLE
chore(deps): bump op-alloy to 0.23.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,9 +266,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.24.2"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01be36ba6f5e6e62563b369e03ca529eac46aea50677f84655084b4750816574"
+checksum = "70cd39002a40b8d528f4a3f8ecc7e59dc2204d9bfae249296d7d379f291f9cba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -383,9 +383,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-op-evm"
-version = "0.24.2"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "231262d7e06000f3fb642d32d38ca75e09e78e04977c10be0a07a5ee2c869cfd"
+checksum = "6bec5d35135e72ab8096f9b7713840725dc0cd0f9e20ed283156808874da76f4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6199,9 +6199,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "op-alloy"
-version = "0.22.4"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3b13412d297c1f9341f678b763750b120a73ffe998fa54a94d6eda98449e7ca"
+checksum = "5f8cef53b364f406ed2be3a447b2d8f2f18b07a6ff1255c287debb4cda68095b"
 dependencies = [
  "op-alloy-consensus",
  "op-alloy-network",
@@ -6212,9 +6212,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.22.4"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726da827358a547be9f1e37c2a756b9e3729cb0350f43408164794b370cad8ae"
+checksum = "baac15f8823a36112356594845beb21df41c9cfbb80d4322b73c18643cc96e89"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6238,9 +6238,9 @@ checksum = "a79f352fc3893dcd670172e615afef993a41798a1d3fc0db88a3e60ef2e70ecc"
 
 [[package]]
 name = "op-alloy-network"
-version = "0.22.4"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63f27e65be273ec8fcb0b6af0fd850b550979465ab93423705ceb3dfddbd2ab"
+checksum = "452c6f2ad049692cb79a5b1a0e454e3044b5b8daf9b6fcaf646e93d932742718"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -6254,9 +6254,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-provider"
-version = "0.22.4"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a71456699aa256dc20119736422ad9a44da8b9585036117afb936778122093b9"
+checksum = "9f1c952895ad45087d35d323e3fb73c0b5de7c6852494d81ebe997030366196a"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -6269,9 +6269,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-jsonrpsee"
-version = "0.22.4"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ef9114426b16172254555aad34a8ea96c01895e40da92f5d12ea680a1baeaa7"
+checksum = "194048ba6426c5c8560e037a33a3d75b00a57b5c2759bf60d459bb010a47b555"
 dependencies = [
  "alloy-primitives",
  "jsonrpsee",
@@ -6279,9 +6279,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types"
-version = "0.22.4"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562dd4462562c41f9fdc4d860858c40e14a25df7f983ae82047f15f08fce4d19"
+checksum = "20aec5a1dc6bf6fb843e3a0476de97783582182058fd564e383d5f177631192e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6299,9 +6299,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types-engine"
-version = "0.22.4"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8f24b8cb66e4b33e6c9e508bf46b8ecafc92eadd0b93fedd306c0accb477657"
+checksum = "7563637aab01688fb7263359939598a4a630db79a59ed5ca9048ad0aec43d2ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6315,6 +6315,7 @@ dependencies = [
  "ethereum_ssz_derive",
  "op-alloy-consensus",
  "serde",
+ "sha2",
  "snap",
  "thiserror 2.0.17",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6212,9 +6212,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baac15f8823a36112356594845beb21df41c9cfbb80d4322b73c18643cc96e89"
+checksum = "736381a95471d23e267263cfcee9e1d96d30b9754a94a2819148f83379de8a86"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6238,9 +6238,9 @@ checksum = "a79f352fc3893dcd670172e615afef993a41798a1d3fc0db88a3e60ef2e70ecc"
 
 [[package]]
 name = "op-alloy-network"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "452c6f2ad049692cb79a5b1a0e454e3044b5b8daf9b6fcaf646e93d932742718"
+checksum = "4034183dca6bff6632e7c24c92e75ff5f0eabb58144edb4d8241814851334d47"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -6269,9 +6269,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-jsonrpsee"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194048ba6426c5c8560e037a33a3d75b00a57b5c2759bf60d459bb010a47b555"
+checksum = "c1c820ef9c802ebc732281a940bfb6ac2345af4d9fff041cbb64b4b546676686"
 dependencies = [
  "alloy-primitives",
  "jsonrpsee",
@@ -6279,9 +6279,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20aec5a1dc6bf6fb843e3a0476de97783582182058fd564e383d5f177631192e"
+checksum = "ddd87c6b9e5b6eee8d6b76f41b04368dca0e9f38d83338e5b00e730c282098a4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6299,9 +6299,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types-engine"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7563637aab01688fb7263359939598a4a630db79a59ed5ca9048ad0aec43d2ba"
+checksum = "77727699310a18cdeed32da3928c709e2704043b6584ed416397d5da65694efc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -527,11 +527,11 @@ alloy-transport-ws = { version = "1.1.3", default-features = false }
 # op
 alloy-op-evm = { version = "0.25.0", default-features = false }
 alloy-op-hardforks = "0.4.4"
-op-alloy-rpc-types = { version = "0.23.0", default-features = false }
-op-alloy-rpc-types-engine = { version = "0.23.0", default-features = false }
-op-alloy-network = { version = "0.23.0", default-features = false }
-op-alloy-consensus = { version = "0.23.0", default-features = false }
-op-alloy-rpc-jsonrpsee = { version = "0.23.0", default-features = false }
+op-alloy-rpc-types = { version = "0.23.1", default-features = false }
+op-alloy-rpc-types-engine = { version = "0.23.1", default-features = false }
+op-alloy-network = { version = "0.23.1", default-features = false }
+op-alloy-consensus = { version = "0.23.1", default-features = false }
+op-alloy-rpc-jsonrpsee = { version = "0.23.1", default-features = false }
 op-alloy-flz = { version = "0.13.1", default-features = false }
 
 # misc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -487,7 +487,7 @@ revm-inspectors = "0.33.1"
 alloy-chains = { version = "0.2.5", default-features = false }
 alloy-dyn-abi = "1.4.1"
 alloy-eip2124 = { version = "0.2.0", default-features = false }
-alloy-evm = { version = "0.24.1", default-features = false }
+alloy-evm = { version = "0.25.0", default-features = false }
 alloy-primitives = { version = "1.4.1", default-features = false, features = ["map-foldhash"] }
 alloy-rlp = { version = "0.3.10", default-features = false, features = ["core-net"] }
 alloy-sol-macro = "1.4.1"
@@ -525,13 +525,13 @@ alloy-transport-ipc = { version = "1.1.3", default-features = false }
 alloy-transport-ws = { version = "1.1.3", default-features = false }
 
 # op
-alloy-op-evm = { version = "0.24.1", default-features = false }
+alloy-op-evm = { version = "0.25.0", default-features = false }
 alloy-op-hardforks = "0.4.4"
-op-alloy-rpc-types = { version = "0.22.4", default-features = false }
-op-alloy-rpc-types-engine = { version = "0.22.4", default-features = false }
-op-alloy-network = { version = "0.22.4", default-features = false }
-op-alloy-consensus = { version = "0.22.4", default-features = false }
-op-alloy-rpc-jsonrpsee = { version = "0.22.4", default-features = false }
+op-alloy-rpc-types = { version = "0.23.0", default-features = false }
+op-alloy-rpc-types-engine = { version = "0.23.0", default-features = false }
+op-alloy-network = { version = "0.23.0", default-features = false }
+op-alloy-consensus = { version = "0.23.0", default-features = false }
+op-alloy-rpc-jsonrpsee = { version = "0.23.0", default-features = false }
 op-alloy-flz = { version = "0.13.1", default-features = false }
 
 # misc

--- a/crates/optimism/consensus/src/lib.rs
+++ b/crates/optimism/consensus/src/lib.rs
@@ -241,7 +241,7 @@ mod tests {
 
     use alloy_consensus::{BlockBody, Eip658Value, Header, Receipt, TxEip7702, TxReceipt};
     use alloy_eips::{eip4895::Withdrawals, eip7685::Requests};
-    use alloy_primitives::{Address, Bytes, Signature, U256};
+    use alloy_primitives::{Address, Bytes, Log, Signature, U256};
     use op_alloy_consensus::{
         encode_holocene_extra_data, encode_jovian_extra_data, OpTypedTransaction,
     };
@@ -367,7 +367,7 @@ mod tests {
 
         let beacon_consensus = OpBeaconConsensus::new(Arc::new(chain_spec));
 
-        let receipt = OpReceipt::Eip7702(Receipt {
+        let receipt = OpReceipt::Eip7702(Receipt::<Log> {
             status: Eip658Value::success(),
             cumulative_gas_used: GAS_USED,
             logs: vec![],
@@ -436,7 +436,7 @@ mod tests {
 
         let beacon_consensus = OpBeaconConsensus::new(Arc::new(chain_spec));
 
-        let receipt = OpReceipt::Eip7702(Receipt {
+        let receipt = OpReceipt::Eip7702(Receipt::<Log> {
             status: Eip658Value::success(),
             cumulative_gas_used: GAS_USED,
             logs: vec![],
@@ -451,7 +451,9 @@ mod tests {
             )),
             gas_used: GAS_USED,
             timestamp: u64::MAX,
-            receipts_root: proofs::calculate_receipt_root(std::slice::from_ref(&receipt)),
+            receipts_root: proofs::calculate_receipt_root(std::slice::from_ref(
+                &receipt.with_bloom_ref(),
+            )),
             logs_bloom: receipt.bloom(),
             ..Default::default()
         };
@@ -509,7 +511,7 @@ mod tests {
 
         let beacon_consensus = OpBeaconConsensus::new(Arc::new(chain_spec));
 
-        let receipt = OpReceipt::Eip7702(Receipt {
+        let receipt = OpReceipt::Eip7702(Receipt::<Log> {
             status: Eip658Value::success(),
             cumulative_gas_used: 0,
             logs: vec![],
@@ -526,7 +528,9 @@ mod tests {
             )),
             gas_used: 0,
             timestamp: u64::MAX - 1,
-            receipts_root: proofs::calculate_receipt_root(std::slice::from_ref(&receipt)),
+            receipts_root: proofs::calculate_receipt_root(std::slice::from_ref(
+                &receipt.with_bloom_ref(),
+            )),
             logs_bloom: receipt.bloom(),
             extra_data: encode_jovian_extra_data(
                 Default::default(),
@@ -549,7 +553,9 @@ mod tests {
             )),
             gas_used: 0,
             timestamp: u64::MAX,
-            receipts_root: proofs::calculate_receipt_root(std::slice::from_ref(&receipt)),
+            receipts_root: proofs::calculate_receipt_root(std::slice::from_ref(
+                &receipt.with_bloom_ref(),
+            )),
             logs_bloom: receipt.bloom(),
             parent_hash: parent.hash(),
             ..Default::default()
@@ -576,7 +582,7 @@ mod tests {
 
         let beacon_consensus = OpBeaconConsensus::new(Arc::new(chain_spec));
 
-        let receipt = OpReceipt::Eip7702(Receipt {
+        let receipt = OpReceipt::Eip7702(Receipt::<Log> {
             status: Eip658Value::success(),
             cumulative_gas_used: 0,
             logs: vec![],
@@ -593,7 +599,9 @@ mod tests {
             )),
             gas_used: 0,
             timestamp: u64::MAX - 1,
-            receipts_root: proofs::calculate_receipt_root(std::slice::from_ref(&receipt)),
+            receipts_root: proofs::calculate_receipt_root(std::slice::from_ref(
+                &receipt.with_bloom_ref(),
+            )),
             logs_bloom: receipt.bloom(),
             extra_data: encode_jovian_extra_data(
                 Default::default(),
@@ -616,7 +624,9 @@ mod tests {
             )),
             gas_used: 0,
             timestamp: u64::MAX,
-            receipts_root: proofs::calculate_receipt_root(std::slice::from_ref(&receipt)),
+            receipts_root: proofs::calculate_receipt_root(std::slice::from_ref(
+                &receipt.with_bloom_ref(),
+            )),
             logs_bloom: receipt.bloom(),
             parent_hash: parent.hash(),
             ..Default::default()
@@ -652,7 +662,7 @@ mod tests {
 
         let beacon_consensus = OpBeaconConsensus::new(Arc::new(chain_spec));
 
-        let receipt = OpReceipt::Eip7702(Receipt {
+        let receipt = OpReceipt::Eip7702(Receipt::<Log> {
             status: Eip658Value::success(),
             cumulative_gas_used: 0,
             logs: vec![],
@@ -669,7 +679,9 @@ mod tests {
             )),
             gas_used: 0,
             timestamp: u64::MAX - 1,
-            receipts_root: proofs::calculate_receipt_root(std::slice::from_ref(&receipt)),
+            receipts_root: proofs::calculate_receipt_root(std::slice::from_ref(
+                &receipt.with_bloom_ref(),
+            )),
             logs_bloom: receipt.bloom(),
             extra_data: encode_jovian_extra_data(
                 Default::default(),
@@ -693,7 +705,9 @@ mod tests {
             )),
             gas_used: 0,
             timestamp: u64::MAX,
-            receipts_root: proofs::calculate_receipt_root(std::slice::from_ref(&receipt)),
+            receipts_root: proofs::calculate_receipt_root(std::slice::from_ref(
+                &receipt.with_bloom_ref(),
+            )),
             logs_bloom: receipt.bloom(),
             parent_hash: parent.hash(),
             ..Default::default()
@@ -722,7 +736,7 @@ mod tests {
 
         let beacon_consensus = OpBeaconConsensus::new(Arc::new(chain_spec));
 
-        let receipt = OpReceipt::Eip7702(Receipt {
+        let receipt = OpReceipt::Eip7702(Receipt::<Log> {
             status: Eip658Value::success(),
             cumulative_gas_used: 0,
             logs: vec![],
@@ -739,7 +753,9 @@ mod tests {
             )),
             gas_used: 0,
             timestamp: u64::MAX - 1,
-            receipts_root: proofs::calculate_receipt_root(std::slice::from_ref(&receipt)),
+            receipts_root: proofs::calculate_receipt_root(std::slice::from_ref(
+                &receipt.with_bloom_ref(),
+            )),
             logs_bloom: receipt.bloom(),
             extra_data: encode_holocene_extra_data(Default::default(), BaseFeeParams::optimism())
                 .unwrap(),
@@ -759,7 +775,9 @@ mod tests {
             )),
             gas_used: 0,
             timestamp: u64::MAX,
-            receipts_root: proofs::calculate_receipt_root(std::slice::from_ref(&receipt)),
+            receipts_root: proofs::calculate_receipt_root(std::slice::from_ref(
+                &receipt.with_bloom_ref(),
+            )),
             logs_bloom: receipt.bloom(),
             parent_hash: parent.hash(),
             ..Default::default()

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -486,14 +486,14 @@ mod tests {
         block2.set_hash(block2_hash);
 
         // Create a random receipt object, receipt1
-        let receipt1 = OpReceipt::Legacy(Receipt {
+        let receipt1 = OpReceipt::Legacy(Receipt::<Log> {
             cumulative_gas_used: 46913,
             logs: vec![],
             status: true.into(),
         });
 
         // Create another random receipt object, receipt2
-        let receipt2 = OpReceipt::Legacy(Receipt {
+        let receipt2 = OpReceipt::Legacy(Receipt::<Log> {
             cumulative_gas_used: 1325345,
             logs: vec![],
             status: true.into(),
@@ -544,7 +544,7 @@ mod tests {
         );
 
         // Create a Receipts object with a vector of receipt vectors
-        let receipts = vec![vec![Some(OpReceipt::Legacy(Receipt {
+        let receipts = vec![vec![Some(OpReceipt::Legacy(Receipt::<Log> {
             cumulative_gas_used: 46913,
             logs: vec![],
             status: true.into(),
@@ -602,7 +602,7 @@ mod tests {
     #[test]
     fn test_block_number_to_index() {
         // Create a Receipts object with a vector of receipt vectors
-        let receipts = vec![vec![Some(OpReceipt::Legacy(Receipt {
+        let receipts = vec![vec![Some(OpReceipt::Legacy(Receipt::<Log> {
             cumulative_gas_used: 46913,
             logs: vec![],
             status: true.into(),
@@ -633,7 +633,7 @@ mod tests {
     #[test]
     fn test_get_logs() {
         // Create a Receipts object with a vector of receipt vectors
-        let receipts = vec![vec![OpReceipt::Legacy(Receipt {
+        let receipts = vec![vec![OpReceipt::Legacy(Receipt::<Log> {
             cumulative_gas_used: 46913,
             logs: vec![Log::<LogData>::default()],
             status: true.into(),
@@ -661,7 +661,7 @@ mod tests {
     #[test]
     fn test_receipts_by_block() {
         // Create a Receipts object with a vector of receipt vectors
-        let receipts = vec![vec![Some(OpReceipt::Legacy(Receipt {
+        let receipts = vec![vec![Some(OpReceipt::Legacy(Receipt::<Log> {
             cumulative_gas_used: 46913,
             logs: vec![Log::<LogData>::default()],
             status: true.into(),
@@ -685,7 +685,7 @@ mod tests {
         // Assert that the receipts for block number 123 match the expected receipts
         assert_eq!(
             receipts_by_block,
-            vec![&Some(OpReceipt::Legacy(Receipt {
+            vec![&Some(OpReceipt::Legacy(Receipt::<Log> {
                 cumulative_gas_used: 46913,
                 logs: vec![Log::<LogData>::default()],
                 status: true.into(),
@@ -696,7 +696,7 @@ mod tests {
     #[test]
     fn test_receipts_len() {
         // Create a Receipts object with a vector of receipt vectors
-        let receipts = vec![vec![Some(OpReceipt::Legacy(Receipt {
+        let receipts = vec![vec![Some(OpReceipt::Legacy(Receipt::<Log> {
             cumulative_gas_used: 46913,
             logs: vec![Log::<LogData>::default()],
             status: true.into(),
@@ -741,7 +741,7 @@ mod tests {
     #[test]
     fn test_revert_to() {
         // Create a random receipt object
-        let receipt = OpReceipt::Legacy(Receipt {
+        let receipt = OpReceipt::Legacy(Receipt::<Log> {
             cumulative_gas_used: 46913,
             logs: vec![],
             status: true.into(),
@@ -786,7 +786,7 @@ mod tests {
     #[test]
     fn test_extend_execution_outcome() {
         // Create a Receipt object with specific attributes.
-        let receipt = OpReceipt::Legacy(Receipt {
+        let receipt = OpReceipt::Legacy(Receipt::<Log> {
             cumulative_gas_used: 46913,
             logs: vec![],
             status: true.into(),
@@ -826,7 +826,7 @@ mod tests {
     #[test]
     fn test_split_at_execution_outcome() {
         // Create a random receipt object
-        let receipt = OpReceipt::Legacy(Receipt {
+        let receipt = OpReceipt::Legacy(Receipt::<Log> {
             cumulative_gas_used: 46913,
             logs: vec![],
             status: true.into(),

--- a/crates/optimism/primitives/src/receipt.rs
+++ b/crates/optimism/primitives/src/receipt.rs
@@ -176,7 +176,7 @@ mod tests {
 
         let mut data = Vec::with_capacity(expected.length());
         let receipt = ReceiptWithBloom {
-            receipt: OpReceipt::Legacy(Receipt {
+            receipt: OpReceipt::Legacy(Receipt::<Log> {
                 status: Eip658Value::Eip658(false),
                 cumulative_gas_used: 0x1,
                 logs: vec![Log::new_unchecked(
@@ -207,7 +207,7 @@ mod tests {
 
         // EIP658Receipt
         let expected = ReceiptWithBloom {
-            receipt: OpReceipt::Legacy(Receipt {
+            receipt: OpReceipt::Legacy(Receipt::<Log> {
                 status: Eip658Value::Eip658(false),
                 cumulative_gas_used: 0x1,
                 logs: vec![Log::new_unchecked(
@@ -235,7 +235,7 @@ mod tests {
         // Deposit Receipt (post-regolith)
         let expected = ReceiptWithBloom {
             receipt: OpReceipt::Deposit(OpDepositReceipt {
-                inner: Receipt {
+                inner: Receipt::<Log> {
                     status: Eip658Value::Eip658(true),
                     cumulative_gas_used: 46913,
                     logs: vec![],
@@ -260,10 +260,10 @@ mod tests {
             "b901117ef9010d0182b741b9010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c0833d3bbf01"
         );
 
-        // Deposit Receipt (post-regolith)
+        // Deposit Receipt (post-canyon)
         let expected = ReceiptWithBloom {
             receipt: OpReceipt::Deposit(OpDepositReceipt {
-                inner: Receipt {
+                inner: Receipt::<Log> {
                     status: Eip658Value::Eip658(true),
                     cumulative_gas_used: 46913,
                     logs: vec![],
@@ -284,7 +284,7 @@ mod tests {
 
     #[test]
     fn gigantic_receipt() {
-        let receipt = OpReceipt::Legacy(Receipt {
+        let receipt = OpReceipt::Legacy(Receipt::<Log> {
             status: Eip658Value::Eip658(true),
             cumulative_gas_used: 16747627,
             logs: vec![
@@ -314,7 +314,7 @@ mod tests {
     #[test]
     fn test_encode_2718_length() {
         let receipt = ReceiptWithBloom {
-            receipt: OpReceipt::Eip1559(Receipt {
+            receipt: OpReceipt::Eip1559(Receipt::<Log> {
                 status: Eip658Value::Eip658(true),
                 cumulative_gas_used: 21000,
                 logs: vec![],
@@ -331,7 +331,7 @@ mod tests {
 
         // Test for legacy receipt as well
         let legacy_receipt = ReceiptWithBloom {
-            receipt: OpReceipt::Legacy(Receipt {
+            receipt: OpReceipt::Legacy(Receipt::<Log> {
                 status: Eip658Value::Eip658(true),
                 cumulative_gas_used: 21000,
                 logs: vec![],

--- a/crates/optimism/rpc/src/eth/receipt.rs
+++ b/crates/optimism/rpc/src/eth/receipt.rs
@@ -11,7 +11,6 @@ use reth_chainspec::ChainSpecProvider;
 use reth_node_api::NodePrimitives;
 use reth_optimism_evm::RethL1BlockInfo;
 use reth_optimism_forks::OpHardforks;
-use reth_optimism_primitives::OpReceipt;
 use reth_primitives_traits::SealedBlock;
 use reth_rpc_eth_api::{
     helpers::LoadReceipt,

--- a/crates/rpc/rpc-convert/src/receipt.rs
+++ b/crates/rpc/rpc-convert/src/receipt.rs
@@ -35,9 +35,7 @@ impl TryFromReceiptResponse<op_alloy_network::Optimism> for reth_optimism_primit
     fn from_receipt_response(
         receipt_response: op_alloy_rpc_types::OpTransactionReceipt,
     ) -> Result<Self, Self::Error> {
-        // Convert ReceiptWithBloom<OpReceipt<Log>> to OpReceiptEnvelope, then map logs
-        let envelope = op_alloy_consensus::OpReceiptEnvelope::from(receipt_response.inner.inner);
-        Ok(envelope.map_logs(Into::into).into())
+        Ok(receipt_response.inner.inner.into_components().0.map_logs(Into::into))
     }
 }
 
@@ -73,15 +71,14 @@ mod tests {
     #[test]
     fn test_try_from_receipt_response_optimism() {
         use alloy_consensus::ReceiptWithBloom;
-        use op_alloy_consensus::OpReceipt as OpConsensusReceipt;
+        use op_alloy_consensus::OpReceipt;
         use op_alloy_network::Optimism;
         use op_alloy_rpc_types::OpTransactionReceipt;
-        use reth_optimism_primitives::OpReceipt;
 
         let op_receipt = OpTransactionReceipt {
             inner: alloy_rpc_types_eth::TransactionReceipt {
                 inner: ReceiptWithBloom {
-                    receipt: OpConsensusReceipt::Eip1559(Default::default()),
+                    receipt: OpReceipt::Eip1559(Default::default()),
                     logs_bloom: Default::default(),
                 },
                 transaction_hash: Default::default(),

--- a/crates/rpc/rpc-convert/src/receipt.rs
+++ b/crates/rpc/rpc-convert/src/receipt.rs
@@ -35,7 +35,9 @@ impl TryFromReceiptResponse<op_alloy_network::Optimism> for reth_optimism_primit
     fn from_receipt_response(
         receipt_response: op_alloy_rpc_types::OpTransactionReceipt,
     ) -> Result<Self, Self::Error> {
-        Ok(receipt_response.inner.inner.map_logs(Into::into).into())
+        // Convert ReceiptWithBloom<OpReceipt<Log>> to OpReceiptEnvelope, then map logs
+        let envelope = op_alloy_consensus::OpReceiptEnvelope::from(receipt_response.inner.inner);
+        Ok(envelope.map_logs(Into::into).into())
     }
 }
 
@@ -70,14 +72,18 @@ mod tests {
     #[cfg(feature = "op")]
     #[test]
     fn test_try_from_receipt_response_optimism() {
-        use op_alloy_consensus::OpReceiptEnvelope;
+        use alloy_consensus::ReceiptWithBloom;
+        use op_alloy_consensus::OpReceipt as OpConsensusReceipt;
         use op_alloy_network::Optimism;
         use op_alloy_rpc_types::OpTransactionReceipt;
         use reth_optimism_primitives::OpReceipt;
 
         let op_receipt = OpTransactionReceipt {
             inner: alloy_rpc_types_eth::TransactionReceipt {
-                inner: OpReceiptEnvelope::Eip1559(Default::default()),
+                inner: ReceiptWithBloom {
+                    receipt: OpConsensusReceipt::Eip1559(Default::default()),
+                    logs_bloom: Default::default(),
+                },
                 transaction_hash: Default::default(),
                 transaction_index: None,
                 block_hash: None,


### PR DESCRIPTION
Bumps op-alloy to 0.23.0 along with alloy-evm and alloy-op-evm to 0.25.0.

Main breaking change: `Receipt` and `OpReceipt` are now generic over the log type, so added explicit `<Log>` annotations where needed. Also updated `OpReceiptBuilder` to use `ReceiptWithBloom<OpReceipt<Log>>` to match the new `OpTransactionReceipt` type

