### PR TITLE
docs: use canonical --rollup.sequencer and note aliases

### DIFF
--- a/docs/vocs/docs/pages/run/opstack.mdx
+++ b/docs/vocs/docs/pages/run/opstack.mdx
@@ -57,16 +57,16 @@ For the sake of this tutorial, we'll use the reference implementation of the Rol
 
 op-reth supports additional OP Stack specific CLI arguments:
 
-1. `--rollup.sequencer-http <uri>` - The sequencer endpoint to connect to. Transactions sent to the `op-reth` EL are also forwarded to this sequencer endpoint for inclusion, as the sequencer is the entity that builds blocks on OP Stack chains.
+1. `--rollup.sequencer <uri>` - The sequencer endpoint to connect to. Transactions sent to the `op-reth` EL are also forwarded to this sequencer endpoint for inclusion, as the sequencer is the entity that builds blocks on OP Stack chains. Aliases: `--rollup.sequencer-http`, `--rollup.sequencer-ws`.
 1. `--rollup.disable-tx-pool-gossip` - Disables gossiping of transactions in the mempool to peers. This can be omitted for personal nodes, though providers should always opt to enable this flag.
 1. `--rollup.discovery.v4` - Enables the discovery v4 protocol for peer discovery. By default, op-reth, similar to op-geth, has discovery v5 enabled and discovery v4 disabled, whereas regular reth has discovery v4 enabled and discovery v5 disabled.
 
-First, ensure that your L1 archival node is running and synced to tip. Also make sure that the beacon node / consensus layer client is running and has http APIs enabled. Then, start `op-reth` with the `--rollup.sequencer-http` flag set to the `Base Mainnet` sequencer endpoint:
+First, ensure that your L1 archival node is running and synced to tip. Also make sure that the beacon node / consensus layer client is running and has http APIs enabled. Then, start `op-reth` with the `--rollup.sequencer` flag set to the `Base Mainnet` sequencer endpoint:
 
 ```sh
 op-reth node \
     --chain base \
-    --rollup.sequencer-http https://mainnet-sequencer.base.org \
+    --rollup.sequencer https://mainnet-sequencer.base.org \
     --http \
     --ws \
     --authrpc.port 9551 \


### PR DESCRIPTION
Source in code: in crates/optimism/node/src/args.rs, the flag is declared as canonical --rollup.sequencer with aliases --rollup.sequencer-http and --rollup.sequencer-ws:

```rust
/// Endpoint for the sequencer mempool (can be both HTTP and WS)
#[arg(long = "rollup.sequencer", visible_aliases = ["rollup.sequencer-http", "rollup.sequencer-ws"])]
pub sequencer: Option<String>,
```