### PR TITLE
ci: use 16 cores for Hive workflow

### DIFF
--- a/.github/assets/hive/run_simulator.sh
+++ b/.github/assets/hive/run_simulator.sh
@@ -7,7 +7,7 @@ sim="${1}"
 limit="${2}"
 
 run_hive() {
-    hive --sim "${sim}" --sim.limit "${limit}" --sim.parallelism 8 --client reth 2>&1 | tee /tmp/log || true
+    hive --sim "${sim}" --sim.limit "${limit}" --sim.parallelism 16 --client reth 2>&1 | tee /tmp/log || true
 }
 
 check_log() {

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -24,7 +24,7 @@ jobs:
   prepare-hive:
     if: github.repository == 'paradigmxyz/reth'
     timeout-minutes: 45
-    runs-on: depot-ubuntu-latest
+    runs-on: depot-ubuntu-latest-16
     steps:
       - uses: actions/checkout@v6
       - name: Checkout hive tests
@@ -178,7 +178,7 @@ jobs:
       - prepare-reth
       - prepare-hive
     name: run ${{ matrix.scenario.sim }}${{ matrix.scenario.limit && format(' - {0}', matrix.scenario.limit) }}
-    runs-on: depot-ubuntu-latest
+    runs-on: depot-ubuntu-latest-16
     permissions:
       issues: write
     steps:


### PR DESCRIPTION
Higher core runners have more disk space too

Failing before: https://github.com/paradigmxyz/reth/actions/runs/20098079300/job/57661485004
Succeeding now: https://github.com/paradigmxyz/reth/actions/runs/20099178741/job/57665234408