### PR TITLE
fix: post-state generator to include deletions in proptest

### DIFF
--- a/crates/trie/trie/src/hashed_cursor/post_state.rs
+++ b/crates/trie/trie/src/hashed_cursor/post_state.rs
@@ -423,14 +423,15 @@ mod tests {
                 result.sort_by(|a, b| a.0.cmp(&b.0));
                 result.dedup_by(|a, b| a.0 == b.0);
                 result
-            })
-        }
+            },
+        )
+    }
 
         /// Generate a sorted vector of (B256, U256) entries (including deletions as ZERO)
         fn sorted_post_state_nodes_strategy() -> impl Strategy<Value = Vec<(B256, U256)>> {
             // Explicitly inject ZERO values to model post-state deletions.
-            prop::collection::vec((any::<u8>(), u256_strategy(), any::<bool>()), 0..20)
-                .prop_map(|entries| {
+            prop::collection::vec((any::<u8>(), u256_strategy(), any::<bool>()), 0..20).prop_map(
+                |entries| {
                     let mut result: Vec<(B256, U256)> = entries
                         .into_iter()
                         .map(|(byte, value, is_deletion)| {

--- a/crates/trie/trie/src/hashed_cursor/post_state.rs
+++ b/crates/trie/trie/src/hashed_cursor/post_state.rs
@@ -423,9 +423,8 @@ mod tests {
                 result.sort_by(|a, b| a.0.cmp(&b.0));
                 result.dedup_by(|a, b| a.0 == b.0);
                 result
-            },
-        )
-    }
+            })
+        }
 
         /// Generate a sorted vector of (B256, U256) entries (including deletions as ZERO)
         fn sorted_post_state_nodes_strategy() -> impl Strategy<Value = Vec<(B256, U256)>> {
@@ -442,7 +441,8 @@ mod tests {
                     result.sort_by(|a, b| a.0.cmp(&b.0));
                     result.dedup_by(|a, b| a.0 == b.0);
                     result
-                })
+                },
+            )
         }
 
         proptest! {

--- a/crates/trie/trie/src/hashed_cursor/post_state.rs
+++ b/crates/trie/trie/src/hashed_cursor/post_state.rs
@@ -428,15 +428,20 @@ mod tests {
 
         /// Generate a sorted vector of (B256, U256) entries (including deletions as ZERO)
         fn sorted_post_state_nodes_strategy() -> impl Strategy<Value = Vec<(B256, U256)>> {
-            prop::collection::vec((any::<u8>(), u256_strategy()), 0..20).prop_map(|entries| {
-                let mut result: Vec<(B256, U256)> = entries
-                    .into_iter()
-                    .map(|(byte, value)| (B256::repeat_byte(byte), value))
-                    .collect();
-                result.sort_by(|a, b| a.0.cmp(&b.0));
-                result.dedup_by(|a, b| a.0 == b.0);
-                result
-            })
+            // Explicitly inject ZERO values to model post-state deletions.
+            prop::collection::vec((any::<u8>(), u256_strategy(), any::<bool>()), 0..20)
+                .prop_map(|entries| {
+                    let mut result: Vec<(B256, U256)> = entries
+                        .into_iter()
+                        .map(|(byte, value, is_deletion)| {
+                            let effective_value = if is_deletion { U256::ZERO } else { value };
+                            (B256::repeat_byte(byte), effective_value)
+                        })
+                        .collect();
+                    result.sort_by(|a, b| a.0.cmp(&b.0));
+                    result.dedup_by(|a, b| a.0 == b.0);
+                    result
+                })
         }
 
         proptest! {


### PR DESCRIPTION

- make `sorted_post_state_nodes_strategy` inject ZERO values to model deletions
- keep sort/dedup logic the same while adding deletion coverage

