### PR TITLE
feat(flashblocks): support eth_getBlockTransactionCount for flashblocks

### DIFF
--- a/crates/optimism/rpc/src/eth/block.rs
+++ b/crates/optimism/rpc/src/eth/block.rs
@@ -1,17 +1,54 @@
 //! Loads and formats OP block RPC response.
 
 use crate::{eth::RpcNodeCore, OpEthApi, OpEthApiError};
+use reth_node_api::BlockBody;
 use reth_rpc_eth_api::{
     helpers::{EthBlocks, LoadBlock},
-    FromEvmError, RpcConvert,
+    FromEthApiError, FromEvmError, RpcConvert, RpcNodeCoreExt,
 };
-
+use reth_storage_api::{BlockIdReader, BlockReader};
 impl<N, Rpc> EthBlocks for OpEthApi<N, Rpc>
 where
     N: RpcNodeCore,
     OpEthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError>,
 {
+    fn block_transaction_count(
+        &self,
+        block_id: alloy_eips::BlockId,
+    ) -> impl std::future::Future<Output = Result<Option<usize>, Self::Error>> + Send {
+        async move {
+            if block_id.is_pending() {
+                if let Ok(Some(pending)) = self.pending_flashblock().await {
+                    return Ok(Some(pending.block().body().transaction_count()));
+                }
+
+                if let Some(pending_block) =
+                    self.provider().pending_block().map_err(Self::Error::from_eth_err)?
+                {
+                    return Ok(Some(pending_block.body().transaction_count()));
+                }
+
+                return Ok(None);
+            }
+
+            let block_hash = match self
+                .provider()
+                .block_hash_for_id(block_id)
+                .map_err(Self::Error::from_eth_err)?
+            {
+                Some(block_hash) => block_hash,
+                None => return Ok(None),
+            };
+
+            Ok(self
+                .cache()
+                .get_recovered_block(block_hash)
+                .await
+                .map_err(Self::Error::from_eth_err)?
+                .map(|b| b.body().transaction_count()))
+        }
+    }
 }
 
 impl<N, Rpc> LoadBlock for OpEthApi<N, Rpc>

--- a/crates/optimism/rpc/src/eth/block.rs
+++ b/crates/optimism/rpc/src/eth/block.rs
@@ -1,54 +1,17 @@
 //! Loads and formats OP block RPC response.
 
 use crate::{eth::RpcNodeCore, OpEthApi, OpEthApiError};
-use reth_node_api::BlockBody;
 use reth_rpc_eth_api::{
     helpers::{EthBlocks, LoadBlock},
-    FromEthApiError, FromEvmError, RpcConvert, RpcNodeCoreExt,
+    FromEvmError, RpcConvert,
 };
-use reth_storage_api::{BlockIdReader, BlockReader};
+
 impl<N, Rpc> EthBlocks for OpEthApi<N, Rpc>
 where
     N: RpcNodeCore,
     OpEthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError>,
 {
-    fn block_transaction_count(
-        &self,
-        block_id: alloy_eips::BlockId,
-    ) -> impl std::future::Future<Output = Result<Option<usize>, Self::Error>> + Send {
-        async move {
-            if block_id.is_pending() {
-                if let Ok(Some(pending)) = self.pending_flashblock().await {
-                    return Ok(Some(pending.block().body().transaction_count()));
-                }
-
-                if let Some(pending_block) =
-                    self.provider().pending_block().map_err(Self::Error::from_eth_err)?
-                {
-                    return Ok(Some(pending_block.body().transaction_count()));
-                }
-
-                return Ok(None);
-            }
-
-            let block_hash = match self
-                .provider()
-                .block_hash_for_id(block_id)
-                .map_err(Self::Error::from_eth_err)?
-            {
-                Some(block_hash) => block_hash,
-                None => return Ok(None),
-            };
-
-            Ok(self
-                .cache()
-                .get_recovered_block(block_hash)
-                .await
-                .map_err(Self::Error::from_eth_err)?
-                .map(|b| b.body().transaction_count()))
-        }
-    }
 }
 
 impl<N, Rpc> LoadBlock for OpEthApi<N, Rpc>

--- a/crates/rpc/rpc-eth-api/src/helpers/block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/block.rs
@@ -74,13 +74,9 @@ pub trait EthBlocks: LoadBlock<RpcConvert: RpcConvert<Primitives = Self::Primiti
         block_id: BlockId,
     ) -> impl Future<Output = Result<Option<usize>, Self::Error>> + Send {
         async move {
-            if block_id.is_pending() {
-                // Pending block can be fetched directly without need for caching
-                return Ok(self
-                    .provider()
-                    .pending_block()
-                    .map_err(Self::Error::from_eth_err)?
-                    .map(|block| block.body().transaction_count()));
+            // If no pending block from provider, build the pending block locally.
+            if let Some(pending) = self.local_pending_block().await? {
+                return Ok(Some(pending.block.body().transaction_count()));
             }
 
             let block_hash = match self
@@ -157,7 +153,7 @@ pub trait EthBlocks: LoadBlock<RpcConvert: RpcConvert<Primitives = Self::Primiti
                 return Ok(self
                     .converter()
                     .convert_receipts_with_block(inputs, block.sealed_block())
-                    .map(Some)?)
+                    .map(Some)?);
             }
 
             Ok(None)

--- a/crates/rpc/rpc-eth-api/src/helpers/block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/block.rs
@@ -153,7 +153,7 @@ pub trait EthBlocks: LoadBlock<RpcConvert: RpcConvert<Primitives = Self::Primiti
                 return Ok(self
                     .converter()
                     .convert_receipts_with_block(inputs, block.sealed_block())
-                    .map(Some)?);
+                    .map(Some)?)
             }
 
             Ok(None)


### PR DESCRIPTION
## Summary 

- Enable support for eth_getBlockTransactionCountByNumber and eth_getBlockTransactionCountByHash apis for flashblock
- Note that the old logic on pending tags is maintained for backwards compatibility since we cant assume the concrete implementations of local_pending_block