### PR TITLE
refactor(era): make era count in era file name optional

### DIFF
--- a/crates/era-utils/src/export.rs
+++ b/crates/era-utils/src/export.rs
@@ -150,6 +150,12 @@ where
         let era1_id = Era1Id::new(&config.network, start_block, block_count as u32)
             .with_hash(historical_root);
 
+        let era1_id = if config.max_blocks_per_file == MAX_BLOCKS_PER_ERA1 as u64 {
+            era1_id
+        } else {
+            era1_id.with_era_count()
+        };
+
         debug!("Final file name {}", era1_id.to_file_name());
         let file_path = config.dir.join(era1_id.to_file_name());
         let file = std::fs::File::create(&file_path)?;

--- a/crates/era-utils/tests/it/genesis.rs
+++ b/crates/era-utils/tests/it/genesis.rs
@@ -24,7 +24,7 @@ fn test_export_with_genesis_only() {
     assert!(file_path.exists(), "Exported file should exist on disk");
     let file_name = file_path.file_name().unwrap().to_str().unwrap();
     assert!(
-        file_name.starts_with("mainnet-00000-00001-"),
+        file_name.starts_with("mainnet-00000-"),
         "File should have correct prefix with era format"
     );
     assert!(file_name.ends_with(".era1"), "File should have correct extension");

--- a/crates/era/src/common/file_ops.rs
+++ b/crates/era/src/common/file_ops.rs
@@ -43,6 +43,45 @@ pub trait EraFileId: Clone {
     fn count(&self) -> u32;
 }
 
+/// Generate era file name
+/// 
+/// Standard format: `<config-name>-<era-number>-<short-historical-root>.<ext>`
+/// <https://github.com/eth-clients/e2store-format-specs/blob/main/formats/era.md#file-name>
+///
+/// With era count, for custom exports:
+/// `<config-name>-<era-number>-<era-count>-<short-historical-root>.<ext>`
+pub fn format_era_filename(
+    network_name: &str,
+    era_number: u64,
+    hash: Option<[u8; 4]>,
+    include_era_count: bool,
+    era_count: u64,
+    extension: &str,
+) -> String {
+    let hash_str = format_hash(hash);
+    
+    if include_era_count {
+        format!(
+            "{}-{:05}-{:05}-{}{}",
+            network_name, era_number, era_count, hash_str, extension
+        )
+    } else {
+        format!(
+            "{}-{:05}-{}{}",
+            network_name, era_number, hash_str, extension
+        )
+    }
+}
+
+/// Format hash as hex string, or placeholder if none
+pub fn format_hash(hash: Option<[u8; 4]>) -> String {
+    match hash {
+        Some(h) => format!("{:02x}{:02x}{:02x}{:02x}", h[0], h[1], h[2], h[3]),
+        None => "00000000".to_string(),
+    }
+}
+
+
 /// [`StreamReader`] for reading era-format files
 pub trait StreamReader<R: Read + Seek>: Sized {
     /// The file type the reader produces

--- a/crates/era/src/common/file_ops.rs
+++ b/crates/era/src/common/file_ops.rs
@@ -44,7 +44,7 @@ pub trait EraFileId: Clone {
 }
 
 /// Generate era file name
-/// 
+///
 /// Standard format: `<config-name>-<era-number>-<short-historical-root>.<ext>`
 /// <https://github.com/eth-clients/e2store-format-specs/blob/main/formats/era.md#file-name>
 ///
@@ -59,17 +59,11 @@ pub fn format_era_filename(
     extension: &str,
 ) -> String {
     let hash_str = format_hash(hash);
-    
+
     if include_era_count {
-        format!(
-            "{}-{:05}-{:05}-{}{}",
-            network_name, era_number, era_count, hash_str, extension
-        )
+        format!("{}-{:05}-{:05}-{}{}", network_name, era_number, era_count, hash_str, extension)
     } else {
-        format!(
-            "{}-{:05}-{}{}",
-            network_name, era_number, hash_str, extension
-        )
+        format!("{}-{:05}-{}{}", network_name, era_number, hash_str, extension)
     }
 }
 
@@ -80,7 +74,6 @@ pub fn format_hash(hash: Option<[u8; 4]>) -> String {
         None => "00000000".to_string(),
     }
 }
-
 
 /// [`StreamReader`] for reading era-format files
 pub trait StreamReader<R: Read + Seek>: Sized {

--- a/crates/era/src/era/types/group.rs
+++ b/crates/era/src/era/types/group.rs
@@ -3,7 +3,7 @@
 //! See also <https://github.com/eth-clients/e2store-format-specs/blob/main/formats/era.md>
 
 use crate::{
-    common::file_ops::{EraFileId, format_era_filename},
+    common::file_ops::{format_era_filename, EraFileId},
     e2s::types::{Entry, IndexEntry, SLOT_INDEX},
     era::types::consensus::{CompressedBeaconState, CompressedSignedBeaconBlock},
 };
@@ -172,7 +172,13 @@ pub struct EraId {
 impl EraId {
     /// Create a new [`EraId`]
     pub fn new(network_name: impl Into<String>, start_slot: u64, slot_count: u32) -> Self {
-        Self { network_name: network_name.into(), start_slot, slot_count, hash: None, include_era_count: false }
+        Self {
+            network_name: network_name.into(),
+            start_slot,
+            slot_count,
+            hash: None,
+            include_era_count: false,
+        }
     }
 
     /// Add a hash identifier to  [`EraId`]
@@ -180,13 +186,12 @@ impl EraId {
         self.hash = Some(hash);
         self
     }
-    
+
     /// Include era count in filename, for custom slot-per-file exports
     pub const fn with_era_count(mut self) -> Self {
         self.include_era_count = true;
         self
     }
-
 
     /// Calculate which era number the file starts at
     pub const fn era_number(&self) -> u64 {
@@ -198,7 +203,7 @@ impl EraId {
     // If the user can decide how many slots per era file there are, we need to calculate it.
     // Most of the time it should be 1, but it can never be more than 2 eras per file
     // as there is a maximum of 8192 slots per era file.
-     const fn era_count(&self) -> u64 {
+    const fn era_count(&self) -> u64 {
         if self.slot_count == 0 {
             return 0;
         }
@@ -225,7 +230,7 @@ impl EraFileId for EraId {
     /// `<config-name>-<era-number>-<era-count>-<short-historical-root>.era`
     /// <https://github.com/eth-clients/e2store-format-specs/blob/main/formats/era.md#file-name>
     /// See also <https://github.com/eth-clients/e2store-format-specs/blob/main/formats/era.md>
-     fn to_file_name(&self) -> String {
+    fn to_file_name(&self) -> String {
         format_era_filename(
             &self.network_name,
             self.era_number(),

--- a/crates/era/src/era/types/group.rs
+++ b/crates/era/src/era/types/group.rs
@@ -3,7 +3,7 @@
 //! See also <https://github.com/eth-clients/e2store-format-specs/blob/main/formats/era.md>
 
 use crate::{
-    common::file_ops::EraFileId,
+    common::file_ops::{EraFileId, format_era_filename},
     e2s::types::{Entry, IndexEntry, SLOT_INDEX},
     era::types::consensus::{CompressedBeaconState, CompressedSignedBeaconBlock},
 };
@@ -163,12 +163,16 @@ pub struct EraId {
     /// Optional hash identifier for this file
     /// First 4 bytes of the last historical root in the last state in the era file
     pub hash: Option<[u8; 4]>,
+
+    /// Whether to include era count in filename
+    /// It is used for custom exports when we don't use the max number of items per file
+    include_era_count: bool,
 }
 
 impl EraId {
     /// Create a new [`EraId`]
     pub fn new(network_name: impl Into<String>, start_slot: u64, slot_count: u32) -> Self {
-        Self { network_name: network_name.into(), start_slot, slot_count, hash: None }
+        Self { network_name: network_name.into(), start_slot, slot_count, hash: None, include_era_count: false }
     }
 
     /// Add a hash identifier to  [`EraId`]
@@ -176,28 +180,31 @@ impl EraId {
         self.hash = Some(hash);
         self
     }
+    
+    /// Include era count in filename, for custom slot-per-file exports
+    pub const fn with_era_count(mut self) -> Self {
+        self.include_era_count = true;
+        self
+    }
+
 
     /// Calculate which era number the file starts at
     pub const fn era_number(&self) -> u64 {
         self.start_slot / SLOTS_PER_HISTORICAL_ROOT
     }
 
-    // Helper function to calculate the number of eras per era1 file,
-    // If the user can decide how many blocks per era1 file there are, we need to calculate it.
+    // Helper function to calculate the number of eras spanned by the file.
+    //
+    // If the user can decide how many slots per era file there are, we need to calculate it.
     // Most of the time it should be 1, but it can never be more than 2 eras per file
-    // as there is a maximum of 8192 blocks per era1 file.
-    const fn calculate_era_count(&self) -> u64 {
+    // as there is a maximum of 8192 slots per era file.
+     const fn era_count(&self) -> u64 {
         if self.slot_count == 0 {
             return 0;
         }
-
         let first_era = self.era_number();
-
-        // Calculate the actual last slot number in the range
         let last_slot = self.start_slot + self.slot_count as u64 - 1;
-        // Find which era the last block belongs to
         let last_era = last_slot / SLOTS_PER_HISTORICAL_ROOT;
-        // Count how many eras we span
         last_era - first_era + 1
     }
 }
@@ -218,20 +225,15 @@ impl EraFileId for EraId {
     /// `<config-name>-<era-number>-<era-count>-<short-historical-root>.era`
     /// <https://github.com/eth-clients/e2store-format-specs/blob/main/formats/era.md#file-name>
     /// See also <https://github.com/eth-clients/e2store-format-specs/blob/main/formats/era.md>
-    fn to_file_name(&self) -> String {
-        let era_number = self.era_number();
-        let era_count = self.calculate_era_count();
-
-        if let Some(hash) = self.hash {
-            format!(
-                "{}-{:05}-{:05}-{:02x}{:02x}{:02x}{:02x}.era",
-                self.network_name, era_number, era_count, hash[0], hash[1], hash[2], hash[3]
-            )
-        } else {
-            // era spec format with placeholder hash when no hash available
-            // Format: `<config-name>-<era-number>-<era-count>-00000000.era`
-            format!("{}-{:05}-{:05}-00000000.era", self.network_name, era_number, era_count)
-        }
+     fn to_file_name(&self) -> String {
+        format_era_filename(
+            &self.network_name,
+            self.era_number(),
+            self.hash,
+            self.include_era_count,
+            self.era_count(),
+            ".era",
+        )
     }
 }
 
@@ -398,5 +400,41 @@ mod tests {
         let index = SlotIndex::from_entry(&entry).unwrap();
         let parsed_offset = index.offsets[0];
         assert_eq!(parsed_offset, -1024);
+    }
+
+    #[test_case::test_case(
+        EraId::new("mainnet", 0, 8192).with_hash([0x4b, 0x36, 0x3d, 0xb9]),
+        "mainnet-00000-4b363db9.era";
+        "Mainnet era 0"
+    )]
+    #[test_case::test_case(
+        EraId::new("mainnet", 8192, 8192).with_hash([0x40, 0xcf, 0x2f, 0x3c]),
+        "mainnet-00001-40cf2f3c.era";
+        "Mainnet era 1"
+    )]
+    #[test_case::test_case(
+        EraId::new("mainnet", 0, 8192),
+        "mainnet-00000-00000000.era";
+        "Without hash"
+    )]
+    fn test_era_id_file_naming(id: EraId, expected_file_name: &str) {
+        let actual_file_name = id.to_file_name();
+        assert_eq!(actual_file_name, expected_file_name);
+    }
+
+    // File naming with era-count, for custom exports
+    #[test_case::test_case(
+        EraId::new("mainnet", 0, 8192).with_hash([0x4b, 0x36, 0x3d, 0xb9]).with_era_count(),
+        "mainnet-00000-00001-4b363db9.era";
+        "Mainnet era 0 with count"
+    )]
+    #[test_case::test_case(
+        EraId::new("mainnet", 8000, 500).with_hash([0xab, 0xcd, 0xef, 0x12]).with_era_count(),
+        "mainnet-00000-00002-abcdef12.era";
+        "Spanning two eras with count"
+    )]
+    fn test_era_id_file_naming_with_era_count(id: EraId, expected_file_name: &str) {
+        let actual_file_name = id.to_file_name();
+        assert_eq!(actual_file_name, expected_file_name);
     }
 }

--- a/crates/era/src/era1/types/group.rs
+++ b/crates/era/src/era1/types/group.rs
@@ -3,7 +3,7 @@
 //! See also <https://github.com/eth-clients/e2store-format-specs/blob/main/formats/era1.md>
 
 use crate::{
-    common::file_ops::{format_era_filename, EraFileId},
+    common::file_ops::{EraFileId, EraFileType},
     e2s::types::{Entry, IndexEntry},
     era1::types::execution::{Accumulator, BlockTuple, MAX_BLOCKS_PER_ERA1},
 };
@@ -138,33 +138,12 @@ impl Era1Id {
         self.include_era_count = true;
         self
     }
-
-    /// Calculate which era number the file starts at
-    pub const fn era_number(&self) -> u64 {
-        self.start_block / MAX_BLOCKS_PER_ERA1 as u64
-    }
-
-    // Helper function to calculate the number of eras spanned by the file.
-    //
-    // If the user can decide how many blocks per era1 file there are, we need to calculate it.
-    // Most of the time it should be 1, but it can never be more than 2 eras per file
-    // as there is a maximum of 8192 blocks per era1 file.
-    const fn era_count(&self) -> u64 {
-        if self.block_count == 0 {
-            return 0;
-        }
-        let first_era = self.era_number();
-
-        // Calculate the actual last block number in the range
-        let last_block = self.start_block + self.block_count as u64 - 1;
-        // Find which era the last block belongs to
-        let last_era = last_block / MAX_BLOCKS_PER_ERA1 as u64;
-        // Count how many eras we span
-        last_era - first_era + 1
-    }
 }
 
 impl EraFileId for Era1Id {
+    const FILE_TYPE: EraFileType = EraFileType::Era1;
+
+    const ITEMS_PER_ERA: u64 = MAX_BLOCKS_PER_ERA1 as u64;
     fn network_name(&self) -> &str {
         &self.network_name
     }
@@ -177,15 +156,12 @@ impl EraFileId for Era1Id {
         self.block_count
     }
 
-    fn to_file_name(&self) -> String {
-        format_era_filename(
-            &self.network_name,
-            self.era_number(),
-            self.hash,
-            self.include_era_count,
-            self.era_count(),
-            ".era1",
-        )
+    fn hash(&self) -> Option<[u8; 4]> {
+        self.hash
+    }
+
+    fn include_era_count(&self) -> bool {
+        self.include_era_count
     }
 }
 

--- a/crates/era/src/era1/types/group.rs
+++ b/crates/era/src/era1/types/group.rs
@@ -180,7 +180,7 @@ impl EraFileId for Era1Id {
     /// Convert to file name following the era file naming:
     ///
     /// Standard format: `<config-name>-<era-number>-<short-historical-root>.era1`
-    /// <https://github.com/eth-clients/e2store-format-specs/blob/main/formats/era1.md>
+    /// <https://github.com/eth-clients/e2store-format-specs/blob/main/formats/era.md#file-name>
     ///
     /// With era count, for custom exports:
     /// `<config-name>-<era-number>-<era-count>-<short-historical-root>.era1`

--- a/crates/era/src/era1/types/group.rs
+++ b/crates/era/src/era1/types/group.rs
@@ -105,6 +105,10 @@ pub struct Era1Id {
     /// Optional hash identifier for this file
     /// First 4 bytes of the last historical root in the last state in the era file
     pub hash: Option<[u8; 4]>,
+
+    /// Whether to include era count in filename
+    /// It is used for custom exports when we don't use the max number of items per file
+    pub include_era_count: bool,
 }
 
 impl Era1Id {
@@ -114,7 +118,13 @@ impl Era1Id {
         start_block: BlockNumber,
         block_count: u32,
     ) -> Self {
-        Self { network_name: network_name.into(), start_block, block_count, hash: None }
+        Self {
+            network_name: network_name.into(),
+            start_block,
+            block_count,
+            hash: None,
+            include_era_count: false,
+        }
     }
 
     /// Add a hash identifier to  [`Era1Id`]
@@ -123,11 +133,28 @@ impl Era1Id {
         self
     }
 
-    // Helper function to calculate the number of eras per era1 file,
+    /// Include era count in filename, for custom block-per-file exports
+    pub const fn with_era_count(mut self) -> Self {
+        self.include_era_count = true;
+        self
+    }
+
+    /// Calculate which era number the file starts at
+    pub const fn era_number(&self) -> u64 {
+        self.start_block / MAX_BLOCKS_PER_ERA1 as u64
+    }
+
+    // Helper function to calculate the number of eras spanned by the file.
+    //
     // If the user can decide how many blocks per era1 file there are, we need to calculate it.
     // Most of the time it should be 1, but it can never be more than 2 eras per file
     // as there is a maximum of 8192 blocks per era1 file.
-    const fn calculate_era_count(&self, first_era: u64) -> u64 {
+    const fn era_count(&self) -> u64 {
+        if self.block_count == 0 {
+            return 0;
+        }
+        let first_era = self.era_number();
+
         // Calculate the actual last block number in the range
         let last_block = self.start_block + self.block_count as u64 - 1;
         // Find which era the last block belongs to
@@ -149,23 +176,26 @@ impl EraFileId for Era1Id {
     fn count(&self) -> u32 {
         self.block_count
     }
+
     /// Convert to file name following the era file naming:
-    /// `<config-name>-<era-number>-<era-count>-<short-historical-root>.era(1)`
-    /// <https://github.com/eth-clients/e2store-format-specs/blob/main/formats/era.md#file-name>
-    /// See also <https://github.com/eth-clients/e2store-format-specs/blob/main/formats/era1.md>
+    ///
+    /// Standard format: `<config-name>-<era-number>-<short-historical-root>.era1`
+    /// <https://github.com/eth-clients/e2store-format-specs/blob/main/formats/era1.md>
+    ///
+    /// With era count, for custom exports:
+    /// `<config-name>-<era-number>-<era-count>-<short-historical-root>.era1`
     fn to_file_name(&self) -> String {
         // Find which era the first block belongs to
-        let era_number = self.start_block / MAX_BLOCKS_PER_ERA1 as u64;
-        let era_count = self.calculate_era_count(era_number);
-        if let Some(hash) = self.hash {
-            format!(
-                "{}-{:05}-{:05}-{:02x}{:02x}{:02x}{:02x}.era1",
-                self.network_name, era_number, era_count, hash[0], hash[1], hash[2], hash[3]
-            )
+        let era_number = self.era_number();
+        let hash = match self.hash {
+            Some(h) => format!("{:02x}{:02x}{:02x}{:02x}", h[0], h[1], h[2], h[3]),
+            None => "00000000".to_string(),
+        };
+        if self.include_era_count {
+            let era_count = self.era_count();
+            format!("{}-{:05}-{:05}-{}.era1", self.network_name, era_number, era_count, hash)
         } else {
-            // era spec format with placeholder hash when no hash available
-            // Format: `<config-name>-<era-number>-<era-count>-00000000.era1`
-            format!("{}-{:05}-{:05}-00000000.era1", self.network_name, era_number, era_count)
+            format!("{}-{:05}-{}.era1", self.network_name, era_number, hash)
         }
     }
 }
@@ -314,35 +344,51 @@ mod tests {
 
     #[test_case::test_case(
         Era1Id::new("mainnet", 0, 8192).with_hash([0x5e, 0xc1, 0xff, 0xb8]),
-        "mainnet-00000-00001-5ec1ffb8.era1";
+        "mainnet-00000-5ec1ffb8.era1";
         "Mainnet era 0"
     )]
     #[test_case::test_case(
         Era1Id::new("mainnet", 8192, 8192).with_hash([0x5e, 0xcb, 0x9b, 0xf9]),
-        "mainnet-00001-00001-5ecb9bf9.era1";
+        "mainnet-00001-5ecb9bf9.era1";
         "Mainnet era 1"
     )]
     #[test_case::test_case(
         Era1Id::new("sepolia", 0, 8192).with_hash([0x90, 0x91, 0x84, 0x72]),
-        "sepolia-00000-00001-90918472.era1";
+        "sepolia-00000-90918472.era1";
         "Sepolia era 0"
     )]
     #[test_case::test_case(
         Era1Id::new("sepolia", 155648, 8192).with_hash([0xfa, 0x77, 0x00, 0x19]),
-        "sepolia-00019-00001-fa770019.era1";
+        "sepolia-00019-fa770019.era1";
         "Sepolia era 19"
     )]
     #[test_case::test_case(
         Era1Id::new("mainnet", 1000, 100),
-        "mainnet-00000-00001-00000000.era1";
+        "mainnet-00000-00000000.era1";
         "ID without hash"
     )]
     #[test_case::test_case(
         Era1Id::new("sepolia", 101130240, 8192).with_hash([0xab, 0xcd, 0xef, 0x12]),
-        "sepolia-12345-00001-abcdef12.era1";
+        "sepolia-12345-abcdef12.era1";
         "Large block number era 12345"
     )]
     fn test_era1id_file_naming(id: Era1Id, expected_file_name: &str) {
+        let actual_file_name = id.to_file_name();
+        assert_eq!(actual_file_name, expected_file_name);
+    }
+
+    // File naming with era-count, for custom exports
+    #[test_case::test_case(
+        Era1Id::new("mainnet", 0, 8192).with_hash([0x5e, 0xc1, 0xff, 0xb8]).with_era_count(),
+        "mainnet-00000-00001-5ec1ffb8.era1";
+        "Mainnet era 0 with count"
+    )]
+    #[test_case::test_case(
+        Era1Id::new("mainnet", 8000, 500).with_hash([0xab, 0xcd, 0xef, 0x12]).with_era_count(),
+        "mainnet-00000-00002-abcdef12.era1";
+        "Spanning two eras with count"
+    )]
+    fn test_era1id_file_naming_with_era_count(id: Era1Id, expected_file_name: &str) {
         let actual_file_name = id.to_file_name();
         assert_eq!(actual_file_name, expected_file_name);
     }

--- a/crates/era/src/era1/types/group.rs
+++ b/crates/era/src/era1/types/group.rs
@@ -187,7 +187,6 @@ impl EraFileId for Era1Id {
             ".era1",
         )
     }
-
 }
 
 #[cfg(test)]


### PR DESCRIPTION
To follow better this change, https://github.com/eth-clients/e2store-format-specs/pull/14 and the name in general

We only want the era count in the file if we export less than the max blocks/slots per file, so it's better to make it optional.

A part of the code was also refactored to deduplicate some era id logic.