### PR TITLE
docs(exex): fix DebugApi comment

### DIFF
--- a/examples/exex-hello-world/src/main.rs
+++ b/examples/exex-hello-world/src/main.rs
@@ -81,7 +81,7 @@ where
     let _eth_pubsub = rpc_handle.eth_handlers().pubsub.clone();
     // The TraceApi type that provides all the trace_ handlers
     let _trace_api = rpc_handle.trace_api();
-    // The DebugApi type that provides all the trace_ handlers
+    // The DebugApi type that provides all the debug_ handlers
     let _debug_api = rpc_handle.debug_api();
 
     while let Some(notification) = ctx.notifications.try_next().await? {


### PR DESCRIPTION
Corrected the comment for DebugApi initialization in the exex-hello-world example. The comment incorrectly stated that DebugApi provides `trace_` handlers, when it actually provides `debug_` handlers.