### PR TITLE
fix(chain-state): correct balance deduction in test block builder

### DIFF
--- a/crates/chain-state/src/test_utils.rs
+++ b/crates/chain-state/src/test_utils.rs
@@ -117,7 +117,7 @@ impl<N: NodePrimitives> TestBlockBuilder<N> {
             .map(|_| {
                 let tx = mock_tx(self.signer_build_account_info.nonce);
                 self.signer_build_account_info.nonce += 1;
-                self.signer_build_account_info.balance -= signer_balance_decrease;
+                self.signer_build_account_info.balance -= Self::single_tx_cost();
                 tx
             })
             .collect();


### PR DESCRIPTION
Fixed a bug in generate_random_block where balance was being deducted incorrectly. The total cost of all transactions was being subtracted for each transaction in the loop, so with 3 transactions the balance would drop by 9x instead of 3x.

Changed it to subtract single_tx_cost() per iteration, which matches how get_execution_outcome does it.