### PR TITLE
feat(engine): Add BAL stub methods to ExecutionPayload and BlockOrPayload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7414,7 +7414,6 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 name = "reth"
 version = "1.9.3"
 dependencies = [
- "alloy-eip7928",
  "alloy-rpc-types",
  "aquamarine",
  "backon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,6 +239,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-eip7928"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "926b2c0d34e641cf8b17bf54ce50fda16715b9f68ad878fa6128bae410c6f890"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "serde",
+]
+
+[[package]]
 name = "alloy-eips"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7402,6 +7414,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 name = "reth"
 version = "1.9.3"
 dependencies = [
+ "alloy-eip7928",
  "alloy-rpc-types",
  "aquamarine",
  "backon",
@@ -8208,6 +8221,7 @@ name = "reth-engine-tree"
 version = "1.9.3"
 dependencies = [
  "alloy-consensus",
+ "alloy-eip7928",
  "alloy-eips",
  "alloy-evm",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -487,6 +487,7 @@ revm-inspectors = "0.33.1"
 alloy-chains = { version = "0.2.5", default-features = false }
 alloy-dyn-abi = "1.4.1"
 alloy-eip2124 = { version = "0.2.0", default-features = false }
+alloy-eip7928 = { version = "0.1.0" }
 alloy-evm = { version = "0.25.0", default-features = false }
 alloy-primitives = { version = "1.4.1", default-features = false, features = ["map-foldhash"] }
 alloy-rlp = { version = "0.3.10", default-features = false, features = ["core-net"] }

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -75,6 +75,7 @@ tokio = { workspace = true, features = ["sync", "macros", "time", "rt-multi-thre
 aquamarine.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 eyre.workspace = true
+alloy-eip7928.workspace = true
 
 [dev-dependencies]
 backon.workspace = true

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -75,7 +75,6 @@ tokio = { workspace = true, features = ["sync", "macros", "time", "rt-multi-thre
 aquamarine.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 eyre.workspace = true
-alloy-eip7928.workspace = true
 
 [dev-dependencies]
 backon.workspace = true

--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -39,6 +39,7 @@ reth-trie.workspace = true
 alloy-evm.workspace = true
 alloy-consensus.workspace = true
 alloy-eips.workspace = true
+alloy-eip7928.workspace = true
 alloy-primitives.workspace = true
 alloy-rlp.workspace = true
 alloy-rpc-types-engine.workspace = true

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -11,6 +11,7 @@ use crate::tree::{
     StateProviderDatabase, TreeConfig,
 };
 use alloy_consensus::transaction::Either;
+use alloy_eip7928::BlockAccessList;
 use alloy_eips::{eip1898::BlockWithParent, NumHash};
 use alloy_evm::Evm;
 use alloy_primitives::B256;
@@ -1242,5 +1243,11 @@ impl<T: PayloadTypes> BlockOrPayload<T> {
             Self::Payload(_) => "payload",
             Self::Block(_) => "block",
         }
+    }
+
+    /// Returns the block access list if available.
+    pub const fn block_access_list(&self) -> Option<Result<BlockAccessList, alloy_rlp::Error>> {
+        // TODO decode and return `BlockAccessList`
+        None
     }
 }

--- a/crates/payload/primitives/src/payload.rs
+++ b/crates/payload/primitives/src/payload.rs
@@ -3,7 +3,7 @@
 use crate::{MessageValidationKind, PayloadAttributes};
 use alloc::vec::Vec;
 use alloy_eips::{eip1898::BlockWithParent, eip4895::Withdrawal, eip7685::Requests, BlockNumHash};
-use alloy_primitives::B256;
+use alloy_primitives::{Bytes, B256};
 use alloy_rpc_types_engine::ExecutionData;
 use core::fmt::Debug;
 use serde::{de::DeserializeOwned, Serialize};
@@ -40,6 +40,11 @@ pub trait ExecutionPayload:
     /// Returns `None` for pre-Shanghai blocks.
     fn withdrawals(&self) -> Option<&Vec<Withdrawal>>;
 
+    /// Returns the access list included in this payload.
+    ///
+    /// Returns `None` for pre-Amsterdam blocks.
+    fn block_access_list(&self) -> Option<&Bytes>;
+
     /// Returns the beacon block root associated with this payload.
     ///
     /// Returns `None` for pre-merge payloads.
@@ -67,6 +72,10 @@ impl ExecutionPayload for ExecutionData {
 
     fn withdrawals(&self) -> Option<&Vec<Withdrawal>> {
         self.payload.withdrawals()
+    }
+
+    fn block_access_list(&self) -> Option<&Bytes> {
+        None
     }
 
     fn parent_beacon_block_root(&self) -> Option<B256> {
@@ -170,6 +179,10 @@ impl ExecutionPayload for op_alloy_rpc_types_engine::OpExecutionData {
 
     fn withdrawals(&self) -> Option<&Vec<Withdrawal>> {
         self.payload.as_v2().map(|p| &p.withdrawals)
+    }
+
+    fn block_access_list(&self) -> Option<&Bytes> {
+        None
     }
 
     fn parent_beacon_block_root(&self) -> Option<B256> {

--- a/examples/custom-node/src/engine.rs
+++ b/examples/custom-node/src/engine.rs
@@ -5,6 +5,7 @@ use crate::{
     CustomNode,
 };
 use alloy_eips::eip2718::WithEncoded;
+use alloy_primitives::Bytes;
 use op_alloy_rpc_types_engine::{OpExecutionData, OpExecutionPayload};
 use reth_engine_primitives::EngineApiValidator;
 use reth_ethereum::{
@@ -51,6 +52,10 @@ impl ExecutionPayload for CustomExecutionData {
     }
 
     fn withdrawals(&self) -> Option<&Vec<alloy_eips::eip4895::Withdrawal>> {
+        None
+    }
+
+    fn block_access_list(&self) -> Option<&Bytes> {
         None
     }
 


### PR DESCRIPTION
This PR adds the alloy-eip7928 crate dependency and uses it to add stub methods for retrieving the BAL from ExecutionPayload's and BlockOrPayload's. This gives us enough to work with to start integrating BAL into payload validator while other required changes are being worked on.

Closes #20270