### PR TITLE
refactor(rpc): remove unnecessary Debug bound

### DIFF
--- a/crates/rpc/rpc-eth-types/src/cache/multi_consumer.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/multi_consumer.rs
@@ -43,7 +43,7 @@ where
 
 impl<K, V, L, S> MultiConsumerLruCache<K, V, L, S>
 where
-    K: Hash + Eq + Debug,
+    K: Hash + Eq,
     L: Limiter<K, V>,
 {
     /// Adds the sender to the queue for the given key.


### PR DESCRIPTION
The generic impl for MultiConsumerLruCache required K: Debug even though none of the methods or the Debug impl format the key. This bound provided no functional value but restricted the cache from being used with non-Debug keys. Dropping the Debug constraint loosens the API without affecting existing usages (which already use B256 as the key) and keeps the implementation consistent with the struct and Debug impl bounds (K: Hash + Eq).