### PR TITLE
feat: bump alloy-evm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,8 +267,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70cd39002a40b8d528f4a3f8ecc7e59dc2204d9bfae249296d7d379f291f9cba"
+source = "git+https://github.com/alloy-rs/evm?rev=a7da37d#a7da37da0fa49204580611bfba6ed93c29a89e54"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -384,8 +383,7 @@ dependencies = [
 [[package]]
 name = "alloy-op-evm"
 version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bec5d35135e72ab8096f9b7713840725dc0cd0f9e20ed283156808874da76f4"
+source = "git+https://github.com/alloy-rs/evm?rev=a7da37d#a7da37da0fa49204580611bfba6ed93c29a89e54"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,8 +266,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.25.0"
-source = "git+https://github.com/alloy-rs/evm?rev=a7da37d#a7da37da0fa49204580611bfba6ed93c29a89e54"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e7b4fb2418490bca9978e74208215ed5fcb21a10aba7eea487abaa60fd588db"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -382,8 +383,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-op-evm"
-version = "0.25.0"
-source = "git+https://github.com/alloy-rs/evm?rev=a7da37d#a7da37da0fa49204580611bfba6ed93c29a89e54"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56afbe3c3b66435c7c3846fe639a60e4cdbc31b9263596eb2f382408b1b160c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -487,7 +487,7 @@ revm-inspectors = "0.33.1"
 alloy-chains = { version = "0.2.5", default-features = false }
 alloy-dyn-abi = "1.4.1"
 alloy-eip2124 = { version = "0.2.0", default-features = false }
-alloy-evm = { version = "0.25.0", default-features = false }
+alloy-evm = { version = "0.25.1", default-features = false }
 alloy-primitives = { version = "1.4.1", default-features = false, features = ["map-foldhash"] }
 alloy-rlp = { version = "0.3.10", default-features = false, features = ["core-net"] }
 alloy-sol-macro = "1.4.1"
@@ -739,10 +739,7 @@ vergen-git2 = "1.0.5"
 # networking
 ipnet = "2.11"
 
-[patch.crates-io]
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "a7da37d" }
-alloy-op-evm = { git = "https://github.com/alloy-rs/evm", rev = "a7da37d" }
-
+# [patch.crates-io]
 # alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
 # alloy-contract = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
 # alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -739,7 +739,10 @@ vergen-git2 = "1.0.5"
 # networking
 ipnet = "2.11"
 
-# [patch.crates-io]
+[patch.crates-io]
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "a7da37d" }
+alloy-op-evm = { git = "https://github.com/alloy-rs/evm", rev = "a7da37d" }
+
 # alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
 # alloy-contract = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
 # alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }

--- a/crates/ethereum/evm/src/build.rs
+++ b/crates/ethereum/evm/src/build.rs
@@ -5,7 +5,6 @@ use alloy_consensus::{
 };
 use alloy_eips::merge::BEACON_NONCE;
 use alloy_evm::{block::BlockExecutorFactory, eth::EthBlockExecutionCtx};
-use alloy_primitives::Bytes;
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_evm::execute::{BlockAssembler, BlockAssemblerInput, BlockExecutionError};
 use reth_execution_types::BlockExecutionResult;
@@ -17,14 +16,12 @@ use revm::context::Block as _;
 pub struct EthBlockAssembler<ChainSpec = reth_chainspec::ChainSpec> {
     /// The chainspec.
     pub chain_spec: Arc<ChainSpec>,
-    /// Extra data to use for the blocks.
-    pub extra_data: Bytes,
 }
 
 impl<ChainSpec> EthBlockAssembler<ChainSpec> {
     /// Creates a new [`EthBlockAssembler`].
-    pub fn new(chain_spec: Arc<ChainSpec>) -> Self {
-        Self { chain_spec, extra_data: Default::default() }
+    pub const fn new(chain_spec: Arc<ChainSpec>) -> Self {
+        Self { chain_spec }
     }
 }
 
@@ -110,7 +107,7 @@ where
             gas_limit: evm_env.block_env.gas_limit(),
             difficulty: evm_env.block_env.difficulty(),
             gas_used: *gas_used,
-            extra_data: self.extra_data.clone(),
+            extra_data: ctx.extra_data,
             parent_beacon_block_root: ctx.parent_beacon_block_root,
             blob_gas_used: block_blob_gas_used,
             excess_blob_gas,

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -116,12 +116,6 @@ impl<ChainSpec, EvmFactory> EthEvmConfig<ChainSpec, EvmFactory> {
     pub const fn chain_spec(&self) -> &Arc<ChainSpec> {
         self.executor_factory.spec()
     }
-
-    /// Sets the extra data for the block assembler.
-    pub fn with_extra_data(mut self, extra_data: Bytes) -> Self {
-        self.block_assembler.extra_data = extra_data;
-        self
-    }
 }
 
 impl<ChainSpec, EvmF> ConfigureEvm for EthEvmConfig<ChainSpec, EvmF>
@@ -193,6 +187,7 @@ where
             parent_beacon_block_root: block.header().parent_beacon_block_root,
             ommers: &block.body().ommers,
             withdrawals: block.body().withdrawals.as_ref().map(Cow::Borrowed),
+            extra_data: block.header().extra_data.clone(),
         })
     }
 
@@ -206,6 +201,7 @@ where
             parent_beacon_block_root: attributes.parent_beacon_block_root,
             ommers: &[],
             withdrawals: attributes.withdrawals.map(Cow::Owned),
+            extra_data: attributes.extra_data,
         })
     }
 }
@@ -282,6 +278,7 @@ where
             parent_beacon_block_root: payload.sidecar.parent_beacon_block_root(),
             ommers: &[],
             withdrawals: payload.payload.withdrawals().map(|w| Cow::Owned(w.clone().into())),
+            extra_data: payload.payload.as_v1().extra_data.clone(),
         })
     }
 

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -32,7 +32,7 @@ use reth_node_builder::{
         EngineValidatorBuilder, EthApiBuilder, EthApiCtx, Identity, PayloadValidatorBuilder,
         RethRpcAddOns, RpcAddOns, RpcHandle,
     },
-    BuilderContext, DebugNode, Node, NodeAdapter, PayloadBuilderConfig,
+    BuilderContext, DebugNode, Node, NodeAdapter,
 };
 use reth_payload_primitives::PayloadTypes;
 use reth_provider::{providers::ProviderFactoryBuilder, EthStorage};
@@ -437,9 +437,7 @@ where
     type EVM = EthEvmConfig<Types::ChainSpec>;
 
     async fn build_evm(self, ctx: &BuilderContext<Node>) -> eyre::Result<Self::EVM> {
-        let evm_config = EthEvmConfig::new(ctx.chain_spec())
-            .with_extra_data(ctx.payload_builder_config().extra_data_bytes());
-        Ok(evm_config)
+        Ok(EthEvmConfig::new(ctx.chain_spec()))
     }
 }
 

--- a/crates/ethereum/node/src/payload.rs
+++ b/crates/ethereum/node/src/payload.rs
@@ -54,7 +54,8 @@ where
             evm_config,
             EthereumBuilderConfig::new()
                 .with_gas_limit(gas_limit)
-                .with_max_blobs_per_block(conf.max_blobs_per_block()),
+                .with_max_blobs_per_block(conf.max_blobs_per_block())
+                .with_extra_data(conf.extra_data_bytes()),
         ))
     }
 }

--- a/crates/ethereum/payload/src/config.rs
+++ b/crates/ethereum/payload/src/config.rs
@@ -1,4 +1,5 @@
 use alloy_eips::eip1559::ETHEREUM_BLOCK_GAS_LIMIT_30M;
+use alloy_primitives::Bytes;
 use reth_primitives_traits::constants::GAS_LIMIT_BOUND_DIVISOR;
 
 /// Settings for the Ethereum builder.
@@ -13,6 +14,8 @@ pub struct EthereumBuilderConfig {
     ///
     /// If `None`, defaults to the protocol maximum.
     pub max_blobs_per_block: Option<u64>,
+    /// Extra data for built blocks.
+    pub extra_data: Bytes,
 }
 
 impl Default for EthereumBuilderConfig {
@@ -28,6 +31,7 @@ impl EthereumBuilderConfig {
             desired_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
             await_payload_on_missing: true,
             max_blobs_per_block: None,
+            extra_data: Bytes::new(),
         }
     }
 
@@ -47,6 +51,12 @@ impl EthereumBuilderConfig {
     /// Set the maximum number of blobs per block (EIP-7872).
     pub const fn with_max_blobs_per_block(mut self, max_blobs_per_block: Option<u64>) -> Self {
         self.max_blobs_per_block = max_blobs_per_block;
+        self
+    }
+
+    /// Set the extra data for built blocks.
+    pub fn with_extra_data(mut self, extra_data: Bytes) -> Self {
+        self.extra_data = extra_data;
         self
     }
 }

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -168,7 +168,7 @@ where
                 gas_limit: builder_config.gas_limit(parent_header.gas_limit),
                 parent_beacon_block_root: attributes.parent_beacon_block_root(),
                 withdrawals: Some(attributes.withdrawals().clone()),
-                extra_data: None,
+                extra_data: builder_config.extra_data,
             },
         )
         .map_err(PayloadBuilderError::other)?;

--- a/crates/evm/evm/src/lib.rs
+++ b/crates/evm/evm/src/lib.rs
@@ -502,7 +502,7 @@ pub struct NextBlockEnvAttributes {
     /// Withdrawals
     pub withdrawals: Option<Withdrawals>,
     /// Optional extra data.
-    pub extra_data: Option<Bytes>,
+    pub extra_data: Bytes,
 }
 
 /// Abstraction over transaction environment.

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -420,7 +420,7 @@ impl<H: BlockHeader> BuildPendingEnv<H> for NextBlockEnvAttributes {
             gas_limit: parent.gas_limit(),
             parent_beacon_block_root: parent.parent_beacon_block_root(),
             withdrawals: parent.withdrawals_root().map(|_| Default::default()),
-            extra_data: None,
+            extra_data: parent.extra_data().clone(),
         }
     }
 }

--- a/crates/rpc/rpc/src/testing.rs
+++ b/crates/rpc/rpc/src/testing.rs
@@ -67,7 +67,7 @@ where
                     gas_limit: parent.gas_limit(),
                     parent_beacon_block_root: request.payload_attributes.parent_beacon_block_root,
                     withdrawals: request.payload_attributes.withdrawals.map(Into::into),
-                    extra_data: request.extra_data,
+                    extra_data: request.extra_data.unwrap_or_default(),
                 };
 
                 let mut builder = evm_config

--- a/examples/custom-engine-types/src/main.rs
+++ b/examples/custom-engine-types/src/main.rs
@@ -41,7 +41,7 @@ use reth_ethereum::{
         builder::{
             components::{BasicPayloadServiceBuilder, ComponentsBuilder, PayloadBuilderBuilder},
             rpc::{PayloadValidatorBuilder, RpcAddOns},
-            BuilderContext, Node, NodeAdapter, NodeBuilder,
+            BuilderContext, Node, NodeAdapter, NodeBuilder, PayloadBuilderConfig,
         },
         core::{args::RpcServerArgs, node_config::NodeConfig},
         node::{
@@ -337,7 +337,8 @@ where
                 ctx.provider().clone(),
                 pool,
                 evm_config,
-                EthereumBuilderConfig::new(),
+                EthereumBuilderConfig::new()
+                    .with_extra_data(ctx.payload_builder_config().extra_data_bytes()),
             ),
         };
         Ok(payload_builder)

--- a/examples/custom-payload-builder/src/main.rs
+++ b/examples/custom-payload-builder/src/main.rs
@@ -62,7 +62,8 @@ where
             ctx.provider().clone(),
             pool,
             evm_config,
-            EthereumBuilderConfig::new(),
+            EthereumBuilderConfig::new()
+                .with_extra_data(ctx.payload_builder_config().extra_data_bytes()),
         );
 
         let conf = ctx.payload_builder_config();


### PR DESCRIPTION
Bumps alloy-evm

This is a slightly breaking change as it fully moves `extra_data` configuration out of `EthEvmConfig` and instead expects payload builder to provide the `extra_data` explicitly as a field  on `NextBlockEnvAttributes`.