### PR TITLE
chore(ethapi): increase visibility `tx_batch_sender`

### DIFF
--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -539,7 +539,7 @@ where
 
     /// Returns the transaction batch sender
     #[inline]
-    const fn tx_batch_sender(
+    pub const fn tx_batch_sender(
         &self,
     ) -> &mpsc::UnboundedSender<BatchTxRequest<<N::Pool as TransactionPool>::Transaction>> {
         &self.tx_batch_sender


### PR DESCRIPTION
Increases the visibility of `tx_batch_sender`, so that it can be accessible by cloning it from `EthApi`. This allows batch insertions of transactions in mempool from other components besides the rpc server