### PR TITLE
refactor(stages): cache hashed address in storage hashing loop

### DIFF
--- a/crates/stages/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/stages/src/stages/hashing_storage.rs
@@ -102,7 +102,7 @@ where
                 // Spawn the hashing task onto the global rayon pool
                 rayon::spawn(move || {
                     // Cache hashed address since PlainStorageState is sorted by address
-                    let (mut last_addr, mut hashed_addr) = (Address::ZERO, B256::ZERO);
+                    let (mut last_addr, mut hashed_addr) = (Address::ZERO, keccak256(Address::Zero));
                     for (address, slot) in chunk {
                         if address != last_addr {
                             last_addr = address;

--- a/crates/stages/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/stages/src/stages/hashing_storage.rs
@@ -102,7 +102,8 @@ where
                 // Spawn the hashing task onto the global rayon pool
                 rayon::spawn(move || {
                     // Cache hashed address since PlainStorageState is sorted by address
-                    let (mut last_addr, mut hashed_addr) = (Address::ZERO, keccak256(Address::Zero));
+                    let (mut last_addr, mut hashed_addr) =
+                        (Address::ZERO, keccak256(Address::ZERO));
                     for (address, slot) in chunk {
                         if address != last_addr {
                             last_addr = address;


### PR DESCRIPTION
Noticed while reviewing the storage hashing code that compute `keccak256(address)` for every storage entry, even though `PlainStorageState` is a DupSort table where entries from the same address are consecutive.

Caches the last hashed address to avoid redundant keccak256 calls within each worker chunk (100 entries).