### PR TITLE
perf(engine, trie): chunk based on idle workers

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/chunking.rs
+++ b/crates/engine/tree/src/tree/payload_processor/chunking.rs
@@ -1,0 +1,80 @@
+//! Generic chunk planning utilities for multiproof scheduling in the engine.
+
+/// A computed plan for splitting `total` items into `chunks` parts.
+///
+/// Sizes are distributed as evenly as possible:
+/// - `base` items per chunk
+/// - the first `increased` chunks get one extra item (size `base + 1`)
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct ChunkPlan {
+    /// Number of chunks to produce.
+    pub chunks: usize,
+    /// Base size for each chunk.
+    pub base: usize,
+    /// Number of leading chunks that receive an extra item.
+    pub increased: usize,
+}
+
+impl ChunkPlan {
+    /// Returns the size for the `index`-th chunk (0-based).
+    #[cfg(test)]
+    pub(super) fn chunk_size(&self, index: usize) -> usize {
+        self.base + usize::from(index < self.increased)
+    }
+
+    /// Returns an iterator of chunk sizes with length `self.chunks`.
+    #[cfg(test)]
+    pub(super) fn sizes(&self) -> impl Iterator<Item = usize> + '_ {
+        (0..self.chunks).map(|i| self.chunk_size(i))
+    }
+}
+
+/// Computes a chunk plan given the total amount of items, the number of idle workers
+/// available to process chunks concurrently, and a minimum chunk size.
+pub(super) fn compute_chunk_plan(total: usize, idle: usize, min_chunk: usize) -> Option<ChunkPlan> {
+    if idle == 0 || total == 0 {
+        return None;
+    }
+
+    let max_chunks_amount = total / min_chunk;
+    let chunks = max_chunks_amount.min(idle);
+
+    (chunks >= 2).then(|| {
+        let base = total / chunks;
+        let increased = total % chunks;
+        ChunkPlan { chunks, base, increased }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_idle_no_plan() {
+        assert_eq!(compute_chunk_plan(10, 0, 1), None);
+        assert_eq!(compute_chunk_plan(0, 4, 1), None);
+    }
+
+    #[test]
+    fn chunks_respect_min_chunk_and_idle() {
+        // total=10, idle=3, min_chunk=4 -> max_chunks=2 -> chunks=2 -> base=5, increased=0
+        let plan = compute_chunk_plan(10, 3, 4).unwrap();
+        assert_eq!(plan, ChunkPlan { chunks: 2, base: 5, increased: 0 });
+        assert_eq!(plan.sizes().collect::<Vec<_>>(), vec![5, 5]);
+    }
+
+    #[test]
+    fn remainder_distributed_to_leading_chunks() {
+        // total=10, idle=4, min_chunk=3 -> max_chunks=3 -> chunks=3 -> base=3, increased=1
+        let plan = compute_chunk_plan(10, 4, 3).unwrap();
+        assert_eq!(plan, ChunkPlan { chunks: 3, base: 3, increased: 1 });
+        assert_eq!(plan.sizes().collect::<Vec<_>>(), vec![4, 3, 3]);
+    }
+
+    #[test]
+    fn no_chunk_if_only_one_possible() {
+        // total=5, idle=8, min_chunk=3 -> max_chunks=1 -> chunks=1 -> None
+        assert_eq!(compute_chunk_plan(5, 8, 3), None);
+    }
+}

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -51,6 +51,7 @@ use std::{
 };
 use tracing::{debug, debug_span, instrument, warn, Span};
 
+mod chunking;
 mod configured_sparse_trie;
 pub mod executor;
 pub mod multiproof;

--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -279,6 +279,12 @@ impl HashedPostState {
         ChunkedHashedPostState::new(self, size)
     }
 
+    /// Returns an iterator that yields chunks where the first `increased` chunks have size
+    /// `size + 1` and the remaining have size `size`.
+    pub fn chunks_with(self, size: usize, increased: usize) -> ChunkedHashedPostState {
+        ChunkedHashedPostState::new_with_increased(self, size, increased)
+    }
+
     /// Returns the number of items that will be considered during chunking in `[Self::chunks]`.
     pub fn chunking_length(&self) -> usize {
         self.accounts.len() +
@@ -692,6 +698,7 @@ impl From<HashedPostStateSorted> for HashedPostState {
 pub struct ChunkedHashedPostState {
     flattened: alloc::vec::IntoIter<(B256, FlattenedHashedPostStateItem)>,
     size: usize,
+    increased: usize,
 }
 
 #[derive(Debug)]
@@ -731,7 +738,17 @@ impl ChunkedHashedPostState {
             // 3. Account update
             .sorted_by_key(|(address, _)| *address);
 
-        Self { flattened, size }
+        Self { flattened, size, increased: 0 }
+    }
+
+    fn new_with_increased(
+        hashed_post_state: HashedPostState,
+        size: usize,
+        increased: usize,
+    ) -> Self {
+        let mut this = Self::new(hashed_post_state, size);
+        this.increased = increased;
+        this
     }
 }
 
@@ -741,8 +758,10 @@ impl Iterator for ChunkedHashedPostState {
     fn next(&mut self) -> Option<Self::Item> {
         let mut chunk = HashedPostState::default();
 
+        let extra = usize::from(self.increased > 0);
+
         let mut current_size = 0;
-        while current_size < self.size {
+        while current_size < (self.size + extra) {
             let Some((address, item)) = self.flattened.next() else { break };
 
             match item {
@@ -763,6 +782,9 @@ impl Iterator for ChunkedHashedPostState {
         if chunk.is_empty() {
             None
         } else {
+            if extra == 1 {
+                self.increased -= 1;
+            }
             Some(chunk)
         }
     }
@@ -775,6 +797,27 @@ mod tests {
     use alloy_primitives::Bytes;
     use revm_database::{states::StorageSlot, StorageWithOriginalValues};
     use revm_state::{AccountInfo, Bytecode};
+
+    // Local copy for testing since chunking utilities are defined in the engine crate now.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    struct ChunkPlan {
+        chunks: usize,
+        base: usize,
+        increased: usize,
+    }
+
+    fn compute_chunk_plan(total: usize, idle: usize, min_chunk: usize) -> Option<ChunkPlan> {
+        if idle == 0 || total == 0 {
+            return None;
+        }
+        let max_chunks_amount = total / min_chunk;
+        let chunks = max_chunks_amount.min(idle);
+        (chunks >= 2).then(|| {
+            let base = total / chunks;
+            let increased = total % chunks;
+            ChunkPlan { chunks, base, increased }
+        })
+    }
 
     #[test]
     fn hashed_state_wiped_extension() {
@@ -1528,5 +1571,42 @@ mod tests {
         // Verify the original storage is not consumed
         assert_eq!(storage.storage.len(), 3);
         assert!(storage.wiped);
+    }
+
+    #[test]
+    fn chunking_distribution_matches_plan() {
+        // Build a hashed post state with:
+        // addr1: wiped + 2 storage updates -> 3 items
+        // addr2: 1 storage update         -> 1 item
+        // addr3: account update (None)    -> 1 item
+        // total = 5 items
+        let addr1 = B256::with_last_byte(0xA1);
+        let addr2 = B256::with_last_byte(0xA2);
+        let addr3 = B256::with_last_byte(0xA3);
+
+        let mut state = HashedPostState::default();
+        let mut st1 = HashedStorage::new(true);
+        st1.storage.insert(B256::with_last_byte(0x01), U256::from(1));
+        st1.storage.insert(B256::with_last_byte(0x02), U256::from(2));
+        state.storages.insert(addr1, st1);
+
+        let mut st2 = HashedStorage::new(false);
+        st2.storage.insert(B256::with_last_byte(0x03), U256::from(3));
+        state.storages.insert(addr2, st2);
+
+        state.accounts.insert(addr3, None);
+
+        assert_eq!(state.chunking_length(), 5);
+
+        // idle=2, min=2 -> chunks=2 -> base=2, increased=1 -> sizes [3,2]
+        let plan = compute_chunk_plan(5, 2, 2).unwrap();
+        assert_eq!(plan, ChunkPlan { chunks: 2, base: 2, increased: 1 });
+
+        let sizes = state
+            .chunks_with(plan.base, plan.increased)
+            .map(|chunk| chunk.chunking_length())
+            .collect::<Vec<_>>();
+        assert_eq!(sizes, vec![3, 2]);
+        assert_eq!(sizes.len(), plan.chunks);
     }
 }


### PR DESCRIPTION
Chunking logic is now based on the amount of available idle workers, instead of hardcoded chunk size.