### PR TITLE
chore(storage): fix reference in comment

### DIFF
--- a/crates/storage/libmdbx-rs/src/txn_manager.rs
+++ b/crates/storage/libmdbx-rs/src/txn_manager.rs
@@ -23,7 +23,7 @@ pub(crate) enum TxnManagerMessage {
 /// - Opening, aborting, and committing transactions using [`TxnManager::send_message`] with the
 ///   corresponding [`TxnManagerMessage`]
 /// - Aborting long-lived read transactions (if the `read-tx-timeouts` feature is enabled and
-///   `TxnManager::with_max_read_transaction_duration` is called)
+///   `TxnManager::new_with_max_read_transaction_duration` is called)
 #[derive(Debug)]
 pub(crate) struct TxnManager {
     sender: SyncSender<TxnManagerMessage>,


### PR DESCRIPTION
The TxnManager documentation was referencing a non-existent method with_max_read_transaction_duration, which is misleading for users trying to enable read transaction timeouts. Updated the comment to point to the actual constructor new_with_max_read_transaction_duration so that the docs accurately reflect the public API and reduce confusion when configuring read-tx-timeouts.