### PR TITLE
docs: clarify receipts vs log filter pruning semantics

### DIFF
--- a/crates/prune/types/src/target.rs
+++ b/crates/prune/types/src/target.rs
@@ -56,8 +56,8 @@ pub struct PruneModes {
     /// Transaction Lookup pruning configuration.
     #[cfg_attr(any(test, feature = "serde"), serde(skip_serializing_if = "Option::is_none"))]
     pub transaction_lookup: Option<PruneMode>,
-    /// Receipts pruning configuration. This setting overrides `receipts_log_filter`
-    /// and offers improved performance.
+    /// Receipts pruning configuration. Defines the global pruning policy for all receipts
+    /// and is the primary control for how aggressively receipts are removed.
     #[cfg_attr(
         any(test, feature = "serde"),
         serde(
@@ -97,8 +97,10 @@ pub struct PruneModes {
     /// `StoragesTrieChangeSets`.
     #[cfg_attr(any(test, feature = "serde"), serde(default = "default_merkle_changesets_mode"))]
     pub merkle_changesets: PruneMode,
-    /// Receipts pruning configuration by retaining only those receipts that contain logs emitted
-    /// by the specified addresses, discarding others. This setting is overridden by `receipts`.
+    /// Receipts pruning configuration that retains only receipts containing logs emitted
+    /// by the specified addresses, discarding others. This can be used in addition to the
+    /// global receipts pruning policy defined by `receipts` to retain receipts for selected
+    /// contracts.
     ///
     /// The [`BlockNumber`](`crate::BlockNumber`) represents the starting block from which point
     /// onwards the receipts are preserved.

--- a/docs/vocs/docs/pages/run/configuration.mdx
+++ b/docs/vocs/docs/pages/run/configuration.mdx
@@ -423,7 +423,7 @@ sender_recovery = { distance = 100_000 } # Prune all transaction senders before 
 # Transaction Lookup pruning configuration
 transaction_lookup = "full" # Prune all TxNumber => TxHash mappings
 
-# Receipts pruning configuration. This setting overrides `receipts_log_filter`.
+# Receipts pruning configuration. Defines the global pruning policy for all receipts.
 receipts = { before = 1920000 } # Prune all receipts from transactions before the block 1920000, i.e. keep receipts from the block 1920000
 
 # Account History pruning configuration
@@ -445,7 +445,8 @@ We can also prune receipts more granular, using the logs filtering:
 
 ```toml
 # Receipts pruning configuration by retaining only those receipts that contain logs emitted
-# by the specified addresses, discarding all others. This setting is overridden by `receipts`.
+# by the specified addresses, discarding all others. Can be used on its own or together with
+# `receipts` to additionally keep receipts for selected contracts on top of the global policy.
 [prune.segments.receipts_log_filter]
 # Prune all receipts, leaving only those which:
 # - Contain logs from address `0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48`, starting from the block 17000000


### PR DESCRIPTION
The previous comments and docs described receipts and receipts_log_filter as if they were mutually exclusive, using “overrides” wording. In reality the implementation allows them to be combined: receipts defines the global receipts pruning policy, while receipts_log_filter can be layered on top to additionally retain receipts for specific contracts, as used in the full node configuration.

This change updates the PruneModes documentation comments and the pruning section in configuration.mdx to describe the actual combined behavior. No pruning logic or CLI flags are changed, only the semantics in comments and user-facing docs are clarified.