### PR TITLE
chore(engine): make `InstrumentedStateProvider` public

### DIFF
--- a/crates/engine/tree/src/tree/instrumented_state.rs
+++ b/crates/engine/tree/src/tree/instrumented_state.rs
@@ -59,7 +59,7 @@ impl AtomicDuration {
 }
 
 /// A wrapper of a state provider and latency metrics.
-pub(crate) struct InstrumentedStateProvider<S> {
+pub struct InstrumentedStateProvider<S> {
     /// The state provider
     state_provider: S,
 
@@ -81,10 +81,10 @@ where
     S: StateProvider,
 {
     /// Creates a new [`InstrumentedStateProvider`] from a state provider
-    pub(crate) fn from_state_provider(state_provider: S) -> Self {
+    pub fn from_state_provider(state_provider: S, source: &'static str) -> Self {
         Self {
             state_provider,
-            metrics: StateProviderMetrics::default(),
+            metrics: StateProviderMetrics::new_with_labels(&[("source", source)]),
             total_storage_fetch_latency: AtomicDuration::zero(),
             total_code_fetch_latency: AtomicDuration::zero(),
             total_account_fetch_latency: AtomicDuration::zero(),

--- a/crates/engine/tree/src/tree/instrumented_state.rs
+++ b/crates/engine/tree/src/tree/instrumented_state.rs
@@ -22,7 +22,7 @@ const NANOS_PER_SEC: u32 = 1_000_000_000;
 
 /// An atomic version of [`Duration`], using an [`AtomicU64`] to store the total nanoseconds in the
 /// duration.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub(crate) struct AtomicDuration {
     /// The nanoseconds part of the duration
     ///
@@ -59,6 +59,7 @@ impl AtomicDuration {
 }
 
 /// A wrapper of a state provider and latency metrics.
+#[derive(Debug)]
 pub struct InstrumentedStateProvider<S> {
     /// The state provider
     state_provider: S,
@@ -80,7 +81,8 @@ impl<S> InstrumentedStateProvider<S>
 where
     S: StateProvider,
 {
-    /// Creates a new [`InstrumentedStateProvider`] from a state provider
+    /// Creates a new [`InstrumentedStateProvider`] from a state provider with the provided label
+    /// for metrics.
     pub fn from_state_provider(state_provider: S, source: &'static str) -> Self {
         Self {
             state_provider,

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -54,7 +54,7 @@ use tracing::*;
 mod block_buffer;
 mod cached_state;
 pub mod error;
-mod instrumented_state;
+pub mod instrumented_state;
 mod invalid_headers;
 mod metrics;
 mod payload_processor;

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -420,7 +420,8 @@ where
 
         // Execute the block and handle any execution errors
         let (output, senders) = match if self.config.state_provider_metrics() {
-            let state_provider = InstrumentedStateProvider::from_state_provider(&state_provider);
+            let state_provider =
+                InstrumentedStateProvider::from_state_provider(&state_provider, "engine");
             let result = self.execute_block(&state_provider, env, &input, &mut handle);
             state_provider.record_total_latency();
             result


### PR DESCRIPTION
Makes it possible to use `InstrumentedStateProvider` externally