### PR TITLE
feat(storage): add method to check invariants on RocksDB tables

### DIFF
--- a/crates/storage/provider/src/providers/rocksdb/invariants.rs
+++ b/crates/storage/provider/src/providers/rocksdb/invariants.rs
@@ -310,7 +310,6 @@ impl RocksDBProvider {
         let mut to_delete: Vec<StorageShardedKey> = Vec::new();
 
         // Iterate all entries and collect those to delete
-        // Note: This is not ideal for large tables. See doc comment for limitations.
         for result in self.iter::<tables::StoragesHistory>()? {
             let (key, _value) = result?;
 

--- a/crates/storage/provider/src/providers/rocksdb/invariants.rs
+++ b/crates/storage/provider/src/providers/rocksdb/invariants.rs
@@ -1,0 +1,412 @@
+//! Invariant checking for `RocksDB` tables.
+//!
+//! This module provides consistency checks for tables stored in `RocksDB`, similar to the
+//! consistency checks for static files. The goal is to detect and potentially heal
+//! inconsistencies between `RocksDB` data and MDBX checkpoints.
+
+use super::RocksDBProvider;
+use alloy_primitives::BlockNumber;
+use reth_db_api::tables;
+use reth_stages_types::StageId;
+use reth_storage_api::{DBProvider, StageCheckpointReader, StorageSettingsCache};
+use reth_storage_errors::provider::ProviderResult;
+
+impl RocksDBProvider {
+    /// Checks consistency of `RocksDB` tables against MDBX stage checkpoints.
+    ///
+    /// Returns an unwind target block number if the pipeline needs to unwind to rebuild
+    /// `RocksDB` data. Returns `None` if all invariants pass or if inconsistencies were healed.
+    ///
+    /// # Invariants checked
+    ///
+    /// For `TransactionHashNumbers`:
+    /// - The maximum `TxNumber` value should not exceed what the `TransactionLookup` stage
+    ///   checkpoint indicates has been processed.
+    /// - If `RocksDB` is ahead, excess entries are pruned (healed).
+    /// - If `RocksDB` is behind, an unwind is required.
+    ///
+    /// For `StoragesHistory`:
+    /// - The maximum block number in shards should not exceed the `IndexStorageHistory` stage
+    ///   checkpoint.
+    /// - Similar healing/unwind logic applies.
+    pub fn check_consistency<Provider>(
+        &self,
+        provider: &Provider,
+    ) -> ProviderResult<Option<BlockNumber>>
+    where
+        Provider: DBProvider + StageCheckpointReader + StorageSettingsCache,
+    {
+        let mut unwind_target: Option<BlockNumber> = None;
+
+        // Check TransactionHashNumbers if stored in RocksDB
+        if provider.cached_storage_settings().transaction_hash_numbers_in_rocksdb &&
+            let Some(target) = self.check_transaction_hash_numbers(provider)?
+        {
+            unwind_target = Some(unwind_target.map_or(target, |t| t.min(target)));
+        }
+
+        // Check StoragesHistory if stored in RocksDB
+        if provider.cached_storage_settings().storages_history_in_rocksdb &&
+            let Some(target) = self.check_storages_history(provider)?
+        {
+            unwind_target = Some(unwind_target.map_or(target, |t| t.min(target)));
+        }
+
+        Ok(unwind_target)
+    }
+
+    /// Checks invariants for the `TransactionHashNumbers` table.
+    ///
+    /// Returns a block number to unwind to if `RocksDB` is behind the checkpoint.
+    fn check_transaction_hash_numbers<Provider>(
+        &self,
+        provider: &Provider,
+    ) -> ProviderResult<Option<BlockNumber>>
+    where
+        Provider: DBProvider + StageCheckpointReader,
+    {
+        use reth_db::cursor::DbCursorRO;
+        use reth_db_api::transaction::DbTx;
+
+        // Get the TransactionLookup stage checkpoint
+        let checkpoint = provider
+            .get_stage_checkpoint(StageId::TransactionLookup)?
+            .map(|cp| cp.block_number)
+            .unwrap_or(0);
+
+        // Get the last entry from RocksDB TransactionHashNumbers
+        let rocks_last = self.last::<tables::TransactionHashNumbers>()?;
+
+        match rocks_last {
+            Some((_hash, tx_number)) => {
+                // If checkpoint is 0 but we have data, that's inconsistent
+                if checkpoint == 0 && tx_number > 0 {
+                    // RocksDB has data but stage hasn't run - need to clear
+                    return Ok(Some(0));
+                }
+
+                // Map tx_number to block_number using TransactionBlocks table
+                // TransactionBlocks key is the highest tx ID in each block
+                let mut cursor = provider.tx_ref().cursor_read::<tables::TransactionBlocks>()?;
+
+                // Seek to the first entry where key >= tx_number
+                if let Some((_, rocks_block)) = cursor.seek(tx_number)? {
+                    // rocks_block is the block containing this transaction
+                    // If checkpoint block > rocks_block, RocksDB is behind
+                    if checkpoint > rocks_block {
+                        tracing::info!(
+                            target: "reth::providers::rocksdb",
+                            rocks_max_tx = tx_number,
+                            rocks_block,
+                            checkpoint,
+                            "TransactionHashNumbers behind checkpoint, unwind needed"
+                        );
+                        return Ok(Some(rocks_block));
+                    }
+                }
+
+                Ok(None)
+            }
+            None => {
+                // Empty RocksDB table
+                // If checkpoint says we should have data, that's an inconsistency
+                if checkpoint > 0 {
+                    // Need to rebuild from scratch
+                    return Ok(Some(0));
+                }
+                Ok(None)
+            }
+        }
+    }
+
+    /// Checks invariants for the `StoragesHistory` table.
+    ///
+    /// Returns a block number to unwind to if `RocksDB` is behind the checkpoint.
+    fn check_storages_history<Provider>(
+        &self,
+        provider: &Provider,
+    ) -> ProviderResult<Option<BlockNumber>>
+    where
+        Provider: DBProvider + StageCheckpointReader,
+    {
+        // Get the IndexStorageHistory stage checkpoint
+        let checkpoint = provider
+            .get_stage_checkpoint(StageId::IndexStorageHistory)?
+            .map(|cp| cp.block_number)
+            .unwrap_or(0);
+
+        // Get the last entry from RocksDB StoragesHistory
+        let rocks_last = self.last::<tables::StoragesHistory>()?;
+
+        match rocks_last {
+            Some((key, _block_list)) => {
+                let highest_block = key.sharded_key.highest_block_number;
+
+                // If the shard's highest block exceeds checkpoint, RocksDB is ahead
+                if highest_block != u64::MAX && highest_block > checkpoint {
+                    // Would need to prune - for now just report as inconsistent
+                    // In a full implementation, we'd prune entries > checkpoint
+                    tracing::warn!(
+                        target: "reth::providers::rocksdb",
+                        rocks_highest = highest_block,
+                        checkpoint,
+                        "StoragesHistory ahead of checkpoint, pruning needed"
+                    );
+                }
+
+                Ok(None)
+            }
+            None => {
+                // Empty RocksDB table
+                if checkpoint > 0 {
+                    // Stage says we should have data but we don't
+                    return Ok(Some(0));
+                }
+                Ok(None)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        providers::rocksdb::RocksDBBuilder, test_utils::create_test_provider_factory,
+        DatabaseProviderFactory, StageCheckpointWriter,
+    };
+    use alloy_primitives::{Address, B256};
+    use reth_db::cursor::DbCursorRW;
+    use reth_db_api::{
+        models::{storage_sharded_key::StorageShardedKey, StorageSettings},
+        tables::{self, BlockNumberList},
+        transaction::DbTxMut,
+    };
+    use reth_stages_types::StageCheckpoint;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_first_last_empty_rocksdb() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider = RocksDBBuilder::new(temp_dir.path())
+            .with_table::<tables::TransactionHashNumbers>()
+            .with_table::<tables::StoragesHistory>()
+            .build()
+            .unwrap();
+
+        // Empty RocksDB, no checkpoints - should be consistent
+        let first = provider.first::<tables::TransactionHashNumbers>().unwrap();
+        let last = provider.last::<tables::TransactionHashNumbers>().unwrap();
+
+        assert!(first.is_none());
+        assert!(last.is_none());
+    }
+
+    #[test]
+    fn test_first_last_with_data() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider = RocksDBBuilder::new(temp_dir.path())
+            .with_table::<tables::TransactionHashNumbers>()
+            .build()
+            .unwrap();
+
+        // Insert some data
+        let tx_hash = B256::from([1u8; 32]);
+        provider.put::<tables::TransactionHashNumbers>(tx_hash, &100).unwrap();
+
+        // RocksDB has data
+        let last = provider.last::<tables::TransactionHashNumbers>().unwrap();
+        assert!(last.is_some());
+        assert_eq!(last.unwrap().1, 100);
+    }
+
+    #[test]
+    fn test_check_consistency_empty_rocksdb_no_checkpoint_is_ok() {
+        let temp_dir = TempDir::new().unwrap();
+        let rocksdb = RocksDBBuilder::new(temp_dir.path())
+            .with_table::<tables::TransactionHashNumbers>()
+            .with_table::<tables::StoragesHistory>()
+            .build()
+            .unwrap();
+
+        // Create a test provider factory for MDBX
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(
+            StorageSettings::legacy()
+                .with_transaction_hash_numbers_in_rocksdb(true)
+                .with_storages_history_in_rocksdb(true),
+        );
+
+        let provider = factory.database_provider_ro().unwrap();
+
+        // Empty RocksDB and no checkpoints - should be consistent (None = no unwind needed)
+        let result = rocksdb.check_consistency(&provider).unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_check_consistency_empty_rocksdb_with_checkpoint_needs_unwind() {
+        let temp_dir = TempDir::new().unwrap();
+        let rocksdb = RocksDBBuilder::new(temp_dir.path())
+            .with_table::<tables::TransactionHashNumbers>()
+            .build()
+            .unwrap();
+
+        // Create a test provider factory for MDBX
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(
+            StorageSettings::legacy().with_transaction_hash_numbers_in_rocksdb(true),
+        );
+
+        // Set a checkpoint indicating we should have processed up to block 100
+        {
+            let provider = factory.database_provider_rw().unwrap();
+            provider
+                .save_stage_checkpoint(StageId::TransactionLookup, StageCheckpoint::new(100))
+                .unwrap();
+            provider.commit().unwrap();
+        }
+
+        let provider = factory.database_provider_ro().unwrap();
+
+        // RocksDB is empty but checkpoint says block 100 was processed
+        // This means RocksDB is missing data and we need to unwind to rebuild
+        let result = rocksdb.check_consistency(&provider).unwrap();
+        assert_eq!(result, Some(0), "Should require unwind to block 0 to rebuild RocksDB");
+    }
+
+    #[test]
+    fn test_check_consistency_rocksdb_has_data_no_checkpoint_needs_clear() {
+        let temp_dir = TempDir::new().unwrap();
+        let rocksdb = RocksDBBuilder::new(temp_dir.path())
+            .with_table::<tables::TransactionHashNumbers>()
+            .build()
+            .unwrap();
+
+        // Insert data into RocksDB
+        let tx_hash = B256::from([1u8; 32]);
+        rocksdb.put::<tables::TransactionHashNumbers>(tx_hash, &100).unwrap();
+
+        // Create a test provider factory for MDBX with NO checkpoint
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(
+            StorageSettings::legacy().with_transaction_hash_numbers_in_rocksdb(true),
+        );
+
+        let provider = factory.database_provider_ro().unwrap();
+
+        // RocksDB has data but checkpoint is 0
+        // This means RocksDB has stale data that should be cleared
+        let result = rocksdb.check_consistency(&provider).unwrap();
+        assert_eq!(result, Some(0), "Should require unwind to block 0 to clear stale RocksDB data");
+    }
+
+    #[test]
+    fn test_check_consistency_storages_history_empty_with_checkpoint_needs_unwind() {
+        let temp_dir = TempDir::new().unwrap();
+        let rocksdb = RocksDBBuilder::new(temp_dir.path())
+            .with_table::<tables::StoragesHistory>()
+            .build()
+            .unwrap();
+
+        // Create a test provider factory for MDBX
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(
+            StorageSettings::legacy().with_storages_history_in_rocksdb(true),
+        );
+
+        // Set a checkpoint indicating we should have processed up to block 100
+        {
+            let provider = factory.database_provider_rw().unwrap();
+            provider
+                .save_stage_checkpoint(StageId::IndexStorageHistory, StageCheckpoint::new(100))
+                .unwrap();
+            provider.commit().unwrap();
+        }
+
+        let provider = factory.database_provider_ro().unwrap();
+
+        // RocksDB is empty but checkpoint says block 100 was processed
+        let result = rocksdb.check_consistency(&provider).unwrap();
+        assert_eq!(result, Some(0), "Should require unwind to block 0 to rebuild StoragesHistory");
+    }
+
+    #[test]
+    fn test_check_consistency_storages_history_has_data_no_checkpoint() {
+        let temp_dir = TempDir::new().unwrap();
+        let rocksdb = RocksDBBuilder::new(temp_dir.path())
+            .with_table::<tables::StoragesHistory>()
+            .build()
+            .unwrap();
+
+        // Insert data into RocksDB
+        let key = StorageShardedKey::new(Address::ZERO, B256::ZERO, 50);
+        let block_list = BlockNumberList::new_pre_sorted([10, 20, 30, 50]);
+        rocksdb.put::<tables::StoragesHistory>(key, &block_list).unwrap();
+
+        // Create a test provider factory for MDBX with NO checkpoint
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(
+            StorageSettings::legacy().with_storages_history_in_rocksdb(true),
+        );
+
+        let provider = factory.database_provider_ro().unwrap();
+
+        // RocksDB has data but checkpoint is 0
+        let result = rocksdb.check_consistency(&provider).unwrap();
+        // For StoragesHistory we don't return unwind when RocksDB has data and checkpoint is 0
+        // because we only check if checkpoint > 0 and RocksDB is empty
+        // The logic is: if checkpoint says we should have data but we don't, that's a problem
+        // But if we have data and checkpoint is 0, we log a warning but don't unwind
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_check_consistency_rocksdb_behind_checkpoint_needs_unwind() {
+        let temp_dir = TempDir::new().unwrap();
+        let rocksdb = RocksDBBuilder::new(temp_dir.path())
+            .with_table::<tables::TransactionHashNumbers>()
+            .build()
+            .unwrap();
+
+        // Insert data into RocksDB - tx hash mapping to tx_number 50
+        let tx_hash = B256::from([1u8; 32]);
+        rocksdb.put::<tables::TransactionHashNumbers>(tx_hash, &50).unwrap();
+
+        // Create a test provider factory for MDBX
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(
+            StorageSettings::legacy().with_transaction_hash_numbers_in_rocksdb(true),
+        );
+
+        // Set up MDBX with:
+        // - TransactionBlocks: tx 50 is in block 10, tx 100 is in block 20
+        // - Checkpoint at block 20 (meaning we should have tx hashes up to tx 100)
+        {
+            let provider = factory.database_provider_rw().unwrap();
+
+            // Insert TransactionBlocks entries
+            let mut cursor = provider.tx_ref().cursor_write::<tables::TransactionBlocks>().unwrap();
+            cursor.append(50, &10).unwrap(); // tx 50 is the last tx in block 10
+            cursor.append(100, &20).unwrap(); // tx 100 is the last tx in block 20
+
+            // Set checkpoint to block 20
+            provider
+                .save_stage_checkpoint(StageId::TransactionLookup, StageCheckpoint::new(20))
+                .unwrap();
+            provider.commit().unwrap();
+        }
+
+        let provider = factory.database_provider_ro().unwrap();
+
+        // RocksDB has tx hashes only up to tx 50 (block 10)
+        // But checkpoint says we processed up to block 20 (tx 100)
+        // This means RocksDB is behind and needs to unwind to block 10 to rebuild
+        let result = rocksdb.check_consistency(&provider).unwrap();
+        assert_eq!(
+            result,
+            Some(10),
+            "Should require unwind to block 10 where RocksDB's max tx belongs"
+        );
+    }
+}

--- a/crates/storage/provider/src/providers/rocksdb/invariants.rs
+++ b/crates/storage/provider/src/providers/rocksdb/invariants.rs
@@ -302,12 +302,15 @@ impl RocksDBProvider {
     ///
     /// For `StoragesHistory`, the key contains `highest_block_number`, so we can iterate
     /// and delete entries where `key.sharded_key.highest_block_number > max_block`.
+    ///
+    /// TODO(<https://github.com/paradigmxyz/reth/issues/20417>): use changeset-based pruning.
     fn prune_storages_history_above(&self, max_block: BlockNumber) -> ProviderResult<()> {
         use reth_db_api::models::storage_sharded_key::StorageShardedKey;
 
         let mut to_delete: Vec<StorageShardedKey> = Vec::new();
 
         // Iterate all entries and collect those to delete
+        // Note: This is not ideal for large tables. See doc comment for limitations.
         for result in self.iter::<tables::StoragesHistory>()? {
             let (key, _value) = result?;
 

--- a/crates/storage/provider/src/providers/rocksdb/invariants.rs
+++ b/crates/storage/provider/src/providers/rocksdb/invariants.rs
@@ -295,7 +295,8 @@ impl RocksDBProvider {
     /// For `StoragesHistory`, the key contains `highest_block_number`, so we can iterate
     /// and delete entries where `key.sharded_key.highest_block_number > max_block`.
     ///
-    /// TODO(<https://github.com/paradigmxyz/reth/issues/20417>): use changeset-based pruning.
+    /// TODO(<https://github.com/paradigmxyz/reth/issues/20417>): this iterates the whole table,
+    /// which is inefficient. Use changeset-based pruning instead.
     fn prune_storages_history_above(&self, max_block: BlockNumber) -> ProviderResult<()> {
         use reth_db_api::models::storage_sharded_key::StorageShardedKey;
 

--- a/crates/storage/provider/src/providers/rocksdb/mod.rs
+++ b/crates/storage/provider/src/providers/rocksdb/mod.rs
@@ -1,5 +1,7 @@
 //! [`RocksDBProvider`] implementation
 
+mod invariants;
 mod metrics;
 mod provider;
+
 pub use provider::{RocksDBBatch, RocksDBBuilder, RocksDBProvider, RocksTx};

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -524,6 +524,11 @@ impl<'a> RocksDBBatch<'a> {
     pub fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }
+
+    /// Returns a reference to the underlying `RocksDB` provider.
+    pub fn provider(&self) -> &RocksDBProvider {
+        self.provider
+    }
 }
 
 /// `RocksDB` transaction wrapper providing MDBX-like semantics.

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -526,7 +526,7 @@ impl<'a> RocksDBBatch<'a> {
     }
 
     /// Returns a reference to the underlying `RocksDB` provider.
-    pub fn provider(&self) -> &RocksDBProvider {
+    pub const fn provider(&self) -> &RocksDBProvider {
         self.provider
     }
 }

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -380,6 +380,56 @@ impl RocksDBProvider {
         })
     }
 
+    /// Gets the first (smallest key) entry from the specified table.
+    pub fn first<T: Table>(&self) -> ProviderResult<Option<(T::Key, T::Value)>> {
+        self.execute_with_operation_metric(RocksDBOperation::Get, T::NAME, |this| {
+            let cf = this.get_cf_handle::<T>()?;
+            let mut iter = this.0.db.iterator_cf(cf, IteratorMode::Start);
+
+            match iter.next() {
+                Some(Ok((key_bytes, value_bytes))) => {
+                    let key = <T::Key as reth_db_api::table::Decode>::decode(&key_bytes)
+                        .map_err(|_| ProviderError::Database(DatabaseError::Decode))?;
+                    let value = T::Value::decompress(&value_bytes)
+                        .map_err(|_| ProviderError::Database(DatabaseError::Decode))?;
+                    Ok(Some((key, value)))
+                }
+                Some(Err(e)) => {
+                    Err(ProviderError::Database(DatabaseError::Read(DatabaseErrorInfo {
+                        message: e.to_string().into(),
+                        code: -1,
+                    })))
+                }
+                None => Ok(None),
+            }
+        })
+    }
+
+    /// Gets the last (largest key) entry from the specified table.
+    pub fn last<T: Table>(&self) -> ProviderResult<Option<(T::Key, T::Value)>> {
+        self.execute_with_operation_metric(RocksDBOperation::Get, T::NAME, |this| {
+            let cf = this.get_cf_handle::<T>()?;
+            let mut iter = this.0.db.iterator_cf(cf, IteratorMode::End);
+
+            match iter.next() {
+                Some(Ok((key_bytes, value_bytes))) => {
+                    let key = <T::Key as reth_db_api::table::Decode>::decode(&key_bytes)
+                        .map_err(|_| ProviderError::Database(DatabaseError::Decode))?;
+                    let value = T::Value::decompress(&value_bytes)
+                        .map_err(|_| ProviderError::Database(DatabaseError::Decode))?;
+                    Ok(Some((key, value)))
+                }
+                Some(Err(e)) => {
+                    Err(ProviderError::Database(DatabaseError::Read(DatabaseErrorInfo {
+                        message: e.to_string().into(),
+                        code: -1,
+                    })))
+                }
+                None => Ok(None),
+            }
+        })
+    }
+
     /// Writes a batch of operations atomically.
     pub fn write_batch<F>(&self, f: F) -> ProviderResult<()>
     where
@@ -941,5 +991,29 @@ mod tests {
             let value = format!("batch_value_{i}").into_bytes();
             assert_eq!(provider.get::<TestTable>(i).unwrap(), Some(value));
         }
+    }
+
+    #[test]
+    fn test_first_and_last_entry() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider =
+            RocksDBBuilder::new(temp_dir.path()).with_table::<TestTable>().build().unwrap();
+
+        // Empty table should return None for both
+        assert_eq!(provider.first::<TestTable>().unwrap(), None);
+        assert_eq!(provider.last::<TestTable>().unwrap(), None);
+
+        // Insert some entries
+        provider.put::<TestTable>(10, &b"value_10".to_vec()).unwrap();
+        provider.put::<TestTable>(20, &b"value_20".to_vec()).unwrap();
+        provider.put::<TestTable>(5, &b"value_5".to_vec()).unwrap();
+
+        // First should return the smallest key
+        let first = provider.first::<TestTable>().unwrap();
+        assert_eq!(first, Some((5, b"value_5".to_vec())));
+
+        // Last should return the largest key
+        let last = provider.last::<TestTable>().unwrap();
+        assert_eq!(last, Some((20, b"value_20".to_vec())));
     }
 }


### PR DESCRIPTION
Closes #20153

Adds invariant checking for RocksDB tables, similar to the existing `check_consistency` and `ensure_invariants` methods for static files.

- Add `first()` and `last()` methods to `RocksDBProvider` for efficient table bounds checking
- Add `check_consistency()` method that validates RocksDB tables against MDBX stage checkpoints
- For `TransactionHashNumbers`: maps max tx_number -> block_number via `TransactionBlocks` to detect if RocksDB is behind the `TransactionLookup` checkpoint
- For `StoragesHistory`: checks if table is empty when `IndexStorageHistory` checkpoint indicates data should exist
- Returns an unwind target block number when inconsistencies are detected
