### PR TITLE
chore: remove unused CustomContext alias from custom-node example

### DIFF
--- a/examples/custom-node/src/evm/alloy.rs
+++ b/examples/custom-node/src/evm/alloy.rs
@@ -15,10 +15,6 @@ use reth_ethereum::evm::revm::{
 use revm::{context_interface::result::EVMError, inspector::NoOpInspector};
 use std::error::Error;
 
-/// EVM context contains data that EVM needs for execution of [`CustomTxEnv`].
-pub type CustomContext<DB> =
-    Context<BlockEnv, OpTransaction<PaymentTxEnv>, CfgEnv<OpSpecId>, DB, Journal<DB>, L1BlockInfo>;
-
 pub struct CustomEvm<DB: Database, I, P = OpPrecompiles> {
     inner: OpEvm<DB, I, P>,
 }


### PR DESCRIPTION
The CustomContext type alias in the custom-node example was unused and referenced OpTransaction<PaymentTxEnv>, a combination that is not used anywhere else in the codebase. The actual EVM context for this example is provided via OpContext<DB> through the EvmFactory implementation and consumed via EvmContextFor.