### PR TITLE
ci(hive): bump actions/cache to v5

### DIFF
--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Restore hive assets cache
         id: cache-hive
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ./hive_assets
           key: hive-assets-${{ steps.hive-commit.outputs.hash }}-${{ hashFiles('.github/assets/hive/build_simulators.sh') }}


### PR DESCRIPTION
Upgrade actions/cache from v4 to v5 in the hive workflow. 

Ref: https://github.com/actions/cache/releases/tag/v5.0.1