### PR TITLE
docs: fix --color auto option description

### DIFF
--- a/docs/vocs/docs/pages/cli/op-reth.md
+++ b/docs/vocs/docs/pages/cli/op-reth.md
@@ -78,7 +78,7 @@ Logging:
 
           Possible values:
           - always: Colors on
-          - auto:   Colors on
+          - auto:   Auto-detect
           - never:  Colors off
 
 Display:

--- a/docs/vocs/docs/pages/cli/reth/debug.mdx
+++ b/docs/vocs/docs/pages/cli/reth/debug.mdx
@@ -78,7 +78,7 @@ Logging:
 
           Possible values:
           - always: Colors on
-          - auto:   Colors on
+          - auto:   Auto-detect
           - never:  Colors off
 
 Display:

--- a/docs/vocs/docs/pages/cli/reth/recover.mdx
+++ b/docs/vocs/docs/pages/cli/reth/recover.mdx
@@ -80,7 +80,7 @@ Logging:
 
           Possible values:
           - always: Colors on
-          - auto:   Colors on
+          - auto:   Auto-detect
           - never:  Colors off
 
           [default: always]

--- a/docs/vocs/docs/pages/cli/reth/recover/storage-tries.mdx
+++ b/docs/vocs/docs/pages/cli/reth/recover/storage-tries.mdx
@@ -134,7 +134,7 @@ Logging:
 
           Possible values:
           - always: Colors on
-          - auto:   Colors on
+          - auto:   Auto-detect
           - never:  Colors off
 
           [default: always]

--- a/docs/vocs/docs/pages/cli/reth/test-vectors/tables.mdx
+++ b/docs/vocs/docs/pages/cli/reth/test-vectors/tables.mdx
@@ -95,7 +95,7 @@ Logging:
 
           Possible values:
           - always: Colors on
-          - auto:   Colors on
+          - auto:   Auto-detect
           - never:  Colors off
 
 Display:


### PR DESCRIPTION
Fix incorrect description for `--color auto` CLI option. The documentation incorrectly stated "Colors on" instead of "Auto-detect" in several CLI reference pages.
