### PR TITLE
docs: fix beacon port comments

### DIFF
--- a/examples/beacon-api-sidecar-fetcher/src/main.rs
+++ b/examples/beacon-api-sidecar-fetcher/src/main.rs
@@ -77,7 +77,7 @@ pub struct BeaconSidecarConfig {
     /// Beacon Node http server address
     #[arg(long = "cl.addr", default_value_t = IpAddr::V4(Ipv4Addr::LOCALHOST))]
     pub cl_addr: IpAddr,
-    /// Beacon Node http server port to listen on
+    /// Beacon Node http server port to connect to
     #[arg(long = "cl.port", default_value_t = 5052)]
     pub cl_port: u16,
 }

--- a/examples/beacon-api-sse/src/main.rs
+++ b/examples/beacon-api-sse/src/main.rs
@@ -46,7 +46,7 @@ struct BeaconEventsConfig {
     /// Beacon Node http server address
     #[arg(long = "cl.addr", default_value_t = IpAddr::V4(Ipv4Addr::LOCALHOST))]
     pub cl_addr: IpAddr,
-    /// Beacon Node http server port to listen on
+    /// Beacon Node http server port to connect to
     #[arg(long = "cl.port", default_value_t = 5052)]
     pub cl_port: u16,
 }


### PR DESCRIPTION
Changed `port to listen on` to `port to connect to` in beacon API examples, these examples act as HTTP clients connecting to beacon nodes.