### PR TITLE
refactor(net): use `NetworkTransactionBuilder`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,8 +113,7 @@ dependencies = [
 [[package]]
 name = "alloy-consensus"
 version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e318e25fb719e747a7e8db1654170fc185024f3ed5b10f86c08d448a912f6e2"
+source = "git+https://github.com/lean-apple/alloy.git?branch=tx-builder-split#efd3a3c4799462e5f7364772bdfda00a6d1cf964"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -141,8 +140,7 @@ dependencies = [
 [[package]]
 name = "alloy-consensus-any"
 version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "364380a845193a317bcb7a5398fc86cdb66c47ebe010771dde05f6869bf9e64a"
+source = "git+https://github.com/lean-apple/alloy.git?branch=tx-builder-split#efd3a3c4799462e5f7364772bdfda00a6d1cf964"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -156,8 +154,7 @@ dependencies = [
 [[package]]
 name = "alloy-contract"
 version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d39c80ffc806f27a76ed42f3351a455f3dc4f81d6ff92c8aad2cf36b7d3a34"
+source = "git+https://github.com/lean-apple/alloy.git?branch=tx-builder-split#efd3a3c4799462e5f7364772bdfda00a6d1cf964"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -253,8 +250,7 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c4d7c5839d9f3a467900c625416b24328450c65702eb3d8caff8813e4d1d33"
+source = "git+https://github.com/lean-apple/alloy.git?branch=tx-builder-split#efd3a3c4799462e5f7364772bdfda00a6d1cf964"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -301,8 +297,7 @@ dependencies = [
 [[package]]
 name = "alloy-genesis"
 version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba4b1be0988c11f0095a2380aa596e35533276b8fa6c9e06961bbfe0aebcac5"
+source = "git+https://github.com/lean-apple/alloy.git?branch=tx-builder-split#efd3a3c4799462e5f7364772bdfda00a6d1cf964"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -342,8 +337,7 @@ dependencies = [
 [[package]]
 name = "alloy-json-rpc"
 version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f72cf87cda808e593381fb9f005ffa4d2475552b7a6c5ac33d087bf77d82abd0"
+source = "git+https://github.com/lean-apple/alloy.git?branch=tx-builder-split#efd3a3c4799462e5f7364772bdfda00a6d1cf964"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -357,8 +351,7 @@ dependencies = [
 [[package]]
 name = "alloy-network"
 version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12aeb37b6f2e61b93b1c3d34d01ee720207c76fe447e2a2c217e433ac75b17f5"
+source = "git+https://github.com/lean-apple/alloy.git?branch=tx-builder-split#efd3a3c4799462e5f7364772bdfda00a6d1cf964"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -383,8 +376,7 @@ dependencies = [
 [[package]]
 name = "alloy-network-primitives"
 version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd29ace62872083e30929cd9b282d82723196d196db589f3ceda67edcc05552"
+source = "git+https://github.com/lean-apple/alloy.git?branch=tx-builder-split#efd3a3c4799462e5f7364772bdfda00a6d1cf964"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -457,8 +449,7 @@ dependencies = [
 [[package]]
 name = "alloy-provider"
 version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b710636d7126e08003b8217e24c09f0cca0b46d62f650a841736891b1ed1fc1"
+source = "git+https://github.com/lean-apple/alloy.git?branch=tx-builder-split#efd3a3c4799462e5f7364772bdfda00a6d1cf964"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -502,8 +493,7 @@ dependencies = [
 [[package]]
 name = "alloy-pubsub"
 version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd4c64eb250a18101d22ae622357c6b505e158e9165d4c7974d59082a600c5e"
+source = "git+https://github.com/lean-apple/alloy.git?branch=tx-builder-split#efd3a3c4799462e5f7364772bdfda00a6d1cf964"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -546,8 +536,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-client"
 version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0882e72d2c1c0c79dcf4ab60a67472d3f009a949f774d4c17d0bdb669cfde05"
+source = "git+https://github.com/lean-apple/alloy.git?branch=tx-builder-split#efd3a3c4799462e5f7364772bdfda00a6d1cf964"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -572,8 +561,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types"
 version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cf1398cb33aacb139a960fa3d8cf8b1202079f320e77e952a0b95967bf7a9f"
+source = "git+https://github.com/lean-apple/alloy.git?branch=tx-builder-split#efd3a3c4799462e5f7364772bdfda00a6d1cf964"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -585,8 +573,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-admin"
 version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65a583d2029b171301f5dcf122aa2ef443a65a373778ec76540d999691ae867d"
+source = "git+https://github.com/lean-apple/alloy.git?branch=tx-builder-split#efd3a3c4799462e5f7364772bdfda00a6d1cf964"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -597,8 +584,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-anvil"
 version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ce4c24e416bd0f17fceeb2f26cd8668df08fe19e1dc02f9d41c3b8ed1e93e0"
+source = "git+https://github.com/lean-apple/alloy.git?branch=tx-builder-split#efd3a3c4799462e5f7364772bdfda00a6d1cf964"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -609,8 +595,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-any"
 version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a63fb40ed24e4c92505f488f9dd256e2afaed17faa1b7a221086ebba74f4122"
+source = "git+https://github.com/lean-apple/alloy.git?branch=tx-builder-split#efd3a3c4799462e5f7364772bdfda00a6d1cf964"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -620,8 +605,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-beacon"
 version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16633087e23d8d75161c3a59aa183203637b817a5a8d2f662f612ccb6d129af0"
+source = "git+https://github.com/lean-apple/alloy.git?branch=tx-builder-split#efd3a3c4799462e5f7364772bdfda00a6d1cf964"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -640,8 +624,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-debug"
 version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4936f579d9d10eae01772b2ab3497f9d568684f05f26f8175e12f9a1a2babc33"
+source = "git+https://github.com/lean-apple/alloy.git?branch=tx-builder-split#efd3a3c4799462e5f7364772bdfda00a6d1cf964"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -652,8 +635,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-engine"
 version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c60bdce3be295924122732b7ecd0b2495ce4790bedc5370ca7019c08ad3f26e"
+source = "git+https://github.com/lean-apple/alloy.git?branch=tx-builder-split#efd3a3c4799462e5f7364772bdfda00a6d1cf964"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -673,8 +655,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-eth"
 version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eae0c7c40da20684548cbc8577b6b7447f7bf4ddbac363df95e3da220e41e72"
+source = "git+https://github.com/lean-apple/alloy.git?branch=tx-builder-split#efd3a3c4799462e5f7364772bdfda00a6d1cf964"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -685,7 +666,7 @@ dependencies = [
  "alloy-serde",
  "alloy-sol-types",
  "arbitrary",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -695,8 +676,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-mev"
 version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81c0dd81c24944cfbf45b5df7cd149d9cd3e354db81ccf08aa47e0e05be8ab97"
+source = "git+https://github.com/lean-apple/alloy.git?branch=tx-builder-split#efd3a3c4799462e5f7364772bdfda00a6d1cf964"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -710,8 +690,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-trace"
 version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef206a4b8d436fbb7cf2e6a61c692d11df78f9382becc3c9a283bd58e64f0583"
+source = "git+https://github.com/lean-apple/alloy.git?branch=tx-builder-split#efd3a3c4799462e5f7364772bdfda00a6d1cf964"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -724,8 +703,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-txpool"
 version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecb5a795264a02222f9534435b8f40dcbd88de8e9d586647884aae24f389ebf2"
+source = "git+https://github.com/lean-apple/alloy.git?branch=tx-builder-split#efd3a3c4799462e5f7364772bdfda00a6d1cf964"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -736,8 +714,7 @@ dependencies = [
 [[package]]
 name = "alloy-serde"
 version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0df1987ed0ff2d0159d76b52e7ddfc4e4fbddacc54d2fbee765e0d14d7c01b5"
+source = "git+https://github.com/lean-apple/alloy.git?branch=tx-builder-split#efd3a3c4799462e5f7364772bdfda00a6d1cf964"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -748,8 +725,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer"
 version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff69deedee7232d7ce5330259025b868c5e6a52fa8dffda2c861fb3a5889b24"
+source = "git+https://github.com/lean-apple/alloy.git?branch=tx-builder-split#efd3a3c4799462e5f7364772bdfda00a6d1cf964"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -763,8 +739,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer-local"
 version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72cfe0be3ec5a8c1a46b2e5a7047ed41121d360d97f4405bb7c1c784880c86cb"
+source = "git+https://github.com/lean-apple/alloy.git?branch=tx-builder-split#efd3a3c4799462e5f7364772bdfda00a6d1cf964"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -852,8 +827,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport"
 version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be98b07210d24acf5b793c99b759e9a696e4a2e67593aec0487ae3b3e1a2478c"
+source = "git+https://github.com/lean-apple/alloy.git?branch=tx-builder-split#efd3a3c4799462e5f7364772bdfda00a6d1cf964"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -875,8 +849,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-http"
 version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4198a1ee82e562cab85e7f3d5921aab725d9bd154b6ad5017f82df1695877c97"
+source = "git+https://github.com/lean-apple/alloy.git?branch=tx-builder-split#efd3a3c4799462e5f7364772bdfda00a6d1cf964"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -890,8 +863,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ipc"
 version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8db249779ebc20dc265920c7e706ed0d31dbde8627818d1cbde60919b875bb0"
+source = "git+https://github.com/lean-apple/alloy.git?branch=tx-builder-split#efd3a3c4799462e5f7364772bdfda00a6d1cf964"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -910,8 +882,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ws"
 version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad2344a12398d7105e3722c9b7a7044ea837128e11d453604dec6e3731a86e2"
+source = "git+https://github.com/lean-apple/alloy.git?branch=tx-builder-split#efd3a3c4799462e5f7364772bdfda00a6d1cf964"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -948,8 +919,7 @@ dependencies = [
 [[package]]
 name = "alloy-tx-macros"
 version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "333544408503f42d7d3792bfc0f7218b643d968a03d2c0ed383ae558fb4a76d0"
+source = "git+https://github.com/lean-apple/alloy.git?branch=tx-builder-split#efd3a3c4799462e5f7364772bdfda00a6d1cf964"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
@@ -6225,8 +6195,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-consensus"
 version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736381a95471d23e267263cfcee9e1d96d30b9754a94a2819148f83379de8a86"
+source = "git+https://github.com/lean-apple/op-alloy?branch=tx-split#85771b171ca442632126a88369d23065ac012ec9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6251,8 +6220,7 @@ checksum = "a79f352fc3893dcd670172e615afef993a41798a1d3fc0db88a3e60ef2e70ecc"
 [[package]]
 name = "op-alloy-network"
 version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4034183dca6bff6632e7c24c92e75ff5f0eabb58144edb4d8241814851334d47"
+source = "git+https://github.com/lean-apple/op-alloy?branch=tx-split#85771b171ca442632126a88369d23065ac012ec9"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -6282,8 +6250,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-rpc-jsonrpsee"
 version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1c820ef9c802ebc732281a940bfb6ac2345af4d9fff041cbb64b4b546676686"
+source = "git+https://github.com/lean-apple/op-alloy?branch=tx-split#85771b171ca442632126a88369d23065ac012ec9"
 dependencies = [
  "alloy-primitives",
  "jsonrpsee",
@@ -6292,11 +6259,11 @@ dependencies = [
 [[package]]
 name = "op-alloy-rpc-types"
 version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd87c6b9e5b6eee8d6b76f41b04368dca0e9f38d83338e5b00e730c282098a4"
+source = "git+https://github.com/lean-apple/op-alloy?branch=tx-split#85771b171ca442632126a88369d23065ac012ec9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
+ "alloy-network",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -6312,8 +6279,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-rpc-types-engine"
 version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727699310a18cdeed32da3928c709e2704043b6584ed416397d5da65694efc"
+source = "git+https://github.com/lean-apple/op-alloy?branch=tx-split#85771b171ca442632126a88369d23065ac012ec9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -741,7 +741,7 @@ vergen-git2 = "1.0.5"
 ipnet = "2.11"
 
 [patch.crates-io]
-alloy-consensus = { git = "https://github.com/lean-apple/alloy.git", branch = "tx-builder-split"}
+alloy-consensus = { git = "https://github.com/lean-apple/alloy.git", branch = "tx-builder-split" }
 alloy-contract = { git = "https://github.com/lean-apple/alloy.git", branch = "tx-builder-split" }
 alloy-eips = { git = "https://github.com/lean-apple/alloy.git", branch = "tx-builder-split" }
 alloy-genesis = { git = "https://github.com/lean-apple/alloy.git", branch = "tx-builder-split" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -740,40 +740,40 @@ vergen-git2 = "1.0.5"
 # networking
 ipnet = "2.11"
 
-# [patch.crates-io]
-# alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-contract = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-genesis = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-admin = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-debug = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-mev = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-txpool = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-signer-local = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
+[patch.crates-io]
+alloy-consensus = { git = "https://github.com/lean-apple/alloy.git", branch = "tx-builder-split"}
+alloy-contract = { git = "https://github.com/lean-apple/alloy.git", branch = "tx-builder-split" }
+alloy-eips = { git = "https://github.com/lean-apple/alloy.git", branch = "tx-builder-split" }
+alloy-genesis = { git = "https://github.com/lean-apple/alloy.git", branch = "tx-builder-split" }
+alloy-json-rpc = { git = "https://github.com/lean-apple/alloy.git", branch = "tx-builder-split" }
+alloy-network = { git = "https://github.com/lean-apple/alloy.git", branch = "tx-builder-split" }
+alloy-network-primitives = { git = "https://github.com/lean-apple/alloy.git", branch = "tx-builder-split" }
+alloy-provider = { git = "https://github.com/lean-apple/alloy.git", branch = "tx-builder-split" }
+alloy-pubsub = { git = "https://github.com/lean-apple/alloy.git", branch = "tx-builder-split" }
+alloy-rpc-client = { git = "https://github.com/lean-apple/alloy.git", branch = "tx-builder-split" }
+alloy-rpc-types = { git = "https://github.com/lean-apple/alloy.git", branch = "tx-builder-split" }
+alloy-rpc-types-admin = { git = "https://github.com/lean-apple/alloy.git", branch = "tx-builder-split" }
+alloy-rpc-types-anvil = { git = "https://github.com/lean-apple/alloy.git", branch = "tx-builder-split" }
+alloy-rpc-types-beacon = { git = "https://github.com/lean-apple/alloy.git", branch = "tx-builder-split" }
+alloy-rpc-types-debug = { git = "https://github.com/lean-apple/alloy.git", branch = "tx-builder-split" }
+alloy-rpc-types-engine = { git = "https://github.com/lean-apple/alloy.git", branch = "tx-builder-split" }
+alloy-rpc-types-eth = { git = "https://github.com/lean-apple/alloy.git", branch = "tx-builder-split" }
+alloy-rpc-types-mev = { git = "https://github.com/lean-apple/alloy.git", branch = "tx-builder-split" }
+alloy-rpc-types-trace = { git = "https://github.com/lean-apple/alloy.git", branch = "tx-builder-split" }
+alloy-rpc-types-txpool = { git = "https://github.com/lean-apple/alloy.git", branch = "tx-builder-split" }
+alloy-serde = { git = "https://github.com/lean-apple/alloy.git", branch = "tx-builder-split" }
+alloy-signer = { git = "https://github.com/lean-apple/alloy.git", branch = "tx-builder-split" }
+alloy-signer-local = { git = "https://github.com/lean-apple/alloy.git", branch = "tx-builder-split" }
+alloy-transport = { git = "https://github.com/lean-apple/alloy.git", branch = "tx-builder-split" }
+alloy-transport-http = { git = "https://github.com/lean-apple/alloy.git", branch = "tx-builder-split" }
+alloy-transport-ipc = { git = "https://github.com/lean-apple/alloy.git", branch = "tx-builder-split" }
+alloy-transport-ws = { git = "https://github.com/lean-apple/alloy.git", branch = "tx-builder-split" }
 
-# op-alloy-consensus = { git = "https://github.com/alloy-rs/op-alloy", rev = "a79d6fc" }
-# op-alloy-network = { git = "https://github.com/alloy-rs/op-alloy", rev = "a79d6fc" }
-# op-alloy-rpc-types = { git = "https://github.com/alloy-rs/op-alloy", rev = "a79d6fc" }
-# op-alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/op-alloy", rev = "a79d6fc" }
-# op-alloy-rpc-jsonrpsee = { git = "https://github.com/alloy-rs/op-alloy", rev = "a79d6fc" }
+op-alloy-consensus = { git = "https://github.com/lean-apple/op-alloy", branch = "tx-split" }
+op-alloy-network = { git = "https://github.com/lean-apple/op-alloy", branch = "tx-split" }
+op-alloy-rpc-types = { git = "https://github.com/lean-apple/op-alloy", branch = "tx-split" }
+op-alloy-rpc-types-engine = { git = "https://github.com/lean-apple/op-alloy", branch = "tx-split" }
+op-alloy-rpc-jsonrpsee = { git = "https://github.com/lean-apple/op-alloy", branch = "tx-split" }
 #
 # revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "1207e33" }
 #

--- a/crates/e2e-test-utils/src/transaction.rs
+++ b/crates/e2e-test-utils/src/transaction.rs
@@ -3,7 +3,7 @@ use alloy_consensus::{
 };
 use alloy_eips::{eip7594::BlobTransactionSidecarVariant, eip7702::SignedAuthorization};
 use alloy_network::{
-    eip2718::Encodable2718, Ethereum, EthereumWallet, TransactionBuilder, TransactionBuilder4844,
+    Ethereum, EthereumWallet, NetworkTransactionBuilder, TransactionBuilder4844, eip2718::Encodable2718
 };
 use alloy_primitives::{hex, Address, Bytes, TxKind, B256, U256};
 use alloy_rpc_types_eth::{Authorization, TransactionInput, TransactionRequest};
@@ -115,7 +115,7 @@ impl TransactionTestContext {
     /// Signs an arbitrary [`TransactionRequest`] using the provided wallet
     pub async fn sign_tx(wallet: PrivateKeySigner, tx: TransactionRequest) -> TxEnvelope {
         let signer = EthereumWallet::from(wallet);
-        <TransactionRequest as TransactionBuilder<Ethereum>>::build(tx, &signer).await.unwrap()
+        <TransactionRequest as NetworkTransactionBuilder<Ethereum>>::build(tx, &signer).await.unwrap()
     }
 
     /// Creates a tx with blob sidecar and sign it, returning bytes
@@ -139,7 +139,7 @@ impl TransactionTestContext {
         ));
         let tx = tx(chain_id, 210000, Some(l1_block_info), None, nonce, Some(20e9 as u128));
         let signer = EthereumWallet::from(wallet);
-        <TransactionRequest as TransactionBuilder<Ethereum>>::build(tx, &signer)
+        <TransactionRequest as NetworkTransactionBuilder<Ethereum>>::build(tx, &signer)
             .await
             .unwrap()
             .encoded_2718()

--- a/crates/e2e-test-utils/src/transaction.rs
+++ b/crates/e2e-test-utils/src/transaction.rs
@@ -3,7 +3,8 @@ use alloy_consensus::{
 };
 use alloy_eips::{eip7594::BlobTransactionSidecarVariant, eip7702::SignedAuthorization};
 use alloy_network::{
-    Ethereum, EthereumWallet, NetworkTransactionBuilder, TransactionBuilder4844, eip2718::Encodable2718
+    eip2718::Encodable2718, Ethereum, EthereumWallet, NetworkTransactionBuilder,
+    TransactionBuilder4844,
 };
 use alloy_primitives::{hex, Address, Bytes, TxKind, B256, U256};
 use alloy_rpc_types_eth::{Authorization, TransactionInput, TransactionRequest};
@@ -115,7 +116,9 @@ impl TransactionTestContext {
     /// Signs an arbitrary [`TransactionRequest`] using the provided wallet
     pub async fn sign_tx(wallet: PrivateKeySigner, tx: TransactionRequest) -> TxEnvelope {
         let signer = EthereumWallet::from(wallet);
-        <TransactionRequest as NetworkTransactionBuilder<Ethereum>>::build(tx, &signer).await.unwrap()
+        <TransactionRequest as NetworkTransactionBuilder<Ethereum>>::build(tx, &signer)
+            .await
+            .unwrap()
     }
 
     /// Creates a tx with blob sidecar and sign it, returning bytes

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use alloy_consensus::{transaction::TxHashRef, BlockHeader, Transaction as _};
 use alloy_eips::eip2718::WithEncoded;
-use alloy_network::{TransactionBuilder, NetworkTransactionBuilder};
+use alloy_network::{NetworkTransactionBuilder, TransactionBuilder};
 use alloy_rpc_types_eth::{
     simulate::{SimCallResult, SimulateError, SimulatedBlock},
     BlockTransactionsKind,

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use alloy_consensus::{transaction::TxHashRef, BlockHeader, Transaction as _};
 use alloy_eips::eip2718::WithEncoded;
-use alloy_network::TransactionBuilder;
+use alloy_network::{TransactionBuilder, NetworkTransactionBuilder};
 use alloy_rpc_types_eth::{
     simulate::{SimCallResult, SimulateError, SimulatedBlock},
     BlockTransactionsKind,

--- a/crates/rpc/rpc/src/eth/helpers/transaction.rs
+++ b/crates/rpc/rpc/src/eth/helpers/transaction.rs
@@ -332,7 +332,7 @@ mod tests {
         let tx_req = TransactionRequest {
             from: Some(address),
             to: Some(Address::random().into()),
-            sidecar: Some(builder.build().unwrap()),
+            sidecar: Some(builder.build().unwrap().into()),
             ..Default::default()
         };
 
@@ -370,7 +370,7 @@ mod tests {
             from: Some(address),
             to: Some(Address::random().into()),
             transaction_type: Some(3), // EIP-4844
-            sidecar: Some(builder.build().unwrap()),
+            sidecar: Some(builder.build().unwrap().into()),
             max_fee_per_blob_gas: Some(provided_blob_fee), // Already set
             ..Default::default()
         };


### PR DESCRIPTION
Linked to https://github.com/alloy-rs/alloy/issues/3331.

Follow-up for https://github.com/alloy-rs/alloy/pull/3344, to check the integration of the new trait `NetworkTransactionBuilder`.

/!\ we need to release the alloy change before