### PR TITLE
fix(node): log forkchoice updates when only head_block_hash changes

### DIFF
--- a/crates/node/events/src/node.rs
+++ b/crates/node/events/src/node.rs
@@ -215,8 +215,13 @@ impl NodeState {
             ConsensusEngineEvent::ForkchoiceUpdated(state, status) => {
                 let ForkchoiceState { head_block_hash, safe_block_hash, finalized_block_hash } =
                     state;
-                if self.safe_block_hash != Some(safe_block_hash) &&
-                    self.finalized_block_hash != Some(finalized_block_hash)
+                // Log when both safe and finalized change (significant event), or when only head
+                // changes.
+                if (self.safe_block_hash != Some(safe_block_hash) &&
+                    self.finalized_block_hash != Some(finalized_block_hash)) ||
+                    (self.head_block_hash != Some(head_block_hash) &&
+                        self.safe_block_hash == Some(safe_block_hash) &&
+                        self.finalized_block_hash == Some(finalized_block_hash))
                 {
                     let msg = match status {
                         ForkchoiceStatus::Valid => "Forkchoice updated",

--- a/crates/node/events/src/node.rs
+++ b/crates/node/events/src/node.rs
@@ -219,9 +219,7 @@ impl NodeState {
                 // changes.
                 if (self.safe_block_hash != Some(safe_block_hash) &&
                     self.finalized_block_hash != Some(finalized_block_hash)) ||
-                    (self.head_block_hash != Some(head_block_hash) &&
-                        self.safe_block_hash == Some(safe_block_hash) &&
-                        self.finalized_block_hash == Some(finalized_block_hash))
+                    self.head_block_hash != Some(head_block_hash)
                 {
                     let msg = match status {
                         ForkchoiceStatus::Valid => "Forkchoice updated",


### PR DESCRIPTION
The handler was only checking safe_block_hash and finalized_block_hash for logging, but head_block_hash was being updated without being checked. 

Added a check for head_block_hash changes when safe and finalized haven't changed.
This preserves the original behavior (log when both safe and finalized change) while also catching head-only updates, avoiding log spam when all three change together.