### PR TITLE
fix(rpc): remove dead flashbots module config

### DIFF
--- a/crates/rpc/rpc-builder/src/config.rs
+++ b/crates/rpc/rpc-builder/src/config.rs
@@ -139,7 +139,7 @@ impl RethRpcServerConfig for RpcServerArgs {
 
     fn transport_rpc_module_config(&self) -> TransportRpcModuleConfig {
         let mut config = TransportRpcModuleConfig::default()
-            .with_config(RpcModuleConfig::new(self.eth_config(), self.flashbots_config()));
+            .with_config(RpcModuleConfig::new(self.eth_config()));
 
         if self.http {
             config = config.with_http(

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -38,7 +38,7 @@ use reth_network_api::{noop::NoopNetwork, NetworkInfo, Peers};
 use reth_primitives_traits::{NodePrimitives, TxTy};
 use reth_rpc::{
     AdminApi, DebugApi, EngineEthApi, EthApi, EthApiBuilder, EthBundle, MinerApi, NetApi,
-    OtterscanApi, RPCApi, RethApi, TraceApi, TxPoolApi, ValidationApiConfig, Web3Api,
+    OtterscanApi, RPCApi, RethApi, TraceApi, TxPoolApi, Web3Api,
 };
 use reth_rpc_api::servers::*;
 use reth_rpc_eth_api::{
@@ -413,8 +413,6 @@ impl<N: NodePrimitives> Default for RpcModuleBuilder<N, (), (), (), (), ()> {
 pub struct RpcModuleConfig {
     /// `eth` namespace settings
     eth: EthConfig,
-    /// `flashbots` namespace settings
-    flashbots: ValidationApiConfig,
 }
 
 // === impl RpcModuleConfig ===
@@ -426,8 +424,8 @@ impl RpcModuleConfig {
     }
 
     /// Returns a new RPC module config given the eth namespace config
-    pub const fn new(eth: EthConfig, flashbots: ValidationApiConfig) -> Self {
-        Self { eth, flashbots }
+    pub const fn new(eth: EthConfig) -> Self {
+        Self { eth }
     }
 
     /// Get a reference to the eth namespace config
@@ -445,7 +443,6 @@ impl RpcModuleConfig {
 #[derive(Clone, Debug, Default)]
 pub struct RpcModuleConfigBuilder {
     eth: Option<EthConfig>,
-    flashbots: Option<ValidationApiConfig>,
 }
 
 // === impl RpcModuleConfigBuilder ===
@@ -457,16 +454,10 @@ impl RpcModuleConfigBuilder {
         self
     }
 
-    /// Configures a custom flashbots namespace config
-    pub fn flashbots(mut self, flashbots: ValidationApiConfig) -> Self {
-        self.flashbots = Some(flashbots);
-        self
-    }
-
     /// Consumes the type and creates the [`RpcModuleConfig`]
     pub fn build(self) -> RpcModuleConfig {
-        let Self { eth, flashbots } = self;
-        RpcModuleConfig { eth: eth.unwrap_or_default(), flashbots: flashbots.unwrap_or_default() }
+        let Self { eth } = self;
+        RpcModuleConfig { eth: eth.unwrap_or_default() }
     }
 
     /// Get a reference to the eth namespace config, if any


### PR DESCRIPTION
RpcModuleConfig used to carry an extra flashbots: ValidationApiConfig field which was never read anywhere in the rpc-builder pipeline. Flashbots configuration is actually sourced from RethRpcServerConfig::flashbots_config() and wired into ValidationApi in the Ethereum node add-ons layer, and the Flashbots RPC module itself is registered there via merge_if_module_configured.

Carrying a write-only flashbots field in RpcModuleConfig was misleading, suggesting that flashbots settings were consumed by 
RpcRegistryInner while in practice they were ignored. This change removes the unused flashbots field and its builder API, updates 
RpcModuleConfig::new to accept only EthConfig, and adjusts the single call site in transport_rpc_module_config.