### PR TITLE
chore: export `FlashBlockDecoder`

### DIFF
--- a/crates/optimism/flashblocks/src/lib.rs
+++ b/crates/optimism/flashblocks/src/lib.rs
@@ -34,7 +34,7 @@ mod cache;
 mod test_utils;
 
 mod ws;
-pub use ws::{WsConnect, WsFlashBlockStream};
+pub use ws::{FlashBlockDecoder, WsConnect, WsFlashBlockStream};
 
 /// Receiver of the most recent [`PendingFlashBlock`] built out of [`FlashBlock`]s.
 ///

--- a/crates/optimism/flashblocks/src/ws/mod.rs
+++ b/crates/optimism/flashblocks/src/ws/mod.rs
@@ -1,6 +1,6 @@
 pub use stream::{WsConnect, WsFlashBlockStream};
 
 mod decoding;
-pub(crate) use decoding::FlashBlockDecoder;
+pub use decoding::FlashBlockDecoder;
 
 mod stream;


### PR DESCRIPTION
`FlashBlockDecoder` is defined as `pub` but not re-exported, making it inaccessible to downstream crates. This PR re-exports it to make it accessible.