### PR TITLE
feat(cli): limit number of blocks to re-execute

### DIFF
--- a/crates/cli/commands/src/re_execute.rs
+++ b/crates/cli/commands/src/re_execute.rs
@@ -131,6 +131,13 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
             })
             .collect();
 
+        info!(
+            tasks = task_ranges.len(),
+            ranges = task_ranges.iter().flatten().count(),
+            blocks = task_ranges.iter().flatten().cloned().flatten().count(),
+            "Prepared task ranges"
+        );
+
         // Calculate total gas from headers for all chunks we'll execute
         let total_gas: u64 = task_ranges
             .par_iter()

--- a/crates/cli/commands/src/re_execute.rs
+++ b/crates/cli/commands/src/re_execute.rs
@@ -95,17 +95,16 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
             }
         };
 
-        let full_range = max_block - min_block;
-
+        let full_range_size = max_block - min_block;
         let (blocks_to_execute, chunk_size) = if let Some(total_blocks) = self.total_blocks {
-            let total_blocks = total_blocks.min(full_range);
+            let total_blocks = total_blocks.min(full_range_size);
             let chunk_size = self.chunk_size.min(total_blocks);
             (total_blocks, chunk_size)
         } else {
-            (full_range, full_range)
+            (full_range_size, full_range_size)
         };
         let blocks_per_task = blocks_to_execute / self.num_tasks;
-        let segment_size = full_range / self.num_tasks;
+        let segment_size = full_range_size / self.num_tasks;
         let chunks_per_task = blocks_per_task / chunk_size;
 
         // Pre-calculate chunk ranges for each task

--- a/docs/vocs/docs/pages/cli/op-reth/re-execute.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/re-execute.mdx
@@ -132,6 +132,14 @@ Static Files:
       --skip-invalid-blocks
           Continues with execution when an invalid block is encountered and collects these blocks
 
+      --total-blocks <TOTAL_BLOCKS>
+          Total number of blocks to execute, distributed evenly across the range. If not set, all blocks in the range are executed
+
+      --chunk-size <CHUNK_SIZE>
+          Size of contiguous block ranges to execute when using --total-blocks
+
+          [default: 10]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/docs/vocs/docs/pages/cli/reth/re-execute.mdx
+++ b/docs/vocs/docs/pages/cli/reth/re-execute.mdx
@@ -132,6 +132,14 @@ Static Files:
       --skip-invalid-blocks
           Continues with execution when an invalid block is encountered and collects these blocks
 
+      --total-blocks <TOTAL_BLOCKS>
+          Total number of blocks to execute, distributed evenly across the range. If not set, all blocks in the range are executed
+
+      --chunk-size <CHUNK_SIZE>
+          Size of contiguous block ranges to execute when using --total-blocks
+
+          [default: 10]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout


### PR DESCRIPTION
Allows to limit the number of blocks to re-execute via `--total-blocks` argument and the number of blocks in a single consecutive batch via `--batch-size` argument. This will split the whole set of `from..=to` into chunks of equal size, which allows to cover the provided range via selecting only a subset of blocks to re-execute.

---

Recommend to review with whitespaces hidden: https://github.com/paradigmxyz/reth/pull/20372/changes?w=1