### PR TITLE
docs(opstack): document all rollup CLI arguments

### DIFF
--- a/docs/vocs/docs/pages/run/opstack.mdx
+++ b/docs/vocs/docs/pages/run/opstack.mdx
@@ -60,6 +60,15 @@ op-reth supports additional OP Stack specific CLI arguments:
 1. `--rollup.sequencer <uri>` - The sequencer endpoint to connect to. Transactions sent to the `op-reth` EL are also forwarded to this sequencer endpoint for inclusion, as the sequencer is the entity that builds blocks on OP Stack chains. Aliases: `--rollup.sequencer-http`, `--rollup.sequencer-ws`.
 1. `--rollup.disable-tx-pool-gossip` - Disables gossiping of transactions in the mempool to peers. This can be omitted for personal nodes, though providers should always opt to enable this flag.
 1. `--rollup.discovery.v4` - Enables the discovery v4 protocol for peer discovery. By default, op-reth, similar to op-geth, has discovery v5 enabled and discovery v4 disabled, whereas regular reth has discovery v4 enabled and discovery v5 disabled.
+1. `--rollup.compute-pending-block` - Enables computing of the pending block from the tx-pool instead of using the latest block. By default the pending block equals the latest block to save resources and not leak txs from the tx-pool.
+1. `--rollup.enable-tx-conditional` - Enable transaction conditional support on sequencer.
+1. `--rollup.supervisor-http <url>` - HTTP endpoint for the interop supervisor.
+1. `--rollup.supervisor-safety-level <level>` - Safety level for the supervisor (default: `CrossUnsafe`).
+1. `--rollup.sequencer-headers <headers>` - Optional headers to use when connecting to the sequencer. Requires `--rollup.sequencer`.
+1. `--rollup.historicalrpc <url>` - RPC endpoint for historical data. Alias: `--rollup.historical-rpc`.
+1. `--min-suggested-priority-fee <wei>` - Minimum suggested priority fee (tip) in wei (default: `1000000`).
+1. `--flashblocks-url <url>` - A URL pointing to a secure websocket subscription that streams out flashblocks. If given, the flashblocks are received to build pending block.
+1. `--flashblock-consensus` - Enable flashblock consensus client to drive the chain forward. Requires `--flashblocks-url`.
 
 First, ensure that your L1 archival node is running and synced to tip. Also make sure that the beacon node / consensus layer client is running and has http APIs enabled. Then, start `op-reth` with the `--rollup.sequencer` flag set to the `Base Mainnet` sequencer endpoint:
 


### PR DESCRIPTION
Added 9 missing CLI arguments to the op-reth documentation that were present in the code but not documented:
- --rollup.compute-pending-block
- --rollup.enable-tx-conditional
- --rollup.supervisor-http
- --rollup.supervisor-safety-level
- --rollup.sequencer-headers
- --rollup.historicalrpc
- --min-suggested-priority-fee
- --flashblocks-url
- --flashblock-consensus