### PR TITLE
docs: add local development guide (dev mode, tracing, Foundry)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,3 +153,12 @@ The `NippyJar` and `Compact` encoding formats and their implementations are desi
 
 [book]: https://paradigmxyz.github.io/reth/
 [tg-url]: https://t.me/paradigm_reth
+
+## Running Reth Locally (December 2025)
+
+### Development Mode (in-memory database, fast sync)
+
+Ideal for local testing and debugging:
+
+```bash
+cargo run --release -- --dev


### PR DESCRIPTION
Adds a new section to the README with practical commands for running Reth locally:

- Development mode with in-memory DB
- Enabling tracing/debugging
- Integration with Foundry/Anvil for contract testing

This helps new contributors quickly set up Reth for local development and debugging.

(Note: minor change in docs/repo/layout.md is incidental from editor formatting)