### PR TITLE
ci: reduce feature powerset depth

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -245,12 +245,8 @@ jobs:
 
   # Checks that selected crates can compile with power set of features
   features:
-    name: features (${{ matrix.partition }}/${{ matrix.total_partitions }})
+    name: features
     runs-on: depot-ubuntu-latest
-    strategy:
-      matrix:
-        partition: [1, 2]
-        total_partitions: [2]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -268,7 +264,7 @@ jobs:
             --package reth-primitives-traits \
             --package reth-primitives \
             --feature-powerset \
-            --partition ${{ matrix.partition }}/${{ matrix.total_partitions }}
+            --depth 2
         env:
           RUSTFLAGS: -D warnings
 

--- a/Makefile
+++ b/Makefile
@@ -521,5 +521,3 @@ pr:
 	make update-book-cli && \
 	cargo docs --document-private-items && \
 	make test
-
-check-features:


### PR DESCRIPTION
--depth 2 is enough for the goal of https://github.com/paradigmxyz/reth/pull/10130. this reduces the number of checks to run from ~900 to ~130