### PR TITLE
fix: tx_count debug log to report actual broadcast size

### DIFF
--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -1223,13 +1223,14 @@ where
         }
 
         // Build and send transaction hashes message
+        let tx_count = pooled_txs.len();
         let mut msg_builder = PooledTransactionsHashesBuilder::new(version);
         for pooled_tx in pooled_txs {
             peer.seen_transactions.insert(*pooled_tx.hash());
             msg_builder.push_pooled(pooled_tx);
         }
 
-        debug!(target: "net::tx", ?peer_id, tx_count = msg_builder.is_empty(), "Broadcasting transaction hashes");
+        debug!(target: "net::tx", ?peer_id, tx_count, "Broadcasting transaction hashes");
         let msg = msg_builder.build();
         self.network.send_transactions_hashes(peer_id, msg);
     }


### PR DESCRIPTION
Log the real number of pooled transaction hashes (`tx_count`) instead of a boolean emptiness flag. Keeps broadcast debug output accurate for troubleshooting network transaction propagation.
