### PR TITLE
fix(discv4): correct ping_interval default value in docs

### DIFF
--- a/crates/net/discv4/src/config.rs
+++ b/crates/net/discv4/src/config.rs
@@ -24,7 +24,7 @@ pub struct Discv4Config {
     /// The number of allowed consecutive failures for `FindNode` requests. Default: 5.
     pub max_find_node_failures: u8,
     /// The interval to use when checking for expired nodes that need to be re-pinged. Default:
-    /// 10min.
+    /// 10 seconds.
     pub ping_interval: Duration,
     /// The duration of we consider a ping timed out.
     pub ping_expiration: Duration,


### PR DESCRIPTION
## Problem

The documentation for `ping_interval` in `Discv4Config` incorrectly states the default value as "10min" while the actual implementation uses 10 seconds (`Duration::from_secs(10)`). This mismatch can mislead developers about the actual behavior of the discovery protocol.

## Solution

Updated the documentation comment to correctly reflect the default value of 10 seconds, matching the implementation and usage pattern where the interval is used for frequent periodic checks of expired nodes.