### PR TITLE
perf: use RwLock for transaction pool listeners

### DIFF
--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -682,6 +682,9 @@ where
             let listeners = self.transaction_listener.read();
             for listener in listeners.iter() {
                 if listener.kind.is_propagate_only() && !event.transaction.propagate {
+                    if listener.sender.is_closed() {
+                        needs_cleanup = true;
+                    }
                     // Skip non-propagate transactions for propagate-only listeners
                     continue
                 }


### PR DESCRIPTION
Transaction notifications are on the hot path (called for every pending transaction) but previously used `Mutex<Vec<Listener>>` which blocked all concurrent notifications. This changes `pending_transaction_listener` and `transaction_listener` to use `RwLock` instead.

The hot path now uses shared read locks allowing multiple threads to notify concurrently. Write locks are only acquired when dead listeners are detected (channel closed) for cleanup. Cleanup also happens when adding new listeners.

With typically 1-2 listeners (network + optional RPC), this eliminates lock contention on transaction notifications with zero change to semantics.