### PR TITLE
docs: add comment explaining unused function warning suppression

### DIFF
--- a/crates/stateless/src/recover_block.rs
+++ b/crates/stateless/src/recover_block.rs
@@ -76,6 +76,8 @@ fn verify_and_compute_sender(
         return Err(StatelessValidationError::HomesteadSignatureNotNormalized);
     }
     let sig_hash = tx.signature_hash();
+    // Prevent unused function warning when both features are enabled.
+    // The k256 function is compiled but not called when secp256k1 has priority.
     #[cfg(all(feature = "k256", feature = "secp256k1"))]
     {
         let _ = verify_and_compute_sender_unchecked_k256;


### PR DESCRIPTION
Adds a comment to clarify why the conditional compilation block references verify_and_compute_sender_unchecked_k256 without calling it.
This prevents compiler warnings when both k256 and secp256k1 features are enabled, as the k256 function is compiled but not used when secp256k1 has priority.