### PR TITLE
docs(exex): sync hello-world notifications loop with code

### DIFF
--- a/docs/vocs/docs/pages/exex/hello-world.mdx
+++ b/docs/vocs/docs/pages/exex/hello-world.mdx
@@ -73,7 +73,7 @@ Now, let's extend our simplest ExEx and start actually listening to new notifica
 
 Woah, there's a lot of new stuff here! Let's go through it step by step:
 
--   First, we've added a `while let Some(notification) = ctx.notifications.recv().await` loop that waits for new notifications to come in.
+-   First, we've added a `while let Some(notification) = ctx.notifications.try_next().await?` loop that waits for new notifications to come in.
     -   The main node is responsible for sending notifications to the ExEx, so we're waiting for them to come in.
 -   Next, we've added a `match &notification { ... }` block that matches on the type of the notification.
     -   In each case, we're logging the notification and the corresponding block range, be it a chain commit, revert, or reorg.


### PR DESCRIPTION
Update the Hello World ExEx documentation to use ctx.notifications.try_next().await?, so the described notifications loop matches the example implementation and clearly explains error propagation.