### PR TITLE
docs: fix incorrect method reference in try_recover_sealed_with_senders

### DIFF
--- a/crates/primitives-traits/src/block/recovered.rs
+++ b/crates/primitives-traits/src/block/recovered.rs
@@ -218,7 +218,7 @@ impl<B: Block> RecoveredBlock<B> {
 
     /// A safer variant of [`Self::new_sealed`] that checks if the number of senders is equal to
     /// the number of transactions in the block and recovers the senders from the transactions, if
-    /// not using [`SignedTransaction::recover_signer_unchecked`](crate::transaction::signed::SignedTransaction)
+    /// not using [`SignedTransaction::recover_signer`](crate::transaction::signed::SignedTransaction)
     /// to recover the senders.
     ///
     /// Returns an error if any of the transactions fail to recover the sender.


### PR DESCRIPTION
Fix copy-paste error in documentation for `try_recover_sealed_with_senders`. The method uses `recover_signer` (checked version) but the documentation incorrectly referenced `recover_signer_unchecked`.

This could mislead developers about the security properties of the method, as the checked version validates the signature's `s` value per EIP-2, while the unchecked version does not.
