### PR TITLE
feat(storage): add with_default_tables() to register RocksDB column families at initialization

### DIFF
--- a/crates/cli/commands/src/common.rs
+++ b/crates/cli/commands/src/common.rs
@@ -112,6 +112,7 @@ impl<C: ChainSpecParser> EnvironmentArgs<C> {
         };
         // TransactionDB only support read-write mode
         let rocksdb_provider = RocksDBProvider::builder(data_dir.rocksdb())
+            .with_default_tables()
             .with_database_log_level(self.db.log_level)
             .build()?;
 

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -485,8 +485,9 @@ where
                 .with_blocks_per_file_for_segments(static_files_config.as_blocks_per_file_map())
                 .build()?;
 
-        // Initialize RocksDB provider with metrics and statistics enabled
+        // Initialize RocksDB provider with metrics, statistics, and default tables
         let rocksdb_provider = RocksDBProvider::builder(self.data_dir().rocksdb())
+            .with_default_tables()
             .with_metrics()
             .with_statistics()
             .build()?;

--- a/crates/storage/provider/src/providers/database/builder.rs
+++ b/crates/storage/provider/src/providers/database/builder.rs
@@ -109,7 +109,7 @@ impl<N> ProviderFactoryBuilder<N> {
         self.db(Arc::new(open_db_read_only(db_dir, db_args)?))
             .chainspec(chainspec)
             .static_file(StaticFileProvider::read_only(static_files_dir, watch_static_files)?)
-            .rocksdb_provider(RocksDBProvider::builder(&rocksdb_dir).build()?)
+            .rocksdb_provider(RocksDBProvider::builder(&rocksdb_dir).with_default_tables().build()?)
             .build_provider_factory()
             .map_err(Into::into)
     }

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -147,9 +147,12 @@ impl RocksDBBuilder {
     ///
     /// This registers:
     /// - [`tables::TransactionHashNumbers`] - Transaction hash to number mapping
+    /// - [`tables::AccountsHistory`] - Account history index
     /// - [`tables::StoragesHistory`] - Storage history index
     pub fn with_default_tables(self) -> Self {
-        self.with_table::<tables::TransactionHashNumbers>().with_table::<tables::StoragesHistory>()
+        self.with_table::<tables::TransactionHashNumbers>()
+            .with_table::<tables::AccountsHistory>()
+            .with_table::<tables::StoragesHistory>()
     }
 
     /// Enables metrics.
@@ -639,15 +642,19 @@ const fn convert_log_level(level: LogLevel) -> rocksdb::LogLevel {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::{TxHash, B256};
-    use reth_db_api::{table::Table, tables};
+    use alloy_primitives::{Address, TxHash, B256};
+    use reth_db_api::{
+        models::{sharded_key::ShardedKey, storage_sharded_key::StorageShardedKey, IntegerList},
+        table::Table,
+        tables,
+    };
     use tempfile::TempDir;
 
     #[test]
     fn test_with_default_tables_registers_required_column_families() {
         let temp_dir = TempDir::new().unwrap();
 
-        // Build with default tables (should register TransactionHashNumbers and StoragesHistory)
+        // Build with default tables
         let provider = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
 
         // Should be able to write/read TransactionHashNumbers
@@ -655,10 +662,14 @@ mod tests {
         provider.put::<tables::TransactionHashNumbers>(tx_hash, &100).unwrap();
         assert_eq!(provider.get::<tables::TransactionHashNumbers>(tx_hash).unwrap(), Some(100));
 
+        // Should be able to write/read AccountsHistory
+        let key = ShardedKey::new(Address::ZERO, 100);
+        let value = IntegerList::default();
+        provider.put::<tables::AccountsHistory>(key.clone(), &value).unwrap();
+        assert!(provider.get::<tables::AccountsHistory>(key).unwrap().is_some());
+
         // Should be able to write/read StoragesHistory
-        use reth_db_api::models::storage_sharded_key::StorageShardedKey;
-        let key = StorageShardedKey::new(alloy_primitives::Address::ZERO, B256::ZERO, 100);
-        let value = reth_db_api::models::IntegerList::default();
+        let key = StorageShardedKey::new(Address::ZERO, B256::ZERO, 100);
         provider.put::<tables::StoragesHistory>(key.clone(), &value).unwrap();
         assert!(provider.get::<tables::StoragesHistory>(key).unwrap().is_some());
     }

--- a/crates/storage/provider/src/providers/rocksdb_stub.rs
+++ b/crates/storage/provider/src/providers/rocksdb_stub.rs
@@ -119,6 +119,11 @@ impl RocksDBBuilder {
         self
     }
 
+    /// Registers the default tables used by reth for `RocksDB` storage (stub implementation).
+    pub const fn with_default_tables(self) -> Self {
+        self
+    }
+
     /// Enables metrics (stub implementation).
     pub const fn with_metrics(self) -> Self {
         self


### PR DESCRIPTION
Closes #20386 

Adds with_default_tables() method to RocksDBBuilder that registers the TransactionHashNumbers and StoragesHistory column families required for RocksDB storage.

  - Add RocksDBBuilder::with_default_tables() that chains registration of both tables
  - Wire up default tables in node launch, CLI commands, and provider factory builder
  - Add test verifying both tables can be written to and read from
