### PR TITLE
docs: document all delegated provider traits

### DIFF
--- a/crates/storage/provider/src/providers/state/macros.rs
+++ b/crates/storage/provider/src/providers/state/macros.rs
@@ -26,6 +26,11 @@ pub(crate) use delegate_impls_to_as_ref;
 /// [`AccountReader`](crate::AccountReader)
 /// [`BlockHashReader`](crate::BlockHashReader)
 /// [`StateProvider`](crate::StateProvider)
+/// [`BytecodeReader`](crate::BytecodeReader)
+/// [`StateRootProvider`](crate::StateRootProvider)
+/// [`StorageRootProvider`](crate::StorageRootProvider)
+/// [`StateProofProvider`](crate::StateProofProvider)
+/// [`HashedPostStateProvider`](crate::HashedPostStateProvider)
 macro_rules! delegate_provider_impls {
     ($target:ty $(where [$($generics:tt)*])?) => {
         $crate::providers::state::macros::delegate_impls_to_as_ref!(


### PR DESCRIPTION
Expand the delegate_provider_impls macro documentation to list all traits it delegates to as_ref, including BytecodeReader, StateRootProvider, StorageRootProvider, StateProofProvider and HashedPostStateProvider.

This keeps the doc comment aligned with the actual macro expansion and avoids confusion for readers expecting a 1:1 mapping between docs and generated impls.