### PR TITLE
fix(optimism): delegate OpPooledTransaction::with_conditional to trait default

### DIFF
--- a/crates/optimism/txpool/src/transaction.rs
+++ b/crates/optimism/txpool/src/transaction.rs
@@ -85,9 +85,8 @@ impl<Cons: SignedTransaction, Pooled> OpPooledTransaction<Cons, Pooled> {
     }
 
     /// Conditional setter.
-    pub fn with_conditional(mut self, conditional: TransactionConditional) -> Self {
-        self.conditional = Some(Box::new(conditional));
-        self
+    pub fn with_conditional(self, conditional: TransactionConditional) -> Self {
+        MaybeConditionalTransaction::with_conditional(self, conditional)
     }
 }
 


### PR DESCRIPTION
The problem was in duplication of with_conditional logic: The MaybeConditionalTransaction tray already has a default implementation of with_conditional, and OpPooledTransaction defines its own method of the same name with the same semantics. 
Replaced the inherent OpPooledTransaction::with_conditional implementation with a call to MaybeConditionalTransaction::with_conditional to avoid duplicated logic.