### PR TITLE
docs: fix duplicate documentation for SparseStateTrieErrorKind

### DIFF
--- a/crates/evm/execution-errors/src/trie.rs
+++ b/crates/evm/execution-errors/src/trie.rs
@@ -96,7 +96,7 @@ impl SparseStateTrieError {
     }
 }
 
-/// Error encountered in `SparseStateTrie`.
+/// [`SparseStateTrieError`] kind.
 #[derive(Error, Debug)]
 pub enum SparseStateTrieErrorKind {
     /// Encountered invalid root node.


### PR DESCRIPTION
## Fix

Fixes duplicate documentation comment for `SparseStateTrieErrorKind` that matched `SparseStateTrieError`.

## Changes

- Updated `SparseStateTrieErrorKind` doc comment to `/// [`SparseStateTrieError`] kind.`
- Aligns with the pattern used for `SparseTrieErrorKind`