### PR TITLE
fix(era-downloader): replace redundant Err(e)? with Err(e.into())

### DIFF
--- a/crates/era-downloader/src/client.rs
+++ b/crates/era-downloader/src/client.rs
@@ -268,7 +268,7 @@ impl<Http: HttpClient + Clone> EraClient<Http> {
                 }
             }
             Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(false),
-            Err(e) => Err(e)?,
+            Err(e) => Err(e.into()),
         }
     }
 


### PR DESCRIPTION
## Problem

The error handling in `is_downloaded` uses the redundant pattern `Err(e)?` when converting `io::Error` to `eyre::Error`. The `?` operator is unnecessary here since we're already constructing an `Err` variant, and this pattern doesn't align with idiomatic Rust error conversion practices used elsewhere in the codebase.

## Solution

Replace `Err(e)?` with `Err(e.into())` to explicitly convert `io::Error` to `eyre::Error` using the `Into` trait. This matches the standard error conversion pattern used throughout the project and makes the type conversion more explicit and readable.