### PR TITLE
feat(stages): use EitherWriter for TransactionLookupStage RocksDB writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10583,6 +10583,7 @@ dependencies = [
  "reth-stages-api",
  "reth-static-file",
  "reth-static-file-types",
+ "reth-storage-api",
  "reth-storage-errors",
  "reth-testing-utils",
  "reth-trie",

--- a/crates/stages/stages/Cargo.toml
+++ b/crates/stages/stages/Cargo.toml
@@ -75,6 +75,7 @@ reth-network-p2p = { workspace = true, features = ["test-utils"] }
 reth-downloaders.workspace = true
 reth-static-file.workspace = true
 reth-stages-api = { workspace = true, features = ["test-utils"] }
+reth-storage-api.workspace = true
 reth-testing-utils.workspace = true
 reth-trie = { workspace = true, features = ["test-utils"] }
 reth-provider = { workspace = true, features = ["test-utils"] }
@@ -116,6 +117,7 @@ test-utils = [
     "reth-ethereum-primitives?/test-utils",
     "reth-evm-ethereum/test-utils",
 ]
+rocksdb = ["reth-provider/rocksdb"]
 
 [[bench]]
 name = "criterion"

--- a/crates/stages/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/stages/src/stages/tx_lookup.rs
@@ -1,19 +1,17 @@
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{TxHash, TxNumber};
-use num_traits::Zero;
 use reth_config::config::{EtlConfig, TransactionLookupConfig};
 use reth_db_api::{
-    cursor::{DbCursorRO, DbCursorRW},
-    table::Value,
+    table::{Decode, Decompress, Value},
     tables,
     transaction::DbTxMut,
-    RawKey, RawValue,
 };
 use reth_etl::Collector;
 use reth_primitives_traits::{NodePrimitives, SignedTransaction};
 use reth_provider::{
-    BlockReader, DBProvider, PruneCheckpointReader, PruneCheckpointWriter,
-    StaticFileProviderFactory, StatsReader, TransactionsProvider, TransactionsProviderExt,
+    BlockReader, DBProvider, EitherWriter, PruneCheckpointReader, PruneCheckpointWriter,
+    RocksDBProviderFactory, StaticFileProviderFactory, StatsReader, StorageSettingsCache,
+    TransactionsProvider, TransactionsProviderExt,
 };
 use reth_prune_types::{PruneCheckpoint, PruneMode, PrunePurpose, PruneSegment};
 use reth_stages_api::{
@@ -65,7 +63,9 @@ where
         + PruneCheckpointReader
         + StatsReader
         + StaticFileProviderFactory<Primitives: NodePrimitives<SignedTx: Value + SignedTransaction>>
-        + TransactionsProviderExt,
+        + TransactionsProviderExt
+        + StorageSettingsCache
+        + RocksDBProviderFactory,
 {
     /// Return the id of the stage
     fn id(&self) -> StageId {
@@ -150,32 +150,39 @@ where
             );
 
             if range_output.is_final_range {
-                let append_only =
-                    provider.count_entries::<tables::TransactionHashNumbers>()?.is_zero();
-                let mut txhash_cursor = provider
-                    .tx_ref()
-                    .cursor_write::<tables::RawTable<tables::TransactionHashNumbers>>()?;
-
                 let total_hashes = hash_collector.len();
                 let interval = (total_hashes / 10).max(1);
+
+                // Create RocksDB batch if feature is enabled
+                #[cfg(all(unix, feature = "rocksdb"))]
+                let rocksdb = provider.rocksdb_provider();
+                #[cfg(all(unix, feature = "rocksdb"))]
+                let rocksdb_batch = rocksdb.batch();
+                #[cfg(not(all(unix, feature = "rocksdb")))]
+                let rocksdb_batch = ();
+
+                // Create writer that routes to either MDBX or RocksDB based on settings
+                let mut writer =
+                    EitherWriter::new_transaction_hash_numbers(provider, rocksdb_batch)?;
+
                 for (index, hash_to_number) in hash_collector.iter()?.enumerate() {
-                    let (hash, number) = hash_to_number?;
+                    let (hash_bytes, number_bytes) = hash_to_number?;
                     if index > 0 && index.is_multiple_of(interval) {
                         info!(
                             target: "sync::stages::transaction_lookup",
-                            ?append_only,
                             progress = %format!("{:.2}%", (index as f64 / total_hashes as f64) * 100.0),
                             "Inserting hashes"
                         );
                     }
 
-                    let key = RawKey::<TxHash>::from_vec(hash);
-                    if append_only {
-                        txhash_cursor.append(key, &RawValue::<TxNumber>::from_vec(number))?
-                    } else {
-                        txhash_cursor.insert(key, &RawValue::<TxNumber>::from_vec(number))?
-                    }
+                    // Decode from raw ETL bytes
+                    let hash = TxHash::decode(&hash_bytes)?;
+                    let tx_num = TxNumber::decompress(&number_bytes)?;
+                    writer.put_transaction_hash_number(hash, tx_num)?;
                 }
+
+                // Commit the writer (no-op for MDBX, commits batch for RocksDB)
+                writer.commit()?;
 
                 trace!(target: "sync::stages::transaction_lookup",
                     total_hashes,
@@ -199,11 +206,19 @@ where
         provider: &Provider,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
-        let tx = provider.tx_ref();
         let (range, unwind_to, _) = input.unwind_block_range_with_threshold(self.chunk_size);
 
-        // Cursor to unwind tx hash to number
-        let mut tx_hash_number_cursor = tx.cursor_write::<tables::TransactionHashNumbers>()?;
+        // Create RocksDB batch if feature is enabled
+        #[cfg(all(unix, feature = "rocksdb"))]
+        let rocksdb = provider.rocksdb_provider();
+        #[cfg(all(unix, feature = "rocksdb"))]
+        let rocksdb_batch = rocksdb.batch();
+        #[cfg(not(all(unix, feature = "rocksdb")))]
+        let rocksdb_batch = ();
+
+        // Create writer that routes to either MDBX or RocksDB based on settings
+        let mut writer = EitherWriter::new_transaction_hash_numbers(provider, rocksdb_batch)?;
+
         let static_file_provider = provider.static_file_provider();
         let rev_walker = provider
             .block_body_indices_range(range.clone())?
@@ -218,14 +233,14 @@ where
 
             // Delete all transactions that belong to this block
             for tx_id in body.tx_num_range() {
-                // First delete the transaction and hash to id mapping
-                if let Some(transaction) = static_file_provider.transaction_by_id(tx_id)? &&
-                    tx_hash_number_cursor.seek_exact(transaction.trie_hash())?.is_some()
-                {
-                    tx_hash_number_cursor.delete_current()?;
+                if let Some(transaction) = static_file_provider.transaction_by_id(tx_id)? {
+                    writer.delete_transaction_hash_number(transaction.trie_hash())?;
                 }
             }
         }
+
+        // Commit the writer (no-op for MDBX, commits batch for RocksDB)
+        writer.commit()?;
 
         Ok(UnwindOutput {
             checkpoint: StageCheckpoint::new(unwind_to)
@@ -266,7 +281,7 @@ mod tests {
     };
     use alloy_primitives::{BlockNumber, B256};
     use assert_matches::assert_matches;
-    use reth_db_api::transaction::DbTx;
+    use reth_db_api::{cursor::DbCursorRO, transaction::DbTx};
     use reth_ethereum_primitives::Block;
     use reth_primitives_traits::SealedBlock;
     use reth_provider::{
@@ -579,6 +594,162 @@ mod tests {
     impl UnwindStageTestRunner for TransactionLookupTestRunner {
         fn validate_unwind(&self, input: UnwindInput) -> Result<(), TestRunnerError> {
             self.ensure_no_hash_by_block(input.unwind_to)
+        }
+    }
+
+    #[cfg(all(unix, feature = "rocksdb"))]
+    mod rocksdb_tests {
+        use super::*;
+        use reth_provider::RocksDBProviderFactory;
+        use reth_storage_api::StorageSettings;
+
+        /// Test that when `transaction_hash_numbers_in_rocksdb` is enabled, the stage
+        /// writes transaction hash mappings to `RocksDB` instead of MDBX.
+        #[tokio::test]
+        async fn execute_writes_to_rocksdb_when_enabled() {
+            let (previous_stage, stage_progress) = (110, 100);
+            let mut rng = generators::rng();
+
+            // Set up the runner
+            let runner = TransactionLookupTestRunner::default();
+
+            // Enable RocksDB for transaction hash numbers
+            runner.db.factory.set_storage_settings_cache(
+                StorageSettings::legacy().with_transaction_hash_numbers_in_rocksdb(true),
+            );
+
+            let input = ExecInput {
+                target: Some(previous_stage),
+                checkpoint: Some(StageCheckpoint::new(stage_progress)),
+            };
+
+            // Insert blocks with transactions
+            let blocks = random_block_range(
+                &mut rng,
+                stage_progress + 1..=previous_stage,
+                BlockRangeParams {
+                    parent: Some(B256::ZERO),
+                    tx_count: 1..3, // Ensure we have transactions
+                    ..Default::default()
+                },
+            );
+            runner
+                .db
+                .insert_blocks(blocks.iter(), StorageKind::Static)
+                .expect("failed to insert blocks");
+
+            // Count expected transactions
+            let expected_tx_count: usize = blocks.iter().map(|b| b.body().transactions.len()).sum();
+            assert!(expected_tx_count > 0, "test requires at least one transaction");
+
+            // Execute the stage
+            let rx = runner.execute(input);
+            let result = rx.await.unwrap();
+            assert!(result.is_ok(), "stage execution failed: {:?}", result);
+
+            // Verify MDBX table is empty (data should be in RocksDB)
+            let mdbx_count = runner.db.count_entries::<tables::TransactionHashNumbers>().unwrap();
+            assert_eq!(
+                mdbx_count, 0,
+                "MDBX TransactionHashNumbers should be empty when RocksDB is enabled"
+            );
+
+            // Verify RocksDB has the data
+            let rocksdb = runner.db.factory.rocksdb_provider();
+            let mut rocksdb_count = 0;
+            for block in &blocks {
+                for tx in &block.body().transactions {
+                    let hash = *tx.tx_hash();
+                    let result = rocksdb.get::<tables::TransactionHashNumbers>(hash).unwrap();
+                    assert!(result.is_some(), "Transaction hash {:?} not found in RocksDB", hash);
+                    rocksdb_count += 1;
+                }
+            }
+            assert_eq!(
+                rocksdb_count, expected_tx_count,
+                "RocksDB should contain all transaction hashes"
+            );
+        }
+
+        /// Test that when `transaction_hash_numbers_in_rocksdb` is enabled, the stage
+        /// unwind deletes transaction hash mappings from `RocksDB` instead of MDBX.
+        #[tokio::test]
+        async fn unwind_deletes_from_rocksdb_when_enabled() {
+            let (previous_stage, stage_progress) = (110, 100);
+            let mut rng = generators::rng();
+
+            // Set up the runner
+            let runner = TransactionLookupTestRunner::default();
+
+            // Enable RocksDB for transaction hash numbers
+            runner.db.factory.set_storage_settings_cache(
+                StorageSettings::legacy().with_transaction_hash_numbers_in_rocksdb(true),
+            );
+
+            // Insert blocks with transactions
+            let blocks = random_block_range(
+                &mut rng,
+                stage_progress + 1..=previous_stage,
+                BlockRangeParams {
+                    parent: Some(B256::ZERO),
+                    tx_count: 1..3, // Ensure we have transactions
+                    ..Default::default()
+                },
+            );
+            runner
+                .db
+                .insert_blocks(blocks.iter(), StorageKind::Static)
+                .expect("failed to insert blocks");
+
+            // Count expected transactions
+            let expected_tx_count: usize = blocks.iter().map(|b| b.body().transactions.len()).sum();
+            assert!(expected_tx_count > 0, "test requires at least one transaction");
+
+            // Execute the stage first to populate RocksDB
+            let exec_input = ExecInput {
+                target: Some(previous_stage),
+                checkpoint: Some(StageCheckpoint::new(stage_progress)),
+            };
+            let rx = runner.execute(exec_input);
+            let result = rx.await.unwrap();
+            assert!(result.is_ok(), "stage execution failed: {:?}", result);
+
+            // Verify RocksDB has the data before unwind
+            let rocksdb = runner.db.factory.rocksdb_provider();
+            for block in &blocks {
+                for tx in &block.body().transactions {
+                    let hash = *tx.tx_hash();
+                    let result = rocksdb.get::<tables::TransactionHashNumbers>(hash).unwrap();
+                    assert!(
+                        result.is_some(),
+                        "Transaction hash {:?} should exist before unwind",
+                        hash
+                    );
+                }
+            }
+
+            // Now unwind to stage_progress (removing all the blocks we added)
+            let unwind_input = UnwindInput {
+                checkpoint: StageCheckpoint::new(previous_stage),
+                unwind_to: stage_progress,
+                bad_block: None,
+            };
+            let unwind_result = runner.unwind(unwind_input).await;
+            assert!(unwind_result.is_ok(), "stage unwind failed: {:?}", unwind_result);
+
+            // Verify RocksDB data is deleted after unwind
+            let rocksdb = runner.db.factory.rocksdb_provider();
+            for block in &blocks {
+                for tx in &block.body().transactions {
+                    let hash = *tx.tx_hash();
+                    let result = rocksdb.get::<tables::TransactionHashNumbers>(hash).unwrap();
+                    assert!(
+                        result.is_none(),
+                        "Transaction hash {:?} should be deleted from RocksDB after unwind",
+                        hash
+                    );
+                }
+            }
         }
     }
 }

--- a/crates/stages/stages/src/test_utils/test_db.rs
+++ b/crates/stages/stages/src/test_utils/test_db.rs
@@ -50,7 +50,7 @@ impl Default for TestStageDB {
                 create_test_rw_db(),
                 MAINNET.clone(),
                 StaticFileProvider::read_write(static_dir_path).unwrap(),
-                RocksDBProvider::builder(rocksdb_dir_path).build().unwrap(),
+                RocksDBProvider::builder(rocksdb_dir_path).with_default_tables().build().unwrap(),
             )
             .expect("failed to create test provider factory"),
         }
@@ -68,7 +68,7 @@ impl TestStageDB {
                 create_test_rw_db_with_path(path),
                 MAINNET.clone(),
                 StaticFileProvider::read_write(static_dir_path).unwrap(),
-                RocksDBProvider::builder(rocksdb_dir_path).build().unwrap(),
+                RocksDBProvider::builder(rocksdb_dir_path).with_default_tables().build().unwrap(),
             )
             .expect("failed to create test provider factory"),
         }

--- a/crates/storage/provider/src/either_writer.rs
+++ b/crates/storage/provider/src/either_writer.rs
@@ -921,7 +921,7 @@ mod rocksdb_tests {
 
     /// Test that `RocksDB` commits happen at `provider.commit()` level, not at writer level.
     ///
-    /// This ensures all storage commits (MDBX, static files, RocksDB) happen atomically
+    /// This ensures all storage commits (MDBX, static files, `RocksDB`) happen atomically
     /// in a single place, making it easier to reason about commit ordering and consistency.
     #[test]
     fn test_rocksdb_commits_at_provider_level() {

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -181,6 +181,11 @@ impl<N: ProviderNodeTypes> RocksDBProviderFactory for BlockchainProvider<N> {
     fn rocksdb_provider(&self) -> RocksDBProvider {
         self.database.rocksdb_provider()
     }
+
+    #[cfg(all(unix, feature = "rocksdb"))]
+    fn set_pending_rocksdb_batch(&self, _batch: rocksdb::WriteBatchWithTransaction<true>) {
+        unimplemented!("BlockchainProvider wraps ProviderFactory - use DatabaseProvider::set_pending_rocksdb_batch instead")
+    }
 }
 
 impl<N: ProviderNodeTypes> HeaderProvider for BlockchainProvider<N> {

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -153,6 +153,11 @@ impl<N: NodeTypesWithDB> RocksDBProviderFactory for ProviderFactory<N> {
     fn rocksdb_provider(&self) -> RocksDBProvider {
         self.rocksdb_provider.clone()
     }
+
+    #[cfg(all(unix, feature = "rocksdb"))]
+    fn set_pending_rocksdb_batch(&self, _batch: rocksdb::WriteBatchWithTransaction<true>) {
+        unimplemented!("ProviderFactory is a factory, not a provider - use DatabaseProvider::set_pending_rocksdb_batch instead")
+    }
 }
 
 impl<N: ProviderNodeTypes<DB = Arc<DatabaseEnv>>> ProviderFactory<N> {

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -450,6 +450,19 @@ impl RocksDBProvider {
             batch_handle.commit()
         })
     }
+
+    /// Commits a raw `WriteBatchWithTransaction` to `RocksDB`.
+    ///
+    /// This is used when the batch was extracted via [`RocksDBBatch::into_inner`]
+    /// and needs to be committed at a later point (e.g., at provider commit time).
+    pub fn commit_batch(&self, batch: WriteBatchWithTransaction<true>) -> ProviderResult<()> {
+        self.0.db.write_opt(batch, &WriteOptions::default()).map_err(|e| {
+            ProviderError::Database(DatabaseError::Commit(DatabaseErrorInfo {
+                message: e.to_string().into(),
+                code: -1,
+            }))
+        })
+    }
 }
 
 /// Handle for building a batch of operations atomically.
@@ -528,6 +541,13 @@ impl<'a> RocksDBBatch<'a> {
     /// Returns a reference to the underlying `RocksDB` provider.
     pub const fn provider(&self) -> &RocksDBProvider {
         self.provider
+    }
+
+    /// Consumes the batch and returns the underlying `WriteBatchWithTransaction`.
+    ///
+    /// This is used to defer commits to the provider level.
+    pub fn into_inner(self) -> WriteBatchWithTransaction<true> {
+        self.inner
     }
 }
 

--- a/crates/storage/provider/src/test_utils/mod.rs
+++ b/crates/storage/provider/src/test_utils/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    providers::{NodeTypesForProvider, ProviderNodeTypes, RocksDBProvider, StaticFileProvider},
+    providers::{NodeTypesForProvider, ProviderNodeTypes, RocksDBBuilder, StaticFileProvider},
     HashingWriter, ProviderFactory, TrieWriter,
 };
 use alloy_primitives::B256;
@@ -62,7 +62,10 @@ pub fn create_test_provider_factory_with_node_types<N: NodeTypesForProvider>(
         db,
         chain_spec,
         StaticFileProvider::read_write(static_dir.keep()).expect("static file provider"),
-        RocksDBProvider::new(&rocksdb_dir).expect("failed to create test RocksDB provider"),
+        RocksDBBuilder::new(&rocksdb_dir)
+            .with_default_tables()
+            .build()
+            .expect("failed to create test RocksDB provider"),
     )
     .expect("failed to create test provider factory")
 }

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -29,4 +29,9 @@ impl<C: Send + Sync, N: NodePrimitives> RocksDBProviderFactory for NoopProvider<
     fn rocksdb_provider(&self) -> RocksDBProvider {
         RocksDBProvider::builder(PathBuf::default()).build().unwrap()
     }
+
+    #[cfg(all(unix, feature = "rocksdb"))]
+    fn set_pending_rocksdb_batch(&self, _batch: rocksdb::WriteBatchWithTransaction<true>) {
+        // No-op for NoopProvider
+    }
 }

--- a/crates/storage/provider/src/traits/rocksdb_provider.rs
+++ b/crates/storage/provider/src/traits/rocksdb_provider.rs
@@ -6,4 +6,11 @@ use crate::providers::RocksDBProvider;
 pub trait RocksDBProviderFactory {
     /// Returns the `RocksDB` provider.
     fn rocksdb_provider(&self) -> RocksDBProvider;
+
+    /// Adds a pending `RocksDB` batch to be committed when this provider is committed.
+    ///
+    /// This allows deferring `RocksDB` commits to happen at the same time as MDBX and static file
+    /// commits, ensuring atomicity across all storage backends.
+    #[cfg(all(unix, feature = "rocksdb"))]
+    fn set_pending_rocksdb_batch(&self, batch: rocksdb::WriteBatchWithTransaction<true>);
 }


### PR DESCRIPTION
Closes #20389 

Changes in `TransactionLookupStage` to use `EitherWriter` abstraction for writing transaction hash mappings, enabling seamless routing to either MDBX or RocksDB based on storage settings.

  - Add `EitherWriter::commit()` for RocksDB batch commits
  - Update execute() and unwind() to use `EitherWriter::new_transaction_hash_numbers()`
  - Update test factory to register RocksDB column families with `with_default_tables()`
