### PR TITLE
fix(payload): clarify PayloadTransactions mark_invalid semantics

### DIFF
--- a/crates/payload/util/src/traits.rs
+++ b/crates/payload/util/src/traits.rs
@@ -19,8 +19,11 @@ pub trait PayloadTransactions {
         ctx: (),
     ) -> Option<Self::Transaction>;
 
-    /// Exclude descendants of the transaction with given sender and nonce from the iterator,
-    /// because this transaction won't be included in the block.
+    /// Marks the transaction identified by `sender` and `nonce` as invalid for this iterator.
+    ///
+    /// Implementations must ensure that subsequent transactions returned from this iterator do not
+    /// depend on this transaction. For example, they may choose to stop yielding any further
+    /// transactions from this sender in the current iteration.
     fn mark_invalid(&mut self, sender: Address, nonce: u64);
 }
 
@@ -46,6 +49,9 @@ impl<T> PayloadTransactions for NoopPayloadTransactions<T> {
 
 /// Wrapper struct that allows to convert `BestTransactions` (used in tx pool) to
 /// `PayloadTransactions` (used in block composition).
+///
+/// Note: `mark_invalid` for this type filters out all further transactions from the given sender
+/// in the current iteration, mirroring the semantics of `BestTransactions::mark_invalid`.
 #[derive(Debug)]
 pub struct BestPayloadTransactions<T, I>
 where


### PR DESCRIPTION
Clarified the contract of PayloadTransactions::mark_invalid so it matches how block builders and the transaction pool actually use it. Instead of promising to exclude only nonce descendants, the docs now state that implementations must avoid returning transactions that depend on the invalid one, and explicitly allow filtering by sender. The comment on BestPayloadTransactions was also updated to document that it drops all further transactions from the given sender in the current iteration, mirroring 
BestTransactions::mark_invalid.