### PR TITLE
docs(exex): document ChainRevert flow in how-it-works

### DIFF
--- a/docs/vocs/docs/pages/exex/how-it-works.mdx
+++ b/docs/vocs/docs/pages/exex/how-it-works.mdx
@@ -24,6 +24,13 @@ sequenceDiagram
     ExEx->>ExEx: Rollback & Re-process
     ExEx->>Reth: New FinishedHeight Event
     deactivate ExEx
+
+    Note over Reth,ExEx: Revert Flow
+    Reth->>ExEx: ChainRevert Notification
+    activate ExEx
+    ExEx->>ExEx: Rollback & Re-process
+    ExEx->>Reth: New FinishedHeight Event
+    deactivate ExEx
 ```
 
 ExExes are just [Futures](https://doc.rust-lang.org/std/future/trait.Future.html) that run indefinitely alongside Reth


### PR DESCRIPTION
Updated the ExEx architecture mermaid sequence in how-it-works.mdx to include a dedicated “Revert Flow” using ChainRevert notifications. This makes the docs consistent with the actual ExExNotification variants and clarifies that ExExes are expected to handle reverts in addition to commits and reorgs.