### PR TITLE
chore: fix blob count in validation benchmark

### DIFF
--- a/crates/primitives/benches/validate_blob_tx.rs
+++ b/crates/primitives/benches/validate_blob_tx.rs
@@ -42,13 +42,12 @@ fn validate_blob_tx(
             blob_sidecar.blobs.extend(blob_sidecar_ext.blobs);
             blob_sidecar.proofs.extend(blob_sidecar_ext.proofs);
             blob_sidecar.commitments.extend(blob_sidecar_ext.commitments);
-
-            if blob_sidecar.blobs.len() > num_blobs as usize {
-                blob_sidecar.blobs.truncate(num_blobs as usize);
-                blob_sidecar.proofs.truncate(num_blobs as usize);
-                blob_sidecar.commitments.truncate(num_blobs as usize);
-            }
         }
+
+        // ensure exactly num_blobs blobs
+        blob_sidecar.blobs.truncate(num_blobs as usize);
+        blob_sidecar.proofs.truncate(num_blobs as usize);
+        blob_sidecar.commitments.truncate(num_blobs as usize);
 
         tx.blob_versioned_hashes = blob_sidecar.versioned_hashes().collect();
 


### PR DESCRIPTION
The truncate logic was inside the while loop, so it never executed when the initial arbitrary-generated sidecar already had more blobs than num_blobs. This caused the benchmark to test with wrong blob counts (e.g. testing "1 blob" with 3+ blobs).

Moved truncate outside the loop to ensure exact blob count regardless of initial sidecar size.