### PR TITLE
perf: remove redundant contains_key check in ProofSequencer::add_proof

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -170,11 +170,6 @@ impl ProofSequencer {
         while let Some(pending) = self.pending_proofs.remove(&current_sequence) {
             consecutive_proofs.push(pending);
             current_sequence += 1;
-
-            // if we don't have the next number, stop collecting
-            if !self.pending_proofs.contains_key(&current_sequence) {
-                break;
-            }
         }
 
         self.next_to_deliver += consecutive_proofs.len() as u64;


### PR DESCRIPTION
Closes: https://github.com/paradigmxyz/reth/issues/20439
Removes a redundant `contains_key()` check inside the `while` loop in `ProofSequencer::add_proof`.

- The loop uses `while let Some(pending) = self.pending_proofs.remove(&current_sequence)` which naturally exits when the key doesn't exist. The inner `contains_key()` check on line 175 is unnecessary since `remove()` will return `None` on the next iteration anyway.

- So we can remove to save one `BTreeMap::contains_key()` lookup (O(log n)) per iteration while maintaining identical behavior.