### PR TITLE
fix: properly determine first stage during pipeline consistency check

### DIFF
--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -938,11 +938,15 @@ where
     ///
     /// A target block hash if the pipeline is inconsistent, otherwise `None`.
     pub fn check_pipeline_consistency(&self) -> ProviderResult<Option<B256>> {
+        // Get the expected first stage based on config.
+        let first_stage =
+            if self.era_import_source().is_some() { StageId::Era } else { StageId::Headers };
+
         // If no target was provided, check if the stages are congruent - check if the
         // checkpoint of the last stage matches the checkpoint of the first.
         let first_stage_checkpoint = self
             .blockchain_db()
-            .get_stage_checkpoint(*StageId::ALL.first().unwrap())?
+            .get_stage_checkpoint(first_stage)?
             .unwrap_or_default()
             .block_number;
 


### PR DESCRIPTION
Right now in some cases era stage checkpoint might be below headers checkpoint which causes weird issues because `HeaderStage` does not behave well when `tip < database_tip`