### PR TITLE
chore(node): Report actual gas price to ethstats

### DIFF
--- a/crates/node/ethstats/src/ethstats.rs
+++ b/crates/node/ethstats/src/ethstats.rs
@@ -208,7 +208,7 @@ where
                 active: true,
                 syncing: self.network.is_syncing(),
                 peers: self.network.num_connected_peers() as u64,
-                gas_price: 0, // TODO
+                gas_price: self.pool.block_info().pending_basefee,
                 uptime: 100,
             },
         };


### PR DESCRIPTION
Replaces hardcoded 0 with pending_basefee from pool, fixes gas price reporting in ethstats service.

Upstreams https://github.com/op-rs/op-reth/pull/495