### PR TITLE
fix: correct debug log key in execution cache update

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -256,7 +256,7 @@ where
         let hash = env.hash;
 
         if let Some(saved_cache) = saved_cache {
-            debug!(target: "engine::caching", parent_hash=?hash, "Updating execution cache");
+            debug!(target: "engine::caching", block_hash=?hash, "Updating execution cache");
             // Perform all cache operations atomically under the lock
             execution_cache.update_with_guard(|cached| {
                 // consumes the `SavedCache` held by the prewarming task, which releases its usage


### PR DESCRIPTION


Fixes incorrect debug log key in `save_cache` method. The log was using `parent_hash` as the key but logging `env.hash` (current block hash), which was misleading.

