### PR TITLE
chore(primitives-traits): correct SealedBlock::senders return description

### DIFF
--- a/crates/primitives-traits/src/block/sealed.rs
+++ b/crates/primitives-traits/src/block/sealed.rs
@@ -179,7 +179,7 @@ impl<B: Block> SealedBlock<B> {
 
     /// Recovers all senders from the transactions in the block.
     ///
-    /// Returns `None` if any of the transactions fail to recover the sender.
+    /// Returns an error if any of the transactions fail to recover the sender.
     pub fn senders(&self) -> Result<Vec<Address>, RecoveryError> {
         self.body().recover_signers()
     }


### PR DESCRIPTION
SealedBlock::senders returns `Result<Vec<Address>, RecoveryError>`, but the doc comment still claimed it returns `None` when sender recovery fails.