### PR TITLE
chore(trie): Rm redundant clone of propagated error

### DIFF
--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -160,15 +160,15 @@ where
     ///
     /// If `metrics` feature is enabled, it also updates the metrics.
     fn next_hashed_entry(&mut self) -> Result<Option<(B256, H::Value)>, DatabaseError> {
-        let result = self.hashed_cursor.next();
+        let next = self.hashed_cursor.next()?;
 
-        self.last_next_result = result.clone()?;
+        self.last_next_result = next.clone();
 
         #[cfg(feature = "metrics")]
         {
             self.metrics.inc_leaf_nodes_advanced();
         }
-        result
+        Ok(next)
     }
 }
 

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -162,7 +162,7 @@ where
     fn next_hashed_entry(&mut self) -> Result<Option<(B256, H::Value)>, DatabaseError> {
         let next = self.hashed_cursor.next()?;
 
-        self.last_next_result = next.clone();
+        self.last_next_result = next;
 
         #[cfg(feature = "metrics")]
         {


### PR DESCRIPTION
Removes redundant clone of error that is propagated directly anyway