### PR TITLE
docs: correct intra-doc link references

### DIFF
--- a/crates/primitives-traits/src/header/sealed.rs
+++ b/crates/primitives-traits/src/header/sealed.rs
@@ -94,7 +94,7 @@ impl<H: Sealable> SealedHeader<H> {
         *self.hash_ref()
     }
 
-    /// This is the inverse of [`Header::seal_slow`] which returns the raw header and hash.
+    /// This is the inverse of [`Self::seal_slow`] which returns the raw header and hash.
     pub fn split(self) -> (H, BlockHash) {
         let hash = self.hash();
         (self.header, hash)

--- a/crates/rpc/rpc-eth-types/src/cache/multi_consumer.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/multi_consumer.rs
@@ -92,7 +92,7 @@ where
     ///
     /// Can fail if the element is rejected by the limiter or if we fail to grow an empty map.
     ///
-    /// See [`Schnellru::insert`](LruMap::insert) for more info.
+    /// See [`LruMap::insert`] for more info.
     pub fn insert<'a>(&mut self, key: L::KeyToInsert<'a>, value: V) -> bool
     where
         L::KeyToInsert<'a>: Hash + PartialEq<K>,


### PR DESCRIPTION
1. `SealedHeader::split`: referenced `Header::seal_slow` but the method is `SealedHeader::seal_slow`
2. `MultiConsumerLruCache::insert`: referenced `Schnellru::insert` but Schnellru is the crate name, not a type. Should be `LruMap::insert`