### PR TITLE
Stop overcounting tx offsets when iterating in-memory blocks

### DIFF
--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -1166,9 +1166,10 @@ impl<N: ProviderNodeTypes> BlockBodyIndicesProvider for ConsistentProvider<N> {
                         state.block_ref().recovered_block().body().transactions().len() as u64;
                     if state.block_ref().recovered_block().number() == number {
                         stored_indices.tx_count = block_tx_count;
-                    } else {
-                        stored_indices.first_tx_num += block_tx_count;
+                      break;
                     }
+
+                    stored_indices.first_tx_num += block_tx_count;
                 }
 
                 Ok(Some(stored_indices))


### PR DESCRIPTION
Ensure block body indices calculation breaks once the target in-memory block is reached, so first_tx_num isn’t advanced past the requested block while still setting the correct tx_count.