### PR TITLE
Remove redundant PartialEq bound from NodePrimitives

### DIFF
--- a/crates/primitives-traits/src/node.rs
+++ b/crates/primitives-traits/src/node.rs
@@ -8,9 +8,7 @@ use core::fmt;
 /// This trait defines the core types used throughout the node for representing
 /// blockchain data. It serves as the foundation for type consistency across
 /// different node implementations.
-pub trait NodePrimitives:
-    Send + Sync + Unpin + Clone + Default + fmt::Debug + PartialEq + Eq + 'static
-{
+pub trait NodePrimitives: Send + Sync + Unpin + Clone + Default + fmt::Debug + Eq + 'static {
     /// Block primitive.
     type Block: FullBlock<Header = Self::BlockHeader, Body = Self::BlockBody>
         + MaybeSerdeBincodeCompat;


### PR DESCRIPTION
Drop the explicit PartialEq bound from NodePrimitives; Eq already implies PartialEq, so this tightens the trait contract without changing behavior. Keeps API and implementations untouched; only removes duplicate constraint noise.