### PR TITLE
docs: fix Docker db-access troubleshooting example

### DIFF
--- a/docs/vocs/docs/pages/run/faq/troubleshooting.mdx
+++ b/docs/vocs/docs/pages/run/faq/troubleshooting.mdx
@@ -24,7 +24,7 @@ This page tries to answer how to deal with the most popular issues.
 
 Externally accessing a `datadir` inside a named docker volume will usually come with folder/file ownership/permissions issues.
 
-**It is not recommended** to use the path to the named volume as it will trigger an error code 13. `RETH_DB_PATH: /var/lib/docker/volumes/named_volume/_data/eth/db cargo r --examples db-access --path ` is **DISCOURAGED** and a mounted volume with the right permissions should be used instead.
+**It is not recommended** to use the path to the named volume as it will trigger an error code 13. For example, `RETH_DATADIR=/var/lib/docker/volumes/named_volume/_data/eth cargo run -p db-access` is **DISCOURAGED** and a mounted volume with the right permissions should be used instead.
 
 ### Error code 13
 


### PR DESCRIPTION
The previous Docker troubleshooting snippet referred to the RETH_DB_PATH environment variable, pointed it at the internal db subdirectory, and used a non-existent cargo r --examples db-access --path command. Updated the example to use the correct RETH_DATADIR variable pointing at the datadir root and a valid cargo run -p db-access invocation, so users can copy and paste the command and have it work against a real datadir instead of a mis-specified path.