### PR TITLE
fix(cli): default to 0 genesis block number

### DIFF
--- a/crates/cli/commands/src/common.rs
+++ b/crates/cli/commands/src/common.rs
@@ -103,7 +103,7 @@ impl<C: ChainSpecParser> EnvironmentArgs<C> {
         }
 
         info!(target: "reth::cli", ?db_path, ?sf_path, "Opening storage");
-        let genesis_block_number = self.chain.genesis().number.unwrap();
+        let genesis_block_number = self.chain.genesis().number.unwrap_or_default();
         let (db, sfp) = match access {
             AccessRights::RW => (
                 Arc::new(init_db(db_path, self.db.database_args())?),


### PR DESCRIPTION
Follow-up to https://github.com/paradigmxyz/reth/pull/19877

Without it, makes all CLI commands crash for genesises without `number` in it.