### PR TITLE
chore(cli): correct p2p body error message

### DIFF
--- a/crates/cli/commands/src/p2p/mod.rs
+++ b/crates/cli/commands/src/p2p/mod.rs
@@ -72,7 +72,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                 .split();
                 if result.len() != 1 {
                     eyre::bail!(
-                        "Invalid number of headers received. Expected: 1. Received: {}",
+                        "Invalid number of bodies received. Expected: 1. Received: {}",
                         result.len()
                     )
                 }


### PR DESCRIPTION
The p2p Body subcommand now reports "Invalid number of bodies received" instead of "headers" when validating the response from get_block_bodies. This aligns the error message with the actual type being fetched and makes debugging failed body downloads less confusing.