### PR TITLE
refactor(db-api): remove redundant clone and unused import in unwind

### DIFF
--- a/crates/storage/db-api/src/unwind.rs
+++ b/crates/storage/db-api/src/unwind.rs
@@ -1,4 +1,4 @@
-use crate::{cursor::DbCursorRO, table::Table, transaction::DbTxMut};
+use crate::{table::Table, transaction::DbTxMut};
 use reth_storage_errors::db::DatabaseError;
 use std::ops::RangeBounds;
 
@@ -30,7 +30,7 @@ pub trait DbTxUnwindExt: DbTxMut {
         let mut deleted = 0;
 
         while let Some(Ok((entry_key, _))) = reverse_walker.next() {
-            if selector(entry_key.clone()) <= key {
+            if selector(entry_key) <= key {
                 break
             }
             reverse_walker.delete_current()?;

--- a/crates/storage/db-api/src/unwind.rs
+++ b/crates/storage/db-api/src/unwind.rs
@@ -1,4 +1,4 @@
-use crate::{table::Table, transaction::DbTxMut};
+use crate::{cursor::DbCursorRO, table::Table, transaction::DbTxMut};
 use reth_storage_errors::db::DatabaseError;
 use std::ops::RangeBounds;
 


### PR DESCRIPTION
This PR removes unnecessary allocations and dead code in the `unwind` module to improve performance and code cleanliness.