### PR TITLE
docs(provider): fix return type documentation in RocksDB consistency check

### DIFF
--- a/crates/storage/provider/src/providers/rocksdb/invariants.rs
+++ b/crates/storage/provider/src/providers/rocksdb/invariants.rs
@@ -22,7 +22,11 @@ impl RocksDBProvider {
     /// Checks consistency of `RocksDB` tables against MDBX stage checkpoints.
     ///
     /// Returns an unwind target block number if the pipeline needs to unwind to rebuild
-    /// `RocksDB` data. Returns `None` if all invariants pass or if inconsistencies were healed.
+    /// `RocksDB` data. Returns `Ok(None)` if all invariants pass or if inconsistencies were healed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if database operations fail during consistency checks.
     ///
     /// # Invariants checked
     ///


### PR DESCRIPTION
The documentation stated:
> Returns `None` if all invariants pass or if inconsistencies were healed.

However, the actual return type is `ProviderResult<Option<BlockNumber>>`, which 
means the function can also return an error. This mismatch could mislead developers 
about proper error handling.
