### PR TITLE
fix(flashblocks): Add flashblock ws connection retry period

### DIFF
--- a/crates/optimism/flashblocks/src/consensus.rs
+++ b/crates/optimism/flashblocks/src/consensus.rs
@@ -135,7 +135,8 @@ where
         }
     }
 
-    /// Runs the consensus client loop.
+    /// Runs the consensus client loop. The flashblock consensus should be the only source that
+    /// drive the chain forward.
     ///
     /// Continuously receives completed flashblock sequences and submits them to the execution
     /// engine:

--- a/crates/optimism/flashblocks/src/consensus.rs
+++ b/crates/optimism/flashblocks/src/consensus.rs
@@ -135,8 +135,7 @@ where
         }
     }
 
-    /// Runs the consensus client loop. The flashblock consensus should be the only source that
-    /// drive the chain forward.
+    /// Runs the consensus client loop.
     ///
     /// Continuously receives completed flashblock sequences and submits them to the execution
     /// engine:

--- a/crates/optimism/flashblocks/src/service.rs
+++ b/crates/optimism/flashblocks/src/service.rs
@@ -22,7 +22,7 @@ use tokio::{
 };
 use tracing::*;
 
-const CONNECTION_RETRY_PERIOD: Duration = Duration::from_secs(5);
+const CONNECTION_BACKOUT_PERIOD: Duration = Duration::from_secs(5);
 
 /// The `FlashBlockService` maintains an in-memory [`PendingFlashBlock`] built out of a sequence of
 /// [`FlashBlock`]s.
@@ -178,10 +178,10 @@ where
                             warn!(
                                 target: "flashblocks",
                                 %err,
-                                retry_period = CONNECTION_RETRY_PERIOD.as_secs(),
+                                retry_period = CONNECTION_BACKOUT_PERIOD.as_secs(),
                                 "Error receiving flashblock"
                             );
-                            sleep(CONNECTION_RETRY_PERIOD).await;
+                            sleep(CONNECTION_BACKOUT_PERIOD).await;
                         }
                         None => {
                             warn!(target: "flashblocks", "Flashblock stream ended");

--- a/crates/optimism/flashblocks/src/service.rs
+++ b/crates/optimism/flashblocks/src/service.rs
@@ -22,7 +22,7 @@ use tokio::{
 };
 use tracing::*;
 
-const CONNECTION_RETRY_DELAY: Duration = Duration::from_secs(5);
+const CONNECTION_RETRY_PERIOD: Duration = Duration::from_secs(5);
 
 /// The `FlashBlockService` maintains an in-memory [`PendingFlashBlock`] built out of a sequence of
 /// [`FlashBlock`]s.
@@ -178,10 +178,10 @@ where
                             warn!(
                                 target: "flashblocks",
                                 %err,
-                                delay_secs = CONNECTION_RETRY_DELAY.as_secs(),
+                                retry_period = CONNECTION_RETRY_PERIOD.as_secs(),
                                 "Error receiving flashblock"
                             );
-                            sleep(CONNECTION_RETRY_DELAY).await;
+                            sleep(CONNECTION_RETRY_PERIOD).await;
                         }
                         None => {
                             warn!(target: "flashblocks", "Flashblock stream ended");


### PR DESCRIPTION
## Summary

This PR adds websocket retry period to prevent unbounded retry loop on websocket connection failures on the flashblock service.