### PR TITLE
fix(tree): correct block buffer eviction policy comment

### DIFF
--- a/crates/engine/tree/src/tree/block_buffer.rs
+++ b/crates/engine/tree/src/tree/block_buffer.rs
@@ -14,7 +14,7 @@ use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 /// * [`BlockBuffer::remove_old_blocks`] to remove old blocks that precede the finalized number.
 ///
 /// Note: Buffer is limited by number of blocks that it can contain and eviction of the block
-/// is done by last recently used block.
+/// is done in FIFO order (oldest inserted block is evicted first).
 #[derive(Debug)]
 pub struct BlockBuffer<B: Block> {
     /// All blocks in the buffer stored by their block hash.


### PR DESCRIPTION
The comment said eviction is done by "last recently used" (LRU), but the code actually uses FIFO - it just pops from the front of a VecDeque without any access tracking. Fixed the comment to match the actual behavior.