### PR TITLE
docs: correct load_toml_config comment

### DIFF
--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -145,7 +145,8 @@ impl LaunchContext {
     /// Loads the reth config with the configured `data_dir` and overrides settings according to the
     /// `config`.
     ///
-    /// This is async because the trusted peers may have to be resolved.
+    /// Persists updated pruning settings back to the config file when needed and merges static file
+    /// CLI options with the config file, giving precedence to CLI values.
     pub fn load_toml_config<ChainSpec>(
         &self,
         config: &NodeConfig<ChainSpec>,


### PR DESCRIPTION
The load_toml_config helper is synchronous and no longer resolves trusted peers. Its doc comment still claimed it was async, which is misleading for readers and for anyone searching for where trusted peers are handled.

Updated the comment to describe the actual side effects (loading the config, persisting pruning settings and merging static file options) and drop the stale async note.