### PR TITLE
refactor(consensus): simplify verify_receipts return

### DIFF
--- a/crates/ethereum/consensus/src/validation.rs
+++ b/crates/ethereum/consensus/src/validation.rs
@@ -87,9 +87,7 @@ fn verify_receipts<R: Receipt>(
         logs_bloom,
         expected_receipts_root,
         expected_logs_bloom,
-    )?;
-
-    Ok(())
+    )
 }
 
 /// Compare the calculated receipts root with the expected receipts root, also compare


### PR DESCRIPTION
Remove unnecessary `?` + `Ok(())` pattern in `verify_receipts` function. Since `compare_receipts_root_and_logs_bloom` already returns `Result<(), ConsensusError>`, we can just return its result directly instead of unwrapping and rewrapping it.