### PR TITLE
chore(evm): remove deprecated `state_change` compatibility alias

### DIFF
--- a/crates/evm/evm/src/lib.rs
+++ b/crates/evm/evm/src/lib.rs
@@ -61,8 +61,6 @@ pub use alloy_evm::{
     *,
 };
 
-pub use alloy_evm::block::state_changes as state_change;
-
 /// A complete configuration of EVM for Reth.
 ///
 /// This trait encapsulates complete configuration required for transaction execution and block


### PR DESCRIPTION
The `state_change` alias was added for backwards compatibility when the module moved to `alloy_evm::block::state_changes`. Since then, all usages have migrated to `state_changes` and no code references the old `state_change` name anymore. 