### PR TITLE
chore: prevent false-positive log when peer not found in transaction propagation

### DIFF
--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -860,7 +860,6 @@ where
         peer_id: PeerId,
         propagation_mode: PropagationMode,
     ) -> Option<PropagatedTransactions> {
-        // Only log after we know the peer exists; otherwise we would emit a false-positive.
         let peer = self.peers.get_mut(&peer_id)?;
         trace!(target: "net::tx", ?peer_id, "Propagating transactions to peer");
         let mut propagated = PropagatedTransactions::default();

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -860,9 +860,9 @@ where
         peer_id: PeerId,
         propagation_mode: PropagationMode,
     ) -> Option<PropagatedTransactions> {
-        trace!(target: "net::tx", ?peer_id, "Propagating transactions to peer");
-
+        // Only log after we know the peer exists; otherwise we would emit a false-positive.
         let peer = self.peers.get_mut(&peer_id)?;
+        trace!(target: "net::tx", ?peer_id, "Propagating transactions to peer");
         let mut propagated = PropagatedTransactions::default();
 
         // filter all transactions unknown to the peer


### PR DESCRIPTION


The trace log was emitted before checking if the peer exists, causing false-positive log entries when `propagate_full_transactions_to_peer` returns early due to a missing peer. This misleads debugging efforts and makes it appear that transactions were propagated when they were actually skipped.

