### PR TITLE
fix: propagate keccak-cache-global feature to reth-node-core

### DIFF
--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -103,6 +103,7 @@ asm-keccak = [
     "reth-node-ethereum/asm-keccak",
 ]
 keccak-cache-global = [
+    "reth-node-core/keccak-cache-global",
     "reth-node-ethereum/keccak-cache-global",
 ]
 jemalloc = [

--- a/crates/ethereum/node/Cargo.toml
+++ b/crates/ethereum/node/Cargo.toml
@@ -91,6 +91,7 @@ asm-keccak = [
 ]
 keccak-cache-global = [
     "alloy-primitives/keccak-cache-global",
+    "reth-node-core/keccak-cache-global",
 ]
 js-tracer = [
     "reth-node-builder/js-tracer",

--- a/crates/ethereum/reth/Cargo.toml
+++ b/crates/ethereum/reth/Cargo.toml
@@ -81,6 +81,7 @@ arbitrary = [
 ]
 keccak-cache-global = [
     "reth-node-ethereum?/keccak-cache-global",
+    "reth-node-core?/keccak-cache-global",
 ]
 test-utils = [
     "reth-chainspec/test-utils",

--- a/crates/node/core/Cargo.toml
+++ b/crates/node/core/Cargo.toml
@@ -80,7 +80,7 @@ tokio.workspace = true
 # Features for vergen to generate correct env vars
 jemalloc = ["reth-cli-util/jemalloc"]
 asm-keccak = ["alloy-primitives/asm-keccak"]
-# Feature to enable opentelemetry export
+keccak-cache-global = ["alloy-primitives/keccak-cache-global"]
 otlp = ["reth-tracing/otlp"]
 
 min-error-logs = ["tracing/release_max_level_error"]

--- a/crates/optimism/node/Cargo.toml
+++ b/crates/optimism/node/Cargo.toml
@@ -96,6 +96,7 @@ asm-keccak = [
 ]
 keccak-cache-global = [
     "alloy-primitives/keccak-cache-global",
+    "reth-node-core/keccak-cache-global",
     "reth-optimism-node/keccak-cache-global",
 ]
 js-tracer = [

--- a/crates/optimism/reth/Cargo.toml
+++ b/crates/optimism/reth/Cargo.toml
@@ -76,6 +76,7 @@ arbitrary = [
 ]
 keccak-cache-global = [
     "reth-optimism-node?/keccak-cache-global",
+    "reth-node-core?/keccak-cache-global",
 ]
 test-utils = [
     "reth-chainspec/test-utils",


### PR DESCRIPTION
Otherwise it's not actually enabled and not visible in `reth --version`