### PR TITLE
chore(net/dns): remove redundant PartialEq bound on LinkEntry Eq impl

### DIFF
--- a/crates/net/dns/src/tree.rs
+++ b/crates/net/dns/src/tree.rs
@@ -273,7 +273,7 @@ where
 impl<K> Eq for LinkEntry<K>
 where
     K: EnrKeyUnambiguous,
-    K::PublicKey: Eq + PartialEq,
+    K::PublicKey: Eq,
 {
 }
 impl<K> Hash for LinkEntry<K>


### PR DESCRIPTION
Removes redundant `PartialEq` trait bound from `LinkEntry<K>`'s `Eq` implementation.