### PR TITLE
fix: remove stale blobs

### DIFF
--- a/crates/transaction-pool/src/blobstore/disk.rs
+++ b/crates/transaction-pool/src/blobstore/disk.rs
@@ -151,6 +151,9 @@ impl BlobStore for DiskFileBlobStore {
     }
 
     fn delete_all(&self, txs: Vec<B256>) -> Result<(), BlobStoreError> {
+        if txs.is_empty() {
+            return Ok(())
+        }
         let txs = self.inner.retain_existing(txs)?;
         self.inner.txs_to_delete.write().extend(txs);
         Ok(())

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -269,17 +269,26 @@ pub async fn maintain_transaction_pool<N, Client, P, St, Tasks>(
                 }
             }
             _ = stale_eviction_interval.tick() => {
-                let stale_txs: Vec<_> = pool
-                    .queued_transactions()
+                let queued = pool
+                    .queued_transactions();
+                let mut stale_blobs = Vec::new();
+                let now = std::time::Instant::now();
+                let stale_txs: Vec<_> = queued
                     .into_iter()
                     .filter(|tx| {
                         // filter stale transactions based on config
-                        (tx.origin.is_external() || config.no_local_exemptions) && tx.timestamp.elapsed() > config.max_tx_lifetime
+                        (tx.origin.is_external() || config.no_local_exemptions) && now - tx.timestamp > config.max_tx_lifetime
                     })
-                    .map(|tx| *tx.hash())
+                    .map(|tx| {
+                        if tx.is_eip4844() {
+                            stale_blobs.push(*tx.hash());
+                        }
+                        *tx.hash()
+                    })
                     .collect();
                 debug!(target: "txpool", count=%stale_txs.len(), "removing stale transactions");
                 pool.remove_transactions(stale_txs);
+                pool.delete_blobs(stale_blobs);
             }
         }
         // handle the result of the account reload


### PR DESCRIPTION
if a tx becomes stale we remove it, but we should also remove stale blobs here

drive by for faster instant cmp:

```
 pub fn elapsed(&self) -> Duration {
        Instant::now() - *self
    }
```