### PR TITLE
chore(net): remove stale ECIES rand TODO

### DIFF
--- a/crates/net/ecies/src/algorithm.rs
+++ b/crates/net/ecies/src/algorithm.rs
@@ -312,7 +312,6 @@ impl ECIES {
 
     /// Create a new ECIES client with the given static secret key and remote peer ID.
     pub fn new_client(secret_key: SecretKey, remote_id: PeerId) -> Result<Self, ECIESError> {
-        // TODO(rand): use rng for nonce
         let mut rng = rng();
         let nonce = B256::random();
         let ephemeral_secret_key = SecretKey::new(&mut rng);


### PR DESCRIPTION
The TODO about using rng for the ECIES client nonce is no longer accurate, since the nonce is already generated randomly and the rng is used for the ephemeral key. This comment is now misleading and suggests missing work where everything is already implemented, so it is removed without changing any behavior.