### PR TITLE
fix: remove outdated TODO comment about rand migration

### DIFF
--- a/testing/testing-utils/src/generators.rs
+++ b/testing/testing-utils/src/generators.rs
@@ -1,7 +1,5 @@
 //! Generators for different data structures like block headers, block bodies and ranges of those.
 
-// TODO(rand): update ::random calls after rand_09 migration
-
 use alloy_consensus::{Header, SignableTransaction, Transaction as _, TxLegacy};
 use alloy_eips::{
     eip1898::BlockWithParent,


### PR DESCRIPTION


The comment `// TODO(rand): update ::random calls after rand_09 migration` is no longer relevant as the codebase already uses rand 0.9 APIs (`rng.random()`, `Address::random()`, `B256::random()`). This misleading TODO suggests unfinished work when the migration is complete.

