### PR TITLE
chore(flashblocks): remove dead cached_reads wipe after finalize

### DIFF
--- a/crates/optimism/flashblocks/src/cache.rs
+++ b/crates/optimism/flashblocks/src/cache.rs
@@ -102,9 +102,6 @@ impl<T: SignedTransaction> SequenceManager<T> {
             // Ring buffer automatically evicts oldest entry when full
             let txs = std::mem::take(&mut self.pending_transactions);
             self.completed_cache.push((completed, txs));
-
-            // ensure cache is wiped on new flashblock
-            let _ = self.pending.take_cached_reads();
         }
 
         self.pending_transactions


### PR DESCRIPTION
FlashBlockPendingSequence::finalize already clears cached_reads, and this behavior is enforced by tests. The extra 
take_cached_reads call in SequenceManager::insert_flashblock always operated on None and had no effect, while its comment suggested that it was responsible for wiping the cache. Removing this no-op call and misleading comment makes the cache lifecycle clearer and keeps the implementation aligned with the tested invariants.