### PR TITLE
fix(consensus): correct got/expected order in BlobGasUsedDiff

### DIFF
--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -82,8 +82,8 @@ pub fn validate_cancun_gas<B: Block>(block: &SealedBlock<B>) -> Result<(), Conse
     let total_blob_gas = block.body().blob_gas_used();
     if total_blob_gas != header_blob_gas_used {
         return Err(ConsensusError::BlobGasUsedDiff(GotExpected {
-            got: header_blob_gas_used,
-            expected: total_blob_gas,
+            got: total_blob_gas,
+            expected: header_blob_gas_used,
         }));
     }
     Ok(())
@@ -503,8 +503,8 @@ mod tests {
         assert_eq!(
             validate_block_pre_execution(&block, &chain_spec),
             Err(ConsensusError::BlobGasUsedDiff(GotExpected {
-                got: 1,
-                expected: expected_blob_gas_used
+                got: expected_blob_gas_used,
+                expected: 1
             }))
         );
     }

--- a/crates/optimism/consensus/src/lib.rs
+++ b/crates/optimism/consensus/src/lib.rs
@@ -347,7 +347,7 @@ mod tests {
         assert!(pre_execution.is_err());
         assert_eq!(
             pre_execution.unwrap_err(),
-            ConsensusError::BlobGasUsedDiff(GotExpected { got: 10, expected: 0 })
+            ConsensusError::BlobGasUsedDiff(GotExpected { got: 0, expected: 10 })
         );
     }
 


### PR DESCRIPTION
## What

Fix inconsistent field order in `BlobGasUsedDiff` error. Changed `got` to contain computed value from block body and `expected` to contain value from header.

## Why

Maintains consistency with other body vs header validation checks (ommers hash, transactions root, withdrawals root) where `got` is the computed value and `expected` is the header value. This improves error message clarity and follows the established pattern across the codebase.