### PR TITLE
docs: add missing trace methods to pruning tables

### DIFF
--- a/docs/vocs/docs/pages/run/faq/pruning.mdx
+++ b/docs/vocs/docs/pages/run/faq/pruning.mdx
@@ -201,13 +201,16 @@ The following tables describe RPC methods available in the full node.
 | RPC / Segment                   | Note                           |
 | ------------------------------- | ------------------------------ |
 | `trace_block`                   | Only for the last 10064 blocks |
+| `trace_blockOpcodeGas`          | Only for the last 10064 blocks |
 | `trace_call`                    | Only for the last 10064 blocks |
 | `trace_callMany`                | Only for the last 10064 blocks |
+| `trace_filter`                  | Only for the last 10064 blocks |
 | `trace_get`                     | Only for the last 10064 blocks |
 | `trace_rawTransaction`          | Only for the last 10064 blocks |
 | `trace_replayBlockTransactions` | Only for the last 10064 blocks |
 | `trace_replayTransaction`       | Only for the last 10064 blocks |
 | `trace_transaction`             | Only for the last 10064 blocks |
+| `trace_transactionOpcodeGas`    | Only for the last 10064 blocks |
 
 #### `txpool` namespace
 
@@ -301,13 +304,16 @@ The following tables describe the requirements for prune segments, per RPC metho
 | RPC / Segment                   | Sender Recovery | Transaction Lookup | Receipts | Account History | Storage History |
 | ------------------------------- | --------------- | ------------------ | -------- | --------------- | --------------- |
 | `trace_block`                   | ✅              | ✅                 | ✅       | ❌              | ❌              |
+| `trace_blockOpcodeGas`          | ✅              | ✅                 | ✅       | ❌              | ❌              |
 | `trace_call`                    | ✅              | ✅                 | ✅       | ❌              | ❌              |
 | `trace_callMany`                | ✅              | ✅                 | ✅       | ❌              | ❌              |
+| `trace_filter`                  | ✅              | ✅                 | ✅       | ❌              | ❌              |
 | `trace_get`                     | ✅              | ❌                 | ✅       | ❌              | ❌              |
 | `trace_rawTransaction`          | ✅              | ✅                 | ✅       | ❌              | ❌              |
 | `trace_replayBlockTransactions` | ✅              | ✅                 | ✅       | ❌              | ❌              |
 | `trace_replayTransaction`       | ✅              | ❌                 | ✅       | ❌              | ❌              |
 | `trace_transaction`             | ✅              | ❌                 | ✅       | ❌              | ❌              |
+| `trace_transactionOpcodeGas`    | ✅              | ❌                 | ✅       | ❌              | ❌              |
 
 #### `txpool` namespace
 


### PR DESCRIPTION
Added trace_filter, trace_blockOpcodeGas, and trace_transactionOpcodeGas to the RPC support tables in pruning.mdx. These methods were missing from both Full Node and Pruned Node sections.