### PR TITLE
fix(node): handle unexpected OUT_DIR layout in build script

### DIFF
--- a/crates/node/core/build.rs
+++ b/crates/node/core/build.rs
@@ -36,8 +36,18 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rustc-env=VERGEN_GIT_SHA_SHORT={}", &sha[..8]);
 
     // Set the build profile
-    let out_dir = env::var("OUT_DIR").unwrap();
-    let profile = out_dir.rsplit(std::path::MAIN_SEPARATOR).nth(3).unwrap();
+    let out_dir = env::var("OUT_DIR")
+    .expect("OUT_DIR environment variable is not set");
+
+let profile = out_dir
+    .rsplit(std::path::MAIN_SEPARATOR)
+    .nth(3)
+    .unwrap_or_else(|| {
+        panic!(
+            "Failed to derive build profile from OUT_DIR: unexpected path layout: {out_dir}"
+        )
+    });
+
     println!("cargo:rustc-env=RETH_BUILD_PROFILE={profile}");
 
     // Set formatted version strings

--- a/crates/node/core/build.rs
+++ b/crates/node/core/build.rs
@@ -43,10 +43,8 @@ let profile = out_dir
     .rsplit(std::path::MAIN_SEPARATOR)
     .nth(3)
     .unwrap_or_else(|| {
-        panic!(
-            "Failed to derive build profile from OUT_DIR: unexpected path layout: {out_dir}"
-        )
-    });
+        panic!("Failed to derive build profile from OUT_DIR: unexpected path layout: {out_dir}")
+    });    
 
     println!("cargo:rustc-env=RETH_BUILD_PROFILE={profile}");
 


### PR DESCRIPTION
Replace unchecked unwraps in the build script with an explicit error when the OUT_DIR path layout is unexpected.