### PR TITLE
docs(libmdbx): add missing # Panics documentation for unwrap calls

### DIFF
--- a/crates/storage/libmdbx-rs/src/transaction.rs
+++ b/crates/storage/libmdbx-rs/src/transaction.rs
@@ -173,7 +173,7 @@ where
     ///
     /// # Panics
     ///
-    /// Panics if the transaction manager's channel is closed (should not happen during normal 
+    /// Panics if the transaction manager's channel is closed (should not happen during normal
     /// operation).
     pub fn commit(self) -> Result<(bool, CommitLatency)> {
         let result = self.txn_execute(|txn| {
@@ -514,8 +514,8 @@ impl Transaction<RW> {
     ///
     /// # Panics
     ///
-    /// Panics if the transaction manager's channel is closed when creating the nested transaction.
-    /// This should not occur during normal operation.
+    /// Panics if the transaction manager's channel is closed when creating the nested
+    /// transaction. This should not occur during normal operation.
     pub fn begin_nested_txn(&mut self) -> Result<Self> {
         if self.inner.env.is_write_map() {
             return Err(Error::NestedTransactionsUnsupportedWithWriteMap)

--- a/crates/storage/libmdbx-rs/src/transaction.rs
+++ b/crates/storage/libmdbx-rs/src/transaction.rs
@@ -173,7 +173,8 @@ where
     ///
     /// # Panics
     ///
-    /// Panics if the transaction manager's channel is closed (should not happen during normal operation).
+    /// Panics if the transaction manager's channel is closed (should not happen during normal 
+    /// operation).
     pub fn commit(self) -> Result<(bool, CommitLatency)> {
         let result = self.txn_execute(|txn| {
             if K::IS_READ_ONLY {


### PR DESCRIPTION
## Problem

Several functions in the transaction module use `.unwrap()` on channel receives and type 
conversions without documenting the panic conditions.

## Summary

Adds missing `# Panics` documentation to 4 public functions and 1 Drop implementation 
in `libmdbx-rs/transaction.rs` that call `.unwrap()` but don't document when they panic.