### PR TITLE
fix: enable file logging for LogFmt format

### DIFF
--- a/crates/tracing/src/formatter.rs
+++ b/crates/tracing/src/formatter.rs
@@ -67,7 +67,15 @@ impl LogFormat {
                     layer.with_filter(filter).boxed()
                 }
             }
-            Self::LogFmt => tracing_logfmt::layer().with_filter(filter).boxed(),
+            Self::LogFmt => {
+                let layer = tracing_logfmt::layer();
+
+                if let Some(writer) = file_writer {
+                    layer.with_writer(writer).with_filter(filter).boxed()
+                } else {
+                    layer.with_filter(filter).boxed()
+                }
+            }
             Self::Terminal => {
                 let layer = tracing_subscriber::fmt::layer().with_ansi(ansi).with_target(target);
 


### PR DESCRIPTION
In the `LogFormat::apply` method, the Json and `Terminal `variants correctly checked for a `file_writer `(a `NonBlocking `writer) and attached it to the tracing layer. However, the `LogFmt `variant was missing this logic, resulting in logs always being printed to stdout, even if the application was configured to write to a log file.

The Solution:
I updated the `LogFormat::LogFmt` match arm to check if `file_writer `is `Some`. If it is, the layer is now configured using `.with_writer(writer)`, ensuring consistency with the other logging formats.

