### PR TITLE
refactor(primitives-traits): remove redundant PartialEq bounds from SignedTransaction

### DIFF
--- a/crates/primitives-traits/src/transaction/signed.rs
+++ b/crates/primitives-traits/src/transaction/signed.rs
@@ -34,7 +34,6 @@ pub trait SignedTransaction:
     + Unpin
     + Clone
     + fmt::Debug
-    + PartialEq
     + Eq
     + Hash
     + Encodable
@@ -133,7 +132,7 @@ pub trait SignedTransaction:
 impl<T> SignedTransaction for EthereumTxEnvelope<T>
 where
     T: RlpEcdsaEncodableTx + SignableTransaction<Signature> + Unpin,
-    Self: Clone + PartialEq + Eq + Decodable + Decodable2718 + MaybeSerde + InMemorySize,
+    Self: Clone + Eq + Decodable + Decodable2718 + MaybeSerde + InMemorySize,
 {
 }
 


### PR DESCRIPTION
Remove redundant PartialEq trait bounds from SignedTransaction trait and its implementations.