### PR TITLE
perf(engine-tree): reuse state provider builder in validation

### DIFF
--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -115,6 +115,10 @@ harness = false
 name = "state_root_task"
 harness = false
 
+[[bench]]
+name = "state_provider_builder"
+harness = false
+
 [features]
 test-utils = [
     "reth-chain-state/test-utils",

--- a/crates/engine/tree/benches/state_provider_builder.rs
+++ b/crates/engine/tree/benches/state_provider_builder.rs
@@ -1,0 +1,49 @@
+//! Benchmark for state provider builder reuse.
+
+#![allow(missing_docs)]
+
+use alloy_consensus::Header;
+use alloy_primitives::B256;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use reth_engine_tree::tree::StateProviderBuilder;
+use reth_ethereum_primitives::EthPrimitives;
+use reth_provider::{test_utils::MockEthProvider, HeaderProvider};
+use std::hint::black_box;
+
+fn build_builder(
+    provider: &MockEthProvider<EthPrimitives>,
+    hash: B256,
+) -> StateProviderBuilder<EthPrimitives, MockEthProvider<EthPrimitives>> {
+    let header = provider.header(hash).expect("header lookup failed");
+    assert!(header.is_some(), "missing header for hash");
+    StateProviderBuilder::new(provider.clone(), hash, None)
+}
+
+fn bench_state_provider_builder(c: &mut Criterion) {
+    let provider = MockEthProvider::<EthPrimitives>::new();
+    let hash = B256::from([0x11u8; 32]);
+    let header = Header { number: 1, ..Header::default() };
+    provider.add_header(hash, header);
+
+    let mut group = c.benchmark_group("state_provider_builder_reuse");
+
+    group.bench_with_input(BenchmarkId::new("single_lookup", 1), &hash, |b, hash| {
+        b.iter(|| {
+            let builder = build_builder(&provider, *hash);
+            black_box(builder);
+        });
+    });
+
+    group.bench_with_input(BenchmarkId::new("double_lookup", 2), &hash, |b, hash| {
+        b.iter(|| {
+            let first = build_builder(&provider, *hash);
+            let second = build_builder(&provider, *hash);
+            black_box((first, second));
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_state_provider_builder);
+criterion_main!(benches);

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -428,7 +428,13 @@ impl ValidatorTestHarness {
             &mut self.harness.tree.state,
             &self.harness.tree.canonical_in_memory_state,
         );
-        let result = self.validator.validate_block(block, ctx);
+        let provider_builder = self
+            .harness
+            .tree
+            .state_provider_builder(block.parent_hash())
+            .expect("state provider builder lookup failed")
+            .expect("missing parent state provider builder");
+        let result = self.validator.validate_block(block, ctx, provider_builder);
         self.metrics.record_validation(result.is_ok());
         result
     }


### PR DESCRIPTION
## Summary
- Reuse a prebuilt state provider builder in the engine validation path to avoid redundant lookups.
- Thread the builder through the validator interface and tree context to keep the hot path single-pass.
- Add a Criterion micro-bench for builder reuse.

## Bench (criterion)
- Command: `cargo bench -p reth-engine-tree --bench state_provider_builder`
- single_lookup/1: ~67.46 ns
- double_lookup/2: ~168.69 ns
- TL;DR: ~2.5x faster for the builder step by avoiding the second lookup/build.

![state-provider-builder-lines](https://gist.githubusercontent.com/yongkangc/3b797b8cff4120952caef867ff8aa9a4/raw/lines.png)
![state-provider-builder-violin](https://gist.githubusercontent.com/yongkangc/3b797b8cff4120952caef867ff8aa9a4/raw/violin.png)
