### PR TITLE
fix(engine): sync invalid header cache count gauge on hit eviction

### DIFF
--- a/crates/engine/tree/src/tree/invalid_headers.rs
+++ b/crates/engine/tree/src/tree/invalid_headers.rs
@@ -48,6 +48,7 @@ impl InvalidHeaderCache {
         // if we get here, the entry has been hit too many times, so we evict it
         self.headers.remove(hash);
         self.metrics.hit_evictions.increment(1);
+        self.metrics.count.set(self.headers.len() as f64);
         None
     }
 


### PR DESCRIPTION
The invalid header cache now updates the count gauge after evicting an entry when its hit counter reaches `INVALID_HEADER_HIT_EVICTION_THRESHOLD`. Previously we only incremented `hit_evictions` and removed the entry from headers without adjusting count, so the metric could remain higher than the actual cache size after repeated hit-based evictions. This change keeps the count gauge consistent with `headers.len()` without altering cache behavior or eviction semantics.