### PR TITLE
fix(fs-util): append .tmp extension instead of replacing original

### DIFF
--- a/crates/fs-util/src/lib.rs
+++ b/crates/fs-util/src/lib.rs
@@ -322,8 +322,9 @@ where
     #[cfg(windows)]
     use std::os::windows::fs::OpenOptionsExt;
 
-    let mut tmp_path = file_path.to_path_buf();
-    tmp_path.set_extension("tmp");
+    let mut tmp_path = file_path.as_os_str().to_os_string();
+    tmp_path.push(".tmp");
+    let tmp_path = PathBuf::from(tmp_path);
 
     // Write to the temporary file
     let mut file =


### PR DESCRIPTION
Fixed atomic_write_file where set_extension("tmp") was replacing the original file extension instead of appending .tmp to the filename.

Before: config.json -> config.tmp
After: config.json -> config.json.tmp

This caused a race condition when atomically writing files with the same name but different extensions (e.g. data.json and data.xml would both use data.tmp as their temp file).