### PR TITLE
fix(era-downloader): ensure download errors are returned for all file types

### DIFF
--- a/crates/era-downloader/src/client.rs
+++ b/crates/era-downloader/src/client.rs
@@ -98,8 +98,11 @@ impl<Http: HttpClient + Clone> EraClient<Http> {
                 }
             }
 
+            // Ensure download succeeded for all file types
+            let actual_checksum = actual_checksum?;
+
             if self.era_type == EraFileType::Era1 {
-                self.assert_checksum(number, actual_checksum?)
+                self.assert_checksum(number, actual_checksum)
                     .await
                     .map_err(|e| eyre!("{e} for {file_name} at {}", path.display()))?;
             }


### PR DESCRIPTION
### What:
Ensures download_to_file returns download errors for all file types, not just Era1.
### Why:
Previously, when all retry attempts failed for non-Era1 files, the function returned Ok(path) even though the download failed. 

This could cause the caller to treat a failed download as successful, leading to incorrect behavior downstream.