### PR TITLE
fix(cli): remove unnecessary bound from Cli::configure

### DIFF
--- a/crates/ethereum/cli/src/interface.rs
+++ b/crates/ethereum/cli/src/interface.rs
@@ -76,10 +76,7 @@ impl<C: ChainSpecParser, Ext: clap::Args + fmt::Debug, Rpc: RpcModuleValidator> 
     ///
     /// This method is used to prepare the CLI for execution by wrapping it in a
     /// [`CliApp`] that can be further configured before running.
-    pub fn configure(self) -> CliApp<C, Ext, Rpc>
-    where
-        C: ChainSpecParser<ChainSpec = ChainSpec>,
-    {
+    pub fn configure(self) -> CliApp<C, Ext, Rpc> {
         CliApp::new(self)
     }
 


### PR DESCRIPTION
CliApp cannot be accessed otherwise from a non-ethereum chainspec