### PR TITLE
chore: prevent false-positive log in trie repair

### DIFF
--- a/crates/cli/commands/src/db/repair_trie.rs
+++ b/crates/cli/commands/src/db/repair_trie.rs
@@ -301,8 +301,8 @@ fn verify_and_repair<N: ProviderNodeTypes>(tool: &DbTool<N>) -> eyre::Result<()>
     if inconsistent_nodes == 0 {
         info!("No inconsistencies found");
     } else {
-        info!("Repaired {} inconsistencies, committing changes", inconsistent_nodes);
         provider_rw.commit()?;
+        info!("Repaired {} inconsistencies, committed changes", inconsistent_nodes);
     }
 
     Ok(())

--- a/crates/cli/commands/src/db/repair_trie.rs
+++ b/crates/cli/commands/src/db/repair_trie.rs
@@ -302,7 +302,7 @@ fn verify_and_repair<N: ProviderNodeTypes>(tool: &DbTool<N>) -> eyre::Result<()>
         info!("No inconsistencies found");
     } else {
         provider_rw.commit()?;
-        info!("Repaired {} inconsistencies, committed changes", inconsistent_nodes);
+        info!("Repaired {} inconsistencies and committed changes", inconsistent_nodes);
     }
 
     Ok(())


### PR DESCRIPTION
Moves the log statement after commit to ensure "Repaired X inconsistencies" only appears when changes are actually persisted, preventing misleading success message if commit fails.