### PR TITLE
perf(witness): avoid unnecessary HashMap clone when converting to BTreeMap

### DIFF
--- a/crates/engine/invalid-block-hooks/src/witness.rs
+++ b/crates/engine/invalid-block-hooks/src/witness.rs
@@ -80,13 +80,13 @@ fn sort_bundle_state_for_comparison(bundle_state: &BundleState) -> BundleStateSo
                     BundleAccountSorted {
                         info: acc.info.clone(),
                         original_info: acc.original_info.clone(),
-                        storage: BTreeMap::from_iter(acc.storage.clone()),
+                        storage: acc.storage.iter().map(|(k, v)| (*k, v.clone())).collect(),
                         status: acc.status,
                     },
                 )
             })
             .collect(),
-        contracts: BTreeMap::from_iter(bundle_state.contracts.clone()),
+        contracts: bundle_state.contracts.iter().map(|(k, v)| (*k, v.clone())).collect(),
         reverts: bundle_state
             .reverts
             .iter()
@@ -98,7 +98,7 @@ fn sort_bundle_state_for_comparison(bundle_state: &BundleState) -> BundleStateSo
                             *addr,
                             AccountRevertSorted {
                                 account: rev.account.clone(),
-                                storage: BTreeMap::from_iter(rev.storage.clone()),
+                                storage: rev.storage.iter().map(|(k, v)| (*k, v.clone())).collect(),
                                 previous_status: rev.previous_status,
                                 wipe_storage: rev.wipe_storage,
                             },

--- a/crates/engine/invalid-block-hooks/src/witness.rs
+++ b/crates/engine/invalid-block-hooks/src/witness.rs
@@ -80,7 +80,7 @@ fn sort_bundle_state_for_comparison(bundle_state: &BundleState) -> BundleStateSo
                     BundleAccountSorted {
                         info: acc.info.clone(),
                         original_info: acc.original_info.clone(),
-                        storage: acc.storage.iter().map(|(k, v)| (*k, v.clone())).collect(),
+                        storage: acc.storage.iter().map(|(k, v)| (*k, *v)).collect(),
                         status: acc.status,
                     },
                 )
@@ -98,7 +98,7 @@ fn sort_bundle_state_for_comparison(bundle_state: &BundleState) -> BundleStateSo
                             *addr,
                             AccountRevertSorted {
                                 account: rev.account.clone(),
-                                storage: rev.storage.iter().map(|(k, v)| (*k, v.clone())).collect(),
+                                storage: rev.storage.iter().map(|(k, v)| (*k, *v)).collect(),
                                 previous_status: rev.previous_status,
                                 wipe_storage: rev.wipe_storage,
                             },


### PR DESCRIPTION
Replace `BTreeMap::from_iter(map.clone())` pattern with direct iteration and collection.
This avoids allocating an intermediate cloned HashMap when converting to BTreeMap for sorted comparison. Keys (U256, B256) are Copy types, so only values need to be cloned.