### PR TITLE
docs(exex): correct comparison order in backfill docs

### DIFF
--- a/crates/exex/exex/src/notifications.rs
+++ b/crates/exex/exex/src/notifications.rs
@@ -354,10 +354,10 @@ where
     /// canonical chain.
     ///
     /// Possible situations are:
-    /// - ExEx is behind the node head (`node_head.number < exex_head.number`). Backfill from the
+    /// - ExEx is behind the node head (`exex_head.number < node_head.number`). Backfill from the
     ///   node database.
-    /// - ExEx is at the same block number as the node head (`node_head.number ==
-    ///   exex_head.number`). Nothing to do.
+    /// - ExEx is at the same block number as the node head (`exex_head.number ==
+    ///   node_head.number`). Nothing to do.
     fn check_backfill(&mut self) -> eyre::Result<()> {
         let backfill_job_factory =
             BackfillJobFactory::new(self.evm_config.clone(), self.provider.clone());


### PR DESCRIPTION
The doc comment had the comparison operands swapped - it said `node_head.number < exex_head.number` when describing ExEx being behind, but the actual code compares `exex_head.number.cmp(&node_head.number)`. Fixed to match the code logic.