### PR TITLE
fix(storage): rocksdb consistency check on startup

### DIFF
--- a/crates/ethereum/cli/src/interface.rs
+++ b/crates/ethereum/cli/src/interface.rs
@@ -76,10 +76,7 @@ impl<C: ChainSpecParser, Ext: clap::Args + fmt::Debug, Rpc: RpcModuleValidator> 
     ///
     /// This method is used to prepare the CLI for execution by wrapping it in a
     /// [`CliApp`] that can be further configured before running.
-    pub fn configure(self) -> CliApp<C, Ext, Rpc>
-    where
-        C: ChainSpecParser<ChainSpec = ChainSpec>,
-    {
+    pub fn configure(self) -> CliApp<C, Ext, Rpc> {
         CliApp::new(self)
     }
 

--- a/crates/ethereum/cli/src/interface.rs
+++ b/crates/ethereum/cli/src/interface.rs
@@ -76,7 +76,10 @@ impl<C: ChainSpecParser, Ext: clap::Args + fmt::Debug, Rpc: RpcModuleValidator> 
     ///
     /// This method is used to prepare the CLI for execution by wrapping it in a
     /// [`CliApp`] that can be further configured before running.
-    pub fn configure(self) -> CliApp<C, Ext, Rpc> {
+    pub fn configure(self) -> CliApp<C, Ext, Rpc>
+    where
+        C: ChainSpecParser<ChainSpec = ChainSpec>,
+    {
         CliApp::new(self)
     }
 

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -951,7 +951,7 @@ where
                 error!(
                     "Op-mainnet has been launched without importing the pre-Bedrock state. The chain can't progress without this. See also https://reth.rs/run/sync-op-mainnet.html?minimal-bootstrap-recommended"
                 );
-                return Err(ProviderError::BestBlockNotFound);
+                return Err(ProviderError::BestBlockNotFound)
             }
         }
 

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -526,7 +526,7 @@ where
                 PipelineTarget::Sync(_) => unreachable!("check_consistency returns Unwind"),
             });
 
-        // Combine unwind targets - take the minimum (most conservative)
+        // Take the minimum block number to ensure all storage layers are consistent.
         let unwind_target = [rocksdb_unwind, static_file_unwind].into_iter().flatten().min();
 
         if let Some(unwind_block) = unwind_target {
@@ -941,9 +941,9 @@ where
     /// This checks for OP-Mainnet and ensures we have all the necessary data to progress (past
     /// bedrock height)
     fn ensure_chain_specific_db_checks(&self) -> ProviderResult<()> {
-        if self.chain_spec().is_optimism()
-            && !self.is_dev()
-            && self.chain_id() == Chain::optimism_mainnet()
+        if self.chain_spec().is_optimism() &&
+            !self.is_dev() &&
+            self.chain_id() == Chain::optimism_mainnet()
         {
             let latest = self.blockchain_db().last_block_number()?;
             // bedrock height

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -502,7 +502,7 @@ where
         )?
         .with_prune_modes(self.prune_modes());
 
-        // Check for consistency between database, static files, and RocksDB. If any
+        // Check for consistency between MDBX, static files, and RocksDB. If any
         // inconsistencies are found, unwind to the first block that's consistent across all
         // storage layers.
         //
@@ -538,14 +538,14 @@ where
             // instead. Unwinding to 0 would leave MDBX with a huge free list size.
             let inconsistency_source = match (file_unwind, rocksdb_unwind, static_file_unwind) {
                 (Some(_), Some(_), Some(_)) => {
-                    "static file healing, RocksDB <> database, and static file <> database"
+                    "static file healing, RocksDB <> MDBX, and static file <> MDBX"
                 }
-                (Some(_), Some(_), None) => "static file healing and RocksDB <> database",
-                (Some(_), None, Some(_)) => "static file healing and static file <> database",
-                (None, Some(_), Some(_)) => "RocksDB <> database and static file <> database",
+                (Some(_), Some(_), None) => "static file healing and RocksDB <> MDBX",
+                (Some(_), None, Some(_)) => "static file healing and static file <> MDBX",
+                (None, Some(_), Some(_)) => "RocksDB <> MDBX and static file <> MDBX",
                 (Some(_), None, None) => "static file healing",
-                (None, Some(_), None) => "RocksDB <> database",
-                (None, None, Some(_)) => "static file <> database",
+                (None, Some(_), None) => "RocksDB <> MDBX",
+                (None, None, Some(_)) => "static file <> MDBX",
                 (None, None, None) => unreachable!(),
             };
             assert_ne!(

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -508,10 +508,10 @@ where
         //
         // Compute one unwind target and run a single unwind.
 
-        // Step 1: heal file-level inconsistencies (no pruning)
-        factory.static_file_provider().check_file_consistency()?;
-
         let provider_ro = factory.database_provider_ro()?;
+
+        // Step 1: heal file-level inconsistencies (no pruning)
+        factory.static_file_provider().check_file_consistency(&provider_ro)?;
 
         // Step 2: RocksDB consistency check (needs static files tx data)
         let rocksdb_unwind = factory.rocksdb_provider().check_consistency(&provider_ro)?;

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -516,7 +516,6 @@ where
         // Step 1: Heal file-level inconsistencies (no pruning)
         factory.static_file_provider().check_file_consistency()?;
 
-        // Reuse the same provider for consistency checks
         let provider_ro = factory.database_provider_ro()?;
 
         // Step 2: RocksDB consistency check (needs static files tx data)
@@ -946,9 +945,9 @@ where
     /// This checks for OP-Mainnet and ensures we have all the necessary data to progress (past
     /// bedrock height)
     fn ensure_chain_specific_db_checks(&self) -> ProviderResult<()> {
-        if self.chain_spec().is_optimism() &&
-            !self.is_dev() &&
-            self.chain_id() == Chain::optimism_mainnet()
+        if self.chain_spec().is_optimism()
+            && !self.is_dev()
+            && self.chain_id() == Chain::optimism_mainnet()
         {
             let latest = self.blockchain_db().last_block_number()?;
             // bedrock height
@@ -956,7 +955,7 @@ where
                 error!(
                     "Op-mainnet has been launched without importing the pre-Bedrock state. The chain can't progress without this. See also https://reth.rs/run/sync-op-mainnet.html?minimal-bootstrap-recommended"
                 );
-                return Err(ProviderError::BestBlockNotFound)
+                return Err(ProviderError::BestBlockNotFound);
             }
         }
 

--- a/crates/storage/provider/src/providers/rocksdb/invariants.rs
+++ b/crates/storage/provider/src/providers/rocksdb/invariants.rs
@@ -56,15 +56,15 @@ impl RocksDBProvider {
         let mut unwind_target: Option<BlockNumber> = None;
 
         // Check TransactionHashNumbers if stored in RocksDB
-        if provider.cached_storage_settings().transaction_hash_numbers_in_rocksdb
-            && let Some(target) = self.check_transaction_hash_numbers(provider)?
+        if provider.cached_storage_settings().transaction_hash_numbers_in_rocksdb &&
+            let Some(target) = self.check_transaction_hash_numbers(provider)?
         {
             unwind_target = Some(unwind_target.map_or(target, |t| t.min(target)));
         }
 
         // Check StoragesHistory if stored in RocksDB
-        if provider.cached_storage_settings().storages_history_in_rocksdb
-            && let Some(target) = self.check_storages_history(provider)?
+        if provider.cached_storage_settings().storages_history_in_rocksdb &&
+            let Some(target) = self.check_storages_history(provider)?
         {
             unwind_target = Some(unwind_target.map_or(target, |t| t.min(target)));
         }
@@ -979,7 +979,7 @@ mod tests {
     }
 
     #[test]
-    fn test_check_consistency_storages_history_behind_checkpoint_needs_unwind() {
+    fn test_check_consistency_storages_history_behind_checkpoint_single_entry() {
         use reth_db_api::models::storage_sharded_key::StorageShardedKey;
 
         let temp_dir = TempDir::new().unwrap();

--- a/crates/storage/provider/src/providers/rocksdb/invariants.rs
+++ b/crates/storage/provider/src/providers/rocksdb/invariants.rs
@@ -56,15 +56,15 @@ impl RocksDBProvider {
         let mut unwind_target: Option<BlockNumber> = None;
 
         // Check TransactionHashNumbers if stored in RocksDB
-        if provider.cached_storage_settings().transaction_hash_numbers_in_rocksdb &&
-            let Some(target) = self.check_transaction_hash_numbers(provider)?
+        if provider.cached_storage_settings().transaction_hash_numbers_in_rocksdb
+            && let Some(target) = self.check_transaction_hash_numbers(provider)?
         {
             unwind_target = Some(unwind_target.map_or(target, |t| t.min(target)));
         }
 
         // Check StoragesHistory if stored in RocksDB
-        if provider.cached_storage_settings().storages_history_in_rocksdb &&
-            let Some(target) = self.check_storages_history(provider)?
+        if provider.cached_storage_settings().storages_history_in_rocksdb
+            && let Some(target) = self.check_storages_history(provider)?
         {
             unwind_target = Some(unwind_target.map_or(target, |t| t.min(target)));
         }
@@ -275,6 +275,15 @@ impl RocksDBProvider {
                         "StoragesHistory ahead of checkpoint, pruning excess data"
                     );
                     self.prune_storages_history_above(checkpoint)?;
+                } else if max_highest_block < checkpoint {
+                    // RocksDB is behind checkpoint, return highest block to signal unwind needed
+                    tracing::warn!(
+                        target: "reth::providers::rocksdb",
+                        rocks_highest = max_highest_block,
+                        checkpoint,
+                        "StoragesHistory behind checkpoint, unwind needed"
+                    );
+                    return Ok(Some(max_highest_block));
                 }
 
                 Ok(None)
@@ -578,6 +587,46 @@ mod tests {
             rocksdb.last::<tables::StoragesHistory>().unwrap().is_none(),
             "RocksDB should be empty after pruning"
         );
+    }
+
+    #[test]
+    fn test_check_consistency_storages_history_behind_checkpoint_needs_unwind() {
+        let temp_dir = TempDir::new().unwrap();
+        let rocksdb = RocksDBBuilder::new(temp_dir.path())
+            .with_table::<tables::StoragesHistory>()
+            .build()
+            .unwrap();
+
+        // Insert data into RocksDB with max highest_block_number = 80
+        let key_block_50 = StorageShardedKey::new(Address::ZERO, B256::ZERO, 50);
+        let key_block_80 = StorageShardedKey::new(Address::ZERO, B256::from([1u8; 32]), 80);
+        let key_block_max = StorageShardedKey::new(Address::ZERO, B256::from([2u8; 32]), u64::MAX);
+
+        let block_list = BlockNumberList::new_pre_sorted([10, 20, 30]);
+        rocksdb.put::<tables::StoragesHistory>(key_block_50, &block_list).unwrap();
+        rocksdb.put::<tables::StoragesHistory>(key_block_80, &block_list).unwrap();
+        rocksdb.put::<tables::StoragesHistory>(key_block_max, &block_list).unwrap();
+
+        // Create a test provider factory for MDBX
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(
+            StorageSettings::legacy().with_storages_history_in_rocksdb(true),
+        );
+
+        // Set checkpoint to block 100
+        {
+            let provider = factory.database_provider_rw().unwrap();
+            provider
+                .save_stage_checkpoint(StageId::IndexStorageHistory, StageCheckpoint::new(100))
+                .unwrap();
+            provider.commit().unwrap();
+        }
+
+        let provider = factory.database_provider_ro().unwrap();
+
+        // RocksDB max highest_block (80) is behind checkpoint (100)
+        let result = rocksdb.check_consistency(&provider).unwrap();
+        assert_eq!(result, Some(80), "Should unwind to the highest block present in RocksDB");
     }
 
     #[test]

--- a/crates/storage/provider/src/providers/rocksdb/invariants.rs
+++ b/crates/storage/provider/src/providers/rocksdb/invariants.rs
@@ -155,16 +155,6 @@ impl RocksDBProvider {
                     "MDBX empty but static files have data, pruning all TransactionHashNumbers"
                 );
                 self.prune_transaction_hash_numbers_in_range(provider, 0..=highest_tx)?;
-
-                // If checkpoint claims progress but MDBX is empty, that's an inconsistency
-                if checkpoint > 0 {
-                    tracing::warn!(
-                        target: "reth::providers::rocksdb",
-                        checkpoint,
-                        "Checkpoint set but MDBX has no transactions, unwind needed"
-                    );
-                    return Ok(Some(0));
-                }
             }
             (None, None) => {
                 // Both MDBX and static files are empty.
@@ -285,18 +275,6 @@ impl RocksDBProvider {
                         "StoragesHistory ahead of checkpoint, pruning excess data"
                     );
                     self.prune_storages_history_above(checkpoint)?;
-                    return Ok(None);
-                }
-
-                // If RocksDB is behind the checkpoint, request an unwind to rebuild.
-                if max_highest_block < checkpoint {
-                    tracing::warn!(
-                        target: "reth::providers::rocksdb",
-                        rocks_highest = max_highest_block,
-                        checkpoint,
-                        "StoragesHistory behind checkpoint, unwind needed"
-                    );
-                    return Ok(Some(max_highest_block));
                 }
 
                 Ok(None)

--- a/crates/storage/provider/src/providers/rocksdb_stub.rs
+++ b/crates/storage/provider/src/providers/rocksdb_stub.rs
@@ -77,6 +77,39 @@ impl RocksDBProvider {
     pub const fn tx(&self) -> RocksTx {
         RocksTx
     }
+
+    /// Creates a new batch for atomic writes (stub implementation).
+    pub const fn batch(&self) -> RocksDBBatch {
+        RocksDBBatch
+    }
+
+    /// Gets the first key-value pair from a table (stub implementation).
+    pub const fn first<T: Table>(&self) -> ProviderResult<Option<(T::Key, T::Value)>> {
+        Ok(None)
+    }
+
+    /// Gets the last key-value pair from a table (stub implementation).
+    pub const fn last<T: Table>(&self) -> ProviderResult<Option<(T::Key, T::Value)>> {
+        Ok(None)
+    }
+
+    /// Creates an iterator for the specified table (stub implementation).
+    ///
+    /// Returns an empty iterator. This is consistent with `first()` and `last()` returning
+    /// `Ok(None)` - the stub behaves as if the database is empty rather than unavailable.
+    pub const fn iter<T: Table>(&self) -> ProviderResult<RocksDBIter<'_, T>> {
+        Ok(RocksDBIter { _marker: std::marker::PhantomData })
+    }
+
+    /// Check consistency of `RocksDB` tables (stub implementation).
+    ///
+    /// Returns `None` since there is no `RocksDB` data to check when the feature is disabled.
+    pub const fn check_consistency<Provider>(
+        &self,
+        _provider: &Provider,
+    ) -> ProviderResult<Option<alloy_primitives::BlockNumber>> {
+        Ok(None)
+    }
 }
 
 /// A stub batch writer for `RocksDB` on non-Unix platforms.
@@ -101,6 +134,25 @@ impl RocksDBBatch {
     /// Deletes a value from the batch (stub implementation).
     pub fn delete<T: Table>(&self, _key: T::Key) -> ProviderResult<()> {
         Err(UnsupportedProvider)
+    }
+
+    /// Commits the batch (stub implementation).
+    pub const fn commit(self) -> ProviderResult<()> {
+        Err(UnsupportedProvider)
+    }
+}
+
+/// A stub iterator for `RocksDB` (non-transactional).
+#[derive(Debug)]
+pub struct RocksDBIter<'a, T> {
+    _marker: std::marker::PhantomData<(&'a (), T)>,
+}
+
+impl<T: Table> Iterator for RocksDBIter<'_, T> {
+    type Item = ProviderResult<(T::Key, T::Value)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        None
     }
 }
 
@@ -212,4 +264,12 @@ impl RocksTx {
 #[derive(Debug)]
 pub struct RocksTxIter<'a, T> {
     _marker: std::marker::PhantomData<(&'a (), T)>,
+}
+
+impl<T: Table> Iterator for RocksTxIter<'_, T> {
+    type Item = ProviderResult<(T::Key, T::Value)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        None
+    }
 }

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -1170,9 +1170,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         info!(target: "reth::cli", "Healing static file inconsistencies.");
 
         for segment in self.segments_to_check(provider) {
-            let (initial_highest_block, highest_block) = self.maybe_heal_segment(segment)?;
-
-            let _ = (initial_highest_block, highest_block, segment);
+            let _ = self.maybe_heal_segment(segment)?;
         }
 
         Ok(())

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -1162,8 +1162,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
     ///
     /// Call before [`Self::check_consistency`] so files are internally consistent.
     /// Uses the same segment-skip logic as [`Self::check_consistency`], but does not compare with
-    /// database checkpoints or prune against them. Healing may truncate to the last committed
-    /// config.
+    /// database checkpoints or prune against them.
     pub fn check_file_consistency<Provider>(&self, provider: &Provider) -> ProviderResult<()>
     where
         Provider: DBProvider + ChainSpecProvider + StorageSettingsCache,
@@ -1173,18 +1172,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         for segment in self.segments_to_check(provider) {
             let (initial_highest_block, highest_block) = self.maybe_heal_segment(segment)?;
 
-            // Healing after an interrupted prune can lower `highest_block`. The follow-up
-            // `check_consistency` compares checkpoints and will request an unwind if
-            // `checkpoint > healed_block`.
-            if initial_highest_block != highest_block {
-                info!(
-                    target: "reth::providers::static_file",
-                    ?initial_highest_block,
-                    ?highest_block,
-                    ?segment,
-                    "Healed segment, highest block changed."
-                );
-            }
+            let _ = (initial_highest_block, highest_block, segment);
         }
 
         Ok(())

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -1173,9 +1173,9 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         for segment in self.segments_to_check(provider) {
             let (initial_highest_block, highest_block) = self.maybe_heal_segment(segment)?;
 
-            // The updated `highest_block` may have decreased if we healed from a pruning
-            // interruption. The subsequent `check_consistency` call will detect this
-            // (checkpoint > healed_block) and request an unwind.
+            // Healing after an interrupted prune can lower `highest_block`. The follow-up
+            // `check_consistency` compares checkpoints and will request an unwind if
+            // `checkpoint > healed_block`.
             if initial_highest_block != highest_block {
                 info!(
                     target: "reth::providers::static_file",

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -1203,9 +1203,9 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
 
     /// Heals file-level (`NippyJar`) inconsistencies for eligible static file segments.
     ///
-    /// Call before [`Self::check_consistency`] so files are internally consistent.
-    /// Uses the same segment-skip logic as [`Self::check_consistency`], but does not compare
-    /// with database checkpoints or prune.
+    /// Call before [`Self::check_consistency`] so files are internally consistent. Uses the same
+    /// segment-skip logic as [`Self::check_consistency`], but does not compare with database
+    /// checkpoints or prune based on them. Healing may truncate files to the last committed config.
     pub fn check_file_consistency<Provider>(&self, provider: &Provider) -> ProviderResult<()>
     where
         Provider: DBProvider + ChainSpecProvider + StorageSettingsCache,

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -1184,6 +1184,45 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         Ok(unwind_target.map(PipelineTarget::Unwind))
     }
 
+    /// Heals file-level (`NippyJar`) inconsistencies for all static file segments.
+    ///
+    /// This should be called BEFORE any checks that depend on static file data (e.g., `RocksDB`
+    /// consistency checks that need transaction data), as it ensures files are in a consistent
+    /// state without pruning any data.
+    ///
+    /// Unlike [`Self::check_consistency`], this method:
+    /// - Does NOT compare with database checkpoints
+    /// - Does NOT prune data
+    /// - Applies to ALL segments unconditionally
+    ///
+    /// Returns an unwind target if file healing detected a decrease in the highest block
+    /// (indicating a pruning interruption that needs a database unwind).
+    pub fn check_file_consistency(&self) -> ProviderResult<Option<BlockNumber>> {
+        info!(target: "reth::cli", "Healing static file inconsistencies.");
+
+        let mut unwind_target: Option<BlockNumber> = None;
+
+        for segment in StaticFileSegment::iter() {
+            let (initial_highest_block, highest_block) = self.maybe_heal_segment(segment)?;
+
+            // The updated `highest_block` may have decreased if we healed from a pruning
+            // interruption.
+            if initial_highest_block != highest_block {
+                info!(
+                    target: "reth::providers::static_file",
+                    ?initial_highest_block,
+                    unwind_target = highest_block,
+                    ?segment,
+                    "Setting unwind target."
+                );
+                let target = highest_block.unwrap_or_default();
+                unwind_target = Some(unwind_target.map_or(target, |t| t.min(target)));
+            }
+        }
+
+        Ok(unwind_target)
+    }
+
     /// Checks consistency of the latest static file segment and throws an error if at fault.
     /// Read-only.
     pub fn check_segment_consistency(&self, segment: StaticFileSegment) -> ProviderResult<()> {

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -1198,6 +1198,12 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         info!(target: "reth::cli", "Healing static file inconsistencies.");
 
         for segment in StaticFileSegment::iter() {
+            // Only heal if static files already exist for this segment.
+            // This avoids creating empty jars for segments stored in DB.
+            if self.get_highest_static_file_block(segment).is_none() {
+                continue;
+            }
+
             let (initial_highest_block, highest_block) = self.maybe_heal_segment(segment)?;
 
             // The updated `highest_block` may have decreased if we healed from a pruning


### PR DESCRIPTION
Addresses [#20392](https://github.com/paradigmxyz/reth/issues/20392) - Initialize RocksDB provider and add consistency check on startup.

## Changes

- Add RocksDB `check_consistency()` call in node launch with correct ordering:
  1. `StaticFileProvider::check_file_consistency()` - heals interrupted writes
  2. `RocksDB::check_consistency()` - uses static file data for tx hash pruning  
  3. `StaticFileProvider::check_consistency()` - compares with MDBX checkpoints


Note for future:

- We have to follow up with passing RocksDB to the stages once implemented in https://github.com/paradigmxyz/reth/issues/20389
- And also we can spin off another pr for Configuration validation


**Related**
- Sibling PR: #20594 (AccountsHistory support)