### PR TITLE
docs: clarify state helpers header comment

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -1,5 +1,5 @@
-//! Loads a pending block from database. Helper trait for `eth_` block, transaction, call and trace
-//! RPC methods.
+//! Loads state from database. Helper trait for `eth_` block, transaction, call and trace
+//! RPC methods related to state (accounts, storage, proofs).
 
 use super::{EthApiSpec, LoadPendingBlock, SpawnBlocking};
 use crate::{EthApiTypes, FromEthApiError, RpcNodeCore, RpcNodeCoreExt};


### PR DESCRIPTION
The state helpers module had a copy-pasted header mentioning loading a pending block, which belongs to the pending_block helpers instead. This updates the top-level comment to describe state-related RPC helpers (accounts, storage, proofs) so that navigation and code search reflect the actual responsibility of the module, without changing any behavior.