### PR TITLE
fix(stages): only iterate over active stages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10734,6 +10734,7 @@ dependencies = [
  "proptest-arbitrary-interop",
  "rand 0.9.2",
  "reth-codecs",
+ "reth-prune-types",
  "reth-trie-common",
  "serde",
 ]

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -938,13 +938,13 @@ where
     ///
     /// A target block hash if the pipeline is inconsistent, otherwise `None`.
     pub fn check_pipeline_consistency(&self) -> ProviderResult<Option<B256>> {
-        // We skip the era stage if it's not enabled
+        // Only check stages that are active based on configuration
         let era_enabled = self.era_import_source().is_some();
-        let mut all_stages =
-            StageId::ALL.into_iter().filter(|id| era_enabled || id != &StageId::Era);
+        let prune_modes = self.prune_modes();
+        let mut active_stages = StageId::active(era_enabled, &prune_modes);
 
         // Get the expected first stage based on config.
-        let first_stage = all_stages.next().expect("there must be at least one stage");
+        let first_stage = active_stages.next().expect("there must be at least one stage");
 
         // If no target was provided, check if the stages are congruent - check if the
         // checkpoint of the last stage matches the checkpoint of the first.
@@ -955,7 +955,7 @@ where
             .block_number;
 
         // Compare all other stages against the first
-        for stage_id in all_stages {
+        for stage_id in active_stages {
             let stage_checkpoint = self
                 .blockchain_db()
                 .get_stage_checkpoint(stage_id)?

--- a/crates/stages/types/Cargo.toml
+++ b/crates/stages/types/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 reth-codecs = { workspace = true, optional = true }
+reth-prune-types.workspace = true
 reth-trie-common.workspace = true
 alloy-primitives.workspace = true
 
@@ -38,6 +39,7 @@ default = ["std"]
 std = [
     "alloy-primitives/std",
     "bytes?/std",
+    "reth-prune-types/std",
     "reth-trie-common/std",
     "serde?/std",
 ]

--- a/crates/stages/types/Cargo.toml
+++ b/crates/stages/types/Cargo.toml
@@ -52,6 +52,7 @@ reth-codec = [
 test-utils = [
     "arbitrary",
     "reth-codecs?/test-utils",
+    "reth-prune-types/test-utils",
     "reth-trie-common/test-utils",
 ]
 arbitrary = [
@@ -59,6 +60,7 @@ arbitrary = [
     "dep:arbitrary",
     "alloy-primitives/arbitrary",
     "reth-codecs?/arbitrary",
+    "reth-prune-types/arbitrary",
     "reth-trie-common/arbitrary",
 ]
 serde = [
@@ -67,5 +69,6 @@ serde = [
     "bytes?/serde",
     "rand/serde",
     "reth-codecs?/serde",
+    "reth-prune-types/serde",
     "reth-trie-common/serde",
 ]

--- a/crates/stages/types/src/id.rs
+++ b/crates/stages/types/src/id.rs
@@ -1,4 +1,5 @@
 use alloc::vec::Vec;
+use reth_prune_types::PruneModes;
 #[cfg(feature = "std")]
 use std::{collections::HashMap, sync::OnceLock};
 
@@ -110,6 +111,18 @@ impl StageId {
     /// Returns true indicating if it's the finish stage [`StageId::Finish`]
     pub const fn is_finish(&self) -> bool {
         matches!(self, Self::Finish)
+    }
+
+    /// Returns an iterator over stages that are active based on configuration.
+    ///
+    /// Optional stages like [`StageId::Era`] and [`StageId::PruneSenderRecovery`] are only
+    /// included when their corresponding configuration is enabled.
+    pub fn active(era_enabled: bool, prune_modes: &PruneModes) -> impl Iterator<Item = Self> {
+        Self::ALL.into_iter().filter(move |id| match id {
+            Self::Era => era_enabled,
+            Self::PruneSenderRecovery => prune_modes.sender_recovery.is_some(),
+            _ => true,
+        })
     }
 
     /// Get a pre-encoded raw Vec, for example, to be used as the DB key for

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1563,9 +1563,11 @@ impl<TX: DbTxMut, N: NodeTypes> StageCheckpointWriter for DatabaseProvider<TX, N
         block_number: BlockNumber,
         drop_stage_checkpoint: bool,
     ) -> ProviderResult<()> {
-        // iterate over all existing stages in the table and update its progress.
+        // iterate over active stages and update their progress.
         let mut cursor = self.tx.cursor_write::<tables::StageCheckpoints>()?;
-        for stage_id in StageId::ALL {
+        // TODO: era_enabled should come from node config
+        let era_enabled = true;
+        for stage_id in StageId::active(era_enabled, self.prune_modes_ref()) {
             let (_, checkpoint) = cursor.seek_exact(stage_id.to_string())?.unwrap_or_default();
             cursor.upsert(
                 stage_id.to_string(),


### PR DESCRIPTION
During engine sync, we iterate over all stages in `StageId::ALL` and bump their checkpoints via `update_pipeline_stages`. During the pipeline consistency check, we iterate all checkpoints and compare them to the header stage.

However, the pipeline itself conditionally adds `PruneSenderRecoveryStage` only if sender pruning is enabled:

https://github.com/paradigmxyz/reth/blob/b79c58d83537b8db52a6a6c02e81d2f868bd4f6d/crates/stages/stages/src/sets.rs#L337-L340

This can result in the following weird scenario if sender pruning is not enabled:

1. `PruneSenderRecovery` checkpoint is set to block 100 by engine sync (via `update_pipeline_stages`)
2. Run unwind command to block 95. Since `PruneSenderRecoveryStage` is not in the pipeline, its checkpoint stays at 100 (ahead of other stages, but not an issue yet)
3. Run pipeline forward to block 105. Once again, `PruneSenderRecoveryStage` is not in the pipeline and won't run, so its checkpoint stays at 100
4. Now `PruneSenderRecovery` (100) < `Headers` (105), which triggers the inconsistency check:

or

1. Engine sync to block 50 → update_pipeline_stages creates PruneSenderRecovery at 50
2. Pipeline sync continues to block 100 → Headers at 100, but PruneSenderRecovery stuck at 50
3. CLI unwind to block 60 → Headers at 60, PruneSenderRecovery still at 50
4. reth node → consistency check: 50 < 60

https://github.com/paradigmxyz/reth/blob/b79c58d83537b8db52a6a6c02e81d2f868bd4f6d/crates/node/builder/src/launch/common.rs#L975-L985
