### PR TITLE
chore: add metric for batch size

### DIFF
--- a/crates/engine/tree/src/metrics.rs
+++ b/crates/engine/tree/src/metrics.rs
@@ -19,6 +19,8 @@ pub(crate) struct PersistenceMetrics {
     pub(crate) remove_blocks_above_duration_seconds: Histogram,
     /// How long it took for blocks to be saved
     pub(crate) save_blocks_duration_seconds: Histogram,
+    /// How many blocks we persist at once.
+    pub(crate) save_blocks_block_count: Histogram,
     /// How long it took for blocks to be pruned
     pub(crate) prune_before_duration_seconds: Histogram,
 }

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -143,7 +143,8 @@ where
     ) -> Result<Option<BlockNumHash>, PersistenceError> {
         let first_block = blocks.first().map(|b| b.recovered_block.num_hash());
         let last_block = blocks.last().map(|b| b.recovered_block.num_hash());
-        debug!(target: "engine::persistence", first=?first_block, last=?last_block, "Saving range of blocks");
+        let block_count = blocks.len();
+        debug!(target: "engine::persistence", ?block_count, first=?first_block, last=?last_block, "Saving range of blocks");
 
         let start_time = Instant::now();
 
@@ -156,6 +157,7 @@ where
 
         debug!(target: "engine::persistence", first=?first_block, last=?last_block, "Saved range of blocks");
 
+        self.metrics.save_blocks_block_count.record(block_count as f64);
         self.metrics.save_blocks_duration_seconds.record(start_time.elapsed());
         Ok(last_block)
     }


### PR DESCRIPTION
we dont have a metric for how many blocks we persist at once