### PR TITLE
fix(ipc): trim leading whitespace in StreamCodec decode

### DIFF
--- a/crates/rpc/ipc/src/stream_codec.rs
+++ b/crates/rpc/ipc/src/stream_codec.rs
@@ -113,7 +113,6 @@ impl tokio_util::codec::Decoder for StreamCodec {
                 is_escaped = byte == b'\\' && !is_escaped && in_str;
 
                 if depth == 0 && idx != start_idx && idx - start_idx + 1 > whitespaces {
-                    // Discard any leading whitespace before the JSON start
                     if start_idx > 0 {
                         let _ = buf.split_to(start_idx);
                     }

--- a/crates/rpc/ipc/src/stream_codec.rs
+++ b/crates/rpc/ipc/src/stream_codec.rs
@@ -27,7 +27,7 @@
 // This basis of this file has been taken from the deprecated jsonrpc codebase:
 // https://github.com/paritytech/jsonrpc
 
-use bytes::BytesMut;
+use bytes::{Buf, BytesMut};
 use std::{io, str};
 
 /// Separator for enveloping messages in streaming codecs
@@ -114,7 +114,7 @@ impl tokio_util::codec::Decoder for StreamCodec {
 
                 if depth == 0 && idx != start_idx && idx - start_idx + 1 > whitespaces {
                     if start_idx > 0 {
-                        let _ = buf.split_to(start_idx);
+                        buf.advance(start_idx);
                     }
                     let bts = buf.split_to(idx + 1 - start_idx);
                     return match String::from_utf8(bts.into()) {


### PR DESCRIPTION
## Summary

Trim leading whitespace from decoded JSON-RPC messages in `StreamCodec`, resolving a TODO and improving IPC message handling.

## Problem

When `StreamCodec::decode()` parses JSON-RPC messages over IPC, it includes leading whitespace (newlines, tabs, spaces) that appears between messages. This is unnecessary since:

1. Leading whitespace is not part of the JSON message
2. It wastes memory storing meaningless bytes
3. It clutters debug logs with extra whitespace
4. The `start_idx` variable already tracks where JSON actually begins, but was not being used to discard prior bytes

## Before

```
Input:  "{ msg: 1 }\n\n\n\n{ msg: 2 }"
Output: "\n\n\n\n{ msg: 2 }"  // includes leading whitespace
```

## After

```
Input:  "{ msg: 1 }\n\n\n\n{ msg: 2 }"
Output: "{ msg: 2 }"  // clean JSON only
```

## User Benefits

- **Cleaner logs**: Debug output shows clean JSON without leading garbage
- **Memory efficiency**: No allocation for unnecessary whitespace bytes
- **Predictable output**: Messages always start with `{` or `[`

## Changes

- `stream_codec.rs`: Discard bytes before `start_idx` in `decode()`
- Updated `whitespace` test expectations
- Updated `huge` test to start with `{` directly
- Removed TODO comment
