### PR TITLE
feat(rpc): add `reth_subscribeLatestPersistedBlock` subscription

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10307,6 +10307,7 @@ dependencies = [
  "reth-storage-api",
  "reth-tasks",
  "reth-testing-utils",
+ "reth-tokio-util",
  "reth-transaction-pool",
  "reth-trie-common",
  "revm",

--- a/crates/engine/primitives/src/event.rs
+++ b/crates/engine/primitives/src/event.rs
@@ -32,6 +32,8 @@ pub enum ConsensusEngineEvent<N: NodePrimitives = EthPrimitives> {
     CanonicalChainCommitted(Box<SealedHeader<N::BlockHeader>>, Duration),
     /// The consensus engine processed an invalid block.
     InvalidBlock(Box<SealedBlock<N::Block>>),
+    /// Latest persisted block with its number and hash.
+    LatestPersistedBlock(BlockNumHash),
 }
 
 impl<N: NodePrimitives> ConsensusEngineEvent<N> {
@@ -72,6 +74,9 @@ where
             }
             Self::BlockReceived(num_hash) => {
                 write!(f, "BlockReceived({num_hash:?})")
+            }
+            Self::LatestPersistedBlock(block) => {
+                write!(f, "LatestPersistedBlock({block:?})")
             }
         }
     }

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1343,6 +1343,13 @@ where
         debug!(target: "engine::tree", ?last_persisted_block_hash, ?last_persisted_block_number, elapsed=?start_time.elapsed(), "Finished persisting, calling finish");
         self.persistence_state.finish(last_persisted_block_hash, last_persisted_block_number);
         self.on_new_persisted_block()?;
+
+        // Emit event for latest persisted block
+        self.emit_event(ConsensusEngineEvent::LatestPersistedBlock(BlockNumHash {
+            number: last_persisted_block_number,
+            hash: last_persisted_block_hash,
+        }));
+
         Ok(())
     }
 

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -25,7 +25,7 @@ use reth_node_core::{
 };
 use reth_payload_builder::{PayloadBuilderHandle, PayloadStore};
 use reth_rpc::{
-    eth::{core::EthRpcConverterFor, DevSigner, EthApiTypes, FullEthApiServer},
+    eth::{core::EthRpcConverterFor, DevSigner, EthApiTypes, FullEthApiServer, RpcNodeCore},
     AdminApi,
 };
 use reth_rpc_api::{eth::helpers::EthTransactions, IntoEngineApiRpcModule};
@@ -1197,7 +1197,8 @@ impl<'a, N: FullNodeComponents<Types: NodeTypes<ChainSpec: Hardforks + EthereumH
 /// A `EthApi` that knows how to build `eth` namespace API from [`FullNodeComponents`].
 pub trait EthApiBuilder<N: FullNodeComponents>: Default + Send + 'static {
     /// The Ethapi implementation this builder will build.
-    type EthApi: FullEthApiServer<Provider = N::Provider, Pool = N::Pool>;
+    type EthApi: FullEthApiServer<Provider = N::Provider, Pool = N::Pool>
+        + RpcNodeCore<Primitives = PrimitivesTy<N::Types>>;
 
     /// Builds the [`EthApiServer`](reth_rpc_api::eth::EthApiServer) from the given context.
     fn build_eth_api(

--- a/crates/node/events/src/node.rs
+++ b/crates/node/events/src/node.rs
@@ -267,6 +267,9 @@ impl NodeState {
             ConsensusEngineEvent::BlockReceived(num_hash) => {
                 info!(number=num_hash.number, hash=?num_hash.hash, "Received block from consensus engine");
             }
+            ConsensusEngineEvent::LatestPersistedBlock(num_hash) => {
+                info!(number=num_hash.number, hash=?num_hash.hash, "Latest persisted block");
+            }
         }
     }
 

--- a/crates/optimism/rpc/src/eth/mod.rs
+++ b/crates/optimism/rpc/src/eth/mod.rs
@@ -21,7 +21,7 @@ pub use receipt::{OpReceiptBuilder, OpReceiptFieldsBuilder};
 use reqwest::Url;
 use reth_chainspec::{EthereumHardforks, Hardforks};
 use reth_evm::ConfigureEvm;
-use reth_node_api::{FullNodeComponents, FullNodeTypes, HeaderTy, NodeTypes};
+use reth_node_api::{FullNodeComponents, FullNodeTypes, HeaderTy, NodeTypes, PrimitivesTy};
 use reth_node_builder::rpc::{EthApiBuilder, EthApiCtx};
 use reth_optimism_flashblocks::{
     FlashBlockBuildInfo, FlashBlockCompleteSequence, FlashBlockCompleteSequenceRx,
@@ -491,9 +491,9 @@ where
         >,
     >,
     NetworkT: RpcTypes,
-    OpRpcConvert<N, NetworkT>: RpcConvert<Network = NetworkT>,
-    OpEthApi<N, OpRpcConvert<N, NetworkT>>:
-        FullEthApiServer<Provider = N::Provider, Pool = N::Pool>,
+    OpRpcConvert<N, NetworkT>: RpcConvert<Network = NetworkT, Primitives = PrimitivesTy<N::Types>>,
+    OpEthApi<N, OpRpcConvert<N, NetworkT>>: FullEthApiServer<Provider = N::Provider, Pool = N::Pool>
+        + RpcNodeCore<Primitives = PrimitivesTy<N::Types>>,
 {
     type EthApi = OpEthApi<N, OpRpcConvert<N, NetworkT>>;
 

--- a/crates/ress/provider/src/pending_state.rs
+++ b/crates/ress/provider/src/pending_state.rs
@@ -123,7 +123,8 @@ pub async fn maintain_pending_state<P>(
             }
             // ignore
             ConsensusEngineEvent::CanonicalChainCommitted(_, _) |
-            ConsensusEngineEvent::BlockReceived(_) => (),
+            ConsensusEngineEvent::BlockReceived(_) |
+            ConsensusEngineEvent::LatestPersistedBlock(_) => (),
         }
     }
 }

--- a/crates/rpc/rpc-api/src/reth.rs
+++ b/crates/rpc/rpc-api/src/reth.rs
@@ -3,7 +3,8 @@ use alloy_primitives::{Address, U256};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use std::collections::HashMap;
 
-// Required for the subscription attribute below
+// Required for the subscription attributes below
+use alloy_eips as _;
 use reth_chain_state as _;
 
 /// Reth API namespace for reth-specific methods
@@ -24,4 +25,14 @@ pub trait RethApi {
         item = reth_chain_state::CanonStateNotification
     )]
     async fn reth_subscribe_chain_notifications(&self) -> jsonrpsee::core::SubscriptionResult;
+
+    /// Subscribe to latest persisted block notifications.
+    ///
+    /// Emits a notification for the latest block when blocks are persisted to disk.
+    #[subscription(
+        name = "subscribeLatestPersistedBlock",
+        unsubscribe = "unsubscribeLatestPersistedBlock",
+        item = alloy_eips::BlockNumHash
+    )]
+    async fn reth_subscribe_latest_persisted_block(&self) -> jsonrpsee::core::SubscriptionResult;
 }

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -42,6 +42,7 @@ reth-ethereum-primitives.workspace = true
 reth-ethereum-engine-primitives.workspace = true
 reth-node-api.workspace = true
 reth-trie-common.workspace = true
+reth-tokio-util.workspace = true
 
 # ethereum
 alloy-evm = { workspace = true, features = ["overrides"] }

--- a/crates/rpc/rpc/src/reth.rs
+++ b/crates/rpc/rpc/src/reth.rs
@@ -7,6 +7,7 @@ use futures::StreamExt;
 use jsonrpsee::{core::RpcResult, PendingSubscriptionSink, SubscriptionMessage, SubscriptionSink};
 use jsonrpsee_types::ErrorObject;
 use reth_chain_state::{CanonStateNotificationStream, CanonStateSubscriptions};
+use reth_engine_primitives::ConsensusEngineEvent;
 use reth_errors::RethResult;
 use reth_primitives_traits::NodePrimitives;
 use reth_rpc_api::RethApiServer;
@@ -14,33 +15,39 @@ use reth_rpc_eth_types::{EthApiError, EthResult};
 use reth_rpc_server_types::result::internal_rpc_err;
 use reth_storage_api::{BlockReaderIdExt, ChangeSetReader, StateProviderFactory};
 use reth_tasks::TaskSpawner;
+use reth_tokio_util::{EventSender, EventStream};
 use tokio::sync::oneshot;
 
 /// `reth` API implementation.
 ///
 /// This type provides the functionality for handling `reth` prototype RPC requests.
-pub struct RethApi<Provider> {
-    inner: Arc<RethApiInner<Provider>>,
+pub struct RethApi<Provider, N: NodePrimitives = reth_ethereum_primitives::EthPrimitives> {
+    inner: Arc<RethApiInner<Provider, N>>,
 }
 
 // === impl RethApi ===
 
-impl<Provider> RethApi<Provider> {
+impl<Provider, N: NodePrimitives> RethApi<Provider, N> {
     /// The provider that can interact with the chain.
     pub fn provider(&self) -> &Provider {
         &self.inner.provider
     }
 
     /// Create a new instance of the [`RethApi`]
-    pub fn new(provider: Provider, task_spawner: Box<dyn TaskSpawner>) -> Self {
-        let inner = Arc::new(RethApiInner { provider, task_spawner });
+    pub fn new(
+        provider: Provider,
+        task_spawner: Box<dyn TaskSpawner>,
+        engine_events: EventSender<ConsensusEngineEvent<N>>,
+    ) -> Self {
+        let inner = Arc::new(RethApiInner { provider, task_spawner, engine_events });
         Self { inner }
     }
 }
 
-impl<Provider> RethApi<Provider>
+impl<Provider, N> RethApi<Provider, N>
 where
     Provider: BlockReaderIdExt + ChangeSetReader + StateProviderFactory + 'static,
+    N: NodePrimitives,
 {
     /// Executes the future on a new blocking task.
     async fn on_blocking_task<C, F, R>(&self, c: C) -> EthResult<R>
@@ -91,13 +98,14 @@ where
 }
 
 #[async_trait]
-impl<Provider> RethApiServer for RethApi<Provider>
+impl<Provider, N> RethApiServer for RethApi<Provider, N>
 where
     Provider: BlockReaderIdExt
         + ChangeSetReader
         + StateProviderFactory
-        + CanonStateSubscriptions
+        + CanonStateSubscriptions<Primitives = N>
         + 'static,
+    N: NodePrimitives,
 {
     /// Handler for `reth_getBalanceChangesInBlock`
     async fn reth_get_balance_changes_in_block(
@@ -116,6 +124,20 @@ where
         let stream = self.provider().canonical_state_stream();
         self.inner.task_spawner.spawn(Box::pin(async move {
             let _ = pipe_from_stream(sink, stream).await;
+        }));
+
+        Ok(())
+    }
+
+    /// Handler for `reth_subscribeLatestPersistedBlock`
+    async fn reth_subscribe_latest_persisted_block(
+        &self,
+        pending: PendingSubscriptionSink,
+    ) -> jsonrpsee::core::SubscriptionResult {
+        let sink = pending.accept().await?;
+        let stream = self.inner.engine_events.new_listener();
+        self.inner.task_spawner.spawn(Box::pin(async move {
+            let _ = pipe_persisted_blocks(sink, stream).await;
         }));
 
         Ok(())
@@ -152,21 +174,57 @@ async fn pipe_from_stream<N: NodePrimitives>(
     }
 }
 
-impl<Provider> std::fmt::Debug for RethApi<Provider> {
+/// Pipes persisted block events to the subscription sink.
+async fn pipe_persisted_blocks<N: NodePrimitives>(
+    sink: SubscriptionSink,
+    mut stream: EventStream<ConsensusEngineEvent<N>>,
+) -> Result<(), ErrorObject<'static>> {
+    loop {
+        tokio::select! {
+            _ = sink.closed() => {
+                // connection dropped
+                break Ok(())
+            }
+            maybe_event = stream.next() => {
+                match maybe_event {
+                    Some(ConsensusEngineEvent::LatestPersistedBlock(block)) => {
+                        let msg = SubscriptionMessage::new(sink.method_name(), sink.subscription_id(), &block)
+                            .map_err(|e| internal_rpc_err(e.to_string()))?;
+
+                        if sink.send(msg).await.is_err() {
+                            break Ok(());
+                        }
+                    }
+                    Some(_) => {
+                        // Ignore other events
+                    }
+                    None => {
+                        // stream ended
+                        break Ok(())
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl<Provider, N: NodePrimitives> std::fmt::Debug for RethApi<Provider, N> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("RethApi").finish_non_exhaustive()
     }
 }
 
-impl<Provider> Clone for RethApi<Provider> {
+impl<Provider, N: NodePrimitives> Clone for RethApi<Provider, N> {
     fn clone(&self) -> Self {
         Self { inner: Arc::clone(&self.inner) }
     }
 }
 
-struct RethApiInner<Provider> {
+struct RethApiInner<Provider, N: NodePrimitives> {
     /// The provider that can interact with the chain.
     provider: Provider,
     /// The type that can spawn tasks which would otherwise block.
     task_spawner: Box<dyn TaskSpawner>,
+    /// Engine events sender for subscribing to consensus engine events.
+    engine_events: EventSender<ConsensusEngineEvent<N>>,
 }


### PR DESCRIPTION
When using direct database access `(examples/db-access)` and subscribing to new header events, it is currently necessary to add a delay to wait for persistence. This happens because the new header event over WebSockets is triggered before persistence. Even when using `--engine.persistence-threshold 0`, the event is emitted before persistence is triggered (and this is totally fine).

This PR adds a WebSocket subscription that emits notifications when blocks are persisted to disk, allowing external services to know when database reads reflect the latest canonical state. This can also be used when `--engine.persistence-threshold 0` is not provided, to determine when the state has been written.

Usage: `{"jsonrpc":"2.0","method":"reth_subscribeLatestPersistedBlock","params":[],"id":1}`

PS: I am currently investigating whether https://github.com/paradigmxyz/reth/issues/7836 is still an issue. You can find a test repo here: https://github.com/cakevm/reth-stale-direct-db. This also allows you to test this feature. I tested it with and without `--engine.persistence-threshold 0`.


I can downgrade this to `debug` but thought it may be useful:
```
ConsensusEngineEvent::LatestPersistedBlock(num_hash) => {
   info!(number=num_hash.number, hash=?num_hash.hash, "Latest persisted block");
}
```
Looks like:
```
2025-12-23T16:26:02.298841Z  INFO Received block from consensus engine number=24076495 hash=0xba428297deae3da18ba9b1731e141283c189daccce1050bb25213f8e185a08a1
2025-12-23T16:26:02.333813Z  INFO State root task finished state_root=0x80fd2171cd0728134f98ac7e2d83d3e28817f517168d00c52a1aa565f6c756fe elapsed=7.41032ms
2025-12-23T16:26:02.333914Z  INFO Block added to canonical chain number=24076495 hash=0xba428297deae3da18ba9b1731e141283c189daccce1050bb25213f8e185a08a1 peers=4 txs=307 gas_used=21.73Mgas gas_throughput=707.14Mgas/second gas_limit=60.00Mgas full=36.2% base_fee=0.10Gwei blobs=8 excess_blobs=998 elapsed=30.722264ms
2025-12-23T16:26:02.447327Z  INFO Canonical chain committed number=24076495 hash=0xba428297deae3da18ba9b1731e141283c189daccce1050bb25213f8e185a08a1 elapsed=354.086µs
2025-12-23T16:26:02.448215Z  INFO New payload job created id=0x028ee883bdbafbdc parent=0xba428297deae3da18ba9b1731e141283c189daccce1050bb25213f8e185a08a1
2025-12-23T16:26:02.949877Z  INFO Latest persisted block number=24076495 hash=0xba428297deae3da18ba9b1731e141283c189daccce1050bb25213f8e185a08a1 <-- NEW
```