### PR TITLE
perf(engine): do not invalidate accounts in cache post Cancun

### DIFF
--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 [dependencies]
 # reth
 reth-chain-state.workspace = true
-reth-chainspec = { workspace = true, optional = true }
+reth-chainspec.workspace = true
 reth-consensus.workspace = true
 reth-db.workspace = true
 reth-engine-primitives = { workspace = true, features = ["std"] }
@@ -79,7 +79,6 @@ reth-tracing = { workspace = true, optional = true }
 # reth
 reth-evm-ethereum = { workspace = true, features = ["test-utils"] }
 reth-chain-state = { workspace = true, features = ["test-utils"] }
-reth-chainspec.workspace = true
 reth-db-common.workspace = true
 reth-ethereum-consensus.workspace = true
 metrics-util = { workspace = true, features = ["debugging"] }

--- a/crates/engine/tree/benches/state_root_task.rs
+++ b/crates/engine/tree/benches/state_root_task.rs
@@ -9,7 +9,7 @@ use alloy_primitives::{Address, B256};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use proptest::test_runner::TestRunner;
 use rand::Rng;
-use reth_chainspec::ChainSpec;
+use reth_chainspec::{ChainSpec, MAINNET};
 use reth_db_common::init::init_genesis;
 use reth_engine_tree::tree::{
     executor::WorkloadExecutor, precompile_cache::PrecompileCacheMap, PayloadProcessor,
@@ -220,6 +220,7 @@ fn bench_state_root(c: &mut Criterion) {
                             EthEvmConfig::new(factory.chain_spec()),
                             &TreeConfig::default(),
                             PrecompileCacheMap::default(),
+                            MAINNET.clone(),
                         );
                         let provider = BlockchainProvider::new(factory).unwrap();
 

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -265,7 +265,8 @@ where
 
                 // Insert state into cache while holding the lock
                 // Access the BundleState through the shared ExecutionOutcome
-                if new_cache.cache().insert_state(execution_outcome.state()).is_err() {
+                if new_cache.cache().insert_state(execution_outcome.state(), &env.spec_id).is_err()
+                {
                     // Clear the cache on error to prevent having a polluted cache
                     *cached = None;
                     debug!(target: "engine::caching", "cleared execution cache on update error");

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -1319,6 +1319,7 @@ where
 impl<Node, EV> EngineValidatorBuilder<Node> for BasicEngineValidatorBuilder<EV>
 where
     Node: FullNodeComponents<
+        Types: NodeTypes<ChainSpec: EthereumHardforks>,
         Evm: ConfigureEngineEvm<
             <<Node::Types as NodeTypes>::Payload as PayloadTypes>::ExecutionData,
         >,


### PR DESCRIPTION
https://github.com/paradigmxyz/reth/blob/0585c84ca8f75a5d55008ab46ebcd9bc77df0bea/crates/engine/tree/src/tree/cached_state.rs#L476-L480

This opens the path to using caches that can't do invalidation in bulk, such as fixed-cache.