### PR TITLE
docs: align admin_nodeInfo example with actual RPC response

### DIFF
--- a/docs/vocs/docs/pages/jsonrpc/admin.mdx
+++ b/docs/vocs/docs/pages/jsonrpc/admin.mdx
@@ -94,20 +94,23 @@ These include general information about the node itself, as well as what protoco
     "id": 1,
     "result": {
         "enode": "enode://44826a5d6a55f88a18298bca4773fca5749cdc3a5c9f308aa7d810e9b31123f3e7c5fba0b1d70aac5308426f47df2a128a6747040a3815cc7dd7167d03be320d@[::]:30303",
-            "id": "44826a5d6a55f88a18298bca4773fca5749cdc3a5c9f308aa7d810e9b31123f3e7c5fba0b1d70aac5308426f47df2a128a6747040a3815cc7dd7167d03be320d",
-            "ip": "::",
-            "listenAddr": "[::]:30303",
-            "name": "reth/v0.0.1/x86_64-unknown-linux-gnu",
-            "ports": {
-                "discovery": 30303,
-                "listener": 30303
+        "id": "44826a5d6a55f88a18298bca4773fca5749cdc3a5c9f308aa7d810e9b31123f3e7c5fba0b1d70aac5308426f47df2a128a6747040a3815cc7dd7167d03be320d",
+        "ip": "::",
+        "listenAddr": "[::]:30303",
+        "name": "reth/v0.0.1/x86_64-unknown-linux-gnu",
+        "ports": {
+            "discovery": 30303,
+            "listener": 30303
         },
         "protocols": {
             "eth": {
-                "difficulty": 17334254859343145000,
+                "network": 1,
                 "genesis": "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3",
                 "head": "0xb83f73fbe6220c111136aefd27b160bf4a34085c65ba89f24246b3162257c36a",
-                "network": 1
+                "difficulty": null,
+                "config": {
+                    "...": "..." // chain configuration fields omitted for brevity
+                }
             }
         }
     }


### PR DESCRIPTION
Update the admin_nodeInfo JSON example in the admin namespace docs to better match the actual RPC response shape.

- Show protocols.eth.difficulty as null instead of a PoW-style numeric value
- Add the protocols.eth.config field to reflect the chain configuration payload
