### PR TITLE
fix: resolve TODO in provider.rs

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -2990,7 +2990,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider + 'static> BlockWrite
         let highest_static_file_block = self
             .static_file_provider()
             .get_highest_static_file_block(StaticFileSegment::Headers)
-            .expect("todo: error handling, headers should exist");
+            .unwrap_or_default();
 
         // IMPORTANT: we use `highest_static_file_block.saturating_sub(block_number)` to make sure
         // we remove only what is ABOVE the block.


### PR DESCRIPTION
Resolved TODO comment and replaced `.expect()` with `.unwrap_or_default()` for handling missing static file headers.