### PR TITLE
chore: correct misleading comment in find_node failure handling

### DIFF
--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -1582,8 +1582,7 @@ impl Discv4Service {
         self.pending_find_nodes.retain(|node_id, find_node_request| {
             if now.duration_since(find_node_request.sent_at) > self.config.neighbours_expiration {
                 if !find_node_request.answered {
-                    // node actually responded but with fewer entries than expected, but we don't
-                    // treat this as an hard error since it responded.
+                    // node did not respond at all
                     failed_find_nodes.push(*node_id);
                 }
                 return false


### PR DESCRIPTION
Fixed incorrect comment in evict_failed_find_nodes. The old comment claimed the node responded with fewer entries than expected, but the condition `!answered` triggers only when there was no response at all. The answered flag gets set on any response, so this branch handles complete timeouts, not partial responses.