### PR TITLE
refactor: deduplicate dev_mining_mode logic

### DIFF
--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -453,11 +453,7 @@ impl<R, ChainSpec: EthChainSpec> LaunchContextWith<Attached<WithConfigs<ChainSpe
     where
         Pool: TransactionPool + Unpin,
     {
-        if let Some(interval) = self.node_config().dev.block_time {
-            MiningMode::interval(interval)
-        } else {
-            MiningMode::instant(pool, self.node_config().dev.block_max_transactions)
-        }
+        self.node_config().dev_mining_mode(pool)
     }
 }
 


### PR DESCRIPTION
Remove duplicated dev_mining_mode implementation in LaunchContextWith. The method was copy-pasting the same logic from NodeConfig instead of delegating to it. Now it just calls self.node_config().dev_mining_mode(pool).