### PR TITLE
docs: remove outdated gas metrics TODO in backfill job

### DIFF
--- a/crates/exex/exex/src/backfill/job.rs
+++ b/crates/exex/exex/src/backfill/job.rs
@@ -118,7 +118,7 @@ where
             results.push(executor.execute_one(&block)?);
             execution_duration += execute_start.elapsed();
 
-            // TODO(alexey): report gas metrics using `block.header.gas_used`
+            // Gas metrics are tracked via cumulative_gas and logged at batch level (see line 143)
 
             // Seal the block back and save it
             blocks.push(block);


### PR DESCRIPTION
## Fix

Removes outdated TODO comment about gas metrics reporting in backfill job execution.

## Changes

- Replace TODO comment with explanatory note that gas metrics are already tracked via `cumulative_gas` and logged at batch level using `format_gas_throughput`
- Individual block-level gas metrics are not needed for backfill operations