### PR TITLE
fix(exex): distinguish revert from reorg in notification conversion

### DIFF
--- a/crates/exex/types/src/notification.rs
+++ b/crates/exex/types/src/notification.rs
@@ -65,7 +65,14 @@ impl<P: NodePrimitives> From<CanonStateNotification<P>> for ExExNotification<P> 
     fn from(notification: CanonStateNotification<P>) -> Self {
         match notification {
             CanonStateNotification::Commit { new } => Self::ChainCommitted { new },
-            CanonStateNotification::Reorg { old, new } => Self::ChainReorged { old, new },
+            CanonStateNotification::Reorg { old, new } => {
+                // If new is empty, this is a revert, not a reorg
+                if new.is_empty() {
+                    Self::ChainReverted { old }
+                } else {
+                    Self::ChainReorged { old, new }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

Fixes incorrect conversion of `CanonStateNotification::Reorg` to `ExExNotification`. When the `new` chain is empty (indicating a revert), the conversion now correctly creates `ChainReverted` instead of `ChainReorged`.

## Changes

- Added empty chain check in `From<CanonStateNotification>` implementation
- `Reorg` with empty `new` chain now converts to `ChainReverted`
- `Reorg` with non-empty `new` chain continues to convert to `ChainReorged`