### PR TITLE
chore: remove stale `insert_block_inner` todo

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -64,7 +64,6 @@ mod persistence_state;
 pub mod precompile_cache;
 #[cfg(test)]
 mod tests;
-// TODO(alexey): compare trie updates in `insert_block_inner`
 #[expect(unused)]
 mod trie_updates;
 


### PR DESCRIPTION
we should update `crates/engine/tree/docs/root.md` too since a lot of it looks deprecated