### PR TITLE
perf(engine): paralellize evm_state_to_hashed_post_state()

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -203,8 +203,7 @@ impl Drop for StateHookSender {
 }
 
 pub(crate) fn evm_state_to_hashed_post_state(update: EvmState) -> HashedPostState {
-    let hashed: Vec<_> = update
-        .into_par_iter()
+    update.into_par_iter()
         .filter_map(|(address, account)| {
             if !account.is_touched() {
                 return None;
@@ -235,17 +234,7 @@ pub(crate) fn evm_state_to_hashed_post_state(update: EvmState) -> HashedPostStat
 
             Some((hashed_address, info, hashed_storage))
         })
-        .collect();
-
-    let mut hashed_state = HashedPostState::with_capacity(hashed.len());
-    for (hashed_address, info, hashed_storage) in hashed {
-        hashed_state.accounts.insert(hashed_address, info);
-        if let Some(storage) = hashed_storage {
-            hashed_state.storages.insert(hashed_address, storage);
-        }
-    }
-
-    hashed_state
+        .collect()
 }
 
 /// Input parameters for dispatching a multiproof calculation.

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -10,6 +10,7 @@ use crossbeam_channel::{unbounded, Receiver as CrossbeamReceiver, Sender as Cros
 use dashmap::DashMap;
 use derive_more::derive::Deref;
 use metrics::{Gauge, Histogram};
+use rayon::prelude::*;
 use reth_metrics::Metrics;
 use reth_provider::AccountReader;
 use reth_revm::state::EvmState;
@@ -202,31 +203,45 @@ impl Drop for StateHookSender {
 }
 
 pub(crate) fn evm_state_to_hashed_post_state(update: EvmState) -> HashedPostState {
-    let mut hashed_state = HashedPostState::with_capacity(update.len());
+    let hashed: Vec<_> = update
+        .into_par_iter()
+        .filter_map(|(address, account)| {
+            if !account.is_touched() {
+                return None;
+            }
 
-    for (address, account) in update {
-        if account.is_touched() {
             let hashed_address = keccak256(address);
             trace!(target: "engine::tree::payload_processor::multiproof", ?address, ?hashed_address, "Adding account to state update");
 
             let destroyed = account.is_selfdestructed();
             let info = if destroyed { None } else { Some(account.info.into()) };
-            hashed_state.accounts.insert(hashed_address, info);
 
-            let mut changed_storage_iter = account
-                .storage
-                .into_iter()
-                .filter(|(_slot, value)| value.is_changed())
-                .map(|(slot, value)| (keccak256(B256::from(slot)), value.present_value))
-                .peekable();
+            let hashed_storage = if destroyed {
+                Some(HashedStorage::new(true))
+            } else {
+                let storage: Vec<_> = account
+                    .storage
+                    .into_iter()
+                    .filter(|(_slot, value)| value.is_changed())
+                    .map(|(slot, value)| (keccak256(B256::from(slot)), value.present_value))
+                    .collect();
 
-            if destroyed {
-                hashed_state.storages.insert(hashed_address, HashedStorage::new(true));
-            } else if changed_storage_iter.peek().is_some() {
-                hashed_state
-                    .storages
-                    .insert(hashed_address, HashedStorage::from_iter(false, changed_storage_iter));
-            }
+                if storage.is_empty() {
+                    None
+                } else {
+                    Some(HashedStorage::from_iter(false, storage))
+                }
+            };
+
+            Some((hashed_address, info, hashed_storage))
+        })
+        .collect();
+
+    let mut hashed_state = HashedPostState::with_capacity(hashed.len());
+    for (hashed_address, info, hashed_storage) in hashed {
+        hashed_state.accounts.insert(hashed_address, info);
+        if let Some(storage) = hashed_storage {
+            hashed_state.storages.insert(hashed_address, storage);
         }
     }
 


### PR DESCRIPTION
according to benchmarks, this increasingly improves perf if accounts accessed >20, below this value a sequential approach is more beneficial due to overhead 

