### PR TITLE
chore: shrink range result vec to fit

### DIFF
--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -1538,6 +1538,8 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
             }
         }
 
+        result.shrink_to_fit();
+
         Ok(result)
     }
 


### PR DESCRIPTION
it's possible that we over allocate here and these vecs frozen, so we should shrink to fit them here