### PR TITLE
chore(e2e): remove unused next_payload_id from NodeState

### DIFF
--- a/crates/e2e-test-utils/src/testsuite/actions/produce_blocks.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions/produce_blocks.rs
@@ -324,8 +324,6 @@ where
                 }
             };
 
-            env.active_node_state_mut()?.next_payload_id = Some(payload_id);
-
             sleep(Duration::from_secs(1)).await;
 
             let built_payload_envelope = EngineApiClient::<Engine>::get_payload_v3(

--- a/crates/e2e-test-utils/src/testsuite/mod.rs
+++ b/crates/e2e-test-utils/src/testsuite/mod.rs
@@ -115,8 +115,6 @@ where
     pub latest_header_time: u64,
     /// Stores payload IDs returned by this node, indexed by block number
     pub payload_id_history: HashMap<u64, PayloadId>,
-    /// Stores the next expected payload ID for this node
-    pub next_payload_id: Option<PayloadId>,
     /// Stores the latest fork choice state for this node
     pub latest_fork_choice_state: ForkchoiceState,
     /// Stores the most recent built execution payload for this node
@@ -139,7 +137,6 @@ where
             payload_attributes: HashMap::new(),
             latest_header_time: 0,
             payload_id_history: HashMap::new(),
-            next_payload_id: None,
             latest_fork_choice_state: ForkchoiceState::default(),
             latest_payload_built: None,
             latest_payload_executed: None,
@@ -159,7 +156,6 @@ where
             .field("payload_attributes", &self.payload_attributes)
             .field("latest_header_time", &self.latest_header_time)
             .field("payload_id_history", &self.payload_id_history)
-            .field("next_payload_id", &self.next_payload_id)
             .field("latest_fork_choice_state", &self.latest_fork_choice_state)
             .field("latest_payload_built", &self.latest_payload_built)
             .field("latest_payload_executed", &self.latest_payload_executed)


### PR DESCRIPTION
The next_payload_id field in NodeState was only ever written once in GenerateNextPayload and never read anywhere in the e2e test suite or upstream sources. This field provided no additional information beyond payload_id_history and latest_payload_* and effectively acted as dead state. This change removes the field, its default initialization and Debug output, and drops the lone write in GenerateNextPayload, keeping NodeState focused on actually used engine state without changing runtime behavior.