### PR TITLE
fix(rpc): use EthereumHardforks trait for Paris activation check

### DIFF
--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -17,7 +17,7 @@ use alloy_rpc_types_trace::{
 };
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
-use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardfork, MAINNET, SEPOLIA};
+use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
 use reth_evm::ConfigureEvm;
 use reth_primitives_traits::{BlockBody, BlockHeader};
 use reth_rpc_api::TraceApiServer;
@@ -276,21 +276,13 @@ where
     ///
     /// - if Paris hardfork is activated, no block rewards are given
     /// - if Paris hardfork is not activated, calculate block rewards with block number only
-    /// - if Paris hardfork is unknown, calculate block rewards with block number and ttd
     fn calculate_base_block_reward<H: BlockHeader>(
         &self,
         header: &H,
     ) -> Result<Option<u128>, Eth::Error> {
         let chain_spec = self.provider().chain_spec();
-        let is_paris_activated = if chain_spec.chain() == MAINNET.chain() {
-            Some(header.number()) >= EthereumHardfork::Paris.mainnet_activation_block()
-        } else if chain_spec.chain() == SEPOLIA.chain() {
-            Some(header.number()) >= EthereumHardfork::Paris.sepolia_activation_block()
-        } else {
-            true
-        };
 
-        if is_paris_activated {
+        if chain_spec.is_paris_active_at_block(header.number()) {
             return Ok(None)
         }
 


### PR DESCRIPTION
This fixes a regression introduced in #13362 where the Paris hardfork check was hardcoded for mainnet and sepolia only. For any other chain (custom PoW networks, testnets, etc.), `is_paris_activated` was always set to `true`, which meant block rewards were never calculated - even on chains that haven't merged yet.

The original code before #13362 used `chain_spec.is_paris_active_at_block()` which works correctly for all chains. The refactor to remove total difficulty checks accidentally replaced this with a broken hardcoded approach.

This change restores the proper behavior by using the `EthereumHardforks` trait method, which checks the chainspec configuration for any network.