### PR TITLE
docs(rpc): fix typos and complete incomplete doc comments

### DIFF
--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -1534,22 +1534,22 @@ impl TransportRpcModuleConfig {
         self
     }
 
-    /// Get a mutable reference to the
+    /// Get a mutable reference to the http module configuration.
     pub const fn http_mut(&mut self) -> &mut Option<RpcModuleSelection> {
         &mut self.http
     }
 
-    /// Get a mutable reference to the
+    /// Get a mutable reference to the ws module configuration.
     pub const fn ws_mut(&mut self) -> &mut Option<RpcModuleSelection> {
         &mut self.ws
     }
 
-    /// Get a mutable reference to the
+    /// Get a mutable reference to the ipc module configuration.
     pub const fn ipc_mut(&mut self) -> &mut Option<RpcModuleSelection> {
         &mut self.ipc
     }
 
-    /// Get a mutable reference to the
+    /// Get a mutable reference to the rpc module configuration.
     pub const fn config_mut(&mut self) -> &mut Option<RpcModuleConfig> {
         &mut self.config
     }

--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -201,7 +201,7 @@ pub enum EthApiError {
 }
 
 impl EthApiError {
-    /// crates a new [`EthApiError::Other`] variant.
+    /// Creates a new [`EthApiError::Other`] variant.
     pub fn other<E: ToRpcError>(err: E) -> Self {
         Self::Other(Box::new(err))
     }
@@ -654,7 +654,7 @@ pub enum RpcInvalidTransactionError {
     /// The transaction is before Spurious Dragon and has a chain ID
     #[error("transactions before Spurious Dragon should not have a chain ID")]
     OldLegacyChainId,
-    /// The transitions is before Berlin and has access list
+    /// The transaction is before Berlin and has access list
     #[error("transactions before Berlin should not have access list")]
     AccessListNotSupported,
     /// `max_fee_per_blob_gas` is not supported for blocks before the Cancun hardfork.
@@ -700,7 +700,7 @@ pub enum RpcInvalidTransactionError {
 }
 
 impl RpcInvalidTransactionError {
-    /// crates a new [`RpcInvalidTransactionError::Other`] variant.
+    /// Creates a new [`RpcInvalidTransactionError::Other`] variant.
     pub fn other<E: ToRpcError>(err: E) -> Self {
         Self::Other(Box::new(err))
     }


### PR DESCRIPTION
## Summary

Fix documentation issues in the `rpc` crates.

## Changes

### `rpc-eth-types`
- Fix typos in error module doc comments
  - `crates` → `Creates` in `EthApiError::other` and `RpcInvalidTransactionError::other`
  - `transitions` → `transaction` in `RpcInvalidTransactionError::AccessListNotSupported`

### `rpc-builder`
- Complete incomplete doc comments for `TransportRpcModuleConfig` methods
  - `http_mut`
  - `ws_mut`
  - `ipc_mut`
  - `config_mut`