### PR TITLE
fix(chainspec): use lazy error formatting in chain spec macro

### DIFF
--- a/crates/optimism/chainspec/src/superchain/chain_spec_macro.rs
+++ b/crates/optimism/chainspec/src/superchain/chain_spec_macro.rs
@@ -6,7 +6,7 @@ macro_rules! create_chain_spec {
             /// The Optimism $name $environment spec
             pub static [<$name:upper _ $environment:upper>]: $crate::LazyLock<alloc::sync::Arc<$crate::OpChainSpec>> = $crate::LazyLock::new(|| {
                 $crate::OpChainSpec::from_genesis($crate::superchain::configs::read_superchain_genesis($name, $environment)
-                    .expect(&alloc::format!("Can't read {}-{} genesis", $name, $environment)))
+                    .unwrap_or_else(|e| panic!("Can't read {}-{} genesis: {}", $name, $environment, e)))
                     .into()
             });
         }


### PR DESCRIPTION
## Problem

`alloc::format!` in the macro runs on every `LazyLock` init, even when there's no error. This allocates memory unnecessarily.

## Solution

Use `unwrap_or_else` so the error message is only formatted when an error occurs. This avoids allocation on the happy path and matches the pattern used elsewhere in the codebase.