### PR TITLE
docs: add comprehensive documentation for NoopPayloadBuilderService

### DIFF
--- a/crates/payload/builder/src/noop.rs
+++ b/crates/payload/builder/src/noop.rs
@@ -1,4 +1,26 @@
 //! A payload builder service task that does nothing.
+//!
+//! This module provides `NoopPayloadBuilderService`, a payload builder implementation that
+//! accepts payload building requests but does not actually build any payloads. All commands
+//! return empty or default responses. Useful for testing and node implementations that do not
+//! require payload building functionality (e.g., nodes that are not validators or sequencers).
+//!
+//! # Examples
+//!
+//! ```rust
+//! use reth_ethereum_engine_primitives::EthEngineTypes;
+//! use reth_payload_builder::noop::NoopPayloadBuilderService;
+//!
+//! let (service, handle) = NoopPayloadBuilderService::<EthEngineTypes>::new();
+//! // The service can be spawned as a task, and the handle can be used to interact with it
+//! ```
+//!
+//! # Use Cases
+//!
+//! - Testing scenarios where payload building is not needed
+//! - Node implementations that do not implement validating or sequencing logic
+//! - Wiring components together that require a payload builder handle but don't need actual payload
+//!   building
 
 use crate::{service::PayloadServiceCommand, PayloadBuilderHandle};
 use futures_util::{ready, StreamExt};
@@ -12,6 +34,13 @@ use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
 /// A service task that does not build any payloads.
+///
+/// This service accepts all payload building commands but returns empty or default responses.
+/// - `BuildNewPayload` returns the payload ID from attributes but does not build a payload
+/// - `BestPayload`, `PayloadTimestamp`, and `Resolve` all return `None`
+/// - `Subscribe` is ignored
+///
+/// Suitable for testing and scenarios where payload building functionality is not required.
 #[derive(Debug)]
 pub struct NoopPayloadBuilderService<T: PayloadTypes> {
     /// Receiver half of the command channel.
@@ -67,6 +96,10 @@ impl<T: PayloadTypes> Default for NoopPayloadBuilderService<T> {
 
 impl<T: PayloadTypes> PayloadBuilderHandle<T> {
     /// Returns a new noop instance.
+    ///
+    /// This creates a handle that is not connected to any active service. All requests
+    /// sent through this handle will be silently ignored. Useful when a payload builder
+    /// handle is required by the API but payload building is not needed.
     pub fn noop() -> Self {
         Self::new(mpsc::unbounded_channel().0)
     }


### PR DESCRIPTION
## Fix

Adds missing documentation for `NoopPayloadBuilderService` to match the documentation standards used by other noop implementations in the codebase.

## Changes

- Added module-level documentation with description, examples, and use cases
- Documented `NoopPayloadBuilderService` struct behavior for each command type
- Documented `PayloadBuilderHandle::noop()` method with usage guidance