### PR TITLE
fix(db-api): set is_done=true in RangeWalker when cursor returns None

### DIFF
--- a/crates/storage/db-api/src/cursor.rs
+++ b/crates/storage/db-api/src/cursor.rs
@@ -282,7 +282,7 @@ impl<T: Table, CURSOR: DbCursorRO<T>> Iterator for RangeWalker<'_, T, CURSOR> {
             },
             Some(res @ Err(_)) => Some(res),
             None => {
-                self.is_done = matches!(self.end_key, Bound::Unbounded);
+                self.is_done = true;
                 None
             }
         }


### PR DESCRIPTION
Set `is_done` to `true` in `RangeWalker::next()` when cursor returns `None`, regardless of the range bound type. Previously, `is_done` was only set for `Unbounded` ranges, leading to unnecessary `cursor.next()` calls on subsequent 
 iterations for bounded ranges.