### PR TITLE
chore: remove duplicate BlockBodyIndices table import

### DIFF
--- a/crates/cli/commands/src/stage/dump/execution.rs
+++ b/crates/cli/commands/src/stage/dump/execution.rs
@@ -78,13 +78,6 @@ fn import_tables_with_range<N: NodeTypesWithDB>(
         )
     })??;
     output_db.update(|tx| {
-        tx.import_table_with_range::<tables::BlockBodyIndices, _>(
-            &db_tool.provider_factory.db_ref().tx()?,
-            Some(from),
-            to,
-        )
-    })??;
-    output_db.update(|tx| {
         tx.import_table_with_range::<tables::BlockOmmers, _>(
             &db_tool.provider_factory.db_ref().tx()?,
             Some(from),


### PR DESCRIPTION
BlockBodyIndices table was imported twice during execution stage dump - first in setup() with range from-1..to+1, then again in import_tables_with_range() with from..to. The second import is redundant since the data already exists from the first call. Removed the unnecessary duplicate.