### PR TITLE
feat: add append_pooled_transaction_elements

### DIFF
--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -554,6 +554,15 @@ where
         self.pool.get_pooled_transaction_elements(tx_hashes, limit)
     }
 
+    fn append_pooled_transaction_elements(
+        &self,
+        tx_hashes: &[TxHash],
+        limit: GetPooledTransactionLimit,
+        out: &mut Vec<<<V as TransactionValidator>::Transaction as PoolTransaction>::Pooled>,
+    ) {
+        self.pool.append_pooled_transaction_elements(tx_hashes, limit, out)
+    }
+
     fn get_pooled_transaction_element(
         &self,
         tx_hash: TxHash,

--- a/crates/transaction-pool/src/noop.rs
+++ b/crates/transaction-pool/src/noop.rs
@@ -155,6 +155,14 @@ impl<T: EthPoolTransaction> TransactionPool for NoopTransactionPool<T> {
         vec![]
     }
 
+    fn append_pooled_transaction_elements(
+        &self,
+        _tx_hashes: &[TxHash],
+        _limit: GetPooledTransactionLimit,
+        _out: &mut Vec<<Self::Transaction as PoolTransaction>::Pooled>,
+    ) {
+    }
+
     fn get_pooled_transaction_element(
         &self,
         _tx_hash: TxHash,

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -339,7 +339,6 @@ where
         <V as TransactionValidator>::Transaction: EthPoolTransaction,
     {
         let transactions = self.get_all_propagatable(tx_hashes);
-        out.reserve(transactions.len());
         let mut size = 0;
         for transaction in transactions {
             let encoded_len = transaction.encoded_length();
@@ -439,6 +438,7 @@ where
     {
         let mut elements = Vec::new();
         self.append_pooled_transaction_elements(&tx_hashes, limit, &mut elements);
+        elements.shrink_to_fit();
         elements
     }
 

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -332,7 +332,7 @@ where
     /// be propagated.
     pub fn append_pooled_transaction_elements(
         &self,
-        tx_hashes: Vec<TxHash>,
+        tx_hashes: &[TxHash],
         limit: GetPooledTransactionLimit,
         out: &mut Vec<<<V as TransactionValidator>::Transaction as PoolTransaction>::Pooled>,
     ) where
@@ -438,7 +438,7 @@ where
         <V as TransactionValidator>::Transaction: EthPoolTransaction,
     {
         let mut elements = Vec::new();
-        self.append_pooled_transaction_elements(tx_hashes, limit, &mut elements);
+        self.append_pooled_transaction_elements(&tx_hashes, limit, &mut elements);
         elements
     }
 
@@ -1146,12 +1146,13 @@ where
     /// If no transaction exists, it is skipped.
     fn get_all_propagatable(
         &self,
-        txs: Vec<TxHash>,
+        txs: &[TxHash],
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
         if txs.is_empty() {
             return Vec::new()
         }
-        self.get_pool_data().get_all(txs).filter(|tx| tx.propagate).collect()
+        let pool = self.get_pool_data();
+        txs.iter().filter_map(|tx| pool.get(tx).filter(|tx| tx.propagate)).collect()
     }
 
     /// Notify about propagated transactions.

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -346,6 +346,21 @@ pub trait TransactionPool: Clone + Debug + Send + Sync {
         limit: GetPooledTransactionLimit,
     ) -> Vec<<Self::Transaction as PoolTransaction>::Pooled>;
 
+    /// Extends the given vector with pooled transactions for the given hashes that are allowed to
+    /// be propagated.
+    ///
+    /// This adheres to the expected behavior of [`Self::get_pooled_transaction_elements`].
+    ///
+    /// Consumer: P2P
+    fn append_pooled_transaction_elements(
+        &self,
+        tx_hashes: &[TxHash],
+        limit: GetPooledTransactionLimit,
+        out: &mut Vec<<Self::Transaction as PoolTransaction>::Pooled>,
+    ) {
+        out.extend(self.get_pooled_transaction_elements(tx_hashes.to_vec(), limit));
+    }
+
     /// Returns the pooled transaction variant for the given transaction hash.
     ///
     /// This adheres to the expected behavior of


### PR DESCRIPTION
This closes issue #20652

- Expose fn append_pooled_transaction_elements for tempo to reuse 
- Prevent clone when we get txs from aa_2d_pool and protocol_pool in this issue :
https://github.com/tempoxyz/tempo/issues/1764

cc @mattsse @yongkangc 