### PR TITLE
refactor: unify witness generation with DebugApi using ExecutionWitnessRecord

### DIFF
--- a/crates/engine/invalid-block-hooks/Cargo.toml
+++ b/crates/engine/invalid-block-hooks/Cargo.toml
@@ -19,7 +19,7 @@ reth-engine-primitives.workspace = true
 reth-evm.workspace = true
 reth-primitives-traits.workspace = true
 reth-provider.workspace = true
-reth-revm = { workspace = true, features = ["serde"] }
+reth-revm = { workspace = true, features = ["serde", "witness"] }
 reth-rpc-api = { workspace = true, features = ["client"] }
 reth-tracing.workspace = true
 reth-trie.workspace = true


### PR DESCRIPTION
## Fix

Unifies witness generation with `DebugApi::debug_execution_witness` by replacing custom implementation with `ExecutionWitnessRecord::from_executed_state()`.

## Changes

- Replace `collect_execution_data()` and `generate()` with `ExecutionWitnessRecord::from_executed_state()`
- Remove duplicate `state_by_block_hash()` call in `re_execute_block()`
- Add `witness` feature to `reth-revm` dependency in `Cargo.toml`
- Update tests to use `ExecutionWitnessRecord` instead of custom functions
- Remove TODO comment about unification