### PR TITLE
feat(txpool): add configurable batch timeout to transaction pool insertions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10442,6 +10442,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tracing",
 ]
 

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -999,11 +999,7 @@ where
             }),
         );
 
-        let eth_config = config
-            .rpc
-            .eth_config()
-            .max_batch_size(config.txpool.max_batch_size())
-            .batch_timeout(config.txpool.batch_timeout());
+        let eth_config = config.rpc.eth_config().batch_config(config.txpool.batch_config());
         let ctx = EthApiCtx {
             components: &node,
             config: eth_config,
@@ -1191,8 +1187,7 @@ impl<'a, N: FullNodeComponents<Types: NodeTypes<ChainSpec: Hardforks + EthereumH
             .fee_history_cache_config(self.config.fee_history_cache)
             .proof_permits(self.config.proof_permits)
             .gas_oracle_config(self.config.gas_oracle)
-            .max_batch_size(self.config.max_batch_size)
-            .batch_timeout(self.config.batch_timeout)
+            .batch_config(self.config.batch_config)
             .max_blocking_io_requests(self.config.max_blocking_io_requests)
             .pending_block_kind(self.config.pending_block_kind)
             .raw_tx_forwarder(self.config.raw_tx_forwarder)

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -999,7 +999,11 @@ where
             }),
         );
 
-        let eth_config = config.rpc.eth_config().max_batch_size(config.txpool.max_batch_size());
+        let eth_config = config
+            .rpc
+            .eth_config()
+            .max_batch_size(config.txpool.max_batch_size())
+            .batch_timeout(config.txpool.batch_timeout());
         let ctx = EthApiCtx {
             components: &node,
             config: eth_config,
@@ -1188,6 +1192,7 @@ impl<'a, N: FullNodeComponents<Types: NodeTypes<ChainSpec: Hardforks + EthereumH
             .proof_permits(self.config.proof_permits)
             .gas_oracle_config(self.config.gas_oracle)
             .max_batch_size(self.config.max_batch_size)
+            .batch_timeout(self.config.batch_timeout)
             .max_blocking_io_requests(self.config.max_blocking_io_requests)
             .pending_block_kind(self.config.pending_block_kind)
             .raw_tx_forwarder(self.config.raw_tx_forwarder)

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -1115,7 +1115,7 @@ where
             cache_new_blocks_task(c, new_canonical_blocks).await;
         });
 
-        let eth_config = config.rpc.eth_config().max_batch_size(config.txpool.max_batch_size());
+        let eth_config = config.rpc.eth_config().batch_config(config.txpool.batch_config());
         let ctx = EthApiCtx {
             components: &node,
             config: eth_config,
@@ -1310,7 +1310,7 @@ impl<'a, N: FullNodeComponents<Types: NodeTypes<ChainSpec: Hardforks + EthereumH
             .fee_history_cache_config(self.config.fee_history_cache)
             .proof_permits(self.config.proof_permits)
             .gas_oracle_config(self.config.gas_oracle)
-            .max_batch_size(self.config.max_batch_size)
+            .batch_config(self.config.batch_config)
             .max_blocking_io_requests(self.config.max_blocking_io_requests)
             .pending_block_kind(self.config.pending_block_kind)
             .raw_tx_forwarder(self.config.raw_tx_forwarder)

--- a/crates/node/core/src/args/txpool.rs
+++ b/crates/node/core/src/args/txpool.rs
@@ -56,6 +56,8 @@ pub struct DefaultTxPoolValues {
     transactions_backup_path: Option<PathBuf>,
     disable_transactions_backup: bool,
     max_batch_size: usize,
+    /// Batch timeout for partial insertion batches. Zero keeps immediate processing.
+    batch_timeout: Duration,
 }
 
 impl DefaultTxPoolValues {
@@ -248,6 +250,12 @@ impl DefaultTxPoolValues {
         self.max_batch_size = v;
         self
     }
+
+    /// Set the default batch timeout. [`Duration::ZERO`] keeps immediate processing.
+    pub const fn with_batch_timeout(mut self, v: Duration) -> Self {
+        self.batch_timeout = v;
+        self
+    }
 }
 
 impl Default for DefaultTxPoolValues {
@@ -283,6 +291,7 @@ impl Default for DefaultTxPoolValues {
             transactions_backup_path: None,
             disable_transactions_backup: false,
             max_batch_size: 1,
+            batch_timeout: Duration::ZERO,
         }
     }
 }
@@ -417,8 +426,8 @@ pub struct TxPoolArgs {
     /// When set to a non-zero duration, transactions are batched until either max-batch-size is
     /// reached or the timeout expires after the first buffered transaction. Requires
     /// txpool.max-batch-size > 1 to coalesce multiple transactions.
-    #[arg(long = "txpool.batch-timeout", value_parser = parse_duration_from_secs_or_ms, value_name = "DURATION")]
-    pub batch_timeout: Option<Duration>,
+    #[arg(long = "txpool.batch-timeout", value_parser = parse_duration_from_secs_or_ms, value_name = "DURATION", default_value = format_duration_as_secs_or_ms(DefaultTxPoolValues::get_global().batch_timeout))]
+    pub batch_timeout: Duration,
 }
 
 impl TxPoolArgs {
@@ -472,6 +481,7 @@ impl Default for TxPoolArgs {
             transactions_backup_path,
             disable_transactions_backup,
             max_batch_size,
+            batch_timeout,
         } = DefaultTxPoolValues::get_global().clone();
         Self {
             pending_max_count,
@@ -504,7 +514,7 @@ impl Default for TxPoolArgs {
             transactions_backup_path,
             disable_transactions_backup,
             max_batch_size,
-            batch_timeout: None,
+            batch_timeout,
         }
     }
 }
@@ -556,7 +566,7 @@ impl RethTransactionPoolConfig for TxPoolArgs {
     fn batch_config(&self) -> BatchConfig {
         BatchConfig {
             max_batch_size: self.max_batch_size,
-            batch_timeout: self.batch_timeout.filter(|timeout| !timeout.is_zero()),
+            batch_timeout: (!self.batch_timeout.is_zero()).then_some(self.batch_timeout),
             max_concurrent_batches: self.additional_validation_tasks.saturating_add(3),
         }
     }
@@ -603,9 +613,9 @@ mod tests {
     }
 
     #[test]
-    fn txpool_parse_batch_timeout_optional() {
+    fn txpool_parse_batch_timeout() {
         let args = CommandParser::<TxPoolArgs>::parse_from(["reth"]).args;
-        assert_eq!(args.batch_timeout, None);
+        assert_eq!(args.batch_timeout, Duration::ZERO);
         assert_eq!(args.batch_config().batch_timeout, None);
         assert_eq!(
             args.batch_config().max_concurrent_batches,
@@ -614,13 +624,13 @@ mod tests {
 
         let args =
             CommandParser::<TxPoolArgs>::parse_from(["reth", "--txpool.batch-timeout", "0"]).args;
-        assert_eq!(args.batch_timeout, Some(Duration::ZERO));
+        assert_eq!(args.batch_timeout, Duration::ZERO);
         assert_eq!(args.batch_config().batch_timeout, None);
 
         let args =
             CommandParser::<TxPoolArgs>::parse_from(["reth", "--txpool.batch-timeout", "50ms"])
                 .args;
-        assert_eq!(args.batch_timeout, Some(Duration::from_millis(50)));
+        assert_eq!(args.batch_timeout, Duration::from_millis(50));
         assert_eq!(args.batch_config().batch_timeout, Some(Duration::from_millis(50)));
     }
 
@@ -660,7 +670,7 @@ mod tests {
             transactions_backup_path: Some(PathBuf::from("/tmp/txpool-backup")),
             disable_transactions_backup: false,
             max_batch_size: 10,
-            batch_timeout: Some(Duration::from_millis(50)),
+            batch_timeout: Duration::from_millis(50),
         };
 
         let parsed_args = CommandParser::<TxPoolArgs>::parse_from([

--- a/crates/node/core/src/args/txpool.rs
+++ b/crates/node/core/src/args/txpool.rs
@@ -10,10 +10,11 @@ use reth_transaction_pool::{
     maintain::MAX_QUEUED_TRANSACTION_LIFETIME,
     pool::{NEW_TX_LISTENER_BUFFER_SIZE, PENDING_TX_LISTENER_BUFFER_SIZE},
     validate::DEFAULT_MAX_TX_INPUT_BYTES,
-    LocalTransactionConfig, PoolConfig, PriceBumpConfig, SubPoolLimit, DEFAULT_PRICE_BUMP,
-    DEFAULT_TXPOOL_ADDITIONAL_VALIDATION_TASKS, MAX_NEW_PENDING_TXS_NOTIFICATIONS,
-    REPLACE_BLOB_PRICE_BUMP, TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
-    TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT, TXPOOL_SUBPOOL_MAX_TXS_DEFAULT,
+    BatchConfig, LocalTransactionConfig, PoolConfig, PriceBumpConfig, SubPoolLimit,
+    DEFAULT_PRICE_BUMP, DEFAULT_TXPOOL_ADDITIONAL_VALIDATION_TASKS,
+    MAX_NEW_PENDING_TXS_NOTIFICATIONS, REPLACE_BLOB_PRICE_BUMP,
+    TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER, TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT,
+    TXPOOL_SUBPOOL_MAX_TXS_DEFAULT,
 };
 use std::{path::PathBuf, sync::OnceLock, time::Duration};
 
@@ -411,6 +412,13 @@ pub struct TxPoolArgs {
     /// Max batch size for transaction pool insertions
     #[arg(long = "txpool.max-batch-size", default_value_t = DefaultTxPoolValues::get_global().max_batch_size)]
     pub max_batch_size: usize,
+
+    /// Batch timeout for transaction pool insertions (e.g. "50ms" or "0" for immediate).
+    /// When set to a non-zero duration, transactions are batched until either max-batch-size is
+    /// reached or the timeout expires after the first buffered transaction. Requires
+    /// txpool.max-batch-size > 1 to coalesce multiple transactions.
+    #[arg(long = "txpool.batch-timeout", value_parser = parse_duration_from_secs_or_ms, value_name = "DURATION")]
+    pub batch_timeout: Option<Duration>,
 }
 
 impl TxPoolArgs {
@@ -496,6 +504,7 @@ impl Default for TxPoolArgs {
             transactions_backup_path,
             disable_transactions_backup,
             max_batch_size,
+            batch_timeout: None,
         }
     }
 }
@@ -543,9 +552,13 @@ impl RethTransactionPoolConfig for TxPoolArgs {
         }
     }
 
-    /// Returns max batch size for transaction batch insertion.
-    fn max_batch_size(&self) -> usize {
-        self.max_batch_size
+    /// Returns batch config for transaction batch insertion.
+    fn batch_config(&self) -> BatchConfig {
+        BatchConfig {
+            max_batch_size: self.max_batch_size,
+            batch_timeout: self.batch_timeout.filter(|timeout| !timeout.is_zero()),
+            max_concurrent_batches: self.additional_validation_tasks.saturating_add(3),
+        }
     }
 }
 
@@ -590,6 +603,28 @@ mod tests {
     }
 
     #[test]
+    fn txpool_parse_batch_timeout_optional() {
+        let args = CommandParser::<TxPoolArgs>::parse_from(["reth"]).args;
+        assert_eq!(args.batch_timeout, None);
+        assert_eq!(args.batch_config().batch_timeout, None);
+        assert_eq!(
+            args.batch_config().max_concurrent_batches,
+            args.additional_validation_tasks.saturating_add(3)
+        );
+
+        let args =
+            CommandParser::<TxPoolArgs>::parse_from(["reth", "--txpool.batch-timeout", "0"]).args;
+        assert_eq!(args.batch_timeout, Some(Duration::ZERO));
+        assert_eq!(args.batch_config().batch_timeout, None);
+
+        let args =
+            CommandParser::<TxPoolArgs>::parse_from(["reth", "--txpool.batch-timeout", "50ms"])
+                .args;
+        assert_eq!(args.batch_timeout, Some(Duration::from_millis(50)));
+        assert_eq!(args.batch_config().batch_timeout, Some(Duration::from_millis(50)));
+    }
+
+    #[test]
     fn txpool_args() {
         let args = TxPoolArgs {
             pending_max_count: 1000,
@@ -625,6 +660,7 @@ mod tests {
             transactions_backup_path: Some(PathBuf::from("/tmp/txpool-backup")),
             disable_transactions_backup: false,
             max_batch_size: 10,
+            batch_timeout: Some(Duration::from_millis(50)),
         };
 
         let parsed_args = CommandParser::<TxPoolArgs>::parse_from([
@@ -685,6 +721,8 @@ mod tests {
             "/tmp/txpool-backup",
             "--txpool.max-batch-size",
             "10",
+            "--txpool.batch-timeout",
+            "50ms",
         ])
         .args;
 

--- a/crates/node/core/src/cli/config.rs
+++ b/crates/node/core/src/cli/config.rs
@@ -4,7 +4,7 @@ use alloy_eips::eip1559::ETHEREUM_BLOCK_GAS_LIMIT_36M;
 use alloy_primitives::Bytes;
 use reth_chainspec::{Chain, ChainKind, NamedChain};
 use reth_network::{protocol::IntoRlpxSubProtocol, NetworkPrimitives};
-use reth_transaction_pool::PoolConfig;
+use reth_transaction_pool::{BatchConfig, PoolConfig};
 use std::{borrow::Cow, time::Duration};
 
 /// 60M gas limit
@@ -89,10 +89,6 @@ pub trait RethTransactionPoolConfig {
     /// Returns transaction pool configuration.
     fn pool_config(&self) -> PoolConfig;
 
-    /// Returns max batch size for transaction batch insertion.
-    fn max_batch_size(&self) -> usize;
-
-    /// Returns batch timeout for transaction batch insertion.
-    /// Use `Duration::ZERO` for immediate processing (zero-cost path).
-    fn batch_timeout(&self) -> Duration;
+    /// Returns batch config for transaction batch insertion.
+    fn batch_config(&self) -> BatchConfig;
 }

--- a/crates/node/core/src/cli/config.rs
+++ b/crates/node/core/src/cli/config.rs
@@ -91,4 +91,8 @@ pub trait RethTransactionPoolConfig {
 
     /// Returns max batch size for transaction batch insertion.
     fn max_batch_size(&self) -> usize;
+
+    /// Returns batch timeout for transaction batch insertion.
+    /// Use `Duration::ZERO` for immediate processing (zero-cost path).
+    fn batch_timeout(&self) -> Duration;
 }

--- a/crates/node/core/src/cli/config.rs
+++ b/crates/node/core/src/cli/config.rs
@@ -4,7 +4,7 @@ use alloy_eips::eip1559::ETHEREUM_BLOCK_GAS_LIMIT_36M;
 use alloy_primitives::Bytes;
 use reth_chainspec::{Chain, ChainKind, NamedChain};
 use reth_network::{protocol::IntoRlpxSubProtocol, NetworkPrimitives};
-use reth_transaction_pool::PoolConfig;
+use reth_transaction_pool::{BatchConfig, PoolConfig};
 use std::time::Duration;
 
 /// 60M gas limit
@@ -84,6 +84,6 @@ pub trait RethTransactionPoolConfig {
     /// Returns transaction pool configuration.
     fn pool_config(&self) -> PoolConfig;
 
-    /// Returns max batch size for transaction batch insertion.
-    fn max_batch_size(&self) -> usize;
+    /// Returns batch config for transaction batch insertion.
+    fn batch_config(&self) -> BatchConfig;
 }

--- a/crates/rpc/rpc-eth-types/Cargo.toml
+++ b/crates/rpc/rpc-eth-types/Cargo.toml
@@ -25,7 +25,7 @@ reth-revm.workspace = true
 reth-rpc-server-types.workspace = true
 reth-rpc-convert.workspace = true
 reth-tasks.workspace = true
-reth-transaction-pool.workspace = true
+reth-transaction-pool = { workspace = true, features = ["serde"] }
 reth-trie.workspace = true
 
 # ethereum

--- a/crates/rpc/rpc-eth-types/src/builder/config.rs
+++ b/crates/rpc/rpc-eth-types/src/builder/config.rs
@@ -13,6 +13,7 @@ use reth_rpc_server_types::constants::{
     DEFAULT_MAX_TRACE_FILTER_BLOCKS, DEFAULT_PROOF_PERMITS,
     RPC_DEFAULT_SEND_RAW_TX_SYNC_TIMEOUT_SECS,
 };
+use reth_transaction_pool::BatchConfig;
 use serde::{Deserialize, Serialize};
 
 /// Default value for stale filter ttl
@@ -97,11 +98,8 @@ pub struct EthConfig {
     pub fee_history_cache: FeeHistoryCacheConfig,
     /// The maximum number of getproof calls that can be executed concurrently.
     pub proof_permits: usize,
-    /// Maximum batch size for transaction pool insertions.
-    pub max_batch_size: usize,
-    /// Batch timeout for transaction pool insertions.
-    /// Use `Duration::ZERO` for immediate processing (zero-cost path).
-    pub batch_timeout: Duration,
+    /// Configuration for transaction pool batching
+    pub batch_config: BatchConfig,
     /// Controls how pending blocks are built when requested via RPC methods
     pub pending_block_kind: PendingBlockKind,
     /// The raw transaction forwarder.
@@ -143,8 +141,7 @@ impl Default for EthConfig {
             stale_filter_ttl: DEFAULT_STALE_FILTER_TTL,
             fee_history_cache: FeeHistoryCacheConfig::default(),
             proof_permits: DEFAULT_PROOF_PERMITS,
-            max_batch_size: 1,
-            batch_timeout: Duration::ZERO,
+            batch_config: BatchConfig::default(),
             pending_block_kind: PendingBlockKind::Full,
             raw_tx_forwarder: ForwardConfig::default(),
             send_raw_transaction_sync_timeout: RPC_DEFAULT_SEND_RAW_TX_SYNC_TIMEOUT_SECS,
@@ -223,14 +220,21 @@ impl EthConfig {
 
     /// Configures the maximum batch size for transaction pool insertions
     pub const fn max_batch_size(mut self, max_batch_size: usize) -> Self {
-        self.max_batch_size = max_batch_size;
+        self.batch_config.max_batch_size = max_batch_size;
         self
     }
 
     /// Configures the batch timeout for transaction pool insertions.
     /// Use `Duration::ZERO` for immediate processing (zero-cost path).
     pub const fn batch_timeout(mut self, batch_timeout: Duration) -> Self {
-        self.batch_timeout = batch_timeout;
+        self.batch_config.batch_timeout =
+            if batch_timeout.is_zero() { None } else { Some(batch_timeout) };
+        self
+    }
+
+    /// Configures the batch config for transaction pool insertions.
+    pub const fn batch_config(mut self, batch_config: BatchConfig) -> Self {
+        self.batch_config = batch_config;
         self
     }
 

--- a/crates/rpc/rpc-eth-types/src/builder/config.rs
+++ b/crates/rpc/rpc-eth-types/src/builder/config.rs
@@ -99,6 +99,9 @@ pub struct EthConfig {
     pub proof_permits: usize,
     /// Maximum batch size for transaction pool insertions.
     pub max_batch_size: usize,
+    /// Batch timeout for transaction pool insertions.
+    /// Use `Duration::ZERO` for immediate processing (zero-cost path).
+    pub batch_timeout: Duration,
     /// Controls how pending blocks are built when requested via RPC methods
     pub pending_block_kind: PendingBlockKind,
     /// The raw transaction forwarder.
@@ -141,6 +144,7 @@ impl Default for EthConfig {
             fee_history_cache: FeeHistoryCacheConfig::default(),
             proof_permits: DEFAULT_PROOF_PERMITS,
             max_batch_size: 1,
+            batch_timeout: Duration::ZERO,
             pending_block_kind: PendingBlockKind::Full,
             raw_tx_forwarder: ForwardConfig::default(),
             send_raw_transaction_sync_timeout: RPC_DEFAULT_SEND_RAW_TX_SYNC_TIMEOUT_SECS,
@@ -220,6 +224,13 @@ impl EthConfig {
     /// Configures the maximum batch size for transaction pool insertions
     pub const fn max_batch_size(mut self, max_batch_size: usize) -> Self {
         self.max_batch_size = max_batch_size;
+        self
+    }
+
+    /// Configures the batch timeout for transaction pool insertions.
+    /// Use `Duration::ZERO` for immediate processing (zero-cost path).
+    pub const fn batch_timeout(mut self, batch_timeout: Duration) -> Self {
+        self.batch_timeout = batch_timeout;
         self
     }
 

--- a/crates/rpc/rpc-eth-types/src/builder/config.rs
+++ b/crates/rpc/rpc-eth-types/src/builder/config.rs
@@ -13,6 +13,7 @@ use reth_rpc_server_types::constants::{
     DEFAULT_MAX_TRACE_FILTER_BLOCKS, DEFAULT_PROOF_PERMITS,
     RPC_DEFAULT_SEND_RAW_TX_SYNC_TIMEOUT_SECS,
 };
+use reth_transaction_pool::BatchConfig;
 use serde::{Deserialize, Serialize};
 
 /// Default value for stale filter ttl
@@ -99,8 +100,8 @@ pub struct EthConfig {
     pub fee_history_cache: FeeHistoryCacheConfig,
     /// The maximum number of getproof calls that can be executed concurrently.
     pub proof_permits: usize,
-    /// Maximum batch size for transaction pool insertions.
-    pub max_batch_size: usize,
+    /// Configuration for transaction pool batching
+    pub batch_config: BatchConfig,
     /// Controls how pending blocks are built when requested via RPC methods
     pub pending_block_kind: PendingBlockKind,
     /// The raw transaction forwarder.
@@ -143,7 +144,7 @@ impl Default for EthConfig {
             stale_filter_ttl: DEFAULT_STALE_FILTER_TTL,
             fee_history_cache: FeeHistoryCacheConfig::default(),
             proof_permits: DEFAULT_PROOF_PERMITS,
-            max_batch_size: 1,
+            batch_config: BatchConfig::default(),
             pending_block_kind: PendingBlockKind::Full,
             raw_tx_forwarder: ForwardConfig::default(),
             send_raw_transaction_sync_timeout: RPC_DEFAULT_SEND_RAW_TX_SYNC_TIMEOUT_SECS,
@@ -228,7 +229,21 @@ impl EthConfig {
 
     /// Configures the maximum batch size for transaction pool insertions
     pub const fn max_batch_size(mut self, max_batch_size: usize) -> Self {
-        self.max_batch_size = max_batch_size;
+        self.batch_config.max_batch_size = max_batch_size;
+        self
+    }
+
+    /// Configures the batch timeout for transaction pool insertions.
+    /// Use `Duration::ZERO` to disable timeout batching and process insertions immediately.
+    pub const fn batch_timeout(mut self, batch_timeout: Duration) -> Self {
+        self.batch_config.batch_timeout =
+            if batch_timeout.is_zero() { None } else { Some(batch_timeout) };
+        self
+    }
+
+    /// Configures the batch config for transaction pool insertions.
+    pub const fn batch_config(mut self, batch_config: BatchConfig) -> Self {
+        self.batch_config = batch_config;
         self
     }
 

--- a/crates/rpc/rpc/src/eth/builder.rs
+++ b/crates/rpc/rpc/src/eth/builder.rs
@@ -19,6 +19,7 @@ use reth_rpc_server_types::constants::{
     DEFAULT_PROOF_PERMITS,
 };
 use reth_tasks::{pool::BlockingTaskPool, TaskSpawner, TokioTaskExecutor};
+use reth_transaction_pool::BatchConfig;
 use std::{sync::Arc, time::Duration};
 
 /// A helper to build the `EthApi` handler instance.
@@ -41,8 +42,7 @@ pub struct EthApiBuilder<N: RpcNodeCore, Rpc, NextEnv = ()> {
     blocking_task_pool: Option<BlockingTaskPool>,
     task_spawner: Box<dyn TaskSpawner + 'static>,
     next_env: NextEnv,
-    max_batch_size: usize,
-    batch_timeout: Duration,
+    batch_config: BatchConfig,
     max_blocking_io_requests: usize,
     pending_block_kind: PendingBlockKind,
     raw_tx_forwarder: ForwardConfig,
@@ -95,8 +95,8 @@ impl<N: RpcNodeCore, Rpc, NextEnv> EthApiBuilder<N, Rpc, NextEnv> {
             blocking_task_pool,
             task_spawner,
             next_env,
-            max_batch_size,
-            batch_timeout,
+
+            batch_config,
             max_blocking_io_requests,
             pending_block_kind,
             raw_tx_forwarder,
@@ -119,8 +119,7 @@ impl<N: RpcNodeCore, Rpc, NextEnv> EthApiBuilder<N, Rpc, NextEnv> {
             blocking_task_pool,
             task_spawner,
             next_env,
-            max_batch_size,
-            batch_timeout,
+            batch_config,
             max_blocking_io_requests,
             pending_block_kind,
             raw_tx_forwarder,
@@ -154,8 +153,7 @@ where
             gas_oracle_config: Default::default(),
             eth_state_cache_config: Default::default(),
             next_env: Default::default(),
-            max_batch_size: 1,
-            batch_timeout: Duration::ZERO,
+            batch_config: BatchConfig::default(),
             max_blocking_io_requests: DEFAULT_MAX_BLOCKING_IO_REQUEST,
             pending_block_kind: PendingBlockKind::Full,
             raw_tx_forwarder: ForwardConfig::default(),
@@ -196,8 +194,7 @@ where
             task_spawner,
             gas_oracle_config,
             next_env,
-            max_batch_size,
-            batch_timeout,
+            batch_config,
             max_blocking_io_requests,
             pending_block_kind,
             raw_tx_forwarder,
@@ -220,8 +217,7 @@ where
             task_spawner,
             gas_oracle_config,
             next_env,
-            max_batch_size,
-            batch_timeout,
+            batch_config,
             max_blocking_io_requests,
             pending_block_kind,
             raw_tx_forwarder,
@@ -251,8 +247,7 @@ where
             task_spawner,
             gas_oracle_config,
             next_env: _,
-            max_batch_size,
-            batch_timeout,
+            batch_config,
             max_blocking_io_requests,
             pending_block_kind,
             raw_tx_forwarder,
@@ -275,8 +270,7 @@ where
             task_spawner,
             gas_oracle_config,
             next_env,
-            max_batch_size,
-            batch_timeout,
+            batch_config,
             max_blocking_io_requests,
             pending_block_kind,
             raw_tx_forwarder,
@@ -356,14 +350,21 @@ where
 
     /// Sets the max batch size for batching transaction insertions.
     pub const fn max_batch_size(mut self, max_batch_size: usize) -> Self {
-        self.max_batch_size = max_batch_size;
+        self.batch_config.max_batch_size = max_batch_size;
         self
     }
 
     /// Sets the batch timeout for batching transaction insertions.
     /// Use `Duration::ZERO` for immediate processing (zero-cost path).
     pub const fn batch_timeout(mut self, batch_timeout: Duration) -> Self {
-        self.batch_timeout = batch_timeout;
+        self.batch_config.batch_timeout =
+            if batch_timeout.is_zero() { None } else { Some(batch_timeout) };
+        self
+    }
+
+    /// Sets the batch config for batching transaction insertions.
+    pub const fn batch_config(mut self, batch_config: BatchConfig) -> Self {
+        self.batch_config = batch_config;
         self
     }
 
@@ -422,7 +423,7 @@ where
 
     /// Returns the max batch size.
     pub const fn get_max_batch_size(&self) -> usize {
-        self.max_batch_size
+        self.batch_config.max_batch_size
     }
 
     /// Returns the pending block kind.
@@ -518,9 +519,9 @@ where
             fee_history_cache_config,
             proof_permits,
             task_spawner,
+
             next_env,
-            max_batch_size,
-            batch_timeout,
+            batch_config,
             max_blocking_io_requests,
             pending_block_kind,
             raw_tx_forwarder,
@@ -567,8 +568,7 @@ where
             proof_permits,
             rpc_converter,
             next_env,
-            max_batch_size,
-            batch_timeout,
+            batch_config,
             max_blocking_io_requests,
             pending_block_kind,
             raw_tx_forwarder.forwarder_client(),

--- a/crates/rpc/rpc/src/eth/builder.rs
+++ b/crates/rpc/rpc/src/eth/builder.rs
@@ -42,6 +42,7 @@ pub struct EthApiBuilder<N: RpcNodeCore, Rpc, NextEnv = ()> {
     task_spawner: Box<dyn TaskSpawner + 'static>,
     next_env: NextEnv,
     max_batch_size: usize,
+    batch_timeout: Duration,
     max_blocking_io_requests: usize,
     pending_block_kind: PendingBlockKind,
     raw_tx_forwarder: ForwardConfig,
@@ -95,6 +96,7 @@ impl<N: RpcNodeCore, Rpc, NextEnv> EthApiBuilder<N, Rpc, NextEnv> {
             task_spawner,
             next_env,
             max_batch_size,
+            batch_timeout,
             max_blocking_io_requests,
             pending_block_kind,
             raw_tx_forwarder,
@@ -118,6 +120,7 @@ impl<N: RpcNodeCore, Rpc, NextEnv> EthApiBuilder<N, Rpc, NextEnv> {
             task_spawner,
             next_env,
             max_batch_size,
+            batch_timeout,
             max_blocking_io_requests,
             pending_block_kind,
             raw_tx_forwarder,
@@ -152,6 +155,7 @@ where
             eth_state_cache_config: Default::default(),
             next_env: Default::default(),
             max_batch_size: 1,
+            batch_timeout: Duration::ZERO,
             max_blocking_io_requests: DEFAULT_MAX_BLOCKING_IO_REQUEST,
             pending_block_kind: PendingBlockKind::Full,
             raw_tx_forwarder: ForwardConfig::default(),
@@ -193,6 +197,7 @@ where
             gas_oracle_config,
             next_env,
             max_batch_size,
+            batch_timeout,
             max_blocking_io_requests,
             pending_block_kind,
             raw_tx_forwarder,
@@ -216,6 +221,7 @@ where
             gas_oracle_config,
             next_env,
             max_batch_size,
+            batch_timeout,
             max_blocking_io_requests,
             pending_block_kind,
             raw_tx_forwarder,
@@ -246,6 +252,7 @@ where
             gas_oracle_config,
             next_env: _,
             max_batch_size,
+            batch_timeout,
             max_blocking_io_requests,
             pending_block_kind,
             raw_tx_forwarder,
@@ -269,6 +276,7 @@ where
             gas_oracle_config,
             next_env,
             max_batch_size,
+            batch_timeout,
             max_blocking_io_requests,
             pending_block_kind,
             raw_tx_forwarder,
@@ -349,6 +357,13 @@ where
     /// Sets the max batch size for batching transaction insertions.
     pub const fn max_batch_size(mut self, max_batch_size: usize) -> Self {
         self.max_batch_size = max_batch_size;
+        self
+    }
+
+    /// Sets the batch timeout for batching transaction insertions.
+    /// Use `Duration::ZERO` for immediate processing (zero-cost path).
+    pub const fn batch_timeout(mut self, batch_timeout: Duration) -> Self {
+        self.batch_timeout = batch_timeout;
         self
     }
 
@@ -505,6 +520,7 @@ where
             task_spawner,
             next_env,
             max_batch_size,
+            batch_timeout,
             max_blocking_io_requests,
             pending_block_kind,
             raw_tx_forwarder,
@@ -552,6 +568,7 @@ where
             rpc_converter,
             next_env,
             max_batch_size,
+            batch_timeout,
             max_blocking_io_requests,
             pending_block_kind,
             raw_tx_forwarder.forwarder_client(),

--- a/crates/rpc/rpc/src/eth/builder.rs
+++ b/crates/rpc/rpc/src/eth/builder.rs
@@ -19,6 +19,7 @@ use reth_rpc_server_types::constants::{
     DEFAULT_PROOF_PERMITS,
 };
 use reth_tasks::{pool::BlockingTaskPool, Runtime};
+use reth_transaction_pool::BatchConfig;
 use std::{sync::Arc, time::Duration};
 
 /// A helper to build the `EthApi` handler instance.
@@ -42,7 +43,7 @@ pub struct EthApiBuilder<N: RpcNodeCore, Rpc, NextEnv = ()> {
     blocking_task_pool: Option<BlockingTaskPool>,
     task_spawner: Runtime,
     next_env: NextEnv,
-    max_batch_size: usize,
+    batch_config: BatchConfig,
     max_blocking_io_requests: usize,
     pending_block_kind: PendingBlockKind,
     raw_tx_forwarder: ForwardConfig,
@@ -96,7 +97,7 @@ impl<N: RpcNodeCore, Rpc, NextEnv> EthApiBuilder<N, Rpc, NextEnv> {
             blocking_task_pool,
             task_spawner,
             next_env,
-            max_batch_size,
+            batch_config,
             max_blocking_io_requests,
             pending_block_kind,
             raw_tx_forwarder,
@@ -120,7 +121,7 @@ impl<N: RpcNodeCore, Rpc, NextEnv> EthApiBuilder<N, Rpc, NextEnv> {
             blocking_task_pool,
             task_spawner,
             next_env,
-            max_batch_size,
+            batch_config,
             max_blocking_io_requests,
             pending_block_kind,
             raw_tx_forwarder,
@@ -155,7 +156,7 @@ where
             gas_oracle_config: Default::default(),
             eth_state_cache_config: Default::default(),
             next_env: Default::default(),
-            max_batch_size: 1,
+            batch_config: BatchConfig::default(),
             max_blocking_io_requests: DEFAULT_MAX_BLOCKING_IO_REQUEST,
             pending_block_kind: PendingBlockKind::Full,
             raw_tx_forwarder: ForwardConfig::default(),
@@ -197,7 +198,7 @@ where
             task_spawner,
             gas_oracle_config,
             next_env,
-            max_batch_size,
+            batch_config,
             max_blocking_io_requests,
             pending_block_kind,
             raw_tx_forwarder,
@@ -221,7 +222,7 @@ where
             task_spawner,
             gas_oracle_config,
             next_env,
-            max_batch_size,
+            batch_config,
             max_blocking_io_requests,
             pending_block_kind,
             raw_tx_forwarder,
@@ -252,7 +253,7 @@ where
             task_spawner,
             gas_oracle_config,
             next_env: _,
-            max_batch_size,
+            batch_config,
             max_blocking_io_requests,
             pending_block_kind,
             raw_tx_forwarder,
@@ -276,7 +277,7 @@ where
             task_spawner,
             gas_oracle_config,
             next_env,
-            max_batch_size,
+            batch_config,
             max_blocking_io_requests,
             pending_block_kind,
             raw_tx_forwarder,
@@ -362,7 +363,21 @@ where
 
     /// Sets the max batch size for batching transaction insertions.
     pub const fn max_batch_size(mut self, max_batch_size: usize) -> Self {
-        self.max_batch_size = max_batch_size;
+        self.batch_config.max_batch_size = max_batch_size;
+        self
+    }
+
+    /// Sets the batch timeout for batching transaction insertions.
+    /// Use `Duration::ZERO` to disable timeout batching and process insertions immediately.
+    pub const fn batch_timeout(mut self, batch_timeout: Duration) -> Self {
+        self.batch_config.batch_timeout =
+            if batch_timeout.is_zero() { None } else { Some(batch_timeout) };
+        self
+    }
+
+    /// Sets the batch config for batching transaction insertions.
+    pub const fn batch_config(mut self, batch_config: BatchConfig) -> Self {
+        self.batch_config = batch_config;
         self
     }
 
@@ -426,7 +441,7 @@ where
 
     /// Returns the max batch size.
     pub const fn get_max_batch_size(&self) -> usize {
-        self.max_batch_size
+        self.batch_config.max_batch_size
     }
 
     /// Returns the pending block kind.
@@ -524,7 +539,7 @@ where
             proof_permits,
             task_spawner,
             next_env,
-            max_batch_size,
+            batch_config,
             max_blocking_io_requests,
             pending_block_kind,
             raw_tx_forwarder,
@@ -577,7 +592,7 @@ where
             proof_permits,
             rpc_converter,
             next_env,
-            max_batch_size,
+            batch_config,
             max_blocking_io_requests,
             pending_block_kind,
             raw_tx_forwarder.forwarder_client(),

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -152,6 +152,7 @@ where
         proof_permits: usize,
         rpc_converter: Rpc,
         max_batch_size: usize,
+        batch_timeout: Duration,
         max_blocking_io_requests: usize,
         pending_block_kind: PendingBlockKind,
         raw_tx_forwarder: ForwardConfig,
@@ -173,6 +174,7 @@ where
             rpc_converter,
             (),
             max_batch_size,
+            batch_timeout,
             max_blocking_io_requests,
             pending_block_kind,
             raw_tx_forwarder.forwarder_client(),
@@ -361,6 +363,7 @@ where
         converter: Rpc,
         next_env: impl PendingEnvBuilder<N::Evm>,
         max_batch_size: usize,
+        batch_timeout: Duration,
         max_blocking_io_requests: usize,
         pending_block_kind: PendingBlockKind,
         raw_tx_forwarder: Option<RpcClient>,
@@ -384,8 +387,8 @@ where
 
         // Create tx pool insertion batcher
         let (processor, tx_batch_sender) =
-            BatchTxProcessor::new(components.pool().clone(), max_batch_size);
-        task_spawner.spawn_critical_task("tx-batcher", Box::pin(processor));
+            BatchTxProcessor::new(components.pool().clone(), max_batch_size, batch_timeout);
+        task_spawner.spawn_critical("tx-batcher", Box::pin(processor));
 
         Self {
             components,

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -31,7 +31,7 @@ use reth_tasks::{
 };
 use reth_transaction_pool::{
     blobstore::BlobSidecarConverter, noop::NoopTransactionPool, AddedTransactionOutcome,
-    BatchTxProcessor, BatchTxRequest, TransactionPool,
+    BatchConfig, BatchTxProcessor, BatchTxRequest, TransactionPool,
 };
 use tokio::sync::{broadcast, mpsc, Mutex, Semaphore};
 
@@ -151,8 +151,7 @@ where
         fee_history_cache: FeeHistoryCache<ProviderHeader<N::Provider>>,
         proof_permits: usize,
         rpc_converter: Rpc,
-        max_batch_size: usize,
-        batch_timeout: Duration,
+        batch_config: BatchConfig,
         max_blocking_io_requests: usize,
         pending_block_kind: PendingBlockKind,
         raw_tx_forwarder: ForwardConfig,
@@ -173,8 +172,7 @@ where
             proof_permits,
             rpc_converter,
             (),
-            max_batch_size,
-            batch_timeout,
+            batch_config,
             max_blocking_io_requests,
             pending_block_kind,
             raw_tx_forwarder.forwarder_client(),
@@ -362,8 +360,7 @@ where
         proof_permits: usize,
         converter: Rpc,
         next_env: impl PendingEnvBuilder<N::Evm>,
-        max_batch_size: usize,
-        batch_timeout: Duration,
+        batch_config: BatchConfig,
         max_blocking_io_requests: usize,
         pending_block_kind: PendingBlockKind,
         raw_tx_forwarder: Option<RpcClient>,
@@ -386,10 +383,6 @@ where
         let (raw_tx_sender, _) = broadcast::channel(DEFAULT_BROADCAST_CAPACITY);
 
         // Create tx pool insertion batcher
-        let batch_config = reth_transaction_pool::BatchConfig {
-            max_batch_size,
-            batch_timeout: if batch_timeout.is_zero() { None } else { Some(batch_timeout) },
-        };
         let (processor, tx_batch_sender) =
             BatchTxProcessor::new(components.pool().clone(), batch_config);
         task_spawner.spawn_critical("tx-batcher", Box::pin(processor));

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -386,8 +386,12 @@ where
         let (raw_tx_sender, _) = broadcast::channel(DEFAULT_BROADCAST_CAPACITY);
 
         // Create tx pool insertion batcher
+        let batch_config = reth_transaction_pool::BatchConfig {
+            max_batch_size,
+            batch_timeout: if batch_timeout.is_zero() { None } else { Some(batch_timeout) },
+        };
         let (processor, tx_batch_sender) =
-            BatchTxProcessor::new(components.pool().clone(), max_batch_size, batch_timeout);
+            BatchTxProcessor::new(components.pool().clone(), batch_config);
         task_spawner.spawn_critical("tx-batcher", Box::pin(processor));
 
         Self {

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -385,7 +385,7 @@ where
         // Create tx pool insertion batcher
         let (processor, tx_batch_sender) =
             BatchTxProcessor::new(components.pool().clone(), batch_config);
-        task_spawner.spawn_critical("tx-batcher", Box::pin(processor));
+        task_spawner.spawn_critical_task("tx-batcher", Box::pin(processor));
 
         Self {
             components,

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -31,7 +31,7 @@ use reth_tasks::{
 };
 use reth_transaction_pool::{
     blobstore::BlobSidecarConverter, noop::NoopTransactionPool, AddedTransactionOutcome,
-    BatchTxProcessor, BatchTxRequest, TransactionPool,
+    BatchConfig, BatchTxProcessor, BatchTxRequest, TransactionPool,
 };
 use tokio::sync::{broadcast, mpsc, Mutex, Semaphore};
 
@@ -310,7 +310,7 @@ where
         proof_permits: usize,
         converter: Rpc,
         next_env: impl PendingEnvBuilder<N::Evm>,
-        max_batch_size: usize,
+        batch_config: BatchConfig,
         max_blocking_io_requests: usize,
         pending_block_kind: PendingBlockKind,
         raw_tx_forwarder: Option<RpcClient>,
@@ -334,7 +334,7 @@ where
 
         // Create tx pool insertion batcher
         let (processor, tx_batch_sender) =
-            BatchTxProcessor::new(components.pool().clone(), max_batch_size);
+            BatchTxProcessor::new(components.pool().clone(), batch_config);
         task_spawner.spawn_critical_task("tx-batcher", processor);
 
         Self {

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -40,6 +40,7 @@ parking_lot.workspace = true
 pin-project.workspace = true
 tokio = { workspace = true, features = ["sync"] }
 tokio-stream.workspace = true
+tokio-util.workspace = true
 
 # metrics
 reth-metrics.workspace = true

--- a/crates/transaction-pool/benches/insertion.rs
+++ b/crates/transaction-pool/benches/insertion.rs
@@ -87,7 +87,8 @@ fn txpool_batch_insertion(c: &mut Criterion) {
                     let rt = tokio::runtime::Runtime::new().unwrap();
                     let pool = testing_pool();
                     let txs = generate_transactions(tx_count, sender_count);
-                    let (processor, request_tx) = BatchTxProcessor::new(pool, tx_count);
+                    let (processor, request_tx) =
+                        BatchTxProcessor::new(pool, tx_count, std::time::Duration::ZERO);
                     let processor_handle = rt.spawn(processor);
 
                     let mut batch_requests = Vec::with_capacity(tx_count);

--- a/crates/transaction-pool/benches/insertion.rs
+++ b/crates/transaction-pool/benches/insertion.rs
@@ -87,8 +87,9 @@ fn txpool_batch_insertion(c: &mut Criterion) {
                     let rt = tokio::runtime::Runtime::new().unwrap();
                     let pool = testing_pool();
                     let txs = generate_transactions(tx_count, sender_count);
-                    let (processor, request_tx) =
-                        BatchTxProcessor::new(pool, tx_count, std::time::Duration::ZERO);
+                    use reth_transaction_pool::BatchConfig;
+                    let config = BatchConfig { max_batch_size: tx_count, batch_timeout: None };
+                    let (processor, request_tx) = BatchTxProcessor::new(pool, config);
                     let processor_handle = rt.spawn(processor);
 
                     let mut batch_requests = Vec::with_capacity(tx_count);

--- a/crates/transaction-pool/src/batcher.rs
+++ b/crates/transaction-pool/src/batcher.rs
@@ -368,7 +368,9 @@ mod tests {
         for i in 0..5 {
             let tx = MockTransaction::legacy().with_nonce(i).with_gas_price(100);
             let (response_tx, response_rx) = tokio::sync::oneshot::channel();
-            request_tx.send(BatchTxRequest::new(tx, response_tx)).expect("Could not send batch tx");
+            request_tx
+                .send(BatchTxRequest::new(TransactionOrigin::Local, tx, response_tx))
+                .expect("Could not send batch tx");
             responses.push(response_rx);
         }
 
@@ -405,7 +407,9 @@ mod tests {
         for i in 0..max_batch_size {
             let tx = MockTransaction::legacy().with_nonce(i as u64).with_gas_price(100);
             let (response_tx, response_rx) = tokio::sync::oneshot::channel();
-            request_tx.send(BatchTxRequest::new(tx, response_tx)).expect("Could not send batch tx");
+            request_tx
+                .send(BatchTxRequest::new(TransactionOrigin::Local, tx, response_tx))
+                .expect("Could not send batch tx");
             responses.push(response_rx);
         }
 
@@ -436,7 +440,9 @@ mod tests {
         // Send a single transaction
         let tx = MockTransaction::legacy().with_nonce(0).with_gas_price(100);
         let (response_tx, response_rx) = tokio::sync::oneshot::channel();
-        request_tx.send(BatchTxRequest::new(tx, response_tx)).expect("Could not send batch tx");
+        request_tx
+            .send(BatchTxRequest::new(TransactionOrigin::Local, tx, response_tx))
+            .expect("Could not send batch tx");
 
         // Should be processed immediately (within a few ms)
         let result = timeout(Duration::from_millis(10), response_rx)
@@ -487,7 +493,9 @@ mod tests {
         for i in 0..max_batch_size {
             let tx = MockTransaction::legacy().with_nonce(i as u64).with_gas_price(100);
             let (response_tx, response_rx) = tokio::sync::oneshot::channel();
-            request_tx.send(BatchTxRequest::new(tx, response_tx)).expect("send failed");
+            request_tx
+                .send(BatchTxRequest::new(TransactionOrigin::Local, tx, response_tx))
+                .expect("send failed");
             responses.push(response_rx);
         }
 
@@ -523,7 +531,9 @@ mod tests {
         // Send fewer items than max_batch_size
         let tx = MockTransaction::legacy().with_nonce(0).with_gas_price(100);
         let (response_tx, mut response_rx) = tokio::sync::oneshot::channel();
-        request_tx.send(BatchTxRequest::new(tx, response_tx)).expect("send failed");
+        request_tx
+            .send(BatchTxRequest::new(TransactionOrigin::Local, tx, response_tx))
+            .expect("send failed");
 
         // Poll once - should return Pending (waiting for interval)
         let waker = futures::task::noop_waker();
@@ -552,7 +562,9 @@ mod tests {
         // Send a single item (partial batch)
         let tx = MockTransaction::legacy().with_nonce(0).with_gas_price(100);
         let (response_tx, mut response_rx) = tokio::sync::oneshot::channel();
-        request_tx.send(BatchTxRequest::new(tx, response_tx)).expect("send failed");
+        request_tx
+            .send(BatchTxRequest::new(TransactionOrigin::Local, tx, response_tx))
+            .expect("send failed");
 
         // Poll once - should spawn batch immediately in immediate mode
         let waker = futures::task::noop_waker();
@@ -583,7 +595,9 @@ mod tests {
         // Send a partial batch
         let tx = MockTransaction::legacy().with_nonce(0).with_gas_price(100);
         let (response_tx, mut response_rx) = tokio::sync::oneshot::channel();
-        request_tx.send(BatchTxRequest::new(tx, response_tx)).expect("send failed");
+        request_tx
+            .send(BatchTxRequest::new(TransactionOrigin::Local, tx, response_tx))
+            .expect("send failed");
 
         // Poll once to receive the item
         let waker = futures::task::noop_waker();

--- a/crates/transaction-pool/src/batcher.rs
+++ b/crates/transaction-pool/src/batcher.rs
@@ -384,7 +384,7 @@ mod tests {
         handle.abort();
     }
 
-    /// Test that max_batch_size triggers flush before timeout
+    /// Test that `max_batch_size` triggers flush before timeout
     #[tokio::test]
     async fn test_max_batch_size_triggers_before_timeout() {
         let pool = testing_pool();

--- a/crates/transaction-pool/src/batcher.rs
+++ b/crates/transaction-pool/src/batcher.rs
@@ -469,7 +469,7 @@ mod tests {
         let pool = testing_pool();
         let config =
             BatchConfig { max_batch_size: 10, batch_timeout: Some(Duration::from_secs(60)) };
-        let (processor, _request_tx) = BatchTxProcessor::new(pool.clone(), config);
+        let (processor, _request_tx) = BatchTxProcessor::new(pool, config);
 
         let mut processor = Box::pin(processor);
 
@@ -527,7 +527,7 @@ mod tests {
         let max_batch_size = 10;
         // Long timeout - batch should NOT flush immediately
         let config = BatchConfig { max_batch_size, batch_timeout: Some(Duration::from_secs(3600)) };
-        let (processor, request_tx) = BatchTxProcessor::new(pool.clone(), config);
+        let (processor, request_tx) = BatchTxProcessor::new(pool, config);
 
         let mut processor = Box::pin(processor);
 

--- a/crates/transaction-pool/src/batcher.rs
+++ b/crates/transaction-pool/src/batcher.rs
@@ -190,8 +190,8 @@ where
                 }
             }
 
-            // 2. Early return if buffer is empty — no need to poll the interval
-            //    since there is nothing buffered to flush
+            // 2. Early return if buffer is empty — no need to poll the interval since there is
+            //    nothing buffered to flush
             if this.buf.is_empty() {
                 return Poll::Pending
             }

--- a/crates/transaction-pool/src/batcher.rs
+++ b/crates/transaction-pool/src/batcher.rs
@@ -12,8 +12,8 @@
 //!   Spawned insertion batches are bounded by `max_concurrent_batches`.
 
 use crate::{
-    config::BatchConfig, error::PoolError, AddedTransactionOutcome, PoolTransaction,
-    TransactionOrigin, TransactionPool,
+    config::BatchConfig, error::PoolError, metrics::BatchMetrics, AddedTransactionOutcome,
+    PoolTransaction, TransactionOrigin, TransactionPool,
 };
 use pin_project::pin_project;
 use std::{
@@ -79,6 +79,7 @@ pub struct BatchTxProcessor<Pool: TransactionPool> {
     ///
     /// Only used in batch-and-timeout mode; immediate mode spawns unbounded.
     batch_permits: PollSemaphore,
+    metrics: BatchMetrics,
 }
 
 impl<Pool> std::fmt::Debug for BatchTxProcessor<Pool>
@@ -119,6 +120,7 @@ where
             batch_deadline: None,
             flush_due: false,
             batch_permits: PollSemaphore::new(Arc::new(Semaphore::new(max_concurrent_batches))),
+            metrics: BatchMetrics::default(),
         };
 
         tracing::debug!(
@@ -162,10 +164,12 @@ where
         pool: &Pool,
         buf: &mut Vec<BatchTxRequest<Pool::Transaction>>,
         permit: Option<OwnedSemaphorePermit>,
+        metrics: &BatchMetrics,
     ) {
         if buf.is_empty() {
             return;
         }
+        metrics.batch_size.record(buf.len() as f64);
         let batch = std::mem::take(buf);
         let pool = pool.clone();
         tokio::spawn(async move {
@@ -185,7 +189,7 @@ where
         loop {
             let n =
                 ready!(this.request_rx.as_mut().poll_recv_many(cx, this.buf, *this.max_batch_size));
-            Self::spawn_batch(this.pool, this.buf, None);
+            Self::spawn_batch(this.pool, this.buf, None, this.metrics);
             if n == 0 {
                 // channel closed
                 return Poll::Ready(())
@@ -209,7 +213,7 @@ where
                             let Some(permit) = ready!(this.batch_permits.poll_acquire(cx)) else {
                                 return Poll::Ready(())
                             };
-                            Self::spawn_batch(this.pool, this.buf, Some(permit));
+                            Self::spawn_batch(this.pool, this.buf, Some(permit), this.metrics);
                         }
                         return Poll::Ready(())
                     }
@@ -239,7 +243,7 @@ where
             let Some(permit) = ready!(this.batch_permits.poll_acquire(cx)) else {
                 return Poll::Ready(())
             };
-            Self::spawn_batch(this.pool, this.buf, Some(permit));
+            Self::spawn_batch(this.pool, this.buf, Some(permit), this.metrics);
             this.batch_deadline.set(None);
             *this.flush_due = false;
         }

--- a/crates/transaction-pool/src/batcher.rs
+++ b/crates/transaction-pool/src/batcher.rs
@@ -2,17 +2,29 @@
 //!
 //! This module provides transaction batching logic to reduce lock contention when processing
 //! many concurrent transaction pool insertions.
+//!
+//! The batcher supports an optional timeout mechanism: when `batch_timeout` is `Some`,
+//! transactions are batched until either `max_batch_size` is reached or the timeout expires after
+//! the first transaction is buffered. When `batch_timeout` is `None`, the batcher processes
+//! requests immediately.
 
 use crate::{
-    error::PoolError, AddedTransactionOutcome, PoolTransaction, TransactionOrigin, TransactionPool,
+    config::BatchConfig, error::PoolError, AddedTransactionOutcome, PoolTransaction,
+    TransactionOrigin, TransactionPool,
 };
 use pin_project::pin_project;
 use std::{
     future::Future,
     pin::Pin,
+    sync::Arc,
     task::{ready, Context, Poll},
+    time::Duration,
 };
-use tokio::sync::{mpsc, oneshot};
+use tokio::{
+    sync::{mpsc, oneshot, OwnedSemaphorePermit, Semaphore},
+    time::Sleep,
+};
+use tokio_util::sync::PollSemaphore;
 
 /// A single batch transaction request
 #[derive(Debug)]
@@ -40,14 +52,42 @@ where
 }
 
 /// Transaction batch processor that handles batch processing
+///
+/// Supports two modes:
+/// - **Immediate mode** (`batch_timeout = None`): Processes requests as soon as available (greedy)
+/// - **Batch-and-timeout mode** (`batch_timeout = Some(...)`): Waits for `max_batch_size` OR
+///   timeout before processing
 #[pin_project]
-#[derive(Debug)]
 pub struct BatchTxProcessor<Pool: TransactionPool> {
     pool: Pool,
     max_batch_size: usize,
+    /// Timeout for partial batches. `None` keeps the immediate processing mode.
+    batch_timeout: Option<Duration>,
     buf: Vec<BatchTxRequest<Pool::Transaction>>,
     #[pin]
     request_rx: mpsc::UnboundedReceiver<BatchTxRequest<Pool::Transaction>>,
+    /// Deadline armed when the first request enters an empty batch.
+    #[pin]
+    batch_deadline: Option<Sleep>,
+    /// Tracks an expired deadline while waiting for an insertion permit.
+    flush_due: bool,
+    /// Limits how many insertion batches can be processed concurrently.
+    batch_permits: PollSemaphore,
+}
+
+impl<Pool> std::fmt::Debug for BatchTxProcessor<Pool>
+where
+    Pool: TransactionPool + std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BatchTxProcessor")
+            .field("pool", &self.pool)
+            .field("max_batch_size", &self.max_batch_size)
+            .field("batch_timeout", &self.batch_timeout)
+            .field("buf_len", &self.buf.len())
+            .field("has_batch_deadline", &self.batch_deadline.is_some())
+            .finish()
+    }
 }
 
 impl<Pool> BatchTxProcessor<Pool>
@@ -57,11 +97,32 @@ where
     /// Create a new `BatchTxProcessor`
     pub fn new(
         pool: Pool,
-        max_batch_size: usize,
+        config: BatchConfig,
     ) -> (Self, mpsc::UnboundedSender<BatchTxRequest<Pool::Transaction>>) {
         let (request_tx, request_rx) = mpsc::unbounded_channel();
+        let BatchConfig { max_batch_size, batch_timeout, max_concurrent_batches } = config;
+        let max_batch_size = max_batch_size.max(1);
+        let max_concurrent_batches = max_concurrent_batches.clamp(1, Semaphore::MAX_PERMITS);
 
-        let processor = Self { pool, max_batch_size, buf: Vec::with_capacity(1), request_rx };
+        let processor = Self {
+            pool,
+            max_batch_size,
+            batch_timeout,
+            buf: Vec::with_capacity(max_batch_size),
+            request_rx,
+            batch_deadline: None,
+            flush_due: false,
+            batch_permits: PollSemaphore::new(Arc::new(Semaphore::new(max_concurrent_batches))),
+        };
+
+        tracing::debug!(
+            target: "txpool::batcher",
+            max_batch_size,
+            ?batch_timeout,
+            max_concurrent_batches,
+            mode = if batch_timeout.is_none() { "immediate" } else { "batch-and-timeout" },
+            "Transaction batcher initialized"
+        );
 
         (processor, request_tx)
     }
@@ -88,6 +149,23 @@ where
             let _ = response_tx.send(pool_result);
         }
     }
+
+    /// Spawn a batch processing task
+    fn spawn_batch(
+        pool: &Pool,
+        buf: &mut Vec<BatchTxRequest<Pool::Transaction>>,
+        permit: OwnedSemaphorePermit,
+    ) {
+        if buf.is_empty() {
+            return;
+        }
+        let batch = std::mem::take(buf);
+        let pool = pool.clone();
+        tokio::spawn(async move {
+            let _permit = permit;
+            Self::process_batch(&pool, batch).await;
+        });
+    }
 }
 
 impl<Pool> Future for BatchTxProcessor<Pool>
@@ -100,22 +178,59 @@ where
         let mut this = self.project();
 
         loop {
-            // Drain all available requests from the receiver
-            ready!(this.request_rx.poll_recv_many(cx, this.buf, *this.max_batch_size));
-
-            if !this.buf.is_empty() {
-                let batch = std::mem::take(this.buf);
-                let pool = this.pool.clone();
-                tokio::spawn(async move {
-                    Self::process_batch(&pool, batch).await;
-                });
-                this.buf.reserve(1);
-
-                continue;
+            while this.buf.len() < *this.max_batch_size {
+                let was_empty = this.buf.is_empty();
+                let remaining_capacity = *this.max_batch_size - this.buf.len();
+                match this.request_rx.as_mut().poll_recv_many(cx, this.buf, remaining_capacity) {
+                    Poll::Ready(0) => {
+                        if !this.buf.is_empty() {
+                            let Some(permit) = ready!(this.batch_permits.poll_acquire(cx)) else {
+                                return Poll::Ready(())
+                            };
+                            Self::spawn_batch(this.pool, this.buf, permit);
+                            this.batch_deadline.set(None);
+                            *this.flush_due = false;
+                        }
+                        return Poll::Ready(())
+                    }
+                    Poll::Ready(_n) => {
+                        if was_empty && let Some(timeout) = *this.batch_timeout {
+                            this.batch_deadline.set(Some(tokio::time::sleep(timeout)));
+                            *this.flush_due = false;
+                        }
+                    }
+                    Poll::Pending => break,
+                }
             }
 
-            // No requests available, return Pending to wait for more
-            return Poll::Pending;
+            if this.buf.is_empty() {
+                return Poll::Pending
+            }
+
+            if this.buf.len() >= *this.max_batch_size {
+                let Some(permit) = ready!(this.batch_permits.poll_acquire(cx)) else {
+                    return Poll::Ready(())
+                };
+                Self::spawn_batch(this.pool, this.buf, permit);
+                this.batch_deadline.set(None);
+                *this.flush_due = false;
+                continue
+            }
+
+            if this.batch_timeout.is_some() && !*this.flush_due {
+                let Some(deadline) = this.batch_deadline.as_mut().as_pin_mut() else {
+                    return Poll::Pending
+                };
+                ready!(deadline.poll(cx));
+                *this.flush_due = true;
+            }
+
+            let Some(permit) = ready!(this.batch_permits.poll_acquire(cx)) else {
+                return Poll::Ready(())
+            };
+            Self::spawn_batch(this.pool, this.buf, permit);
+            this.batch_deadline.set(None);
+            *this.flush_due = false;
         }
     }
 }
@@ -124,9 +239,30 @@ where
 mod tests {
     use super::*;
     use crate::test_utils::{testing_pool, MockTransaction};
-    use futures::stream::{FuturesUnordered, StreamExt};
-    use std::time::Duration;
+    use futures::{
+        stream::{FuturesUnordered, StreamExt},
+        task::{waker_ref, ArcWake},
+    };
+    use std::{
+        sync::atomic::{AtomicUsize, Ordering},
+        time::Duration,
+    };
     use tokio::time::timeout;
+
+    #[derive(Default)]
+    struct WakeCounter {
+        wakes: AtomicUsize,
+    }
+
+    impl ArcWake for WakeCounter {
+        fn wake_by_ref(arc_self: &std::sync::Arc<Self>) {
+            arc_self.wakes.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    fn batch_config(max_batch_size: usize, batch_timeout: Option<Duration>) -> BatchConfig {
+        BatchConfig { max_batch_size, batch_timeout, ..Default::default() }
+    }
 
     #[tokio::test]
     async fn test_process_batch() {
@@ -157,7 +293,8 @@ mod tests {
     #[tokio::test]
     async fn test_batch_processor() {
         let pool = testing_pool();
-        let (processor, request_tx) = BatchTxProcessor::new(pool.clone(), 1000);
+        let config = batch_config(1000, None);
+        let (processor, request_tx) = BatchTxProcessor::new(pool.clone(), config);
 
         // Spawn the processor
         let handle = tokio::spawn(processor);
@@ -191,7 +328,8 @@ mod tests {
     #[tokio::test]
     async fn test_add_transaction() {
         let pool = testing_pool();
-        let (processor, request_tx) = BatchTxProcessor::new(pool.clone(), 1000);
+        let config = batch_config(1000, None);
+        let (processor, request_tx) = BatchTxProcessor::new(pool.clone(), config);
 
         // Spawn the processor
         let handle = tokio::spawn(processor);
@@ -219,7 +357,8 @@ mod tests {
     async fn test_max_batch_size() {
         let pool = testing_pool();
         let max_batch_size = 10;
-        let (processor, request_tx) = BatchTxProcessor::new(pool.clone(), max_batch_size);
+        let config = batch_config(max_batch_size, None);
+        let (processor, request_tx) = BatchTxProcessor::new(pool.clone(), config);
 
         // Spawn batch processor with threshold
         let handle = tokio::spawn(processor);
@@ -246,5 +385,452 @@ mod tests {
         }
 
         handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_max_batch_size_zero_is_clamped() {
+        let pool = testing_pool();
+        let config = batch_config(0, None);
+        let (processor, request_tx) = BatchTxProcessor::new(pool.clone(), config);
+        assert_eq!(processor.max_batch_size, 1);
+
+        let handle = tokio::spawn(processor);
+
+        let tx = MockTransaction::legacy().with_nonce(0).with_gas_price(100);
+        let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+        request_tx
+            .send(BatchTxRequest::new(TransactionOrigin::Local, tx, response_tx))
+            .expect("Could not send batch tx");
+
+        let result = timeout(Duration::from_millis(50), response_rx)
+            .await
+            .expect("max_batch_size = 0 should be clamped and not hang")
+            .expect("Response channel was closed unexpectedly");
+        assert!(result.is_ok());
+
+        handle.abort();
+    }
+
+    /// Test that batch is flushed when timeout expires (even if batch is not full)
+    #[tokio::test]
+    async fn test_batch_timeout_triggers_flush() {
+        let pool = testing_pool();
+        // Large batch size, small timeout - timeout should trigger the flush
+        let batch_timeout = Duration::from_millis(50);
+        let config = batch_config(1000, Some(batch_timeout));
+        let (processor, request_tx) = BatchTxProcessor::new(pool.clone(), config);
+
+        let handle = tokio::spawn(processor);
+
+        // Send fewer transactions than max_batch_size
+        let mut responses = Vec::new();
+        for i in 0..5 {
+            let tx = MockTransaction::legacy().with_nonce(i).with_gas_price(100);
+            let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+            request_tx
+                .send(BatchTxRequest::new(TransactionOrigin::Local, tx, response_tx))
+                .expect("Could not send batch tx");
+            responses.push(response_rx);
+        }
+
+        // Wait slightly longer than batch_timeout
+        tokio::time::sleep(batch_timeout + Duration::from_millis(20)).await;
+
+        // All transactions should be processed even though batch wasn't full
+        for rx in responses {
+            let result = timeout(Duration::from_millis(10), rx)
+                .await
+                .expect("Timeout waiting for response - batch timeout did not trigger flush")
+                .expect("Response channel was closed unexpectedly");
+            assert!(result.is_ok());
+        }
+
+        drop(request_tx);
+        handle.abort();
+    }
+
+    /// Test that `max_batch_size` triggers flush before timeout
+    #[tokio::test]
+    async fn test_max_batch_size_triggers_before_timeout() {
+        let pool = testing_pool();
+        let max_batch_size = 5;
+        // Long timeout, small batch size - batch size should trigger first
+        let batch_timeout = Duration::from_secs(60);
+        let config = batch_config(max_batch_size, Some(batch_timeout));
+        let (processor, request_tx) = BatchTxProcessor::new(pool.clone(), config);
+
+        let handle = tokio::spawn(processor);
+
+        // Send exactly max_batch_size transactions
+        let mut responses = Vec::new();
+        for i in 0..max_batch_size {
+            let tx = MockTransaction::legacy().with_nonce(i as u64).with_gas_price(100);
+            let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+            request_tx
+                .send(BatchTxRequest::new(TransactionOrigin::Local, tx, response_tx))
+                .expect("Could not send batch tx");
+            responses.push(response_rx);
+        }
+
+        // Should complete quickly without waiting for the 60s timeout
+        for rx in responses {
+            let result = timeout(Duration::from_millis(100), rx)
+                .await
+                .expect("Timeout - max_batch_size did not trigger flush before timeout")
+                .expect("Response channel was closed unexpectedly");
+            assert!(result.is_ok());
+        }
+
+        drop(request_tx);
+        handle.abort();
+    }
+
+    /// Test that `None` timeout maintains original immediate processing behavior
+    #[tokio::test]
+    async fn test_none_timeout_immediate_processing() {
+        let pool = testing_pool();
+        let config = batch_config(1000, None);
+        let (processor, request_tx) = BatchTxProcessor::new(pool.clone(), config);
+
+        let handle = tokio::spawn(processor);
+
+        // Send a single transaction
+        let tx = MockTransaction::legacy().with_nonce(0).with_gas_price(100);
+        let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+        request_tx
+            .send(BatchTxRequest::new(TransactionOrigin::Local, tx, response_tx))
+            .expect("Could not send batch tx");
+
+        // Should be processed immediately (within a few ms)
+        let result = timeout(Duration::from_millis(10), response_rx)
+            .await
+            .expect("None timeout mode should process immediately")
+            .expect("Response channel was closed unexpectedly");
+        assert!(result.is_ok());
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_timeout_starts_when_first_item_is_buffered() {
+        use std::future::Future;
+
+        let pool = testing_pool();
+        let batch_timeout = Duration::from_millis(25);
+        let config = batch_config(10, Some(batch_timeout));
+        let (processor, request_tx) = BatchTxProcessor::new(pool.clone(), config);
+        let mut processor = Box::pin(processor);
+
+        tokio::time::sleep(batch_timeout + Duration::from_millis(10)).await;
+
+        let tx = MockTransaction::legacy().with_nonce(0).with_gas_price(100);
+        let (response_tx, mut response_rx) = tokio::sync::oneshot::channel();
+        request_tx
+            .send(BatchTxRequest::new(TransactionOrigin::Local, tx, response_tx))
+            .expect("send failed");
+
+        let waker = futures::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        let result = processor.as_mut().poll(&mut cx);
+        assert!(result.is_pending(), "Partial batch should wait for its own deadline");
+        assert!(response_rx.try_recv().is_err(), "Timeout should not fire from idle time");
+
+        tokio::time::sleep(batch_timeout + Duration::from_millis(10)).await;
+
+        let result = processor.as_mut().poll(&mut cx);
+        assert!(result.is_pending(), "Should return Pending after spawning timed-out batch");
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(response_rx.try_recv().is_ok(), "Batch should flush after its own timeout");
+    }
+
+    // ===== Manual Poll Tests =====
+
+    /// Test that polling with empty buffer returns Pending
+    #[tokio::test]
+    async fn test_poll_empty_returns_pending() {
+        use std::future::Future;
+
+        let pool = testing_pool();
+        let config = batch_config(10, Some(Duration::from_secs(60)));
+        let (processor, _request_tx) = BatchTxProcessor::new(pool, config);
+
+        let mut processor = Box::pin(processor);
+
+        // Poll once - should return Pending since no items
+        let waker = futures::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        let result = processor.as_mut().poll(&mut cx);
+        assert!(result.is_pending(), "Empty buffer should return Pending");
+    }
+
+    /// Test that full batch spawns immediately without waiting for interval
+    #[tokio::test]
+    async fn test_poll_full_batch_spawns_immediately() {
+        use std::future::Future;
+
+        let pool = testing_pool();
+        let max_batch_size = 5;
+        // Very long timeout - should NOT be needed for full batch
+        let config = batch_config(max_batch_size, Some(Duration::from_secs(3600)));
+        let (processor, request_tx) = BatchTxProcessor::new(pool.clone(), config);
+
+        let mut processor = Box::pin(processor);
+
+        // Send exactly max_batch_size items
+        let mut responses = Vec::new();
+        for i in 0..max_batch_size {
+            let tx = MockTransaction::legacy().with_nonce(i as u64).with_gas_price(100);
+            let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+            request_tx
+                .send(BatchTxRequest::new(TransactionOrigin::Local, tx, response_tx))
+                .expect("send failed");
+            responses.push(response_rx);
+        }
+
+        // Poll once - should process the full batch immediately
+        let waker = futures::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        let result = processor.as_mut().poll(&mut cx);
+        assert!(result.is_pending(), "Should return Pending after spawning batch");
+
+        // Give spawned task time to complete
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // All responses should be ready
+        for mut rx in responses {
+            let result = rx.try_recv();
+            assert!(result.is_ok(), "Response should be ready after batch spawned");
+        }
+    }
+
+    /// Test that batch dispatch waits for a concurrency permit.
+    #[tokio::test]
+    async fn test_poll_full_batch_waits_for_batch_permit() {
+        use std::future::Future;
+
+        let pool = testing_pool();
+        let config =
+            BatchConfig { max_batch_size: 1, batch_timeout: None, max_concurrent_batches: 1 };
+        let (mut processor, request_tx) = BatchTxProcessor::new(pool.clone(), config);
+
+        let waker = futures::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        let held_permit = match processor.batch_permits.poll_acquire(&mut cx) {
+            Poll::Ready(Some(permit)) => permit,
+            _ => panic!("expected available batch permit"),
+        };
+
+        let mut processor = Box::pin(processor);
+        let tx = MockTransaction::legacy().with_nonce(0).with_gas_price(100);
+        let (response_tx, mut response_rx) = tokio::sync::oneshot::channel();
+        request_tx
+            .send(BatchTxRequest::new(TransactionOrigin::Local, tx, response_tx))
+            .expect("send failed");
+
+        let result = processor.as_mut().poll(&mut cx);
+        assert!(result.is_pending(), "Should wait for a batch permit");
+        assert!(response_rx.try_recv().is_err(), "Batch should not be dispatched without permit");
+
+        drop(held_permit);
+
+        let result = processor.as_mut().poll(&mut cx);
+        assert!(result.is_pending(), "Should return Pending after spawning");
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(response_rx.try_recv().is_ok(), "Batch should be dispatched after permit release");
+    }
+
+    /// Test that partial batch with timeout waits before flushing
+    #[tokio::test]
+    async fn test_poll_partial_batch_with_timeout_waits() {
+        use std::future::Future;
+
+        let pool = testing_pool();
+        let max_batch_size = 10;
+        // Long timeout - batch should NOT flush immediately
+        let config = batch_config(max_batch_size, Some(Duration::from_secs(3600)));
+        let (processor, request_tx) = BatchTxProcessor::new(pool, config);
+
+        let mut processor = Box::pin(processor);
+
+        // Send fewer items than max_batch_size
+        let tx = MockTransaction::legacy().with_nonce(0).with_gas_price(100);
+        let (response_tx, mut response_rx) = tokio::sync::oneshot::channel();
+        request_tx
+            .send(BatchTxRequest::new(TransactionOrigin::Local, tx, response_tx))
+            .expect("send failed");
+
+        // Poll once - should return Pending (waiting for timeout)
+        let waker = futures::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        let result = processor.as_mut().poll(&mut cx);
+        assert!(result.is_pending(), "Partial batch with timeout should return Pending");
+
+        // Response should NOT be ready yet (batch not flushed)
+        let try_result = response_rx.try_recv();
+        assert!(try_result.is_err(), "Partial batch should not be flushed immediately");
+    }
+
+    #[tokio::test]
+    async fn test_partial_batch_registers_channel_waker() {
+        use std::future::Future;
+
+        let pool = testing_pool();
+        let config = batch_config(2, Some(Duration::from_secs(3600)));
+        let (processor, request_tx) = BatchTxProcessor::new(pool.clone(), config);
+        let mut processor = Box::pin(processor);
+
+        let tx = MockTransaction::legacy().with_nonce(0).with_gas_price(100);
+        let (response_tx, response_rx_0) = tokio::sync::oneshot::channel();
+        request_tx
+            .send(BatchTxRequest::new(TransactionOrigin::Local, tx, response_tx))
+            .expect("send failed");
+
+        let wake_counter = std::sync::Arc::new(WakeCounter::default());
+        let waker = waker_ref(&wake_counter);
+        let mut cx = Context::from_waker(&waker);
+
+        let result = processor.as_mut().poll(&mut cx);
+        assert!(result.is_pending(), "Partial batch should wait for more transactions");
+
+        let wakes_before = wake_counter.wakes.load(Ordering::SeqCst);
+        let tx = MockTransaction::legacy().with_nonce(1).with_gas_price(100);
+        let (response_tx, response_rx_1) = tokio::sync::oneshot::channel();
+        request_tx
+            .send(BatchTxRequest::new(TransactionOrigin::Local, tx, response_tx))
+            .expect("send failed");
+        assert!(
+            wake_counter.wakes.load(Ordering::SeqCst) > wakes_before,
+            "Partial batch must register the channel waker while waiting for timeout"
+        );
+
+        let result = processor.as_mut().poll(&mut cx);
+        assert!(result.is_pending(), "Should return Pending after spawning full batch");
+
+        for rx in [response_rx_0, response_rx_1] {
+            let result = timeout(Duration::from_millis(50), rx)
+                .await
+                .expect("Timeout waiting for full batch response")
+                .expect("Response channel was closed unexpectedly");
+            assert!(result.is_ok());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_due_timeout_flushes_after_permit_released() {
+        use std::future::Future;
+
+        let pool = testing_pool();
+        let config = BatchConfig {
+            max_batch_size: 10,
+            batch_timeout: Some(Duration::from_millis(10)),
+            max_concurrent_batches: 1,
+        };
+        let (mut processor, request_tx) = BatchTxProcessor::new(pool.clone(), config);
+
+        let waker = futures::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        let held_permit = match processor.batch_permits.poll_acquire(&mut cx) {
+            Poll::Ready(Some(permit)) => permit,
+            _ => panic!("expected available batch permit"),
+        };
+
+        let mut processor = Box::pin(processor);
+        let tx = MockTransaction::legacy().with_nonce(0).with_gas_price(100);
+        let (response_tx, mut response_rx) = tokio::sync::oneshot::channel();
+        request_tx
+            .send(BatchTxRequest::new(TransactionOrigin::Local, tx, response_tx))
+            .expect("send failed");
+
+        let result = processor.as_mut().poll(&mut cx);
+        assert!(result.is_pending(), "Partial batch should wait for timeout");
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        let result = processor.as_mut().poll(&mut cx);
+        assert!(result.is_pending(), "Due batch should wait for permit");
+        assert!(response_rx.try_recv().is_err(), "Batch should not flush without permit");
+
+        drop(held_permit);
+
+        let result = processor.as_mut().poll(&mut cx);
+        assert!(result.is_pending(), "Should flush due batch after permit release");
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(response_rx.try_recv().is_ok(), "Due batch should not wait for another timeout");
+    }
+
+    /// Test that partial batch in immediate mode (no interval) flushes right away
+    #[tokio::test]
+    async fn test_poll_partial_batch_immediate_mode_flushes() {
+        use std::future::Future;
+
+        let pool = testing_pool();
+        let max_batch_size = 10;
+        // No timeout = immediate mode
+        let config = batch_config(max_batch_size, None);
+        let (processor, request_tx) = BatchTxProcessor::new(pool.clone(), config);
+
+        let mut processor = Box::pin(processor);
+
+        // Send a single item (partial batch)
+        let tx = MockTransaction::legacy().with_nonce(0).with_gas_price(100);
+        let (response_tx, mut response_rx) = tokio::sync::oneshot::channel();
+        request_tx
+            .send(BatchTxRequest::new(TransactionOrigin::Local, tx, response_tx))
+            .expect("send failed");
+
+        // Poll once - should spawn batch immediately in immediate mode
+        let waker = futures::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        let result = processor.as_mut().poll(&mut cx);
+        assert!(result.is_pending(), "Should return Pending after spawning");
+
+        // Give spawned task time to complete
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Response should be ready
+        let result = response_rx.try_recv();
+        assert!(result.is_ok(), "Immediate mode should flush partial batch right away");
+    }
+
+    /// Test that channel close flushes remaining items
+    #[tokio::test]
+    async fn test_poll_channel_close_flushes_remaining() {
+        use std::future::Future;
+
+        let pool = testing_pool();
+        let max_batch_size = 10;
+        let config = batch_config(max_batch_size, Some(Duration::from_secs(3600)));
+        let (processor, request_tx) = BatchTxProcessor::new(pool.clone(), config);
+
+        let mut processor = Box::pin(processor);
+
+        // Send a partial batch
+        let tx = MockTransaction::legacy().with_nonce(0).with_gas_price(100);
+        let (response_tx, mut response_rx) = tokio::sync::oneshot::channel();
+        request_tx
+            .send(BatchTxRequest::new(TransactionOrigin::Local, tx, response_tx))
+            .expect("send failed");
+
+        // Poll once to receive the item
+        let waker = futures::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        let _ = processor.as_mut().poll(&mut cx);
+
+        // Drop sender to close channel
+        drop(request_tx);
+
+        // Poll again - should flush remaining and return Ready
+        let result = processor.as_mut().poll(&mut cx);
+        assert!(result.is_ready(), "Should return Ready when channel closes");
+
+        // Give spawned task time to complete
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Response should be ready
+        let result = response_rx.try_recv();
+        assert!(result.is_ok(), "Channel close should flush remaining items");
     }
 }

--- a/crates/transaction-pool/src/batcher.rs
+++ b/crates/transaction-pool/src/batcher.rs
@@ -3,10 +3,13 @@
 //! This module provides transaction batching logic to reduce lock contention when processing
 //! many concurrent transaction pool insertions.
 //!
-//! The batcher supports an optional timeout mechanism: when `batch_timeout` is `Some`,
-//! transactions are batched until either `max_batch_size` is reached or the timeout expires after
-//! the first transaction is buffered. When `batch_timeout` is `None`, the batcher processes
-//! requests immediately.
+//! The batcher operates in one of two modes:
+//! - **Immediate mode** (`batch_timeout = None`, the default): requests are processed as soon as
+//!   they arrive and each insertion task is spawned without a concurrency bound, identical to an
+//!   unbatched processor.
+//! - **Batch-and-timeout mode** (`batch_timeout = Some(..)`): requests are coalesced until either
+//!   `max_batch_size` is reached or the timeout expires after the first request was buffered.
+//!   Spawned insertion batches are bounded by `max_concurrent_batches`.
 
 use crate::{
     config::BatchConfig, error::PoolError, AddedTransactionOutcome, PoolTransaction,
@@ -54,9 +57,10 @@ where
 /// Transaction batch processor that handles batch processing
 ///
 /// Supports two modes:
-/// - **Immediate mode** (`batch_timeout = None`): Processes requests as soon as available (greedy)
+/// - **Immediate mode** (`batch_timeout = None`): Processes requests as soon as available (greedy),
+///   spawning insertion tasks without a concurrency bound
 /// - **Batch-and-timeout mode** (`batch_timeout = Some(...)`): Waits for `max_batch_size` OR
-///   timeout before processing
+///   timeout before processing, with spawned batches bounded by `batch_permits`
 #[pin_project]
 pub struct BatchTxProcessor<Pool: TransactionPool> {
     pool: Pool,
@@ -72,6 +76,8 @@ pub struct BatchTxProcessor<Pool: TransactionPool> {
     /// Tracks an expired deadline while waiting for an insertion permit.
     flush_due: bool,
     /// Limits how many insertion batches can be processed concurrently.
+    ///
+    /// Only used in batch-and-timeout mode; immediate mode spawns unbounded.
     batch_permits: PollSemaphore,
 }
 
@@ -150,11 +156,12 @@ where
         }
     }
 
-    /// Spawn a batch processing task
+    /// Spawn a batch processing task, holding the concurrency permit (if any) until the batch is
+    /// fully processed
     fn spawn_batch(
         pool: &Pool,
         buf: &mut Vec<BatchTxRequest<Pool::Transaction>>,
-        permit: OwnedSemaphorePermit,
+        permit: Option<OwnedSemaphorePermit>,
     ) {
         if buf.is_empty() {
             return;
@@ -166,15 +173,29 @@ where
             Self::process_batch(&pool, batch).await;
         });
     }
-}
 
-impl<Pool> Future for BatchTxProcessor<Pool>
-where
-    Pool: TransactionPool + 'static,
-{
-    type Output = ();
+    /// Immediate mode: greedily spawn whatever requests are available, without a concurrency
+    /// bound.
+    ///
+    /// This is the pass-through path used when no `batch_timeout` is configured and matches the
+    /// behavior of an unbatched processor.
+    fn poll_immediate(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        let mut this = self.project();
 
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        loop {
+            let n =
+                ready!(this.request_rx.as_mut().poll_recv_many(cx, this.buf, *this.max_batch_size));
+            Self::spawn_batch(this.pool, this.buf, None);
+            if n == 0 {
+                // channel closed
+                return Poll::Ready(())
+            }
+        }
+    }
+
+    /// Batch-and-timeout mode: coalesce requests until the batch is full or the deadline armed by
+    /// the first buffered request expires, bounding spawned batches with `batch_permits`.
+    fn poll_batched(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
         let mut this = self.project();
 
         loop {
@@ -183,13 +204,12 @@ where
                 let remaining_capacity = *this.max_batch_size - this.buf.len();
                 match this.request_rx.as_mut().poll_recv_many(cx, this.buf, remaining_capacity) {
                     Poll::Ready(0) => {
+                        // Channel closed, flush remaining and exit
                         if !this.buf.is_empty() {
                             let Some(permit) = ready!(this.batch_permits.poll_acquire(cx)) else {
                                 return Poll::Ready(())
                             };
-                            Self::spawn_batch(this.pool, this.buf, permit);
-                            this.batch_deadline.set(None);
-                            *this.flush_due = false;
+                            Self::spawn_batch(this.pool, this.buf, Some(permit));
                         }
                         return Poll::Ready(())
                     }
@@ -207,17 +227,8 @@ where
                 return Poll::Pending
             }
 
-            if this.buf.len() >= *this.max_batch_size {
-                let Some(permit) = ready!(this.batch_permits.poll_acquire(cx)) else {
-                    return Poll::Ready(())
-                };
-                Self::spawn_batch(this.pool, this.buf, permit);
-                this.batch_deadline.set(None);
-                *this.flush_due = false;
-                continue
-            }
-
-            if this.batch_timeout.is_some() && !*this.flush_due {
+            // A full batch flushes without consulting the deadline
+            if this.buf.len() < *this.max_batch_size && !*this.flush_due {
                 let Some(deadline) = this.batch_deadline.as_mut().as_pin_mut() else {
                     return Poll::Pending
                 };
@@ -228,9 +239,24 @@ where
             let Some(permit) = ready!(this.batch_permits.poll_acquire(cx)) else {
                 return Poll::Ready(())
             };
-            Self::spawn_batch(this.pool, this.buf, permit);
+            Self::spawn_batch(this.pool, this.buf, Some(permit));
             this.batch_deadline.set(None);
             *this.flush_due = false;
+        }
+    }
+}
+
+impl<Pool> Future for BatchTxProcessor<Pool>
+where
+    Pool: TransactionPool + 'static,
+{
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.batch_timeout.is_none() {
+            self.poll_immediate(cx)
+        } else {
+            self.poll_batched(cx)
         }
     }
 }
@@ -604,14 +630,17 @@ mod tests {
         }
     }
 
-    /// Test that batch dispatch waits for a concurrency permit.
+    /// Test that batch dispatch waits for a concurrency permit in batch-and-timeout mode.
     #[tokio::test]
     async fn test_poll_full_batch_waits_for_batch_permit() {
         use std::future::Future;
 
         let pool = testing_pool();
-        let config =
-            BatchConfig { max_batch_size: 1, batch_timeout: None, max_concurrent_batches: 1 };
+        let config = BatchConfig {
+            max_batch_size: 1,
+            batch_timeout: Some(Duration::from_secs(3600)),
+            max_concurrent_batches: 1,
+        };
         let (mut processor, request_tx) = BatchTxProcessor::new(pool.clone(), config);
 
         let waker = futures::task::noop_waker();
@@ -639,6 +668,41 @@ mod tests {
 
         tokio::time::sleep(Duration::from_millis(50)).await;
         assert!(response_rx.try_recv().is_ok(), "Batch should be dispatched after permit release");
+    }
+
+    /// Test that immediate mode spawns insertions without acquiring a concurrency permit.
+    #[tokio::test]
+    async fn test_immediate_mode_ignores_permit_cap() {
+        use std::future::Future;
+
+        let pool = testing_pool();
+        let config =
+            BatchConfig { max_batch_size: 1, batch_timeout: None, max_concurrent_batches: 1 };
+        let (mut processor, request_tx) = BatchTxProcessor::new(pool.clone(), config);
+
+        // Hold the only permit; immediate mode must dispatch regardless
+        let waker = futures::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        let _held_permit = match processor.batch_permits.poll_acquire(&mut cx) {
+            Poll::Ready(Some(permit)) => permit,
+            _ => panic!("expected available batch permit"),
+        };
+
+        let mut processor = Box::pin(processor);
+        let tx = MockTransaction::legacy().with_nonce(0).with_gas_price(100);
+        let (response_tx, mut response_rx) = tokio::sync::oneshot::channel();
+        request_tx
+            .send(BatchTxRequest::new(TransactionOrigin::Local, tx, response_tx))
+            .expect("send failed");
+
+        let result = processor.as_mut().poll(&mut cx);
+        assert!(result.is_pending(), "Should return Pending after spawning");
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            response_rx.try_recv().is_ok(),
+            "Immediate mode should dispatch without a concurrency permit"
+        );
     }
 
     /// Test that partial batch with timeout waits before flushing

--- a/crates/transaction-pool/src/config.rs
+++ b/crates/transaction-pool/src/config.rs
@@ -6,6 +6,8 @@ use crate::{
 use alloy_consensus::constants::EIP4844_TX_TYPE_ID;
 use alloy_eips::eip1559::{ETHEREUM_BLOCK_GAS_LIMIT_30M, MIN_PROTOCOL_BASE_FEE};
 use alloy_primitives::{map::AddressSet, Address};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use std::{ops::Mul, time::Duration};
 
 /// Guarantees max transactions for one sender, compatible with geth/erigon
@@ -215,6 +217,7 @@ impl Default for PriceBumpConfig {
 
 /// Configuration for transaction batching
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct BatchConfig {
     /// Maximum number of transactions to batch before processing.
     pub max_batch_size: usize,

--- a/crates/transaction-pool/src/config.rs
+++ b/crates/transaction-pool/src/config.rs
@@ -213,6 +213,22 @@ impl Default for PriceBumpConfig {
     }
 }
 
+/// Configuration for transaction batching
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BatchConfig {
+    /// Maximum number of transactions to batch before processing.
+    pub max_batch_size: usize,
+    /// Maximum duration to wait before processing a partial batch.
+    /// If None, batching is disabled (immediate processing).
+    pub batch_timeout: Option<Duration>,
+}
+
+impl Default for BatchConfig {
+    fn default() -> Self {
+        Self { max_batch_size: 1, batch_timeout: None }
+    }
+}
+
 /// Configuration options for the locally received transactions:
 /// [`TransactionOrigin::Local`](TransactionOrigin)
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/crates/transaction-pool/src/config.rs
+++ b/crates/transaction-pool/src/config.rs
@@ -213,6 +213,35 @@ impl Default for PriceBumpConfig {
     }
 }
 
+/// Configuration for transaction batching
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct BatchConfig {
+    /// Maximum number of transactions to batch before processing.
+    pub max_batch_size: usize,
+    /// Maximum duration to wait after the first buffered transaction before processing a partial
+    /// batch.
+    /// If None, batching is disabled (immediate processing).
+    pub batch_timeout: Option<Duration>,
+    /// Maximum number of insertion batches to process concurrently.
+    ///
+    /// This bounds how many spawned insertion batches can compete for transaction validation at
+    /// once. Size this from the number of txpool validation tasks plus a small buffer so
+    /// validation workers stay saturated while submission bursts cannot create unbounded
+    /// in-flight batches.
+    pub max_concurrent_batches: usize,
+}
+
+impl Default for BatchConfig {
+    fn default() -> Self {
+        Self {
+            max_batch_size: 1,
+            batch_timeout: None,
+            max_concurrent_batches: DEFAULT_TXPOOL_ADDITIONAL_VALIDATION_TASKS.saturating_add(3),
+        }
+    }
+}
+
 /// Configuration options for the locally received transactions:
 /// [`TransactionOrigin::Local`](TransactionOrigin)
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/crates/transaction-pool/src/config.rs
+++ b/crates/transaction-pool/src/config.rs
@@ -229,6 +229,9 @@ pub struct BatchConfig {
     /// once. Size this from the number of txpool validation tasks plus a small buffer so
     /// validation workers stay saturated while submission bursts cannot create unbounded
     /// in-flight batches.
+    ///
+    /// Only applies in batch-and-timeout mode (`batch_timeout` set); immediate mode spawns
+    /// insertions without a concurrency bound.
     pub max_concurrent_batches: usize,
 }
 

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -282,7 +282,7 @@ pub use crate::{
     batcher::{BatchTxProcessor, BatchTxRequest},
     blobstore::{BlobStore, BlobStoreError},
     config::{
-        LocalTransactionConfig, PoolConfig, PriceBumpConfig, SubPoolLimit,
+        BatchConfig, LocalTransactionConfig, PoolConfig, PriceBumpConfig, SubPoolLimit,
         DEFAULT_MAX_INFLIGHT_DELEGATED_SLOTS, DEFAULT_PRICE_BUMP,
         DEFAULT_TXPOOL_ADDITIONAL_VALIDATION_TASKS, MAX_NEW_PENDING_TXS_NOTIFICATIONS,
         REPLACE_BLOB_PRICE_BUMP, TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,

--- a/crates/transaction-pool/src/metrics.rs
+++ b/crates/transaction-pool/src/metrics.rs
@@ -154,3 +154,11 @@ pub struct TxPoolValidatorMetrics {
     /// Number of in-flight validation job sends waiting for channel capacity
     pub inflight_validation_jobs: Gauge,
 }
+
+/// Transaction batcher metrics
+#[derive(Metrics)]
+#[metrics(scope = "transaction_pool")]
+pub struct BatchMetrics {
+    /// Size of the dispatched transaction insertion batches
+    pub batch_size: Histogram,
+}

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -678,6 +678,11 @@ TxPool:
 
           [default: 1]
 
+      --txpool.batch-timeout <DURATION>
+          Batch timeout for transaction pool insertions (e.g. "50ms" or "0" for immediate). When non-zero, transactions are batched until either max-batch-size is reached OR timeout expires. Use "0" for immediate processing (zero-cost path, original behavior)
+
+          [default: 0]
+
 Builder:
       --builder.extradata <EXTRA_DATA>
           Block extra data set by the payload builder

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -679,7 +679,7 @@ TxPool:
           [default: 1]
 
       --txpool.batch-timeout <DURATION>
-          Batch timeout for transaction pool insertions (e.g. "50ms" or "0" for immediate). When non-zero, transactions are batched until either max-batch-size is reached OR timeout expires. Use "0" for immediate processing (zero-cost path, original behavior)
+          Batch timeout for transaction pool insertions (e.g. "50ms" or "0" for immediate). When non-zero, transactions are batched until either max-batch-size is reached OR timeout expires. Use "0" for immediate processing
 
           [default: 0]
 

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -716,6 +716,8 @@ TxPool:
       --txpool.batch-timeout <DURATION>
           Batch timeout for transaction pool insertions (e.g. "50ms" or "0" for immediate). When set to a non-zero duration, transactions are batched until either max-batch-size is reached or the timeout expires after the first buffered transaction. Requires txpool.max-batch-size > 1 to coalesce multiple transactions
 
+          [default: 0]
+
 Builder:
       --builder.extradata <EXTRA_DATA>
           Block extra data set by the payload builder.

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -713,6 +713,9 @@ TxPool:
 
           [default: 1]
 
+      --txpool.batch-timeout <DURATION>
+          Batch timeout for transaction pool insertions (e.g. "50ms" or "0" for immediate). When set to a non-zero duration, transactions are batched until either max-batch-size is reached or the timeout expires after the first buffered transaction. Requires txpool.max-batch-size > 1 to coalesce multiple transactions
+
 Builder:
       --builder.extradata <EXTRA_DATA>
           Block extra data set by the payload builder.


### PR DESCRIPTION
Adds configurable transaction pool insertion batching with `--txpool.batch-timeout`.

The batcher now has two explicit modes. Immediate mode (no timeout, the default) processes requests as soon as they arrive and spawns insertion tasks without a concurrency bound, identical to the previous behavior. Batch-and-timeout mode coalesces requests until either `max-batch-size` is reached or the timeout expires after the first buffered transaction, and bounds in-flight insertion batches via `max_concurrent_batches` (derived from `txpool.additional-validation-tasks + 3`) so submission bursts cannot create unbounded concurrent batches while keeping validation workers saturated.