### PR TITLE
perf: preallocate block body indices vec

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1413,7 +1413,12 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> ReceiptProvider for DatabasePr
         }
 
         // collect block body indices for each block in the range
-        let mut block_body_indices = Vec::new();
+        let range_len = block_range
+            .end()
+            .checked_sub(*block_range.start())
+            .and_then(|diff| diff.checked_add(1))
+            .expect("block range should not be empty") as usize;
+        let mut block_body_indices = Vec::with_capacity(range_len);
         for block_num in block_range {
             if let Some(indices) = self.block_body_indices(block_num)? {
                 block_body_indices.push(indices);


### PR DESCRIPTION
Preallocates exact capacity for block_body_indices vector in receipts_by_block_range, reduces memory reallocations during block range iteration.