### PR TITLE
refactor(db-api): remove dead data field from DatabaseMock

### DIFF
--- a/crates/storage/db-api/src/mock.rs
+++ b/crates/storage/db-api/src/mock.rs
@@ -23,13 +23,7 @@ use std::{collections::BTreeMap, ops::RangeBounds};
 /// Provides a lightweight implementation of the [`Database`] trait suitable
 /// for testing scenarios where actual database operations are not required.
 #[derive(Clone, Debug, Default)]
-pub struct DatabaseMock {
-    /// Internal data storage using a `BTreeMap`.
-    ///
-    /// TODO: Make the mock database table-aware by properly utilizing
-    /// this data structure to simulate realistic database behavior during testing.
-    pub data: BTreeMap<Vec<u8>, Vec<u8>>,
-}
+pub struct DatabaseMock {}
 
 impl Database for DatabaseMock {
     type TX = TxMock;


### PR DESCRIPTION
The public DatabaseMock::data field was never read or written anywhere in the codebase and was not connected to TxMock or cursor implementations. At the same time its documentation claimed it was internal storage for the mock database, which does not match the actual stateless, no-op behavior of DatabaseMock and TxMock. This change removes the dead data field and its misleading comment, keeping DatabaseMock as a simple empty mock type that reflects the current semantics without altering any runtime behavior or tests.