### PR TITLE
perf(trie): flatten sparse trie branch node masks to reduce overhead

### DIFF
--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -19,8 +19,9 @@ use alloy_rlp::Decodable;
 use reth_execution_errors::{SparseTrieErrorKind, SparseTrieResult};
 use reth_trie_common::{
     prefix_set::{PrefixSet, PrefixSetMut},
-    BranchNodeCompact, BranchNodeRef, ExtensionNodeRef, LeafNodeRef, Nibbles, ProofTrieNode,
-    RlpNode, TrieMask, TrieMasks, TrieNode, CHILD_INDEX_RANGE, EMPTY_ROOT_HASH,
+    BranchNodeCompact, BranchNodeMasks, BranchNodeMasksMap, BranchNodeRef, ExtensionNodeRef,
+    LeafNodeRef, Nibbles, ProofTrieNode, RlpNode, TrieMask, TrieMasks, TrieNode, CHILD_INDEX_RANGE,
+    EMPTY_ROOT_HASH,
 };
 use smallvec::SmallVec;
 use tracing::{debug, instrument, trace};
@@ -298,10 +299,12 @@ pub struct SerialSparseTrie {
     /// Map from a path (nibbles) to its corresponding sparse trie node.
     /// This contains all of the revealed nodes in trie.
     nodes: HashMap<Nibbles, SparseNode>,
-    /// When a branch is set, the corresponding child subtree is stored in the database.
-    branch_node_tree_masks: HashMap<Nibbles, TrieMask>,
-    /// When a bit is set, the corresponding child is stored as a hash in the database.
-    branch_node_hash_masks: HashMap<Nibbles, TrieMask>,
+    /// Branch node masks containing tree_mask and hash_mask for each path.
+    /// - `tree_mask`: When a bit is set, the corresponding child subtree is stored in the
+    ///   database.
+    /// - `hash_mask`: When a bit is set, the corresponding child is stored as a hash in the
+    ///   database.
+    branch_node_masks: BranchNodeMasksMap,
     /// Map from leaf key paths to their values.
     /// All values are stored here instead of directly in leaf nodes.
     values: HashMap<Nibbles, Vec<u8>>,
@@ -318,8 +321,7 @@ impl fmt::Debug for SerialSparseTrie {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SerialSparseTrie")
             .field("nodes", &self.nodes)
-            .field("branch_tree_masks", &self.branch_node_tree_masks)
-            .field("branch_hash_masks", &self.branch_node_hash_masks)
+            .field("branch_node_masks", &self.branch_node_masks)
             .field("values", &self.values)
             .field("prefix_set", &self.prefix_set)
             .field("updates", &self.updates)
@@ -404,8 +406,7 @@ impl Default for SerialSparseTrie {
     fn default() -> Self {
         Self {
             nodes: HashMap::from_iter([(Nibbles::default(), SparseNode::Empty)]),
-            branch_node_tree_masks: HashMap::default(),
-            branch_node_hash_masks: HashMap::default(),
+            branch_node_masks: BranchNodeMasksMap::default(),
             values: HashMap::default(),
             prefix_set: PrefixSetMut::default(),
             updates: None,
@@ -456,11 +457,14 @@ impl SparseTrieInterface for SerialSparseTrie {
             return Ok(())
         }
 
-        if let Some(tree_mask) = masks.tree_mask {
-            self.branch_node_tree_masks.insert(path, tree_mask);
-        }
-        if let Some(hash_mask) = masks.hash_mask {
-            self.branch_node_hash_masks.insert(path, hash_mask);
+        if masks.tree_mask.is_some() || masks.hash_mask.is_some() {
+            self.branch_node_masks.insert(
+                path,
+                BranchNodeMasks {
+                    tree_mask: masks.tree_mask.unwrap_or_default(),
+                    hash_mask: masks.hash_mask.unwrap_or_default(),
+                },
+            );
         }
 
         match node {
@@ -959,8 +963,7 @@ impl SparseTrieInterface for SerialSparseTrie {
         self.nodes.clear();
         self.nodes.insert(Nibbles::default(), SparseNode::Empty);
 
-        self.branch_node_tree_masks.clear();
-        self.branch_node_hash_masks.clear();
+        self.branch_node_masks.clear();
         self.values.clear();
         self.prefix_set.clear();
         self.updates = None;
@@ -1087,8 +1090,7 @@ impl SparseTrieInterface for SerialSparseTrie {
 
     fn shrink_nodes_to(&mut self, size: usize) {
         self.nodes.shrink_to(size);
-        self.branch_node_tree_masks.shrink_to(size);
-        self.branch_node_hash_masks.shrink_to(size);
+        self.branch_node_masks.shrink_to(size);
     }
 
     fn shrink_values_to(&mut self, size: usize) {
@@ -1637,6 +1639,9 @@ impl SerialSparseTrie {
                                 // SAFETY: it's a child, so it's never empty
                                 let last_child_nibble = child_path.last().unwrap();
 
+                                // Get the branch node masks for this path once (single lookup)
+                                let path_masks = self.branch_node_masks.get(&path);
+
                                 // Determine whether we need to set trie mask bit.
                                 let should_set_tree_mask_bit = if let Some(store_in_db_trie) =
                                     child_node_type.store_in_db_trie()
@@ -1647,9 +1652,9 @@ impl SerialSparseTrie {
                                 } else {
                                     // A blinded node has the tree mask bit set
                                     child_node_type.is_hash() &&
-                                        self.branch_node_tree_masks.get(&path).is_some_and(
-                                            |mask| mask.is_bit_set(last_child_nibble),
-                                        )
+                                        path_masks.is_some_and(|masks| {
+                                            masks.tree_mask.is_bit_set(last_child_nibble)
+                                        })
                                 };
                                 if should_set_tree_mask_bit {
                                     tree_mask.set_bit(last_child_nibble);
@@ -1661,11 +1666,9 @@ impl SerialSparseTrie {
                                 let hash = child.as_hash().filter(|_| {
                                     child_node_type.is_branch() ||
                                         (child_node_type.is_hash() &&
-                                            self.branch_node_hash_masks
-                                                .get(&path)
-                                                .is_some_and(|mask| {
-                                                    mask.is_bit_set(last_child_nibble)
-                                                }))
+                                            path_masks.is_some_and(|masks| {
+                                                masks.hash_mask.is_bit_set(last_child_nibble)
+                                            }))
                                 });
                                 if let Some(hash) = hash {
                                     hash_mask.set_bit(last_child_nibble);
@@ -1729,27 +1732,17 @@ impl SerialSparseTrie {
                                 hash.filter(|_| path.is_empty()),
                             );
                             updates.updated_nodes.insert(path, branch_node);
-                        } else if self
-                            .branch_node_tree_masks
-                            .get(&path)
-                            .is_some_and(|mask| !mask.is_empty()) ||
-                            self.branch_node_hash_masks
-                                .get(&path)
-                                .is_some_and(|mask| !mask.is_empty())
-                        {
+                        } else if self.branch_node_masks.get(&path).is_some_and(|masks| {
+                            !masks.tree_mask.is_empty() || !masks.hash_mask.is_empty()
+                        }) {
                             // If new tree and hash masks are empty, but previously they weren't, we
                             // need to remove the node update and add the node itself to the list of
                             // removed nodes.
                             updates.updated_nodes.remove(&path);
                             updates.removed_nodes.insert(path);
-                        } else if self
-                            .branch_node_tree_masks
-                            .get(&path)
-                            .is_none_or(|mask| mask.is_empty()) &&
-                            self.branch_node_hash_masks
-                                .get(&path)
-                                .is_none_or(|mask| mask.is_empty())
-                        {
+                        } else if self.branch_node_masks.get(&path).is_none_or(|masks| {
+                            masks.tree_mask.is_empty() && masks.hash_mask.is_empty()
+                        }) {
                             // If new tree and hash masks are empty, and they were previously empty
                             // as well, we need to remove the node update.
                             updates.updated_nodes.remove(&path);
@@ -2223,8 +2216,7 @@ mod find_leaf_tests {
 
         let sparse = SerialSparseTrie {
             nodes,
-            branch_node_tree_masks: Default::default(),
-            branch_node_hash_masks: Default::default(),
+            branch_node_masks: Default::default(),
             /* The value is not in the values map, or else it would early return */
             values: Default::default(),
             prefix_set: Default::default(),
@@ -2266,8 +2258,7 @@ mod find_leaf_tests {
 
         let sparse = SerialSparseTrie {
             nodes,
-            branch_node_tree_masks: Default::default(),
-            branch_node_hash_masks: Default::default(),
+            branch_node_masks: Default::default(),
             values,
             prefix_set: Default::default(),
             updates: None,


### PR DESCRIPTION
Follow up from #20659
Consolidate into a single `HashMap<Nibbles, BranchNodeMasks>`, reusing the `BranchNodeMasks` struct and `BranchNodeMasksMap` type alias introduced in #20659.

**Problem**
`SerialSparseTrie` and `ParallelSparseTrie` use two separate `HashMap<Nibbles, TrieMask>` fields (`branch_node_tree_masks` and `branch_node_hash_masks`) to store branch node mask information. This results in:
- Double HashMap overhead per path
- Two lookups instead of one when accessing both masks for the same path
- Increased memory footprint

**Impact**

Benchmark:

E2E: https://github.com/paradigmxyz/reth/pull/20664#issuecomment-3698212688

Micro: https://gist.github.com/yongkangc/a7ebeb047362fa1690fbd4a1c264ed43

| Operation | Elements | Old (µs) | New (µs) | Speedup |
|-----------|----------|----------|----------|---------|
| Insert | 1000 | 43.4 | 28.0 | **1.55x** |
| Lookup | 1000 | 13.8 | 5.6 | **2.47x** |
| Clone | 1000 | 3.3 | 1.7 | **1.94x** |
| Clear | 1000 | 2.4 | 0.7 | **3.42x** |
| Conditional Access | 1000 | 8.5 | 4.3 | **1.98x** |

Memory:
- Old: 96 bytes per struct (two HashMaps × 48 bytes each)
- New: 48 bytes per struct (single HashMap)
- Savings: 48 bytes (50% reduction)