### PR TITLE
chore(stages): use with_capacity() at populate_range()

### DIFF
--- a/crates/stages/stages/src/stages/merkle_changesets.rs
+++ b/crates/stages/stages/src/stages/merkle_changesets.rs
@@ -195,7 +195,8 @@ impl MerkleChangeSets {
             ?target_range,
             "Computing per-block state reverts",
         );
-        let mut per_block_state_reverts = Vec::new();
+        let range_len = target_end - target_start;
+        let mut per_block_state_reverts = Vec::with_capacity(range_len as usize);
         for block_number in target_range.clone() {
             per_block_state_reverts.push(HashedPostStateSorted::from_reverts::<KeccakKeyHasher>(
                 provider.tx_ref(),


### PR DESCRIPTION
uses the provided range of blocks to allocate the vector