### PR TITLE
chore: shrink outgoing broadcast messages

### DIFF
--- a/crates/net/eth-wire-types/src/broadcast.rs
+++ b/crates/net/eth-wire-types/src/broadcast.rs
@@ -409,6 +409,13 @@ impl NewPooledTransactionHashes68 {
         }
     }
 
+    /// Shrinks the capacity of the message vectors as much as possible.
+    pub fn shrink_to_fit(&mut self) {
+        self.hashes.shrink_to_fit();
+        self.sizes.shrink_to_fit();
+        self.types.shrink_to_fit()
+    }
+
     /// Consumes and appends a transaction
     pub fn with_transaction<T: SignedTransaction>(mut self, tx: &T) -> Self {
         self.push(tx);

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -1931,8 +1931,14 @@ impl PooledTransactionsHashesBuilder {
 
     fn build(self) -> NewPooledTransactionHashes {
         match self {
-            Self::Eth66(msg) => msg.into(),
-            Self::Eth68(msg) => msg.into(),
+            Self::Eth66(mut msg) => {
+                msg.0.shrink_to_fit();
+                msg.into()
+            }
+            Self::Eth68(mut msg) => {
+                msg.shrink_to_fit();
+                msg.into()
+            }
         }
     }
 }


### PR DESCRIPTION
the number of items per peer specific message is dynamic and is buffered internally and also immutable, we can freeze the vecs before emitting it to avoid having over allocated capacity for the time this message is buffered