### PR TITLE
perf(trie): consolidate TrieUpdates account_nodes and removed_nodes

### DIFF
--- a/crates/trie/common/Cargo.toml
+++ b/crates/trie/common/Cargo.toml
@@ -141,3 +141,7 @@ harness = false
 name = "hashed_state"
 harness = false
 required-features = ["rayon"]
+
+[[bench]]
+name = "trie_updates"
+harness = false

--- a/crates/trie/common/benches/trie_updates.rs
+++ b/crates/trie/common/benches/trie_updates.rs
@@ -1,0 +1,494 @@
+#![allow(missing_docs, unreachable_pub)]
+//! Benchmark comparing two representations for trie updates:
+//! 1. Current: `HashMap<Nibbles, BranchNodeCompact>` + `HashSet<Nibbles>` (separate)
+//! 2. Consolidated: `HashMap<Nibbles, Option<BranchNodeCompact>>` (unified)
+//!
+//! The consolidation aims to:
+//! - Reduce `HashMap` overhead (one map instead of two)
+//! - Improve memory layout (less fragmentation)
+//! - Reduce cache misses (related data stored together)
+
+use alloy_primitives::map::{HashMap, HashSet};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use prop::test_runner::TestRng;
+use proptest::{prelude::*, strategy::ValueTree, test_runner::TestRunner};
+use reth_trie_common::{BranchNodeCompact, Nibbles, TrieMask};
+use std::hint::black_box;
+
+/// Current representation: separate `HashMap` and `HashSet`
+#[derive(Default, Clone)]
+struct TrieUpdatesSeparate {
+    account_nodes: HashMap<Nibbles, BranchNodeCompact>,
+    removed_nodes: HashSet<Nibbles>,
+}
+
+impl TrieUpdatesSeparate {
+    fn insert_node(&mut self, path: Nibbles, node: BranchNodeCompact) {
+        self.removed_nodes.remove(&path);
+        self.account_nodes.insert(path, node);
+    }
+
+    fn remove_node(&mut self, path: Nibbles) {
+        self.account_nodes.remove(&path);
+        self.removed_nodes.insert(path);
+    }
+
+    fn get_node(&self, path: &Nibbles) -> Option<&BranchNodeCompact> {
+        self.account_nodes.get(path)
+    }
+
+    fn is_removed(&self, path: &Nibbles) -> bool {
+        self.removed_nodes.contains(path)
+    }
+
+    fn is_empty(&self) -> bool {
+        self.account_nodes.is_empty() && self.removed_nodes.is_empty()
+    }
+
+    fn len(&self) -> usize {
+        self.account_nodes.len() + self.removed_nodes.len()
+    }
+
+    fn extend(&mut self, other: Self) {
+        // Removed nodes in other should remove existing account nodes
+        self.account_nodes.retain(|k, _| !other.removed_nodes.contains(k));
+        self.account_nodes.extend(other.account_nodes);
+        self.removed_nodes.extend(other.removed_nodes);
+    }
+
+    fn iter_all(&self) -> impl Iterator<Item = (&Nibbles, Option<&BranchNodeCompact>)> {
+        self.account_nodes
+            .iter()
+            .map(|(k, v)| (k, Some(v)))
+            .chain(self.removed_nodes.iter().map(|k| (k, None)))
+    }
+}
+
+/// Consolidated representation: single `HashMap` with `Option`
+#[derive(Default, Clone)]
+struct TrieUpdatesConsolidated {
+    /// None = removed, Some = updated
+    nodes: HashMap<Nibbles, Option<BranchNodeCompact>>,
+}
+
+impl TrieUpdatesConsolidated {
+    fn insert_node(&mut self, path: Nibbles, node: BranchNodeCompact) {
+        self.nodes.insert(path, Some(node));
+    }
+
+    fn remove_node(&mut self, path: Nibbles) {
+        self.nodes.insert(path, None);
+    }
+
+    fn get_node(&self, path: &Nibbles) -> Option<&BranchNodeCompact> {
+        self.nodes.get(path).and_then(|opt| opt.as_ref())
+    }
+
+    fn is_removed(&self, path: &Nibbles) -> bool {
+        self.nodes.get(path).is_some_and(|opt| opt.is_none())
+    }
+
+    fn is_empty(&self) -> bool {
+        self.nodes.is_empty()
+    }
+
+    fn len(&self) -> usize {
+        self.nodes.len()
+    }
+
+    fn extend(&mut self, other: Self) {
+        // When extending, other's entries override ours
+        // If other marks a path as removed (None), it overrides our entry
+        // If other has a node (Some), it overrides our entry
+        self.nodes.extend(other.nodes);
+    }
+
+    fn iter_all(&self) -> impl Iterator<Item = (&Nibbles, Option<&BranchNodeCompact>)> {
+        self.nodes.iter().map(|(k, v)| (k, v.as_ref()))
+    }
+}
+
+fn print_sizes() {
+    println!("\n=== Type Sizes ===");
+    println!("Nibbles: {} bytes", std::mem::size_of::<Nibbles>());
+    println!("BranchNodeCompact: {} bytes", std::mem::size_of::<BranchNodeCompact>());
+    println!(
+        "Option<BranchNodeCompact>: {} bytes",
+        std::mem::size_of::<Option<BranchNodeCompact>>()
+    );
+    println!(
+        "(Nibbles, BranchNodeCompact): {} bytes",
+        std::mem::size_of::<(Nibbles, BranchNodeCompact)>()
+    );
+    println!(
+        "(Nibbles, Option<BranchNodeCompact>): {} bytes",
+        std::mem::size_of::<(Nibbles, Option<BranchNodeCompact>)>()
+    );
+    println!();
+}
+
+fn generate_nibbles(runner: &mut TestRunner, count: usize) -> Vec<Nibbles> {
+    use prop::collection::vec;
+    let strategy = vec(any_with::<Nibbles>((1..=32usize).into()), count);
+    let mut nibbles = strategy.new_tree(runner).unwrap().current();
+    nibbles.sort();
+    nibbles.dedup();
+    nibbles
+}
+
+fn generate_branch_node() -> BranchNodeCompact {
+    // Create a valid BranchNodeCompact with matching hash_mask and hashes count
+    // hash_mask must have exactly the same number of bits set as hashes.len()
+    BranchNodeCompact::new(
+        TrieMask::new(0b1111_0000_1111_0000), // state_mask
+        TrieMask::new(0b0011_0000_0011_0000), // tree_mask
+        TrieMask::new(0),                     // hash_mask (0 bits = 0 hashes)
+        vec![],                               // hashes (empty)
+        None,                                 // root_hash
+    )
+}
+
+fn bench_insert(c: &mut Criterion) {
+    print_sizes();
+    let mut group = c.benchmark_group("trie_updates_insert");
+
+    for size in [100, 1_000, 10_000] {
+        let config = proptest::test_runner::Config::default();
+        let rng = TestRng::deterministic_rng(config.rng_algorithm);
+        let mut runner = TestRunner::new_with_rng(config, rng);
+        let nibbles = generate_nibbles(&mut runner, size);
+        let node = generate_branch_node();
+
+        group.throughput(Throughput::Elements(size as u64));
+
+        group.bench_with_input(BenchmarkId::new("separate", size), &size, |b, _| {
+            b.iter(|| {
+                let mut updates = TrieUpdatesSeparate::default();
+                for path in &nibbles {
+                    updates.insert_node(*path, node.clone());
+                }
+                black_box(updates)
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("consolidated", size), &size, |b, _| {
+            b.iter(|| {
+                let mut updates = TrieUpdatesConsolidated::default();
+                for path in &nibbles {
+                    updates.insert_node(*path, node.clone());
+                }
+                black_box(updates)
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_mixed_operations(c: &mut Criterion) {
+    let mut group = c.benchmark_group("trie_updates_mixed");
+
+    for size in [100, 1_000, 10_000] {
+        let config = proptest::test_runner::Config::default();
+        let rng = TestRng::deterministic_rng(config.rng_algorithm);
+        let mut runner = TestRunner::new_with_rng(config, rng);
+        let nibbles = generate_nibbles(&mut runner, size);
+        let node = generate_branch_node();
+
+        group.throughput(Throughput::Elements(size as u64));
+
+        // Mix of 70% inserts, 30% removes
+        group.bench_with_input(BenchmarkId::new("separate", size), &size, |b, _| {
+            b.iter(|| {
+                let mut updates = TrieUpdatesSeparate::default();
+                for (i, path) in nibbles.iter().enumerate() {
+                    if i % 10 < 7 {
+                        updates.insert_node(*path, node.clone());
+                    } else {
+                        updates.remove_node(*path);
+                    }
+                }
+                black_box(updates)
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("consolidated", size), &size, |b, _| {
+            b.iter(|| {
+                let mut updates = TrieUpdatesConsolidated::default();
+                for (i, path) in nibbles.iter().enumerate() {
+                    if i % 10 < 7 {
+                        updates.insert_node(*path, node.clone());
+                    } else {
+                        updates.remove_node(*path);
+                    }
+                }
+                black_box(updates)
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_lookup(c: &mut Criterion) {
+    let mut group = c.benchmark_group("trie_updates_lookup");
+
+    for size in [100, 1_000, 10_000] {
+        let config = proptest::test_runner::Config::default();
+        let rng = TestRng::deterministic_rng(config.rng_algorithm);
+        let mut runner = TestRunner::new_with_rng(config, rng);
+        let nibbles = generate_nibbles(&mut runner, size);
+        let node = generate_branch_node();
+
+        // Pre-populate the structures
+        let mut separate = TrieUpdatesSeparate::default();
+        let mut consolidated = TrieUpdatesConsolidated::default();
+        for (i, path) in nibbles.iter().enumerate() {
+            if i % 10 < 7 {
+                separate.insert_node(*path, node.clone());
+                consolidated.insert_node(*path, node.clone());
+            } else {
+                separate.remove_node(*path);
+                consolidated.remove_node(*path);
+            }
+        }
+
+        group.throughput(Throughput::Elements(size as u64));
+
+        group.bench_with_input(BenchmarkId::new("separate", size), &size, |b, _| {
+            b.iter(|| {
+                let mut found = 0usize;
+                for path in &nibbles {
+                    if separate.get_node(path).is_some() {
+                        found += 1;
+                    }
+                    if separate.is_removed(path) {
+                        found += 1;
+                    }
+                }
+                black_box(found)
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("consolidated", size), &size, |b, _| {
+            b.iter(|| {
+                let mut found = 0usize;
+                for path in &nibbles {
+                    if consolidated.get_node(path).is_some() {
+                        found += 1;
+                    }
+                    if consolidated.is_removed(path) {
+                        found += 1;
+                    }
+                }
+                black_box(found)
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_extend(c: &mut Criterion) {
+    let mut group = c.benchmark_group("trie_updates_extend");
+
+    for size in [100, 1_000, 10_000] {
+        let config = proptest::test_runner::Config::default();
+        let rng = TestRng::deterministic_rng(config.rng_algorithm);
+        let mut runner = TestRunner::new_with_rng(config, rng);
+        let nibbles1 = generate_nibbles(&mut runner, size);
+        let nibbles2 = generate_nibbles(&mut runner, size);
+        let node = generate_branch_node();
+
+        // Pre-populate first set
+        let mut separate1 = TrieUpdatesSeparate::default();
+        let mut consolidated1 = TrieUpdatesConsolidated::default();
+        for (i, path) in nibbles1.iter().enumerate() {
+            if i % 10 < 7 {
+                separate1.insert_node(*path, node.clone());
+                consolidated1.insert_node(*path, node.clone());
+            } else {
+                separate1.remove_node(*path);
+                consolidated1.remove_node(*path);
+            }
+        }
+
+        // Pre-populate second set
+        let mut separate2 = TrieUpdatesSeparate::default();
+        let mut consolidated2 = TrieUpdatesConsolidated::default();
+        for (i, path) in nibbles2.iter().enumerate() {
+            if i % 10 < 7 {
+                separate2.insert_node(*path, node.clone());
+                consolidated2.insert_node(*path, node.clone());
+            } else {
+                separate2.remove_node(*path);
+                consolidated2.remove_node(*path);
+            }
+        }
+
+        group.throughput(Throughput::Elements((size * 2) as u64));
+
+        group.bench_with_input(BenchmarkId::new("separate", size), &size, |b, _| {
+            b.iter_batched(
+                || (separate1.clone(), separate2.clone()),
+                |(mut s1, s2)| {
+                    s1.extend(s2);
+                    black_box(s1)
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+
+        group.bench_with_input(BenchmarkId::new("consolidated", size), &size, |b, _| {
+            b.iter_batched(
+                || (consolidated1.clone(), consolidated2.clone()),
+                |(mut c1, c2)| {
+                    c1.extend(c2);
+                    black_box(c1)
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_iteration(c: &mut Criterion) {
+    let mut group = c.benchmark_group("trie_updates_iteration");
+
+    for size in [100, 1_000, 10_000] {
+        let config = proptest::test_runner::Config::default();
+        let rng = TestRng::deterministic_rng(config.rng_algorithm);
+        let mut runner = TestRunner::new_with_rng(config, rng);
+        let nibbles = generate_nibbles(&mut runner, size);
+        let node = generate_branch_node();
+
+        // Pre-populate the structures
+        let mut separate = TrieUpdatesSeparate::default();
+        let mut consolidated = TrieUpdatesConsolidated::default();
+        for (i, path) in nibbles.iter().enumerate() {
+            if i % 10 < 7 {
+                separate.insert_node(*path, node.clone());
+                consolidated.insert_node(*path, node.clone());
+            } else {
+                separate.remove_node(*path);
+                consolidated.remove_node(*path);
+            }
+        }
+
+        group.throughput(Throughput::Elements(size as u64));
+
+        group.bench_with_input(BenchmarkId::new("separate", size), &size, |b, _| {
+            b.iter(|| {
+                let mut count = 0usize;
+                for (_, node) in separate.iter_all() {
+                    if node.is_some() {
+                        count += 1;
+                    }
+                }
+                black_box(count)
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("consolidated", size), &size, |b, _| {
+            b.iter(|| {
+                let mut count = 0usize;
+                for (_, node) in consolidated.iter_all() {
+                    if node.is_some() {
+                        count += 1;
+                    }
+                }
+                black_box(count)
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_memory_size(c: &mut Criterion) {
+    let mut group = c.benchmark_group("trie_updates_memory");
+
+    for size in [100, 1_000, 10_000] {
+        let config = proptest::test_runner::Config::default();
+        let rng = TestRng::deterministic_rng(config.rng_algorithm);
+        let mut runner = TestRunner::new_with_rng(config, rng);
+        let nibbles = generate_nibbles(&mut runner, size);
+        let node = generate_branch_node();
+
+        // Pre-populate with 70% inserts, 30% removes
+        let mut separate = TrieUpdatesSeparate::default();
+        let mut consolidated = TrieUpdatesConsolidated::default();
+        for (i, path) in nibbles.iter().enumerate() {
+            if i % 10 < 7 {
+                separate.insert_node(*path, node.clone());
+                consolidated.insert_node(*path, node.clone());
+            } else {
+                separate.remove_node(*path);
+                consolidated.remove_node(*path);
+            }
+        }
+
+        // Calculate approximate memory usage
+        let separate_size = std::mem::size_of::<TrieUpdatesSeparate>() +
+            separate.account_nodes.capacity() *
+                (std::mem::size_of::<Nibbles>() + std::mem::size_of::<BranchNodeCompact>()) +
+            separate.removed_nodes.capacity() * std::mem::size_of::<Nibbles>();
+
+        let consolidated_size = std::mem::size_of::<TrieUpdatesConsolidated>() +
+            consolidated.nodes.capacity() *
+                (std::mem::size_of::<Nibbles>() +
+                    std::mem::size_of::<Option<BranchNodeCompact>>());
+
+        println!(
+            "Size {}: Separate={} bytes, Consolidated={} bytes, Savings={}%",
+            size,
+            separate_size,
+            consolidated_size,
+            100 - (consolidated_size * 100 / separate_size.max(1))
+        );
+
+        // Benchmark memory allocation overhead
+        group.bench_with_input(BenchmarkId::new("separate_alloc", size), &size, |b, _| {
+            b.iter(|| {
+                let mut updates = TrieUpdatesSeparate::default();
+                for (i, path) in nibbles.iter().enumerate() {
+                    if i % 10 < 7 {
+                        updates.insert_node(*path, node.clone());
+                    } else {
+                        updates.remove_node(*path);
+                    }
+                }
+                black_box((updates.len(), updates.is_empty()))
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("consolidated_alloc", size), &size, |b, _| {
+            b.iter(|| {
+                let mut updates = TrieUpdatesConsolidated::default();
+                for (i, path) in nibbles.iter().enumerate() {
+                    if i % 10 < 7 {
+                        updates.insert_node(*path, node.clone());
+                    } else {
+                        updates.remove_node(*path);
+                    }
+                }
+                black_box((updates.len(), updates.is_empty()))
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    trie_updates,
+    bench_insert,
+    bench_mixed_operations,
+    bench_lookup,
+    bench_extend,
+    bench_iteration,
+    bench_memory_size,
+);
+criterion_main!(trie_updates);

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -9,8 +9,8 @@ use alloy_trie::{BranchNodeCompact, TrieMask, EMPTY_ROOT_HASH};
 use reth_execution_errors::{SparseTrieErrorKind, SparseTrieResult};
 use reth_trie_common::{
     prefix_set::{PrefixSet, PrefixSetMut},
-    BranchNodeRef, ExtensionNodeRef, LeafNodeRef, Nibbles, ProofTrieNode, RlpNode, TrieMasks,
-    TrieNode, CHILD_INDEX_RANGE,
+    BranchNodeMasks, BranchNodeMasksMap, BranchNodeRef, ExtensionNodeRef, LeafNodeRef, Nibbles,
+    ProofTrieNode, RlpNode, TrieMasks, TrieNode, CHILD_INDEX_RANGE,
 };
 use reth_trie_sparse::{
     provider::{RevealedNode, TrieNodeProvider},
@@ -112,10 +112,12 @@ pub struct ParallelSparseTrie {
     prefix_set: PrefixSetMut,
     /// Optional tracking of trie updates for later use.
     updates: Option<SparseTrieUpdates>,
-    /// When a bit is set, the corresponding child subtree is stored in the database.
-    branch_node_tree_masks: HashMap<Nibbles, TrieMask>,
-    /// When a bit is set, the corresponding child is stored as a hash in the database.
-    branch_node_hash_masks: HashMap<Nibbles, TrieMask>,
+    /// Branch node masks containing `tree_mask` and `hash_mask` for each path.
+    /// - `tree_mask`: When a bit is set, the corresponding child subtree is stored in the
+    ///   database.
+    /// - `hash_mask`: When a bit is set, the corresponding child is stored as a hash in the
+    ///   database.
+    branch_node_masks: BranchNodeMasksMap,
     /// Reusable buffer pool used for collecting [`SparseTrieUpdatesAction`]s during hash
     /// computations.
     update_actions_buffers: Vec<Vec<SparseTrieUpdatesAction>>,
@@ -136,8 +138,7 @@ impl Default for ParallelSparseTrie {
             lower_subtries: [const { LowerSparseSubtrie::Blind(None) }; NUM_LOWER_SUBTRIES],
             prefix_set: PrefixSetMut::default(),
             updates: None,
-            branch_node_tree_masks: HashMap::default(),
-            branch_node_hash_masks: HashMap::default(),
+            branch_node_masks: BranchNodeMasksMap::default(),
             update_actions_buffers: Vec::default(),
             parallelism_thresholds: Default::default(),
             #[cfg(feature = "metrics")]
@@ -187,11 +188,14 @@ impl SparseTrieInterface for ParallelSparseTrie {
 
         // Update the top-level branch node masks. This is simple and can't be done in parallel.
         for ProofTrieNode { path, masks, .. } in &nodes {
-            if let Some(tree_mask) = masks.tree_mask {
-                self.branch_node_tree_masks.insert(*path, tree_mask);
-            }
-            if let Some(hash_mask) = masks.hash_mask {
-                self.branch_node_hash_masks.insert(*path, hash_mask);
+            if masks.tree_mask.is_some() || masks.hash_mask.is_some() {
+                self.branch_node_masks.insert(
+                    *path,
+                    BranchNodeMasks {
+                        tree_mask: masks.tree_mask.unwrap_or_default(),
+                        hash_mask: masks.hash_mask.unwrap_or_default(),
+                    },
+                );
             }
         }
 
@@ -719,8 +723,7 @@ impl SparseTrieInterface for ParallelSparseTrie {
                 changed_subtrie.subtrie.update_hashes(
                     &mut changed_subtrie.prefix_set,
                     &mut changed_subtrie.update_actions_buf,
-                    &self.branch_node_tree_masks,
-                    &self.branch_node_hash_masks,
+                    &self.branch_node_masks,
                 );
             }
 
@@ -736,8 +739,7 @@ impl SparseTrieInterface for ParallelSparseTrie {
         {
             use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
-            let branch_node_tree_masks = &self.branch_node_tree_masks;
-            let branch_node_hash_masks = &self.branch_node_hash_masks;
+            let branch_node_masks = &self.branch_node_masks;
             let updated_subtries: Vec<_> = changed_subtries
                 .into_par_iter()
                 .map(|mut changed_subtrie| {
@@ -746,8 +748,7 @@ impl SparseTrieInterface for ParallelSparseTrie {
                     changed_subtrie.subtrie.update_hashes(
                         &mut changed_subtrie.prefix_set,
                         &mut changed_subtrie.update_actions_buf,
-                        branch_node_tree_masks,
-                        branch_node_hash_masks,
+                        branch_node_masks,
                     );
                     #[cfg(feature = "metrics")]
                     self.metrics.subtrie_hash_update_latency.record(start.elapsed());
@@ -786,8 +787,7 @@ impl SparseTrieInterface for ParallelSparseTrie {
         }
         self.prefix_set.clear();
         self.updates = None;
-        self.branch_node_tree_masks.clear();
-        self.branch_node_hash_masks.clear();
+        self.branch_node_masks.clear();
         // `update_actions_buffers` doesn't need to be cleared; we want to reuse the Vecs it has
         // buffered, and all of those are already inherently cleared when they get used.
     }
@@ -870,9 +870,8 @@ impl SparseTrieInterface for ParallelSparseTrie {
             subtrie.shrink_nodes_to(size_per_subtrie);
         }
 
-        // shrink masks maps
-        self.branch_node_hash_masks.shrink_to(size);
-        self.branch_node_tree_masks.shrink_to(size);
+        // shrink masks map
+        self.branch_node_masks.shrink_to(size);
     }
 
     fn shrink_values_to(&mut self, size: usize) {
@@ -1377,8 +1376,7 @@ impl ParallelSparseTrie {
                 &mut update_actions_buf,
                 stack_item,
                 node,
-                &self.branch_node_tree_masks,
-                &self.branch_node_hash_masks,
+                &self.branch_node_masks,
             );
         }
 
@@ -2047,8 +2045,7 @@ impl SparseSubtrie {
     /// - `update_actions`: A buffer which `SparseTrieUpdatesAction`s will be written to in the
     ///   event that any changes to the top-level updates are required. If None then update
     ///   retention is disabled.
-    /// - `branch_node_tree_masks`: The tree masks for branch nodes
-    /// - `branch_node_hash_masks`: The hash masks for branch nodes
+    /// - `branch_node_masks`: The tree and hash masks for branch nodes.
     ///
     /// # Returns
     ///
@@ -2062,8 +2059,7 @@ impl SparseSubtrie {
         &mut self,
         prefix_set: &mut PrefixSet,
         update_actions: &mut Option<Vec<SparseTrieUpdatesAction>>,
-        branch_node_tree_masks: &HashMap<Nibbles, TrieMask>,
-        branch_node_hash_masks: &HashMap<Nibbles, TrieMask>,
+        branch_node_masks: &BranchNodeMasksMap,
     ) -> RlpNode {
         trace!(target: "trie::parallel_sparse", "Updating subtrie hashes");
 
@@ -2082,14 +2078,7 @@ impl SparseSubtrie {
                 .get_mut(&path)
                 .unwrap_or_else(|| panic!("node at path {path:?} does not exist"));
 
-            self.inner.rlp_node(
-                prefix_set,
-                update_actions,
-                stack_item,
-                node,
-                branch_node_tree_masks,
-                branch_node_hash_masks,
-            );
+            self.inner.rlp_node(prefix_set, update_actions, stack_item, node, branch_node_masks);
         }
 
         debug_assert_eq!(self.inner.buffers.rlp_node_stack.len(), 1);
@@ -2149,8 +2138,7 @@ impl SparseSubtrieInner {
     ///   retention is disabled.
     /// - `stack_item`: The stack item to process
     /// - `node`: The sparse node to process (will be mutated to update hash)
-    /// - `branch_node_tree_masks`: The tree masks for branch nodes
-    /// - `branch_node_hash_masks`: The hash masks for branch nodes
+    /// - `branch_node_masks`: The tree and hash masks for branch nodes.
     ///
     /// # Side Effects
     ///
@@ -2168,8 +2156,7 @@ impl SparseSubtrieInner {
         update_actions: &mut Option<Vec<SparseTrieUpdatesAction>>,
         mut stack_item: RlpNodePathStackItem,
         node: &mut SparseNode,
-        branch_node_tree_masks: &HashMap<Nibbles, TrieMask>,
-        branch_node_hash_masks: &HashMap<Nibbles, TrieMask>,
+        branch_node_masks: &BranchNodeMasksMap,
     ) {
         let path = stack_item.path;
         trace!(
@@ -2303,6 +2290,12 @@ impl SparseSubtrieInner {
                 let mut tree_mask = TrieMask::default();
                 let mut hash_mask = TrieMask::default();
                 let mut hashes = Vec::new();
+
+                // Lazy lookup for branch node masks - shared across loop iterations
+                let mut path_masks_storage = None;
+                let mut path_masks =
+                    || *path_masks_storage.get_or_insert_with(|| branch_node_masks.get(&path));
+
                 for (i, child_path) in self.buffers.branch_child_buf.iter().enumerate() {
                     if self.buffers.rlp_node_stack.last().is_some_and(|e| &e.path == child_path) {
                         let RlpNodeStackItem {
@@ -2326,9 +2319,9 @@ impl SparseSubtrieInner {
                             } else {
                                 // A blinded node has the tree mask bit set
                                 child_node_type.is_hash() &&
-                                    branch_node_tree_masks
-                                        .get(&path)
-                                        .is_some_and(|mask| mask.is_bit_set(last_child_nibble))
+                                    path_masks().is_some_and(|masks| {
+                                        masks.tree_mask.is_bit_set(last_child_nibble)
+                                    })
                             };
                             if should_set_tree_mask_bit {
                                 tree_mask.set_bit(last_child_nibble);
@@ -2340,9 +2333,9 @@ impl SparseSubtrieInner {
                             let hash = child.as_hash().filter(|_| {
                                 child_node_type.is_branch() ||
                                     (child_node_type.is_hash() &&
-                                        branch_node_hash_masks.get(&path).is_some_and(
-                                            |mask| mask.is_bit_set(last_child_nibble),
-                                        ))
+                                        path_masks().is_some_and(|masks| {
+                                            masks.hash_mask.is_bit_set(last_child_nibble)
+                                        }))
                             });
                             if let Some(hash) = hash {
                                 hash_mask.set_bit(last_child_nibble);
@@ -2409,19 +2402,17 @@ impl SparseSubtrieInner {
                         );
                         update_actions
                             .push(SparseTrieUpdatesAction::InsertUpdated(path, branch_node));
-                    } else if branch_node_tree_masks.get(&path).is_some_and(|mask| !mask.is_empty()) ||
-                        branch_node_hash_masks.get(&path).is_some_and(|mask| !mask.is_empty())
-                    {
-                        // If new tree and hash masks are empty, but previously they weren't, we
-                        // need to remove the node update and add the node itself to the list of
-                        // removed nodes.
-                        update_actions.push(SparseTrieUpdatesAction::InsertRemoved(path));
-                    } else if branch_node_tree_masks.get(&path).is_none_or(|mask| mask.is_empty()) &&
-                        branch_node_hash_masks.get(&path).is_none_or(|mask| mask.is_empty())
-                    {
-                        // If new tree and hash masks are empty, and they were previously empty
-                        // as well, we need to remove the node update.
-                        update_actions.push(SparseTrieUpdatesAction::RemoveUpdated(path));
+                    } else {
+                        // New tree and hash masks are empty - check previous state
+                        let prev_had_masks = path_masks()
+                            .is_some_and(|m| !m.tree_mask.is_empty() || !m.hash_mask.is_empty());
+                        if prev_had_masks {
+                            // Previously had masks, now empty - mark as removed
+                            update_actions.push(SparseTrieUpdatesAction::InsertRemoved(path));
+                        } else {
+                            // Previously empty too - just remove the update
+                            update_actions.push(SparseTrieUpdatesAction::RemoveUpdated(path));
+                        }
                     }
 
                     store_in_db_trie
@@ -2667,8 +2658,8 @@ mod tests {
         prefix_set::PrefixSetMut,
         proof::{ProofNodes, ProofRetainer},
         updates::TrieUpdates,
-        BranchNode, ExtensionNode, HashBuilder, LeafNode, ProofTrieNode, RlpNode, TrieMask,
-        TrieMasks, TrieNode, EMPTY_ROOT_HASH,
+        BranchNode, BranchNodeMasksMap, ExtensionNode, HashBuilder, LeafNode, ProofTrieNode,
+        RlpNode, TrieMask, TrieMasks, TrieNode, EMPTY_ROOT_HASH,
     };
     use reth_trie_db::DatabaseTrieCursorFactory;
     use reth_trie_sparse::{
@@ -3608,8 +3599,7 @@ mod tests {
             &mut PrefixSetMut::from([leaf_1_full_path, leaf_2_full_path, leaf_3_full_path])
                 .freeze(),
             &mut None,
-            &HashMap::default(),
-            &HashMap::default(),
+            &BranchNodeMasksMap::default(),
         );
 
         // Compare hashes between hash builder and subtrie

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -376,7 +376,12 @@ mod tests {
         let mut trie_updates = TrieUpdates::default();
         trie_updates.finalize(hash_builder, Default::default(), Default::default());
 
-        trie_updates.account_nodes
+        // Extract only updated nodes (Some), not removed nodes (None)
+        trie_updates
+            .account_nodes
+            .into_iter()
+            .filter_map(|(k, v)| v.map(|node| (k, node)))
+            .collect()
     }
 
     #[test]

--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -369,9 +369,13 @@ impl StateRootContext {
         K: AsRef<AddedRemovedKeys>,
     {
         let (walker_stack, walker_deleted_keys) = account_node_iter.walker.split();
-        self.trie_updates.removed_nodes.extend(walker_deleted_keys);
+        // Add removed nodes as None entries
+        self.trie_updates.account_nodes.extend(walker_deleted_keys.into_iter().map(|k| (k, None)));
         let (hash_builder, hash_builder_updates) = hash_builder.split();
-        self.trie_updates.account_nodes.extend(hash_builder_updates);
+        // Add updated nodes as Some entries
+        self.trie_updates
+            .account_nodes
+            .extend(hash_builder_updates.into_iter().map(|(k, v)| (k, Some(v))));
 
         let account_state = IntermediateRootState { hash_builder, walker_stack, last_hashed_key };
 

--- a/crates/trie/trie/src/trie_cursor/mock.rs
+++ b/crates/trie/trie/src/trie_cursor/mock.rs
@@ -40,9 +40,12 @@ impl MockTrieCursorFactory {
 
     /// Creates a new mock trie cursor factory from `TrieUpdates`.
     pub fn from_trie_updates(updates: TrieUpdates) -> Self {
-        // Convert account nodes from HashMap to BTreeMap
-        let account_trie_nodes: BTreeMap<Nibbles, BranchNodeCompact> =
-            updates.account_nodes.into_iter().collect();
+        // Convert account nodes from HashMap to BTreeMap (only updated nodes, not removed)
+        let account_trie_nodes: BTreeMap<Nibbles, BranchNodeCompact> = updates
+            .account_nodes
+            .into_iter()
+            .filter_map(|(k, v)| v.map(|node| (k, node)))
+            .collect();
 
         // Convert storage tries
         let storage_tries: B256Map<BTreeMap<Nibbles, BranchNodeCompact>> = updates

--- a/crates/trie/trie/src/verify.rs
+++ b/crates/trie/trie/src/verify.rs
@@ -119,7 +119,10 @@ impl<H: HashedCursorFactory + Clone> Iterator for StateRootBranchNodesIter<H> {
 
             // collect account updates and sort them in descending order, so that when we pop them
             // off the Vec they are popped in ascending order.
-            self.account_nodes.extend(updates.account_nodes);
+            // Only include updated nodes (Some), not removed nodes (None)
+            self.account_nodes.extend(
+                updates.account_nodes.into_iter().filter_map(|(k, v)| v.map(|node| (k, node))),
+            );
             Self::sort_updates(&mut self.account_nodes);
 
             self.storage_tries = updates


### PR DESCRIPTION
**Problem**
`TrieUpdates` maintains separate data structures for updated and removed nodes:
- `account_nodes: HashMap<Nibbles, BranchNodeCompact>` 
- `removed_nodes: HashSet<Nibbles>`

This creates redundant storage overhead and requires iterating over two collections when processing trie updates.

**Solution**
Consolidate into a single `HashMap<Nibbles, Option<BranchNodeCompact>>` where:
- `Some(node)` = updated node
- `None` = removed node

This leverages Rust's niche optimization - `Option<BranchNodeCompact>` is the same size (48 bytes) as `BranchNodeCompact` due to the internal `Vec` pointer.

**Changes**
- Modified `TrieUpdates` struct to use consolidated format
- Updated `finalize()` to add removed keys first, then updated nodes (updates take precedence)
- Updated all dependent crates: `reth-trie`, `reth-trie-sparse`, `reth-trie-sparse-parallel`, `reth-engine-tree`, `reth-trie-db`
- Added benchmark for trie updates operations

**Expected Impact**
- Reduced memory overhead (one HashMap allocation instead of HashMap + HashSet)
- Improved cache locality when iterating over trie updates
- Simpler API with single collection to iterate