### PR TITLE
docs(eth-wire): add missing eth/70 message types

### DIFF
--- a/docs/crates/eth-wire.md
+++ b/docs/crates/eth-wire.md
@@ -41,9 +41,12 @@ pub enum EthMessage<N: NetworkPrimitives = EthNetworkPrimitives> {
     GetNodeData(RequestPair<GetNodeData>),
     NodeData(RequestPair<NodeData>),
     GetReceipts(RequestPair<GetReceipts>),
+    GetReceipts70(RequestPair<GetReceipts70>),
     Receipts(RequestPair<Receipts<N::Receipt>>),
     Receipts69(RequestPair<Receipts69<N::Receipt>>),
+    Receipts70(RequestPair<Receipts70<N::Receipt>>),
     BlockRangeUpdate(BlockRangeUpdate),
+    Other(RawCapabilityMessage),
 }
 
 /// Represents message IDs for eth protocol messages.
@@ -66,6 +69,7 @@ pub enum EthMessageID {
     GetReceipts = 0x0f,
     Receipts = 0x10,
     BlockRangeUpdate = 0x11,
+    Other(u8),
 }
 
 ```


### PR DESCRIPTION
Adds missing GetReceipts70, Receipts70, and Other variants to EthMessage and EthMessageID enums in documentation, syncs with current API implementation.