### PR TITLE
docs(network): update Swarm struct to use NetworkPrimitives generic

### DIFF
--- a/docs/crates/network.md
+++ b/docs/crates/network.md
@@ -183,13 +183,13 @@ The discovery task progresses as the network management task is polled, handling
 
 [File: crates/net/network/src/swarm.rs](https://github.com/paradigmxyz/reth/blob/1563506aea09049a85e5cc72c2894f3f7a371581/crates/net/network/src/swarm.rs)
 ```rust,ignore
-pub(crate) struct Swarm<C> {
+pub(crate) struct Swarm<N: NetworkPrimitives = EthNetworkPrimitives> {
     /// Listens for new incoming connections.
     incoming: ConnectionListener,
     /// All sessions.
-    sessions: SessionManager,
+    sessions: SessionManager<N>,
     /// Tracks the entire state of the network and handles events received from the sessions.
-    state: NetworkState<C>,
+    state: NetworkState<N>,
 }
 ```
 


### PR DESCRIPTION
The documentation in `docs/crates/network.md` shows an outdated `Swarm` struct definition that uses the generic parameter `<C>` instead of `<N: NetworkPrimitives>`. This inconsistency makes it harder for developers to understand how the Swarm component works with different network types.