### PR TITLE
feat: avoid mutex locking

### DIFF
--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -309,18 +309,18 @@ where
 
     #[inline]
     fn has_event_listeners(&self) -> bool {
-        self.has_event_listeners.load(Ordering::Acquire)
+        self.has_event_listeners.load(Ordering::Relaxed)
     }
 
     #[inline]
     fn mark_event_listener_installed(&self) {
-        self.has_event_listeners.store(true, Ordering::Release);
+        self.has_event_listeners.store(true, Ordering::Relaxed);
     }
 
     #[inline]
     fn update_event_listener_state(&self, listener: &PoolEventBroadcast<T::Transaction>) {
         if listener.is_empty() {
-            self.has_event_listeners.store(false, Ordering::Release);
+            self.has_event_listeners.store(false, Ordering::Relaxed);
         }
     }
 
@@ -850,7 +850,7 @@ where
             for tx in &discarded {
                 listener.discarded(tx.hash());
             }
-        });
+        })
     }
 
     /// Notifies all listeners about the transaction movements.

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -325,7 +325,7 @@ where
     }
 
     #[inline]
-    fn with_event_listener<F>(&self, f: F)
+    fn with_event_listener<F>(&self, emit: F)
     where
         F: FnOnce(&mut PoolEventBroadcast<T::Transaction>),
     {
@@ -334,7 +334,7 @@ where
         }
         let mut listener = self.event_listener.write();
         if !listener.is_empty() {
-            f(&mut listener);
+            emit(&mut listener);
         }
         self.update_event_listener_state(&listener);
     }


### PR DESCRIPTION
This closes issue #20667
### ChangeSet

-  Implemented an event-listener fast path in the txpool to avoid acquiring the event_listener write lock when no listeners are present 

- Added an atomic listener-activity flag that is set on first subscription and can be reset when all listeners are gone

- Centralized the repeated lock/check/broadcast/update pattern into a single helper (with_event_listener) to reduce duplication and keep the event emission logic cohesive.

cc @mattsse 