### PR TITLE
perf: pre-alloc removed vec

### DIFF
--- a/crates/transaction-pool/src/config.rs
+++ b/crates/transaction-pool/src/config.rs
@@ -158,6 +158,11 @@ impl SubPoolLimit {
     pub const fn is_exceeded(&self, txs: usize, size: usize) -> bool {
         self.max_txs < txs || self.max_size < size
     }
+
+    /// Returns how many transactions exceed the configured limit.
+    pub const fn tx_excess(&self, txs: usize) -> Option<usize> {
+        txs.checked_sub(self.max_txs)
+    }
 }
 
 impl Mul<usize> for SubPoolLimit {

--- a/crates/transaction-pool/src/pool/parked.rs
+++ b/crates/transaction-pool/src/pool/parked.rs
@@ -180,7 +180,7 @@ impl<T: ParkedOrd> ParkedPool<T> {
             return Vec::new()
         }
 
-        let mut removed = Vec::new();
+        let mut removed = Vec::with_capacity(limit.tx_excess(self.len()).unwrap_or(1));
 
         while !self.last_sender_submission.is_empty() && limit.is_exceeded(self.len(), self.size())
         {


### PR DESCRIPTION
this will always fill at least `max(1, count - limit)` transactions, so we can pre-alloc this