### PR TITLE
chore(tree): use with_capacity at collect_blocks_for_canonical_unwind()

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -825,7 +825,8 @@ where
         new_head_number: u64,
         current_head_number: u64,
     ) -> Vec<ExecutedBlock<N>> {
-        let mut old_blocks = Vec::with_capacity((current_head_number.saturating_sub(new_head_number)) as usize);
+        let mut old_blocks =
+            Vec::with_capacity((current_head_number.saturating_sub(new_head_number)) as usize);
 
         for block_num in (new_head_number + 1)..=current_head_number {
             if let Some(block_state) = self.canonical_in_memory_state.state_by_number(block_num) {

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -825,7 +825,7 @@ where
         new_head_number: u64,
         current_head_number: u64,
     ) -> Vec<ExecutedBlock<N>> {
-        let mut old_blocks = Vec::new();
+        let mut old_blocks = Vec::with_capacity((current_head_number.saturating_sub(new_head_number)) as usize);
 
         for block_num in (new_head_number + 1)..=current_head_number {
             if let Some(block_state) = self.canonical_in_memory_state.state_by_number(block_num) {


### PR DESCRIPTION
pre allocates vector with `current_head_number.saturating_sub(new_head_number)` 

current_head_number() < new_head_number() should never happen but i think saturating_sub() makes that more clear and doesn't add any complexity