### PR TITLE
fix(config): call validate() when loading static file config

### DIFF
--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -1173,90 +1173,35 @@ connect_trusted_nodes_only = true
 
     #[test]
     fn test_static_files_config_validation_on_load() {
-        // Create invalid configuration with headers blocks_per_file set to 0
-        let invalid_toml = r#"
-[static_files.blocks_per_file]
-headers = 0
-"#;
+        let invalid_toml = r#"[static_files.blocks_per_file]
+headers = 0"#;
 
-        // Create a temporary directory for the config file
-        let config_dir = tempfile::tempdir().expect("creating test fixture failed");
-        let config_path =
-            config_dir.path().join("example-app").join("test-config").with_extension("toml");
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.toml");
+        std::fs::write(&path, invalid_toml).unwrap();
 
-        // Create the parent directory if it doesn't exist
-        if let Some(parent) = config_path.parent() {
-            std::fs::create_dir_all(parent).expect("Failed to create directories");
-        }
-
-        // Write invalid TOML data to the file
-        std::fs::write(&config_path, invalid_toml).expect("Failed to write invalid config");
-
-        // Attempt to load the config should fail due to validation
-        let result = Config::from_path(&config_path);
+        let result = Config::from_path(&path);
         assert!(result.is_err());
-        let err = result.unwrap_err().to_string();
-        assert!(
-            err.contains("Headers segment blocks per file must be greater than 0"),
-            "Expected validation error, got: {}",
-            err
-        );
-
-        config_dir.close().expect("removing test fixture failed");
+        assert!(result.unwrap_err().to_string().contains("Headers segment"));
     }
 
     #[test]
     fn test_static_files_config_validation_all_segments() {
-        // Test that all segment validations work
-        let test_cases = vec![
-            (
-                r#"[static_files.blocks_per_file]
-headers = 0"#,
-                "Headers segment blocks per file must be greater than 0",
-            ),
-            (
-                r#"[static_files.blocks_per_file]
-transactions = 0"#,
-                "Transactions segment blocks per file must be greater than 0",
-            ),
-            (
-                r#"[static_files.blocks_per_file]
-receipts = 0"#,
-                "Receipts segment blocks per file must be greater than 0",
-            ),
-            (
-                r#"[static_files.blocks_per_file]
-transaction_senders = 0"#,
-                "Transaction senders segment blocks per file must be greater than 0",
-            ),
+        let cases = [
+            ("headers = 0", "Headers segment"),
+            ("transactions = 0", "Transactions segment"),
+            ("receipts = 0", "Receipts segment"),
+            ("transaction_senders = 0", "Transaction senders segment"),
         ];
 
-        for (invalid_toml, expected_error) in test_cases {
-            // Create a temporary directory for the config file
-            let config_dir = tempfile::tempdir().expect("creating test fixture failed");
-            let config_path =
-                config_dir.path().join("example-app").join("test-config").with_extension("toml");
+        for (field, expected) in cases {
+            let toml = format!("[static_files.blocks_per_file]\n{}", field);
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("test.toml");
+            std::fs::write(&path, toml).unwrap();
 
-            // Create the parent directory if it doesn't exist
-            if let Some(parent) = config_path.parent() {
-                std::fs::create_dir_all(parent).expect("Failed to create directories");
-            }
-
-            // Write invalid TOML data to the file
-            std::fs::write(&config_path, invalid_toml).expect("Failed to write invalid config");
-
-            // Attempt to load the config should fail due to validation
-            let result = Config::from_path(&config_path);
-            assert!(result.is_err());
-            let err = result.unwrap_err().to_string();
-            assert!(
-                err.contains(expected_error),
-                "Expected '{}', got: {}",
-                expected_error,
-                err
-            );
-
-            config_dir.close().expect("removing test fixture failed");
+            let err = Config::from_path(&path).unwrap_err().to_string();
+            assert!(err.contains(expected), "expected '{}' in: {}", expected, err);
         }
     }
 }


### PR DESCRIPTION
validate() was already implemented but never called in from_path(), so invalid blocks_per_file values (like 0) would only blow up at runtime.

now we validate right after parsing.