### PR TITLE
chore: update todo

### DIFF
--- a/crates/rpc/rpc/src/eth/pubsub.rs
+++ b/crates/rpc/rpc/src/eth/pubsub.rs
@@ -193,7 +193,7 @@ where
                 Ok(())
             }
             _ => {
-                // TODO: implement once https://github.com/alloy-rs/alloy/pull/2974 is released
+                // TODO: implement once https://github.com/alloy-rs/alloy/pull/3410 is released
                 Err(invalid_params_rpc_err("Unsupported subscription kind"))
             }
         }


### PR DESCRIPTION
https://github.com/alloy-rs/alloy/pull/2974 had been merged and release with revert in https://github.com/alloy-rs/alloy/pull/3409.   
and maybe needs to wait for https://github.com/alloy-rs/alloy/pull/3410 release.  