### PR TITLE
fix(era): correct error messages in CompressedBody and CompressedReceipts

### DIFF
--- a/crates/era/src/era1/types/execution.rs
+++ b/crates/era/src/era1/types/execution.rs
@@ -252,7 +252,7 @@ impl CompressedBody {
             let mut encoder = FrameEncoder::new(&mut compressed);
 
             Write::write_all(&mut encoder, rlp_data).map_err(|e| {
-                E2sError::SnappyCompression(format!("Failed to compress header: {e}"))
+                E2sError::SnappyCompression(format!("Failed to compress body: {e}"))
             })?;
 
             encoder.flush().map_err(|e| {
@@ -339,7 +339,7 @@ impl CompressedReceipts {
             let mut encoder = FrameEncoder::new(&mut compressed);
 
             Write::write_all(&mut encoder, rlp_data).map_err(|e| {
-                E2sError::SnappyCompression(format!("Failed to compress header: {e}"))
+                E2sError::SnappyCompression(format!("Failed to compress receipts: {e}"))
             })?;
 
             encoder.flush().map_err(|e| {


### PR DESCRIPTION
Fixed wrong error messages in CompressedBody and CompressedReceipts. 
They were saying "header" instead of "body" and "receipts" respectively.