### PR TITLE
refactor(stages): extract IncrementalSettings struct from MerkleStage

### DIFF
--- a/crates/cli/commands/src/stage/dump/merkle.rs
+++ b/crates/cli/commands/src/stage/dump/merkle.rs
@@ -160,11 +160,11 @@ where
     info!(target: "reth::cli", "Executing stage.");
     let provider = output_provider_factory.database_provider_rw()?;
 
-    let mut stage = MerkleStage::Execution {
+    let mut stage = MerkleStage::Execution(reth_stages::stages::IncrementalSettings {
         // Forces updating the root instead of calculating from scratch
         rebuild_threshold: u64::MAX,
         incremental_threshold: u64::MAX,
-    };
+    });
 
     loop {
         let input = reth_stages::ExecInput {

--- a/crates/stages/stages/benches/criterion.rs
+++ b/crates/stages/stages/benches/criterion.rs
@@ -9,7 +9,7 @@ use reth_provider::{
     test_utils::MockNodeTypesWithDB, DBProvider, DatabaseProvider, DatabaseProviderFactory,
 };
 use reth_stages::{
-    stages::{MerkleStage, SenderRecoveryStage, TransactionLookupStage},
+    stages::{IncrementalSettings, MerkleStage, SenderRecoveryStage, TransactionLookupStage},
     test_utils::TestStageDB,
     StageCheckpoint,
 };
@@ -115,7 +115,10 @@ fn merkle(c: &mut Criterion, runtime: &Runtime) {
 
     let db = setup::txs_testdata(DEFAULT_NUM_BLOCKS);
 
-    let stage = MerkleStage::Both { rebuild_threshold: u64::MAX, incremental_threshold: u64::MAX };
+    let stage = MerkleStage::Both(IncrementalSettings {
+        rebuild_threshold: u64::MAX,
+        incremental_threshold: u64::MAX,
+    });
     measure_stage(
         runtime,
         &mut group,
@@ -126,7 +129,8 @@ fn merkle(c: &mut Criterion, runtime: &Runtime) {
         "Merkle-incremental".to_string(),
     );
 
-    let stage = MerkleStage::Both { rebuild_threshold: 0, incremental_threshold: 0 };
+    let stage =
+        MerkleStage::Both(IncrementalSettings { rebuild_threshold: 0, incremental_threshold: 0 });
     measure_stage(
         runtime,
         &mut group,

--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -228,8 +228,8 @@ where
             }
             .unwrap_or(EntitiesCheckpoint {
                 processed: 0,
-                total: (provider.count_entries::<tables::HashedAccounts>()?
-                    + provider.count_entries::<tables::HashedStorages>()?)
+                total: (provider.count_entries::<tables::HashedAccounts>()? +
+                    provider.count_entries::<tables::HashedStorages>()?)
                     as u64,
             });
 
@@ -323,8 +323,8 @@ where
                 "Incremental merkle hashing did not produce a final root".into(),
             ))?;
 
-            let total_hashed_entries = (provider.count_entries::<tables::HashedAccounts>()?
-                + provider.count_entries::<tables::HashedStorages>()?)
+            let total_hashed_entries = (provider.count_entries::<tables::HashedAccounts>()? +
+                provider.count_entries::<tables::HashedStorages>()?)
                 as u64;
 
             let entities_checkpoint = EntitiesCheckpoint {
@@ -366,8 +366,8 @@ where
         let mut entities_checkpoint =
             input.checkpoint.entities_stage_checkpoint().unwrap_or(EntitiesCheckpoint {
                 processed: 0,
-                total: (tx.entries::<tables::HashedAccounts>()?
-                    + tx.entries::<tables::HashedStorages>()?) as u64,
+                total: (tx.entries::<tables::HashedAccounts>()? +
+                    tx.entries::<tables::HashedStorages>()?) as u64,
             });
 
         if input.unwind_to == 0 {


### PR DESCRIPTION
refactor(stages): extract IncrementalSettings struct from MerkleStage

## Problem

The `MerkleStage` enum duplicated the `rebuild_threshold` and `incremental_threshold` fields across both the `Execution` and `Both` variants. This required making the same changes in multiple places when modifying threshold-related behavior, increasing maintenance overhead and the risk of inconsistencies.

## Analysis

Both variants use these thresholds in exactly the same way inside `execute()`: they determine when to rebuild the trie versus apply incremental updates, and they control the chunk size in incremental mode. The `unwind()` path does not reference these values at all. The only behavioral difference between the variants is that `Execution` skips unwind, while `Both` supports both execution and unwind. No behavioral changes are introduced by this refactor, making it safe to consolidate the duplicated fields.

## Solution

Introduce a new `IncrementalSettings` struct that encapsulates both threshold fields and provides a `Default` implementation. The relevant `MerkleStage` variants now store this struct instead of duplicating the fields. This refactor is purely structural and does not change stage semantics or public behavior.

## Changes

- `crates/stages/stages/src/stages/merkle.rs`: added `IncrementalSettings`, updated enum variants, and adjusted match patterns
- `crates/cli/commands/src/stage/dump/merkle.rs`: updated `MerkleStage::Execution` construction
- `crates/stages/stages/benches/criterion.rs`: updated `MerkleStage::Both` construction

Code paths using `new_execution()` or `default_unwind()` required no changes.

## Verification

- All 104 tests in `reth-stages` passed
- Full workspace build succeeded
- Clippy passed with no warnings