### PR TITLE
perf(era-utils): replace Box<dyn Fn> with function pointer

### DIFF
--- a/crates/era-utils/src/history.rs
+++ b/crates/era-utils/src/history.rs
@@ -170,18 +170,14 @@ where
     <P as NodePrimitivesProvider>::Primitives: NodePrimitives<BlockHeader = BH, BlockBody = BB>,
 {
     let reader = open(meta)?;
-    let iter =
-        reader
-            .iter()
-            .map(Box::new(decode)
-                as Box<dyn Fn(Result<BlockTuple, E2sError>) -> eyre::Result<(BH, BB)>>);
+    let iter = reader.iter().map(decode as fn(_) -> _);
     let iter = ProcessIter { iter, era: meta };
 
     process_iter(iter, writer, provider, hash_collector, block_numbers)
 }
 
 type ProcessInnerIter<R, BH, BB> =
-    Map<BlockTupleIterator<R>, Box<dyn Fn(Result<BlockTuple, E2sError>) -> eyre::Result<(BH, BB)>>>;
+    Map<BlockTupleIterator<R>, fn(Result<BlockTuple, E2sError>) -> eyre::Result<(BH, BB)>>;
 
 /// An iterator that wraps era file extraction. After the final item [`EraMeta::mark_as_processed`]
 /// is called to ensure proper cleanup.


### PR DESCRIPTION
The `decode` function is a pure function that doesn't capture any state, so using `Box<dyn Fn>` was unnecessary overhead.

This change:
- Removes heap allocation from `Box::new(decode)`
- Eliminates dynamic dispatch (vtable lookup) on each iterator call
- Simplifies the code from 5 lines to 1 line

The function pointer `fn(...)` is sufficient since `decode` doesn't need to capture any environment.