### PR TITLE
feat(cli): make Cli extensible with custom subcommands

### DIFF
--- a/crates/ethereum/cli/src/app.rs
+++ b/crates/ethereum/cli/src/app.rs
@@ -1,4 +1,8 @@
-use crate::{interface::Commands, Cli};
+use crate::{
+    interface::{Commands, NoSubCmd},
+    Cli,
+};
+use clap::Subcommand;
 use eyre::{eyre, Result};
 use reth_chainspec::{ChainSpec, EthChainSpec, Hardforks};
 use reth_cli::chainspec::ChainSpecParser;
@@ -18,20 +22,26 @@ use std::{fmt, sync::Arc};
 
 /// A wrapper around a parsed CLI that handles command execution.
 #[derive(Debug)]
-pub struct CliApp<Spec: ChainSpecParser, Ext: clap::Args + fmt::Debug, Rpc: RpcModuleValidator> {
-    cli: Cli<Spec, Ext, Rpc>,
+pub struct CliApp<
+    Spec: ChainSpecParser,
+    Ext: clap::Args + fmt::Debug,
+    Rpc: RpcModuleValidator,
+    SubCmd: Subcommand + fmt::Debug = NoSubCmd,
+> {
+    cli: Cli<Spec, Ext, Rpc, SubCmd>,
     runner: Option<CliRunner>,
     layers: Option<Layers>,
     guard: Option<FileWorkerGuard>,
 }
 
-impl<C, Ext, Rpc> CliApp<C, Ext, Rpc>
+impl<C, Ext, Rpc, SubCmd> CliApp<C, Ext, Rpc, SubCmd>
 where
     C: ChainSpecParser,
     Ext: clap::Args + fmt::Debug,
     Rpc: RpcModuleValidator,
+    SubCmd: ExtendedCommand + Subcommand + fmt::Debug,
 {
-    pub(crate) fn new(cli: Cli<C, Ext, Rpc>) -> Self {
+    pub(crate) fn new(cli: Cli<C, Ext, Rpc, SubCmd>) -> Self {
         Self { cli, runner: None, layers: Some(Layers::new()), guard: None }
     }
 
@@ -100,7 +110,7 @@ where
         // Install the prometheus recorder to be sure to record all metrics
         let _ = install_prometheus_recorder();
 
-        run_commands_with::<C, Ext, Rpc, N>(self.cli, runner, components, launcher)
+        run_commands_with::<C, Ext, Rpc, N, SubCmd>(self.cli, runner, components, launcher)
     }
 
     /// Initializes tracing with the configured options.
@@ -117,8 +127,8 @@ where
 
 /// Run CLI commands with the provided runner, components and launcher.
 /// This is the shared implementation used by both `CliApp` and Cli methods.
-pub(crate) fn run_commands_with<C, Ext, Rpc, N>(
-    cli: Cli<C, Ext, Rpc>,
+pub(crate) fn run_commands_with<C, Ext, Rpc, N, SubCmd>(
+    cli: Cli<C, Ext, Rpc, SubCmd>,
     runner: CliRunner,
     components: impl CliComponentsBuilder<N>,
     launcher: impl AsyncFnOnce(
@@ -131,6 +141,7 @@ where
     Ext: clap::Args + fmt::Debug,
     Rpc: RpcModuleValidator,
     N: CliNodeTypes<Primitives: NodePrimitives<BlockHeader: HeaderMut>, ChainSpec: Hardforks>,
+    SubCmd: ExtendedCommand + Subcommand + fmt::Debug,
 {
     match cli.command {
         Commands::Node(command) => {
@@ -167,7 +178,17 @@ where
         #[cfg(feature = "dev")]
         Commands::TestVectors(command) => runner.run_until_ctrl_c(command.execute()),
         Commands::ReExecute(command) => runner.run_until_ctrl_c(command.execute::<N>(components)),
+        Commands::Ext(command) => command.execute(runner),
     }
+}
+
+/// A trait for extension subcommands that can be added to the CLI.
+///
+/// Consumers implement this trait for their custom subcommands to define
+/// how they should be executed.
+pub trait ExtendedCommand {
+    /// Execute the extension command with the provided CLI runner.
+    fn execute(self, runner: CliRunner) -> Result<()>;
 }
 
 #[cfg(test)]

--- a/crates/ethereum/cli/src/lib.rs
+++ b/crates/ethereum/cli/src/lib.rs
@@ -14,8 +14,8 @@ pub mod app;
 pub mod chainspec;
 pub mod interface;
 
-pub use app::CliApp;
-pub use interface::{Cli, Commands};
+pub use app::{CliApp, ExtendedCommand};
+pub use interface::{Cli, Commands, NoSubCmd};
 
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
Add a generic `SubCmd` parameter to `Cli` and `Commands` that allows consumers to add their own subcommands to the reth CLI.

- Add `SubCmd` generic parameter with `NoSubCmd` as default
- Add `ExtendedCommand` trait for executing custom subcommands
- Add `Commands::Ext` variant using `#[command(flatten)]`
- Export `ExtendedCommand` and `NoSubCmd` from lib.rs
- Add test demonstrating extensible subcommand usage

Example consumer PR: https://github.com/tempoxyz/tempo/pull/1839

Amp-Thread-ID: https://ampcode.com/threads/T-019b7ef3-7b08-736f-b149-b93fd7b7ee1d