### PR TITLE
fix: history index stages incorrectly detect first sync with non-zero…

### DIFF
--- a/crates/stages/stages/src/stages/index_account_history.rs
+++ b/crates/stages/stages/src/stages/index_account_history.rs
@@ -2,7 +2,11 @@ use super::{collect_history_indices, load_history_indices};
 use alloy_primitives::Address;
 use reth_config::config::{EtlConfig, IndexHistoryConfig};
 use reth_db_api::{
-    cursor::DbCursorRO, models::ShardedKey, table::Decode, tables, transaction::{DbTx, DbTxMut},
+    cursor::DbCursorRO,
+    models::ShardedKey,
+    table::Decode,
+    tables,
+    transaction::{DbTx, DbTxMut},
 };
 use reth_provider::{DBProvider, HistoryWriter, PruneCheckpointReader, PruneCheckpointWriter};
 use reth_prune_types::{PruneCheckpoint, PruneMode, PrunePurpose, PruneSegment};
@@ -95,7 +99,8 @@ where
         let mut range = input.next_block_range();
         // Check if the history table is empty to determine if this is the first sync.
         // We cannot use checkpoint == 0 because genesis block number might not be 0.
-        let first_sync = provider.tx_ref().cursor_read::<tables::AccountsHistory>()?.last()?.is_none();
+        let first_sync =
+            provider.tx_ref().cursor_read::<tables::AccountsHistory>()?.last()?.is_none();
 
         // On first sync we might have history coming from genesis. We clear the table since it's
         // faster to rebuild from scratch.

--- a/crates/stages/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/stages/src/stages/index_storage_history.rs
@@ -97,7 +97,8 @@ where
         let mut range = input.next_block_range();
         // Check if the history table is empty to determine if this is the first sync.
         // We cannot use checkpoint == 0 because genesis block number might not be 0.
-        let first_sync = provider.tx_ref().cursor_read::<tables::StoragesHistory>()?.last()?.is_none();
+        let first_sync =
+            provider.tx_ref().cursor_read::<tables::StoragesHistory>()?.last()?.is_none();
 
         // On first sync we might have history coming from genesis. We clear the table since it's
         // faster to rebuild from scratch.


### PR DESCRIPTION
The history index stages were hardcoding block 0 to check for first sync, which fails when genesis starts at a non-zero block. This prevented the first-sync optimization (clearing tables and rebuilding from scratch) from running.

Changed to check if the history table is empty instead, and use the actual checkpoint block number as the starting point rather than assuming 0.