### PR TITLE
perf: remove unnecessary code

### DIFF
--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -1786,8 +1786,7 @@ mod tests {
         // Collect targets; partially from real keys, partially random keys which probably won't
         // exist.
         let num_real_targets = post_state.accounts.len() * 5;
-        let mut targets =
-            post_state.accounts.keys().copied().collect::<Vec<_>>();
+        let mut targets = post_state.accounts.keys().copied().collect::<Vec<_>>();
         for _ in 0..post_state.accounts.len() / 5 {
             targets.push(rand_b256());
         }

--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -1785,7 +1785,6 @@ mod tests {
 
         // Collect targets; partially from real keys, partially random keys which probably won't
         // exist.
-        let num_real_targets = post_state.accounts.len() * 5;
         let mut targets = post_state.accounts.keys().copied().collect::<Vec<_>>();
         for _ in 0..post_state.accounts.len() / 5 {
             targets.push(rand_b256());

--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -1787,7 +1787,7 @@ mod tests {
         // exist.
         let num_real_targets = post_state.accounts.len() * 5;
         let mut targets =
-            post_state.accounts.keys().copied().sorted().take(num_real_targets).collect::<Vec<_>>();
+            post_state.accounts.keys().copied().collect::<Vec<_>>();
         for _ in 0..post_state.accounts.len() / 5 {
             targets.push(rand_b256());
         }


### PR DESCRIPTION
1. num_real_targets >= len of vec always true, so  take is not need.  
2. sort is call below, so sorted is not needed.  