### PR TITLE
docs: fix doc comment errors

### DIFF
--- a/crates/optimism/flashblocks/src/consensus.rs
+++ b/crates/optimism/flashblocks/src/consensus.rs
@@ -41,9 +41,9 @@ where
     /// Attempts to submit a new payload to the engine.
     ///
     /// The `TryFrom` conversion will fail if `execution_outcome.state_root` is `B256::ZERO`,
-    /// in which case this returns the `parent_hash` instead to drive the chain forward.
+    /// in which case this method uses the `parent_hash` instead to drive the chain forward.
     ///
-    /// Returns the block hash to use for FCU (either the new block or parent).
+    /// Returns the block hash to use for FCU (either the new block's hash or the parent hash).
     async fn submit_new_payload(&self, sequence: &FlashBlockCompleteSequence) -> B256 {
         let payload = match P::ExecutionData::try_from(sequence) {
             Ok(payload) => payload,

--- a/crates/optimism/flashblocks/src/service.rs
+++ b/crates/optimism/flashblocks/src/service.rs
@@ -84,14 +84,14 @@ where
         }
     }
 
-    /// Returns the sender half to the received flashblocks.
+    /// Returns the sender half for the received flashblocks broadcast channel.
     pub const fn flashblocks_broadcaster(
         &self,
     ) -> &tokio::sync::broadcast::Sender<Arc<FlashBlock>> {
         &self.received_flashblocks_tx
     }
 
-    /// Returns the sender half to the flashblock sequence.
+    /// Returns the sender half for the flashblock sequence broadcast channel.
     pub const fn block_sequence_broadcaster(
         &self,
     ) -> &tokio::sync::broadcast::Sender<FlashBlockCompleteSequence> {


### PR DESCRIPTION
Clarifies broadcast channel return value descriptions in service, improves forkchoice update return value description in consensus.