### PR TITLE
perf(engine): avoid double cloning header in advance method

### DIFF
--- a/crates/engine/local/src/miner.rs
+++ b/crates/engine/local/src/miner.rs
@@ -217,8 +217,10 @@ where
             eyre::bail!("No payload")
         };
 
-        let header = payload.block().sealed_header().clone();
-        let payload = T::block_to_payload(payload.block().clone());
+        // Clone the block once and extract header from it to avoid double cloning
+        let block = payload.block().clone();
+        let header = block.sealed_header().clone();
+        let payload = T::block_to_payload(block);
         let res = self.to_engine.new_payload(payload).await?;
 
         if !res.is_valid() {


### PR DESCRIPTION
Clone the block once and extract header from it instead of cloning header separately and then cloning the entire block again. This
eliminates redundant header cloning in the advance method.