### PR TITLE
chore(chain-state): remove needless collect in test assertions

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -1467,7 +1467,6 @@ mod tests {
         assert_eq!(parents[0].block().recovered_block().number, 2);
         assert_eq!(parents[1].block().recovered_block().number, 1);
 
-        let parents: Vec<_> = chain[0].parent_state_chain();
         assert_eq!(chain[0].parent_state_chain().count(), 0);
     }
 

--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -1467,8 +1467,8 @@ mod tests {
         assert_eq!(parents[0].block().recovered_block().number, 2);
         assert_eq!(parents[1].block().recovered_block().number, 1);
 
-        let parents: Vec<_> = chain[0].parent_state_chain().collect();
-        assert_eq!(parents.len(), 0);
+        let parents: Vec<_> = chain[0].parent_state_chain();
+        assert_eq!(chain[0].parent_state_chain().count(), 0);
     }
 
     #[test]


### PR DESCRIPTION
Use iterator `.count()` instead of collecting into Vec and checking length. This avoids unnecessary allocation in test assertions.