### PR TITLE
perf(trie): reuse StoredNibblesSubKey in seek_exact

### DIFF
--- a/crates/trie/db/src/trie_cursor.rs
+++ b/crates/trie/db/src/trie_cursor.rs
@@ -167,10 +167,11 @@ where
         &mut self,
         key: Nibbles,
     ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
+        let subkey = StoredNibblesSubKey(key);
         Ok(self
             .cursor
-            .seek_by_key_subkey(self.hashed_address, StoredNibblesSubKey(key))?
-            .filter(|e| e.nibbles == StoredNibblesSubKey(key))
+            .seek_by_key_subkey(self.hashed_address, subkey.clone())?
+            .filter(|e| e.nibbles == subkey)
             .map(|value| (value.nibbles.0, value.node)))
     }
 


### PR DESCRIPTION

`DatabaseStorageTrieCursor::seek_exact` creates `StoredNibblesSubKey` twice - once for the seek and once for the filter comparison.

**Solution**
Create `StoredNibblesSubKey` once and clone it for reuse.

**Impact**
Benchmark results from `reth-trie-parallel` state root calculation:

| Benchmark | Baseline | Optimized | Improvement |
|-----------|----------|-----------|-------------|
| sync root/3000 | 1.2472s | 1.2268s | **1.6%** |
| sync root/5000 | 2.0621s | 2.0375s | **1.2%** |
| sync root/10000 | 4.1338s | 4.0637s | **1.7%** |
| parallel root/5000 | 366.53ms | 338.65ms | **7.6%** |
| parallel root/10000 | 677.09ms | 652.74ms | **3.6%** |