### PR TITLE
perf(trie): use mem::take instead of clone for account RLP buffer

### DIFF
--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -728,7 +728,8 @@ where
         let nibbles = Nibbles::unpack(address);
         self.account_rlp_buf.clear();
         account.into_trie_account(storage_root).encode(&mut self.account_rlp_buf);
-        self.update_account_leaf(nibbles, self.account_rlp_buf.clone(), provider_factory)?;
+        let rlp_encoded_account = core::mem::take(&mut self.account_rlp_buf);
+        self.update_account_leaf(nibbles, rlp_encoded_account, provider_factory)?;
 
         Ok(true)
     }
@@ -781,7 +782,8 @@ where
         let nibbles = Nibbles::unpack(address);
         self.account_rlp_buf.clear();
         trie_account.encode(&mut self.account_rlp_buf);
-        self.update_account_leaf(nibbles, self.account_rlp_buf.clone(), provider_factory)?;
+        let rlp_encoded_account = core::mem::take(&mut self.account_rlp_buf);
+        self.update_account_leaf(nibbles, rlp_encoded_account, provider_factory)?;
 
         Ok(true)
     }


### PR DESCRIPTION
**Summary**
Replace `self.account_rlp_buf.clone()` with `core::mem::take()` to avoid allocation and memcpy when updating account leaves.

**Performance Impact**
Eliminates one allocation + memcpy per account update. The buffer is re-used on the next encode operation (starts empty, grows as needed).

Trade-offs
this pattern loses the pre-allocated capacity after each `mem::take()`, so subsequent encodes may need to grow the buffer. However, CPU savings from avoiding the copy typically outweigh the small reallocation cost for typical account RLP sizes.