### PR TITLE
docs: fix discv5 multiaddr peer id conversion comment

### DIFF
--- a/crates/net/discv5/src/enr.rs
+++ b/crates/net/discv5/src/enr.rs
@@ -24,7 +24,7 @@ pub fn discv4_id_to_discv5_id(peer_id: PeerId) -> Result<NodeId, secp256k1::Erro
     Ok(id2pk(peer_id)?.into())
 }
 
-/// Converts a [`PeerId`] to a [`reth_network_peers::PeerId`].
+/// Converts a [`PeerId`] to a [`discv5::libp2p_identity::PeerId`].
 pub fn discv4_id_to_multiaddr_id(
     peer_id: PeerId,
 ) -> Result<discv5::libp2p_identity::PeerId, secp256k1::Error> {


### PR DESCRIPTION
The documentation for discv4_id_to_multiaddr_id incorrectly stated that the function converts a PeerId to reth_network_peers::PeerId. In reality, it converts our PeerId into discv5::libp2p_identity::PeerId. This updates the doc comment to reference the correct target type so that the documentation matches the actual behavior and does not mislead callers.