### PR TITLE
docs(net): fix typos in comments

### DIFF
--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -77,7 +77,7 @@ pub struct Discv5 {
     metrics: Discv5Metrics,
     /// Returns the _local_ [`NodeRecord`] this service was started with.
     // Note: we must track this separately because the `discv5::Discv5` does not necessarily
-    // provide this via it's [`local_enr`](discv5::Discv5::local_ner()) This is intended for
+    // provide this via its [`local_enr`](discv5::Discv5::local_enr()). This is intended for
     // obtaining the port this service was launched at
     local_node_record: NodeRecord,
 }

--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -179,7 +179,7 @@ impl<N: NetworkPrimitives> StateFetcher<N> {
 
         let request = self.queued_requests.pop_front().expect("not empty");
         let Some(peer_id) = self.next_best_peer(request.best_peer_requirements()) else {
-            // need to put back the the request
+            // need to put back the request
             self.queued_requests.push_front(request);
             return PollAction::NoPeersAvailable
         };
@@ -397,7 +397,7 @@ impl Peer {
     /// A peer has a "better range" if:
     /// 1. It can fully cover the requested range while the other cannot
     /// 2. None can fully cover the range, but this peer has lower start value
-    /// 3. If a peer doesnt announce a range we assume it has full history, but check the other's
+    /// 3. If a peer doesn't announce a range we assume it has full history, but check the other's
     ///    range and treat that as better if it can cover the range
     fn has_better_range(&self, other: &Self, range: &RangeInclusive<u64>) -> bool {
         let self_range = self.range();

--- a/crates/net/p2p/src/headers/downloader.rs
+++ b/crates/net/p2p/src/headers/downloader.rs
@@ -100,9 +100,7 @@ impl<H: BlockHeader + Sealable> HeaderSyncGap<H> {
     }
 }
 
-/// Validate whether the header is valid in relation to it's parent
-///
-/// Returns Ok(false) if the
+/// Validate whether the header is valid in relation to its parent.
 pub fn validate_header_download<H: BlockHeader>(
     consensus: &dyn HeaderValidator<H>,
     header: &SealedHeader<H>,


### PR DESCRIPTION
Fix various typos and grammar errors in the networking crates:

- Fix duplicate word "the the" → "the" in fetch/mod.rs
- Fix typo "local_ner()" → "local_enr()" in discv5/src/lib.rs
- Fix missing apostrophe "doesnt" → "doesn't" in fetch/mod.rs
- Fix possessive "it's" → "its" in multiple files
- Remove incomplete/incorrect doc comment in headers/downloader.rs
- Add missing periods at end of sentences