### PR TITLE
perf: preallocate capacity in block body processing

### DIFF
--- a/crates/primitives-traits/src/block/body.rs
+++ b/crates/primitives-traits/src/block/body.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use alloc::{fmt, vec::Vec};
 use alloy_consensus::{
-    transaction::{Recovered, TxHashRef},
+    transaction::{Recovered, SignerRecoverable, TxHashRef},
     Transaction, Typed2718,
 };
 use alloy_eips::{eip2718::Encodable2718, eip4895::Withdrawals};

--- a/crates/primitives-traits/src/block/body.rs
+++ b/crates/primitives-traits/src/block/body.rs
@@ -190,13 +190,12 @@ pub trait BlockBody:
     /// Recovers signers for all transactions in the block body and returns a vector of
     /// [`Recovered`].
     fn recover_transactions(&self) -> Result<Vec<Recovered<Self::Transaction>>, RecoveryError> {
-        self.recover_signers().map(|signers| {
-            self.transactions()
-                .iter()
-                .zip(signers)
-                .map(|(tx, signer)| tx.clone().with_signer(signer))
-                .collect()
-        })
+        let mut recovered = Vec::with_capacity(self.transactions().len());
+        for tx in self.transactions() {
+            let signer = tx.recover_signer()?;
+            recovered.push(tx.clone().with_signer(signer));
+        }
+        Ok(recovered)
     }
 
     /// Returns an iterator over `Recovered<&Transaction>` for all transactions in the block body.


### PR DESCRIPTION
Adds capacity hint to avoid reallocation during iteration. small change but this runs on every block.