### PR TITLE
fix(engine): do not create another cache for multiproof task

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/bal.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal.rs
@@ -1,6 +1,5 @@
 //! BAL (Block Access List, EIP-7928) related functionality.
 
-use crate::tree::cached_state::CachedStateProvider;
 use alloy_consensus::constants::KECCAK_EMPTY;
 use alloy_eip7928::BlockAccessList;
 use alloy_primitives::{keccak256, Address, StorageKey, U256};
@@ -118,7 +117,7 @@ impl<'a> Iterator for BALSlotIter<'a> {
 /// of modified accounts and storage slots.
 pub(crate) fn bal_to_hashed_post_state<P>(
     bal: &BlockAccessList,
-    provider: &CachedStateProvider<P>,
+    provider: P,
 ) -> Result<HashedPostState, ProviderError>
 where
     P: AccountReader,
@@ -198,16 +197,11 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tree::cached_state::{ExecutionCache, ExecutionCacheBuilder};
     use alloy_eip7928::{
         AccountChanges, BalanceChange, CodeChange, NonceChange, SlotChanges, StorageChange,
     };
     use alloy_primitives::{Address, Bytes, StorageKey, B256};
     use reth_revm::test_utils::StateProviderTest;
-
-    fn new_cache() -> ExecutionCache {
-        ExecutionCacheBuilder::default().build_caches(1000)
-    }
 
     #[test]
     fn test_bal_to_hashed_post_state_basic() {
@@ -224,7 +218,6 @@ mod tests {
         };
 
         let bal = vec![account_changes];
-        let provider = CachedStateProvider::new(provider, new_cache(), Default::default());
         let result = bal_to_hashed_post_state(&bal, &provider).unwrap();
 
         assert_eq!(result.accounts.len(), 1);
@@ -259,7 +252,6 @@ mod tests {
         };
 
         let bal = vec![account_changes];
-        let provider = CachedStateProvider::new(provider, new_cache(), Default::default());
         let result = bal_to_hashed_post_state(&bal, &provider).unwrap();
 
         let hashed_address = keccak256(address);
@@ -289,7 +281,6 @@ mod tests {
         };
 
         let bal = vec![account_changes];
-        let provider = CachedStateProvider::new(provider, new_cache(), Default::default());
         let result = bal_to_hashed_post_state(&bal, &provider).unwrap();
 
         let hashed_address = keccak256(address);
@@ -317,7 +308,6 @@ mod tests {
         };
 
         let bal = vec![account_changes];
-        let provider = CachedStateProvider::new(provider, new_cache(), Default::default());
         let result = bal_to_hashed_post_state(&bal, &provider).unwrap();
 
         let hashed_address = keccak256(address);
@@ -352,7 +342,6 @@ mod tests {
         };
 
         let bal = vec![account_changes];
-        let provider = CachedStateProvider::new(provider, new_cache(), Default::default());
         let result = bal_to_hashed_post_state(&bal, &provider).unwrap();
 
         let hashed_address = keccak256(address);
@@ -385,7 +374,6 @@ mod tests {
         };
 
         let bal = vec![account_changes];
-        let provider = CachedStateProvider::new(provider, new_cache(), Default::default());
         let result = bal_to_hashed_post_state(&bal, &provider).unwrap();
 
         let hashed_address = keccak256(address);
@@ -426,7 +414,6 @@ mod tests {
         };
 
         let bal = vec![account_changes];
-        let provider = CachedStateProvider::new(provider, new_cache(), Default::default());
         let result = bal_to_hashed_post_state(&bal, &provider).unwrap();
 
         let hashed_address = keccak256(address);

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -3,8 +3,8 @@
 use super::precompile_cache::PrecompileCacheMap;
 use crate::tree::{
     cached_state::{
-        CachedStateMetrics, CachedStateProvider, ExecutionCache as StateExecutionCache,
-        ExecutionCacheBuilder, SavedCache,
+        CachedStateMetrics, ExecutionCache as StateExecutionCache, ExecutionCacheBuilder,
+        SavedCache,
     },
     payload_processor::{
         prewarm::{PrewarmCacheTask, PrewarmContext, PrewarmMode, PrewarmTaskEvent},
@@ -30,9 +30,7 @@ use reth_evm::{
 };
 use reth_execution_types::ExecutionOutcome;
 use reth_primitives_traits::NodePrimitives;
-use reth_provider::{
-    BlockReader, DatabaseProviderROFactory, StateProvider, StateProviderFactory, StateReader,
-};
+use reth_provider::{BlockReader, DatabaseProviderROFactory, StateProviderFactory, StateReader};
 use reth_revm::{db::BundleState, state::EvmState};
 use reth_trie::{hashed_cursor::HashedCursorFactory, trie_cursor::TrieCursorFactory};
 use reth_trie_parallel::{
@@ -295,18 +293,10 @@ where
         // spawn multi-proof task
         let parent_span = span.clone();
         self.executor.spawn_blocking({
-            let saved_cache = prewarm_handle.saved_cache.clone();
             move || {
                 let _enter = parent_span.entered();
                 // Build a state provider for the multiproof task
                 let provider = provider_builder.build().expect("failed to build provider");
-                let provider = if let Some(saved_cache) = saved_cache {
-                    let (cache, metrics) = saved_cache.split();
-                    Box::new(CachedStateProvider::new(provider, cache, metrics))
-                        as Box<dyn StateProvider>
-                } else {
-                    Box::new(provider)
-                };
                 multi_proof_task.run(provider);
             }
         });

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -1,8 +1,6 @@
 //! Multiproof task related functionality.
 
-use crate::tree::{
-    cached_state::CachedStateProvider, payload_processor::bal::bal_to_hashed_post_state,
-};
+use crate::tree::payload_processor::bal::bal_to_hashed_post_state;
 use alloy_eip7928::BlockAccessList;
 use alloy_evm::block::StateChangeSource;
 use alloy_primitives::{keccak256, map::HashSet, B256};
@@ -879,7 +877,7 @@ impl MultiProofTask {
         msg: MultiProofMessage,
         ctx: &mut MultiproofBatchCtx,
         batch_metrics: &mut MultiproofBatchMetrics,
-        provider: &CachedStateProvider<P>,
+        provider: &P,
     ) -> bool
     where
         P: AccountReader,
@@ -1184,7 +1182,7 @@ impl MultiProofTask {
         target = "engine::tree::payload_processor::multiproof",
         skip_all
     )]
-    pub(crate) fn run<P>(mut self, provider: CachedStateProvider<P>)
+    pub(crate) fn run<P>(mut self, provider: P)
     where
         P: AccountReader,
     {
@@ -1501,7 +1499,7 @@ fn estimate_evm_state_targets(state: &EvmState) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tree::cached_state::ExecutionCacheBuilder;
+    use crate::tree::cached_state::{CachedStateProvider, ExecutionCacheBuilder};
     use alloy_eip7928::{AccountChanges, BalanceChange};
     use alloy_primitives::{map::B256Set, Address};
     use reth_provider::{


### PR DESCRIPTION
### Problem

Every time `cache_for` is called, we check that it's going to be the only cache in use: https://github.com/paradigmxyz/reth/blob/790a73cd2af02849bba85bd48b1e5fe90b2292fe/crates/engine/tree/src/tree/payload_processor/mod.rs#L786-L788

First `cache_for` call is happening here https://github.com/paradigmxyz/reth/blob/fa05d19f1b225259500b49f46468f314a1070855/crates/engine/tree/src/tree/payload_processor/mod.rs#L252

Second is here https://github.com/paradigmxyz/reth/blob/fa05d19f1b225259500b49f46468f314a1070855/crates/engine/tree/src/tree/payload_processor/mod.rs#L297

Which leads to always creating a new cache on the second call

### Solution

Get cache once with `cache_for` and pass to all consumers.