### PR TITLE
feat(primitives-traits): add set_timestamp to test utils

### DIFF
--- a/crates/primitives-traits/src/block/mod.rs
+++ b/crates/primitives-traits/src/block/mod.rs
@@ -268,6 +268,11 @@ pub trait TestBlock: Block<Header: crate::test_utils::TestHeader> {
         crate::header::test_utils::TestHeader::set_block_number(self.header_mut(), number);
     }
 
+    /// Updates the block timestamp.
+    fn set_timestamp(&mut self, timestamp: u64) {
+        crate::header::test_utils::TestHeader::set_timestamp(self.header_mut(), timestamp);
+    }
+
     /// Updates the block state root.
     fn set_state_root(&mut self, state_root: alloy_primitives::B256) {
         crate::header::test_utils::TestHeader::set_state_root(self.header_mut(), state_root);

--- a/crates/primitives-traits/src/block/recovered.rs
+++ b/crates/primitives-traits/src/block/recovered.rs
@@ -586,6 +586,11 @@ impl<B: crate::test_utils::TestBlock> RecoveredBlock<B> {
         self.block.set_block_number(number);
     }
 
+    /// Updates the block timestamp.
+    pub fn set_timestamp(&mut self, timestamp: u64) {
+        self.block.set_timestamp(timestamp);
+    }
+
     /// Updates the block state root.
     pub fn set_state_root(&mut self, state_root: alloy_primitives::B256) {
         self.block.set_state_root(state_root);

--- a/crates/primitives-traits/src/block/sealed.rs
+++ b/crates/primitives-traits/src/block/sealed.rs
@@ -365,6 +365,11 @@ impl<B: crate::test_utils::TestBlock> SealedBlock<B> {
         self.header.set_block_number(number)
     }
 
+    /// Updates the block timestamp.
+    pub fn set_timestamp(&mut self, timestamp: u64) {
+        self.header.set_timestamp(timestamp)
+    }
+
     /// Updates the block state root.
     pub fn set_state_root(&mut self, state_root: alloy_primitives::B256) {
         self.header.set_state_root(state_root)

--- a/crates/primitives-traits/src/header/sealed.rs
+++ b/crates/primitives-traits/src/header/sealed.rs
@@ -228,6 +228,11 @@ impl<H: crate::test_utils::TestHeader> SealedHeader<H> {
         self.header.set_block_number(number);
     }
 
+    /// Updates the block timestamp.
+    pub fn set_timestamp(&mut self, timestamp: u64) {
+        self.header.set_timestamp(timestamp);
+    }
+
     /// Updates the block state root.
     pub fn set_state_root(&mut self, state_root: alloy_primitives::B256) {
         self.header.set_state_root(state_root);


### PR DESCRIPTION
Adds missing set_timestamp method to TestBlock trait and related test utils (SealedBlock, RecoveredBlock, SealedHeader)

all other HeaderMut setters were already there except this one