### PR TITLE
fix(cli): rely on Config::from_path for missing config files

### DIFF
--- a/crates/cli/commands/src/config_cmd.rs
+++ b/crates/cli/commands/src/config_cmd.rs
@@ -26,9 +26,6 @@ impl Command {
                 Some(path) => path,
                 None => bail!("No config file provided. Use --config <FILE> or pass --default"),
             };
-            if !path.exists() {
-                bail!("Config file does not exist: {}", path.display());
-            }
             Config::from_path(path)
                 .wrap_err_with(|| format!("Could not load config file: {}", path.display()))?
         };


### PR DESCRIPTION
reth config now relies on the documented behavior of Config::from_path to create a configuration file with default values when the specified path does not exist. This removes the manual path.exists() check that prevented the NotFound branch in from_path from running and made reth config --config <FILE> inconsistent with other commands such as node and p2p, which already trust from_path to handle missing files.