### PR TITLE
ci(hive): revert to self-hosted Reth runner group

### DIFF
--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -24,7 +24,8 @@ jobs:
   prepare-hive:
     if: github.repository == 'paradigmxyz/reth'
     timeout-minutes: 45
-    runs-on: depot-ubuntu-latest-16
+    runs-on:
+      group: Reth
     steps:
       - uses: actions/checkout@v6
       - name: Checkout hive tests
@@ -178,7 +179,8 @@ jobs:
       - prepare-reth
       - prepare-hive
     name: run ${{ matrix.scenario.sim }}${{ matrix.scenario.limit && format(' - {0}', matrix.scenario.limit) }}
-    runs-on: depot-ubuntu-latest-16
+    runs-on:
+      group: Reth
     permissions:
       issues: write
     steps:


### PR DESCRIPTION
**Problem**
Hive tests have been consistently failing since Dec 8, 2025 when PR #20196 temporarily switched from self-hosted Reth runners to `ubuntu-latest` because the custom runner group was down. The PR explicitly stated "should be reverted later".

**Solution**
Revert the hive workflow to use the self-hosted `Reth` runner group instead of Depot runners.

**Changes**
- Changed `runs-on: depot-ubuntu-latest-16` to `runs-on: group: Reth` for `prepare-hive` and `test` jobs

**Expected Impact**
- Hive tests should pass again once the Reth runner group is available
- Fork ID tests (DevP2P peering tests) that fail within ~1.5s on non-Reth runners should work correctly

---

**Investigation Summary:**
| Finding | Details |
|---------|---------|
| Last passing run | Run 2589 - Dec 7, 2025 18:06 UTC |
| First consistent failure | Run 2593 - Dec 8, 2025 18:07 UTC |
| Root cause commit | `f633efc96` - PR #20196 |
| Subsequent fix attempts | Depot runners + 16 cores - still failing |

The Fork ID tests are DevP2P peering tests that fail quickly (~1.5s) on non-Reth runners, suggesting runner-specific networking or timing characteristics are required.