### PR TITLE
perf(trie): add cursor locality optimization for storage cursors

### DIFF
--- a/crates/trie/db/src/hashed_cursor.rs
+++ b/crates/trie/db/src/hashed_cursor.rs
@@ -78,18 +78,25 @@ where
 /// The structure wrapping a database cursor for hashed storage and
 /// a target hashed address. Implements [`HashedCursor`] and [`HashedStorageCursor`]
 /// for iterating over hashed storage.
+///
+/// This cursor implements locality optimization: when seeking forward from the current position,
+/// it uses `next_dup_val` (O(1)) to walk forward instead of `seek_by_key_subkey` (O(log N)) when
+/// the target key is close to the current position.
 #[derive(Debug)]
 pub struct DatabaseHashedStorageCursor<C> {
     /// Database hashed storage cursor.
     cursor: C,
     /// Target hashed address of the account that the storage belongs to.
     hashed_address: B256,
+    /// The last key returned by the cursor, used for locality optimization.
+    /// When seeking forward from this position, we can use `next_dup_val` instead of re-seeking.
+    last_key: Option<B256>,
 }
 
 impl<C> DatabaseHashedStorageCursor<C> {
     /// Create new [`DatabaseHashedStorageCursor`].
     pub const fn new(cursor: C, hashed_address: B256) -> Self {
-        Self { cursor, hashed_address }
+        Self { cursor, hashed_address, last_key: None }
     }
 }
 
@@ -99,16 +106,50 @@ where
 {
     type Value = U256;
 
+    /// Seeks the given key in the hashed storage.
+    ///
+    /// This method implements a locality optimization: if the cursor is already positioned
+    /// and the target key is >= the current position, we use `next_dup_val` to walk forward
+    /// instead of performing an expensive `seek_by_key_subkey` operation.
     fn seek(&mut self, subkey: B256) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
-        Ok(self.cursor.seek_by_key_subkey(self.hashed_address, subkey)?.map(|e| (e.key, e.value)))
+        // Locality optimization: if cursor is positioned and target is ahead,
+        // walk forward using next_dup_val instead of seeking
+        if let Some(last) = self.last_key {
+            if subkey > last {
+                // Walk forward using next_dup_val until we find a key >= target
+                while let Some(entry) = self.cursor.next_dup_val()? {
+                    if entry.key >= subkey {
+                        self.last_key = Some(entry.key);
+                        return Ok(Some((entry.key, entry.value)));
+                    }
+                }
+                // Exhausted the duplicates, no match found
+                self.last_key = None;
+                return Ok(None);
+            } else if subkey == last &&
+                let Some((_, entry)) = self.cursor.current()? &&
+                entry.key == subkey
+            {
+                // Re-seeking the same key, return current position if still valid
+                return Ok(Some((entry.key, entry.value)));
+            }
+        }
+
+        // Fall back to seek_by_key_subkey for backward seeks or when cursor is not positioned
+        let result =
+            self.cursor.seek_by_key_subkey(self.hashed_address, subkey)?.map(|e| (e.key, e.value));
+        self.last_key = result.as_ref().map(|(k, _)| *k);
+        Ok(result)
     }
 
     fn next(&mut self) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
-        Ok(self.cursor.next_dup_val()?.map(|e| (e.key, e.value)))
+        let result = self.cursor.next_dup_val()?.map(|e| (e.key, e.value));
+        self.last_key = result.as_ref().map(|(k, _)| *k);
+        Ok(result)
     }
 
     fn reset(&mut self) {
-        // Database cursors are stateless, no reset needed
+        self.last_key = None;
     }
 }
 
@@ -122,5 +163,7 @@ where
 
     fn set_hashed_address(&mut self, hashed_address: B256) {
         self.hashed_address = hashed_address;
+        // Reset cursor position tracking when switching to a different storage
+        self.last_key = None;
     }
 }

--- a/crates/trie/db/src/hashed_cursor.rs
+++ b/crates/trie/db/src/hashed_cursor.rs
@@ -167,3 +167,255 @@ where
         self.last_key = None;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reth_db_api::{cursor::DbCursorRW, transaction::DbTxMut};
+    use reth_primitives_traits::StorageEntry;
+    use reth_provider::test_utils::create_test_provider_factory;
+
+    fn create_test_keys(count: usize) -> Vec<B256> {
+        (0..count as u64)
+            .map(|i| {
+                let mut bytes = [0u8; 32];
+                bytes[24..32].copy_from_slice(&i.to_be_bytes());
+                B256::from(bytes)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_forward_sequential_seek_uses_optimization() {
+        let factory = create_test_provider_factory();
+        let provider = factory.provider_rw().unwrap();
+        let hashed_address = B256::random();
+        let keys = create_test_keys(10);
+
+        // Insert test data
+        {
+            let mut cursor =
+                provider.tx_ref().cursor_dup_write::<tables::HashedStorages>().unwrap();
+            for (i, key) in keys.iter().enumerate() {
+                cursor
+                    .upsert(
+                        hashed_address,
+                        &StorageEntry { key: *key, value: U256::from(i as u64) },
+                    )
+                    .unwrap();
+            }
+        }
+
+        let mut cursor = DatabaseHashedStorageCursor::new(
+            provider.tx_ref().cursor_dup_read::<tables::HashedStorages>().unwrap(),
+            hashed_address,
+        );
+
+        // Forward sequential seeks should all succeed
+        for (i, key) in keys.iter().enumerate() {
+            let result = cursor.seek(*key).unwrap();
+            assert!(result.is_some(), "Should find key at index {i}");
+            let (found_key, value) = result.unwrap();
+            assert_eq!(found_key, *key);
+            assert_eq!(value, U256::from(i as u64));
+        }
+    }
+
+    #[test]
+    fn test_backward_seek_falls_back_to_seek_by_key_subkey() {
+        let factory = create_test_provider_factory();
+        let provider = factory.provider_rw().unwrap();
+        let hashed_address = B256::random();
+        let keys = create_test_keys(10);
+
+        // Insert test data
+        {
+            let mut cursor =
+                provider.tx_ref().cursor_dup_write::<tables::HashedStorages>().unwrap();
+            for (i, key) in keys.iter().enumerate() {
+                cursor
+                    .upsert(
+                        hashed_address,
+                        &StorageEntry { key: *key, value: U256::from(i as u64) },
+                    )
+                    .unwrap();
+            }
+        }
+
+        let mut cursor = DatabaseHashedStorageCursor::new(
+            provider.tx_ref().cursor_dup_read::<tables::HashedStorages>().unwrap(),
+            hashed_address,
+        );
+
+        // Seek to last key first
+        let result = cursor.seek(keys[9]).unwrap();
+        assert!(result.is_some());
+
+        // Backward seek should still work (falls back to seek_by_key_subkey)
+        let result = cursor.seek(keys[2]).unwrap();
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().0, keys[2]);
+    }
+
+    #[test]
+    fn test_cursor_exhaustion_then_new_seek() {
+        let factory = create_test_provider_factory();
+        let provider = factory.provider_rw().unwrap();
+        let hashed_address = B256::random();
+        let keys = create_test_keys(5);
+
+        // Insert test data
+        {
+            let mut cursor =
+                provider.tx_ref().cursor_dup_write::<tables::HashedStorages>().unwrap();
+            for (i, key) in keys.iter().enumerate() {
+                cursor
+                    .upsert(
+                        hashed_address,
+                        &StorageEntry { key: *key, value: U256::from(i as u64) },
+                    )
+                    .unwrap();
+            }
+        }
+
+        let mut cursor = DatabaseHashedStorageCursor::new(
+            provider.tx_ref().cursor_dup_read::<tables::HashedStorages>().unwrap(),
+            hashed_address,
+        );
+
+        // Exhaust cursor by seeking past all keys
+        let high_key = {
+            let mut bytes = [0xffu8; 32];
+            bytes[0] = 0xff;
+            B256::from(bytes)
+        };
+
+        // First seek to position the cursor
+        let _ = cursor.seek(keys[0]).unwrap();
+        // Then seek past all entries
+        let result = cursor.seek(high_key).unwrap();
+        assert!(result.is_none(), "Should not find key past all entries");
+
+        // Now seek back to an existing key - should work via fallback
+        let result = cursor.seek(keys[0]).unwrap();
+        assert!(result.is_some(), "Should find first key after exhaustion");
+        assert_eq!(result.unwrap().0, keys[0]);
+    }
+
+    #[test]
+    fn test_address_switch_resets_position() {
+        let factory = create_test_provider_factory();
+        let provider = factory.provider_rw().unwrap();
+        let address1 = B256::random();
+        let address2 = B256::random();
+        let keys = create_test_keys(5);
+
+        // Insert test data for both addresses
+        {
+            let mut cursor =
+                provider.tx_ref().cursor_dup_write::<tables::HashedStorages>().unwrap();
+            for (i, key) in keys.iter().enumerate() {
+                cursor
+                    .upsert(
+                        address1,
+                        &StorageEntry { key: *key, value: U256::from(i as u64) },
+                    )
+                    .unwrap();
+                cursor
+                    .upsert(
+                        address2,
+                        &StorageEntry { key: *key, value: U256::from((i + 100) as u64) },
+                    )
+                    .unwrap();
+            }
+        }
+
+        let mut cursor = DatabaseHashedStorageCursor::new(
+            provider.tx_ref().cursor_dup_read::<tables::HashedStorages>().unwrap(),
+            address1,
+        );
+
+        // Seek in first address
+        let result = cursor.seek(keys[2]).unwrap();
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().1, U256::from(2));
+
+        // Switch address and seek
+        cursor.set_hashed_address(address2);
+        let result = cursor.seek(keys[2]).unwrap();
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().1, U256::from(102));
+    }
+
+    #[test]
+    fn test_seek_same_key_returns_current() {
+        let factory = create_test_provider_factory();
+        let provider = factory.provider_rw().unwrap();
+        let hashed_address = B256::random();
+        let keys = create_test_keys(5);
+
+        // Insert test data
+        {
+            let mut cursor =
+                provider.tx_ref().cursor_dup_write::<tables::HashedStorages>().unwrap();
+            for (i, key) in keys.iter().enumerate() {
+                cursor
+                    .upsert(
+                        hashed_address,
+                        &StorageEntry { key: *key, value: U256::from(i as u64) },
+                    )
+                    .unwrap();
+            }
+        }
+
+        let mut cursor = DatabaseHashedStorageCursor::new(
+            provider.tx_ref().cursor_dup_read::<tables::HashedStorages>().unwrap(),
+            hashed_address,
+        );
+
+        // Seek to a key
+        let result1 = cursor.seek(keys[2]).unwrap();
+        assert!(result1.is_some());
+
+        // Seek to the same key again - should use cached current position
+        let result2 = cursor.seek(keys[2]).unwrap();
+        assert!(result2.is_some());
+        assert_eq!(result1.unwrap(), result2.unwrap());
+    }
+
+    #[test]
+    fn test_reset_clears_last_key() {
+        let factory = create_test_provider_factory();
+        let provider = factory.provider_rw().unwrap();
+        let hashed_address = B256::random();
+        let keys = create_test_keys(5);
+
+        // Insert test data
+        {
+            let mut cursor =
+                provider.tx_ref().cursor_dup_write::<tables::HashedStorages>().unwrap();
+            for (i, key) in keys.iter().enumerate() {
+                cursor
+                    .upsert(
+                        hashed_address,
+                        &StorageEntry { key: *key, value: U256::from(i as u64) },
+                    )
+                    .unwrap();
+            }
+        }
+
+        let mut cursor = DatabaseHashedStorageCursor::new(
+            provider.tx_ref().cursor_dup_read::<tables::HashedStorages>().unwrap(),
+            hashed_address,
+        );
+
+        // Seek to position cursor
+        let _ = cursor.seek(keys[2]).unwrap();
+
+        // Reset and verify we can still seek
+        cursor.reset();
+        let result = cursor.seek(keys[0]).unwrap();
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().0, keys[0]);
+    }
+}

--- a/crates/trie/db/src/trie_cursor.rs
+++ b/crates/trie/db/src/trie_cursor.rs
@@ -192,6 +192,7 @@ where
     /// This method implements a locality optimization: if the cursor is already positioned
     /// and the target key is >= the current position, we use `next_dup` to walk forward
     /// instead of performing an expensive `seek_by_key_subkey` operation.
+    #[allow(clippy::collapsible_if)]
     fn seek(
         &mut self,
         key: Nibbles,
@@ -210,12 +211,13 @@ where
                 // Exhausted the duplicates, no match found
                 self.last_key = None;
                 return Ok(None);
-            } else if key == last &&
-                let Some((_, entry)) = self.cursor.current()? &&
-                entry.nibbles.0 == key
-            {
+            } else if key == last {
                 // Re-seeking the same key, return current position if still valid
-                return Ok(Some((entry.nibbles.0, entry.node)));
+                if let Some((_, entry)) = self.cursor.current()? {
+                    if entry.nibbles.0 == key {
+                        return Ok(Some((entry.nibbles.0, entry.node)));
+                    }
+                }
             }
         }
 
@@ -346,13 +348,15 @@ mod tests {
 
         // Insert test data
         {
-            let mut cursor =
-                provider.tx_ref().cursor_dup_write::<tables::StoragesTrie>().unwrap();
+            let mut cursor = provider.tx_ref().cursor_dup_write::<tables::StoragesTrie>().unwrap();
             for key in &keys {
                 cursor
                     .upsert(
                         hashed_address,
-                        &StorageTrieEntry { nibbles: StoredNibblesSubKey(*key), node: create_test_node() },
+                        &StorageTrieEntry {
+                            nibbles: StoredNibblesSubKey(*key),
+                            node: create_test_node(),
+                        },
                     )
                     .unwrap();
             }
@@ -381,13 +385,15 @@ mod tests {
 
         // Insert test data
         {
-            let mut cursor =
-                provider.tx_ref().cursor_dup_write::<tables::StoragesTrie>().unwrap();
+            let mut cursor = provider.tx_ref().cursor_dup_write::<tables::StoragesTrie>().unwrap();
             for key in &keys {
                 cursor
                     .upsert(
                         hashed_address,
-                        &StorageTrieEntry { nibbles: StoredNibblesSubKey(*key), node: create_test_node() },
+                        &StorageTrieEntry {
+                            nibbles: StoredNibblesSubKey(*key),
+                            node: create_test_node(),
+                        },
                     )
                     .unwrap();
             }
@@ -417,13 +423,15 @@ mod tests {
 
         // Insert test data
         {
-            let mut cursor =
-                provider.tx_ref().cursor_dup_write::<tables::StoragesTrie>().unwrap();
+            let mut cursor = provider.tx_ref().cursor_dup_write::<tables::StoragesTrie>().unwrap();
             for key in &keys {
                 cursor
                     .upsert(
                         hashed_address,
-                        &StorageTrieEntry { nibbles: StoredNibblesSubKey(*key), node: create_test_node() },
+                        &StorageTrieEntry {
+                            nibbles: StoredNibblesSubKey(*key),
+                            node: create_test_node(),
+                        },
                     )
                     .unwrap();
             }
@@ -463,19 +471,24 @@ mod tests {
 
         // Insert test data for both addresses
         {
-            let mut cursor =
-                provider.tx_ref().cursor_dup_write::<tables::StoragesTrie>().unwrap();
+            let mut cursor = provider.tx_ref().cursor_dup_write::<tables::StoragesTrie>().unwrap();
             for key in &keys {
                 cursor
                     .upsert(
                         address1,
-                        &StorageTrieEntry { nibbles: StoredNibblesSubKey(*key), node: node1.clone() },
+                        &StorageTrieEntry {
+                            nibbles: StoredNibblesSubKey(*key),
+                            node: node1.clone(),
+                        },
                     )
                     .unwrap();
                 cursor
                     .upsert(
                         address2,
-                        &StorageTrieEntry { nibbles: StoredNibblesSubKey(*key), node: node2.clone() },
+                        &StorageTrieEntry {
+                            nibbles: StoredNibblesSubKey(*key),
+                            node: node2.clone(),
+                        },
                     )
                     .unwrap();
             }
@@ -507,13 +520,15 @@ mod tests {
 
         // Insert test data
         {
-            let mut cursor =
-                provider.tx_ref().cursor_dup_write::<tables::StoragesTrie>().unwrap();
+            let mut cursor = provider.tx_ref().cursor_dup_write::<tables::StoragesTrie>().unwrap();
             for key in &keys {
                 cursor
                     .upsert(
                         hashed_address,
-                        &StorageTrieEntry { nibbles: StoredNibblesSubKey(*key), node: create_test_node() },
+                        &StorageTrieEntry {
+                            nibbles: StoredNibblesSubKey(*key),
+                            node: create_test_node(),
+                        },
                     )
                     .unwrap();
             }
@@ -543,13 +558,15 @@ mod tests {
 
         // Insert test data
         {
-            let mut cursor =
-                provider.tx_ref().cursor_dup_write::<tables::StoragesTrie>().unwrap();
+            let mut cursor = provider.tx_ref().cursor_dup_write::<tables::StoragesTrie>().unwrap();
             for key in &keys {
                 cursor
                     .upsert(
                         hashed_address,
-                        &StorageTrieEntry { nibbles: StoredNibblesSubKey(*key), node: create_test_node() },
+                        &StorageTrieEntry {
+                            nibbles: StoredNibblesSubKey(*key),
+                            node: create_test_node(),
+                        },
                     )
                     .unwrap();
             }
@@ -579,13 +596,15 @@ mod tests {
 
         // Insert test data
         {
-            let mut cursor =
-                provider.tx_ref().cursor_dup_write::<tables::StoragesTrie>().unwrap();
+            let mut cursor = provider.tx_ref().cursor_dup_write::<tables::StoragesTrie>().unwrap();
             for key in &keys {
                 cursor
                     .upsert(
                         hashed_address,
-                        &StorageTrieEntry { nibbles: StoredNibblesSubKey(*key), node: create_test_node() },
+                        &StorageTrieEntry {
+                            nibbles: StoredNibblesSubKey(*key),
+                            node: create_test_node(),
+                        },
                     )
                     .unwrap();
             }

--- a/crates/trie/db/src/trie_cursor.rs
+++ b/crates/trie/db/src/trie_cursor.rs
@@ -272,7 +272,7 @@ mod tests {
             .map(|i| {
                 let mut bytes = [0u8; 8];
                 bytes.copy_from_slice(&i.to_be_bytes());
-                Nibbles::unpack(&bytes)
+                Nibbles::unpack(bytes)
             })
             .collect()
     }


### PR DESCRIPTION
**Problem**
Storage trie cursors use `seek_by_key_subkey` (O(log N)) for every lookup, even during forward-sequential traversal where keys are accessed in sorted order.

**Solution**
Track `last_key` in `DatabaseHashedStorageCursor` and `DatabaseStorageTrieCursor`. When seeking forward past the current position, use `next_dup`/`next_dup_val` (O(1)) instead of re-seeking.

**Bench**
HashedStorages Cursor

| Entries | Optimized (forward_sequential_seek) | Baseline (always_seek) | Improvement |
|---------|-------------------------------------|------------------------|-------------|
| 100     | 12.4 µs                            | 15.8 µs                | **27%**     |
| 1,000   | 123 µs                             | 178 µs                 | **31%**     |
| 10,000  | 1.24 ms                            | 2.15 ms                | **42%**     |

StoragesTrie Cursor

| Entries | Optimized (forward_sequential_seek) | Baseline (always_seek) | Improvement |
|---------|-------------------------------------|------------------------|-------------|
| 100     | 14.1 µs                            | 18.2 µs                | **29%**     |
| 1,000   | 141 µs                             | 215 µs                 | **34%**     |
| 10,000  | 1.41 ms                            | 2.58 ms                | **45%**     |

Benchmark results and code: https://gist.github.com/yongkangc/0b5d9fde2758cf87b2ab4c4a43c7e173

https://github.com/paradigmxyz/reth/issues/20766#issue-3783674047


Closes: https://github.com/paradigmxyz/reth/issues/20766