### PR TITLE
perf: handle RPC errors instead of panicking

### DIFF
--- a/bin/reth-bench/src/bench/context.rs
+++ b/bin/reth-bench/src/bench/context.rs
@@ -105,14 +105,21 @@ impl BenchContext {
 
         // If `--to` are not provided, we will run the benchmark continuously,
         // starting at the latest block.
-        let latest_block =
-            block_provider.get_block_by_number(BlockNumberOrTag::Latest).full().await?.unwrap();
+        let latest_block = block_provider
+            .get_block_by_number(BlockNumberOrTag::Latest)
+            .full()
+            .await?
+            .ok_or_else(|| eyre::eyre!("Failed to fetch latest block from RPC"))?;
         let mut benchmark_mode = BenchMode::new(from, to, latest_block.into_inner().number())?;
 
         let first_block = match benchmark_mode {
-            BenchMode::Continuous(start) => {
-                block_provider.get_block_by_number(start.into()).full().await?.unwrap()
-            }
+            BenchMode::Continuous(start) => block_provider
+                .get_block_by_number(start.into())
+                .full()
+                .await?
+                .ok_or_else(|| {
+                    eyre::eyre!("Failed to fetch block {} from RPC for continuous mode", start)
+                })?,
             BenchMode::Range(ref mut range) => {
                 match range.next() {
                     Some(block_number) => {
@@ -121,7 +128,9 @@ impl BenchContext {
                             .get_block_by_number(block_number.into())
                             .full()
                             .await?
-                            .unwrap()
+                            .ok_or_else(|| {
+                                eyre::eyre!("Failed to fetch block {} from RPC", block_number)
+                            })?
                     }
                     None => {
                         return Err(eyre::eyre!(

--- a/bin/reth-bench/src/bench/context.rs
+++ b/bin/reth-bench/src/bench/context.rs
@@ -113,13 +113,11 @@ impl BenchContext {
         let mut benchmark_mode = BenchMode::new(from, to, latest_block.into_inner().number())?;
 
         let first_block = match benchmark_mode {
-            BenchMode::Continuous(start) => block_provider
-                .get_block_by_number(start.into())
-                .full()
-                .await?
-                .ok_or_else(|| {
+            BenchMode::Continuous(start) => {
+                block_provider.get_block_by_number(start.into()).full().await?.ok_or_else(|| {
                     eyre::eyre!("Failed to fetch block {} from RPC for continuous mode", start)
-                })?,
+                })?
+            }
             BenchMode::Range(ref mut range) => {
                 match range.next() {
                     Some(block_number) => {


### PR DESCRIPTION
These were in the benchmark initialization path and would panic on network issues or missing blocks. Since the function returns Result anyway, now it returns clear error messages instead.