### PR TITLE
chore: make error handling consistent

### DIFF
--- a/bin/reth-bench-compare/src/node.rs
+++ b/bin/reth-bench-compare/src/node.rs
@@ -408,7 +408,7 @@ impl NodeManager {
 
     /// Stop the reth node gracefully
     pub(crate) async fn stop_node(&self, child: &mut tokio::process::Child) -> Result<()> {
-        let pid = child.id().expect("Child process ID should be available");
+        let pid = child.id().ok_or_eyre("Child process ID should be available")?;
 
         // Check if the process has already exited
         match child.try_wait() {


### PR DESCRIPTION
Replaces `.expect()` with `.ok_or_eyre()?` on line 411 to match the same error handling pattern used on line 306. Both functions return Result, so propagating the error makes more sense than panicking.