### PR TITLE
chore: remove outdated network TODO

### DIFF
--- a/docs/crates/network.md
+++ b/docs/crates/network.md
@@ -100,7 +100,6 @@ where
         .split_with_handle();
 
     tokio::task::spawn(network);
-    // TODO: tokio::task::spawn(txpool); 
     tokio::task::spawn(eth);
     Ok(handle)
 }


### PR DESCRIPTION
Removes outdated TODO comment about spawning txpool in NetworkConfig::start_network(), the txpool field is unit type and intentionally not spawned in this simplified setup.