### PR TITLE
docs(payload): fix typos and incorrect references in comments

### DIFF
--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -297,7 +297,7 @@ impl Default for BasicPayloadJobGeneratorConfig {
 /// resolved or the deadline is reached, or until the built payload is marked as frozen:
 /// [`BuildOutcome::Freeze`]. Once a frozen payload is returned, no additional payloads will be
 /// built and this future will wait to be resolved: [`PayloadJob::resolve`] or terminated if the
-/// deadline is reached..
+/// deadline is reached.
 #[derive(Debug)]
 pub struct BasicPayloadJob<Tasks, Builder>
 where

--- a/crates/payload/basic/src/metrics.rs
+++ b/crates/payload/basic/src/metrics.rs
@@ -2,7 +2,7 @@
 
 use reth_metrics::{metrics::Counter, Metrics};
 
-/// Transaction pool metrics
+/// Payload builder metrics
 #[derive(Metrics)]
 #[metrics(scope = "payloads")]
 pub(crate) struct PayloadBuilderMetrics {

--- a/crates/payload/builder/src/test_utils.rs
+++ b/crates/payload/builder/src/test_utils.rs
@@ -65,7 +65,7 @@ impl PayloadJobGenerator for TestPayloadJobGenerator {
     }
 }
 
-/// A [`PayloadJobGenerator`] for testing purposes
+/// A [`PayloadJob`] for testing purposes
 #[derive(Debug)]
 pub struct TestPayloadJob {
     attr: EthPayloadBuilderAttributes,

--- a/crates/payload/util/src/transaction.rs
+++ b/crates/payload/util/src/transaction.rs
@@ -44,7 +44,7 @@ impl<T: Clone> PayloadTransactions for PayloadTransactionsFixed<T> {
 /// `PayloadTransactions` iterators and keeps track of the gas for both of iterators.
 ///
 /// We can't use [`Iterator::chain`], because:
-/// (a) we need to propagate the `mark_invalid` and `no_updates`
+/// (a) we need to propagate the `mark_invalid`
 /// (b) we need to keep track of the gas
 ///
 /// Notes that [`PayloadTransactionsChain`] fully drains the first iterator


### PR DESCRIPTION
This PR fixes several documentation typos and incorrect references in the `crates/payload` module.


## Details

- The `PayloadBuilderMetrics` struct was incorrectly documented as "Transaction pool metrics" when it actually contains payload builder metrics
- The `PayloadTransactions` trait does not have a `no_updates` method (it only exists in `BestTransactions` trait in transaction-pool)
- `TestPayloadJob` implements `PayloadJob`, not `PayloadJobGenerator`
- Simple typo fix for double period in doc comment