### PR TITLE
fix(consensus): prevent infinite reconnection loop in RpcBlockProvider when channel is closed

### DIFF
--- a/crates/consensus/debug-client/src/providers/rpc.rs
+++ b/crates/consensus/debug-client/src/providers/rpc.rs
@@ -89,8 +89,8 @@ where
                 match res {
                     Ok(block) => {
                         if tx.send((self.convert)(block)).await.is_err() {
-                            // Channel closed.
-                            break;
+                            // Channel closed - receiver dropped, exit completely.
+                            return;
                         }
                     }
                     Err(err) => {


### PR DESCRIPTION
## Summary
Fix a potential infinite loop in `RpcBlockProvider::subscribe_blocks()` that occurs when the receiving channel is closed.

## Problem
When `DebugConsensusClient::run()` terminates and drops the receiver, the `RpcBlockProvider` enters an infinite reconnection loop instead of gracefully shutting down.

### Root Cause
```rust
if tx.send((self.convert)(block)).await.is_err() {
    // Channel closed.
    break;  // Only exits inner while loop, outer loop continues
}
```

The `break` only exits the inner `while` loop. The outer `loop` continues to re-establish subscriptions, receive blocks, fail to send, and repeat indefinitely.

### When This Happens
This is a **corner case** that occurs when the receiver is dropped before the sender (e.g., graceful shutdown, error handling, or program termination).

## Solution
Replace `break` with `return` to exit the function completely:

```rust
if tx.send((self.convert)(block)).await.is_err() {
    // Channel closed - receiver dropped, exit completely.
    return;
}
```

## Impact
- Prevents zombie tasks and repeated WebSocket reconnection attempts
- Eliminates unnecessary CPU/network usage and log spam
- Aligns behavior with `EtherscanBlockProvider`
- Ensures proper resource cleanup during shutdown

### Note
This is a corner case fix for the `debug-client` crate, primarily used for testing and debugging.