### PR TITLE
chore(consensus): fix typo in RpcBlockProvider log message

### DIFF
--- a/crates/consensus/debug-client/src/providers/rpc.rs
+++ b/crates/consensus/debug-client/src/providers/rpc.rs
@@ -107,7 +107,7 @@ where
             debug!(
                 target: "consensus::debug-client",
                 url=%self.url,
-                "Re-estbalishing block subscription",
+                "Re-establishing block subscription",
             );
         }
     }


### PR DESCRIPTION
Fix "Re-estbalishing" -> "Re-establishing" typo in debug log message.