### PR TITLE
docs: fix doc comment errors

### DIFF
--- a/crates/consensus/consensus/src/lib.rs
+++ b/crates/consensus/consensus/src/lib.rs
@@ -135,7 +135,7 @@ pub enum ConsensusError {
         /// The gas limit in the block header.
         gas_limit: u64,
     },
-    /// Error when the gas the gas limit is more than the maximum allowed.
+    /// Error when the gas limit is more than the maximum allowed.
     #[error(
         "header gas limit ({gas_limit}) exceed the maximum allowed gas limit ({MAXIMUM_GAS_LIMIT_BLOCK})"
     )]

--- a/crates/optimism/flashblocks/src/test_utils.rs
+++ b/crates/optimism/flashblocks/src/test_utils.rs
@@ -7,7 +7,7 @@
 //! ## Simple: Create a flashblock sequence for the same block
 //!
 //! ```ignore
-//! let factory = FlashBlockTestFactory::new(2); // 2 second block time
+//! let factory = TestFlashBlockFactory::new(); // Default 2 second block time
 //! let fb0 = factory.flashblock_at(0).build();
 //! let fb1 = factory.flashblock_after(&fb0).build();
 //! let fb2 = factory.flashblock_after(&fb1).build();
@@ -16,7 +16,7 @@
 //! ## Create flashblocks with transactions
 //!
 //! ```ignore
-//! let factory = FlashBlockTestFactory::new(2);
+//! let factory = TestFlashBlockFactory::new();
 //! let fb0 = factory.flashblock_at(0).build();
 //! let txs = vec![Bytes::from_static(&[1, 2, 3])];
 //! let fb1 = factory.flashblock_after(&fb0).transactions(txs).build();
@@ -25,7 +25,7 @@
 //! ## Test across multiple blocks (timestamps auto-increment)
 //!
 //! ```ignore
-//! let factory = FlashBlockTestFactory::new(2); // 2 second blocks
+//! let factory = TestFlashBlockFactory::new(); // Default 2 second blocks
 //!
 //! // Block 100 at timestamp 1000000
 //! let fb0 = factory.flashblock_at(0).build();
@@ -39,8 +39,8 @@
 //! ## Full control with builder
 //!
 //! ```ignore
-//! let factory = FlashBlockTestFactory::new(1);
-//! let fb = factory.custom()
+//! let factory = TestFlashBlockFactory::new();
+//! let fb = factory.builder()
 //!     .block_number(100)
 //!     .parent_hash(specific_hash)
 //!     .state_root(computed_root)

--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -90,7 +90,7 @@ pub struct ProofCalculator<TC, HC, VE: LeafValueEncoder> {
     /// Free-list of re-usable buffers of [`RlpNode`]s, used for encoding branch nodes to RLP.
     ///
     /// We are generally able to re-use these buffers across different branch nodes for the
-    /// duration of a proof calculation, but occasionally we will lose one when when a branch
+    /// duration of a proof calculation, but occasionally we will lose one when a branch
     /// node is returned as a `ProofTrieNode`.
     rlp_nodes_bufs: Vec<Vec<RlpNode>>,
     /// Re-usable byte buffer, used for RLP encoding.


### PR DESCRIPTION
Fixes duplicate words and incorrect example code in doc comments.