### PR TITLE
chore(chain-state): remove needless collect in test assertions

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -1478,8 +1478,7 @@ mod tests {
             create_mock_state(&mut test_block_builder, single_block_number, B256::random());
         let single_block_hash = single_block.block().recovered_block().hash();
 
-        let parents: Vec<_> = single_block.parent_state_chain().collect();
-        assert_eq!(parents.len(), 0);
+        assert_eq!(single_block.parent_state_chain().count(), 0);
 
         let block_state_chain = single_block.chain().collect::<Vec<_>>();
         assert_eq!(block_state_chain.len(), 1);


### PR DESCRIPTION
Use iterator .count() instead of collecting into Vec and checking length. This avoids unnecessary allocation in test assertions.