### PR TITLE
fix: shrink default storage trie capacity

### DIFF
--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -865,6 +865,10 @@ impl<S: SparseTrieInterface> StorageTries<S> {
             trie.shrink_nodes_to(node_size_per_trie);
             trie.shrink_values_to(value_size_per_trie);
         }
+
+        // Shrink default storage trie
+        self.default_trie.shrink_nodes_to(node_size_per_trie);
+        self.default_trie.shrink_values_to(value_size_per_trie);
     }
 }
 


### PR DESCRIPTION
Update StorageTries::shrink_to to also shrink the default_trie so the implementation matches the documented behavior. Previously the capacity distribution logic counted the default trie when computing per-trie limits but never applied the shrink, which made the comment misleading and could leave the default trie over-allocated compared to active and cleared tries.