### PR TITLE
perf: use parallel signature recovery in debug_trace_raw_block

### DIFF
--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -180,14 +180,13 @@ where
             .map_err(Eth::Error::from_eth_err)?;
 
         // Depending on EIP-2 we need to recover the transactions differently
-        // Use BlockBody's recover methods which utilize parallel recovery when rayon feature is
-        // enabled
         let senders =
             if self.provider().chain_spec().is_homestead_active_at_block(block.header().number()) {
-                block.body().recover_signers().map_err(Eth::Error::from_eth_err)?
+                block.body().recover_signers()
             } else {
-                block.body().recover_signers_unchecked().map_err(Eth::Error::from_eth_err)?
-            };
+                block.body().recover_signers_unchecked()
+            }
+            .map_err(Eth::Error::from_eth_err)?;
 
         self.trace_block(Arc::new(block.into_recovered_with_signers(senders)), evm_env, opts).await
     }


### PR DESCRIPTION
uses BlockBody's recover_signers instead of manual iteration to enable parallel recovery when rayon is enabled.

before:
`block.body().transactions().iter().map(|tx| tx.recover_signer()...).collect()`

after:
`block.body().recover_signers()`

Make ECDSA recovery run in parallel for blocks with many transactions, should improve debug tracing performance.