### PR TITLE
docs(flashblocks): fix outdated API examples in test_utils module documentation

### DIFF
--- a/crates/optimism/flashblocks/src/test_utils.rs
+++ b/crates/optimism/flashblocks/src/test_utils.rs
@@ -7,7 +7,7 @@
 //! ## Simple: Create a flashblock sequence for the same block
 //!
 //! ```ignore
-//! let factory = TestFlashBlockFactory::new(); // Default 2 second block time
+//! let factory = TestFlashBlockFactory::new().with_block_time(2); // 2 second block time
 //! let fb0 = factory.flashblock_at(0).build();
 //! let fb1 = factory.flashblock_after(&fb0).build();
 //! let fb2 = factory.flashblock_after(&fb1).build();


### PR DESCRIPTION
Fixes outdated code examples in the `flashblocks/test_utils.rs` module documentation that reference old API that no longer exists.