### PR TITLE
chore: add debug log for peer lookup miss in tx fetcher

### DIFF
--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -57,7 +57,7 @@ use std::{
     time::Duration,
 };
 use tokio::sync::{mpsc::error::TrySendError, oneshot, oneshot::error::RecvError};
-use tracing::trace;
+use tracing::{debug, trace};
 
 /// The type responsible for fetching missing transactions from peers.
 ///
@@ -449,7 +449,10 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
         );
 
         // peer should always exist since `is_session_active` already checked
-        let Some(peer) = peers.get(&peer_id) else { return false };
+        let Some(peer) = peers.get(&peer_id) else {
+            debug!(target: "net::tx", ?peer_id, "peer not found after is_session_active check, possible race condition");
+            return false
+        };
         let conn_eth_version = peer.version;
 
         // fill the request with more hashes pending fetch that have been announced by the peer.


### PR DESCRIPTION
The comment says "peer should always exist" but there's a defensive else branch with silent failure. added debug logging to track if/when this happens.