### PR TITLE
chore: relax = requirement on cc dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -694,7 +694,7 @@ ahash = "0.8"
 anyhow = "1.0"
 bindgen = { version = "0.71", default-features = false }
 block-padding = "0.3.2"
-cc = "=1.2.15"
+cc = "1.2.15"
 cipher = "0.4.3"
 comfy-table = "7.0"
 concat-kdf = "0.1.0"


### PR DESCRIPTION
Need this because `aws-lc-sys` has `cc = "1.26.26`, which prevents cargo from finding a version of cc that fulfills both the `reth` and the `aws-ls-sys` requirement.