### PR TITLE
docs: clarify TreeRootEntry::content unsigned format

### DIFF
--- a/crates/net/dns/src/tree.rs
+++ b/crates/net/dns/src/tree.rs
@@ -122,10 +122,10 @@ impl TreeRootEntry {
         Ok(Self { enr_root, link_root, sequence_number, signature })
     }
 
-    /// Returns the _unsigned_ content pairs of the entry:
+    /// Returns the _unsigned_ content of the entry used for signing:
     ///
     /// ```text
-    /// e=<enr-root> l=<link-root> seq=<sequence-number> sig=<signature>
+    /// enrtree-root:v1 e=<enr-root> l=<link-root> seq=<sequence-number>
     /// ```
     fn content(&self) -> String {
         format!(


### PR DESCRIPTION
The documentation for TreeRootEntry::content did not match the actual string being signed. It mentioned a sig field and omitted the enrtree-root:v1 prefix, which is misleading given EIP-1459 specifies that the signature is computed over the unsigned content without the sig= part. This change updates the comment to document the real unsigned payload, including the root prefix and excluding the signature field.