### PR TITLE
chore: skip empty masks in branch node storage

### DIFF
--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -188,10 +188,10 @@ impl SparseTrieInterface for ParallelSparseTrie {
 
         // Update the top-level branch node masks. This is simple and can't be done in parallel.
         for ProofTrieNode { path, masks, .. } in &nodes {
-            if let Some(branch_masks) = masks {
-                if !branch_masks.hash_mask.is_empty() || !branch_masks.tree_mask.is_empty() {
-                    self.branch_node_masks.insert(*path, *branch_masks);
-                }
+            if let Some(branch_masks) = masks &&
+                (!branch_masks.hash_mask.is_empty() || !branch_masks.tree_mask.is_empty())
+            {
+                self.branch_node_masks.insert(*path, *branch_masks);
             }
         }
 

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -189,7 +189,9 @@ impl SparseTrieInterface for ParallelSparseTrie {
         // Update the top-level branch node masks. This is simple and can't be done in parallel.
         for ProofTrieNode { path, masks, .. } in &nodes {
             if let Some(branch_masks) = masks {
-                self.branch_node_masks.insert(*path, *branch_masks);
+                if !branch_masks.hash_mask.is_empty() || !branch_masks.tree_mask.is_empty() {
+                    self.branch_node_masks.insert(*path, *branch_masks);
+                }
             }
         }
 

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -458,7 +458,9 @@ impl SparseTrieInterface for SerialSparseTrie {
         }
 
         if let Some(branch_masks) = masks {
-            self.branch_node_masks.insert(path, branch_masks);
+            if !branch_masks.hash_mask.is_empty() || !branch_masks.tree_mask.is_empty() {
+                self.branch_node_masks.insert(path, branch_masks);
+            }
         }
 
         match node {

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -457,10 +457,10 @@ impl SparseTrieInterface for SerialSparseTrie {
             return Ok(())
         }
 
-        if let Some(branch_masks) = masks {
-            if !branch_masks.hash_mask.is_empty() || !branch_masks.tree_mask.is_empty() {
-                self.branch_node_masks.insert(path, branch_masks);
-            }
+        if let Some(branch_masks) = masks &&
+            (!branch_masks.hash_mask.is_empty() || !branch_masks.tree_mask.is_empty())
+        {
+            self.branch_node_masks.insert(path, branch_masks);
         }
 
         match node {


### PR DESCRIPTION
Filters out empty masks before inserting into branch_node_masks, aligns with existing mask handling patterns throughout the codebase.