### PR TITLE
docs: fix article and grammar errors in comments

### DIFF
--- a/crates/evm/execution-types/src/execution_outcome.rs
+++ b/crates/evm/execution-types/src/execution_outcome.rs
@@ -396,7 +396,7 @@ impl ExecutionOutcome {
     /// Returns the ethereum receipt root for all recorded receipts.
     ///
     /// Note: this function calculated Bloom filters for every receipt and created merkle trees
-    /// of receipt. This is a expensive operation.
+    /// of receipt. This is an expensive operation.
     pub fn ethereum_receipts_root(&self, block_number: BlockNumber) -> Option<B256> {
         self.generic_receipts_root_slow(
             block_number,

--- a/crates/net/eth-wire-types/src/broadcast.rs
+++ b/crates/net/eth-wire-types/src/broadcast.rs
@@ -757,12 +757,12 @@ impl RequestTxHashes {
         Self::new(HashSet::with_capacity_and_hasher(capacity, Default::default()))
     }
 
-    /// Returns an new empty instance.
+    /// Returns a new empty instance.
     fn empty() -> Self {
         Self::new(HashSet::default())
     }
 
-    /// Retains the given number of elements, returning and iterator over the rest.
+    /// Retains the given number of elements, returning an iterator over the rest.
     pub fn retain_count(&mut self, count: usize) -> Self {
         let rest_capacity = self.hashes.len().saturating_sub(count);
         if rest_capacity == 0 {

--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -1245,7 +1245,7 @@ pub enum PeerAction {
     PeerRemoved(PeerId),
 }
 
-/// Error thrown when a incoming connection is rejected right away
+/// Error thrown when an incoming connection is rejected right away
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum InboundConnectionError {
     /// The remote's ip address is banned

--- a/crates/ress/protocol/src/handlers.rs
+++ b/crates/ress/protocol/src/handlers.rs
@@ -38,7 +38,7 @@ pub enum ProtocolEvent {
     },
 }
 
-/// Protocol state is an helper struct to store the protocol events.
+/// Protocol state is a helper struct to store the protocol events.
 #[derive(Clone, Debug)]
 pub struct ProtocolState {
     /// Protocol event sender.

--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -878,7 +878,7 @@ pub struct RevertError {
 impl RevertError {
     /// Wraps the output bytes
     ///
-    /// Note: this is intended to wrap an revm output
+    /// Note: this is intended to wrap a revm output
     pub fn new(output: Bytes) -> Self {
         if output.is_empty() {
             Self { output: None }

--- a/crates/transaction-pool/src/noop.rs
+++ b/crates/transaction-pool/src/noop.rs
@@ -409,7 +409,7 @@ impl<T> MockTransactionValidator<T> {
     pub fn no_propagate_local() -> Self {
         Self { propagate_local: false, return_invalid: false, _marker: Default::default() }
     }
-    /// Creates a new [`MockTransactionValidator`] that always return a invalid outcome.
+    /// Creates a new [`MockTransactionValidator`] that always returns an invalid outcome.
     pub fn return_invalid() -> Self {
         Self { propagate_local: false, return_invalid: true, _marker: Default::default() }
     }


### PR DESCRIPTION
Fixes incorrect article usage a/an and verb tense in documentation comments.