### PR TITLE
ci(hive): add flaky tests to ignored_tests.yaml

### DIFF
--- a/.github/assets/hive/ignored_tests.yaml
+++ b/.github/assets/hive/ignored_tests.yaml
@@ -17,12 +17,21 @@ engine-withdrawals:
   - Withdrawals Fork on Block 8 - 10 Block Re-Org NewPayload (Paris) (reth)
   - Withdrawals Fork on Canonical Block 8 / Side Block 7 - 10 Block Re-Org (Paris) (reth)
   - Sync after 128 blocks - Withdrawals on Block 2 - Multiple Withdrawal Accounts (Paris) (reth)
+  # Flaky sync timeouts - similar to the 128 blocks variant above
+  - Sync after 2 blocks - Withdrawals on Block 2 - Multiple Withdrawal Accounts - No Transactions (Paris) (reth)
+  - Sync after 2 blocks - Withdrawals on Block 2 - Multiple Withdrawal Accounts (Paris) (reth)
 engine-cancun:
   - Transaction Re-Org, New Payload on Revert Back (Cancun) (reth)
   - Transaction Re-Org, Re-Org to Different Block (Cancun) (reth)
   - Transaction Re-Org, Re-Org Out (Cancun) (reth)
   - Invalid Missing Ancestor ReOrg, StateRoot, EmptyTxs=False, Invalid P9 (Cancun) (reth)
   - Multiple New Payloads Extending Canonical Chain, Wait for Canonical Payload (Cancun) (reth)
+  # Tests using Modified Geth Module that intermittently fail with timeouts
+  - Invalid Missing Ancestor Syncing ReOrg, Timestamp, EmptyTxs=False, CanonicalReOrg=False, Invalid P8 (Cancun) (reth)
+  - Invalid Missing Ancestor Syncing ReOrg, Timestamp, EmptyTxs=False, CanonicalReOrg=True, Invalid P8 (Cancun) (reth)
+  - Invalid Missing Ancestor Syncing ReOrg, Transaction Value, EmptyTxs=False, CanonicalReOrg=True, Invalid P9 (Cancun) (reth)
+  # Flaky - returns SYNCING instead of VALID for consecutive payloads
+  - In-Order Consecutive Payload Execution (Cancun) (reth)
 engine-api:
   - Transaction Re-Org, Re-Org Out (Paris) (reth)
   - Transaction Re-Org, Re-Org to Different Block (Paris) (reth)


### PR DESCRIPTION
**Problem**
Hive tests are failing on main with flaky tests that intermittently timeout or return unexpected status codes.

**Solution**
Add these flaky tests to `ignored_tests.yaml` to prevent false negatives in CI.

**Changes**
Added to `engine-withdrawals`:
- `Sync after 2 blocks - Withdrawals on Block 2 - Multiple Withdrawal Accounts - No Transactions` - Flaky sync timeout, similar to already-ignored `Sync after 128 blocks` variant
- `Sync after 2 blocks - Withdrawals on Block 2 - Multiple Withdrawal Accounts` - Same pattern

Added to `engine-cancun`:
- `Invalid Missing Ancestor Syncing ReOrg, Timestamp` (2 variants) - Uses Modified Geth Module that intermittently times out
- `Invalid Missing Ancestor Syncing ReOrg, Transaction Value, CanonicalReOrg=True` - Same Modified Geth Module timeout pattern
- `In-Order Consecutive Payload Execution` - Flaky, returns SYNCING instead of VALID for consecutive payloads

**Expected Impact**
Hive CI should no longer fail due to these intermittent test failures.