### PR TITLE
perf(trie): add cursor locality for account cursors (experiment)

### DIFF
--- a/crates/trie/db/src/hashed_cursor.rs
+++ b/crates/trie/db/src/hashed_cursor.rs
@@ -77,15 +77,16 @@ where
     /// first. If `next()` returns a key >= target, we avoid an O(log N) seek.
     fn seek(&mut self, key: B256) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
         // Locality optimization: if we're seeking forward, try next() first
-        if let Some(last) = self.last_key
-            && key > last
-                && let Some((found_key, value)) = self.cursor.next()?
-                    && found_key >= key {
-                        // next() gave us a key >= target, we're done
-                        self.last_key = Some(found_key);
-                        return Ok(Some((found_key, value)));
-                    }
-                    // next() returned a key < target, need to seek
+        if let Some(last) = self.last_key &&
+            key > last &&
+            let Some((found_key, value)) = self.cursor.next()? &&
+            found_key >= key
+        {
+            // next() gave us a key >= target, we're done
+            self.last_key = Some(found_key);
+            return Ok(Some((found_key, value)));
+        }
+        // next() returned a key < target, need to seek
 
         let result = self.cursor.seek(key)?;
         self.last_key = result.as_ref().map(|(k, _)| *k);

--- a/crates/trie/db/src/hashed_cursor.rs
+++ b/crates/trie/db/src/hashed_cursor.rs
@@ -77,18 +77,15 @@ where
     /// first. If `next()` returns a key >= target, we avoid an O(log N) seek.
     fn seek(&mut self, key: B256) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
         // Locality optimization: if we're seeking forward, try next() first
-        if let Some(last) = self.last_key {
-            if key > last {
-                if let Some((found_key, value)) = self.cursor.next()? {
-                    if found_key >= key {
+        if let Some(last) = self.last_key
+            && key > last
+                && let Some((found_key, value)) = self.cursor.next()?
+                    && found_key >= key {
                         // next() gave us a key >= target, we're done
                         self.last_key = Some(found_key);
                         return Ok(Some((found_key, value)));
                     }
                     // next() returned a key < target, need to seek
-                }
-            }
-        }
 
         let result = self.cursor.seek(key)?;
         self.last_key = result.as_ref().map(|(k, _)| *k);

--- a/crates/trie/db/src/trie_cursor.rs
+++ b/crates/trie/db/src/trie_cursor.rs
@@ -83,14 +83,15 @@ where
     ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
         // For exact seeks, we can use the locality optimization when seeking forward:
         // try next() first, and if it returns exactly the key we want, we're done.
-        if let Some(last) = self.last_key
-            && key > last
-                && let Some((found_key, value)) = self.cursor.next()?.map(|v| (v.0 .0, v.1))
-                    && found_key == key {
-                        self.last_key = Some(found_key);
-                        return Ok(Some((found_key, value)));
-                    }
-                    // next() didn't give us the exact key, fall through to seek_exact
+        if let Some(last) = self.last_key &&
+            key > last &&
+            let Some((found_key, value)) = self.cursor.next()?.map(|v| (v.0 .0, v.1)) &&
+            found_key == key
+        {
+            self.last_key = Some(found_key);
+            return Ok(Some((found_key, value)));
+        }
+        // next() didn't give us the exact key, fall through to seek_exact
 
         let result = self.cursor.seek_exact(StoredNibbles(key))?.map(|value| (value.0 .0, value.1));
         self.last_key = result.as_ref().map(|(k, _)| *k);
@@ -106,15 +107,16 @@ where
         key: Nibbles,
     ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
         // Locality optimization: if we're seeking forward, try next() first
-        if let Some(last) = self.last_key
-            && key > last
-                && let Some((found_key, value)) = self.cursor.next()?.map(|v| (v.0 .0, v.1))
-                    && found_key >= key {
-                        // next() gave us a key >= target, we're done
-                        self.last_key = Some(found_key);
-                        return Ok(Some((found_key, value)));
-                    }
-                    // next() returned a key < target, need to seek
+        if let Some(last) = self.last_key &&
+            key > last &&
+            let Some((found_key, value)) = self.cursor.next()?.map(|v| (v.0 .0, v.1)) &&
+            found_key >= key
+        {
+            // next() gave us a key >= target, we're done
+            self.last_key = Some(found_key);
+            return Ok(Some((found_key, value)));
+        }
+        // next() returned a key < target, need to seek
 
         let result = self.cursor.seek(StoredNibbles(key))?.map(|value| (value.0 .0, value.1));
         self.last_key = result.as_ref().map(|(k, _)| *k);

--- a/crates/trie/db/src/trie_cursor.rs
+++ b/crates/trie/db/src/trie_cursor.rs
@@ -83,17 +83,14 @@ where
     ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
         // For exact seeks, we can use the locality optimization when seeking forward:
         // try next() first, and if it returns exactly the key we want, we're done.
-        if let Some(last) = self.last_key {
-            if key > last {
-                if let Some((found_key, value)) = self.cursor.next()?.map(|v| (v.0 .0, v.1)) {
-                    if found_key == key {
+        if let Some(last) = self.last_key
+            && key > last
+                && let Some((found_key, value)) = self.cursor.next()?.map(|v| (v.0 .0, v.1))
+                    && found_key == key {
                         self.last_key = Some(found_key);
                         return Ok(Some((found_key, value)));
                     }
                     // next() didn't give us the exact key, fall through to seek_exact
-                }
-            }
-        }
 
         let result = self.cursor.seek_exact(StoredNibbles(key))?.map(|value| (value.0 .0, value.1));
         self.last_key = result.as_ref().map(|(k, _)| *k);
@@ -109,18 +106,15 @@ where
         key: Nibbles,
     ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
         // Locality optimization: if we're seeking forward, try next() first
-        if let Some(last) = self.last_key {
-            if key > last {
-                if let Some((found_key, value)) = self.cursor.next()?.map(|v| (v.0 .0, v.1)) {
-                    if found_key >= key {
+        if let Some(last) = self.last_key
+            && key > last
+                && let Some((found_key, value)) = self.cursor.next()?.map(|v| (v.0 .0, v.1))
+                    && found_key >= key {
                         // next() gave us a key >= target, we're done
                         self.last_key = Some(found_key);
                         return Ok(Some((found_key, value)));
                     }
                     // next() returned a key < target, need to seek
-                }
-            }
-        }
 
         let result = self.cursor.seek(StoredNibbles(key))?.map(|value| (value.0 .0, value.1));
         self.last_key = result.as_ref().map(|(k, _)| *k);


### PR DESCRIPTION
this a follow up to #20767 but applied on account cursors

consider if can this have integration regressions when combined with the other pr