### PR TITLE
perf(rpc): reuse EVM instance in debug_traceBlock

### DIFF
--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -121,7 +121,6 @@ where
                 let mut transactions = block.transactions_recovered().enumerate().peekable();
                 let inspector = DebugInspector::new(opts).map_err(Eth::Error::from_eth_err)?;
 
-                // Create EVM once and reuse it for all transactions in the block
                 let mut evm = eth_api.evm_config().evm_with_env_and_inspector(
                     &mut db,
                     evm_env.clone(),
@@ -133,7 +132,6 @@ where
                     let tx_env = eth_api.evm_config().tx_env(tx);
                     let res = evm.transact(tx_env.clone()).map_err(Eth::Error::from_evm_err)?;
 
-                    // Access inspector and db through EVM components
                     let (db_ref, inspector_ref, _) = evm.components_mut();
                     let result = inspector_ref
                         .get_result(

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -116,6 +116,7 @@ where
             .spawn_with_state_at_block(block.parent_hash(), move |eth_api, mut db| {
                 let mut results = Vec::with_capacity(block.body().transactions().len());
 
+                let block_env = evm_env.block_env.clone();
                 eth_api.apply_pre_execution_changes(&block, &mut db, &evm_env)?;
 
                 let mut transactions = block.transactions_recovered().enumerate().peekable();
@@ -123,7 +124,7 @@ where
 
                 let mut evm = eth_api.evm_config().evm_with_env_and_inspector(
                     &mut db,
-                    evm_env.clone(),
+                    evm_env,
                     inspector,
                 );
 
@@ -141,7 +142,7 @@ where
                                 tx_index: Some(index),
                             }),
                             &tx_env,
-                            &evm_env.block_env,
+                            &block_env,
                             &res,
                             db,
                         )

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -132,8 +132,8 @@ where
                     let tx_env = eth_api.evm_config().tx_env(tx);
                     let res = evm.transact(tx_env.clone()).map_err(Eth::Error::from_evm_err)?;
 
-                    let (db_ref, inspector_ref, _) = evm.components_mut();
-                    let result = inspector_ref
+                    let (db, inspector, _) = evm.components_mut();
+                    let result = inspector
                         .get_result(
                             Some(TransactionContext {
                                 block_hash: Some(block.hash()),
@@ -143,16 +143,16 @@ where
                             &tx_env,
                             &evm_env.block_env,
                             &res,
-                            db_ref,
+                            db,
                         )
                         .map_err(Eth::Error::from_eth_err)?;
 
                     results.push(TraceResult::Success { result, tx_hash: Some(tx_hash) });
                     if transactions.peek().is_some() {
-                        inspector_ref.fuse().map_err(Eth::Error::from_eth_err)?;
+                        inspector.fuse().map_err(Eth::Error::from_eth_err)?;
                         // need to apply the state changes of this transaction before executing the
                         // next transaction
-                        db_ref.commit(res.state)
+                        db.commit(res.state)
                     }
                 }
 


### PR DESCRIPTION
This closes #17045

Noticed this issue was sitting idle, so I took a stab at it.

## Summary

Reuse a single EVM instance across all transactions when tracing a block in the `debug_` API, matching the optimization already present in the `trace_` API.

## Motivation

Previously, `debug_traceBlock` (and related methods) called `eth_api.inspect()` for each transaction in a loop, which creates a new EVM instance every time:

## Changes

This PR implements EVM reuse manually in `debug.rs`:

1. Create the EVM once before the loop using `evm_with_env_and_inspector()`
2. Call `evm.transact()` for each transaction (reusing the same EVM)
3. Access inspector and database through `evm.components_mut()` for `get_result()`, `fuse()`, and `commit()`

> we recently added support for reusing the evm for block tracing:
which we can mirror for the debug_ api as well.

The `trace_` API already solved this problem using `create_tracer().try_trace_many()` and `trace_block_until_with_inspector()`. However, these APIs require `Inspector: Clone`.

