### PR TITLE
fix(trie): account for all flag in PrefixSet::is_empty()

### DIFF
--- a/crates/trie/common/src/prefix_set.rs
+++ b/crates/trie/common/src/prefix_set.rs
@@ -147,9 +147,9 @@ impl PrefixSetMut {
         self.keys.len()
     }
 
-    /// Returns `true` if the set is empty.
+    /// Returns `true` if the set is empty and `all` flag is not set.
     pub const fn is_empty(&self) -> bool {
-        self.keys.is_empty()
+        !self.all && self.keys.is_empty()
     }
 
     /// Clears the inner vec for reuse, setting `all` to `false`.
@@ -240,9 +240,9 @@ impl PrefixSet {
         self.keys.len()
     }
 
-    /// Returns `true` if the set is empty.
+    /// Returns `true` if the set is empty and `all` flag is not set.
     pub fn is_empty(&self) -> bool {
-        self.keys.is_empty()
+        !self.all && self.keys.is_empty()
     }
 }
 

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -1408,7 +1408,7 @@ impl ParallelSparseTrie {
     ) -> (Vec<ChangedSubtrie>, PrefixSetMut) {
         // Fast-path: If the prefix set is empty then no subtries can have been changed. Just return
         // empty values.
-        if prefix_set.is_empty() && !prefix_set.all() {
+        if prefix_set.is_empty() {
             return Default::default();
         }
 


### PR DESCRIPTION
`is_empty()` was returning `true` even when `all` flag was set. This is incorrect because `all=true` means "all keys are changed", so the set is logically not empty.

Found existing workaround in codebase: `is_empty() && !all()` check in sparse-parallel, which confirms this was a known issue.