### PR TITLE
ci(hive): ignore timing-sensitive flaky tests

### DIFF
--- a/.github/assets/hive/ignored_tests.yaml
+++ b/.github/assets/hive/ignored_tests.yaml
@@ -17,12 +17,17 @@ engine-withdrawals:
   - Withdrawals Fork on Block 8 - 10 Block Re-Org NewPayload (Paris) (reth)
   - Withdrawals Fork on Canonical Block 8 / Side Block 7 - 10 Block Re-Org (Paris) (reth)
   - Sync after 128 blocks - Withdrawals on Block 2 - Multiple Withdrawal Accounts (Paris) (reth)
+  # flaky sync timeout - same pattern as "Sync after 128 blocks" above
+  - Sync after 2 blocks - Withdrawals on Block 2 - Multiple Withdrawal Accounts (Paris) (reth)
+  - Sync after 2 blocks - Withdrawals on Block 2 - Multiple Withdrawal Accounts - No Transactions (Paris) (reth)
 engine-cancun:
   - Transaction Re-Org, New Payload on Revert Back (Cancun) (reth)
   - Transaction Re-Org, Re-Org to Different Block (Cancun) (reth)
   - Transaction Re-Org, Re-Org Out (Cancun) (reth)
   - Invalid Missing Ancestor ReOrg, StateRoot, EmptyTxs=False, Invalid P9 (Cancun) (reth)
   - Multiple New Payloads Extending Canonical Chain, Wait for Canonical Payload (Cancun) (reth)
+  # flaky network timeout on getPayload in parallel test environment
+  - In-Order Consecutive Payload Execution (Cancun) (reth)
 engine-api:
   - Transaction Re-Org, Re-Org Out (Paris) (reth)
   - Transaction Re-Org, Re-Org to Different Block (Paris) (reth)


### PR DESCRIPTION
**Problem**
Hive CI has been consistently failing since Dec 8, 2025 with 3 timing-sensitive tests.

**Solution**
Add these tests to `ignored_tests.yaml` after confirming they are infrastructure flakiness, not code bugs.

**Changes**
- Add `In-Order Consecutive Payload Execution (Cancun) (reth)` to engine-cancun ignore list
- Add `Sync after 2 blocks - Withdrawals on Block 2 - Multiple Withdrawal Accounts (Paris) (reth)` to engine-withdrawals ignore list
- Add `Sync after 2 blocks - Withdrawals on Block 2 - Multiple Withdrawal Accounts - No Transactions (Paris) (reth)` to engine-withdrawals ignore list

**Expected Impact**
Hive CI should pass once these flaky tests are ignored.

---

## Root Cause Analysis

### Evidence These Are Flaky, Not Bugs

1. **Same commit passed and failed**: Commit `2f55b1c30` succeeded at Dec 7 18:06:16Z (run 20008227962) and failed at Dec 8 00:22:17Z (run 20012732512)

2. **CI infrastructure change coincides with failures**: CI moved from self-hosted runners to ubuntu runners around Dec 8 (PR #20196)

3. **Failures are timing-related, not logic errors**:
   - `In-Order Consecutive Payload Execution (Cancun)`: `context deadline exceeded` on `engine_getPayloadV3` - this is an HTTP network timeout, not a wrong response
   - `Sync after 2 blocks - Withdrawals`: `Timeout while waiting for secondary client to sync` - timing issue identical to already-ignored `Sync after 128 blocks`

### Failure Logs

**engine-cancun:**
```
>> (ed5504c4) {"jsonrpc":"2.0","id":26,"method":"engine_getPayloadV3","params":["0x06c1aa6e75fea2db"]}
CLMocker: Could not getPayload (ed5504c4, 0x06c1aa6e75fea2db): Post "http://172.17.0.13:8551/": context deadline exceeded
```

**engine-withdrawals:**
```
FAIL (Sync after 2 blocks - Withdrawals on Block 2 - Multiple Withdrawal Accounts): Timeout while waiting for secondary client to sync
```

### Why These Should Be Ignored

1. `Sync after 128 blocks - Withdrawals...` is already in the ignore list for the same reason
2. The issue is Docker container networking under parallel test load (16 tests in parallel), not reth behavior
3. No code change in reth can fix HTTP network timeouts between containers