### PR TITLE
feat(sdk): Add custom `TrieType`

### DIFF
--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -726,6 +726,8 @@ pub enum TrieType {
     State,
     /// Storage trie type.
     Storage,
+    /// Custom trie type. Can be used in ExEx.
+    Custom(&'static str),
 }
 
 impl TrieType {
@@ -734,6 +736,7 @@ impl TrieType {
         match self {
             Self::State => "state",
             Self::Storage => "storage",
+            Self::Custom(s) => s,
         }
     }
 }


### PR DESCRIPTION
Upstreams part of https://github.com/op-rs/op-reth/pull/397. Makes it possible to enable trie metrics for OP's external expanded trie DB which uses the reth metrics library. Otherwise the labels would collide with the regular trie db when metrics is enabled for both.