### PR TITLE
revert: "perf(engine): parellelize multiproof_targets_from_state (#206…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,7 +458,6 @@ dependencies = [
  "proptest-derive 0.6.0",
  "rand 0.9.2",
  "rapidhash",
- "rayon",
  "ruint",
  "rustc-hash",
  "serde",
@@ -4565,7 +4564,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
- "rayon",
  "serde",
  "serde_core",
 ]
@@ -5069,7 +5067,6 @@ dependencies = [
  "arbitrary",
  "equivalent",
  "hashbrown 0.16.1",
- "rayon",
  "serde",
  "serde_core",
 ]

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -29,7 +29,6 @@ use alloy_evm::Database;
 use alloy_primitives::{keccak256, map::B256Set, B256};
 use crossbeam_channel::Sender as CrossbeamSender;
 use metrics::{Counter, Gauge, Histogram};
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use reth_evm::{execute::ExecutableTxFor, ConfigureEvm, Evm, EvmFor, SpecFor};
 use reth_execution_types::ExecutionOutcome;
 use reth_metrics::Metrics;
@@ -619,8 +618,7 @@ where
                 let _enter =
                     debug_span!(target: "engine::tree::payload_processor::prewarm", "prewarm outcome", index, tx_hash=%tx.tx().tx_hash())
                         .entered();
-                let targets = multiproof_targets_from_state(res.state);
-                let storage_targets = targets.storage_targets_count();
+                let (targets, storage_targets) = multiproof_targets_from_state(res.state);
                 metrics.prefetch_storage_targets.record(storage_targets as f64);
                 let _ = sender.send(PrewarmTaskEvent::Outcome { proof_targets: Some(targets) });
                 drop(_enter);
@@ -767,33 +765,37 @@ where
 
 /// Returns a set of [`MultiProofTargets`] and the total amount of storage targets, based on the
 /// given state.
-fn multiproof_targets_from_state(state: EvmState) -> MultiProofTargets {
-    state
-        .into_par_iter()
-        .filter_map(|(address, account)| {
-            // if the account was not touched, or if the account was selfdestructed, do not
-            // fetch proofs for it
-            //
-            // Since selfdestruct can only happen in the same transaction, we can skip
-            // prefetching proofs for selfdestructed accounts
-            //
-            // See: https://eips.ethereum.org/EIPS/eip-6780
-            if !account.is_touched() || account.is_selfdestructed() {
-                return None;
+fn multiproof_targets_from_state(state: EvmState) -> (MultiProofTargets, usize) {
+    let mut targets = MultiProofTargets::with_capacity(state.len());
+    let mut storage_targets = 0;
+    for (addr, account) in state {
+        // if the account was not touched, or if the account was selfdestructed, do not
+        // fetch proofs for it
+        //
+        // Since selfdestruct can only happen in the same transaction, we can skip
+        // prefetching proofs for selfdestructed accounts
+        //
+        // See: https://eips.ethereum.org/EIPS/eip-6780
+        if !account.is_touched() || account.is_selfdestructed() {
+            continue
+        }
+
+        let mut storage_set =
+            B256Set::with_capacity_and_hasher(account.storage.len(), Default::default());
+        for (key, slot) in account.storage {
+            // do nothing if unchanged
+            if !slot.is_changed() {
+                continue
             }
 
-            let hashed_address = keccak256(address);
+            storage_set.insert(keccak256(B256::new(key.to_be_bytes())));
+        }
 
-            let storage_set: B256Set = account
-                .storage
-                .into_iter()
-                .filter(|(_, slot)| slot.is_changed())
-                .map(|(key, _)| keccak256(B256::new(key.to_be_bytes())))
-                .collect();
+        storage_targets += storage_set.len();
+        targets.insert(keccak256(addr), storage_set);
+    }
 
-            Some((hashed_address, storage_set))
-        })
-        .collect()
+    (targets, storage_targets)
 }
 
 /// The events the pre-warm task can handle.

--- a/crates/trie/common/Cargo.toml
+++ b/crates/trie/common/Cargo.toml
@@ -131,7 +131,7 @@ arbitrary = [
     "reth-codecs/arbitrary",
     "alloy-rpc-types-eth?/arbitrary",
 ]
-rayon = ["dep:rayon", "alloy-primitives/rayon"]
+rayon = ["dep:rayon"]
 
 [[bench]]
 name = "prefix_set"

--- a/crates/trie/common/src/proofs.rs
+++ b/crates/trie/common/src/proofs.rs
@@ -16,8 +16,6 @@ use alloy_trie::{
 };
 use derive_more::{Deref, DerefMut, IntoIterator};
 use itertools::Itertools;
-#[cfg(feature = "rayon")]
-use rayon::iter::{FromParallelIterator, IntoParallelIterator, ParallelIterator};
 use reth_primitives_traits::Account;
 
 /// Proof targets map.
@@ -27,16 +25,6 @@ pub struct MultiProofTargets(B256Map<B256Set>);
 impl FromIterator<(B256, B256Set)> for MultiProofTargets {
     fn from_iter<T: IntoIterator<Item = (B256, B256Set)>>(iter: T) -> Self {
         Self(B256Map::from_iter(iter))
-    }
-}
-
-#[cfg(feature = "rayon")]
-impl FromParallelIterator<(B256, B256Set)> for MultiProofTargets {
-    fn from_par_iter<I>(par_iter: I) -> Self
-    where
-        I: IntoParallelIterator<Item = (B256, B256Set)>,
-    {
-        Self(par_iter.into_par_iter().collect())
     }
 }
 
@@ -105,11 +93,6 @@ impl MultiProofTargets {
     /// Returns the number of items that will be considered during chunking in `[Self::chunks]`.
     pub fn chunking_length(&self) -> usize {
         self.values().map(|slots| 1 + slots.len().saturating_sub(1)).sum::<usize>()
-    }
-
-    /// Returns the total count of storage slot targets across all accounts.
-    pub fn storage_targets_count(&self) -> usize {
-        self.values().map(|slots| slots.len()).sum()
     }
 }
 


### PR DESCRIPTION
…69)"

This reverts commit 63842264f3109b11a828c5f07dc157381a5f6296.

cc @figtracer this actually degraded perf, so we need to investigate this a bit more