### PR TITLE
feat(reth-bench-compare): Do unwind first

### DIFF
--- a/bin/reth-bench-compare/src/cli.rs
+++ b/bin/reth-bench-compare/src/cli.rs
@@ -512,6 +512,7 @@ async fn run_compilation_phase(
     Ok((baseline_commit, feature_commit))
 }
 
+#[allow(clippy::too_many_arguments)]
 /// Run warmup phase to warm up caches before benchmarking
 async fn run_warmup_phase(
     git_manager: &GitManager,

--- a/bin/reth-bench-compare/src/cli.rs
+++ b/bin/reth-bench-compare/src/cli.rs
@@ -526,8 +526,10 @@ async fn run_warmup_phase(
 ) -> Result<()> {
     info!("=== Running warmup phase ===");
 
-    // Unwind to starting block before warmup
-    node_manager.unwind_to_block(starting_tip).await?;
+    // Unwind to starting block minus warmup blocks, so we end up back at starting_tip
+    let warmup_blocks = args.get_warmup_blocks();
+    let unwind_target = starting_tip.saturating_sub(warmup_blocks);
+    node_manager.unwind_to_block(unwind_target).await?;
 
     // Use baseline for warmup
     let warmup_ref = &args.baseline_ref;
@@ -641,8 +643,9 @@ async fn run_benchmark_workflow(
         let commit = commits[i];
         info!("=== Processing {} reference: {} ===", ref_type, git_ref);
 
-        // Unwind to starting block before running this benchmark
-        node_manager.unwind_to_block(starting_tip).await?;
+        // Unwind to starting block minus benchmark blocks, so we end up back at starting_tip
+        let unwind_target = starting_tip.saturating_sub(args.blocks);
+        node_manager.unwind_to_block(unwind_target).await?;
 
         // Switch to target reference
         git_manager.switch_ref(git_ref)?;


### PR DESCRIPTION
reth-bench-compare currently performs its unwind _after_ each of its workflows (warmup, baseline, and feature). This means that:

* When synced to the tip, you must first manually unwind by however many blocks you want to bench against, otherwise they won't be available.
* When RBC completes the node will be behind by however many blocks were benched against.

This PR changes RBC to perform the unwind step prior to each workflow. This requires initially starting the node to get the current block number, but this is fine.