### PR TITLE
refactor(config): delegate PruneConfig::has_receipts_pruning

### DIFF
--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -527,7 +527,7 @@ impl PruneConfig {
 
     /// Returns whether there is any kind of receipt pruning configuration.
     pub fn has_receipts_pruning(&self) -> bool {
-        self.segments.receipts.is_some() || !self.segments.receipts_log_filter.is_empty()
+        self.segments.has_receipts_pruning()
     }
 
     /// Merges values from `other` into `self`.


### PR DESCRIPTION
`PruneConfig::has_receipts_pruning` duplicated the same condition already implemented on `PruneModes`. This change makes the config-layer helper method delegate directly to `self.segments.has_receipts_pruning()`, so there is a single source of truth for the receipts pruning check. Public API and behavior remain unchanged, but future changes to `PruneModes` logic will be consistently reflected everywhere.