### PR TITLE
feat(metrics): jemalloc heap dump endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5256,6 +5256,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jemalloc_pprof"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74ff642505c7ce8d31c0d43ec0e235c6fd4585d9b8172d8f9dd04d36590200b5"
+dependencies = [
+ "anyhow",
+ "libc",
+ "mappings",
+ "once_cell",
+ "pprof_util",
+ "tempfile",
+ "tikv-jemalloc-ctl",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5783,6 +5800,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.113",
+]
+
+[[package]]
+name = "mappings"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db4d277bb50d4508057e7bddd7fcd19ef4a4cc38051b6a5a36868d75ae2cbeb9"
+dependencies = [
+ "anyhow",
+ "libc",
+ "once_cell",
+ "pprof_util",
+ "tracing",
 ]
 
 [[package]]
@@ -6525,7 +6555,7 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost",
+ "prost 0.14.1",
  "reqwest",
  "thiserror 2.0.17",
  "tokio",
@@ -6541,7 +6571,7 @@ checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost",
+ "prost 0.14.1",
  "tonic",
  "tonic-prost",
 ]
@@ -6883,6 +6913,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "pprof_util"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4429d44e5e2c8a69399fc0070379201eed018e3df61e04eb7432811df073c224"
+dependencies = [
+ "anyhow",
+ "backtrace",
+ "flate2",
+ "num",
+ "paste",
+ "prost 0.13.5",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7070,12 +7114,35 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.14.1",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -9481,8 +9548,11 @@ dependencies = [
 name = "reth-node-metrics"
 version = "1.9.3"
 dependencies = [
+ "bytes",
  "eyre",
  "http",
+ "http-body-util",
+ "jemalloc_pprof",
  "jsonrpsee-server",
  "metrics",
  "metrics-exporter-prometheus",
@@ -13028,7 +13098,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
 dependencies = [
  "bytes",
- "prost",
+ "prost 0.14.1",
  "tonic",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -684,6 +684,7 @@ ethereum_ssz = "0.9.0"
 ethereum_ssz_derive = "0.9.0"
 
 # allocators
+jemalloc_pprof = { version = "0.8", default-features = false }
 tikv-jemalloc-ctl = "0.6"
 tikv-jemallocator = "0.6"
 tracy-client = "0.18.0"

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -117,6 +117,10 @@ jemalloc-prof = [
     "reth-cli-util/jemalloc-prof",
     "reth-ethereum-cli/jemalloc-prof",
 ]
+jemalloc-symbols = [
+    "jemalloc-prof",
+    "reth-ethereum-cli/jemalloc-symbols",
+]
 jemalloc-unprefixed = [
     "reth-cli-util/jemalloc-unprefixed",
     "reth-node-core/jemalloc",

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -116,6 +116,7 @@ jemalloc-prof = [
     "reth-cli-util/jemalloc",
     "reth-cli-util/jemalloc-prof",
     "reth-ethereum-cli/jemalloc-prof",
+    "reth-node-metrics/jemalloc-prof",
 ]
 jemalloc-symbols = [
     "jemalloc-prof",

--- a/bin/reth/src/main.rs
+++ b/bin/reth/src/main.rs
@@ -3,6 +3,10 @@
 #[global_allocator]
 static ALLOC: reth_cli_util::allocator::Allocator = reth_cli_util::allocator::new_allocator();
 
+#[cfg(all(feature = "jemalloc-prof", unix))]
+#[unsafe(export_name = "_rjem_malloc_conf")]
+static MALLOC_CONF: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
+
 use clap::Parser;
 use reth::{args::RessArgs, cli::Cli, ress::install_ress_subprotocol};
 use reth_ethereum_cli::chainspec::EthereumChainSpecParser;

--- a/crates/ethereum/cli/Cargo.toml
+++ b/crates/ethereum/cli/Cargo.toml
@@ -51,7 +51,12 @@ jemalloc = [
     "reth-node-metrics/jemalloc",
 ]
 jemalloc-prof = [
-    "reth-node-core/jemalloc",
+    "jemalloc",
+    "reth-node-metrics/jemalloc-prof",
+]
+jemalloc-symbols = [
+    "jemalloc-prof",
+    "reth-node-metrics/jemalloc-symbols",
 ]
 tracy-allocator = []
 

--- a/crates/ethereum/reth/Cargo.toml
+++ b/crates/ethereum/reth/Cargo.toml
@@ -152,6 +152,15 @@ jemalloc = [
     "reth-ethereum-cli?/jemalloc",
     "reth-node-core?/jemalloc",
 ]
+jemalloc-prof = [
+    "jemalloc",
+    "reth-cli-util?/jemalloc-prof",
+    "reth-ethereum-cli?/jemalloc-prof",
+]
+jemalloc-symbols = [
+    "jemalloc-prof",
+    "reth-ethereum-cli?/jemalloc-symbols",
+]
 js-tracer = [
     "rpc",
     "reth-rpc/js-tracer",

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -664,7 +664,9 @@ where
                         }
                     })
                     .build(),
-            ).with_push_gateway(self.node_config().metrics.push_gateway_url.clone(), self.node_config().metrics.push_gateway_interval);
+            )
+            .with_push_gateway(self.node_config().metrics.push_gateway_url.clone(), self.node_config().metrics.push_gateway_interval)
+            .with_heap_profiling(self.node_config().debug.heap_profiling);
 
             MetricServer::new(config).serve().await?;
         }

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -665,8 +665,7 @@ where
                     })
                     .build(),
             )
-            .with_push_gateway(self.node_config().metrics.push_gateway_url.clone(), self.node_config().metrics.push_gateway_interval)
-            .with_heap_profiling(self.node_config().debug.heap_profiling);
+            .with_push_gateway(self.node_config().metrics.push_gateway_url.clone(), self.node_config().metrics.push_gateway_interval);
 
             MetricServer::new(config).serve().await?;
         }

--- a/crates/node/core/src/args/debug.rs
+++ b/crates/node/core/src/args/debug.rs
@@ -108,6 +108,15 @@ pub struct DebugArgs {
     /// the backfill, but did not yet receive any new blocks.
     #[arg(long = "debug.startup-sync-state-idle", help_heading = "Debug")]
     pub startup_sync_state_idle: bool,
+
+    /// Enable the `/debug/pprof/heap` endpoint on the metrics server for heap profiling.
+    ///
+    /// This endpoint returns jemalloc heap profiles in pprof format, compatible with
+    /// the `pprof` tool.
+    ///
+    /// Requires building with the `jemalloc-prof` feature.
+    #[arg(long = "debug.heap-profiling", help_heading = "Debug")]
+    pub heap_profiling: bool,
 }
 
 impl Default for DebugArgs {
@@ -127,6 +136,7 @@ impl Default for DebugArgs {
             healthy_node_rpc_url: None,
             ethstats: None,
             startup_sync_state_idle: false,
+            heap_profiling: false,
         }
     }
 }

--- a/crates/node/core/src/args/debug.rs
+++ b/crates/node/core/src/args/debug.rs
@@ -108,15 +108,6 @@ pub struct DebugArgs {
     /// the backfill, but did not yet receive any new blocks.
     #[arg(long = "debug.startup-sync-state-idle", help_heading = "Debug")]
     pub startup_sync_state_idle: bool,
-
-    /// Enable the `/debug/pprof/heap` endpoint on the metrics server for heap profiling.
-    ///
-    /// This endpoint returns jemalloc heap profiles in pprof format, compatible with
-    /// the `pprof` tool.
-    ///
-    /// Requires building with the `jemalloc-prof` feature.
-    #[arg(long = "debug.heap-profiling", help_heading = "Debug")]
-    pub heap_profiling: bool,
 }
 
 impl Default for DebugArgs {
@@ -136,7 +127,6 @@ impl Default for DebugArgs {
             healthy_node_rpc_url: None,
             ethstats: None,
             startup_sync_state_idle: false,
-            heap_profiling: false,
         }
     }
 }

--- a/crates/node/metrics/Cargo.toml
+++ b/crates/node/metrics/Cargo.toml
@@ -20,6 +20,8 @@ tokio.workspace = true
 
 jsonrpsee-server.workspace = true
 http.workspace = true
+http-body-util.workspace = true
+bytes.workspace = true
 tower.workspace = true
 reqwest.workspace = true
 
@@ -28,6 +30,7 @@ eyre.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 tikv-jemalloc-ctl = { workspace = true, optional = true, features = ["stats"] }
+jemalloc_pprof = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = "0.17.0"
@@ -41,3 +44,5 @@ workspace = true
 
 [features]
 jemalloc = ["dep:tikv-jemalloc-ctl"]
+jemalloc-prof = ["jemalloc", "dep:jemalloc_pprof"]
+jemalloc-symbols = ["jemalloc-prof", "jemalloc_pprof?/symbolize"]

--- a/crates/node/metrics/src/server.rs
+++ b/crates/node/metrics/src/server.rs
@@ -4,8 +4,10 @@ use crate::{
     recorder::install_prometheus_recorder,
     version::VersionInfo,
 };
+use bytes::Bytes;
 use eyre::WrapErr;
-use http::{header::CONTENT_TYPE, HeaderValue, Response};
+use http::{header::CONTENT_TYPE, HeaderValue, Request, Response, StatusCode};
+use http_body_util::Full;
 use metrics::describe_gauge;
 use metrics_process::Collector;
 use reqwest::Client;
@@ -23,6 +25,7 @@ pub struct MetricServerConfig {
     hooks: Hooks,
     push_gateway_url: Option<String>,
     push_gateway_interval: Duration,
+    heap_profiling_enabled: bool,
 }
 
 impl MetricServerConfig {
@@ -42,6 +45,7 @@ impl MetricServerConfig {
             chain_spec_info,
             push_gateway_url: None,
             push_gateway_interval: Duration::from_secs(5),
+            heap_profiling_enabled: false,
         }
     }
 
@@ -49,6 +53,12 @@ impl MetricServerConfig {
     pub fn with_push_gateway(mut self, url: Option<String>, interval: Duration) -> Self {
         self.push_gateway_url = url;
         self.push_gateway_interval = interval;
+        self
+    }
+
+    /// Enable the `/debug/pprof/heap` endpoint for heap profiling
+    pub const fn with_heap_profiling(mut self, enabled: bool) -> Self {
+        self.heap_profiling_enabled = enabled;
         self
     }
 }
@@ -75,6 +85,7 @@ impl MetricServer {
             chain_spec_info,
             push_gateway_url,
             push_gateway_interval,
+            heap_profiling_enabled,
         } = &self.config;
 
         let hooks_for_endpoint = hooks.clone();
@@ -82,6 +93,7 @@ impl MetricServer {
             *listen_addr,
             Arc::new(move || hooks_for_endpoint.iter().for_each(|hook| hook())),
             task_executor.clone(),
+            *heap_profiling_enabled,
         )
         .await
         .wrap_err_with(|| format!("Could not start Prometheus endpoint at {listen_addr}"))?;
@@ -114,6 +126,7 @@ impl MetricServer {
         listen_addr: SocketAddr,
         hook: Arc<F>,
         task_executor: TaskExecutor,
+        heap_profiling_enabled: bool,
     ) -> eyre::Result<()> {
         let listener = tokio::net::TcpListener::bind(listen_addr)
             .await
@@ -139,13 +152,13 @@ impl MetricServer {
 
                     let handle = install_prometheus_recorder();
                     let hook = hook.clone();
-                    let service = tower::service_fn(move |_| {
-                        (hook)();
-                        let metrics = handle.handle().render();
-                        let mut response = Response::new(metrics);
-                        response
-                            .headers_mut()
-                            .insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
+                    let service = tower::service_fn(move |req: Request<_>| {
+                        let response = handle_request(
+                            req.uri().path(),
+                            &*hook,
+                            handle,
+                            heap_profiling_enabled,
+                        );
                         async move { Ok::<_, Infallible>(response) }
                     });
 
@@ -286,6 +299,77 @@ fn describe_io_stats() {
 
 #[cfg(not(target_os = "linux"))]
 const fn describe_io_stats() {}
+
+fn handle_request(
+    path: &str,
+    hook: impl Fn(),
+    handle: &crate::recorder::PrometheusRecorder,
+    heap_profiling_enabled: bool,
+) -> Response<Full<Bytes>> {
+    match path {
+        "/debug/pprof/heap" if heap_profiling_enabled => handle_pprof_heap(),
+        _ => {
+            hook();
+            let metrics = handle.handle().render();
+            let mut response = Response::new(Full::new(Bytes::from(metrics)));
+            response.headers_mut().insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
+            response
+        }
+    }
+}
+
+#[cfg(all(feature = "jemalloc-prof", unix))]
+fn handle_pprof_heap() -> Response<Full<Bytes>> {
+    use http::header::CONTENT_ENCODING;
+
+    match jemalloc_pprof::PROF_CTL.as_ref() {
+        Some(prof_ctl) => match prof_ctl.try_lock() {
+            Ok(mut ctl) => match ctl.dump_pprof() {
+                Ok(pprof) => {
+                    let mut response = Response::new(Full::new(Bytes::from(pprof)));
+                    response
+                        .headers_mut()
+                        .insert(CONTENT_TYPE, HeaderValue::from_static("application/octet-stream"));
+                    response
+                        .headers_mut()
+                        .insert(CONTENT_ENCODING, HeaderValue::from_static("gzip"));
+                    response
+                }
+                Err(err) => {
+                    let mut response = Response::new(Full::new(Bytes::from(format!(
+                        "Failed to dump pprof: {err}"
+                    ))));
+                    *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+                    response
+                }
+            },
+            Err(_) => {
+                let mut response = Response::new(Full::new(Bytes::from_static(
+                    b"Profile dump already in progress. Try again later.",
+                )));
+                *response.status_mut() = StatusCode::SERVICE_UNAVAILABLE;
+                response
+            }
+        },
+        None => {
+            let mut response = Response::new(Full::new(Bytes::from_static(
+                b"jemalloc profiling not enabled. \
+                 Set MALLOC_CONF=prof:true or rebuild with jemalloc-prof feature.",
+            )));
+            *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+            response
+        }
+    }
+}
+
+#[cfg(not(all(feature = "jemalloc-prof", unix)))]
+fn handle_pprof_heap() -> Response<Full<Bytes>> {
+    let mut response = Response::new(Full::new(Bytes::from_static(
+        b"jemalloc pprof support not compiled. Rebuild with the jemalloc-prof feature.",
+    )));
+    *response.status_mut() = StatusCode::NOT_IMPLEMENTED;
+    response
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/optimism/bin/Cargo.toml
+++ b/crates/optimism/bin/Cargo.toml
@@ -36,7 +36,8 @@ js-tracer = [
 ]
 
 jemalloc = ["reth-cli-util/jemalloc", "reth-optimism-cli/jemalloc"]
-jemalloc-prof = ["reth-cli-util/jemalloc-prof"]
+jemalloc-prof = ["jemalloc", "reth-cli-util/jemalloc-prof", "reth-optimism-cli/jemalloc-prof"]
+jemalloc-symbols = ["jemalloc-prof", "reth-optimism-cli/jemalloc-symbols"]
 tracy-allocator = ["reth-cli-util/tracy-allocator"]
 
 asm-keccak = ["reth-optimism-cli/asm-keccak", "reth-optimism-node/asm-keccak"]

--- a/crates/optimism/bin/src/main.rs
+++ b/crates/optimism/bin/src/main.rs
@@ -8,6 +8,10 @@ use tracing::info;
 #[global_allocator]
 static ALLOC: reth_cli_util::allocator::Allocator = reth_cli_util::allocator::new_allocator();
 
+#[cfg(all(feature = "jemalloc-prof", unix))]
+#[unsafe(export_name = "_rjem_malloc_conf")]
+static MALLOC_CONF: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
+
 fn main() {
     reth_cli_util::sigsegv_handler::install();
 

--- a/crates/optimism/cli/Cargo.toml
+++ b/crates/optimism/cli/Cargo.toml
@@ -90,6 +90,14 @@ jemalloc = [
     "reth-node-core/jemalloc",
     "reth-node-metrics/jemalloc",
 ]
+jemalloc-prof = [
+    "jemalloc",
+    "reth-node-metrics/jemalloc-prof",
+]
+jemalloc-symbols = [
+    "jemalloc-prof",
+    "reth-node-metrics/jemalloc-symbols",
+]
 
 dev = [
     "dep:proptest",

--- a/docs/vocs/docs/pages/run/faq/profiling.mdx
+++ b/docs/vocs/docs/pages/run/faq/profiling.mdx
@@ -161,3 +161,14 @@ If everything is working, this will output `jeprof.*.heap` files while reth is r
 [The jemalloc website](https://jemalloc.net/jemalloc.3.html#opt.abort) has a helpful overview of the options available, for example `lg_prof_interval`, `lg_prof_sample`, `prof_leak`, and `prof_final`.
 
 Now that we have the heap snapshots, we can analyze them using `jeprof`. An example of jeprof usage and output can be seen on the jemalloc github repository: https://github.com/jemalloc/jemalloc/wiki/Use-Case:-Leak-Checking
+
+### HTTP pprof endpoint
+
+When built with the `jemalloc-prof` feature and started with the `--debug.heap-profiling` flag, reth exposes a heap profiling endpoint on the metrics server (default port 9001) at `/debug/pprof/heap`. This endpoint returns heap profiles in [pprof format](https://github.com/google/pprof), which is compatible with the standard `pprof` toolchain.
+
+By default, the pprof output contains raw addresses that require external symbolization. You need either `addr2line` or `llvm-addr2line` in your PATH for `pprof` to resolve function names.
+
+For pre-symbolized profiles (useful on macOS or when external tools are unavailable), build with the `jemalloc-symbols` feature:
+```
+cargo build --features jemalloc-prof,jemalloc-symbols --profile profiling
+```

--- a/docs/vocs/docs/pages/run/faq/profiling.mdx
+++ b/docs/vocs/docs/pages/run/faq/profiling.mdx
@@ -164,7 +164,7 @@ Now that we have the heap snapshots, we can analyze them using `jeprof`. An exam
 
 ### HTTP pprof endpoint
 
-When built with the `jemalloc-prof` feature and started with the `--debug.heap-profiling` flag, reth exposes a heap profiling endpoint on the metrics server (default port 9001) at `/debug/pprof/heap`. This endpoint returns heap profiles in [pprof format](https://github.com/google/pprof), which is compatible with the standard `pprof` toolchain.
+When built with the `jemalloc-prof` feature, reth exposes a heap profiling endpoint on the metrics server (default port 9001) at `/debug/pprof/heap`. This endpoint returns heap profiles in [pprof format](https://github.com/google/pprof), which is compatible with the standard `pprof` toolchain.
 
 By default, the pprof output contains raw addresses that require external symbolization. You need either `addr2line` or `llvm-addr2line` in your PATH for `pprof` to resolve function names.
 


### PR DESCRIPTION
https://www.polarsignals.com/blog/posts/2023/12/20/rust-memory-profiling

```console
cargo r --features jemalloc-prof,jemalloc-symbols -- node --metrics 9000 --debug.heap-profiling
```

```console
❯ let file = mktemp --dry --suffix .pb.gz; curl -s localhost:9000/debug/pprof/heap | save $file; nix shell nixpkgs#llvm nixpkgs#go -c go tool pprof -top -nodecount 20 (pwd)/target/debug/reth $file; rm $file
File: reth
Type: inuse_space
Time: 2026-01-07 16:25:52 GMT
Showing nodes accounting for 138.43MB, 100% of 138.43MB total
Dropped 41 nodes (cum <= 0.69MB)
Showing top 20 nodes out of 196
      flat  flat%   sum%        cum   cum%
  138.43MB   100%   100%   138.43MB   100%  rjem_je_prof_backtrace
         0     0%   100%    97.57MB 70.48%  <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once (inline)
         0     0%   100%    40.87MB 29.52%  [reth]
         0     0%   100%    97.57MB 70.48%  __rust_try
         0     0%   100%    97.57MB 70.48%  _pthread_cond_wait
         0     0%   100%    48.87MB 35.30%  _rust_alloc
         0     0%   100%    40.87MB 29.52%  _rust_begin_short_backtrace<fn(), ()>
         0     0%   100%    97.57MB 70.48%  _rust_begin_short_backtrace<tokio::runtime::blocking::pool::{impl#6}::spawn_thread::{closure_env#0}, ()>
         0     0%   100%    89.56MB 64.70%  _rust_realloc
         0     0%   100%     1.01MB  0.73%  abbreviations
         0     0%   100%     4.01MB  2.90%  add_default_value
         0     0%   100%     4.01MB  2.90%  add_defaults
         0     0%   100%    48.87MB 35.30%  alloc (partial-inline)
         0     0%   100%    34.78MB 25.12%  alloc::raw_vec::RawVecInner<A>::finish_grow
         0     0%   100%    34.78MB 25.12%  alloc::raw_vec::RawVecInner<A>::grow_amortized
         0     0%   100%    34.78MB 25.12%  alloc::raw_vec::RawVecInner<A>::reserve::do_reserve_and_handle
         0     0%   100%    34.35MB 24.81%  alloc::raw_vec::RawVecInner<A>::try_allocate_in
         0     0%   100%     9.53MB  6.88%  alloc_impl
         0     0%   100%     9.53MB  6.88%  allocate
         0     0%   100%    32.86MB 23.74%  block_on
```