### PR TITLE
perf(engine): use crossbeam select for persistence events

### DIFF
--- a/crates/engine/tree/src/engine.rs
+++ b/crates/engine/tree/src/engine.rs
@@ -6,6 +6,7 @@ use crate::{
     download::{BlockDownloader, DownloadAction, DownloadOutcome},
 };
 use alloy_primitives::B256;
+use crossbeam_channel::Sender;
 use futures::{Stream, StreamExt};
 use reth_chain_state::ExecutedBlock;
 use reth_engine_primitives::{BeaconEngineMessage, ConsensusEngineEvent};
@@ -15,7 +16,6 @@ use reth_primitives_traits::{Block, NodePrimitives, SealedBlock};
 use std::{
     collections::HashSet,
     fmt::Display,
-    sync::mpsc::Sender,
     task::{ready, Context, Poll},
 };
 use tokio::sync::mpsc::UnboundedReceiver;

--- a/crates/engine/tree/src/tree/error.rs
+++ b/crates/engine/tree/src/tree/error.rs
@@ -6,15 +6,13 @@ use reth_errors::{BlockExecutionError, BlockValidationError, ProviderError};
 use reth_evm::execute::InternalBlockExecutionError;
 use reth_payload_primitives::NewPayloadError;
 use reth_primitives_traits::{Block, BlockBody, SealedBlock};
-use tokio::sync::oneshot::error::TryRecvError;
 
-/// This is an error that can come from advancing persistence. Either this can be a
-/// [`TryRecvError`], or this can be a [`ProviderError`]
+/// This is an error that can come from advancing persistence.
 #[derive(Debug, thiserror::Error)]
 pub enum AdvancePersistenceError {
-    /// An error that can be from failing to receive a value from persistence
-    #[error(transparent)]
-    RecvError(#[from] TryRecvError),
+    /// The persistence channel was closed unexpectedly
+    #[error("persistence channel closed")]
+    ChannelClosed,
     /// A provider error
     #[error(transparent)]
     Provider(#[from] ProviderError),

--- a/crates/engine/tree/src/tree/persistence_state.rs
+++ b/crates/engine/tree/src/tree/persistence_state.rs
@@ -22,12 +22,12 @@
 
 use alloy_eips::BlockNumHash;
 use alloy_primitives::B256;
+use crossbeam_channel::Receiver as CrossbeamReceiver;
 use std::time::Instant;
-use tokio::sync::oneshot;
 use tracing::trace;
 
 /// The state of the persistence task.
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub struct PersistenceState {
     /// Hash and number of the last block persisted.
     ///
@@ -36,7 +36,7 @@ pub struct PersistenceState {
     /// Receiver end of channel where the result of the persistence task will be
     /// sent when done. A None value means there's no persistence task in progress.
     pub(crate) rx:
-        Option<(oneshot::Receiver<Option<BlockNumHash>>, Instant, CurrentPersistenceAction)>,
+        Option<(CrossbeamReceiver<Option<BlockNumHash>>, Instant, CurrentPersistenceAction)>,
 }
 
 impl PersistenceState {
@@ -50,7 +50,7 @@ impl PersistenceState {
     pub(crate) fn start_remove(
         &mut self,
         new_tip_num: u64,
-        rx: oneshot::Receiver<Option<BlockNumHash>>,
+        rx: CrossbeamReceiver<Option<BlockNumHash>>,
     ) {
         self.rx =
             Some((rx, Instant::now(), CurrentPersistenceAction::RemovingBlocks { new_tip_num }));
@@ -60,7 +60,7 @@ impl PersistenceState {
     pub(crate) fn start_save(
         &mut self,
         highest: BlockNumHash,
-        rx: oneshot::Receiver<Option<BlockNumHash>>,
+        rx: CrossbeamReceiver<Option<BlockNumHash>>,
     ) {
         self.rx = Some((rx, Instant::now(), CurrentPersistenceAction::SavingBlocks { highest }));
     }

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -31,7 +31,7 @@ use std::{
     collections::BTreeMap,
     str::FromStr,
     sync::{
-        mpsc::{channel, Receiver, Sender},
+        mpsc::{Receiver, Sender},
         Arc,
     },
 };
@@ -97,6 +97,7 @@ struct TestChannel<T> {
 impl<T: Send + 'static> TestChannel<T> {
     /// Creates a new test channel
     fn spawn_channel() -> (Sender<T>, Receiver<T>, TestChannelHandle) {
+        use std::sync::mpsc::channel;
         let (original_tx, original_rx) = channel();
         let (wrapped_tx, wrapped_rx) = channel();
         let (release_tx, release_rx) = channel();
@@ -143,7 +144,9 @@ struct TestHarness {
         BasicEngineValidator<MockEthProvider, MockEvmConfig, MockEngineValidator>,
         MockEvmConfig,
     >,
-    to_tree_tx: Sender<FromEngine<EngineApiRequest<EthEngineTypes, EthPrimitives>, Block>>,
+    to_tree_tx: crossbeam_channel::Sender<
+        FromEngine<EngineApiRequest<EthEngineTypes, EthPrimitives>, Block>,
+    >,
     from_tree_rx: UnboundedReceiver<EngineApiEvent>,
     blocks: Vec<ExecutedBlock>,
     action_rx: Receiver<PersistenceAction>,
@@ -153,6 +156,7 @@ struct TestHarness {
 
 impl TestHarness {
     fn new(chain_spec: Arc<ChainSpec>) -> Self {
+        use std::sync::mpsc::channel;
         let (action_tx, action_rx) = channel();
         Self::with_persistence_channel(chain_spec, action_tx, action_rx)
     }
@@ -205,7 +209,7 @@ impl TestHarness {
             engine_api_tree_state,
             canonical_in_memory_state,
             persistence_handle,
-            PersistenceState::default(),
+            PersistenceState { last_persisted_block: BlockNumHash::default(), rx: None },
             payload_builder,
             // always assume enough parallelism for tests
             TreeConfig::default().with_legacy_state_root(false).with_has_enough_parallelism(true),
@@ -399,10 +403,8 @@ impl ValidatorTestHarness {
 
     /// Configure `PersistenceState` for specific persistence scenarios
     fn start_persistence_operation(&mut self, action: CurrentPersistenceAction) {
-        use tokio::sync::oneshot;
-
         // Create a dummy receiver for testing - it will never receive a value
-        let (_tx, rx) = oneshot::channel();
+        let (_tx, rx) = crossbeam_channel::bounded(1);
 
         match action {
             CurrentPersistenceAction::SavingBlocks { highest } => {
@@ -498,11 +500,17 @@ fn test_tree_persist_block_batch() {
     test_harness.to_tree_tx.send(FromEngine::DownloadedBlocks(blocks)).unwrap();
 
     // process the message
-    let msg = test_harness.tree.try_recv_engine_message().unwrap().unwrap();
+    let msg = match test_harness.tree.wait_for_event() {
+        super::LoopEvent::EngineMessage(msg) => msg,
+        other => panic!("unexpected event: {other:?}"),
+    };
     let _ = test_harness.tree.on_engine_message(msg).unwrap();
 
     // we now should receive the other batch
-    let msg = test_harness.tree.try_recv_engine_message().unwrap().unwrap();
+    let msg = match test_harness.tree.wait_for_event() {
+        super::LoopEvent::EngineMessage(msg) => msg,
+        other => panic!("unexpected event: {other:?}"),
+    };
     match msg {
         FromEngine::DownloadedBlocks(blocks) => {
             assert_eq!(blocks.len(), tree_config.max_execute_block_batch_size());
@@ -753,8 +761,8 @@ async fn test_tree_state_on_new_head_reorg() {
         })
     );
 
-    // after advancing persistence, we should be at `None` for the next action
-    test_harness.tree.advance_persistence().unwrap();
+    // after polling persistence completion, we should be at `None` for the next action
+    test_harness.tree.try_poll_persistence().unwrap();
     let current_action = test_harness.tree.persistence_state.current_action().cloned();
     assert_eq!(current_action, None);
 


### PR DESCRIPTION
Follow-up to #20626 which added a signal channel for persistence completion.

This PR takes it further by replacing the 500ms `recv_timeout` polling approach with proper event-driven waiting using `crossbeam_channel::select_biased!`. The engine now waits on both the incoming message channel and persistence response channel simultaneously, waking immediately when either is ready.

Previously, if a persistence task completed but no new engine message arrived, the engine would wait up to 500ms before processing the completion. Now it wakes immediately.

Changes:
- Use `crossbeam_channel` for persistence responses instead of `tokio::sync::oneshot`
- Use `select_biased!` to prioritize persistence completion over new messages, ensuring disk writes are processed as soon as they complete and in memory state is updated and ready to perform the next regular engine message
- Remove the `recv_timeout` polling pattern entirely

