### PR TITLE
chore(engine): more logs when cache is not available

### DIFF
--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -629,6 +629,11 @@ impl SavedCache {
         Arc::strong_count(&self.usage_guard) == 1
     }
 
+    /// Returns the current strong count of the usage guard.
+    pub(crate) fn usage_count(&self) -> usize {
+        Arc::strong_count(&self.usage_guard)
+    }
+
     /// Returns the [`ExecutionCache`] belonging to the tracked hash.
     pub(crate) const fn cache(&self) -> &ExecutionCache {
         &self.caches


### PR DESCRIPTION
Adds better logs to figure out why do we end up recreating the cache, as it shouldn't happen in normal case.