### PR TITLE
perf: remove redundant contains_key

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -153,16 +153,6 @@ impl ProofSequencer {
             self.pending_proofs.insert(sequence, update);
         }
 
-        // BTreeMap::first_key_value is more efficient than contains_key for checking
-        // if the next expected proof exists, since we only need to check the first key
-        let Some(first_key) = self.pending_proofs.first_key_value().map(|(k, _)| *k) else {
-            return Vec::new()
-        };
-
-        if first_key != self.next_to_deliver {
-            return Vec::new()
-        }
-
         let mut consecutive_proofs = Vec::with_capacity(self.pending_proofs.len());
         let mut current_sequence = self.next_to_deliver;
 

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -153,6 +153,11 @@ impl ProofSequencer {
             self.pending_proofs.insert(sequence, update);
         }
 
+        // return early if we don't have the next expected proof to avoid unnecessary allocation
+        if self.pending_proofs.is_empty() {
+            return Vec::new()
+        }
+
         let mut consecutive_proofs = Vec::with_capacity(self.pending_proofs.len());
         let mut current_sequence = self.next_to_deliver;
 

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -153,8 +153,13 @@ impl ProofSequencer {
             self.pending_proofs.insert(sequence, update);
         }
 
-        // return early if we don't have the next expected proof to avoid unnecessary allocation
-        if self.pending_proofs.is_empty() {
+        // BTreeMap::first_key_value is more efficient than contains_key for checking
+        // if the next expected proof exists, since we only need to check the first key
+        let Some(first_key) = self.pending_proofs.first_key_value().map(|(k, _)| *k) else {
+            return Vec::new()
+        };
+
+        if first_key != self.next_to_deliver {
             return Vec::new()
         }
 

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -153,11 +153,6 @@ impl ProofSequencer {
             self.pending_proofs.insert(sequence, update);
         }
 
-        // return early if we don't have the next expected proof
-        if !self.pending_proofs.contains_key(&self.next_to_deliver) {
-            return Vec::new()
-        }
-
         let mut consecutive_proofs = Vec::with_capacity(self.pending_proofs.len());
         let mut current_sequence = self.next_to_deliver;
 


### PR DESCRIPTION
The contains_key check is redundant since the while let loop immediately tries to remove the same key anyway. 