### PR TITLE
docs: clarify bodies downloader set_download_range semantics

### DIFF
--- a/crates/net/downloaders/src/bodies/bodies.rs
+++ b/crates/net/downloaders/src/bodies/bodies.rs
@@ -307,12 +307,14 @@ where
 {
     type Block = B;
 
-    /// Set a new download range (exclusive).
+    /// Set a new download range (inclusive).
     ///
-    /// This method will drain all queued bodies, filter out ones outside the range and put them
-    /// back into the buffer.
-    /// If there are any bodies between the range start and last queued body that have not been
-    /// downloaded or are not in progress, they will be re-requested.
+    /// If the provided range is a suffix of the current range with the same end block, the
+    /// existing download already covers it and the call is a no-op.
+    /// If the range starts immediately after the current range, it is treated as the next
+    /// consecutive range and appended without resetting the in-flight state.
+    /// For all other ranges, the downloader state is cleared and the new range replaces the old
+    /// one.
     fn set_download_range(&mut self, range: RangeInclusive<BlockNumber>) -> DownloadResult<()> {
         // Check if the range is valid.
         if range.is_empty() {


### PR DESCRIPTION
The previous documentation for BodiesDownloader::set_download_range described an exclusive range and implied draining and re-requesting queued bodies, which does not match the actual implementation or tests. This change updates the comment to document the inclusive range and the three real code paths (suffix no-op, consecutive range, and full reset) so that callers and maintainers can rely on accurate behavior without reading the implementation.