### PR TITLE
perf(sidecar): skip processing for blocks without blob txs

### DIFF
--- a/examples/beacon-api-sidecar-fetcher/src/mined_sidecar.rs
+++ b/examples/beacon-api-sidecar-fetcher/src/mined_sidecar.rs
@@ -106,12 +106,13 @@ where
             .map(|tx| (tx.clone(), tx.blob_count().unwrap_or(0) as usize))
             .collect();
 
+        // FIX: Optimization to skip processing for blocks with no blob transactions
+        if txs.is_empty() {
+            return;
+        }
+
         let mut all_blobs_available = true;
         let mut actions_to_queue: Vec<BlobTransactionEvent> = Vec::new();
-
-        if txs.is_empty() {
-            return
-        }
 
         match self.pool.get_all_blobs_exact(txs.iter().map(|(tx, _)| *tx.tx_hash()).collect()) {
             Ok(blobs) => {


### PR DESCRIPTION

This PR introduces a performance optimization to the MinedSidecarStream.

Changes:

Added an early return check in process_block to verify if the block contains any EIP-4844 transactions.

Reasoning:
Previously, the stream would proceed to query the transaction pool via get_all_blobs_exact and potentially set up Beacon API request logic even for blocks that had no blob transactions. Since most blocks currently may not contain blobs, this avoids unnecessary overhead and logic execution for the majority of canonical state notifications.