### PR TITLE
perf(trie): use sorted_unstable for proof target chunking

### DIFF
--- a/crates/trie/common/src/proofs.rs
+++ b/crates/trie/common/src/proofs.rs
@@ -138,7 +138,7 @@ impl ChunkedMultiProofTargets {
                     )
                 }
             })
-            .sorted();
+            .sorted_unstable();
         Self { flattened_targets, size }
     }
 }


### PR DESCRIPTION
Stability is unnecessary when sorting `(B256, Option<B256>)` tuples since equal elements are identical.