### PR TITLE
chore: correct `StorageHistory` prune map size constant name

### DIFF
--- a/crates/prune/prune/src/segments/user/storage_history.rs
+++ b/crates/prune/prune/src/segments/user/storage_history.rs
@@ -75,7 +75,7 @@ where
         // block number deleted for that key.
         //
         // The size of this map it's limited by `prune_delete_limit * blocks_since_last_run /
-        // ACCOUNT_HISTORY_TABLES_TO_PRUNE`, and with current default it's usually `3500 * 5
+        // STORAGE_HISTORY_TABLES_TO_PRUNE`, and with current default it's usually `3500 * 5
         // / 2`, so 8750 entries. Each entry is `160 bit + 256 bit + 64 bit`, so the total
         // size should be up to 0.5MB + some hashmap overhead. `blocks_since_last_run` is
         // additionally limited by the `max_reorg_depth`, so no OOM is expected here.


### PR DESCRIPTION
StorageHistory pruning comment referenced ACCOUNT_HISTORY_TABLES_TO_PRUNE even though the code uses STORAGE_HISTORY_TABLES_TO_PRUNE. This was a copy-paste leftover from AccountHistory and could confuse readers reviewing memory usage estimates. The change only updates the comment to match the actual constant name and does not affect runtime behavior.