### PR TITLE
docs: mention optional EraStage in DefaultStages documentation

### DIFF
--- a/crates/stages/stages/src/sets.rs
+++ b/crates/stages/stages/src/sets.rs
@@ -66,6 +66,7 @@ use tokio::sync::watch;
 /// - [`FinishStage`]
 ///
 /// This expands to the following series of stages:
+/// - [`EraStage`] (optional, for ERA1 import)
 /// - [`HeaderStage`]
 /// - [`BodyStage`]
 /// - [`SenderRecoveryStage`]


### PR DESCRIPTION


The `OnlineStages::builder()` implementation adds `EraStage` as the first stage when `era_import_source` is configured, but this was not reflected in the `DefaultStages` rustdoc. This mismatch could mislead developers reading the documentation about the actual pipeline order.
