### PR TITLE
docs: fix incorrect API reference and mermaid include in Pipeline docs

### DIFF
--- a/crates/stages/api/src/pipeline/mod.rs
+++ b/crates/stages/api/src/pipeline/mod.rs
@@ -53,9 +53,9 @@ pub type PipelineWithResult<N> = (Pipeline<N>, Result<ControlFlow, PipelineError
 /// tip.
 ///
 /// After the entire pipeline has been run, it will run again unless asked to stop (see
-/// [`Pipeline::set_max_block`]).
+/// [`PipelineBuilder::with_max_block`]).
 ///
-/// `include_mmd!("docs/mermaid/pipeline.mmd`")
+/// include_mmd!("docs/mermaid/pipeline.mmd")
 ///
 /// # Unwinding
 ///

--- a/crates/stages/api/src/pipeline/mod.rs
+++ b/crates/stages/api/src/pipeline/mod.rs
@@ -55,7 +55,7 @@ pub type PipelineWithResult<N> = (Pipeline<N>, Result<ControlFlow, PipelineError
 /// After the entire pipeline has been run, it will run again unless asked to stop (see
 /// [`PipelineBuilder::with_max_block`]).
 ///
-/// include_mmd!("docs/mermaid/pipeline.mmd")
+/// `include_mmd!("docs/mermaid/pipeline.mmd`")
 ///
 /// # Unwinding
 ///


### PR DESCRIPTION

Fixes documentation issues in `Pipeline` rustdoc comments:

 **Incorrect method reference**: Changed `Pipeline::set_max_block` → `PipelineBuilder::with_max_block`
   - The referenced method doesn't exist on `Pipeline`
   - The correct API is available via `PipelineBuilder`


