### PR TITLE
feat(trie): Keep cached storage roots on proof workers

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -5,7 +5,6 @@ use alloy_eip7928::BlockAccessList;
 use alloy_evm::block::StateChangeSource;
 use alloy_primitives::{keccak256, map::HashSet, B256};
 use crossbeam_channel::{unbounded, Receiver as CrossbeamReceiver, Sender as CrossbeamSender};
-use dashmap::DashMap;
 use derive_more::derive::Deref;
 use metrics::{Gauge, Histogram};
 use reth_metrics::Metrics;


### PR DESCRIPTION
Towards #19515

Renames `missed_leaves_storage_roots`  to `storage_root_cache`, and populate it also for non-missed leaf cases via the storage workers.

This also changes how the cache is propagated; it is now held on the worker structs themselves rather than being propagated via the proof inputs. This simplifies the code a bit.

Related to RETH-166