### PR TITLE
docs(stages): clarify PruneSenderRecoveryStage is optional in pipeline

### DIFF
--- a/crates/stages/stages/src/sets.rs
+++ b/crates/stages/stages/src/sets.rs
@@ -71,7 +71,7 @@ use tokio::sync::watch;
 /// - [`BodyStage`]
 /// - [`SenderRecoveryStage`]
 /// - [`ExecutionStage`]
-/// - [`PruneSenderRecoveryStage`] (execute)
+/// - [`PruneSenderRecoveryStage`] (execute, optional; only if sender recovery pruning is enabled)
 /// - [`MerkleStage`] (unwind)
 /// - [`AccountHashingStage`]
 /// - [`StorageHashingStage`]
@@ -294,7 +294,7 @@ where
 /// A combination of (in order)
 ///
 /// - [`ExecutionStages`]
-/// - [`PruneSenderRecoveryStage`]
+/// - [`PruneSenderRecoveryStage`] (optional; only if sender recovery pruning is enabled)
 /// - [`HashingStages`]
 /// - [`HistoryIndexingStages`]
 /// - [`PruneStage`]


### PR DESCRIPTION
Updates rustdoc comments to accurately reflect that `PruneSenderRecoveryStage` is conditionally added to the pipeline only when sender recovery pruning is enabled, rather than being always present.

### Changes

- Updated documentation for `DefaultStages` and `OfflineStages` to indicate that `PruneSenderRecoveryStage` is optional
- Added clarification that the stage is only included when `PruneModes::sender_recovery` is configured

### Details

The stage is added via `add_stage_opt()` which only includes it when `prune_modes.sender_recovery` is `Some(...)`. By default, `PruneModes::default()` sets `sender_recovery: None`, meaning the stage is not part of the default pipeline.

This change aligns the documentation with the actual implementation behavior.


