### PR TITLE
perf(engine): avoid unnecessary B256 copy in get_proof_targets

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -1284,9 +1284,9 @@ fn get_proof_targets(
     let mut targets = MultiProofTargets::default();
 
     // first collect all new accounts (not previously fetched)
-    for &hashed_address in state_update.accounts.keys() {
-        if !fetched_proof_targets.contains_key(&hashed_address) {
-            targets.insert(hashed_address, HashSet::default());
+    for hashed_address in state_update.accounts.keys() {
+        if !fetched_proof_targets.contains_key(hashed_address) {
+            targets.insert(*hashed_address, HashSet::default());
         }
     }
 


### PR DESCRIPTION
Use reference iteration instead of destructuring pattern to avoid copying B256 (32 bytes) on each iteration. The copy only happens when actually needed for insertion into the targets map.

```rust
// Before: copies B256 on every iteration
for &hashed_address in state_update.accounts.keys() {
    if !fetched_proof_targets.contains_key(&hashed_address) {

// After: only copies when inserting
for hashed_address in state_update.accounts.keys() {
    if !fetched_proof_targets.contains_key(hashed_address) {
        targets.insert(*hashed_address, ...);
```