### PR TITLE
fix: initialize `transaction-senders` sf during genesis

### DIFF
--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -216,6 +216,13 @@ where
         .user_header_mut()
         .set_block_range(genesis_block_number, genesis_block_number);
 
+    if genesis_storage_settings.transaction_senders_in_static_files {
+        static_file_provider
+            .get_writer(genesis_block_number, StaticFileSegment::TransactionSenders)?
+            .user_header_mut()
+            .set_block_range(genesis_block_number, genesis_block_number);
+    }
+
     // `commit_unwind`` will first commit the DB and then the static file provider, which is
     // necessary on `init_genesis`.
     provider_rw.commit()?;


### PR DESCRIPTION
fixes [CI failure](https://github.com/paradigmxyz/reth/actions/runs/20820256303/job/59806550216) on https://github.com/paradigmxyz/reth/pull/20841 when running with all storage settings enabled

This has not been an issue because:
* tx senders in static files is always disabled
* if enabled we usually run pipeline stage first which calls `ensure_at_block`. This will initialize it, if its not. So, if pipeline is not started (eg. test, new chain), this fails when trying to append senders.

https://github.com/paradigmxyz/reth/blob/8eecad3d1d433ed509373713c21c31504290d17d/crates/stages/stages/src/stages/sender_recovery.rs#L89-L96 

https://github.com/paradigmxyz/reth/blob/8eecad3d1d433ed509373713c21c31504290d17d/crates/storage/provider/src/providers/static_file/writer.rs#L427-L433