### PR TITLE
feat(metrics): add block_size_bytes histogram to engine tree

### DIFF
--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -348,6 +348,8 @@ pub(crate) struct BlockValidationMetrics {
     pub(crate) post_execution_validation_duration: Histogram,
     /// Total duration of the new payload call
     pub(crate) total_duration: Histogram,
+    /// Block size in bytes (in-memory size of validated blocks)
+    pub(crate) block_size_bytes: Histogram,
 }
 
 impl BlockValidationMetrics {

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -28,7 +28,9 @@ use reth_payload_builder::PayloadBuilderHandle;
 use reth_payload_primitives::{
     BuiltPayload, EngineApiMessageVersion, NewPayloadError, PayloadBuilderAttributes, PayloadTypes,
 };
-use reth_primitives_traits::{NodePrimitives, RecoveredBlock, SealedBlock, SealedHeader};
+use reth_primitives_traits::{
+    InMemorySize, NodePrimitives, RecoveredBlock, SealedBlock, SealedHeader,
+};
 use reth_provider::{
     BlockReader, DatabaseProviderFactory, HashedPostStateProvider, ProviderError, StateProviderBox,
     StateProviderFactory, StateReader, TransactionVariant, TrieReader,
@@ -2571,6 +2573,12 @@ where
 
         self.state.tree_state.insert_executed(executed.clone());
         self.metrics.engine.executed_blocks.set(self.state.tree_state.block_count() as f64);
+
+        // record block size
+        self.metrics
+            .block_validation
+            .block_size_bytes
+            .record(executed.recovered_block().size() as f64);
 
         // emit insert event
         let elapsed = start.elapsed();


### PR DESCRIPTION
Track in-memory size of validated blocks via new block_size_bytes metric, enabling visibility into block size distribution during Engine API calls.