### PR TITLE
feat: allow `TransactionHashNumbers` to be written to `rocksdb` during live sync

### DIFF
--- a/crates/stages/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/stages/src/stages/hashing_storage.rs
@@ -356,6 +356,7 @@ mod tests {
             );
 
             self.db.insert_headers(blocks.iter().map(|block| block.sealed_header()))?;
+            let mut tx_hash_numbers = Vec::new();
 
             let iter = blocks.iter();
             let mut next_tx_num = 0;
@@ -366,10 +367,7 @@ mod tests {
                 self.db.commit(|tx| {
                     progress.body().transactions.iter().try_for_each(
                         |transaction| -> Result<(), reth_db::DatabaseError> {
-                            tx.put::<tables::TransactionHashNumbers>(
-                                *transaction.tx_hash(),
-                                next_tx_num,
-                            )?;
+                            tx_hash_numbers.push((*transaction.tx_hash(), next_tx_num));
                             tx.put::<tables::Transactions>(next_tx_num, transaction.clone())?;
 
                             let (addr, _) = accounts
@@ -419,6 +417,7 @@ mod tests {
                     Ok(())
                 })?;
             }
+            self.db.insert_tx_hash_numbers(tx_hash_numbers)?;
 
             Ok(blocks)
         }

--- a/crates/stages/stages/src/test_utils/test_db.rs
+++ b/crates/stages/stages/src/test_utils/test_db.rs
@@ -331,7 +331,7 @@ impl TestStageDB {
         self.commit_with_provider(|provider| {
             provider.with_rocksdb_batch(|batch: RocksBatchArg<'_>| {
                 let mut writer = EitherWriter::new_transaction_hash_numbers(provider, batch)?;
-                for (tx_hash, tx_num) in tx_hash_numbers.into_iter() {
+                for (tx_hash, tx_num) in tx_hash_numbers {
                     writer.put_transaction_hash_number(tx_hash, tx_num, false)?;
                 }
                 Ok(((), writer.into_raw_rocksdb_batch()))

--- a/crates/storage/provider/src/either_writer.rs
+++ b/crates/storage/provider/src/either_writer.rs
@@ -61,17 +61,38 @@ type EitherWriterTy<'a, P, T> = EitherWriter<
     <P as NodePrimitivesProvider>::Primitives,
 >;
 
-// Helper types so constructors stay exported even when RocksDB feature is off.
-// Historical data tables use a write-only RocksDB batch (no read-your-writes needed).
+/// Helper type for RocksDB batch argument in writer constructors.
+///
+/// When `rocksdb` feature is enabled, this is a real RocksDB batch.
+/// Otherwise, it's `()` (unit type) to allow the same API without feature gates.
 #[cfg(all(unix, feature = "rocksdb"))]
-type RocksBatchArg<'a> = crate::providers::rocksdb::RocksDBBatch<'a>;
+pub type RocksBatchArg<'a> = crate::providers::rocksdb::RocksDBBatch<'a>;
+/// Helper type for RocksDB batch argument in writer constructors.
+///
+/// When `rocksdb` feature is enabled, this is a real RocksDB batch.
+/// Otherwise, it's `()` (unit type) to allow the same API without feature gates.
 #[cfg(not(all(unix, feature = "rocksdb")))]
-type RocksBatchArg<'a> = ();
+pub type RocksBatchArg<'a> = ();
 
+/// The raw RocksDB batch type returned by [`EitherWriter::into_raw_rocksdb_batch`].
 #[cfg(all(unix, feature = "rocksdb"))]
-type RocksTxRefArg<'a> = &'a crate::providers::rocksdb::RocksTx<'a>;
+pub type RawRocksDBBatch = rocksdb::WriteBatchWithTransaction<true>;
+/// The raw RocksDB batch type returned by [`EitherWriter::into_raw_rocksdb_batch`].
 #[cfg(not(all(unix, feature = "rocksdb")))]
-type RocksTxRefArg<'a> = ();
+pub type RawRocksDBBatch = ();
+
+/// Helper type for RocksDB transaction reference argument in reader constructors.
+///
+/// When `rocksdb` feature is enabled, this is a reference to a RocksDB transaction.
+/// Otherwise, it's `()` (unit type) to allow the same API without feature gates.
+#[cfg(all(unix, feature = "rocksdb"))]
+pub type RocksTxRefArg<'a> = &'a crate::providers::rocksdb::RocksTx<'a>;
+/// Helper type for RocksDB transaction reference argument in reader constructors.
+///
+/// When `rocksdb` feature is enabled, this is a reference to a RocksDB transaction.
+/// Otherwise, it's `()` (unit type) to allow the same API without feature gates.
+#[cfg(not(all(unix, feature = "rocksdb")))]
+pub type RocksTxRefArg<'a> = ();
 
 /// Represents a destination for writing data, either to database, static files, or `RocksDB`.
 #[derive(Debug, Display)]
@@ -254,6 +275,16 @@ impl<'a, CURSOR, N: NodePrimitives> EitherWriter<'a, CURSOR, N> {
         match self {
             Self::Database(_) | Self::StaticFile(_) => None,
             Self::RocksDB(batch) => Some(batch.into_inner()),
+        }
+    }
+
+    /// Extracts the raw `RocksDB` write batch from this writer, if it contains one.
+    ///
+    /// Without the `rocksdb` feature, this always returns `None`.
+    #[cfg(not(all(unix, feature = "rocksdb")))]
+    pub fn into_raw_rocksdb_batch(self) -> Option<RawRocksDBBatch> {
+        match self {
+            Self::Database(_) | Self::StaticFile(_) => None,
         }
     }
 

--- a/crates/storage/provider/src/either_writer.rs
+++ b/crates/storage/provider/src/either_writer.rs
@@ -408,7 +408,7 @@ where
     ///
     /// When `append_only` is true, uses `cursor.append()` which is significantly faster
     /// but requires entries to be inserted in order and the table to be empty.
-    /// When false, uses `cursor.insert()` which handles arbitrary insertion order.
+    /// When false, uses `cursor.upsert()` which handles arbitrary insertion order and duplicates.
     pub fn put_transaction_hash_number(
         &mut self,
         hash: TxHash,
@@ -420,7 +420,7 @@ where
                 if append_only {
                     Ok(cursor.append(hash, &tx_num)?)
                 } else {
-                    Ok(cursor.insert(hash, &tx_num)?)
+                    Ok(cursor.upsert(hash, &tx_num)?)
                 }
             }
             Self::StaticFile(_) => Err(ProviderError::UnsupportedProvider),

--- a/crates/storage/provider/src/either_writer.rs
+++ b/crates/storage/provider/src/either_writer.rs
@@ -61,35 +61,35 @@ type EitherWriterTy<'a, P, T> = EitherWriter<
     <P as NodePrimitivesProvider>::Primitives,
 >;
 
-/// Helper type for RocksDB batch argument in writer constructors.
+/// Helper type for `RocksDB` batch argument in writer constructors.
 ///
-/// When `rocksdb` feature is enabled, this is a real RocksDB batch.
+/// When `rocksdb` feature is enabled, this is a real `RocksDB` batch.
 /// Otherwise, it's `()` (unit type) to allow the same API without feature gates.
 #[cfg(all(unix, feature = "rocksdb"))]
 pub type RocksBatchArg<'a> = crate::providers::rocksdb::RocksDBBatch<'a>;
-/// Helper type for RocksDB batch argument in writer constructors.
+/// Helper type for `RocksDB` batch argument in writer constructors.
 ///
-/// When `rocksdb` feature is enabled, this is a real RocksDB batch.
+/// When `rocksdb` feature is enabled, this is a real `RocksDB` batch.
 /// Otherwise, it's `()` (unit type) to allow the same API without feature gates.
 #[cfg(not(all(unix, feature = "rocksdb")))]
 pub type RocksBatchArg<'a> = ();
 
-/// The raw RocksDB batch type returned by [`EitherWriter::into_raw_rocksdb_batch`].
+/// The raw `RocksDB` batch type returned by [`EitherWriter::into_raw_rocksdb_batch`].
 #[cfg(all(unix, feature = "rocksdb"))]
 pub type RawRocksDBBatch = rocksdb::WriteBatchWithTransaction<true>;
-/// The raw RocksDB batch type returned by [`EitherWriter::into_raw_rocksdb_batch`].
+/// The raw `RocksDB` batch type returned by [`EitherWriter::into_raw_rocksdb_batch`].
 #[cfg(not(all(unix, feature = "rocksdb")))]
 pub type RawRocksDBBatch = ();
 
-/// Helper type for RocksDB transaction reference argument in reader constructors.
+/// Helper type for `RocksDB` transaction reference argument in reader constructors.
 ///
-/// When `rocksdb` feature is enabled, this is a reference to a RocksDB transaction.
+/// When `rocksdb` feature is enabled, this is a reference to a `RocksDB` transaction.
 /// Otherwise, it's `()` (unit type) to allow the same API without feature gates.
 #[cfg(all(unix, feature = "rocksdb"))]
 pub type RocksTxRefArg<'a> = &'a crate::providers::rocksdb::RocksTx<'a>;
-/// Helper type for RocksDB transaction reference argument in reader constructors.
+/// Helper type for `RocksDB` transaction reference argument in reader constructors.
 ///
-/// When `rocksdb` feature is enabled, this is a reference to a RocksDB transaction.
+/// When `rocksdb` feature is enabled, this is a reference to a `RocksDB` transaction.
 /// Otherwise, it's `()` (unit type) to allow the same API without feature gates.
 #[cfg(not(all(unix, feature = "rocksdb")))]
 pub type RocksTxRefArg<'a> = ();

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -17,10 +17,10 @@ use crate::{
     DBProvider, EitherReader, EitherWriter, EitherWriterDestination, HashingWriter, HeaderProvider,
     HeaderSyncGapProvider, HistoricalStateProvider, HistoricalStateProviderRef, HistoryWriter,
     LatestStateProvider, LatestStateProviderRef, OriginalValuesKnown, ProviderError,
-    PruneCheckpointReader, PruneCheckpointWriter, RevertsInit, RocksDBProviderFactory,
-    StageCheckpointReader, StateProviderBox, StateWriter, StaticFileProviderFactory, StatsReader,
-    StorageReader, StorageTrieWriter, TransactionVariant, TransactionsProvider,
-    TransactionsProviderExt, TrieReader, TrieWriter,
+    PruneCheckpointReader, PruneCheckpointWriter, RawRocksDBBatch, RevertsInit, RocksBatchArg,
+    RocksDBProviderFactory, RocksTxRefArg, StageCheckpointReader, StateProviderBox, StateWriter,
+    StaticFileProviderFactory, StatsReader, StorageReader, StorageTrieWriter, TransactionVariant,
+    TransactionsProvider, TransactionsProviderExt, TrieReader, TrieWriter,
 };
 use alloy_consensus::{
     transaction::{SignerRecoverable, TransactionMeta, TxHashRef},
@@ -327,6 +327,31 @@ impl<TX, N: NodeTypes> AsRef<Self> for DatabaseProvider<TX, N> {
 }
 
 impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX, N> {
+    /// Executes a closure with a RocksDB batch, automatically registering it for commit.
+    ///
+    /// This helper encapsulates all the cfg-gated RocksDB batch handling.
+    pub fn with_rocksdb_batch<F, R>(&self, f: F) -> ProviderResult<R>
+    where
+        F: FnOnce(RocksBatchArg<'_>) -> ProviderResult<(R, Option<RawRocksDBBatch>)>,
+    {
+        #[cfg(all(unix, feature = "rocksdb"))]
+        let rocksdb = self.rocksdb_provider();
+        #[cfg(all(unix, feature = "rocksdb"))]
+        let rocksdb_batch = rocksdb.batch();
+        #[cfg(not(all(unix, feature = "rocksdb")))]
+        let rocksdb_batch = ();
+
+        let (result, raw_batch) = f(rocksdb_batch)?;
+
+        #[cfg(all(unix, feature = "rocksdb"))]
+        if let Some(batch) = raw_batch {
+            self.set_pending_rocksdb_batch(batch);
+        }
+        let _ = raw_batch; // silence unused warning when rocksdb feature is disabled
+
+        Ok(result)
+    }
+
     /// Writes executed blocks and state to storage.
     pub fn save_blocks(&self, blocks: Vec<ExecutedBlock<N::Primitives>>) -> ProviderResult<()> {
         if blocks.is_empty() {
@@ -594,6 +619,25 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> DatabaseProvider<TX, N> {
     /// Returns a reference to the chain specification.
     pub fn chain_spec(&self) -> &N::ChainSpec {
         &self.chain_spec
+    }
+
+    /// Executes a closure with a RocksDB transaction for reading.
+    ///
+    /// This helper encapsulates all the cfg-gated RocksDB transaction handling for reads.
+    fn with_rocksdb_tx<F, R>(&self, f: F) -> ProviderResult<R>
+    where
+        F: FnOnce(RocksTxRefArg<'_>) -> ProviderResult<R>,
+    {
+        #[cfg(all(unix, feature = "rocksdb"))]
+        let rocksdb = self.rocksdb_provider();
+        #[cfg(all(unix, feature = "rocksdb"))]
+        let rocksdb_tx = rocksdb.tx();
+        #[cfg(all(unix, feature = "rocksdb"))]
+        let rocksdb_tx_ref = &rocksdb_tx;
+        #[cfg(not(all(unix, feature = "rocksdb")))]
+        let rocksdb_tx_ref = ();
+
+        f(rocksdb_tx_ref)
     }
 }
 
@@ -1349,7 +1393,10 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> TransactionsProvider for Datab
     type Transaction = TxTy<N>;
 
     fn transaction_id(&self, tx_hash: TxHash) -> ProviderResult<Option<TxNumber>> {
-        Ok(self.tx.get::<tables::TransactionHashNumbers>(tx_hash)?)
+        self.with_rocksdb_tx(|tx_ref| {
+            let mut reader = EitherReader::new_transaction_hash_numbers(self, tx_ref)?;
+            reader.get_transaction_hash_number(tx_hash)
+        })
     }
 
     fn transaction_by_id(&self, id: TxNumber) -> ProviderResult<Option<Self::Transaction>> {
@@ -2997,10 +3044,14 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider + 'static> BlockWrite
         }
 
         if self.prune_modes.transaction_lookup.is_none_or(|m| !m.is_full()) {
-            for (tx_num, transaction) in tx_nums_iter.zip(block.body().transactions_iter()) {
-                let hash = transaction.tx_hash();
-                self.tx.put::<tables::TransactionHashNumbers>(*hash, tx_num)?;
-            }
+            self.with_rocksdb_batch(|batch| {
+                let mut writer = EitherWriter::new_transaction_hash_numbers(self, batch)?;
+                for (tx_num, transaction) in tx_nums_iter.zip(block.body().transactions_iter()) {
+                    let hash = transaction.tx_hash();
+                    writer.put_transaction_hash_number(*hash, tx_num, false)?;
+                }
+                Ok(((), writer.into_raw_rocksdb_batch()))
+            })?;
             durations_recorder.record_relative(metrics::Action::InsertTransactionHashNumbers);
         }
 
@@ -3108,9 +3159,14 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider + 'static> BlockWrite
             .last_tx_num();
 
         if unwind_tx_from <= unwind_tx_to {
-            for (hash, _) in self.transaction_hashes_by_range(unwind_tx_from..(unwind_tx_to + 1))? {
-                self.tx.delete::<tables::TransactionHashNumbers>(hash, None)?;
-            }
+            let hashes = self.transaction_hashes_by_range(unwind_tx_from..(unwind_tx_to + 1))?;
+            self.with_rocksdb_batch(|batch| {
+                let mut writer = EitherWriter::new_transaction_hash_numbers(self, batch)?;
+                for (hash, _) in hashes {
+                    writer.delete_transaction_hash_number(hash)?;
+                }
+                Ok(((), writer.into_raw_rocksdb_batch()))
+            })?;
         }
 
         EitherWriter::new_senders(self, last_block_number)?.prune_senders(unwind_tx_from, block)?;

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -327,9 +327,9 @@ impl<TX, N: NodeTypes> AsRef<Self> for DatabaseProvider<TX, N> {
 }
 
 impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX, N> {
-    /// Executes a closure with a RocksDB batch, automatically registering it for commit.
+    /// Executes a closure with a `RocksDB` batch, automatically registering it for commit.
     ///
-    /// This helper encapsulates all the cfg-gated RocksDB batch handling.
+    /// This helper encapsulates all the cfg-gated `RocksDB` batch handling.
     pub fn with_rocksdb_batch<F, R>(&self, f: F) -> ProviderResult<R>
     where
         F: FnOnce(RocksBatchArg<'_>) -> ProviderResult<(R, Option<RawRocksDBBatch>)>,
@@ -621,9 +621,9 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> DatabaseProvider<TX, N> {
         &self.chain_spec
     }
 
-    /// Executes a closure with a RocksDB transaction for reading.
+    /// Executes a closure with a `RocksDB` transaction for reading.
     ///
-    /// This helper encapsulates all the cfg-gated RocksDB transaction handling for reads.
+    /// This helper encapsulates all the cfg-gated `RocksDB` transaction handling for reads.
     fn with_rocksdb_tx<F, R>(&self, f: F) -> ProviderResult<R>
     where
         F: FnOnce(RocksTxRefArg<'_>) -> ProviderResult<R>,


### PR DESCRIPTION
We were only using `EitherWriter/EitherReader` during the stage. This PR:
* `EitherWriter/EitherReader` adds to other places like tests and live sync so it can be used with [reth-edge](https://github.com/paradigmxyz/reth/pull/20841)
* some helpers to make the whole `cfg` less ugly


Still missing the pruning bit - follow up