### PR TITLE
refactor(ecies): avoid duplicate keccak digest in MAC::update_body

### DIFF
--- a/crates/net/ecies/src/mac.rs
+++ b/crates/net/ecies/src/mac.rs
@@ -57,7 +57,7 @@ impl MAC {
         self.hasher.update(data);
         let prev = self.digest();
         let aes = Aes256Enc::new_from_slice(self.secret.as_ref()).unwrap();
-        let mut encrypted = self.digest().0;
+        let mut encrypted = prev.0;
 
         aes.encrypt_padded::<NoPadding>(&mut encrypted, B128::len_bytes()).unwrap();
         for i in 0..16 {


### PR DESCRIPTION
Removed redundant call to digest() inside MAC::update_body and reuses the already computed digest instead. The previous implementation cloned and finalized the Keccak256 state twice in a row without any intermediate updates, which produced the same value but added extra work on every frame. The new code keeps the exact same RLPx MAC semantics by using the single digest result both as AES input and for the XOR step, matching the specification while reducing unnecessary hashing overhead.