### PR TITLE
refactor(net): remove incorrect `dead_code` lint suppression from `TrustedPeersResolver::set_interval`

### DIFF
--- a/crates/net/network/src/trusted_peers_resolver.rs
+++ b/crates/net/network/src/trusted_peers_resolver.rs
@@ -28,7 +28,6 @@ impl TrustedPeersResolver {
     }
 
     /// Update the resolution interval (useful for testing purposes)
-    #[allow(dead_code)]
     pub fn set_interval(&mut self, interval: Interval) {
         self.interval = interval;
     }


### PR DESCRIPTION
Removes the incorrect #[allow(dead_code)] attribute from the TrustedPeersResolver::set_interval method, as this method is actively used in the codebase.