### PR TITLE
perf(engine): eliminate redundant allocation in block transaction iterator

### DIFF
--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -240,7 +240,7 @@ where
             }
             BlockOrPayload::Block(block) => {
                 let iter = Either::Right(
-                    block.body().clone_transactions().into_par_iter().map(Either::Right),
+                    block.body().transactions().par_iter().cloned().map(Either::Right),
                 );
                 let convert = move |tx: Either<_, N::SignedTx>| {
                     let Either::Right(tx) = tx else { unreachable!() };


### PR DESCRIPTION
Removes an unnecessary intermediate Vec allocation when creating a parallel iterator over block transactions in the payload validator.