### PR TITLE
Simplify core trait bounds by dropping redundant PartialEq

### DIFF
--- a/crates/primitives-traits/src/node.rs
+++ b/crates/primitives-traits/src/node.rs
@@ -9,7 +9,7 @@ use core::fmt;
 /// blockchain data. It serves as the foundation for type consistency across
 /// different node implementations.
 pub trait NodePrimitives:
-    Send + Sync + Unpin + Clone + Default + fmt::Debug + PartialEq + Eq + 'static
+    Send + Sync + Unpin + Clone + Default + fmt::Debug + Eq + 'static
 {
     /// Block primitive.
     type Block: FullBlock<Header = Self::BlockHeader, Body = Self::BlockBody>

--- a/crates/primitives-traits/src/transaction/signed.rs
+++ b/crates/primitives-traits/src/transaction/signed.rs
@@ -133,7 +133,7 @@ pub trait SignedTransaction:
 impl<T> SignedTransaction for EthereumTxEnvelope<T>
 where
     T: RlpEcdsaEncodableTx + SignableTransaction<Signature> + Unpin,
-    Self: Clone + PartialEq + Eq + Decodable + Decodable2718 + MaybeSerde + InMemorySize,
+    Self: Clone + Eq + Decodable + Decodable2718 + MaybeSerde + InMemorySize,
 {
 }
 


### PR DESCRIPTION
Removes duplicated PartialEq from NodePrimitives and SignedTransaction bounds (already implied by Eq), no logic changes; purely trait constraint cleanup, verified with cargo check -p reth-primitives-traits