### PR TITLE
feat(network): add customizable announcement filtering policy to APIs

### DIFF
--- a/crates/net/network/src/builder.rs
+++ b/crates/net/network/src/builder.rs
@@ -3,7 +3,9 @@
 use crate::{
     eth_requests::EthRequestHandler,
     transactions::{
-        config::{StrictEthAnnouncementFilter, TransactionPropagationKind},
+        config::{
+            AnnouncementFilteringPolicy, StrictEthAnnouncementFilter, TransactionPropagationKind,
+        },
         policy::NetworkPolicies,
         TransactionPropagationPolicy, TransactionsManager, TransactionsManagerConfig,
     },
@@ -84,17 +86,41 @@ impl<Tx, Eth, N: NetworkPrimitives> NetworkBuilder<Tx, Eth, N> {
     }
 
     /// Creates a new [`TransactionsManager`] and wires it to the network.
-    pub fn transactions_with_policy<Pool: TransactionPool>(
+    ///
+    /// Uses the default [`StrictEthAnnouncementFilter`] for announcement filtering.
+    pub fn transactions_with_policy<Pool: TransactionPool, P: TransactionPropagationPolicy<N>>(
         self,
         pool: Pool,
         transactions_manager_config: TransactionsManagerConfig,
-        propagation_policy: impl TransactionPropagationPolicy<N>,
+        propagation_policy: P,
+    ) -> NetworkBuilder<TransactionsManager<Pool, N>, Eth, N> {
+        self.transactions_with_policies(
+            pool,
+            transactions_manager_config,
+            propagation_policy,
+            StrictEthAnnouncementFilter::default(),
+        )
+    }
+
+    /// Creates a new [`TransactionsManager`] with custom propagation and announcement policies.
+    ///
+    /// This allows chains with custom transaction types (like CATX) to configure
+    /// the announcement filter to accept their transaction types.
+    pub fn transactions_with_policies<
+        Pool: TransactionPool,
+        P: TransactionPropagationPolicy<N>,
+        A: AnnouncementFilteringPolicy<N>,
+    >(
+        self,
+        pool: Pool,
+        transactions_manager_config: TransactionsManagerConfig,
+        propagation_policy: P,
+        announcement_policy: A,
     ) -> NetworkBuilder<TransactionsManager<Pool, N>, Eth, N> {
         let Self { mut network, request_handler, .. } = self;
         let (tx, rx) = mpsc::unbounded_channel();
         network.set_transactions(tx);
         let handle = network.handle().clone();
-        let announcement_policy = StrictEthAnnouncementFilter::default();
         let policies = NetworkPolicies::new(propagation_policy, announcement_policy);
 
         let transactions = TransactionsManager::with_policy(

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -870,9 +870,8 @@ impl<Node: FullNodeTypes> BuilderContext<Node> {
     /// Convenience function to start the network tasks with custom policies.
     ///
     /// Accepts the config for the transaction task, the policy for propagation,
-    /// and a custom announcement filter. This is useful for chains with custom
-    /// transaction types (like CATX) that need to configure which tx types are
-    /// accepted in announcements.
+    /// and a custom announcement filter. This is useful for configuring which tx types are accepted
+    /// in announcements.
     ///
     /// Spawns the configured network and associated tasks and returns the [`NetworkHandle`]
     /// connected to that network.


### PR DESCRIPTION
Enable SDK chains to configure announcement filtering by exposing the AnnouncementFilteringPolicy as a parameter in the network builder API instead of hardcoding to strict filtering.

- Add transactions_with_policies() accepting both propagation and announcement policies
- Add start_network_with_policies() to BuilderContext for custom announcement filters
- Existing transactions_with_policy() defaults to StrictEthAnnouncementFilter