### PR TITLE
feat(exex): Make WAL Block Threshold Configurable

### DIFF
--- a/crates/exex/exex/src/manager.rs
+++ b/crates/exex/exex/src/manager.rs
@@ -38,11 +38,14 @@ use tokio_util::sync::{PollSendError, PollSender, ReusableBoxFuture};
 /// or 17 minutes of 1-second blocks.
 pub const DEFAULT_EXEX_MANAGER_CAPACITY: usize = 1024;
 
-/// The maximum number of blocks allowed in the WAL before emitting a warning.
+/// Default maximum number of blocks allowed in the WAL before emitting a warning.
 ///
-/// This constant defines the threshold for the Write-Ahead Log (WAL) size. If the number of blocks
-/// in the WAL exceeds this limit, a warning is logged to indicate potential issues.
-pub const WAL_BLOCKS_WARNING: usize = 128;
+/// This constant defines the default threshold for the Write-Ahead Log (WAL) size. If the number
+/// of blocks in the WAL exceeds this limit, a warning is logged to indicate potential issues.
+///
+/// This value is appropriate for Ethereum mainnet with ~12 second block times. For L2 chains with
+/// faster block times, this value should be increased proportionally to avoid excessive warnings.
+pub const DEFAULT_WAL_BLOCKS_WARNING: usize = 128;
 
 /// The source of the notification.
 ///
@@ -247,6 +250,8 @@ pub struct ExExManager<P, N: NodePrimitives> {
     wal: Wal<N>,
     /// A stream of finalized headers.
     finalized_header_stream: ForkChoiceStream<SealedHeader<N::BlockHeader>>,
+    /// The threshold for the number of blocks in the WAL before emitting a warning.
+    wal_blocks_warning: usize,
 
     /// A handle to the `ExEx` manager.
     handle: ExExManagerHandle<N>,
@@ -306,6 +311,7 @@ where
 
             wal,
             finalized_header_stream,
+            wal_blocks_warning: DEFAULT_WAL_BLOCKS_WARNING,
 
             handle: ExExManagerHandle {
                 exex_tx: handle_tx,
@@ -322,6 +328,16 @@ where
     /// Returns the handle to the manager.
     pub fn handle(&self) -> ExExManagerHandle<N> {
         self.handle.clone()
+    }
+
+    /// Sets the threshold for the number of blocks in the WAL before emitting a warning.
+    ///
+    /// For L2 chains with faster block times, this value should be increased proportionally
+    /// to avoid excessive warnings. For example, a chain with 2-second block times might use
+    /// a value 6x higher than the default.
+    pub const fn with_wal_blocks_warning(mut self, threshold: usize) -> Self {
+        self.wal_blocks_warning = threshold;
+        self
     }
 
     /// Updates the current buffer capacity and notifies all `is_ready` watchers of the manager's
@@ -390,10 +406,11 @@ where
                 .unwrap();
 
             self.wal.finalize(lowest_finished_height)?;
-            if self.wal.num_blocks() > WAL_BLOCKS_WARNING {
+            if self.wal.num_blocks() > self.wal_blocks_warning {
                 warn!(
                     target: "exex::manager",
                     blocks = ?self.wal.num_blocks(),
+                    threshold = self.wal_blocks_warning,
                     "WAL contains too many blocks and is not getting cleared. That will lead to increased disk space usage. Check that you emit the FinishedHeight event from your ExExes."
                 );
             }

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -1042,14 +1042,34 @@ where
             Box<dyn crate::exex::BoxedLaunchExEx<NodeAdapter<T, CB::Components>>>,
         )>,
     ) -> eyre::Result<Option<ExExManagerHandle<PrimitivesTy<T::Types>>>> {
+        self.exex_launcher(installed_exex).launch().await
+    }
+
+    /// Creates an [`ExExLauncher`] for the installed ExExes.
+    ///
+    /// This returns the launcher before calling `.launch()`, allowing custom configuration
+    /// such as setting the WAL blocks warning threshold for L2 chains with faster block times:
+    ///
+    /// ```ignore
+    /// ctx.exex_launcher(exexes)
+    ///     .with_wal_blocks_warning(768)  // For 2-second block times
+    ///     .launch()
+    ///     .await
+    /// ```
+    #[allow(clippy::type_complexity)]
+    pub fn exex_launcher(
+        &self,
+        installed_exex: Vec<(
+            String,
+            Box<dyn crate::exex::BoxedLaunchExEx<NodeAdapter<T, CB::Components>>>,
+        )>,
+    ) -> ExExLauncher<NodeAdapter<T, CB::Components>> {
         ExExLauncher::new(
             self.head(),
             self.node_adapter().clone(),
             installed_exex,
             self.configs().clone(),
         )
-        .launch()
-        .await
     }
 
     /// Creates the ERA import source based on node configuration.


### PR DESCRIPTION
### Problem

The `WAL_BLOCKS_WARNING` threshold is hardcoded to `128` blocks, which is appropriate for Ethereum mainnet with ~12 second block times. However, L2 chains have significantly faster block times (often 2 seconds or less), causing the WAL to accumulate blocks much faster than on mainnet. This results in the following [ExExManager warning](https://github.com/paradigmxyz/reth/blob/1866db4d5/crates/exex/exex/src/manager.rs#L393-L399) appearing frequently even during normal operation:

```
WAL contains too many blocks and is not getting cleared. That will lead to increased disk space usage. Check that you emit the FinishedHeight event from your ExExes. blocks=...
```

This creates noise in logs and can mask real issues where ExExes are genuinely failing to emit `FinishedHeight` events.

### Solution

Make the WAL blocks warning threshold configurable via a builder pattern, allowing node operators to set an appropriate value based on their chain's block time.

### Usage

```rust
// Configure a higher threshold for L2 chains with faster block times
ctx.exex_launcher(installed_exexes)
    .with_wal_blocks_warning(768)  // 6x default for ~2 second blocks
    .launch()
    .await?;
```

Or when constructing `ExExManager` directly:

```rust
ExExManager::new(provider, handles, capacity, wal, finalized_stream).with_wal_blocks_warning(1024)
```

### Changeset

- Renamed `WAL_BLOCKS_WARNING` to `DEFAULT_WAL_BLOCKS_WARNING` and kept the default at 128
- Added `wal_blocks_warning` field to `ExExManager` with a `with_wal_blocks_warning()` builder method
- Added `wal_blocks_warning` field to `ExExLauncher` with a `with_wal_blocks_warning()` builder method
- Added `exex_launcher()` method that returns the launcher before calling `.launch()`, enabling custom configuration
- Updated the warning log to include the configured threshold for better observability