### PR TITLE
feat(bench): add persistence-based flow optimization for rbc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7704,6 +7704,7 @@ dependencies = [
  "csv",
  "eyre",
  "futures",
+ "http",
  "humantime",
  "op-alloy-consensus",
  "op-alloy-rpc-types-engine",
@@ -7719,6 +7720,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.17",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tracing",
 ]
@@ -10412,6 +10414,7 @@ dependencies = [
  "reth-storage-api",
  "reth-tasks",
  "reth-testing-utils",
+ "reth-tokio-util",
  "reth-transaction-pool",
  "reth-trie-common",
  "revm",

--- a/bin/reth-bench-compare/src/benchmark.rs
+++ b/bin/reth-bench-compare/src/benchmark.rs
@@ -17,17 +17,23 @@ use tracing::{debug, error, info, warn};
 pub(crate) struct BenchmarkRunner {
     rpc_url: String,
     jwt_secret: String,
-    wait_time: Option<String>,
     warmup_blocks: u64,
 }
 
 impl BenchmarkRunner {
     /// Create a new `BenchmarkRunner` from CLI arguments
     pub(crate) fn new(args: &Args) -> Self {
+        // Log deprecation warning if wait_time was provided
+        if args.wait_time.is_some() {
+            warn!(
+                "--wait-time is deprecated and will be ignored. \
+                 reth-bench now uses persistence-based flow instead of fixed wait times."
+            );
+        }
+
         Self {
             rpc_url: args.get_rpc_url(),
             jwt_secret: args.jwt_secret_path().to_string_lossy().to_string(),
-            wait_time: args.wait_time.clone(),
             warmup_blocks: args.get_warmup_blocks(),
         }
     }
@@ -182,10 +188,8 @@ impl BenchmarkRunner {
             &output_dir.to_string_lossy(),
         ]);
 
-        // Add wait-time argument if provided
-        if let Some(ref wait_time) = self.wait_time {
-            cmd.args(["--wait-time", wait_time]);
-        }
+        // Note: --wait-time is deprecated and not passed to reth-bench.
+        // reth-bench now uses persistence-based flow instead of fixed wait times.
 
         cmd.env("RUST_LOG_STYLE", "never")
             .stdout(std::process::Stdio::piped())

--- a/bin/reth-bench-compare/src/cli.rs
+++ b/bin/reth-bench-compare/src/cli.rs
@@ -115,7 +115,10 @@ pub(crate) struct Args {
     pub profile: bool,
 
     /// Wait time between engine API calls (passed to reth-bench)
-    #[arg(long, value_name = "DURATION")]
+    ///
+    /// **DEPRECATED**: This flag is deprecated and will be ignored.
+    /// reth-bench now uses persistence-based flow instead of fixed wait times.
+    #[arg(long, value_name = "DURATION", hide = true)]
     pub wait_time: Option<String>,
 
     /// Number of blocks to run for cache warmup after clearing caches.

--- a/bin/reth-bench/Cargo.toml
+++ b/bin/reth-bench/Cargo.toml
@@ -54,6 +54,8 @@ serde_json.workspace = true
 async-trait.workspace = true
 futures.workspace = true
 tokio = { workspace = true, features = ["sync", "macros", "time", "rt-multi-thread"] }
+tokio-tungstenite = { workspace = true, features = ["rustls-tls-native-roots"] }
+http.workspace = true
 
 # misc
 clap = { workspace = true, features = ["derive", "env"] }

--- a/bin/reth-bench/src/bench/new_payload_fcu.rs
+++ b/bin/reth-bench/src/bench/new_payload_fcu.rs
@@ -1,26 +1,41 @@
 //! Runs the `reth bench` command, calling first newPayload for each block, then calling
 //! forkchoiceUpdated.
+//!
+//! Uses persistence-based flow: waits for every Nth block to be persisted instead of
+//! using fixed wait times between blocks.
 
 use crate::{
     bench::{
         context::BenchContext,
         output::{
-            CombinedResult, NewPayloadResult, TotalGasOutput, TotalGasRow, COMBINED_OUTPUT_SUFFIX,
-            GAS_OUTPUT_SUFFIX,
+            CombinedResult, NewPayloadResult, PersistenceStats, TotalGasOutput, TotalGasRow,
+            COMBINED_OUTPUT_SUFFIX, GAS_OUTPUT_SUFFIX, PERSISTENCE_STATS_SUFFIX,
         },
     },
     valid_payload::{block_to_new_payload, call_forkchoice_updated, call_new_payload},
 };
+use alloy_eips::BlockNumHash;
 use alloy_provider::Provider;
-use alloy_rpc_types_engine::ForkchoiceState;
+use alloy_rpc_types_engine::{ForkchoiceState, JwtSecret};
 use clap::Parser;
 use csv::Writer;
 use eyre::{Context, OptionExt};
+use futures::{SinkExt, StreamExt};
 use humantime::parse_duration;
+use reqwest::Url;
 use reth_cli_runner::CliContext;
 use reth_node_core::args::BenchmarkArgs;
+use serde_json::{json, Value};
 use std::time::{Duration, Instant};
-use tracing::{debug, info};
+use tokio::sync::mpsc;
+use tokio_tungstenite::{connect_async_with_config, tungstenite::Message};
+use tracing::{debug, info, warn};
+
+/// Persistence threshold: wait for persistence every N blocks
+const PERSISTENCE_THRESHOLD: u64 = 2;
+
+/// Final sync timeout: wait up to 5 minutes for remaining blocks to persist
+const PERSISTENCE_TIMEOUT: Duration = Duration::from_secs(300);
 
 /// `reth benchmark new-payload-fcu` command
 #[derive(Debug, Parser)]
@@ -29,8 +44,9 @@ pub struct Command {
     #[arg(long, value_name = "RPC_URL", verbatim_doc_comment)]
     rpc_url: String,
 
-    /// How long to wait after a forkchoice update before sending the next payload.
-    #[arg(long, value_name = "WAIT_TIME", value_parser = parse_duration, default_value = "250ms", verbatim_doc_comment)]
+    /// DEPRECATED: Wait time is ignored. Uses persistence-based flow instead.
+    /// This flag is kept for backwards compatibility but has no effect.
+    #[arg(long, value_name = "WAIT_TIME", value_parser = parse_duration, default_value = "0ms", hide = true, verbatim_doc_comment)]
     wait_time: Duration,
 
     /// The size of the block buffer (channel capacity) for prefetching blocks from the RPC
@@ -50,6 +66,15 @@ pub struct Command {
 impl Command {
     /// Execute `benchmark new-payload-fcu` command
     pub async fn execute(self, _ctx: CliContext) -> eyre::Result<()> {
+        // Warn if wait_time was explicitly provided (non-zero)
+        if !self.wait_time.is_zero() {
+            warn!(
+                "Warning: --wait-time is deprecated and ignored. \
+                 Using persistence-based flow with threshold={} blocks",
+                PERSISTENCE_THRESHOLD
+            );
+        }
+
         let BenchContext {
             benchmark_mode,
             block_provider,
@@ -57,6 +82,136 @@ impl Command {
             mut next_block,
             is_optimism,
         } = BenchContext::new(&self.benchmark, self.rpc_url).await?;
+
+        // Set up WebSocket connection for persistence subscription
+        let auth_jwt =
+            self.benchmark.auth_jwtsecret.clone().ok_or_else(|| {
+                eyre::eyre!("--jwt-secret must be provided for authenticated RPC")
+            })?;
+        let jwt_str = std::fs::read_to_string(&auth_jwt)?;
+        let jwt = JwtSecret::from_hex(&jwt_str)?;
+
+        // Convert HTTP URL to WebSocket URL for subscription
+        let mut ws_url: Url = self.benchmark.engine_rpc_url.parse()?;
+        match ws_url.scheme() {
+            "http" => {
+                ws_url.set_scheme("ws").map_err(|_| eyre::eyre!("Failed to set WS scheme"))?
+            }
+            "https" => {
+                ws_url.set_scheme("wss").map_err(|_| eyre::eyre!("Failed to set WSS scheme"))?
+            }
+            "ws" | "wss" => {} // Already WebSocket
+            scheme => return Err(eyre::eyre!("Unsupported URL scheme: {}", scheme)),
+        }
+
+        // Create JWT authorization header
+        let claims = alloy_rpc_types_engine::Claims::default();
+        let token = jwt.encode(&claims)?;
+        let auth_header = format!("Bearer {}", token);
+
+        info!("Connecting to WebSocket at {} for persistence subscription", ws_url);
+
+        // Build WebSocket request with auth header
+        let ws_request = http::Request::builder()
+            .uri(ws_url.as_str())
+            .header("Authorization", &auth_header)
+            .header("Host", ws_url.host_str().unwrap_or("localhost"))
+            .header("Connection", "Upgrade")
+            .header("Upgrade", "websocket")
+            .header("Sec-WebSocket-Version", "13")
+            .header(
+                "Sec-WebSocket-Key",
+                tokio_tungstenite::tungstenite::handshake::client::generate_key(),
+            )
+            .body(())
+            .wrap_err("Failed to build WebSocket request")?;
+
+        let (ws_stream, _) = connect_async_with_config(ws_request, None, false)
+            .await
+            .wrap_err("Failed to connect to WebSocket for persistence subscription")?;
+
+        let (mut ws_sink, mut ws_stream) = ws_stream.split();
+
+        // Subscribe to latest persisted block notifications via JSON-RPC
+        let subscribe_request = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "reth_subscribeLatestPersistedBlock",
+            "params": []
+        });
+
+        ws_sink
+            .send(Message::Text(subscribe_request.to_string().into()))
+            .await
+            .wrap_err("Failed to send subscription request")?;
+
+        // Wait for subscription confirmation
+        let sub_response = ws_stream
+            .next()
+            .await
+            .ok_or_else(|| eyre::eyre!("WebSocket closed before subscription response"))?
+            .wrap_err("Failed to receive subscription response")?;
+
+        let sub_id: String = match sub_response {
+            Message::Text(text) => {
+                let resp: Value = serde_json::from_str(&text)
+                    .wrap_err("Failed to parse subscription response")?;
+                resp["result"]
+                    .as_str()
+                    .ok_or_else(|| eyre::eyre!("Invalid subscription response: {}", text))?
+                    .to_string()
+            }
+            _ => return Err(eyre::eyre!("Unexpected message type from subscription")),
+        };
+
+        info!("Subscribed to persistence notifications (subscription_id={})", sub_id);
+
+        // Create channel for persistence notifications
+        let (persistence_tx, mut persistence_rx) = mpsc::channel::<BlockNumHash>(100);
+
+        // Spawn task to receive persistence notifications
+        tokio::spawn(async move {
+            while let Some(msg_result) = ws_stream.next().await {
+                match msg_result {
+                    Ok(Message::Text(text)) => {
+                        if let Ok(notification) = serde_json::from_str::<Value>(&text) {
+                            // Check if this is a subscription notification
+                            if notification.get("method").map(|m| m.as_str()) ==
+                                Some(Some("reth_subscribeLatestPersistedBlock"))
+                            {
+                                if let Some(params) =
+                                    notification.get("params").and_then(|p| p.get("result"))
+                                {
+                                    if let (Some(number), Some(hash)) = (
+                                        params.get("number").and_then(|n| n.as_u64()),
+                                        params.get("hash").and_then(|h| h.as_str()),
+                                    ) {
+                                        let block_num_hash = BlockNumHash {
+                                            number,
+                                            hash: hash.parse().unwrap_or_default(),
+                                        };
+                                        if persistence_tx.send(block_num_hash).await.is_err() {
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Ok(Message::Close(_)) => break,
+                    Err(e) => {
+                        tracing::error!("WebSocket error: {}", e);
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+        });
+
+        info!(
+            "Subscribed to persistence notifications (threshold={} blocks)",
+            PERSISTENCE_THRESHOLD
+        );
 
         let buffer_size = self.rpc_block_buffer_size;
 
@@ -110,6 +265,19 @@ impl Command {
             }
         });
 
+        // Persistence tracking state
+        let mut blocks_sent: u64 = 0;
+        let mut last_persisted_block: u64 = 0;
+        let mut first_block_number: Option<u64> = None;
+        let mut last_block_number: u64 = 0;
+
+        // Persistence stats tracking
+        let mut persistence_wait_count: u64 = 0;
+        let mut total_persistence_wait_time = Duration::ZERO;
+        let mut max_gap: u64 = 0;
+        let mut gap_sum: u64 = 0;
+        let mut gap_count: u64 = 0;
+
         // put results in a summary vec so they can be printed at the end
         let mut results = Vec::new();
         let total_benchmark_duration = Instant::now();
@@ -126,7 +294,12 @@ impl Command {
             let block_number = block.header.number;
             let transaction_count = block.transactions.len() as u64;
 
-            debug!(target: "reth-bench", ?block_number, "Sending payload",);
+            if first_block_number.is_none() {
+                first_block_number = Some(block_number);
+            }
+            last_block_number = block_number;
+
+            debug!(target: "reth-bench", ?block_number, "Sending payload");
 
             // construct fcu to call
             let forkchoice_state = ForkchoiceState {
@@ -154,15 +327,62 @@ impl Command {
                 total_latency,
             };
 
+            // Track blocks sent (after newPayload, as per plan)
+            blocks_sent += 1;
+
+            // Track gap for stats
+            let current_gap = block_number.saturating_sub(last_persisted_block);
+            if current_gap > max_gap {
+                max_gap = current_gap;
+            }
+            gap_sum += current_gap;
+            gap_count += 1;
+
+            // Every N blocks, wait for persistence to catch up
+            if blocks_sent % PERSISTENCE_THRESHOLD == 0 {
+                let target_block = block_number;
+                debug!(
+                    target: "reth-bench",
+                    ?target_block,
+                    ?last_persisted_block,
+                    "Waiting for persistence"
+                );
+
+                let wait_start = Instant::now();
+                while last_persisted_block < target_block {
+                    match persistence_rx.recv().await {
+                        Some(persisted) => {
+                            last_persisted_block = persisted.number;
+                            debug!(
+                                target: "reth-bench",
+                                persisted_block = ?last_persisted_block,
+                                "Received persistence notification"
+                            );
+                        }
+                        None => {
+                            return Err(eyre::eyre!(
+                                "Persistence subscription closed unexpectedly. Benchmark failed."
+                            ));
+                        }
+                    }
+                }
+                let wait_elapsed = wait_start.elapsed();
+                total_persistence_wait_time += wait_elapsed;
+                persistence_wait_count += 1;
+
+                debug!(
+                    target: "reth-bench",
+                    ?wait_elapsed,
+                    "Persistence caught up"
+                );
+            }
+
             // current duration since the start of the benchmark minus the time
             // waiting for blocks
             let current_duration = total_benchmark_duration.elapsed() - total_wait_time;
 
             // convert gas used to gigagas, then compute gigagas per second
             info!(%combined_result);
-
-            // wait before sending the next payload
-            tokio::time::sleep(self.wait_time).await;
 
             // record the current result
             let gas_row =
@@ -175,15 +395,67 @@ impl Command {
             return Err(error);
         }
 
+        // Final sync: wait for all remaining blocks to be persisted
+        if last_persisted_block < last_block_number {
+            info!(
+                "Waiting for final blocks to persist (current: {}, target: {})",
+                last_persisted_block, last_block_number
+            );
+
+            let final_sync_result = tokio::time::timeout(PERSISTENCE_TIMEOUT, async {
+                while last_persisted_block < last_block_number {
+                    match persistence_rx.recv().await {
+                        Some(persisted) => {
+                            last_persisted_block = persisted.number;
+                            debug!(
+                                target: "reth-bench",
+                                persisted_block = ?last_persisted_block,
+                                "Final sync: received persistence notification"
+                            );
+                        }
+                        None => {
+                            return Err(eyre::eyre!("Persistence subscription closed"));
+                        }
+                    }
+                }
+                Ok(())
+            })
+            .await;
+
+            match final_sync_result {
+                Ok(Ok(())) => {
+                    info!("All blocks persisted successfully");
+                }
+                Ok(Err(e)) => {
+                    warn!("Final sync failed: {}", e);
+                }
+                Err(_) => {
+                    warn!(
+                        "Persistence timeout: not all blocks persisted within {:?}. \
+                         Last persisted: {}, target: {}",
+                        PERSISTENCE_TIMEOUT, last_persisted_block, last_block_number
+                    );
+                }
+            }
+        }
+
         let (gas_output_results, combined_results): (_, Vec<CombinedResult>) =
             results.into_iter().unzip();
 
+        // Calculate persistence stats
+        let persistence_stats = PersistenceStats {
+            wait_count: persistence_wait_count,
+            total_wait_time: total_persistence_wait_time,
+            max_gap,
+            avg_gap: if gap_count > 0 { gap_sum as f64 / gap_count as f64 } else { 0.0 },
+        };
+
         // write the csv output to files
-        if let Some(path) = self.benchmark.output {
+        if let Some(ref path) = self.benchmark.output {
             // first write the combined results to a file
             let output_path = path.join(COMBINED_OUTPUT_SUFFIX);
             info!("Writing engine api call latency output to file: {:?}", output_path);
-            let mut writer = Writer::from_path(output_path)?;
+            let mut writer = Writer::from_path(&output_path)?;
             for result in combined_results {
                 writer.serialize(result)?;
             }
@@ -192,10 +464,17 @@ impl Command {
             // now write the gas output to a file
             let output_path = path.join(GAS_OUTPUT_SUFFIX);
             info!("Writing total gas output to file: {:?}", output_path);
-            let mut writer = Writer::from_path(output_path)?;
+            let mut writer = Writer::from_path(&output_path)?;
             for row in &gas_output_results {
                 writer.serialize(row)?;
             }
+            writer.flush()?;
+
+            // write persistence stats to a file
+            let output_path = path.join(PERSISTENCE_STATS_SUFFIX);
+            info!("Writing persistence stats to file: {:?}", output_path);
+            let mut writer = Writer::from_path(&output_path)?;
+            writer.serialize(&persistence_stats)?;
             writer.flush()?;
 
             info!("Finished writing benchmark output files to {:?}.", path);
@@ -207,6 +486,8 @@ impl Command {
             total_duration=?gas_output.total_duration,
             total_gas_used=?gas_output.total_gas_used,
             blocks_processed=?gas_output.blocks_processed,
+            persistence_waits=?persistence_stats.wait_count,
+            persistence_wait_time=?persistence_stats.total_wait_time,
             "Total Ggas/s: {:.4}",
             gas_output.total_gigagas_per_second()
         );

--- a/bin/reth-bench/src/bench/output.rs
+++ b/bin/reth-bench/src/bench/output.rs
@@ -15,6 +15,37 @@ pub(crate) const COMBINED_OUTPUT_SUFFIX: &str = "combined_latency.csv";
 /// This is the suffix for new payload output csv files.
 pub(crate) const NEW_PAYLOAD_OUTPUT_SUFFIX: &str = "new_payload_latency.csv";
 
+/// This is the suffix for persistence stats csv files.
+pub(crate) const PERSISTENCE_STATS_SUFFIX: &str = "persistence_stats.csv";
+
+/// Statistics about persistence waits during the benchmark.
+#[derive(Debug)]
+pub(crate) struct PersistenceStats {
+    /// Number of times we waited for persistence
+    pub(crate) wait_count: u64,
+    /// Total time spent waiting for persistence
+    pub(crate) total_wait_time: Duration,
+    /// Maximum gap observed between sent and persisted blocks
+    pub(crate) max_gap: u64,
+    /// Average gap observed
+    pub(crate) avg_gap: f64,
+}
+
+impl Serialize for PersistenceStats {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        let total_wait_time_ms = self.total_wait_time.as_millis() as u64;
+        let mut state = serializer.serialize_struct("PersistenceStats", 4)?;
+        state.serialize_field("wait_count", &self.wait_count)?;
+        state.serialize_field("total_wait_time_ms", &total_wait_time_ms)?;
+        state.serialize_field("max_gap_blocks", &self.max_gap)?;
+        state.serialize_field("avg_gap_blocks", &self.avg_gap)?;
+        state.end()
+    }
+}
+
 /// This represents the results of a single `newPayload` call in the benchmark, containing the gas
 /// used and the `newPayload` latency.
 #[derive(Debug)]

--- a/crates/engine/primitives/src/event.rs
+++ b/crates/engine/primitives/src/event.rs
@@ -32,6 +32,8 @@ pub enum ConsensusEngineEvent<N: NodePrimitives = EthPrimitives> {
     CanonicalChainCommitted(Box<SealedHeader<N::BlockHeader>>, Duration),
     /// The consensus engine processed an invalid block.
     InvalidBlock(Box<SealedBlock<N::Block>>),
+    /// Latest persisted block with its number and hash.
+    LatestPersistedBlock(BlockNumHash),
 }
 
 impl<N: NodePrimitives> ConsensusEngineEvent<N> {
@@ -72,6 +74,9 @@ where
             }
             Self::BlockReceived(num_hash) => {
                 write!(f, "BlockReceived({num_hash:?})")
+            }
+            Self::LatestPersistedBlock(block) => {
+                write!(f, "LatestPersistedBlock({block:?})")
             }
         }
     }

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1366,6 +1366,13 @@ where
         debug!(target: "engine::tree", ?last_persisted_block_hash, ?last_persisted_block_number, elapsed=?start_time.elapsed(), "Finished persisting, calling finish");
         self.persistence_state.finish(last_persisted_block_hash, last_persisted_block_number);
         self.on_new_persisted_block()?;
+
+        // Emit event for latest persisted block
+        self.emit_event(ConsensusEngineEvent::LatestPersistedBlock(BlockNumHash {
+            number: last_persisted_block_number,
+            hash: last_persisted_block_hash,
+        }));
+
         Ok(())
     }
 

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -25,7 +25,7 @@ use reth_node_core::{
 };
 use reth_payload_builder::{PayloadBuilderHandle, PayloadStore};
 use reth_rpc::{
-    eth::{core::EthRpcConverterFor, DevSigner, EthApiTypes, FullEthApiServer},
+    eth::{core::EthRpcConverterFor, DevSigner, EthApiTypes, FullEthApiServer, RpcNodeCore},
     AdminApi,
 };
 use reth_rpc_api::{eth::helpers::EthTransactions, IntoEngineApiRpcModule};
@@ -1197,7 +1197,8 @@ impl<'a, N: FullNodeComponents<Types: NodeTypes<ChainSpec: Hardforks + EthereumH
 /// A `EthApi` that knows how to build `eth` namespace API from [`FullNodeComponents`].
 pub trait EthApiBuilder<N: FullNodeComponents>: Default + Send + 'static {
     /// The Ethapi implementation this builder will build.
-    type EthApi: FullEthApiServer<Provider = N::Provider, Pool = N::Pool>;
+    type EthApi: FullEthApiServer<Provider = N::Provider, Pool = N::Pool>
+        + RpcNodeCore<Primitives = PrimitivesTy<N::Types>>;
 
     /// Builds the [`EthApiServer`](reth_rpc_api::eth::EthApiServer) from the given context.
     fn build_eth_api(

--- a/crates/node/events/src/node.rs
+++ b/crates/node/events/src/node.rs
@@ -267,6 +267,9 @@ impl NodeState {
             ConsensusEngineEvent::BlockReceived(num_hash) => {
                 info!(number=num_hash.number, hash=?num_hash.hash, "Received block from consensus engine");
             }
+            ConsensusEngineEvent::LatestPersistedBlock(num_hash) => {
+                info!(number=num_hash.number, hash=?num_hash.hash, "Latest persisted block");
+            }
         }
     }
 

--- a/crates/rpc/rpc-api/src/reth.rs
+++ b/crates/rpc/rpc-api/src/reth.rs
@@ -24,4 +24,14 @@ pub trait RethApi {
         item = reth_chain_state::CanonStateNotification
     )]
     async fn reth_subscribe_chain_notifications(&self) -> jsonrpsee::core::SubscriptionResult;
+
+    /// Subscribe to latest persisted block notifications.
+    ///
+    /// Emits a notification for the latest block when blocks are persisted to disk.
+    #[subscription(
+        name = "subscribeLatestPersistedBlock",
+        unsubscribe = "unsubscribeLatestPersistedBlock",
+        item = alloy_eips::BlockNumHash
+    )]
+    async fn reth_subscribe_latest_persisted_block(&self) -> jsonrpsee::core::SubscriptionResult;
 }

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -28,6 +28,7 @@ reth-network-api.workspace = true
 reth-rpc-engine-api.workspace = true
 reth-revm = { workspace = true, features = ["witness"] }
 reth-tasks = { workspace = true, features = ["rayon"] }
+reth-tokio-util.workspace = true
 reth-rpc-convert.workspace = true
 revm-inspectors.workspace = true
 reth-network-peers = { workspace = true, features = ["secp256k1"] }


### PR DESCRIPTION
**Problem**
The current reth-bench implementation uses static wait times between block submissions, resulting in ~long rbc time for 1000 blocks (at 500ms wait). 

**Solution**
Implement an event-driven pipelined approach using WebSocket-based persistence notifications. The benchmark now tracks the gap between sent and persisted blocks, waiting only when the gap reaches a configurable threshold (default N=2).