### PR TITLE
chore(trie): fix typo in comment

### DIFF
--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -601,7 +601,7 @@ where
     pub fn root(self) -> Result<B256, StorageRootError> {
         match self.calculate(false)? {
             StorageRootProgress::Complete(root, _, _) => Ok(root),
-            StorageRootProgress::Progress(..) => unreachable!(), // update retenion is disabled
+            StorageRootProgress::Progress(..) => unreachable!(), // update retention is disabled
         }
     }
 


### PR DESCRIPTION
Fix typo "retenion" → "retention" in `StorageRoot::root` comment.