### PR TITLE
test(storage): add parametrized MDBX/RocksDB history lookup equivalence tests

### DIFF
--- a/crates/storage/provider/src/either_writer.rs
+++ b/crates/storage/provider/src/either_writer.rs
@@ -976,10 +976,7 @@ mod tests {
 mod rocksdb_tests {
     use super::*;
     use crate::{
-        providers::{
-            rocksdb::{RocksDBBuilder, RocksDBProvider},
-            HistoricalStateProviderRef, HistoryInfo, LowestAvailableBlocks,
-        },
+        providers::rocksdb::{RocksDBBuilder, RocksDBProvider},
         test_utils::create_test_provider_factory,
         RocksDBProviderFactory,
     };

--- a/crates/storage/provider/src/either_writer.rs
+++ b/crates/storage/provider/src/either_writer.rs
@@ -27,6 +27,7 @@ use reth_db::{
 use reth_db_api::{
     cursor::DbCursorRW,
     models::{storage_sharded_key::StorageShardedKey, ShardedKey},
+    table::Table,
     tables,
     tables::BlockNumberList,
 };
@@ -37,6 +38,58 @@ use reth_static_file_types::StaticFileSegment;
 use reth_storage_api::{ChangeSetReader, DBProvider, NodePrimitivesProvider, StorageSettingsCache};
 use reth_storage_errors::provider::ProviderResult;
 use strum::{Display, EnumIs};
+
+/// Generic history lookup for sharded MDBX history tables.
+///
+/// Seeks to the shard containing `block_number`, verifies the key via `key_matches`,
+/// and uses `prev_key_matches` to detect if a previous shard exists for the same key.
+fn history_info_mdbx<T, C, Matches, PrevMatches>(
+    cursor: &mut C,
+    seek_key: T::Key,
+    block_number: BlockNumber,
+    lowest_available_block_number: Option<BlockNumber>,
+    key_matches: Matches,
+    prev_key_matches: PrevMatches,
+) -> ProviderResult<HistoryInfo>
+where
+    T: Table<Value = BlockNumberList>,
+    C: DbCursorRO<T>,
+    Matches: FnOnce(&T::Key) -> bool,
+    PrevMatches: Fn(&T::Key) -> bool,
+{
+    // Seek to the smallest key >= seek_key.
+    if let Some(chunk) = cursor.seek(seek_key)?.filter(|(k, _)| key_matches(k)).map(|x| x.1) {
+        // Get the rank of the first entry before or equal to our block.
+        let mut rank = chunk.rank(block_number);
+
+        // Adjust the rank, so that we have the rank of the first entry strictly before our
+        // block (not equal to it).
+        if rank.checked_sub(1).and_then(|r| chunk.select(r)) == Some(block_number) {
+            rank -= 1;
+        }
+
+        let found_block = chunk.select(rank);
+
+        // Lazy check for previous shard - only called when needed.
+        // If we can step to a previous shard for this same key, history already exists,
+        // so the target block is not before the first write.
+        let is_before_first_write = needs_prev_shard_check(rank, found_block, block_number) &&
+            cursor.prev()?.is_none_or(|(k, _)| !prev_key_matches(&k));
+
+        Ok(HistoryInfo::from_lookup(
+            found_block,
+            is_before_first_write,
+            lowest_available_block_number,
+        ))
+    } else if lowest_available_block_number.is_some() {
+        // The key may have been written, but due to pruning we may not have changesets
+        // and history, so we need to make a plain state lookup.
+        Ok(HistoryInfo::MaybeInPlainState)
+    } else {
+        // The key has not been written to at all.
+        Ok(HistoryInfo::NotYetWritten)
+    }
+}
 
 /// Type alias for [`EitherReader`] constructors.
 type EitherReaderTy<'a, P, T> =
@@ -734,31 +787,14 @@ where
         match self {
             Self::Database(cursor, _) => {
                 let key = StorageShardedKey::new(address, storage_key, block_number);
-                if let Some(chunk) = cursor
-                    .seek(key)?
-                    .filter(|(k, _)| k.address == address && k.sharded_key.key == storage_key)
-                    .map(|x| x.1)
-                {
-                    let mut rank = chunk.rank(block_number);
-                    if rank.checked_sub(1).and_then(|r| chunk.select(r)) == Some(block_number) {
-                        rank -= 1;
-                    }
-                    let found_block = chunk.select(rank);
-                    let is_before_first_write =
-                        needs_prev_shard_check(rank, found_block, block_number) &&
-                            cursor.prev()?.is_none_or(|(k, _)| {
-                                k.address != address || k.sharded_key.key != storage_key
-                            });
-                    Ok(HistoryInfo::from_lookup(
-                        found_block,
-                        is_before_first_write,
-                        lowest_available_block_number,
-                    ))
-                } else if lowest_available_block_number.is_some() {
-                    Ok(HistoryInfo::MaybeInPlainState)
-                } else {
-                    Ok(HistoryInfo::NotYetWritten)
-                }
+                history_info_mdbx::<tables::StoragesHistory, _, _, _>(
+                    cursor,
+                    key,
+                    block_number,
+                    lowest_available_block_number,
+                    |k| k.address == address && k.sharded_key.key == storage_key,
+                    |k| k.address == address && k.sharded_key.key == storage_key,
+                )
             }
             Self::StaticFile(_, _) => Err(ProviderError::UnsupportedProvider),
             #[cfg(all(unix, feature = "rocksdb"))]
@@ -799,27 +835,14 @@ where
         match self {
             Self::Database(cursor, _) => {
                 let key = ShardedKey::new(address, block_number);
-                if let Some(chunk) =
-                    cursor.seek(key)?.filter(|(k, _)| k.key == address).map(|x| x.1)
-                {
-                    let mut rank = chunk.rank(block_number);
-                    if rank.checked_sub(1).and_then(|r| chunk.select(r)) == Some(block_number) {
-                        rank -= 1;
-                    }
-                    let found_block = chunk.select(rank);
-                    let is_before_first_write =
-                        needs_prev_shard_check(rank, found_block, block_number) &&
-                            cursor.prev()?.is_none_or(|(k, _)| k.key != address);
-                    Ok(HistoryInfo::from_lookup(
-                        found_block,
-                        is_before_first_write,
-                        lowest_available_block_number,
-                    ))
-                } else if lowest_available_block_number.is_some() {
-                    Ok(HistoryInfo::MaybeInPlainState)
-                } else {
-                    Ok(HistoryInfo::NotYetWritten)
-                }
+                history_info_mdbx::<tables::AccountsHistory, _, _, _>(
+                    cursor,
+                    key,
+                    block_number,
+                    lowest_available_block_number,
+                    |k| k.key == address,
+                    |k| k.key == address,
+                )
             }
             Self::StaticFile(_, _) => Err(ProviderError::UnsupportedProvider),
             #[cfg(all(unix, feature = "rocksdb"))]

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -16,8 +16,8 @@ pub use static_file::{
 mod state;
 pub use state::{
     historical::{
-        needs_prev_shard_check, HistoricalStateProvider, HistoricalStateProviderRef, HistoryInfo,
-        LowestAvailableBlocks,
+        history_info, needs_prev_shard_check, HistoricalStateProvider, HistoricalStateProviderRef,
+        HistoryInfo, LowestAvailableBlocks,
     },
     latest::{LatestStateProvider, LatestStateProviderRef},
     overlay::{OverlayStateProvider, OverlayStateProviderFactory},

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -1264,101 +1264,9 @@ mod tests {
         assert_eq!(last, Some((20, b"value_20".to_vec())));
     }
 
-    #[test]
-    fn test_account_history_info_single_shard() {
-        let temp_dir = TempDir::new().unwrap();
-        let provider = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
-
-        let address = Address::from([0x42; 20]);
-
-        // Create a single shard with blocks [100, 200, 300] and highest_block = u64::MAX
-        // This is the "last shard" invariant
-        let chunk = IntegerList::new([100, 200, 300]).unwrap();
-        let shard_key = ShardedKey::new(address, u64::MAX);
-        provider.put::<tables::AccountsHistory>(shard_key, &chunk).unwrap();
-
-        let tx = provider.tx();
-
-        // Query for block 150: should find block 200 in changeset
-        let result = tx.account_history_info(address, 150, None).unwrap();
-        assert_eq!(result, HistoryInfo::InChangeset(200));
-
-        // Query for block 50: should return NotYetWritten (before first entry, no prev shard)
-        let result = tx.account_history_info(address, 50, None).unwrap();
-        assert_eq!(result, HistoryInfo::NotYetWritten);
-
-        // Query for block 300: should return InChangeset(300) - exact match means look at
-        // changeset at that block for the previous value
-        let result = tx.account_history_info(address, 300, None).unwrap();
-        assert_eq!(result, HistoryInfo::InChangeset(300));
-
-        // Query for block 500: should return InPlainState (after last entry in last shard)
-        let result = tx.account_history_info(address, 500, None).unwrap();
-        assert_eq!(result, HistoryInfo::InPlainState);
-
-        tx.rollback().unwrap();
-    }
-
-    #[test]
-    fn test_account_history_info_multiple_shards() {
-        let temp_dir = TempDir::new().unwrap();
-        let provider = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
-
-        let address = Address::from([0x42; 20]);
-
-        // Create two shards: first shard ends at block 500, second is the last shard
-        let chunk1 = IntegerList::new([100, 200, 300, 400, 500]).unwrap();
-        let shard_key1 = ShardedKey::new(address, 500);
-        provider.put::<tables::AccountsHistory>(shard_key1, &chunk1).unwrap();
-
-        let chunk2 = IntegerList::new([600, 700, 800]).unwrap();
-        let shard_key2 = ShardedKey::new(address, u64::MAX);
-        provider.put::<tables::AccountsHistory>(shard_key2, &chunk2).unwrap();
-
-        let tx = provider.tx();
-
-        // Query for block 50: should return NotYetWritten (before first shard, no prev)
-        let result = tx.account_history_info(address, 50, None).unwrap();
-        assert_eq!(result, HistoryInfo::NotYetWritten);
-
-        // Query for block 150: should find block 200 in first shard's changeset
-        let result = tx.account_history_info(address, 150, None).unwrap();
-        assert_eq!(result, HistoryInfo::InChangeset(200));
-
-        // Query for block 550: should find block 600 in second shard's changeset
-        // prev() should detect first shard exists
-        let result = tx.account_history_info(address, 550, None).unwrap();
-        assert_eq!(result, HistoryInfo::InChangeset(600));
-
-        // Query for block 900: should return InPlainState (after last entry in last shard)
-        let result = tx.account_history_info(address, 900, None).unwrap();
-        assert_eq!(result, HistoryInfo::InPlainState);
-
-        tx.rollback().unwrap();
-    }
-
-    #[test]
-    fn test_account_history_info_no_history() {
-        let temp_dir = TempDir::new().unwrap();
-        let provider = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
-
-        let address1 = Address::from([0x42; 20]);
-        let address2 = Address::from([0x43; 20]);
-
-        // Only add history for address1
-        let chunk = IntegerList::new([100, 200, 300]).unwrap();
-        let shard_key = ShardedKey::new(address1, u64::MAX);
-        provider.put::<tables::AccountsHistory>(shard_key, &chunk).unwrap();
-
-        let tx = provider.tx();
-
-        // Query for address2 (no history exists): should return NotYetWritten
-        let result = tx.account_history_info(address2, 150, None).unwrap();
-        assert_eq!(result, HistoryInfo::NotYetWritten);
-
-        tx.rollback().unwrap();
-    }
-
+    /// Tests the edge case where block < `lowest_available_block_number`.
+    /// This case cannot be tested via `HistoricalStateProviderRef` (which errors before lookup),
+    /// so we keep this RocksDB-specific test to verify the low-level behavior.
     #[test]
     fn test_account_history_info_pruned_before_first_entry() {
         let temp_dir = TempDir::new().unwrap();
@@ -1379,41 +1287,6 @@ mod tests {
         // check the changeset at the first write block.
         let result = tx.account_history_info(address, 50, Some(100)).unwrap();
         assert_eq!(result, HistoryInfo::InChangeset(100));
-
-        tx.rollback().unwrap();
-    }
-
-    #[test]
-    fn test_storage_history_info() {
-        let temp_dir = TempDir::new().unwrap();
-        let provider = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
-
-        let address = Address::from([0x42; 20]);
-        let storage_key = B256::from([0x01; 32]);
-
-        // Create a single shard for this storage slot
-        let chunk = IntegerList::new([100, 200, 300]).unwrap();
-        let shard_key = StorageShardedKey::new(address, storage_key, u64::MAX);
-        provider.put::<tables::StoragesHistory>(shard_key, &chunk).unwrap();
-
-        let tx = provider.tx();
-
-        // Query for block 150: should find block 200 in changeset
-        let result = tx.storage_history_info(address, storage_key, 150, None).unwrap();
-        assert_eq!(result, HistoryInfo::InChangeset(200));
-
-        // Query for block 50: should return NotYetWritten
-        let result = tx.storage_history_info(address, storage_key, 50, None).unwrap();
-        assert_eq!(result, HistoryInfo::NotYetWritten);
-
-        // Query for block 500: should return InPlainState
-        let result = tx.storage_history_info(address, storage_key, 500, None).unwrap();
-        assert_eq!(result, HistoryInfo::InPlainState);
-
-        // Query for different storage key (no history): should return NotYetWritten
-        let other_key = B256::from([0x02; 32]);
-        let result = tx.storage_history_info(address, other_key, 150, None).unwrap();
-        assert_eq!(result, HistoryInfo::NotYetWritten);
 
         tx.rollback().unwrap();
     }


### PR DESCRIPTION
**Problem**
#20543 added RocksDB history lookup tests, but they only tested the RocksDB backend. There was no verification that MDBX and RocksDB produce identical results for the same inputs.

**Solution**
Add parametrized tests that run identical scenarios against both backends and assert they return the same `HistoryInfo`, so its behaviorally equivalent.

**Changes**
- Add `run_account_history_scenario()` and `run_storage_history_scenario()` test helpers
- Add `test_account_history_info_both_backends` covering 4 scenarios (single shard, multiple shards, no history, pruning boundary)
- Add `test_storage_history_info_both_backends` covering 2 scenarios