### PR TITLE
refactor: extract common TypedValueParser validation logic

### DIFF
--- a/crates/cli/cli/src/lib.rs
+++ b/crates/cli/cli/src/lib.rs
@@ -17,6 +17,9 @@ use std::{borrow::Cow, ffi::OsString};
 pub mod chainspec;
 use crate::chainspec::ChainSpecParser;
 
+/// Utility functions for clap value parsers
+mod utils;
+
 /// Reth based node cli.
 ///
 /// This trait is supposed to be implemented by the main struct of the CLI.

--- a/crates/cli/cli/src/utils.rs
+++ b/crates/cli/cli/src/utils.rs
@@ -3,7 +3,7 @@
 use clap::{error::ErrorKind, Arg, Error};
 use std::ffi::OsStr;
 
-/// Converts an OsStr to UTF-8, returning InvalidUtf8 error on failure.
+/// Converts an `OsStr` to UTF-8, returning `InvalidUtf8` error on failure.
 pub(crate) fn parse_osstr_to_str(value: &OsStr) -> Result<&str, Error> {
     value.to_str().ok_or_else(|| Error::new(ErrorKind::InvalidUtf8))
 }
@@ -13,7 +13,7 @@ pub(crate) fn format_arg_name(arg: Option<&Arg>) -> String {
     arg.map(|a| a.to_string()).unwrap_or_else(|| "...".to_owned())
 }
 
-/// Builds a standardized InvalidValue error with possible values listed.
+/// Builds a standardized `InvalidValue` error with possible values listed.
 pub(crate) fn build_invalid_value_error<E: std::fmt::Display>(
     val: &str,
     arg: Option<&Arg>,
@@ -26,4 +26,3 @@ pub(crate) fn build_invalid_value_error<E: std::fmt::Display>(
     );
     Error::raw(ErrorKind::InvalidValue, msg)
 }
-

--- a/crates/cli/cli/src/utils.rs
+++ b/crates/cli/cli/src/utils.rs
@@ -1,0 +1,29 @@
+//! Utility functions for clap TypedValueParser implementations
+
+use clap::{error::ErrorKind, Arg, Error};
+use std::ffi::OsStr;
+
+/// Converts an OsStr to UTF-8, returning InvalidUtf8 error on failure.
+pub(crate) fn parse_osstr_to_str(value: &OsStr) -> Result<&str, Error> {
+    value.to_str().ok_or_else(|| Error::new(ErrorKind::InvalidUtf8))
+}
+
+/// Formats argument name for error messages, returning "..." if None.
+pub(crate) fn format_arg_name(arg: Option<&Arg>) -> String {
+    arg.map(|a| a.to_string()).unwrap_or_else(|| "...".to_owned())
+}
+
+/// Builds a standardized InvalidValue error with possible values listed.
+pub(crate) fn build_invalid_value_error<E: std::fmt::Display>(
+    val: &str,
+    arg: Option<&Arg>,
+    err: E,
+    possible_values: &str,
+) -> Error {
+    let arg_name = format_arg_name(arg);
+    let msg = format!(
+        "Invalid value '{val}' for {arg_name}: {err}.\n    [possible values: {possible_values}]"
+    );
+    Error::raw(ErrorKind::InvalidValue, msg)
+}
+

--- a/crates/node/core/src/args/debug.rs
+++ b/crates/node/core/src/args/debug.rs
@@ -1,5 +1,6 @@
 //! clap [Args](clap::Args) for debugging purposes
 
+use crate::args::value_parser_utils;
 use alloy_primitives::B256;
 use clap::{
     builder::{PossibleValue, TypedValueParser},
@@ -263,15 +264,10 @@ impl TypedValueParser for InvalidBlockSelectionValueParser {
         arg: Option<&Arg>,
         value: &OsStr,
     ) -> Result<Self::Value, clap::Error> {
-        let val =
-            value.to_str().ok_or_else(|| clap::Error::new(clap::error::ErrorKind::InvalidUtf8))?;
+        let val = value_parser_utils::parse_osstr_to_str(value)?;
         val.parse::<InvalidBlockSelection>().map_err(|err| {
-            let arg = arg.map(|a| a.to_string()).unwrap_or_else(|| "...".to_owned());
             let possible_values = InvalidBlockHookType::all_variant_names().to_vec().join(",");
-            let msg = format!(
-                "Invalid value '{val}' for {arg}: {err}.\n    [possible values: {possible_values}]"
-            );
-            clap::Error::raw(clap::error::ErrorKind::InvalidValue, msg)
+            value_parser_utils::build_invalid_value_error(val, arg, err, &possible_values)
         })
     }
 

--- a/crates/node/core/src/args/mod.rs
+++ b/crates/node/core/src/args/mod.rs
@@ -82,3 +82,6 @@ pub use static_files::StaticFilesArgs;
 
 mod error;
 pub mod types;
+
+/// Utility functions for clap value parsers
+pub mod value_parser_utils;

--- a/crates/node/core/src/args/payload_builder.rs
+++ b/crates/node/core/src/args/payload_builder.rs
@@ -1,4 +1,6 @@
-use crate::{cli::config::PayloadBuilderConfig, version::default_extra_data};
+use crate::{
+    args::value_parser_utils, cli::config::PayloadBuilderConfig, version::default_extra_data,
+};
 use alloy_consensus::constants::MAXIMUM_EXTRA_DATA_SIZE;
 use clap::{
     builder::{RangedU64ValueParser, TypedValueParser},
@@ -179,8 +181,7 @@ impl TypedValueParser for ExtraDataValueParser {
         _arg: Option<&Arg>,
         value: &OsStr,
     ) -> Result<Self::Value, clap::Error> {
-        let val =
-            value.to_str().ok_or_else(|| clap::Error::new(clap::error::ErrorKind::InvalidUtf8))?;
+        let val = value_parser_utils::parse_osstr_to_str(value)?;
         if val.len() > MAXIMUM_EXTRA_DATA_SIZE {
             return Err(clap::Error::raw(
                 clap::error::ErrorKind::InvalidValue,

--- a/crates/node/core/src/args/rpc_server.rs
+++ b/crates/node/core/src/args/rpc_server.rs
@@ -2,7 +2,7 @@
 
 use crate::args::{
     types::{MaxU32, ZeroAsNoneU64},
-    GasPriceOracleArgs, RpcStateCacheArgs,
+    value_parser_utils, GasPriceOracleArgs, RpcStateCacheArgs,
 };
 use alloy_primitives::Address;
 use alloy_rpc_types_engine::JwtSecret;
@@ -870,8 +870,7 @@ impl TypedValueParser for RpcModuleSelectionValueParser {
         _arg: Option<&Arg>,
         value: &OsStr,
     ) -> Result<Self::Value, clap::Error> {
-        let val =
-            value.to_str().ok_or_else(|| clap::Error::new(clap::error::ErrorKind::InvalidUtf8))?;
+        let val = value_parser_utils::parse_osstr_to_str(value)?;
         // This will now accept any module name, creating Other(name) for unknowns
         Ok(val
             .parse::<RpcModuleSelection>()

--- a/crates/node/core/src/args/value_parser_utils.rs
+++ b/crates/node/core/src/args/value_parser_utils.rs
@@ -3,7 +3,7 @@
 use clap::{error::ErrorKind, Arg, Error};
 use std::ffi::OsStr;
 
-/// Converts an OsStr to UTF-8, returning InvalidUtf8 error on failure.
+/// Converts an `OsStr` to UTF-8, returning `InvalidUtf8` error on failure.
 pub fn parse_osstr_to_str(value: &OsStr) -> Result<&str, Error> {
     value.to_str().ok_or_else(|| Error::new(ErrorKind::InvalidUtf8))
 }
@@ -13,7 +13,7 @@ pub fn format_arg_name(arg: Option<&Arg>) -> String {
     arg.map(|a| a.to_string()).unwrap_or_else(|| "...".to_owned())
 }
 
-/// Builds a standardized InvalidValue error with possible values listed.
+/// Builds a standardized `InvalidValue` error with possible values listed.
 pub fn build_invalid_value_error<E: std::fmt::Display>(
     val: &str,
     arg: Option<&Arg>,
@@ -26,4 +26,3 @@ pub fn build_invalid_value_error<E: std::fmt::Display>(
     );
     Error::raw(ErrorKind::InvalidValue, msg)
 }
-

--- a/crates/node/core/src/args/value_parser_utils.rs
+++ b/crates/node/core/src/args/value_parser_utils.rs
@@ -1,0 +1,29 @@
+//! Utility functions for clap TypedValueParser implementations
+
+use clap::{error::ErrorKind, Arg, Error};
+use std::ffi::OsStr;
+
+/// Converts an OsStr to UTF-8, returning InvalidUtf8 error on failure.
+pub fn parse_osstr_to_str(value: &OsStr) -> Result<&str, Error> {
+    value.to_str().ok_or_else(|| Error::new(ErrorKind::InvalidUtf8))
+}
+
+/// Formats argument name for error messages, returning "..." if None.
+pub fn format_arg_name(arg: Option<&Arg>) -> String {
+    arg.map(|a| a.to_string()).unwrap_or_else(|| "...".to_owned())
+}
+
+/// Builds a standardized InvalidValue error with possible values listed.
+pub fn build_invalid_value_error<E: std::fmt::Display>(
+    val: &str,
+    arg: Option<&Arg>,
+    err: E,
+    possible_values: &str,
+) -> Error {
+    let arg_name = format_arg_name(arg);
+    let msg = format!(
+        "Invalid value '{val}' for {arg_name}: {err}.\n    [possible values: {possible_values}]"
+    );
+    Error::raw(ErrorKind::InvalidValue, msg)
+}
+


### PR DESCRIPTION
The same UTF-8 validation and error formatting pattern repeated across 5 different TypedValueParser implementations. Pulled out the common bits into utility functions to make future clap API updates easier to handle.

1.Added value_parser_utils.rs for reth-node-core parsers
2.Added utils.rs for reth-cli parsers  
3.Refactored LogLevelValueParser, InvalidBlockSelectionValueParser, RpcModuleSelectionValueParser, ExtraDataValueParser, and chainspec Parser
