### PR TITLE
chore(consensus): Add trait object error variant to `ConsensusError`

### DIFF
--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -500,13 +500,11 @@ mod tests {
         let expected_blob_gas_used = 10 * DATA_GAS_PER_BLOB;
 
         // validate blob, it should fail blob gas used validation
-        assert_eq!(
-            validate_block_pre_execution(&block, &chain_spec),
-            Err(ConsensusError::BlobGasUsedDiff(GotExpected {
-                got: 1,
-                expected: expected_blob_gas_used
-            }))
-        );
+        assert!(matches!(
+            validate_block_pre_execution(&block, &chain_spec).unwrap_err(),
+            ConsensusError::BlobGasUsedDiff(diff)
+                if diff.got == 1 && diff.expected == expected_blob_gas_used
+        ));
     }
 
     #[test]
@@ -517,10 +515,10 @@ mod tests {
 
         // Test exceeding default - should fail
         let header_33 = Header { extra_data: Bytes::from(vec![0; 33]), ..Default::default() };
-        assert_eq!(
-            validate_header_extra_data(&header_33, 32),
-            Err(ConsensusError::ExtraDataExceedsMax { len: 33 })
-        );
+        assert!(matches!(
+            validate_header_extra_data(&header_33, 32).unwrap_err(),
+            ConsensusError::ExtraDataExceedsMax { len } if len == 33
+        ));
 
         // Test with custom larger limit - should pass
         assert!(validate_header_extra_data(&header_33, 64).is_ok());

--- a/crates/ethereum/consensus/src/validation.rs
+++ b/crates/ethereum/consensus/src/validation.rs
@@ -170,18 +170,16 @@ mod tests {
         let expected_receipts_root = B256::random();
         let expected_logs_bloom = calculated_logs_bloom;
 
-        assert_eq!(
+        assert!(matches!(
             compare_receipts_root_and_logs_bloom(
                 calculated_receipts_root,
                 calculated_logs_bloom,
                 expected_receipts_root,
                 expected_logs_bloom
-            ),
-            Err(ConsensusError::BodyReceiptRootDiff(
-                GotExpected { got: calculated_receipts_root, expected: expected_receipts_root }
-                    .into()
-            ))
-        );
+            ).unwrap_err(),
+            ConsensusError::BodyReceiptRootDiff(diff)
+                if diff.got == calculated_receipts_root && diff.expected == expected_receipts_root
+        ));
     }
 
     #[test]
@@ -192,16 +190,15 @@ mod tests {
         let expected_receipts_root = calculated_receipts_root;
         let expected_logs_bloom = Bloom::random();
 
-        assert_eq!(
+        assert!(matches!(
             compare_receipts_root_and_logs_bloom(
                 calculated_receipts_root,
                 calculated_logs_bloom,
                 expected_receipts_root,
                 expected_logs_bloom
-            ),
-            Err(ConsensusError::BodyBloomLogDiff(
-                GotExpected { got: calculated_logs_bloom, expected: expected_logs_bloom }.into()
-            ))
-        );
+            ).unwrap_err(),
+            ConsensusError::BodyBloomLogDiff(diff)
+                if diff.got == calculated_logs_bloom && diff.expected == expected_logs_bloom
+        ));
     }
 }

--- a/crates/net/downloaders/src/file_client.rs
+++ b/crates/net/downloaders/src/file_client.rs
@@ -726,7 +726,7 @@ mod tests {
         downloader.update_sync_target(SyncTarget::Tip(p0.hash()));
 
         let headers = downloader.next().await.unwrap();
-        assert_eq!(headers, Ok(vec![p0, p1, p2]));
+        assert_eq!(headers.unwrap(), vec![p0, p1, p2]);
         assert!(downloader.next().await.is_none());
         assert!(downloader.next().await.is_none());
     }

--- a/crates/net/downloaders/src/headers/reverse_headers.rs
+++ b/crates/net/downloaders/src/headers/reverse_headers.rs
@@ -1464,7 +1464,7 @@ mod tests {
             .await;
 
         let headers = downloader.next().await.unwrap();
-        assert_eq!(headers, Ok(vec![p0, p1, p2,]));
+        assert_eq!(headers.unwrap(), vec![p0, p1, p2,]);
         assert!(downloader.buffered_responses.is_empty());
         assert!(downloader.next().await.is_none());
         assert!(downloader.next().await.is_none());
@@ -1496,18 +1496,18 @@ mod tests {
             .await;
 
         let headers = downloader.next().await.unwrap();
-        assert_eq!(headers, Ok(vec![p0]));
         let headers = headers.unwrap();
+        assert_eq!(headers, vec![p0]);
         assert_eq!(headers.capacity(), headers.len());
 
         let headers = downloader.next().await.unwrap();
-        assert_eq!(headers, Ok(vec![p1]));
         let headers = headers.unwrap();
+        assert_eq!(headers, vec![p1]);
         assert_eq!(headers.capacity(), headers.len());
 
         let headers = downloader.next().await.unwrap();
-        assert_eq!(headers, Ok(vec![p2]));
         let headers = headers.unwrap();
+        assert_eq!(headers, vec![p2]);
         assert_eq!(headers.capacity(), headers.len());
 
         assert!(downloader.next().await.is_none());
@@ -1539,18 +1539,18 @@ mod tests {
             .await;
 
         let headers = downloader.next().await.unwrap();
-        assert_eq!(headers, Ok(vec![p0]));
         let headers = headers.unwrap();
+        assert_eq!(headers, vec![p0]);
         assert_eq!(headers.capacity(), headers.len());
 
         let headers = downloader.next().await.unwrap();
-        assert_eq!(headers, Ok(vec![p1]));
         let headers = headers.unwrap();
+        assert_eq!(headers, vec![p1]);
         assert_eq!(headers.capacity(), headers.len());
 
         let headers = downloader.next().await.unwrap();
-        assert_eq!(headers, Ok(vec![p2]));
         let headers = headers.unwrap();
+        assert_eq!(headers, vec![p2]);
         assert_eq!(headers.capacity(), headers.len());
 
         assert!(downloader.next().await.is_none());

--- a/crates/net/downloaders/src/headers/task.rs
+++ b/crates/net/downloaders/src/headers/task.rs
@@ -223,11 +223,11 @@ mod tests {
             .await;
 
         let headers = downloader.next().await.unwrap();
-        assert_eq!(headers, Ok(vec![p0]));
+        assert_eq!(headers.unwrap(), vec![p0]);
 
         let headers = downloader.next().await.unwrap();
-        assert_eq!(headers, Ok(vec![p1]));
+        assert_eq!(headers.unwrap(), vec![p1]);
         let headers = downloader.next().await.unwrap();
-        assert_eq!(headers, Ok(vec![p2]));
+        assert_eq!(headers.unwrap(), vec![p2]);
     }
 }

--- a/crates/net/p2p/src/headers/error.rs
+++ b/crates/net/p2p/src/headers/error.rs
@@ -7,7 +7,7 @@ use reth_primitives_traits::SealedHeader;
 pub type HeadersDownloaderResult<T, H> = Result<T, HeadersDownloaderError<H>>;
 
 /// Error variants that can happen when sending requests to a session.
-#[derive(Debug, Clone, Eq, PartialEq, Display, Error)]
+#[derive(Debug, Clone, Display, Error)]
 pub enum HeadersDownloaderError<H: Sealable> {
     /// The downloaded header cannot be attached to the local head,
     /// but is valid otherwise.

--- a/crates/optimism/consensus/src/lib.rs
+++ b/crates/optimism/consensus/src/lib.rs
@@ -247,7 +247,7 @@ mod tests {
     use reth_consensus::{Consensus, ConsensusError, FullConsensus, HeaderValidator};
     use reth_optimism_chainspec::{OpChainSpec, OpChainSpecBuilder, OP_MAINNET};
     use reth_optimism_primitives::{OpPrimitives, OpReceipt, OpTransactionSigned};
-    use reth_primitives_traits::{proofs, GotExpected, RecoveredBlock, SealedBlock, SealedHeader};
+    use reth_primitives_traits::{proofs, RecoveredBlock, SealedBlock, SealedHeader};
     use reth_provider::BlockExecutionResult;
 
     use crate::OpBeaconConsensus;
@@ -342,11 +342,10 @@ mod tests {
         // validate blob, it should fail blob gas used validation
         let pre_execution = beacon_consensus.validate_block_pre_execution(&block);
 
-        assert!(pre_execution.is_err());
-        assert_eq!(
+        assert!(matches!(
             pre_execution.unwrap_err(),
-            ConsensusError::BlobGasUsedDiff(GotExpected { got: 10, expected: 0 })
-        );
+            ConsensusError::BlobGasUsedDiff(diff) if diff.got == 10 && diff.expected == 0
+        ));
     }
 
     #[test]
@@ -484,14 +483,11 @@ mod tests {
         );
 
         // validate blob, it should fail blob gas used validation post execution.
-        assert!(post_execution.is_err());
-        assert_eq!(
+        assert!(matches!(
             post_execution.unwrap_err(),
-            ConsensusError::BlobGasUsedDiff(GotExpected {
-                got: BLOB_GAS_USED + 1,
-                expected: BLOB_GAS_USED,
-            })
-        );
+            ConsensusError::BlobGasUsedDiff(diff)
+                if diff.got == BLOB_GAS_USED + 1 && diff.expected == BLOB_GAS_USED
+        ));
     }
 
     #[test]
@@ -633,14 +629,11 @@ mod tests {
 
         let result = beacon_consensus.validate_header_against_parent(&header, &parent);
 
-        assert!(result.is_err());
-        assert_eq!(
+        assert!(matches!(
             result.unwrap_err(),
-            ConsensusError::BaseFeeDiff(GotExpected {
-                got: MIN_BASE_FEE - 1,
-                expected: MIN_BASE_FEE,
-            })
-        );
+            ConsensusError::BaseFeeDiff(diff)
+                if diff.got == MIN_BASE_FEE - 1 && diff.expected == MIN_BASE_FEE
+        ));
     }
 
     #[test]
@@ -784,10 +777,10 @@ mod tests {
 
         let result = beacon_consensus.validate_header_against_parent(&header, &parent);
 
-        assert!(result.is_err());
-        assert_eq!(
+        assert!(matches!(
             result.unwrap_err(),
-            ConsensusError::BlobGasUsedDiff(GotExpected { got: DA_FOOTPRINT, expected: 0 })
-        );
+            ConsensusError::BlobGasUsedDiff(diff)
+                if diff.got == DA_FOOTPRINT && diff.expected == 0
+        ));
     }
 }

--- a/crates/optimism/consensus/src/validation/mod.rs
+++ b/crates/optimism/consensus/src/validation/mod.rs
@@ -564,12 +564,10 @@ mod tests {
             requests: Requests::default(),
             gas_used: GAS_USED,
         };
-        assert_eq!(
-            validate_block_post_execution(&header, &chainspec, &result),
-            Err(ConsensusError::BlobGasUsedDiff(GotExpected {
-                got: BLOB_GAS_USED,
-                expected: BLOB_GAS_USED + 1,
-            }))
-        );
+        assert!(matches!(
+            validate_block_post_execution(&header, &chainspec, &result).unwrap_err(),
+            ConsensusError::BlobGasUsedDiff(diff)
+                if diff.got == BLOB_GAS_USED && diff.expected == BLOB_GAS_USED + 1
+        ));
     }
 }


### PR DESCRIPTION
Upstreams https://github.com/op-rs/op-reth/pull/492

Removes redundant `PartialEq` and `Eq` impls for `ConsensusError`, which were only used in tests, and adds `ConsensusError::Custom` variant wrapping a trait object error.

Follow up to https://github.com/paradigmxyz/reth/pull/20843