### PR TITLE
feat(rpc): add persisted block subscription

### DIFF
--- a/crates/rpc/rpc-api/src/reth.rs
+++ b/crates/rpc/rpc-api/src/reth.rs
@@ -24,4 +24,14 @@ pub trait RethApi {
         item = reth_chain_state::CanonStateNotification
     )]
     async fn reth_subscribe_chain_notifications(&self) -> jsonrpsee::core::SubscriptionResult;
+
+    /// Subscribe to persisted block notifications.
+    ///
+    /// Emits a notification with the block number and hash when a new block is persisted to disk.
+    #[subscription(
+        name = "subscribePersistedBlock",
+        unsubscribe = "unsubscribePersistedBlock",
+        item = alloy_eips::BlockNumHash
+    )]
+    async fn reth_subscribe_persisted_block(&self) -> jsonrpsee::core::SubscriptionResult;
 }

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -103,7 +103,7 @@ pub use eth::EthHandlers;
 mod metrics;
 use crate::middleware::RethRpcMiddleware;
 pub use metrics::{MeteredBatchRequestsFuture, MeteredRequestFuture, RpcRequestMetricsService};
-use reth_chain_state::CanonStateSubscriptions;
+use reth_chain_state::{CanonStateSubscriptions, PersistedBlockSubscriptions};
 use reth_rpc::eth::sim_bundle::EthSimBundle;
 
 // Rpc rate limiter
@@ -311,6 +311,7 @@ where
     N: NodePrimitives,
     Provider: FullRpcProvider<Block = N::Block, Receipt = N::Receipt, Header = N::BlockHeader>
         + CanonStateSubscriptions<Primitives = N>
+        + PersistedBlockSubscriptions
         + AccountReader
         + ChangeSetReader,
     Pool: TransactionPool + Clone + 'static,
@@ -655,7 +656,8 @@ where
             Transaction = N::SignedTx,
         > + AccountReader
         + ChangeSetReader
-        + CanonStateSubscriptions,
+        + CanonStateSubscriptions
+        + PersistedBlockSubscriptions,
     Network: NetworkInfo + Peers + Clone + 'static,
     EthApi: EthApiServer<
             RpcTxReq<EthApi::NetworkTypes>,
@@ -843,6 +845,7 @@ where
     N: NodePrimitives,
     Provider: FullRpcProvider<Block = N::Block>
         + CanonStateSubscriptions<Primitives = N>
+        + PersistedBlockSubscriptions
         + AccountReader
         + ChangeSetReader,
     Pool: TransactionPool + Clone + 'static,


### PR DESCRIPTION
Adds `reth_subscribePersistedBlock` RPC subscription that emits `BlockNumHash` notifications when blocks are persisted to disk. Uses the `PersistedBlockSubscriptions` trait introduced in #20876.

Also generalizes `pipe_from_stream` to work with any `Stream<Item: Serialize>`.

Follow-up to #20876.