### PR TITLE
feat(metrics): Add metrics for save_block steps and computed trie input sizes

### DIFF
--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -321,7 +321,7 @@ impl NewPayloadStatusMetrics {
 }
 
 /// Metrics for non-execution related block validation.
-#[derive(Metrics)]
+#[derive(Metrics, Clone)]
 #[metrics(scope = "sync.block_validation")]
 pub(crate) struct BlockValidationMetrics {
     /// Total number of storage tries updated in the state root calculation
@@ -348,6 +348,14 @@ pub(crate) struct BlockValidationMetrics {
     pub(crate) post_execution_validation_duration: Histogram,
     /// Total duration of the new payload call
     pub(crate) total_duration: Histogram,
+    /// Size of `HashedPostStateSorted` (`total_len`)
+    pub(crate) hashed_post_state_size: Histogram,
+    /// Size of `TrieUpdatesSorted` (`total_len`)
+    pub(crate) trie_updates_sorted_size: Histogram,
+    /// Size of `AnchoredTrieInput` overlay `TrieUpdatesSorted` (`total_len`)
+    pub(crate) anchored_overlay_trie_updates_size: Histogram,
+    /// Size of `AnchoredTrieInput` overlay `HashedPostStateSorted` (`total_len`)
+    pub(crate) anchored_overlay_hashed_state_size: Histogram,
 }
 
 impl BlockValidationMetrics {

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1085,16 +1085,33 @@ where
             ancestors,
         );
         let deferred_handle_task = deferred_trie_data.clone();
-        let deferred_compute_duration =
-            self.metrics.block_validation.deferred_trie_compute_duration.clone();
+        let block_validation_metrics = self.metrics.block_validation.clone();
 
         // Spawn background task to compute trie data. Calling `wait_cloned` will compute from
         // the stored inputs and cache the result, so subsequent calls return immediately.
         let compute_trie_input_task = move || {
             let result = panic::catch_unwind(AssertUnwindSafe(|| {
                 let compute_start = Instant::now();
-                let _ = deferred_handle_task.wait_cloned();
-                deferred_compute_duration.record(compute_start.elapsed().as_secs_f64());
+                let computed = deferred_handle_task.wait_cloned();
+                block_validation_metrics
+                    .deferred_trie_compute_duration
+                    .record(compute_start.elapsed().as_secs_f64());
+
+                // Record sizes of the computed trie data
+                block_validation_metrics
+                    .hashed_post_state_size
+                    .record(computed.hashed_state.total_len() as f64);
+                block_validation_metrics
+                    .trie_updates_sorted_size
+                    .record(computed.trie_updates.total_len() as f64);
+                if let Some(anchored) = &computed.anchored_trie_input {
+                    block_validation_metrics
+                        .anchored_overlay_trie_updates_size
+                        .record(anchored.trie_input.nodes.total_len() as f64);
+                    block_validation_metrics
+                        .anchored_overlay_hashed_state_size
+                        .record(anchored.trie_input.state.total_len() as f64);
+                }
             }));
 
             if result.is_err() {

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -85,6 +85,7 @@ use std::{
     fmt::Debug,
     ops::{Deref, DerefMut, Range, RangeBounds, RangeFrom, RangeInclusive},
     sync::Arc,
+    time::{Duration, Instant},
 };
 use tracing::{debug, trace};
 
@@ -171,6 +172,8 @@ pub struct DatabaseProvider<TX, N: NodeTypes> {
     pending_rocksdb_batches: parking_lot::Mutex<Vec<rocksdb::WriteBatchWithTransaction<true>>>,
     /// Minimum distance from tip required for pruning
     minimum_pruning_distance: u64,
+    /// Database provider metrics
+    metrics: metrics::DatabaseProviderMetrics,
 }
 
 impl<TX: Debug, N: NodeTypes> Debug for DatabaseProvider<TX, N> {
@@ -296,7 +299,7 @@ impl<TX: Debug + Send, N: NodeTypes<ChainSpec: EthChainSpec + 'static>> ChainSpe
 
 impl<TX: DbTxMut, N: NodeTypes> DatabaseProvider<TX, N> {
     /// Creates a provider with an inner read-write transaction.
-    pub const fn new_rw(
+    pub fn new_rw(
         tx: TX,
         chain_spec: Arc<N::ChainSpec>,
         static_file_provider: StaticFileProvider<N::Primitives>,
@@ -316,6 +319,7 @@ impl<TX: DbTxMut, N: NodeTypes> DatabaseProvider<TX, N> {
             #[cfg(all(unix, feature = "rocksdb"))]
             pending_rocksdb_batches: parking_lot::Mutex::new(Vec::new()),
             minimum_pruning_distance: MINIMUM_PRUNING_DISTANCE,
+            metrics: metrics::DatabaseProviderMetrics::default(),
         }
     }
 }
@@ -368,6 +372,13 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
 
         debug!(target: "providers::db", block_count = %blocks.len(), "Writing blocks and execution data to storage");
 
+        // Accumulate durations for each step
+        let mut total_insert_block = Duration::ZERO;
+        let mut total_write_state = Duration::ZERO;
+        let mut total_write_hashed_state = Duration::ZERO;
+        let mut total_write_trie_changesets = Duration::ZERO;
+        let mut total_write_trie_updates = Duration::ZERO;
+
         // TODO: Do performant / batched writes for each type of object
         // instead of a loop over all blocks,
         // meaning:
@@ -381,24 +392,60 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
             let trie_data = block.trie_data();
             let ExecutedBlock { recovered_block, execution_output, .. } = block;
             let block_number = recovered_block.number();
+
+            let start = Instant::now();
             self.insert_block(&recovered_block)?;
+            total_insert_block += start.elapsed();
 
             // Write state and changesets to the database.
             // Must be written after blocks because of the receipt lookup.
+            let start = Instant::now();
             self.write_state(&execution_output, OriginalValuesKnown::No)?;
+            total_write_state += start.elapsed();
 
             // insert hashes and intermediate merkle nodes
+            let start = Instant::now();
             self.write_hashed_state(&trie_data.hashed_state)?;
+            total_write_hashed_state += start.elapsed();
 
+            let start = Instant::now();
             self.write_trie_changesets(block_number, &trie_data.trie_updates, None)?;
+            total_write_trie_changesets += start.elapsed();
+
+            let start = Instant::now();
             self.write_trie_updates_sorted(&trie_data.trie_updates)?;
+            total_write_trie_updates += start.elapsed();
         }
 
         // update history indices
+        let start = Instant::now();
         self.update_history_indices(first_number..=last_block_number)?;
+        let duration_update_history_indices = start.elapsed();
 
         // Update pipeline progress
+        let start = Instant::now();
         self.update_pipeline_stages(last_block_number, false)?;
+        let duration_update_pipeline_stages = start.elapsed();
+
+        // Record all metrics at the end
+        self.metrics.record_duration(metrics::Action::SaveBlocksInsertBlock, total_insert_block);
+        self.metrics.record_duration(metrics::Action::SaveBlocksWriteState, total_write_state);
+        self.metrics
+            .record_duration(metrics::Action::SaveBlocksWriteHashedState, total_write_hashed_state);
+        self.metrics.record_duration(
+            metrics::Action::SaveBlocksWriteTrieChangesets,
+            total_write_trie_changesets,
+        );
+        self.metrics
+            .record_duration(metrics::Action::SaveBlocksWriteTrieUpdates, total_write_trie_updates);
+        self.metrics.record_duration(
+            metrics::Action::SaveBlocksUpdateHistoryIndices,
+            duration_update_history_indices,
+        );
+        self.metrics.record_duration(
+            metrics::Action::SaveBlocksUpdatePipelineStages,
+            duration_update_pipeline_stages,
+        );
 
         debug!(target: "providers::db", range = ?first_number..=last_block_number, "Appended block data");
 
@@ -578,7 +625,7 @@ where
 
 impl<TX: DbTx + 'static, N: NodeTypesForProvider> DatabaseProvider<TX, N> {
     /// Creates a provider with an inner read-only transaction.
-    pub const fn new(
+    pub fn new(
         tx: TX,
         chain_spec: Arc<N::ChainSpec>,
         static_file_provider: StaticFileProvider<N::Primitives>,
@@ -598,6 +645,7 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> DatabaseProvider<TX, N> {
             #[cfg(all(unix, feature = "rocksdb"))]
             pending_rocksdb_batches: parking_lot::Mutex::new(Vec::new()),
             minimum_pruning_distance: MINIMUM_PRUNING_DISTANCE,
+            metrics: metrics::DatabaseProviderMetrics::default(),
         }
     }
 
@@ -3016,7 +3064,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider + 'static> BlockWrite
         let block_number = block.number();
         let tx_count = block.body().transaction_count() as u64;
 
-        let mut durations_recorder = metrics::DurationsRecorder::default();
+        let mut durations_recorder = metrics::DurationsRecorder::new(&self.metrics);
 
         self.static_file_provider
             .get_writer(block_number, StaticFileSegment::Headers)?
@@ -3090,7 +3138,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider + 'static> BlockWrite
             let tx_count = body.as_ref().map(|b| b.transactions().len() as u64).unwrap_or_default();
             let block_indices = StoredBlockBodyIndices { first_tx_num: next_tx_num, tx_count };
 
-            let mut durations_recorder = metrics::DurationsRecorder::default();
+            let mut durations_recorder = metrics::DurationsRecorder::new(&self.metrics);
 
             // insert block meta
             block_indices_cursor.append(*block_number, &block_indices)?;
@@ -3222,7 +3270,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider + 'static> BlockWrite
         // `None`.
         let last_block_number = blocks[blocks.len() - 1].number();
 
-        let mut durations_recorder = metrics::DurationsRecorder::default();
+        let mut durations_recorder = metrics::DurationsRecorder::new(&self.metrics);
 
         // Extract account and storage transitions from the bundle reverts BEFORE writing state.
         // This is necessary because with edge storage, changesets are written to static files


### PR DESCRIPTION
This PR adds metrics for the following:

* Each step of save_blocks, so we can see which steps are taking the most time.

* Total sizes of HashedPostStateSorted/TrieInputsSorted per-block.

* Total sizes of the anchored (flattened) overlay computed for each block, which is used as trie input for its child block.

The second two are computed and recorded async as part of the deferred trie task, so they won't affect nP latency.