### PR TITLE
fix(optimism): clarify pending sequence insert contract

### DIFF
--- a/crates/optimism/flashblocks/src/sequence.rs
+++ b/crates/optimism/flashblocks/src/sequence.rs
@@ -65,7 +65,9 @@ impl FlashBlockPendingSequence {
 
     /// Inserts a new block into the sequence.
     ///
-    /// A [`FlashBlock`] with index 0 resets the set.
+    /// A [`FlashBlock`] with index 0 is treated as the first element of a new sequence.
+    /// The caller is responsible for finalizing or clearing any previous sequence before
+    /// inserting such a block.
     pub fn insert(&mut self, flashblock: FlashBlock) {
         if flashblock.index == 0 {
             trace!(target: "flashblocks", number=%flashblock.block_number(), "Tracking new flashblock sequence");


### PR DESCRIPTION
The previous comment on `FlashBlockPendingSequence::insert` claimed that a flashblock with index 0 “resets the set”, but the implementation does not clear any prior state. Actual reset and caching logic now lives in`SequenceManager::insert_flashblock`, which finalizes and clears the previous sequence before inserting a new index-0 block.

This change updates the documentation to reflect the real contract: index 0 is treated as the first element of a new sequence, and callers are responsible for finalizing or clearing any previous sequence before inserting it.