### PR TITLE
docs(engine): update outdated EthBuiltPayload comment

### DIFF
--- a/crates/ethereum/engine-primitives/src/payload.rs
+++ b/crates/ethereum/engine-primitives/src/payload.rs
@@ -27,7 +27,7 @@ use crate::BuiltPayloadConversionError;
 ///
 /// This struct represents a single built block at a point in time. The payload building process
 /// creates a sequence of these payloads, starting with an empty block and progressively including
-/// more transactions as the [`PayloadBuilderService`] runs.
+/// more transactions.
 #[derive(Debug, Clone)]
 pub struct EthBuiltPayload<N: NodePrimitives = EthPrimitives> {
     /// Identifier of the payload

--- a/crates/ethereum/engine-primitives/src/payload.rs
+++ b/crates/ethereum/engine-primitives/src/payload.rs
@@ -24,8 +24,10 @@ use crate::BuiltPayloadConversionError;
 /// Contains the built payload.
 ///
 /// According to the [engine API specification](https://github.com/ethereum/execution-apis/blob/main/src/engine/README.md) the execution layer should build the initial version of the payload with an empty transaction set and then keep update it in order to maximize the revenue.
-/// Therefore, the empty-block here is always available and full-block will be set/updated
-/// afterward.
+///
+/// This struct represents a single built block at a point in time. The payload building process
+/// creates a sequence of these payloads, starting with an empty block and progressively including
+/// more transactions as the [`PayloadBuilderService`] runs.
 #[derive(Debug, Clone)]
 pub struct EthBuiltPayload<N: NodePrimitives = EthPrimitives> {
     /// Identifier of the payload


### PR DESCRIPTION
The comment stated "the empty-block here is always available and full-block will be set/updated afterward", which implied that the struct stores both an empty block and a full block that can be updated in place. This was accurate when the struct contained a `_initial_empty_block: SealedBlock` field.