### PR TITLE
chore: remove unused implementation 

### DIFF
--- a/crates/trie/common/benches/prefix_set.rs
+++ b/crates/trie/common/benches/prefix_set.rs
@@ -248,48 +248,4 @@ mod implementations {
         }
     }
 
-    #[derive(Default)]
-    #[allow(dead_code)]
-    pub struct VecBinarySearchWithLastFoundPrefixSet {
-        keys: Vec<Nibbles>,
-        last_found_idx: usize,
-        sorted: bool,
-    }
-
-    impl PrefixSetMutAbstraction for VecBinarySearchWithLastFoundPrefixSet {
-        type Frozen = Self;
-
-        fn insert(&mut self, key: Nibbles) {
-            self.sorted = false;
-            self.keys.push(key);
-        }
-
-        fn freeze(self) -> Self::Frozen {
-            self
-        }
-    }
-
-    impl PrefixSetAbstraction for VecBinarySearchWithLastFoundPrefixSet {
-        fn contains(&mut self, prefix: Nibbles) -> bool {
-            if !self.sorted {
-                self.keys.sort();
-                self.sorted = true;
-            }
-
-            while self.last_found_idx > 0 && self.keys[self.last_found_idx] > prefix {
-                self.last_found_idx -= 1;
-            }
-
-            match self.keys[self.last_found_idx..].binary_search(&prefix) {
-                Ok(_) => true,
-                Err(idx) => match self.keys.get(idx) {
-                    Some(key) => {
-                        self.last_found_idx = idx;
-                        key.starts_with(&prefix)
-                    }
-                    None => false, // prefix > last key
-                },
-            }
-        }
-    }
 }

--- a/crates/trie/common/benches/prefix_set.rs
+++ b/crates/trie/common/benches/prefix_set.rs
@@ -247,5 +247,4 @@ mod implementations {
             false
         }
     }
-
 }


### PR DESCRIPTION
The prefix_set benchmark only uses BTreeAnyPrefixSet, BTreeRangeLastCheckedPrefixSet, and VecCursorPrefixSet, So..... dead code bye bye~