### PR TITLE
docs: clarify BatchTxProcessor local origin

### DIFF
--- a/crates/transaction-pool/src/batcher.rs
+++ b/crates/transaction-pool/src/batcher.rs
@@ -71,7 +71,7 @@ where
         let _ = response_tx.send(pool_result);
     }
 
-    /// Process a batch of transaction requests, grouped by origin
+    /// Process a batch of local transaction requests.
     async fn process_batch(pool: &Pool, mut batch: Vec<BatchTxRequest<Pool::Transaction>>) {
         if batch.len() == 1 {
             Self::process_request(pool, batch.remove(0)).await;


### PR DESCRIPTION
The batcher is only used from the RPC path and always inserts transactions into the pool with TransactionOrigin::Local. The previous comment on  process_batch mentioned grouping by origin, which does not reflect the actual API or implementation and can mislead readers about supported use cases. This change updates the doc comment to state explicitly that the function processes a batch of local transaction requests, keeping the behavior unchanged but aligning the documentation with reality.