### PR TITLE
feat(bench-compare): add --wait-for-persistence flag support

### DIFF
--- a/bin/reth-bench-compare/README.md
+++ b/bin/reth-bench-compare/README.md
@@ -1,0 +1,166 @@
+# reth-bench-compare
+
+Compare reth performance between two git references (branches, tags, or commits).
+
+## Quick Start
+
+```bash
+reth-bench-compare \
+  --baseline-ref main \
+  --feature-ref my-feature \
+  --blocks 100 \
+  --chain base \
+  --wait-for-persistence
+```
+
+## CLI Arguments
+
+### Required Arguments
+
+| Argument | Description | Optional |
+|----------|-------------|----------|
+| `--baseline-ref <REF>` | Git reference for baseline comparison | ❌ Required |
+| `--feature-ref <REF>` | Git reference to compare against baseline | ❌ Required |
+
+### Core Options
+
+| Argument | Description | Default | Optional |
+|----------|-------------|---------|----------|
+| `--blocks <N>` | Number of blocks to benchmark | `100` | ✅ Optional |
+| `--chain <CHAIN>` | Chain to benchmark (mainnet, base, etc.) | `mainnet` | ✅ Optional |
+| `--datadir <PATH>` | Path to reth data directory | OS-specific | ✅ Optional |
+| `--rpc-url <URL>` | RPC endpoint for fetching blocks | Chain default | ✅ Optional |
+| `--jwt-secret <PATH>` | JWT secret file path | `<datadir>/<chain>/jwt.hex` | ✅ Optional |
+| `--output-dir <PATH>` | Output directory for results | `./reth-bench-compare` | ✅ Optional |
+
+### Wait Mode Options
+
+| Argument | Description | Default | Optional |
+|----------|-------------|---------|----------|
+| `--wait-for-persistence` | Wait for block persistence (recommended) | `false` | ✅ Optional |
+| `--persistence-threshold <N>` | Wait after every N+1 blocks | `2` | ✅ Optional |
+| `--wait-time <DURATION>` | Fixed delay between blocks (legacy) | None | ✅ Optional |
+
+**Note:** `--wait-time` takes precedence over `--wait-for-persistence`.
+
+### Warmup Options
+
+| Argument | Description | Default | Optional |
+|----------|-------------|---------|----------|
+| `--warmup-blocks <N>` | Blocks to run for cache warmup | Same as `--blocks` | ✅ Optional |
+| `--no-clear-cache` | Skip cache clearing before warmup | `false` | ✅ Optional |
+
+### Output Options
+
+| Argument | Description | Default | Optional |
+|----------|-------------|---------|----------|
+| `--draw` | Generate comparison charts (requires Python/uv) | `false` | ✅ Optional |
+| `--profile` | Enable CPU profiling with samply | `false` | ✅ Optional |
+| `-vvvv` | Verbose logging (debug level) | Info | ✅ Optional |
+
+### Compilation Options
+
+| Argument | Description | Default | Optional |
+|----------|-------------|---------|----------|
+| `--features <FEATURES>` | Rust features for both builds | `jemalloc,asm-keccak` | ✅ Optional |
+| `--baseline-features <FEATURES>` | Features for baseline only | Inherits `--features` | ✅ Optional |
+| `--feature-features <FEATURES>` | Features for feature build only | Inherits `--features` | ✅ Optional |
+| `--rustflags <FLAGS>` | RUSTFLAGS for both builds | `-C target-cpu=native` | ✅ Optional |
+| `--baseline-rustflags <FLAGS>` | RUSTFLAGS for baseline only | Inherits `--rustflags` | ✅ Optional |
+| `--feature-rustflags <FLAGS>` | RUSTFLAGS for feature only | Inherits `--rustflags` | ✅ Optional |
+
+### Node Options
+
+| Argument | Description | Default | Optional |
+|----------|-------------|---------|----------|
+| `--metrics-port <PORT>` | Port for reth metrics endpoint | `5005` | ✅ Optional |
+| `--sudo` | Run reth with elevated privileges | `false` | ✅ Optional |
+| `--baseline-args <ARGS>` | Extra args for baseline node | None | ✅ Optional |
+| `--feature-args <ARGS>` | Extra args for feature node | None | ✅ Optional |
+| `[RETH_ARGS]...` | Args for both nodes (after `--`) | None | ✅ Optional |
+
+### Advanced Options
+
+| Argument | Description | Default | Optional |
+|----------|-------------|---------|----------|
+| `--skip-git-validation` | Skip git state validation | `false` | ✅ Optional |
+| `--disable-startup-sync-state-idle <TARGET>` | Disable idle flag for specific runs | None | ✅ Optional |
+
+## Examples
+
+### Basic Comparison
+
+```bash
+reth-bench-compare \
+  --baseline-ref main \
+  --feature-ref my-optimization \
+  --blocks 50
+```
+
+### Persistence-Based Benchmarking
+
+```bash
+reth-bench-compare \
+  --baseline-ref v1.0.0 \
+  --feature-ref v1.1.0 \
+  --wait-for-persistence \
+  --persistence-threshold 2 \
+  --blocks 100 \
+  --chain base
+```
+
+### With Custom RPC and Output
+
+```bash
+reth-bench-compare \
+  --baseline-ref main \
+  --feature-ref pr/12345 \
+  --blocks 100 \
+  --rpc-url https://base-mainnet.example.com \
+  --output-dir ./my-results \
+  --draw \
+  -vvvv
+```
+
+### With Profiling
+
+```bash
+reth-bench-compare \
+  --baseline-ref main \
+  --feature-ref optimization-branch \
+  --blocks 50 \
+  --profile \
+  --draw
+```
+
+### Custom Compilation Flags
+
+```bash
+reth-bench-compare \
+  --baseline-ref main \
+  --feature-ref my-feature \
+  --baseline-rustflags "-C target-cpu=native" \
+  --feature-rustflags "-C target-cpu=native -C lto" \
+  --blocks 100
+```
+
+## Output
+
+Results are saved in the output directory (default: `./reth-bench-compare/results/<timestamp>/`):
+
+- `comparison_report.json` - Detailed metrics comparison
+- `per_block_comparison.csv` - Per-block statistics
+- `baseline/` - Baseline benchmark results
+  - `combined_latency.csv` - Latency measurements
+  - `reth_bench.log` - Benchmark logs
+  - `reth_node.log` - Node logs
+- `feature/` - Feature benchmark results (same structure)
+- `latency_comparison.png` - Visual comparison (if `--draw` used)
+
+## Notes
+
+- **Persistence Mode (Recommended)**: Use `--wait-for-persistence` for realistic benchmarks that account for persistence overhead
+- **Legacy Mode**: Use `--wait-time <duration>` for fixed delays (e.g., `--wait-time 100ms`)
+- **Warmup**: By default, runs warmup phase with same block count as benchmark to warm caches
+- **Profiling**: Requires `samply` installed (`cargo install samply`)
+- **Charts**: Requires Python with `uv` package manager

--- a/bin/reth-bench-compare/README.md
+++ b/bin/reth-bench-compare/README.md
@@ -1,166 +1,50 @@
 # reth-bench-compare
 
-Compare reth performance between two git references (branches, tags, or commits).
+Compare reth performance between two git references.
 
-## Quick Start
+## Usage
 
 ```bash
 reth-bench-compare \
   --baseline-ref main \
   --feature-ref my-feature \
   --blocks 100 \
-  --chain base \
   --wait-for-persistence
 ```
 
-## CLI Arguments
+## Arguments
 
-### Required Arguments
-
-| Argument | Description | Optional |
-|----------|-------------|----------|
-| `--baseline-ref <REF>` | Git reference for baseline comparison | ❌ Required |
-| `--feature-ref <REF>` | Git reference to compare against baseline | ❌ Required |
-
-### Core Options
-
-| Argument | Description | Default | Optional |
+| Argument | Description | Default | Required |
 |----------|-------------|---------|----------|
-| `--blocks <N>` | Number of blocks to benchmark | `100` | ✅ Optional |
-| `--chain <CHAIN>` | Chain to benchmark (mainnet, base, etc.) | `mainnet` | ✅ Optional |
-| `--datadir <PATH>` | Path to reth data directory | OS-specific | ✅ Optional |
-| `--rpc-url <URL>` | RPC endpoint for fetching blocks | Chain default | ✅ Optional |
-| `--jwt-secret <PATH>` | JWT secret file path | `<datadir>/<chain>/jwt.hex` | ✅ Optional |
-| `--output-dir <PATH>` | Output directory for results | `./reth-bench-compare` | ✅ Optional |
-
-### Wait Mode Options
-
-| Argument | Description | Default | Optional |
-|----------|-------------|---------|----------|
-| `--wait-for-persistence` | Wait for block persistence (recommended) | `false` | ✅ Optional |
-| `--persistence-threshold <N>` | Wait after every N+1 blocks | `2` | ✅ Optional |
-| `--wait-time <DURATION>` | Fixed delay between blocks (legacy) | None | ✅ Optional |
-
-**Note:** `--wait-time` takes precedence over `--wait-for-persistence`.
-
-### Warmup Options
-
-| Argument | Description | Default | Optional |
-|----------|-------------|---------|----------|
-| `--warmup-blocks <N>` | Blocks to run for cache warmup | Same as `--blocks` | ✅ Optional |
-| `--no-clear-cache` | Skip cache clearing before warmup | `false` | ✅ Optional |
-
-### Output Options
-
-| Argument | Description | Default | Optional |
-|----------|-------------|---------|----------|
-| `--draw` | Generate comparison charts (requires Python/uv) | `false` | ✅ Optional |
-| `--profile` | Enable CPU profiling with samply | `false` | ✅ Optional |
-| `-vvvv` | Verbose logging (debug level) | Info | ✅ Optional |
-
-### Compilation Options
-
-| Argument | Description | Default | Optional |
-|----------|-------------|---------|----------|
-| `--features <FEATURES>` | Rust features for both builds | `jemalloc,asm-keccak` | ✅ Optional |
-| `--baseline-features <FEATURES>` | Features for baseline only | Inherits `--features` | ✅ Optional |
-| `--feature-features <FEATURES>` | Features for feature build only | Inherits `--features` | ✅ Optional |
-| `--rustflags <FLAGS>` | RUSTFLAGS for both builds | `-C target-cpu=native` | ✅ Optional |
-| `--baseline-rustflags <FLAGS>` | RUSTFLAGS for baseline only | Inherits `--rustflags` | ✅ Optional |
-| `--feature-rustflags <FLAGS>` | RUSTFLAGS for feature only | Inherits `--rustflags` | ✅ Optional |
-
-### Node Options
-
-| Argument | Description | Default | Optional |
-|----------|-------------|---------|----------|
-| `--metrics-port <PORT>` | Port for reth metrics endpoint | `5005` | ✅ Optional |
-| `--sudo` | Run reth with elevated privileges | `false` | ✅ Optional |
-| `--baseline-args <ARGS>` | Extra args for baseline node | None | ✅ Optional |
-| `--feature-args <ARGS>` | Extra args for feature node | None | ✅ Optional |
-| `[RETH_ARGS]...` | Args for both nodes (after `--`) | None | ✅ Optional |
-
-### Advanced Options
-
-| Argument | Description | Default | Optional |
-|----------|-------------|---------|----------|
-| `--skip-git-validation` | Skip git state validation | `false` | ✅ Optional |
-| `--disable-startup-sync-state-idle <TARGET>` | Disable idle flag for specific runs | None | ✅ Optional |
-
-## Examples
-
-### Basic Comparison
-
-```bash
-reth-bench-compare \
-  --baseline-ref main \
-  --feature-ref my-optimization \
-  --blocks 50
-```
-
-### Persistence-Based Benchmarking
-
-```bash
-reth-bench-compare \
-  --baseline-ref v1.0.0 \
-  --feature-ref v1.1.0 \
-  --wait-for-persistence \
-  --persistence-threshold 2 \
-  --blocks 100 \
-  --chain base
-```
-
-### With Custom RPC and Output
-
-```bash
-reth-bench-compare \
-  --baseline-ref main \
-  --feature-ref pr/12345 \
-  --blocks 100 \
-  --rpc-url https://base-mainnet.example.com \
-  --output-dir ./my-results \
-  --draw \
-  -vvvv
-```
-
-### With Profiling
-
-```bash
-reth-bench-compare \
-  --baseline-ref main \
-  --feature-ref optimization-branch \
-  --blocks 50 \
-  --profile \
-  --draw
-```
-
-### Custom Compilation Flags
-
-```bash
-reth-bench-compare \
-  --baseline-ref main \
-  --feature-ref my-feature \
-  --baseline-rustflags "-C target-cpu=native" \
-  --feature-rustflags "-C target-cpu=native -C lto" \
-  --blocks 100
-```
+| `--baseline-ref <REF>` | Git reference for baseline | - | Yes |
+| `--feature-ref <REF>` | Git reference to compare | - | Yes |
+| `--blocks <N>` | Number of blocks to benchmark | `100` | No |
+| `--chain <CHAIN>` | Chain to benchmark | `mainnet` | No |
+| `--datadir <PATH>` | Data directory path | OS-specific | No |
+| `--rpc-url <URL>` | RPC endpoint for block data | Chain default | No |
+| `--output-dir <PATH>` | Output directory | `./reth-bench-compare` | No |
+| `--wait-for-persistence` | Wait for block persistence | `false` | No |
+| `--persistence-threshold <N>` | Wait after every N+1 blocks | `2` | No |
+| `--wait-time <DURATION>` | Fixed delay (legacy) | - | No |
+| `--warmup-blocks <N>` | Cache warmup blocks | Same as `--blocks` | No |
+| `--draw` | Generate charts (needs Python/uv) | `false` | No |
+| `--profile` | Enable CPU profiling (needs samply) | `false` | No |
+| `-vvvv` | Debug logging | Info | No |
+| `--features <FEATURES>` | Rust features for both builds | `jemalloc,asm-keccak` | No |
+| `--rustflags <FLAGS>` | RUSTFLAGS for both builds | `-C target-cpu=native` | No |
+| `--baseline-features <FEATURES>` | Features for baseline only | Inherits `--features` | No |
+| `--feature-features <FEATURES>` | Features for feature only | Inherits `--features` | No |
+| `--baseline-rustflags <FLAGS>` | RUSTFLAGS for baseline only | Inherits `--rustflags` | No |
+| `--feature-rustflags <FLAGS>` | RUSTFLAGS for feature only | Inherits `--rustflags` | No |
+| `--baseline-args <ARGS>` | Extra args for baseline node | - | No |
+| `--feature-args <ARGS>` | Extra args for feature node | - | No |
+| `--metrics-port <PORT>` | Metrics endpoint port | `5005` | No |
+| `--sudo` | Run with elevated privileges | `false` | No |
 
 ## Output
 
-Results are saved in the output directory (default: `./reth-bench-compare/results/<timestamp>/`):
-
-- `comparison_report.json` - Detailed metrics comparison
+Results in `./reth-bench-compare/results/<timestamp>/`:
+- `comparison_report.json` - Metrics comparison
 - `per_block_comparison.csv` - Per-block statistics
-- `baseline/` - Baseline benchmark results
-  - `combined_latency.csv` - Latency measurements
-  - `reth_bench.log` - Benchmark logs
-  - `reth_node.log` - Node logs
-- `feature/` - Feature benchmark results (same structure)
-- `latency_comparison.png` - Visual comparison (if `--draw` used)
-
-## Notes
-
-- **Persistence Mode (Recommended)**: Use `--wait-for-persistence` for realistic benchmarks that account for persistence overhead
-- **Legacy Mode**: Use `--wait-time <duration>` for fixed delays (e.g., `--wait-time 100ms`)
-- **Warmup**: By default, runs warmup phase with same block count as benchmark to warm caches
-- **Profiling**: Requires `samply` installed (`cargo install samply`)
-- **Charts**: Requires Python with `uv` package manager
+- `baseline/` and `feature/` - Individual run results
+- `latency_comparison.png` - Chart (if `--draw` used)

--- a/bin/reth-bench-compare/src/benchmark.rs
+++ b/bin/reth-bench-compare/src/benchmark.rs
@@ -18,6 +18,8 @@ pub(crate) struct BenchmarkRunner {
     rpc_url: String,
     jwt_secret: String,
     wait_time: Option<String>,
+    wait_for_persistence: bool,
+    persistence_threshold: Option<u64>,
     warmup_blocks: u64,
 }
 
@@ -28,6 +30,8 @@ impl BenchmarkRunner {
             rpc_url: args.get_rpc_url(),
             jwt_secret: args.jwt_secret_path().to_string_lossy().to_string(),
             wait_time: args.wait_time.clone(),
+            wait_for_persistence: args.wait_for_persistence,
+            persistence_threshold: args.persistence_threshold,
             warmup_blocks: args.get_warmup_blocks(),
         }
     }
@@ -182,9 +186,16 @@ impl BenchmarkRunner {
             &output_dir.to_string_lossy(),
         ]);
 
-        // If wait_time is provided, use wait-time mode; otherwise uses persistence-based flow
+        // Configure wait mode: wait-time takes precedence over persistence-based flow
         if let Some(ref wait_time) = self.wait_time {
             cmd.args(["--wait-time", wait_time]);
+        } else if self.wait_for_persistence {
+            cmd.arg("--wait-for-persistence");
+
+            // Add persistence threshold if specified
+            if let Some(threshold) = self.persistence_threshold {
+                cmd.args(["--persistence-threshold", &threshold.to_string()]);
+            }
         }
 
         cmd.env("RUST_LOG_STYLE", "never")

--- a/bin/reth-bench-compare/src/cli.rs
+++ b/bin/reth-bench-compare/src/cli.rs
@@ -121,6 +121,22 @@ pub(crate) struct Args {
     #[arg(long, value_name = "DURATION", hide = true)]
     pub wait_time: Option<String>,
 
+    /// Wait for blocks to be persisted before sending the next batch (passed to reth-bench).
+    ///
+    /// When enabled, waits for every Nth block to be persisted using the
+    /// `reth_subscribePersistedBlock` subscription. This ensures the benchmark
+    /// doesn't outpace persistence.
+    #[arg(long)]
+    pub wait_for_persistence: bool,
+
+    /// Engine persistence threshold (passed to reth-bench).
+    ///
+    /// The benchmark waits after every `(threshold + 1)` blocks. By default this
+    /// matches the engine's default persistence threshold (2), so waits occur
+    /// at blocks 3, 6, 9, etc.
+    #[arg(long, value_name = "PERSISTENCE_THRESHOLD")]
+    pub persistence_threshold: Option<u64>,
+
     /// Number of blocks to run for cache warmup after clearing caches.
     /// If not specified, defaults to the same as --blocks
     #[arg(long, value_name = "N")]


### PR DESCRIPTION

Adds support for persistence-based benchmarking in `reth-bench-compare` by passing the `--wait-for-persistence` flag to `reth-bench`.
