### PR TITLE
fix: correct typos in error messages and logs

### DIFF
--- a/crates/node/ethstats/src/error.rs
+++ b/crates/node/ethstats/src/error.rs
@@ -64,6 +64,6 @@ pub enum EthStatsError {
     DataFetchError(String),
 
     /// The request sent to the server was invalid or malformed
-    #[error("Inivalid request")]
+    #[error("Invalid request")]
     InvalidRequest,
 }

--- a/crates/trie/trie/src/verify.rs
+++ b/crates/trie/trie/src/verify.rs
@@ -373,7 +373,7 @@ impl<'a, T: TrieCursorFactory, H: HashedCursorFactory + Clone> Verifier<'a, T, H
             };
 
             if curr_account < next_account || (end_inclusive && curr_account == next_account) {
-                trace!(target: "trie::verify", account = ?curr_account, "Verying account has empty storage");
+                trace!(target: "trie::verify", account = ?curr_account, "Verifying account has empty storage");
 
                 let mut storage_cursor =
                     self.trie_cursor_factory.storage_trie_cursor(curr_account)?;


### PR DESCRIPTION


Fixed two typos in error messages and trace logs:

- **Error message**: Fixed typo in `EthStatsError::InvalidRequest` error attribute (`Inivalid` → `Invalid`)
- **Trace log**: Fixed typo in trie verification trace message (`Verying` → `Verifying`)
