### PR TITLE
refactor(trie): avoid building prefix set for v2 storage proofs

### DIFF
--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -115,8 +115,11 @@ impl ParallelProof {
         target_slots: B256Set,
     ) -> Result<DecodedStorageMultiProof, ParallelStateRootError> {
         let total_targets = target_slots.len();
-        let prefix_set = PrefixSetMut::from(target_slots.iter().map(Nibbles::unpack));
-        let prefix_set = prefix_set.freeze();
+        let prefix_set = if self.v2_proofs_enabled {
+            PrefixSet::default()
+        } else {
+            PrefixSetMut::from(target_slots.iter().map(Nibbles::unpack)).freeze()
+        };
 
         trace!(
             target: "trie::parallel_proof",


### PR DESCRIPTION
ParallelProof::storage_proof was always constructing a PrefixSet from target_slots, even when v2_proofs_enabled was true. The V2 storage proof path ignores the prefix set and only consumes the V2 targets, so this work was wasted. Update storage_proof to only build the PrefixSet for the legacy path and pass a cheap default PrefixSet for V2, matching how dispatch_storage_proofs already treats v2 proofs and avoiding unnecessary allocations and sorting on the hot path.