### PR TITLE
docs: fix incorrect field type references in EnumHandler comments

### DIFF
--- a/crates/storage/codecs/derive/src/compact/enums.rs
+++ b/crates/storage/codecs/derive/src/compact/enums.rs
@@ -46,8 +46,8 @@ impl<'a> EnumHandler<'a> {
 
     /// Generates `from_compact` code for an enum variant.
     ///
-    /// `fields_iterator` might look something like \[`EnumVariant`, `EnumUnnamedField`, `StructField`,
-    /// `EnumVariant`...\].
+    /// `fields_iterator` might look something like \[`EnumVariant`, `EnumUnnamedField`,
+    /// `StructField`, `EnumVariant`...\].
     pub fn from(&mut self, variant_name: &str, ident: &Ident) {
         let variant_name = format_ident!("{variant_name}");
         let current_variant_index = self.current_variant_index;
@@ -89,8 +89,8 @@ impl<'a> EnumHandler<'a> {
 
     /// Generates `to_compact` code for an enum variant.
     ///
-    /// `fields_iterator` might look something like [`EnumVariant`, `EnumUnnamedField`, `StructField`,
-    /// `EnumVariant`...].
+    /// `fields_iterator` might look something like [`EnumVariant`, `EnumUnnamedField`,
+    /// `StructField`, `EnumVariant`...].
     pub fn to(&mut self, variant_name: &str, ident: &Ident) {
         let variant_name = format_ident!("{variant_name}");
         let current_variant_index = self.current_variant_index;

--- a/crates/storage/codecs/derive/src/compact/enums.rs
+++ b/crates/storage/codecs/derive/src/compact/enums.rs
@@ -46,7 +46,7 @@ impl<'a> EnumHandler<'a> {
 
     /// Generates `from_compact` code for an enum variant.
     ///
-    /// `fields_iterator` might look something like \[`EnumVariant`, `EnumUnnamedField`, StructField,
+    /// `fields_iterator` might look something like \[`EnumVariant`, `EnumUnnamedField`, `StructField`,
     /// `EnumVariant`...\].
     pub fn from(&mut self, variant_name: &str, ident: &Ident) {
         let variant_name = format_ident!("{variant_name}");
@@ -89,7 +89,7 @@ impl<'a> EnumHandler<'a> {
 
     /// Generates `to_compact` code for an enum variant.
     ///
-    /// `fields_iterator` might look something like [`EnumVariant`, `EnumUnnamedField`, StructField,
+    /// `fields_iterator` might look something like [`EnumVariant`, `EnumUnnamedField`, `StructField`,
     /// `EnumVariant`...].
     pub fn to(&mut self, variant_name: &str, ident: &Ident) {
         let variant_name = format_ident!("{variant_name}");

--- a/crates/storage/codecs/derive/src/compact/enums.rs
+++ b/crates/storage/codecs/derive/src/compact/enums.rs
@@ -46,8 +46,8 @@ impl<'a> EnumHandler<'a> {
 
     /// Generates `from_compact` code for an enum variant.
     ///
-    /// `fields_iterator` might look something like \[`VariantUnit`, `VariantUnnamedField`, Field,
-    /// `VariantUnit`...\].
+    /// `fields_iterator` might look something like \[`EnumVariant`, `EnumUnnamedField`, StructField,
+    /// `EnumVariant`...\].
     pub fn from(&mut self, variant_name: &str, ident: &Ident) {
         let variant_name = format_ident!("{variant_name}");
         let current_variant_index = self.current_variant_index;
@@ -89,8 +89,8 @@ impl<'a> EnumHandler<'a> {
 
     /// Generates `to_compact` code for an enum variant.
     ///
-    /// `fields_iterator` might look something like [`VariantUnit`, `VariantUnnamedField`, Field,
-    /// `VariantUnit`...].
+    /// `fields_iterator` might look something like [`EnumVariant`, `EnumUnnamedField`, StructField,
+    /// `EnumVariant`...].
     pub fn to(&mut self, variant_name: &str, ident: &Ident) {
         let variant_name = format_ident!("{variant_name}");
         let current_variant_index = self.current_variant_index;


### PR DESCRIPTION

This PR corrects the documentation comments for the from and to methods within EnumHandler. The comments previously referred to non-existent variants (e.g., VariantUnit, VariantUnnamedField), whereas the implementation actually matches against FieldTypes::EnumVariant and FieldTypes::EnumUnnamedField. This change aligns the comments with the actual code logic.