### PR TITLE
docs: document account_change_sets static files config

### DIFF
--- a/docs/vocs/docs/pages/run/configuration.mdx
+++ b/docs/vocs/docs/pages/run/configuration.mdx
@@ -466,6 +466,7 @@ headers = 8192
 transactions = 8192
 receipts = 8192
 transaction_senders = 8192
+account_change_sets = 8192
 ```
 
 [TOML]: https://toml.io/


### PR DESCRIPTION
Extend the static_files.blocks_per_file example in configuration.mdx with the account_change_sets key so it matches BlocksPerFileConfig in the code. This makes it clear that account change sets can be configured and prevents users from overlooking this segment when tuning static file segmentation.