### PR TITLE
docs: fix Performant card link on landing page

### DIFF
--- a/docs/vocs/docs/pages/index.mdx
+++ b/docs/vocs/docs/pages/index.mdx
@@ -107,7 +107,7 @@ import { TrustedBy } from "../components/TrustedBy";
       </div>
       <div className="pl-2 pr-2 max-sm:px-0 max-lg:pb-3 max-lg:pr-0 w-1/4 max-lg:w-1/2 max-sm:w-full z-0">
         <div className="relative w-full h-[168px] max-lg:h-[142px]">
-          <a href="#" className="hover:bg-black/2 dark:hover:bg-white/2 border-black/10 dark:border-white/10 border border-solid rounded-lg h-full px-5 py-6 absolute z-10 flex flex-col justify-between w-full vocs_Link vocs_Link_styleless">
+          <a href="/overview" className="hover:bg-black/2 dark:hover:bg-white/2 border-black/10 dark:border-white/10 border border-solid rounded-lg h-full px-5 py-6 absolute z-10 flex flex-col justify-between w-full vocs_Link vocs_Link_styleless">
             <div className="text-xl font-medium text-black dark:text-white">Performant</div>
             <div className="text-[17px] text-[#919193]">Sync faster with optimal transaction processing</div>
           </a>


### PR DESCRIPTION
<img width="1741" height="983" alt="image" src="https://github.com/user-attachments/assets/1688c08d-ad87-45f6-b6bc-a0b1114301b6" />

when you click on "Performant' you just get back on https://reth.rs/

with this change it must be fixed