### PR TITLE
docs: fix broken Next Chapter link in reth-db crate docs

### DIFF
--- a/docs/crates/db.md
+++ b/docs/crates/db.md
@@ -297,4 +297,4 @@ This chapter was packed with information, so let's do a quick review. The databa
 
 # Next Chapter
 
-[Next Chapter]()
+[Next Chapter](eth-wire.md)


### PR DESCRIPTION
Pointed a broken \"Next Chapter\" link to `eth-wire.md`, following the crate list order in `README.md`.