### PR TITLE
fix: typos in error messages and comments

### DIFF
--- a/crates/storage/errors/src/db.rs
+++ b/crates/storage/errors/src/db.rs
@@ -32,7 +32,7 @@ pub enum DatabaseError {
     /// Failed to commit transaction changes into the database.
     #[error("failed to commit transaction changes: {_0}")]
     Commit(DatabaseErrorInfo),
-    /// Failed to initiate a transaction.
+    /// Failed to initialize a transaction.
     #[error("failed to initialize a transaction: {_0}")]
     InitTx(DatabaseErrorInfo),
     /// Failed to initialize a cursor.

--- a/crates/storage/errors/src/provider.rs
+++ b/crates/storage/errors/src/provider.rs
@@ -183,7 +183,7 @@ impl ProviderError {
         other.downcast_ref()
     }
 
-    /// Returns true if the this type is a [`ProviderError::Other`] of that error
+    /// Returns true if this type is a [`ProviderError::Other`] of that error
     /// type. Returns false otherwise.
     pub fn is_other<T: core::error::Error + 'static>(&self) -> bool {
         self.as_other().map(|err| err.is::<T>()).unwrap_or(false)


### PR DESCRIPTION
Corrected `initiate` to `initialize` 
Corrected `Returns true if the this type` to `Returns true if this type` 
