### PR TITLE
docs: fix grammar in comments

### DIFF
--- a/crates/ethereum/primitives/src/transaction.rs
+++ b/crates/ethereum/primitives/src/transaction.rs
@@ -236,7 +236,7 @@ impl reth_codecs::Compact for Transaction {
     // # Panics
     //
     // A panic will be triggered if an identifier larger than 3 is passed from the database. For
-    // optimism a identifier with value [`DEPOSIT_TX_TYPE_ID`] is allowed.
+    // optimism an identifier with value [`DEPOSIT_TX_TYPE_ID`] is allowed.
     fn from_compact(buf: &[u8], identifier: usize) -> (Self, &[u8]) {
         let (tx_type, buf) = TxType::from_compact(buf, identifier);
 

--- a/crates/storage/libmdbx-rs/src/cursor.rs
+++ b/crates/storage/libmdbx-rs/src/cursor.rs
@@ -312,7 +312,7 @@ where
     }
 
     /// Position at first key-value pair greater than or equal to specified, return both key and
-    /// data, and the return code depends on a exact match.
+    /// data, and the return code depends on an exact match.
     ///
     /// For non DupSort-ed collections this works the same as [`Self::set_range()`], but returns
     /// [false] if key found exactly and [true] if greater key was found.

--- a/crates/storage/nippy-jar/src/consistency.rs
+++ b/crates/storage/nippy-jar/src/consistency.rs
@@ -37,12 +37,12 @@ impl<H: NippyJarHeader> NippyJarChecker<H> {
         Self { jar, data_file: None, offsets_file: None }
     }
 
-    /// It will throw an error if the [`NippyJar`] is in a inconsistent state.
+    /// It will throw an error if the [`NippyJar`] is in an inconsistent state.
     pub fn check_consistency(&mut self) -> Result<(), NippyJarError> {
         self.handle_consistency(ConsistencyFailStrategy::ThrowError)
     }
 
-    /// It will attempt to heal if the [`NippyJar`] is in a inconsistent state.
+    /// It will attempt to heal if the [`NippyJar`] is in an inconsistent state.
     ///
     /// **ATTENTION**: disk commit should be handled externally by consuming `Self`
     pub fn ensure_consistency(&mut self) -> Result<(), NippyJarError> {


### PR DESCRIPTION
Fixes incorrect article usage a/an.