### PR TITLE
fix: dead documentation link

### DIFF
--- a/bin/reth/src/lib.rs
+++ b/bin/reth/src/lib.rs
@@ -25,7 +25,7 @@
 //! - `jemalloc-unprefixed`: Uses unprefixed jemalloc symbols.
 //! - `tracy-allocator`: Enables [Tracy](https://github.com/wolfpld/tracy) profiler allocator
 //!   integration for memory profiling.
-//! - `snmalloc`: Uses [snmalloc](https://github.com/snmalloc/snmalloc) as the global allocator. Use
+//! - `snmalloc`: Uses [snmalloc](https://github.com/microsoft/snmalloc) as the global allocator. Use
 //!   `--no-default-features` when enabling this, as jemalloc takes precedence.
 //! - `snmalloc-native`: Uses snmalloc with native CPU optimizations. Use `--no-default-features`
 //!   when enabling this.

--- a/bin/reth/src/lib.rs
+++ b/bin/reth/src/lib.rs
@@ -25,8 +25,8 @@
 //! - `jemalloc-unprefixed`: Uses unprefixed jemalloc symbols.
 //! - `tracy-allocator`: Enables [Tracy](https://github.com/wolfpld/tracy) profiler allocator
 //!   integration for memory profiling.
-//! - `snmalloc`: Uses [snmalloc](https://github.com/microsoft/snmalloc) as the global allocator. Use
-//!   `--no-default-features` when enabling this, as jemalloc takes precedence.
+//! - `snmalloc`: Uses [snmalloc](https://github.com/microsoft/snmalloc) as the global allocator.
+//!   Use `--no-default-features` when enabling this, as jemalloc takes precedence.
 //! - `snmalloc-native`: Uses snmalloc with native CPU optimizations. Use `--no-default-features`
 //!   when enabling this.
 //!


### PR DESCRIPTION

* Updated the `snmalloc` repository link to the correct **microsoft/snmalloc** URL in `bin/reth/src/lib.rs`.
