### PR TITLE
chore: remove unused field

### DIFF
--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -1271,7 +1271,7 @@ mod tests {
             task_executor,
             client,
             EngineCapabilities::default(),
-            EthereumEngineValidator::new(chain_spec.clone()),
+            EthereumEngineValidator::new(chain_spec),
             false,
             NoopNetwork::default(),
         );

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -1275,7 +1275,7 @@ mod tests {
             false,
             NoopNetwork::default(),
         );
-        let handle = EngineApiTestHandle { chain_spec, provider, from_api: engine_rx };
+        let handle = EngineApiTestHandle { provider, from_api: engine_rx };
         (handle, api)
     }
 
@@ -1293,8 +1293,6 @@ mod tests {
     }
 
     struct EngineApiTestHandle {
-        #[allow(dead_code)]
-        chain_spec: Arc<ChainSpec>,
         provider: Arc<MockEthProvider>,
         from_api: UnboundedReceiver<BeaconEngineMessage<EthEngineTypes>>,
     }


### PR DESCRIPTION
Cleaned up unused field in test helper struct. The chain_spec field was marked with #[allow(dead_code)] and was never accessed in any tests, only the provider and from_api fields are actually used.