### PR TITLE
fix: documentation typos and comment grammar

### DIFF
--- a/crates/net/discv5/src/config.rs
+++ b/crates/net/discv5/src/config.rs
@@ -279,7 +279,7 @@ pub struct Config {
     /// Additional kv-pairs (besides tcp port, udp port and fork) that should be advertised to
     /// peers by including in local node record.
     pub(super) other_enr_kv_pairs: Vec<(&'static [u8], Bytes)>,
-    /// Interval in seconds at which to run a lookup up query with to populate kbuckets.
+    /// Interval in seconds at which to run a lookup up query to populate kbuckets.
     pub(super) lookup_interval: u64,
     /// Interval in seconds at which to run pulse lookup queries at bootstrap to boost kbucket
     /// population.

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1296,7 +1296,7 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> BlockReader for DatabaseProvid
             let Some(header) = self.header_by_number(number)?
         {
             // If the body indices are not found, this means that the transactions either do not
-             // exist in the database yet, or they do exist but are not indexed.
+            // exist in the database yet, or they do exist but are not indexed.
             // If they exist but are not indexed, we don't have enough
             // information to return the block anyways, so we return `None`.
             let Some(transactions) = self.transactions_by_block(number.into())? else {

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -708,7 +708,7 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> DatabaseProvider<TX, N> {
         // Get the block body
         //
         // If the body indices are not found, this means that the transactions either do not exist
-        // in the database yet, or they do exit but are not indexed. If they exist but are not
+        // in the database yet, or they do exist but are not indexed. If they exist but are not
         // indexed, we don't have enough information to return the block anyways, so we return
         // `None`.
         let Some(body) = self.block_body_indices(block_number)? else { return Ok(None) };
@@ -761,7 +761,7 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> DatabaseProvider<TX, N> {
         let headers = headers_range(range.clone())?;
 
         // If the body indices are not found, this means that the transactions either do
-        // not exist in the database yet, or they do exit but are
+        // not exist in the database yet, or they do exist but are
         // not indexed. If they exist but are not indexed, we don't
         // have enough information to return the block anyways, so
         // we skip the block.
@@ -1296,7 +1296,7 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> BlockReader for DatabaseProvid
             let Some(header) = self.header_by_number(number)?
         {
             // If the body indices are not found, this means that the transactions either do not
-            // exist in the database yet, or they do exit but are not indexed.
+             // exist in the database yet, or they do exist but are not indexed.
             // If they exist but are not indexed, we don't have enough
             // information to return the block anyways, so we return `None`.
             let Some(transactions) = self.transactions_by_block(number.into())? else {


### PR DESCRIPTION


* **`crates/net/discv5`**: fixed a redundant word (`with`) in the `lookup_interval` docstring.
* **`crates/storage/provider`**: corrected `exit` to **`exist`** in the `DatabaseProvider` comments across multiple methods.

