### PR TITLE
fix(libmdbx): remove duplicate assertion

### DIFF
--- a/crates/storage/libmdbx-rs/tests/cursor.rs
+++ b/crates/storage/libmdbx-rs/tests/cursor.rs
@@ -179,7 +179,6 @@ fn test_iter_empty_dup_database() {
     assert!(cursor.iter::<(), ()>().next().is_none());
     assert!(cursor.iter_start::<(), ()>().next().is_none());
     assert!(cursor.iter_from::<(), ()>(b"foo").next().is_none());
-    assert!(cursor.iter_from::<(), ()>(b"foo").next().is_none());
     assert!(cursor.iter_dup::<(), ()>().flatten().next().is_none());
     assert!(cursor.iter_dup_start::<(), ()>().flatten().next().is_none());
     assert!(cursor.iter_dup_from::<(), ()>(b"foo").flatten().next().is_none());


### PR DESCRIPTION
Removes a duplicate assertion in `test_iter_empty_dup_database` test that was checking the same iterator method twice.