### PR TITLE
docs(reth): replace dead downloads.merkle.io snapshot URL

### DIFF
--- a/docs/vocs/docs/pages/cli/reth/download.mdx
+++ b/docs/vocs/docs/pages/cli/reth/download.mdx
@@ -5,6 +5,7 @@ Download public node snapshots
 ```bash
 $ reth download --help
 ```
+
 ```txt
 Usage: reth download [OPTIONS]
 

--- a/docs/vocs/docs/pages/cli/reth/download.mdx
+++ b/docs/vocs/docs/pages/cli/reth/download.mdx
@@ -137,7 +137,7 @@ Static Files:
           - https://publicnode.com/snapshots (full nodes & testnets)
 
           If no URL is provided, the latest mainnet archive snapshot
-          will be proposed for download from https://downloads.merkle.io
+          will be proposed for download from https://publicnode.com/snapshots
 
 Logging:
       --log.stdout.format <FORMAT>


### PR DESCRIPTION
The snapshot download link pointing to downloads.merkle.io is no longer valid.

This PR updates the documentation to use PublicNode’s snapshot index
(https://publicnode.com/snapshots), which is actively maintained and
works directly with `reth download --url`.
