### PR TITLE
Makefile: POSIX compliant IO redirect

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -453,7 +453,7 @@ lint-typos: ensure-typos
 	typos
 
 ensure-typos:
-	@if ! command -v typos &> /dev/null; then \
+	@if ! command -v typos > /dev/null 2>&1; then \
 		echo "typos not found. Please install it by running the command 'cargo install typos-cli' or refer to the following link for more information: https://github.com/crate-ci/typos"; \
 		exit 1; \
     fi
@@ -472,7 +472,7 @@ lint-toml: ensure-dprint
 	dprint fmt
 
 ensure-dprint:
-	@if ! command -v dprint &> /dev/null; then \
+	@if ! command -v dprint > /dev/null 2>&1; then \
 		echo "dprint not found. Please install it by running the command 'cargo install --locked dprint' or refer to the following link for more information: https://github.com/dprint/dprint"; \
 		exit 1; \
     fi


### PR DESCRIPTION
Solves #20912 

Replaced `&>` operator with POSIX compliant `> ___ 2>&1` that runs properly on sh/dash