### PR TITLE
fix(rpc): correct parameter name in MinerApi::set_gas_limit

### DIFF
--- a/crates/rpc/rpc/src/miner.rs
+++ b/crates/rpc/rpc/src/miner.rs
@@ -19,7 +19,7 @@ impl MinerApiServer for MinerApi {
         Ok(false)
     }
 
-    fn set_gas_limit(&self, _gas_price: U128) -> RpcResult<bool> {
+    fn set_gas_limit(&self, _gas_limit: U128) -> RpcResult<bool> {
         Ok(false)
     }
 }


### PR DESCRIPTION
Fix copy-paste error in `set_gas_limit` implementation where the parameter was incorrectly named `_gas_price` instead of `_gas_limit`. This aligns the implementation with the trait definition in `rpc-api`.