### PR TITLE
chore: replace io::copy with write_all for Bytes writing

### DIFF
--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -367,7 +367,10 @@ mod tests {
         let (tx, rx) = crossbeam_channel::bounded(1);
 
         persistence_handle.save_blocks(blocks, tx).unwrap();
-        let BlockNumHash { hash: actual_hash, number: _ } = rx.recv().unwrap().unwrap();
+        let BlockNumHash { hash: actual_hash, number: _ } = rx
+            .recv_timeout(std::time::Duration::from_secs(10))
+            .expect("test timed out")
+            .expect("no hash returned");
         assert_eq!(last_hash, actual_hash);
     }
 
@@ -385,7 +388,10 @@ mod tests {
 
             persistence_handle.save_blocks(blocks, tx).unwrap();
 
-            let BlockNumHash { hash: actual_hash, number: _ } = rx.recv().unwrap().unwrap();
+            let BlockNumHash { hash: actual_hash, number: _ } = rx
+                .recv_timeout(std::time::Duration::from_secs(10))
+                .expect("test timed out")
+                .expect("no hash returned");
             assert_eq!(last_hash, actual_hash);
         }
     }

--- a/crates/era-downloader/src/client.rs
+++ b/crates/era-downloader/src/client.rs
@@ -85,7 +85,7 @@ impl<Http: HttpClient + Clone> EraClient<Http> {
                     let mut hasher = Sha256::new();
 
                     while let Some(item) = stream.next().await.transpose()? {
-                        io::copy(&mut item.as_ref(), &mut file).await?;
+                        file.write_all(item.as_ref()).await?;
                         hasher.update(item);
                     }
 
@@ -225,7 +225,7 @@ impl<Http: HttpClient + Clone> EraClient<Http> {
         let mut file = File::create(path).await?;
 
         while let Some(item) = stream.next().await.transpose()? {
-            io::copy(&mut item.as_ref(), &mut file).await?;
+            file.write_all(item.as_ref()).await?;
         }
 
         Ok(())


### PR DESCRIPTION
### Description
Replaces io::copy with write_all for writing Bytes chunks. write_all is more appropriate for byte slices.