### PR TITLE
chore: correct deprecation message for SealedBlockFor

### DIFF
--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -17,7 +17,7 @@ pub type BlockBody<T = TransactionSigned, H = Header> = alloy_consensus::BlockBo
 pub type SealedBlock<B = Block> = reth_primitives_traits::block::SealedBlock<B>;
 
 /// Helper type for constructing the block
-#[deprecated(note = "Use `RecoveredBlock` instead")]
+#[deprecated(note = "Use `SealedBlock` instead")]
 pub type SealedBlockFor<B = Block> = reth_primitives_traits::block::SealedBlock<B>;
 
 /// Ethereum recovered block


### PR DESCRIPTION
SealedBlockFor is an alias for SealedBlock, not RecoveredBlock. The deprecation message was pointing users to the wrong type.