### PR TITLE
perf(payload): remove unnecessary parent_header clone

### DIFF
--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -158,12 +158,12 @@ where
                 .ok_or_else(|| PayloadBuilderError::MissingParentHeader(attributes.parent()))?
         };
 
-        let config = PayloadConfig::new(Arc::new(parent_header.clone()), attributes);
+        let cached_reads = self.maybe_pre_cached(parent_header.hash());
+
+        let config = PayloadConfig::new(Arc::new(parent_header), attributes);
 
         let until = self.job_deadline(config.attributes.timestamp());
         let deadline = Box::pin(tokio::time::sleep_until(until));
-
-        let cached_reads = self.maybe_pre_cached(parent_header.hash());
 
         let mut job = BasicPayloadJob {
             config,


### PR DESCRIPTION
Reorder operations to avoid cloning parent_header before wrapping it in Arc. The hash is now extracted first, then the header is moved into Arc instead of being cloned. Saves one full header allocation per payload job.