### PR TITLE
fix(optimism): add missing Holocene hardfork to DEV_HARDFORKS

### DIFF
--- a/crates/optimism/hardforks/src/lib.rs
+++ b/crates/optimism/hardforks/src/lib.rs
@@ -61,6 +61,7 @@ pub static DEV_HARDFORKS: LazyLock<ChainHardforks> = LazyLock::new(|| {
         (OpHardfork::Ecotone.boxed(), ForkCondition::Timestamp(0)),
         (OpHardfork::Fjord.boxed(), ForkCondition::Timestamp(0)),
         (OpHardfork::Granite.boxed(), ForkCondition::Timestamp(0)),
+        (OpHardfork::Holocene.boxed(), ForkCondition::Timestamp(0)),
         (EthereumHardfork::Prague.boxed(), ForkCondition::Timestamp(0)),
         (OpHardfork::Isthmus.boxed(), ForkCondition::Timestamp(0)),
         (OpHardfork::Jovian.boxed(), JOVIAN_TIMESTAMP),


### PR DESCRIPTION
DEV_HARDFORKS was missing OpHardfork::Holocene between Granite and Prague. All other hardfork configurations (OP_MAINNET, OP_SEPOLIA, BASE_MAINNET, BASE_SEPOLIA) include Holocene in the correct position. This caused dev chains to skip Holocene activation, breaking any Holocene-specific logic like the base fee calculation.