### PR TITLE
fix(net): use saturating_sub consistently in transaction fetcher

### DIFF
--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -737,7 +737,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
             }
 
             if let Some(ref mut bud) = budget_fill_request {
-                *bud -= 1;
+                *bud = bud.saturating_sub(1);
                 if *bud == 0 {
                     break
                 }


### PR DESCRIPTION
Use `saturating_sub` for budget decrement in `fill_request_from_hashes_pending_fetch` (line 740) to match the same pattern already used in `find_any_idle_fallback_peer_for_any_pending_hash` (line 223).