### PR TITLE
fix(metrics): correct section comment for UnboundedMeteredReceiver

### DIFF
--- a/crates/metrics/src/common/mpsc.rs
+++ b/crates/metrics/src/common/mpsc.rs
@@ -79,7 +79,7 @@ pub struct UnboundedMeteredReceiver<T> {
     metrics: MeteredReceiverMetrics,
 }
 
-// === impl MeteredReceiver ===
+// === impl UnboundedMeteredReceiver ===
 
 impl<T> UnboundedMeteredReceiver<T> {
     /// Creates a new [`UnboundedMeteredReceiver`] wrapping around the provided


### PR DESCRIPTION
The section divider comment incorrectly referenced MeteredReceiver instead of UnboundedMeteredReceiver. 

Updated to match the actual  impl block that follows.