### PR TITLE
fix: remove unused random bytes generation in test

### DIFF
--- a/crates/evm/execution-types/src/execution_outcome.rs
+++ b/crates/evm/execution-types/src/execution_outcome.rs
@@ -528,7 +528,6 @@ pub(super) mod serde_bincode_compat {
     #[cfg(test)]
     mod tests {
         use super::super::{serde_bincode_compat, ExecutionOutcome};
-        use rand::Rng;
         use reth_ethereum_primitives::Receipt;
         use reth_primitives_traits::serde_bincode_compat::SerdeBincodeCompat;
         use serde::{Deserialize, Serialize};
@@ -543,8 +542,6 @@ pub(super) mod serde_bincode_compat {
                 data: ExecutionOutcome<T>,
             }
 
-            let mut bytes = [0u8; 1024];
-            rand::rng().fill(bytes.as_mut_slice());
             let data = Data {
                 data: ExecutionOutcome {
                     bundle: Default::default(),


### PR DESCRIPTION
### Fix
Removed unused random bytes generation in test_chain_bincode_roundtrip.
### Changes
- Removed unused bytes array and rand::rng().fill() call
- Removed unused use rand::Rng; import
The test creates ExecutionOutcome with default values, so the random data generation was unnecessary leftover code.