### PR TITLE
fix: typos and grammatical errors in comments and docstrings

### DIFF
--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -637,7 +637,7 @@ impl<Pool: TransactionPool, N: NetworkPrimitives> TransactionsManager<Pool, N> {
         //
         // known txns have already been successfully fetched or received over gossip.
         //
-        // most hashes will be filtered out here since this the mempool protocol is a gossip
+        // most hashes will be filtered out here since the mempool protocol is a gossip
         // protocol, healthy peers will send many of the same hashes.
         //
         let hashes_count_pre_pool_filter = partially_valid_msg.len();

--- a/crates/prune/types/src/target.rs
+++ b/crates/prune/types/src/target.rs
@@ -188,7 +188,7 @@ impl PruneModes {
             if let Some(PruneMode::Distance(limit)) = prune_mode {
                 // check if distance exceeds the configured limit
                 if distance > *limit {
-                    // but only if have haven't pruned the target yet, if we dont have a checkpoint
+                    // but only if we haven't pruned the target yet, if we don't have a checkpoint
                     // yet, it's fully unpruned yet
                     let pruned_height = checkpoint
                         .and_then(|checkpoint| checkpoint.1.block_number)

--- a/crates/stages/api/src/error.rs
+++ b/crates/stages/api/src/error.rs
@@ -91,7 +91,7 @@ pub enum StageError {
     /// Database is ahead of static file data.
     #[error("missing static file data for block number: {number}", number = block.block.number)]
     MissingStaticFileData {
-        /// Starting block with  missing data.
+        /// Starting block with missing data.
         block: Box<BlockWithParent>,
         /// Static File segment
         segment: StaticFileSegment,


### PR DESCRIPTION


* Removed redundant word `this` in transaction manager comments.
* Corrected grammar (`have` to `we`, `dont` to `don't`) in pruning logic comments.
* Fixed a double space typo in the `MissingStaticFileData` docstring.

