### PR TITLE
Remove dead test-only helpers from storage state providers

### DIFF
--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -596,13 +596,6 @@ mod tests {
     const STORAGE: B256 =
         b256!("0x0000000000000000000000000000000000000000000000000000000000000001");
 
-    const fn assert_state_provider<T: StateProvider>() {}
-    #[expect(dead_code)]
-    const fn assert_historical_state_provider<
-        T: DBProvider + BlockNumReader + BlockHashReader + ChangeSetReader,
-    >() {
-        assert_state_provider::<HistoricalStateProvider<T>>();
-    }
 
     #[test]
     fn history_provider_get_account() {

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -196,13 +196,3 @@ impl<Provider: DBProvider> LatestStateProvider<Provider> {
 // Delegates all provider impls to [LatestStateProviderRef]
 reth_storage_api::macros::delegate_provider_impls!(LatestStateProvider<Provider> where [Provider: DBProvider + BlockHashReader ]);
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    const fn assert_state_provider<T: StateProvider>() {}
-    #[expect(dead_code)]
-    const fn assert_latest_state_provider<T: DBProvider + BlockHashReader>() {
-        assert_state_provider::<LatestStateProvider<T>>();
-    }
-}


### PR DESCRIPTION
Drop unused test assertions in historical.rs that were silencing dead_code, remove empty test module in latest.rs to avoid needless dead_code suppression