### PR TITLE
docs(rpc): fix incorrect transport in with_ipc comment

### DIFF
--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -1663,7 +1663,7 @@ impl TransportRpcModules {
         self
     }
 
-    /// Sets the [`RpcModule`] for the http transport.
+    /// Sets the [`RpcModule`] for the ipc transport.
     /// This will overwrite current module, if any.
     pub fn with_ipc(mut self, ipc: RpcModule<()>) -> Self {
         self.ipc = Some(ipc);


### PR DESCRIPTION
The comment incorrectly stated that the method configures the http transport, but it sets the module for the ipc transport.