### PR TITLE
docs: fix typos and incorrect documentation

### DIFF
--- a/crates/metrics/src/common/mpsc.rs
+++ b/crates/metrics/src/common/mpsc.rs
@@ -70,10 +70,11 @@ impl<T> Clone for UnboundedMeteredSender<T> {
     }
 }
 
-/// A wrapper type around [Receiver](mpsc::UnboundedReceiver) that updates metrics on receive.
+/// A wrapper type around [`UnboundedReceiver`](mpsc::UnboundedReceiver) that updates metrics on
+/// receive.
 #[derive(Debug)]
 pub struct UnboundedMeteredReceiver<T> {
-    /// The [Receiver](mpsc::UnboundedReceiver) that this wraps around
+    /// The [`UnboundedReceiver`](mpsc::UnboundedReceiver) that this wraps around
     receiver: mpsc::UnboundedReceiver<T>,
     /// Holds metrics for this type
     metrics: MeteredReceiverMetrics,

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -637,7 +637,7 @@ impl<Pool: TransactionPool, N: NetworkPrimitives> TransactionsManager<Pool, N> {
         //
         // known txns have already been successfully fetched or received over gossip.
         //
-        // most hashes will be filtered out here since this the mempool protocol is a gossip
+        // most hashes will be filtered out here since the mempool protocol is a gossip
         // protocol, healthy peers will send many of the same hashes.
         //
         let hashes_count_pre_pool_filter = partially_valid_msg.len();

--- a/crates/prune/types/src/target.rs
+++ b/crates/prune/types/src/target.rs
@@ -188,7 +188,7 @@ impl PruneModes {
             if let Some(PruneMode::Distance(limit)) = prune_mode {
                 // check if distance exceeds the configured limit
                 if distance > *limit {
-                    // but only if have haven't pruned the target yet, if we dont have a checkpoint
+                    // but only if we haven't pruned the target yet, if we don't have a checkpoint
                     // yet, it's fully unpruned yet
                     let pruned_height = checkpoint
                         .and_then(|checkpoint| checkpoint.1.block_number)

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -1525,7 +1525,7 @@ impl TransportRpcModuleConfig {
         self
     }
 
-    /// Sets the [`RpcModuleSelection`] for the http transport.
+    /// Sets the [`RpcModuleSelection`] for the ipc transport.
     pub fn with_ipc(mut self, ipc: impl Into<RpcModuleSelection>) -> Self {
         self.ipc = Some(ipc.into());
         self
@@ -1663,7 +1663,7 @@ impl TransportRpcModules {
         self
     }
 
-    /// Sets the [`RpcModule`] for the http transport.
+    /// Sets the [`RpcModule`] for the ipc transport.
     /// This will overwrite current module, if any.
     pub fn with_ipc(mut self, ipc: RpcModule<()>) -> Self {
         self.ipc = Some(ipc);

--- a/crates/rpc/rpc/src/miner.rs
+++ b/crates/rpc/rpc/src/miner.rs
@@ -19,7 +19,7 @@ impl MinerApiServer for MinerApi {
         Ok(false)
     }
 
-    fn set_gas_limit(&self, _gas_price: U128) -> RpcResult<bool> {
+    fn set_gas_limit(&self, _gas_limit: U128) -> RpcResult<bool> {
         Ok(false)
     }
 }

--- a/crates/stages/api/src/error.rs
+++ b/crates/stages/api/src/error.rs
@@ -91,7 +91,7 @@ pub enum StageError {
     /// Database is ahead of static file data.
     #[error("missing static file data for block number: {number}", number = block.block.number)]
     MissingStaticFileData {
-        /// Starting block with  missing data.
+        /// Starting block with missing data.
         block: Box<BlockWithParent>,
         /// Static File segment
         segment: StaticFileSegment,

--- a/crates/storage/errors/src/db.rs
+++ b/crates/storage/errors/src/db.rs
@@ -32,7 +32,7 @@ pub enum DatabaseError {
     /// Failed to commit transaction changes into the database.
     #[error("failed to commit transaction changes: {_0}")]
     Commit(DatabaseErrorInfo),
-    /// Failed to initiate a transaction.
+    /// Failed to initialize a transaction.
     #[error("failed to initialize a transaction: {_0}")]
     InitTx(DatabaseErrorInfo),
     /// Failed to initialize a cursor.

--- a/crates/storage/errors/src/provider.rs
+++ b/crates/storage/errors/src/provider.rs
@@ -183,7 +183,7 @@ impl ProviderError {
         other.downcast_ref()
     }
 
-    /// Returns true if the this type is a [`ProviderError::Other`] of that error
+    /// Returns true if this type is a [`ProviderError::Other`] of that error
     /// type. Returns false otherwise.
     pub fn is_other<T: core::error::Error + 'static>(&self) -> bool {
         self.as_other().map(|err| err.is::<T>()).unwrap_or(false)

--- a/docs/crates/db.md
+++ b/docs/crates/db.md
@@ -297,4 +297,4 @@ This chapter was packed with information, so let's do a quick review. The databa
 
 # Next Chapter
 
-[Next Chapter]()
+[Next Chapter](eth-wire.md)


### PR DESCRIPTION
Consolidates fixes from unmerged spelling PRs:

- Fix incorrect transport in `with_ipc` comments - said "http" but should be "ipc" (#20939 pattern)
- Fix "initiate" to "initialize" in `DatabaseError::InitTx` doc (#20908)
- Fix "the this" to "this" in `ProviderError::is_other` doc (#20908)
- Fix `UnboundedMeteredReceiver` doc references from `Receiver` to `UnboundedReceiver` (#20129)
- Fix broken Next Chapter link in db.md docs (#20907)
- Fix "since this the" to "since the" in transaction manager comment (#20936)
- Fix "have haven't" to "we haven't" and "dont" to "don't" in pruning comment (#20936)
- Fix double space in `MissingStaticFileData` docstring (#20936)
- Fix parameter name `_gas_price` -> `_gas_limit` in `MinerApi::set_gas_limit` (#20926)