### PR TITLE
docs: fix incorrect panic documentation in Transaction::from_compact

### DIFF
--- a/crates/ethereum/primitives/src/transaction.rs
+++ b/crates/ethereum/primitives/src/transaction.rs
@@ -235,8 +235,9 @@ impl reth_codecs::Compact for Transaction {
     //
     // # Panics
     //
-    // A panic will be triggered if an identifier larger than 3 is passed from the database. For
-    // optimism a identifier with value [`DEPOSIT_TX_TYPE_ID`] is allowed.
+    // A panic will be triggered if an unsupported transaction type identifier is passed from the
+    // database. Valid identifiers are 0-2 for legacy transaction types, and 3 for extended types
+    // (EIP-4844, EIP-7702) where the type is read from the buffer.
     fn from_compact(buf: &[u8], identifier: usize) -> (Self, &[u8]) {
         let (tx_type, buf) = TxType::from_compact(buf, identifier);
 


### PR DESCRIPTION
Fixes misleading panic documentation in `Transaction::from_compact` that incorrectly referenced Optimism-specific functionality.