### PR TITLE
docs: update run command

### DIFF
--- a/examples/full-contract-state/README.md
+++ b/examples/full-contract-state/README.md
@@ -25,8 +25,8 @@ export RETH_DATADIR="/path/to/your/reth/datadir"
 # Set target contract address
 export CONTRACT_ADDRESS="0x0..."
 
-# Run the example
-cargo run --example full-contract-state
+# Run the example (workspace package name)
+cargo run -p example-full-contract-state
 ```
 
 ## Code Structure


### PR DESCRIPTION
Switch the run command to the actual workspace package example-full-contract-state (the example isn’t built via --example).