### PR TITLE
perf(engine): save clock reads and improve consistency in multiproof metrics

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -1124,7 +1124,9 @@ impl MultiProofTask {
             .record(batch_metrics.state_update_proofs_requested as f64);
         self.metrics.proofs_processed_histogram.record(batch_metrics.proofs_processed as f64);
         if let Some(first_update_time) = ctx.first_update_time {
-            self.metrics.multiproof_task_total_duration_histogram.record(end.duration_since(first_update_time));
+            self.metrics
+                .multiproof_task_total_duration_histogram
+                .record(end.duration_since(first_update_time));
         }
 
         if let Some(updates_finished_time) = ctx.updates_finished_time {

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -1107,12 +1107,14 @@ impl MultiProofTask {
             }
         }
 
+        let end = Instant::now();
+
         debug!(
             target: "engine::tree::payload_processor::multiproof",
             total_updates = batch_metrics.state_update_proofs_requested,
             total_proofs = batch_metrics.proofs_processed,
-            total_time = ?ctx.first_update_time.map(|t|t.elapsed()),
-            time_since_updates_finished = ?ctx.updates_finished_time.map(|t|t.elapsed()),
+            total_time = ?ctx.first_update_time.map(|t|end.duration_since(t)),
+            time_since_updates_finished = ?ctx.updates_finished_time.map(|t|end.duration_since(t)),
             "All proofs processed, ending calculation"
         );
 
@@ -1121,14 +1123,14 @@ impl MultiProofTask {
             .state_updates_received_histogram
             .record(batch_metrics.state_update_proofs_requested as f64);
         self.metrics.proofs_processed_histogram.record(batch_metrics.proofs_processed as f64);
-        if let Some(total_time) = ctx.first_update_time.map(|t| t.elapsed()) {
-            self.metrics.multiproof_task_total_duration_histogram.record(total_time);
+        if let Some(first_update_time) = ctx.first_update_time {
+            self.metrics.multiproof_task_total_duration_histogram.record(end.duration_since(first_update_time));
         }
 
         if let Some(updates_finished_time) = ctx.updates_finished_time {
             self.metrics
                 .last_proof_wait_time_histogram
-                .record(updates_finished_time.elapsed().as_secs_f64());
+                .record(end.duration_since(updates_finished_time).as_secs_f64());
         }
     }
 }


### PR DESCRIPTION
Reduces clock reads from four to one when recording multiproof metrics, ensures all timing measurements use the same end timestamp.