### PR TITLE
chore: export OpBuilderConfig types from optimism payload root

### DIFF
--- a/crates/optimism/payload/src/lib.rs
+++ b/crates/optimism/payload/src/lib.rs
@@ -28,6 +28,7 @@ pub mod validator;
 pub use validator::OpExecutionPayloadValidator;
 
 pub mod config;
+pub use config::*;
 
 /// ZST that aggregates Optimism [`PayloadTypes`].
 #[derive(Debug, Default, Clone, serde::Deserialize, serde::Serialize)]


### PR DESCRIPTION
exports OpBuilderConfig, OpDAConfig, and OpGasLimitConfig from optimism/payload rootbefore:
`use reth_optimism_payload::config::{OpBuilderConfig, OpDAConfig, OpGasLimitConfig};`

after:
`use reth_optimism_payload::{OpBuilderConfig, OpDAConfig, OpGasLimitConfig};`

Matches how ethereum/payload already works with pub use config::*. makes the API cleaner and consistent across modules.