### PR TITLE
perf(eth-consensus): drop useless receipt alloc

### DIFF
--- a/crates/ethereum/consensus/src/validation.rs
+++ b/crates/ethereum/consensus/src/validation.rs
@@ -1,7 +1,7 @@
 use alloc::vec::Vec;
 use alloy_consensus::{proofs::calculate_receipt_root, BlockHeader, TxReceipt};
-use alloy_eips::{eip7685::Requests, Encodable2718};
-use alloy_primitives::{Bloom, Bytes, B256};
+use alloy_eips::eip7685::Requests;
+use alloy_primitives::{Bloom, B256};
 use reth_chainspec::EthereumHardforks;
 use reth_consensus::ConsensusError;
 use reth_primitives_traits::{
@@ -44,11 +44,7 @@ where
             receipts,
         )
     {
-        let receipts = receipts
-            .iter()
-            .map(|r| Bytes::from(r.with_bloom_ref().encoded_2718()))
-            .collect::<Vec<_>>();
-        tracing::debug!(%error, ?receipts, "receipts verification failed");
+        tracing::debug!(%error, "receipts verification failed");
         return Err(error)
     }
 


### PR DESCRIPTION
Removed an unnecessary O(N) allocation and RLP encoding of receipts that happened during receipt root validation failures. The code was eagerly serializing all receipts into a vector just for a debug log, which creates useless overhead and is a potential DoS vector.