### PR TITLE
feat(db): implement extra dup methods

### DIFF
--- a/crates/storage/db-api/src/cursor.rs
+++ b/crates/storage/db-api/src/cursor.rs
@@ -62,8 +62,14 @@ pub trait DbCursorRO<T: Table> {
 
 /// A read-only cursor over the dup table `T`.
 pub trait DbDupCursorRO<T: DupSort> {
+    /// Positions the cursor at the prev KV pair of the table, returning it.
+    fn prev_dup(&mut self) -> PairResult<T>;
+
     /// Positions the cursor at the next KV pair of the table, returning it.
     fn next_dup(&mut self) -> PairResult<T>;
+
+    /// Positions the cursor at the last duplicate value of the current key.
+    fn last_dup(&mut self) -> ValueOnlyResult<T>;
 
     /// Positions the cursor at the next KV pair of the table, skipping duplicates.
     fn next_no_dup(&mut self) -> PairResult<T>;

--- a/crates/storage/db-api/src/mock.rs
+++ b/crates/storage/db-api/src/mock.rs
@@ -296,6 +296,18 @@ impl<T: DupSort> DbDupCursorRO<T> for CursorMock {
         Ok(None)
     }
 
+    /// Moves to the previous duplicate entry.
+    /// **Mock behavior**: Always returns `None`.
+    fn prev_dup(&mut self) -> PairResult<T> {
+        Ok(None)
+    }
+
+    /// Moves to the last duplicate entry.
+    /// **Mock behavior**: Always returns `None`.
+    fn last_dup(&mut self) -> ValueOnlyResult<T> {
+        Ok(None)
+    }
+
     /// Moves to the next entry with a different key.
     /// **Mock behavior**: Always returns `None`.
     fn next_no_dup(&mut self) -> PairResult<T> {

--- a/crates/storage/db/src/implementation/mdbx/cursor.rs
+++ b/crates/storage/db/src/implementation/mdbx/cursor.rs
@@ -158,9 +158,23 @@ impl<K: TransactionKind, T: Table> DbCursorRO<T> for Cursor<K, T> {
 }
 
 impl<K: TransactionKind, T: DupSort> DbDupCursorRO<T> for Cursor<K, T> {
+    /// Returns the previous `(key, value)` pair of a DUPSORT table.
+    fn prev_dup(&mut self) -> PairResult<T> {
+        decode::<T>(self.inner.prev_dup())
+    }
+
     /// Returns the next `(key, value)` pair of a DUPSORT table.
     fn next_dup(&mut self) -> PairResult<T> {
         decode::<T>(self.inner.next_dup())
+    }
+
+    /// Returns the last `value` of the current duplicate `key`.
+    fn last_dup(&mut self) -> ValueOnlyResult<T> {
+        self.inner
+            .last_dup()
+            .map_err(|e| DatabaseError::Read(e.into()))?
+            .map(decode_one::<T>)
+            .transpose()
     }
 
     /// Returns the next `(key, value)` pair skipping the duplicates.


### PR DESCRIPTION
Implements `last_dup` and `prev_dup` which help with scanning dup items in reverse. We use this in the Proofs ExEx for finding the last entry before a certain block number.