### PR TITLE
fix(trie): remove redundant storage trie root calculation in witness

### DIFF
--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -184,9 +184,6 @@ where
                 }
             }
 
-            // Calculate storage root after updates.
-            storage_trie.root();
-
             let account = state
                 .accounts
                 .get(&hashed_address)


### PR DESCRIPTION
TrieWitness::compute() was calling storage_trie.root() right after applying storage updates and then SparseStateTrie::update_account() was computing the storage root again via SparseTrie::root(). The extra call had no effect on correctness (update_account always derives the storage root itself) and only added unnecessary work for large storage tries. This change removes the redundant root() call so that the storage root is calculated only once during account update.