### PR TITLE
fix: use global default for rpc_proof_permits CLI flag

### DIFF
--- a/crates/node/core/src/args/rpc_server.rs
+++ b/crates/node/core/src/args/rpc_server.rs
@@ -605,7 +605,7 @@ pub struct RpcServerArgs {
     pub rpc_eth_proof_window: u64,
 
     /// Maximum number of concurrent getproof requests.
-    #[arg(long = "rpc.proof-permits", alias = "rpc-proof-permits", value_name = "COUNT", default_value_t = constants::DEFAULT_PROOF_PERMITS)]
+    #[arg(long = "rpc.proof-permits", alias = "rpc-proof-permits", value_name = "COUNT", default_value_t = DefaultRpcServerArgs::get_global().rpc_proof_permits)]
     pub rpc_proof_permits: usize,
 
     /// Configures the pending block behavior for RPC responses.


### PR DESCRIPTION
Previously the --rpc.proof-permits argument used the hard-coded DEFAULT_PROOF_PERMITS constant as its CLI default, ignoring any overrides applied via DefaultRpcServerArgs::try_init().with_rpc_proof_permits(...). This change makes the CLI default rely on 
DefaultRpcServerArgs::get_global().rpc_proof_permits, aligning it with the pattern used by other RPC limit flags and ensuring that global RPC defaults are respected consistently across both programmatic and CLI usage.