### PR TITLE
fix(rpc): validate eth_feeHistory newest_block against chain head

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/fee.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/fee.rs
@@ -97,7 +97,7 @@ pub trait EthFees:
             // For explicit block numbers, validate against chain head before resolution
             if let BlockNumberOrTag::Number(requested) = newest_block {
                 let latest_block =
-                    self.provider().last_block_number().map_err(Self::Error::from_eth_err)?;
+                    self.provider().best_block_number().map_err(Self::Error::from_eth_err)?;
                 if requested > latest_block {
                     return Err(
                         EthApiError::RequestBeyondHead { requested, head: latest_block }.into()

--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -92,6 +92,14 @@ pub enum EthApiError {
     /// When an invalid block range is provided
     #[error("invalid block range")]
     InvalidBlockRange,
+    /// Requested block number is beyond the head block
+    #[error("request beyond head block: requested {requested}, head {head}")]
+    RequestBeyondHead {
+        /// The requested block number
+        requested: u64,
+        /// The current head block number
+        head: u64,
+    },
     /// Thrown when the target block for proof computation exceeds the maximum configured window.
     #[error("distance to target block exceeds maximum proof window")]
     ExceedsMaxProofWindow,
@@ -268,6 +276,7 @@ impl From<EthApiError> for jsonrpsee_types::error::ErrorObject<'static> {
             EthApiError::InvalidTransactionSignature |
             EthApiError::EmptyRawTransactionData |
             EthApiError::InvalidBlockRange |
+            EthApiError::RequestBeyondHead { .. } |
             EthApiError::ExceedsMaxProofWindow |
             EthApiError::ConflictingFeeFieldsInRequest |
             EthApiError::Signing(_) |


### PR DESCRIPTION
Adds a check to validate that explicit block numbers in `eth_feeHistory` requests don't exceed the current chain head. This prevents an integer overflow when calculating `end_block + 1` for block numbers like `0xffffffffffffffff`, which could cause panics in debug builds or logic errors in release builds.

The issue occurs when a client sends a request like:
```
curl -X POST http://localhost:8545/ \
    -H "Content-Type: application/json" \
    -d '{"jsonrpc":"2.0","method":"eth_feeHistory","params":["0x1","0xffffffffffffffff",null],"id":1}'
```

The check only applies to explicit `BlockNumberOrTag::Number` variants, as other variants (like `latest`, `safe`, etc.) are resolved from the actual chain state.

Introduces a new `EthApiError::RequestBeyondHead` error variant that returns a clear error message: `"request beyond head block: requested {requested}, head {head}"`.