### PR TITLE
fix(libmdbx): use correct size for freelist u32 values

### DIFF
--- a/crates/storage/libmdbx-rs/src/environment.rs
+++ b/crates/storage/libmdbx-rs/src/environment.rs
@@ -215,11 +215,10 @@ impl Environment {
 
         for result in cursor.iter_slices() {
             let (_key, value) = result?;
-            if value.len() < size_of::<usize>() {
+            if value.len() < size_of::<u32>() {
                 return Err(Error::Corrupted)
             }
-
-            let s = &value[..size_of::<usize>()];
+            let s = &value[..size_of::<u32>()];
             freelist += NativeEndian::read_u32(s) as usize;
         }
 


### PR DESCRIPTION
The freelist parsing was checking value.len() against `size_of::<usize>()` (8 bytes on 64-bit) but then reading a u32 (4 bytes). This mismatch could incorrectly reject valid freelist entries on 64-bit systems.