### PR TITLE
fix(stages): use static files for unwind in SenderRecovery stage

### DIFF
--- a/crates/stages/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/stages/src/stages/sender_recovery.rs
@@ -161,7 +161,6 @@ where
             .ok_or(ProviderError::BlockBodyIndicesNotFound(unwind_to))?
             .next_tx_num();
 
-        // Prune senders from both database and static files
         EitherWriter::new_senders(provider, unwind_to)?.prune_senders(unwind_tx_from, unwind_to)?;
 
         Ok(UnwindOutput {


### PR DESCRIPTION
**Summary**

The SenderRecovery stage unwind now correctly handles static files when senders are stored there.

**Problem**

Previously, the `SenderRecovery` stage unwind only removed entries from the database `TransactionSenders` table using `unwind_table_by_num`, but did not handle static files when senders are configured to be stored there. This could leave stale data in static files after an unwind.

Use `EitherWriter::prune_senders` which handles both database and static file storage destinations, consistent with how unwind is handled elsewhere in the codebase (e.g., `DatabaseProvider::remove_block_data_above`).