### PR TITLE
docs: align pipeline stages documentation with code

### DIFF
--- a/docs/crates/stages.md
+++ b/docs/crates/stages.md
@@ -7,7 +7,7 @@ The `stages` lib plays a central role in syncing the node, maintaining state, up
 - BodyStage
 - SenderRecoveryStage
 - ExecutionStage
-- PruneSenderRecoveryStage (if pruning for sender recovery is enabled)
+- PruneSenderRecoveryStage (execute, if pruning for sender recovery is enabled)
 - MerkleStage (unwind)
 - AccountHashingStage
 - StorageHashingStage
@@ -16,7 +16,7 @@ The `stages` lib plays a central role in syncing the node, maintaining state, up
 - TransactionLookupStage
 - IndexStorageHistoryStage
 - IndexAccountHistoryStage
-- PruneStage
+- PruneStage (execute)
 - FinishStage
 
 


### PR DESCRIPTION


This PR synchronizes the pipeline stages documentation in `docs/crates/stages.md` 
with the actual implementation in `crates/stages/stages/src/sets.rs`.

