### PR TITLE
perf(db): throttle metrics reporting

### DIFF
--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -1264,12 +1264,12 @@ pub fn metrics_hooks<N: NodeTypesWithDB>(provider_factory: &ProviderFactory<N>) 
     Hooks::builder()
         .with_hook({
             let db = provider_factory.db_ref().clone();
-            move || throttle!(Duration::from_mins(5), || db.report_metrics())
+            move || throttle!(Duration::from_secs(5 * 60), || db.report_metrics())
         })
         .with_hook({
             let sfp = provider_factory.static_file_provider();
             move || {
-                throttle!(Duration::from_mins(5), || {
+                throttle!(Duration::from_secs(5 * 60), || {
                     if let Err(error) = sfp.report_metrics() {
                         error!(%error, "Failed to report metrics from static file provider");
                     }

--- a/crates/tracing/src/lib.rs
+++ b/crates/tracing/src/lib.rs
@@ -56,6 +56,7 @@ pub use test_tracer::TestTracer;
 mod formatter;
 mod layers;
 mod test_tracer;
+mod throttle;
 
 use tracing::level_filters::LevelFilter;
 use tracing_appender::non_blocking::WorkerGuard;

--- a/crates/tracing/src/lib.rs
+++ b/crates/tracing/src/lib.rs
@@ -53,6 +53,11 @@ pub use formatter::LogFormat;
 pub use layers::{FileInfo, FileWorkerGuard, Layers};
 pub use test_tracer::TestTracer;
 
+#[doc(hidden)]
+pub mod __private {
+    pub use super::throttle::*;
+}
+
 mod formatter;
 mod layers;
 mod test_tracer;

--- a/crates/tracing/src/throttle.rs
+++ b/crates/tracing/src/throttle.rs
@@ -1,0 +1,69 @@
+//! Throttling utilities for rate-limiting expression execution.
+
+/// Throttles the execution of an expression to run at most once per specified duration.
+///
+/// Uses static variables with lazy initialization to track the last execution time.
+/// Thread-safe via atomic operations.
+///
+/// # Examples
+///
+/// ```ignore
+/// use std::time::Duration;
+/// use reth_tracing::throttle;
+///
+/// // Log at most once per second.
+/// throttle!(Duration::from_secs(1), || {
+///     tracing::info!("This message is throttled");
+/// });
+/// ```
+#[macro_export]
+macro_rules! throttle {
+    ($duration:expr, || $expr:expr) => {{
+        fn should_run(duration: ::core::time::Duration) -> bool {
+            use ::core::sync::atomic::Ordering;
+
+            const NOT_YET_RUN: u64 = u64::MAX;
+
+            static START: ::std::sync::LazyLock<::std::time::Instant> =
+                ::std::sync::LazyLock::new(::std::time::Instant::now);
+            static LAST: ::std::sync::atomic::AtomicU64 =
+                ::std::sync::atomic::AtomicU64::new(NOT_YET_RUN);
+
+            let now = START.elapsed().as_millis() as u64;
+            let last = LAST.load(Ordering::Relaxed);
+
+            if last == NOT_YET_RUN {
+                return LAST
+                    .compare_exchange(NOT_YET_RUN, now, Ordering::Relaxed, Ordering::Relaxed)
+                    .is_ok();
+            }
+
+            let duration_nanos = duration.as_millis() as u64;
+            if now.saturating_sub(last) >= duration_nanos {
+                LAST.compare_exchange(last, now, Ordering::Relaxed, Ordering::Relaxed).is_ok()
+            } else {
+                false
+            }
+        }
+
+        if should_run($duration) {
+            $expr
+        }
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[test]
+    fn test_throttle_runs_once_initially() {
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+        throttle!(std::time::Duration::from_secs(10), || {
+            COUNTER.fetch_add(1, Ordering::SeqCst);
+        });
+
+        assert_eq!(COUNTER.load(Ordering::SeqCst), 1);
+    }
+}

--- a/crates/tracing/src/throttle.rs
+++ b/crates/tracing/src/throttle.rs
@@ -53,9 +53,9 @@ macro_rules! throttle {
         static START: ::std::sync::LazyLock<::std::time::Instant> =
             ::std::sync::LazyLock::new(::std::time::Instant::now);
         static LAST: ::core::sync::atomic::AtomicU64 =
-            ::core::sync::atomic::AtomicU64::new($crate::__private::THROTTLE_NOT_YET_RUN);
+            ::core::sync::atomic::AtomicU64::new($crate::__private::NOT_YET_RUN);
 
-        if $crate::__private::should_throttle(&START, &LAST, $duration.as_millis() as u64) {
+        if $crate::__private::should_run(&START, &LAST, $duration.as_millis() as u64) {
             $expr
         }
     }};


### PR DESCRIPTION
db and static files metrics iterate over a bunch of entries, which is pretty expensive. throttle only these metrics to improve overall performance.

fixes #20966