### PR TITLE
fix: correct comment references and remove duplicate in codecs derive

### DIFF
--- a/crates/storage/codecs/derive/src/compact/generator.rs
+++ b/crates/storage/codecs/derive/src/compact/generator.rs
@@ -69,7 +69,7 @@ pub fn generate_from_to(
     }
 }
 
-/// Generates code to implement the `Compact` trait method `to_compact`.
+/// Generates code to implement the `Compact` trait method `from_compact`.
 fn generate_from_compact(
     fields: &FieldList,
     ident: &Ident,
@@ -155,7 +155,7 @@ fn generate_from_compact(
     }
 }
 
-/// Generates code to implement the `Compact` trait method `from_compact`.
+/// Generates code to implement the `Compact` trait method `to_compact`.
 fn generate_to_compact(
     fields: &FieldList,
     ident: &Ident,

--- a/crates/storage/codecs/derive/src/compact/mod.rs
+++ b/crates/storage/codecs/derive/src/compact/mod.rs
@@ -175,7 +175,7 @@ fn should_use_alt_impl(ftype: &str, segment: &syn::PathSegment) -> bool {
         let syn::PathArguments::AngleBracketed(ref args) = segment.arguments &&
         let Some(syn::GenericArgument::Type(syn::Type::Path(arg_path))) = args.args.last() &&
         let (Some(path), 1) = (arg_path.path.segments.first(), arg_path.path.segments.len()) &&
-        ["B256", "Address", "Address", "Bloom", "TxHash", "BlockHash", "CompactPlaceholder"]
+        ["B256", "Address", "Bloom", "TxHash", "BlockHash", "CompactPlaceholder"]
             .iter()
             .any(|&s| path.ident == s)
     {


### PR DESCRIPTION
Fixed documentation comments and a code typo in the codecs derive macro.

### Changes
- **generator.rs**: Swapped incorrect doc comments between `generate_from_compact` and `generate_to_compact` functions
- **mod.rs**: Removed duplicate "Address" entry in the `should_use_alt_impl` type array