### PR TITLE
fix: add missing AccountsHistory and StoragesHistory to RocksDB metrics

### DIFF
--- a/crates/storage/provider/src/providers/rocksdb/metrics.rs
+++ b/crates/storage/provider/src/providers/rocksdb/metrics.rs
@@ -6,7 +6,11 @@ use reth_db::Tables;
 use reth_metrics::Metrics;
 use strum::{EnumIter, IntoEnumIterator};
 
-const ROCKSDB_TABLES: &[&str] = &[Tables::TransactionHashNumbers.name()];
+const ROCKSDB_TABLES: &[&str] = &[
+    Tables::TransactionHashNumbers.name(),
+    Tables::AccountsHistory.name(),
+    Tables::StoragesHistory.name(),
+];
 
 /// Metrics for the `RocksDB` provider.
 #[derive(Debug)]


### PR DESCRIPTION
The metrics setup was only tracking TransactionHashNumbers but we actually have 3 tables in RocksDB (AccountsHistory and StoragesHistory too). This would panic on the expect() call when trying to record metrics for the other two tables.

Just added them to the array.