### PR TITLE
fix: fix RocksDB initialization in rpc-db example

### DIFF
--- a/examples/rpc-db/src/main.rs
+++ b/examples/rpc-db/src/main.rs
@@ -53,10 +53,7 @@ async fn main() -> eyre::Result<()> {
         db.clone(),
         spec.clone(),
         StaticFileProvider::read_only(db_path.join("static_files"), true)?,
-        RocksDBProvider::builder(db_path.join("rocksdb"))
-            .with_default_tables()
-            .build()
-            .unwrap(),
+        RocksDBProvider::builder(db_path.join("rocksdb")).with_default_tables().build().unwrap(),
     )?;
 
     // 2. Set up the blockchain provider using only the database provider and a noop for the tree to

--- a/examples/rpc-db/src/main.rs
+++ b/examples/rpc-db/src/main.rs
@@ -53,7 +53,10 @@ async fn main() -> eyre::Result<()> {
         db.clone(),
         spec.clone(),
         StaticFileProvider::read_only(db_path.join("static_files"), true)?,
-        RocksDBProvider::builder(db_path.join("rocksdb")).build().unwrap(),
+        RocksDBProvider::builder(db_path.join("rocksdb"))
+            .with_default_tables()
+            .build()
+            .unwrap(),
     )?;
 
     // 2. Set up the blockchain provider using only the database provider and a noop for the tree to


### PR DESCRIPTION
The rpc-db example wasn't registering column families when creating RocksDBProvider. This would cause runtime errors if the code tried to access TransactionHashNumbers, AccountsHistory, or StoragesHistory tables.