### PR TITLE
feat(debug): add `debug_setFailpoint` for runtime fault injection testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3990,6 +3990,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fail"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe5e43d0f78a42ad591453aedb1d7ae631ce7ee445c7643691055a9ed8d3b01c"
+dependencies = [
+ "log",
+ "once_cell",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "fast-float2"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8046,6 +8057,7 @@ dependencies = [
  "codspeed-criterion-compat",
  "derive_more",
  "eyre",
+ "fail",
  "metrics",
  "page_size",
  "parking_lot",
@@ -10378,6 +10390,7 @@ dependencies = [
  "async-trait",
  "derive_more",
  "dyn-clone",
+ "fail",
  "futures",
  "http",
  "http-body",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -554,6 +554,7 @@ derive_more = { version = "2", default-features = false, features = ["full"] }
 dirs-next = "2.0.0"
 dyn-clone = "1.0.17"
 eyre = "0.6"
+fail = "0.5"
 fdlimit = "0.3.0"
 humantime = "2.1"
 humantime-serde = "1.1"

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -176,6 +176,8 @@ min-trace-logs = [
     "reth-node-core/min-trace-logs",
 ]
 
+failpoints = ["reth-node-ethereum/failpoints"]
+
 edge = ["reth-ethereum-cli/edge"]
 
 [[bin]]

--- a/crates/ethereum/node/Cargo.toml
+++ b/crates/ethereum/node/Cargo.toml
@@ -113,3 +113,5 @@ test-utils = [
     "reth-evm-ethereum/test-utils",
     "reth-stages-types/test-utils",
 ]
+
+failpoints = ["reth-node-builder/failpoints"]

--- a/crates/node/builder/Cargo.toml
+++ b/crates/node/builder/Cargo.toml
@@ -126,3 +126,8 @@ op = [
     "reth-evm/op",
     "reth-primitives-traits/op",
 ]
+
+failpoints = [
+    "reth-rpc/failpoints",
+    "reth-provider/failpoints",
+]

--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -426,6 +426,16 @@ pub trait DebugApi<TxReq: RpcObject> {
     /// Writes a goroutine blocking profile to the given file.
     #[method(name = "writeMutexProfile")]
     async fn debug_write_mutex_profile(&self, file: String) -> RpcResult<()>;
+
+    /// Sets a failpoint with the given name and action.
+    ///
+    /// This method allows runtime fault injection for testing recovery logic.
+    /// Actions: "off", "return", "sleep(ms)", "panic", "print", "pause", "yield"
+    /// Example: "100%return" triggers 100% of the time
+    ///
+    /// Note: Only available when built with the `failpoints` feature.
+    #[method(name = "setFailpoint")]
+    async fn debug_set_failpoint(&self, name: String, actions: String) -> RpcResult<()>;
 }
 
 /// An extension to the `debug_` namespace that provides additional methods for retrieving

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -96,6 +96,7 @@ sha2.workspace = true
 thiserror.workspace = true
 derive_more.workspace = true
 itertools.workspace = true
+fail = { workspace = true, optional = true }
 
 [dev-dependencies]
 reth-ethereum-primitives.workspace = true
@@ -114,3 +115,4 @@ js-tracer = [
     "reth-rpc-eth-types/js-tracer",
     "reth-rpc-eth-api/js-tracer",
 ]
+failpoints = ["fail/failpoints"]

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -1092,6 +1092,23 @@ where
     async fn debug_write_mutex_profile(&self, _file: String) -> RpcResult<()> {
         Ok(())
     }
+
+    /// Handler for `debug_setFailpoint`
+    ///
+    /// Sets a failpoint with the given name and action for runtime fault injection.
+    async fn debug_set_failpoint(&self, name: String, actions: String) -> RpcResult<()> {
+        #[cfg(feature = "failpoints")]
+        {
+            fail::cfg(name, &actions).map_err(internal_rpc_err)
+        }
+        #[cfg(not(feature = "failpoints"))]
+        {
+            let _ = (name, actions);
+            Err(internal_rpc_err(
+                "Failpoints feature is not enabled. Rebuild with --features failpoints",
+            ))
+        }
+    }
 }
 
 impl<Eth: RpcNodeCore> std::fmt::Debug for DebugApi<Eth> {

--- a/crates/storage/db/Cargo.toml
+++ b/crates/storage/db/Cargo.toml
@@ -39,6 +39,7 @@ derive_more.workspace = true
 rustc-hash = { workspace = true, optional = true, features = ["std"] }
 sysinfo = { workspace = true, features = ["system"] }
 parking_lot = { workspace = true, optional = true }
+fail = { workspace = true, optional = true }
 
 # arbitrary utils
 strum = { workspace = true, features = ["derive"], optional = true }
@@ -96,6 +97,7 @@ op = [
     "reth-db-api/op",
     "reth-primitives-traits/op",
 ]
+failpoints = ["fail/failpoints"]
 disable-lock = []
 
 [[bench]]

--- a/crates/storage/db/src/lib.rs
+++ b/crates/storage/db/src/lib.rs
@@ -37,6 +37,38 @@ pub use mdbx::{create_db, init_db, open_db, open_db_read_only, DatabaseEnv, Data
 pub use models::ClientVersion;
 pub use reth_db_api::*;
 
+// Re-export fail crate when failpoints feature is enabled
+#[cfg(feature = "failpoints")]
+#[doc(hidden)]
+pub use fail;
+
+/// Generic failpoint injection macro that panics when triggered.
+/// When `failpoints` feature is enabled, this triggers the failpoint and panics if activated.
+/// When disabled, this is a no-op (compiles to nothing).
+///
+/// # Example
+/// ```ignore
+/// set_fail_point!("my::failpoint::name");
+/// ```
+///
+/// To trigger via RPC: `debug_setFailpoint("my::failpoint::name", "panic")`
+#[cfg(feature = "failpoints")]
+#[macro_export]
+macro_rules! set_fail_point {
+    ($name:expr) => {
+        $crate::fail::fail_point!($name, |_| {
+            panic!("failpoint triggered: {}", $name);
+        });
+    };
+}
+
+/// No-op version when failpoints feature is disabled.
+#[cfg(not(feature = "failpoints"))]
+#[macro_export]
+macro_rules! set_fail_point {
+    ($name:expr) => {};
+}
+
 /// Collection of database test utilities
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils {

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -104,3 +104,4 @@ test-utils = [
     "revm-state",
     "tokio",
 ]
+failpoints = ["reth-db/failpoints"]

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -1,6 +1,7 @@
 use super::metrics::{RocksDBMetrics, RocksDBOperation};
 use crate::providers::{needs_prev_shard_check, HistoryInfo};
 use alloy_primitives::{Address, BlockNumber, B256};
+use reth_db::set_fail_point;
 use reth_db_api::{
     models::{storage_sharded_key::StorageShardedKey, ShardedKey},
     table::{Compress, Decode, Decompress, Encode, Table},
@@ -536,7 +537,9 @@ impl<'a> RocksDBBatch<'a> {
                 message: e.to_string().into(),
                 code: -1,
             }))
-        })
+        })?;
+        set_fail_point!("rocksdb::batch::after_commit");
+        Ok(())
     }
 
     /// Returns the number of write operations (puts + deletes) queued in this batch.
@@ -668,7 +671,9 @@ impl<'db> RocksTx<'db> {
                 message: e.to_string().into(),
                 code: -1,
             }))
-        })
+        })?;
+        set_fail_point!("rocksdb::tx::after_commit");
+        Ok(())
     }
 
     /// Rolls back the transaction, discarding all changes.

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -6,7 +6,7 @@ use alloy_consensus::BlockHeader;
 use alloy_primitives::{BlockHash, BlockNumber, TxNumber, U256};
 use parking_lot::{lock_api::RwLockWriteGuard, RawRwLock, RwLock};
 use reth_codecs::Compact;
-use reth_db::models::AccountBeforeTx;
+use reth_db::{models::AccountBeforeTx, set_fail_point};
 use reth_db_api::models::CompactU256;
 use reth_nippy_jar::{NippyJar, NippyJarError, NippyJarWriter};
 use reth_node_types::NodePrimitives;
@@ -120,6 +120,7 @@ impl<N: NodePrimitives> StaticFileWriters<N> {
             }
         }
 
+        set_fail_point!("static_file::after_commit");
         debug!(target: "provider::static_file", "Committed all static file segments");
         Ok(())
     }
@@ -352,6 +353,7 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
                 "Committed writer to disk"
             );
 
+            set_fail_point!("static_file::segment::after_commit");
             self.update_index()?;
         }
 

--- a/docs/vocs/docs/pages/jsonrpc/debug.mdx
+++ b/docs/vocs/docs/pages/jsonrpc/debug.mdx
@@ -154,3 +154,51 @@ Returns the storage at the given block height and transaction index. The result 
 | Client | Method invocation                                                                                 |
 | ------ | ------------------------------------------------------------------------------------------------- |
 | RPC    | `{"method": "debug_storageRangeAt", "params": [block_hash, tx_index, address, key_start, limit]}` |
+
+## `debug_setFailpoint`
+
+Sets a failpoint with the given name and action for runtime fault injection. This method is useful for testing crash recovery and consistency mechanisms.
+
+> **Note**
+>
+> This RPC method is only available when reth is built with the `failpoints` feature enabled.
+
+**Parameters:**
+
+- `name` (string): The name of the failpoint to set (e.g., `"provider::commit::after_rocksdb"`)
+- `actions` (string): The action to perform when the failpoint is triggered. Common actions include:
+  - `"off"`: Disable the failpoint
+  - `"return"`: Return early from the function
+  - `"panic"`: Trigger a panic
+  - `"sleep(ms)"`: Sleep for the specified milliseconds
+  - `"print"`: Print a message
+  - Actions can be prefixed with a probability, e.g., `"50%panic"` for 50% chance to panic
+
+**Available Failpoints:**
+
+| Failpoint Name | Description |
+| -------------- | ----------- |
+| `provider::commit::after_mdbx` | After MDBX transaction commit (normal path) |
+| `provider::commit::after_rocksdb` | After RocksDB batches commit (normal path) |
+| `provider::commit::after_static_files` | After static files commit (normal path) |
+| `provider::commit::after_mdbx_unwind` | After MDBX transaction commit (unwind path) |
+| `provider::commit::after_rocksdb_unwind` | After RocksDB batches commit (unwind path) |
+| `provider::commit::after_static_files_unwind` | After static files commit (unwind path) |
+| `rocksdb::batch::after_commit` | After RocksDB batch commit |
+| `rocksdb::tx::after_commit` | After RocksDB transaction commit |
+| `static_file::after_commit` | After all static file segments commit |
+| `static_file::segment::after_commit` | After a single static file segment commit |
+
+| Client | Method invocation                                                    |
+| ------ | -------------------------------------------------------------------- |
+| RPC    | `{"method": "debug_setFailpoint", "params": ["failpoint_name", "action"]}` |
+
+**Example:**
+
+```bash
+# Enable a failpoint that will panic
+cast rpc debug_setFailpoint "provider::commit::after_rocksdb" "panic"
+
+# Disable a failpoint
+cast rpc debug_setFailpoint "provider::commit::after_rocksdb" "off"
+```


### PR DESCRIPTION
## Summary

This PR introduces runtime fault injection support via the `fail` crate, enabling crash recovery testing for reth's multi-storage architecture. Since reth now uses multiple storage backends (MDBX, RocksDB, and Static Files) without cross-system atomic transactions, this feature allows testing and validating the consistency recovery mechanisms when crashes occur between storage system commits.

## Motivation

Reth's storage layer has evolved to use three different storage systems:
- **MDBX**: Primary database for state data (transactional)
- **RocksDB**: Used for history indices (https://github.com/paradigmxyz/reth/issues/19942)
- **Static Files**: Immutable historical data

While MDBX provides block-level transactionality internally, the overall commit process involves multiple independent storage systems that cannot be atomically committed together. This breaks the traditional single-database transactional guarantees and requires careful recovery logic to handle partial commits.

Inspired by [Aptos's failpoint implementation](https://github.com/aptos-labs/aptos-core), this PR adds failpoint support to test these critical consistency boundaries.

## Changes

### New Feature: `failpoints`

A new optional feature `failpoints` that can be enabled at build time:

```bash
cargo build -p reth --features failpoints