### PR TITLE
feat(storage): split static file commit into sync_all and finalize

### DIFF
--- a/crates/storage/errors/src/provider.rs
+++ b/crates/storage/errors/src/provider.rs
@@ -20,6 +20,9 @@ pub enum ProviderError {
     /// Pruning error.
     #[error(transparent)]
     Pruning(#[from] PruneSegmentError),
+    /// Static file writer error.
+    #[error(transparent)]
+    StaticFileWriter(#[from] StaticFileWriterError),
     /// RLP error.
     #[error("{_0}")]
     Rlp(alloy_rlp::Error),
@@ -216,18 +219,21 @@ pub struct RootMismatch {
     pub block_hash: BlockHash,
 }
 
-/// A Static File Write Error.
-#[derive(Debug, thiserror::Error)]
-#[error("{message}")]
-pub struct StaticFileWriterError {
-    /// The error message.
-    pub message: String,
+/// A Static File Writer Error.
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum StaticFileWriterError {
+    /// Cannot call `sync_all` or `finalize` when prune is queued.
+    #[error("cannot call sync_all or finalize when prune is queued, use commit() instead")]
+    FinalizeWithPruneQueued,
+    /// Other error with message.
+    #[error("{0}")]
+    Other(String),
 }
 
 impl StaticFileWriterError {
-    /// Creates a new [`StaticFileWriterError`] with the given message.
+    /// Creates a new [`StaticFileWriterError::Other`] with the given message.
     pub fn new(message: impl Into<String>) -> Self {
-        Self { message: message.into() }
+        Self::Other(message.into())
     }
 }
 /// Consistent database view error.

--- a/crates/storage/nippy-jar/src/writer.rs
+++ b/crates/storage/nippy-jar/src/writer.rs
@@ -347,11 +347,27 @@ impl<H: NippyJarHeader> NippyJarWriter<H> {
 
     /// Commits configuration and offsets to disk. It drains the internal offset list.
     pub fn commit(&mut self) -> Result<(), NippyJarError> {
+        self.sync_all()?;
+        self.finalize()?;
+        Ok(())
+    }
+
+    /// Syncs data and offsets to disk.
+    ///
+    /// This does NOT commit the configuration. Call [`Self::finalize`] after to write the
+    /// configuration and mark the writer as clean.
+    pub fn sync_all(&mut self) -> Result<(), NippyJarError> {
         self.data_file.flush()?;
         self.data_file.get_ref().sync_all()?;
 
         self.commit_offsets()?;
+        Ok(())
+    }
 
+    /// Commits configuration to disk and marks the writer as clean.
+    ///
+    /// Must be called after [`Self::sync_all`] to complete the commit.
+    pub fn finalize(&mut self) -> Result<(), NippyJarError> {
         // Flushes `max_row_size` and total `rows` to disk.
         self.jar.freeze_config()?;
         self.dirty = false;

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -1851,6 +1851,8 @@ pub trait StaticFileWriter {
     fn has_unwind_queued(&self) -> bool;
 
     /// Finalizes all static file writers by committing their configuration to disk.
+    ///
+    /// Returns an error if prune is queued (use [`Self::commit`] instead).
     fn finalize(&self) -> ProviderResult<()>;
 }
 

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -1849,6 +1849,9 @@ pub trait StaticFileWriter {
 
     /// Returns `true` if the static file provider has unwind queued.
     fn has_unwind_queued(&self) -> bool;
+
+    /// Finalizes all static file writers by committing their configuration to disk.
+    fn finalize(&self) -> ProviderResult<()>;
 }
 
 impl<N: NodePrimitives> StaticFileWriter for StaticFileProvider<N> {
@@ -1886,6 +1889,10 @@ impl<N: NodePrimitives> StaticFileWriter for StaticFileProvider<N> {
 
     fn has_unwind_queued(&self) -> bool {
         self.writers.has_unwind_queued()
+    }
+
+    fn finalize(&self) -> ProviderResult<()> {
+        self.writers.finalize()
     }
 }
 

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -330,9 +330,7 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
     /// Returns an error if prune is queued (use [`Self::commit`] instead).
     pub fn sync_all(&mut self) -> ProviderResult<()> {
         if self.prune_on_commit.is_some() {
-            return Err(ProviderError::other(StaticFileWriterError::new(
-                "Cannot call sync_all when prune is queued, use commit() instead",
-            )));
+            return Err(StaticFileWriterError::FinalizeWithPruneQueued.into());
         }
         if self.writer.is_dirty() {
             self.writer.sync_all().map_err(ProviderError::other)?;
@@ -347,9 +345,7 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
     /// Returns an error if prune is queued (use [`Self::commit`] instead).
     pub fn finalize(&mut self) -> ProviderResult<()> {
         if self.prune_on_commit.is_some() {
-            return Err(ProviderError::other(StaticFileWriterError::new(
-                "Cannot call finalize when prune is queued, use commit() instead",
-            )));
+            return Err(StaticFileWriterError::FinalizeWithPruneQueued.into());
         }
         if self.writer.is_dirty() {
             self.writer.finalize().map_err(ProviderError::other)?;


### PR DESCRIPTION
Currently, committing static files performs three sequential operations (per segment):
1. fsync data file
2. write pending offsets to disk + fsync offset file
3. write pending configuration + fsync config file + fsync dir

--

This PR splits sf writers `commit()` into:
- `sync_all()` - performs (1) and (2): syncs data and offsets to disk
- `finalize()` - performs (3): writes configuration and marks writer clean

When parallelizing writes in the future, only `finalize()` needs to be sequential across all storage types. `sync_all()` can be run in parallel. 

This only applies to appending data, and not unwinding (eg. we don't want to erase data, before we know that `db.commit` has succeeded)
