### PR TITLE
fix(trie): account for flags in sorted is_empty()

### DIFF
--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -673,9 +673,9 @@ impl HashedStorageSorted {
         self.storage_slots.len()
     }
 
-    /// Returns `true` if there are no storage slot updates.
+    /// Returns `true` if there are no storage slot updates and storage was not wiped.
     pub const fn is_empty(&self) -> bool {
-        self.storage_slots.is_empty()
+        !self.wiped && self.storage_slots.is_empty()
     }
 
     /// Extends the storage slots updates with another set of sorted updates.

--- a/crates/trie/common/src/updates.rs
+++ b/crates/trie/common/src/updates.rs
@@ -681,9 +681,9 @@ impl StorageTrieUpdatesSorted {
         self.storage_nodes.len()
     }
 
-    /// Returns `true` if there are no storage node updates.
+    /// Returns `true` if there are no storage node updates and trie was not deleted.
     pub const fn is_empty(&self) -> bool {
-        self.storage_nodes.is_empty()
+        !self.is_deleted && self.storage_nodes.is_empty()
     }
 
     /// Extends the storage trie updates with another set of sorted updates.


### PR DESCRIPTION
Follow-up to #20801