### PR TITLE
chore(test): use `reth_optimism_chainspec::BASE_SEPOLIA` in tests

### DIFF
--- a/crates/optimism/node/src/engine.rs
+++ b/crates/optimism/node/src/engine.rs
@@ -393,8 +393,10 @@ mod test {
 
     #[test]
     fn test_well_formed_attributes_holocene_eip1559_params_zero_elasticity() {
-        let validator =
-            OpEngineValidator::new::<KeccakKeyHasher>(BASE_SEPOLIA.clone(), NoopProvider::default());
+        let validator = OpEngineValidator::new::<KeccakKeyHasher>(
+            BASE_SEPOLIA.clone(),
+            NoopProvider::default(),
+        );
         let attributes = get_attributes(Some(b64!("0000000800000000")), None, 1732633200);
 
         let result = <engine::OpEngineValidator<_, _, _> as EngineApiValidator<

--- a/crates/optimism/node/src/engine.rs
+++ b/crates/optimism/node/src/engine.rs
@@ -306,8 +306,7 @@ mod test {
     use alloy_op_hardforks::BASE_SEPOLIA_JOVIAN_TIMESTAMP;
     use alloy_primitives::{b64, Address, B256, B64};
     use alloy_rpc_types_engine::PayloadAttributes;
-    use reth_chainspec::ChainSpec;
-    use reth_optimism_chainspec::{OpChainSpec, BASE_SEPOLIA};
+    use reth_optimism_chainspec::BASE_SEPOLIA;
     use reth_provider::noop::NoopProvider;
     use reth_trie_common::KeccakKeyHasher;
 
@@ -321,24 +320,6 @@ mod test {
                 other => panic!("expected InvalidParams, got {other:?}"),
             }
         }};
-    }
-
-    fn get_chainspec() -> Arc<OpChainSpec> {
-        let base_sepolia_spec = BASE_SEPOLIA.inner.clone();
-
-        Arc::new(OpChainSpec {
-            inner: ChainSpec {
-                chain: base_sepolia_spec.chain,
-                genesis: base_sepolia_spec.genesis,
-                genesis_header: base_sepolia_spec.genesis_header,
-                paris_block_and_final_difficulty: base_sepolia_spec
-                    .paris_block_and_final_difficulty,
-                hardforks: base_sepolia_spec.hardforks,
-                base_fee_params: base_sepolia_spec.base_fee_params,
-                prune_delete_limit: 10000,
-                ..Default::default()
-            },
-        })
     }
 
     const fn get_attributes(
@@ -364,8 +345,10 @@ mod test {
 
     #[test]
     fn test_well_formed_attributes_pre_holocene() {
-        let validator =
-            OpEngineValidator::new::<KeccakKeyHasher>(get_chainspec(), NoopProvider::default());
+        let validator = OpEngineValidator::new::<KeccakKeyHasher>(
+            BASE_SEPOLIA.clone(),
+            NoopProvider::default(),
+        );
         let attributes = get_attributes(None, None, 1732633199);
 
         let result = <engine::OpEngineValidator<_, _, _> as EngineApiValidator<
@@ -378,8 +361,10 @@ mod test {
 
     #[test]
     fn test_well_formed_attributes_holocene_no_eip1559_params() {
-        let validator =
-            OpEngineValidator::new::<KeccakKeyHasher>(get_chainspec(), NoopProvider::default());
+        let validator = OpEngineValidator::new::<KeccakKeyHasher>(
+            BASE_SEPOLIA.clone(),
+            NoopProvider::default(),
+        );
         let attributes = get_attributes(None, None, 1732633200);
 
         let result = <engine::OpEngineValidator<_, _, _> as EngineApiValidator<
@@ -392,8 +377,10 @@ mod test {
 
     #[test]
     fn test_well_formed_attributes_holocene_eip1559_params_zero_denominator() {
-        let validator =
-            OpEngineValidator::new::<KeccakKeyHasher>(get_chainspec(), NoopProvider::default());
+        let validator = OpEngineValidator::new::<KeccakKeyHasher>(
+            BASE_SEPOLIA.clone(),
+            NoopProvider::default(),
+        );
         let attributes = get_attributes(Some(b64!("0000000000000008")), None, 1732633200);
 
         let result = <engine::OpEngineValidator<_, _, _> as EngineApiValidator<
@@ -407,7 +394,7 @@ mod test {
     #[test]
     fn test_well_formed_attributes_holocene_eip1559_params_zero_elasticity() {
         let validator =
-            OpEngineValidator::new::<KeccakKeyHasher>(get_chainspec(), NoopProvider::default());
+            OpEngineValidator::new::<KeccakKeyHasher>(BASE_SEPOLIA.clone(), NoopProvider::default());
         let attributes = get_attributes(Some(b64!("0000000800000000")), None, 1732633200);
 
         let result = <engine::OpEngineValidator<_, _, _> as EngineApiValidator<
@@ -420,8 +407,10 @@ mod test {
 
     #[test]
     fn test_well_formed_attributes_holocene_valid() {
-        let validator =
-            OpEngineValidator::new::<KeccakKeyHasher>(get_chainspec(), NoopProvider::default());
+        let validator = OpEngineValidator::new::<KeccakKeyHasher>(
+            BASE_SEPOLIA.clone(),
+            NoopProvider::default(),
+        );
         let attributes = get_attributes(Some(b64!("0000000800000008")), None, 1732633200);
 
         let result = <engine::OpEngineValidator<_, _, _> as EngineApiValidator<
@@ -434,8 +423,10 @@ mod test {
 
     #[test]
     fn test_well_formed_attributes_holocene_valid_all_zero() {
-        let validator =
-            OpEngineValidator::new::<KeccakKeyHasher>(get_chainspec(), NoopProvider::default());
+        let validator = OpEngineValidator::new::<KeccakKeyHasher>(
+            BASE_SEPOLIA.clone(),
+            NoopProvider::default(),
+        );
         let attributes = get_attributes(Some(b64!("0000000000000000")), None, 1732633200);
 
         let result = <engine::OpEngineValidator<_, _, _> as EngineApiValidator<
@@ -448,8 +439,10 @@ mod test {
 
     #[test]
     fn test_well_formed_attributes_jovian_valid() {
-        let validator =
-            OpEngineValidator::new::<KeccakKeyHasher>(get_chainspec(), NoopProvider::default());
+        let validator = OpEngineValidator::new::<KeccakKeyHasher>(
+            BASE_SEPOLIA.clone(),
+            NoopProvider::default(),
+        );
         let attributes =
             get_attributes(Some(b64!("0000000000000000")), Some(1), BASE_SEPOLIA_JOVIAN_TIMESTAMP);
 
@@ -464,8 +457,10 @@ mod test {
     /// After Jovian (and holocene), eip1559 params must be Some
     #[test]
     fn test_malformed_attributes_jovian_with_eip_1559_params_none() {
-        let validator =
-            OpEngineValidator::new::<KeccakKeyHasher>(get_chainspec(), NoopProvider::default());
+        let validator = OpEngineValidator::new::<KeccakKeyHasher>(
+            BASE_SEPOLIA.clone(),
+            NoopProvider::default(),
+        );
         let attributes = get_attributes(None, Some(1), BASE_SEPOLIA_JOVIAN_TIMESTAMP);
 
         let result = <engine::OpEngineValidator<_, _, _> as EngineApiValidator<
@@ -479,8 +474,10 @@ mod test {
     /// Before Jovian, min base fee must be None
     #[test]
     fn test_malformed_attributes_pre_jovian_with_min_base_fee() {
-        let validator =
-            OpEngineValidator::new::<KeccakKeyHasher>(get_chainspec(), NoopProvider::default());
+        let validator = OpEngineValidator::new::<KeccakKeyHasher>(
+            BASE_SEPOLIA.clone(),
+            NoopProvider::default(),
+        );
         let attributes = get_attributes(Some(b64!("0000000000000000")), Some(1), 1732633200);
 
         let result = <engine::OpEngineValidator<_, _, _> as EngineApiValidator<
@@ -494,8 +491,10 @@ mod test {
     /// After Jovian, min base fee must be Some
     #[test]
     fn test_malformed_attributes_post_jovian_with_min_base_fee_none() {
-        let validator =
-            OpEngineValidator::new::<KeccakKeyHasher>(get_chainspec(), NoopProvider::default());
+        let validator = OpEngineValidator::new::<KeccakKeyHasher>(
+            BASE_SEPOLIA.clone(),
+            NoopProvider::default(),
+        );
         let attributes =
             get_attributes(Some(b64!("0000000000000000")), None, BASE_SEPOLIA_JOVIAN_TIMESTAMP);
 


### PR DESCRIPTION
Update to use `reth_optimism_chainspec::BASE_SEPOLIA` in engine tests, now that the jovian timestamp is known

Upstreams https://github.com/op-rs/op-reth/pull/505