### PR TITLE
fix(bin): remove unknown clippy lint

### DIFF
--- a/bin/reth-bench/src/bench/new_payload_fcu.rs
+++ b/bin/reth-bench/src/bench/new_payload_fcu.rs
@@ -470,7 +470,6 @@ impl PersistenceWaiter {
     }
 
     /// Called once per block. Waits based on the configured mode.
-    #[allow(clippy::manual_is_multiple_of)]
     async fn on_block(&mut self, block_number: u64) -> eyre::Result<()> {
         if let Some(wait_time) = self.wait_time {
             tokio::time::sleep(wait_time).await;


### PR DESCRIPTION
Removed an #[allow(clippy::manual_is_multiple_of)] attribute that no longer exists in the current Clippy version. Keeping this attribute was causing unknown_lints warnings without providing any benefit.

```
warning: unknown lint: clippy::manual_is_multiple_of 
   --> bin/reth-bench/src/bench/new_payload_fcu.rs:473:13
    |
473 |     #[allow(clippy::manual_is_multiple_of)]
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: did you mean: clippy::manual_is_finite 
    |
    = note: #[warn(unknown_lints)] on by default

warning: reth-network (lib test) generated 2 warnings (2 duplicates)
```