### PR TITLE
fix: propagate edge feature to reth-node-core for version output

### DIFF
--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -176,7 +176,7 @@ min-trace-logs = [
     "reth-node-core/min-trace-logs",
 ]
 
-edge = ["reth-ethereum-cli/edge"]
+edge = ["reth-ethereum-cli/edge", "reth-node-core/edge"]
 
 [[bin]]
 name = "reth"

--- a/crates/node/core/Cargo.toml
+++ b/crates/node/core/Cargo.toml
@@ -90,6 +90,9 @@ min-info-logs = ["tracing/release_max_level_info"]
 min-debug-logs = ["tracing/release_max_level_debug"]
 min-trace-logs = ["tracing/release_max_level_trace"]
 
+# Marker feature for edge/unstable builds - captured by vergen in build.rs
+edge = []
+
 [build-dependencies]
 vergen = { workspace = true, features = ["build", "cargo", "emit_and_set"] }
 vergen-git2.workspace = true

--- a/crates/optimism/cli/Cargo.toml
+++ b/crates/optimism/cli/Cargo.toml
@@ -117,4 +117,4 @@ serde = [
     "reth-optimism-chainspec/serde",
 ]
 
-edge = ["reth-cli-commands/edge"]
+edge = ["reth-cli-commands/edge", "reth-node-core/edge"]


### PR DESCRIPTION
## Summary

The `edge` feature was not appearing in `reth --version` output because `reth-node-core` (where `build.rs` generates version info via vergen) was not receiving the edge feature flag.

When running:
```
docker run --rm ghcr.io/paradigmxyz/reth:nightly-edge-profiling --version
```

The "Build Features" line should include `edge`, but currently it doesn't because the feature is not propagated to `reth-node-core`.

## Changes

1. Added `edge = []` marker feature to `reth-node-core/Cargo.toml`
2. Updated `bin/reth/Cargo.toml` to forward `edge` to `reth-node-core`
3. Updated `reth-optimism-cli/Cargo.toml` to forward `edge` to `reth-node-core`

Now `VERGEN_CARGO_FEATURES` will include 'edge' when building with `--features edge`, making it visible in the Build Features line of `reth --version` output.

## Related

Follow-up to #20841 which introduced the `edge` feature flag.