### PR TITLE
refactor(fs-util): use create_file wrapper in atomic_write_file

### DIFF
--- a/crates/fs-util/src/lib.rs
+++ b/crates/fs-util/src/lib.rs
@@ -326,8 +326,7 @@ where
     tmp_path.set_extension("tmp");
 
     // Write to the temporary file
-    let mut file =
-        File::create(&tmp_path).map_err(|err| FsPathError::create_file(err, &tmp_path))?;
+    let mut file = create_file(&tmp_path)?;
 
     // Execute the write function and handle errors properly
     // If write_fn fails, we need to clean up the temporary file before returning


### PR DESCRIPTION
Removes code duplication in `atomic_write_file` by using the existing `create_file` wrapper instead of manually creating a file with error handling.
The `create_file` wrapper already provides the same functionality (creating a file with proper error context), so duplicating this logic inline violates DRY principles and creates a maintenance risk. Using the wrapper ensures consistency and reduces the chance of divergence if error handling logic changes in the future.

