### PR TITLE
fix: use POSIX-compliant IO redirection in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -453,7 +453,7 @@ lint-typos: ensure-typos
 	typos
 
 ensure-typos:
-	@if ! command -v typos &> /dev/null; then \
+	@if ! command -v typos > /dev/null 2>&1; then \
 		echo "typos not found. Please install it by running the command 'cargo install typos-cli' or refer to the following link for more information: https://github.com/crate-ci/typos"; \
 		exit 1; \
     fi
@@ -472,7 +472,7 @@ lint-toml: ensure-dprint
 	dprint fmt
 
 ensure-dprint:
-	@if ! command -v dprint &> /dev/null; then \
+	@if ! command -v dprint > /dev/null 2>&1; then \
 		echo "dprint not found. Please install it by running the command 'cargo install --locked dprint' or refer to the following link for more information: https://github.com/dprint/dprint"; \
 		exit 1; \
     fi


### PR DESCRIPTION
## Summary
- Replace `&>` with `> /dev/null 2>&1` in `ensure-typos` and `ensure-dprint` targets
- The `&>` operator is bash-specific and fails in sh/dash shells that make typically uses
- This caused command detection to incorrectly report tools as not installed even when available in PATH

Closes #20912

## Test plan
- Verified `make ensure-typos` works correctly when typos is installed
- Verified `make ensure-dprint` works correctly when dprint is installed
- Confirmed the POSIX-compliant syntax works with /bin/sh