### PR TITLE
perf(trie): batch load hashed storage entries to reduce database seeks (experiment)

### DIFF
--- a/crates/trie/db/src/lib.rs
+++ b/crates/trie/db/src/lib.rs
@@ -11,7 +11,8 @@ mod trie_cursor;
 mod witness;
 
 pub use hashed_cursor::{
-    DatabaseHashedAccountCursor, DatabaseHashedCursorFactory, DatabaseHashedStorageCursor,
+    CachedHashedCursorFactory, CachedHashedStorageCursor, DatabaseHashedAccountCursor,
+    DatabaseHashedCursorFactory, DatabaseHashedStorageCursor,
 };
 pub use prefix_set::{load_prefix_sets_with_provider, PrefixSetLoader};
 pub use proof::{DatabaseProof, DatabaseStorageProof};


### PR DESCRIPTION
Implements batch loading optimization for hashed storage cursors during trie calculations. Instead of performing expensive individual database seeks for each storage slot, this change preloads storage entries into memory using sequential reads.

## Problem

MDBX profiling over 45 minutes (223 blocks) revealed that `HashedStorages` table operations are a significant bottleneck:

| Metric | Value |
|--------|-------|
| Total operations | 11.5M (29.8% of all DB ops) |
| Page faults | 1.4M (14.8% of total) |
| Time lost to slow ops | **507 seconds** |
| Random access ratio | 86.9% |

The key insight from profiling cursor operations:

| Operation | Count | Avg Latency |
|-----------|-------|-------------|
| `GET_BOTH_RANGE` (seek) | 10.7M | **99μs** |
| `NEXT_DUP` (sequential) | 2.6M | **12.5μs** |

Sequential reads are **~8x faster** than seeks. During storage root calculation, each storage slot access triggers an expensive seek operation.

## Solution

Introduced `CachedHashedStorageCursor` that:

1. **Preloads** all storage entries for an account using a single `walk_dup()` call (1 seek + N-1 sequential reads)
2. **Serves subsequent operations from memory**:
   - `seek()` → Binary search O(log n) instead of DB seek
   - `next()` → Array indexing O(1) instead of DB cursor

### Memory Safety

To prevent memory issues with large contracts (e.g., USDT with millions of storage slots):
- Cache limited to **10,000 entries** per account (~640KB max)
- Contracts exceeding this limit fall back to direct database seeks
- Covers 99%+ of contracts modified in typical blocks

## Changes

- **`crates/trie/db/src/hashed_cursor.rs`**: Added `CachedHashedStorageCursor` and `CachedHashedCursorFactory`
- **`crates/storage/provider/src/providers/state/overlay.rs`**: Use cached cursor factory in `OverlayStateProvider`
- **`crates/trie/db/tests/post_state.rs`**: Added unit tests for cached cursor

## Tracing

Added trace-level logging to monitor cache effectiveness:
```
RUST_LOG=trie::cache=trace reth node ...