### PR TITLE
perf(cli): use available_parallelism as default for re-execute

### DIFF
--- a/crates/cli/commands/src/re_execute.rs
+++ b/crates/cli/commands/src/re_execute.rs
@@ -42,9 +42,9 @@ pub struct Command<C: ChainSpecParser> {
     #[arg(long)]
     to: Option<u64>,
 
-    /// Number of tasks to run in parallel
-    #[arg(long, default_value = "10")]
-    num_tasks: u64,
+    /// Number of tasks to run in parallel. Defaults to the number of available CPUs.
+    #[arg(long)]
+    num_tasks: Option<u64>,
 
     /// Continues with execution when an invalid block is encountered and collects these blocks.
     #[arg(long)]
@@ -84,12 +84,16 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
             }
         };
 
+        let num_tasks = self.num_tasks.unwrap_or_else(|| {
+            std::thread::available_parallelism().map(|n| n.get() as u64).unwrap_or(10)
+        });
+
         let total_blocks = max_block - min_block;
         let total_gas = calculate_gas_used_from_headers(
             &provider_factory.static_file_provider(),
             min_block..=max_block,
         )?;
-        let blocks_per_task = total_blocks / self.num_tasks;
+        let blocks_per_task = total_blocks / num_tasks;
 
         let db_at = {
             let provider_factory = provider_factory.clone();
@@ -107,10 +111,10 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
         let _guard = cancellation.drop_guard();
 
         let mut tasks = JoinSet::new();
-        for i in 0..self.num_tasks {
+        for i in 0..num_tasks {
             let start_block = min_block + i * blocks_per_task;
             let end_block =
-                if i == self.num_tasks - 1 { max_block } else { start_block + blocks_per_task };
+                if i == num_tasks - 1 { max_block } else { start_block + blocks_per_task };
 
             // Spawn thread executing blocks
             let provider_factory = provider_factory.clone();

--- a/docs/vocs/docs/pages/cli/op-reth/re-execute.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/re-execute.mdx
@@ -138,9 +138,7 @@ Static Files:
           The height to end at. Defaults to the latest block
 
       --num-tasks <NUM_TASKS>
-          Number of tasks to run in parallel
-
-          [default: 10]
+          Number of tasks to run in parallel. Defaults to the number of available CPUs
 
       --skip-invalid-blocks
           Continues with execution when an invalid block is encountered and collects these blocks

--- a/docs/vocs/docs/pages/cli/reth/re-execute.mdx
+++ b/docs/vocs/docs/pages/cli/reth/re-execute.mdx
@@ -138,9 +138,7 @@ Static Files:
           The height to end at. Defaults to the latest block
 
       --num-tasks <NUM_TASKS>
-          Number of tasks to run in parallel
-
-          [default: 10]
+          Number of tasks to run in parallel. Defaults to the number of available CPUs
 
       --skip-invalid-blocks
           Continues with execution when an invalid block is encountered and collects these blocks


### PR DESCRIPTION
The re-execute command now automatically detects and uses the number of available CPU cores as the default for num-tasks, replacing the hardcoded default of 10.

This allows the command to better utilize multi-core systems without requiring manual configuration. On a 12-core system, this provides an immediate 20% increase in parallelism compared to the previous default.

The implementation falls back to 10 if CPU detection fails, and users can still override with --num-tasks if needed.