### PR TITLE
feat: enable account changesets on `save_blocks`

### DIFF
--- a/crates/optimism/cli/src/commands/import_receipts.rs
+++ b/crates/optimism/cli/src/commands/import_receipts.rs
@@ -18,7 +18,7 @@ use reth_optimism_primitives::{bedrock::is_dup_tx, OpPrimitives, OpReceipt};
 use reth_primitives_traits::NodePrimitives;
 use reth_provider::{
     providers::ProviderNodeTypes, DBProvider, DatabaseProviderFactory, OriginalValuesKnown,
-    ProviderFactory, StageCheckpointReader, StageCheckpointWriter, StateWriter,
+    ProviderFactory, StageCheckpointReader, StageCheckpointWriter, StateWriteConfig, StateWriter,
     StaticFileProviderFactory, StatsReader,
 };
 use reth_stages::{StageCheckpoint, StageId};
@@ -228,7 +228,11 @@ where
             ExecutionOutcome::new(Default::default(), receipts, first_block, Default::default());
 
         // finally, write the receipts
-        provider.write_state(&execution_outcome, OriginalValuesKnown::Yes, true)?;
+        provider.write_state(
+            &execution_outcome,
+            OriginalValuesKnown::Yes,
+            StateWriteConfig::default(),
+        )?;
     }
 
     // Only commit if we have imported as many receipts as the number of transactions.

--- a/crates/stages/stages/src/stages/execution.rs
+++ b/crates/stages/stages/src/stages/execution.rs
@@ -12,7 +12,7 @@ use reth_primitives_traits::{format_gas_throughput, BlockBody, NodePrimitives};
 use reth_provider::{
     providers::{StaticFileProvider, StaticFileWriter},
     BlockHashReader, BlockReader, DBProvider, EitherWriter, ExecutionOutcome, HeaderProvider,
-    LatestStateProviderRef, OriginalValuesKnown, ProviderError, StateWriter,
+    LatestStateProviderRef, OriginalValuesKnown, ProviderError, StateWriteConfig, StateWriter,
     StaticFileProviderFactory, StatsReader, StorageSettingsCache, TransactionVariant,
 };
 use reth_revm::database::StateProviderDatabase;
@@ -463,7 +463,7 @@ where
         }
 
         // write output
-        provider.write_state(&state, OriginalValuesKnown::Yes, true)?;
+        provider.write_state(&state, OriginalValuesKnown::Yes, StateWriteConfig::default())?;
 
         let db_write_duration = time.elapsed();
         debug!(

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -16,8 +16,8 @@ use reth_provider::{
     errors::provider::ProviderResult, providers::StaticFileWriter, BlockHashReader, BlockNumReader,
     BundleStateInit, ChainSpecProvider, DBProvider, DatabaseProviderFactory, ExecutionOutcome,
     HashingWriter, HeaderProvider, HistoryWriter, MetadataWriter, OriginalValuesKnown,
-    ProviderError, RevertsInit, StageCheckpointReader, StageCheckpointWriter, StateWriter,
-    StaticFileProviderFactory, StorageSettings, StorageSettingsCache, TrieWriter,
+    ProviderError, RevertsInit, StageCheckpointReader, StageCheckpointWriter, StateWriteConfig,
+    StateWriter, StaticFileProviderFactory, StorageSettings, StorageSettingsCache, TrieWriter,
 };
 use reth_stages_types::{StageCheckpoint, StageId};
 use reth_static_file_types::StaticFileSegment;
@@ -334,7 +334,11 @@ where
         Vec::new(),
     );
 
-    provider.write_state(&execution_outcome, OriginalValuesKnown::Yes, true)?;
+    provider.write_state(
+        &execution_outcome,
+        OriginalValuesKnown::Yes,
+        StateWriteConfig::default(),
+    )?;
 
     trace!(target: "reth::cli", "Inserted state");
 

--- a/crates/storage/provider/src/lib.rs
+++ b/crates/storage/provider/src/lib.rs
@@ -45,8 +45,8 @@ pub use revm_database::states::OriginalValuesKnown;
 // reexport traits to avoid breaking changes
 pub use reth_static_file_types as static_file;
 pub use reth_storage_api::{
-    HistoryWriter, MetadataProvider, MetadataWriter, StatsReader, StorageSettings,
-    StorageSettingsCache,
+    HistoryWriter, MetadataProvider, MetadataWriter, StateWriteConfig, StatsReader,
+    StorageSettings, StorageSettingsCache,
 };
 /// Re-export provider error.
 pub use reth_storage_errors::provider::{ProviderError, ProviderResult};

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -808,8 +808,8 @@ mod tests {
     use reth_storage_api::{
         BlockBodyIndicesProvider, BlockHashReader, BlockIdReader, BlockNumReader, BlockReader,
         BlockReaderIdExt, BlockSource, ChangeSetReader, DBProvider, DatabaseProviderFactory,
-        HeaderProvider, ReceiptProvider, ReceiptProviderIdExt, StateProviderFactory, StateWriter,
-        TransactionVariant, TransactionsProvider,
+        HeaderProvider, ReceiptProvider, ReceiptProviderIdExt, StateProviderFactory,
+        StateWriteConfig, StateWriter, TransactionVariant, TransactionsProvider,
     };
     use reth_testing_utils::generators::{
         self, random_block, random_block_range, random_changeset_range, random_eoa_accounts,
@@ -907,7 +907,7 @@ mod tests {
                     ..Default::default()
                 },
                 OriginalValuesKnown::No,
-                true,
+                StateWriteConfig::default(),
             )?;
         }
 

--- a/crates/storage/provider/src/providers/database/metrics.rs
+++ b/crates/storage/provider/src/providers/database/metrics.rs
@@ -40,16 +40,8 @@ pub(crate) enum Action {
     InsertHeaderNumbers,
     InsertBlockBodyIndices,
     InsertTransactionBlocks,
-    GetNextTxNum,
     InsertTransactionSenders,
     InsertTransactionHashNumbers,
-    SaveBlocksInsertBlock,
-    SaveBlocksWriteState,
-    SaveBlocksWriteHashedState,
-    SaveBlocksWriteTrieChangesets,
-    SaveBlocksWriteTrieUpdates,
-    SaveBlocksUpdateHistoryIndices,
-    SaveBlocksUpdatePipelineStages,
 }
 
 /// Database provider metrics
@@ -66,19 +58,24 @@ pub(crate) struct DatabaseProviderMetrics {
     insert_history_indices: Histogram,
     /// Duration of update pipeline stages
     update_pipeline_stages: Histogram,
-    /// Duration of insert canonical headers
     /// Duration of insert header numbers
     insert_header_numbers: Histogram,
     /// Duration of insert block body indices
     insert_block_body_indices: Histogram,
     /// Duration of insert transaction blocks
     insert_tx_blocks: Histogram,
-    /// Duration of get next tx num
-    get_next_tx_num: Histogram,
     /// Duration of insert transaction senders
     insert_transaction_senders: Histogram,
     /// Duration of insert transaction hash numbers
     insert_transaction_hash_numbers: Histogram,
+    /// Duration of `save_blocks`
+    save_blocks_total: Histogram,
+    /// Duration of MDBX work in `save_blocks`
+    save_blocks_mdbx: Histogram,
+    /// Duration of static file work in `save_blocks`
+    save_blocks_sf: Histogram,
+    /// Duration of `RocksDB` work in `save_blocks`
+    save_blocks_rocksdb: Histogram,
     /// Duration of `insert_block` in `save_blocks`
     save_blocks_insert_block: Histogram,
     /// Duration of `write_state` in `save_blocks`
@@ -93,6 +90,39 @@ pub(crate) struct DatabaseProviderMetrics {
     save_blocks_update_history_indices: Histogram,
     /// Duration of `update_pipeline_stages` in `save_blocks`
     save_blocks_update_pipeline_stages: Histogram,
+    /// Number of blocks per `save_blocks` call
+    save_blocks_block_count: Histogram,
+    /// Duration of MDBX commit in `save_blocks`
+    save_blocks_commit_mdbx: Histogram,
+    /// Duration of static file commit in `save_blocks`
+    save_blocks_commit_sf: Histogram,
+    /// Duration of `RocksDB` commit in `save_blocks`
+    save_blocks_commit_rocksdb: Histogram,
+}
+
+/// Timings collected during a `save_blocks` call.
+#[derive(Debug, Default)]
+pub(crate) struct SaveBlocksTimings {
+    pub total: Duration,
+    pub mdbx: Duration,
+    pub sf: Duration,
+    pub rocksdb: Duration,
+    pub insert_block: Duration,
+    pub write_state: Duration,
+    pub write_hashed_state: Duration,
+    pub write_trie_changesets: Duration,
+    pub write_trie_updates: Duration,
+    pub update_history_indices: Duration,
+    pub update_pipeline_stages: Duration,
+    pub block_count: u64,
+}
+
+/// Timings collected during a `commit` call.
+#[derive(Debug, Default)]
+pub(crate) struct CommitTimings {
+    pub mdbx: Duration,
+    pub sf: Duration,
+    pub rocksdb: Duration,
 }
 
 impl DatabaseProviderMetrics {
@@ -107,28 +137,33 @@ impl DatabaseProviderMetrics {
             Action::InsertHeaderNumbers => self.insert_header_numbers.record(duration),
             Action::InsertBlockBodyIndices => self.insert_block_body_indices.record(duration),
             Action::InsertTransactionBlocks => self.insert_tx_blocks.record(duration),
-            Action::GetNextTxNum => self.get_next_tx_num.record(duration),
             Action::InsertTransactionSenders => self.insert_transaction_senders.record(duration),
             Action::InsertTransactionHashNumbers => {
                 self.insert_transaction_hash_numbers.record(duration)
             }
-            Action::SaveBlocksInsertBlock => self.save_blocks_insert_block.record(duration),
-            Action::SaveBlocksWriteState => self.save_blocks_write_state.record(duration),
-            Action::SaveBlocksWriteHashedState => {
-                self.save_blocks_write_hashed_state.record(duration)
-            }
-            Action::SaveBlocksWriteTrieChangesets => {
-                self.save_blocks_write_trie_changesets.record(duration)
-            }
-            Action::SaveBlocksWriteTrieUpdates => {
-                self.save_blocks_write_trie_updates.record(duration)
-            }
-            Action::SaveBlocksUpdateHistoryIndices => {
-                self.save_blocks_update_history_indices.record(duration)
-            }
-            Action::SaveBlocksUpdatePipelineStages => {
-                self.save_blocks_update_pipeline_stages.record(duration)
-            }
         }
+    }
+
+    /// Records all `save_blocks` timings.
+    pub(crate) fn record_save_blocks(&self, timings: &SaveBlocksTimings) {
+        self.save_blocks_total.record(timings.total);
+        self.save_blocks_mdbx.record(timings.mdbx);
+        self.save_blocks_sf.record(timings.sf);
+        self.save_blocks_rocksdb.record(timings.rocksdb);
+        self.save_blocks_insert_block.record(timings.insert_block);
+        self.save_blocks_write_state.record(timings.write_state);
+        self.save_blocks_write_hashed_state.record(timings.write_hashed_state);
+        self.save_blocks_write_trie_changesets.record(timings.write_trie_changesets);
+        self.save_blocks_write_trie_updates.record(timings.write_trie_updates);
+        self.save_blocks_update_history_indices.record(timings.update_history_indices);
+        self.save_blocks_update_pipeline_stages.record(timings.update_pipeline_stages);
+        self.save_blocks_block_count.record(timings.block_count as f64);
+    }
+
+    /// Records all commit timings.
+    pub(crate) fn record_commit(&self, timings: &CommitTimings) {
+        self.save_blocks_commit_mdbx.record(timings.mdbx);
+        self.save_blocks_commit_sf.record(timings.sf);
+        self.save_blocks_commit_rocksdb.record(timings.rocksdb);
     }
 }

--- a/crates/storage/provider/src/writer/mod.rs
+++ b/crates/storage/provider/src/writer/mod.rs
@@ -13,7 +13,9 @@ mod tests {
     use reth_ethereum_primitives::Receipt;
     use reth_execution_types::ExecutionOutcome;
     use reth_primitives_traits::{Account, StorageEntry};
-    use reth_storage_api::{DatabaseProviderFactory, HashedPostStateProvider, StateWriter};
+    use reth_storage_api::{
+        DatabaseProviderFactory, HashedPostStateProvider, StateWriteConfig, StateWriter,
+    };
     use reth_trie::{
         test_utils::{state_root, storage_root_prehashed},
         HashedPostState, HashedStorage, StateRoot, StorageRoot, StorageRootProgress,
@@ -135,7 +137,7 @@ mod tests {
         provider.write_state_changes(plain_state).expect("Could not write plain state to DB");
 
         assert_eq!(reverts.storage, [[]]);
-        provider.write_state_reverts(reverts, 1).expect("Could not write reverts to DB");
+        provider.write_state_reverts(reverts, 1, StateWriteConfig::default()).expect("Could not write reverts to DB");
 
         let reth_account_a = account_a.into();
         let reth_account_b = account_b.into();
@@ -201,7 +203,7 @@ mod tests {
             reverts.storage,
             [[PlainStorageRevert { address: address_b, wiped: true, storage_revert: vec![] }]]
         );
-        provider.write_state_reverts(reverts, 2).expect("Could not write reverts to DB");
+        provider.write_state_reverts(reverts, 2, StateWriteConfig::default()).expect("Could not write reverts to DB");
 
         // Check new plain state for account B
         assert_eq!(
@@ -280,7 +282,7 @@ mod tests {
 
         let outcome = ExecutionOutcome::new(state.take_bundle(), Default::default(), 1, Vec::new());
         provider
-            .write_state(&outcome, OriginalValuesKnown::Yes, true)
+            .write_state(&outcome, OriginalValuesKnown::Yes, StateWriteConfig::default())
             .expect("Could not write bundle state to DB");
 
         // Check plain storage state
@@ -380,7 +382,7 @@ mod tests {
         state.merge_transitions(BundleRetention::Reverts);
         let outcome = ExecutionOutcome::new(state.take_bundle(), Default::default(), 2, Vec::new());
         provider
-            .write_state(&outcome, OriginalValuesKnown::Yes, true)
+            .write_state(&outcome, OriginalValuesKnown::Yes, StateWriteConfig::default())
             .expect("Could not write bundle state to DB");
 
         assert_eq!(
@@ -448,7 +450,7 @@ mod tests {
         let outcome =
             ExecutionOutcome::new(init_state.take_bundle(), Default::default(), 0, Vec::new());
         provider
-            .write_state(&outcome, OriginalValuesKnown::Yes, true)
+            .write_state(&outcome, OriginalValuesKnown::Yes, StateWriteConfig::default())
             .expect("Could not write bundle state to DB");
 
         let mut state = State::builder().with_bundle_update().build();
@@ -607,7 +609,7 @@ mod tests {
         let outcome: ExecutionOutcome =
             ExecutionOutcome::new(bundle, Default::default(), 1, Vec::new());
         provider
-            .write_state(&outcome, OriginalValuesKnown::Yes, true)
+            .write_state(&outcome, OriginalValuesKnown::Yes, StateWriteConfig::default())
             .expect("Could not write bundle state to DB");
 
         let mut storage_changeset_cursor = provider
@@ -773,7 +775,7 @@ mod tests {
         let outcome =
             ExecutionOutcome::new(init_state.take_bundle(), Default::default(), 0, Vec::new());
         provider
-            .write_state(&outcome, OriginalValuesKnown::Yes, true)
+            .write_state(&outcome, OriginalValuesKnown::Yes, StateWriteConfig::default())
             .expect("Could not write bundle state to DB");
 
         let mut state = State::builder().with_bundle_update().build();
@@ -822,7 +824,7 @@ mod tests {
         state.merge_transitions(BundleRetention::Reverts);
         let outcome = ExecutionOutcome::new(state.take_bundle(), Default::default(), 1, Vec::new());
         provider
-            .write_state(&outcome, OriginalValuesKnown::Yes, true)
+            .write_state(&outcome, OriginalValuesKnown::Yes, StateWriteConfig::default())
             .expect("Could not write bundle state to DB");
 
         let mut storage_changeset_cursor = provider

--- a/crates/storage/storage-api/src/state_writer.rs
+++ b/crates/storage/storage-api/src/state_writer.rs
@@ -14,22 +14,24 @@ pub trait StateWriter {
 
     /// Write the state and optionally receipts to the database.
     ///
-    /// If `write_receipts` is false, receipts are skipped (useful when receipts are written
-    /// separately to static files).
+    /// Use `config` to skip writing certain data types when they are written elsewhere.
     fn write_state(
         &self,
         execution_outcome: &ExecutionOutcome<Self::Receipt>,
         is_value_known: OriginalValuesKnown,
-        write_receipts: bool,
+        config: StateWriteConfig,
     ) -> ProviderResult<()>;
 
     /// Write state reverts to the database.
     ///
     /// NOTE: Reverts will delete all wiped storage from plain state.
+    ///
+    /// Use `config` to skip writing certain data types when they are written elsewhere.
     fn write_state_reverts(
         &self,
         reverts: PlainStateReverts,
         first_block: BlockNumber,
+        config: StateWriteConfig,
     ) -> ProviderResult<()>;
 
     /// Write state changes to the database.
@@ -48,4 +50,21 @@ pub trait StateWriter {
         &self,
         block: BlockNumber,
     ) -> ProviderResult<ExecutionOutcome<Self::Receipt>>;
+}
+
+/// Configuration for what to write when calling [`StateWriter::write_state`].
+///
+/// Used to skip writing certain data types, when they are being written separately.
+#[derive(Debug, Clone, Copy)]
+pub struct StateWriteConfig {
+    /// Whether to write receipts.
+    pub write_receipts: bool,
+    /// Whether to write account changesets.
+    pub write_account_changesets: bool,
+}
+
+impl Default for StateWriteConfig {
+    fn default() -> Self {
+        Self { write_receipts: true, write_account_changesets: true }
+    }
 }

--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -17,7 +17,7 @@ use reth_primitives_traits::{Block as BlockTrait, RecoveredBlock, SealedBlock};
 use reth_provider::{
     test_utils::create_test_provider_factory_with_chain_spec, BlockWriter, DatabaseProviderFactory,
     ExecutionOutcome, HeaderProvider, HistoryWriter, OriginalValuesKnown, StateProofProvider,
-    StateWriter, StaticFileProviderFactory, StaticFileSegment, StaticFileWriter,
+    StateWriteConfig, StateWriter, StaticFileProviderFactory, StaticFileSegment, StaticFileWriter,
 };
 use reth_revm::{database::StateProviderDatabase, witness::ExecutionWitnessRecord, State};
 use reth_stateless::{
@@ -328,7 +328,7 @@ fn run_case(
             .write_state(
                 &ExecutionOutcome::single(block.number, output),
                 OriginalValuesKnown::Yes,
-                true,
+                StateWriteConfig::default(),
             )
             .map_err(|err| Error::block_failed(block_number, program_inputs.clone(), err))?;
 


### PR DESCRIPTION
* Adds account changesets to the segment list being written in parallel on SF
* Adds the struct below so we can cover cases when we call `write_state` BUT we have already written either receipts or account changesets elsewhere. 
  *  `reth-edge` will always pass `false` through `save_blocks` (they get written to SF in parallel) but MIGHT call it with `true` in other usages (eg. tests, legacy nodes writing fully to `mdbx`)

```rust
/// Configuration for what to write when calling [`StateWriter::write_state`].
///
/// Used to skip writing certain data types, when they are being written separately.
#[derive(Debug, Clone, Copy)]
pub struct StateWriteConfig {
    /// Whether to write receipts.
    pub write_receipts: bool,
    /// Whether to write account changesets.
    pub write_account_changesets: bool,
}
```

---

## PR Stack

```
#21045 (metrics)    #21003 (rocksdb)
         \           /
          \         /
           #21012 (account changesets) ◀
              ↓
           #20993 (parallelize save_blocks)
              ↓
            main
```

- https://github.com/paradigmxyz/reth/pull/21045
- https://github.com/paradigmxyz/reth/pull/21003
- https://github.com/paradigmxyz/reth/pull/21012 ◀
- https://github.com/paradigmxyz/reth/pull/20993