### PR TITLE
fix(pipeline): only check history limits when history-dependent stages need unwinding

### DIFF
--- a/crates/cli/commands/src/common.rs
+++ b/crates/cli/commands/src/common.rs
@@ -188,11 +188,8 @@ impl<C: ChainSpecParser> EnvironmentArgs<C> {
                     target: "reth::cli",
                     %err,
                     unwind_block,
-                    "Cannot recover from storage inconsistency: required history data has been pruned."
-                );
-                error!(
-                    target: "reth::cli",
-                    "Recovery options:\n\
+                    "Cannot recover from storage inconsistency: required history data has been pruned.\n\
+                     Recovery options:\n\
                      1. Re-sync from scratch by removing the data directory\n\
                      2. Restore from a backup that has the required history\n\
                      3. If only static files are corrupted, try deleting the affected static files \

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -556,11 +556,8 @@ where
                     %err,
                     unwind_block,
                     %inconsistency_source,
-                    "Cannot recover from storage inconsistency: required history data has been pruned."
-                );
-                error!(
-                    target: "reth::cli",
-                    "Recovery options:\n\
+                    "Cannot recover from storage inconsistency: required history data has been pruned.\n\
+                     Recovery options:\n\
                      1. Re-sync from scratch by removing the data directory\n\
                      2. Restore from a backup that has the required history\n\
                      3. If only static files are corrupted, try deleting the affected static files \

--- a/crates/prune/types/src/target.rs
+++ b/crates/prune/types/src/target.rs
@@ -148,10 +148,10 @@ impl PruneModes {
         false
     }
 
-    /// Returns an error if we can't unwind to the targeted block because the target block is
-    /// outside the range.
+    /// Returns an error if the unwind target is beyond the pruned history.
     ///
-    /// This is only relevant for certain tables that are required by other stages
+    /// Only relevant for the Execution stage which requires account/storage history to unwind.
+    /// Callers should gate this check on `execution_checkpoint > unwind_target`.
     ///
     /// See also <https://github.com/paradigmxyz/reth/issues/16579>
     pub fn ensure_unwind_target_unpruned(

--- a/crates/stages/api/src/pipeline/mod.rs
+++ b/crates/stages/api/src/pipeline/mod.rs
@@ -39,9 +39,10 @@ pub use set::*;
 /// - `Execution`: needs changesets to revert plain state
 /// - `AccountHashing`: calls `unwind_account_hashing_range` which reads `AccountChangeSets`
 /// - `StorageHashing`: calls `unwind_storage_hashing_range` which reads `StorageChangeSets`
-/// - `Merkle`: depends on AccountHashing/StorageHashing outputs
+/// - `MerkleUnwind`: calls `incremental_root_with_updates` which reads changesets via
+///   `load_prefix_sets_with_provider`
 const STAGES_REQUIRING_HISTORY_FOR_UNWIND: [StageId; 4] =
-    [StageId::Execution, StageId::AccountHashing, StageId::StorageHashing, StageId::Merkle];
+    [StageId::Execution, StageId::AccountHashing, StageId::StorageHashing, StageId::MerkleUnwind];
 
 /// Returns `true` if any stage that requires history changesets would need to unwind
 /// (i.e., has a checkpoint above the unwind target).

--- a/crates/stages/api/src/pipeline/mod.rs
+++ b/crates/stages/api/src/pipeline/mod.rs
@@ -65,8 +65,8 @@ where
 /// Checks if we can safely unwind to the target block given current pruning state.
 ///
 /// Only stages that require account/storage history changesets to unwind (`Execution`,
-/// `AccountHashing`, `StorageHashing`) need this check. Other stages like `Headers`, `Bodies`,
-/// and `SenderRecovery` can unwind without history data.
+/// `AccountHashing`, `StorageHashing`, `MerkleUnwind`) need this check. Other stages like
+/// `Headers`, `Bodies`, and `SenderRecovery` can unwind without history data.
 ///
 /// Returns `Ok(())` if:
 /// - No history-dependent stage needs to unwind (all checkpoints <= unwind target)

--- a/crates/stages/api/src/pipeline/mod.rs
+++ b/crates/stages/api/src/pipeline/mod.rs
@@ -39,8 +39,9 @@ pub use set::*;
 /// - `Execution`: needs changesets to revert plain state
 /// - `AccountHashing`: calls `unwind_account_hashing_range` which reads `AccountChangeSets`
 /// - `StorageHashing`: calls `unwind_storage_hashing_range` which reads `StorageChangeSets`
-const STAGES_REQUIRING_HISTORY_FOR_UNWIND: [StageId; 3] =
-    [StageId::Execution, StageId::AccountHashing, StageId::StorageHashing];
+/// - `Merkle`: depends on AccountHashing/StorageHashing outputs
+const STAGES_REQUIRING_HISTORY_FOR_UNWIND: [StageId; 4] =
+    [StageId::Execution, StageId::AccountHashing, StageId::StorageHashing, StageId::Merkle];
 
 /// Returns `true` if any stage that requires history changesets would need to unwind
 /// (i.e., has a checkpoint above the unwind target).


### PR DESCRIPTION
Fixes cases where a static file inconsistency (e.g., corrupted TransactionSenders) triggers an unwind that fails due to pruned history, even though the affected stage doesn't need history to unwind.

The `ensure_unwind_target_unpruned` check was applied universally, but only three stages actually need account/storage changesets to unwind:
- `Execution`: reverts plain state using changesets
- `AccountHashing`: reads `AccountChangeSets` via `unwind_account_hashing_range()`
- `StorageHashing`: reads `StorageChangeSets` via `unwind_storage_hashing_range()`

Other stages like Headers, Bodies, and SenderRecovery can unwind without history data.