### PR TITLE
refactor: change PayloadTypes::block_to_payload to accept &SealedBlock

### DIFF
--- a/crates/consensus/debug-client/src/client.rs
+++ b/crates/consensus/debug-client/src/client.rs
@@ -94,7 +94,7 @@ where
         };
 
         while let Some(block) = block_stream.recv().await {
-            let payload = T::block_to_payload(SealedBlock::new_unhashed(block));
+            let payload = T::block_to_payload(&SealedBlock::new_unhashed(block));
 
             let block_hash = payload.block_hash();
             let block_number = payload.block_number();

--- a/crates/e2e-test-utils/src/node.rs
+++ b/crates/e2e-test-utils/src/node.rs
@@ -283,7 +283,7 @@ where
         self.inner
             .add_ons_handle
             .beacon_engine_handle
-            .new_payload(Payload::block_to_payload(payload.block().clone()))
+            .new_payload(Payload::block_to_payload(payload.block()))
             .await?;
 
         Ok(block_hash)

--- a/crates/engine/local/src/miner.rs
+++ b/crates/engine/local/src/miner.rs
@@ -218,7 +218,7 @@ where
         };
 
         let header = payload.block().sealed_header().clone();
-        let payload = T::block_to_payload(payload.block().clone());
+        let payload = T::block_to_payload(payload.block());
         let res = self.to_engine.new_payload(payload).await?;
 
         if !res.is_valid() {

--- a/crates/engine/util/src/reorg.rs
+++ b/crates/engine/util/src/reorg.rs
@@ -194,7 +194,7 @@ where
                         BeaconEngineMessage::NewPayload { payload, tx },
                         // Reorg payload
                         BeaconEngineMessage::NewPayload {
-                            payload: T::block_to_payload(reorg_block),
+                            payload: T::block_to_payload(&reorg_block),
                             tx: reorg_payload_tx,
                         },
                         // Reorg forkchoice state

--- a/crates/ethereum/engine-primitives/src/lib.rs
+++ b/crates/ethereum/engine-primitives/src/lib.rs
@@ -48,12 +48,12 @@ impl<
     type PayloadBuilderAttributes = T::PayloadBuilderAttributes;
 
     fn block_to_payload(
-        block: SealedBlock<
+        block: &SealedBlock<
             <<Self::BuiltPayload as BuiltPayload>::Primitives as NodePrimitives>::Block,
         >,
     ) -> Self::ExecutionData {
         let (payload, sidecar) =
-            ExecutionPayload::from_block_unchecked(block.hash(), &block.into_block());
+            ExecutionPayload::from_block_unchecked(block.hash(), &block.clone_block());
         ExecutionData { payload, sidecar }
     }
 }
@@ -87,12 +87,12 @@ impl PayloadTypes for EthPayloadTypes {
     type ExecutionData = ExecutionData;
 
     fn block_to_payload(
-        block: SealedBlock<
+        block: &SealedBlock<
             <<Self::BuiltPayload as BuiltPayload>::Primitives as NodePrimitives>::Block,
         >,
     ) -> Self::ExecutionData {
         let (payload, sidecar) =
-            ExecutionPayload::from_block_unchecked(block.hash(), &block.into_block());
+            ExecutionPayload::from_block_unchecked(block.hash(), &block.clone_block());
         ExecutionData { payload, sidecar }
     }
 }

--- a/crates/optimism/node/src/engine.rs
+++ b/crates/optimism/node/src/engine.rs
@@ -38,13 +38,13 @@ impl<T: PayloadTypes<ExecutionData = OpExecutionData>> PayloadTypes for OpEngine
     type PayloadBuilderAttributes = T::PayloadBuilderAttributes;
 
     fn block_to_payload(
-        block: SealedBlock<
+        block: &SealedBlock<
             <<Self::BuiltPayload as BuiltPayload>::Primitives as NodePrimitives>::Block,
         >,
     ) -> <T as PayloadTypes>::ExecutionData {
         OpExecutionData::from_block_unchecked(
             block.hash(),
-            &block.into_block().into_ethereum_block(),
+            &block.clone_block().into_ethereum_block(),
         )
     }
 }

--- a/crates/optimism/payload/src/lib.rs
+++ b/crates/optimism/payload/src/lib.rs
@@ -44,13 +44,13 @@ where
     type PayloadBuilderAttributes = OpPayloadBuilderAttributes<N::SignedTx>;
 
     fn block_to_payload(
-        block: SealedBlock<
+        block: &SealedBlock<
             <<Self::BuiltPayload as BuiltPayload>::Primitives as NodePrimitives>::Block,
         >,
     ) -> Self::ExecutionData {
         OpExecutionData::from_block_unchecked(
             block.hash(),
-            &block.into_block().into_ethereum_block(),
+            &block.clone_block().into_ethereum_block(),
         )
     }
 }

--- a/crates/payload/primitives/src/lib.rs
+++ b/crates/payload/primitives/src/lib.rs
@@ -59,7 +59,7 @@ pub trait PayloadTypes: Send + Sync + Unpin + core::fmt::Debug + Clone + 'static
 
     /// Converts a sealed block into the execution payload format.
     fn block_to_payload(
-        block: SealedBlock<
+        block: &SealedBlock<
             <<Self::BuiltPayload as BuiltPayload>::Primitives as NodePrimitives>::Block,
         >,
     ) -> Self::ExecutionData;

--- a/examples/bsc-p2p/src/block_import/service.rs
+++ b/examples/bsc-p2p/src/block_import/service.rs
@@ -94,7 +94,7 @@ where
 
         Box::pin(async move {
             let sealed_block = block.block.block.clone().seal();
-            let payload = T::block_to_payload(sealed_block);
+            let payload = T::block_to_payload(&sealed_block);
 
             match engine.new_payload(payload).await {
                 Ok(payload_status) => match payload_status.status {

--- a/examples/custom-engine-types/src/main.rs
+++ b/examples/custom-engine-types/src/main.rs
@@ -153,12 +153,12 @@ impl PayloadTypes for CustomEngineTypes {
     type PayloadBuilderAttributes = CustomPayloadBuilderAttributes;
 
     fn block_to_payload(
-        block: SealedBlock<
+        block: &SealedBlock<
                 <<Self::BuiltPayload as reth_ethereum::node::api::BuiltPayload>::Primitives as reth_ethereum::node::api::NodePrimitives>::Block,
             >,
     ) -> ExecutionData {
         let (payload, sidecar) =
-            ExecutionPayload::from_block_unchecked(block.hash(), &block.into_block());
+            ExecutionPayload::from_block_unchecked(block.hash(), &block.clone_block());
         ExecutionData { payload, sidecar }
     }
 }

--- a/examples/custom-node/src/engine.rs
+++ b/examples/custom-node/src/engine.rs
@@ -210,13 +210,13 @@ impl PayloadTypes for CustomPayloadTypes {
     type PayloadBuilderAttributes = CustomPayloadBuilderAttributes;
 
     fn block_to_payload(
-        block: SealedBlock<
+        block: &SealedBlock<
             <<Self::BuiltPayload as BuiltPayload>::Primitives as NodePrimitives>::Block,
         >,
     ) -> Self::ExecutionData {
         let extension = block.header().extension;
         let block_hash = block.hash();
-        let block = block.into_block().map_header(|header| header.inner);
+        let block = block.clone_block().map_header(|header| header.inner);
         let (payload, sidecar) = OpExecutionPayload::from_block_unchecked(block_hash, &block);
         CustomExecutionData { inner: OpExecutionData { payload, sidecar }, extension }
     }


### PR DESCRIPTION
changes block_to_payload to accept &SealedBlock instead of owned value to avoid unnecessary cloning.

removes forced .clone() calls at miner.rs and e2e-test-utils where blocks are only read to construct payloads.
