### PR TITLE
chore: remove redundant root calculation in stateless trie

### DIFF
--- a/crates/stateless/src/trie.rs
+++ b/crates/stateless/src/trie.rs
@@ -268,7 +268,7 @@ fn calculate_state_root(
         }
 
         // Finalise the storage‑trie root before pushing the result
-        storage_trie.root();
+
         storage_results.push((address, storage_trie));
     }
 


### PR DESCRIPTION
Remove redundant storage root calculation in stateless trie, eliminating unnecessary hash computation.