### PR TITLE
chore: release 1.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3328,7 +3328,7 @@ dependencies = [
 
 [[package]]
 name = "ef-test-runner"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "clap",
  "ef-tests",
@@ -3336,7 +3336,7 @@ dependencies = [
 
 [[package]]
 name = "ef-tests"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3826,7 +3826,7 @@ dependencies = [
 
 [[package]]
 name = "example-full-contract-state"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "eyre",
  "reth-ethereum",
@@ -3965,7 +3965,7 @@ dependencies = [
 
 [[package]]
 name = "exex-subscription"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -6474,7 +6474,7 @@ dependencies = [
 
 [[package]]
 name = "op-reth"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "clap",
  "reth-cli-util",
@@ -7614,7 +7614,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -7661,7 +7661,7 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7684,7 +7684,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bench"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-eips",
  "alloy-json-rpc",
@@ -7727,7 +7727,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bench-compare"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -7755,7 +7755,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7787,7 +7787,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7807,7 +7807,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7820,7 +7820,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7904,7 +7904,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7913,7 +7913,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7934,7 +7934,7 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7958,7 +7958,7 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7968,7 +7968,7 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -7986,7 +7986,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7998,7 +7998,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8012,7 +8012,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8037,7 +8037,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8071,7 +8071,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8101,7 +8101,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8131,7 +8131,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8147,7 +8147,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8173,7 +8173,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8198,7 +8198,7 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8226,7 +8226,7 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8264,7 +8264,7 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8321,7 +8321,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8348,7 +8348,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8372,7 +8372,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8396,7 +8396,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-service"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "futures",
  "pin-project",
@@ -8425,7 +8425,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8498,7 +8498,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8525,7 +8525,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8547,7 +8547,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8565,7 +8565,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8591,7 +8591,7 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8601,7 +8601,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8639,7 +8639,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8664,7 +8664,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8704,7 +8704,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "clap",
  "eyre",
@@ -8726,7 +8726,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8742,7 +8742,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8760,7 +8760,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8773,7 +8773,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8801,7 +8801,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8828,7 +8828,7 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-primitives",
  "rayon",
@@ -8838,7 +8838,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8863,7 +8863,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8887,7 +8887,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8899,7 +8899,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8919,7 +8919,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8964,7 +8964,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-test-utils"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-eips",
  "eyre",
@@ -8995,7 +8995,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9012,7 +9012,7 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -9021,7 +9021,7 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9054,7 +9054,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "bytes",
  "futures",
@@ -9076,7 +9076,7 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -9094,7 +9094,7 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -9102,7 +9102,7 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "futures",
  "metrics",
@@ -9113,7 +9113,7 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9121,7 +9121,7 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9135,7 +9135,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9196,7 +9196,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9220,7 +9220,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9242,7 +9242,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9259,7 +9259,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9272,7 +9272,7 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -9290,7 +9290,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9313,7 +9313,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9384,7 +9384,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9441,7 +9441,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -9501,7 +9501,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9524,7 +9524,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9547,7 +9547,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "bytes",
  "eyre",
@@ -9576,7 +9576,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9587,7 +9587,7 @@ dependencies = [
 
 [[package]]
 name = "reth-op"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "reth-chainspec",
  "reth-cli-util",
@@ -9627,7 +9627,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-chainspec"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9655,7 +9655,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-cli"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9704,7 +9704,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-consensus"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9735,7 +9735,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-evm"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9764,7 +9764,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-flashblocks"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9802,7 +9802,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-forks"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-op-hardforks",
  "alloy-primitives",
@@ -9812,7 +9812,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-node"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9872,7 +9872,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-payload-builder"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9911,7 +9911,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-primitives"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9938,7 +9938,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-rpc"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10000,7 +10000,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-storage"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "reth-codecs",
@@ -10012,7 +10012,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-txpool"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10049,7 +10049,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10069,7 +10069,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10080,7 +10080,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10103,7 +10103,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-util"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10112,7 +10112,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10121,7 +10121,7 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10143,7 +10143,7 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10180,7 +10180,7 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10229,7 +10229,7 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10261,11 +10261,11 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-db"
-version = "1.9.3"
+version = "1.10.0"
 
 [[package]]
 name = "reth-prune-types"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10284,7 +10284,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-protocol"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10310,7 +10310,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-provider"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10336,7 +10336,7 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10350,7 +10350,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10435,7 +10435,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -10466,7 +10466,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api-testing-util"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10485,7 +10485,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -10541,7 +10541,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10567,7 +10567,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-e2e-tests"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-genesis",
  "alloy-rpc-types-engine",
@@ -10587,7 +10587,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10623,7 +10623,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10666,7 +10666,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10714,7 +10714,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -10731,7 +10731,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10746,7 +10746,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10804,7 +10804,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10836,7 +10836,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10852,7 +10852,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stateless"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -10880,7 +10880,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-primitives",
  "assert_matches",
@@ -10903,7 +10903,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10917,7 +10917,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10940,7 +10940,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10955,7 +10955,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-rpc-provider"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10984,7 +10984,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -11001,7 +11001,7 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11017,7 +11017,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11026,7 +11026,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "clap",
  "eyre",
@@ -11044,7 +11044,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "clap",
  "eyre",
@@ -11060,7 +11060,7 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11108,7 +11108,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11142,7 +11142,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -11175,7 +11175,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11202,7 +11202,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11232,7 +11232,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11265,7 +11265,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse-parallel"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11294,7 +11294,7 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "1.9.3"
+version = "1.10.0"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.9.3"
+version = "1.10.0"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/docs/vocs/vocs.config.ts
+++ b/docs/vocs/vocs.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
     },
     { text: 'GitHub', link: 'https://github.com/paradigmxyz/reth' },
     {
-      text: 'v1.9.3',
+      text: 'v1.10.0',
       items: [
         {
           text: 'Releases',


### PR DESCRIPTION
## Summary

This PR prepares the release candidate for reth v1.10.0.

### Changes
- Bumps workspace version from 1.9.3 to 1.10.0
- Updates Cargo.lock with new version
- Updates vocs config with the new version

* I also created a skill for this - will push to the ai repo - so we can build on a skill for releasing reth

### Next Steps
After this PR is merged:
1. Create and push the `v1.10.0` tag
2. The release workflow will build binaries and create a draft GitHub release
3. Complete the release checklist in the draft release