### PR TITLE
refactor(payload): return header from block_to_payload to avoid redun…

### DIFF
--- a/crates/consensus/debug-client/src/client.rs
+++ b/crates/consensus/debug-client/src/client.rs
@@ -94,7 +94,7 @@ where
         };
 
         while let Some(block) = block_stream.recv().await {
-            let payload = T::block_to_payload(SealedBlock::new_unhashed(block));
+            let (payload, _header) = T::block_to_payload(SealedBlock::new_unhashed(block));
 
             let block_hash = payload.block_hash();
             let block_number = payload.block_number();

--- a/crates/e2e-test-utils/src/node.rs
+++ b/crates/e2e-test-utils/src/node.rs
@@ -283,7 +283,7 @@ where
         self.inner
             .add_ons_handle
             .beacon_engine_handle
-            .new_payload(Payload::block_to_payload(payload.block().clone()))
+            .new_payload(Payload::block_to_payload(payload.block().clone()).0)
             .await?;
 
         Ok(block_hash)

--- a/crates/engine/local/src/miner.rs
+++ b/crates/engine/local/src/miner.rs
@@ -217,9 +217,8 @@ where
             eyre::bail!("No payload")
         };
 
-        let header = payload.block().sealed_header().clone();
-        let payload = T::block_to_payload(payload.block().clone());
-        let res = self.to_engine.new_payload(payload).await?;
+        let (payload_data, header) = T::block_to_payload(payload.block().clone());
+        let res = self.to_engine.new_payload(payload_data).await?;
 
         if !res.is_valid() {
             eyre::bail!("Invalid payload")

--- a/crates/engine/util/src/reorg.rs
+++ b/crates/engine/util/src/reorg.rs
@@ -194,7 +194,7 @@ where
                         BeaconEngineMessage::NewPayload { payload, tx },
                         // Reorg payload
                         BeaconEngineMessage::NewPayload {
-                            payload: T::block_to_payload(reorg_block),
+                            payload: T::block_to_payload(reorg_block).0,
                             tx: reorg_payload_tx,
                         },
                         // Reorg forkchoice state

--- a/crates/ethereum/engine-primitives/src/lib.rs
+++ b/crates/ethereum/engine-primitives/src/lib.rs
@@ -24,7 +24,7 @@ pub use alloy_rpc_types_engine::{
 };
 use reth_engine_primitives::EngineTypes;
 use reth_payload_primitives::{BuiltPayload, PayloadTypes};
-use reth_primitives_traits::{NodePrimitives, SealedBlock};
+use reth_primitives_traits::{NodePrimitives, SealedBlock, SealedHeader};
 
 /// The types used in the default mainnet ethereum beacon consensus engine.
 #[derive(Debug, Default, Clone, serde::Deserialize, serde::Serialize)]
@@ -51,10 +51,16 @@ impl<
         block: SealedBlock<
             <<Self::BuiltPayload as BuiltPayload>::Primitives as NodePrimitives>::Block,
         >,
-    ) -> Self::ExecutionData {
+    ) -> (
+        Self::ExecutionData,
+        SealedHeader<
+            <<<Self::BuiltPayload as BuiltPayload>::Primitives as NodePrimitives>::Block as reth_primitives_traits::Block>::Header,
+        >,
+    ){
+        let header = block.sealed_header().clone();
         let (payload, sidecar) =
             ExecutionPayload::from_block_unchecked(block.hash(), &block.into_block());
-        ExecutionData { payload, sidecar }
+        (ExecutionData { payload, sidecar }, header)
     }
 }
 
@@ -90,9 +96,15 @@ impl PayloadTypes for EthPayloadTypes {
         block: SealedBlock<
             <<Self::BuiltPayload as BuiltPayload>::Primitives as NodePrimitives>::Block,
         >,
-    ) -> Self::ExecutionData {
+    ) -> (
+        Self::ExecutionData,
+        SealedHeader<
+            <<<Self::BuiltPayload as BuiltPayload>::Primitives as NodePrimitives>::Block as reth_primitives_traits::Block>::Header,
+        >,
+    ){
+        let header = block.sealed_header().clone();
         let (payload, sidecar) =
             ExecutionPayload::from_block_unchecked(block.hash(), &block.into_block());
-        ExecutionData { payload, sidecar }
+        (ExecutionData { payload, sidecar }, header)
     }
 }

--- a/crates/optimism/node/src/engine.rs
+++ b/crates/optimism/node/src/engine.rs
@@ -19,7 +19,7 @@ use reth_optimism_consensus::isthmus;
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_payload_builder::{OpExecutionPayloadValidator, OpPayloadTypes};
 use reth_optimism_primitives::{OpBlock, L2_TO_L1_MESSAGE_PASSER_ADDRESS};
-use reth_primitives_traits::{Block, RecoveredBlock, SealedBlock, SignedTransaction};
+use reth_primitives_traits::{Block, RecoveredBlock, SealedBlock, SealedHeader, SignedTransaction};
 use reth_provider::StateProviderFactory;
 use reth_trie_common::{HashedPostState, KeyHasher};
 use std::{marker::PhantomData, sync::Arc};
@@ -41,11 +41,18 @@ impl<T: PayloadTypes<ExecutionData = OpExecutionData>> PayloadTypes for OpEngine
         block: SealedBlock<
             <<Self::BuiltPayload as BuiltPayload>::Primitives as NodePrimitives>::Block,
         >,
-    ) -> <T as PayloadTypes>::ExecutionData {
-        OpExecutionData::from_block_unchecked(
+    ) -> (
+        <T as PayloadTypes>::ExecutionData,
+        SealedHeader<
+            <<<Self::BuiltPayload as BuiltPayload>::Primitives as NodePrimitives>::Block as Block>::Header,
+        >,
+    ){
+        let header = block.sealed_header().clone();
+        let execution_data = OpExecutionData::from_block_unchecked(
             block.hash(),
             &block.into_block().into_ethereum_block(),
-        )
+        );
+        (execution_data, header)
     }
 }
 

--- a/crates/optimism/payload/src/lib.rs
+++ b/crates/optimism/payload/src/lib.rs
@@ -22,7 +22,7 @@ pub use payload::{
 mod traits;
 use reth_optimism_primitives::OpPrimitives;
 use reth_payload_primitives::{BuiltPayload, PayloadTypes};
-use reth_primitives_traits::{Block, NodePrimitives, SealedBlock};
+use reth_primitives_traits::{Block, NodePrimitives, SealedBlock, SealedHeader};
 pub use traits::*;
 pub mod validator;
 pub use validator::OpExecutionPayloadValidator;
@@ -47,10 +47,17 @@ where
         block: SealedBlock<
             <<Self::BuiltPayload as BuiltPayload>::Primitives as NodePrimitives>::Block,
         >,
-    ) -> Self::ExecutionData {
-        OpExecutionData::from_block_unchecked(
+    ) -> (
+        Self::ExecutionData,
+        SealedHeader<
+            <<<Self::BuiltPayload as BuiltPayload>::Primitives as NodePrimitives>::Block as Block>::Header,
+        >,
+    ){
+        let header = block.sealed_header().clone();
+        let execution_data = OpExecutionData::from_block_unchecked(
             block.hash(),
             &block.into_block().into_ethereum_block(),
-        )
+        );
+        (execution_data, header)
     }
 }

--- a/crates/payload/primitives/src/lib.rs
+++ b/crates/payload/primitives/src/lib.rs
@@ -15,7 +15,7 @@ extern crate alloc;
 
 use alloy_primitives::Bytes;
 use reth_chainspec::EthereumHardforks;
-use reth_primitives_traits::{NodePrimitives, SealedBlock};
+use reth_primitives_traits::{NodePrimitives, SealedBlock, SealedHeader};
 
 mod error;
 pub use error::{
@@ -58,11 +58,19 @@ pub trait PayloadTypes: Send + Sync + Unpin + core::fmt::Debug + Clone + 'static
         + Unpin;
 
     /// Converts a sealed block into the execution payload format.
+    ///
+    /// Returns both the execution data and the sealed header to avoid redundant header clones.
+    #[allow(clippy::type_complexity)]
     fn block_to_payload(
         block: SealedBlock<
             <<Self::BuiltPayload as BuiltPayload>::Primitives as NodePrimitives>::Block,
         >,
-    ) -> Self::ExecutionData;
+    ) -> (
+        Self::ExecutionData,
+        SealedHeader<
+            <<<Self::BuiltPayload as BuiltPayload>::Primitives as NodePrimitives>::Block as reth_primitives_traits::Block>::Header,
+        >,
+    );
 }
 
 /// Validates the timestamp depending on the version called:

--- a/examples/bsc-p2p/src/block_import/service.rs
+++ b/examples/bsc-p2p/src/block_import/service.rs
@@ -94,7 +94,7 @@ where
 
         Box::pin(async move {
             let sealed_block = block.block.block.clone().seal();
-            let payload = T::block_to_payload(sealed_block);
+            let (payload, _header) = T::block_to_payload(sealed_block);
 
             match engine.new_payload(payload).await {
                 Ok(payload_status) => match payload_status.status {

--- a/examples/custom-engine-types/src/main.rs
+++ b/examples/custom-engine-types/src/main.rs
@@ -59,6 +59,7 @@ use reth_ethereum::{
 };
 use reth_ethereum_payload_builder::{EthereumBuilderConfig, EthereumExecutionPayloadValidator};
 use reth_payload_builder::{EthBuiltPayload, EthPayloadBuilderAttributes, PayloadBuilderError};
+use reth_primitives_traits::SealedHeader;
 use reth_tracing::{RethTracer, Tracer};
 use serde::{Deserialize, Serialize};
 use std::{convert::Infallible, sync::Arc};
@@ -156,10 +157,16 @@ impl PayloadTypes for CustomEngineTypes {
         block: SealedBlock<
                 <<Self::BuiltPayload as reth_ethereum::node::api::BuiltPayload>::Primitives as reth_ethereum::node::api::NodePrimitives>::Block,
             >,
-    ) -> ExecutionData {
+    ) -> (
+        ExecutionData,
+        SealedHeader<
+            <<<Self::BuiltPayload as reth_ethereum::node::api::BuiltPayload>::Primitives as reth_ethereum::node::api::NodePrimitives>::Block as reth_primitives_traits::Block>::Header,
+        >,
+    ){
+        let header = block.sealed_header().clone();
         let (payload, sidecar) =
             ExecutionPayload::from_block_unchecked(block.hash(), &block.into_block());
-        ExecutionData { payload, sidecar }
+        (ExecutionData { payload, sidecar }, header)
     }
 }
 

--- a/examples/custom-node/src/engine.rs
+++ b/examples/custom-node/src/engine.rs
@@ -24,6 +24,7 @@ use reth_op::node::{
     engine::OpEngineValidator, payload::OpAttributes, OpBuiltPayload, OpEngineTypes,
     OpPayloadAttributes, OpPayloadBuilderAttributes,
 };
+use reth_primitives_traits::SealedHeader;
 use revm_primitives::U256;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -213,12 +214,18 @@ impl PayloadTypes for CustomPayloadTypes {
         block: SealedBlock<
             <<Self::BuiltPayload as BuiltPayload>::Primitives as NodePrimitives>::Block,
         >,
-    ) -> Self::ExecutionData {
+    ) -> (
+        Self::ExecutionData,
+        SealedHeader<
+            <<<Self::BuiltPayload as BuiltPayload>::Primitives as NodePrimitives>::Block as reth_primitives_traits::Block>::Header,
+        >,
+    ){
+        let header = block.sealed_header().clone();
         let extension = block.header().extension;
         let block_hash = block.hash();
         let block = block.into_block().map_header(|header| header.inner);
         let (payload, sidecar) = OpExecutionPayload::from_block_unchecked(block_hash, &block);
-        CustomExecutionData { inner: OpExecutionData { payload, sidecar }, extension }
+        (CustomExecutionData { inner: OpExecutionData { payload, sidecar }, extension }, header)
     }
 }
 


### PR DESCRIPTION
## Summary

Relaterd to https://github.com/paradigmxyz/reth/pull/20732#issuecomment-3709493424

Modifies `PayloadTypes::block_to_payload` to return `(ExecutionData, SealedHeader)` tuple, eliminating redundant header clones.

## Problem

Callers cloned the header separately while `block_to_payload` also cloned it internally when cloning the block, resulting in duplicate header clones.

## Solution

`block_to_payload` now extracts and returns the header before consuming the block, allowing callers to use the returned header without additional cloning.

## Changes

- Updated `PayloadTypes::block_to_payload` signature
- Updated all implementations and call sites