### PR TITLE
feat(cli): support file:// URLs in reth download

### DIFF
--- a/docs/vocs/docs/pages/cli/reth/download.mdx
+++ b/docs/vocs/docs/pages/cli/reth/download.mdx
@@ -137,7 +137,9 @@ Static Files:
           - https://publicnode.com/snapshots (full nodes & testnets)
 
           If no URL is provided, the latest mainnet archive snapshot
-          will be proposed for download from https://downloads.merkle.io
+          will be proposed for download from https://downloads.merkle.io.
+
+          Local file:// URLs are also supported for extracting snapshots from disk.
 
 Logging:
       --log.stdout.format <FORMAT>


### PR DESCRIPTION
Add support for extracting snapshots from local files using file:// URLs. This is useful for users who have already downloaded snapshot archives and want to extract them without re-downloading.

The implementation refactors the extraction logic into separate functions:
- extract_archive: common decompression and unpacking with progress
- extract_from_file: handles local file:// URLs
- download_and_extract: handles remote HTTP(S) URLs