### PR TITLE
fix(prune): prevent overflow in TransactionLookup prune range calculation

### DIFF
--- a/crates/prune/prune/src/segments/user/transaction_lookup.rs
+++ b/crates/prune/prune/src/segments/user/transaction_lookup.rs
@@ -84,7 +84,12 @@ where
         .into_inner();
         let tx_range = start..=
             Some(end)
-                .min(input.limiter.deleted_entries_limit_left().map(|left| start + left as u64 - 1))
+                .min(
+                    input
+                        .limiter
+                        .deleted_entries_limit_left()
+                        .map(|left| start.saturating_add(left as u64).saturating_sub(1)),
+                )
                 .unwrap();
         let tx_range_end = *tx_range.end();
 


### PR DESCRIPTION
## Summary

Fixes #20161

Use saturating arithmetic when calculating the transaction range end in `TransactionLookup::prune` to prevent overflow panic in debug builds when `deleted_entries_limit_left()` returns a large value.

## Changes

- Replace `start + left as u64 - 1` with `start.saturating_add(left as u64).saturating_sub(1)` to prevent overflow

## Test Plan

- Existing `transaction_lookup::tests::prune` test passes