### PR TITLE
chore: bump fixed-cache to 0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4031,9 +4031,9 @@ dependencies = [
 
 [[package]]
 name = "fixed-cache"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c468bde9b2db8d745d7c9fc33964f1923c6222f0211e10ffd818e6f28b4e190"
+checksum = "25d3af83468398d500e9bc19e001812dcb1a11e4d3d6a5956c789aa3c11a8cb5"
 dependencies = [
  "equivalent",
  "typeid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -587,7 +587,7 @@ tracing-appender = "0.2"
 url = { version = "2.3", default-features = false }
 zstd = "0.13"
 byteorder = "1"
-fixed-cache = { version = "0.1.4", features = ["stats"] }
+fixed-cache = { version = "0.1.5", features = ["stats"] }
 moka = "0.12"
 tar-no-std = { version = "0.3.2", default-features = false }
 miniz_oxide = { version = "0.8.4", default-features = false }

--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -507,11 +507,8 @@ impl ExecutionCache {
     pub(crate) const fn bytes_to_entries(size_bytes: usize, entry_size: usize) -> usize {
         let entries = size_bytes / entry_size;
         // Round down to nearest power of two
-        let rounded = if entries == 0 {
-            1
-        } else {
-            1 << (usize::BITS - 1 - entries.leading_zeros())
-        };
+        let rounded =
+            if entries == 0 { 1 } else { 1 << (usize::BITS - 1 - entries.leading_zeros()) };
         // Ensure minimum size for epoch tracking
         if rounded < Self::MIN_CACHE_SIZE_WITH_EPOCHS {
             Self::MIN_CACHE_SIZE_WITH_EPOCHS


### PR DESCRIPTION
Bumps fixed-cache from 0.1.4 to 0.1.5