### PR TITLE
chore: release 1.9.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3328,7 +3328,7 @@ dependencies = [
 
 [[package]]
 name = "ef-test-runner"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "clap",
  "ef-tests",
@@ -3336,7 +3336,7 @@ dependencies = [
 
 [[package]]
 name = "ef-tests"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3826,7 +3826,7 @@ dependencies = [
 
 [[package]]
 name = "example-full-contract-state"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "eyre",
  "reth-ethereum",
@@ -3965,7 +3965,7 @@ dependencies = [
 
 [[package]]
 name = "exex-subscription"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -6495,7 +6495,7 @@ dependencies = [
 
 [[package]]
 name = "op-reth"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "clap",
  "reth-cli-util",
@@ -7635,7 +7635,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -7682,7 +7682,7 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7705,7 +7705,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bench"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-eips",
  "alloy-json-rpc",
@@ -7748,7 +7748,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bench-compare"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -7776,7 +7776,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7808,7 +7808,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7828,7 +7828,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7841,7 +7841,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7926,7 +7926,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7935,7 +7935,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7956,7 +7956,7 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7980,7 +7980,7 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7990,7 +7990,7 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -8008,7 +8008,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8020,7 +8020,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8034,7 +8034,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8059,7 +8059,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8093,7 +8093,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8123,7 +8123,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8153,7 +8153,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8169,7 +8169,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8195,7 +8195,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8220,7 +8220,7 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8248,7 +8248,7 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8286,7 +8286,7 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8343,7 +8343,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8370,7 +8370,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8394,7 +8394,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8418,7 +8418,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-service"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "futures",
  "pin-project",
@@ -8447,7 +8447,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8520,7 +8520,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8547,7 +8547,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8569,7 +8569,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8587,7 +8587,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8613,7 +8613,7 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8623,7 +8623,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8661,7 +8661,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8686,7 +8686,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8726,7 +8726,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "clap",
  "eyre",
@@ -8748,7 +8748,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8764,7 +8764,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8782,7 +8782,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8795,7 +8795,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8823,7 +8823,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8850,7 +8850,7 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-primitives",
  "rayon",
@@ -8860,7 +8860,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8885,7 +8885,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8909,7 +8909,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8921,7 +8921,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8941,7 +8941,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8986,7 +8986,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-test-utils"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-eips",
  "eyre",
@@ -9017,7 +9017,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9034,7 +9034,7 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -9043,7 +9043,7 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9076,7 +9076,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "bytes",
  "futures",
@@ -9098,7 +9098,7 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -9116,7 +9116,7 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -9124,7 +9124,7 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "futures",
  "metrics",
@@ -9135,7 +9135,7 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9143,7 +9143,7 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9157,7 +9157,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9218,7 +9218,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9242,7 +9242,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9264,7 +9264,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9281,7 +9281,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9294,7 +9294,7 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -9312,7 +9312,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9335,7 +9335,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9406,7 +9406,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9463,7 +9463,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -9523,7 +9523,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9546,7 +9546,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9569,7 +9569,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "bytes",
  "eyre",
@@ -9598,7 +9598,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9609,7 +9609,7 @@ dependencies = [
 
 [[package]]
 name = "reth-op"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "reth-chainspec",
  "reth-cli-util",
@@ -9649,7 +9649,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-chainspec"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9677,7 +9677,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-cli"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9726,7 +9726,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-consensus"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9757,7 +9757,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-evm"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9786,7 +9786,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-flashblocks"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9824,7 +9824,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-forks"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-op-hardforks",
  "alloy-primitives",
@@ -9834,7 +9834,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-node"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9894,7 +9894,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-payload-builder"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9933,7 +9933,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-primitives"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9960,7 +9960,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-rpc"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10022,7 +10022,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-storage"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "reth-codecs",
@@ -10034,7 +10034,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-txpool"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10071,7 +10071,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10091,7 +10091,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10102,7 +10102,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10125,7 +10125,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-util"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10134,7 +10134,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10143,7 +10143,7 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10165,7 +10165,7 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10202,7 +10202,7 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10251,7 +10251,7 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10283,11 +10283,11 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-db"
-version = "1.9.3"
+version = "1.9.4"
 
 [[package]]
 name = "reth-prune-types"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10306,7 +10306,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-protocol"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10332,7 +10332,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-provider"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10358,7 +10358,7 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10372,7 +10372,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10457,7 +10457,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -10488,7 +10488,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api-testing-util"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10507,7 +10507,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -10563,7 +10563,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10589,7 +10589,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-e2e-tests"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-genesis",
  "alloy-rpc-types-engine",
@@ -10609,7 +10609,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10645,7 +10645,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10688,7 +10688,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10736,7 +10736,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -10753,7 +10753,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10768,7 +10768,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10826,7 +10826,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10858,7 +10858,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10874,7 +10874,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stateless"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -10902,7 +10902,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-primitives",
  "assert_matches",
@@ -10925,7 +10925,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10940,7 +10940,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10963,7 +10963,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10978,7 +10978,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-rpc-provider"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11007,7 +11007,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -11024,7 +11024,7 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11040,7 +11040,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11049,7 +11049,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "clap",
  "eyre",
@@ -11067,7 +11067,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "clap",
  "eyre",
@@ -11083,7 +11083,7 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11131,7 +11131,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11165,7 +11165,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -11198,7 +11198,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11225,7 +11225,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11255,7 +11255,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11288,7 +11288,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse-parallel"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11317,7 +11317,7 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.9.3"
+version = "1.9.4"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/docs/vocs/vocs.config.ts
+++ b/docs/vocs/vocs.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
     },
     { text: 'GitHub', link: 'https://github.com/paradigmxyz/reth' },
     {
-      text: 'v1.9.3',
+      text: 'v1.9.4',
       items: [
         {
           text: 'Releases',


### PR DESCRIPTION
This PR prepares the release candidate and tag for version 1.9.4.

## Changes
- Bumps workspace version to 1.9.4
- Updates documentation version in vocs config
- Updates Cargo.lock

## Release Checklist
- [ ] All CI checks pass
- [ ] Version bumped in Cargo.toml
- [ ] Version updated in docs/vocs/vocs.config.ts
- [ ] Ready for tagging after merge