### PR TITLE
fix: improve valueError to preserve transaction context

### DIFF
--- a/crates/rpc/rpc-convert/src/transaction.rs
+++ b/crates/rpc/rpc-convert/src/transaction.rs
@@ -486,7 +486,7 @@ where
 #[derive(Debug, thiserror::Error)]
 pub enum TransactionConversionError {
     /// Transaction request validation error.
-    /// 
+    ///
     /// Contains the complete error information including which fields are missing or invalid.
     /// The error message preserves the full Debug representation of the underlying ValueError,
     /// which includes the transaction request and detailed error context.
@@ -1000,7 +1000,7 @@ mod transaction_response_tests {
         // Test Other variant
         let error = TransactionConversionError::Other("Unknown error".to_string());
         assert!(error.to_string().contains("Unknown error"));
-        
+
         // The ValueError variant now uses Debug format which includes full context
         let debug_info = "ValueError { request: TransactionRequest { gas: Some(21000), ... }, message: \"invalid gas price\" }";
         let error = TransactionConversionError::ValueError(debug_info.to_string());

--- a/crates/rpc/rpc-convert/src/transaction.rs
+++ b/crates/rpc/rpc-convert/src/transaction.rs
@@ -488,7 +488,7 @@ pub enum TransactionConversionError {
     /// Transaction request validation error.
     ///
     /// Contains the complete error information including which fields are missing or invalid.
-    /// The error message preserves the full Debug representation of the underlying ValueError,
+    /// The error message preserves the full Debug representation of the underlying `ValueError`,
     /// which includes the transaction request and detailed error context.
     #[error("Failed to convert transaction request: {0}")]
     ValueError(String),


### PR DESCRIPTION
Changed TransactionConversionError to use Debug format instead of Display when wrapping ValueError. Keeps the complete transaction request data in error messages instead of just a string.

Before: "Failed to convert transaction into RPC response: Required fields missing"
After: Shows the actual TransactionRequest with all fields so you can see exactly what's missing

(The ValueError<TxReq> is generic so can't store it directly, but using {:?} gives us basically the same debugging info.)