### PR TITLE
fix: propagate keccak-cache-global feature to reth-optimism-cli

### DIFF
--- a/crates/optimism/bin/Cargo.toml
+++ b/crates/optimism/bin/Cargo.toml
@@ -43,6 +43,7 @@ tracy = ["reth-optimism-cli/tracy"]
 
 asm-keccak = ["reth-optimism-cli/asm-keccak", "reth-optimism-node/asm-keccak"]
 keccak-cache-global = [
+    "reth-optimism-cli/keccak-cache-global",
     "reth-optimism-node/keccak-cache-global",
 ]
 dev = [

--- a/crates/optimism/cli/Cargo.toml
+++ b/crates/optimism/cli/Cargo.toml
@@ -85,6 +85,12 @@ asm-keccak = [
     "reth-optimism-node/asm-keccak",
 ]
 
+keccak-cache-global = [
+    "alloy-primitives/keccak-cache-global",
+    "reth-node-core/keccak-cache-global",
+    "reth-optimism-node/keccak-cache-global",
+]
+
 # Jemalloc feature for vergen to generate correct env vars
 jemalloc = [
     "reth-node-core/jemalloc",

--- a/crates/optimism/reth/Cargo.toml
+++ b/crates/optimism/reth/Cargo.toml
@@ -75,9 +75,9 @@ arbitrary = [
     "reth-codecs?/arbitrary",
 ]
 keccak-cache-global = [
-	"reth-optimism-node?/keccak-cache-global",
-	"reth-node-core?/keccak-cache-global",
-	"reth-optimism-cli?/keccak-cache-global"
+    "reth-optimism-node?/keccak-cache-global",
+    "reth-node-core?/keccak-cache-global",
+    "reth-optimism-cli?/keccak-cache-global",
 ]
 test-utils = [
     "reth-chainspec/test-utils",

--- a/crates/optimism/reth/Cargo.toml
+++ b/crates/optimism/reth/Cargo.toml
@@ -75,8 +75,9 @@ arbitrary = [
     "reth-codecs?/arbitrary",
 ]
 keccak-cache-global = [
-    "reth-optimism-node?/keccak-cache-global",
-    "reth-node-core?/keccak-cache-global",
+	"reth-optimism-node?/keccak-cache-global",
+	"reth-node-core?/keccak-cache-global",
+	"reth-optimism-cli?/keccak-cache-global"
 ]
 test-utils = [
     "reth-chainspec/test-utils",


### PR DESCRIPTION
fixes the feature propagation issue mentioned in #20524. the keccak-cache-global feature now properly flows through op-reth -> reth-optimism-cli -> reth-node-core, matching how asm-keccak is already set up. this should make the feature show up correctly in op-reth --version output.