### PR TITLE
feat(cli): add --storage.rocksdb flag for RocksDB history indices

### DIFF
--- a/crates/cli/commands/src/db/settings.rs
+++ b/crates/cli/commands/src/db/settings.rs
@@ -54,6 +54,21 @@ pub enum SetCommand {
         #[clap(action(ArgAction::Set))]
         value: bool,
     },
+    /// Store storages history in RocksDB instead of MDBX
+    StoragesHistory {
+        #[clap(action(ArgAction::Set))]
+        value: bool,
+    },
+    /// Store account history in RocksDB instead of MDBX
+    AccountHistory {
+        #[clap(action(ArgAction::Set))]
+        value: bool,
+    },
+    /// Store transaction hash numbers in RocksDB instead of MDBX
+    TxHashNumbers {
+        #[clap(action(ArgAction::Set))]
+        value: bool,
+    },
 }
 
 impl Command {
@@ -127,6 +142,30 @@ impl Command {
                 }
                 settings.account_changesets_in_static_files = value;
                 println!("Set account_changesets_in_static_files = {}", value);
+            }
+            SetCommand::StoragesHistory { value } => {
+                if settings.storages_history_in_rocksdb == value {
+                    println!("storages_history_in_rocksdb is already set to {}", value);
+                    return Ok(());
+                }
+                settings.storages_history_in_rocksdb = value;
+                println!("Set storages_history_in_rocksdb = {}", value);
+            }
+            SetCommand::AccountHistory { value } => {
+                if settings.account_history_in_rocksdb == value {
+                    println!("account_history_in_rocksdb is already set to {}", value);
+                    return Ok(());
+                }
+                settings.account_history_in_rocksdb = value;
+                println!("Set account_history_in_rocksdb = {}", value);
+            }
+            SetCommand::TxHashNumbers { value } => {
+                if settings.transaction_hash_numbers_in_rocksdb == value {
+                    println!("transaction_hash_numbers_in_rocksdb is already set to {}", value);
+                    return Ok(());
+                }
+                settings.transaction_hash_numbers_in_rocksdb = value;
+                println!("Set transaction_hash_numbers_in_rocksdb = {}", value);
             }
         }
 

--- a/crates/node/core/src/args/static_files.rs
+++ b/crates/node/core/src/args/static_files.rs
@@ -61,6 +61,16 @@ pub struct StaticFilesArgs {
     /// the node has been initialized, changing this flag requires re-syncing from scratch.
     #[arg(long = "static-files.account-change-sets")]
     pub account_changesets: bool,
+
+    /// Use `RocksDB` for history indices instead of MDBX.
+    ///
+    /// When enabled, `AccountsHistory`, `StoragesHistory`, and `TransactionHashNumbers`
+    /// tables will be stored in `RocksDB` for better write performance.
+    ///
+    /// Note: This setting can only be configured at genesis initialization. Once
+    /// the node has been initialized, changing this flag requires re-syncing from scratch.
+    #[arg(long = "storage.rocksdb")]
+    pub rocksdb: bool,
 }
 
 impl StaticFilesArgs {
@@ -101,5 +111,8 @@ impl StaticFilesArgs {
             .with_receipts_in_static_files(self.receipts)
             .with_transaction_senders_in_static_files(self.transaction_senders)
             .with_account_changesets_in_static_files(self.account_changesets)
+            .with_account_history_in_rocksdb(self.rocksdb)
+            .with_storages_history_in_rocksdb(self.rocksdb)
+            .with_transaction_hash_numbers_in_rocksdb(self.rocksdb)
     }
 }

--- a/crates/node/core/src/node_config.rs
+++ b/crates/node/core/src/node_config.rs
@@ -342,6 +342,14 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
         self
     }
 
+    /// Converts the node configuration to [`StorageSettings`].
+    ///
+    /// This returns storage settings configured via CLI arguments including
+    /// static file settings and `RocksDB` settings.
+    pub const fn to_storage_settings(&self) -> reth_provider::StorageSettings {
+        self.static_files.to_settings()
+    }
+
     /// Returns pruning configuration.
     pub fn prune_config(&self) -> Option<PruneConfig>
     where

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -1019,6 +1019,13 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
+      --storage.rocksdb
+          Use RocksDB for history indices instead of MDBX.
+
+          When enabled, AccountsHistory, StoragesHistory, and TransactionHashNumbers tables will be stored in RocksDB for better write performance.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
 Ress:
       --ress.enable
           Enable support for `ress` subprotocol


### PR DESCRIPTION
**Summary**
Adds a single `--storage.rocksdb` CLI flag to enable RocksDB for all history tables. When enabled, AccountsHistory, StoragesHistory, and TransactionHashNumbers are stored in RocksDB instead of MDBX for better write performance.

**Changes**
- Add `--storage.rocksdb` flag to StaticFilesArgs
- Add `reth db settings set` subcommands for individual table control (storages-history, account-history, tx-hash-numbers)
- Add `to_storage_settings()` method to NodeConfig
- Update CLI documentation

**Testing**
CLI help verified. Manual testing of flag parsing.