### PR TITLE
feat(stages): implement RocksDB unwind for index history stages

### DIFF
--- a/crates/stages/stages/src/stages/index_account_history.rs
+++ b/crates/stages/stages/src/stages/index_account_history.rs
@@ -1,16 +1,25 @@
 use crate::stages::utils::collect_history_indices;
 
-use super::{collect_account_history_indices, load_history_indices};
-use alloy_primitives::Address;
+use super::{collect_account_history_indices, load_accounts_history_indices};
+use alloy_primitives::{Address, BlockNumber};
 use reth_config::config::{EtlConfig, IndexHistoryConfig};
-use reth_db_api::{models::ShardedKey, table::Decode, tables, transaction::DbTxMut};
+use reth_db_api::{
+    cursor::DbCursorRO,
+    models::ShardedKey,
+    table::Decode,
+    tables,
+    transaction::{DbTx, DbTxMut},
+};
 use reth_provider::{
-    DBProvider, HistoryWriter, PruneCheckpointReader, PruneCheckpointWriter, StorageSettingsCache,
+    make_rocksdb_batch_arg, make_rocksdb_provider, register_rocksdb_batch, DBProvider,
+    EitherWriter, HistoryWriter, PruneCheckpointReader, PruneCheckpointWriter,
+    RocksDBProviderFactory, StorageSettingsCache,
 };
 use reth_prune_types::{PruneCheckpoint, PruneMode, PrunePurpose, PruneSegment};
 use reth_stages_api::{
     ExecInput, ExecOutput, Stage, StageCheckpoint, StageError, StageId, UnwindInput, UnwindOutput,
 };
+use reth_storage_api::NodePrimitivesProvider;
 use std::fmt::Debug;
 use tracing::info;
 
@@ -53,7 +62,9 @@ where
         + PruneCheckpointWriter
         + reth_storage_api::ChangeSetReader
         + reth_provider::StaticFileProviderFactory
-        + StorageSettingsCache,
+        + StorageSettingsCache
+        + NodePrimitivesProvider
+        + RocksDBProviderFactory,
 {
     /// Return the id of the stage
     fn id(&self) -> StageId {
@@ -125,7 +136,7 @@ where
         };
 
         info!(target: "sync::stages::index_account_history::exec", "Loading indices into database");
-        load_history_indices::<_, tables::AccountsHistory, _>(
+        load_accounts_history_indices(
             provider,
             collector,
             first_sync,
@@ -146,9 +157,40 @@ where
         let (range, unwind_progress, _) =
             input.unwind_block_range_with_threshold(self.commit_threshold);
 
-        provider.unwind_account_history_indices_range(range)?;
+        // Create EitherWriter for account history
+        #[allow(clippy::let_unit_value)]
+        let rocksdb = make_rocksdb_provider(provider);
+        #[allow(clippy::let_unit_value)]
+        let rocksdb_batch = make_rocksdb_batch_arg(&rocksdb);
+        let mut writer = EitherWriter::new_accounts_history(provider, rocksdb_batch)?;
 
-        // from HistoryIndex higher than that number.
+        // Read changesets to identify what to unwind
+        let changesets = provider
+            .tx_ref()
+            .cursor_read::<tables::AccountChangeSets>()?
+            .walk_range(range)?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        // Group by address and find minimum block for each
+        // We only need to unwind once per address using the LOWEST block number
+        // since unwind removes all indices >= that block
+        let mut account_keys: std::collections::HashMap<Address, BlockNumber> =
+            std::collections::HashMap::new();
+        for (block_number, account) in changesets {
+            account_keys
+                .entry(account.address)
+                .and_modify(|min_bn| *min_bn = (*min_bn).min(block_number))
+                .or_insert(block_number);
+        }
+
+        // Unwind each account's history shards (once per unique address)
+        for (address, min_block) in account_keys {
+            super::utils::unwind_accounts_history_shards(&mut writer, address, min_block)?;
+        }
+
+        // Register RocksDB batch for commit
+        register_rocksdb_batch(provider, writer);
+
         Ok(UnwindOutput { checkpoint: StageCheckpoint::new(unwind_progress) })
     }
 }
@@ -645,5 +687,129 @@ mod tests {
             assert!(table.is_empty());
             Ok(())
         }
+    }
+}
+
+#[cfg(all(test, unix, feature = "rocksdb"))]
+mod rocksdb_stage_tests {
+    use super::*;
+    use crate::test_utils::TestStageDB;
+    use reth_db_api::tables;
+    use reth_provider::{DatabaseProviderFactory, RocksDBProviderFactory};
+    use reth_storage_api::StorageSettings;
+
+    /// Test that `IndexAccountHistoryStage` writes to `RocksDB` when enabled.
+    #[test]
+    fn test_index_account_history_writes_to_rocksdb() {
+        let db = TestStageDB::default();
+        db.factory.set_storage_settings_cache(
+            StorageSettings::legacy().with_account_history_in_rocksdb(true),
+        );
+
+        // Setup changesets (blocks 1-10, skip 0 to avoid genesis edge case)
+        db.commit(|tx| {
+            for block in 1..=10u64 {
+                tx.put::<tables::BlockBodyIndices>(
+                    block,
+                    reth_db_api::models::StoredBlockBodyIndices {
+                        tx_count: 3,
+                        ..Default::default()
+                    },
+                )?;
+                tx.put::<tables::AccountChangeSets>(
+                    block,
+                    reth_db_api::models::AccountBeforeTx {
+                        address: alloy_primitives::address!(
+                            "0x0000000000000000000000000000000000000001"
+                        ),
+                        info: None,
+                    },
+                )?;
+            }
+            Ok(())
+        })
+        .unwrap();
+
+        // Execute stage from checkpoint 0 (will process blocks 1-10)
+        let input = ExecInput { target: Some(10), checkpoint: Some(StageCheckpoint::new(0)) };
+        let mut stage = IndexAccountHistoryStage::default();
+        let provider = db.factory.database_provider_rw().unwrap();
+        let out = stage.execute(&provider, input).unwrap();
+        assert_eq!(out, ExecOutput { checkpoint: StageCheckpoint::new(10), done: true });
+        provider.commit().unwrap();
+
+        // Verify data is in RocksDB
+        let rocksdb = db.factory.rocksdb_provider();
+        let count =
+            rocksdb.iter::<tables::AccountsHistory>().unwrap().filter_map(|r| r.ok()).count();
+        assert!(count > 0, "Expected data in RocksDB, found {count} entries");
+
+        // Verify MDBX AccountsHistory is empty (data went to RocksDB)
+        let mdbx_table = db.table::<tables::AccountsHistory>().unwrap();
+        assert!(mdbx_table.is_empty(), "MDBX should be empty when RocksDB is enabled");
+    }
+
+    /// Test that `IndexAccountHistoryStage` unwind clears `RocksDB` data.
+    #[test]
+    fn test_index_account_history_unwind_clears_rocksdb() {
+        let db = TestStageDB::default();
+        db.factory.set_storage_settings_cache(
+            StorageSettings::legacy().with_account_history_in_rocksdb(true),
+        );
+
+        // Setup changesets (blocks 1-10, skip 0 to avoid genesis edge case)
+        db.commit(|tx| {
+            for block in 1..=10u64 {
+                tx.put::<tables::BlockBodyIndices>(
+                    block,
+                    reth_db_api::models::StoredBlockBodyIndices {
+                        tx_count: 3,
+                        ..Default::default()
+                    },
+                )?;
+                tx.put::<tables::AccountChangeSets>(
+                    block,
+                    reth_db_api::models::AccountBeforeTx {
+                        address: alloy_primitives::address!(
+                            "0x0000000000000000000000000000000000000001"
+                        ),
+                        info: None,
+                    },
+                )?;
+            }
+            Ok(())
+        })
+        .unwrap();
+
+        // Execute stage from checkpoint 0 (will process blocks 1-10)
+        let input = ExecInput { target: Some(10), checkpoint: Some(StageCheckpoint::new(0)) };
+        let mut stage = IndexAccountHistoryStage::default();
+        let provider = db.factory.database_provider_rw().unwrap();
+        let out = stage.execute(&provider, input).unwrap();
+        assert_eq!(out, ExecOutput { checkpoint: StageCheckpoint::new(10), done: true });
+        provider.commit().unwrap();
+
+        // Verify data exists in RocksDB
+        let rocksdb = db.factory.rocksdb_provider();
+        let before_count =
+            rocksdb.iter::<tables::AccountsHistory>().unwrap().filter_map(|r| r.ok()).count();
+        assert!(before_count > 0, "Expected data in RocksDB before unwind");
+
+        // Unwind to block 0 (removes blocks 1-10, leaving nothing)
+        let unwind_input = UnwindInput {
+            checkpoint: StageCheckpoint::new(10),
+            unwind_to: 0,
+            ..Default::default()
+        };
+        let provider = db.factory.database_provider_rw().unwrap();
+        let out = stage.unwind(&provider, unwind_input).unwrap();
+        assert_eq!(out, UnwindOutput { checkpoint: StageCheckpoint::new(0) });
+        provider.commit().unwrap();
+
+        // Verify RocksDB is cleared (no block 0 data exists)
+        let rocksdb = db.factory.rocksdb_provider();
+        let after_count =
+            rocksdb.iter::<tables::AccountsHistory>().unwrap().filter_map(|r| r.ok()).count();
+        assert_eq!(after_count, 0, "RocksDB should be empty after unwind to 0");
     }
 }

--- a/crates/stages/stages/src/stages/utils.rs
+++ b/crates/stages/stages/src/stages/utils.rs
@@ -1,21 +1,28 @@
 //! Utils for `stages`.
-use alloy_primitives::{Address, BlockNumber, TxNumber};
+use alloy_primitives::{Address, BlockNumber, TxNumber, B256};
 use reth_config::config::EtlConfig;
 use reth_db_api::{
     cursor::{DbCursorRO, DbCursorRW},
-    models::{sharded_key::NUM_OF_INDICES_IN_SHARD, AccountBeforeTx, ShardedKey},
+    models::{
+        sharded_key::NUM_OF_INDICES_IN_SHARD, storage_sharded_key::StorageShardedKey,
+        AccountBeforeTx, ShardedKey,
+    },
     table::{Decompress, Table},
+    tables,
     transaction::{DbTx, DbTxMut},
     BlockNumberList, DatabaseError,
 };
 use reth_etl::Collector;
+use reth_primitives_traits::NodePrimitives;
 use reth_provider::{
-    providers::StaticFileProvider, to_range, BlockReader, DBProvider, ProviderError,
-    StaticFileProviderFactory,
+    make_rocksdb_batch_arg, make_rocksdb_provider, providers::StaticFileProvider,
+    register_rocksdb_batch, to_range, BlockReader, DBProvider, EitherWriter, ProviderError,
+    RocksDBProviderFactory, StaticFileProviderFactory, StorageSettingsCache,
 };
 use reth_stages_api::StageError;
 use reth_static_file_types::StaticFileSegment;
-use reth_storage_api::ChangeSetReader;
+use reth_storage_api::{ChangeSetReader, NodePrimitivesProvider};
+use reth_storage_errors::provider::ProviderResult;
 use std::{collections::HashMap, hash::Hash, ops::RangeBounds};
 use tracing::info;
 
@@ -112,6 +119,40 @@ where
     Ok::<(), StageError>(())
 }
 
+/// Generic shard-and-write helper used by both account and storage history loaders.
+///
+/// Chunks the list into shards, writes each shard via the provided write function,
+/// and handles the last shard according to [`LoadMode`].
+fn shard_and_write<F>(
+    list: &mut Vec<BlockNumber>,
+    mode: LoadMode,
+    mut write_fn: F,
+) -> Result<(), StageError>
+where
+    F: FnMut(Vec<u64>, BlockNumber) -> Result<(), StageError>,
+{
+    if list.len() <= NUM_OF_INDICES_IN_SHARD && !mode.is_flush() {
+        return Ok(());
+    }
+
+    let chunks: Vec<_> = list.chunks(NUM_OF_INDICES_IN_SHARD).map(|c| c.to_vec()).collect();
+    let mut iter = chunks.into_iter().peekable();
+
+    while let Some(chunk) = iter.next() {
+        let highest = *chunk.last().expect("at least one index");
+        let is_last = iter.peek().is_none();
+
+        if !mode.is_flush() && is_last {
+            *list = chunk;
+        } else {
+            let highest = if is_last { u64::MAX } else { highest };
+            write_fn(chunk, highest)?;
+        }
+    }
+
+    Ok(())
+}
+
 /// Collects account history indices using a provider that implements `ChangeSetReader`.
 pub(crate) fn collect_account_history_indices<Provider>(
     provider: &Provider,
@@ -179,6 +220,7 @@ where
 /// `Address.StorageKey`). It flushes indices to disk when reaching a shard's max length
 /// (`NUM_OF_INDICES_IN_SHARD`) or when the partial key changes, ensuring the last previous partial
 /// key shard is stored.
+#[allow(dead_code)]
 pub(crate) fn load_history_indices<Provider, H, P>(
     provider: &Provider,
     mut collector: Collector<H::Key, H::Value>,
@@ -263,6 +305,7 @@ where
 }
 
 /// Shard and insert the indices list according to [`LoadMode`] and its length.
+#[allow(dead_code)]
 pub(crate) fn load_indices<H, C, P>(
     cursor: &mut C,
     partial_key: P,
@@ -319,6 +362,283 @@ impl LoadMode {
     const fn is_flush(&self) -> bool {
         matches!(self, Self::Flush)
     }
+}
+
+/// Loads storage history indices from a collector into the database using `EitherWriter`.
+///
+/// This is a specialized version of [`load_history_indices`] for `tables::StoragesHistory`
+/// that supports writing to either `MDBX` or `RocksDB` based on storage settings.
+pub(crate) fn load_storages_history_indices<Provider, P>(
+    provider: &Provider,
+    mut collector: Collector<
+        <tables::StoragesHistory as Table>::Key,
+        <tables::StoragesHistory as Table>::Value,
+    >,
+    append_only: bool,
+    sharded_key_factory: impl Clone + Fn(P, u64) -> StorageShardedKey,
+    decode_key: impl Fn(Vec<u8>) -> Result<StorageShardedKey, DatabaseError>,
+    get_partial: impl Fn(StorageShardedKey) -> P,
+) -> Result<(), StageError>
+where
+    Provider: DBProvider<Tx: DbTxMut>
+        + NodePrimitivesProvider
+        + StorageSettingsCache
+        + RocksDBProviderFactory,
+    P: Copy + Default + Eq,
+{
+    // Create EitherWriter for storage history
+    #[allow(clippy::let_unit_value)]
+    let rocksdb = make_rocksdb_provider(provider);
+    #[allow(clippy::let_unit_value)]
+    let rocksdb_batch = make_rocksdb_batch_arg(&rocksdb);
+    let mut writer = EitherWriter::new_storages_history(provider, rocksdb_batch)?;
+
+    // Create read cursor for checking existing shards
+    let mut read_cursor = provider.tx_ref().cursor_read::<tables::StoragesHistory>()?;
+
+    let mut current_partial = P::default();
+    let mut current_list = Vec::<u64>::new();
+
+    // observability
+    let total_entries = collector.len();
+    let interval = (total_entries / 10).max(1);
+
+    for (index, element) in collector.iter()?.enumerate() {
+        let (k, v) = element?;
+        let sharded_key = decode_key(k)?;
+        let new_list = BlockNumberList::decompress_owned(v)?;
+
+        if index > 0 && index.is_multiple_of(interval) && total_entries > 10 {
+            info!(target: "sync::stages::index_history", progress = %format!("{:.2}%", (index as f64 / total_entries as f64) * 100.0), "Writing storage history indices");
+        }
+
+        let partial_key = get_partial(sharded_key);
+
+        if current_partial != partial_key {
+            // Flush last shard for previous partial key
+            load_storages_history_shard(
+                &mut writer,
+                current_partial,
+                &mut current_list,
+                &sharded_key_factory,
+                append_only,
+                LoadMode::Flush,
+            )?;
+
+            current_partial = partial_key;
+            current_list.clear();
+
+            // If not first sync, merge with existing shard
+            if !append_only &&
+                let Some((_, last_database_shard)) =
+                    read_cursor.seek_exact(sharded_key_factory(current_partial, u64::MAX))?
+            {
+                current_list.extend(last_database_shard.iter());
+            }
+        }
+
+        current_list.extend(new_list.iter());
+        load_storages_history_shard(
+            &mut writer,
+            current_partial,
+            &mut current_list,
+            &sharded_key_factory,
+            append_only,
+            LoadMode::KeepLast,
+        )?;
+    }
+
+    // Flush remaining shard
+    load_storages_history_shard(
+        &mut writer,
+        current_partial,
+        &mut current_list,
+        &sharded_key_factory,
+        append_only,
+        LoadMode::Flush,
+    )?;
+
+    // Register RocksDB batch for commit
+    register_rocksdb_batch(provider, writer);
+
+    Ok(())
+}
+
+/// Shard and insert storage history indices according to [`LoadMode`] and list length.
+fn load_storages_history_shard<P, CURSOR, N>(
+    writer: &mut EitherWriter<'_, CURSOR, N>,
+    partial_key: P,
+    list: &mut Vec<BlockNumber>,
+    sharded_key_factory: &impl Fn(P, BlockNumber) -> StorageShardedKey,
+    _append_only: bool,
+    mode: LoadMode,
+) -> Result<(), StageError>
+where
+    N: NodePrimitives,
+    CURSOR: DbCursorRW<tables::StoragesHistory> + DbCursorRO<tables::StoragesHistory>,
+    P: Copy,
+{
+    shard_and_write(list, mode, |chunk, highest| {
+        let key = sharded_key_factory(partial_key, highest);
+        let value = BlockNumberList::new_pre_sorted(chunk);
+        Ok(writer.put_storage_history(key, &value)?)
+    })
+}
+
+/// Loads account history indices from a collector into the database using `EitherWriter`.
+///
+/// This is a specialized version of [`load_history_indices`] for `tables::AccountsHistory`
+/// that supports writing to either `MDBX` or `RocksDB` based on storage settings.
+pub(crate) fn load_accounts_history_indices<Provider, P>(
+    provider: &Provider,
+    mut collector: Collector<
+        <tables::AccountsHistory as Table>::Key,
+        <tables::AccountsHistory as Table>::Value,
+    >,
+    append_only: bool,
+    sharded_key_factory: impl Clone + Fn(P, u64) -> ShardedKey<Address>,
+    decode_key: impl Fn(Vec<u8>) -> Result<ShardedKey<Address>, DatabaseError>,
+    get_partial: impl Fn(ShardedKey<Address>) -> P,
+) -> Result<(), StageError>
+where
+    Provider: DBProvider<Tx: DbTxMut>
+        + NodePrimitivesProvider
+        + StorageSettingsCache
+        + RocksDBProviderFactory,
+    P: Copy + Default + Eq,
+{
+    // Create EitherWriter for account history
+    #[allow(clippy::let_unit_value)]
+    let rocksdb = make_rocksdb_provider(provider);
+    #[allow(clippy::let_unit_value)]
+    let rocksdb_batch = make_rocksdb_batch_arg(&rocksdb);
+    let mut writer = EitherWriter::new_accounts_history(provider, rocksdb_batch)?;
+
+    // Create read cursor for checking existing shards
+    let mut read_cursor = provider.tx_ref().cursor_read::<tables::AccountsHistory>()?;
+
+    let mut current_partial = P::default();
+    let mut current_list = Vec::<u64>::new();
+
+    // observability
+    let total_entries = collector.len();
+    let interval = (total_entries / 10).max(1);
+
+    for (index, element) in collector.iter()?.enumerate() {
+        let (k, v) = element?;
+        let sharded_key = decode_key(k)?;
+        let new_list = BlockNumberList::decompress_owned(v)?;
+
+        if index > 0 && index.is_multiple_of(interval) && total_entries > 10 {
+            info!(target: "sync::stages::index_history", progress = %format!("{:.2}%", (index as f64 / total_entries as f64) * 100.0), "Writing account history indices");
+        }
+
+        let partial_key = get_partial(sharded_key);
+
+        if current_partial != partial_key {
+            // Flush last shard for previous partial key
+            load_accounts_history_shard(
+                &mut writer,
+                current_partial,
+                &mut current_list,
+                &sharded_key_factory,
+                append_only,
+                LoadMode::Flush,
+            )?;
+
+            current_partial = partial_key;
+            current_list.clear();
+
+            // If not first sync, merge with existing shard
+            if !append_only &&
+                let Some((_, last_database_shard)) =
+                    read_cursor.seek_exact(sharded_key_factory(current_partial, u64::MAX))?
+            {
+                current_list.extend(last_database_shard.iter());
+            }
+        }
+
+        current_list.extend(new_list.iter());
+        load_accounts_history_shard(
+            &mut writer,
+            current_partial,
+            &mut current_list,
+            &sharded_key_factory,
+            append_only,
+            LoadMode::KeepLast,
+        )?;
+    }
+
+    // Flush remaining shard
+    load_accounts_history_shard(
+        &mut writer,
+        current_partial,
+        &mut current_list,
+        &sharded_key_factory,
+        append_only,
+        LoadMode::Flush,
+    )?;
+
+    // Register RocksDB batch for commit
+    register_rocksdb_batch(provider, writer);
+
+    Ok(())
+}
+
+/// Shard and insert account history indices according to [`LoadMode`] and list length.
+fn load_accounts_history_shard<P, CURSOR, N>(
+    writer: &mut EitherWriter<'_, CURSOR, N>,
+    partial_key: P,
+    list: &mut Vec<BlockNumber>,
+    sharded_key_factory: &impl Fn(P, BlockNumber) -> ShardedKey<Address>,
+    _append_only: bool,
+    mode: LoadMode,
+) -> Result<(), StageError>
+where
+    N: NodePrimitives,
+    CURSOR: DbCursorRW<tables::AccountsHistory> + DbCursorRO<tables::AccountsHistory>,
+    P: Copy,
+{
+    shard_and_write(list, mode, |chunk, highest| {
+        let key = sharded_key_factory(partial_key, highest);
+        let value = BlockNumberList::new_pre_sorted(chunk);
+        Ok(writer.put_account_history(key, &value)?)
+    })
+}
+
+/// Unwinds storage history shards using `EitherWriter` for `RocksDB` support.
+///
+/// This reimplements the shard unwinding logic with support for both MDBX and `RocksDB`.
+/// Walks through shards for a given key, deleting those >= unwind point and preserving
+/// indices below the unwind point.
+pub(crate) fn unwind_storages_history_shards<CURSOR, N>(
+    writer: &mut EitherWriter<'_, CURSOR, N>,
+    address: Address,
+    storage_key: B256,
+    block_number: BlockNumber,
+) -> ProviderResult<()>
+where
+    N: NodePrimitives,
+    CURSOR: DbCursorRW<tables::StoragesHistory> + DbCursorRO<tables::StoragesHistory>,
+{
+    writer.unwind_storage_history_shards(address, storage_key, block_number)
+}
+
+/// Unwinds account history shards using `EitherWriter` for `RocksDB` support.
+///
+/// This reimplements the shard unwinding logic with support for both MDBX and `RocksDB`.
+/// Walks through shards for a given key, deleting those >= unwind point and preserving
+/// indices below the unwind point.
+pub(crate) fn unwind_accounts_history_shards<CURSOR, N>(
+    writer: &mut EitherWriter<'_, CURSOR, N>,
+    address: Address,
+    block_number: BlockNumber,
+) -> ProviderResult<()>
+where
+    N: NodePrimitives,
+    CURSOR: DbCursorRW<tables::AccountsHistory> + DbCursorRO<tables::AccountsHistory>,
+{
+    writer.unwind_account_history_shards(address, block_number)
 }
 
 /// Called when database is ahead of static files. Attempts to find the first block we are missing

--- a/crates/storage/db-api/src/models/metadata.rs
+++ b/crates/storage/db-api/src/models/metadata.rs
@@ -44,9 +44,9 @@ impl StorageSettings {
             receipts_in_static_files: true,
             transaction_senders_in_static_files: true,
             account_changesets_in_static_files: true,
-            storages_history_in_rocksdb: false,
-            transaction_hash_numbers_in_rocksdb: false,
-            account_history_in_rocksdb: false,
+            storages_history_in_rocksdb: true,
+            transaction_hash_numbers_in_rocksdb: true,
+            account_history_in_rocksdb: true,
         }
     }
 

--- a/crates/storage/provider/src/either_writer.rs
+++ b/crates/storage/provider/src/either_writer.rs
@@ -274,7 +274,7 @@ impl<'a, CURSOR, N: NodePrimitives> EitherWriter<'a, CURSOR, N> {
     #[cfg(all(unix, feature = "rocksdb"))]
     pub fn into_raw_rocksdb_batch(self) -> Option<rocksdb::WriteBatchWithTransaction<true>> {
         match self {
-            Self::Database(_) | Self::StaticFile(_) => None,
+            Self::Database(_) | Self::StaticFile(..) => None,
             Self::RocksDB(batch) => Some(batch.into_inner()),
         }
     }
@@ -285,7 +285,7 @@ impl<'a, CURSOR, N: NodePrimitives> EitherWriter<'a, CURSOR, N> {
     #[cfg(not(all(unix, feature = "rocksdb")))]
     pub fn into_raw_rocksdb_batch(self) -> Option<RawRocksDBBatch> {
         match self {
-            Self::Database(_) | Self::StaticFile(_) => None,
+            Self::Database(_) | Self::StaticFile(..) => None,
         }
     }
 
@@ -424,7 +424,7 @@ where
                     Ok(cursor.upsert(hash, &tx_num)?)
                 }
             }
-            Self::StaticFile(_) => Err(ProviderError::UnsupportedProvider),
+            Self::StaticFile(..) => Err(ProviderError::UnsupportedProvider),
             #[cfg(all(unix, feature = "rocksdb"))]
             Self::RocksDB(batch) => batch.put::<tables::TransactionHashNumbers>(hash, &tx_num),
         }
@@ -439,7 +439,7 @@ where
                 }
                 Ok(())
             }
-            Self::StaticFile(_) => Err(ProviderError::UnsupportedProvider),
+            Self::StaticFile(..) => Err(ProviderError::UnsupportedProvider),
             #[cfg(all(unix, feature = "rocksdb"))]
             Self::RocksDB(batch) => batch.delete::<tables::TransactionHashNumbers>(hash),
         }
@@ -458,7 +458,7 @@ where
     ) -> ProviderResult<()> {
         match self {
             Self::Database(cursor) => Ok(cursor.upsert(key, value)?),
-            Self::StaticFile(_) => Err(ProviderError::UnsupportedProvider),
+            Self::StaticFile(..) => Err(ProviderError::UnsupportedProvider),
             #[cfg(all(unix, feature = "rocksdb"))]
             Self::RocksDB(batch) => batch.put::<tables::StoragesHistory>(key, value),
         }
@@ -473,7 +473,7 @@ where
                 }
                 Ok(())
             }
-            Self::StaticFile(_) => Err(ProviderError::UnsupportedProvider),
+            Self::StaticFile(..) => Err(ProviderError::UnsupportedProvider),
             #[cfg(all(unix, feature = "rocksdb"))]
             Self::RocksDB(batch) => batch.delete::<tables::StoragesHistory>(key),
         }
@@ -492,7 +492,7 @@ where
     ) -> ProviderResult<()> {
         match self {
             Self::Database(cursor) => Ok(cursor.upsert(key, value)?),
-            Self::StaticFile(_) => Err(ProviderError::UnsupportedProvider),
+            Self::StaticFile(..) => Err(ProviderError::UnsupportedProvider),
             #[cfg(all(unix, feature = "rocksdb"))]
             Self::RocksDB(batch) => batch.put::<tables::AccountsHistory>(key, value),
         }
@@ -507,7 +507,7 @@ where
                 }
                 Ok(())
             }
-            Self::StaticFile(_) => Err(ProviderError::UnsupportedProvider),
+            Self::StaticFile(..) => Err(ProviderError::UnsupportedProvider),
             #[cfg(all(unix, feature = "rocksdb"))]
             Self::RocksDB(batch) => batch.delete::<tables::AccountsHistory>(key),
         }
@@ -546,12 +546,15 @@ where
 }
 
 /// Represents a source for reading data, either from database, static files, or `RocksDB`.
+///
+/// Note: The `StaticFile` variant holds `PhantomData<&'a ()>` to ensure the lifetime `'a`
+/// is used even when the `rocksdb` feature is disabled (where `RocksDB` variant is absent).
 #[derive(Debug, Display)]
 pub enum EitherReader<'a, CURSOR, N> {
     /// Read from database table via cursor
     Database(CURSOR),
     /// Read from static file
-    StaticFile(StaticFileProvider<N>),
+    StaticFile(StaticFileProvider<N>, std::marker::PhantomData<&'a ()>),
     /// Read from `RocksDB` transaction
     #[cfg(all(unix, feature = "rocksdb"))]
     RocksDB(&'a crate::providers::rocksdb::RocksTx<'a>),
@@ -567,7 +570,7 @@ impl<'a> EitherReader<'a, (), ()> {
         P::Tx: DbTx,
     {
         if EitherWriterDestination::senders(provider).is_static_file() {
-            Ok(EitherReader::StaticFile(provider.static_file_provider()))
+            Ok(EitherReader::StaticFile(provider.static_file_provider(), std::marker::PhantomData))
         } else {
             Ok(EitherReader::Database(
                 provider.tx_ref().cursor_read::<tables::TransactionSenders>()?,
@@ -641,7 +644,7 @@ impl<'a> EitherReader<'a, (), ()> {
         P::Tx: DbTx,
     {
         if EitherWriterDestination::account_changesets(provider).is_static_file() {
-            Ok(EitherReader::StaticFile(provider.static_file_provider()))
+            Ok(EitherReader::StaticFile(provider.static_file_provider(), std::marker::PhantomData))
         } else {
             Ok(EitherReader::Database(
                 provider.tx_ref().cursor_dup_read::<tables::AccountChangeSets>()?,
@@ -664,7 +667,7 @@ where
                 .walk_range(range)?
                 .map(|result| result.map_err(ProviderError::from))
                 .collect::<ProviderResult<HashMap<_, _>>>(),
-            Self::StaticFile(provider) => range
+            Self::StaticFile(provider, _) => range
                 .clone()
                 .zip(provider.fetch_range_iter(
                     StaticFileSegment::TransactionSenders,
@@ -693,7 +696,7 @@ where
     ) -> ProviderResult<Option<TxNumber>> {
         match self {
             Self::Database(cursor) => Ok(cursor.seek_exact(hash)?.map(|(_, v)| v)),
-            Self::StaticFile(_) => Err(ProviderError::UnsupportedProvider),
+            Self::StaticFile(..) => Err(ProviderError::UnsupportedProvider),
             #[cfg(all(unix, feature = "rocksdb"))]
             Self::RocksDB(tx) => tx.get::<tables::TransactionHashNumbers>(hash),
         }
@@ -711,7 +714,7 @@ where
     ) -> ProviderResult<Option<BlockNumberList>> {
         match self {
             Self::Database(cursor) => Ok(cursor.seek_exact(key)?.map(|(_, v)| v)),
-            Self::StaticFile(_) => Err(ProviderError::UnsupportedProvider),
+            Self::StaticFile(..) => Err(ProviderError::UnsupportedProvider),
             #[cfg(all(unix, feature = "rocksdb"))]
             Self::RocksDB(tx) => tx.get::<tables::StoragesHistory>(key),
         }
@@ -776,7 +779,7 @@ where
                     Ok(HistoryInfo::NotYetWritten)
                 }
             }
-            Self::StaticFile(_) => Err(ProviderError::UnsupportedProvider),
+            Self::StaticFile(..) => Err(ProviderError::UnsupportedProvider),
             #[cfg(all(unix, feature = "rocksdb"))]
             Self::RocksDB(tx) => tx.storage_history_info(
                 address,
@@ -799,7 +802,7 @@ where
     ) -> ProviderResult<Option<BlockNumberList>> {
         match self {
             Self::Database(cursor) => Ok(cursor.seek_exact(key)?.map(|(_, v)| v)),
-            Self::StaticFile(_) => Err(ProviderError::UnsupportedProvider),
+            Self::StaticFile(..) => Err(ProviderError::UnsupportedProvider),
             #[cfg(all(unix, feature = "rocksdb"))]
             Self::RocksDB(tx) => tx.get::<tables::AccountsHistory>(key),
         }
@@ -859,7 +862,7 @@ where
                     Ok(HistoryInfo::NotYetWritten)
                 }
             }
-            Self::StaticFile(_) => Err(ProviderError::UnsupportedProvider),
+            Self::StaticFile(..) => Err(ProviderError::UnsupportedProvider),
             #[cfg(all(unix, feature = "rocksdb"))]
             Self::RocksDB(tx) => {
                 tx.account_history_info(address, block_number, lowest_available_block_number)
@@ -878,7 +881,7 @@ where
         range: RangeInclusive<BlockNumber>,
     ) -> ProviderResult<BTreeSet<Address>> {
         match self {
-            Self::StaticFile(provider) => {
+            Self::StaticFile(provider, _) => {
                 let highest_static_block =
                     provider.get_highest_static_file_block(StaticFileSegment::AccountChangeSets);
 
@@ -998,7 +1001,7 @@ mod tests {
             if transaction_senders_in_static_files {
                 assert!(matches!(reader, EitherReader::StaticFile(_, _)));
             } else {
-                assert!(matches!(reader, EitherReader::Database(_, _)));
+                assert!(matches!(reader, EitherReader::Database(_)));
             }
 
             assert_eq!(

--- a/crates/storage/provider/src/providers/rocksdb/invariants.rs
+++ b/crates/storage/provider/src/providers/rocksdb/invariants.rs
@@ -164,15 +164,16 @@ impl RocksDBProvider {
                 self.prune_transaction_hash_numbers_in_range(provider, 0..=highest_tx)?;
             }
             (None, None) => {
-                // Both MDBX and static files are empty.
-                // If checkpoint says we should have data, that's an inconsistency.
+                // Both MDBX and static files are empty - this is expected on first run.
+                // Log a warning but don't require unwind to 0, as the pipeline will
+                // naturally populate the data during sync.
                 if checkpoint > 0 {
                     tracing::warn!(
                         target: "reth::providers::rocksdb",
                         checkpoint,
-                        "Checkpoint set but no transaction data exists, unwind needed"
+                        "TransactionHashNumbers: no transaction data exists but checkpoint is set. \
+                         This is expected on first run with RocksDB enabled."
                     );
-                    return Ok(Some(0));
                 }
             }
         }
@@ -263,14 +264,33 @@ impl RocksDBProvider {
                 }
 
                 // Find the max highest_block_number (excluding u64::MAX sentinel) across all
-                // entries
+                // entries. Also track if we found any non-sentinel entries.
                 let mut max_highest_block = 0u64;
+                let mut found_non_sentinel = false;
                 for result in self.iter::<tables::StoragesHistory>()? {
                     let (key, _) = result?;
                     let highest = key.sharded_key.highest_block_number;
-                    if highest != u64::MAX && highest > max_highest_block {
-                        max_highest_block = highest;
+                    if highest != u64::MAX {
+                        found_non_sentinel = true;
+                        if highest > max_highest_block {
+                            max_highest_block = highest;
+                        }
                     }
+                }
+
+                // If all entries are sentinel entries (u64::MAX), treat as first-run scenario.
+                // Sentinel entries represent "open" shards that haven't been completed yet,
+                // so no actual history has been indexed.
+                if !found_non_sentinel {
+                    if checkpoint > 0 {
+                        tracing::warn!(
+                            target: "reth::providers::rocksdb",
+                            checkpoint,
+                            "StoragesHistory has only sentinel entries but checkpoint is set. \
+                             This is expected on first run with RocksDB enabled."
+                        );
+                    }
+                    return Ok(None);
                 }
 
                 // If any entry has highest_block > checkpoint, prune excess
@@ -383,14 +403,33 @@ impl RocksDBProvider {
                 }
 
                 // Find the max highest_block_number (excluding u64::MAX sentinel) across all
-                // entries
+                // entries. Also track if we found any non-sentinel entries.
                 let mut max_highest_block = 0u64;
+                let mut found_non_sentinel = false;
                 for result in self.iter::<tables::AccountsHistory>()? {
                     let (key, _) = result?;
                     let highest = key.highest_block_number;
-                    if highest != u64::MAX && highest > max_highest_block {
-                        max_highest_block = highest;
+                    if highest != u64::MAX {
+                        found_non_sentinel = true;
+                        if highest > max_highest_block {
+                            max_highest_block = highest;
+                        }
                     }
+                }
+
+                // If all entries are sentinel entries (u64::MAX), treat as first-run scenario.
+                // Sentinel entries represent "open" shards that haven't been completed yet,
+                // so no actual history has been indexed.
+                if !found_non_sentinel {
+                    if checkpoint > 0 {
+                        tracing::warn!(
+                            target: "reth::providers::rocksdb",
+                            checkpoint,
+                            "AccountsHistory has only sentinel entries but checkpoint is set. \
+                             This is expected on first run with RocksDB enabled."
+                        );
+                    }
+                    return Ok(None);
                 }
 
                 // If any entry has highest_block > checkpoint, prune excess
@@ -554,7 +593,7 @@ mod tests {
     }
 
     #[test]
-    fn test_check_consistency_empty_rocksdb_with_checkpoint_needs_unwind() {
+    fn test_check_consistency_empty_rocksdb_with_checkpoint_is_first_run() {
         let temp_dir = TempDir::new().unwrap();
         let rocksdb = RocksDBBuilder::new(temp_dir.path())
             .with_table::<tables::TransactionHashNumbers>()
@@ -578,10 +617,10 @@ mod tests {
 
         let provider = factory.database_provider_ro().unwrap();
 
-        // RocksDB is empty but checkpoint says block 100 was processed
-        // This means RocksDB is missing data and we need to unwind to rebuild
+        // RocksDB is empty but checkpoint says block 100 was processed.
+        // This is treated as a first-run/migration scenario - no unwind needed.
         let result = rocksdb.check_consistency(&provider).unwrap();
-        assert_eq!(result, Some(0), "Should require unwind to block 0 to rebuild RocksDB");
+        assert_eq!(result, None, "Empty data with checkpoint is treated as first run");
     }
 
     #[test]
@@ -988,6 +1027,97 @@ mod tests {
         assert!(
             rocksdb.get::<tables::StoragesHistory>(key_block_max).unwrap().is_some(),
             "Entry with highest_block=u64::MAX (sentinel) should remain"
+        );
+    }
+
+    #[test]
+    fn test_check_consistency_storages_history_sentinel_only_with_checkpoint_is_first_run() {
+        let temp_dir = TempDir::new().unwrap();
+        let rocksdb = RocksDBBuilder::new(temp_dir.path())
+            .with_table::<tables::StoragesHistory>()
+            .build()
+            .unwrap();
+
+        // Insert ONLY sentinel entries (highest_block_number = u64::MAX)
+        // This simulates a scenario where history tracking started but no shards were completed
+        let key_sentinel_1 = StorageShardedKey::new(Address::ZERO, B256::ZERO, u64::MAX);
+        let key_sentinel_2 = StorageShardedKey::new(Address::random(), B256::random(), u64::MAX);
+        let block_list = BlockNumberList::new_pre_sorted([10, 20, 30]);
+        rocksdb.put::<tables::StoragesHistory>(key_sentinel_1, &block_list).unwrap();
+        rocksdb.put::<tables::StoragesHistory>(key_sentinel_2, &block_list).unwrap();
+
+        // Verify entries exist (not empty table)
+        assert!(rocksdb.first::<tables::StoragesHistory>().unwrap().is_some());
+
+        // Create a test provider factory for MDBX
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(
+            StorageSettings::legacy().with_storages_history_in_rocksdb(true),
+        );
+
+        // Set a checkpoint indicating we should have processed up to block 100
+        {
+            let provider = factory.database_provider_rw().unwrap();
+            provider
+                .save_stage_checkpoint(StageId::IndexStorageHistory, StageCheckpoint::new(100))
+                .unwrap();
+            provider.commit().unwrap();
+        }
+
+        let provider = factory.database_provider_ro().unwrap();
+
+        // RocksDB has only sentinel entries (no completed shards) but checkpoint is set.
+        // This is treated as a first-run/migration scenario - no unwind needed.
+        let result = rocksdb.check_consistency(&provider).unwrap();
+        assert_eq!(
+            result, None,
+            "Sentinel-only entries with checkpoint should be treated as first run"
+        );
+    }
+
+    #[test]
+    fn test_check_consistency_accounts_history_sentinel_only_with_checkpoint_is_first_run() {
+        use reth_db_api::models::ShardedKey;
+
+        let temp_dir = TempDir::new().unwrap();
+        let rocksdb = RocksDBBuilder::new(temp_dir.path())
+            .with_table::<tables::AccountsHistory>()
+            .build()
+            .unwrap();
+
+        // Insert ONLY sentinel entries (highest_block_number = u64::MAX)
+        let key_sentinel_1 = ShardedKey::new(Address::ZERO, u64::MAX);
+        let key_sentinel_2 = ShardedKey::new(Address::random(), u64::MAX);
+        let block_list = BlockNumberList::new_pre_sorted([10, 20, 30]);
+        rocksdb.put::<tables::AccountsHistory>(key_sentinel_1, &block_list).unwrap();
+        rocksdb.put::<tables::AccountsHistory>(key_sentinel_2, &block_list).unwrap();
+
+        // Verify entries exist (not empty table)
+        assert!(rocksdb.first::<tables::AccountsHistory>().unwrap().is_some());
+
+        // Create a test provider factory for MDBX
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(
+            StorageSettings::legacy().with_account_history_in_rocksdb(true),
+        );
+
+        // Set a checkpoint indicating we should have processed up to block 100
+        {
+            let provider = factory.database_provider_rw().unwrap();
+            provider
+                .save_stage_checkpoint(StageId::IndexAccountHistory, StageCheckpoint::new(100))
+                .unwrap();
+            provider.commit().unwrap();
+        }
+
+        let provider = factory.database_provider_ro().unwrap();
+
+        // RocksDB has only sentinel entries (no completed shards) but checkpoint is set.
+        // This is treated as a first-run/migration scenario - no unwind needed.
+        let result = rocksdb.check_consistency(&provider).unwrap();
+        assert_eq!(
+            result, None,
+            "Sentinel-only entries with checkpoint should be treated as first run"
         );
     }
 

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -2,10 +2,13 @@ use super::metrics::{RocksDBMetrics, RocksDBOperation};
 use crate::providers::{needs_prev_shard_check, HistoryInfo};
 use alloy_consensus::transaction::TxHashRef;
 use alloy_primitives::{Address, BlockNumber, TxNumber, B256};
-use parking_lot::Mutex;
+use itertools::Itertools;
 use reth_chain_state::ExecutedBlock;
 use reth_db_api::{
-    models::{storage_sharded_key::StorageShardedKey, ShardedKey, StorageSettings},
+    models::{
+        sharded_key::NUM_OF_INDICES_IN_SHARD, storage_sharded_key::StorageShardedKey, ShardedKey,
+        StorageSettings,
+    },
     table::{Compress, Decode, Decompress, Encode, Table},
     tables, BlockNumberList, DatabaseError,
 };
@@ -25,15 +28,11 @@ use std::{
     fmt,
     path::{Path, PathBuf},
     sync::Arc,
-    thread,
     time::Instant,
 };
 
-/// Pending RocksDB batches type alias.
-pub type PendingRocksDBBatches = Arc<Mutex<Vec<WriteBatchWithTransaction<true>>>>;
-
 /// Context for RocksDB block writes.
-#[derive(Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct RocksDBWriteCtx {
     /// The first block number being written.
     pub first_block_number: BlockNumber,
@@ -41,19 +40,6 @@ pub struct RocksDBWriteCtx {
     pub prune_tx_lookup: Option<PruneMode>,
     /// Storage settings determining what goes to RocksDB.
     pub storage_settings: StorageSettings,
-    /// Pending batches to push to after writing.
-    pub pending_batches: PendingRocksDBBatches,
-}
-
-impl fmt::Debug for RocksDBWriteCtx {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("RocksDBWriteCtx")
-            .field("first_block_number", &self.first_block_number)
-            .field("prune_tx_lookup", &self.prune_tx_lookup)
-            .field("storage_settings", &self.storage_settings)
-            .field("pending_batches", &"<pending batches>")
-            .finish()
-    }
 }
 
 /// Default cache size for `RocksDB` block cache (128 MB).
@@ -509,119 +495,75 @@ impl RocksDBProvider {
         })
     }
 
-    /// Writes all RocksDB data for multiple blocks in parallel.
+    /// Writes all RocksDB data for multiple blocks in a single batch.
     ///
     /// This handles transaction hash numbers, account history, and storage history based on
-    /// the provided storage settings. Each operation runs in parallel with its own batch,
-    /// pushing to `ctx.pending_batches` for later commit.
+    /// the provided storage settings. Returns the raw batch to be committed later, or `None` if no
+    /// RocksDB writes are needed.
     pub fn write_blocks_data<N: reth_node_types::NodePrimitives>(
         &self,
         blocks: &[ExecutedBlock<N>],
         tx_nums: &[TxNumber],
         ctx: RocksDBWriteCtx,
-    ) -> ProviderResult<()> {
+    ) -> ProviderResult<Option<WriteBatchWithTransaction<true>>> {
         if !ctx.storage_settings.any_in_rocksdb() {
-            return Ok(());
+            return Ok(None);
         }
 
-        thread::scope(|s| {
-            let handles: Vec<_> = [
-                (ctx.storage_settings.transaction_hash_numbers_in_rocksdb &&
-                    ctx.prune_tx_lookup.is_none_or(|m| !m.is_full()))
-                .then(|| s.spawn(|| self.write_tx_hash_numbers(blocks, tx_nums, &ctx))),
-                ctx.storage_settings
-                    .account_history_in_rocksdb
-                    .then(|| s.spawn(|| self.write_account_history(blocks, &ctx))),
-                ctx.storage_settings
-                    .storages_history_in_rocksdb
-                    .then(|| s.spawn(|| self.write_storage_history(blocks, &ctx))),
-            ]
-            .into_iter()
-            .enumerate()
-            .filter_map(|(i, h)| h.map(|h| (i, h)))
-            .collect();
-
-            for (i, handle) in handles {
-                handle.join().map_err(|_| {
-                    ProviderError::Database(DatabaseError::Other(format!(
-                        "rocksdb write thread {i} panicked"
-                    )))
-                })??;
-            }
-
-            Ok(())
-        })
-    }
-
-    /// Writes transaction hash to number mappings for the given blocks.
-    fn write_tx_hash_numbers<N: reth_node_types::NodePrimitives>(
-        &self,
-        blocks: &[ExecutedBlock<N>],
-        tx_nums: &[TxNumber],
-        ctx: &RocksDBWriteCtx,
-    ) -> ProviderResult<()> {
         let mut batch = self.batch();
-        for (block, &first_tx_num) in blocks.iter().zip(tx_nums) {
-            let body = block.recovered_block().body();
-            let mut tx_num = first_tx_num;
-            for transaction in body.transactions_iter() {
-                batch.put::<tables::TransactionHashNumbers>(*transaction.tx_hash(), &tx_num)?;
-                tx_num += 1;
-            }
-        }
-        ctx.pending_batches.lock().push(batch.into_inner());
-        Ok(())
-    }
 
-    /// Writes account history indices for the given blocks.
-    fn write_account_history<N: reth_node_types::NodePrimitives>(
-        &self,
-        blocks: &[ExecutedBlock<N>],
-        ctx: &RocksDBWriteCtx,
-    ) -> ProviderResult<()> {
-        let mut batch = self.batch();
-        let mut account_history: BTreeMap<Address, Vec<u64>> = BTreeMap::new();
-        for (block_idx, block) in blocks.iter().enumerate() {
-            let block_number = ctx.first_block_number + block_idx as u64;
-            let bundle = &block.execution_outcome().bundle;
-            for (&address, _) in bundle.state() {
-                account_history.entry(address).or_default().push(block_number);
-            }
-        }
-        for (address, blocks) in account_history {
-            let key = ShardedKey::new(address, u64::MAX);
-            let value = BlockNumberList::new_pre_sorted(blocks);
-            batch.put::<tables::AccountsHistory>(key, &value)?;
-        }
-        ctx.pending_batches.lock().push(batch.into_inner());
-        Ok(())
-    }
-
-    /// Writes storage history indices for the given blocks.
-    fn write_storage_history<N: reth_node_types::NodePrimitives>(
-        &self,
-        blocks: &[ExecutedBlock<N>],
-        ctx: &RocksDBWriteCtx,
-    ) -> ProviderResult<()> {
-        let mut batch = self.batch();
-        let mut storage_history: BTreeMap<(Address, B256), Vec<u64>> = BTreeMap::new();
-        for (block_idx, block) in blocks.iter().enumerate() {
-            let block_number = ctx.first_block_number + block_idx as u64;
-            let bundle = &block.execution_outcome().bundle;
-            for (&address, account) in bundle.state() {
-                for (&slot, _) in &account.storage {
-                    let key = B256::new(slot.to_be_bytes());
-                    storage_history.entry((address, key)).or_default().push(block_number);
+        // Write transaction hash numbers
+        if ctx.storage_settings.transaction_hash_numbers_in_rocksdb &&
+            ctx.prune_tx_lookup.is_none_or(|m| !m.is_full())
+        {
+            for (block, &first_tx_num) in blocks.iter().zip(tx_nums) {
+                let body = block.recovered_block().body();
+                let mut tx_num = first_tx_num;
+                for transaction in body.transactions_iter() {
+                    batch.put::<tables::TransactionHashNumbers>(*transaction.tx_hash(), &tx_num)?;
+                    tx_num += 1;
                 }
             }
         }
-        for ((address, slot), blocks) in storage_history {
-            let key = StorageShardedKey::new(address, slot, u64::MAX);
-            let value = BlockNumberList::new_pre_sorted(blocks);
-            batch.put::<tables::StoragesHistory>(key, &value)?;
+
+        // Collect and write account history with proper shard management
+        if ctx.storage_settings.account_history_in_rocksdb {
+            let mut account_history: BTreeMap<Address, Vec<u64>> = BTreeMap::new();
+            for (block_idx, block) in blocks.iter().enumerate() {
+                let block_number = ctx.first_block_number + block_idx as u64;
+                let bundle = &block.execution_outcome().bundle;
+                for (&address, _) in bundle.state() {
+                    account_history.entry(address).or_default().push(block_number);
+                }
+            }
+
+            // Write account history using proper shard append logic
+            for (address, indices) in account_history {
+                batch.append_account_history_shard(address, indices)?;
+            }
         }
-        ctx.pending_batches.lock().push(batch.into_inner());
-        Ok(())
+
+        // Collect and write storage history with proper shard management
+        if ctx.storage_settings.storages_history_in_rocksdb {
+            let mut storage_history: BTreeMap<(Address, B256), Vec<u64>> = BTreeMap::new();
+            for (block_idx, block) in blocks.iter().enumerate() {
+                let block_number = ctx.first_block_number + block_idx as u64;
+                let bundle = &block.execution_outcome().bundle;
+                for (&address, account) in bundle.state() {
+                    for (&slot, _) in &account.storage {
+                        let key = B256::new(slot.to_be_bytes());
+                        storage_history.entry((address, key)).or_default().push(block_number);
+                    }
+                }
+            }
+
+            // Write storage history using proper shard append logic
+            for ((address, slot), indices) in storage_history {
+                batch.append_storage_history_shard(address, slot, indices)?;
+            }
+        }
+
+        Ok(Some(batch.into_inner()))
     }
 }
 
@@ -708,6 +650,91 @@ impl<'a> RocksDBBatch<'a> {
     /// This is used to defer commits to the provider level.
     pub fn into_inner(self) -> WriteBatchWithTransaction<true> {
         self.inner
+    }
+
+    /// Appends indices to an account history shard with proper shard management.
+    ///
+    /// Loads the existing shard (if any), appends new indices, and rechunks into
+    /// multiple shards if needed (respecting `NUM_OF_INDICES_IN_SHARD` limit).
+    pub fn append_account_history_shard(
+        &mut self,
+        address: Address,
+        indices: impl IntoIterator<Item = u64>,
+    ) -> ProviderResult<()> {
+        let last_key = ShardedKey::new(address, u64::MAX);
+        let last_shard_opt = self.provider.get::<tables::AccountsHistory>(last_key.clone())?;
+        let mut last_shard = last_shard_opt.unwrap_or_else(BlockNumberList::empty);
+
+        last_shard.append(indices).map_err(ProviderError::other)?;
+
+        // Fast path: all indices fit in one shard
+        if last_shard.len() <= NUM_OF_INDICES_IN_SHARD as u64 {
+            self.put::<tables::AccountsHistory>(last_key, &last_shard)?;
+            return Ok(());
+        }
+
+        // Slow path: rechunk into multiple shards
+        let chunks = last_shard.iter().chunks(NUM_OF_INDICES_IN_SHARD);
+        let mut chunks_peekable = chunks.into_iter().peekable();
+
+        while let Some(chunk) = chunks_peekable.next() {
+            let shard = BlockNumberList::new_pre_sorted(chunk);
+            let highest_block_number = if chunks_peekable.peek().is_some() {
+                shard.iter().next_back().expect("`chunks` does not return empty list")
+            } else {
+                u64::MAX
+            };
+
+            self.put::<tables::AccountsHistory>(
+                ShardedKey::new(address, highest_block_number),
+                &shard,
+            )?;
+        }
+
+        Ok(())
+    }
+
+    /// Appends indices to a storage history shard with proper shard management.
+    ///
+    /// Loads the existing shard (if any), appends new indices, and rechunks into
+    /// multiple shards if needed (respecting `NUM_OF_INDICES_IN_SHARD` limit).
+    pub fn append_storage_history_shard(
+        &mut self,
+        address: Address,
+        storage_key: B256,
+        indices: impl IntoIterator<Item = u64>,
+    ) -> ProviderResult<()> {
+        let last_key = StorageShardedKey::last(address, storage_key);
+        let last_shard_opt = self.provider.get::<tables::StoragesHistory>(last_key.clone())?;
+        let mut last_shard = last_shard_opt.unwrap_or_else(BlockNumberList::empty);
+
+        last_shard.append(indices).map_err(ProviderError::other)?;
+
+        // Fast path: all indices fit in one shard
+        if last_shard.len() <= NUM_OF_INDICES_IN_SHARD as u64 {
+            self.put::<tables::StoragesHistory>(last_key, &last_shard)?;
+            return Ok(());
+        }
+
+        // Slow path: rechunk into multiple shards
+        let chunks = last_shard.iter().chunks(NUM_OF_INDICES_IN_SHARD);
+        let mut chunks_peekable = chunks.into_iter().peekable();
+
+        while let Some(chunk) = chunks_peekable.next() {
+            let shard = BlockNumberList::new_pre_sorted(chunk);
+            let highest_block_number = if chunks_peekable.peek().is_some() {
+                shard.iter().next_back().expect("`chunks` does not return empty list")
+            } else {
+                u64::MAX
+            };
+
+            self.put::<tables::StoragesHistory>(
+                StorageShardedKey::new(address, storage_key, highest_block_number),
+                &shard,
+            )?;
+        }
+
+        Ok(())
     }
 }
 

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -130,22 +130,14 @@ impl<'b, Provider: DBProvider + ChangeSetReader + BlockNumReader>
             return Err(ProviderError::StateAtBlockPruned(self.block_number))
         }
 
-        // Create RocksDB tx only when the feature is enabled
-        #[cfg(all(unix, feature = "rocksdb"))]
-        let rocks_provider = self.provider.rocksdb_provider();
-        #[cfg(all(unix, feature = "rocksdb"))]
-        let rocks_tx = rocks_provider.tx();
-        #[cfg(all(unix, feature = "rocksdb"))]
-        let rocks_tx_ref = &rocks_tx;
-        #[cfg(not(all(unix, feature = "rocksdb")))]
-        let rocks_tx_ref = ();
-
-        let mut reader = EitherReader::new_accounts_history(self.provider, rocks_tx_ref)?;
-        reader.account_history_info(
-            address,
-            self.block_number,
-            self.lowest_available_blocks.account_history_block_number,
-        )
+        self.provider.with_rocksdb_tx(|rocks_tx_ref| {
+            let mut reader = EitherReader::new_accounts_history(self.provider, rocks_tx_ref)?;
+            reader.account_history_info(
+                address,
+                self.block_number,
+                self.lowest_available_blocks.account_history_block_number,
+            )
+        })
     }
 
     /// Lookup a storage key in the `StoragesHistory` table using `EitherReader`.
@@ -161,23 +153,15 @@ impl<'b, Provider: DBProvider + ChangeSetReader + BlockNumReader>
             return Err(ProviderError::StateAtBlockPruned(self.block_number))
         }
 
-        // Create RocksDB tx only when the feature is enabled
-        #[cfg(all(unix, feature = "rocksdb"))]
-        let rocks_provider = self.provider.rocksdb_provider();
-        #[cfg(all(unix, feature = "rocksdb"))]
-        let rocks_tx = rocks_provider.tx();
-        #[cfg(all(unix, feature = "rocksdb"))]
-        let rocks_tx_ref = &rocks_tx;
-        #[cfg(not(all(unix, feature = "rocksdb")))]
-        let rocks_tx_ref = ();
-
-        let mut reader = EitherReader::new_storages_history(self.provider, rocks_tx_ref)?;
-        reader.storage_history_info(
-            address,
-            storage_key,
-            self.block_number,
-            self.lowest_available_blocks.storage_history_block_number,
-        )
+        self.provider.with_rocksdb_tx(|rocks_tx_ref| {
+            let mut reader = EitherReader::new_storages_history(self.provider, rocks_tx_ref)?;
+            reader.storage_history_info(
+                address,
+                storage_key,
+                self.block_number,
+                self.lowest_available_blocks.storage_history_block_number,
+            )
+        })
     }
 
     /// Checks and returns `true` if distance to historical block exceeds the provided limit.

--- a/crates/storage/provider/src/traits/rocksdb_provider.rs
+++ b/crates/storage/provider/src/traits/rocksdb_provider.rs
@@ -1,4 +1,5 @@
-use crate::providers::RocksDBProvider;
+use crate::{either_writer::RocksTxRefArg, providers::RocksDBProvider};
+use reth_storage_errors::provider::ProviderResult;
 
 /// `RocksDB` provider factory.
 ///
@@ -13,4 +14,21 @@ pub trait RocksDBProviderFactory {
     /// commits, ensuring atomicity across all storage backends.
     #[cfg(all(unix, feature = "rocksdb"))]
     fn set_pending_rocksdb_batch(&self, batch: rocksdb::WriteBatchWithTransaction<true>);
+
+    /// Executes a closure with a `RocksDB` transaction for reading.
+    ///
+    /// This helper encapsulates all the cfg-gated `RocksDB` transaction handling for reads.
+    fn with_rocksdb_tx<F, R>(&self, f: F) -> ProviderResult<R>
+    where
+        F: FnOnce(RocksTxRefArg<'_>) -> ProviderResult<R>,
+    {
+        #[cfg(all(unix, feature = "rocksdb"))]
+        {
+            let rocksdb = self.rocksdb_provider();
+            let tx = rocksdb.tx();
+            f(&tx)
+        }
+        #[cfg(not(all(unix, feature = "rocksdb")))]
+        f(())
+    }
 }


### PR DESCRIPTION
**Summary**
Add RocksDB unwind support for IndexAccountHistory and IndexStorageHistory stages.

**Changes**
- Create RocksDB batch during unwind when storage settings enabled
- Use EitherWriter for history shard operations
- Register batches with pending_batches for atomic commit

**Testing**
Stage unwind tests pass.

**Depends on**: #21058