### PR TITLE
feat(stages): add RocksDB helper functions for stage operations

### DIFF
--- a/crates/storage/db-api/src/models/metadata.rs
+++ b/crates/storage/db-api/src/models/metadata.rs
@@ -44,9 +44,9 @@ impl StorageSettings {
             receipts_in_static_files: true,
             transaction_senders_in_static_files: true,
             account_changesets_in_static_files: true,
-            storages_history_in_rocksdb: false,
-            transaction_hash_numbers_in_rocksdb: false,
-            account_history_in_rocksdb: false,
+            storages_history_in_rocksdb: true,
+            transaction_hash_numbers_in_rocksdb: true,
+            account_history_in_rocksdb: true,
         }
     }
 

--- a/crates/storage/provider/src/either_writer.rs
+++ b/crates/storage/provider/src/either_writer.rs
@@ -190,7 +190,7 @@ pub fn make_rocksdb_batch_arg(
 #[cfg(not(all(unix, feature = "rocksdb")))]
 pub const fn make_rocksdb_batch_arg<T>(_rocksdb: &T) -> RocksBatchArg<'static> {}
 
-/// Gets the `RocksDB` provider from a provider that implements [`RocksDBProviderFactory`].
+/// Gets the `RocksDB` provider from a provider that implements [`crate::RocksDBProviderFactory`].
 ///
 /// On `RocksDB`-enabled builds, returns the real provider.
 /// On other builds, returns `()` to allow the same API without feature gates.

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -471,7 +471,7 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
                 Ok::<_, ProviderError>(start.elapsed())
             });
 
-            // RocksDB writes
+            // RocksDB writes (batches are pushed to pending_batches inside write_blocks_data)
             let rocksdb_handle = rocksdb_ctx.storage_settings.any_in_rocksdb().then(|| {
                 s.spawn(|| {
                     let start = Instant::now();
@@ -543,10 +543,11 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
                 .join()
                 .map_err(|_| StaticFileWriterError::ThreadPanic("static file"))??;
 
-            // Wait for RocksDB thread
+            // Wait for RocksDB thread (batches already pushed to pending_batches)
             #[cfg(all(unix, feature = "rocksdb"))]
             if let Some(handle) = rocksdb_handle {
-                timings.rocksdb = handle.join().expect("RocksDB thread panicked")?;
+                let elapsed = handle.join().expect("RocksDB thread panicked")?;
+                timings.rocksdb = elapsed;
             }
             #[cfg(not(all(unix, feature = "rocksdb")))]
             let _ = rocksdb_handle;

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -2,9 +2,9 @@ use super::metrics::{RocksDBMetrics, RocksDBOperation};
 use crate::providers::{compute_history_rank, needs_prev_shard_check, HistoryInfo};
 use alloy_consensus::transaction::TxHashRef;
 use alloy_primitives::{Address, BlockNumber, TxNumber, B256};
+use itertools::Itertools;
 use parking_lot::Mutex;
 use reth_chain_state::ExecutedBlock;
-use itertools::Itertools;
 use reth_db_api::{
     models::{
         sharded_key::NUM_OF_INDICES_IN_SHARD, storage_sharded_key::StorageShardedKey, ShardedKey,
@@ -512,6 +512,22 @@ impl RocksDBProvider {
                 code: -1,
             }))
         })
+    }
+
+    /// Creates a reverse iterator over a table starting from the given key.
+    ///
+    /// Iterates from the key towards the beginning of the table.
+    pub fn iter_from_reverse<T: Table>(
+        &self,
+        key: T::Key,
+    ) -> ProviderResult<RocksDBIterReverse<'_, T>> {
+        let cf = self.get_cf_handle::<T>()?;
+        let encoded_key = key.encode();
+        let iter = self
+            .0
+            .db
+            .iterator_cf(cf, IteratorMode::From(encoded_key.as_ref(), rocksdb::Direction::Reverse));
+        Ok(RocksDBIterReverse { inner: iter, _marker: std::marker::PhantomData })
     }
 
     /// Writes all `RocksDB` data for multiple blocks in parallel.
@@ -1116,6 +1132,60 @@ impl<T: Table> Iterator for RocksDBIter<'_, T> {
         };
 
         Some(Ok((key, value)))
+    }
+}
+
+/// Result type for raw iterator items.
+type RocksDBRawIterResult = Result<(Box<[u8]>, Box<[u8]>), rocksdb::Error>;
+
+/// Decodes an iterator result from `RocksDB` into a table key-value pair.
+fn decode_iter_result<T: Table>(
+    result: RocksDBRawIterResult,
+) -> Option<ProviderResult<(T::Key, T::Value)>> {
+    let (key_bytes, value_bytes) = match result {
+        Ok(kv) => kv,
+        Err(e) => {
+            return Some(Err(ProviderError::Database(DatabaseError::Read(DatabaseErrorInfo {
+                message: e.to_string().into(),
+                code: -1,
+            }))))
+        }
+    };
+
+    // Decode key
+    let key = match <T::Key as reth_db_api::table::Decode>::decode(&key_bytes) {
+        Ok(k) => k,
+        Err(_) => return Some(Err(ProviderError::Database(DatabaseError::Decode))),
+    };
+
+    // Decompress value
+    let value = match T::Value::decompress(&value_bytes) {
+        Ok(v) => v,
+        Err(_) => return Some(Err(ProviderError::Database(DatabaseError::Decode))),
+    };
+
+    Some(Ok((key, value)))
+}
+
+/// Reverse iterator over a `RocksDB` table (non-transactional).
+///
+/// Yields decoded `(Key, Value)` pairs in reverse key order.
+pub struct RocksDBIterReverse<'db, T: Table> {
+    inner: rocksdb::DBIteratorWithThreadMode<'db, OptimisticTransactionDB>,
+    _marker: std::marker::PhantomData<T>,
+}
+
+impl<T: Table> fmt::Debug for RocksDBIterReverse<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RocksDBIterReverse").field("table", &T::NAME).finish_non_exhaustive()
+    }
+}
+
+impl<T: Table> Iterator for RocksDBIterReverse<'_, T> {
+    type Item = ProviderResult<(T::Key, T::Value)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        decode_iter_result::<T>(self.inner.next()?)
     }
 }
 


### PR DESCRIPTION
**Summary**
Helper functions for RocksDB integration in stage operations.

**Changes**
- Add stage-level utilities for RocksDB operations
- Support unwinding and rewinding of history indices

**Testing**
Stage operations verified.

---

## PR Stack

```
main
  ↑
#21063 (rocksdb-either-reader)
  ↑
#21065 (rocksdb-stage-utils) ◀ you are here
  ↑
#21066 (rocksdb-index-history-stages)
  ↑
#21068 (rocksdb-init-txlookup)
  ↑
#21069 (rocksdb-cli-testutils)
  ↑
#21070 (rocksdb-cli)
  ↑
#21071 (rocksdb-docs)
```

- https://github.com/paradigmxyz/reth/pull/21063
- https://github.com/paradigmxyz/reth/pull/21065 ◀
- https://github.com/paradigmxyz/reth/pull/21066
- https://github.com/paradigmxyz/reth/pull/21068
- https://github.com/paradigmxyz/reth/pull/21069
- https://github.com/paradigmxyz/reth/pull/21070
- https://github.com/paradigmxyz/reth/pull/21071