### PR TITLE
refactor: avoid redundant allocation in create_reorg_head

### DIFF
--- a/crates/engine/util/src/reorg.rs
+++ b/crates/engine/util/src/reorg.rs
@@ -257,7 +257,8 @@ where
 
     // Fetch reorg target block depending on its depth and its parent.
     let mut previous_hash = next_block.parent_hash();
-    let mut candidate_transactions = next_block.into_body().transactions().to_vec();
+    let mut candidate_transactions =
+        if depth == 0 { next_block.into_body().transactions().to_vec() } else { Vec::new() };
     let reorg_target = 'target: {
         loop {
             let reorg_target = provider


### PR DESCRIPTION
`create_reorg_head` always cloned transactions from next_block into candidate_transactions, even when depth > 0. In that case the vector was immediately overwritten in the loop with into_transactions() from the selected reorg target child and the initial allocation was never used.

This change makes the initialization of candidate_transactions conditional on depth == 0, preserving the existing reorg semantics while avoiding an unnecessary allocation and copy for deeper reorg simulations.