### PR TITLE
fix(storage): allow enabling static file segments on existing nodes

### DIFF
--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -1361,6 +1361,14 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         Provider: DBProvider + BlockReader + StageCheckpointReader,
     {
         debug!(target: "reth::providers::static_file", ?segment, ?highest_static_file_entry, ?highest_static_file_block, "Ensuring invariants");
+
+        // If the static file is truly empty (never had data), this is a valid scenario when
+        // enabling static files for the first time on an existing node. No invariants to check.
+        if highest_static_file_entry.is_none() && highest_static_file_block.is_none() {
+            debug!(target: "reth::providers::static_file", ?segment, "Static file is empty, allowing fresh start");
+            return Ok(None);
+        }
+
         let mut db_cursor = provider.tx_ref().cursor_read::<T>()?;
 
         if let Some((db_last_entry, _)) = db_cursor.last()? &&

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -428,8 +428,9 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
         let current_block = if let Some(current_block_number) = self.current_block_number() {
             current_block_number
         } else {
-            self.increment_block(0)?;
-            0
+            let start_block = self.writer.user_header().expected_block_start();
+            self.increment_block(start_block)?;
+            start_block
         };
 
         match current_block.cmp(&advance_to) {


### PR DESCRIPTION
## Summary

This PR contains two stacked changes:

### 1. Remove gap check between database and static files (Closes #19721)

Data types no longer exist simultaneously in static files and database. Headers, transactions, etc. are only written to static files now, never to the database. This makes the continuity gap check unnecessary.

### 2. Allow enabling static file segments on existing nodes

When a user runs `reth db settings set transaction_senders true` (or `account_changesets true`) on an existing node that was previously running with these settings as `false`, the node would fail to start.

The `ensure_invariants` function was incorrectly detecting data corruption when the static file was empty (never had data) but the stage checkpoint was ahead. The code would default `highest_static_file_block` to 0 and compare it with the checkpoint, triggering an incorrect unwind to block 0.

This fix adds an early return at the start of `ensure_invariants` when the static file is truly empty (both `highest_static_file_entry` and `highest_static_file_block` are None). This is treated as a valid "fresh start" scenario when enabling static files for the first time.

## Acceptance Criteria

- ✅ Node starts successfully after enabling any static file segment on an existing node (when the static file is empty)
- ✅ Gap check removed since data no longer exists simultaneously in DB and static files
- ✅ Logic is generalized across segment types