### PR TITLE
fix(db): change commit return type from Result<bool> to Result<()>

### DIFF
--- a/crates/storage/db-api/src/mock.rs
+++ b/crates/storage/db-api/src/mock.rs
@@ -92,10 +92,10 @@ impl DbTx for TxMock {
 
     /// Commits the transaction.
     ///
-    /// **Mock behavior**: Always returns `Ok(true)`, indicating successful commit.
+    /// **Mock behavior**: Always returns `Ok(())`, indicating successful commit.
     /// No actual data is persisted since this is a mock implementation.
-    fn commit(self) -> Result<bool, DatabaseError> {
-        Ok(true)
+    fn commit(self) -> Result<(), DatabaseError> {
+        Ok(())
     }
 
     /// Aborts the transaction.

--- a/crates/storage/db-api/src/transaction.rs
+++ b/crates/storage/db-api/src/transaction.rs
@@ -35,7 +35,7 @@ pub trait DbTx: Debug + Send {
     ) -> Result<Option<T::Value>, DatabaseError>;
     /// Commit for read only transaction will consume and free transaction and allows
     /// freeing of memory pages
-    fn commit(self) -> Result<bool, DatabaseError>;
+    fn commit(self) -> Result<(), DatabaseError>;
     /// Aborts transaction
     fn abort(self);
     /// Iterate over read only values in table.

--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -295,10 +295,10 @@ impl<K: TransactionKind> DbTx for Tx<K> {
         })
     }
 
-    fn commit(self) -> Result<bool, DatabaseError> {
+    fn commit(self) -> Result<(), DatabaseError> {
         self.execute_with_close_transaction_metric(TransactionOutcome::Commit, |this| {
             match this.inner.commit().map_err(|e| DatabaseError::Commit(e.into())) {
-                Ok((v, latency)) => (Ok(v), Some(latency)),
+                Ok(latency) => (Ok(()), Some(latency)),
                 Err(e) => (Err(e), None),
             }
         })

--- a/crates/storage/libmdbx-rs/src/codec.rs
+++ b/crates/storage/libmdbx-rs/src/codec.rs
@@ -42,7 +42,9 @@ impl TableObject for Cow<'_, [u8]> {
         #[cfg(not(feature = "return-borrowed"))]
         {
             let is_dirty = (!K::IS_READ_ONLY) &&
-                crate::error::mdbx_result(ffi::mdbx_is_dirty(_txn, data_val.iov_base))?;
+                crate::error::mdbx_result(unsafe {
+                    ffi::mdbx_is_dirty(_txn, data_val.iov_base)
+                })?;
 
             Ok(if is_dirty { Cow::Owned(s.to_vec()) } else { Cow::Borrowed(s) })
         }

--- a/crates/storage/libmdbx-rs/src/environment.rs
+++ b/crates/storage/libmdbx-rs/src/environment.rs
@@ -989,7 +989,10 @@ mod tests {
                     result @ Err(_) => result.unwrap(),
                 }
             }
-            tx.commit().unwrap();
+            // The transaction may be in an error state after hitting MapFull,
+            // so commit could fail. We don't care about the result here since
+            // the purpose of this test is to verify the HSR callback was called.
+            let _ = tx.commit();
         }
 
         // Expect the HSR to be called

--- a/crates/storage/libmdbx-rs/tests/cursor.rs
+++ b/crates/storage/libmdbx-rs/tests/cursor.rs
@@ -110,7 +110,7 @@ fn test_iter() {
         for (key, data) in &items {
             txn.put(db.dbi(), key, data, WriteFlags::empty()).unwrap();
         }
-        assert!(!txn.commit().unwrap().0);
+        txn.commit().unwrap();
     }
 
     let txn = env.begin_ro_txn().unwrap();

--- a/crates/storage/libmdbx-rs/tests/transaction.rs
+++ b/crates/storage/libmdbx-rs/tests/transaction.rs
@@ -148,13 +148,13 @@ fn test_clear_db() {
     {
         let txn = env.begin_rw_txn().unwrap();
         txn.put(txn.open_db(None).unwrap().dbi(), b"key", b"val", WriteFlags::empty()).unwrap();
-        assert!(!txn.commit().unwrap().0);
+        txn.commit().unwrap();
     }
 
     {
         let txn = env.begin_rw_txn().unwrap();
         txn.clear_db(txn.open_db(None).unwrap().dbi()).unwrap();
-        assert!(!txn.commit().unwrap().0);
+        txn.commit().unwrap();
     }
 
     let txn = env.begin_ro_txn().unwrap();
@@ -178,7 +178,7 @@ fn test_drop_db() {
             .unwrap();
             // Workaround for MDBX dbi drop issue
             txn.create_db(Some("canary"), DatabaseFlags::empty()).unwrap();
-            assert!(!txn.commit().unwrap().0);
+            txn.commit().unwrap();
         }
         {
             let txn = env.begin_rw_txn().unwrap();
@@ -187,7 +187,7 @@ fn test_drop_db() {
                 txn.drop_db(db).unwrap();
             }
             assert!(matches!(txn.open_db(Some("test")).unwrap_err(), Error::NotFound));
-            assert!(!txn.commit().unwrap().0);
+            txn.commit().unwrap();
         }
     }
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -125,7 +125,7 @@ impl<DB: Database, N: NodeTypes> AsRef<DatabaseProvider<<DB as Database>::TXMut,
 
 impl<DB: Database, N: NodeTypes + 'static> DatabaseProviderRW<DB, N> {
     /// Commit database transaction and static file if it exists.
-    pub fn commit(self) -> ProviderResult<bool> {
+    pub fn commit(self) -> ProviderResult<()> {
         self.0.commit()
     }
 
@@ -3422,7 +3422,7 @@ impl<TX: DbTx + 'static, N: NodeTypes + 'static> DBProvider for DatabaseProvider
     }
 
     /// Commit database transaction, static files, and pending `RocksDB` batches.
-    fn commit(self) -> ProviderResult<bool> {
+    fn commit(self) -> ProviderResult<()> {
         // For unwinding it makes more sense to commit the database first, since if
         // it is interrupted before the static files commit, we can just
         // truncate the static files according to the
@@ -3453,7 +3453,7 @@ impl<TX: DbTx + 'static, N: NodeTypes + 'static> DBProvider for DatabaseProvider
             self.tx.commit()?;
         }
 
-        Ok(true)
+        Ok(())
     }
 }
 

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -267,7 +267,7 @@ impl<T: NodePrimitives, ChainSpec: EthChainSpec + 'static> DBProvider
         self.tx
     }
 
-    fn commit(self) -> ProviderResult<bool> {
+    fn commit(self) -> ProviderResult<()> {
         Ok(self.tx.commit()?)
     }
 

--- a/crates/storage/rpc-provider/src/lib.rs
+++ b/crates/storage/rpc-provider/src/lib.rs
@@ -1357,7 +1357,7 @@ where
         self
     }
 
-    fn commit(self) -> ProviderResult<bool> {
+    fn commit(self) -> ProviderResult<()> {
         unimplemented!("commit not supported for RPC provider")
     }
 

--- a/crates/storage/storage-api/src/database_provider.rs
+++ b/crates/storage/storage-api/src/database_provider.rs
@@ -37,7 +37,7 @@ pub trait DBProvider: Sized {
     }
 
     /// Commit database transaction
-    fn commit(self) -> ProviderResult<bool>;
+    fn commit(self) -> ProviderResult<()>;
 
     /// Returns a reference to prune modes.
     fn prune_modes_ref(&self) -> &PruneModes;

--- a/crates/storage/storage-api/src/noop.rs
+++ b/crates/storage/storage-api/src/noop.rs
@@ -639,7 +639,7 @@ impl<ChainSpec: Send + Sync, N: NodePrimitives> DBProvider for NoopProvider<Chai
         &self.prune_modes
     }
 
-    fn commit(self) -> ProviderResult<bool> {
+    fn commit(self) -> ProviderResult<()> {
         use reth_db_api::transaction::DbTx;
 
         Ok(self.tx.commit()?)

--- a/docs/crates/db.md
+++ b/docs/crates/db.md
@@ -159,7 +159,7 @@ pub trait DbTx: Debug + Send + Sync {
     ) -> Result<Option<T::Value>, DatabaseError>;
     /// Commit for read only transaction will consume and free transaction and allows
     /// freeing of memory pages
-    fn commit(self) -> Result<bool, DatabaseError>;
+    fn commit(self) -> Result<(), DatabaseError>;
     /// Aborts transaction
     fn abort(self);
     /// Iterate over read only values in table.


### PR DESCRIPTION
The boolean return value from mdbx_txn_commit was never checked by callers. When MDBX returns MDBX_RESULT_TRUE, it means the transaction was aborted due to previous errors - this is now properly surfaced as Error::BotchedTransaction instead of being silently ignored.