### PR TITLE
feat(primitives): add From<Sealed<B>> for SealedBlock<B>

### DIFF
--- a/crates/primitives-traits/src/block/sealed.rs
+++ b/crates/primitives-traits/src/block/sealed.rs
@@ -282,6 +282,13 @@ where
     }
 }
 
+impl<B: Block> From<Sealed<B>> for SealedBlock<B> {
+    fn from(sealed: Sealed<B>) -> Self {
+        let (block, hash) = sealed.into_parts();
+        Self::new_unchecked(block, hash)
+    }
+}
+
 impl<B> Default for SealedBlock<B>
 where
     B: Block + Default,


### PR DESCRIPTION
## Summary

Add `From<Sealed<B>> for SealedBlock<B>` conversion to enable converting from alloy's `Sealed<B>` wrapper to reth's `SealedBlock<B>`.

## Changes

- Add `impl<B: Block> From<Sealed<B>> for SealedBlock<B>` that extracts the block and hash from the sealed wrapper