### PR TITLE
refactor: make use of dbi consistent across mdbx interface

### DIFF
--- a/crates/cli/commands/src/db/list.rs
+++ b/crates/cli/commands/src/db/list.rs
@@ -100,7 +100,7 @@ impl<N: NodeTypes> TableViewer<()> for ListTableViewer<'_, N> {
             tx.disable_long_read_transaction_safety();
 
             let table_db = tx.inner.open_db(Some(self.args.table.name())).wrap_err("Could not open db.")?;
-            let stats = tx.inner.db_stat(&table_db).wrap_err(format!("Could not find table: {}", self.args.table.name()))?;
+            let stats = tx.inner.db_stat(table_db.dbi()).wrap_err(format!("Could not find table: {}", self.args.table.name()))?;
             let total_entries = stats.entries();
             let final_entry_idx = total_entries.saturating_sub(1);
             if self.args.skip > final_entry_idx {

--- a/crates/cli/commands/src/db/stats.rs
+++ b/crates/cli/commands/src/db/stats.rs
@@ -88,7 +88,7 @@ impl Command {
 
                 let stats = tx
                     .inner
-                    .db_stat(&table_db)
+                    .db_stat(table_db.dbi())
                     .wrap_err(format!("Could not find table: {db_table}"))?;
 
                 // Defaults to 16KB right now but we should
@@ -129,7 +129,8 @@ impl Command {
             table.add_row(row);
 
             let freelist = tx.inner.env().freelist()?;
-            let pagesize = tx.inner.db_stat(&mdbx::Database::freelist_db())?.page_size() as usize;
+            let pagesize =
+                tx.inner.db_stat(mdbx::Database::freelist_db().dbi())?.page_size() as usize;
             let freelist_size = freelist * pagesize;
 
             let mut row = Row::new();

--- a/crates/storage/db/benches/hash_keys.rs
+++ b/crates/storage/db/benches/hash_keys.rs
@@ -248,7 +248,7 @@ where
         println!(
             "{:?}\n",
             tx.inner
-                .db_stat(&table_db)
+                .db_stat(table_db.dbi())
                 .map_err(|_| format!("Could not find table: {}", T::NAME))
                 .map(|stats| {
                     let num_pages =

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -278,7 +278,7 @@ impl DatabaseMetrics for DatabaseEnv {
 
                     let stats = tx
                         .inner
-                        .db_stat(&table_db)
+                        .db_stat(table_db.dbi())
                         .wrap_err(format!("Could not find table: {table}"))?;
 
                     let page_size = stats.page_size() as usize;

--- a/crates/storage/libmdbx-rs/benches/cursor.rs
+++ b/crates/storage/libmdbx-rs/benches/cursor.rs
@@ -12,10 +12,10 @@ fn bench_get_seq_iter(c: &mut Criterion) {
     let (_dir, env) = setup_bench_db(n);
     let txn = env.begin_ro_txn().unwrap();
     let db = txn.open_db(None).unwrap();
-
+    let dbi = db.dbi();
     c.bench_function("bench_get_seq_iter", |b| {
         b.iter(|| {
-            let mut cursor = txn.cursor(&db).unwrap();
+            let mut cursor = txn.cursor(dbi).unwrap();
             let mut i = 0;
             let mut count = 0u32;
 
@@ -54,11 +54,11 @@ fn bench_get_seq_cursor(c: &mut Criterion) {
     let (_dir, env) = setup_bench_db(n);
     let txn = env.begin_ro_txn().unwrap();
     let db = txn.open_db(None).unwrap();
-
+    let dbi = db.dbi();
     c.bench_function("bench_get_seq_cursor", |b| {
         b.iter(|| {
             let (i, count) = txn
-                .cursor(&db)
+                .cursor(dbi)
                 .unwrap()
                 .iter::<ObjectLength, ObjectLength>()
                 .map(Result::unwrap)

--- a/crates/storage/libmdbx-rs/src/environment.rs
+++ b/crates/storage/libmdbx-rs/src/environment.rs
@@ -211,7 +211,7 @@ impl Environment {
         let mut freelist: usize = 0;
         let txn = self.begin_ro_txn()?;
         let db = Database::freelist_db();
-        let cursor = txn.cursor(&db)?;
+        let cursor = txn.cursor(db.dbi())?;
 
         for result in cursor.iter_slices() {
             let (_key, value) = result?;

--- a/crates/storage/libmdbx-rs/tests/transaction.rs
+++ b/crates/storage/libmdbx-rs/tests/transaction.rs
@@ -50,9 +50,9 @@ fn test_put_get_del_multi() {
     txn.commit().unwrap();
 
     let txn = env.begin_rw_txn().unwrap();
-    let db = txn.open_db(None).unwrap();
+    let dbi = txn.open_db(None).unwrap().dbi();
     {
-        let mut cur = txn.cursor(&db).unwrap();
+        let mut cur = txn.cursor(dbi).unwrap();
         let iter = cur.iter_dup_of::<(), [u8; 4]>(b"key1");
         let vals = iter.map(|x| x.unwrap()).map(|(_, x)| x).collect::<Vec<_>>();
         assert_eq!(vals, vec![*b"val1", *b"val2", *b"val3"]);
@@ -66,9 +66,9 @@ fn test_put_get_del_multi() {
     txn.commit().unwrap();
 
     let txn = env.begin_rw_txn().unwrap();
-    let db = txn.open_db(None).unwrap();
+    let dbi = txn.open_db(None).unwrap().dbi();
     {
-        let mut cur = txn.cursor(&db).unwrap();
+        let mut cur = txn.cursor(dbi).unwrap();
         let iter = cur.iter_dup_of::<(), [u8; 4]>(b"key1");
         let vals = iter.map(|x| x.unwrap()).map(|(_, x)| x).collect::<Vec<_>>();
         assert_eq!(vals, vec![*b"val1", *b"val3"]);
@@ -103,9 +103,9 @@ fn test_reserve() {
     let env = Environment::builder().open(dir.path()).unwrap();
 
     let txn = env.begin_rw_txn().unwrap();
-    let db = txn.open_db(None).unwrap();
+    let dbi = txn.open_db(None).unwrap().dbi();
     {
-        let mut writer = txn.reserve(&db, b"key1", 4, WriteFlags::empty()).unwrap();
+        let mut writer = txn.reserve(dbi, b"key1", 4, WriteFlags::empty()).unwrap();
         writer.write_all(b"val1").unwrap();
     }
     txn.commit().unwrap();
@@ -182,9 +182,9 @@ fn test_drop_db() {
         }
         {
             let txn = env.begin_rw_txn().unwrap();
-            let db = txn.open_db(Some("test")).unwrap();
+            let dbi = txn.open_db(Some("test")).unwrap().dbi();
             unsafe {
-                txn.drop_db(db).unwrap();
+                txn.drop_db(dbi).unwrap();
             }
             assert!(matches!(txn.open_db(Some("test")).unwrap_err(), Error::NotFound));
             assert!(!txn.commit().unwrap().0);
@@ -291,8 +291,8 @@ fn test_stat() {
 
     {
         let txn = env.begin_ro_txn().unwrap();
-        let db = txn.open_db(None).unwrap();
-        let stat = txn.db_stat(&db).unwrap();
+        let dbi = txn.open_db(None).unwrap().dbi();
+        let stat = txn.db_stat(dbi).unwrap();
         assert_eq!(stat.entries(), 3);
     }
 
@@ -304,8 +304,8 @@ fn test_stat() {
 
     {
         let txn = env.begin_ro_txn().unwrap();
-        let db = txn.open_db(None).unwrap();
-        let stat = txn.db_stat(&db).unwrap();
+        let dbi = txn.open_db(None).unwrap().dbi();
+        let stat = txn.db_stat(dbi).unwrap();
         assert_eq!(stat.entries(), 1);
     }
 
@@ -318,8 +318,8 @@ fn test_stat() {
 
     {
         let txn = env.begin_ro_txn().unwrap();
-        let db = txn.open_db(None).unwrap();
-        let stat = txn.db_stat(&db).unwrap();
+        let dbi = txn.open_db(None).unwrap().dbi();
+        let stat = txn.db_stat(dbi).unwrap();
         assert_eq!(stat.entries(), 4);
     }
 }
@@ -331,20 +331,22 @@ fn test_stat_dupsort() {
 
     let txn = env.begin_rw_txn().unwrap();
     let db = txn.create_db(None, DatabaseFlags::DUP_SORT).unwrap();
-    txn.put(db.dbi(), b"key1", b"val1", WriteFlags::empty()).unwrap();
-    txn.put(db.dbi(), b"key1", b"val2", WriteFlags::empty()).unwrap();
-    txn.put(db.dbi(), b"key1", b"val3", WriteFlags::empty()).unwrap();
-    txn.put(db.dbi(), b"key2", b"val1", WriteFlags::empty()).unwrap();
-    txn.put(db.dbi(), b"key2", b"val2", WriteFlags::empty()).unwrap();
-    txn.put(db.dbi(), b"key2", b"val3", WriteFlags::empty()).unwrap();
-    txn.put(db.dbi(), b"key3", b"val1", WriteFlags::empty()).unwrap();
-    txn.put(db.dbi(), b"key3", b"val2", WriteFlags::empty()).unwrap();
-    txn.put(db.dbi(), b"key3", b"val3", WriteFlags::empty()).unwrap();
+    let dbi = db.dbi();
+    txn.put(dbi, b"key1", b"val1", WriteFlags::empty()).unwrap();
+    txn.put(dbi, b"key1", b"val2", WriteFlags::empty()).unwrap();
+    txn.put(dbi, b"key1", b"val3", WriteFlags::empty()).unwrap();
+    txn.put(dbi, b"key2", b"val1", WriteFlags::empty()).unwrap();
+    txn.put(dbi, b"key2", b"val2", WriteFlags::empty()).unwrap();
+    txn.put(dbi, b"key2", b"val3", WriteFlags::empty()).unwrap();
+    txn.put(dbi, b"key3", b"val1", WriteFlags::empty()).unwrap();
+    txn.put(dbi, b"key3", b"val2", WriteFlags::empty()).unwrap();
+    txn.put(dbi, b"key3", b"val3", WriteFlags::empty()).unwrap();
     txn.commit().unwrap();
 
     {
         let txn = env.begin_ro_txn().unwrap();
-        let stat = txn.db_stat(&txn.open_db(None).unwrap()).unwrap();
+        let dbi = txn.open_db(None).unwrap().dbi();
+        let stat = txn.db_stat(dbi).unwrap();
         assert_eq!(stat.entries(), 9);
     }
 
@@ -356,7 +358,8 @@ fn test_stat_dupsort() {
 
     {
         let txn = env.begin_ro_txn().unwrap();
-        let stat = txn.db_stat(&txn.open_db(None).unwrap()).unwrap();
+        let dbi = txn.open_db(None).unwrap().dbi();
+        let stat = txn.db_stat(dbi).unwrap();
         assert_eq!(stat.entries(), 5);
     }
 
@@ -369,7 +372,8 @@ fn test_stat_dupsort() {
 
     {
         let txn = env.begin_ro_txn().unwrap();
-        let stat = txn.db_stat(&txn.open_db(None).unwrap()).unwrap();
+        let dbi = txn.open_db(None).unwrap().dbi();
+        let stat = txn.db_stat(dbi).unwrap();
         assert_eq!(stat.entries(), 8);
     }
 }


### PR DESCRIPTION
- changes the interface of `Transaction<K>` to be consistent in use of `u32` instead of `&Database`
- corrects the documentation of `get_dbi` and adds `get_dbi_raw` as a drive-by