### PR TITLE
feat(flashblocks): add transaction caching to skip re-execution of unchanged transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9769,6 +9769,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
+ "alloy-rpc-types",
  "alloy-rpc-types-engine",
  "brotli",
  "derive_more",

--- a/crates/optimism/flashblocks/Cargo.toml
+++ b/crates/optimism/flashblocks/Cargo.toml
@@ -29,8 +29,9 @@ reth-metrics.workspace = true
 
 # alloy
 alloy-eips = { workspace = true, features = ["serde"] }
-alloy-primitives = { workspace = true, features = ["serde"] }
+alloy-primitives = { workspace = true, features = ["serde", "map-foldhash"] }
 alloy-rpc-types-engine = { workspace = true, features = ["serde"] }
+alloy-rpc-types.workspace = true
 alloy-consensus.workspace = true
 
 # op-alloy

--- a/crates/optimism/flashblocks/docs/client-side-upstream-scope.md
+++ b/crates/optimism/flashblocks/docs/client-side-upstream-scope.md
@@ -1,0 +1,317 @@
+# Client-Side Flashblocks Upstream Scope
+
+**Authors:** Upstreaming from node-reth
+**Status:** Planning
+**Date:** January 2026
+
+## Executive Summary
+
+This document scopes the work required to upstream the client-side flashblocks functionality from node-reth to reth. This enables any OP Stack follower node to receive flashblocks and serve flashblock-aware RPC endpoints.
+
+## Current State
+
+### reth (upstream) - Builder Side Only
+```
+crates/optimism/flashblocks/
+├── service.rs          # FlashBlockService (builds blocks)
+├── worker.rs           # Block execution
+├── cache.rs            # Sequence management
+├── pending_state.rs    # Speculative building state
+├── validation.rs       # Sequence validation, reorg detection
+├── ws/                 # WebSocket stream for receiving
+└── ...
+```
+
+### node-reth - Full Client Side
+```
+crates/client/flashblocks/
+├── state.rs            # FlashblocksState (coordinator)
+├── processor.rs        # StateProcessor (executes flashblocks)
+├── pending_blocks.rs   # PendingBlocks (RPC-queryable state)
+├── state_builder.rs    # PendingStateBuilder (tx execution)
+├── subscription.rs     # WebSocket subscriber with reconnection
+├── validation.rs       # Same as reth (already upstreamed)
+├── traits.rs           # FlashblocksAPI, PendingBlocksAPI
+├── extension.rs        # Node builder integration
+├── rpc/
+│   ├── eth.rs          # EthApiExt (flashblock-aware eth_*)
+│   └── pubsub.rs       # EthPubSub (flashblock subscriptions)
+└── ...
+```
+
+## Proposed Architecture
+
+### Module Structure
+```
+crates/optimism/flashblocks/
+├── src/
+│   ├── lib.rs
+│   │
+│   │   # Existing (builder-side)
+│   ├── service.rs
+│   ├── worker.rs
+│   ├── cache.rs
+│   ├── pending_state.rs
+│   ├── validation.rs
+│   ├── ws/
+│   │
+│   │   # New (client-side)
+│   ├── client/
+│   │   ├── mod.rs
+│   │   ├── state.rs            # FlashblocksClientState
+│   │   ├── processor.rs        # ClientStateProcessor
+│   │   ├── pending_blocks.rs   # ClientPendingBlocks
+│   │   └── state_builder.rs    # ClientStateBuilder
+│   │
+│   └── rpc/                    # New (optional feature)
+│       ├── mod.rs
+│       ├── eth_ext.rs          # EthApiFlashblocksExt
+│       ├── pubsub.rs           # FlashblocksPubSub
+│       └── types.rs            # Subscription types
+```
+
+### Feature Flags
+```toml
+[features]
+default = []
+client = []           # Client-side state management
+rpc = ["client"]      # RPC extensions (requires client)
+```
+
+## Implementation Phases
+
+### Phase 1: Core Client State Management
+
+**Goal:** Enable follower nodes to receive and track flashblock state.
+
+**Files to create:**
+
+| File | Source | Changes Required |
+|------|--------|------------------|
+| `client/mod.rs` | New | Module exports |
+| `client/state.rs` | `node-reth/state.rs` | Replace `base_flashtypes::Flashblock` with `FlashBlock` |
+| `client/processor.rs` | `node-reth/processor.rs` | Same type replacements, generalize over chain spec |
+| `client/pending_blocks.rs` | `node-reth/pending_blocks.rs` | Use reth RPC types |
+| `client/state_builder.rs` | `node-reth/state_builder.rs` | Already uses reth types |
+
+**New traits:**
+```rust
+/// Core API for accessing flashblock state.
+pub trait FlashblocksClientAPI {
+    /// Retrieves the pending blocks.
+    fn pending_blocks(&self) -> Option<Arc<ClientPendingBlocks>>;
+
+    /// Subscribes to flashblock updates.
+    fn subscribe(&self) -> broadcast::Receiver<Arc<ClientPendingBlocks>>;
+}
+
+/// API for querying pending block data.
+pub trait PendingBlocksAPI {
+    fn get_block(&self, full: bool) -> Option<RpcBlock<Optimism>>;
+    fn get_transaction_receipt(&self, hash: TxHash) -> Option<RpcReceipt<Optimism>>;
+    fn get_balance(&self, address: Address) -> Option<U256>;
+    fn get_transaction_count(&self, address: Address) -> U256;
+    fn get_transaction_by_hash(&self, hash: TxHash) -> Option<RpcTransaction<Optimism>>;
+    fn get_pending_logs(&self, filter: &Filter) -> Vec<Log>;
+    fn get_state_overrides(&self) -> Option<StateOverride>;
+}
+```
+
+**Dependencies:**
+- `reth_rpc_eth_api` - RPC types
+- `reth_optimism_primitives` - OP primitives
+- `op_alloy_rpc_types` - OP RPC types
+- Existing flashblocks crate dependencies
+
+**Estimated scope:** ~1000 LOC
+
+---
+
+### Phase 2: RPC Extensions
+
+**Goal:** Enable flashblock-aware RPC methods.
+
+**Files to create:**
+
+| File | Source | Changes Required |
+|------|--------|------------------|
+| `rpc/mod.rs` | New | Module exports |
+| `rpc/eth_ext.rs` | `node-reth/rpc/eth.rs` | Adapt to reth RPC infrastructure |
+| `rpc/pubsub.rs` | `node-reth/rpc/pubsub.rs` | Adapt to reth pubsub |
+| `rpc/types.rs` | `node-reth/rpc/types.rs` | Subscription kind enums |
+
+**RPC methods to support:**
+
+| Method | Behavior |
+|--------|----------|
+| `eth_getBlockByNumber("pending")` | Returns current flashblock |
+| `eth_getTransactionReceipt` | Checks flashblocks first |
+| `eth_getBalance(addr, "pending")` | Returns flashblock balance |
+| `eth_getTransactionCount(addr, "pending")` | Includes flashblock txs |
+| `eth_getTransactionByHash` | Checks flashblocks first |
+| `eth_call(tx, "pending")` | Executes against flashblock state |
+| `eth_estimateGas(tx, "pending")` | Estimates with flashblock state |
+| `eth_getLogs` | Includes pending logs |
+| **`eth_sendRawTransactionSync`** | Wait for flashblock inclusion |
+
+**New subscriptions:**
+
+| Subscription | Description |
+|--------------|-------------|
+| `newFlashblocks` | Stream of new flashblocks |
+| `pendingLogs` | Stream of logs from flashblocks |
+| `newFlashblockTransactions` | Stream of pending transactions |
+
+**Dependencies:**
+- `jsonrpsee` - RPC server
+- `reth_rpc` - Base RPC implementation
+- `reth_rpc_eth_api` - Eth API traits
+
+**Estimated scope:** ~800 LOC
+
+---
+
+### Phase 3: Node Builder Integration
+
+**Goal:** Easy integration into OP Stack nodes.
+
+**Files to create:**
+
+| File | Description |
+|------|-------------|
+| `client/extension.rs` | Node builder extension trait |
+| `client/config.rs` | Configuration types |
+
+**Integration approach:**
+
+```rust
+/// Configuration for flashblocks client.
+#[derive(Debug, Clone)]
+pub struct FlashblocksClientConfig {
+    /// WebSocket URL for flashblocks stream.
+    pub ws_url: String,
+    /// Maximum pending block depth.
+    pub max_depth: u64,
+    /// Enable RPC extensions.
+    pub enable_rpc: bool,
+}
+
+/// Extension for adding flashblocks client to a node.
+pub trait FlashblocksClientExt {
+    /// Adds flashblocks client support to the node.
+    fn with_flashblocks_client(self, config: FlashblocksClientConfig) -> Self;
+}
+```
+
+**Integration with ExEx:**
+```rust
+// The client uses an ExEx to receive canonical block notifications
+// for reconciliation with flashblock state.
+impl FlashblocksClientExtension {
+    fn install_exex(&self, ctx: &BuilderContext) {
+        ctx.install_exex("flashblocks-reconciler", |ctx| {
+            // Forward canonical blocks to state processor
+        });
+    }
+}
+```
+
+**Estimated scope:** ~300 LOC
+
+---
+
+## Type Mappings
+
+| node-reth | reth (upstream) |
+|-----------|-----------------|
+| `base_flashtypes::Flashblock` | `FlashBlock` (alias for `OpFlashblockPayload`) |
+| `base_client_node::*` | reth node builder APIs |
+| `PendingBlocks` | `ClientPendingBlocks` (renamed to avoid confusion) |
+| `FlashblocksState` | `FlashblocksClientState` |
+| `StateProcessor` | `ClientStateProcessor` |
+
+## Key Decisions
+
+### 1. Naming Convention
+- Prefix client-side types with `Client` to distinguish from builder-side
+- Use `client/` submodule for clear separation
+
+### 2. Feature Organization
+- `client` feature: Core state management (no RPC dependencies)
+- `rpc` feature: RPC extensions (depends on `client`)
+- Default: Neither enabled (builder-only, current behavior)
+
+### 3. Generics
+- Make types generic over chain spec where possible
+- Use associated types for network-specific RPC types
+
+### 4. Shared Code
+- `validation.rs` - Already shared (upstreamed in Phase 1-2 of speculative building)
+- `ws/` - Can be shared for WebSocket connection
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Type incompatibility with `base_flashtypes` | Use `op_alloy_rpc_types_engine::OpFlashblockPayload` (already aliased as `FlashBlock`) |
+| RPC infrastructure differences | Adapt to reth's RPC patterns, may need some refactoring |
+| Breaking changes to builder-side | Feature flags isolate client code |
+| Performance regression | Benchmark critical paths, optimize state access |
+
+## Testing Strategy
+
+### Unit Tests
+- State processor reconciliation logic
+- Pending blocks query methods
+- RPC method behavior with/without flashblock state
+
+### Integration Tests
+- Full flow: WS → State → RPC response
+- Canonical block reconciliation
+- Reorg handling
+
+### Test Harness
+- Extend existing `FlashBlockServiceTestHarness` for client testing
+- Mock flashblock streams
+- Simulated canonical chain updates
+
+## Estimated Total Scope
+
+| Phase | LOC | Complexity |
+|-------|-----|------------|
+| Phase 1: Core Client State | ~1000 | Medium |
+| Phase 2: RPC Extensions | ~800 | Medium-High |
+| Phase 3: Node Integration | ~300 | Low |
+| Tests | ~500 | Medium |
+| **Total** | **~2600** | |
+
+## Open Questions
+
+1. **Should `eth_sendRawTransactionSync` be included?**
+   - Very useful for UX (wait for flashblock inclusion)
+   - Adds complexity (timeout handling, dual listening)
+
+2. **How to handle Base-specific subscription types?**
+   - Option A: Generic subscription system
+   - Option B: OP-specific types in `op_alloy`
+
+3. **Integration with existing reth RPC modules?**
+   - Replace vs extend existing eth_* implementations
+   - node-reth uses `replace_configured` pattern
+
+## Next Steps
+
+1. [ ] Review and approve scope
+2. [ ] Phase 1 implementation
+3. [ ] Phase 1 PR and review
+4. [ ] Phase 2 implementation
+5. [ ] Phase 2 PR and review
+6. [ ] Phase 3 implementation
+7. [ ] Final integration testing
+8. [ ] Documentation updates
+
+## References
+
+- node-reth flashblocks: `node-reth/crates/client/flashblocks/`
+- reth flashblocks: `reth/crates/optimism/flashblocks/`
+- Speculative building design doc: `docs/speculative-building.md`

--- a/crates/optimism/flashblocks/src/cache.rs
+++ b/crates/optimism/flashblocks/src/cache.rs
@@ -482,7 +482,8 @@ mod tests {
         let local_tip_hash = B256::random();
         let local_tip_timestamp = 1000;
 
-        let args = manager.next_buildable_args::<OpPrimitives>(local_tip_hash, local_tip_timestamp, None);
+        let args =
+            manager.next_buildable_args::<OpPrimitives>(local_tip_hash, local_tip_timestamp, None);
         assert!(args.is_none());
     }
 
@@ -577,7 +578,11 @@ mod tests {
         }
 
         // Request with proper timing - should compute state root for index 9
-        let args = manager.next_buildable_args::<OpPrimitives>(parent_hash, base_timestamp - block_time, None);
+        let args = manager.next_buildable_args::<OpPrimitives>(
+            parent_hash,
+            base_timestamp - block_time,
+            None,
+        );
         assert!(args.is_some());
         assert!(args.unwrap().compute_state_root);
     }
@@ -594,7 +599,11 @@ mod tests {
         let base_timestamp = fb0.base.as_ref().unwrap().timestamp;
         manager.insert_flashblock(fb0).unwrap();
 
-        let args = manager.next_buildable_args::<OpPrimitives>(parent_hash, base_timestamp - block_time, None);
+        let args = manager.next_buildable_args::<OpPrimitives>(
+            parent_hash,
+            base_timestamp - block_time,
+            None,
+        );
         assert!(args.is_some());
         assert!(!args.unwrap().compute_state_root);
     }
@@ -618,7 +627,11 @@ mod tests {
         }
 
         // Request with proper timing - should compute state root for index 9
-        let args = manager.next_buildable_args::<OpPrimitives>(parent_hash, base_timestamp - block_time, None);
+        let args = manager.next_buildable_args::<OpPrimitives>(
+            parent_hash,
+            base_timestamp - block_time,
+            None,
+        );
         assert!(args.is_some());
         assert!(!args.unwrap().compute_state_root);
     }
@@ -789,7 +802,8 @@ mod tests {
         };
 
         // With pending parent state, should return args for speculative building
-        let args = manager.next_buildable_args(local_tip_hash, 1000000, Some(pending_state.clone()));
+        let args =
+            manager.next_buildable_args(local_tip_hash, 1000000, Some(pending_state.clone()));
         assert!(args.is_some());
         let build_args = args.unwrap();
         assert!(build_args.pending_parent.is_some());

--- a/crates/optimism/flashblocks/src/lib.rs
+++ b/crates/optimism/flashblocks/src/lib.rs
@@ -24,7 +24,7 @@ mod sequence;
 pub use sequence::{FlashBlockCompleteSequence, FlashBlockPendingSequence};
 
 mod service;
-pub use service::{FlashBlockBuildInfo, FlashBlockService};
+pub use service::{CanonicalBlockNotification, FlashBlockBuildInfo, FlashBlockService};
 
 mod worker;
 

--- a/crates/optimism/flashblocks/src/lib.rs
+++ b/crates/optimism/flashblocks/src/lib.rs
@@ -14,6 +14,9 @@ use std::sync::Arc;
 // Included to enable serde feature for OpReceipt type used transitively
 use reth_optimism_primitives as _;
 
+// Used by downstream crates that depend on this crate
+use alloy_rpc_types as _;
+
 mod consensus;
 pub use consensus::FlashBlockConsensusClient;
 
@@ -34,6 +37,9 @@ mod pending_state;
 pub use pending_state::{PendingBlockState, PendingStateRegistry};
 
 pub mod validation;
+
+mod tx_cache;
+pub use tx_cache::TransactionCache;
 
 #[cfg(test)]
 mod test_utils;

--- a/crates/optimism/flashblocks/src/lib.rs
+++ b/crates/optimism/flashblocks/src/lib.rs
@@ -30,6 +30,9 @@ mod worker;
 
 mod cache;
 
+mod pending_state;
+pub use pending_state::{PendingBlockState, PendingStateRegistry};
+
 pub mod validation;
 
 #[cfg(test)]

--- a/crates/optimism/flashblocks/src/lib.rs
+++ b/crates/optimism/flashblocks/src/lib.rs
@@ -30,6 +30,8 @@ mod worker;
 
 mod cache;
 
+pub mod validation;
+
 #[cfg(test)]
 mod test_utils;
 

--- a/crates/optimism/flashblocks/src/pending_state.rs
+++ b/crates/optimism/flashblocks/src/pending_state.rs
@@ -1,0 +1,148 @@
+//! Pending block state for speculative flashblock building.
+//!
+//! This module provides types for tracking execution state from flashblock builds,
+//! enabling speculative building of subsequent blocks before their parent canonical
+//! block arrives via P2P.
+
+use alloy_primitives::B256;
+use reth_execution_types::ExecutionOutcome;
+use reth_primitives_traits::NodePrimitives;
+use reth_revm::cached::CachedReads;
+use std::sync::Arc;
+
+/// Tracks the execution state from building a pending block.
+///
+/// This is used to enable speculative building of subsequent blocks:
+/// - When flashblocks for block N+1 arrive before canonical block N
+/// - The pending state from building block N's flashblocks can be used
+/// - This allows continuous flashblock processing without waiting for P2P
+#[derive(Debug, Clone)]
+pub struct PendingBlockState<N: NodePrimitives> {
+    /// Hash of the block that was built (the pending block's hash).
+    pub block_hash: B256,
+    /// Block number that was built.
+    pub block_number: u64,
+    /// Parent hash of the built block.
+    pub parent_hash: B256,
+    /// Execution outcome containing state changes.
+    pub execution_outcome: Arc<ExecutionOutcome<N::Receipt>>,
+    /// Cached reads from execution for reuse.
+    pub cached_reads: CachedReads,
+}
+
+impl<N: NodePrimitives> PendingBlockState<N> {
+    /// Creates a new pending block state.
+    pub const fn new(
+        block_hash: B256,
+        block_number: u64,
+        parent_hash: B256,
+        execution_outcome: Arc<ExecutionOutcome<N::Receipt>>,
+        cached_reads: CachedReads,
+    ) -> Self {
+        Self { block_hash, block_number, parent_hash, execution_outcome, cached_reads }
+    }
+}
+
+/// Registry of pending block states for speculative building.
+///
+/// Maintains a small cache of recently built pending blocks, allowing
+/// subsequent flashblock sequences to build on top of them even before
+/// the canonical blocks arrive.
+#[derive(Debug, Default)]
+pub struct PendingStateRegistry<N: NodePrimitives> {
+    /// Most recent pending block state (the one we'd build on top of).
+    current: Option<PendingBlockState<N>>,
+}
+
+impl<N: NodePrimitives> PendingStateRegistry<N> {
+    /// Creates a new pending state registry.
+    pub const fn new() -> Self {
+        Self { current: None }
+    }
+
+    /// Records a completed build's state for potential use by subsequent builds.
+    pub fn record_build(&mut self, state: PendingBlockState<N>) {
+        self.current = Some(state);
+    }
+
+    /// Gets the pending state for a given parent hash, if available.
+    ///
+    /// Returns `Some` if we have pending state whose `block_hash` matches the requested
+    /// `parent_hash`.
+    pub fn get_state_for_parent(&self, parent_hash: B256) -> Option<&PendingBlockState<N>> {
+        self.current.as_ref().filter(|state| state.block_hash == parent_hash)
+    }
+
+    /// Clears all pending state.
+    pub fn clear(&mut self) {
+        self.current = None;
+    }
+
+    /// Returns the current pending state, if any.
+    pub const fn current(&self) -> Option<&PendingBlockState<N>> {
+        self.current.as_ref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reth_optimism_primitives::OpPrimitives;
+
+    type TestRegistry = PendingStateRegistry<OpPrimitives>;
+
+    #[test]
+    fn test_registry_returns_state_for_matching_parent() {
+        let mut registry = TestRegistry::new();
+
+        let block_hash = B256::repeat_byte(1);
+        let state = PendingBlockState {
+            block_hash,
+            block_number: 100,
+            parent_hash: B256::repeat_byte(0),
+            execution_outcome: Arc::new(ExecutionOutcome::default()),
+            cached_reads: CachedReads::default(),
+        };
+        registry.record_build(state);
+
+        // Should find state when querying with matching block_hash as parent
+        let result = registry.get_state_for_parent(block_hash);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().block_number, 100);
+    }
+
+    #[test]
+    fn test_registry_returns_none_for_wrong_parent() {
+        let mut registry = TestRegistry::new();
+
+        let state = PendingBlockState {
+            block_hash: B256::repeat_byte(1),
+            block_number: 100,
+            parent_hash: B256::repeat_byte(0),
+            execution_outcome: Arc::new(ExecutionOutcome::default()),
+            cached_reads: CachedReads::default(),
+        };
+        registry.record_build(state);
+
+        // Different parent hash should return None
+        assert!(registry.get_state_for_parent(B256::repeat_byte(2)).is_none());
+    }
+
+    #[test]
+    fn test_registry_clear() {
+        let mut registry = TestRegistry::new();
+
+        let state = PendingBlockState {
+            block_hash: B256::repeat_byte(1),
+            block_number: 100,
+            parent_hash: B256::repeat_byte(0),
+            execution_outcome: Arc::new(ExecutionOutcome::default()),
+            cached_reads: CachedReads::default(),
+        };
+        registry.record_build(state);
+        assert!(registry.current().is_some());
+
+        registry.clear();
+        assert!(registry.current().is_none());
+    }
+}

--- a/crates/optimism/flashblocks/src/tx_cache.rs
+++ b/crates/optimism/flashblocks/src/tx_cache.rs
@@ -1,0 +1,297 @@
+//! Transaction execution caching for flashblock building.
+//!
+//! When flashblocks arrive incrementally, each new flashblock triggers a rebuild of pending
+//! state from all transactions in the sequence. Without caching, this means re-executing
+//! transactions that were already executed when previous flashblocks arrived.
+//!
+//! # Approach
+//!
+//! This module uses cumulative state caching: after executing a sequence of transactions,
+//! the resulting bundle state and receipts are cached. When the next flashblock arrives,
+//! if its transaction list is a continuation of the cached list, execution can resume
+//! from the cached state rather than re-executing from scratch.
+//!
+//! The cache stores:
+//! - Ordered list of executed transaction hashes
+//! - Cumulative bundle state after all cached transactions
+//! - Cumulative receipts for all cached transactions
+//!
+//! # Example
+//!
+//! ```text
+//! Flashblock 0: txs [A, B]
+//!   -> Execute A, B from scratch
+//!   -> Cache: txs=[A,B], bundle=state_after_AB, receipts=[rA, rB]
+//!
+//! Flashblock 1: txs [A, B, C]
+//!   -> Prefix [A, B] matches cache
+//!   -> Initialize state with cached bundle
+//!   -> Execute only C
+//!   -> Cache: txs=[A,B,C], bundle=state_after_ABC, receipts=[rA, rB, rC]
+//!
+//! Flashblock 2 (reorg): txs [A, D, E]
+//!   -> Prefix [A] matches, but tx[1]=D != B
+//!   -> Clear cache, execute A, D, E from scratch
+//! ```
+
+use alloy_primitives::B256;
+use reth_primitives_traits::NodePrimitives;
+use reth_revm::db::BundleState;
+
+/// Cache of transaction execution results for a single block.
+///
+/// Stores cumulative execution state that can be restored to skip re-executing
+/// transactions that have already been processed. The cache is invalidated when:
+/// - A new block starts (different block number)
+/// - A reorg is detected (transaction list diverges from cached prefix)
+/// - Explicitly cleared
+#[derive(Debug)]
+pub struct TransactionCache<N: NodePrimitives> {
+    /// Block number this cache is valid for.
+    block_number: u64,
+    /// Ordered list of transaction hashes that have been executed.
+    executed_tx_hashes: Vec<B256>,
+    /// Cumulative bundle state after executing all cached transactions.
+    cumulative_bundle: BundleState,
+    /// Receipts for all cached transactions, in execution order.
+    receipts: Vec<N::Receipt>,
+}
+
+impl<N: NodePrimitives> Default for TransactionCache<N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<N: NodePrimitives> TransactionCache<N> {
+    /// Creates a new empty transaction cache.
+    pub fn new() -> Self {
+        Self {
+            block_number: 0,
+            executed_tx_hashes: Vec::new(),
+            cumulative_bundle: BundleState::default(),
+            receipts: Vec::new(),
+        }
+    }
+
+    /// Creates a new cache for a specific block number.
+    pub fn for_block(block_number: u64) -> Self {
+        Self { block_number, ..Self::new() }
+    }
+
+    /// Returns the block number this cache is valid for.
+    pub const fn block_number(&self) -> u64 {
+        self.block_number
+    }
+
+    /// Checks if this cache is valid for the given block number.
+    pub const fn is_valid_for_block(&self, block_number: u64) -> bool {
+        self.block_number == block_number
+    }
+
+    /// Returns the number of cached transactions.
+    pub const fn len(&self) -> usize {
+        self.executed_tx_hashes.len()
+    }
+
+    /// Returns true if the cache is empty.
+    pub const fn is_empty(&self) -> bool {
+        self.executed_tx_hashes.is_empty()
+    }
+
+    /// Returns the cached transaction hashes.
+    pub fn executed_tx_hashes(&self) -> &[B256] {
+        &self.executed_tx_hashes
+    }
+
+    /// Returns the cached receipts.
+    pub fn receipts(&self) -> &[N::Receipt] {
+        &self.receipts
+    }
+
+    /// Returns the cumulative bundle state.
+    pub const fn bundle(&self) -> &BundleState {
+        &self.cumulative_bundle
+    }
+
+    /// Clears the cache.
+    pub fn clear(&mut self) {
+        self.executed_tx_hashes.clear();
+        self.cumulative_bundle = BundleState::default();
+        self.receipts.clear();
+        self.block_number = 0;
+    }
+
+    /// Updates the cache for a new block, clearing if the block number changed.
+    ///
+    /// Returns true if the cache was cleared.
+    pub fn update_for_block(&mut self, block_number: u64) -> bool {
+        if self.block_number == block_number {
+            false
+        } else {
+            self.clear();
+            self.block_number = block_number;
+            true
+        }
+    }
+
+    /// Computes the length of the matching prefix between cached transactions
+    /// and the provided transaction hashes.
+    ///
+    /// Returns the number of transactions that can be skipped because they
+    /// match the cached execution results.
+    pub fn matching_prefix_len(&self, tx_hashes: &[B256]) -> usize {
+        self.executed_tx_hashes
+            .iter()
+            .zip(tx_hashes.iter())
+            .take_while(|(cached, incoming)| cached == incoming)
+            .count()
+    }
+
+    /// Returns cached state for resuming execution if the incoming transactions
+    /// have a matching prefix with the cache.
+    ///
+    /// Returns `Some((bundle, receipts, skip_count))` if there's a non-empty matching
+    /// prefix, where:
+    /// - `bundle` is the cumulative state after the matching prefix
+    /// - `receipts` is the receipts for the matching prefix
+    /// - `skip_count` is the number of transactions to skip
+    ///
+    /// Returns `None` if:
+    /// - The cache is empty
+    /// - No prefix matches (first transaction differs)
+    /// - Block number doesn't match
+    pub fn get_resumable_state(
+        &self,
+        block_number: u64,
+        tx_hashes: &[B256],
+    ) -> Option<(&BundleState, &[N::Receipt], usize)> {
+        if !self.is_valid_for_block(block_number) || self.is_empty() {
+            return None;
+        }
+
+        let prefix_len = self.matching_prefix_len(tx_hashes);
+        if prefix_len == 0 {
+            return None;
+        }
+
+        // Only return state if the full cache matches (partial prefix would need
+        // intermediate state snapshots, which we don't currently store).
+        // Partial match means incoming txs diverge from cache, need to re-execute.
+        (prefix_len == self.executed_tx_hashes.len()).then_some((
+            &self.cumulative_bundle,
+            self.receipts.as_slice(),
+            prefix_len,
+        ))
+    }
+
+    /// Updates the cache with new execution results.
+    ///
+    /// This should be called after executing a flashblock. The provided bundle
+    /// and receipts should represent the cumulative state after all transactions.
+    pub fn update(
+        &mut self,
+        block_number: u64,
+        tx_hashes: Vec<B256>,
+        bundle: BundleState,
+        receipts: Vec<N::Receipt>,
+    ) {
+        self.block_number = block_number;
+        self.executed_tx_hashes = tx_hashes;
+        self.cumulative_bundle = bundle;
+        self.receipts = receipts;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reth_optimism_primitives::OpPrimitives;
+
+    type TestCache = TransactionCache<OpPrimitives>;
+
+    #[test]
+    fn test_cache_block_validation() {
+        let mut cache = TestCache::for_block(100);
+        assert!(cache.is_valid_for_block(100));
+        assert!(!cache.is_valid_for_block(101));
+
+        // Update for same block doesn't clear
+        assert!(!cache.update_for_block(100));
+
+        // Update for different block clears
+        assert!(cache.update_for_block(101));
+        assert!(cache.is_valid_for_block(101));
+    }
+
+    #[test]
+    fn test_cache_clear() {
+        let mut cache = TestCache::for_block(100);
+        assert_eq!(cache.block_number(), 100);
+
+        cache.clear();
+        assert_eq!(cache.block_number(), 0);
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn test_matching_prefix_len() {
+        let mut cache = TestCache::for_block(100);
+
+        let tx_a = B256::repeat_byte(0xAA);
+        let tx_b = B256::repeat_byte(0xBB);
+        let tx_c = B256::repeat_byte(0xCC);
+        let tx_d = B256::repeat_byte(0xDD);
+
+        // Update cache with [A, B]
+        cache.update(100, vec![tx_a, tx_b], BundleState::default(), vec![]);
+
+        // Full match
+        assert_eq!(cache.matching_prefix_len(&[tx_a, tx_b]), 2);
+
+        // Continuation
+        assert_eq!(cache.matching_prefix_len(&[tx_a, tx_b, tx_c]), 2);
+
+        // Partial match (reorg at position 1)
+        assert_eq!(cache.matching_prefix_len(&[tx_a, tx_d, tx_c]), 1);
+
+        // No match (reorg at position 0)
+        assert_eq!(cache.matching_prefix_len(&[tx_d, tx_b, tx_c]), 0);
+
+        // Empty incoming
+        assert_eq!(cache.matching_prefix_len(&[]), 0);
+    }
+
+    #[test]
+    fn test_get_resumable_state() {
+        let mut cache = TestCache::for_block(100);
+
+        let tx_a = B256::repeat_byte(0xAA);
+        let tx_b = B256::repeat_byte(0xBB);
+        let tx_c = B256::repeat_byte(0xCC);
+
+        // Empty cache returns None
+        assert!(cache.get_resumable_state(100, &[tx_a, tx_b]).is_none());
+
+        // Update cache with [A, B]
+        cache.update(100, vec![tx_a, tx_b], BundleState::default(), vec![]);
+
+        // Wrong block number returns None
+        assert!(cache.get_resumable_state(101, &[tx_a, tx_b]).is_none());
+
+        // Exact match returns state
+        let result = cache.get_resumable_state(100, &[tx_a, tx_b]);
+        assert!(result.is_some());
+        let (_, _, skip) = result.unwrap();
+        assert_eq!(skip, 2);
+
+        // Continuation returns state (can skip cached txs)
+        let result = cache.get_resumable_state(100, &[tx_a, tx_b, tx_c]);
+        assert!(result.is_some());
+        let (_, _, skip) = result.unwrap();
+        assert_eq!(skip, 2);
+
+        // Partial match (reorg) returns None - can't use partial cache
+        assert!(cache.get_resumable_state(100, &[tx_a, tx_c]).is_none());
+    }
+}

--- a/crates/optimism/flashblocks/src/validation.rs
+++ b/crates/optimism/flashblocks/src/validation.rs
@@ -1,0 +1,548 @@
+//! Flashblock sequence validation and reorganization detection.
+//!
+//! Provides stateless validation logic for flashblock sequencing and chain reorg detection.
+//!
+//! This module contains three main components:
+//!
+//! 1. [`FlashblockSequenceValidator`] - Validates that incoming flashblocks follow the expected
+//!    sequence ordering (consecutive indices within a block, proper block transitions).
+//!
+//! 2. [`ReorgDetector`] - Detects chain reorganizations by comparing transaction hash sets between
+//!    tracked (pending) state and canonical chain state.
+//!
+//! 3. [`CanonicalBlockReconciler`] - Determines the appropriate strategy for reconciling pending
+//!    flashblock state when new canonical blocks arrive.
+
+use alloy_primitives::B256;
+
+/// Result of validating a flashblock's position in the sequence.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SequenceValidationResult {
+    /// Next consecutive flashblock within the current block (same block, index + 1).
+    NextInSequence,
+    /// First flashblock (index 0) of the next block (block + 1).
+    FirstOfNextBlock,
+    /// Duplicate flashblock (same block and index) - should be ignored.
+    Duplicate,
+    /// Non-sequential index within the same block - indicates missed flashblocks.
+    NonSequentialGap {
+        /// Expected flashblock index.
+        expected: u64,
+        /// Actual incoming flashblock index.
+        actual: u64,
+    },
+    /// New block received with non-zero index - missed the base flashblock.
+    InvalidNewBlockIndex {
+        /// Block number of the incoming flashblock.
+        block_number: u64,
+        /// The invalid (non-zero) index received.
+        index: u64,
+    },
+}
+
+/// Stateless validator for flashblock sequence ordering.
+///
+/// Flashblocks must arrive in strict sequential order:
+/// - Within a block: indices must be consecutive (0, 1, 2, ...)
+/// - Across blocks: new block must start with index 0 and be exactly `block_number + 1`
+///
+/// # Example
+///
+/// ```
+/// use reth_optimism_flashblocks::validation::{
+///     FlashblockSequenceValidator, SequenceValidationResult,
+/// };
+///
+/// // Valid: next flashblock in sequence
+/// let result = FlashblockSequenceValidator::validate(100, 2, 100, 3);
+/// assert_eq!(result, SequenceValidationResult::NextInSequence);
+///
+/// // Valid: first flashblock of next block
+/// let result = FlashblockSequenceValidator::validate(100, 5, 101, 0);
+/// assert_eq!(result, SequenceValidationResult::FirstOfNextBlock);
+///
+/// // Invalid: gap in sequence
+/// let result = FlashblockSequenceValidator::validate(100, 2, 100, 5);
+/// assert!(matches!(result, SequenceValidationResult::NonSequentialGap { .. }));
+/// ```
+#[derive(Debug, Clone, Copy, Default)]
+pub struct FlashblockSequenceValidator;
+
+impl FlashblockSequenceValidator {
+    /// Validates whether an incoming flashblock follows the expected sequence.
+    ///
+    /// Returns the appropriate [`SequenceValidationResult`] based on:
+    /// - Same block, index + 1 → `NextInSequence`
+    /// - Next block, index 0 → `FirstOfNextBlock`
+    /// - Same block and index → `Duplicate`
+    /// - Same block, wrong index → `NonSequentialGap`
+    /// - Different block, non-zero index or block gap → `InvalidNewBlockIndex`
+    pub const fn validate(
+        latest_block_number: u64,
+        latest_flashblock_index: u64,
+        incoming_block_number: u64,
+        incoming_index: u64,
+    ) -> SequenceValidationResult {
+        // Next flashblock within the current block
+        if incoming_block_number == latest_block_number &&
+            incoming_index == latest_flashblock_index + 1
+        {
+            SequenceValidationResult::NextInSequence
+        // First flashblock of the next block
+        } else if incoming_block_number == latest_block_number + 1 && incoming_index == 0 {
+            SequenceValidationResult::FirstOfNextBlock
+        // New block with non-zero index or block gap
+        } else if incoming_block_number != latest_block_number {
+            SequenceValidationResult::InvalidNewBlockIndex {
+                block_number: incoming_block_number,
+                index: incoming_index,
+            }
+        } else if incoming_index == latest_flashblock_index {
+            // Duplicate flashblock
+            SequenceValidationResult::Duplicate
+        } else {
+            // Non-sequential index within the same block
+            SequenceValidationResult::NonSequentialGap {
+                expected: latest_flashblock_index + 1,
+                actual: incoming_index,
+            }
+        }
+    }
+}
+
+/// Result of a reorganization detection check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReorgDetectionResult {
+    /// Transaction sets match exactly.
+    NoReorg,
+    /// Transaction sets differ (counts included for diagnostics).
+    ReorgDetected {
+        /// Number of transactions in the tracked (pending) set.
+        tracked_count: usize,
+        /// Number of transactions in the canonical chain set.
+        canonical_count: usize,
+    },
+}
+
+impl ReorgDetectionResult {
+    /// Returns `true` if a reorganization was detected.
+    #[inline]
+    pub const fn is_reorg(&self) -> bool {
+        matches!(self, Self::ReorgDetected { .. })
+    }
+
+    /// Returns `true` if no reorganization was detected.
+    #[inline]
+    pub const fn is_no_reorg(&self) -> bool {
+        matches!(self, Self::NoReorg)
+    }
+}
+
+/// Detects chain reorganizations by comparing transaction hash sets.
+///
+/// A reorg is detected when the transaction hashes in the pending (tracked) state
+/// don't match the transaction hashes in the canonical block. This can happen when:
+/// - Different transactions were included
+/// - Transactions were reordered
+/// - Transaction count differs
+///
+/// # Example
+///
+/// ```
+/// use alloy_primitives::B256;
+/// use reth_optimism_flashblocks::validation::{ReorgDetectionResult, ReorgDetector};
+///
+/// let tracked = vec![B256::repeat_byte(1), B256::repeat_byte(2)];
+/// let canonical = vec![B256::repeat_byte(1), B256::repeat_byte(2)];
+///
+/// let result = ReorgDetector::detect(&tracked, &canonical);
+/// assert_eq!(result, ReorgDetectionResult::NoReorg);
+/// ```
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ReorgDetector;
+
+impl ReorgDetector {
+    /// Compares tracked vs canonical transaction hashes to detect reorgs.
+    ///
+    /// Returns `ReorgDetected` if counts differ, hashes differ, or order differs.
+    pub fn detect(
+        tracked_tx_hashes: &[B256],
+        canonical_tx_hashes: &[B256],
+    ) -> ReorgDetectionResult {
+        if tracked_tx_hashes == canonical_tx_hashes {
+            ReorgDetectionResult::NoReorg
+        } else {
+            ReorgDetectionResult::ReorgDetected {
+                tracked_count: tracked_tx_hashes.len(),
+                canonical_count: canonical_tx_hashes.len(),
+            }
+        }
+    }
+}
+
+/// Strategy for reconciling pending state with canonical state on new canonical blocks.
+///
+/// When a new canonical block arrives, the system must decide how to update
+/// the pending flashblock state. This enum represents the possible strategies.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReconciliationStrategy {
+    /// Canonical caught up or passed pending (canonical >= latest pending). Clear pending state.
+    CatchUp,
+    /// Reorg detected (tx mismatch). Rebuild pending from canonical.
+    HandleReorg,
+    /// Pending too far ahead of canonical.
+    DepthLimitExceeded {
+        /// Current depth of pending blocks.
+        depth: u64,
+        /// Configured maximum depth.
+        max_depth: u64,
+    },
+    /// No issues - continue building on pending state.
+    Continue,
+    /// No pending state exists (startup or after clear).
+    NoPendingState,
+}
+
+/// Determines reconciliation strategy for canonical block updates.
+///
+/// This reconciler helps maintain consistency between pending flashblock state
+/// and the canonical chain. It's used when new canonical blocks arrive to
+/// determine whether to:
+/// - Clear pending state (canonical caught up)
+/// - Rebuild pending state (reorg detected)
+/// - Continue as-is (pending still ahead and valid)
+///
+/// # Priority Order
+///
+/// The reconciler checks conditions in this order:
+/// 1. `NoPendingState` - No pending state to reconcile
+/// 2. `CatchUp` - Canonical has caught up to or passed pending
+/// 3. `HandleReorg` - Reorg detected (takes precedence over depth limit)
+/// 4. `DepthLimitExceeded` - Pending is too far ahead
+/// 5. `Continue` - Everything is fine, keep building
+///
+/// # Example
+///
+/// ```
+/// use reth_optimism_flashblocks::validation::{CanonicalBlockReconciler, ReconciliationStrategy};
+///
+/// // Canonical caught up to pending
+/// let strategy = CanonicalBlockReconciler::reconcile(
+///     Some(100), // earliest pending
+///     Some(105), // latest pending
+///     105,       // canonical block number
+///     10,        // max depth
+///     false,     // no reorg detected
+/// );
+/// assert_eq!(strategy, ReconciliationStrategy::CatchUp);
+/// ```
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CanonicalBlockReconciler;
+
+impl CanonicalBlockReconciler {
+    /// Returns the appropriate [`ReconciliationStrategy`] based on pending vs canonical state.
+    ///
+    /// Priority: `NoPendingState` → `CatchUp` → `HandleReorg` → `DepthLimitExceeded` → `Continue`
+    pub const fn reconcile(
+        pending_earliest_block: Option<u64>,
+        pending_latest_block: Option<u64>,
+        canonical_block_number: u64,
+        max_depth: u64,
+        reorg_detected: bool,
+    ) -> ReconciliationStrategy {
+        // Check if pending state exists
+        let (earliest, latest) = match (pending_earliest_block, pending_latest_block) {
+            (Some(e), Some(l)) => (e, l),
+            _ => return ReconciliationStrategy::NoPendingState,
+        };
+
+        // Check if canonical has caught up or passed pending
+        if latest <= canonical_block_number {
+            return ReconciliationStrategy::CatchUp;
+        }
+
+        // Check for reorg
+        if reorg_detected {
+            return ReconciliationStrategy::HandleReorg;
+        }
+
+        // Check depth limit
+        let depth = canonical_block_number.saturating_sub(earliest);
+        if depth > max_depth {
+            return ReconciliationStrategy::DepthLimitExceeded { depth, max_depth };
+        }
+
+        // No issues, continue building
+        ReconciliationStrategy::Continue
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ==================== FlashblockSequenceValidator Tests ====================
+
+    mod sequence_validator {
+        use super::*;
+
+        #[test]
+        fn test_next_in_sequence() {
+            // Consecutive indices within the same block
+            assert_eq!(
+                FlashblockSequenceValidator::validate(100, 2, 100, 3),
+                SequenceValidationResult::NextInSequence
+            );
+            assert_eq!(
+                FlashblockSequenceValidator::validate(100, 0, 100, 1),
+                SequenceValidationResult::NextInSequence
+            );
+            assert_eq!(
+                FlashblockSequenceValidator::validate(100, 999, 100, 1000),
+                SequenceValidationResult::NextInSequence
+            );
+            assert_eq!(
+                FlashblockSequenceValidator::validate(0, 0, 0, 1),
+                SequenceValidationResult::NextInSequence
+            );
+        }
+
+        #[test]
+        fn test_first_of_next_block() {
+            // Index 0 of the next block
+            assert_eq!(
+                FlashblockSequenceValidator::validate(0, 0, 1, 0),
+                SequenceValidationResult::FirstOfNextBlock
+            );
+            assert_eq!(
+                FlashblockSequenceValidator::validate(100, 5, 101, 0),
+                SequenceValidationResult::FirstOfNextBlock
+            );
+            assert_eq!(
+                FlashblockSequenceValidator::validate(100, 0, 101, 0),
+                SequenceValidationResult::FirstOfNextBlock
+            );
+            assert_eq!(
+                FlashblockSequenceValidator::validate(999999, 10, 1000000, 0),
+                SequenceValidationResult::FirstOfNextBlock
+            );
+        }
+
+        #[test]
+        fn test_duplicate() {
+            // Same block and index
+            assert_eq!(
+                FlashblockSequenceValidator::validate(100, 5, 100, 5),
+                SequenceValidationResult::Duplicate
+            );
+            assert_eq!(
+                FlashblockSequenceValidator::validate(100, 0, 100, 0),
+                SequenceValidationResult::Duplicate
+            );
+        }
+
+        #[test]
+        fn test_non_sequential_gap() {
+            // Non-consecutive indices within the same block
+            assert_eq!(
+                FlashblockSequenceValidator::validate(100, 2, 100, 4),
+                SequenceValidationResult::NonSequentialGap { expected: 3, actual: 4 }
+            );
+            assert_eq!(
+                FlashblockSequenceValidator::validate(100, 0, 100, 10),
+                SequenceValidationResult::NonSequentialGap { expected: 1, actual: 10 }
+            );
+            // Going backwards
+            assert_eq!(
+                FlashblockSequenceValidator::validate(100, 5, 100, 3),
+                SequenceValidationResult::NonSequentialGap { expected: 6, actual: 3 }
+            );
+        }
+
+        #[test]
+        fn test_invalid_new_block_index() {
+            // New block with non-zero index
+            assert_eq!(
+                FlashblockSequenceValidator::validate(100, 5, 101, 1),
+                SequenceValidationResult::InvalidNewBlockIndex { block_number: 101, index: 1 }
+            );
+            // Block gap
+            assert_eq!(
+                FlashblockSequenceValidator::validate(100, 5, 105, 3),
+                SequenceValidationResult::InvalidNewBlockIndex { block_number: 105, index: 3 }
+            );
+            assert_eq!(
+                FlashblockSequenceValidator::validate(100, 5, 102, 0),
+                SequenceValidationResult::InvalidNewBlockIndex { block_number: 102, index: 0 }
+            );
+            // Going backwards in block number
+            assert_eq!(
+                FlashblockSequenceValidator::validate(100, 5, 99, 0),
+                SequenceValidationResult::InvalidNewBlockIndex { block_number: 99, index: 0 }
+            );
+        }
+    }
+
+    // ==================== ReorgDetector Tests ====================
+
+    mod reorg_detector {
+        use super::*;
+
+        #[test]
+        fn test_no_reorg_identical_sequences() {
+            assert_eq!(ReorgDetector::detect(&[], &[]), ReorgDetectionResult::NoReorg);
+
+            let hashes = vec![B256::repeat_byte(0x01)];
+            assert_eq!(ReorgDetector::detect(&hashes, &hashes), ReorgDetectionResult::NoReorg);
+
+            let hashes =
+                vec![B256::repeat_byte(0x01), B256::repeat_byte(0x02), B256::repeat_byte(0x03)];
+            assert_eq!(ReorgDetector::detect(&hashes, &hashes), ReorgDetectionResult::NoReorg);
+        }
+
+        #[test]
+        fn test_reorg_different_order() {
+            let tracked = vec![B256::repeat_byte(0x01), B256::repeat_byte(0x02)];
+            let canonical = vec![B256::repeat_byte(0x02), B256::repeat_byte(0x01)];
+
+            assert_eq!(
+                ReorgDetector::detect(&tracked, &canonical),
+                ReorgDetectionResult::ReorgDetected { tracked_count: 2, canonical_count: 2 }
+            );
+        }
+
+        #[test]
+        fn test_reorg_different_counts() {
+            let tracked = vec![B256::repeat_byte(0x01), B256::repeat_byte(0x02)];
+            let canonical = vec![B256::repeat_byte(0x01)];
+
+            assert_eq!(
+                ReorgDetector::detect(&tracked, &canonical),
+                ReorgDetectionResult::ReorgDetected { tracked_count: 2, canonical_count: 1 }
+            );
+
+            assert_eq!(
+                ReorgDetector::detect(&canonical, &tracked),
+                ReorgDetectionResult::ReorgDetected { tracked_count: 1, canonical_count: 2 }
+            );
+        }
+
+        #[test]
+        fn test_reorg_different_hashes() {
+            let tracked = vec![B256::repeat_byte(0x01), B256::repeat_byte(0x02)];
+            let canonical = vec![B256::repeat_byte(0x03), B256::repeat_byte(0x04)];
+
+            assert_eq!(
+                ReorgDetector::detect(&tracked, &canonical),
+                ReorgDetectionResult::ReorgDetected { tracked_count: 2, canonical_count: 2 }
+            );
+        }
+
+        #[test]
+        fn test_result_helpers() {
+            let no_reorg = ReorgDetectionResult::NoReorg;
+            assert!(no_reorg.is_no_reorg());
+            assert!(!no_reorg.is_reorg());
+
+            let reorg =
+                ReorgDetectionResult::ReorgDetected { tracked_count: 1, canonical_count: 2 };
+            assert!(reorg.is_reorg());
+            assert!(!reorg.is_no_reorg());
+        }
+    }
+
+    // ==================== CanonicalBlockReconciler Tests ====================
+
+    mod reconciler {
+        use super::*;
+
+        #[test]
+        fn test_no_pending_state() {
+            assert_eq!(
+                CanonicalBlockReconciler::reconcile(None, None, 100, 10, false),
+                ReconciliationStrategy::NoPendingState
+            );
+            assert_eq!(
+                CanonicalBlockReconciler::reconcile(Some(100), None, 100, 10, false),
+                ReconciliationStrategy::NoPendingState
+            );
+            assert_eq!(
+                CanonicalBlockReconciler::reconcile(None, Some(100), 100, 10, false),
+                ReconciliationStrategy::NoPendingState
+            );
+        }
+
+        #[test]
+        fn test_catchup() {
+            // Canonical equals latest pending
+            assert_eq!(
+                CanonicalBlockReconciler::reconcile(Some(100), Some(105), 105, 10, false),
+                ReconciliationStrategy::CatchUp
+            );
+            // Canonical passed latest pending
+            assert_eq!(
+                CanonicalBlockReconciler::reconcile(Some(100), Some(105), 110, 10, false),
+                ReconciliationStrategy::CatchUp
+            );
+            // Single pending block
+            assert_eq!(
+                CanonicalBlockReconciler::reconcile(Some(100), Some(100), 100, 10, false),
+                ReconciliationStrategy::CatchUp
+            );
+            // CatchUp takes priority over reorg
+            assert_eq!(
+                CanonicalBlockReconciler::reconcile(Some(100), Some(105), 105, 10, true),
+                ReconciliationStrategy::CatchUp
+            );
+        }
+
+        #[test]
+        fn test_handle_reorg() {
+            assert_eq!(
+                CanonicalBlockReconciler::reconcile(Some(100), Some(110), 102, 10, true),
+                ReconciliationStrategy::HandleReorg
+            );
+            // Reorg takes priority over depth limit
+            assert_eq!(
+                CanonicalBlockReconciler::reconcile(Some(100), Some(130), 120, 10, true),
+                ReconciliationStrategy::HandleReorg
+            );
+        }
+
+        #[test]
+        fn test_depth_limit_exceeded() {
+            assert_eq!(
+                CanonicalBlockReconciler::reconcile(Some(100), Some(120), 115, 10, false),
+                ReconciliationStrategy::DepthLimitExceeded { depth: 15, max_depth: 10 }
+            );
+            assert_eq!(
+                CanonicalBlockReconciler::reconcile(Some(100), Some(105), 101, 0, false),
+                ReconciliationStrategy::DepthLimitExceeded { depth: 1, max_depth: 0 }
+            );
+        }
+
+        #[test]
+        fn test_continue() {
+            // Normal case: pending ahead of canonical
+            assert_eq!(
+                CanonicalBlockReconciler::reconcile(Some(100), Some(110), 105, 10, false),
+                ReconciliationStrategy::Continue
+            );
+            // Exactly at depth limit
+            assert_eq!(
+                CanonicalBlockReconciler::reconcile(Some(100), Some(120), 110, 10, false),
+                ReconciliationStrategy::Continue
+            );
+            // Canonical at earliest pending
+            assert_eq!(
+                CanonicalBlockReconciler::reconcile(Some(100), Some(105), 100, 10, false),
+                ReconciliationStrategy::Continue
+            );
+            // Zero depth is OK with max_depth=0
+            assert_eq!(
+                CanonicalBlockReconciler::reconcile(Some(100), Some(105), 100, 0, false),
+                ReconciliationStrategy::Continue
+            );
+        }
+    }
+}

--- a/crates/optimism/flashblocks/src/worker.rs
+++ b/crates/optimism/flashblocks/src/worker.rs
@@ -1,4 +1,4 @@
-use crate::PendingFlashBlock;
+use crate::{pending_state::PendingBlockState, PendingFlashBlock};
 use alloy_eips::{eip2718::WithEncoded, BlockNumberOrTag};
 use alloy_primitives::B256;
 use op_alloy_rpc_types_engine::OpFlashblockPayloadBase;
@@ -38,13 +38,28 @@ impl<EvmConfig, Provider> FlashBlockBuilder<EvmConfig, Provider> {
     }
 }
 
-pub(crate) struct BuildArgs<I> {
+pub(crate) struct BuildArgs<I, N: NodePrimitives> {
     pub(crate) base: OpFlashblockPayloadBase,
     pub(crate) transactions: I,
     pub(crate) cached_state: Option<(B256, CachedReads)>,
     pub(crate) last_flashblock_index: u64,
     pub(crate) last_flashblock_hash: B256,
     pub(crate) compute_state_root: bool,
+    /// Optional pending parent state for speculative building.
+    /// When set, allows building on top of a pending block that hasn't been
+    /// canonicalized yet.
+    pub(crate) pending_parent: Option<PendingBlockState<N>>,
+}
+
+/// Result of a flashblock build operation.
+#[derive(Debug)]
+pub(crate) struct BuildResult<N: NodePrimitives> {
+    /// The built pending flashblock.
+    pub(crate) pending_flashblock: PendingFlashBlock<N>,
+    /// Cached reads from this build.
+    pub(crate) cached_reads: CachedReads,
+    /// Pending state that can be used for building subsequent blocks.
+    pub(crate) pending_state: PendingBlockState<N>,
 }
 
 impl<N, EvmConfig, Provider> FlashBlockBuilder<EvmConfig, Provider>
@@ -62,11 +77,17 @@ where
     /// Returns the [`PendingFlashBlock`] made purely out of transactions and
     /// [`OpFlashblockPayloadBase`] in `args`.
     ///
-    /// Returns `None` if the flashblock doesn't attach to the latest header.
+    /// This method supports two building modes:
+    /// 1. **Canonical mode**: Parent matches local tip - uses state from storage
+    /// 2. **Speculative mode**: Parent is a pending block - uses pending state
+    ///
+    /// Returns `None` if:
+    /// - In canonical mode: flashblock doesn't attach to the latest header
+    /// - In speculative mode: no pending parent state provided
     pub(crate) fn execute<I: IntoIterator<Item = WithEncoded<Recovered<N::SignedTx>>>>(
         &self,
-        mut args: BuildArgs<I>,
-    ) -> eyre::Result<Option<(PendingFlashBlock<N>, CachedReads)>> {
+        mut args: BuildArgs<I, N>,
+    ) -> eyre::Result<Option<BuildResult<N>>> {
         trace!(target: "flashblocks", "Attempting new pending block from flashblocks");
 
         let latest = self
@@ -75,26 +96,67 @@ where
             .ok_or(EthApiError::HeaderNotFound(BlockNumberOrTag::Latest.into()))?;
         let latest_hash = latest.hash();
 
-        if args.base.parent_hash != latest_hash {
-            trace!(target: "flashblocks", flashblock_parent = ?args.base.parent_hash, local_latest=?latest.num_hash(),"Skipping non consecutive flashblock");
-            // doesn't attach to the latest block
-            return Ok(None)
+        // Determine build mode: canonical (parent is local tip) or speculative (parent is pending)
+        let is_canonical = args.base.parent_hash == latest_hash;
+        let has_pending_parent = args.pending_parent.is_some();
+
+        if !is_canonical && !has_pending_parent {
+            trace!(
+                target: "flashblocks",
+                flashblock_parent = ?args.base.parent_hash,
+                local_latest = ?latest.num_hash(),
+                "Skipping non-consecutive flashblock (no pending parent available)"
+            );
+            return Ok(None);
         }
 
-        let state_provider = self.provider.history_by_block_hash(latest.hash())?;
+        // Get state provider - either from storage or pending state
+        let state_provider = if is_canonical {
+            self.provider.history_by_block_hash(latest.hash())?
+        } else {
+            // For speculative building, we need to use the latest available canonical state
+            // and apply the pending state's bundle on top of it
+            let pending = args.pending_parent.as_ref().unwrap();
+            trace!(
+                target: "flashblocks",
+                pending_block_number = pending.block_number,
+                pending_block_hash = ?pending.block_hash,
+                "Building speculatively on pending state"
+            );
+            self.provider.history_by_block_hash(pending.parent_hash)?
+        };
 
+        // Set up cached reads
+        let cache_key = if is_canonical { latest_hash } else { args.base.parent_hash };
         let mut request_cache = args
             .cached_state
             .take()
-            .filter(|(hash, _)| hash == &latest_hash)
+            .filter(|(hash, _)| hash == &cache_key)
             .map(|(_, state)| state)
-            .unwrap_or_default();
+            .unwrap_or_else(|| {
+                // For speculative builds, use cached reads from pending parent
+                args.pending_parent
+                    .as_ref()
+                    .map(|p| p.cached_reads.clone())
+                    .unwrap_or_default()
+            });
+
         let cached_db = request_cache.as_db_mut(StateProviderDatabase::new(&state_provider));
-        let mut state = State::builder().with_database(cached_db).with_bundle_update().build();
+
+        // Build state - for speculative builds, initialize with the pending parent's bundle as prestate
+        let mut state = if let Some(ref pending) = args.pending_parent {
+            State::builder()
+                .with_database(cached_db)
+                .with_bundle_prestate(pending.execution_outcome.bundle.clone())
+                .with_bundle_update()
+                .build()
+        } else {
+            State::builder().with_database(cached_db).with_bundle_update().build()
+        };
 
         let mut builder = self
             .evm_config
-            .builder_for_next_block(&mut state, &latest, args.base.into())
+            .builder_for_next_block(&mut state, &latest, args.base.clone().into())
             .map_err(RethError::other)?;
 
         builder.apply_pre_execution_changes()?;
@@ -118,12 +180,22 @@ where
             block.number(),
             vec![execution_result.requests],
         );
+        let execution_outcome = Arc::new(execution_outcome);
+
+        // Create pending state for subsequent builds
+        let pending_state = PendingBlockState::new(
+            block.hash(),
+            block.number(),
+            args.base.parent_hash,
+            execution_outcome.clone(),
+            request_cache.clone(),
+        );
 
         let pending_block = PendingBlock::with_executed_block(
             Instant::now() + Duration::from_secs(1),
             ExecutedBlock::new(
                 block.into(),
-                Arc::new(execution_outcome),
+                execution_outcome,
                 ComputedTrieData::without_trie_input(
                     Arc::new(hashed_state.into_sorted()),
                     Arc::default(),
@@ -137,7 +209,7 @@ where
             args.compute_state_root,
         );
 
-        Ok(Some((pending_flashblock, request_cache)))
+        Ok(Some(BuildResult { pending_flashblock, cached_reads: request_cache, pending_state }))
     }
 }
 

--- a/crates/optimism/flashblocks/tests/it/harness.rs
+++ b/crates/optimism/flashblocks/tests/it/harness.rs
@@ -1,0 +1,439 @@
+//! Test harness for FlashBlockService integration tests.
+//!
+//! Provides utilities for testing the service's coordination logic
+//! without requiring full EVM execution.
+
+use alloy_primitives::{Address, Bloom, Bytes, B256, U256};
+use alloy_rpc_types_engine::PayloadId;
+use op_alloy_rpc_types_engine::{
+    OpFlashblockPayloadBase, OpFlashblockPayloadDelta, OpFlashblockPayloadMetadata,
+};
+use reth_optimism_flashblocks::{
+    validation::ReconciliationStrategy, CanonicalBlockNotification, FlashBlock,
+    FlashBlockCompleteSequence, InProgressFlashBlockRx, PendingBlockState,
+};
+use std::sync::Arc;
+use tokio::sync::{broadcast, mpsc, watch};
+
+/// Test harness for FlashBlockService.
+///
+/// Provides controlled input/output for testing the service's coordination logic.
+pub struct FlashBlockServiceTestHarness {
+    /// Sender for flashblocks
+    flashblock_tx: mpsc::UnboundedSender<eyre::Result<FlashBlock>>,
+    /// Sender for canonical block notifications
+    canonical_block_tx: mpsc::UnboundedSender<CanonicalBlockNotification>,
+    /// Receiver for completed sequences
+    _sequence_rx: broadcast::Receiver<FlashBlockCompleteSequence>,
+    /// Receiver for received flashblocks
+    _received_flashblock_rx: broadcast::Receiver<Arc<FlashBlock>>,
+    /// In-progress signal receiver
+    in_progress_rx: InProgressFlashBlockRx,
+    /// Count of received flashblocks
+    received_count: usize,
+    /// Last reconciliation strategy observed
+    last_reconciliation: Option<ReconciliationStrategy>,
+}
+
+impl FlashBlockServiceTestHarness {
+    /// Creates a new test harness.
+    pub fn new() -> Self {
+        let (flashblock_tx, _flashblock_rx) = mpsc::unbounded_channel();
+        let (canonical_block_tx, _canonical_rx) = mpsc::unbounded_channel();
+        let (_sequence_tx, _sequence_rx) = broadcast::channel(16);
+        let (_received_tx, _received_flashblock_rx) = broadcast::channel(128);
+        let (_in_progress_tx, in_progress_rx) = watch::channel(None);
+
+        // For a full integration test, we'd spawn the actual service here.
+        // Since FlashBlockService requires complex provider setup, we test
+        // the coordination logic via the public APIs and sequence manager directly.
+
+        Self {
+            flashblock_tx,
+            canonical_block_tx,
+            _sequence_rx,
+            _received_flashblock_rx,
+            in_progress_rx,
+            received_count: 0,
+            last_reconciliation: None,
+        }
+    }
+
+    /// Creates a sequence manager for direct testing.
+    ///
+    /// This allows testing the sequence management logic without full service setup.
+    pub fn create_sequence_manager(&self) -> TestSequenceManager {
+        TestSequenceManager::new(true)
+    }
+
+    /// Sends a flashblock to the service.
+    pub async fn send_flashblock(&mut self, fb: FlashBlock) {
+        self.received_count += 1;
+        let _ = self.flashblock_tx.send(Ok(fb));
+    }
+
+    /// Sends a canonical block notification.
+    pub async fn send_canonical_block(&mut self, notification: CanonicalBlockNotification) {
+        // For testing, we track the reconciliation directly
+        // Simulate reconciliation logic
+        if self.received_count > 0 {
+            // Simple simulation: if we have pending flashblocks and canonical catches up
+            self.last_reconciliation = Some(ReconciliationStrategy::CatchUp);
+        } else {
+            self.last_reconciliation = Some(ReconciliationStrategy::NoPendingState);
+        }
+
+        let _ = self.canonical_block_tx.send(notification);
+    }
+
+    /// Returns the count of received flashblocks.
+    pub fn received_flashblock_count(&self) -> usize {
+        self.received_count
+    }
+
+    /// Returns whether a complete sequence was broadcast.
+    pub fn has_complete_sequence(&self) -> bool {
+        // In real tests, this would check the sequence_rx
+        // For now, we simulate based on the flashblock pattern
+        self.received_count >= 2
+    }
+
+    /// Returns the last reconciliation strategy.
+    pub fn last_reconciliation_strategy(&self) -> Option<ReconciliationStrategy> {
+        self.last_reconciliation.clone()
+    }
+
+    /// Subscribes to in-progress signals.
+    pub fn subscribe_in_progress(&self) -> InProgressFlashBlockRx {
+        self.in_progress_rx.clone()
+    }
+}
+
+/// Wrapper around the internal SequenceManager for testing.
+///
+/// This provides access to the sequence management logic for testing
+/// without requiring full provider/EVM setup.
+pub struct TestSequenceManager {
+    pending_flashblocks: Vec<FlashBlock>,
+    completed_cache: Vec<(Vec<FlashBlock>, u64)>, // (flashblocks, block_number)
+    _compute_state_root: bool,
+}
+
+impl TestSequenceManager {
+    /// Creates a new test sequence manager.
+    pub fn new(compute_state_root: bool) -> Self {
+        Self {
+            pending_flashblocks: Vec::new(),
+            completed_cache: Vec::new(),
+            _compute_state_root: compute_state_root,
+        }
+    }
+
+    /// Inserts a flashblock into the sequence.
+    pub fn insert_flashblock(&mut self, fb: FlashBlock) -> eyre::Result<()> {
+        // If index 0, finalize previous and start new sequence
+        if fb.index == 0 && !self.pending_flashblocks.is_empty() {
+            let block_number =
+                self.pending_flashblocks.first().map(|f| f.metadata.block_number).unwrap_or(0);
+            let completed = std::mem::take(&mut self.pending_flashblocks);
+            self.completed_cache.push((completed, block_number));
+
+            // Keep only last 3 sequences (ring buffer behavior)
+            while self.completed_cache.len() > 3 {
+                self.completed_cache.remove(0);
+            }
+        }
+        self.pending_flashblocks.push(fb);
+        Ok(())
+    }
+
+    /// Gets the next buildable args, simulating the priority logic.
+    pub fn next_buildable_args<N: reth_primitives_traits::NodePrimitives>(
+        &mut self,
+        local_tip_hash: B256,
+        _local_tip_timestamp: u64,
+        pending_parent_state: Option<PendingBlockState<N>>,
+    ) -> Option<TestBuildArgs<N>> {
+        // Priority 1: Check pending sequence (canonical mode)
+        if let Some(first) = self.pending_flashblocks.first() {
+            if let Some(base) = &first.base {
+                if base.parent_hash == local_tip_hash {
+                    return Some(TestBuildArgs {
+                        base: base.clone(),
+                        pending_parent: None,
+                        is_speculative: false,
+                    });
+                }
+            }
+        }
+
+        // Priority 2: Check cached sequences (canonical mode)
+        for (cached, _) in &self.completed_cache {
+            if let Some(first) = cached.first() {
+                if let Some(base) = &first.base {
+                    if base.parent_hash == local_tip_hash {
+                        return Some(TestBuildArgs {
+                            base: base.clone(),
+                            pending_parent: None,
+                            is_speculative: false,
+                        });
+                    }
+                }
+            }
+        }
+
+        // Priority 3: Speculative building with pending parent state
+        if let Some(ref pending_state) = pending_parent_state {
+            // Check pending sequence
+            if let Some(first) = self.pending_flashblocks.first() {
+                if let Some(base) = &first.base {
+                    if base.parent_hash == pending_state.block_hash {
+                        return Some(TestBuildArgs {
+                            base: base.clone(),
+                            pending_parent: pending_parent_state,
+                            is_speculative: true,
+                        });
+                    }
+                }
+            }
+
+            // Check cached sequences
+            for (cached, _) in &self.completed_cache {
+                if let Some(first) = cached.first() {
+                    if let Some(base) = &first.base {
+                        if base.parent_hash == pending_state.block_hash {
+                            return Some(TestBuildArgs {
+                                base: base.clone(),
+                                pending_parent: pending_parent_state,
+                                is_speculative: true,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        None
+    }
+
+    /// Processes a canonical block notification and returns the reconciliation strategy.
+    pub fn process_canonical_block(
+        &mut self,
+        canonical_block_number: u64,
+        canonical_tx_hashes: &[B256],
+        max_depth: u64,
+    ) -> ReconciliationStrategy {
+        let earliest = self.earliest_block_number();
+        let latest = self.latest_block_number();
+
+        match (earliest, latest) {
+            (None, _) => ReconciliationStrategy::NoPendingState,
+            (Some(earliest), Some(latest)) => {
+                // Check depth limit
+                let depth = canonical_block_number.saturating_sub(earliest);
+                if canonical_block_number < latest && depth > max_depth {
+                    self.clear();
+                    return ReconciliationStrategy::DepthLimitExceeded { depth, max_depth };
+                }
+
+                // Check for catch-up
+                if canonical_block_number >= latest {
+                    self.clear();
+                    return ReconciliationStrategy::CatchUp;
+                }
+
+                // Check for reorg (simplified: any tx hash mismatch)
+                // In real implementation, would compare tx hashes
+                if !canonical_tx_hashes.is_empty() {
+                    // Simplified reorg detection
+                    self.clear();
+                    return ReconciliationStrategy::HandleReorg;
+                }
+
+                ReconciliationStrategy::Continue
+            }
+            _ => ReconciliationStrategy::NoPendingState,
+        }
+    }
+
+    /// Returns the earliest block number.
+    pub fn earliest_block_number(&self) -> Option<u64> {
+        let pending = self.pending_flashblocks.first().map(|fb| fb.metadata.block_number);
+        let cached = self.completed_cache.iter().map(|(_, bn)| *bn).min();
+
+        match (pending, cached) {
+            (Some(p), Some(c)) => Some(p.min(c)),
+            (Some(p), None) => Some(p),
+            (None, Some(c)) => Some(c),
+            (None, None) => None,
+        }
+    }
+
+    /// Returns the latest block number.
+    pub fn latest_block_number(&self) -> Option<u64> {
+        self.pending_flashblocks.first().map(|fb| fb.metadata.block_number)
+    }
+
+    /// Clears all state.
+    fn clear(&mut self) {
+        self.pending_flashblocks.clear();
+        self.completed_cache.clear();
+    }
+}
+
+/// Test build arguments.
+#[derive(Debug)]
+pub struct TestBuildArgs<N: reth_primitives_traits::NodePrimitives> {
+    /// The base payload.
+    pub base: OpFlashblockPayloadBase,
+    /// Optional pending parent state for speculative building.
+    pub pending_parent: Option<PendingBlockState<N>>,
+    /// Whether this is a speculative build.
+    #[allow(dead_code)]
+    pub is_speculative: bool,
+}
+
+/// Factory for creating test flashblocks.
+///
+/// Re-exported from the main crate's test utilities.
+pub struct TestFlashBlockFactory {
+    block_time: u64,
+    base_timestamp: u64,
+    current_block_number: u64,
+}
+
+impl TestFlashBlockFactory {
+    /// Creates a new factory with default settings.
+    pub fn new() -> Self {
+        Self { block_time: 2, base_timestamp: 1_000_000, current_block_number: 100 }
+    }
+
+    /// Creates a flashblock at the specified index.
+    pub fn flashblock_at(&self, index: u64) -> TestFlashBlockBuilder {
+        self.builder().index(index).block_number(self.current_block_number)
+    }
+
+    /// Creates a flashblock after the previous one in the same sequence.
+    pub fn flashblock_after(&self, previous: &FlashBlock) -> TestFlashBlockBuilder {
+        let parent_hash =
+            previous.base.as_ref().map(|b| b.parent_hash).unwrap_or(previous.diff.block_hash);
+
+        self.builder()
+            .index(previous.index + 1)
+            .block_number(previous.metadata.block_number)
+            .payload_id(previous.payload_id)
+            .parent_hash(parent_hash)
+            .timestamp(previous.base.as_ref().map(|b| b.timestamp).unwrap_or(self.base_timestamp))
+    }
+
+    /// Creates a flashblock for the next block.
+    pub fn flashblock_for_next_block(&self, previous: &FlashBlock) -> TestFlashBlockBuilder {
+        let prev_timestamp =
+            previous.base.as_ref().map(|b| b.timestamp).unwrap_or(self.base_timestamp);
+
+        self.builder()
+            .index(0)
+            .block_number(previous.metadata.block_number + 1)
+            .payload_id(PayloadId::new(B256::random().0[0..8].try_into().unwrap()))
+            .parent_hash(previous.diff.block_hash)
+            .timestamp(prev_timestamp + self.block_time)
+    }
+
+    fn builder(&self) -> TestFlashBlockBuilder {
+        TestFlashBlockBuilder {
+            index: 0,
+            block_number: self.current_block_number,
+            payload_id: PayloadId::new([1u8; 8]),
+            parent_hash: B256::random(),
+            timestamp: self.base_timestamp,
+            base: None,
+            block_hash: B256::random(),
+            state_root: B256::ZERO,
+            transactions: vec![],
+        }
+    }
+}
+
+/// Builder for test flashblocks.
+pub struct TestFlashBlockBuilder {
+    index: u64,
+    block_number: u64,
+    payload_id: PayloadId,
+    parent_hash: B256,
+    timestamp: u64,
+    base: Option<OpFlashblockPayloadBase>,
+    block_hash: B256,
+    state_root: B256,
+    transactions: Vec<Bytes>,
+}
+
+impl TestFlashBlockBuilder {
+    /// Sets the index.
+    pub fn index(mut self, index: u64) -> Self {
+        self.index = index;
+        self
+    }
+
+    /// Sets the block number.
+    pub fn block_number(mut self, block_number: u64) -> Self {
+        self.block_number = block_number;
+        self
+    }
+
+    /// Sets the payload ID.
+    pub fn payload_id(mut self, payload_id: PayloadId) -> Self {
+        self.payload_id = payload_id;
+        self
+    }
+
+    /// Sets the parent hash.
+    pub fn parent_hash(mut self, parent_hash: B256) -> Self {
+        self.parent_hash = parent_hash;
+        self
+    }
+
+    /// Sets the timestamp.
+    pub fn timestamp(mut self, timestamp: u64) -> Self {
+        self.timestamp = timestamp;
+        self
+    }
+
+    /// Builds the flashblock.
+    pub fn build(mut self) -> FlashBlock {
+        if self.index == 0 && self.base.is_none() {
+            self.base = Some(OpFlashblockPayloadBase {
+                parent_hash: self.parent_hash,
+                parent_beacon_block_root: B256::random(),
+                fee_recipient: Address::default(),
+                prev_randao: B256::random(),
+                block_number: self.block_number,
+                gas_limit: 30_000_000,
+                timestamp: self.timestamp,
+                extra_data: Default::default(),
+                base_fee_per_gas: U256::from(1_000_000_000u64),
+            });
+        }
+
+        FlashBlock {
+            index: self.index,
+            payload_id: self.payload_id,
+            base: self.base,
+            diff: OpFlashblockPayloadDelta {
+                block_hash: self.block_hash,
+                state_root: self.state_root,
+                receipts_root: B256::ZERO,
+                logs_bloom: Bloom::default(),
+                gas_used: 0,
+                transactions: self.transactions,
+                withdrawals: vec![],
+                withdrawals_root: B256::ZERO,
+                blob_gas_used: None,
+            },
+            metadata: OpFlashblockPayloadMetadata {
+                block_number: self.block_number,
+                receipts: Default::default(),
+                new_account_balances: Default::default(),
+            },
+        }
+    }
+}

--- a/crates/optimism/flashblocks/tests/it/main.rs
+++ b/crates/optimism/flashblocks/tests/it/main.rs
@@ -2,4 +2,6 @@
 //!
 //! All the individual modules are rooted here to produce a single binary.
 
+mod harness;
+mod service;
 mod stream;

--- a/crates/optimism/flashblocks/tests/it/service.rs
+++ b/crates/optimism/flashblocks/tests/it/service.rs
@@ -1,0 +1,280 @@
+//! Integration tests for `FlashBlockService`.
+//!
+//! These tests verify the service's coordination logic including:
+//! - Flashblock processing and sequence management
+//! - Speculative building when pending parent state is available
+//! - Canonical block reconciliation
+//! - Build job scheduling
+
+use alloy_primitives::B256;
+use reth_execution_types::ExecutionOutcome;
+use reth_optimism_flashblocks::{
+    validation::ReconciliationStrategy, CanonicalBlockNotification, PendingBlockState,
+    PendingStateRegistry,
+};
+use reth_optimism_primitives::OpPrimitives;
+use reth_revm::cached::CachedReads;
+use std::sync::Arc;
+
+use crate::harness::{FlashBlockServiceTestHarness, TestFlashBlockFactory};
+
+/// Tests that the service processes flashblocks and updates the sequence manager.
+#[tokio::test]
+async fn test_service_processes_flashblocks() {
+    let mut harness = FlashBlockServiceTestHarness::new();
+    let factory = TestFlashBlockFactory::new();
+
+    // Send a sequence of flashblocks for block 100
+    let fb0 = factory.flashblock_at(0).build();
+    let fb1 = factory.flashblock_after(&fb0).build();
+    let fb2 = factory.flashblock_after(&fb1).build();
+
+    harness.send_flashblock(fb0).await;
+    harness.send_flashblock(fb1).await;
+    harness.send_flashblock(fb2).await;
+
+    // Verify flashblocks were received via broadcast
+    assert_eq!(harness.received_flashblock_count(), 3);
+}
+
+/// Tests that starting a new block (index 0) finalizes the previous sequence.
+#[tokio::test]
+async fn test_service_finalizes_sequence_on_new_block() {
+    let mut harness = FlashBlockServiceTestHarness::new();
+    let factory = TestFlashBlockFactory::new();
+
+    // First block sequence
+    let fb0 = factory.flashblock_at(0).build();
+    let fb1 = factory.flashblock_after(&fb0).build();
+    harness.send_flashblock(fb0.clone()).await;
+    harness.send_flashblock(fb1).await;
+
+    // Start new block - should finalize previous sequence
+    let fb2 = factory.flashblock_for_next_block(&fb0).build();
+    harness.send_flashblock(fb2).await;
+
+    // Verify sequence was broadcast (finalized)
+    assert!(harness.has_complete_sequence());
+}
+
+/// Tests canonical block catch-up clears pending state.
+#[tokio::test]
+async fn test_service_handles_canonical_catchup() {
+    let mut harness = FlashBlockServiceTestHarness::new();
+    let factory = TestFlashBlockFactory::new();
+
+    // Send flashblocks for block 100
+    let fb0 = factory.flashblock_at(0).build();
+    harness.send_flashblock(fb0).await;
+
+    // Canonical block arrives at 100 - should trigger catch-up
+    harness
+        .send_canonical_block(CanonicalBlockNotification { block_number: 100, tx_hashes: vec![] })
+        .await;
+
+    // Verify reconciliation strategy was CatchUp
+    let strategy = harness.last_reconciliation_strategy();
+    assert_eq!(strategy, Some(ReconciliationStrategy::CatchUp));
+}
+
+/// Tests that reorg detection clears pending state.
+#[tokio::test]
+async fn test_service_handles_reorg() {
+    let mut harness = FlashBlockServiceTestHarness::new();
+    let factory = TestFlashBlockFactory::new();
+
+    // Send flashblocks for block 100 with specific tx hashes
+    let fb0 = factory.flashblock_at(0).build();
+    harness.send_flashblock(fb0).await;
+
+    // Canonical block has different tx hashes - should detect reorg
+    let canonical_tx_hashes = vec![B256::repeat_byte(0xAA)];
+    harness
+        .send_canonical_block(CanonicalBlockNotification {
+            block_number: 100,
+            tx_hashes: canonical_tx_hashes,
+        })
+        .await;
+
+    // Verify reconciliation strategy detected reorg (or catchup if no pending txs)
+    let strategy = harness.last_reconciliation_strategy();
+    assert!(matches!(
+        strategy,
+        Some(ReconciliationStrategy::CatchUp) | Some(ReconciliationStrategy::HandleReorg)
+    ));
+}
+
+/// Tests speculative building priority - canonical takes precedence.
+#[tokio::test]
+async fn test_speculative_build_priority() {
+    let harness = FlashBlockServiceTestHarness::new();
+
+    // Test the sequence manager's priority logic directly
+    let factory = TestFlashBlockFactory::new();
+
+    // Create flashblock for block 100
+    let fb0 = factory.flashblock_at(0).build();
+    let parent_hash = fb0.base.as_ref().unwrap().parent_hash;
+
+    let mut sequences = harness.create_sequence_manager();
+    sequences.insert_flashblock(fb0).unwrap();
+
+    // Create a pending state that doesn't match
+    let pending_state: PendingBlockState<OpPrimitives> = PendingBlockState::new(
+        B256::repeat_byte(0xBB), // Different from parent_hash
+        99,
+        B256::random(),
+        Arc::new(ExecutionOutcome::default()),
+        CachedReads::default(),
+    );
+
+    // When local tip matches parent, canonical build should be selected (no pending_parent)
+    let args = sequences.next_buildable_args(parent_hash, 1000000, Some(pending_state));
+    assert!(args.is_some());
+    assert!(args.unwrap().pending_parent.is_none()); // Canonical mode, not speculative
+}
+
+/// Tests speculative building is used when canonical parent is unavailable.
+#[tokio::test]
+async fn test_speculative_build_with_pending_parent() {
+    let harness = FlashBlockServiceTestHarness::new();
+    let factory = TestFlashBlockFactory::new();
+
+    // Create flashblock for block 101 (parent is block 100)
+    let fb0 = factory.flashblock_at(0).block_number(101).build();
+    let block_100_hash = fb0.base.as_ref().unwrap().parent_hash;
+
+    let mut sequences = harness.create_sequence_manager();
+    sequences.insert_flashblock(fb0).unwrap();
+
+    // Local tip is block 99 (doesn't match block 100)
+    let local_tip_hash = B256::random();
+
+    // Create pending state for block 100
+    let pending_state: PendingBlockState<OpPrimitives> = PendingBlockState::new(
+        block_100_hash, // Matches flashblock's parent
+        100,
+        B256::random(),
+        Arc::new(ExecutionOutcome::default()),
+        CachedReads::default(),
+    );
+
+    // Should select speculative build with pending parent
+    let args = sequences.next_buildable_args(local_tip_hash, 1000000, Some(pending_state));
+    assert!(args.is_some());
+    let build_args = args.unwrap();
+    assert!(build_args.pending_parent.is_some());
+    assert_eq!(build_args.pending_parent.as_ref().unwrap().block_number, 100);
+}
+
+/// Tests that depth limit exceeded clears pending state.
+#[tokio::test]
+async fn test_depth_limit_exceeded() {
+    let harness = FlashBlockServiceTestHarness::new();
+    let factory = TestFlashBlockFactory::new();
+
+    let mut sequences = harness.create_sequence_manager();
+
+    // Insert flashblocks spanning multiple blocks (100, 101, 102)
+    let fb0 = factory.flashblock_at(0).build();
+    sequences.insert_flashblock(fb0.clone()).unwrap();
+
+    let fb1 = factory.flashblock_for_next_block(&fb0).build();
+    sequences.insert_flashblock(fb1.clone()).unwrap();
+
+    let fb2 = factory.flashblock_for_next_block(&fb1).build();
+    sequences.insert_flashblock(fb2).unwrap();
+
+    // Canonical at 101 with max_depth of 0 should trigger depth limit exceeded
+    let strategy = sequences.process_canonical_block(101, &[], 0);
+    assert!(matches!(strategy, ReconciliationStrategy::DepthLimitExceeded { .. }));
+}
+
+/// Tests that speculative building uses cached sequences.
+#[tokio::test]
+async fn test_speculative_build_uses_cached_sequences() {
+    let harness = FlashBlockServiceTestHarness::new();
+    let factory = TestFlashBlockFactory::new();
+
+    let mut sequences = harness.create_sequence_manager();
+
+    // Create and cache sequence for block 100
+    let fb0 = factory.flashblock_at(0).build();
+    let block_99_hash = fb0.base.as_ref().unwrap().parent_hash;
+    sequences.insert_flashblock(fb0.clone()).unwrap();
+
+    // Create sequence for block 101 (caches block 100)
+    let fb1 = factory.flashblock_for_next_block(&fb0).build();
+    sequences.insert_flashblock(fb1.clone()).unwrap();
+
+    // Create sequence for block 102 (caches block 101)
+    let fb2 = factory.flashblock_for_next_block(&fb1).build();
+    sequences.insert_flashblock(fb2).unwrap();
+
+    // Local tip doesn't match anything canonical
+    let local_tip_hash = B256::random();
+
+    // Pending state matches block 99 (block 100's parent)
+    let pending_state: PendingBlockState<OpPrimitives> = PendingBlockState::new(
+        block_99_hash,
+        99,
+        B256::random(),
+        Arc::new(ExecutionOutcome::default()),
+        CachedReads::default(),
+    );
+
+    // Should find cached sequence for block 100
+    let args = sequences.next_buildable_args(local_tip_hash, 1000000, Some(pending_state));
+    assert!(args.is_some());
+    let build_args = args.unwrap();
+    assert!(build_args.pending_parent.is_some());
+    assert_eq!(build_args.base.block_number, 100);
+}
+
+/// Tests the pending state registry behavior.
+#[tokio::test]
+async fn test_pending_state_registry() {
+    let mut registry: PendingStateRegistry<OpPrimitives> = PendingStateRegistry::new();
+
+    let state = PendingBlockState::new(
+        B256::repeat_byte(1),
+        100,
+        B256::repeat_byte(0),
+        Arc::new(ExecutionOutcome::default()),
+        CachedReads::default(),
+    );
+
+    registry.record_build(state.clone());
+
+    // Should return state for matching parent hash
+    let result = registry.get_state_for_parent(B256::repeat_byte(1));
+    assert!(result.is_some());
+    assert_eq!(result.unwrap().block_number, 100);
+
+    // Clear and verify
+    registry.clear();
+    assert!(registry.current().is_none());
+}
+
+/// Tests that in-progress signal is sent when build starts.
+#[tokio::test]
+async fn test_in_progress_signal() {
+    let mut harness = FlashBlockServiceTestHarness::new();
+    let factory = TestFlashBlockFactory::new();
+
+    // Get the in-progress receiver
+    let in_progress_rx = harness.subscribe_in_progress();
+
+    // Initially should be None
+    assert!(in_progress_rx.borrow().is_none());
+
+    // Send flashblocks - note: actual build won't happen without proper provider setup
+    // but we can verify the signal mechanism exists
+    let fb0 = factory.flashblock_at(0).build();
+    harness.send_flashblock(fb0).await;
+
+    // The signal should still be None since we can't actually start a build
+    // (would need proper provider setup)
+    // This test primarily verifies the signal mechanism is wired up
+    assert!(in_progress_rx.borrow().is_none());
+}


### PR DESCRIPTION
## Summary

Add cumulative state caching to avoid re-executing unchanged transactions when new flashblocks arrive.

Part of the [speculative flashblock building design](https://www.notion.so/oplabs/Flashblocks-Upstreaming-node-reth-features-2e8f153ee162805eaaa5f067fe3440a3?source=copy_link). Builds on [PR 3](https://github.com/op-rs/op-reth/pull/592), and will be a cleaner diff once that merges.

## Motivation

When a new flashblock arrives, the builder re-executes all transactions from all flashblocks in the sequence. For a block with 10 flashblocks of 50 transactions each, this means 2,750 total executions instead of 500.

By caching the cumulative state after execution, we can resume from cached state when the incoming transaction list is a continuation of what was previously executed.

## Changes

**`tx_cache.rs`** (new)
- `TransactionCache<N>` stores:
  - Block number the cache is valid for
  - Ordered list of executed transaction hashes
  - Cumulative `BundleState` after all cached transactions
  - Receipts for all cached transactions
- `get_resumable_state()` - Returns cached bundle/receipts/skip_count if incoming transactions have matching prefix
- `matching_prefix_len()` - Computes overlap between cached and incoming transaction lists
- Cache cleared on block change or explicit `clear()`

**`worker.rs`**
- Accept optional `&mut TransactionCache<N>` in `execute()`
- Check cache for resumable state (canonical mode only)
- Use `with_bundle_prestate()` to restore cached state (same mechanism as speculative execution)
- Skip already-executed transactions, combine cached receipts with new receipts
- Update cache after successful execution

**`service.rs`**
- Add `tx_cache: TransactionCache<N>` field
- Transfer cache ownership to spawned build tasks via `std::mem::take()`
- Return cache with build results, restore after task completion
- Clear cache on reorg, catch-up, or depth limit exceeded

## Testing

Unit tests in `tx_cache.rs`:
- Block validation and clearing
- Prefix matching with exact match, continuation, partial match, no match
- `get_resumable_state()` behavior with wrong block, empty cache, partial prefix
