### PR TITLE
feat(engine): add engine_getPayloadV4Hacked for megablock benchmarking

### DIFF
--- a/crates/rpc/rpc-api/src/engine.rs
+++ b/crates/rpc/rpc-api/src/engine.rs
@@ -254,6 +254,29 @@ pub trait EngineApi<Engine: EngineTypes> {
     ) -> RpcResult<Option<Vec<Option<BlobAndProofV2>>>>;
 }
 
+/// Hacked Engine API for megablock creation (benchmarking).
+///
+/// This trait provides `engine_getPayloadV4Hacked` which matches Nethermind's implementation
+/// from the `cber/get-payload-hacked` branch for compatibility with execution-payloads-benchmarks.
+///
+/// **Warning:** This is a powerful testing-only API. It should only be enabled for benchmarking
+/// and never exposed on public-facing RPC.
+#[cfg_attr(not(feature = "client"), rpc(server, namespace = "engine"))]
+#[cfg_attr(feature = "client", rpc(server, client, namespace = "engine"))]
+pub trait EngineApiHacked {
+    /// Builds a megablock using the current head as parent.
+    ///
+    /// Takes raw signed transaction RLP bytes, builds a block with all transactions executed,
+    /// and returns the V4 payload envelope with execution requests.
+    ///
+    /// This matches Nethermind's `engine_getPayloadV4Hacked` from `cber/get-payload-hacked`.
+    #[method(name = "getPayloadV4Hacked")]
+    async fn get_payload_v4_hacked(
+        &self,
+        transactions: Vec<Bytes>,
+    ) -> RpcResult<alloy_rpc_types_engine::ExecutionPayloadEnvelopeV4>;
+}
+
 /// A subset of the ETH rpc interface: <https://ethereum.github.io/execution-apis/api-documentation>
 ///
 /// This also includes additional eth functions required by optimism.

--- a/crates/rpc/rpc-api/src/lib.rs
+++ b/crates/rpc/rpc-api/src/lib.rs
@@ -41,7 +41,7 @@ pub mod servers {
     pub use crate::{
         admin::AdminApiServer,
         debug::{DebugApiServer, DebugExecutionWitnessApiServer},
-        engine::{EngineApiServer, EngineEthApiServer, IntoEngineApiRpcModule},
+        engine::{EngineApiHackedServer, EngineApiServer, EngineEthApiServer, IntoEngineApiRpcModule},
         mev::{MevFullApiServer, MevSimApiServer},
         miner::MinerApiServer,
         net::NetApiServer,

--- a/crates/rpc/rpc/src/testing.rs
+++ b/crates/rpc/rpc/src/testing.rs
@@ -1,11 +1,13 @@
 //! Implementation of the `testing` namespace.
 //!
 //! This exposes `testing_buildBlockV1`, intended for non-production/debug use.
+//! Also provides `build_megablock` for `engine_getPayloadV4Hacked` compatibility.
 
 use alloy_consensus::{Header, Transaction};
+use alloy_eips::eip4895::Withdrawals;
 use alloy_evm::Evm;
-use alloy_primitives::U256;
-use alloy_rpc_types_engine::ExecutionPayloadEnvelopeV5;
+use alloy_primitives::{Address, Bytes, U256};
+use alloy_rpc_types_engine::{ExecutionPayloadEnvelopeV4, ExecutionPayloadEnvelopeV5};
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
 use reth_errors::RethError;
@@ -14,10 +16,10 @@ use reth_ethereum_primitives::EthPrimitives;
 use reth_evm::{execute::BlockBuilder, ConfigureEvm, NextBlockEnvAttributes};
 use reth_primitives_traits::{AlloyBlockHeader as BlockTrait, Recovered, TxTy};
 use reth_revm::{database::StateProviderDatabase, db::State};
-use reth_rpc_api::{TestingApiServer, TestingBuildBlockRequestV1};
+use reth_rpc_api::{EngineApiHackedServer, TestingApiServer, TestingBuildBlockRequestV1};
 use reth_rpc_eth_api::{helpers::Call, FromEthApiError};
 use reth_rpc_eth_types::{utils::recover_raw_transaction, EthApiError};
-use reth_storage_api::{BlockReader, HeaderProvider};
+use reth_storage_api::{BlockNumReader, BlockReader, BlockReaderIdExt, HeaderProvider};
 use revm::context::Block;
 use std::sync::Arc;
 
@@ -37,10 +39,92 @@ impl<Eth, Evm> TestingApi<Eth, Evm> {
 
 impl<Eth, Evm> TestingApi<Eth, Evm>
 where
-    Eth: Call<Provider: BlockReader<Header = Header>>,
+    Eth: Call<Provider: BlockReader<Header = Header> + BlockReaderIdExt>,
     Evm: ConfigureEvm<NextBlockEnvCtx = NextBlockEnvAttributes, Primitives = EthPrimitives>
         + 'static,
 {
+    /// Build a megablock using the current head as parent.
+    ///
+    /// This is compatible with Nethermind's `engine_getPayloadV4Hacked` - it takes only
+    /// raw transactions and auto-derives parent block and payload attributes from head.
+    pub async fn build_megablock(
+        &self,
+        transactions: Vec<Bytes>,
+    ) -> Result<ExecutionPayloadEnvelopeV4, Eth::Error> {
+        let evm_config = self.evm_config.clone();
+        
+        // Get current head block hash
+        let head = self.eth_api.provider().best_block_number()
+            .map_err(RethError::other)
+            .map_err(Eth::Error::from_eth_err)?;
+        let head_header = self.eth_api.provider()
+            .sealed_header(head.into())
+            .map_err(RethError::other)
+            .map_err(Eth::Error::from_eth_err)?
+            .ok_or_else(|| Eth::Error::from_eth_err(EthApiError::HeaderNotFound(head.into())))?;
+        let parent_hash = head_header.hash();
+
+        self.eth_api
+            .spawn_with_state_at_block(parent_hash, move |eth_api, state| {
+                let state = state.database.0;
+                let mut db = State::builder()
+                    .with_bundle_update()
+                    .with_database(StateProviderDatabase::new(&state))
+                    .build();
+                let parent = eth_api
+                    .provider()
+                    .sealed_header_by_hash(parent_hash)?
+                    .ok_or_else(|| EthApiError::HeaderNotFound(parent_hash.into()))?;
+
+                // Auto-generate payload attributes from parent (matching Nethermind's behavior)
+                let env_attrs = NextBlockEnvAttributes {
+                    timestamp: parent.timestamp() + 1,
+                    suggested_fee_recipient: Address::ZERO,
+                    prev_randao: parent.mix_hash().unwrap_or_default(),
+                    gas_limit: parent.gas_limit(),
+                    parent_beacon_block_root: parent.parent_beacon_block_root(),
+                    withdrawals: Some(Withdrawals::default()),
+                    extra_data: Bytes::default(),
+                };
+
+                let mut builder = evm_config
+                    .builder_for_next_block(&mut db, &parent, env_attrs)
+                    .map_err(RethError::other)
+                    .map_err(Eth::Error::from_eth_err)?;
+                builder.apply_pre_execution_changes().map_err(Eth::Error::from_eth_err)?;
+
+                let mut total_fees = U256::ZERO;
+                let base_fee = builder.evm_mut().block().basefee();
+
+                for tx in transactions {
+                    let tx: Recovered<TxTy<Evm::Primitives>> = recover_raw_transaction(&tx)?;
+                    let tip = tx.effective_tip_per_gas(base_fee).unwrap_or_default();
+                    let gas_used =
+                        builder.execute_transaction(tx).map_err(Eth::Error::from_eth_err)?;
+
+                    total_fees += U256::from(tip) * U256::from(gas_used);
+                }
+                let outcome = builder.finish(&state).map_err(Eth::Error::from_eth_err)?;
+
+                let requests = outcome
+                    .block
+                    .requests_hash()
+                    .is_some()
+                    .then_some(outcome.execution_result.requests);
+
+                EthBuiltPayload::new(
+                    alloy_rpc_types_engine::PayloadId::default(),
+                    Arc::new(outcome.block.into_sealed_block()),
+                    total_fees,
+                    requests,
+                )
+                .try_into_v4()
+                .map_err(RethError::other)
+                .map_err(Eth::Error::from_eth_err)
+            })
+            .await
+    }
+
     async fn build_block_v1(
         &self,
         request: TestingBuildBlockRequestV1,
@@ -112,7 +196,7 @@ where
 #[async_trait]
 impl<Eth, Evm> TestingApiServer for TestingApi<Eth, Evm>
 where
-    Eth: Call<Provider: BlockReader<Header = Header>>,
+    Eth: Call<Provider: BlockReader<Header = Header> + BlockReaderIdExt>,
     Evm: ConfigureEvm<NextBlockEnvCtx = NextBlockEnvAttributes, Primitives = EthPrimitives>
         + 'static,
 {
@@ -123,5 +207,23 @@ where
         request: TestingBuildBlockRequestV1,
     ) -> RpcResult<ExecutionPayloadEnvelopeV5> {
         self.build_block_v1(request).await.map_err(Into::into)
+    }
+}
+
+#[async_trait]
+impl<Eth, Evm> EngineApiHackedServer for TestingApi<Eth, Evm>
+where
+    Eth: Call<Provider: BlockReader<Header = Header> + BlockReaderIdExt>,
+    Evm: ConfigureEvm<NextBlockEnvCtx = NextBlockEnvAttributes, Primitives = EthPrimitives>
+        + 'static,
+{
+    /// Handles `engine_getPayloadV4Hacked` for megablock creation.
+    ///
+    /// This is compatible with Nethermind's hacked endpoint for benchmarking.
+    async fn get_payload_v4_hacked(
+        &self,
+        transactions: Vec<Bytes>,
+    ) -> RpcResult<ExecutionPayloadEnvelopeV4> {
+        self.build_megablock(transactions).await.map_err(Into::into)
     }
 }


### PR DESCRIPTION
## Summary

Add `engine_getPayloadV4Hacked` endpoint for compatibility with Nethermind's [execution-payloads-benchmarks](https://github.com/NethermindEth/execution-payloads-benchmarks) tool.

This enables building **megablocks** (blocks with transactions from multiple source blocks merged together) for benchmarking execution client performance.

## Background

Nethermind created the `cber/get-payload-hacked` branch (Oct 2025) as a quick solution for megablock benchmarking. This was later formalized as `testing_buildBlockV1` spec ([execution-apis #710](https://github.com/ethereum/execution-apis/pull/710)).

This PR adds the hacked endpoint for backward compatibility with existing tooling, while reth already supports the standard `testing_buildBlockV1`.

## Implementation

- Adds `EngineApiHacked` trait with `getPayloadV4Hacked` method in `engine` namespace
- Reuses `TestingApi`'s block building logic (`build_megablock()`)
- Auto-derives parent and payload attributes from current head
- Registers on auth RPC when `testing` module is enabled

## How to use

Start reth with `--http.api testing` to enable both:
- `testing_buildBlockV1` on regular RPC
- `engine_getPayloadV4Hacked` on auth RPC

## API

```json
{
  "method": "engine_getPayloadV4Hacked",
  "params": [["0x02f8...", "0x02f8..."]],  // raw tx RLP bytes
  "id": 1
}
```

Returns `ExecutionPayloadEnvelopeV4` with execution requests.