### PR TITLE
fix(exex): use max when updating highest_committed_block_height

### DIFF
--- a/crates/exex/exex/src/wal/cache.rs
+++ b/crates/exex/exex/src/wal/cache.rs
@@ -121,7 +121,11 @@ impl BlockCache {
                 self.lowest_committed_block_height
                     .map_or(first_block_number, |lowest| lowest.min(first_block_number)),
             );
-            self.highest_committed_block_height = Some(committed_chain.tip().number());
+            let tip_block_number = committed_chain.tip().number();
+            self.highest_committed_block_height = Some(
+                self.highest_committed_block_height
+                    .map_or(tip_block_number, |highest| highest.max(tip_block_number)),
+            );
         }
     }
 


### PR DESCRIPTION
Fix incorrect update of highest_committed_block_height in BlockCache.

Previously, the value was directly assigned from the new committed chain's
tip, which could decrease the maximum when notifications with lower block
numbers were inserted. Now it uses max() to ensure the value only increases,
matching the logic used for lowest_committed_block_height.