### PR TITLE
perf(trie): fix extend_sorted_vec O(n log n) → O(n+m) merge

### DIFF
--- a/crates/trie/common/src/utils.rs
+++ b/crates/trie/common/src/utils.rs
@@ -26,7 +26,7 @@ where
         .collect()
 }
 
-/// Extend a sorted vector with another sorted vector using O(n+m) merge.
+/// Extend a sorted vector with another sorted vector using 2 pointer merge.
 /// Values from `other` take precedence for duplicate keys.
 pub(crate) fn extend_sorted_vec<K, V>(target: &mut Vec<(K, V)>, other: &[(K, V)])
 where

--- a/crates/trie/common/src/utils.rs
+++ b/crates/trie/common/src/utils.rs
@@ -26,46 +26,56 @@ where
         .collect()
 }
 
-/// Extend a sorted vector with another sorted vector.
-/// Values from `other` take precedence for duplicate keys.
-///
+/// Extend a sorted vector with another sorted vector using O(n+m) merge.
 /// Values from `other` take precedence for duplicate keys.
 pub(crate) fn extend_sorted_vec<K, V>(target: &mut Vec<(K, V)>, other: &[(K, V)])
 where
     K: Clone + Ord,
     V: Clone,
 {
-    let cmp = |a: &(K, V), b: &(K, V)| a.0.cmp(&b.0);
-
     if other.is_empty() {
         return;
     }
-    target.reserve(other.len());
 
-    let mut other_iter = other.iter().peekable();
-    let initial_len = target.len();
-    for i in 0..initial_len {
-        while let Some(other_item) = other_iter.peek() {
-            let target_item = &mut target[i];
-            match cmp(other_item, target_item) {
-                Ordering::Less => {
-                    target.push(other_iter.next().unwrap().clone());
-                }
-                Ordering::Equal => {
-                    target_item.1 = other_iter.next().unwrap().1.clone();
-                    break;
-                }
-                Ordering::Greater => {
-                    break;
-                }
+    if target.is_empty() {
+        target.extend_from_slice(other);
+        return;
+    }
+
+    // Fast path: non-overlapping ranges - just append
+    if target.last().map(|(k, _)| k) < other.first().map(|(k, _)| k) {
+        target.extend_from_slice(other);
+        return;
+    }
+
+    // Move ownership of target to avoid cloning owned elements
+    let left = core::mem::take(target);
+    let mut out = Vec::with_capacity(left.len() + other.len());
+
+    let mut a = left.into_iter().peekable();
+    let mut b = other.iter().peekable();
+
+    while let (Some(aa), Some(bb)) = (a.peek(), b.peek()) {
+        match aa.0.cmp(&bb.0) {
+            Ordering::Less => {
+                out.push(a.next().unwrap());
+            }
+            Ordering::Greater => {
+                out.push(b.next().unwrap().clone());
+            }
+            Ordering::Equal => {
+                // `other` takes precedence for duplicate keys - reuse key from `a`
+                let (k, _) = a.next().unwrap();
+                out.push((k, b.next().unwrap().1.clone()));
             }
         }
     }
 
-    target.extend(other_iter.cloned());
-    if target.len() > initial_len {
-        target.sort_by(cmp);
-    }
+    // Drain remaining: `a` moves, `b` clones
+    out.extend(a);
+    out.extend(b.cloned());
+
+    *target = out;
 }
 
 #[cfg(test)]
@@ -78,6 +88,55 @@ mod tests {
         let other = vec![(2, "b"), (3, "c_new")];
         extend_sorted_vec(&mut target, &other);
         assert_eq!(target, vec![(1, "a"), (2, "b"), (3, "c_new")]);
+    }
+
+    #[test]
+    fn test_extend_sorted_vec_empty_target() {
+        let mut target: Vec<(i32, &str)> = vec![];
+        let other = vec![(1, "a"), (2, "b")];
+        extend_sorted_vec(&mut target, &other);
+        assert_eq!(target, vec![(1, "a"), (2, "b")]);
+    }
+
+    #[test]
+    fn test_extend_sorted_vec_empty_other() {
+        let mut target = vec![(1, "a"), (2, "b")];
+        let other: Vec<(i32, &str)> = vec![];
+        extend_sorted_vec(&mut target, &other);
+        assert_eq!(target, vec![(1, "a"), (2, "b")]);
+    }
+
+    #[test]
+    fn test_extend_sorted_vec_all_duplicates() {
+        let mut target = vec![(1, "old1"), (2, "old2"), (3, "old3")];
+        let other = vec![(1, "new1"), (2, "new2"), (3, "new3")];
+        extend_sorted_vec(&mut target, &other);
+        // other takes precedence
+        assert_eq!(target, vec![(1, "new1"), (2, "new2"), (3, "new3")]);
+    }
+
+    #[test]
+    fn test_extend_sorted_vec_interleaved() {
+        let mut target = vec![(1, "a"), (3, "c"), (5, "e")];
+        let other = vec![(2, "b"), (4, "d"), (6, "f")];
+        extend_sorted_vec(&mut target, &other);
+        assert_eq!(target, vec![(1, "a"), (2, "b"), (3, "c"), (4, "d"), (5, "e"), (6, "f")]);
+    }
+
+    #[test]
+    fn test_extend_sorted_vec_other_all_smaller() {
+        let mut target = vec![(5, "e"), (6, "f")];
+        let other = vec![(1, "a"), (2, "b")];
+        extend_sorted_vec(&mut target, &other);
+        assert_eq!(target, vec![(1, "a"), (2, "b"), (5, "e"), (6, "f")]);
+    }
+
+    #[test]
+    fn test_extend_sorted_vec_other_all_larger() {
+        let mut target = vec![(1, "a"), (2, "b")];
+        let other = vec![(5, "e"), (6, "f")];
+        extend_sorted_vec(&mut target, &other);
+        assert_eq!(target, vec![(1, "a"), (2, "b"), (5, "e"), (6, "f")]);
     }
 
     #[test]


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/21034 Replace the previous algorithm that appended elements then re-sorted with a proper two-pointer merge that maintains O(n+m) complexity. 

Follow up to https://github.com/paradigmxyz/reth/pull/21080


The two pointer merge works much for large blocks where n is really large. but not as much when n is small. n here refers to the size HashPostStateSorted, TrieUpdateSorted.

<img width="1727" height="609" alt="image" src="https://github.com/user-attachments/assets/dbc41fe7-60ca-4b78-828e-76f964f6e047" />

The context is that our current sorting is really slow. based on the benchmark, with realistic big blocks number, it performed badly.

<img width="2956" height="1700" alt="image" src="https://github.com/user-attachments/assets/ed003fd8-f4d3-42cb-b058-33206eeb30d4" />

**Problem**
The old implementation would append new elements and call `sort_by()`, resulting in O(n log n) complexity per merge.

**Solution**
Use a two-pointer merge algorithm that processes both sorted inputs in a single pass, achieving O(n+m) complexity.

---

**Benchmark Results**

| Type | n | k | extend_ref_old | extend_ref_new | kway_merge | Winner |
|------|--:|--:|---------------:|---------------:|-----------:|--------|
| **HashedPostState** | 5000 | 3 | 890µs | **617µs** | 1.43ms | extend_ref_new (1.4x) |
| | 5000 | 10 | 6.17ms | 6.18ms | 7.62ms | old ≈ new |
| | 10000 | 3 | 3.23ms | **2.04ms** | 3.32ms | extend_ref_new (1.6x) |
| | 10000 | 10 | 14.2ms | **13.6ms** | 20.2ms | extend_ref_new |
| | 15000 | 3 | 5.47ms | **4.03ms** | 6.66ms | extend_ref_new (1.4x) |
| | 15000 | 10 | 24.0ms | **22.4ms** | 31.9ms | extend_ref_new |
| **TrieUpdates** | 5000 | 3 | 963µs | **581µs** | 1.02ms | extend_ref_new (1.7x) |
| | 5000 | 10 | 7.74ms | **5.56ms** | 6.97ms | extend_ref_new (1.4x) |
| | 10000 | 3 | 3.80ms | **1.86ms** | 2.67ms | extend_ref_new (2.0x) |
| | 10000 | 10 | 17.0ms | **13.0ms** | 18.5ms | extend_ref_new (1.3x) |
| | 15000 | 3 | 6.36ms | **3.74ms** | 4.96ms | extend_ref_new (1.7x) |
| | 15000 | 10 | 30.0ms | **21.1ms** | 29.3ms | extend_ref_new (1.4x) |

**Key Findings:**
- For small k (3-10 blocks), `extend_ref_new` consistently wins with 1.3-2.0x speedup

[Full benchmark results](https://gist.github.com/yongkangc/fb9dea26961d727298e342b5e242d8dd)