### PR TITLE
feat(trie): proofs v2 completion - reveal methods and target generation

### DIFF
--- a/.config/zepter.yaml
+++ b/.config/zepter.yaml
@@ -12,7 +12,7 @@ workflows:
         # Check that `A` activates the features of `B`.
         "propagate-feature",
         # These are the features to check:
-        "--features=std,op,dev,asm-keccak,jemalloc,jemalloc-prof,tracy-allocator,serde-bincode-compat,serde,test-utils,arbitrary,bench,alloy-compat,min-error-logs,min-warn-logs,min-info-logs,min-debug-logs,min-trace-logs,otlp,js-tracer,portable,keccak-cache-global",
+        "--features=std,op,dev,asm-keccak,jemalloc,jemalloc-prof,tracy-allocator,tracy,serde-bincode-compat,serde,test-utils,arbitrary,bench,alloy-compat,min-error-logs,min-warn-logs,min-info-logs,min-debug-logs,min-trace-logs,otlp,js-tracer,portable,keccak-cache-global",
         # Do not try to add a new section to `[features]` of `A` only because `B` exposes that feature. There are edge-cases where this is still needed, but we can add them manually.
         "--left-side-feature-missing=ignore",
         # Ignore the case that `A` it outside of the workspace. Otherwise it will report errors in external dependencies that we have no influence on.

--- a/.config/zepter.yaml
+++ b/.config/zepter.yaml
@@ -12,7 +12,7 @@ workflows:
         # Check that `A` activates the features of `B`.
         "propagate-feature",
         # These are the features to check:
-        "--features=std,op,dev,asm-keccak,jemalloc,jemalloc-prof,tracy-allocator,tracy,serde-bincode-compat,serde,test-utils,arbitrary,bench,alloy-compat,min-error-logs,min-warn-logs,min-info-logs,min-debug-logs,min-trace-logs,otlp,js-tracer,portable,keccak-cache-global",
+        "--features=std,op,dev,asm-keccak,jemalloc,jemalloc-prof,tracy-allocator,tracy,serde-bincode-compat,serde,test-utils,arbitrary,bench,alloy-compat,min-error-logs,min-warn-logs,min-info-logs,min-debug-logs,min-trace-logs,otlp,otlp-logs,js-tracer,portable,keccak-cache-global",
         # Do not try to add a new section to `[features]` of `A` only because `B` exposes that feature. There are edge-cases where this is still needed, but we can add them manually.
         "--left-side-feature-missing=ignore",
         # Ignore the case that `A` it outside of the workspace. Otherwise it will report errors in external dependencies that we have no influence on.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Reth is a high-performance Ethereum execution client written in Rust, focusing o
 6. **Pipeline (`crates/stages/`)**: Staged sync architecture for blockchain synchronization
 7. **Trie (`crates/trie/`)**: Merkle Patricia Trie implementation with parallel state root computation
 8. **Node Builder (`crates/node/`)**: High-level node orchestration and configuration
-9  **The Consensus Engine (`crates/engine/`)**: Handles processing blocks received from the consensus layer with the Engine API (newPayload, forkchoiceUpdated)
+9. **The Consensus Engine (`crates/engine/`)**: Handles processing blocks received from the consensus layer with the Engine API (newPayload, forkchoiceUpdated)
 
 ### Key Design Principles
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,9 +51,7 @@ elsewhere.
 <!-- -   **Asking in the support Telegram:** The [Foundry Support Telegram][support-tg] is a fast and easy way to ask questions. -->
 <!-- -   **Opening a discussion:** This repository comes with a discussions board where you can also ask for help. Click the "Discussions" tab at the top. -->
 
-If you have reviewed existing documentation and still have questions, or you are having problems, you can get help by *
-*opening a discussion**. This repository comes with a discussions board where you can also ask for help. Click the "
-Discussions" tab at the top.
+If you have reviewed existing documentation and still have questions, or you are having problems, you can get help by **opening a discussion**. This repository comes with a discussions board where you can also ask for help. Click the "Discussions" tab at the top.
 
 As Reth is still in heavy development, the documentation can be a bit scattered. The [Reth Docs][reth-docs] is our
 current best-effort attempt at keeping up-to-date information.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7ea09cffa9ad82f6404e6ab415ea0c41a7674c0f2e2e689cb8683f772b5940d"
+checksum = "5c3a590d13de3944675987394715f37537b50b856e3b23a0e66e97d963edbf38"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aafa1f0ddb5cbb6cba6b10e8fa6e31f8c5d5c22e262b30a5d2fa9d336c3b637"
+checksum = "0f28f769d5ea999f0d8a105e434f483456a15b4e1fcb08edbbbe1650a497ff6d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -164,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "398c81368b864fdea950071a00b298c22b21506fed1ed8abc7f2902727f987f1"
+checksum = "990fa65cd132a99d3c3795a82b9f93ec82b81c7de3bab0bf26ca5c73286f7186"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -260,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "691fed81bbafefae0f5a6cedd837ebb3fade46e7d91c5b67a463af12ecf5b11a"
+checksum = "09535cbc646b0e0c6fcc12b7597eaed12cf86dff4c4fba9507a61e71b94f30eb"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -308,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf91e325928dfffe90c769c2c758cc6e9ba35331c6e984310fe8276548df4a9e"
+checksum = "1005520ccf89fa3d755e46c1d992a9e795466c2e7921be2145ef1f749c5727de"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -349,9 +349,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8618cd8431d82d21ed98c300b6072f73fe925dff73b548aa2d4573b5a8d3ca91"
+checksum = "72b626409c98ba43aaaa558361bca21440c88fd30df7542c7484b9c7a1489cdb"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -364,9 +364,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390641d0e7e51d5d39b905be654ef391a89d62b9e6d3a74fd931b4df26daae20"
+checksum = "89924fdcfeee0e0fa42b1f10af42f92802b5d16be614a70897382565663bf7cf"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -390,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9badd9de9f310f0c17602c642c043eee40033c0651f45809189e411f6b166e0f"
+checksum = "0f0dbe56ff50065713ff8635d8712a0895db3ad7f209db9793ad8fcb6b1734aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -466,9 +466,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b7dcf6452993e31ea728b9fc316ebe4e4e3a820c094f2aad55646041ee812a0"
+checksum = "8b56f7a77513308a21a2ba0e9d57785a9d9d2d609e77f4e71a78a1192b83ff2d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -511,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "040dabce173e246b9522cf189db8e383c811b89cf6bd07a6ab952ec3b822a1e6"
+checksum = "94813abbd7baa30c700ea02e7f92319dbcb03bff77aeea92a3a9af7ba19c5c70"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -555,9 +555,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce4a28b1302733f565a2900a0d7cb3db94ffd1dd58ad7ebf5b0ec302e868ed1e"
+checksum = "ff01723afc25ec4c5b04de399155bef7b6a96dfde2475492b1b7b4e7a4f46445"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -581,9 +581,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1408505e2a41c71f7b3f83ee52e5ecd0f2a6f2db98046d0a4defb9f85a007a9e"
+checksum = "f91bf006bb06b7d812591b6ac33395cb92f46c6a65cda11ee30b348338214f0f"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -594,9 +594,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee46cb2875073395f936482392d63f8128f1676a788762468857bd81390f8a4"
+checksum = "b934c3bcdc6617563b45deb36a40881c8230b94d0546ea739dff7edb3aa2f6fd"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -606,9 +606,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456a35438dc5631320a747466a0366bf21b03494fc2e33ac903c128504a68edf"
+checksum = "7e82145856df8abb1fefabef58cdec0f7d9abf337d4abd50c1ed7e581634acdd"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -618,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6792425a4a8e74be38e8785f90f497f8f325188f40f13c168a220310fd421d12"
+checksum = "212ca1c1dab27f531d3858f8b1a2d6bfb2da664be0c1083971078eb7b71abe4b"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -629,9 +629,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5e181ada2cd52aaad734a03a541e2ccc5a6198eb5b011843c41b0d6c0d245f5"
+checksum = "6d92a9b4b268fac505ef7fb1dac9bb129d4fd7de7753f22a5b6e9f666f7f7de6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -649,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f72b891c28aa7376f7e4468c40d2bdcc1013ab47ceae57a2696e78b0cd1e8341"
+checksum = "bab1ebed118b701c497e6541d2d11dfa6f3c6ae31a3c52999daa802fcdcc16b7"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -661,9 +661,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7bcd9ead89076095806364327a1b18c2215998b6fff5a45f82c658bfbabf2df"
+checksum = "232f00fcbcd3ee3b9399b96223a8fc884d17742a70a44f9d7cef275f93e6e872"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -682,9 +682,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3b505d6223c88023fb1217ac24eab950e4368f6634405bea3977d34cae6935b"
+checksum = "5715d0bf7efbd360873518bd9f6595762136b5327a9b759a8c42ccd9b5e44945"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -704,9 +704,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da6c1a9891c2fe0582fe19dda5064e7ad8f21762ed51731717cce676193b3baa"
+checksum = "c7b61941d2add2ee64646612d3eda92cbbde8e6c933489760b6222c8898c79be"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -719,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca8db59fa69da9da5bb6b75823c2b07c27b0f626a0f3af72bac32a7c361a418"
+checksum = "9763cc931a28682bd4b9a68af90057b0fbe80e2538a82251afd69d7ae00bbebf"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -733,9 +733,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14194567368b8c8b7aeef470831bbe90cc8b12ef5f48b18acdda9cf20070ff1"
+checksum = "359a8caaa98cb49eed62d03f5bc511dd6dd5dee292238e8627a6e5690156df0f"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -745,9 +745,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a755a3cc0297683c2879bbfe2ff22778f35068f07444f0b52b5b87570142b6"
+checksum = "5ed8531cae8d21ee1c6571d0995f8c9f0652a6ef6452fde369283edea6ab7138"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -757,9 +757,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d73afcd1fb2d851bf4ba67504a951b73231596f819cc814f50d11126db7ac1b"
+checksum = "fb10ccd49d0248df51063fce6b716f68a315dd912d55b32178c883fd48b4021d"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -772,9 +772,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "807b043936012acc788c96cba06b8580609d124bb105dc470a1617051cc4aa63"
+checksum = "f4d992d44e6c414ece580294abbadb50e74cfd4eaa69787350a4dfd4b20eaa1b"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -861,9 +861,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b84a605484a03959436e5bea194e6d62f77c3caef750196b4b4f1c8d23254df"
+checksum = "3f50a9516736d22dd834cc2240e5bf264f338667cc1d9e514b55ec5a78b987ca"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -884,9 +884,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a400ad5b73590a099111481d4a66a2ca1266ebc85972a844958caf42bfdd37d"
+checksum = "0a18b541a6197cf9a084481498a766fdf32fefda0c35ea6096df7d511025e9f1"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -899,9 +899,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74adc2ef0cb8c2cad4de2044afec2d4028061bc016148a251704dc204f259477"
+checksum = "8075911680ebc537578cacf9453464fd394822a0f68614884a9c63f9fbaf5e89"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -919,9 +919,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c1672b97fef0057f3ca268507fb4f1bc59497531603f39ccaf47cc1e5b9cb4"
+checksum = "921d37a57e2975e5215f7dd0f28873ed5407c7af630d4831a4b5c737de4b0b8b"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -956,9 +956,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17272de4df6b8b59889b264f0306eba47a69f23f57f1c08f1366a4617b48c30"
+checksum = "b2289a842d02fe63f8c466db964168bb2c7a9fdfb7b24816dbb17d45520575fb"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7920,6 +7920,7 @@ dependencies = [
  "tokio-stream",
  "toml",
  "tracing",
+ "url",
  "zstd",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3328,7 +3328,7 @@ dependencies = [
 
 [[package]]
 name = "ef-test-runner"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "clap",
  "ef-tests",
@@ -3336,7 +3336,7 @@ dependencies = [
 
 [[package]]
 name = "ef-tests"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3826,7 +3826,7 @@ dependencies = [
 
 [[package]]
 name = "example-full-contract-state"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "eyre",
  "reth-ethereum",
@@ -3965,7 +3965,7 @@ dependencies = [
 
 [[package]]
 name = "exex-subscription"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -6495,7 +6495,7 @@ dependencies = [
 
 [[package]]
 name = "op-reth"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "clap",
  "reth-cli-util",
@@ -7647,7 +7647,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -7694,7 +7694,7 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7717,7 +7717,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bench"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-eips",
  "alloy-json-rpc",
@@ -7760,7 +7760,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bench-compare"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -7788,7 +7788,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7820,7 +7820,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7840,7 +7840,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7853,7 +7853,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7938,7 +7938,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7947,7 +7947,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7968,7 +7968,7 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7992,7 +7992,7 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8002,7 +8002,7 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -8020,7 +8020,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8032,7 +8032,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8046,7 +8046,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8071,7 +8071,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8105,7 +8105,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8135,7 +8135,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8165,7 +8165,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8181,7 +8181,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8207,7 +8207,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8232,7 +8232,7 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8260,7 +8260,7 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8298,7 +8298,7 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8355,7 +8355,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8382,7 +8382,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8406,7 +8406,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8430,7 +8430,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-service"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "futures",
  "pin-project",
@@ -8459,7 +8459,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8532,7 +8532,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8559,7 +8559,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8581,7 +8581,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8599,7 +8599,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8625,7 +8625,7 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8635,7 +8635,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8673,7 +8673,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8698,7 +8698,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8738,7 +8738,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "clap",
  "eyre",
@@ -8760,7 +8760,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8776,7 +8776,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8794,7 +8794,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8807,7 +8807,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8835,7 +8835,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8862,7 +8862,7 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-primitives",
  "rayon",
@@ -8872,7 +8872,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8897,7 +8897,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8921,7 +8921,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8933,7 +8933,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8953,7 +8953,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8998,7 +8998,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-test-utils"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-eips",
  "eyre",
@@ -9029,7 +9029,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9046,7 +9046,7 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -9055,7 +9055,7 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9088,7 +9088,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "bytes",
  "futures",
@@ -9110,7 +9110,7 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -9128,7 +9128,7 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -9136,7 +9136,7 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "futures",
  "metrics",
@@ -9147,7 +9147,7 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9155,7 +9155,7 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9169,7 +9169,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9230,7 +9230,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9254,7 +9254,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9276,7 +9276,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9293,7 +9293,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9306,7 +9306,7 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -9324,7 +9324,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9347,7 +9347,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9418,7 +9418,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9475,7 +9475,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -9535,7 +9535,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9558,7 +9558,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9581,7 +9581,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "bytes",
  "eyre",
@@ -9610,7 +9610,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9621,7 +9621,7 @@ dependencies = [
 
 [[package]]
 name = "reth-op"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "reth-chainspec",
  "reth-cli-util",
@@ -9661,7 +9661,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-chainspec"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9689,7 +9689,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-cli"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9738,7 +9738,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-consensus"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9769,7 +9769,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-evm"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9798,7 +9798,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-flashblocks"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9836,7 +9836,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-forks"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-op-hardforks",
  "alloy-primitives",
@@ -9846,7 +9846,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-node"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9906,7 +9906,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-payload-builder"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9945,7 +9945,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-primitives"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9972,7 +9972,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-rpc"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10034,7 +10034,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-storage"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "reth-codecs",
@@ -10046,7 +10046,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-txpool"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10083,7 +10083,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10103,7 +10103,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10114,7 +10114,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10137,7 +10137,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-util"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10146,7 +10146,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10155,7 +10155,7 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10177,7 +10177,7 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10214,7 +10214,7 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10263,7 +10263,7 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10295,11 +10295,11 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-db"
-version = "1.9.4"
+version = "1.10.0"
 
 [[package]]
 name = "reth-prune-types"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10318,7 +10318,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-protocol"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10344,7 +10344,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-provider"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10370,7 +10370,7 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10384,7 +10384,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10469,7 +10469,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -10500,7 +10500,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api-testing-util"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10519,7 +10519,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -10575,7 +10575,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10601,7 +10601,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-e2e-tests"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-genesis",
  "alloy-rpc-types-engine",
@@ -10621,7 +10621,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10657,7 +10657,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10700,7 +10700,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10748,7 +10748,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -10765,7 +10765,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10780,7 +10780,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10838,7 +10838,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10870,7 +10870,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10886,7 +10886,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stateless"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -10914,7 +10914,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-primitives",
  "assert_matches",
@@ -10937,7 +10937,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10952,7 +10952,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10975,7 +10975,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10990,7 +10990,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-rpc-provider"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11019,7 +11019,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -11036,7 +11036,7 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11052,7 +11052,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11061,7 +11061,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "clap",
  "eyre",
@@ -11079,7 +11079,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "clap",
  "eyre",
@@ -11096,7 +11096,7 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11144,7 +11144,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11178,7 +11178,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -11211,7 +11211,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11238,7 +11238,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11268,7 +11268,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11301,7 +11301,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse-parallel"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11331,7 +11331,7 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4092,6 +4092,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixed-map"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ed19add84e8cb9e8cc5f7074de0324247149ffef0b851e215fb0edc50c229b"
+dependencies = [
+ "fixed-map-derive",
+ "serde",
+]
+
+[[package]]
+name = "fixed-map-derive"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dc7a9cb3326bafb80642c5ce99b39a2c0702d4bfa8ee8a3e773791a6cbe2407"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.113",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10908,6 +10929,7 @@ dependencies = [
  "alloy-primitives",
  "clap",
  "derive_more",
+ "fixed-map",
  "insta",
  "reth-nippy-jar",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7923,6 +7923,7 @@ dependencies = [
  "rand 0.8.5",
  "rand 0.9.2",
  "reth-fs-util",
+ "reth-tracing",
  "secp256k1 0.30.0",
  "serde",
  "snmalloc-rs",
@@ -11037,6 +11038,8 @@ dependencies = [
  "tracing-logfmt",
  "tracing-samply",
  "tracing-subscriber 0.3.22",
+ "tracing-tracy",
+ "tracy-client",
 ]
 
 [[package]]
@@ -13345,6 +13348,17 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "tracing-tracy"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eaa1852afa96e0fe9e44caa53dc0bd2d9d05e0f2611ce09f97f8677af56e4ba"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber 0.3.22",
+ "tracy-client",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3328,7 +3328,7 @@ dependencies = [
 
 [[package]]
 name = "ef-test-runner"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "clap",
  "ef-tests",
@@ -3336,7 +3336,7 @@ dependencies = [
 
 [[package]]
 name = "ef-tests"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3826,7 +3826,7 @@ dependencies = [
 
 [[package]]
 name = "example-full-contract-state"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "eyre",
  "reth-ethereum",
@@ -3965,7 +3965,7 @@ dependencies = [
 
 [[package]]
 name = "exex-subscription"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -6495,7 +6495,7 @@ dependencies = [
 
 [[package]]
 name = "op-reth"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "clap",
  "reth-cli-util",
@@ -7647,7 +7647,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -7694,7 +7694,7 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7717,7 +7717,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bench"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-eips",
  "alloy-json-rpc",
@@ -7760,7 +7760,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bench-compare"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -7788,7 +7788,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7820,7 +7820,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7840,7 +7840,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7853,7 +7853,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7938,7 +7938,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7947,7 +7947,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7968,7 +7968,7 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7992,7 +7992,7 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8002,7 +8002,7 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -8020,7 +8020,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8032,7 +8032,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8046,7 +8046,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8071,7 +8071,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8105,7 +8105,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8135,7 +8135,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8165,7 +8165,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8181,7 +8181,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8207,7 +8207,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8232,7 +8232,7 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8260,7 +8260,7 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8298,7 +8298,7 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8355,7 +8355,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8382,7 +8382,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8406,7 +8406,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8430,7 +8430,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-service"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "futures",
  "pin-project",
@@ -8459,7 +8459,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8532,7 +8532,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8559,7 +8559,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8581,7 +8581,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8599,7 +8599,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8625,7 +8625,7 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8635,7 +8635,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8673,7 +8673,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8698,7 +8698,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8738,7 +8738,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "clap",
  "eyre",
@@ -8760,7 +8760,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8776,7 +8776,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8794,7 +8794,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8807,7 +8807,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8835,7 +8835,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8862,7 +8862,7 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-primitives",
  "rayon",
@@ -8872,7 +8872,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8897,7 +8897,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8921,7 +8921,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8933,7 +8933,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8953,7 +8953,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8998,7 +8998,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-test-utils"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-eips",
  "eyre",
@@ -9029,7 +9029,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9046,7 +9046,7 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -9055,7 +9055,7 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9088,7 +9088,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "bytes",
  "futures",
@@ -9110,7 +9110,7 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -9128,7 +9128,7 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -9136,7 +9136,7 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "futures",
  "metrics",
@@ -9147,7 +9147,7 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9155,7 +9155,7 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9169,7 +9169,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9230,7 +9230,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9254,7 +9254,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9276,7 +9276,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9293,7 +9293,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9306,7 +9306,7 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -9324,7 +9324,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9347,7 +9347,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9418,7 +9418,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9475,7 +9475,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -9535,7 +9535,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9558,7 +9558,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9581,7 +9581,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "bytes",
  "eyre",
@@ -9610,7 +9610,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9621,7 +9621,7 @@ dependencies = [
 
 [[package]]
 name = "reth-op"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "reth-chainspec",
  "reth-cli-util",
@@ -9661,7 +9661,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-chainspec"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9689,7 +9689,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-cli"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9738,7 +9738,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-consensus"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9769,7 +9769,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-evm"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9798,7 +9798,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-flashblocks"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9836,7 +9836,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-forks"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-op-hardforks",
  "alloy-primitives",
@@ -9846,7 +9846,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-node"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9906,7 +9906,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-payload-builder"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9945,7 +9945,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-primitives"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9972,7 +9972,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-rpc"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10034,7 +10034,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-storage"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "reth-codecs",
@@ -10046,7 +10046,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-txpool"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10083,7 +10083,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10103,7 +10103,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10114,7 +10114,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10137,7 +10137,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-util"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10146,7 +10146,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10155,7 +10155,7 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10177,7 +10177,7 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10214,7 +10214,7 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10263,7 +10263,7 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10295,11 +10295,11 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-db"
-version = "1.9.3"
+version = "1.9.4"
 
 [[package]]
 name = "reth-prune-types"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10318,7 +10318,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-protocol"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10344,7 +10344,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-provider"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10370,7 +10370,7 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10384,7 +10384,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10469,7 +10469,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -10500,7 +10500,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api-testing-util"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10519,7 +10519,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -10575,7 +10575,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10601,7 +10601,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-e2e-tests"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-genesis",
  "alloy-rpc-types-engine",
@@ -10621,7 +10621,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10657,7 +10657,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10700,7 +10700,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10748,7 +10748,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -10765,7 +10765,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10780,7 +10780,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10838,7 +10838,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10870,7 +10870,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10886,7 +10886,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stateless"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -10914,7 +10914,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-primitives",
  "assert_matches",
@@ -10937,7 +10937,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10952,7 +10952,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10975,7 +10975,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10990,7 +10990,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-rpc-provider"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11019,7 +11019,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -11036,7 +11036,7 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11052,7 +11052,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11061,7 +11061,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "clap",
  "eyre",
@@ -11079,7 +11079,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "clap",
  "eyre",
@@ -11096,7 +11096,7 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11144,7 +11144,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11178,7 +11178,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -11211,7 +11211,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11238,7 +11238,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11268,7 +11268,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11301,7 +11301,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse-parallel"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11331,7 +11331,7 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3dcd2b4e208ce5477de90ccdcbd4bde2c8fb06af49a443974e92bb8f2c5e93f"
+checksum = "f7ea09cffa9ad82f6404e6ab415ea0c41a7674c0f2e2e689cb8683f772b5940d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee5655f234985f5ab1e31bef7e02ed11f0a899468cf3300e061e1b96e9e11de0"
+checksum = "8aafa1f0ddb5cbb6cba6b10e8fa6e31f8c5d5c22e262b30a5d2fa9d336c3b637"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -164,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f01b6d8e5b4f3222aaf7f18613a7292e2fbc9163fe120649cd1b078ca534349"
+checksum = "398c81368b864fdea950071a00b298c22b21506fed1ed8abc7f2902727f987f1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -260,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6847d641141b92a1557094aa6c236cbe49c06fb24144d4a21fe6acb970c15888"
+checksum = "691fed81bbafefae0f5a6cedd837ebb3fade46e7d91c5b67a463af12ecf5b11a"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -308,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe3192fca2eb0b0c4b122b3c2d8254496b88a4e810558dddd3ea2f30ad9469df"
+checksum = "bf91e325928dfffe90c769c2c758cc6e9ba35331c6e984310fe8276548df4a9e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -349,9 +349,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4ab3330e491053e9608b2a315f147357bb8acb9377a988c1203f2e8e2b296c9"
+checksum = "8618cd8431d82d21ed98c300b6072f73fe925dff73b548aa2d4573b5a8d3ca91"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -364,9 +364,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e22ff194b1e34b4defd1e257e3fe4dce0eee37451c7757a1510d6b23e7379a"
+checksum = "390641d0e7e51d5d39b905be654ef391a89d62b9e6d3a74fd931b4df26daae20"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -390,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a6cbb9f431bdad294eebb5af9b293d6979e633bfe5468d1e87c1421a858265"
+checksum = "9badd9de9f310f0c17602c642c043eee40033c0651f45809189e411f6b166e0f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -466,9 +466,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f5dde1abc3d582e53d139904fcdd8b2103f0bd03e8f2acb4292edbbaeaa7e6e"
+checksum = "3b7dcf6452993e31ea728b9fc316ebe4e4e3a820c094f2aad55646041ee812a0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -496,7 +496,7 @@ dependencies = [
  "either",
  "futures",
  "futures-utils-wasm",
- "lru 0.13.0",
+ "lru 0.16.3",
  "parking_lot",
  "pin-project",
  "reqwest",
@@ -511,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbfe0a3c553a027f722185fb574124d205147fffb309cae52d0a2094f076887"
+checksum = "040dabce173e246b9522cf189db8e383c811b89cf6bd07a6ab952ec3b822a1e6"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -555,9 +555,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a94bdef2710322c6770be08689fee0878c2ad75615b8fc40e05d7f3c9618c0b"
+checksum = "ce4a28b1302733f565a2900a0d7cb3db94ffd1dd58ad7ebf5b0ec302e868ed1e"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -581,9 +581,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "811a573c8080e1b492d488e6a240ec5dd7677d7167e91ce9cb4d0ec1fcac8027"
+checksum = "1408505e2a41c71f7b3f83ee52e5ecd0f2a6f2db98046d0a4defb9f85a007a9e"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -594,9 +594,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d2d901eeaf99067f54c97a98c8afddcb9f63e35af1efe0ce8d45d04f9223e50"
+checksum = "7ee46cb2875073395f936482392d63f8128f1676a788762468857bd81390f8a4"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -606,9 +606,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "838ca94be532a929f27961851000ec8bbbaeb06e2a2bcca44fac7855a2fe0f6f"
+checksum = "456a35438dc5631320a747466a0366bf21b03494fc2e33ac903c128504a68edf"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -618,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12df0b34551ca2eab8ec83b56cb709ee5da991737282180d354a659b907f00dc"
+checksum = "6792425a4a8e74be38e8785f90f497f8f325188f40f13c168a220310fd421d12"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -629,9 +629,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32598a2443750a2e884c1b48efccaeeaae75e7eb4e0f13df9146b78107b4c301"
+checksum = "e5e181ada2cd52aaad734a03a541e2ccc5a6198eb5b011843c41b0d6c0d245f5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -649,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49a3a168a5bf18f1cf7ed5723a650aebe714edf7665b53dacf5707716733d0"
+checksum = "f72b891c28aa7376f7e4468c40d2bdcc1013ab47ceae57a2696e78b0cd1e8341"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -661,9 +661,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe16cd1dea6089902ec609e04261a9ae6d11ec66005ba24c1f97f0eefbc0fa9"
+checksum = "c7bcd9ead89076095806364327a1b18c2215998b6fff5a45f82c658bfbabf2df"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -682,9 +682,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f9f130511b8632686dfe6f9909b38d7ae4c68de3ce17d28991400646a39b25"
+checksum = "a3b505d6223c88023fb1217ac24eab950e4368f6634405bea3977d34cae6935b"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -704,9 +704,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdeb95f21ba043cbbbc074f7af9c7bb22e2727de02dc3fe95d5ae963a96767a6"
+checksum = "da6c1a9891c2fe0582fe19dda5064e7ad8f21762ed51731717cce676193b3baa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -719,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cafe859944638c5d57d1a3a0034cdb5d07c98c37de8adce5508f28834acf958f"
+checksum = "4ca8db59fa69da9da5bb6b75823c2b07c27b0f626a0f3af72bac32a7c361a418"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -733,9 +733,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afaa06544e36f223b99b1415a12911230fd527994f020736c3c7950d5080208e"
+checksum = "e14194567368b8c8b7aeef470831bbe90cc8b12ef5f48b18acdda9cf20070ff1"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -745,9 +745,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "067b718d2e6ac1bb889341fcc7a250cfa49bcd3ba4f23923f1c1eb1f2b10cb7c"
+checksum = "75a755a3cc0297683c2879bbfe2ff22778f35068f07444f0b52b5b87570142b6"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -757,9 +757,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acff6b251740ef473932386d3b71657d3825daebf2217fb41a7ef676229225d4"
+checksum = "9d73afcd1fb2d851bf4ba67504a951b73231596f819cc814f50d11126db7ac1b"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -772,9 +772,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9129ef31975d987114c27c9930ee817cf3952355834d47f2fdf4596404507e8"
+checksum = "807b043936012acc788c96cba06b8580609d124bb105dc470a1617051cc4aa63"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -861,9 +861,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec1fb08ee484e615f24867c0b154fff5722bb00176102a16868c6532b7c3623"
+checksum = "9b84a605484a03959436e5bea194e6d62f77c3caef750196b4b4f1c8d23254df"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -884,9 +884,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64b722073c76f2de7e118d546ee1921c50710f97feb32aed50db94cfa5b663e1"
+checksum = "1a400ad5b73590a099111481d4a66a2ca1266ebc85972a844958caf42bfdd37d"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -899,9 +899,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdedcf401aab4b96d8b5e6638b79d04a6afb96c0bfcb50a2324fbadfe65c47b3"
+checksum = "74adc2ef0cb8c2cad4de2044afec2d4028061bc016148a251704dc204f259477"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -919,9 +919,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942210908f0c56941097f5653a5f334546940e6fd9073495b257e52216469feb"
+checksum = "c2c1672b97fef0057f3ca268507fb4f1bc59497531603f39ccaf47cc1e5b9cb4"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -956,9 +956,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04950a13cc4209d8e9b78f306e87782466bad8538c94324702d061ff03e211c9"
+checksum = "f17272de4df6b8b59889b264f0306eba47a69f23f57f1c08f1366a4617b48c30"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
@@ -5740,11 +5740,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.13.0"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -10709,6 +10709,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5879,16 +5879,16 @@ dependencies = [
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.16.2"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
+checksum = "3589659543c04c7dc5526ec858591015b87cd8746583b51b48ef4353f99dbcda"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.12.1",
  "metrics",
  "metrics-util",
  "quanta",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -5909,13 +5909,13 @@ dependencies = [
 
 [[package]]
 name = "metrics-util"
-version = "0.19.1"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
+checksum = "cdfb1365fea27e6dd9dc1dbc19f570198bc86914533ad639dae939635f096be4"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "indexmap 2.12.1",
  "metrics",
  "ordered-float",
@@ -6601,9 +6601,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
-version = "4.6.0"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+checksum = "7f4779c6901a562440c3786d08192c6fbda7c1c2060edd10006b05ee35d10f2d"
 dependencies = [
  "num-traits",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8338,7 +8338,6 @@ dependencies = [
  "reth-network-peers",
  "secp256k1 0.30.0",
  "sha2",
- "sha3",
  "thiserror 2.0.17",
  "tokio",
  "tokio-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6549,6 +6549,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-appender-tracing"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef6a1ac5ca3accf562b8c306fa8483c85f4390f768185ab775f242f7fe8fdcc2"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber 0.3.22",
+]
+
+[[package]]
 name = "opentelemetry-http"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11072,6 +11084,7 @@ dependencies = [
  "clap",
  "eyre",
  "opentelemetry",
+ "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10204,7 +10204,6 @@ dependencies = [
  "reth-ethereum-engine-primitives",
  "reth-ethereum-primitives",
  "reth-execution-types",
- "reth-fs-util",
  "reth-metrics",
  "reth-nippy-jar",
  "reth-node-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11307,6 +11307,7 @@ dependencies = [
  "reth-metrics",
  "reth-primitives-traits",
  "reth-provider",
+ "reth-tracing",
  "reth-trie",
  "reth-trie-common",
  "reth-trie-db",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -497,33 +497,33 @@ alloy-trie = { version = "0.9.1", default-features = false }
 
 alloy-hardforks = "0.4.5"
 
-alloy-consensus = { version = "1.2.1", default-features = false }
-alloy-contract = { version = "1.2.1", default-features = false }
-alloy-eips = { version = "1.2.1", default-features = false }
-alloy-genesis = { version = "1.2.1", default-features = false }
-alloy-json-rpc = { version = "1.2.1", default-features = false }
-alloy-network = { version = "1.2.1", default-features = false }
-alloy-network-primitives = { version = "1.2.1", default-features = false }
-alloy-provider = { version = "1.2.1", features = ["reqwest", "debug-api"], default-features = false }
-alloy-pubsub = { version = "1.2.1", default-features = false }
-alloy-rpc-client = { version = "1.2.1", default-features = false }
-alloy-rpc-types = { version = "1.2.1", features = ["eth"], default-features = false }
-alloy-rpc-types-admin = { version = "1.2.1", default-features = false }
-alloy-rpc-types-anvil = { version = "1.2.1", default-features = false }
-alloy-rpc-types-beacon = { version = "1.2.1", default-features = false }
-alloy-rpc-types-debug = { version = "1.2.1", default-features = false }
-alloy-rpc-types-engine = { version = "1.2.1", default-features = false }
-alloy-rpc-types-eth = { version = "1.2.1", default-features = false }
-alloy-rpc-types-mev = { version = "1.2.1", default-features = false }
-alloy-rpc-types-trace = { version = "1.2.1", default-features = false }
-alloy-rpc-types-txpool = { version = "1.2.1", default-features = false }
-alloy-serde = { version = "1.2.1", default-features = false }
-alloy-signer = { version = "1.2.1", default-features = false }
-alloy-signer-local = { version = "1.2.1", default-features = false }
-alloy-transport = { version = "1.2.1" }
-alloy-transport-http = { version = "1.2.1", features = ["reqwest-rustls-tls"], default-features = false }
-alloy-transport-ipc = { version = "1.2.1", default-features = false }
-alloy-transport-ws = { version = "1.2.1", default-features = false }
+alloy-consensus = { version = "1.4.1", default-features = false }
+alloy-contract = { version = "1.4.1", default-features = false }
+alloy-eips = { version = "1.4.1", default-features = false }
+alloy-genesis = { version = "1.4.1", default-features = false }
+alloy-json-rpc = { version = "1.4.1", default-features = false }
+alloy-network = { version = "1.4.1", default-features = false }
+alloy-network-primitives = { version = "1.4.1", default-features = false }
+alloy-provider = { version = "1.4.1", features = ["reqwest", "debug-api"], default-features = false }
+alloy-pubsub = { version = "1.4.1", default-features = false }
+alloy-rpc-client = { version = "1.4.1", default-features = false }
+alloy-rpc-types = { version = "1.4.1", features = ["eth"], default-features = false }
+alloy-rpc-types-admin = { version = "1.4.1", default-features = false }
+alloy-rpc-types-anvil = { version = "1.4.1", default-features = false }
+alloy-rpc-types-beacon = { version = "1.4.1", default-features = false }
+alloy-rpc-types-debug = { version = "1.4.1", default-features = false }
+alloy-rpc-types-engine = { version = "1.4.1", default-features = false }
+alloy-rpc-types-eth = { version = "1.4.1", default-features = false }
+alloy-rpc-types-mev = { version = "1.4.1", default-features = false }
+alloy-rpc-types-trace = { version = "1.4.1", default-features = false }
+alloy-rpc-types-txpool = { version = "1.4.1", default-features = false }
+alloy-serde = { version = "1.4.1", default-features = false }
+alloy-signer = { version = "1.4.1", default-features = false }
+alloy-signer-local = { version = "1.4.1", default-features = false }
+alloy-transport = { version = "1.4.1" }
+alloy-transport-http = { version = "1.4.1", features = ["reqwest-rustls-tls"], default-features = false }
+alloy-transport-ipc = { version = "1.4.1", default-features = false }
+alloy-transport-ws = { version = "1.4.1", default-features = false }
 
 # op
 alloy-op-evm = { version = "0.25.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -555,6 +555,7 @@ dirs-next = "2.0.0"
 dyn-clone = "1.0.17"
 eyre = "0.6"
 fdlimit = "0.3.0"
+fixed-map = { version = "0.9", default-features = false }
 humantime = "2.1"
 humantime-serde = "1.1"
 itertools = { version = "0.14", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -596,9 +596,9 @@ chrono = "0.4.41"
 # metrics
 metrics = "0.24.0"
 metrics-derive = "0.1"
-metrics-exporter-prometheus = { version = "0.16.0", default-features = false }
+metrics-exporter-prometheus = { version = "0.18.0", default-features = false }
 metrics-process = "2.1.0"
-metrics-util = { default-features = false, version = "0.19.0" }
+metrics-util = { default-features = false, version = "0.20.0" }
 
 # proc-macros
 proc-macro2 = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -665,6 +665,7 @@ opentelemetry_sdk = "0.31"
 opentelemetry = "0.31"
 opentelemetry-otlp = "0.31"
 opentelemetry-semantic-conventions = "0.31"
+opentelemetry-appender-tracing = "0.31"
 tracing-opentelemetry = "0.32"
 
 # misc-testing

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.9.4"
+version = "1.10.0"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.9.3"
+version = "1.9.4"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -485,7 +485,7 @@ revm-inspectors = "0.33.2"
 
 # eth
 alloy-chains = { version = "0.2.5", default-features = false }
-alloy-dyn-abi = "1.4.1"
+alloy-dyn-abi = "1.4.3"
 alloy-eip2124 = { version = "0.2.0", default-features = false }
 alloy-eip7928 = { version = "0.1.0", default-features = false }
 alloy-evm = { version = "0.25.1", default-features = false }
@@ -497,33 +497,33 @@ alloy-trie = { version = "0.9.1", default-features = false }
 
 alloy-hardforks = "0.4.5"
 
-alloy-consensus = { version = "1.4.1", default-features = false }
-alloy-contract = { version = "1.4.1", default-features = false }
-alloy-eips = { version = "1.4.1", default-features = false }
-alloy-genesis = { version = "1.4.1", default-features = false }
-alloy-json-rpc = { version = "1.4.1", default-features = false }
-alloy-network = { version = "1.4.1", default-features = false }
-alloy-network-primitives = { version = "1.4.1", default-features = false }
-alloy-provider = { version = "1.4.1", features = ["reqwest", "debug-api"], default-features = false }
-alloy-pubsub = { version = "1.4.1", default-features = false }
-alloy-rpc-client = { version = "1.4.1", default-features = false }
-alloy-rpc-types = { version = "1.4.1", features = ["eth"], default-features = false }
-alloy-rpc-types-admin = { version = "1.4.1", default-features = false }
-alloy-rpc-types-anvil = { version = "1.4.1", default-features = false }
-alloy-rpc-types-beacon = { version = "1.4.1", default-features = false }
-alloy-rpc-types-debug = { version = "1.4.1", default-features = false }
-alloy-rpc-types-engine = { version = "1.4.1", default-features = false }
-alloy-rpc-types-eth = { version = "1.4.1", default-features = false }
-alloy-rpc-types-mev = { version = "1.4.1", default-features = false }
-alloy-rpc-types-trace = { version = "1.4.1", default-features = false }
-alloy-rpc-types-txpool = { version = "1.4.1", default-features = false }
-alloy-serde = { version = "1.4.1", default-features = false }
-alloy-signer = { version = "1.4.1", default-features = false }
-alloy-signer-local = { version = "1.4.1", default-features = false }
-alloy-transport = { version = "1.4.1" }
-alloy-transport-http = { version = "1.4.1", features = ["reqwest-rustls-tls"], default-features = false }
-alloy-transport-ipc = { version = "1.4.1", default-features = false }
-alloy-transport-ws = { version = "1.4.1", default-features = false }
+alloy-consensus = { version = "1.4.3", default-features = false }
+alloy-contract = { version = "1.4.3", default-features = false }
+alloy-eips = { version = "1.4.3", default-features = false }
+alloy-genesis = { version = "1.4.3", default-features = false }
+alloy-json-rpc = { version = "1.4.3", default-features = false }
+alloy-network = { version = "1.4.3", default-features = false }
+alloy-network-primitives = { version = "1.4.3", default-features = false }
+alloy-provider = { version = "1.4.3", features = ["reqwest", "debug-api"], default-features = false }
+alloy-pubsub = { version = "1.4.3", default-features = false }
+alloy-rpc-client = { version = "1.4.3", default-features = false }
+alloy-rpc-types = { version = "1.4.3", features = ["eth"], default-features = false }
+alloy-rpc-types-admin = { version = "1.4.3", default-features = false }
+alloy-rpc-types-anvil = { version = "1.4.3", default-features = false }
+alloy-rpc-types-beacon = { version = "1.4.3", default-features = false }
+alloy-rpc-types-debug = { version = "1.4.3", default-features = false }
+alloy-rpc-types-engine = { version = "1.4.3", default-features = false }
+alloy-rpc-types-eth = { version = "1.4.3", default-features = false }
+alloy-rpc-types-mev = { version = "1.4.3", default-features = false }
+alloy-rpc-types-trace = { version = "1.4.3", default-features = false }
+alloy-rpc-types-txpool = { version = "1.4.3", default-features = false }
+alloy-serde = { version = "1.4.3", default-features = false }
+alloy-signer = { version = "1.4.3", default-features = false }
+alloy-signer-local = { version = "1.4.3", default-features = false }
+alloy-transport = { version = "1.4.3" }
+alloy-transport-http = { version = "1.4.3", features = ["reqwest-rustls-tls"], default-features = false }
+alloy-transport-ipc = { version = "1.4.3", default-features = false }
+alloy-transport-ws = { version = "1.4.3", default-features = false }
 
 # op
 alloy-op-evm = { version = "0.25.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -734,6 +734,7 @@ tracing-journald = "0.3"
 tracing-logfmt = "0.3.3"
 tracing-samply = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false }
+tracing-tracy = "0.11"
 triehash = "0.8"
 typenum = "1.15.0"
 vergen = "9.0.4"

--- a/Makefile
+++ b/Makefile
@@ -283,11 +283,11 @@ docker-build-push-nightly-edge-profiling: ## Build and push cross-arch Docker im
 
 # Create a cross-arch Docker image with the given tags and push it
 define docker_build_push
-	$(MAKE) build-x86_64-unknown-linux-gnu
+	$(MAKE) FEATURES="$(FEATURES)" build-x86_64-unknown-linux-gnu
 	mkdir -p $(BIN_DIR)/amd64
 	cp $(CARGO_TARGET_DIR)/x86_64-unknown-linux-gnu/$(PROFILE)/reth $(BIN_DIR)/amd64/reth
 
-	$(MAKE) build-aarch64-unknown-linux-gnu
+	$(MAKE) FEATURES="$(FEATURES)" build-aarch64-unknown-linux-gnu
 	mkdir -p $(BIN_DIR)/arm64
 	cp $(CARGO_TARGET_DIR)/aarch64-unknown-linux-gnu/$(PROFILE)/reth $(BIN_DIR)/arm64/reth
 
@@ -357,11 +357,11 @@ op-docker-build-push-nightly-profiling: ## Build and push cross-arch Docker imag
 
 # Create a cross-arch Docker image with the given tags and push it
 define op_docker_build_push
-	$(MAKE) op-build-x86_64-unknown-linux-gnu
+	$(MAKE) FEATURES="$(FEATURES)" op-build-x86_64-unknown-linux-gnu
 	mkdir -p $(BIN_DIR)/amd64
 	cp $(CARGO_TARGET_DIR)/x86_64-unknown-linux-gnu/$(PROFILE)/op-reth $(BIN_DIR)/amd64/op-reth
 
-	$(MAKE) op-build-aarch64-unknown-linux-gnu
+	$(MAKE) FEATURES="$(FEATURES)" op-build-aarch64-unknown-linux-gnu
 	mkdir -p $(BIN_DIR)/arm64
 	cp $(CARGO_TARGET_DIR)/aarch64-unknown-linux-gnu/$(PROFILE)/op-reth $(BIN_DIR)/arm64/op-reth
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ More historical context below:
 -   We released 1.0 "production-ready" stable Reth in June 2024.
     -   Reth completed an audit with [Sigma Prime](https://sigmaprime.io/), the developers of [Lighthouse](https://github.com/sigp/lighthouse), the Rust Consensus Layer implementation. Find it [here](./audit/sigma_prime_audit_v2.pdf).
     -   Revm (the EVM used in Reth) underwent an audit with [Guido Vranken](https://x.com/guidovranken) (#1 [Ethereum Bug Bounty](https://ethereum.org/en/bug-bounty)). We will publish the results soon.
--   We released multiple iterative beta versions, up to [beta.9](https://github.com/paradigmxyz/reth/releases/tag/v0.2.0-beta.9) on Monday June 3, 2024,the last beta release.
+-   We released multiple iterative beta versions, up to [beta.9](https://github.com/paradigmxyz/reth/releases/tag/v0.2.0-beta.9) on Monday June 3, 2024, the last beta release.
 -   We released [beta](https://github.com/paradigmxyz/reth/releases/tag/v0.2.0-beta.1) on Monday March 4, 2024, our first breaking change to the database model, providing faster query speed, smaller database footprint, and allowing "history" to be mounted on separate drives.
 -   We shipped iterative improvements until the last alpha release on February 28, 2024, [0.1.0-alpha.21](https://github.com/paradigmxyz/reth/releases/tag/v0.1.0-alpha.21).
 -   We [initially announced](https://www.paradigm.xyz/2023/06/reth-alpha) [0.1.0-alpha.1](https://github.com/paradigmxyz/reth/releases/tag/v0.1.0-alpha.1) on June 20, 2023.

--- a/bin/reth-bench-compare/Cargo.toml
+++ b/bin/reth-bench-compare/Cargo.toml
@@ -71,7 +71,11 @@ jemalloc = [
     "reth-node-core/jemalloc",
 ]
 jemalloc-prof = ["reth-cli-util/jemalloc-prof"]
-tracy-allocator = ["reth-cli-util/tracy-allocator"]
+tracy-allocator = ["reth-cli-util/tracy-allocator", "tracy"]
+tracy = [
+    "reth-node-core/tracy",
+    "reth-tracing/tracy",
+]
 
 min-error-logs = [
     "tracing/release_max_level_error",

--- a/bin/reth-bench-compare/README.md
+++ b/bin/reth-bench-compare/README.md
@@ -1,0 +1,50 @@
+# reth-bench-compare
+
+Compare reth performance between two git references.
+
+## Usage
+
+```bash
+reth-bench-compare \
+  --baseline-ref main \
+  --feature-ref my-feature \
+  --blocks 100 \
+  --wait-for-persistence
+```
+
+## Arguments
+
+| Argument | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `--baseline-ref <REF>` | Git reference for baseline | - | Yes |
+| `--feature-ref <REF>` | Git reference to compare | - | Yes |
+| `--blocks <N>` | Number of blocks to benchmark | `100` | No |
+| `--chain <CHAIN>` | Chain to benchmark | `mainnet` | No |
+| `--datadir <PATH>` | Data directory path | OS-specific | No |
+| `--rpc-url <URL>` | RPC endpoint for block data | Chain default | No |
+| `--output-dir <PATH>` | Output directory | `./reth-bench-compare` | No |
+| `--wait-for-persistence` | Wait for block persistence | `false` | No |
+| `--persistence-threshold <N>` | Wait after every N+1 blocks | `2` | No |
+| `--wait-time <DURATION>` | Fixed delay (legacy) | - | No |
+| `--warmup-blocks <N>` | Cache warmup blocks | Same as `--blocks` | No |
+| `--draw` | Generate charts (needs Python/uv) | `false` | No |
+| `--profile` | Enable CPU profiling (needs samply) | `false` | No |
+| `-vvvv` | Debug logging | Info | No |
+| `--features <FEATURES>` | Rust features for both builds | `jemalloc,asm-keccak` | No |
+| `--rustflags <FLAGS>` | RUSTFLAGS for both builds | `-C target-cpu=native` | No |
+| `--baseline-features <FEATURES>` | Features for baseline only | Inherits `--features` | No |
+| `--feature-features <FEATURES>` | Features for feature only | Inherits `--features` | No |
+| `--baseline-rustflags <FLAGS>` | RUSTFLAGS for baseline only | Inherits `--rustflags` | No |
+| `--feature-rustflags <FLAGS>` | RUSTFLAGS for feature only | Inherits `--rustflags` | No |
+| `--baseline-args <ARGS>` | Extra args for baseline node | - | No |
+| `--feature-args <ARGS>` | Extra args for feature node | - | No |
+| `--metrics-port <PORT>` | Metrics endpoint port | `5005` | No |
+| `--sudo` | Run with elevated privileges | `false` | No |
+
+## Output
+
+Results in `./reth-bench-compare/results/<timestamp>/`:
+- `comparison_report.json` - Metrics comparison
+- `per_block_comparison.csv` - Per-block statistics
+- `baseline/` and `feature/` - Individual run results
+- `latency_comparison.png` - Chart (if `--draw` used)

--- a/bin/reth-bench-compare/src/benchmark.rs
+++ b/bin/reth-bench-compare/src/benchmark.rs
@@ -18,6 +18,8 @@ pub(crate) struct BenchmarkRunner {
     rpc_url: String,
     jwt_secret: String,
     wait_time: Option<String>,
+    wait_for_persistence: bool,
+    persistence_threshold: Option<u64>,
     warmup_blocks: u64,
 }
 
@@ -28,6 +30,8 @@ impl BenchmarkRunner {
             rpc_url: args.get_rpc_url(),
             jwt_secret: args.jwt_secret_path().to_string_lossy().to_string(),
             wait_time: args.wait_time.clone(),
+            wait_for_persistence: args.wait_for_persistence,
+            persistence_threshold: args.persistence_threshold,
             warmup_blocks: args.get_warmup_blocks(),
         }
     }
@@ -182,9 +186,16 @@ impl BenchmarkRunner {
             &output_dir.to_string_lossy(),
         ]);
 
-        // If wait_time is provided, use wait-time mode; otherwise uses persistence-based flow
+        // Configure wait mode: wait-time takes precedence over persistence-based flow
         if let Some(ref wait_time) = self.wait_time {
             cmd.args(["--wait-time", wait_time]);
+        } else if self.wait_for_persistence {
+            cmd.arg("--wait-for-persistence");
+
+            // Add persistence threshold if specified
+            if let Some(threshold) = self.persistence_threshold {
+                cmd.args(["--persistence-threshold", &threshold.to_string()]);
+            }
         }
 
         cmd.env("RUST_LOG_STYLE", "never")

--- a/bin/reth-bench-compare/src/cli.rs
+++ b/bin/reth-bench-compare/src/cli.rs
@@ -121,6 +121,22 @@ pub(crate) struct Args {
     #[arg(long, value_name = "DURATION", hide = true)]
     pub wait_time: Option<String>,
 
+    /// Wait for blocks to be persisted before sending the next batch (passed to reth-bench).
+    ///
+    /// When enabled, waits for every Nth block to be persisted using the
+    /// `reth_subscribePersistedBlock` subscription. This ensures the benchmark
+    /// doesn't outpace persistence.
+    #[arg(long)]
+    pub wait_for_persistence: bool,
+
+    /// Engine persistence threshold (passed to reth-bench).
+    ///
+    /// The benchmark waits after every `(threshold + 1)` blocks. By default this
+    /// matches the engine's default persistence threshold (2), so waits occur
+    /// at blocks 3, 6, 9, etc.
+    #[arg(long, value_name = "PERSISTENCE_THRESHOLD")]
+    pub persistence_threshold: Option<u64>,
+
     /// Number of blocks to run for cache warmup after clearing caches.
     /// If not specified, defaults to the same as --blocks
     #[arg(long, value_name = "N")]

--- a/bin/reth-bench-compare/src/cli.rs
+++ b/bin/reth-bench-compare/src/cli.rs
@@ -578,7 +578,7 @@ async fn run_warmup_phase(
         node_manager.start_node(&binary_path, warmup_ref, "warmup", &additional_args).await?;
 
     // Wait for node to be ready and get its current tip
-    let current_tip = node_manager.wait_for_node_ready_and_get_tip().await?;
+    let current_tip = node_manager.wait_for_node_ready_and_get_tip(&mut node_process).await?;
     info!("Warmup node is ready at tip: {}", current_tip);
 
     // Clear filesystem caches before warmup run only (unless disabled)
@@ -632,7 +632,7 @@ async fn run_benchmark_workflow(
     let (mut node_process, _) = node_manager
         .start_node(&binary_path, &args.baseline_ref, "baseline", &additional_args)
         .await?;
-    let starting_tip = node_manager.wait_for_node_ready_and_get_tip().await?;
+    let starting_tip = node_manager.wait_for_node_ready_and_get_tip(&mut node_process).await?;
     info!("Node starting tip: {}", starting_tip);
     node_manager.stop_node(&mut node_process).await?;
 
@@ -699,7 +699,7 @@ async fn run_benchmark_workflow(
             node_manager.start_node(&binary_path, git_ref, ref_type, &additional_args).await?;
 
         // Wait for node to be ready and get its current tip (wherever it is)
-        let current_tip = node_manager.wait_for_node_ready_and_get_tip().await?;
+        let current_tip = node_manager.wait_for_node_ready_and_get_tip(&mut node_process).await?;
         info!("Node is ready at tip: {}", current_tip);
 
         // Calculate benchmark range

--- a/bin/reth-bench-compare/src/node.rs
+++ b/bin/reth-bench-compare/src/node.rs
@@ -367,8 +367,13 @@ impl NodeManager {
         Ok((child, reth_command))
     }
 
-    /// Wait for the node to be ready and return its current tip
-    pub(crate) async fn wait_for_node_ready_and_get_tip(&self) -> Result<u64> {
+    /// Wait for the node to be ready and return its current tip.
+    ///
+    /// Fails early if the node process exits before becoming ready.
+    pub(crate) async fn wait_for_node_ready_and_get_tip(
+        &self,
+        child: &mut tokio::process::Child,
+    ) -> Result<u64> {
         info!("Waiting for node to be ready and synced...");
 
         let max_wait = Duration::from_secs(120); // 2 minutes to allow for sync
@@ -390,6 +395,11 @@ impl NodeManager {
                     iteration,
                     start_time.elapsed()
                 );
+
+                // Check if the node process has exited.
+                if let Some(status) = child.try_wait()? {
+                    return Err(eyre!("Node process exited unexpectedly with {status}"));
+                }
 
                 // First check if RPC is up and node is not syncing
                 match provider.syncing().await {

--- a/bin/reth-bench/Cargo.toml
+++ b/bin/reth-bench/Cargo.toml
@@ -85,7 +85,11 @@ jemalloc = [
     "reth-node-core/jemalloc",
 ]
 jemalloc-prof = ["reth-cli-util/jemalloc-prof"]
-tracy-allocator = ["reth-cli-util/tracy-allocator"]
+tracy-allocator = ["reth-cli-util/tracy-allocator", "tracy"]
+tracy = [
+    "reth-node-core/tracy",
+    "reth-tracing/tracy",
+]
 
 min-error-logs = [
     "tracing/release_max_level_error",

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -131,6 +131,11 @@ jemalloc-unprefixed = [
 tracy-allocator = [
     "reth-cli-util/tracy-allocator",
     "reth-ethereum-cli/tracy-allocator",
+    "tracy",
+]
+tracy = [
+    "reth-ethereum-cli/tracy",
+    "reth-node-core/tracy",
 ]
 
 # Because jemalloc is default and preferred over snmalloc when both features are

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -176,7 +176,7 @@ min-trace-logs = [
     "reth-node-core/min-trace-logs",
 ]
 
-edge = ["reth-ethereum-cli/edge"]
+edge = ["reth-ethereum-cli/edge", "reth-node-core/edge"]
 
 [[bin]]
 name = "reth"

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -81,11 +81,15 @@ backon.workspace = true
 tempfile.workspace = true
 
 [features]
-default = ["jemalloc", "otlp", "reth-revm/portable", "js-tracer", "keccak-cache-global", "asm-keccak"]
+default = ["jemalloc", "otlp", "otlp-logs", "reth-revm/portable", "js-tracer", "keccak-cache-global", "asm-keccak"]
 
 otlp = [
     "reth-ethereum-cli/otlp",
     "reth-node-core/otlp",
+]
+otlp-logs = [
+    "reth-ethereum-cli/otlp-logs",
+    "reth-node-core/otlp-logs",
 ]
 js-tracer = [
     "reth-node-builder/js-tracer",

--- a/crates/chain-state/src/deferred_trie.rs
+++ b/crates/chain-state/src/deferred_trie.rs
@@ -37,12 +37,19 @@ pub struct ComputedTrieData {
 
 /// Trie input bundled with its anchor hash.
 ///
-/// This is used to store the trie input and anchor hash for a block together.
+/// The `trie_input` contains the **cumulative** overlay of all in-memory ancestor blocks,
+/// not just this block's changes. Child blocks reuse the parent's overlay in O(1) by
+/// cloning the Arc-wrapped data.
+///
+/// The `anchor_hash` is metadata indicating which persisted base state this overlay
+/// sits on top of. It is CRITICAL for overlay reuse decisions: an overlay built on top
+/// of Anchor A cannot be reused for a block anchored to Anchor B, as it would result
+/// in an incorrect state.
 #[derive(Clone, Debug)]
 pub struct AnchoredTrieInput {
     /// The persisted ancestor hash this trie input is anchored to.
     pub anchor_hash: B256,
-    /// Trie input constructed from in-memory overlays.
+    /// Cumulative trie input overlay from all in-memory ancestors.
     pub trie_input: Arc<TrieInputSorted>,
 }
 
@@ -139,8 +146,9 @@ impl DeferredTrieData {
     ///
     /// # Process
     /// 1. Sort the current block's hashed state and trie updates
-    /// 2. Merge ancestor overlays (oldest -> newest, so later state takes precedence)
-    /// 3. Extend the merged overlay with this block's sorted data
+    /// 2. Reuse parent's cached overlay if available (O(1) - the common case)
+    /// 3. Otherwise, rebuild overlay from ancestors (rare fallback)
+    /// 4. Extend the overlay with this block's sorted data
     ///
     /// Used by both the async background task and the synchronous fallback path.
     ///
@@ -148,7 +156,7 @@ impl DeferredTrieData {
     /// * `hashed_state` - Unsorted hashed post-state (account/storage changes) from execution
     /// * `trie_updates` - Unsorted trie node updates from state root computation
     /// * `anchor_hash` - The persisted ancestor hash this trie input is anchored to
-    /// * `ancestors` - Deferred trie data from ancestor blocks for merging
+    /// * `ancestors` - Deferred trie data from ancestor blocks for merging (oldest -> newest)
     pub fn sort_and_build_trie_input(
         hashed_state: Arc<HashedPostState>,
         trie_updates: Arc<TrieUpdates>,
@@ -164,9 +172,71 @@ impl DeferredTrieData {
             Err(arc) => arc.clone_into_sorted(),
         };
 
-        // Build overlay by merging ancestors oldest-to-newest, then this block's data last.
-        // Later entries take precedence, so this block's state overwrites any ancestor conflicts.
+        // Reuse parent's overlay if available and anchors match.
+        // We can only reuse the parent's overlay if it was built on top of the same
+        // persisted anchor. If the anchor has changed (e.g., due to persistence),
+        // the parent's overlay is relative to an old state and cannot be used.
+        let overlay = if let Some(parent) = ancestors.last() {
+            let parent_data = parent.wait_cloned();
+
+            match &parent_data.anchored_trie_input {
+                // Case 1: Parent has cached overlay AND anchors match.
+                Some(AnchoredTrieInput { anchor_hash: parent_anchor, trie_input })
+                    if *parent_anchor == anchor_hash =>
+                {
+                    // O(1): Reuse parent's overlay, extend with current block's data.
+                    let mut overlay = TrieInputSorted::new(
+                        Arc::clone(&trie_input.nodes),
+                        Arc::clone(&trie_input.state),
+                        Default::default(), // prefix_sets are per-block, not cumulative
+                    );
+                    // Only trigger COW clone if there's actually data to add.
+                    if !sorted_hashed_state.is_empty() {
+                        Arc::make_mut(&mut overlay.state).extend_ref(&sorted_hashed_state);
+                    }
+                    if !sorted_trie_updates.is_empty() {
+                        Arc::make_mut(&mut overlay.nodes).extend_ref(&sorted_trie_updates);
+                    }
+                    overlay
+                }
+                // Case 2: Parent exists but anchor mismatch or no cached overlay.
+                // We must rebuild from the ancestors list (which only contains unpersisted blocks).
+                _ => Self::merge_ancestors_into_overlay(
+                    ancestors,
+                    &sorted_hashed_state,
+                    &sorted_trie_updates,
+                ),
+            }
+        } else {
+            // Case 3: No in-memory ancestors (first block after persisted anchor).
+            // Build overlay with just this block's data.
+            Self::merge_ancestors_into_overlay(&[], &sorted_hashed_state, &sorted_trie_updates)
+        };
+
+        ComputedTrieData::with_trie_input(
+            Arc::new(sorted_hashed_state),
+            Arc::new(sorted_trie_updates),
+            anchor_hash,
+            Arc::new(overlay),
+        )
+    }
+
+    /// Merge all ancestors and current block's data into a single overlay.
+    ///
+    /// This is a rare fallback path, only used when no ancestor has a cached
+    /// `anchored_trie_input` (e.g., blocks created via alternative constructors).
+    /// In normal operation, the parent always has a cached overlay and this
+    /// function is never called.
+    ///
+    /// Iterates ancestors oldest -> newest, then extends with current block's data,
+    /// so later state takes precedence.
+    fn merge_ancestors_into_overlay(
+        ancestors: &[Self],
+        sorted_hashed_state: &HashedPostStateSorted,
+        sorted_trie_updates: &TrieUpdatesSorted,
+    ) -> TrieInputSorted {
         let mut overlay = TrieInputSorted::default();
+
         let state_mut = Arc::make_mut(&mut overlay.state);
         let nodes_mut = Arc::make_mut(&mut overlay.nodes);
 
@@ -176,15 +246,11 @@ impl DeferredTrieData {
             nodes_mut.extend_ref(ancestor_data.trie_updates.as_ref());
         }
 
-        state_mut.extend_ref(&sorted_hashed_state);
-        nodes_mut.extend_ref(&sorted_trie_updates);
+        // Extend with current block's sorted data last (takes precedence)
+        state_mut.extend_ref(sorted_hashed_state);
+        nodes_mut.extend_ref(sorted_trie_updates);
 
-        ComputedTrieData::with_trie_input(
-            Arc::new(sorted_hashed_state),
-            Arc::new(sorted_trie_updates),
-            anchor_hash,
-            Arc::new(overlay),
-        )
+        overlay
     }
 
     /// Returns trie data, computing synchronously if the async task hasn't completed.
@@ -440,5 +506,366 @@ mod tests {
         assert_eq!(overlay_state.len(), 1);
         let (_, account) = &overlay_state[0];
         assert_eq!(account.unwrap().nonce, 2);
+    }
+
+    /// Helper to create a ready block with anchored trie input containing specific state.
+    fn ready_block_with_state(
+        anchor_hash: B256,
+        accounts: Vec<(B256, Option<Account>)>,
+    ) -> DeferredTrieData {
+        let hashed_state = Arc::new(HashedPostStateSorted::new(accounts, B256Map::default()));
+        let trie_updates = Arc::default();
+        let mut overlay = TrieInputSorted::default();
+        Arc::make_mut(&mut overlay.state).extend_ref(hashed_state.as_ref());
+
+        DeferredTrieData::ready(ComputedTrieData {
+            hashed_state,
+            trie_updates,
+            anchored_trie_input: Some(AnchoredTrieInput {
+                anchor_hash,
+                trie_input: Arc::new(overlay),
+            }),
+        })
+    }
+
+    /// Verifies that first block after anchor (no ancestors) creates empty base overlay.
+    #[test]
+    fn first_block_after_anchor_creates_empty_base() {
+        let anchor = B256::with_last_byte(1);
+        let key = B256::with_last_byte(42);
+        let account = Account { nonce: 1, balance: U256::ZERO, bytecode_hash: None };
+
+        // First block after anchor - no ancestors
+        let first_block = DeferredTrieData::pending(
+            Arc::new(HashedPostState::default().with_accounts([(key, Some(account))])),
+            Arc::new(TrieUpdates::default()),
+            anchor,
+            vec![], // No ancestors
+        );
+
+        let result = first_block.wait_cloned();
+
+        // Should have overlay with just this block's data
+        let overlay = result.anchored_trie_input.as_ref().unwrap();
+        assert_eq!(overlay.anchor_hash, anchor);
+        assert_eq!(overlay.trie_input.state.accounts.len(), 1);
+        let (found_key, found_account) = &overlay.trie_input.state.accounts[0];
+        assert_eq!(*found_key, key);
+        assert_eq!(found_account.unwrap().nonce, 1);
+    }
+
+    /// Verifies that parent's overlay is reused regardless of anchor.
+    #[test]
+    fn reuses_parent_overlay() {
+        let anchor = B256::with_last_byte(1);
+        let key = B256::with_last_byte(42);
+        let account = Account { nonce: 100, balance: U256::ZERO, bytecode_hash: None };
+
+        // Create parent with anchored trie input
+        let parent = ready_block_with_state(anchor, vec![(key, Some(account))]);
+
+        // Create child - should reuse parent's overlay
+        let child = DeferredTrieData::pending(
+            Arc::new(HashedPostState::default()),
+            Arc::new(TrieUpdates::default()),
+            anchor,
+            vec![parent],
+        );
+
+        let result = child.wait_cloned();
+
+        // Verify parent's account is in the overlay
+        let overlay = result.anchored_trie_input.as_ref().unwrap();
+        assert_eq!(overlay.anchor_hash, anchor);
+        assert_eq!(overlay.trie_input.state.accounts.len(), 1);
+        let (found_key, found_account) = &overlay.trie_input.state.accounts[0];
+        assert_eq!(*found_key, key);
+        assert_eq!(found_account.unwrap().nonce, 100);
+    }
+
+    /// Verifies that parent's overlay is NOT reused when anchor changes (after persist).
+    /// The overlay data is dependent on the anchor, so it must be rebuilt from the
+    /// remaining ancestors.
+    #[test]
+    fn rebuilds_overlay_when_anchor_changes() {
+        let old_anchor = B256::with_last_byte(1);
+        let new_anchor = B256::with_last_byte(2);
+        let key = B256::with_last_byte(42);
+        let account = Account { nonce: 50, balance: U256::ZERO, bytecode_hash: None };
+
+        // Create parent with OLD anchor
+        let parent = ready_block_with_state(old_anchor, vec![(key, Some(account))]);
+
+        // Create child with NEW anchor (simulates after persist)
+        // Should NOT reuse parent's overlay because anchor changed
+        let child = DeferredTrieData::pending(
+            Arc::new(HashedPostState::default()),
+            Arc::new(TrieUpdates::default()),
+            new_anchor,
+            vec![parent],
+        );
+
+        let result = child.wait_cloned();
+
+        // Verify result uses new anchor
+        let overlay = result.anchored_trie_input.as_ref().unwrap();
+        assert_eq!(overlay.anchor_hash, new_anchor);
+
+        // Crucially, since we provided `parent` in ancestors but it has a different anchor,
+        // the code falls back to `merge_ancestors_into_overlay`.
+        // `merge_ancestors_into_overlay` reads `parent.hashed_state` (which has the account).
+        // So the account IS present, but it was obtained via REBUILD, not REUSE.
+        // We can check `DEFERRED_TRIE_METRICS` if we want to be sure, but functionally:
+        assert_eq!(overlay.trie_input.state.accounts.len(), 1);
+        let (found_key, found_account) = &overlay.trie_input.state.accounts[0];
+        assert_eq!(*found_key, key);
+        assert_eq!(found_account.unwrap().nonce, 50);
+    }
+
+    /// Verifies that parent without `anchored_trie_input` triggers rebuild path.
+    #[test]
+    fn rebuilds_when_parent_has_no_anchored_input() {
+        let anchor = B256::with_last_byte(1);
+        let key = B256::with_last_byte(42);
+        let account = Account { nonce: 25, balance: U256::ZERO, bytecode_hash: None };
+
+        // Create parent WITHOUT anchored trie input (e.g., from without_trie_input constructor)
+        let parent_state =
+            HashedPostStateSorted::new(vec![(key, Some(account))], B256Map::default());
+        let parent = DeferredTrieData::ready(ComputedTrieData {
+            hashed_state: Arc::new(parent_state),
+            trie_updates: Arc::default(),
+            anchored_trie_input: None, // No anchored input
+        });
+
+        // Create child - should rebuild from parent's hashed_state
+        let child = DeferredTrieData::pending(
+            Arc::new(HashedPostState::default()),
+            Arc::new(TrieUpdates::default()),
+            anchor,
+            vec![parent],
+        );
+
+        let result = child.wait_cloned();
+
+        // Verify overlay is built and contains parent's data
+        let overlay = result.anchored_trie_input.as_ref().unwrap();
+        assert_eq!(overlay.anchor_hash, anchor);
+        assert_eq!(overlay.trie_input.state.accounts.len(), 1);
+    }
+
+    /// Verifies that a chain of blocks with matching anchors builds correct cumulative overlay.
+    #[test]
+    fn chain_of_blocks_builds_cumulative_overlay() {
+        let anchor = B256::with_last_byte(1);
+        let key1 = B256::with_last_byte(1);
+        let key2 = B256::with_last_byte(2);
+        let key3 = B256::with_last_byte(3);
+
+        // Block 1: sets account at key1
+        let block1 = ready_block_with_state(
+            anchor,
+            vec![(key1, Some(Account { nonce: 1, balance: U256::ZERO, bytecode_hash: None }))],
+        );
+
+        // Block 2: adds account at key2, ancestor is block1
+        let block2_hashed = HashedPostState::default().with_accounts([(
+            key2,
+            Some(Account { nonce: 2, balance: U256::ZERO, bytecode_hash: None }),
+        )]);
+        let block2 = DeferredTrieData::pending(
+            Arc::new(block2_hashed),
+            Arc::new(TrieUpdates::default()),
+            anchor,
+            vec![block1.clone()],
+        );
+        // Compute block2's trie data
+        let block2_computed = block2.wait_cloned();
+        let block2_ready = DeferredTrieData::ready(block2_computed);
+
+        // Block 3: adds account at key3, ancestor is block2 (which includes block1)
+        let block3_hashed = HashedPostState::default().with_accounts([(
+            key3,
+            Some(Account { nonce: 3, balance: U256::ZERO, bytecode_hash: None }),
+        )]);
+        let block3 = DeferredTrieData::pending(
+            Arc::new(block3_hashed),
+            Arc::new(TrieUpdates::default()),
+            anchor,
+            vec![block1, block2_ready],
+        );
+
+        let result = block3.wait_cloned();
+
+        // Verify all three accounts are in the cumulative overlay
+        let overlay = result.anchored_trie_input.as_ref().unwrap();
+        assert_eq!(overlay.trie_input.state.accounts.len(), 3);
+
+        // Accounts should be sorted by key (B256 ordering)
+        let accounts = &overlay.trie_input.state.accounts;
+        assert!(accounts.iter().any(|(k, a)| *k == key1 && a.unwrap().nonce == 1));
+        assert!(accounts.iter().any(|(k, a)| *k == key2 && a.unwrap().nonce == 2));
+        assert!(accounts.iter().any(|(k, a)| *k == key3 && a.unwrap().nonce == 3));
+    }
+
+    /// Verifies that child block's state overwrites parent's state for the same key.
+    #[test]
+    fn child_state_overwrites_parent() {
+        let anchor = B256::with_last_byte(1);
+        let key = B256::with_last_byte(42);
+
+        // Parent sets nonce to 10
+        let parent = ready_block_with_state(
+            anchor,
+            vec![(key, Some(Account { nonce: 10, balance: U256::ZERO, bytecode_hash: None }))],
+        );
+
+        // Child overwrites nonce to 99
+        let child_hashed = HashedPostState::default().with_accounts([(
+            key,
+            Some(Account { nonce: 99, balance: U256::ZERO, bytecode_hash: None }),
+        )]);
+        let child = DeferredTrieData::pending(
+            Arc::new(child_hashed),
+            Arc::new(TrieUpdates::default()),
+            anchor,
+            vec![parent],
+        );
+
+        let result = child.wait_cloned();
+
+        // Verify child's value wins (extend_ref uses later value)
+        let overlay = result.anchored_trie_input.as_ref().unwrap();
+        // Note: extend_ref may result in duplicate keys; check the last occurrence
+        let accounts = &overlay.trie_input.state.accounts;
+        let last_account = accounts.iter().rfind(|(k, _)| *k == key).unwrap();
+        assert_eq!(last_account.1.unwrap().nonce, 99);
+    }
+
+    /// Stress test: verify O(N) behavior by building a chain of many blocks.
+    /// This test ensures the fix doesn't regress - previously this would be O(N²).
+    #[test]
+    fn long_chain_builds_in_linear_time() {
+        let anchor = B256::with_last_byte(1);
+        let num_blocks = 50; // Enough to notice O(N²) vs O(N) difference
+
+        let mut ancestors: Vec<DeferredTrieData> = Vec::new();
+
+        let start = Instant::now();
+
+        for i in 0..num_blocks {
+            let key = B256::with_last_byte(i as u8);
+            let account = Account { nonce: i as u64, balance: U256::ZERO, bytecode_hash: None };
+            let hashed = HashedPostState::default().with_accounts([(key, Some(account))]);
+
+            let block = DeferredTrieData::pending(
+                Arc::new(hashed),
+                Arc::new(TrieUpdates::default()),
+                anchor,
+                ancestors.clone(),
+            );
+
+            // Compute and add to ancestors for next iteration
+            let computed = block.wait_cloned();
+            ancestors.push(DeferredTrieData::ready(computed));
+        }
+
+        let elapsed = start.elapsed();
+
+        // With O(N) fix, 50 blocks should complete quickly (< 1 second)
+        // With O(N²), this would take significantly longer
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "Chain of {num_blocks} blocks took {:?}, possible O(N²) regression",
+            elapsed
+        );
+
+        // Verify final overlay has all accounts
+        let final_result = ancestors.last().unwrap().wait_cloned();
+        let overlay = final_result.anchored_trie_input.as_ref().unwrap();
+        assert_eq!(overlay.trie_input.state.accounts.len(), num_blocks);
+    }
+
+    /// Verifies that a multi-ancestor overlay is rebuilt when anchor changes.
+    /// This simulates the "persist prefix then keep building" scenario where:
+    /// 1. A chain of blocks is built with anchor A
+    /// 2. Some blocks are persisted, changing anchor to B
+    /// 3. New blocks must rebuild the overlay from the remaining ancestors
+    #[test]
+    fn multi_ancestor_overlay_rebuilt_after_anchor_change() {
+        let old_anchor = B256::with_last_byte(1);
+        let new_anchor = B256::with_last_byte(2);
+        let key1 = B256::with_last_byte(1);
+        let key2 = B256::with_last_byte(2);
+        let key3 = B256::with_last_byte(3);
+        let key4 = B256::with_last_byte(4);
+
+        // Build a chain of 3 blocks with old_anchor
+        let block1 = ready_block_with_state(
+            old_anchor,
+            vec![(key1, Some(Account { nonce: 1, balance: U256::ZERO, bytecode_hash: None }))],
+        );
+
+        let block2_hashed = HashedPostState::default().with_accounts([(
+            key2,
+            Some(Account { nonce: 2, balance: U256::ZERO, bytecode_hash: None }),
+        )]);
+        let block2 = DeferredTrieData::pending(
+            Arc::new(block2_hashed),
+            Arc::new(TrieUpdates::default()),
+            old_anchor,
+            vec![block1.clone()],
+        );
+        let block2_ready = DeferredTrieData::ready(block2.wait_cloned());
+
+        let block3_hashed = HashedPostState::default().with_accounts([(
+            key3,
+            Some(Account { nonce: 3, balance: U256::ZERO, bytecode_hash: None }),
+        )]);
+        let block3 = DeferredTrieData::pending(
+            Arc::new(block3_hashed),
+            Arc::new(TrieUpdates::default()),
+            old_anchor,
+            vec![block1.clone(), block2_ready.clone()],
+        );
+        let block3_ready = DeferredTrieData::ready(block3.wait_cloned());
+
+        // Verify block3's overlay has all 3 accounts with old_anchor
+        let block3_overlay = block3_ready.wait_cloned().anchored_trie_input.unwrap();
+        assert_eq!(block3_overlay.anchor_hash, old_anchor);
+        assert_eq!(block3_overlay.trie_input.state.accounts.len(), 3);
+
+        // Now simulate persist: create block4 with NEW anchor but same ancestors.
+        // To verify correct rebuilding, we must provide ALL unpersisted ancestors.
+        // If we only provided block3, the rebuild would only see block3's state.
+        // We pass block1, block2, block3 to simulate that they are all still in memory
+        // but the anchor check forces a rebuild (e.g. artificial anchor change).
+        let block4_hashed = HashedPostState::default().with_accounts([(
+            key4,
+            Some(Account { nonce: 4, balance: U256::ZERO, bytecode_hash: None }),
+        )]);
+        let block4 = DeferredTrieData::pending(
+            Arc::new(block4_hashed),
+            Arc::new(TrieUpdates::default()),
+            new_anchor, // Different anchor - simulates post-persist
+            vec![block1, block2_ready, block3_ready],
+        );
+
+        let result = block4.wait_cloned();
+
+        // Verify:
+        // 1. New anchor is used in result
+        assert_eq!(result.anchor_hash(), Some(new_anchor));
+
+        // 2. All 4 accounts are in the overlay (rebuilt from ancestors + extended)
+        let overlay = result.anchored_trie_input.as_ref().unwrap();
+        assert_eq!(overlay.trie_input.state.accounts.len(), 4);
+
+        // 3. All accounts have correct values
+        let accounts = &overlay.trie_input.state.accounts;
+        assert!(accounts.iter().any(|(k, a)| *k == key1 && a.unwrap().nonce == 1));
+        assert!(accounts.iter().any(|(k, a)| *k == key2 && a.unwrap().nonce == 2));
+        assert!(accounts.iter().any(|(k, a)| *k == key3 && a.unwrap().nonce == 3));
+        assert!(accounts.iter().any(|(k, a)| *k == key4 && a.unwrap().nonce == 4));
     }
 }

--- a/crates/cli/commands/Cargo.toml
+++ b/crates/cli/commands/Cargo.toml
@@ -83,6 +83,7 @@ backon.workspace = true
 secp256k1 = { workspace = true, features = ["global-context", "std", "recovery"] }
 tokio-stream.workspace = true
 reqwest.workspace = true
+url.workspace = true
 metrics.workspace = true
 
 # io

--- a/crates/cli/commands/src/db/clear.rs
+++ b/crates/cli/commands/src/db/clear.rs
@@ -29,7 +29,7 @@ impl Command {
                 let static_file_provider = tool.provider_factory.static_file_provider();
                 let static_files = iter_static_files(static_file_provider.directory())?;
 
-                if let Some(segment_static_files) = static_files.get(&segment) {
+                if let Some(segment_static_files) = static_files.get(segment) {
                     for (block_range, _) in segment_static_files {
                         static_file_provider.delete_jar(segment, block_range.start())?;
                     }

--- a/crates/cli/commands/src/db/list.rs
+++ b/crates/cli/commands/src/db/list.rs
@@ -100,7 +100,7 @@ impl<N: NodeTypes> TableViewer<()> for ListTableViewer<'_, N> {
             tx.disable_long_read_transaction_safety();
 
             let table_db = tx.inner.open_db(Some(self.args.table.name())).wrap_err("Could not open db.")?;
-            let stats = tx.inner.db_stat(&table_db).wrap_err(format!("Could not find table: {}", self.args.table.name()))?;
+            let stats = tx.inner.db_stat(table_db.dbi()).wrap_err(format!("Could not find table: {}", self.args.table.name()))?;
             let total_entries = stats.entries();
             let final_entry_idx = total_entries.saturating_sub(1);
             if self.args.skip > final_entry_idx {

--- a/crates/cli/commands/src/db/stats.rs
+++ b/crates/cli/commands/src/db/stats.rs
@@ -88,7 +88,7 @@ impl Command {
 
                 let stats = tx
                     .inner
-                    .db_stat(&table_db)
+                    .db_stat(table_db.dbi())
                     .wrap_err(format!("Could not find table: {db_table}"))?;
 
                 // Defaults to 16KB right now but we should
@@ -129,7 +129,8 @@ impl Command {
             table.add_row(row);
 
             let freelist = tx.inner.env().freelist()?;
-            let pagesize = tx.inner.db_stat(&mdbx::Database::freelist_db())?.page_size() as usize;
+            let pagesize =
+                tx.inner.db_stat(mdbx::Database::freelist_db().dbi())?.page_size() as usize;
             let freelist_size = freelist * pagesize;
 
             let mut row = Row::new();

--- a/crates/cli/commands/src/download.rs
+++ b/crates/cli/commands/src/download.rs
@@ -16,6 +16,7 @@ use std::{
 use tar::Archive;
 use tokio::task;
 use tracing::info;
+use url::Url;
 use zstd::stream::read::Decoder as ZstdDecoder;
 
 const BYTE_UNITS: [&str; 4] = ["B", "KB", "MB", "GB"];
@@ -170,12 +171,14 @@ struct DownloadProgress {
     downloaded: u64,
     total_size: u64,
     last_displayed: Instant,
+    started_at: Instant,
 }
 
 impl DownloadProgress {
     /// Creates new progress tracker with given total size
     fn new(total_size: u64) -> Self {
-        Self { downloaded: 0, total_size, last_displayed: Instant::now() }
+        let now = Instant::now();
+        Self { downloaded: 0, total_size, last_displayed: now, started_at: now }
     }
 
     /// Converts bytes to human readable format (B, KB, MB, GB)
@@ -191,6 +194,18 @@ impl DownloadProgress {
         format!("{:.2} {}", size, BYTE_UNITS[unit_index])
     }
 
+    /// Format duration as human readable string
+    fn format_duration(duration: Duration) -> String {
+        let secs = duration.as_secs();
+        if secs < 60 {
+            format!("{secs}s")
+        } else if secs < 3600 {
+            format!("{}m {}s", secs / 60, secs % 60)
+        } else {
+            format!("{}h {}m", secs / 3600, (secs % 3600) / 60)
+        }
+    }
+
     /// Updates progress bar
     fn update(&mut self, chunk_size: u64) -> Result<()> {
         self.downloaded += chunk_size;
@@ -201,8 +216,24 @@ impl DownloadProgress {
             let formatted_total = Self::format_size(self.total_size);
             let progress = (self.downloaded as f64 / self.total_size as f64) * 100.0;
 
+            // Calculate ETA based on current speed
+            let elapsed = self.started_at.elapsed();
+            let eta = if self.downloaded > 0 {
+                let remaining = self.total_size.saturating_sub(self.downloaded);
+                let speed = self.downloaded as f64 / elapsed.as_secs_f64();
+                if speed > 0.0 {
+                    Duration::from_secs_f64(remaining as f64 / speed)
+                } else {
+                    Duration::ZERO
+                }
+            } else {
+                Duration::ZERO
+            };
+            let eta_str = Self::format_duration(eta);
+
+            // Pad with spaces to clear any previous longer line
             print!(
-                "\rDownloading and extracting... {progress:.2}% ({formatted_downloaded} / {formatted_total})",
+                "\rDownloading and extracting... {progress:.2}% ({formatted_downloaded} / {formatted_total}) ETA: {eta_str}     ",
             );
             io::stdout().flush()?;
             self.last_displayed = Instant::now();
@@ -246,12 +277,18 @@ enum CompressionFormat {
 impl CompressionFormat {
     /// Detect compression format from file extension
     fn from_url(url: &str) -> Result<Self> {
-        if url.ends_with(EXTENSION_TAR_LZ4) {
+        let path =
+            Url::parse(url).map(|u| u.path().to_string()).unwrap_or_else(|_| url.to_string());
+
+        if path.ends_with(EXTENSION_TAR_LZ4) {
             Ok(Self::Lz4)
-        } else if url.ends_with(EXTENSION_TAR_ZSTD) {
+        } else if path.ends_with(EXTENSION_TAR_ZSTD) {
             Ok(Self::Zstd)
         } else {
-            Err(eyre::eyre!("Unsupported file format. Expected .tar.lz4 or .tar.zst, got: {}", url))
+            Err(eyre::eyre!(
+                "Unsupported file format. Expected .tar.lz4 or .tar.zst, got: {}",
+                path
+            ))
         }
     }
 }

--- a/crates/cli/runner/src/lib.rs
+++ b/crates/cli/runner/src/lib.rs
@@ -18,8 +18,8 @@ use tracing::{debug, error, trace};
 ///
 /// Provides utilities for running a cli command to completion.
 #[derive(Debug)]
-#[non_exhaustive]
 pub struct CliRunner {
+    config: CliRunnerConfig,
     tokio_runtime: tokio::runtime::Runtime,
 }
 
@@ -29,12 +29,18 @@ impl CliRunner {
     ///
     /// The default tokio runtime is multi-threaded, with both I/O and time drivers enabled.
     pub fn try_default_runtime() -> Result<Self, std::io::Error> {
-        Ok(Self { tokio_runtime: tokio_runtime()? })
+        Ok(Self { config: CliRunnerConfig::default(), tokio_runtime: tokio_runtime()? })
     }
 
     /// Create a new [`CliRunner`] from a provided tokio [`Runtime`](tokio::runtime::Runtime).
     pub const fn from_runtime(tokio_runtime: tokio::runtime::Runtime) -> Self {
-        Self { tokio_runtime }
+        Self { config: CliRunnerConfig::new(), tokio_runtime }
+    }
+
+    /// Sets the [`CliRunnerConfig`] for this runner.
+    pub const fn with_config(mut self, config: CliRunnerConfig) -> Self {
+        self.config = config;
+        self
     }
 
     /// Executes an async block on the runtime and blocks until completion.
@@ -74,7 +80,7 @@ impl CliRunner {
             // after the command has finished or exit signal was received we shutdown the task
             // manager which fires the shutdown signal to all tasks spawned via the task
             // executor and awaiting on tasks spawned with graceful shutdown
-            task_manager.graceful_shutdown_with_timeout(Duration::from_secs(5));
+            task_manager.graceful_shutdown_with_timeout(self.config.graceful_shutdown_timeout);
         }
 
         // `drop(tokio_runtime)` would block the current thread until its pools
@@ -128,7 +134,7 @@ impl CliRunner {
             error!(target: "reth::cli", "shutting down due to error");
         } else {
             debug!(target: "reth::cli", "shutting down gracefully");
-            task_manager.graceful_shutdown_with_timeout(Duration::from_secs(5));
+            task_manager.graceful_shutdown_with_timeout(self.config.graceful_shutdown_timeout);
         }
 
         // Shutdown the runtime on a separate thread
@@ -209,6 +215,38 @@ impl AsyncCliRunner {
 pub struct CliContext {
     /// Used to execute/spawn tasks
     pub task_executor: TaskExecutor,
+}
+
+/// Default timeout for graceful shutdown of tasks.
+const DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Configuration for [`CliRunner`].
+#[derive(Debug, Clone)]
+pub struct CliRunnerConfig {
+    /// Timeout for graceful shutdown of tasks.
+    ///
+    /// After the command completes, this is the maximum time to wait for spawned tasks
+    /// to finish before forcefully terminating them.
+    pub graceful_shutdown_timeout: Duration,
+}
+
+impl Default for CliRunnerConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CliRunnerConfig {
+    /// Creates a new config with default values.
+    pub const fn new() -> Self {
+        Self { graceful_shutdown_timeout: DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT }
+    }
+
+    /// Sets the graceful shutdown timeout.
+    pub const fn with_graceful_shutdown_timeout(mut self, timeout: Duration) -> Self {
+        self.graceful_shutdown_timeout = timeout;
+        self
+    }
 }
 
 /// Creates a new default tokio multi-thread [Runtime](tokio::runtime::Runtime) with all features

--- a/crates/cli/util/Cargo.toml
+++ b/crates/cli/util/Cargo.toml
@@ -26,7 +26,8 @@ rand_08.workspace = true
 thiserror.workspace = true
 serde.workspace = true
 
-tracy-client = { workspace = true, optional = true, features = ["demangle"] }
+tracy-client = { workspace = true, optional = true }
+reth-tracing = { workspace = true, optional = true }
 
 [dev-dependencies]
 rand.workspace = true
@@ -46,7 +47,7 @@ jemalloc-prof = ["jemalloc", "tikv-jemallocator?/profiling"]
 jemalloc-unprefixed = ["jemalloc", "tikv-jemallocator?/unprefixed_malloc_on_supported_platforms"]
 
 # Wraps the selected allocator in the tracy profiling allocator
-tracy-allocator = ["dep:tracy-client"]
+tracy-allocator = ["dep:tracy-client", "dep:reth-tracing"]
 
 snmalloc = ["dep:snmalloc-rs"]
 

--- a/crates/cli/util/src/allocator.rs
+++ b/crates/cli/util/src/allocator.rs
@@ -25,7 +25,6 @@ cfg_if::cfg_if! {
 cfg_if::cfg_if! {
     if #[cfg(feature = "tracy-allocator")] {
         type AllocatorWrapper = tracy_client::ProfiledAllocator<AllocatorInner>;
-        tracy_client::register_demangler!();
         const fn new_allocator_wrapper() -> AllocatorWrapper {
             AllocatorWrapper::new(AllocatorInner {}, 100)
         }

--- a/crates/cli/util/src/lib.rs
+++ b/crates/cli/util/src/lib.rs
@@ -8,6 +8,9 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+#[cfg(feature = "tracy-allocator")]
+use reth_tracing as _;
+
 pub mod allocator;
 pub mod cancellation;
 

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -1079,18 +1079,6 @@ transaction_lookup = 'full'
 receipts = { distance = 16384 }
 #";
         let _conf: Config = toml::from_str(s).unwrap();
-
-        let s = r"#
-[prune]
-block_interval = 5
-
-[prune.segments]
-sender_recovery = { distance = 16384 }
-transaction_lookup = 'full'
-receipts = 'full'
-#";
-        let err = toml::from_str::<Config>(s).unwrap_err().to_string();
-        assert!(err.contains("invalid value: string \"full\""), "{}", err);
     }
 
     #[test]

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -2,9 +2,8 @@
 use reth_network_types::{PeersConfig, SessionsConfig};
 use reth_prune_types::PruneModes;
 use reth_stages_types::ExecutionStageThresholds;
-use reth_static_file_types::StaticFileSegment;
+use reth_static_file_types::{StaticFileMap, StaticFileSegment};
 use std::{
-    collections::HashMap,
     path::{Path, PathBuf},
     time::Duration,
 };
@@ -473,8 +472,8 @@ impl StaticFilesConfig {
         Ok(())
     }
 
-    /// Converts the blocks per file configuration into a [`HashMap`] per segment.
-    pub fn as_blocks_per_file_map(&self) -> HashMap<StaticFileSegment, u64> {
+    /// Converts the blocks per file configuration into a [`StaticFileMap`].
+    pub fn as_blocks_per_file_map(&self) -> StaticFileMap<u64> {
         let BlocksPerFileConfig {
             headers,
             transactions,
@@ -483,7 +482,7 @@ impl StaticFilesConfig {
             account_change_sets,
         } = self.blocks_per_file;
 
-        let mut map = HashMap::new();
+        let mut map = StaticFileMap::default();
         // Iterating over all possible segments allows us to do an exhaustive match here,
         // to not forget to configure new segments in the future.
         for segment in StaticFileSegment::iter() {

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -289,7 +289,8 @@ where
             config.multiproof_chunking_enabled().then_some(config.multiproof_chunk_size()),
             to_multi_proof.clone(),
             from_multi_proof,
-        );
+        )
+        .with_v2_proofs_enabled(v2_proofs_enabled);
 
         // spawn multi-proof task
         let parent_span = span.clone();

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -257,8 +257,6 @@ pub struct MultiproofManager {
     proof_result_tx: CrossbeamSender<ProofResultMessage>,
     /// Metrics
     metrics: MultiProofTaskMetrics,
-    /// Whether to use V2 storage proofs
-    v2_proofs_enabled: bool,
 }
 
 impl MultiproofManager {
@@ -272,9 +270,7 @@ impl MultiproofManager {
         metrics.max_storage_workers.set(proof_worker_handle.total_storage_workers() as f64);
         metrics.max_account_workers.set(proof_worker_handle.total_account_workers() as f64);
 
-        let v2_proofs_enabled = proof_worker_handle.v2_proofs_enabled();
-
-        Self { metrics, proof_worker_handle, proof_result_tx, v2_proofs_enabled }
+        Self { metrics, proof_worker_handle, proof_result_tx }
     }
 
     /// Dispatches a new multiproof calculation to worker pools.
@@ -351,7 +347,6 @@ impl MultiproofManager {
                 hashed_state_update,
                 start,
             ),
-            v2_proofs_enabled: self.v2_proofs_enabled,
         };
 
         if let Err(e) = self.proof_worker_handle.dispatch_account_multiproof(input) {

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -810,22 +810,16 @@ impl MultiProofTask {
         num_chunks as u64
     }
 
-    // Returns true if all state updates finished and all proofs processed.
-    fn is_done(
-        &self,
-        proofs_processed: u64,
-        state_update_proofs_requested: u64,
-        prefetch_proofs_requested: u64,
-        updates_finished: bool,
-    ) -> bool {
-        let all_proofs_processed =
-            proofs_processed >= state_update_proofs_requested + prefetch_proofs_requested;
+    /// Returns true if all state updates finished and all pending proofs processed.
+    fn is_done(&self, metrics: &MultiproofBatchMetrics, ctx: &MultiproofBatchCtx) -> bool {
+        let all_proofs_processed = metrics.all_proofs_processed();
         let no_pending = !self.proof_sequencer.has_pending();
+        let updates_finished = ctx.updates_finished();
         trace!(
             target: "engine::tree::payload_processor::multiproof",
-            proofs_processed,
-            state_update_proofs_requested,
-            prefetch_proofs_requested,
+            proofs_processed = metrics.proofs_processed,
+            state_update_proofs_requested = metrics.state_update_proofs_requested,
+            prefetch_proofs_requested = metrics.prefetch_proofs_requested,
             no_pending,
             updates_finished,
             "Checking end condition"
@@ -1106,12 +1100,7 @@ impl MultiProofTask {
                 ctx.updates_finished_time = Some(Instant::now());
 
                 // Check if we're done (might need to wait for proofs to complete)
-                if self.is_done(
-                    batch_metrics.proofs_processed,
-                    batch_metrics.state_update_proofs_requested,
-                    batch_metrics.prefetch_proofs_requested,
-                    ctx.updates_finished(),
-                ) {
+                if self.is_done(batch_metrics, ctx) {
                     debug!(
                         target: "engine::tree::payload_processor::multiproof",
                         "BAL processed and all proofs complete, ending calculation"
@@ -1126,12 +1115,7 @@ impl MultiProofTask {
 
                 ctx.updates_finished_time = Some(Instant::now());
 
-                if self.is_done(
-                    batch_metrics.proofs_processed,
-                    batch_metrics.state_update_proofs_requested,
-                    batch_metrics.prefetch_proofs_requested,
-                    ctx.updates_finished(),
-                ) {
+                if self.is_done(batch_metrics, ctx) {
                     debug!(
                         target: "engine::tree::payload_processor::multiproof",
                         "State updates finished and all proofs processed, ending calculation"
@@ -1160,12 +1144,7 @@ impl MultiProofTask {
                     let _ = self.to_sparse_trie.send(combined_update);
                 }
 
-                if self.is_done(
-                    batch_metrics.proofs_processed,
-                    batch_metrics.state_update_proofs_requested,
-                    batch_metrics.prefetch_proofs_requested,
-                    ctx.updates_finished(),
-                ) {
+                if self.is_done(batch_metrics, ctx) {
                     debug!(
                         target: "engine::tree::payload_processor::multiproof",
                         "State updates finished and all proofs processed, ending calculation"
@@ -1278,12 +1257,7 @@ impl MultiProofTask {
                                 }
                             }
 
-                            if self.is_done(
-                                batch_metrics.proofs_processed,
-                                batch_metrics.state_update_proofs_requested,
-                                batch_metrics.prefetch_proofs_requested,
-                                ctx.updates_finished(),
-                            ) {
+                            if self.is_done(&batch_metrics, &ctx) {
                                 debug!(
                                     target: "engine::tree::payload_processor::multiproof",
                                     "State updates finished and all proofs processed, ending calculation"
@@ -1388,6 +1362,13 @@ struct MultiproofBatchMetrics {
     state_update_proofs_requested: u64,
     /// Number of prefetch proofs requested.
     prefetch_proofs_requested: u64,
+}
+
+impl MultiproofBatchMetrics {
+    /// Returns `true` if all requested proofs have been processed.
+    const fn all_proofs_processed(&self) -> bool {
+        self.proofs_processed >= self.state_update_proofs_requested + self.prefetch_proofs_requested
+    }
 }
 
 /// Returns accounts only with those storages that were not already fetched, and

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -16,7 +16,7 @@ use crate::tree::{
     payload_processor::{
         bal::{total_slots, BALSlotIter},
         executor::WorkloadExecutor,
-        multiproof::MultiProofMessage,
+        multiproof::{MultiProofMessage, VersionedMultiProofTargets},
         ExecutionCache as PayloadExecutionCache,
     },
     precompile_cache::{CachedPrecompile, PrecompileCacheMap},
@@ -243,7 +243,9 @@ where
         }
 
         if let Some((proof_targets, to_multi_proof)) = targets.zip(self.to_multi_proof.as_ref()) {
-            let _ = to_multi_proof.send(MultiProofMessage::PrefetchProofs(proof_targets));
+            let _ = to_multi_proof.send(MultiProofMessage::PrefetchProofs(
+                VersionedMultiProofTargets::Legacy(proof_targets),
+            ));
         }
     }
 

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -4,7 +4,7 @@ use crate::tree::payload_processor::multiproof::{MultiProofTaskMetrics, SparseTr
 use alloy_primitives::B256;
 use rayon::iter::{ParallelBridge, ParallelIterator};
 use reth_trie::{updates::TrieUpdates, Nibbles};
-use reth_trie_parallel::root::ParallelStateRootError;
+use reth_trie_parallel::{proof_task::ProofResult, root::ParallelStateRootError};
 use reth_trie_sparse::{
     errors::{SparseStateTrieResult, SparseTrieErrorKind},
     provider::{TrieNodeProvider, TrieNodeProviderFactory},
@@ -156,7 +156,18 @@ where
     let started_at = Instant::now();
 
     // Reveal new accounts and storage slots.
-    trie.reveal_decoded_multiproof(multiproof)?;
+    match multiproof {
+        ProofResult::Legacy(decoded) => {
+            trie.reveal_decoded_multiproof(decoded)?;
+        }
+        ProofResult::V2(decoded_v2) => {
+            // TODO(mediocregopher): Once reveal_decoded_multiproof_v2 is implemented on
+            // SparseStateTrie, replace this unimplemented with:
+            // trie.reveal_decoded_multiproof_v2(decoded_v2)?;
+            let _ = decoded_v2;
+            unimplemented!("V2 multiproof reveal not yet implemented on SparseStateTrie")
+        }
+    }
     let reveal_multiproof_elapsed = started_at.elapsed();
     trace!(
         target: "engine::root::sparse",

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -97,8 +97,8 @@ where
             debug!(
                 target: "engine::root",
                 num_updates,
-                account_proofs = update.multiproof.account_subtree.len(),
-                storage_proofs = update.multiproof.storages.len(),
+                account_proofs = update.multiproof.account_proofs_len(),
+                storage_proofs = update.multiproof.storage_proofs_len(),
                 "Updating sparse trie"
             );
 

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -121,8 +121,9 @@ where
                 ParallelStateRootError::Other(format!("could not calculate state root: {e:?}"))
             })?;
 
-        self.metrics.sparse_trie_final_update_duration_histogram.record(start.elapsed());
-        self.metrics.sparse_trie_total_duration_histogram.record(now.elapsed());
+        let end = Instant::now();
+        self.metrics.sparse_trie_final_update_duration_histogram.record(end.duration_since(start));
+        self.metrics.sparse_trie_total_duration_histogram.record(end.duration_since(now));
 
         Ok(StateRootComputeOutcome { state_root, trie_updates })
     }

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -161,11 +161,7 @@ where
             trie.reveal_decoded_multiproof(decoded)?;
         }
         ProofResult::V2(decoded_v2) => {
-            // TODO(mediocregopher): Once reveal_decoded_multiproof_v2 is implemented on
-            // SparseStateTrie, replace this unimplemented with:
-            // trie.reveal_decoded_multiproof_v2(decoded_v2)?;
-            let _ = decoded_v2;
-            unimplemented!("V2 multiproof reveal not yet implemented on SparseStateTrie")
+            trie.reveal_decoded_multiproof_v2(decoded_v2)?;
         }
     }
     let reveal_multiproof_elapsed = started_at.elapsed();

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -622,7 +622,8 @@ where
             .without_state_clear()
             .build();
 
-        let evm = self.evm_config.evm_with_env(&mut db, env.evm_env.clone());
+        let spec_id = *env.evm_env.spec_id();
+        let evm = self.evm_config.evm_with_env(&mut db, env.evm_env);
         let ctx =
             self.execution_ctx_for(input).map_err(|e| InsertBlockErrorKind::Other(Box::new(e)))?;
         let mut executor = self.evm_config.create_executor(evm, ctx);
@@ -638,7 +639,7 @@ where
                 CachedPrecompile::wrap(
                     precompile,
                     self.precompile_cache_map.cache_for_address(*address),
-                    *env.evm_env.spec_id(),
+                    spec_id,
                     Some(metrics),
                 )
             });

--- a/crates/ethereum/cli/Cargo.toml
+++ b/crates/ethereum/cli/Cargo.toml
@@ -58,7 +58,8 @@ jemalloc-symbols = [
     "jemalloc-prof",
     "reth-node-metrics/jemalloc-symbols",
 ]
-tracy-allocator = []
+tracy-allocator = ["tracy"]
+tracy = ["reth-tracing/tracy", "reth-node-core/tracy"]
 
 # Because jemalloc is default and preferred over snmalloc when both features are
 # enabled, `--no-default-features` should be used when enabling snmalloc or

--- a/crates/ethereum/cli/Cargo.toml
+++ b/crates/ethereum/cli/Cargo.toml
@@ -38,6 +38,7 @@ tempfile.workspace = true
 default = []
 
 otlp = ["reth-tracing/otlp", "reth-node-core/otlp"]
+otlp-logs = ["reth-tracing/otlp-logs", "reth-node-core/otlp-logs"]
 
 dev = ["reth-cli-commands/arbitrary"]
 

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -303,6 +303,8 @@ where
         let eth_config =
             EthConfigHandler::new(ctx.node.provider().clone(), ctx.node.evm_config().clone());
 
+        let testing_skip_invalid_transactions = ctx.config.rpc.testing_skip_invalid_transactions;
+
         self.inner
             .launch_add_ons_with(ctx, move |container| {
                 container.modules.merge_if_module_configured(
@@ -316,14 +318,16 @@ where
 
                 // testing_buildBlockV1: only wire when the hidden testing module is explicitly
                 // requested on any transport. Default stays disabled to honor security guidance.
-                let testing_api = TestingApi::new(
+                let mut testing_api = TestingApi::new(
                     container.registry.eth_api().clone(),
                     container.registry.evm_config().clone(),
-                )
-                .into_rpc();
+                );
+                if testing_skip_invalid_transactions {
+                    testing_api = testing_api.with_skip_invalid_transactions();
+                }
                 container
                     .modules
-                    .merge_if_module_configured(RethRpcModule::Testing, testing_api)?;
+                    .merge_if_module_configured(RethRpcModule::Testing, testing_api.into_rpc())?;
 
                 Ok(())
             })

--- a/crates/ethereum/node/tests/e2e/eth.rs
+++ b/crates/ethereum/node/tests/e2e/eth.rs
@@ -1,6 +1,10 @@
 use crate::utils::eth_payload_attributes;
+use alloy_eips::eip7685::RequestsOrHash;
 use alloy_genesis::Genesis;
-use reth_chainspec::{ChainSpecBuilder, MAINNET};
+use alloy_primitives::{Address, B256};
+use alloy_rpc_types_engine::{PayloadAttributes, PayloadStatusEnum};
+use jsonrpsee_core::client::ClientT;
+use reth_chainspec::{ChainSpecBuilder, EthChainSpec, MAINNET};
 use reth_e2e_test_utils::{
     node::NodeTestContext, setup, transaction::TransactionTestContext, wallet::Wallet,
 };
@@ -8,6 +12,7 @@ use reth_node_builder::{NodeBuilder, NodeHandle};
 use reth_node_core::{args::RpcServerArgs, node_config::NodeConfig};
 use reth_node_ethereum::EthereumNode;
 use reth_provider::BlockNumReader;
+use reth_rpc_api::TestingBuildBlockRequestV1;
 use reth_tasks::TaskManager;
 use std::sync::Arc;
 
@@ -177,6 +182,77 @@ async fn test_engine_graceful_shutdown() -> eyre::Result<()> {
 
     let db_block = node.inner.provider.last_block_number()?;
     assert_eq!(db_block, 1, "Database should have persisted block 1");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_testing_build_block_v1_osaka() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+    let tasks = TaskManager::current();
+    let exec = tasks.executor();
+
+    let genesis: Genesis = serde_json::from_str(include_str!("../assets/genesis.json")).unwrap();
+    let chain_spec = Arc::new(
+        ChainSpecBuilder::default().chain(MAINNET.chain).genesis(genesis).osaka_activated().build(),
+    );
+    let genesis_hash = chain_spec.genesis_hash();
+
+    let node_config =
+        NodeConfig::test().with_chain(chain_spec.clone()).with_unused_ports().with_rpc(
+            RpcServerArgs::default()
+                .with_unused_ports()
+                .with_http()
+                .with_http_api(reth_rpc_server_types::RpcModuleSelection::All),
+        );
+
+    let NodeHandle { node, node_exit_future: _ } = NodeBuilder::new(node_config)
+        .testing_node(exec)
+        .node(EthereumNode::default())
+        .launch()
+        .await?;
+
+    let node = NodeTestContext::new(node, eth_payload_attributes).await?;
+
+    let wallet = Wallet::default();
+    let raw_tx = TransactionTestContext::transfer_tx_bytes(1, wallet.inner).await;
+
+    let payload_attributes = PayloadAttributes {
+        timestamp: chain_spec.genesis().timestamp + 1,
+        prev_randao: B256::ZERO,
+        suggested_fee_recipient: Address::ZERO,
+        withdrawals: Some(vec![]),
+        parent_beacon_block_root: Some(B256::ZERO),
+    };
+
+    let request = TestingBuildBlockRequestV1 {
+        parent_block_hash: genesis_hash,
+        payload_attributes,
+        transactions: vec![raw_tx],
+        extra_data: None,
+    };
+
+    let envelope = node.testing_build_block_v1(request).await?;
+
+    let engine_client = node.auth_server_handle().http_client();
+    let payload = envelope.execution_payload.clone();
+    let block_hash = payload.payload_inner.payload_inner.block_hash;
+
+    let versioned_hashes: Vec<B256> = Vec::new();
+    let parent_beacon_block_root = B256::ZERO;
+    let execution_requests = RequestsOrHash::Requests(envelope.execution_requests);
+
+    let status: alloy_rpc_types_engine::PayloadStatus = engine_client
+        .request(
+            "engine_newPayloadV4",
+            (payload, versioned_hashes, parent_beacon_block_root, execution_requests),
+        )
+        .await?;
+    assert_eq!(status.status, PayloadStatusEnum::Valid);
+
+    node.update_forkchoice(genesis_hash, block_hash).await?;
+
+    node.wait_block(1, block_hash, false).await?;
 
     Ok(())
 }

--- a/crates/metrics/src/common/mpsc.rs
+++ b/crates/metrics/src/common/mpsc.rs
@@ -70,10 +70,11 @@ impl<T> Clone for UnboundedMeteredSender<T> {
     }
 }
 
-/// A wrapper type around [Receiver](mpsc::UnboundedReceiver) that updates metrics on receive.
+/// A wrapper type around [`UnboundedReceiver`](mpsc::UnboundedReceiver) that updates metrics on
+/// receive.
 #[derive(Debug)]
 pub struct UnboundedMeteredReceiver<T> {
-    /// The [Receiver](mpsc::UnboundedReceiver) that this wraps around
+    /// The [`UnboundedReceiver`](mpsc::UnboundedReceiver) that this wraps around
     receiver: mpsc::UnboundedReceiver<T>,
     /// Holds metrics for this type
     metrics: MeteredReceiverMetrics,

--- a/crates/net/ecies/Cargo.toml
+++ b/crates/net/ecies/Cargo.toml
@@ -34,7 +34,6 @@ secp256k1 = { workspace = true, features = ["global-context", "std", "recovery",
 rand_08.workspace = true
 concat-kdf.workspace = true
 sha2.workspace = true
-sha3.workspace = true
 aes.workspace = true
 hmac.workspace = true
 block-padding.workspace = true

--- a/crates/net/ecies/src/algorithm.rs
+++ b/crates/net/ecies/src/algorithm.rs
@@ -9,12 +9,12 @@ use crate::{
 use aes::{cipher::StreamCipher, Aes128, Aes256};
 use alloy_primitives::{
     bytes::{BufMut, Bytes, BytesMut},
-    B128, B256, B512 as PeerId,
+    Keccak256, B128, B256, B512 as PeerId,
 };
 use alloy_rlp::{Encodable, Rlp, RlpEncodable, RlpMaxEncodedLen};
 use byteorder::{BigEndian, ByteOrder, ReadBytesExt};
 use ctr::Ctr64BE;
-use digest::{crypto_common::KeyIvInit, Digest};
+use digest::crypto_common::KeyIvInit;
 use rand_08::{thread_rng as rng, Rng};
 use reth_network_peers::{id2pk, pk2id};
 use secp256k1::{
@@ -22,7 +22,6 @@ use secp256k1::{
     PublicKey, SecretKey, SECP256K1,
 };
 use sha2::Sha256;
-use sha3::Keccak256;
 
 const PROTOCOL_VERSION: usize = 4;
 

--- a/crates/net/ecies/src/mac.rs
+++ b/crates/net/ecies/src/mac.rs
@@ -10,11 +10,10 @@
 //! For more information, refer to the [Ethereum MAC specification](https://github.com/ethereum/devp2p/blob/master/rlpx.md#mac).
 
 use aes::Aes256Enc;
-use alloy_primitives::{B128, B256};
+use alloy_primitives::{Keccak256, B128, B256};
 use block_padding::NoPadding;
 use cipher::BlockEncrypt;
 use digest::KeyInit;
-use sha3::{Digest, Keccak256};
 
 /// [`Ethereum MAC`](https://github.com/ethereum/devp2p/blob/master/rlpx.md#mac) state.
 ///

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -637,7 +637,7 @@ impl<Pool: TransactionPool, N: NetworkPrimitives> TransactionsManager<Pool, N> {
         //
         // known txns have already been successfully fetched or received over gossip.
         //
-        // most hashes will be filtered out here since this the mempool protocol is a gossip
+        // most hashes will be filtered out here since the mempool protocol is a gossip
         // protocol, healthy peers will send many of the same hashes.
         //
         let hashes_count_pre_pool_filter = partially_valid_msg.len();

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -170,7 +170,8 @@ impl LaunchContext {
         toml_config.peers.trusted_nodes_only = config.network.trusted_only;
 
         // Merge static file CLI arguments with config file, giving priority to CLI
-        toml_config.static_files = config.static_files.merge_with_config(toml_config.static_files);
+        toml_config.static_files =
+            config.static_files.merge_with_config(toml_config.static_files, config.pruning.minimal);
 
         Ok(toml_config)
     }
@@ -1301,6 +1302,7 @@ mod tests {
             let node_config = NodeConfig {
                 pruning: PruningArgs {
                     full: true,
+                    minimal: false,
                     block_interval: None,
                     sender_recovery_full: false,
                     sender_recovery_distance: None,

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -483,7 +483,7 @@ where
         let static_file_provider =
             StaticFileProviderBuilder::read_write(self.data_dir().static_files())
                 .with_metrics()
-                .with_blocks_per_file_for_segments(static_files_config.as_blocks_per_file_map())
+                .with_blocks_per_file_for_segments(&static_files_config.as_blocks_per_file_map())
                 .with_genesis_block_number(self.chain_spec().genesis().number.unwrap_or_default())
                 .build()?;
 
@@ -946,7 +946,7 @@ where
                 error!(
                     "Op-mainnet has been launched without importing the pre-Bedrock state. The chain can't progress without this. See also https://reth.rs/run/sync-op-mainnet.html?minimal-bootstrap-recommended"
                 );
-                return Err(ProviderError::BestBlockNotFound)
+                return Err(ProviderError::BestBlockNotFound);
             }
         }
 

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -79,9 +79,12 @@ use reth_stages::{
 };
 use reth_static_file::StaticFileProducer;
 use reth_tasks::TaskExecutor;
-use reth_tracing::tracing::{debug, error, info, warn};
+use reth_tracing::{
+    throttle,
+    tracing::{debug, error, info, warn},
+};
 use reth_transaction_pool::TransactionPool;
-use std::{sync::Arc, thread::available_parallelism};
+use std::{sync::Arc, thread::available_parallelism, time::Duration};
 use tokio::sync::{
     mpsc::{unbounded_channel, UnboundedSender},
     oneshot, watch,
@@ -650,23 +653,13 @@ where
                 },
                 ChainSpecInfo { name: self.chain_id().to_string() },
                 self.task_executor().clone(),
-                Hooks::builder()
-                    .with_hook({
-                        let db = self.database().clone();
-                        move || db.report_metrics()
-                    })
-                    .with_hook({
-                        let sfp = self.static_file_provider();
-                        move || {
-                            if let Err(error) = sfp.report_metrics() {
-                                error!(%error, "Failed to report metrics for the static file provider");
-                            }
-                        }
-                    })
-                    .build(),
+                metrics_hooks(self.provider_factory()),
                 self.data_dir().pprof_dumps(),
             )
-            .with_push_gateway(self.node_config().metrics.push_gateway_url.clone(), self.node_config().metrics.push_gateway_interval);
+            .with_push_gateway(
+                self.node_config().metrics.push_gateway_url.clone(),
+                self.node_config().metrics.push_gateway_interval,
+            );
 
             MetricServer::new(config).serve().await?;
         }
@@ -1264,6 +1257,26 @@ where
     db_provider_container: WithMeteredProvider<NodeTypesWithDBAdapter<T::Types, T::DB>>,
     node_adapter: NodeAdapter<T, CB::Components>,
     head: Head,
+}
+
+/// Returns the metrics hooks for the node.
+pub fn metrics_hooks<N: NodeTypesWithDB>(provider_factory: &ProviderFactory<N>) -> Hooks {
+    Hooks::builder()
+        .with_hook({
+            let db = provider_factory.db_ref().clone();
+            move || throttle!(Duration::from_secs(5 * 60), || db.report_metrics())
+        })
+        .with_hook({
+            let sfp = provider_factory.static_file_provider();
+            move || {
+                throttle!(Duration::from_secs(5 * 60), || {
+                    if let Err(error) = sfp.report_metrics() {
+                        error!(%error, "Failed to report metrics from static file provider");
+                    }
+                })
+            }
+        })
+        .build()
 }
 
 #[cfg(test)]

--- a/crates/node/core/Cargo.toml
+++ b/crates/node/core/Cargo.toml
@@ -90,6 +90,9 @@ min-info-logs = ["tracing/release_max_level_info"]
 min-debug-logs = ["tracing/release_max_level_debug"]
 min-trace-logs = ["tracing/release_max_level_trace"]
 
+# Marker feature for edge/unstable builds - captured by vergen in build.rs
+edge = []
+
 [build-dependencies]
 vergen = { workspace = true, features = ["build", "cargo", "emit_and_set"] }
 vergen-git2.workspace = true

--- a/crates/node/core/Cargo.toml
+++ b/crates/node/core/Cargo.toml
@@ -81,7 +81,8 @@ tokio.workspace = true
 jemalloc = ["reth-cli-util/jemalloc"]
 asm-keccak = ["alloy-primitives/asm-keccak"]
 keccak-cache-global = ["alloy-primitives/keccak-cache-global"]
-otlp = ["reth-tracing/otlp"]
+otlp = ["reth-tracing/otlp", "reth-tracing-otlp/otlp"]
+otlp-logs = ["reth-tracing/otlp-logs", "reth-tracing-otlp/otlp-logs"]
 tracy = ["reth-tracing/tracy"]
 
 min-error-logs = ["tracing/release_max_level_error"]

--- a/crates/node/core/Cargo.toml
+++ b/crates/node/core/Cargo.toml
@@ -82,6 +82,7 @@ jemalloc = ["reth-cli-util/jemalloc"]
 asm-keccak = ["alloy-primitives/asm-keccak"]
 keccak-cache-global = ["alloy-primitives/keccak-cache-global"]
 otlp = ["reth-tracing/otlp"]
+tracy = ["reth-tracing/tracy"]
 
 min-error-logs = ["tracing/release_max_level_error"]
 min-warn-logs = ["tracing/release_max_level_warn"]

--- a/crates/node/core/src/args/log.rs
+++ b/crates/node/core/src/args/log.rs
@@ -75,6 +75,20 @@ pub struct LogArgs {
     )]
     pub samply_filter: String,
 
+    /// Emit traces to tracy. Only useful when profiling.
+    #[arg(long = "log.tracy", global = true, hide = true)]
+    pub tracy: bool,
+
+    /// The filter to use for traces emitted to tracy.
+    #[arg(
+        long = "log.tracy.filter",
+        value_name = "FILTER",
+        global = true,
+        default_value = "debug",
+        hide = true
+    )]
+    pub tracy_filter: String,
+
     /// Sets whether or not the formatter emits ANSI terminal escape codes for colors and other
     /// text formatting.
     #[arg(
@@ -146,6 +160,12 @@ impl LogArgs {
         if self.samply {
             let config = self.layer_info(LogFormat::Terminal, self.samply_filter.clone(), false);
             tracer = tracer.with_samply(config);
+        }
+
+        #[cfg(feature = "tracy")]
+        if self.tracy {
+            let config = self.layer_info(LogFormat::Terminal, self.tracy_filter.clone(), false);
+            tracer = tracer.with_tracy(config);
         }
 
         let guard = tracer.init_with_layers(layers)?;

--- a/crates/node/core/src/args/mod.rs
+++ b/crates/node/core/src/args/mod.rs
@@ -78,7 +78,7 @@ pub use era::{DefaultEraHost, EraArgs, EraSourceArgs};
 
 /// `StaticFilesArgs` for configuring static files.
 mod static_files;
-pub use static_files::StaticFilesArgs;
+pub use static_files::{StaticFilesArgs, MINIMAL_BLOCKS_PER_FILE};
 
 mod error;
 pub mod types;

--- a/crates/node/core/src/args/mod.rs
+++ b/crates/node/core/src/args/mod.rs
@@ -26,7 +26,7 @@ pub use log::{ColorMode, LogArgs, Verbosity};
 
 /// `TraceArgs` for tracing and spans support
 mod trace;
-pub use trace::{OtlpInitStatus, TraceArgs};
+pub use trace::{OtlpInitStatus, OtlpLogsStatus, TraceArgs};
 
 /// `MetricArgs` to configure metrics.
 mod metric;

--- a/crates/node/core/src/args/pruning.rs
+++ b/crates/node/core/src/args/pruning.rs
@@ -16,8 +16,17 @@ use std::{collections::BTreeMap, ops::Not};
 #[command(next_help_heading = "Pruning")]
 pub struct PruningArgs {
     /// Run full node. Only the most recent [`MINIMUM_PRUNING_DISTANCE`] block states are stored.
-    #[arg(long, default_value_t = false)]
+    #[arg(long, default_value_t = false, conflicts_with = "minimal")]
     pub full: bool,
+
+    /// Run minimal storage mode with maximum pruning and smaller static files.
+    ///
+    /// This mode configures the node to use minimal disk space by:
+    /// - Fully pruning sender recovery, transaction lookup, receipts
+    /// - Leaving 10,064 blocks for account, storage history and block bodies
+    /// - Using 10,000 blocks per static file segment
+    #[arg(long, default_value_t = false, conflicts_with = "full")]
+    pub minimal: bool,
 
     /// Minimum pruning interval measured in blocks.
     #[arg(long = "prune.block-interval", alias = "block-interval", value_parser = RangedU64ValueParser::<u64>::new().range(1..))]
@@ -134,6 +143,23 @@ impl PruningArgs {
                         .ethereum_fork_activation(EthereumHardfork::Paris)
                         .block_number()
                         .map(PruneMode::Before),
+                    merkle_changesets: PruneMode::Distance(MERKLE_CHANGESETS_RETENTION_BLOCKS),
+                    receipts_log_filter: Default::default(),
+                },
+            }
+        }
+
+        // If --minimal is set, use minimal storage mode with aggressive pruning.
+        if self.minimal {
+            config = PruneConfig {
+                block_interval: config.block_interval,
+                segments: PruneModes {
+                    sender_recovery: Some(PruneMode::Full),
+                    transaction_lookup: Some(PruneMode::Full),
+                    receipts: Some(PruneMode::Full),
+                    account_history: Some(PruneMode::Distance(10064)),
+                    storage_history: Some(PruneMode::Distance(10064)),
+                    bodies_history: Some(PruneMode::Distance(10064)),
                     merkle_changesets: PruneMode::Distance(MERKLE_CHANGESETS_RETENTION_BLOCKS),
                     receipts_log_filter: Default::default(),
                 },

--- a/crates/node/core/src/args/rpc_server.rs
+++ b/crates/node/core/src/args/rpc_server.rs
@@ -640,6 +640,13 @@ pub struct RpcServerArgs {
         value_parser = parse_duration_from_secs_or_ms,
     )]
     pub rpc_send_raw_transaction_sync_timeout: Duration,
+
+    /// Skip invalid transactions in `testing_buildBlockV1` instead of failing.
+    ///
+    /// When enabled, transactions that fail execution will be skipped, and all subsequent
+    /// transactions from the same sender will also be skipped.
+    #[arg(long = "testing.skip-invalid-transactions", default_value_t = false)]
+    pub testing_skip_invalid_transactions: bool,
 }
 
 impl RpcServerArgs {
@@ -852,6 +859,7 @@ impl Default for RpcServerArgs {
             rpc_state_cache,
             gas_price_oracle,
             rpc_send_raw_transaction_sync_timeout,
+            testing_skip_invalid_transactions: false,
         }
     }
 }
@@ -1026,6 +1034,7 @@ mod tests {
                 default_suggested_fee: None,
             },
             rpc_send_raw_transaction_sync_timeout: std::time::Duration::from_secs(30),
+            testing_skip_invalid_transactions: true,
         };
 
         let parsed_args = CommandParser::<RpcServerArgs>::parse_from([
@@ -1114,6 +1123,7 @@ mod tests {
             "60",
             "--rpc.send-raw-transaction-sync-timeout",
             "30s",
+            "--testing.skip-invalid-transactions",
         ])
         .args;
 

--- a/crates/node/core/src/args/rpc_server.rs
+++ b/crates/node/core/src/args/rpc_server.rs
@@ -605,7 +605,7 @@ pub struct RpcServerArgs {
     pub rpc_eth_proof_window: u64,
 
     /// Maximum number of concurrent getproof requests.
-    #[arg(long = "rpc.proof-permits", alias = "rpc-proof-permits", value_name = "COUNT", default_value_t = constants::DEFAULT_PROOF_PERMITS)]
+    #[arg(long = "rpc.proof-permits", alias = "rpc-proof-permits", value_name = "COUNT", default_value_t = DefaultRpcServerArgs::get_global().rpc_proof_permits)]
     pub rpc_proof_permits: usize,
 
     /// Configures the pending block behavior for RPC responses.

--- a/crates/node/core/src/args/static_files.rs
+++ b/crates/node/core/src/args/static_files.rs
@@ -4,6 +4,11 @@ use clap::Args;
 use reth_config::config::{BlocksPerFileConfig, StaticFilesConfig};
 use reth_provider::StorageSettings;
 
+/// Blocks per static file when running in `--minimal` node.
+///
+/// 10000 blocks per static file allows us to prune all history every 10k blocks.
+pub const MINIMAL_BLOCKS_PER_FILE: u64 = 10000;
+
 /// Parameters for static files configuration
 #[derive(Debug, Args, PartialEq, Eq, Default, Clone, Copy)]
 #[command(next_help_heading = "Static Files")]
@@ -61,14 +66,25 @@ pub struct StaticFilesArgs {
 impl StaticFilesArgs {
     /// Merges the CLI arguments with an existing [`StaticFilesConfig`], giving priority to CLI
     /// args.
-    pub fn merge_with_config(&self, config: StaticFilesConfig) -> StaticFilesConfig {
+    ///
+    /// If `minimal` is true, uses [`MINIMAL_BLOCKS_PER_FILE`] blocks per file as the default for
+    /// headers, transactions, and receipts segments.
+    pub fn merge_with_config(&self, config: StaticFilesConfig, minimal: bool) -> StaticFilesConfig {
+        let minimal_blocks_per_file = minimal.then_some(MINIMAL_BLOCKS_PER_FILE);
         StaticFilesConfig {
             blocks_per_file: BlocksPerFileConfig {
-                headers: self.blocks_per_file_headers.or(config.blocks_per_file.headers),
+                headers: self
+                    .blocks_per_file_headers
+                    .or(minimal_blocks_per_file)
+                    .or(config.blocks_per_file.headers),
                 transactions: self
                     .blocks_per_file_transactions
+                    .or(minimal_blocks_per_file)
                     .or(config.blocks_per_file.transactions),
-                receipts: self.blocks_per_file_receipts.or(config.blocks_per_file.receipts),
+                receipts: self
+                    .blocks_per_file_receipts
+                    .or(minimal_blocks_per_file)
+                    .or(config.blocks_per_file.receipts),
                 transaction_senders: self
                     .blocks_per_file_transaction_senders
                     .or(config.blocks_per_file.transaction_senders),

--- a/crates/node/core/src/lib.rs
+++ b/crates/node/core/src/lib.rs
@@ -24,12 +24,12 @@ pub mod primitives {
 
 /// Re-export of `reth_rpc_*` crates.
 pub mod rpc {
-    /// Re-exported from `reth_rpc::rpc`.
+    /// Re-exported from `reth_rpc_server_types::result`.
     pub mod result {
         pub use reth_rpc_server_types::result::*;
     }
 
-    /// Re-exported from `reth_rpc::eth`.
+    /// Re-exported from `reth_rpc_convert`.
     pub mod compat {
         pub use reth_rpc_convert::*;
     }

--- a/crates/node/ethstats/src/error.rs
+++ b/crates/node/ethstats/src/error.rs
@@ -64,6 +64,6 @@ pub enum EthStatsError {
     DataFetchError(String),
 
     /// The request sent to the server was invalid or malformed
-    #[error("Inivalid request")]
+    #[error("Invalid request")]
     InvalidRequest,
 }

--- a/crates/optimism/bin/Cargo.toml
+++ b/crates/optimism/bin/Cargo.toml
@@ -38,7 +38,8 @@ js-tracer = [
 jemalloc = ["reth-cli-util/jemalloc", "reth-optimism-cli/jemalloc"]
 jemalloc-prof = ["jemalloc", "reth-cli-util/jemalloc-prof", "reth-optimism-cli/jemalloc-prof"]
 jemalloc-symbols = ["jemalloc-prof", "reth-optimism-cli/jemalloc-symbols"]
-tracy-allocator = ["reth-cli-util/tracy-allocator"]
+tracy-allocator = ["reth-cli-util/tracy-allocator", "tracy"]
+tracy = ["reth-optimism-cli/tracy"]
 
 asm-keccak = ["reth-optimism-cli/asm-keccak", "reth-optimism-node/asm-keccak"]
 keccak-cache-global = [

--- a/crates/optimism/bin/Cargo.toml
+++ b/crates/optimism/bin/Cargo.toml
@@ -43,6 +43,7 @@ tracy = ["reth-optimism-cli/tracy"]
 
 asm-keccak = ["reth-optimism-cli/asm-keccak", "reth-optimism-node/asm-keccak"]
 keccak-cache-global = [
+    "reth-optimism-cli/keccak-cache-global",
     "reth-optimism-node/keccak-cache-global",
 ]
 dev = [

--- a/crates/optimism/cli/Cargo.toml
+++ b/crates/optimism/cli/Cargo.toml
@@ -76,8 +76,9 @@ reth-optimism-chainspec = { workspace = true, features = ["std", "superchain-con
 [features]
 default = []
 
-# Opentelemtry feature to activate metrics export
+# Opentelemetry feature to activate tracing and logs export
 otlp = ["reth-tracing/otlp", "reth-node-core/otlp"]
+otlp-logs = ["reth-tracing/otlp-logs", "reth-node-core/otlp-logs"]
 
 asm-keccak = [
     "alloy-primitives/asm-keccak",

--- a/crates/optimism/cli/Cargo.toml
+++ b/crates/optimism/cli/Cargo.toml
@@ -85,6 +85,12 @@ asm-keccak = [
     "reth-optimism-node/asm-keccak",
 ]
 
+keccak-cache-global = [
+    "alloy-primitives/keccak-cache-global",
+    "reth-node-core/keccak-cache-global",
+    "reth-optimism-node/keccak-cache-global",
+]
+
 # Jemalloc feature for vergen to generate correct env vars
 jemalloc = [
     "reth-node-core/jemalloc",

--- a/crates/optimism/cli/Cargo.toml
+++ b/crates/optimism/cli/Cargo.toml
@@ -117,4 +117,4 @@ serde = [
     "reth-optimism-chainspec/serde",
 ]
 
-edge = ["reth-cli-commands/edge"]
+edge = ["reth-cli-commands/edge", "reth-node-core/edge"]

--- a/crates/optimism/cli/Cargo.toml
+++ b/crates/optimism/cli/Cargo.toml
@@ -99,6 +99,8 @@ jemalloc-symbols = [
     "reth-node-metrics/jemalloc-symbols",
 ]
 
+tracy = ["reth-tracing/tracy", "reth-node-core/tracy"]
+
 dev = [
     "dep:proptest",
     "reth-cli-commands/arbitrary",

--- a/crates/optimism/cli/src/app.rs
+++ b/crates/optimism/cli/src/app.rs
@@ -3,7 +3,7 @@ use eyre::{eyre, Result};
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_commands::launcher::Launcher;
 use reth_cli_runner::CliRunner;
-use reth_node_core::args::OtlpInitStatus;
+use reth_node_core::args::{OtlpInitStatus, OtlpLogsStatus};
 use reth_node_metrics::recorder::install_prometheus_recorder;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_consensus::OpBeaconConsensus;
@@ -124,9 +124,11 @@ where
             let mut layers = self.layers.take().unwrap_or_default();
 
             let otlp_status = runner.block_on(self.cli.traces.init_otlp_tracing(&mut layers))?;
+            let otlp_logs_status = runner.block_on(self.cli.traces.init_otlp_logs(&mut layers))?;
 
             self.guard = self.cli.logs.init_tracing_with_layers(layers)?;
             info!(target: "reth::cli", "Initialized tracing, debug log directory: {}", self.cli.logs.log_file_directory);
+
             match otlp_status {
                 OtlpInitStatus::Started(endpoint) => {
                     info!(target: "reth::cli", "Started OTLP {:?} tracing export to {endpoint}", self.cli.traces.protocol);
@@ -135,6 +137,16 @@ where
                     warn!(target: "reth::cli", "Provided OTLP tracing arguments do not have effect, compile with the `otlp` feature")
                 }
                 OtlpInitStatus::Disabled => {}
+            }
+
+            match otlp_logs_status {
+                OtlpLogsStatus::Started(endpoint) => {
+                    info!(target: "reth::cli", "Started OTLP {:?} logs export to {endpoint}", self.cli.traces.protocol);
+                }
+                OtlpLogsStatus::NoFeature => {
+                    warn!(target: "reth::cli", "Provided OTLP logs arguments do not have effect, compile with the `otlp-logs` feature")
+                }
+                OtlpLogsStatus::Disabled => {}
             }
         }
         Ok(())

--- a/crates/optimism/hardforks/src/lib.rs
+++ b/crates/optimism/hardforks/src/lib.rs
@@ -61,6 +61,7 @@ pub static DEV_HARDFORKS: LazyLock<ChainHardforks> = LazyLock::new(|| {
         (OpHardfork::Ecotone.boxed(), ForkCondition::Timestamp(0)),
         (OpHardfork::Fjord.boxed(), ForkCondition::Timestamp(0)),
         (OpHardfork::Granite.boxed(), ForkCondition::Timestamp(0)),
+        (OpHardfork::Holocene.boxed(), ForkCondition::Timestamp(0)),
         (EthereumHardfork::Prague.boxed(), ForkCondition::Timestamp(0)),
         (OpHardfork::Isthmus.boxed(), ForkCondition::Timestamp(0)),
         (OpHardfork::Jovian.boxed(), JOVIAN_TIMESTAMP),

--- a/crates/optimism/node/src/engine.rs
+++ b/crates/optimism/node/src/engine.rs
@@ -306,8 +306,7 @@ mod test {
     use alloy_op_hardforks::BASE_SEPOLIA_JOVIAN_TIMESTAMP;
     use alloy_primitives::{b64, Address, B256, B64};
     use alloy_rpc_types_engine::PayloadAttributes;
-    use reth_chainspec::ChainSpec;
-    use reth_optimism_chainspec::{OpChainSpec, BASE_SEPOLIA};
+    use reth_optimism_chainspec::BASE_SEPOLIA;
     use reth_provider::noop::NoopProvider;
     use reth_trie_common::KeccakKeyHasher;
 
@@ -321,24 +320,6 @@ mod test {
                 other => panic!("expected InvalidParams, got {other:?}"),
             }
         }};
-    }
-
-    fn get_chainspec() -> Arc<OpChainSpec> {
-        let base_sepolia_spec = BASE_SEPOLIA.inner.clone();
-
-        Arc::new(OpChainSpec {
-            inner: ChainSpec {
-                chain: base_sepolia_spec.chain,
-                genesis: base_sepolia_spec.genesis,
-                genesis_header: base_sepolia_spec.genesis_header,
-                paris_block_and_final_difficulty: base_sepolia_spec
-                    .paris_block_and_final_difficulty,
-                hardforks: base_sepolia_spec.hardforks,
-                base_fee_params: base_sepolia_spec.base_fee_params,
-                prune_delete_limit: 10000,
-                ..Default::default()
-            },
-        })
     }
 
     const fn get_attributes(
@@ -364,8 +345,10 @@ mod test {
 
     #[test]
     fn test_well_formed_attributes_pre_holocene() {
-        let validator =
-            OpEngineValidator::new::<KeccakKeyHasher>(get_chainspec(), NoopProvider::default());
+        let validator = OpEngineValidator::new::<KeccakKeyHasher>(
+            BASE_SEPOLIA.clone(),
+            NoopProvider::default(),
+        );
         let attributes = get_attributes(None, None, 1732633199);
 
         let result = <engine::OpEngineValidator<_, _, _> as EngineApiValidator<
@@ -378,8 +361,10 @@ mod test {
 
     #[test]
     fn test_well_formed_attributes_holocene_no_eip1559_params() {
-        let validator =
-            OpEngineValidator::new::<KeccakKeyHasher>(get_chainspec(), NoopProvider::default());
+        let validator = OpEngineValidator::new::<KeccakKeyHasher>(
+            BASE_SEPOLIA.clone(),
+            NoopProvider::default(),
+        );
         let attributes = get_attributes(None, None, 1732633200);
 
         let result = <engine::OpEngineValidator<_, _, _> as EngineApiValidator<
@@ -392,8 +377,10 @@ mod test {
 
     #[test]
     fn test_well_formed_attributes_holocene_eip1559_params_zero_denominator() {
-        let validator =
-            OpEngineValidator::new::<KeccakKeyHasher>(get_chainspec(), NoopProvider::default());
+        let validator = OpEngineValidator::new::<KeccakKeyHasher>(
+            BASE_SEPOLIA.clone(),
+            NoopProvider::default(),
+        );
         let attributes = get_attributes(Some(b64!("0000000000000008")), None, 1732633200);
 
         let result = <engine::OpEngineValidator<_, _, _> as EngineApiValidator<
@@ -406,8 +393,10 @@ mod test {
 
     #[test]
     fn test_well_formed_attributes_holocene_eip1559_params_zero_elasticity() {
-        let validator =
-            OpEngineValidator::new::<KeccakKeyHasher>(get_chainspec(), NoopProvider::default());
+        let validator = OpEngineValidator::new::<KeccakKeyHasher>(
+            BASE_SEPOLIA.clone(),
+            NoopProvider::default(),
+        );
         let attributes = get_attributes(Some(b64!("0000000800000000")), None, 1732633200);
 
         let result = <engine::OpEngineValidator<_, _, _> as EngineApiValidator<
@@ -420,8 +409,10 @@ mod test {
 
     #[test]
     fn test_well_formed_attributes_holocene_valid() {
-        let validator =
-            OpEngineValidator::new::<KeccakKeyHasher>(get_chainspec(), NoopProvider::default());
+        let validator = OpEngineValidator::new::<KeccakKeyHasher>(
+            BASE_SEPOLIA.clone(),
+            NoopProvider::default(),
+        );
         let attributes = get_attributes(Some(b64!("0000000800000008")), None, 1732633200);
 
         let result = <engine::OpEngineValidator<_, _, _> as EngineApiValidator<
@@ -434,8 +425,10 @@ mod test {
 
     #[test]
     fn test_well_formed_attributes_holocene_valid_all_zero() {
-        let validator =
-            OpEngineValidator::new::<KeccakKeyHasher>(get_chainspec(), NoopProvider::default());
+        let validator = OpEngineValidator::new::<KeccakKeyHasher>(
+            BASE_SEPOLIA.clone(),
+            NoopProvider::default(),
+        );
         let attributes = get_attributes(Some(b64!("0000000000000000")), None, 1732633200);
 
         let result = <engine::OpEngineValidator<_, _, _> as EngineApiValidator<
@@ -448,8 +441,10 @@ mod test {
 
     #[test]
     fn test_well_formed_attributes_jovian_valid() {
-        let validator =
-            OpEngineValidator::new::<KeccakKeyHasher>(get_chainspec(), NoopProvider::default());
+        let validator = OpEngineValidator::new::<KeccakKeyHasher>(
+            BASE_SEPOLIA.clone(),
+            NoopProvider::default(),
+        );
         let attributes =
             get_attributes(Some(b64!("0000000000000000")), Some(1), BASE_SEPOLIA_JOVIAN_TIMESTAMP);
 
@@ -464,8 +459,10 @@ mod test {
     /// After Jovian (and holocene), eip1559 params must be Some
     #[test]
     fn test_malformed_attributes_jovian_with_eip_1559_params_none() {
-        let validator =
-            OpEngineValidator::new::<KeccakKeyHasher>(get_chainspec(), NoopProvider::default());
+        let validator = OpEngineValidator::new::<KeccakKeyHasher>(
+            BASE_SEPOLIA.clone(),
+            NoopProvider::default(),
+        );
         let attributes = get_attributes(None, Some(1), BASE_SEPOLIA_JOVIAN_TIMESTAMP);
 
         let result = <engine::OpEngineValidator<_, _, _> as EngineApiValidator<
@@ -479,8 +476,10 @@ mod test {
     /// Before Jovian, min base fee must be None
     #[test]
     fn test_malformed_attributes_pre_jovian_with_min_base_fee() {
-        let validator =
-            OpEngineValidator::new::<KeccakKeyHasher>(get_chainspec(), NoopProvider::default());
+        let validator = OpEngineValidator::new::<KeccakKeyHasher>(
+            BASE_SEPOLIA.clone(),
+            NoopProvider::default(),
+        );
         let attributes = get_attributes(Some(b64!("0000000000000000")), Some(1), 1732633200);
 
         let result = <engine::OpEngineValidator<_, _, _> as EngineApiValidator<
@@ -494,8 +493,10 @@ mod test {
     /// After Jovian, min base fee must be Some
     #[test]
     fn test_malformed_attributes_post_jovian_with_min_base_fee_none() {
-        let validator =
-            OpEngineValidator::new::<KeccakKeyHasher>(get_chainspec(), NoopProvider::default());
+        let validator = OpEngineValidator::new::<KeccakKeyHasher>(
+            BASE_SEPOLIA.clone(),
+            NoopProvider::default(),
+        );
         let attributes =
             get_attributes(Some(b64!("0000000000000000")), None, BASE_SEPOLIA_JOVIAN_TIMESTAMP);
 

--- a/crates/optimism/reth/Cargo.toml
+++ b/crates/optimism/reth/Cargo.toml
@@ -77,6 +77,7 @@ arbitrary = [
 keccak-cache-global = [
     "reth-optimism-node?/keccak-cache-global",
     "reth-node-core?/keccak-cache-global",
+    "reth-optimism-cli?/keccak-cache-global",
 ]
 test-utils = [
     "reth-chainspec/test-utils",

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -158,12 +158,12 @@ where
                 .ok_or_else(|| PayloadBuilderError::MissingParentHeader(attributes.parent()))?
         };
 
-        let config = PayloadConfig::new(Arc::new(parent_header.clone()), attributes);
+        let cached_reads = self.maybe_pre_cached(parent_header.hash());
+
+        let config = PayloadConfig::new(Arc::new(parent_header), attributes);
 
         let until = self.job_deadline(config.attributes.timestamp());
         let deadline = Box::pin(tokio::time::sleep_until(until));
-
-        let cached_reads = self.maybe_pre_cached(parent_header.hash());
 
         let mut job = BasicPayloadJob {
             config,

--- a/crates/primitives-traits/src/block/sealed.rs
+++ b/crates/primitives-traits/src/block/sealed.rs
@@ -282,6 +282,13 @@ where
     }
 }
 
+impl<B: Block> From<Sealed<B>> for SealedBlock<B> {
+    fn from(sealed: Sealed<B>) -> Self {
+        let (block, hash) = sealed.into_parts();
+        Self::new_unchecked(block, hash)
+    }
+}
+
 impl<B> Default for SealedBlock<B>
 where
     B: Block + Default,

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -17,7 +17,7 @@ pub type BlockBody<T = TransactionSigned, H = Header> = alloy_consensus::BlockBo
 pub type SealedBlock<B = Block> = reth_primitives_traits::block::SealedBlock<B>;
 
 /// Helper type for constructing the block
-#[deprecated(note = "Use `RecoveredBlock` instead")]
+#[deprecated(note = "Use `SealedBlock` instead")]
 pub type SealedBlockFor<B = Block> = reth_primitives_traits::block::SealedBlock<B>;
 
 /// Ethereum recovered block

--- a/crates/prune/types/src/mode.rs
+++ b/crates/prune/types/src/mode.rs
@@ -42,15 +42,15 @@ impl PruneMode {
         purpose: PrunePurpose,
     ) -> Result<Option<(BlockNumber, Self)>, PruneSegmentError> {
         let result = match self {
-            Self::Full if segment.min_blocks(purpose) == 0 => Some((tip, *self)),
+            Self::Full if segment.min_blocks() == 0 => Some((tip, *self)),
             Self::Distance(distance) if *distance > tip => None, // Nothing to prune yet
-            Self::Distance(distance) if *distance >= segment.min_blocks(purpose) => {
+            Self::Distance(distance) if *distance >= segment.min_blocks() => {
                 Some((tip - distance, *self))
             }
             Self::Before(n) if *n == tip + 1 && purpose.is_static_file() => Some((tip, *self)),
             Self::Before(n) if *n > tip => None, // Nothing to prune yet
             Self::Before(n) => {
-                (tip - n >= segment.min_blocks(purpose)).then(|| ((*n).saturating_sub(1), *self))
+                (tip - n >= segment.min_blocks()).then(|| ((*n).saturating_sub(1), *self))
             }
             _ => return Err(PruneSegmentError::Configuration(segment)),
         };
@@ -93,7 +93,7 @@ mod tests {
     #[test]
     fn test_prune_target_block() {
         let tip = 20000;
-        let segment = PruneSegment::Receipts;
+        let segment = PruneSegment::AccountHistory;
 
         let tests = vec![
             // MINIMUM_PRUNING_DISTANCE makes this impossible
@@ -101,8 +101,8 @@ mod tests {
             // Nothing to prune
             (PruneMode::Distance(tip + 1), Ok(None)),
             (
-                PruneMode::Distance(segment.min_blocks(PrunePurpose::User) + 1),
-                Ok(Some(tip - (segment.min_blocks(PrunePurpose::User) + 1))),
+                PruneMode::Distance(segment.min_blocks() + 1),
+                Ok(Some(tip - (segment.min_blocks() + 1))),
             ),
             // Nothing to prune
             (PruneMode::Before(tip + 1), Ok(None)),

--- a/crates/prune/types/src/segment.rs
+++ b/crates/prune/types/src/segment.rs
@@ -61,15 +61,12 @@ impl PruneSegment {
     }
 
     /// Returns minimum number of blocks to keep in the database for this segment.
-    pub const fn min_blocks(&self, purpose: PrunePurpose) -> u64 {
+    pub const fn min_blocks(&self) -> u64 {
         match self {
-            Self::SenderRecovery | Self::TransactionLookup => 0,
-            Self::Receipts if purpose.is_static_file() => 0,
-            Self::ContractLogs |
-            Self::AccountHistory |
-            Self::StorageHistory |
-            Self::Bodies |
-            Self::Receipts => MINIMUM_PRUNING_DISTANCE,
+            Self::SenderRecovery | Self::TransactionLookup | Self::Receipts | Self::Bodies => 0,
+            Self::ContractLogs | Self::AccountHistory | Self::StorageHistory => {
+                MINIMUM_PRUNING_DISTANCE
+            }
             Self::MerkleChangeSets => MERKLE_CHANGESETS_RETENTION_BLOCKS,
             #[expect(deprecated)]
             #[expect(clippy::match_same_arms)]

--- a/crates/prune/types/src/target.rs
+++ b/crates/prune/types/src/target.rs
@@ -188,7 +188,7 @@ impl PruneModes {
             if let Some(PruneMode::Distance(limit)) = prune_mode {
                 // check if distance exceeds the configured limit
                 if distance > *limit {
-                    // but only if have haven't pruned the target yet, if we dont have a checkpoint
+                    // but only if we haven't pruned the target yet, if we don't have a checkpoint
                     // yet, it's fully unpruned yet
                     let pruned_height = checkpoint
                         .and_then(|checkpoint| checkpoint.1.block_number)

--- a/crates/prune/types/src/target.rs
+++ b/crates/prune/types/src/target.rs
@@ -58,13 +58,7 @@ pub struct PruneModes {
     pub transaction_lookup: Option<PruneMode>,
     /// Receipts pruning configuration. This setting overrides `receipts_log_filter`
     /// and offers improved performance.
-    #[cfg_attr(
-        any(test, feature = "serde"),
-        serde(
-            skip_serializing_if = "Option::is_none",
-            deserialize_with = "deserialize_opt_prune_mode_with_min_blocks::<MINIMUM_PRUNING_DISTANCE, _>"
-        )
-    )]
+    #[cfg_attr(any(test, feature = "serde"), serde(skip_serializing_if = "Option::is_none",))]
     pub receipts: Option<PruneMode>,
     /// Account History pruning configuration.
     #[cfg_attr(
@@ -85,13 +79,7 @@ pub struct PruneModes {
     )]
     pub storage_history: Option<PruneMode>,
     /// Bodies History pruning configuration.
-    #[cfg_attr(
-        any(test, feature = "serde"),
-        serde(
-            skip_serializing_if = "Option::is_none",
-            deserialize_with = "deserialize_opt_prune_mode_with_min_blocks::<MINIMUM_PRUNING_DISTANCE, _>"
-        )
-    )]
+    #[cfg_attr(any(test, feature = "serde"), serde(skip_serializing_if = "Option::is_none",))]
     pub bodies_history: Option<PruneMode>,
     /// Merkle Changesets pruning configuration for `AccountsTrieChangeSets` and
     /// `StoragesTrieChangeSets`.

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -1663,7 +1663,7 @@ impl TransportRpcModules {
         self
     }
 
-    /// Sets the [`RpcModule`] for the http transport.
+    /// Sets the [`RpcModule`] for the ipc transport.
     /// This will overwrite current module, if any.
     pub fn with_ipc(mut self, ipc: RpcModule<()>) -> Self {
         self.ipc = Some(ipc);

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -1525,7 +1525,7 @@ impl TransportRpcModuleConfig {
         self
     }
 
-    /// Sets the [`RpcModuleSelection`] for the http transport.
+    /// Sets the [`RpcModuleSelection`] for the ipc transport.
     pub fn with_ipc(mut self, ipc: impl Into<RpcModuleSelection>) -> Self {
         self.ipc = Some(ipc.into());
         self

--- a/crates/rpc/rpc-eth-api/src/helpers/fee.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/fee.rs
@@ -13,7 +13,9 @@ use reth_rpc_eth_types::{
     fee_history::calculate_reward_percentiles_for_block, utils::checked_blob_gas_used_ratio,
     EthApiError, FeeHistoryCache, FeeHistoryEntry, GasPriceOracle, RpcInvalidTransactionError,
 };
-use reth_storage_api::{BlockIdReader, BlockReaderIdExt, HeaderProvider, ProviderHeader};
+use reth_storage_api::{
+    BlockIdReader, BlockNumReader, BlockReaderIdExt, HeaderProvider, ProviderHeader,
+};
 use tracing::debug;
 
 /// Fee related functions for the [`EthApiServer`](crate::EthApiServer) trait in the
@@ -90,6 +92,17 @@ pub trait EthFees:
             if newest_block.is_pending() {
                 // cap the target block since we don't have fee history for the pending block
                 newest_block = BlockNumberOrTag::Latest;
+            }
+
+            // For explicit block numbers, validate against chain head before resolution
+            if let BlockNumberOrTag::Number(requested) = newest_block {
+                let latest_block =
+                    self.provider().best_block_number().map_err(Self::Error::from_eth_err)?;
+                if requested > latest_block {
+                    return Err(
+                        EthApiError::RequestBeyondHead { requested, head: latest_block }.into()
+                    )
+                }
             }
 
             let end_block = self

--- a/crates/rpc/rpc-eth-types/Cargo.toml
+++ b/crates/rpc/rpc-eth-types/Cargo.toml
@@ -56,6 +56,7 @@ metrics.workspace = true
 
 # misc
 serde = { workspace = true, features = ["derive"] }
+url = { workspace = true, features = ["serde"] }
 thiserror.workspace = true
 derive_more.workspace = true
 schnellru.workspace = true

--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -92,6 +92,14 @@ pub enum EthApiError {
     /// When an invalid block range is provided
     #[error("invalid block range")]
     InvalidBlockRange,
+    /// Requested block number is beyond the head block
+    #[error("request beyond head block: requested {requested}, head {head}")]
+    RequestBeyondHead {
+        /// The requested block number
+        requested: u64,
+        /// The current head block number
+        head: u64,
+    },
     /// Thrown when the target block for proof computation exceeds the maximum configured window.
     #[error("distance to target block exceeds maximum proof window")]
     ExceedsMaxProofWindow,
@@ -268,6 +276,7 @@ impl From<EthApiError> for jsonrpsee_types::error::ErrorObject<'static> {
             EthApiError::InvalidTransactionSignature |
             EthApiError::EmptyRawTransactionData |
             EthApiError::InvalidBlockRange |
+            EthApiError::RequestBeyondHead { .. } |
             EthApiError::ExceedsMaxProofWindow |
             EthApiError::ConflictingFeeFieldsInRequest |
             EthApiError::Signing(_) |

--- a/crates/rpc/rpc-eth-types/src/lib.rs
+++ b/crates/rpc/rpc-eth-types/src/lib.rs
@@ -8,6 +8,9 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
+// `url` is needed for serde support on `reqwest::Url`
+use url as _;
+
 pub mod block;
 pub mod builder;
 pub mod cache;

--- a/crates/rpc/rpc/src/eth/helpers/transaction.rs
+++ b/crates/rpc/rpc/src/eth/helpers/transaction.rs
@@ -134,7 +134,9 @@ where
 mod tests {
     use super::*;
     use crate::eth::helpers::types::EthRpcConverter;
-    use alloy_consensus::{Block, Header, SidecarBuilder, SimpleCoder, Transaction};
+    use alloy_consensus::{
+        BlobTransactionSidecar, Block, Header, SidecarBuilder, SimpleCoder, Transaction,
+    };
     use alloy_primitives::{Address, U256};
     use alloy_rpc_types_eth::request::TransactionRequest;
     use reth_chainspec::{ChainSpec, ChainSpecBuilder};
@@ -332,7 +334,9 @@ mod tests {
         let tx_req = TransactionRequest {
             from: Some(address),
             to: Some(Address::random().into()),
-            sidecar: Some(builder.build().unwrap().into()),
+            sidecar: Some(BlobTransactionSidecarVariant::from(
+                builder.build::<BlobTransactionSidecar>().unwrap(),
+            )),
             ..Default::default()
         };
 
@@ -370,7 +374,9 @@ mod tests {
             from: Some(address),
             to: Some(Address::random().into()),
             transaction_type: Some(3), // EIP-4844
-            sidecar: Some(builder.build().unwrap().into()),
+            sidecar: Some(BlobTransactionSidecarVariant::from(
+                builder.build::<BlobTransactionSidecar>().unwrap(),
+            )),
             max_fee_per_blob_gas: Some(provided_blob_fee), // Already set
             ..Default::default()
         };

--- a/crates/rpc/rpc/src/miner.rs
+++ b/crates/rpc/rpc/src/miner.rs
@@ -19,7 +19,7 @@ impl MinerApiServer for MinerApi {
         Ok(false)
     }
 
-    fn set_gas_limit(&self, _gas_price: U128) -> RpcResult<bool> {
+    fn set_gas_limit(&self, _gas_limit: U128) -> RpcResult<bool> {
         Ok(false)
     }
 }

--- a/crates/stages/api/src/error.rs
+++ b/crates/stages/api/src/error.rs
@@ -91,7 +91,7 @@ pub enum StageError {
     /// Database is ahead of static file data.
     #[error("missing static file data for block number: {number}", number = block.block.number)]
     MissingStaticFileData {
-        /// Starting block with  missing data.
+        /// Starting block with missing data.
         block: Box<BlockWithParent>,
         /// Static File segment
         segment: StaticFileSegment,

--- a/crates/stages/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/stages/src/stages/sender_recovery.rs
@@ -7,7 +7,7 @@ use reth_db_api::{
     table::Value,
     tables,
     transaction::{DbTx, DbTxMut},
-    DbTxUnwindExt, RawValue,
+    RawValue,
 };
 use reth_primitives_traits::{GotExpected, NodePrimitives, SignedTransaction};
 use reth_provider::{
@@ -158,12 +158,13 @@ where
     ) -> Result<UnwindOutput, StageError> {
         let (_, unwind_to, _) = input.unwind_block_range_with_threshold(self.commit_threshold);
 
-        // Lookup latest tx id that we should unwind to
-        let latest_tx_id = provider
+        // Lookup the next tx id after unwind_to block (first tx to remove)
+        let unwind_tx_from = provider
             .block_body_indices(unwind_to)?
             .ok_or(ProviderError::BlockBodyIndicesNotFound(unwind_to))?
-            .last_tx_num();
-        provider.tx_ref().unwind_table_by_num::<tables::TransactionSenders>(latest_tx_id)?;
+            .next_tx_num();
+
+        EitherWriter::new_senders(provider, unwind_to)?.prune_senders(unwind_tx_from, unwind_to)?;
 
         Ok(UnwindOutput {
             checkpoint: StageCheckpoint::new(unwind_to)

--- a/crates/static-file/types/Cargo.toml
+++ b/crates/static-file/types/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 alloy-primitives.workspace = true
 
 clap = { workspace = true, features = ["derive"], optional = true }
+fixed-map.workspace = true
 derive_more.workspace = true
 serde = { workspace = true, features = ["alloc", "derive"] }
 strum = { workspace = true, features = ["derive"] }
@@ -32,5 +33,6 @@ std = [
     "serde/std",
     "strum/std",
     "serde_json/std",
+    "fixed-map/std",
 ]
 clap = ["dep:clap"]

--- a/crates/static-file/types/src/lib.rs
+++ b/crates/static-file/types/src/lib.rs
@@ -21,6 +21,9 @@ use core::ops::RangeInclusive;
 pub use event::StaticFileProducerEvent;
 pub use segment::{SegmentConfig, SegmentHeader, SegmentRangeInclusive, StaticFileSegment};
 
+/// Map keyed by [`StaticFileSegment`].
+pub type StaticFileMap<T> = alloc::boxed::Box<fixed_map::Map<StaticFileSegment, T>>;
+
 /// Default static file block count.
 pub const DEFAULT_BLOCKS_PER_STATIC_FILE: u64 = 500_000;
 

--- a/crates/static-file/types/src/segment.rs
+++ b/crates/static-file/types/src/segment.rs
@@ -22,6 +22,7 @@ use strum::{EnumIs, EnumString};
     EnumIs,
     Serialize,
     Deserialize,
+    fixed_map::Key,
 )]
 #[strum(serialize_all = "kebab-case")]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]

--- a/crates/storage/db-api/src/mock.rs
+++ b/crates/storage/db-api/src/mock.rs
@@ -92,10 +92,10 @@ impl DbTx for TxMock {
 
     /// Commits the transaction.
     ///
-    /// **Mock behavior**: Always returns `Ok(true)`, indicating successful commit.
+    /// **Mock behavior**: Always returns `Ok(())`, indicating successful commit.
     /// No actual data is persisted since this is a mock implementation.
-    fn commit(self) -> Result<bool, DatabaseError> {
-        Ok(true)
+    fn commit(self) -> Result<(), DatabaseError> {
+        Ok(())
     }
 
     /// Aborts the transaction.

--- a/crates/storage/db-api/src/transaction.rs
+++ b/crates/storage/db-api/src/transaction.rs
@@ -35,7 +35,7 @@ pub trait DbTx: Debug + Send {
     ) -> Result<Option<T::Value>, DatabaseError>;
     /// Commit for read only transaction will consume and free transaction and allows
     /// freeing of memory pages
-    fn commit(self) -> Result<bool, DatabaseError>;
+    fn commit(self) -> Result<(), DatabaseError>;
     /// Aborts transaction
     fn abort(self);
     /// Iterate over read only values in table.

--- a/crates/storage/db/benches/hash_keys.rs
+++ b/crates/storage/db/benches/hash_keys.rs
@@ -248,7 +248,7 @@ where
         println!(
             "{:?}\n",
             tx.inner
-                .db_stat(&table_db)
+                .db_stat(table_db.dbi())
                 .map_err(|_| format!("Could not find table: {}", T::NAME))
                 .map(|stats| {
                     let num_pages =

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -278,7 +278,7 @@ impl DatabaseMetrics for DatabaseEnv {
 
                     let stats = tx
                         .inner
-                        .db_stat(&table_db)
+                        .db_stat(table_db.dbi())
                         .wrap_err(format!("Could not find table: {table}"))?;
 
                     let page_size = stats.page_size() as usize;

--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -302,10 +302,10 @@ impl<K: TransactionKind> DbTx for Tx<K> {
         })
     }
 
-    fn commit(self) -> Result<bool, DatabaseError> {
+    fn commit(self) -> Result<(), DatabaseError> {
         self.execute_with_close_transaction_metric(TransactionOutcome::Commit, |this| {
             match this.inner.commit().map_err(|e| DatabaseError::Commit(e.into())) {
-                Ok((v, latency)) => (Ok(v), Some(latency)),
+                Ok(latency) => (Ok(()), Some(latency)),
                 Err(e) => (Err(e), None),
             }
         })

--- a/crates/storage/db/src/static_file/mod.rs
+++ b/crates/storage/db/src/static_file/mod.rs
@@ -1,6 +1,9 @@
 //! reth's static file database table import and access
 
-use alloy_primitives::map::HashMap;
+use reth_nippy_jar::{NippyJar, NippyJarError};
+use reth_static_file_types::{
+    SegmentHeader, SegmentRangeInclusive, StaticFileMap, StaticFileSegment,
+};
 use std::path::Path;
 
 mod cursor;
@@ -8,14 +11,12 @@ pub use cursor::StaticFileCursor;
 
 mod mask;
 pub use mask::*;
-use reth_nippy_jar::{NippyJar, NippyJarError};
 
 mod masks;
 pub use masks::*;
-use reth_static_file_types::{SegmentHeader, SegmentRangeInclusive, StaticFileSegment};
 
 /// Alias type for a map of [`StaticFileSegment`] and sorted lists of existing static file ranges.
-type SortedStaticFiles = HashMap<StaticFileSegment, Vec<(SegmentRangeInclusive, SegmentHeader)>>;
+type SortedStaticFiles = StaticFileMap<Vec<(SegmentRangeInclusive, SegmentHeader)>>;
 
 /// Given the `static_files` directory path, it returns a list over the existing `static_files`
 /// organized by [`StaticFileSegment`]. Each segment has a sorted list of block ranges and

--- a/crates/storage/db/src/static_file/mod.rs
+++ b/crates/storage/db/src/static_file/mod.rs
@@ -1,6 +1,7 @@
 //! reth's static file database table import and access
 
-use std::{collections::HashMap, path::Path};
+use alloy_primitives::map::HashMap;
+use std::path::Path;
 
 mod cursor;
 pub use cursor::StaticFileCursor;
@@ -44,8 +45,8 @@ pub fn iter_static_files(path: &Path) -> Result<SortedStaticFiles, NippyJarError
         }
     }
 
+    // Sort by block end range.
     for range_list in static_files.values_mut() {
-        // Sort by block end range.
         range_list.sort_by_key(|(block_range, _)| block_range.end());
     }
 

--- a/crates/storage/errors/src/db.rs
+++ b/crates/storage/errors/src/db.rs
@@ -32,7 +32,7 @@ pub enum DatabaseError {
     /// Failed to commit transaction changes into the database.
     #[error("failed to commit transaction changes: {_0}")]
     Commit(DatabaseErrorInfo),
-    /// Failed to initiate a transaction.
+    /// Failed to initialize a transaction.
     #[error("failed to initialize a transaction: {_0}")]
     InitTx(DatabaseErrorInfo),
     /// Failed to initialize a cursor.

--- a/crates/storage/errors/src/provider.rs
+++ b/crates/storage/errors/src/provider.rs
@@ -20,6 +20,9 @@ pub enum ProviderError {
     /// Pruning error.
     #[error(transparent)]
     Pruning(#[from] PruneSegmentError),
+    /// Static file writer error.
+    #[error(transparent)]
+    StaticFileWriter(#[from] StaticFileWriterError),
     /// RLP error.
     #[error("{_0}")]
     Rlp(alloy_rlp::Error),
@@ -216,18 +219,21 @@ pub struct RootMismatch {
     pub block_hash: BlockHash,
 }
 
-/// A Static File Write Error.
-#[derive(Debug, thiserror::Error)]
-#[error("{message}")]
-pub struct StaticFileWriterError {
-    /// The error message.
-    pub message: String,
+/// A Static File Writer Error.
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum StaticFileWriterError {
+    /// Cannot call `sync_all` or `finalize` when prune is queued.
+    #[error("cannot call sync_all or finalize when prune is queued, use commit() instead")]
+    FinalizeWithPruneQueued,
+    /// Other error with message.
+    #[error("{0}")]
+    Other(String),
 }
 
 impl StaticFileWriterError {
-    /// Creates a new [`StaticFileWriterError`] with the given message.
+    /// Creates a new [`StaticFileWriterError::Other`] with the given message.
     pub fn new(message: impl Into<String>) -> Self {
-        Self { message: message.into() }
+        Self::Other(message.into())
     }
 }
 /// Consistent database view error.

--- a/crates/storage/errors/src/provider.rs
+++ b/crates/storage/errors/src/provider.rs
@@ -183,7 +183,7 @@ impl ProviderError {
         other.downcast_ref()
     }
 
-    /// Returns true if the this type is a [`ProviderError::Other`] of that error
+    /// Returns true if this type is a [`ProviderError::Other`] of that error
     /// type. Returns false otherwise.
     pub fn is_other<T: core::error::Error + 'static>(&self) -> bool {
         self.as_other().map(|err| err.is::<T>()).unwrap_or(false)

--- a/crates/storage/libmdbx-rs/benches/cursor.rs
+++ b/crates/storage/libmdbx-rs/benches/cursor.rs
@@ -12,10 +12,10 @@ fn bench_get_seq_iter(c: &mut Criterion) {
     let (_dir, env) = setup_bench_db(n);
     let txn = env.begin_ro_txn().unwrap();
     let db = txn.open_db(None).unwrap();
-
+    let dbi = db.dbi();
     c.bench_function("bench_get_seq_iter", |b| {
         b.iter(|| {
-            let mut cursor = txn.cursor(&db).unwrap();
+            let mut cursor = txn.cursor(dbi).unwrap();
             let mut i = 0;
             let mut count = 0u32;
 
@@ -54,11 +54,11 @@ fn bench_get_seq_cursor(c: &mut Criterion) {
     let (_dir, env) = setup_bench_db(n);
     let txn = env.begin_ro_txn().unwrap();
     let db = txn.open_db(None).unwrap();
-
+    let dbi = db.dbi();
     c.bench_function("bench_get_seq_cursor", |b| {
         b.iter(|| {
             let (i, count) = txn
-                .cursor(&db)
+                .cursor(dbi)
                 .unwrap()
                 .iter::<ObjectLength, ObjectLength>()
                 .map(Result::unwrap)

--- a/crates/storage/libmdbx-rs/src/codec.rs
+++ b/crates/storage/libmdbx-rs/src/codec.rs
@@ -42,7 +42,9 @@ impl TableObject for Cow<'_, [u8]> {
         #[cfg(not(feature = "return-borrowed"))]
         {
             let is_dirty = (!K::IS_READ_ONLY) &&
-                crate::error::mdbx_result(ffi::mdbx_is_dirty(_txn, data_val.iov_base))?;
+                crate::error::mdbx_result(unsafe {
+                    ffi::mdbx_is_dirty(_txn, data_val.iov_base)
+                })?;
 
             Ok(if is_dirty { Cow::Owned(s.to_vec()) } else { Cow::Borrowed(s) })
         }

--- a/crates/storage/libmdbx-rs/src/environment.rs
+++ b/crates/storage/libmdbx-rs/src/environment.rs
@@ -989,7 +989,10 @@ mod tests {
                     result @ Err(_) => result.unwrap(),
                 }
             }
-            tx.commit().unwrap();
+            // The transaction may be in an error state after hitting MapFull,
+            // so commit could fail. We don't care about the result here since
+            // the purpose of this test is to verify the HSR callback was called.
+            let _ = tx.commit();
         }
 
         // Expect the HSR to be called

--- a/crates/storage/libmdbx-rs/src/environment.rs
+++ b/crates/storage/libmdbx-rs/src/environment.rs
@@ -211,7 +211,7 @@ impl Environment {
         let mut freelist: usize = 0;
         let txn = self.begin_ro_txn()?;
         let db = Database::freelist_db();
-        let cursor = txn.cursor(&db)?;
+        let cursor = txn.cursor(db.dbi())?;
 
         for result in cursor.iter_slices() {
             let (_key, value) = result?;

--- a/crates/storage/libmdbx-rs/src/environment.rs
+++ b/crates/storage/libmdbx-rs/src/environment.rs
@@ -215,11 +215,10 @@ impl Environment {
 
         for result in cursor.iter_slices() {
             let (_key, value) = result?;
-            if value.len() < size_of::<usize>() {
+            if value.len() < size_of::<u32>() {
                 return Err(Error::Corrupted)
             }
-
-            let s = &value[..size_of::<usize>()];
+            let s = &value[..size_of::<u32>()];
             freelist += NativeEndian::read_u32(s) as usize;
         }
 

--- a/crates/storage/libmdbx-rs/tests/cursor.rs
+++ b/crates/storage/libmdbx-rs/tests/cursor.rs
@@ -111,7 +111,7 @@ fn test_iter() {
         for (key, data) in &items {
             txn.put(db.dbi(), key, data, WriteFlags::empty()).unwrap();
         }
-        assert!(!txn.commit().unwrap().0);
+        txn.commit().unwrap();
     }
 
     let txn = env.begin_ro_txn().unwrap();

--- a/crates/storage/libmdbx-rs/tests/transaction.rs
+++ b/crates/storage/libmdbx-rs/tests/transaction.rs
@@ -148,13 +148,13 @@ fn test_clear_db() {
     {
         let txn = env.begin_rw_txn().unwrap();
         txn.put(txn.open_db(None).unwrap().dbi(), b"key", b"val", WriteFlags::empty()).unwrap();
-        assert!(!txn.commit().unwrap().0);
+        txn.commit().unwrap();
     }
 
     {
         let txn = env.begin_rw_txn().unwrap();
         txn.clear_db(txn.open_db(None).unwrap().dbi()).unwrap();
-        assert!(!txn.commit().unwrap().0);
+        txn.commit().unwrap();
     }
 
     let txn = env.begin_ro_txn().unwrap();
@@ -178,7 +178,7 @@ fn test_drop_db() {
             .unwrap();
             // Workaround for MDBX dbi drop issue
             txn.create_db(Some("canary"), DatabaseFlags::empty()).unwrap();
-            assert!(!txn.commit().unwrap().0);
+            txn.commit().unwrap();
         }
         {
             let txn = env.begin_rw_txn().unwrap();
@@ -187,7 +187,7 @@ fn test_drop_db() {
                 txn.drop_db(dbi).unwrap();
             }
             assert!(matches!(txn.open_db(Some("test")).unwrap_err(), Error::NotFound));
-            assert!(!txn.commit().unwrap().0);
+            txn.commit().unwrap();
         }
     }
 

--- a/crates/storage/libmdbx-rs/tests/transaction.rs
+++ b/crates/storage/libmdbx-rs/tests/transaction.rs
@@ -50,9 +50,9 @@ fn test_put_get_del_multi() {
     txn.commit().unwrap();
 
     let txn = env.begin_rw_txn().unwrap();
-    let db = txn.open_db(None).unwrap();
+    let dbi = txn.open_db(None).unwrap().dbi();
     {
-        let mut cur = txn.cursor(&db).unwrap();
+        let mut cur = txn.cursor(dbi).unwrap();
         let iter = cur.iter_dup_of::<(), [u8; 4]>(b"key1");
         let vals = iter.map(|x| x.unwrap()).map(|(_, x)| x).collect::<Vec<_>>();
         assert_eq!(vals, vec![*b"val1", *b"val2", *b"val3"]);
@@ -66,9 +66,9 @@ fn test_put_get_del_multi() {
     txn.commit().unwrap();
 
     let txn = env.begin_rw_txn().unwrap();
-    let db = txn.open_db(None).unwrap();
+    let dbi = txn.open_db(None).unwrap().dbi();
     {
-        let mut cur = txn.cursor(&db).unwrap();
+        let mut cur = txn.cursor(dbi).unwrap();
         let iter = cur.iter_dup_of::<(), [u8; 4]>(b"key1");
         let vals = iter.map(|x| x.unwrap()).map(|(_, x)| x).collect::<Vec<_>>();
         assert_eq!(vals, vec![*b"val1", *b"val3"]);
@@ -103,9 +103,9 @@ fn test_reserve() {
     let env = Environment::builder().open(dir.path()).unwrap();
 
     let txn = env.begin_rw_txn().unwrap();
-    let db = txn.open_db(None).unwrap();
+    let dbi = txn.open_db(None).unwrap().dbi();
     {
-        let mut writer = txn.reserve(&db, b"key1", 4, WriteFlags::empty()).unwrap();
+        let mut writer = txn.reserve(dbi, b"key1", 4, WriteFlags::empty()).unwrap();
         writer.write_all(b"val1").unwrap();
     }
     txn.commit().unwrap();
@@ -182,9 +182,9 @@ fn test_drop_db() {
         }
         {
             let txn = env.begin_rw_txn().unwrap();
-            let db = txn.open_db(Some("test")).unwrap();
+            let dbi = txn.open_db(Some("test")).unwrap().dbi();
             unsafe {
-                txn.drop_db(db).unwrap();
+                txn.drop_db(dbi).unwrap();
             }
             assert!(matches!(txn.open_db(Some("test")).unwrap_err(), Error::NotFound));
             assert!(!txn.commit().unwrap().0);
@@ -291,8 +291,8 @@ fn test_stat() {
 
     {
         let txn = env.begin_ro_txn().unwrap();
-        let db = txn.open_db(None).unwrap();
-        let stat = txn.db_stat(&db).unwrap();
+        let dbi = txn.open_db(None).unwrap().dbi();
+        let stat = txn.db_stat(dbi).unwrap();
         assert_eq!(stat.entries(), 3);
     }
 
@@ -304,8 +304,8 @@ fn test_stat() {
 
     {
         let txn = env.begin_ro_txn().unwrap();
-        let db = txn.open_db(None).unwrap();
-        let stat = txn.db_stat(&db).unwrap();
+        let dbi = txn.open_db(None).unwrap().dbi();
+        let stat = txn.db_stat(dbi).unwrap();
         assert_eq!(stat.entries(), 1);
     }
 
@@ -318,8 +318,8 @@ fn test_stat() {
 
     {
         let txn = env.begin_ro_txn().unwrap();
-        let db = txn.open_db(None).unwrap();
-        let stat = txn.db_stat(&db).unwrap();
+        let dbi = txn.open_db(None).unwrap().dbi();
+        let stat = txn.db_stat(dbi).unwrap();
         assert_eq!(stat.entries(), 4);
     }
 }
@@ -331,20 +331,22 @@ fn test_stat_dupsort() {
 
     let txn = env.begin_rw_txn().unwrap();
     let db = txn.create_db(None, DatabaseFlags::DUP_SORT).unwrap();
-    txn.put(db.dbi(), b"key1", b"val1", WriteFlags::empty()).unwrap();
-    txn.put(db.dbi(), b"key1", b"val2", WriteFlags::empty()).unwrap();
-    txn.put(db.dbi(), b"key1", b"val3", WriteFlags::empty()).unwrap();
-    txn.put(db.dbi(), b"key2", b"val1", WriteFlags::empty()).unwrap();
-    txn.put(db.dbi(), b"key2", b"val2", WriteFlags::empty()).unwrap();
-    txn.put(db.dbi(), b"key2", b"val3", WriteFlags::empty()).unwrap();
-    txn.put(db.dbi(), b"key3", b"val1", WriteFlags::empty()).unwrap();
-    txn.put(db.dbi(), b"key3", b"val2", WriteFlags::empty()).unwrap();
-    txn.put(db.dbi(), b"key3", b"val3", WriteFlags::empty()).unwrap();
+    let dbi = db.dbi();
+    txn.put(dbi, b"key1", b"val1", WriteFlags::empty()).unwrap();
+    txn.put(dbi, b"key1", b"val2", WriteFlags::empty()).unwrap();
+    txn.put(dbi, b"key1", b"val3", WriteFlags::empty()).unwrap();
+    txn.put(dbi, b"key2", b"val1", WriteFlags::empty()).unwrap();
+    txn.put(dbi, b"key2", b"val2", WriteFlags::empty()).unwrap();
+    txn.put(dbi, b"key2", b"val3", WriteFlags::empty()).unwrap();
+    txn.put(dbi, b"key3", b"val1", WriteFlags::empty()).unwrap();
+    txn.put(dbi, b"key3", b"val2", WriteFlags::empty()).unwrap();
+    txn.put(dbi, b"key3", b"val3", WriteFlags::empty()).unwrap();
     txn.commit().unwrap();
 
     {
         let txn = env.begin_ro_txn().unwrap();
-        let stat = txn.db_stat(&txn.open_db(None).unwrap()).unwrap();
+        let dbi = txn.open_db(None).unwrap().dbi();
+        let stat = txn.db_stat(dbi).unwrap();
         assert_eq!(stat.entries(), 9);
     }
 
@@ -356,7 +358,8 @@ fn test_stat_dupsort() {
 
     {
         let txn = env.begin_ro_txn().unwrap();
-        let stat = txn.db_stat(&txn.open_db(None).unwrap()).unwrap();
+        let dbi = txn.open_db(None).unwrap().dbi();
+        let stat = txn.db_stat(dbi).unwrap();
         assert_eq!(stat.entries(), 5);
     }
 
@@ -369,7 +372,8 @@ fn test_stat_dupsort() {
 
     {
         let txn = env.begin_ro_txn().unwrap();
-        let stat = txn.db_stat(&txn.open_db(None).unwrap()).unwrap();
+        let dbi = txn.open_db(None).unwrap().dbi();
+        let stat = txn.db_stat(dbi).unwrap();
         assert_eq!(stat.entries(), 8);
     }
 }

--- a/crates/storage/nippy-jar/src/writer.rs
+++ b/crates/storage/nippy-jar/src/writer.rs
@@ -347,11 +347,27 @@ impl<H: NippyJarHeader> NippyJarWriter<H> {
 
     /// Commits configuration and offsets to disk. It drains the internal offset list.
     pub fn commit(&mut self) -> Result<(), NippyJarError> {
+        self.sync_all()?;
+        self.finalize()?;
+        Ok(())
+    }
+
+    /// Syncs data and offsets to disk.
+    ///
+    /// This does NOT commit the configuration. Call [`Self::finalize`] after to write the
+    /// configuration and mark the writer as clean.
+    pub fn sync_all(&mut self) -> Result<(), NippyJarError> {
         self.data_file.flush()?;
         self.data_file.get_ref().sync_all()?;
 
         self.commit_offsets()?;
+        Ok(())
+    }
 
+    /// Commits configuration to disk and marks the writer as clean.
+    ///
+    /// Must be called after [`Self::sync_all`] to complete the commit.
+    pub fn finalize(&mut self) -> Result<(), NippyJarError> {
         // Flushes `max_row_size` and total `rows` to disk.
         self.jar.freeze_config()?;
         self.dirty = false;

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -17,7 +17,6 @@ reth-chainspec.workspace = true
 reth-execution-types.workspace = true
 reth-ethereum-primitives = { workspace = true, features = ["reth-codec"] }
 reth-primitives-traits = { workspace = true, features = ["reth-codec", "secp256k1"] }
-reth-fs-util.workspace = true
 reth-errors.workspace = true
 reth-storage-errors.workspace = true
 reth-storage-api = { workspace = true, features = ["std", "db-api"] }

--- a/crates/storage/provider/src/either_writer.rs
+++ b/crates/storage/provider/src/either_writer.rs
@@ -10,7 +10,7 @@ use std::{
 #[cfg(all(unix, feature = "rocksdb"))]
 use crate::providers::rocksdb::RocksDBBatch;
 use crate::{
-    providers::{StaticFileProvider, StaticFileProviderRWRefMut},
+    providers::{history_info, HistoryInfo, StaticFileProvider, StaticFileProviderRWRefMut},
     StaticFileProviderFactory,
 };
 use alloy_primitives::{map::HashMap, Address, BlockNumber, TxHash, TxNumber};
@@ -708,7 +708,7 @@ impl<CURSOR, N: NodePrimitives> EitherReader<'_, CURSOR, N>
 where
     CURSOR: DbCursorRO<tables::StoragesHistory>,
 {
-    /// Gets a storage history entry.
+    /// Gets a storage history shard entry for the given [`StorageShardedKey`], if present.
     pub fn get_storage_history(
         &mut self,
         key: StorageShardedKey,
@@ -720,13 +720,43 @@ where
             Self::RocksDB(tx) => tx.get::<tables::StoragesHistory>(key),
         }
     }
+
+    /// Lookup storage history and return [`HistoryInfo`].
+    pub fn storage_history_info(
+        &mut self,
+        address: Address,
+        storage_key: alloy_primitives::B256,
+        block_number: BlockNumber,
+        lowest_available_block_number: Option<BlockNumber>,
+    ) -> ProviderResult<HistoryInfo> {
+        match self {
+            Self::Database(cursor, _) => {
+                let key = StorageShardedKey::new(address, storage_key, block_number);
+                history_info::<tables::StoragesHistory, _, _>(
+                    cursor,
+                    key,
+                    block_number,
+                    |k| k.address == address && k.sharded_key.key == storage_key,
+                    lowest_available_block_number,
+                )
+            }
+            Self::StaticFile(_, _) => Err(ProviderError::UnsupportedProvider),
+            #[cfg(all(unix, feature = "rocksdb"))]
+            Self::RocksDB(tx) => tx.storage_history_info(
+                address,
+                storage_key,
+                block_number,
+                lowest_available_block_number,
+            ),
+        }
+    }
 }
 
 impl<CURSOR, N: NodePrimitives> EitherReader<'_, CURSOR, N>
 where
     CURSOR: DbCursorRO<tables::AccountsHistory>,
 {
-    /// Gets an account history entry.
+    /// Gets an account history shard entry for the given [`ShardedKey`], if present.
     pub fn get_account_history(
         &mut self,
         key: ShardedKey<Address>,
@@ -736,6 +766,32 @@ where
             Self::StaticFile(_, _) => Err(ProviderError::UnsupportedProvider),
             #[cfg(all(unix, feature = "rocksdb"))]
             Self::RocksDB(tx) => tx.get::<tables::AccountsHistory>(key),
+        }
+    }
+
+    /// Lookup account history and return [`HistoryInfo`].
+    pub fn account_history_info(
+        &mut self,
+        address: Address,
+        block_number: BlockNumber,
+        lowest_available_block_number: Option<BlockNumber>,
+    ) -> ProviderResult<HistoryInfo> {
+        match self {
+            Self::Database(cursor, _) => {
+                let key = ShardedKey::new(address, block_number);
+                history_info::<tables::AccountsHistory, _, _>(
+                    cursor,
+                    key,
+                    block_number,
+                    |k| k.key == address,
+                    lowest_available_block_number,
+                )
+            }
+            Self::StaticFile(_, _) => Err(ProviderError::UnsupportedProvider),
+            #[cfg(all(unix, feature = "rocksdb"))]
+            Self::RocksDB(tx) => {
+                tx.account_history_info(address, block_number, lowest_available_block_number)
+            }
         }
     }
 }
@@ -894,8 +950,11 @@ mod rocksdb_tests {
     use reth_db_api::{
         models::{storage_sharded_key::StorageShardedKey, IntegerList, ShardedKey},
         tables,
+        transaction::DbTxMut,
     };
+    use reth_ethereum_primitives::EthPrimitives;
     use reth_storage_api::{DatabaseProviderFactory, StorageSettings};
+    use std::marker::PhantomData;
     use tempfile::TempDir;
 
     fn create_rocksdb_provider() -> (TempDir, RocksDBProvider) {
@@ -1125,10 +1184,391 @@ mod rocksdb_tests {
         assert_eq!(provider.get::<tables::AccountsHistory>(key).unwrap(), None);
     }
 
-    /// Test that `RocksDB` commits happen at `provider.commit()` level, not at writer level.
+    // ==================== Parametrized Backend Equivalence Tests ====================
+    //
+    // These tests verify that MDBX and RocksDB produce identical results for history lookups.
+    // Each scenario sets up the same data in both backends and asserts identical HistoryInfo.
+
+    /// Query parameters for a history lookup test case.
+    struct HistoryQuery {
+        block_number: BlockNumber,
+        lowest_available: Option<BlockNumber>,
+        expected: HistoryInfo,
+    }
+
+    // Type aliases for cursor types (needed for EitherWriter/EitherReader type inference)
+    type AccountsHistoryWriteCursor =
+        reth_db::mdbx::cursor::Cursor<reth_db::mdbx::RW, tables::AccountsHistory>;
+    type StoragesHistoryWriteCursor =
+        reth_db::mdbx::cursor::Cursor<reth_db::mdbx::RW, tables::StoragesHistory>;
+    type AccountsHistoryReadCursor =
+        reth_db::mdbx::cursor::Cursor<reth_db::mdbx::RO, tables::AccountsHistory>;
+    type StoragesHistoryReadCursor =
+        reth_db::mdbx::cursor::Cursor<reth_db::mdbx::RO, tables::StoragesHistory>;
+
+    /// Runs the same account history queries against both MDBX and `RocksDB` backends,
+    /// asserting they produce identical results.
+    fn run_account_history_scenario(
+        scenario_name: &str,
+        address: Address,
+        shards: &[(BlockNumber, Vec<BlockNumber>)], // (shard_highest_block, blocks_in_shard)
+        queries: &[HistoryQuery],
+    ) {
+        // Setup MDBX and RocksDB with identical data using EitherWriter
+        let factory = create_test_provider_factory();
+        let mdbx_provider = factory.database_provider_rw().unwrap();
+        let (temp_dir, rocks_provider) = create_rocksdb_provider();
+
+        // Create writers for both backends
+        let mut mdbx_writer: EitherWriter<'_, AccountsHistoryWriteCursor, EthPrimitives> =
+            EitherWriter::Database(
+                mdbx_provider.tx_ref().cursor_write::<tables::AccountsHistory>().unwrap(),
+            );
+        let mut rocks_writer: EitherWriter<'_, AccountsHistoryWriteCursor, EthPrimitives> =
+            EitherWriter::RocksDB(rocks_provider.batch());
+
+        // Write identical data to both backends in a single loop
+        for (highest_block, blocks) in shards {
+            let key = ShardedKey::new(address, *highest_block);
+            let value = IntegerList::new(blocks.clone()).unwrap();
+            mdbx_writer.put_account_history(key.clone(), &value).unwrap();
+            rocks_writer.put_account_history(key, &value).unwrap();
+        }
+
+        // Commit both backends
+        drop(mdbx_writer);
+        mdbx_provider.commit().unwrap();
+        if let EitherWriter::RocksDB(batch) = rocks_writer {
+            batch.commit().unwrap();
+        }
+
+        // Run queries against both backends using EitherReader
+        let mdbx_ro = factory.database_provider_ro().unwrap();
+        let rocks_tx = rocks_provider.tx();
+
+        for (i, query) in queries.iter().enumerate() {
+            // MDBX query via EitherReader
+            let mut mdbx_reader: EitherReader<'_, AccountsHistoryReadCursor, EthPrimitives> =
+                EitherReader::Database(
+                    mdbx_ro.tx_ref().cursor_read::<tables::AccountsHistory>().unwrap(),
+                    PhantomData,
+                );
+            let mdbx_result = mdbx_reader
+                .account_history_info(address, query.block_number, query.lowest_available)
+                .unwrap();
+
+            // RocksDB query via EitherReader
+            let mut rocks_reader: EitherReader<'_, AccountsHistoryReadCursor, EthPrimitives> =
+                EitherReader::RocksDB(&rocks_tx);
+            let rocks_result = rocks_reader
+                .account_history_info(address, query.block_number, query.lowest_available)
+                .unwrap();
+
+            // Assert both backends produce identical results
+            assert_eq!(
+                mdbx_result,
+                rocks_result,
+                "Backend mismatch in scenario '{}' query {}: block={}, lowest={:?}\n\
+                 MDBX: {:?}, RocksDB: {:?}",
+                scenario_name,
+                i,
+                query.block_number,
+                query.lowest_available,
+                mdbx_result,
+                rocks_result
+            );
+
+            // Also verify against expected result
+            assert_eq!(
+                mdbx_result,
+                query.expected,
+                "Unexpected result in scenario '{}' query {}: block={}, lowest={:?}\n\
+                 Got: {:?}, Expected: {:?}",
+                scenario_name,
+                i,
+                query.block_number,
+                query.lowest_available,
+                mdbx_result,
+                query.expected
+            );
+        }
+
+        rocks_tx.rollback().unwrap();
+        drop(temp_dir);
+    }
+
+    /// Runs the same storage history queries against both MDBX and `RocksDB` backends,
+    /// asserting they produce identical results.
+    fn run_storage_history_scenario(
+        scenario_name: &str,
+        address: Address,
+        storage_key: B256,
+        shards: &[(BlockNumber, Vec<BlockNumber>)], // (shard_highest_block, blocks_in_shard)
+        queries: &[HistoryQuery],
+    ) {
+        // Setup MDBX and RocksDB with identical data using EitherWriter
+        let factory = create_test_provider_factory();
+        let mdbx_provider = factory.database_provider_rw().unwrap();
+        let (temp_dir, rocks_provider) = create_rocksdb_provider();
+
+        // Create writers for both backends
+        let mut mdbx_writer: EitherWriter<'_, StoragesHistoryWriteCursor, EthPrimitives> =
+            EitherWriter::Database(
+                mdbx_provider.tx_ref().cursor_write::<tables::StoragesHistory>().unwrap(),
+            );
+        let mut rocks_writer: EitherWriter<'_, StoragesHistoryWriteCursor, EthPrimitives> =
+            EitherWriter::RocksDB(rocks_provider.batch());
+
+        // Write identical data to both backends in a single loop
+        for (highest_block, blocks) in shards {
+            let key = StorageShardedKey::new(address, storage_key, *highest_block);
+            let value = IntegerList::new(blocks.clone()).unwrap();
+            mdbx_writer.put_storage_history(key.clone(), &value).unwrap();
+            rocks_writer.put_storage_history(key, &value).unwrap();
+        }
+
+        // Commit both backends
+        drop(mdbx_writer);
+        mdbx_provider.commit().unwrap();
+        if let EitherWriter::RocksDB(batch) = rocks_writer {
+            batch.commit().unwrap();
+        }
+
+        // Run queries against both backends using EitherReader
+        let mdbx_ro = factory.database_provider_ro().unwrap();
+        let rocks_tx = rocks_provider.tx();
+
+        for (i, query) in queries.iter().enumerate() {
+            // MDBX query via EitherReader
+            let mut mdbx_reader: EitherReader<'_, StoragesHistoryReadCursor, EthPrimitives> =
+                EitherReader::Database(
+                    mdbx_ro.tx_ref().cursor_read::<tables::StoragesHistory>().unwrap(),
+                    PhantomData,
+                );
+            let mdbx_result = mdbx_reader
+                .storage_history_info(
+                    address,
+                    storage_key,
+                    query.block_number,
+                    query.lowest_available,
+                )
+                .unwrap();
+
+            // RocksDB query via EitherReader
+            let mut rocks_reader: EitherReader<'_, StoragesHistoryReadCursor, EthPrimitives> =
+                EitherReader::RocksDB(&rocks_tx);
+            let rocks_result = rocks_reader
+                .storage_history_info(
+                    address,
+                    storage_key,
+                    query.block_number,
+                    query.lowest_available,
+                )
+                .unwrap();
+
+            // Assert both backends produce identical results
+            assert_eq!(
+                mdbx_result,
+                rocks_result,
+                "Backend mismatch in scenario '{}' query {}: block={}, lowest={:?}\n\
+                 MDBX: {:?}, RocksDB: {:?}",
+                scenario_name,
+                i,
+                query.block_number,
+                query.lowest_available,
+                mdbx_result,
+                rocks_result
+            );
+
+            // Also verify against expected result
+            assert_eq!(
+                mdbx_result,
+                query.expected,
+                "Unexpected result in scenario '{}' query {}: block={}, lowest={:?}\n\
+                 Got: {:?}, Expected: {:?}",
+                scenario_name,
+                i,
+                query.block_number,
+                query.lowest_available,
+                mdbx_result,
+                query.expected
+            );
+        }
+
+        rocks_tx.rollback().unwrap();
+        drop(temp_dir);
+    }
+
+    /// Tests account history lookups across both MDBX and `RocksDB` backends.
     ///
-    /// This ensures all storage commits (MDBX, static files, `RocksDB`) happen atomically
-    /// in a single place, making it easier to reason about commit ordering and consistency.
+    /// Covers the following scenarios from PR2's `RocksDB`-only tests:
+    /// 1. Single shard - basic lookups within one shard
+    /// 2. Multiple shards - `prev()` shard detection and transitions
+    /// 3. No history - query address with no entries
+    /// 4. Pruning boundary - `lowest_available` boundary behavior (block at/after boundary)
+    #[test]
+    fn test_account_history_info_both_backends() {
+        let address = Address::from([0x42; 20]);
+
+        // Scenario 1: Single shard with blocks [100, 200, 300]
+        run_account_history_scenario(
+            "single_shard",
+            address,
+            &[(u64::MAX, vec![100, 200, 300])],
+            &[
+                // Before first entry -> NotYetWritten
+                HistoryQuery {
+                    block_number: 50,
+                    lowest_available: None,
+                    expected: HistoryInfo::NotYetWritten,
+                },
+                // Between entries -> InChangeset(next_write)
+                HistoryQuery {
+                    block_number: 150,
+                    lowest_available: None,
+                    expected: HistoryInfo::InChangeset(200),
+                },
+                // Exact match on entry -> InChangeset(same_block)
+                HistoryQuery {
+                    block_number: 300,
+                    lowest_available: None,
+                    expected: HistoryInfo::InChangeset(300),
+                },
+                // After last entry in last shard -> InPlainState
+                HistoryQuery {
+                    block_number: 500,
+                    lowest_available: None,
+                    expected: HistoryInfo::InPlainState,
+                },
+            ],
+        );
+
+        // Scenario 2: Multiple shards - tests prev() shard detection
+        run_account_history_scenario(
+            "multiple_shards",
+            address,
+            &[
+                (500, vec![100, 200, 300, 400, 500]), // First shard ends at 500
+                (u64::MAX, vec![600, 700, 800]),      // Last shard
+            ],
+            &[
+                // Before first shard, no prev -> NotYetWritten
+                HistoryQuery {
+                    block_number: 50,
+                    lowest_available: None,
+                    expected: HistoryInfo::NotYetWritten,
+                },
+                // Within first shard
+                HistoryQuery {
+                    block_number: 150,
+                    lowest_available: None,
+                    expected: HistoryInfo::InChangeset(200),
+                },
+                // Between shards - prev() should find first shard
+                HistoryQuery {
+                    block_number: 550,
+                    lowest_available: None,
+                    expected: HistoryInfo::InChangeset(600),
+                },
+                // After all entries
+                HistoryQuery {
+                    block_number: 900,
+                    lowest_available: None,
+                    expected: HistoryInfo::InPlainState,
+                },
+            ],
+        );
+
+        // Scenario 3: No history for address
+        let address_without_history = Address::from([0x43; 20]);
+        run_account_history_scenario(
+            "no_history",
+            address_without_history,
+            &[], // No shards for this address
+            &[HistoryQuery {
+                block_number: 150,
+                lowest_available: None,
+                expected: HistoryInfo::NotYetWritten,
+            }],
+        );
+
+        // Scenario 4: Query at pruning boundary
+        // Note: We test block >= lowest_available because HistoricalStateProviderRef
+        // errors on blocks below the pruning boundary before doing the lookup.
+        // The RocksDB implementation doesn't have this check at the same level.
+        // This tests that when pruning IS available, both backends agree.
+        run_account_history_scenario(
+            "with_pruning_boundary",
+            address,
+            &[(u64::MAX, vec![100, 200, 300])],
+            &[
+                // At pruning boundary -> InChangeset(first entry after block)
+                HistoryQuery {
+                    block_number: 100,
+                    lowest_available: Some(100),
+                    expected: HistoryInfo::InChangeset(100),
+                },
+                // After pruning boundary, between entries
+                HistoryQuery {
+                    block_number: 150,
+                    lowest_available: Some(100),
+                    expected: HistoryInfo::InChangeset(200),
+                },
+            ],
+        );
+    }
+
+    /// Tests storage history lookups across both MDBX and `RocksDB` backends.
+    #[test]
+    fn test_storage_history_info_both_backends() {
+        let address = Address::from([0x42; 20]);
+        let storage_key = B256::from([0x01; 32]);
+        let other_storage_key = B256::from([0x02; 32]);
+
+        // Single shard with blocks [100, 200, 300]
+        run_storage_history_scenario(
+            "storage_single_shard",
+            address,
+            storage_key,
+            &[(u64::MAX, vec![100, 200, 300])],
+            &[
+                // Before first entry -> NotYetWritten
+                HistoryQuery {
+                    block_number: 50,
+                    lowest_available: None,
+                    expected: HistoryInfo::NotYetWritten,
+                },
+                // Between entries -> InChangeset(next_write)
+                HistoryQuery {
+                    block_number: 150,
+                    lowest_available: None,
+                    expected: HistoryInfo::InChangeset(200),
+                },
+                // After last entry -> InPlainState
+                HistoryQuery {
+                    block_number: 500,
+                    lowest_available: None,
+                    expected: HistoryInfo::InPlainState,
+                },
+            ],
+        );
+
+        // No history for different storage key
+        run_storage_history_scenario(
+            "storage_no_history",
+            address,
+            other_storage_key,
+            &[], // No shards for this storage key
+            &[HistoryQuery {
+                block_number: 150,
+                lowest_available: None,
+                expected: HistoryInfo::NotYetWritten,
+            }],
+        );
+    }
+
+    /// Test that `RocksDB` batches created via `EitherWriter` are only made visible when
+    /// `provider.commit()` is called, not when the writer is dropped.
     #[test]
     fn test_rocksdb_commits_at_provider_level() {
         let factory = create_test_provider_factory();

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -125,7 +125,7 @@ impl<DB: Database, N: NodeTypes> AsRef<DatabaseProvider<<DB as Database>::TXMut,
 
 impl<DB: Database, N: NodeTypes + 'static> DatabaseProviderRW<DB, N> {
     /// Commit database transaction and static file if it exists.
-    pub fn commit(self) -> ProviderResult<bool> {
+    pub fn commit(self) -> ProviderResult<()> {
         self.0.commit()
     }
 
@@ -3422,7 +3422,7 @@ impl<TX: DbTx + 'static, N: NodeTypes + 'static> DBProvider for DatabaseProvider
     }
 
     /// Commit database transaction, static files, and pending `RocksDB` batches.
-    fn commit(self) -> ProviderResult<bool> {
+    fn commit(self) -> ProviderResult<()> {
         // For unwinding it makes more sense to commit the database first, since if
         // it is interrupted before the static files commit, we can just
         // truncate the static files according to the
@@ -3453,7 +3453,7 @@ impl<TX: DbTx + 'static, N: NodeTypes + 'static> DBProvider for DatabaseProvider
             self.tx.commit()?;
         }
 
-        Ok(true)
+        Ok(())
     }
 }
 

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -16,8 +16,8 @@ pub use static_file::{
 mod state;
 pub use state::{
     historical::{
-        needs_prev_shard_check, HistoricalStateProvider, HistoricalStateProviderRef, HistoryInfo,
-        LowestAvailableBlocks,
+        history_info, needs_prev_shard_check, HistoricalStateProvider, HistoricalStateProviderRef,
+        HistoryInfo, LowestAvailableBlocks,
     },
     latest::{LatestStateProvider, LatestStateProviderRef},
     overlay::{OverlayStateProvider, OverlayStateProviderFactory},

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -1272,101 +1272,9 @@ mod tests {
         assert_eq!(last, Some((20, b"value_20".to_vec())));
     }
 
-    #[test]
-    fn test_account_history_info_single_shard() {
-        let temp_dir = TempDir::new().unwrap();
-        let provider = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
-
-        let address = Address::from([0x42; 20]);
-
-        // Create a single shard with blocks [100, 200, 300] and highest_block = u64::MAX
-        // This is the "last shard" invariant
-        let chunk = IntegerList::new([100, 200, 300]).unwrap();
-        let shard_key = ShardedKey::new(address, u64::MAX);
-        provider.put::<tables::AccountsHistory>(shard_key, &chunk).unwrap();
-
-        let tx = provider.tx();
-
-        // Query for block 150: should find block 200 in changeset
-        let result = tx.account_history_info(address, 150, None).unwrap();
-        assert_eq!(result, HistoryInfo::InChangeset(200));
-
-        // Query for block 50: should return NotYetWritten (before first entry, no prev shard)
-        let result = tx.account_history_info(address, 50, None).unwrap();
-        assert_eq!(result, HistoryInfo::NotYetWritten);
-
-        // Query for block 300: should return InChangeset(300) - exact match means look at
-        // changeset at that block for the previous value
-        let result = tx.account_history_info(address, 300, None).unwrap();
-        assert_eq!(result, HistoryInfo::InChangeset(300));
-
-        // Query for block 500: should return InPlainState (after last entry in last shard)
-        let result = tx.account_history_info(address, 500, None).unwrap();
-        assert_eq!(result, HistoryInfo::InPlainState);
-
-        tx.rollback().unwrap();
-    }
-
-    #[test]
-    fn test_account_history_info_multiple_shards() {
-        let temp_dir = TempDir::new().unwrap();
-        let provider = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
-
-        let address = Address::from([0x42; 20]);
-
-        // Create two shards: first shard ends at block 500, second is the last shard
-        let chunk1 = IntegerList::new([100, 200, 300, 400, 500]).unwrap();
-        let shard_key1 = ShardedKey::new(address, 500);
-        provider.put::<tables::AccountsHistory>(shard_key1, &chunk1).unwrap();
-
-        let chunk2 = IntegerList::new([600, 700, 800]).unwrap();
-        let shard_key2 = ShardedKey::new(address, u64::MAX);
-        provider.put::<tables::AccountsHistory>(shard_key2, &chunk2).unwrap();
-
-        let tx = provider.tx();
-
-        // Query for block 50: should return NotYetWritten (before first shard, no prev)
-        let result = tx.account_history_info(address, 50, None).unwrap();
-        assert_eq!(result, HistoryInfo::NotYetWritten);
-
-        // Query for block 150: should find block 200 in first shard's changeset
-        let result = tx.account_history_info(address, 150, None).unwrap();
-        assert_eq!(result, HistoryInfo::InChangeset(200));
-
-        // Query for block 550: should find block 600 in second shard's changeset
-        // prev() should detect first shard exists
-        let result = tx.account_history_info(address, 550, None).unwrap();
-        assert_eq!(result, HistoryInfo::InChangeset(600));
-
-        // Query for block 900: should return InPlainState (after last entry in last shard)
-        let result = tx.account_history_info(address, 900, None).unwrap();
-        assert_eq!(result, HistoryInfo::InPlainState);
-
-        tx.rollback().unwrap();
-    }
-
-    #[test]
-    fn test_account_history_info_no_history() {
-        let temp_dir = TempDir::new().unwrap();
-        let provider = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
-
-        let address1 = Address::from([0x42; 20]);
-        let address2 = Address::from([0x43; 20]);
-
-        // Only add history for address1
-        let chunk = IntegerList::new([100, 200, 300]).unwrap();
-        let shard_key = ShardedKey::new(address1, u64::MAX);
-        provider.put::<tables::AccountsHistory>(shard_key, &chunk).unwrap();
-
-        let tx = provider.tx();
-
-        // Query for address2 (no history exists): should return NotYetWritten
-        let result = tx.account_history_info(address2, 150, None).unwrap();
-        assert_eq!(result, HistoryInfo::NotYetWritten);
-
-        tx.rollback().unwrap();
-    }
-
+    /// Tests the edge case where block < `lowest_available_block_number`.
+    /// This case cannot be tested via `HistoricalStateProviderRef` (which errors before lookup),
+    /// so we keep this RocksDB-specific test to verify the low-level behavior.
     #[test]
     fn test_account_history_info_pruned_before_first_entry() {
         let temp_dir = TempDir::new().unwrap();
@@ -1387,41 +1295,6 @@ mod tests {
         // check the changeset at the first write block.
         let result = tx.account_history_info(address, 50, Some(100)).unwrap();
         assert_eq!(result, HistoryInfo::InChangeset(100));
-
-        tx.rollback().unwrap();
-    }
-
-    #[test]
-    fn test_storage_history_info() {
-        let temp_dir = TempDir::new().unwrap();
-        let provider = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
-
-        let address = Address::from([0x42; 20]);
-        let storage_key = B256::from([0x01; 32]);
-
-        // Create a single shard for this storage slot
-        let chunk = IntegerList::new([100, 200, 300]).unwrap();
-        let shard_key = StorageShardedKey::new(address, storage_key, u64::MAX);
-        provider.put::<tables::StoragesHistory>(shard_key, &chunk).unwrap();
-
-        let tx = provider.tx();
-
-        // Query for block 150: should find block 200 in changeset
-        let result = tx.storage_history_info(address, storage_key, 150, None).unwrap();
-        assert_eq!(result, HistoryInfo::InChangeset(200));
-
-        // Query for block 50: should return NotYetWritten
-        let result = tx.storage_history_info(address, storage_key, 50, None).unwrap();
-        assert_eq!(result, HistoryInfo::NotYetWritten);
-
-        // Query for block 500: should return InPlainState
-        let result = tx.storage_history_info(address, storage_key, 500, None).unwrap();
-        assert_eq!(result, HistoryInfo::InPlainState);
-
-        // Query for different storage key (no history): should return NotYetWritten
-        let other_key = B256::from([0x02; 32]);
-        let result = tx.storage_history_info(address, other_key, 150, None).unwrap();
-        assert_eq!(result, HistoryInfo::NotYetWritten);
 
         tx.rollback().unwrap();
     }

--- a/crates/storage/provider/src/providers/static_file/jar.rs
+++ b/crates/storage/provider/src/providers/static_file/jar.rs
@@ -85,6 +85,11 @@ impl<'a, N: NodePrimitives> StaticFileJarProvider<'a, N> {
         self.metrics = Some(metrics);
         self
     }
+
+    /// Returns the total size of the data and offsets files (from the in-memory mmap).
+    pub fn size(&self) -> usize {
+        self.jar.value().size()
+    }
 }
 
 impl<N: NodePrimitives<BlockHeader: Value>> HeaderProvider for StaticFileJarProvider<'_, N> {

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -1830,6 +1830,11 @@ pub trait StaticFileWriter {
 
     /// Returns `true` if the static file provider has unwind queued.
     fn has_unwind_queued(&self) -> bool;
+
+    /// Finalizes all static file writers by committing their configuration to disk.
+    ///
+    /// Returns an error if prune is queued (use [`Self::commit`] instead).
+    fn finalize(&self) -> ProviderResult<()>;
 }
 
 impl<N: NodePrimitives> StaticFileWriter for StaticFileProvider<N> {
@@ -1867,6 +1872,10 @@ impl<N: NodePrimitives> StaticFileWriter for StaticFileProvider<N> {
 
     fn has_unwind_queued(&self) -> bool {
         self.writers.has_unwind_queued()
+    }
+
+    fn finalize(&self) -> ProviderResult<()> {
+        self.writers.finalize()
     }
 }
 

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -474,6 +474,9 @@ impl<N: NodePrimitives> StaticFileProviderInner<N> {
 
 impl<N: NodePrimitives> StaticFileProvider<N> {
     /// Reports metrics for the static files.
+    ///
+    /// This uses the in-memory index to get file sizes from mmap handles instead of reading
+    /// filesystem metadata.
     pub fn report_metrics(&self) -> ProviderResult<()> {
         let Some(metrics) = &self.metrics else { return Ok(()) };
 
@@ -491,29 +494,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                     })?;
 
                 entries += jar_provider.rows();
-
-                let data_path = jar_provider.data_path().to_path_buf();
-                let index_path = jar_provider.index_path();
-                let offsets_path = jar_provider.offsets_path();
-                let config_path = jar_provider.config_path();
-
-                // can release jar early
-                drop(jar_provider);
-
-                let data_size = reth_fs_util::metadata(data_path)
-                    .map(|metadata| metadata.len())
-                    .unwrap_or_default();
-                let index_size = reth_fs_util::metadata(index_path)
-                    .map(|metadata| metadata.len())
-                    .unwrap_or_default();
-                let offsets_size = reth_fs_util::metadata(offsets_path)
-                    .map(|metadata| metadata.len())
-                    .unwrap_or_default();
-                let config_size = reth_fs_util::metadata(config_path)
-                    .map(|metadata| metadata.len())
-                    .unwrap_or_default();
-
-                size += data_size + index_size + offsets_size + config_size;
+                size += jar_provider.size() as u64;
             }
 
             metrics.record_segment(segment, size, headers.len(), entries);

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -35,15 +35,15 @@ use reth_node_types::NodePrimitives;
 use reth_primitives_traits::{RecoveredBlock, SealedHeader, SignedTransaction};
 use reth_stages_types::{PipelineTarget, StageId};
 use reth_static_file_types::{
-    find_fixed_range, HighestStaticFiles, SegmentHeader, SegmentRangeInclusive, StaticFileSegment,
-    DEFAULT_BLOCKS_PER_STATIC_FILE,
+    find_fixed_range, HighestStaticFiles, SegmentHeader, SegmentRangeInclusive, StaticFileMap,
+    StaticFileSegment, DEFAULT_BLOCKS_PER_STATIC_FILE,
 };
 use reth_storage_api::{
     BlockBodyIndicesProvider, ChangeSetReader, DBProvider, StorageSettingsCache,
 };
 use reth_storage_errors::provider::{ProviderError, ProviderResult};
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::BTreeMap,
     fmt::Debug,
     ops::{Deref, Range, RangeBounds, RangeInclusive},
     path::{Path, PathBuf},
@@ -99,7 +99,7 @@ impl<N> Clone for StaticFileProvider<N> {
 pub struct StaticFileProviderBuilder<P> {
     access: StaticFileAccess,
     use_metrics: bool,
-    blocks_per_file: HashMap<StaticFileSegment, u64>,
+    blocks_per_file: StaticFileMap<u64>,
     path: P,
     genesis_block_number: u64,
 }
@@ -140,9 +140,11 @@ impl<P: AsRef<Path>> StaticFileProviderBuilder<P> {
     /// setting.
     pub fn with_blocks_per_file_for_segments(
         mut self,
-        segments: HashMap<StaticFileSegment, u64>,
+        segments: &<StaticFileMap<u64> as Deref>::Target,
     ) -> Self {
-        self.blocks_per_file.extend(segments);
+        for (segment, &blocks_per_file) in segments {
+            self.blocks_per_file.insert(segment, blocks_per_file);
+        }
         self
     }
 
@@ -194,7 +196,9 @@ impl<P: AsRef<Path>> StaticFileProviderBuilder<P> {
             provider.metrics = Some(Arc::new(StaticFileProviderMetrics::default()));
         }
 
-        provider.blocks_per_file.extend(self.blocks_per_file);
+        for (segment, blocks_per_file) in *self.blocks_per_file {
+            provider.blocks_per_file.insert(segment, blocks_per_file);
+        }
         provider.genesis_block_number = self.genesis_block_number;
 
         let provider = StaticFileProvider(Arc::new(provider));
@@ -269,7 +273,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                                 notify::EventKind::Create(_) |
                                 notify::EventKind::Remove(_)
                         ) {
-                            continue
+                            continue;
                         }
 
                         // We only trigger a re-initialization if a configuration file was
@@ -282,7 +286,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                                 .extension()
                                 .is_none_or(|s| s.to_str() != Some(CONFIG_FILE_EXTENSION))
                             {
-                                continue
+                                continue;
                             }
 
                             // Ensure it's well formatted static file name
@@ -291,7 +295,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                             )
                             .is_none()
                             {
-                                continue
+                                continue;
                             }
 
                             // If we can read the metadata and modified timestamp, ensure this is
@@ -302,7 +306,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                                 if last_event_timestamp.is_some_and(|last_timestamp| {
                                     last_timestamp >= current_modified_timestamp
                                 }) {
-                                    continue
+                                    continue;
                                 }
                                 last_event_timestamp = Some(current_modified_timestamp);
                             }
@@ -311,7 +315,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                             if let Err(err) = provider.initialize_index() {
                                 warn!(target: "providers::static_file", "failed to re-initialize index: {err}");
                             }
-                            break
+                            break;
                         }
                     }
 
@@ -337,7 +341,7 @@ pub struct StaticFileProviderInner<N> {
     /// segments and ranges.
     map: DashMap<(BlockNumber, StaticFileSegment), LoadedJar>,
     /// Indexes per segment.
-    indexes: RwLock<HashMap<StaticFileSegment, StaticFileSegmentIndex>>,
+    indexes: RwLock<StaticFileMap<StaticFileSegmentIndex>>,
     /// This is an additional index that tracks the expired height, this will track the highest
     /// block number that has been expired (missing). The first, non expired block is
     /// `expired_history_height + 1`.
@@ -358,7 +362,7 @@ pub struct StaticFileProviderInner<N> {
     /// Access rights of the provider.
     access: StaticFileAccess,
     /// Number of blocks per file, per segment.
-    blocks_per_file: HashMap<StaticFileSegment, u64>,
+    blocks_per_file: StaticFileMap<u64>,
     /// Write lock for when access is [`StaticFileAccess::RW`].
     _lock_file: Option<StorageLock>,
     /// Genesis block number, default is 0;
@@ -374,7 +378,7 @@ impl<N: NodePrimitives> StaticFileProviderInner<N> {
             None
         };
 
-        let mut blocks_per_file = HashMap::new();
+        let mut blocks_per_file = StaticFileMap::default();
         for segment in StaticFileSegment::iter() {
             blocks_per_file.insert(segment, DEFAULT_BLOCKS_PER_STATIC_FILE);
         }
@@ -414,14 +418,14 @@ impl<N: NodePrimitives> StaticFileProviderInner<N> {
         block: BlockNumber,
     ) -> SegmentRangeInclusive {
         let blocks_per_file =
-            self.blocks_per_file.get(&segment).copied().unwrap_or(DEFAULT_BLOCKS_PER_STATIC_FILE);
+            self.blocks_per_file.get(segment).copied().unwrap_or(DEFAULT_BLOCKS_PER_STATIC_FILE);
 
         if let Some(block_index) = block_index {
             // Find first block range that contains the requested block
             if let Some((_, range)) = block_index.iter().find(|(max_block, _)| block <= **max_block)
             {
                 // Found matching range for an existing file using block index
-                return *range
+                return *range;
             } else if let Some((_, range)) = block_index.last_key_value() {
                 // Didn't find matching range for an existing file, derive a new range from the end
                 // of the last existing file range.
@@ -431,7 +435,7 @@ impl<N: NodePrimitives> StaticFileProviderInner<N> {
                 let blocks_after_last_range = block - range.end();
                 let segments_to_skip = (blocks_after_last_range - 1) / blocks_per_file;
                 let start = range.end() + 1 + segments_to_skip * blocks_per_file;
-                return SegmentRangeInclusive::new(start, start + blocks_per_file - 1)
+                return SegmentRangeInclusive::new(start, start + blocks_per_file - 1);
             }
         }
         // No block index is available, derive a new range using the fixed number of blocks,
@@ -458,10 +462,7 @@ impl<N: NodePrimitives> StaticFileProviderInner<N> {
     ) -> SegmentRangeInclusive {
         self.find_fixed_range_with_block_index(
             segment,
-            self.indexes
-                .read()
-                .get(&segment)
-                .map(|index| &index.expected_block_ranges_by_max_block),
+            self.indexes.read().get(segment).map(|index| &index.expected_block_ranges_by_max_block),
             block,
         )
     }
@@ -481,11 +482,11 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         let Some(metrics) = &self.metrics else { return Ok(()) };
 
         let static_files = iter_static_files(&self.path).map_err(ProviderError::other)?;
-        for (segment, headers) in static_files {
+        for (segment, headers) in &*static_files {
             let mut entries = 0;
             let mut size = 0;
 
-            for (block_range, _) in &headers {
+            for (block_range, _) in headers {
                 let fixed_block_range = self.find_fixed_range(segment, block_range.start());
                 let jar_provider = self
                     .get_segment_provider_for_range(segment, || Some(fixed_block_range), None)?
@@ -594,7 +595,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
             )
             .and_then(|(parsed_segment, block_range)| {
                 if parsed_segment == segment {
-                    return Some(block_range)
+                    return Some(block_range);
                 }
                 None
             }),
@@ -603,7 +604,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
 
         // Return cached `LoadedJar` or insert it for the first time, and then, return it.
         if let Some(block_range) = block_range {
-            return Ok(Some(self.get_or_create_jar_provider(segment, &block_range)?))
+            return Ok(Some(self.get_or_create_jar_provider(segment, &block_range)?));
         }
 
         Ok(None)
@@ -658,7 +659,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
     ) -> ProviderResult<Vec<SegmentHeader>> {
         // Nothing to delete if block is 0.
         if block == 0 {
-            return Ok(Vec::new())
+            return Ok(Vec::new());
         }
 
         let highest_block = self.get_highest_static_file_block(segment);
@@ -666,12 +667,12 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
 
         loop {
             let Some(block_height) = self.get_lowest_range_end(segment) else {
-                return Ok(deleted_headers)
+                return Ok(deleted_headers);
             };
 
             // Stop if we've reached the target block or the highest static file
             if block_height >= block || Some(block_height) == highest_block {
-                return Ok(deleted_headers)
+                return Ok(deleted_headers);
             }
 
             debug!(
@@ -765,7 +766,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         block: u64,
     ) -> Option<SegmentRangeInclusive> {
         let indexes = self.indexes.read();
-        let index = indexes.get(&segment)?;
+        let index = indexes.get(segment)?;
 
         (index.max_block >= block).then(|| {
             self.find_fixed_range_with_block_index(
@@ -784,7 +785,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         tx: u64,
     ) -> Option<SegmentRangeInclusive> {
         let indexes = self.indexes.read();
-        let index = indexes.get(&segment)?;
+        let index = indexes.get(segment)?;
         let available_block_ranges_by_max_tx = index.available_block_ranges_by_max_tx.as_ref()?;
 
         // It's more probable that the request comes from a newer tx height, so we iterate
@@ -794,7 +795,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         while let Some((tx_end, block_range)) = static_files_rev_iter.next() {
             if tx > *tx_end {
                 // request tx is higher than highest static file tx
-                return None
+                return None;
             }
             let tx_start = static_files_rev_iter.peek().map(|(tx_end, _)| *tx_end + 1).unwrap_or(0);
             if tx_start <= tx {
@@ -802,7 +803,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                     segment,
                     Some(&index.expected_block_ranges_by_max_block),
                     block_range.end(),
-                ))
+                ));
             }
         }
         None
@@ -831,7 +832,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
             Some(segment_max_block) => {
                 let fixed_range = self.find_fixed_range_with_block_index(
                     segment,
-                    indexes.get(&segment).map(|index| &index.expected_block_ranges_by_max_block),
+                    indexes.get(segment).map(|index| &index.expected_block_ranges_by_max_block),
                     segment_max_block,
                 );
 
@@ -941,7 +942,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
             }
             None => {
                 debug!(target: "provider::static_file", ?segment, "Removing segment from index");
-                indexes.remove(&segment);
+                indexes.remove(segment);
             }
         };
 
@@ -954,7 +955,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         let mut indexes = self.indexes.write();
         indexes.clear();
 
-        for (segment, headers) in iter_static_files(&self.path).map_err(ProviderError::other)? {
+        for (segment, headers) in &*iter_static_files(&self.path).map_err(ProviderError::other)? {
             // Update first and last block for each segment
             //
             // It's safe to call `expect` here, because every segment has at least one header
@@ -976,7 +977,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
 
                     available_block_ranges_by_max_tx
                         .get_or_insert_with(BTreeMap::default)
-                        .insert(tx_end, block_range);
+                        .insert(tx_end, *block_range);
                 }
             }
 
@@ -996,7 +997,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
 
         // initialize the expired history height to the lowest static file block
         if let Some(lowest_range) =
-            indexes.get(&StaticFileSegment::Transactions).and_then(|index| index.min_block_range)
+            indexes.get(StaticFileSegment::Transactions).and_then(|index| index.min_block_range)
         {
             // the earliest height is the lowest available block number
             self.earliest_history_height
@@ -1057,7 +1058,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                 info!(target: "reth::cli",
                     "Skipping storage verification for OP mainnet, expected inconsistency in OVM chain"
                 );
-                return Ok(None)
+                return Ok(None);
             }
         }
 
@@ -1107,18 +1108,18 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                     if let Some(indices) = provider.block_body_indices(last_block)? {
                         debug!(target: "reth::providers::static_file", ?segment, last_block, last_tx_num = indices.last_tx_num(), highest_tx, "Found block body indices");
                         if indices.last_tx_num() <= highest_tx {
-                            break
+                            break;
                         }
                     } else {
                         debug!(target: "reth::providers::static_file", ?segment, last_block, "Block body indices not found, static files ahead of database");
                         // If the block body indices can not be found, then it means that static
                         // files is ahead of database, and the `ensure_invariants` check will fix
                         // it by comparing with stage checkpoints.
-                        break
+                        break;
                     }
                     if last_block == 0 {
                         debug!(target: "reth::providers::static_file", ?segment, "Reached block 0 in verification loop");
-                        break
+                        break;
                     }
                     last_block -= 1;
 
@@ -1227,7 +1228,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                     // Old pruned nodes (including full node) do not store receipts as static
                     // files.
                     debug!(target: "reth::providers::static_file", ?segment, "Skipping receipts segment: receipts stored in database");
-                    return false
+                    return false;
                 }
 
                 if NamedChain::Gnosis == provider.chain_spec().chain_id() ||
@@ -1248,7 +1249,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
             StaticFileSegment::AccountChangeSets => {
                 if EitherWriter::account_changesets_destination(provider).is_database() {
                     debug!(target: "reth::providers::static_file", ?segment, "Skipping account changesets segment: changesets stored in database");
-                    return false
+                    return false;
                 }
                 true
             }
@@ -1361,7 +1362,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                         ?segment,
                         "Setting unwind target."
                     );
-                    return Ok(Some(highest_block))
+                    return Ok(Some(highest_block));
                 }
             }
 
@@ -1370,7 +1371,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                     .is_none_or(|highest_entry| db_last_entry > highest_entry)
             {
                 debug!(target: "reth::providers::static_file", ?segment, db_last_entry, ?highest_static_file_entry, "Database has entries beyond static files, no unwind needed");
-                return Ok(None)
+                return Ok(None);
             }
         } else {
             debug!(target: "reth::providers::static_file", ?segment, "No database entries found");
@@ -1402,7 +1403,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                 ?segment,
                 "Setting unwind target."
             );
-            return Ok(Some(highest_static_file_block))
+            return Ok(Some(highest_static_file_block));
         }
 
         // If the checkpoint is behind, then we failed to do a database commit **but committed** to
@@ -1477,7 +1478,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
     ///
     /// If there is nothing on disk for the given segment, this will return [`None`].
     pub fn get_lowest_range(&self, segment: StaticFileSegment) -> Option<SegmentRangeInclusive> {
-        self.indexes.read().get(&segment).and_then(|index| index.min_block_range)
+        self.indexes.read().get(segment).and_then(|index| index.min_block_range)
     }
 
     /// Gets the lowest static file's block range start if it exists for a static file segment.
@@ -1502,7 +1503,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
     ///
     /// If there is nothing on disk for the given segment, this will return [`None`].
     pub fn get_highest_static_file_block(&self, segment: StaticFileSegment) -> Option<BlockNumber> {
-        self.indexes.read().get(&segment).map(|index| index.max_block)
+        self.indexes.read().get(segment).map(|index| index.max_block)
     }
 
     /// Gets the highest static file transaction.
@@ -1511,7 +1512,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
     pub fn get_highest_static_file_tx(&self, segment: StaticFileSegment) -> Option<TxNumber> {
         self.indexes
             .read()
-            .get(&segment)
+            .get(segment)
             .and_then(|index| index.available_block_ranges_by_max_tx.as_ref())
             .and_then(|index| index.last_key_value().map(|(last_tx, _)| *last_tx))
     }
@@ -1531,12 +1532,12 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         func: impl Fn(StaticFileJarProvider<'_, N>) -> ProviderResult<Option<T>>,
     ) -> ProviderResult<Option<T>> {
         if let Some(ranges) =
-            self.indexes.read().get(&segment).map(|index| &index.expected_block_ranges_by_max_block)
+            self.indexes.read().get(segment).map(|index| &index.expected_block_ranges_by_max_block)
         {
             // Iterate through all ranges in reverse order (highest to lowest)
             for range in ranges.values().rev() {
                 if let Some(res) = func(self.get_or_create_jar_provider(segment, range)?)? {
-                    return Ok(Some(res))
+                    return Ok(Some(res));
                 }
             }
         }
@@ -1593,14 +1594,14 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                 match get_fn(&mut cursor, number)? {
                     Some(res) => {
                         if !predicate(&res) {
-                            break 'outer
+                            break 'outer;
                         }
                         result.push(res);
-                        break 'inner
+                        break 'inner;
                     }
                     None => {
                         if retrying {
-                            return Ok(result)
+                            return Ok(result);
                         }
                         // There is a very small chance of hitting a deadlock if two consecutive
                         // static files share the same bucket in the
@@ -1694,7 +1695,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         if static_file_upper_bound
             .is_some_and(|static_file_upper_bound| static_file_upper_bound >= number)
         {
-            return fetch_from_static_file(self)
+            return fetch_from_static_file(self);
         }
         fetch_from_database()
     }
@@ -1759,7 +1760,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
     pub fn tx_index(&self, segment: StaticFileSegment) -> Option<SegmentRanges> {
         self.indexes
             .read()
-            .get(&segment)
+            .get(segment)
             .and_then(|index| index.available_block_ranges_by_max_tx.as_ref())
             .cloned()
     }
@@ -1769,7 +1770,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
     pub fn expected_block_index(&self, segment: StaticFileSegment) -> Option<SegmentRanges> {
         self.indexes
             .read()
-            .get(&segment)
+            .get(segment)
             .map(|index| &index.expected_block_ranges_by_max_block)
             .cloned()
     }
@@ -1846,7 +1847,7 @@ impl<N: NodePrimitives> StaticFileWriter for StaticFileProvider<N> {
         segment: StaticFileSegment,
     ) -> ProviderResult<StaticFileProviderRWRefMut<'_, Self::Primitives>> {
         if self.access.is_read_only() {
-            return Err(ProviderError::ReadOnlyStaticFileAccess)
+            return Err(ProviderError::ReadOnlyStaticFileAccess);
         }
 
         trace!(target: "provider::static_file", ?block, ?segment, "Getting static file writer.");
@@ -1988,7 +1989,7 @@ impl<N: NodePrimitives> ChangeSetReader for StaticFileProvider<N> {
 
         // iterate through static files and sum changeset metadata via each static file header
         let static_files = iter_static_files(&self.path).map_err(ProviderError::other)?;
-        if let Some(changeset_segments) = static_files.get(&StaticFileSegment::AccountChangeSets) {
+        if let Some(changeset_segments) = static_files.get(StaticFileSegment::AccountChangeSets) {
             for (_, header) in changeset_segments {
                 if let Some(changeset_offsets) = header.changeset_offsets() {
                     for offset in changeset_offsets {
@@ -2030,7 +2031,7 @@ impl<N: NodePrimitives<BlockHeader: Value>> HeaderProvider for StaticFileProvide
                 .get_two::<HeaderWithHashMask<Self::Header>>((&block_hash).into())?
                 .and_then(|(header, hash)| {
                     if hash == block_hash {
-                        return Some(header)
+                        return Some(header);
                     }
                     None
                 }))
@@ -2140,7 +2141,7 @@ impl<N: NodePrimitives<SignedTx: Value + SignedTransaction, Receipt: Value>> Rec
 
     fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Self::Receipt>> {
         if let Some(num) = self.transaction_id(hash)? {
-            return self.receipt(num)
+            return self.receipt(num);
         }
         Ok(None)
     }

--- a/crates/storage/provider/src/providers/static_file/metrics.rs
+++ b/crates/storage/provider/src/providers/static_file/metrics.rs
@@ -3,13 +3,13 @@ use std::{collections::HashMap, time::Duration};
 use itertools::Itertools;
 use metrics::{Counter, Gauge, Histogram};
 use reth_metrics::Metrics;
-use reth_static_file_types::StaticFileSegment;
+use reth_static_file_types::{StaticFileMap, StaticFileSegment};
 use strum::{EnumIter, IntoEnumIterator};
 
 /// Metrics for the static file provider.
 #[derive(Debug)]
 pub struct StaticFileProviderMetrics {
-    segments: HashMap<StaticFileSegment, StaticFileSegmentMetrics>,
+    segments: StaticFileMap<StaticFileSegmentMetrics>,
     segment_operations: HashMap<
         (StaticFileSegment, StaticFileProviderOperation),
         StaticFileProviderOperationMetrics,
@@ -19,14 +19,19 @@ pub struct StaticFileProviderMetrics {
 impl Default for StaticFileProviderMetrics {
     fn default() -> Self {
         Self {
-            segments: StaticFileSegment::iter()
-                .map(|segment| {
-                    (
-                        segment,
-                        StaticFileSegmentMetrics::new_with_labels(&[("segment", segment.as_str())]),
-                    )
-                })
-                .collect(),
+            segments: Box::new(
+                StaticFileSegment::iter()
+                    .map(|segment| {
+                        (
+                            segment,
+                            StaticFileSegmentMetrics::new_with_labels(&[(
+                                "segment",
+                                segment.as_str(),
+                            )]),
+                        )
+                    })
+                    .collect(),
+            ),
             segment_operations: StaticFileSegment::iter()
                 .cartesian_product(StaticFileProviderOperation::iter())
                 .map(|(segment, operation)| {
@@ -51,10 +56,10 @@ impl StaticFileProviderMetrics {
         files: usize,
         entries: usize,
     ) {
-        self.segments.get(&segment).expect("segment metrics should exist").size.set(size as f64);
-        self.segments.get(&segment).expect("segment metrics should exist").files.set(files as f64);
+        self.segments.get(segment).expect("segment metrics should exist").size.set(size as f64);
+        self.segments.get(segment).expect("segment metrics should exist").files.set(files as f64);
         self.segments
-            .get(&segment)
+            .get(segment)
             .expect("segment metrics should exist")
             .entries
             .set(entries as f64);

--- a/crates/storage/provider/src/providers/static_file/mod.rs
+++ b/crates/storage/provider/src/providers/static_file/mod.rs
@@ -44,6 +44,11 @@ impl LoadedJar {
     const fn segment(&self) -> StaticFileSegment {
         self.jar.user_header().segment()
     }
+
+    /// Returns the total size of the data and offsets files (from the in-memory mmap).
+    fn size(&self) -> usize {
+        self.mmap_handle.size() + self.mmap_handle.offsets_size()
+    }
 }
 
 impl Deref for LoadedJar {

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -141,6 +141,30 @@ impl<N: NodePrimitives> StaticFileWriters<N> {
         }
         false
     }
+
+    /// Finalizes all writers by committing their configuration to disk and updating indices.
+    ///
+    /// Must be called after `sync_all` was called on individual writers.
+    /// Returns an error if any writer has prune queued.
+    pub(crate) fn finalize(&self) -> ProviderResult<()> {
+        debug!(target: "provider::static_file", "Finalizing all static file segments into disk");
+
+        for writer_lock in [
+            &self.headers,
+            &self.transactions,
+            &self.receipts,
+            &self.transaction_senders,
+            &self.account_change_sets,
+        ] {
+            let mut writer = writer_lock.write();
+            if let Some(writer) = writer.as_mut() {
+                writer.finalize()?;
+            }
+        }
+
+        debug!(target: "provider::static_file", "Finalized all static file segments into disk");
+        Ok(())
+    }
 }
 
 /// Mutable reference to a [`StaticFileProviderRW`] behind a [`RwLockWriteGuard`].
@@ -296,6 +320,38 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
     /// Returns `true` if the writer will prune on commit.
     pub const fn will_prune_on_commit(&self) -> bool {
         self.prune_on_commit.is_some()
+    }
+
+    /// Syncs all data (rows and offsets) to disk.
+    ///
+    /// This does NOT commit the configuration. Call [`Self::finalize`] after to write the
+    /// configuration and mark the writer as clean.
+    ///
+    /// Returns an error if prune is queued (use [`Self::commit`] instead).
+    pub fn sync_all(&mut self) -> ProviderResult<()> {
+        if self.prune_on_commit.is_some() {
+            return Err(StaticFileWriterError::FinalizeWithPruneQueued.into());
+        }
+        if self.writer.is_dirty() {
+            self.writer.sync_all().map_err(ProviderError::other)?;
+        }
+        Ok(())
+    }
+
+    /// Commits configuration to disk and updates the reader index.
+    ///
+    /// Must be called after [`Self::sync_all`] to complete the commit.
+    ///
+    /// Returns an error if prune is queued (use [`Self::commit`] instead).
+    pub fn finalize(&mut self) -> ProviderResult<()> {
+        if self.prune_on_commit.is_some() {
+            return Err(StaticFileWriterError::FinalizeWithPruneQueued.into());
+        }
+        if self.writer.is_dirty() {
+            self.writer.finalize().map_err(ProviderError::other)?;
+            self.update_index()?;
+        }
+        Ok(())
     }
 
     /// Commits configuration changes to disk and updates the reader index with the new changes.

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -267,7 +267,7 @@ impl<T: NodePrimitives, ChainSpec: EthChainSpec + 'static> DBProvider
         self.tx
     }
 
-    fn commit(self) -> ProviderResult<bool> {
+    fn commit(self) -> ProviderResult<()> {
         Ok(self.tx.commit()?)
     }
 

--- a/crates/storage/rpc-provider/src/lib.rs
+++ b/crates/storage/rpc-provider/src/lib.rs
@@ -1357,7 +1357,7 @@ where
         self
     }
 
-    fn commit(self) -> ProviderResult<bool> {
+    fn commit(self) -> ProviderResult<()> {
         unimplemented!("commit not supported for RPC provider")
     }
 

--- a/crates/storage/storage-api/src/database_provider.rs
+++ b/crates/storage/storage-api/src/database_provider.rs
@@ -37,7 +37,7 @@ pub trait DBProvider: Sized {
     }
 
     /// Commit database transaction
-    fn commit(self) -> ProviderResult<bool>;
+    fn commit(self) -> ProviderResult<()>;
 
     /// Returns a reference to prune modes.
     fn prune_modes_ref(&self) -> &PruneModes;

--- a/crates/storage/storage-api/src/noop.rs
+++ b/crates/storage/storage-api/src/noop.rs
@@ -639,7 +639,7 @@ impl<ChainSpec: Send + Sync, N: NodePrimitives> DBProvider for NoopProvider<Chai
         &self.prune_modes
     }
 
-    fn commit(self) -> ProviderResult<bool> {
+    fn commit(self) -> ProviderResult<()> {
         use reth_db_api::transaction::DbTx;
 
         Ok(self.tx.commit()?)

--- a/crates/tracing-otlp/Cargo.toml
+++ b/crates/tracing-otlp/Cargo.toml
@@ -14,6 +14,7 @@ opentelemetry_sdk = { workspace = true, optional = true }
 opentelemetry = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true, features = ["grpc-tonic"] }
 opentelemetry-semantic-conventions = { workspace = true, optional = true }
+opentelemetry-appender-tracing = { workspace = true, optional = true }
 tracing-opentelemetry = { workspace = true, optional = true }
 tracing-subscriber.workspace = true
 tracing.workspace = true
@@ -35,4 +36,11 @@ otlp = [
     "opentelemetry-otlp",
     "opentelemetry-semantic-conventions",
     "tracing-opentelemetry",
+]
+
+otlp-logs = [
+    "otlp",
+    "opentelemetry-appender-tracing",
+    "opentelemetry-otlp/logs",
+    "opentelemetry_sdk/logs",
 ]

--- a/crates/tracing/Cargo.toml
+++ b/crates/tracing/Cargo.toml
@@ -33,4 +33,5 @@ rolling-file.workspace = true
 [features]
 default = ["otlp"]
 otlp = ["reth-tracing-otlp"]
+otlp-logs = ["reth-tracing-otlp/otlp-logs"]
 tracy = ["tracing-tracy", "tracy-client"]

--- a/crates/tracing/Cargo.toml
+++ b/crates/tracing/Cargo.toml
@@ -22,6 +22,8 @@ tracing-appender.workspace = true
 tracing-journald.workspace = true
 tracing-logfmt.workspace = true
 tracing-samply.workspace = true
+tracing-tracy = { workspace = true, optional = true }
+tracy-client = { workspace = true, optional = true, features = ["demangle"] }
 
 # misc
 clap = { workspace = true, features = ["derive"] }
@@ -31,3 +33,4 @@ rolling-file.workspace = true
 [features]
 default = ["otlp"]
 otlp = ["reth-tracing-otlp"]
+tracy = ["tracing-tracy", "tracy-client"]

--- a/crates/tracing/src/layers.rs
+++ b/crates/tracing/src/layers.rs
@@ -1,4 +1,6 @@
 use crate::{formatter::LogFormat, LayerInfo};
+#[cfg(feature = "otlp-logs")]
+use reth_tracing_otlp::{log_layer, OtlpLogsConfig};
 #[cfg(feature = "otlp")]
 use reth_tracing_otlp::{span_layer, OtlpConfig};
 use rolling_file::{RollingConditionBasic, RollingFileAppender};
@@ -165,6 +167,22 @@ impl Layers {
             .with_filter(filter);
 
         self.add_layer(span_layer);
+
+        Ok(())
+    }
+
+    /// Add OTLP logs layer to the layer collection
+    #[cfg(feature = "otlp-logs")]
+    pub fn with_log_layer(
+        &mut self,
+        otlp_config: OtlpLogsConfig,
+        filter: EnvFilter,
+    ) -> eyre::Result<()> {
+        let log_layer = log_layer(otlp_config)
+            .map_err(|e| eyre::eyre!("Failed to build OTLP log exporter {}", e))?
+            .with_filter(filter);
+
+        self.add_layer(log_layer);
 
         Ok(())
     }

--- a/crates/tracing/src/layers.rs
+++ b/crates/tracing/src/layers.rs
@@ -142,6 +142,15 @@ impl Layers {
         Ok(())
     }
 
+    #[cfg(feature = "tracy")]
+    pub(crate) fn tracy(&mut self, config: LayerInfo) -> eyre::Result<()> {
+        self.add_layer(tracing_tracy::TracyLayer::default().with_filter(build_env_filter(
+            Some(config.default_directive.parse()?),
+            &config.filters,
+        )?));
+        Ok(())
+    }
+
     /// Add OTLP spans layer to the layer collection
     #[cfg(feature = "otlp")]
     pub fn with_span_layer(

--- a/crates/tracing/src/lib.rs
+++ b/crates/tracing/src/lib.rs
@@ -48,6 +48,9 @@ pub use tracing;
 pub use tracing_appender;
 pub use tracing_subscriber;
 
+#[cfg(feature = "tracy")]
+tracy_client::register_demangler!();
+
 // Re-export our types
 pub use formatter::LogFormat;
 pub use layers::{FileInfo, FileWorkerGuard, Layers};
@@ -71,6 +74,8 @@ pub struct RethTracer {
     journald: Option<String>,
     file: Option<(LayerInfo, FileInfo)>,
     samply: Option<LayerInfo>,
+    #[cfg(feature = "tracy")]
+    tracy: Option<LayerInfo>,
 }
 
 impl RethTracer {
@@ -79,7 +84,14 @@ impl RethTracer {
     /// Initializes with default stdout layer configuration.
     /// Journald and file layers are not set by default.
     pub fn new() -> Self {
-        Self { stdout: LayerInfo::default(), journald: None, file: None, samply: None }
+        Self {
+            stdout: LayerInfo::default(),
+            journald: None,
+            file: None,
+            samply: None,
+            #[cfg(feature = "tracy")]
+            tracy: None,
+        }
     }
 
     /// Sets a custom configuration for the stdout layer.
@@ -113,6 +125,13 @@ impl RethTracer {
     /// Sets the samply layer configuration.
     pub fn with_samply(mut self, config: LayerInfo) -> Self {
         self.samply = Some(config);
+        self
+    }
+
+    /// Sets the tracy layer configuration.
+    #[cfg(feature = "tracy")]
+    pub fn with_tracy(mut self, config: LayerInfo) -> Self {
+        self.tracy = Some(config);
         self
     }
 }
@@ -233,6 +252,11 @@ impl Tracer for RethTracer {
 
         if let Some(config) = self.samply {
             layers.samply(config)?;
+        }
+
+        #[cfg(feature = "tracy")]
+        if let Some(config) = self.tracy {
+            layers.tracy(config)?;
         }
 
         // The error is returned if the global default subscriber is already set,

--- a/crates/tracing/src/lib.rs
+++ b/crates/tracing/src/lib.rs
@@ -56,9 +56,15 @@ pub use formatter::LogFormat;
 pub use layers::{FileInfo, FileWorkerGuard, Layers};
 pub use test_tracer::TestTracer;
 
+#[doc(hidden)]
+pub mod __private {
+    pub use super::throttle::*;
+}
+
 mod formatter;
 mod layers;
 mod test_tracer;
+mod throttle;
 
 use tracing::level_filters::LevelFilter;
 use tracing_appender::non_blocking::WorkerGuard;

--- a/crates/tracing/src/throttle.rs
+++ b/crates/tracing/src/throttle.rs
@@ -1,0 +1,78 @@
+//! Throttling utilities for rate-limiting expression execution.
+
+use std::{
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        LazyLock,
+    },
+    time::Instant,
+};
+
+/// Sentinel value indicating the throttle has never run.
+#[doc(hidden)]
+pub const NOT_YET_RUN: u64 = u64::MAX;
+
+/// Checks if enough time has passed since the last run. Implementation detail for [`throttle!`].
+#[doc(hidden)]
+pub fn should_run(start: &LazyLock<Instant>, last: &AtomicU64, duration_millis: u64) -> bool {
+    let now = start.elapsed().as_millis() as u64;
+    let last_val = last.load(Ordering::Relaxed);
+
+    if last_val == NOT_YET_RUN {
+        return last
+            .compare_exchange(NOT_YET_RUN, now, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok();
+    }
+
+    if now.saturating_sub(last_val) >= duration_millis {
+        last.compare_exchange(last_val, now, Ordering::Relaxed, Ordering::Relaxed).is_ok()
+    } else {
+        false
+    }
+}
+
+/// Throttles the execution of an expression to run at most once per specified duration.
+///
+/// Uses static variables with lazy initialization to track the last execution time.
+/// Thread-safe via atomic operations.
+///
+/// # Examples
+///
+/// ```ignore
+/// use std::time::Duration;
+/// use reth_tracing::throttle;
+///
+/// // Log at most once per second.
+/// throttle!(Duration::from_secs(1), || {
+///     tracing::info!("This message is throttled");
+/// });
+/// ```
+#[macro_export]
+macro_rules! throttle {
+    ($duration:expr, || $expr:expr) => {{
+        static START: ::std::sync::LazyLock<::std::time::Instant> =
+            ::std::sync::LazyLock::new(::std::time::Instant::now);
+        static LAST: ::core::sync::atomic::AtomicU64 =
+            ::core::sync::atomic::AtomicU64::new($crate::__private::NOT_YET_RUN);
+
+        if $crate::__private::should_run(&START, &LAST, $duration.as_millis() as u64) {
+            $expr
+        }
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[test]
+    fn test_throttle_runs_once_initially() {
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+        throttle!(std::time::Duration::from_secs(10), || {
+            COUNTER.fetch_add(1, Ordering::SeqCst);
+        });
+
+        assert_eq!(COUNTER.load(Ordering::SeqCst), 1);
+    }
+}

--- a/crates/trie/common/src/added_removed_keys.rs
+++ b/crates/trie/common/src/added_removed_keys.rs
@@ -7,8 +7,10 @@ use alloy_trie::proof::AddedRemovedKeys;
 /// Tracks added and removed keys across account and storage tries.
 #[derive(Debug, Clone)]
 pub struct MultiAddedRemovedKeys {
-    account: AddedRemovedKeys,
-    storages: B256Map<AddedRemovedKeys>,
+    /// Added and removed accounts.
+    pub account: AddedRemovedKeys,
+    /// Added and removed storage keys for each account.
+    pub storages: B256Map<AddedRemovedKeys>,
 }
 
 /// Returns [`AddedRemovedKeys`] with default parameters. This is necessary while we are not yet

--- a/crates/trie/common/src/utils.rs
+++ b/crates/trie/common/src/utils.rs
@@ -2,53 +2,42 @@ use alloc::vec::Vec;
 use core::cmp::Ordering;
 
 /// Helper function to extend a sorted vector with another sorted vector.
-/// Values from `other` take precedence for duplicate keys.
 ///
-/// This function efficiently merges two sorted vectors by:
-/// 1. Iterating through the target vector with mutable references
-/// 2. Using a peekable iterator for the other vector
-/// 3. For each target item, processing other items that come before or equal to it
-/// 4. Collecting items from other that need to be inserted
-/// 5. Appending and re-sorting only if new items were added
+/// Values from `other` take precedence for duplicate keys.
 pub(crate) fn extend_sorted_vec<K, V>(target: &mut Vec<(K, V)>, other: &[(K, V)])
 where
     K: Clone + Ord,
     V: Clone,
 {
+    let cmp = |a: &(K, V), b: &(K, V)| a.0.cmp(&b.0);
+
     if other.is_empty() {
         return;
     }
 
     let mut other_iter = other.iter().peekable();
-    let mut to_insert = Vec::new();
-
-    // Iterate through target and update/collect items from other
-    for target_item in target.iter_mut() {
+    let initial_len = target.len();
+    for i in 0..initial_len {
         while let Some(other_item) = other_iter.peek() {
-            match other_item.0.cmp(&target_item.0) {
+            let target_item = &mut target[i];
+            match cmp(other_item, target_item) {
                 Ordering::Less => {
-                    // Other item comes before current target item, collect it
-                    to_insert.push(other_iter.next().unwrap().clone());
+                    target.push(other_iter.next().unwrap().clone());
                 }
                 Ordering::Equal => {
-                    // Same key, update target with other's value
                     target_item.1 = other_iter.next().unwrap().1.clone();
                     break;
                 }
                 Ordering::Greater => {
-                    // Other item comes after current target item, keep target unchanged
                     break;
                 }
             }
         }
     }
 
-    // Append collected new items, as well as any remaining from `other` which are necessarily also
-    // new, and sort if needed
-    if !to_insert.is_empty() || other_iter.peek().is_some() {
-        target.extend(to_insert);
-        target.extend(other_iter.cloned());
-        target.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+    target.extend(other_iter.cloned());
+    if target.len() > initial_len {
+        target.sort_by(cmp);
     }
 }
 

--- a/crates/trie/parallel/Cargo.toml
+++ b/crates/trie/parallel/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 # reth
+reth-primitives-traits.workspace = true
 reth-execution-errors.workspace = true
 reth-provider.workspace = true
 reth-storage-errors.workspace = true

--- a/crates/trie/parallel/src/lib.rs
+++ b/crates/trie/parallel/src/lib.rs
@@ -22,6 +22,9 @@ pub mod proof;
 
 pub mod proof_task;
 
+/// V2 multiproof targets and chunking.
+pub mod targets_v2;
+
 /// Parallel state root metrics.
 #[cfg(feature = "metrics")]
 pub mod metrics;

--- a/crates/trie/parallel/src/lib.rs
+++ b/crates/trie/parallel/src/lib.rs
@@ -30,5 +30,5 @@ pub mod metrics;
 #[cfg(feature = "metrics")]
 pub mod proof_task_metrics;
 
-/// Implementation of value encoder for proof_v2
+/// Implementation of value encoder for `proof_v2`
 mod value_encoder;

--- a/crates/trie/parallel/src/lib.rs
+++ b/crates/trie/parallel/src/lib.rs
@@ -29,3 +29,6 @@ pub mod metrics;
 /// Proof task manager metrics.
 #[cfg(feature = "metrics")]
 pub mod proof_task_metrics;
+
+/// Implementation of value encoder for proof_v2
+mod value_encoder;

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -110,8 +110,11 @@ impl ParallelProof {
         target_slots: B256Set,
     ) -> Result<DecodedStorageMultiProof, ParallelStateRootError> {
         let total_targets = target_slots.len();
-        let prefix_set = PrefixSetMut::from(target_slots.iter().map(Nibbles::unpack));
-        let prefix_set = prefix_set.freeze();
+        let prefix_set = if self.v2_proofs_enabled {
+            PrefixSet::default()
+        } else {
+            PrefixSetMut::from(target_slots.iter().map(Nibbles::unpack)).freeze()
+        };
 
         trace!(
             target: "trie::parallel_proof",

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -1381,8 +1381,9 @@ where
             start_time: start,
         } = proof_result_sender;
 
-        let proof_elapsed = proof_start.elapsed();
-        let total_elapsed = start.elapsed();
+        let now = Instant::now();
+        let proof_elapsed = now.duration_since(proof_start);
+        let total_elapsed = now.duration_since(start);
         *account_proofs_processed += 1;
 
         // Send result to MultiProofTask

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -30,7 +30,7 @@
 //! ```
 
 use crate::{
-    root::ParallelStateRootError, stats::ParallelTrieTracker,
+    root::ParallelStateRootError, stats::ParallelTrieTracker, targets_v2::MultiProofTargetsV2,
     value_encoder::AsyncAccountValueEncoder, StorageRootTargets,
 };
 use alloy_primitives::{
@@ -1851,23 +1851,6 @@ impl StorageProofInput {
                 *hashed_address
             }
         }
-    }
-}
-
-/// A set of account and storage V2 proof targets. The account and storage targets do not need to
-/// necessarily overlap.
-#[derive(Debug, Default)]
-pub struct MultiProofTargetsV2 {
-    /// The set of account proof targets to generate proofs for.
-    pub account_targets: Vec<proof_v2::Target>,
-    /// The sets of storage proof targets to generate proofs for.
-    pub storage_targets: B256Map<Vec<proof_v2::Target>>,
-}
-
-impl MultiProofTargetsV2 {
-    /// Returns true is there are no account or storage targets.
-    pub fn is_empty(&self) -> bool {
-        self.account_targets.is_empty() && self.storage_targets.is_empty()
     }
 }
 

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -51,8 +51,8 @@ use reth_trie::{
     proof_v2,
     trie_cursor::{InstrumentedTrieCursor, TrieCursorFactory, TrieCursorMetricsCache},
     walker::TrieWalker,
-    DecodedMultiProof, DecodedStorageMultiProof, HashBuilder, HashedPostState, MultiProofTargets,
-    Nibbles, ProofTrieNode, TRIE_ACCOUNT_RLP_MAX_SIZE,
+    DecodedMultiProof, DecodedMultiProofV2, DecodedStorageMultiProof, HashBuilder, HashedPostState,
+    MultiProofTargets, Nibbles, ProofTrieNode, TRIE_ACCOUNT_RLP_MAX_SIZE,
 };
 use reth_trie_common::{
     added_removed_keys::MultiAddedRemovedKeys,
@@ -595,32 +595,6 @@ impl TrieNodeProvider for ProofTaskTrieNodeProvider {
                     .map_err(|error| SparseTrieErrorKind::Other(Box::new(error)))?;
                 rx.recv().map_err(|error| SparseTrieErrorKind::Other(Box::new(error)))?
             }
-        }
-    }
-}
-
-/// Result of a V2 multiproof calculation.
-#[derive(Debug, Default)]
-pub struct DecodedMultiProofV2 {
-    /// Account trie proof nodes
-    pub account_proofs: Vec<ProofTrieNode>,
-    /// Storage trie proof nodes indexed by account
-    pub storage_proofs: B256Map<Vec<ProofTrieNode>>,
-}
-
-impl DecodedMultiProofV2 {
-    /// Returns true if there are no proofs
-    pub fn is_empty(&self) -> bool {
-        self.account_proofs.is_empty() && self.storage_proofs.is_empty()
-    }
-
-    /// Appends the given multiproof's data to this one.
-    ///
-    /// This implementation does not deduplicate redundant proofs.
-    pub fn extend(&mut self, other: Self) {
-        self.account_proofs.extend(other.account_proofs);
-        for (hashed_address, other_storage_proofs) in other.storage_proofs {
-            self.storage_proofs.entry(hashed_address).or_default().extend(other_storage_proofs);
         }
     }
 }

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -41,7 +41,7 @@ use alloy_primitives::{
 use alloy_rlp::{BufMut, Encodable};
 use crossbeam_channel::{unbounded, Receiver as CrossbeamReceiver, Sender as CrossbeamSender};
 use dashmap::DashMap;
-use reth_execution_errors::{SparseTrieError, SparseTrieErrorKind};
+use reth_execution_errors::{SparseTrieError, SparseTrieErrorKind, StateProofError};
 use reth_provider::{DatabaseProviderROFactory, ProviderError, ProviderResult};
 use reth_storage_errors::db::DatabaseError;
 use reth_trie::{
@@ -305,17 +305,17 @@ impl ProofWorkerHandle {
         self.storage_work_tx
             .send(StorageWorkerJob::StorageProof { input, proof_result_sender })
             .map_err(|err| {
-                let error =
-                    ProviderError::other(std::io::Error::other("storage workers unavailable"));
-
                 if let StorageWorkerJob::StorageProof { proof_result_sender, .. } = err.0 {
                     let _ = proof_result_sender.send(StorageProofResultMessage {
                         hashed_address,
-                        result: Err(ParallelStateRootError::Provider(error.clone())),
+                        result: Err(DatabaseError::Other(
+                            "storage workers unavailable".to_string(),
+                        )
+                        .into()),
                     });
                 }
 
-                error
+                ProviderError::other(std::io::Error::other("storage workers unavailable"))
             })
     }
 
@@ -432,7 +432,7 @@ where
         input: StorageProofInput,
         trie_cursor_metrics: &mut TrieCursorMetricsCache,
         hashed_cursor_metrics: &mut HashedCursorMetricsCache,
-    ) -> Result<StorageProofResult, ParallelStateRootError> {
+    ) -> Result<StorageProofResult, StateProofError> {
         // Consume the input so we can move large collections (e.g. target slots) without cloning.
         let StorageProofInput::Legacy {
             hashed_address,
@@ -469,20 +469,13 @@ where
                 .with_added_removed_keys(added_removed_keys)
                 .with_trie_cursor_metrics(trie_cursor_metrics)
                 .with_hashed_cursor_metrics(hashed_cursor_metrics)
-                .storage_multiproof(target_slots)
-                .map_err(|e| ParallelStateRootError::Other(e.to_string()));
+                .storage_multiproof(target_slots);
         trie_cursor_metrics.record_span("trie_cursor");
         hashed_cursor_metrics.record_span("hashed_cursor");
 
         // Decode proof into DecodedStorageMultiProof
-        let decoded_result = raw_proof_result.and_then(|raw_proof| {
-            raw_proof.try_into().map_err(|e: alloy_rlp::Error| {
-                ParallelStateRootError::Other(format!(
-                    "Failed to decode storage proof for {}: {}",
-                    hashed_address, e
-                ))
-            })
-        })?;
+        let decoded_result =
+            raw_proof_result.and_then(|raw_proof| raw_proof.try_into().map_err(Into::into))?;
 
         trace!(
             target: "trie::proof_task",
@@ -502,7 +495,7 @@ where
             <Provider as TrieCursorFactory>::StorageTrieCursor<'_>,
             <Provider as HashedCursorFactory>::StorageCursor<'_>,
         >,
-    ) -> Result<StorageProofResult, ParallelStateRootError> {
+    ) -> Result<StorageProofResult, StateProofError> {
         let StorageProofInput::V2 { hashed_address, mut targets } = input else {
             panic!("compute_v2_storage_proof only accepts StorageProofInput::V2")
         };
@@ -717,7 +710,7 @@ pub struct StorageProofResultMessage {
     /// The hashed address this storage proof belongs to
     pub(crate) hashed_address: B256,
     /// The storage proof calculation result
-    pub(crate) result: Result<StorageProofResult, ParallelStateRootError>,
+    pub(crate) result: Result<StorageProofResult, StateProofError>,
 }
 
 /// Internal message for storage workers.
@@ -1642,7 +1635,7 @@ impl StorageProofInput {
         }
     }
 
-    /// Creates a new [`StorageProofInput`] with the given hashed address  and target slots.
+    /// Creates a new [`StorageProofInput`] with the given hashed address and target slots.
     pub const fn new(hashed_address: B256, targets: Vec<proof_v2::Target>) -> Self {
         Self::V2 { hashed_address, targets }
     }

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -1279,13 +1279,13 @@ where
         let storage_proof_receivers =
             dispatch_v2_storage_proofs(&self.storage_work_tx, &account_targets, storage_targets)?;
 
-        let value_encoder = AsyncAccountValueEncoder::new(
+        let mut value_encoder = AsyncAccountValueEncoder::new(
             self.storage_work_tx.clone(),
             storage_proof_receivers,
             self.cached_storage_roots.clone(),
         );
 
-        let proof = v2_calculator.proof(&value_encoder, &mut account_targets)?;
+        let proof = v2_calculator.proof(&mut value_encoder, &mut account_targets)?;
         todo!()
     }
 

--- a/crates/trie/parallel/src/stats.rs
+++ b/crates/trie/parallel/src/stats.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "metrics")]
-use crate::proof_task_metrics::ProofTaskCursorMetricsCache;
 use derive_more::Deref;
 use reth_trie::stats::{TrieStats, TrieTracker};
 
@@ -36,9 +34,6 @@ pub struct ParallelTrieTracker {
     trie: TrieTracker,
     precomputed_storage_roots: u64,
     missed_leaves: u64,
-    #[cfg(feature = "metrics")]
-    /// Local tracking of cursor-related metrics
-    pub cursor_metrics: ProofTaskCursorMetricsCache,
 }
 
 impl ParallelTrieTracker {

--- a/crates/trie/parallel/src/targets_v2.rs
+++ b/crates/trie/parallel/src/targets_v2.rs
@@ -1,0 +1,148 @@
+//! V2 multiproof targets and chunking.
+
+use alloy_primitives::{map::B256Map, B256};
+use reth_trie::proof_v2;
+
+/// A set of account and storage V2 proof targets. The account and storage targets do not need to
+/// necessarily overlap.
+#[derive(Debug, Default)]
+pub struct MultiProofTargetsV2 {
+    /// The set of account proof targets to generate proofs for.
+    pub account_targets: Vec<proof_v2::Target>,
+    /// The sets of storage proof targets to generate proofs for.
+    pub storage_targets: B256Map<Vec<proof_v2::Target>>,
+}
+
+impl MultiProofTargetsV2 {
+    /// Returns true is there are no account or storage targets.
+    pub fn is_empty(&self) -> bool {
+        self.account_targets.is_empty() && self.storage_targets.is_empty()
+    }
+}
+
+/// An iterator that yields chunks of V2 proof targets of at most `size` account and storage
+/// targets.
+///
+/// Unlike legacy chunking, V2 preserves account targets exactly as they were (with their min_len
+/// metadata). Account targets must appear in a chunk. Storage targets for those accounts are
+/// chunked together, but if they exceed the chunk size, subsequent chunks contain only the
+/// remaining storage targets without repeating the account target.
+#[derive(Debug)]
+pub struct ChunkedMultiProofTargetsV2 {
+    /// Remaining account targets to process
+    account_targets: std::vec::IntoIter<proof_v2::Target>,
+    /// Storage targets by account address
+    storage_targets: B256Map<Vec<proof_v2::Target>>,
+    /// Current account being processed (if any storage slots remain)
+    current_account_storage: Option<(B256, std::vec::IntoIter<proof_v2::Target>)>,
+    /// Chunk size
+    size: usize,
+}
+
+impl ChunkedMultiProofTargetsV2 {
+    /// Creates a new chunked iterator for the given targets.
+    pub fn new(targets: MultiProofTargetsV2, size: usize) -> Self {
+        Self {
+            account_targets: targets.account_targets.into_iter(),
+            storage_targets: targets.storage_targets,
+            current_account_storage: None,
+            size,
+        }
+    }
+}
+
+impl Iterator for ChunkedMultiProofTargetsV2 {
+    type Item = MultiProofTargetsV2;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut chunk = MultiProofTargetsV2::default();
+        let mut count = 0;
+
+        // First, finish any remaining storage slots from previous account
+        if let Some((account_addr, ref mut storage_iter)) = self.current_account_storage {
+            let remaining_capacity = self.size - count;
+            let slots: Vec<_> = storage_iter.by_ref().take(remaining_capacity).collect();
+
+            count += slots.len();
+            chunk.storage_targets.insert(account_addr, slots);
+
+            // If iterator is exhausted, clear current_account_storage
+            if storage_iter.len() == 0 {
+                self.current_account_storage = None;
+            }
+        }
+
+        // Process account targets and their storage
+        while count < self.size {
+            let Some(account_target) = self.account_targets.next() else {
+                break;
+            };
+
+            // Add the account target
+            chunk.account_targets.push(account_target);
+            count += 1;
+
+            // Check if this account has storage targets
+            let account_addr = account_target.key();
+            if let Some(storage_slots) = self.storage_targets.remove(&account_addr) {
+                let remaining_capacity = self.size - count;
+
+                if storage_slots.len() <= remaining_capacity {
+                    // Optimization: We can take all slots, just move the vec
+                    count += storage_slots.len();
+                    chunk.storage_targets.insert(account_addr, storage_slots);
+                } else {
+                    // We need to split the storage slots
+                    let mut storage_iter = storage_slots.into_iter();
+                    let slots_in_chunk: Vec<_> =
+                        storage_iter.by_ref().take(remaining_capacity).collect();
+                    count += slots_in_chunk.len();
+
+                    chunk.storage_targets.insert(account_addr, slots_in_chunk);
+
+                    // Save remaining storage slots for next chunk
+                    self.current_account_storage = Some((account_addr, storage_iter));
+                    break;
+                }
+            }
+        }
+
+        // Process any remaining storage-only entries (accounts not in account_targets)
+        while let Some((account_addr, storage_slots)) = self.storage_targets.iter_mut().next() &&
+            count < self.size
+        {
+            let account_addr = *account_addr;
+            let storage_slots = std::mem::take(storage_slots);
+            let remaining_capacity = self.size - count;
+
+            // Always remove from the map - if there are remaining slots they go to
+            // current_account_storage
+            self.storage_targets.remove(&account_addr);
+
+            if storage_slots.len() <= remaining_capacity {
+                // Optimization: We can take all slots, just move the vec
+                count += storage_slots.len();
+                chunk.storage_targets.insert(account_addr, storage_slots);
+            } else {
+                // We need to split the storage slots
+                let mut storage_iter = storage_slots.into_iter();
+                let slots_in_chunk: Vec<_> =
+                    storage_iter.by_ref().take(remaining_capacity).collect();
+
+                chunk.storage_targets.insert(account_addr, slots_in_chunk);
+
+                // Save remaining storage slots for next chunk
+                if storage_iter.len() > 0 {
+                    self.current_account_storage = Some((account_addr, storage_iter));
+                }
+                break;
+            }
+        }
+
+        if chunk.account_targets.is_empty() && chunk.storage_targets.is_empty() {
+            None
+        } else {
+            Some(chunk)
+        }
+    }
+}

--- a/crates/trie/parallel/src/value_encoder.rs
+++ b/crates/trie/parallel/src/value_encoder.rs
@@ -1,74 +1,115 @@
 use crate::proof_task::{
-    ProofWorkerHandle, StorageProofInput, StorageProofResult, StorageProofResultMessage,
+    StorageProofInput, StorageProofResult, StorageProofResultMessage, StorageWorkerJob,
 };
 use alloy_primitives::{map::B256Map, B256};
 use alloy_rlp::Encodable;
-use crossbeam_channel::Receiver as CrossbeamReceiver;
+use core::cell::RefCell;
+use crossbeam_channel::{Receiver as CrossbeamReceiver, Sender as CrossbeamSender};
+use dashmap::DashMap;
 use reth_execution_errors::trie::StateProofError;
 use reth_primitives_traits::Account;
-use reth_provider::ProviderError;
 use reth_storage_errors::db::DatabaseError;
-use reth_trie::proof_v2::{DeferredValueEncoder, LeafValueEncoder, Target};
+use reth_trie::{
+    proof_v2::{DeferredValueEncoder, LeafValueEncoder, Target},
+    ProofTrieNode,
+};
+use std::{cell::Cell, rc::Rc, sync::Arc};
+
+/// Tracks the receiver used for receiving the results from storage proof jobs, as well as a Cell
+/// which is used to exfiltrate those results after they've been used within the
+/// [`AsyncAccountDeferredValueEncoder`].
+pub(crate) struct DispatchedStorageProof {
+    proof_result_rx: CrossbeamReceiver<StorageProofResultMessage>,
+    proof_nodes: Cell<Option<Result<StorageProofResult, StateProofError>>>,
+}
 
 /// Returned from [`AsyncAccountValueEncoder`], used to track an async storage root calculation.
-pub(crate) struct AsyncAccountDeferredValueEncoder {
-    hashed_address: B256,
-    account: Account,
-    proof_result_rx: Result<CrossbeamReceiver<StorageProofResultMessage>, ProviderError>,
+pub(crate) enum AsyncAccountDeferredValueEncoder {
+    Dispatched {
+        hashed_address: B256,
+        account: Account,
+        proof_result_rx: Result<CrossbeamReceiver<StorageProofResultMessage>, DatabaseError>,
+        storage_proof_results: Rc<RefCell<B256Map<Vec<ProofTrieNode>>>>,
+    },
+    FromCache {
+        account: Account,
+        root: B256,
+    },
 }
 
 impl DeferredValueEncoder for AsyncAccountDeferredValueEncoder {
     fn encode(self, buf: &mut Vec<u8>) -> Result<(), StateProofError> {
-        let result = self
-            .proof_result_rx
-            .map_err(|err| {
-                StateProofError::Database(DatabaseError::Other(format!(
-                    "Failed to dispatch storage proof for {}: {err}",
-                    self.hashed_address,
-                )))
-            })?
-            .recv()
-            .map_err(|_| {
-                StateProofError::Database(DatabaseError::Other(format!(
-                    "Storage proof channel closed for {}",
-                    self.hashed_address,
-                )))
-            })?
-            .result?;
+        let (account, root) = match self {
+            Self::Dispatched {
+                hashed_address,
+                account,
+                proof_result_rx,
+                storage_proof_results,
+            } => {
+                let result = proof_result_rx?
+                    .recv()
+                    .map_err(|_| {
+                        StateProofError::Database(DatabaseError::Other(format!(
+                            "Storage proof channel closed for {hashed_address:?}",
+                        )))
+                    })?
+                    .result?;
 
-        let StorageProofResult::V2 { root: Some(root), .. } = result else {
-            panic!("StorageProofResult is not V2 with root: {result:?}")
+                let StorageProofResult::V2 { root: Some(root), proof } = result else {
+                    panic!("StorageProofResult is not V2 with root: {result:?}")
+                };
+
+                storage_proof_results.borrow_mut().insert(hashed_address, proof);
+
+                (account, root)
+            }
+            Self::FromCache { account, root } => (account, root),
         };
 
-        let account = self.account.into_trie_account(root);
+        let account = account.into_trie_account(root);
         account.encode(buf);
         Ok(())
     }
 }
 
-/// Implements the [`LeafValueEncoder`] trait for accounts using a [`ProofWorkerHandle`] to dispatch
+/// Implements the [`LeafValueEncoder`] trait for accounts using a [`CrossbeamSender`] to dispatch
 /// and compute storage roots asyncronously. Can also accept a set of already dispatched account
-/// storage roots, for cases where it's possible to determine some necessary accounts ahead of time.
+/// storage proofs, for cases where it's possible to determine some necessary accounts ahead of
+/// time.
 pub(crate) struct AsyncAccountValueEncoder {
-    handle: ProofWorkerHandle,
+    storage_work_tx: CrossbeamSender<StorageWorkerJob>,
+    /// Storage proof jobs which were dispatched ahead of time.
     dispatched: B256Map<CrossbeamReceiver<StorageProofResultMessage>>,
+    /// Storage roots which have already been computed. This can be used only if a storage proof
+    /// wasn't dispatched for an account, otherwise we must consume the proof result.
+    cached_storage_roots: Arc<DashMap<B256, B256>>,
+    /// Tracks storage proof results received from the storage workers. [`Rc`] + [`RefCell`] is
+    /// required because [`DeferredValueEncoder`] cannot have a lifetime.
+    storage_proof_results: Rc<RefCell<B256Map<Vec<ProofTrieNode>>>>,
 }
 
 impl AsyncAccountValueEncoder {
     /// Initializes a [`Self`] using a [`ProofWorkerHandle`] which will be used to calculate storage
     /// roots asynchronously.
-    pub(crate) fn new(handle: ProofWorkerHandle) -> Self {
-        Self { handle, dispatched: B256Map::default() }
+    pub(crate) fn new(
+        storage_work_tx: CrossbeamSender<StorageWorkerJob>,
+        dispatched: B256Map<CrossbeamReceiver<StorageProofResultMessage>>,
+        cached_storage_roots: Arc<DashMap<B256, B256>>,
+    ) -> Self {
+        Self {
+            storage_work_tx,
+            dispatched,
+            cached_storage_roots,
+            storage_proof_results: Default::default(),
+        }
     }
 
-    /// Use the given set of already dispatched storage root calculations.
-    pub(crate) fn with_dispatched(
-        mut self,
-        dispatched: B256Map<CrossbeamReceiver<StorageProofResultMessage>>,
-    ) -> Self {
-        self.dispatched = dispatched;
-        self
-    }
+    ///// Consume [`Self`] and return all collected storage proofs which had been dispatched.
+    //pub(crate) fn into_storage_proofs(
+    //    mut self,
+    //) -> Result<B256Map<Vec<ProofTrieNode>>, DatabaseError> {
+    //    let mut storage_proof_results = self.storage_proof_results.into_inner();
+    //}
 }
 
 impl LeafValueEncoder for AsyncAccountValueEncoder {
@@ -83,22 +124,38 @@ impl LeafValueEncoder for AsyncAccountValueEncoder {
         // If the proof job has already been dispatched for this account then it's not necessary to
         // dispatch another.
         if let Some(rx) = self.dispatched.get(&hashed_address) {
-            return AsyncAccountDeferredValueEncoder {
+            return AsyncAccountDeferredValueEncoder::Dispatched {
                 hashed_address,
                 account,
                 proof_result_rx: Ok(rx.clone()),
+                storage_proof_results: self.storage_proof_results.clone(),
             }
         }
 
-        // Create a proof input which just targets a bogus key, so that we calculate the root as a
+        // If the address didn't have a job dispatched for it then we can assume it has no targets,
+        // and we only need its root.
+
+        // If the root is already calculated then just use it directly
+        if let Some(root) = self.cached_storage_roots.get(&hashed_address) {
+            return AsyncAccountDeferredValueEncoder::FromCache { account, root: *root }
+        }
+
+        // Create a proof input which targets a bogus key, so that we calculate the root as a
         // side-effect.
         let input = StorageProofInput::new(hashed_address, vec![Target::new(B256::ZERO)]);
         let (tx, rx) = crossbeam_channel::bounded(1);
 
-        AsyncAccountDeferredValueEncoder {
+        let proof_result_rx = self
+            .storage_work_tx
+            .send(StorageWorkerJob::StorageProof { input, proof_result_sender: tx })
+            .map_err(|_| DatabaseError::Other("storage workers unavailable".to_string()))
+            .map(|_| rx);
+
+        AsyncAccountDeferredValueEncoder::Dispatched {
             hashed_address,
             account,
-            proof_result_rx: self.handle.dispatch_storage_proof(input, tx).map(|_| rx),
+            proof_result_rx,
+            storage_proof_results: self.storage_proof_results.clone(),
         }
     }
 }

--- a/crates/trie/parallel/src/value_encoder.rs
+++ b/crates/trie/parallel/src/value_encoder.rs
@@ -117,7 +117,7 @@ impl LeafValueEncoder for AsyncAccountValueEncoder {
     type DeferredEncoder = AsyncAccountDeferredValueEncoder;
 
     fn deferred_encoder(
-        &self,
+        &mut self,
         hashed_address: B256,
         account: Self::Value,
     ) -> Self::DeferredEncoder {

--- a/crates/trie/parallel/src/value_encoder.rs
+++ b/crates/trie/parallel/src/value_encoder.rs
@@ -1,0 +1,104 @@
+use crate::proof_task::{
+    ProofWorkerHandle, StorageProofInput, StorageProofResult, StorageProofResultMessage,
+};
+use alloy_primitives::{map::B256Map, B256};
+use alloy_rlp::Encodable;
+use crossbeam_channel::Receiver as CrossbeamReceiver;
+use reth_execution_errors::trie::StateProofError;
+use reth_primitives_traits::Account;
+use reth_provider::ProviderError;
+use reth_storage_errors::db::DatabaseError;
+use reth_trie::proof_v2::{DeferredValueEncoder, LeafValueEncoder, Target};
+
+/// Returned from [`AsyncAccountValueEncoder`], used to track an async storage root calculation.
+pub(crate) struct AsyncAccountDeferredValueEncoder {
+    hashed_address: B256,
+    account: Account,
+    proof_result_rx: Result<CrossbeamReceiver<StorageProofResultMessage>, ProviderError>,
+}
+
+impl DeferredValueEncoder for AsyncAccountDeferredValueEncoder {
+    fn encode(self, buf: &mut Vec<u8>) -> Result<(), StateProofError> {
+        let result = self
+            .proof_result_rx
+            .map_err(|err| {
+                StateProofError::Database(DatabaseError::Other(format!(
+                    "Failed to dispatch storage proof for {}: {err}",
+                    self.hashed_address,
+                )))
+            })?
+            .recv()
+            .map_err(|_| {
+                StateProofError::Database(DatabaseError::Other(format!(
+                    "Storage proof channel closed for {}",
+                    self.hashed_address,
+                )))
+            })?
+            .result?;
+
+        let StorageProofResult::V2 { root: Some(root), .. } = result else {
+            panic!("StorageProofResult is not V2 with root: {result:?}")
+        };
+
+        let account = self.account.into_trie_account(root);
+        account.encode(buf);
+        Ok(())
+    }
+}
+
+/// Implements the [`LeafValueEncoder`] trait for accounts using a [`ProofWorkerHandle`] to dispatch
+/// and compute storage roots asyncronously. Can also accept a set of already dispatched account
+/// storage roots, for cases where it's possible to determine some necessary accounts ahead of time.
+pub(crate) struct AsyncAccountValueEncoder {
+    handle: ProofWorkerHandle,
+    dispatched: B256Map<CrossbeamReceiver<StorageProofResultMessage>>,
+}
+
+impl AsyncAccountValueEncoder {
+    /// Initializes a [`Self`] using a [`ProofWorkerHandle`] which will be used to calculate storage
+    /// roots asynchronously.
+    pub(crate) fn new(handle: ProofWorkerHandle) -> Self {
+        Self { handle, dispatched: B256Map::default() }
+    }
+
+    /// Use the given set of already dispatched storage root calculations.
+    pub(crate) fn with_dispatched(
+        mut self,
+        dispatched: B256Map<CrossbeamReceiver<StorageProofResultMessage>>,
+    ) -> Self {
+        self.dispatched = dispatched;
+        self
+    }
+}
+
+impl LeafValueEncoder for AsyncAccountValueEncoder {
+    type Value = Account;
+    type DeferredEncoder = AsyncAccountDeferredValueEncoder;
+
+    fn deferred_encoder(
+        &self,
+        hashed_address: B256,
+        account: Self::Value,
+    ) -> Self::DeferredEncoder {
+        // If the proof job has already been dispatched for this account then it's not necessary to
+        // dispatch another.
+        if let Some(rx) = self.dispatched.get(&hashed_address) {
+            return AsyncAccountDeferredValueEncoder {
+                hashed_address,
+                account,
+                proof_result_rx: Ok(rx.clone()),
+            }
+        }
+
+        // Create a proof input which just targets a bogus key, so that we calculate the root as a
+        // side-effect.
+        let input = StorageProofInput::new(hashed_address, vec![Target::new(B256::ZERO)]);
+        let (tx, rx) = crossbeam_channel::bounded(1);
+
+        AsyncAccountDeferredValueEncoder {
+            hashed_address,
+            account,
+            proof_result_rx: self.handle.dispatch_storage_proof(input, tx).map(|_| rx),
+        }
+    }
+}

--- a/crates/trie/sparse-parallel/Cargo.toml
+++ b/crates/trie/sparse-parallel/Cargo.toml
@@ -39,6 +39,7 @@ reth-trie-common = { workspace = true, features = ["test-utils", "arbitrary"] }
 reth-trie-db.workspace = true
 reth-trie-sparse = { workspace = true, features = ["test-utils"] }
 reth-trie.workspace = true
+reth-tracing.workspace = true
 
 # misc
 arbitrary.workspace = true

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -339,7 +339,12 @@ impl SparseTrieInterface for ParallelSparseTrie {
 
                     if let Some(reveal_path) = reveal_path {
                         let subtrie = self.subtrie_for_path_mut(&reveal_path);
-                        if subtrie.nodes.get(&reveal_path).expect("node must exist").is_hash() {
+                        let reveal_masks = if subtrie
+                            .nodes
+                            .get(&reveal_path)
+                            .expect("node must exist")
+                            .is_hash()
+                        {
                             debug!(
                                 target: "trie::parallel_sparse",
                                 child_path = ?reveal_path,
@@ -360,12 +365,19 @@ impl SparseTrieInterface for ParallelSparseTrie {
                                 );
                                 let masks = BranchNodeMasks::from_optional(hash_mask, tree_mask);
                                 subtrie.reveal_node(reveal_path, &decoded, masks)?;
+                                masks
                             } else {
                                 return Err(SparseTrieErrorKind::NodeNotFoundInProvider {
                                     path: reveal_path,
                                 }
                                 .into())
                             }
+                        } else {
+                            None
+                        };
+
+                        if let Some(masks) = reveal_masks {
+                            self.branch_node_masks.insert(reveal_path, masks);
                         }
                     }
 
@@ -436,7 +448,11 @@ impl SparseTrieInterface for ParallelSparseTrie {
 
             // If we didn't update the target leaf, we need to call update_leaf on the subtrie
             // to ensure that the leaf is updated correctly.
-            subtrie.update_leaf(full_path, value, provider, retain_updates)?;
+            if let Some((revealed_path, revealed_masks)) =
+                subtrie.update_leaf(full_path, value, provider, retain_updates)?
+            {
+                self.branch_node_masks.insert(revealed_path, revealed_masks);
+            }
         }
 
         Ok(())
@@ -1232,7 +1248,7 @@ impl ParallelSparseTrie {
     ) -> SparseTrieResult<SparseNode> {
         let remaining_child_subtrie = self.subtrie_for_path_mut(remaining_child_path);
 
-        let remaining_child_node = match remaining_child_subtrie
+        let (remaining_child_node, remaining_child_masks) = match remaining_child_subtrie
             .nodes
             .get(remaining_child_path)
             .unwrap()
@@ -1258,7 +1274,10 @@ impl ParallelSparseTrie {
                     );
                     let masks = BranchNodeMasks::from_optional(hash_mask, tree_mask);
                     remaining_child_subtrie.reveal_node(*remaining_child_path, &decoded, masks)?;
-                    remaining_child_subtrie.nodes.get(remaining_child_path).unwrap().clone()
+                    (
+                        remaining_child_subtrie.nodes.get(remaining_child_path).unwrap().clone(),
+                        masks,
+                    )
                 } else {
                     return Err(SparseTrieErrorKind::NodeNotFoundInProvider {
                         path: *remaining_child_path,
@@ -1266,8 +1285,14 @@ impl ParallelSparseTrie {
                     .into())
                 }
             }
-            node => node.clone(),
+            // The node is already revealed so we don't need to return its masks here, as they don't
+            // need to be inserted.
+            node => (node.clone(), None),
         };
+
+        if let Some(masks) = remaining_child_masks {
+            self.branch_node_masks.insert(*remaining_child_path, masks);
+        }
 
         // If `recurse_into_extension` is true, and the remaining child is an extension node, then
         // its child will be ensured to be revealed as well. This is required for generation of
@@ -1636,9 +1661,9 @@ impl SparseSubtrie {
     ///
     /// # Returns
     ///
-    /// Returns the `Ok` if the update is successful.
+    /// Returns the path and masks of any blinded node revealed as a result of updating the leaf.
     ///
-    /// Note: If an update requires revealing a blinded node, an error is returned if the blinded
+    /// If an update requires revealing a blinded node, an error is returned if the blinded
     /// provider returns an error.
     pub fn update_leaf(
         &mut self,
@@ -1646,16 +1671,17 @@ impl SparseSubtrie {
         value: Vec<u8>,
         provider: impl TrieNodeProvider,
         retain_updates: bool,
-    ) -> SparseTrieResult<()> {
+    ) -> SparseTrieResult<Option<(Nibbles, BranchNodeMasks)>> {
         debug_assert!(full_path.starts_with(&self.path));
         let existing = self.inner.values.insert(full_path, value);
         if existing.is_some() {
             // trie structure unchanged, return immediately
-            return Ok(())
+            return Ok(None)
         }
 
         // Here we are starting at the root of the subtrie, and traversing from there.
         let mut current = Some(self.path);
+        let mut revealed = None;
         while let Some(current_path) = current {
             match self.update_next_node(current_path, &full_path, retain_updates)? {
                 LeafUpdateStep::Continue { next_node } => {
@@ -1685,6 +1711,12 @@ impl SparseSubtrie {
                             );
                             let masks = BranchNodeMasks::from_optional(hash_mask, tree_mask);
                             self.reveal_node(reveal_path, &decoded, masks)?;
+
+                            debug_assert_eq!(
+                                revealed, None,
+                                "Only a single blinded node should be revealed during update_leaf"
+                            );
+                            revealed = masks.map(|masks| (reveal_path, masks));
                         } else {
                             return Err(SparseTrieErrorKind::NodeNotFoundInProvider {
                                 path: reveal_path,
@@ -1701,7 +1733,7 @@ impl SparseSubtrie {
             }
         }
 
-        Ok(())
+        Ok(revealed)
     }
 
     /// Processes the current node, returning what to do next in the leaf update process.
@@ -6802,5 +6834,138 @@ mod tests {
         assert_matches!(result, Err(LeafLookupError::BlindedNode { path, hash })
             if path == path_to_blind && hash == blinded_hash
         );
+    }
+
+    #[test]
+    fn test_mainnet_block_24185431_storage_0x6ba784ee() {
+        reth_tracing::init_test_tracing();
+
+        // Reveal branch at 0x3 with full state
+        let mut branch_0x3_hashes = vec![
+            B256::from(hex!("fc11ba8de4b220b8f19a09f0676c69b8e18bae1350788392640069e59b41733d")),
+            B256::from(hex!("8afe085cc6685680bd8ba4bac6e65937a4babf737dc5e7413d21cdda958e8f74")),
+            B256::from(hex!("c7b6f7c0fc601a27aece6ec178fd9be17cdee77c4884ecfbe1ee459731eb57da")),
+            B256::from(hex!("71c1aec60db78a2deb4e10399b979a2ed5be42b4ee0c0a17c614f9ddc9f9072e")),
+            B256::from(hex!("e9261302e7c0b77930eaf1851b585210906cd01e015ab6be0f7f3c0cc947c32a")),
+            B256::from(hex!("38ce8f369c56bd77fabdf679b27265b1f8d0a54b09ef612c8ee8ddfc6b3fab95")),
+            B256::from(hex!("7b507a8936a28c5776b647d1c4bda0bbbb3d0d227f16c5f5ebba58d02e31918d")),
+            B256::from(hex!("0f456b9457a824a81e0eb555aa861461acb38674dcf36959b3b26deb24ed0af9")),
+            B256::from(hex!("2145420289652722ad199ba932622e3003c779d694fa5a2acfb2f77b0782b38a")),
+            B256::from(hex!("2c1a04dce1a9e2f1cfbf8806edce50a356dfa58e7e7c542c848541502613b796")),
+            B256::from(hex!("dad7ca55186ac8f40d4450dc874166df8267b44abc07e684d9507260f5712df3")),
+            B256::from(hex!("3a8c2a1d7d2423e92965ec29014634e7f0307ded60b1a63d28c86c3222b24236")),
+            B256::from(hex!("4e9929e6728b3a7bf0db6a0750ab376045566b556c9c605e606ecb8ec25200d7")),
+            B256::from(hex!("1797c36f98922f52292c161590057a1b5582d5503e3370bcfbf6fd939f3ec98b")),
+            B256::from(hex!("9e514589a9c9210b783c19fa3f0b384bbfaefe98f10ea189a2bfc58c6bf000a1")),
+            B256::from(hex!("85bdaabbcfa583cbd049650e41d3d19356bd833b3ed585cf225a3548557c7fa3")),
+        ];
+        let branch_0x3_node = create_branch_node_with_children(
+            &[0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf],
+            branch_0x3_hashes.iter().map(RlpNode::word_rlp),
+        );
+
+        // Reveal branch at 0x31
+        let branch_0x31_hashes = vec![B256::from(hex!(
+            "3ca994ba59ce70b83fee1f01731c8dac4fdd0f70ade79bf9b0695c4c53531aab"
+        ))];
+        let branch_0x31_node = create_branch_node_with_children(
+            &[0xc],
+            branch_0x31_hashes.into_iter().map(|h| RlpNode::word_rlp(&h)),
+        );
+
+        // Reveal leaf at 0x31b0b645a6c4a0a1bb3d2f0c1d31c39f4aba2e3b015928a8eef7161e28388b81
+        let leaf_path = hex!("31b0b645a6c4a0a1bb3d2f0c1d31c39f4aba2e3b015928a8eef7161e28388b81");
+        let leaf_nibbles = Nibbles::unpack(leaf_path.as_slice());
+        let leaf_value = hex!("0009ae8ce8245bff").to_vec();
+
+        // Reveal branch at 0x31c
+        let branch_0x31c_hashes = vec![
+            B256::from(hex!("1a68fdb36b77e9332b49a977faf800c22d0199e6cecf44032bb083c78943e540")),
+            B256::from(hex!("cd4622c6df6fd7172c7fed1b284ef241e0f501b4c77b675ef10c612bd0948a7a")),
+            B256::from(hex!("abf3603d2f991787e21f1709ee4c7375d85dfc506995c0435839fccf3fe2add4")),
+        ];
+        let branch_0x31c_node = create_branch_node_with_children(
+            &[0x3, 0x7, 0xc],
+            branch_0x31c_hashes.into_iter().map(|h| RlpNode::word_rlp(&h)),
+        );
+        let mut branch_0x31c_node_encoded = Vec::new();
+        branch_0x31c_node.encode(&mut branch_0x31c_node_encoded);
+
+        // Create a mock provider and preload 0x31c onto it, it will be revealed during remove_leaf.
+        let mut provider = MockTrieNodeProvider::new();
+        provider.add_revealed_node(
+            Nibbles::from_nibbles([0x3, 0x1, 0xc]),
+            RevealedNode {
+                node: branch_0x31c_node_encoded.into(),
+                tree_mask: Some(0.into()),
+                hash_mask: Some(4096.into()),
+            },
+        );
+
+        // Reveal the trie structure using ProofTrieNode
+        let proof_nodes = vec![
+            ProofTrieNode {
+                path: Nibbles::from_nibbles([0x3]),
+                node: branch_0x3_node,
+                masks: Some(BranchNodeMasks {
+                    tree_mask: TrieMask::new(26099),
+                    hash_mask: TrieMask::new(65535),
+                }),
+            },
+            ProofTrieNode {
+                path: Nibbles::from_nibbles([0x3, 0x1]),
+                node: branch_0x31_node,
+                masks: Some(BranchNodeMasks {
+                    tree_mask: TrieMask::new(4096),
+                    hash_mask: TrieMask::new(4096),
+                }),
+            },
+        ];
+
+        // Create a sparse trie and reveal nodes
+        let mut trie = ParallelSparseTrie::default()
+            .with_root(
+                TrieNode::Extension(ExtensionNode {
+                    key: Nibbles::from_nibbles([0x3]),
+                    child: RlpNode::word_rlp(&B256::ZERO),
+                }),
+                None,
+                true,
+            )
+            .expect("root revealed");
+
+        trie.reveal_nodes(proof_nodes).unwrap();
+
+        // Update the leaf in order to reveal it in the trie
+        trie.update_leaf(leaf_nibbles, leaf_value, &provider).unwrap();
+
+        // Now delete the leaf
+        trie.remove_leaf(&leaf_nibbles, &provider).unwrap();
+
+        // Compute the root to trigger updates
+        let _ = trie.root();
+
+        // Assert the resulting branch node updates
+        let updates = trie.updates_ref();
+
+        // Check that the branch at 0x3 was updated with the expected structure
+        let branch_0x3_update = updates
+            .updated_nodes
+            .get(&Nibbles::from_nibbles([0x3]))
+            .expect("Branch at 0x3 should be in updates");
+
+        // We no longer expect to track the hash for child 1
+        branch_0x3_hashes.remove(1);
+
+        // Expected structure from prompt.md
+        let expected_branch = BranchNodeCompact::new(
+            0b1111111111111111,
+            0b0110010111110011,
+            0b1111111111111101,
+            branch_0x3_hashes,
+            None,
+        );
+
+        assert_eq!(branch_0x3_update, &expected_branch);
     }
 }

--- a/crates/trie/trie/src/forward_cursor.rs
+++ b/crates/trie/trie/src/forward_cursor.rs
@@ -53,9 +53,13 @@ impl<'a, K, V> ForwardInMemoryCursor<'a, K, V> {
     }
 }
 
+/// Threshold for remaining entries above which binary search is used instead of linear scan.
+/// For small slices, linear scan has better cache locality and lower overhead.
+const BINARY_SEARCH_THRESHOLD: usize = 64;
+
 impl<K, V> ForwardInMemoryCursor<'_, K, V>
 where
-    K: PartialOrd + Clone,
+    K: Ord + Clone,
     V: Clone,
 {
     /// Returns the first entry from the current cursor position that's greater or equal to the
@@ -73,19 +77,22 @@ where
     /// Advances the cursor forward while `predicate` returns `true` or until the collection is
     /// exhausted.
     ///
+    /// Uses binary search for large remaining slices (>= 64 entries), linear scan for small ones.
+    ///
     /// Returns the first entry for which `predicate` returns `false` or `None`. The cursor will
     /// point to the returned entry.
     fn advance_while(&mut self, predicate: impl Fn(&K) -> bool) -> Option<(K, V)> {
-        let mut entry;
-        loop {
-            entry = self.current();
-            if entry.is_some_and(|(k, _)| predicate(k)) {
+        let remaining = self.entries.len().saturating_sub(self.idx);
+        if remaining >= BINARY_SEARCH_THRESHOLD {
+            let slice = &self.entries[self.idx..];
+            let pos = slice.partition_point(|(k, _)| predicate(k));
+            self.idx += pos;
+        } else {
+            while self.current().is_some_and(|(k, _)| predicate(k)) {
                 self.next();
-            } else {
-                break;
             }
         }
-        entry.cloned()
+        self.current().cloned()
     }
 }
 
@@ -94,7 +101,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_cursor() {
+    fn test_cursor_small() {
         let mut cursor = ForwardInMemoryCursor::new(&[(1, ()), (2, ()), (3, ()), (4, ()), (5, ())]);
         assert_eq!(cursor.current(), Some(&(1, ())));
 
@@ -112,5 +119,73 @@ mod tests {
 
         assert_eq!(cursor.seek(&6), None);
         assert_eq!(cursor.current(), None);
+    }
+
+    #[test]
+    fn test_cursor_large_binary_search() {
+        // Create a large enough collection to trigger binary search
+        let entries: Vec<(i32, ())> = (0..200).map(|i| (i * 2, ())).collect();
+        let mut cursor = ForwardInMemoryCursor::new(&entries);
+
+        // Seek to beginning
+        assert_eq!(cursor.seek(&0), Some((0, ())));
+        assert_eq!(cursor.idx, 0);
+
+        // Seek to middle (should use binary search)
+        assert_eq!(cursor.seek(&100), Some((100, ())));
+        assert_eq!(cursor.idx, 50);
+
+        // Seek to non-existent key (should find next greater)
+        assert_eq!(cursor.seek(&101), Some((102, ())));
+        assert_eq!(cursor.idx, 51);
+
+        // Seek to end
+        assert_eq!(cursor.seek(&398), Some((398, ())));
+        assert_eq!(cursor.idx, 199);
+
+        // Seek past end
+        assert_eq!(cursor.seek(&1000), None);
+    }
+
+    #[test]
+    fn test_first_after_large() {
+        let entries: Vec<(i32, ())> = (0..200).map(|i| (i * 2, ())).collect();
+        let mut cursor = ForwardInMemoryCursor::new(&entries);
+
+        // first_after should find strictly greater
+        assert_eq!(cursor.first_after(&0), Some((2, ())));
+        assert_eq!(cursor.idx, 1);
+
+        // Reset and test from beginning
+        cursor.reset();
+        assert_eq!(cursor.first_after(&99), Some((100, ())));
+
+        // first_after on exact match
+        cursor.reset();
+        assert_eq!(cursor.first_after(&100), Some((102, ())));
+    }
+
+    #[test]
+    fn test_cursor_consistency() {
+        // Verify binary search and linear scan produce same results
+        let entries: Vec<(i32, ())> = (0..200).map(|i| (i * 3, ())).collect();
+
+        for search_key in [0, 1, 3, 50, 150, 299, 300, 597, 598, 599, 1000] {
+            // Test with fresh cursor (binary search path)
+            let mut cursor1 = ForwardInMemoryCursor::new(&entries);
+            let result1 = cursor1.seek(&search_key);
+
+            // Manually advance to trigger linear path by getting close first
+            let mut cursor2 = ForwardInMemoryCursor::new(&entries);
+            if search_key > 100 {
+                cursor2.seek(&(search_key - 50));
+            }
+            let result2 = cursor2.seek(&search_key);
+
+            assert_eq!(
+                result1, result2,
+                "Mismatch for key {search_key}: binary={result1:?}, linear={result2:?}"
+            );
+        }
     }
 }

--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -642,7 +642,7 @@ where
     )]
     fn calculate_key_range<'a>(
         &mut self,
-        value_encoder: &VE,
+        value_encoder: &mut VE,
         targets: &mut TargetsCursor<'a>,
         hashed_cursor_current: &mut Option<(Nibbles, VE::DeferredEncoder)>,
         lower_bound: Nibbles,
@@ -651,7 +651,7 @@ where
         // A helper closure for mapping entries returned from the `hashed_cursor`, converting the
         // key to Nibbles and immediately creating the DeferredValueEncoder so that encoding of the
         // leaf value can begin ASAP.
-        let map_hashed_cursor_entry = |(key_b256, val): (B256, _)| {
+        let mut map_hashed_cursor_entry = |(key_b256, val): (B256, _)| {
             debug_assert_eq!(key_b256.len(), 32);
             // SAFETY: key is a B256 and so is exactly 32-bytes.
             let key = unsafe { Nibbles::unpack_unchecked(key_b256.as_slice()) };
@@ -670,7 +670,7 @@ where
 
             let lower_key = B256::right_padding_from(&lower_bound.pack());
             *hashed_cursor_current =
-                self.hashed_cursor.seek(lower_key)?.map(map_hashed_cursor_entry);
+                self.hashed_cursor.seek(lower_key)?.map(&mut map_hashed_cursor_entry);
         }
 
         // Loop over all keys in the range, calling `push_leaf` on each.
@@ -680,7 +680,7 @@ where
             let (key, val) =
                 core::mem::take(hashed_cursor_current).expect("while-let checks for Some");
             self.push_leaf(targets, key, val)?;
-            *hashed_cursor_current = self.hashed_cursor.next()?.map(map_hashed_cursor_entry);
+            *hashed_cursor_current = self.hashed_cursor.next()?.map(&mut map_hashed_cursor_entry);
         }
 
         trace!(target: TRACE_TARGET, "No further keys within range");
@@ -1116,7 +1116,7 @@ where
     )]
     fn proof_subtrie<'a>(
         &mut self,
-        value_encoder: &VE,
+        value_encoder: &mut VE,
         trie_cursor_state: &mut TrieCursorState,
         hashed_cursor_current: &mut Option<(Nibbles, VE::DeferredEncoder)>,
         sub_trie_targets: SubTrieTargets<'a>,
@@ -1245,7 +1245,7 @@ where
     /// See docs on [`Self::proof`] for expected behavior.
     fn proof_inner(
         &mut self,
-        value_encoder: &VE,
+        value_encoder: &mut VE,
         targets: &mut [Target],
     ) -> Result<Vec<ProofTrieNode>, StateProofError> {
         // If there are no targets then nothing could be returned, return early.
@@ -1296,7 +1296,7 @@ where
     #[instrument(target = TRACE_TARGET, level = "trace", skip_all)]
     pub fn proof(
         &mut self,
-        value_encoder: &VE,
+        value_encoder: &mut VE,
         targets: &mut [Target],
     ) -> Result<Vec<ProofTrieNode>, StateProofError> {
         self.trie_cursor.reset();
@@ -1332,9 +1332,6 @@ where
         hashed_address: B256,
         targets: &mut [Target],
     ) -> Result<Vec<ProofTrieNode>, StateProofError> {
-        /// Static storage value encoder instance used by all storage proofs.
-        static STORAGE_VALUE_ENCODER: StorageValueEncoder = StorageValueEncoder;
-
         self.hashed_cursor.set_hashed_address(hashed_address);
 
         // Shortcut: check if storage is empty
@@ -1351,8 +1348,9 @@ where
         // been checked.
         self.trie_cursor.set_hashed_address(hashed_address);
 
-        // Use the static StorageValueEncoder and pass it to proof_inner
-        self.proof_inner(&STORAGE_VALUE_ENCODER, targets)
+        // Create a mutable storage value encoder
+        let mut storage_value_encoder = StorageValueEncoder;
+        self.proof_inner(&mut storage_value_encoder, targets)
     }
 
     /// Computes the root hash from a set of proof nodes.
@@ -1630,13 +1628,13 @@ mod tests {
                 InstrumentedHashedCursor::new(hashed_cursor, &mut hashed_cursor_metrics);
 
             // Call ProofCalculator::proof with account targets
-            let value_encoder = SyncAccountValueEncoder::new(
+            let mut value_encoder = SyncAccountValueEncoder::new(
                 self.trie_cursor_factory.clone(),
                 self.hashed_cursor_factory.clone(),
             );
             let mut proof_calculator = ProofCalculator::new(trie_cursor, hashed_cursor);
             let proof_v2_result =
-                proof_calculator.proof(&value_encoder, &mut targets_vec.clone())?;
+                proof_calculator.proof(&mut value_encoder, &mut targets_vec.clone())?;
 
             // Output metrics
             trace!(target: TRACE_TARGET, ?trie_cursor_metrics, "V2 trie cursor metrics");

--- a/crates/trie/trie/src/proof_v2/target.rs
+++ b/crates/trie/trie/src/proof_v2/target.rs
@@ -19,6 +19,11 @@ impl Target {
         Self { key, min_len: 0 }
     }
 
+    /// Returns the key the target was initialized with.
+    pub fn key(&self) -> B256 {
+        B256::from_slice(&self.key.pack())
+    }
+
     /// Only match trie nodes whose path is at least this long.
     ///
     /// # Panics

--- a/crates/trie/trie/src/proof_v2/value.rs
+++ b/crates/trie/trie/src/proof_v2/value.rs
@@ -44,7 +44,7 @@ pub trait LeafValueEncoder {
     ///
     /// The returned deferred encoder will be called as late as possible in the algorithm to
     /// maximize the time available for parallel computation (e.g., storage root calculation).
-    fn deferred_encoder(&self, key: B256, value: Self::Value) -> Self::DeferredEncoder;
+    fn deferred_encoder(&mut self, key: B256, value: Self::Value) -> Self::DeferredEncoder;
 }
 
 /// An encoder for storage slot values.
@@ -68,7 +68,7 @@ impl LeafValueEncoder for StorageValueEncoder {
     type Value = U256;
     type DeferredEncoder = StorageDeferredValueEncoder;
 
-    fn deferred_encoder(&self, _key: B256, value: Self::Value) -> Self::DeferredEncoder {
+    fn deferred_encoder(&mut self, _key: B256, value: Self::Value) -> Self::DeferredEncoder {
         StorageDeferredValueEncoder(value)
     }
 }
@@ -157,7 +157,7 @@ where
     type DeferredEncoder = SyncAccountDeferredValueEncoder<T, H>;
 
     fn deferred_encoder(
-        &self,
+        &mut self,
         hashed_address: B256,
         account: Self::Value,
     ) -> Self::DeferredEncoder {

--- a/crates/trie/trie/src/verify.rs
+++ b/crates/trie/trie/src/verify.rs
@@ -373,7 +373,7 @@ impl<'a, T: TrieCursorFactory, H: HashedCursorFactory + Clone> Verifier<'a, T, H
             };
 
             if curr_account < next_account || (end_inclusive && curr_account == next_account) {
-                trace!(target: "trie::verify", account = ?curr_account, "Verying account has empty storage");
+                trace!(target: "trie::verify", account = ?curr_account, "Verifying account has empty storage");
 
                 let mut storage_cursor =
                     self.trie_cursor_factory.storage_trie_cursor(curr_account)?;

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -184,9 +184,6 @@ where
                 }
             }
 
-            // Calculate storage root after updates.
-            storage_trie.root();
-
             let account = state
                 .accounts
                 .get(&hashed_address)

--- a/docs/crates/db.md
+++ b/docs/crates/db.md
@@ -297,4 +297,4 @@ This chapter was packed with information, so let's do a quick review. The databa
 
 # Next Chapter
 
-[Next Chapter]()
+[Next Chapter](eth-wire.md)

--- a/docs/crates/db.md
+++ b/docs/crates/db.md
@@ -159,7 +159,7 @@ pub trait DbTx: Debug + Send + Sync {
     ) -> Result<Option<T::Value>, DatabaseError>;
     /// Commit for read only transaction will consume and free transaction and allows
     /// freeing of memory pages
-    fn commit(self) -> Result<bool, DatabaseError>;
+    fn commit(self) -> Result<(), DatabaseError>;
     /// Aborts transaction
     fn abort(self);
     /// Iterate over read only values in table.

--- a/docs/vocs/docs/pages/cli/op-reth.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth.mdx
@@ -99,6 +99,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -123,9 +141,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/config.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/config.mdx
@@ -87,6 +87,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -111,9 +129,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/db.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/db.mdx
@@ -214,6 +214,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -238,9 +256,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/db/account-storage.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/db/account-storage.mdx
@@ -95,6 +95,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -119,9 +137,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/db/checksum.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/db/checksum.mdx
@@ -104,6 +104,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -128,9 +146,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/db/clear.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/db/clear.mdx
@@ -96,6 +96,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -120,9 +138,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/db/clear/mdbx.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/db/clear/mdbx.mdx
@@ -95,6 +95,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -119,9 +137,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/db/clear/static-file.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/db/clear/static-file.mdx
@@ -100,6 +100,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -124,9 +142,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/db/diff.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/db/diff.mdx
@@ -147,6 +147,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -171,9 +189,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/db/drop.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/db/drop.mdx
@@ -94,6 +94,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -118,9 +136,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/db/get.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/db/get.mdx
@@ -96,6 +96,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -120,9 +138,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/db/get/mdbx.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/db/get/mdbx.mdx
@@ -110,6 +110,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -134,9 +152,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/db/get/static-file.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/db/get/static-file.mdx
@@ -109,6 +109,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -133,9 +151,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/db/list.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/db/list.mdx
@@ -137,6 +137,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -161,9 +179,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/db/path.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/db/path.mdx
@@ -91,6 +91,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -115,9 +133,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/db/repair-trie.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/db/repair-trie.mdx
@@ -99,6 +99,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -123,9 +141,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/db/settings.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/db/settings.mdx
@@ -96,6 +96,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -120,9 +138,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/db/settings/get.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/db/settings/get.mdx
@@ -91,6 +91,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -115,9 +133,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/db/settings/set.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/db/settings/set.mdx
@@ -97,6 +97,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -121,9 +139,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/db/settings/set/account_changesets.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/db/settings/set/account_changesets.mdx
@@ -95,6 +95,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -119,9 +137,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/db/settings/set/receipts.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/db/settings/set/receipts.mdx
@@ -95,6 +95,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -119,9 +137,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/db/settings/set/transaction_senders.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/db/settings/set/transaction_senders.mdx
@@ -95,6 +95,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -119,9 +137,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/db/static-file-header.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/db/static-file-header.mdx
@@ -96,6 +96,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -120,9 +138,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/db/static-file-header/block.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/db/static-file-header/block.mdx
@@ -105,6 +105,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -129,9 +147,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/db/static-file-header/path.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/db/static-file-header/path.mdx
@@ -95,6 +95,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -119,9 +137,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/db/stats.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/db/stats.mdx
@@ -107,6 +107,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -131,9 +149,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/db/version.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/db/version.mdx
@@ -91,6 +91,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -115,9 +133,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/dump-genesis.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/dump-genesis.mdx
@@ -90,6 +90,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -114,9 +132,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/import-op.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/import-op.mdx
@@ -207,6 +207,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -231,9 +249,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/import-receipts-op.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/import-receipts-op.mdx
@@ -207,6 +207,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -231,9 +249,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/init-state.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/init-state.mdx
@@ -237,6 +237,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -261,9 +279,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/init.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/init.mdx
@@ -198,6 +198,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -222,9 +240,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/node.mdx
@@ -1139,6 +1139,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -1163,9 +1181,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/node.mdx
@@ -530,6 +530,11 @@ Gas Price Oracle:
 
           [default: 30s]
 
+      --testing.skip-invalid-transactions
+          Skip invalid transactions in `testing_buildBlockV1` instead of failing.
+
+          When enabled, transactions that fail execution will be skipped, and all subsequent transactions from the same sender will also be skipped.
+
 TxPool:
       --txpool.pending-max-count <PENDING_MAX_COUNT>
           Max number of transaction in the pending sub-pool

--- a/docs/vocs/docs/pages/cli/op-reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/node.mdx
@@ -824,6 +824,11 @@ Pruning:
       --full
           Run full node. Only the most recent [`MINIMUM_PRUNING_DISTANCE`] block states are stored
 
+      --minimal
+          Run minimal storage mode with maximum pruning and smaller static files.
+
+          This mode configures the node to use minimal disk space by: - Fully pruning sender recovery, transaction lookup, receipts - Leaving 10,064 blocks for account, storage history and block bodies - Using 10,000 blocks per static file segment
+
       --prune.block-interval <BLOCK_INTERVAL>
           Minimum pruning interval measured in blocks
 

--- a/docs/vocs/docs/pages/cli/op-reth/p2p.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/p2p.mdx
@@ -88,6 +88,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -112,9 +130,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/p2p/body.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/p2p/body.mdx
@@ -338,6 +338,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -362,9 +380,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/p2p/bootnode.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/p2p/bootnode.mdx
@@ -99,6 +99,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -123,9 +141,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/p2p/header.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/p2p/header.mdx
@@ -338,6 +338,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -362,9 +380,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/p2p/rlpx.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/p2p/rlpx.mdx
@@ -85,6 +85,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -109,9 +127,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/p2p/rlpx/ping.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/p2p/rlpx/ping.mdx
@@ -85,6 +85,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -109,9 +127,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/prune.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/prune.mdx
@@ -198,6 +198,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -222,9 +240,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/re-execute.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/re-execute.mdx
@@ -214,6 +214,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -238,9 +256,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/stage.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/stage.mdx
@@ -88,6 +88,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -112,9 +130,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/stage/drop.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/stage/drop.mdx
@@ -213,6 +213,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -237,9 +255,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/stage/dump.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/stage/dump.mdx
@@ -205,6 +205,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -229,9 +247,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/stage/dump/account-hashing.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/stage/dump/account-hashing.mdx
@@ -103,6 +103,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -127,9 +145,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/stage/dump/execution.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/stage/dump/execution.mdx
@@ -103,6 +103,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -127,9 +145,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/stage/dump/merkle.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/stage/dump/merkle.mdx
@@ -103,6 +103,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -127,9 +145,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/stage/dump/storage-hashing.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/stage/dump/storage-hashing.mdx
@@ -103,6 +103,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -127,9 +145,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/stage/run.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/stage/run.mdx
@@ -460,6 +460,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -484,9 +502,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/stage/unwind.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/stage/unwind.mdx
@@ -206,6 +206,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -230,9 +248,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/stage/unwind/num-blocks.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/stage/unwind/num-blocks.mdx
@@ -95,6 +95,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -119,9 +137,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/op-reth/stage/unwind/to-block.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/stage/unwind/to-block.mdx
@@ -95,6 +95,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -119,9 +137,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth.mdx
+++ b/docs/vocs/docs/pages/cli/reth.mdx
@@ -101,6 +101,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -125,9 +143,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/config.mdx
+++ b/docs/vocs/docs/pages/cli/reth/config.mdx
@@ -87,6 +87,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -111,9 +129,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db.mdx
@@ -214,6 +214,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -238,9 +256,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/account-storage.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/account-storage.mdx
@@ -95,6 +95,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -119,9 +137,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/checksum.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/checksum.mdx
@@ -104,6 +104,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -128,9 +146,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/clear.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/clear.mdx
@@ -96,6 +96,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -120,9 +138,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/clear/mdbx.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/clear/mdbx.mdx
@@ -95,6 +95,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -119,9 +137,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/clear/static-file.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/clear/static-file.mdx
@@ -100,6 +100,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -124,9 +142,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/diff.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/diff.mdx
@@ -147,6 +147,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -171,9 +189,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/drop.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/drop.mdx
@@ -94,6 +94,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -118,9 +136,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/get.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/get.mdx
@@ -96,6 +96,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -120,9 +138,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/get/mdbx.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/get/mdbx.mdx
@@ -110,6 +110,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -134,9 +152,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/get/static-file.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/get/static-file.mdx
@@ -109,6 +109,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -133,9 +151,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/list.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/list.mdx
@@ -137,6 +137,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -161,9 +179,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/path.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/path.mdx
@@ -91,6 +91,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -115,9 +133,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/repair-trie.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/repair-trie.mdx
@@ -99,6 +99,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -123,9 +141,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/settings.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/settings.mdx
@@ -96,6 +96,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -120,9 +138,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/settings/get.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/settings/get.mdx
@@ -91,6 +91,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -115,9 +133,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/settings/set.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/settings/set.mdx
@@ -97,6 +97,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -121,9 +139,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/settings/set/account_changesets.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/settings/set/account_changesets.mdx
@@ -95,6 +95,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -119,9 +137,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/settings/set/receipts.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/settings/set/receipts.mdx
@@ -95,6 +95,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -119,9 +137,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/settings/set/transaction_senders.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/settings/set/transaction_senders.mdx
@@ -95,6 +95,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -119,9 +137,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/static-file-header.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/static-file-header.mdx
@@ -96,6 +96,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -120,9 +138,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/static-file-header/block.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/static-file-header/block.mdx
@@ -105,6 +105,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -129,9 +147,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/static-file-header/path.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/static-file-header/path.mdx
@@ -95,6 +95,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -119,9 +137,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/stats.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/stats.mdx
@@ -107,6 +107,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -131,9 +149,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/db/version.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/version.mdx
@@ -91,6 +91,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -115,9 +133,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/download.mdx
+++ b/docs/vocs/docs/pages/cli/reth/download.mdx
@@ -137,7 +137,9 @@ Static Files:
           - https://publicnode.com/snapshots (full nodes & testnets)
 
           If no URL is provided, the latest mainnet archive snapshot
-          will be proposed for download from https://downloads.merkle.io
+          will be proposed for download from https://downloads.merkle.io.
+
+          Local file:// URLs are also supported for extracting snapshots from disk.
 
 Logging:
       --log.stdout.format <FORMAT>

--- a/docs/vocs/docs/pages/cli/reth/download.mdx
+++ b/docs/vocs/docs/pages/cli/reth/download.mdx
@@ -208,6 +208,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -232,9 +250,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/dump-genesis.mdx
+++ b/docs/vocs/docs/pages/cli/reth/dump-genesis.mdx
@@ -90,6 +90,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -114,9 +132,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/export-era.mdx
+++ b/docs/vocs/docs/pages/cli/reth/export-era.mdx
@@ -214,6 +214,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -238,9 +256,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/import-era.mdx
+++ b/docs/vocs/docs/pages/cli/reth/import-era.mdx
@@ -209,6 +209,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -233,9 +251,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/import.mdx
+++ b/docs/vocs/docs/pages/cli/reth/import.mdx
@@ -210,6 +210,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -234,9 +252,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/init-state.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init-state.mdx
@@ -230,6 +230,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -254,9 +272,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/init.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init.mdx
@@ -198,6 +198,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -222,9 +240,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -1112,6 +1112,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -1136,9 +1154,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -530,6 +530,11 @@ Gas Price Oracle:
 
           [default: 30s]
 
+      --testing.skip-invalid-transactions
+          Skip invalid transactions in `testing_buildBlockV1` instead of failing.
+
+          When enabled, transactions that fail execution will be skipped, and all subsequent transactions from the same sender will also be skipped.
+
 TxPool:
       --txpool.pending-max-count <PENDING_MAX_COUNT>
           Max number of transaction in the pending sub-pool

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -824,6 +824,11 @@ Pruning:
       --full
           Run full node. Only the most recent [`MINIMUM_PRUNING_DISTANCE`] block states are stored
 
+      --minimal
+          Run minimal storage mode with maximum pruning and smaller static files.
+
+          This mode configures the node to use minimal disk space by: - Fully pruning sender recovery, transaction lookup, receipts - Leaving 10,064 blocks for account, storage history and block bodies - Using 10,000 blocks per static file segment
+
       --prune.block-interval <BLOCK_INTERVAL>
           Minimum pruning interval measured in blocks
 

--- a/docs/vocs/docs/pages/cli/reth/p2p.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p.mdx
@@ -88,6 +88,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -112,9 +130,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/p2p/body.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/body.mdx
@@ -338,6 +338,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -362,9 +380,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/p2p/bootnode.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/bootnode.mdx
@@ -99,6 +99,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -123,9 +141,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/p2p/header.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/header.mdx
@@ -338,6 +338,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -362,9 +380,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/p2p/rlpx.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/rlpx.mdx
@@ -85,6 +85,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -109,9 +127,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/p2p/rlpx/ping.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/rlpx/ping.mdx
@@ -85,6 +85,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -109,9 +127,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/prune.mdx
+++ b/docs/vocs/docs/pages/cli/reth/prune.mdx
@@ -198,6 +198,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -222,9 +240,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/re-execute.mdx
+++ b/docs/vocs/docs/pages/cli/reth/re-execute.mdx
@@ -214,6 +214,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -238,9 +256,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/stage.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage.mdx
@@ -88,6 +88,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -112,9 +130,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/drop.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/drop.mdx
@@ -213,6 +213,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -237,9 +255,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/dump.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump.mdx
@@ -205,6 +205,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -229,9 +247,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/dump/account-hashing.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump/account-hashing.mdx
@@ -103,6 +103,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -127,9 +145,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/dump/execution.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump/execution.mdx
@@ -103,6 +103,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -127,9 +145,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/dump/merkle.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump/merkle.mdx
@@ -103,6 +103,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -127,9 +145,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/dump/storage-hashing.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump/storage-hashing.mdx
@@ -103,6 +103,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -127,9 +145,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/run.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/run.mdx
@@ -460,6 +460,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -484,9 +502,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/unwind.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/unwind.mdx
@@ -206,6 +206,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -230,9 +248,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/unwind/num-blocks.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/unwind/num-blocks.mdx
@@ -95,6 +95,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -119,9 +137,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/unwind/to-block.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/unwind/to-block.mdx
@@ -95,6 +95,24 @@ Logging:
 
           [default: always]
 
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
 Display:
   -v, --verbosity...
           Set the minimum log level.
@@ -119,9 +137,9 @@ Tracing:
           [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
 
       --tracing-otlp-protocol <PROTOCOL>
-          OTLP transport protocol to use for exporting traces.
+          OTLP transport protocol to use for exporting traces and logs.
 
-          - `http`: expects endpoint path to end with `/v1/traces` - `grpc`: expects endpoint without a path
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
 
           Defaults to HTTP if not specified.
 

--- a/docs/vocs/docs/pages/index.mdx
+++ b/docs/vocs/docs/pages/index.mdx
@@ -107,7 +107,7 @@ import { TrustedBy } from "../components/TrustedBy";
       </div>
       <div className="pl-2 pr-2 max-sm:px-0 max-lg:pb-3 max-lg:pr-0 w-1/4 max-lg:w-1/2 max-sm:w-full z-0">
         <div className="relative w-full h-[168px] max-lg:h-[142px]">
-          <a href="#" className="hover:bg-black/2 dark:hover:bg-white/2 border-black/10 dark:border-white/10 border border-solid rounded-lg h-full px-5 py-6 absolute z-10 flex flex-col justify-between w-full vocs_Link vocs_Link_styleless">
+          <a href="/overview" className="hover:bg-black/2 dark:hover:bg-white/2 border-black/10 dark:border-white/10 border border-solid rounded-lg h-full px-5 py-6 absolute z-10 flex flex-col justify-between w-full vocs_Link vocs_Link_styleless">
             <div className="text-xl font-medium text-black dark:text-white">Performant</div>
             <div className="text-[17px] text-[#919193]">Sync faster with optimal transaction processing</div>
           </a>

--- a/docs/vocs/docs/pages/run/configuration.mdx
+++ b/docs/vocs/docs/pages/run/configuration.mdx
@@ -466,6 +466,7 @@ headers = 8192
 transactions = 8192
 receipts = 8192
 transaction_senders = 8192
+account_change_sets = 8192
 ```
 
 [TOML]: https://toml.io/

--- a/docs/vocs/vocs.config.ts
+++ b/docs/vocs/vocs.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
     },
     { text: 'GitHub', link: 'https://github.com/paradigmxyz/reth' },
     {
-      text: 'v1.9.4',
+      text: 'v1.10.0',
       items: [
         {
           text: 'Releases',

--- a/docs/vocs/vocs.config.ts
+++ b/docs/vocs/vocs.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
     },
     { text: 'GitHub', link: 'https://github.com/paradigmxyz/reth' },
     {
-      text: 'v1.9.3',
+      text: 'v1.9.4',
       items: [
         {
           text: 'Releases',

--- a/examples/bsc-p2p/src/chainspec.rs
+++ b/examples/bsc-p2p/src/chainspec.rs
@@ -1,4 +1,4 @@
-//! Chain specification for BSC, credits to: <https://github.com/bnb-chain/reth/blob/main/crates/bsc/chainspec/src/bsc.rs>
+//! Chain specification for BSC, credits to: <https://github.com/bnb-chain/reth/blob/main/examples/bsc-p2p/src/chainspec.rs>
 
 use alloy_primitives::{BlockHash, U256};
 use reth_chainspec::{


### PR DESCRIPTION
## Summary

Completes the proofs v2 implementation for the tracking issue #19511.

### Changes

1. **`reveal_v2_decoded` methods in SparseStateTrie** (`crates/trie/sparse/src/state.rs`)
   - `reveal_v2_account_decoded`: Reveals account trie nodes from v2 proof format (`Vec<ProofTrieNode>`)
   - `reveal_v2_storage_decoded`: Reveals storage trie nodes from v2 proof format
   - `filter_v2_proof_nodes`: Helper to filter already-revealed nodes with metrics tracking

2. **Proof v2 target generation in prewarm workers** (`crates/engine/tree/src/tree/payload_processor/prewarm.rs`)
   - `proof_v2_targets_from_state`: Converts `EvmState` to `Vec<proof_v2::Target>` with `min_len=0` (full proofs)

3. **Proof v2 target generation in multiproof task** (`crates/engine/tree/src/tree/payload_processor/multiproof.rs`)
   - `state_to_proof_v2_targets`: Converts `HashedPostState` to v2 targets
   - `evm_state_to_proof_v2_targets`: Convenience wrapper for `EvmState`

### Testing

- All `reth-trie-sparse` tests pass (35 tests)
- All crates build successfully with `--all-features`

### Related

- Tracking issue: #19511
- CLI flag: `--engine.enable-proof-v2`

cc @mediocregopher (who is very handsome)