### PR TITLE
refactor(engine): sparse trie as cache - move sequencer and add proof target generation

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -8,7 +8,7 @@ use crate::tree::{
     },
     payload_processor::{
         prewarm::{PrewarmCacheTask, PrewarmContext, PrewarmMode, PrewarmTaskEvent},
-        sparse_trie::StateRootComputeOutcome,
+        sparse_trie::{SparseTrieMessage, StateRootComputeOutcome},
     },
     sparse_trie::SparseTrieTask,
     StateProviderBuilder, TreeConfig,
@@ -19,7 +19,7 @@ use alloy_evm::{block::StateChangeSource, ToTxEnv};
 use alloy_primitives::B256;
 use crossbeam_channel::Sender as CrossbeamSender;
 use executor::WorkloadExecutor;
-use multiproof::{SparseTrieUpdate, *};
+use multiproof::*;
 use parking_lot::RwLock;
 use prewarm::PrewarmMetrics;
 use rayon::prelude::*;
@@ -483,7 +483,7 @@ where
     #[instrument(level = "debug", target = "engine::tree::payload_processor", skip_all)]
     fn spawn_sparse_trie_task<BPF>(
         &self,
-        sparse_trie_rx: mpsc::Receiver<SparseTrieUpdate>,
+        sparse_trie_rx: mpsc::Receiver<SparseTrieMessage>,
         proof_worker_handle: BPF,
         state_root_tx: mpsc::Sender<Result<StateRootComputeOutcome, ParallelStateRootError>>,
     ) where

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -87,7 +87,7 @@ impl ProofSequencer {
 
     /// Sets the next sequence number (for testing purposes).
     #[cfg(test)]
-    pub(super) fn set_next_sequence(&mut self, seq: u64) {
+    pub(super) const fn set_next_sequence(&mut self, seq: u64) {
         self.next_sequence = seq;
     }
 }

--- a/crates/trie/sparse-parallel/src/lib.rs
+++ b/crates/trie/sparse-parallel/src/lib.rs
@@ -10,5 +10,8 @@ pub use trie::*;
 mod lower;
 use lower::*;
 
+mod state;
+pub use state::*;
+
 #[cfg(feature = "metrics")]
 mod metrics;

--- a/crates/trie/sparse-parallel/src/state.rs
+++ b/crates/trie/sparse-parallel/src/state.rs
@@ -1,0 +1,45 @@
+//! Extensions for `SparseStateTrie` when using `ParallelSparseTrie`.
+
+use crate::ParallelSparseTrie;
+use alloy_primitives::B256;
+use reth_trie_sparse::SparseStateTrie;
+
+/// Extension trait for `SparseStateTrie<ParallelSparseTrie, ParallelSparseTrie>` that provides
+/// optimized proof target generation methods.
+pub trait ParallelSparseStateTrieExt {
+    /// Generate account proof targets using the parallel trie's optimized method.
+    ///
+    /// For each key, finds the deepest revealed node and returns a `(key, min_len)` pair.
+    /// Keys that are already fully revealed (leaf exists) are excluded.
+    fn generate_account_proof_targets_optimized(&self, keys: &[B256]) -> Vec<(B256, u8)>;
+
+    /// Generate storage proof targets using the parallel trie's optimized method.
+    ///
+    /// For each storage key, finds the deepest revealed node and returns a `(key, min_len)` pair.
+    /// Keys that are already fully revealed (leaf exists) are excluded.
+    fn generate_storage_proof_targets_optimized(
+        &self,
+        account: B256,
+        storage_keys: &[B256],
+    ) -> Vec<(B256, u8)>;
+}
+
+impl ParallelSparseStateTrieExt for SparseStateTrie<ParallelSparseTrie, ParallelSparseTrie> {
+    fn generate_account_proof_targets_optimized(&self, keys: &[B256]) -> Vec<(B256, u8)> {
+        match self.state_trie_ref() {
+            None => keys.iter().map(|key| (*key, 0u8)).collect(),
+            Some(trie) => trie.generate_proof_targets(keys),
+        }
+    }
+
+    fn generate_storage_proof_targets_optimized(
+        &self,
+        account: B256,
+        storage_keys: &[B256],
+    ) -> Vec<(B256, u8)> {
+        match self.storage_trie_ref(&account) {
+            None => storage_keys.iter().map(|key| (*key, 0u8)).collect(),
+            Some(trie) => trie.generate_proof_targets(storage_keys),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Major architectural step toward making sparse trie the source of proof v2 targets.

### Changes

1. **Move ProofSequencer to sparse trie task** (`crates/engine/tree/src/tree/payload_processor/sparse_trie.rs`)
   - Moved `ProofSequencer` from `multiproof.rs` to `sparse_trie.rs`
   - Re-exported from multiproof module for backward compatibility
   - The sparse trie task will be the one receiving and sequencing proofs

2. **Add SparseTrieMessage enum for flexible message handling**
   - Added `SparseTrieMessage` enum with `ProofUpdate` and `StateUpdate` variants
   - Updated `SparseTrieTask` to receive `SparseTrieMessage` instead of `SparseTrieUpdate`
   - Updated `MultiProofTask` to send `SparseTrieMessage::ProofUpdate`
   - Prepares infrastructure for receiving `HashedPostState` directly

3. **Implement generate_proof_v2_targets on SparseStateTrie** (`crates/trie/sparse/src/state.rs`)
   - `generate_account_proof_targets`: Walks the account trie to find the deepest revealed node for each key
   - `generate_storage_proof_targets`: Same for storage tries
   - Returns `Vec<(B256, u8)>` where u8 is the `min_len` for partial proofs
   - If a key is already fully revealed (leaf exists), it's skipped
   - Added optimized versions for `SerialSparseTrie` and generic fallback for other trie types

### How it works

For each requested key:
1. Convert B256 to Nibbles
2. Walk down the trie following the path
3. Track the deepest revealed non-Hash node
4. If we hit a Leaf at the exact path → key is fully revealed, skip it
5. Otherwise, return the key with min_len = depth of deepest revealed node

This enables partial proofs - we only request nodes we don't already have in the sparse trie.

### Testing

- All `reth-trie-sparse` tests pass (38 tests)
- All `reth-engine-tree` tests pass (115 tests - 106 unit + 9 e2e)
- Clippy passes with no warnings
- Formatting passes

### Next Steps

- Wire `handle_state_update` to dispatch proof requests to `ProofWorkerHandle`
- Route proof results back to sparse trie task
- Enable sending `StateUpdate` messages from prewarm/multiproof sources

cc @mediocregopher (who is very handsome)