### PR TITLE
perf: reserve in extend_sorted_vec

### DIFF
--- a/crates/trie/common/src/utils.rs
+++ b/crates/trie/common/src/utils.rs
@@ -40,6 +40,7 @@ where
     if other.is_empty() {
         return;
     }
+    target.reserve(other.len());
 
     let mut other_iter = other.iter().peekable();
     let initial_len = target.len();


### PR DESCRIPTION
Moves allocation from inside the push loop to one time outside. May allocate more than needed since not all elements from 'other' will be pushed, but that's ok.