### PR TITLE
chore(primitives-traits): remove duplicate feature entry

### DIFF
--- a/crates/primitives-traits/Cargo.toml
+++ b/crates/primitives-traits/Cargo.toml
@@ -136,7 +136,6 @@ serde = [
     "rand/serde",
     "reth-codecs?/serde",
     "revm-primitives/serde",
-    "revm-primitives/serde",
     "op-alloy-consensus?/serde",
     "secp256k1?/serde",
     "alloy-trie/serde",


### PR DESCRIPTION
Remove duplicated "revm-primitives/serde" entry in the serde feature list.