### PR TITLE
fix(payload): correct pattern matching in `is_frozen()`

### DIFF
--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -729,7 +729,7 @@ impl<Payload> BuildOutcome<Payload> {
 
     /// Returns true if the outcome is `Freeze`.
     pub const fn is_frozen(&self) -> bool {
-        matches!(self, Self::Freeze { .. })
+        matches!(self, Self::Freeze(..))
     }
 
     /// Returns true if the outcome is `Aborted`.


### PR DESCRIPTION
`is_frozen()` used struct variant syntax `Self::Freeze { .. }` for a tuple variant `Freeze(Payload)`, causing it to always return false. This meant frozen payloads were never detected, and the builder kept spawning new build jobs even when it shouldn't. Fixed by using the correct tuple pattern `Self::Freeze(..)`.