### PR TITLE
fix(engine): persist blocks immediately when persistence_threshold=0

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1761,7 +1761,7 @@ where
         }
 
         let min_block = self.persistence_state.last_persisted_block.number;
-        self.state.tree_state.canonical_block_number().saturating_sub(min_block) >
+        self.state.tree_state.canonical_block_number().saturating_sub(min_block) >=
             self.config.persistence_threshold()
     }
 

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -491,7 +491,7 @@ fn test_tree_persist_block_batch() {
     let chain_spec = MAINNET.clone();
     let mut test_block_builder = TestBlockBuilder::eth().with_chain_spec((*chain_spec).clone());
 
-    // we need more than tree_config.persistence_threshold() +1 blocks to
+    // we need at least tree_config.persistence_threshold() + 1 blocks to
     // trigger the persistence task.
     let blocks: Vec<_> = test_block_builder
         .get_executed_blocks(1..tree_config.persistence_threshold() + 2)
@@ -531,7 +531,7 @@ async fn test_tree_persist_blocks() {
     let chain_spec = MAINNET.clone();
     let mut test_block_builder = TestBlockBuilder::eth().with_chain_spec((*chain_spec).clone());
 
-    // we need more than tree_config.persistence_threshold() +1 blocks to
+    // we need at least tree_config.persistence_threshold() + 1 blocks to
     // trigger the persistence task.
     let blocks: Vec<_> = test_block_builder
         .get_executed_blocks(1..tree_config.persistence_threshold() + 2)


### PR DESCRIPTION
## Summary

Fixes #21093

When running reth with `--engine.persistence-threshold=0`, blocks were not being persisted to disk immediately as expected. Instead, they accumulated in memory until either a restart or memory pressure forced a flush.

## Root Cause

The `should_persist()` function in [mod.rs](https://github.com/paradigmxyz/reth/blob/main/crates/engine/tree/src/tree/mod.rs#L1764) was using `>` instead of `>=`:

```rust
canonical_block_number.saturating_sub(min_block) > self.config.persistence_threshold()
```

With `persistence_threshold=0`:
- **Expected**: persist immediately (0 blocks allowed without triggering persistence)
- **Actual**: `diff > 0` required at least 1 block difference before persisting

## Fix

Changed `>` to `>=` so that `persistence_threshold=0` correctly means "persist immediately".

## Testing

Existing tests pass with updated comments to reflect the corrected behavior.