### PR TITLE
perf(db): remove unnecessary Vec clone in benchmark utils

### DIFF
--- a/crates/storage/db/benches/utils.rs
+++ b/crates/storage/db/benches/utils.rs
@@ -65,8 +65,9 @@ where
     {
         // Prepare data to be read
         let tx = db.tx_mut().expect("tx");
-        for (k, _, v, _) in pair.clone() {
-            tx.put::<T>(k, v).expect("submit");
+        // Avoid cloning the entire vector (including `Bytes`) when we only need key/value.
+        for (k, _, v, _) in pair.iter() {
+            tx.put::<T>(k.clone(), v.clone()).expect("submit");
         }
         tx.inner.commit().unwrap();
     }


### PR DESCRIPTION
The set_up_db function in reth-db benchmark utilities was calling pair.clone() to iterate over test data, which unnecessarily cloned the entire vector including all Bytes fields for each tuple element.