### PR TITLE
feat(stages): add RocksDB helper functions and unwind for index history stages

### DIFF
--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -6,7 +6,8 @@ use reth_errors::ProviderError;
 use reth_ethereum_primitives::EthPrimitives;
 use reth_primitives_traits::NodePrimitives;
 use reth_provider::{
-    BlockExecutionWriter, BlockHashReader, ChainStateBlockWriter, DBProvider, DatabaseProviderFactory, ProviderFactory, SaveBlocksMode, providers::ProviderNodeTypes
+    providers::ProviderNodeTypes, BlockExecutionWriter, BlockHashReader, ChainStateBlockWriter,
+    DBProvider, DatabaseProviderFactory, ProviderFactory, SaveBlocksMode,
 };
 use reth_prune::{PrunerError, PrunerOutput, PrunerWithFactory};
 use reth_stages_api::{MetricEvent, MetricEventsSender};

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -6,8 +6,7 @@ use reth_errors::ProviderError;
 use reth_ethereum_primitives::EthPrimitives;
 use reth_primitives_traits::NodePrimitives;
 use reth_provider::{
-    providers::ProviderNodeTypes, BlockExecutionWriter, BlockHashReader, ChainStateBlockWriter,
-    DBProvider, DatabaseProviderFactory, ProviderFactory,
+    BlockExecutionWriter, BlockHashReader, ChainStateBlockWriter, DBProvider, DatabaseProviderFactory, ProviderFactory, SaveBlocksMode, providers::ProviderNodeTypes
 };
 use reth_prune::{PrunerError, PrunerOutput, PrunerWithFactory};
 use reth_stages_api::{MetricEvent, MetricEventsSender};
@@ -151,7 +150,7 @@ where
         if last_block.is_some() {
             let provider_rw = self.provider.database_provider_rw()?;
 
-            provider_rw.save_blocks(blocks)?;
+            provider_rw.save_blocks(blocks, SaveBlocksMode::Full)?;
             provider_rw.commit()?;
         }
 

--- a/crates/optimism/cli/src/commands/import_receipts.rs
+++ b/crates/optimism/cli/src/commands/import_receipts.rs
@@ -18,7 +18,7 @@ use reth_optimism_primitives::{bedrock::is_dup_tx, OpPrimitives, OpReceipt};
 use reth_primitives_traits::NodePrimitives;
 use reth_provider::{
     providers::ProviderNodeTypes, DBProvider, DatabaseProviderFactory, OriginalValuesKnown,
-    ProviderFactory, StageCheckpointReader, StageCheckpointWriter, StateWriter,
+    ProviderFactory, StageCheckpointReader, StageCheckpointWriter, StateWriteConfig, StateWriter,
     StaticFileProviderFactory, StatsReader,
 };
 use reth_stages::{StageCheckpoint, StageId};
@@ -228,7 +228,11 @@ where
             ExecutionOutcome::new(Default::default(), receipts, first_block, Default::default());
 
         // finally, write the receipts
-        provider.write_state(&execution_outcome, OriginalValuesKnown::Yes, true)?;
+        provider.write_state(
+            &execution_outcome,
+            OriginalValuesKnown::Yes,
+            StateWriteConfig::default(),
+        )?;
     }
 
     // Only commit if we have imported as many receipts as the number of transactions.

--- a/crates/optimism/cli/src/commands/import_receipts.rs
+++ b/crates/optimism/cli/src/commands/import_receipts.rs
@@ -228,7 +228,7 @@ where
             ExecutionOutcome::new(Default::default(), receipts, first_block, Default::default());
 
         // finally, write the receipts
-        provider.write_state(&execution_outcome, OriginalValuesKnown::Yes)?;
+        provider.write_state(&execution_outcome, OriginalValuesKnown::Yes, true)?;
     }
 
     // Only commit if we have imported as many receipts as the number of transactions.

--- a/crates/stages/stages/src/stages/execution.rs
+++ b/crates/stages/stages/src/stages/execution.rs
@@ -12,7 +12,7 @@ use reth_primitives_traits::{format_gas_throughput, BlockBody, NodePrimitives};
 use reth_provider::{
     providers::{StaticFileProvider, StaticFileWriter},
     BlockHashReader, BlockReader, DBProvider, EitherWriter, ExecutionOutcome, HeaderProvider,
-    LatestStateProviderRef, OriginalValuesKnown, ProviderError, StateWriter,
+    LatestStateProviderRef, OriginalValuesKnown, ProviderError, StateWriteConfig, StateWriter,
     StaticFileProviderFactory, StatsReader, StorageSettingsCache, TransactionVariant,
 };
 use reth_revm::database::StateProviderDatabase;
@@ -463,7 +463,7 @@ where
         }
 
         // write output
-        provider.write_state(&state, OriginalValuesKnown::Yes, true)?;
+        provider.write_state(&state, OriginalValuesKnown::Yes, StateWriteConfig::default())?;
 
         let db_write_duration = time.elapsed();
         debug!(

--- a/crates/stages/stages/src/stages/execution.rs
+++ b/crates/stages/stages/src/stages/execution.rs
@@ -463,7 +463,7 @@ where
         }
 
         // write output
-        provider.write_state(&state, OriginalValuesKnown::Yes)?;
+        provider.write_state(&state, OriginalValuesKnown::Yes, true)?;
 
         let db_write_duration = time.elapsed();
         debug!(

--- a/crates/stages/stages/src/stages/hashing_account.rs
+++ b/crates/stages/stages/src/stages/hashing_account.rs
@@ -59,7 +59,7 @@ impl AccountHashingStage {
     ///
     /// Proceeds to go to the `BlockTransitionIndex` end, go back `transitions` and change the
     /// account state in the `AccountChangeSets` table.
-    pub fn seed<Tx: DbTx + DbTxMut + Sync + 'static, N: reth_provider::providers::ProviderNodeTypes>(
+    pub fn seed<Tx: DbTx + DbTxMut + 'static, N: reth_provider::providers::ProviderNodeTypes>(
         provider: &reth_provider::DatabaseProvider<Tx, N>,
         opts: SeedOpts,
     ) -> Result<Vec<(alloy_primitives::Address, Account)>, StageError>

--- a/crates/stages/stages/src/stages/hashing_account.rs
+++ b/crates/stages/stages/src/stages/hashing_account.rs
@@ -59,7 +59,7 @@ impl AccountHashingStage {
     ///
     /// Proceeds to go to the `BlockTransitionIndex` end, go back `transitions` and change the
     /// account state in the `AccountChangeSets` table.
-    pub fn seed<Tx: DbTx + DbTxMut + 'static, N: reth_provider::providers::ProviderNodeTypes>(
+    pub fn seed<Tx: DbTx + DbTxMut + Sync + 'static, N: reth_provider::providers::ProviderNodeTypes>(
         provider: &reth_provider::DatabaseProvider<Tx, N>,
         opts: SeedOpts,
     ) -> Result<Vec<(alloy_primitives::Address, Account)>, StageError>

--- a/crates/stages/stages/src/stages/index_account_history.rs
+++ b/crates/stages/stages/src/stages/index_account_history.rs
@@ -1,16 +1,25 @@
 use crate::stages::utils::collect_history_indices;
 
-use super::{collect_account_history_indices, load_history_indices};
-use alloy_primitives::Address;
+use super::{collect_account_history_indices, load_accounts_history_indices};
+use alloy_primitives::{Address, BlockNumber};
 use reth_config::config::{EtlConfig, IndexHistoryConfig};
-use reth_db_api::{models::ShardedKey, table::Decode, tables, transaction::DbTxMut};
+use reth_db_api::{
+    cursor::DbCursorRO,
+    models::ShardedKey,
+    table::Decode,
+    tables,
+    transaction::{DbTx, DbTxMut},
+};
 use reth_provider::{
-    DBProvider, HistoryWriter, PruneCheckpointReader, PruneCheckpointWriter, StorageSettingsCache,
+    make_rocksdb_batch_arg, make_rocksdb_provider, register_rocksdb_batch, DBProvider,
+    EitherWriter, HistoryWriter, PruneCheckpointReader, PruneCheckpointWriter,
+    RocksDBProviderFactory, StorageSettingsCache,
 };
 use reth_prune_types::{PruneCheckpoint, PruneMode, PrunePurpose, PruneSegment};
 use reth_stages_api::{
     ExecInput, ExecOutput, Stage, StageCheckpoint, StageError, StageId, UnwindInput, UnwindOutput,
 };
+use reth_storage_api::NodePrimitivesProvider;
 use std::fmt::Debug;
 use tracing::info;
 
@@ -53,7 +62,9 @@ where
         + PruneCheckpointWriter
         + reth_storage_api::ChangeSetReader
         + reth_provider::StaticFileProviderFactory
-        + StorageSettingsCache,
+        + StorageSettingsCache
+        + NodePrimitivesProvider
+        + RocksDBProviderFactory,
 {
     /// Return the id of the stage
     fn id(&self) -> StageId {
@@ -125,7 +136,7 @@ where
         };
 
         info!(target: "sync::stages::index_account_history::exec", "Loading indices into database");
-        load_history_indices::<_, tables::AccountsHistory, _>(
+        load_accounts_history_indices(
             provider,
             collector,
             first_sync,
@@ -146,9 +157,40 @@ where
         let (range, unwind_progress, _) =
             input.unwind_block_range_with_threshold(self.commit_threshold);
 
-        provider.unwind_account_history_indices_range(range)?;
+        // Create EitherWriter for account history
+        #[allow(clippy::let_unit_value)]
+        let rocksdb = make_rocksdb_provider(provider);
+        #[allow(clippy::let_unit_value)]
+        let rocksdb_batch = make_rocksdb_batch_arg(&rocksdb);
+        let mut writer = EitherWriter::new_accounts_history(provider, rocksdb_batch)?;
 
-        // from HistoryIndex higher than that number.
+        // Read changesets to identify what to unwind
+        let changesets = provider
+            .tx_ref()
+            .cursor_read::<tables::AccountChangeSets>()?
+            .walk_range(range)?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        // Group by address and find minimum block for each
+        // We only need to unwind once per address using the LOWEST block number
+        // since unwind removes all indices >= that block
+        let mut account_keys: std::collections::HashMap<Address, BlockNumber> =
+            std::collections::HashMap::new();
+        for (block_number, account) in changesets {
+            account_keys
+                .entry(account.address)
+                .and_modify(|min_bn| *min_bn = (*min_bn).min(block_number))
+                .or_insert(block_number);
+        }
+
+        // Unwind each account's history shards (once per unique address)
+        for (address, min_block) in account_keys {
+            super::utils::unwind_accounts_history_shards(&mut writer, address, min_block)?;
+        }
+
+        // Register RocksDB batch for commit
+        register_rocksdb_batch(provider, writer);
+
         Ok(UnwindOutput { checkpoint: StageCheckpoint::new(unwind_progress) })
     }
 }
@@ -645,5 +687,129 @@ mod tests {
             assert!(table.is_empty());
             Ok(())
         }
+    }
+}
+
+#[cfg(all(test, unix, feature = "rocksdb"))]
+mod rocksdb_stage_tests {
+    use super::*;
+    use crate::test_utils::TestStageDB;
+    use reth_db_api::tables;
+    use reth_provider::{DatabaseProviderFactory, RocksDBProviderFactory};
+    use reth_storage_api::StorageSettings;
+
+    /// Test that `IndexAccountHistoryStage` writes to `RocksDB` when enabled.
+    #[test]
+    fn test_index_account_history_writes_to_rocksdb() {
+        let db = TestStageDB::default();
+        db.factory.set_storage_settings_cache(
+            StorageSettings::legacy().with_account_history_in_rocksdb(true),
+        );
+
+        // Setup changesets (blocks 1-10, skip 0 to avoid genesis edge case)
+        db.commit(|tx| {
+            for block in 1..=10u64 {
+                tx.put::<tables::BlockBodyIndices>(
+                    block,
+                    reth_db_api::models::StoredBlockBodyIndices {
+                        tx_count: 3,
+                        ..Default::default()
+                    },
+                )?;
+                tx.put::<tables::AccountChangeSets>(
+                    block,
+                    reth_db_api::models::AccountBeforeTx {
+                        address: alloy_primitives::address!(
+                            "0x0000000000000000000000000000000000000001"
+                        ),
+                        info: None,
+                    },
+                )?;
+            }
+            Ok(())
+        })
+        .unwrap();
+
+        // Execute stage from checkpoint 0 (will process blocks 1-10)
+        let input = ExecInput { target: Some(10), checkpoint: Some(StageCheckpoint::new(0)) };
+        let mut stage = IndexAccountHistoryStage::default();
+        let provider = db.factory.database_provider_rw().unwrap();
+        let out = stage.execute(&provider, input).unwrap();
+        assert_eq!(out, ExecOutput { checkpoint: StageCheckpoint::new(10), done: true });
+        provider.commit().unwrap();
+
+        // Verify data is in RocksDB
+        let rocksdb = db.factory.rocksdb_provider();
+        let count =
+            rocksdb.iter::<tables::AccountsHistory>().unwrap().filter_map(|r| r.ok()).count();
+        assert!(count > 0, "Expected data in RocksDB, found {count} entries");
+
+        // Verify MDBX AccountsHistory is empty (data went to RocksDB)
+        let mdbx_table = db.table::<tables::AccountsHistory>().unwrap();
+        assert!(mdbx_table.is_empty(), "MDBX should be empty when RocksDB is enabled");
+    }
+
+    /// Test that `IndexAccountHistoryStage` unwind clears `RocksDB` data.
+    #[test]
+    fn test_index_account_history_unwind_clears_rocksdb() {
+        let db = TestStageDB::default();
+        db.factory.set_storage_settings_cache(
+            StorageSettings::legacy().with_account_history_in_rocksdb(true),
+        );
+
+        // Setup changesets (blocks 1-10, skip 0 to avoid genesis edge case)
+        db.commit(|tx| {
+            for block in 1..=10u64 {
+                tx.put::<tables::BlockBodyIndices>(
+                    block,
+                    reth_db_api::models::StoredBlockBodyIndices {
+                        tx_count: 3,
+                        ..Default::default()
+                    },
+                )?;
+                tx.put::<tables::AccountChangeSets>(
+                    block,
+                    reth_db_api::models::AccountBeforeTx {
+                        address: alloy_primitives::address!(
+                            "0x0000000000000000000000000000000000000001"
+                        ),
+                        info: None,
+                    },
+                )?;
+            }
+            Ok(())
+        })
+        .unwrap();
+
+        // Execute stage from checkpoint 0 (will process blocks 1-10)
+        let input = ExecInput { target: Some(10), checkpoint: Some(StageCheckpoint::new(0)) };
+        let mut stage = IndexAccountHistoryStage::default();
+        let provider = db.factory.database_provider_rw().unwrap();
+        let out = stage.execute(&provider, input).unwrap();
+        assert_eq!(out, ExecOutput { checkpoint: StageCheckpoint::new(10), done: true });
+        provider.commit().unwrap();
+
+        // Verify data exists in RocksDB
+        let rocksdb = db.factory.rocksdb_provider();
+        let before_count =
+            rocksdb.iter::<tables::AccountsHistory>().unwrap().filter_map(|r| r.ok()).count();
+        assert!(before_count > 0, "Expected data in RocksDB before unwind");
+
+        // Unwind to block 0 (removes blocks 1-10, leaving nothing)
+        let unwind_input = UnwindInput {
+            checkpoint: StageCheckpoint::new(10),
+            unwind_to: 0,
+            ..Default::default()
+        };
+        let provider = db.factory.database_provider_rw().unwrap();
+        let out = stage.unwind(&provider, unwind_input).unwrap();
+        assert_eq!(out, UnwindOutput { checkpoint: StageCheckpoint::new(0) });
+        provider.commit().unwrap();
+
+        // Verify RocksDB is cleared (no block 0 data exists)
+        let rocksdb = db.factory.rocksdb_provider();
+        let after_count =
+            rocksdb.iter::<tables::AccountsHistory>().unwrap().filter_map(|r| r.ok()).count();
+        assert_eq!(after_count, 0, "RocksDB should be empty after unwind to 0");
     }
 }

--- a/crates/stages/stages/src/stages/utils.rs
+++ b/crates/stages/stages/src/stages/utils.rs
@@ -1,21 +1,28 @@
 //! Utils for `stages`.
-use alloy_primitives::{Address, BlockNumber, TxNumber};
+use alloy_primitives::{Address, BlockNumber, TxNumber, B256};
 use reth_config::config::EtlConfig;
 use reth_db_api::{
     cursor::{DbCursorRO, DbCursorRW},
-    models::{sharded_key::NUM_OF_INDICES_IN_SHARD, AccountBeforeTx, ShardedKey},
+    models::{
+        sharded_key::NUM_OF_INDICES_IN_SHARD, storage_sharded_key::StorageShardedKey,
+        AccountBeforeTx, ShardedKey,
+    },
     table::{Decompress, Table},
+    tables,
     transaction::{DbTx, DbTxMut},
     BlockNumberList, DatabaseError,
 };
 use reth_etl::Collector;
+use reth_primitives_traits::NodePrimitives;
 use reth_provider::{
-    providers::StaticFileProvider, to_range, BlockReader, DBProvider, ProviderError,
-    StaticFileProviderFactory,
+    make_rocksdb_batch_arg, make_rocksdb_provider, providers::StaticFileProvider,
+    register_rocksdb_batch, to_range, BlockReader, DBProvider, EitherWriter, ProviderError,
+    RocksDBProviderFactory, StaticFileProviderFactory, StorageSettingsCache,
 };
 use reth_stages_api::StageError;
 use reth_static_file_types::StaticFileSegment;
-use reth_storage_api::ChangeSetReader;
+use reth_storage_api::{ChangeSetReader, NodePrimitivesProvider};
+use reth_storage_errors::provider::ProviderResult;
 use std::{collections::HashMap, hash::Hash, ops::RangeBounds};
 use tracing::info;
 
@@ -112,6 +119,46 @@ where
     Ok::<(), StageError>(())
 }
 
+/// Generic shard-and-write helper used by both account and storage history loaders.
+///
+/// Chunks the list into shards, writes each shard via the provided write function,
+/// and handles the last shard according to [`LoadMode`].
+fn shard_and_write<F>(
+    list: &mut Vec<BlockNumber>,
+    mode: LoadMode,
+    mut write_fn: F,
+) -> Result<(), StageError>
+where
+    F: FnMut(Vec<u64>, BlockNumber) -> Result<(), StageError>,
+{
+    if list.len() <= NUM_OF_INDICES_IN_SHARD && !mode.is_flush() {
+        return Ok(());
+    }
+
+    let total = list.len();
+    let mut start = 0;
+
+    while start < total {
+        let end = (start + NUM_OF_INDICES_IN_SHARD).min(total);
+        let is_last = end == total;
+        let chunk = list[start..end].to_vec();
+
+        let highest = *chunk.last().expect("at least one index");
+
+        if !mode.is_flush() && is_last {
+            *list = chunk;
+            break;
+        }
+
+        let highest = if is_last { u64::MAX } else { highest };
+        write_fn(chunk, highest)?;
+
+        start = end;
+    }
+
+    Ok(())
+}
+
 /// Collects account history indices using a provider that implements `ChangeSetReader`.
 pub(crate) fn collect_account_history_indices<Provider>(
     provider: &Provider,
@@ -179,6 +226,7 @@ where
 /// `Address.StorageKey`). It flushes indices to disk when reaching a shard's max length
 /// (`NUM_OF_INDICES_IN_SHARD`) or when the partial key changes, ensuring the last previous partial
 /// key shard is stored.
+#[allow(dead_code)]
 pub(crate) fn load_history_indices<Provider, H, P>(
     provider: &Provider,
     mut collector: Collector<H::Key, H::Value>,
@@ -263,6 +311,7 @@ where
 }
 
 /// Shard and insert the indices list according to [`LoadMode`] and its length.
+#[allow(dead_code)]
 pub(crate) fn load_indices<H, C, P>(
     cursor: &mut C,
     partial_key: P,
@@ -319,6 +368,289 @@ impl LoadMode {
     const fn is_flush(&self) -> bool {
         matches!(self, Self::Flush)
     }
+}
+
+/// Loads storage history indices from a collector into the database using `EitherWriter`.
+///
+/// This is a specialized version of [`load_history_indices`] for `tables::StoragesHistory`
+/// that supports writing to either `MDBX` or `RocksDB` based on storage settings.
+#[allow(dead_code)]
+pub(crate) fn load_storages_history_indices<Provider, P>(
+    provider: &Provider,
+    mut collector: Collector<
+        <tables::StoragesHistory as Table>::Key,
+        <tables::StoragesHistory as Table>::Value,
+    >,
+    append_only: bool,
+    sharded_key_factory: impl Clone + Fn(P, u64) -> StorageShardedKey,
+    decode_key: impl Fn(Vec<u8>) -> Result<StorageShardedKey, DatabaseError>,
+    get_partial: impl Fn(StorageShardedKey) -> P,
+) -> Result<(), StageError>
+where
+    Provider: DBProvider<Tx: DbTxMut>
+        + NodePrimitivesProvider
+        + StorageSettingsCache
+        + RocksDBProviderFactory,
+    P: Copy + Default + Eq,
+{
+    // Create EitherWriter for storage history
+    #[allow(clippy::let_unit_value)]
+    let rocksdb = make_rocksdb_provider(provider);
+    #[allow(clippy::let_unit_value)]
+    let rocksdb_batch = make_rocksdb_batch_arg(&rocksdb);
+    let mut writer = EitherWriter::new_storages_history(provider, rocksdb_batch)?;
+
+    // Create read cursor for checking existing shards
+    let mut read_cursor = provider.tx_ref().cursor_read::<tables::StoragesHistory>()?;
+
+    let mut current_partial = P::default();
+    let mut current_list = Vec::<u64>::new();
+
+    // observability
+    let total_entries = collector.len();
+    let interval = (total_entries / 10).max(1);
+
+    for (index, element) in collector.iter()?.enumerate() {
+        let (k, v) = element?;
+        let sharded_key = decode_key(k)?;
+        let new_list = BlockNumberList::decompress_owned(v)?;
+
+        if index > 0 && index.is_multiple_of(interval) && total_entries > 10 {
+            info!(target: "sync::stages::index_history", progress = %format!("{:.2}%", (index as f64 / total_entries as f64) * 100.0), "Writing storage history indices");
+        }
+
+        let partial_key = get_partial(sharded_key);
+
+        if current_partial != partial_key {
+            // Flush last shard for previous partial key
+            load_storages_history_shard(
+                &mut writer,
+                current_partial,
+                &mut current_list,
+                &sharded_key_factory,
+                append_only,
+                LoadMode::Flush,
+            )?;
+
+            current_partial = partial_key;
+            current_list.clear();
+
+            // If not first sync, merge with existing shard
+            if !append_only &&
+                let Some((_, last_database_shard)) =
+                    read_cursor.seek_exact(sharded_key_factory(current_partial, u64::MAX))?
+            {
+                current_list.extend(last_database_shard.iter());
+            }
+        }
+
+        current_list.extend(new_list.iter());
+        load_storages_history_shard(
+            &mut writer,
+            current_partial,
+            &mut current_list,
+            &sharded_key_factory,
+            append_only,
+            LoadMode::KeepLast,
+        )?;
+    }
+
+    // Flush remaining shard
+    load_storages_history_shard(
+        &mut writer,
+        current_partial,
+        &mut current_list,
+        &sharded_key_factory,
+        append_only,
+        LoadMode::Flush,
+    )?;
+
+    // Register RocksDB batch for commit
+    register_rocksdb_batch(provider, writer);
+
+    Ok(())
+}
+
+/// Shard and insert storage history indices according to [`LoadMode`] and list length.
+#[allow(dead_code)]
+fn load_storages_history_shard<P, CURSOR, N>(
+    writer: &mut EitherWriter<'_, CURSOR, N>,
+    partial_key: P,
+    list: &mut Vec<BlockNumber>,
+    sharded_key_factory: &impl Fn(P, BlockNumber) -> StorageShardedKey,
+    _append_only: bool,
+    mode: LoadMode,
+) -> Result<(), StageError>
+where
+    N: NodePrimitives,
+    CURSOR: DbCursorRW<tables::StoragesHistory> + DbCursorRO<tables::StoragesHistory>,
+    P: Copy,
+{
+    shard_and_write(list, mode, |chunk, highest| {
+        let key = sharded_key_factory(partial_key, highest);
+        let value = BlockNumberList::new_pre_sorted(chunk);
+        Ok(writer.put_storage_history(key, &value)?)
+    })
+}
+
+/// Loads account history indices from a collector into the database using `EitherWriter`.
+///
+/// This is a specialized version of [`load_history_indices`] for `tables::AccountsHistory`
+/// that supports writing to either `MDBX` or `RocksDB` based on storage settings.
+#[allow(dead_code)]
+pub(crate) fn load_accounts_history_indices<Provider, P>(
+    provider: &Provider,
+    mut collector: Collector<
+        <tables::AccountsHistory as Table>::Key,
+        <tables::AccountsHistory as Table>::Value,
+    >,
+    append_only: bool,
+    sharded_key_factory: impl Clone + Fn(P, u64) -> ShardedKey<Address>,
+    decode_key: impl Fn(Vec<u8>) -> Result<ShardedKey<Address>, DatabaseError>,
+    get_partial: impl Fn(ShardedKey<Address>) -> P,
+) -> Result<(), StageError>
+where
+    Provider: DBProvider<Tx: DbTxMut>
+        + NodePrimitivesProvider
+        + StorageSettingsCache
+        + RocksDBProviderFactory,
+    P: Copy + Default + Eq,
+{
+    // Create EitherWriter for account history
+    #[allow(clippy::let_unit_value)]
+    let rocksdb = make_rocksdb_provider(provider);
+    #[allow(clippy::let_unit_value)]
+    let rocksdb_batch = make_rocksdb_batch_arg(&rocksdb);
+    let mut writer = EitherWriter::new_accounts_history(provider, rocksdb_batch)?;
+
+    // Create read cursor for checking existing shards
+    let mut read_cursor = provider.tx_ref().cursor_read::<tables::AccountsHistory>()?;
+
+    let mut current_partial = P::default();
+    let mut current_list = Vec::<u64>::new();
+
+    // observability
+    let total_entries = collector.len();
+    let interval = (total_entries / 10).max(1);
+
+    for (index, element) in collector.iter()?.enumerate() {
+        let (k, v) = element?;
+        let sharded_key = decode_key(k)?;
+        let new_list = BlockNumberList::decompress_owned(v)?;
+
+        if index > 0 && index.is_multiple_of(interval) && total_entries > 10 {
+            info!(target: "sync::stages::index_history", progress = %format!("{:.2}%", (index as f64 / total_entries as f64) * 100.0), "Writing account history indices");
+        }
+
+        let partial_key = get_partial(sharded_key);
+
+        if current_partial != partial_key {
+            // Flush last shard for previous partial key
+            load_accounts_history_shard(
+                &mut writer,
+                current_partial,
+                &mut current_list,
+                &sharded_key_factory,
+                append_only,
+                LoadMode::Flush,
+            )?;
+
+            current_partial = partial_key;
+            current_list.clear();
+
+            // If not first sync, merge with existing shard
+            if !append_only &&
+                let Some((_, last_database_shard)) =
+                    read_cursor.seek_exact(sharded_key_factory(current_partial, u64::MAX))?
+            {
+                current_list.extend(last_database_shard.iter());
+            }
+        }
+
+        current_list.extend(new_list.iter());
+        load_accounts_history_shard(
+            &mut writer,
+            current_partial,
+            &mut current_list,
+            &sharded_key_factory,
+            append_only,
+            LoadMode::KeepLast,
+        )?;
+    }
+
+    // Flush remaining shard
+    load_accounts_history_shard(
+        &mut writer,
+        current_partial,
+        &mut current_list,
+        &sharded_key_factory,
+        append_only,
+        LoadMode::Flush,
+    )?;
+
+    // Register RocksDB batch for commit
+    register_rocksdb_batch(provider, writer);
+
+    Ok(())
+}
+
+/// Shard and insert account history indices according to [`LoadMode`] and list length.
+#[allow(dead_code)]
+fn load_accounts_history_shard<P, CURSOR, N>(
+    writer: &mut EitherWriter<'_, CURSOR, N>,
+    partial_key: P,
+    list: &mut Vec<BlockNumber>,
+    sharded_key_factory: &impl Fn(P, BlockNumber) -> ShardedKey<Address>,
+    _append_only: bool,
+    mode: LoadMode,
+) -> Result<(), StageError>
+where
+    N: NodePrimitives,
+    CURSOR: DbCursorRW<tables::AccountsHistory> + DbCursorRO<tables::AccountsHistory>,
+    P: Copy,
+{
+    shard_and_write(list, mode, |chunk, highest| {
+        let key = sharded_key_factory(partial_key, highest);
+        let value = BlockNumberList::new_pre_sorted(chunk);
+        Ok(writer.put_account_history(key, &value)?)
+    })
+}
+
+/// Unwinds storage history shards using `EitherWriter` for `RocksDB` support.
+///
+/// This reimplements the shard unwinding logic with support for both MDBX and `RocksDB`.
+/// Walks through shards for a given key, deleting those >= unwind point and preserving
+/// indices below the unwind point.
+#[allow(dead_code)]
+pub(crate) fn unwind_storages_history_shards<CURSOR, N>(
+    writer: &mut EitherWriter<'_, CURSOR, N>,
+    address: Address,
+    storage_key: B256,
+    block_number: BlockNumber,
+) -> ProviderResult<()>
+where
+    N: NodePrimitives,
+    CURSOR: DbCursorRW<tables::StoragesHistory> + DbCursorRO<tables::StoragesHistory>,
+{
+    writer.unwind_storage_history_shards(address, storage_key, block_number)
+}
+
+/// Unwinds account history shards using `EitherWriter` for `RocksDB` support.
+///
+/// This reimplements the shard unwinding logic with support for both MDBX and `RocksDB`.
+/// Walks through shards for a given key, deleting those >= unwind point and preserving
+/// indices below the unwind point.
+#[allow(dead_code)]
+pub(crate) fn unwind_accounts_history_shards<CURSOR, N>(
+    writer: &mut EitherWriter<'_, CURSOR, N>,
+    address: Address,
+    block_number: BlockNumber,
+) -> ProviderResult<()>
+where
+    N: NodePrimitives,
+    CURSOR: DbCursorRW<tables::AccountsHistory> + DbCursorRO<tables::AccountsHistory>,
+{
+    writer.unwind_account_history_shards(address, block_number)
 }
 
 /// Called when database is ahead of static files. Attempts to find the first block we are missing

--- a/crates/storage/db-api/src/models/metadata.rs
+++ b/crates/storage/db-api/src/models/metadata.rs
@@ -44,9 +44,9 @@ impl StorageSettings {
             receipts_in_static_files: true,
             transaction_senders_in_static_files: true,
             account_changesets_in_static_files: true,
-            storages_history_in_rocksdb: false,
-            transaction_hash_numbers_in_rocksdb: false,
-            account_history_in_rocksdb: false,
+            storages_history_in_rocksdb: true,
+            transaction_hash_numbers_in_rocksdb: true,
+            account_history_in_rocksdb: true,
         }
     }
 

--- a/crates/storage/db-api/src/models/metadata.rs
+++ b/crates/storage/db-api/src/models/metadata.rs
@@ -101,4 +101,11 @@ impl StorageSettings {
         self.account_changesets_in_static_files = value;
         self
     }
+
+    /// Returns `true` if any tables are configured to be stored in `RocksDB`.
+    pub const fn any_in_rocksdb(&self) -> bool {
+        self.transaction_hash_numbers_in_rocksdb ||
+            self.account_history_in_rocksdb ||
+            self.storages_history_in_rocksdb
+    }
 }

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -334,7 +334,7 @@ where
         Vec::new(),
     );
 
-    provider.write_state(&execution_outcome, OriginalValuesKnown::Yes)?;
+    provider.write_state(&execution_outcome, OriginalValuesKnown::Yes, true)?;
 
     trace!(target: "reth::cli", "Inserted state");
 

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -16,8 +16,8 @@ use reth_provider::{
     errors::provider::ProviderResult, providers::StaticFileWriter, BlockHashReader, BlockNumReader,
     BundleStateInit, ChainSpecProvider, DBProvider, DatabaseProviderFactory, ExecutionOutcome,
     HashingWriter, HeaderProvider, HistoryWriter, MetadataWriter, OriginalValuesKnown,
-    ProviderError, RevertsInit, StageCheckpointReader, StageCheckpointWriter, StateWriter,
-    StaticFileProviderFactory, StorageSettings, StorageSettingsCache, TrieWriter,
+    ProviderError, RevertsInit, StageCheckpointReader, StageCheckpointWriter, StateWriteConfig,
+    StateWriter, StaticFileProviderFactory, StorageSettings, StorageSettingsCache, TrieWriter,
 };
 use reth_stages_types::{StageCheckpoint, StageId};
 use reth_static_file_types::StaticFileSegment;
@@ -334,7 +334,11 @@ where
         Vec::new(),
     );
 
-    provider.write_state(&execution_outcome, OriginalValuesKnown::Yes, true)?;
+    provider.write_state(
+        &execution_outcome,
+        OriginalValuesKnown::Yes,
+        StateWriteConfig::default(),
+    )?;
 
     trace!(target: "reth::cli", "Inserted state");
 

--- a/crates/storage/errors/src/provider.rs
+++ b/crates/storage/errors/src/provider.rs
@@ -225,6 +225,9 @@ pub enum StaticFileWriterError {
     /// Cannot call `sync_all` or `finalize` when prune is queued.
     #[error("cannot call sync_all or finalize when prune is queued, use commit() instead")]
     FinalizeWithPruneQueued,
+    /// Thread panicked during execution.
+    #[error("thread panicked: {_0}")]
+    ThreadPanic(&'static str),
     /// Other error with message.
     #[error("{0}")]
     Other(String),

--- a/crates/storage/libmdbx-rs/src/txn_manager.rs
+++ b/crates/storage/libmdbx-rs/src/txn_manager.rs
@@ -58,6 +58,9 @@ impl TxnManager {
                 match rx.recv() {
                     Ok(msg) => match msg {
                         TxnManagerMessage::Begin { parent, flags, sender } => {
+                            let _span =
+                                tracing::debug_span!(target: "libmdbx::txn", "begin", flags)
+                                    .entered();
                             let mut txn: *mut ffi::MDBX_txn = ptr::null_mut();
                             let res = mdbx_result(unsafe {
                                 ffi::mdbx_txn_begin_ex(
@@ -72,9 +75,13 @@ impl TxnManager {
                             sender.send(res).unwrap();
                         }
                         TxnManagerMessage::Abort { tx, sender } => {
+                            let _span =
+                                tracing::debug_span!(target: "libmdbx::txn", "abort").entered();
                             sender.send(mdbx_result(unsafe { ffi::mdbx_txn_abort(tx.0) })).unwrap();
                         }
                         TxnManagerMessage::Commit { tx, sender } => {
+                            let _span =
+                                tracing::debug_span!(target: "libmdbx::txn", "commit").entered();
                             sender
                                 .send({
                                     let mut latency = CommitLatency::new();

--- a/crates/storage/provider/src/either_writer.rs
+++ b/crates/storage/provider/src/either_writer.rs
@@ -592,9 +592,7 @@ impl<'a> EitherReader<'a, (), ()> {
             return Ok(EitherReader::RocksDB(_rocksdb_tx));
         }
 
-        Ok(EitherReader::Database(
-            provider.tx_ref().cursor_read::<tables::StoragesHistory>()?,
-        ))
+        Ok(EitherReader::Database(provider.tx_ref().cursor_read::<tables::StoragesHistory>()?))
     }
 
     /// Creates a new [`EitherReader`] for transaction hash numbers based on storage settings.
@@ -630,9 +628,7 @@ impl<'a> EitherReader<'a, (), ()> {
             return Ok(EitherReader::RocksDB(_rocksdb_tx));
         }
 
-        Ok(EitherReader::Database(
-            provider.tx_ref().cursor_read::<tables::AccountsHistory>()?,
-        ))
+        Ok(EitherReader::Database(provider.tx_ref().cursor_read::<tables::AccountsHistory>()?))
     }
 
     /// Creates a new [`EitherReader`] for account changesets based on storage settings.

--- a/crates/storage/provider/src/either_writer.rs
+++ b/crates/storage/provider/src/either_writer.rs
@@ -38,6 +38,71 @@ use reth_storage_api::{ChangeSetReader, DBProvider, NodePrimitivesProvider, Stor
 use reth_storage_errors::provider::ProviderResult;
 use strum::{Display, EnumIs};
 
+/// Collects shards to unwind from a `RocksDB` reverse iterator.
+///
+/// This is a generic helper for the `RocksDB` unwind logic used by both account and storage
+/// history. It iterates through shards from highest to lowest block number, collecting shards to
+/// delete and identifying any partial shard that needs to be preserved.
+///
+/// # Arguments
+/// * `iter` - An iterator yielding `(K, BlockNumberList)` pairs in reverse order
+/// * `belongs_to_target` - Predicate that returns `true` if the key belongs to the target being
+///   unwound
+/// * `highest_block_number` - Function to extract the highest block number from the key
+/// * `block_number` - The unwind target block number
+///
+/// # Returns
+/// A tuple of `(shards_to_delete, partial_shard_to_keep)` where:
+/// - `shards_to_delete` contains all keys that should be deleted
+/// - `partial_shard_to_keep` contains block numbers to preserve if a boundary shard was found
+#[cfg(all(unix, feature = "rocksdb"))]
+fn collect_shards_for_unwind<K, I, E>(
+    iter: I,
+    belongs_to_target: impl Fn(&K) -> bool,
+    highest_block_number: impl Fn(&K) -> BlockNumber,
+    block_number: BlockNumber,
+) -> Result<(Vec<K>, Option<Vec<u64>>), E>
+where
+    I: Iterator<Item = Result<(K, BlockNumberList), E>>,
+{
+    let mut shards_to_delete = Vec::new();
+    let mut partial_shard_to_keep: Option<Vec<u64>> = None;
+
+    for result in iter {
+        let (key, list) = result?;
+
+        if !belongs_to_target(&key) {
+            break;
+        }
+
+        shards_to_delete.push(key);
+        let key = shards_to_delete.last().unwrap();
+
+        let first = list.iter().next().expect("List can't be empty");
+
+        // Case 1: Entire shard is at or above the unwinding point - keep it deleted
+        if first >= block_number {
+            continue;
+        }
+
+        // Case 2: Boundary shard - spans across the unwinding point
+        if block_number <= highest_block_number(key) {
+            let indices_to_keep: Vec<_> = list.iter().take_while(|i| *i < block_number).collect();
+            if !indices_to_keep.is_empty() {
+                partial_shard_to_keep = Some(indices_to_keep);
+            }
+            break;
+        }
+
+        // Case 3: Entire shard is below the unwinding point - keep all indices
+        let indices_to_keep: Vec<_> = list.iter().collect();
+        partial_shard_to_keep = Some(indices_to_keep);
+        break;
+    }
+
+    Ok((shards_to_delete, partial_shard_to_keep))
+}
+
 /// Type alias for [`EitherReader`] constructors.
 type EitherReaderTy<'a, P, T> =
     EitherReader<'a, CursorTy<<P as DBProvider>::Tx, T>, <P as NodePrimitivesProvider>::Primitives>;
@@ -106,6 +171,67 @@ pub enum EitherWriter<'a, CURSOR, N> {
     /// Write to `RocksDB` using a write-only batch (historical tables).
     #[cfg(all(unix, feature = "rocksdb"))]
     RocksDB(RocksDBBatch<'a>),
+}
+
+/// Creates a `RocksDB` batch from the provider for use in [`EitherWriter`] constructors.
+///
+/// On `RocksDB`-enabled builds, returns a real batch.
+/// On other builds, returns `()` to allow the same API without feature gates.
+///
+/// The `rocksdb` parameter should be obtained from [`make_rocksdb_provider`].
+#[cfg(all(unix, feature = "rocksdb"))]
+pub fn make_rocksdb_batch_arg(
+    rocksdb: &crate::providers::rocksdb::RocksDBProvider,
+) -> RocksBatchArg<'_> {
+    rocksdb.batch()
+}
+
+/// Stub for non-`RocksDB` builds.
+#[cfg(not(all(unix, feature = "rocksdb")))]
+pub const fn make_rocksdb_batch_arg<T>(_rocksdb: &T) -> RocksBatchArg<'static> {}
+
+/// Gets the `RocksDB` provider from a provider that implements [`crate::RocksDBProviderFactory`].
+///
+/// On `RocksDB`-enabled builds, returns the real provider.
+/// On other builds, returns `()` to allow the same API without feature gates.
+///
+/// This should be called first, and the result passed to [`make_rocksdb_batch_arg`].
+/// The returned value must be kept alive for as long as the batch is used.
+#[cfg(all(unix, feature = "rocksdb"))]
+pub fn make_rocksdb_provider<P>(provider: &P) -> crate::providers::rocksdb::RocksDBProvider
+where
+    P: crate::RocksDBProviderFactory,
+{
+    provider.rocksdb_provider()
+}
+
+/// Stub for non-`RocksDB` builds.
+#[cfg(not(all(unix, feature = "rocksdb")))]
+pub const fn make_rocksdb_provider<P>(_provider: &P) {}
+
+/// Registers a `RocksDB` batch extracted from an [`EitherWriter`] with the provider.
+///
+/// This should be called after operations on an [`EitherWriter`] that may use `RocksDB`,
+/// to ensure the batch is committed when the provider commits.
+///
+/// On non-`RocksDB` builds, this is a no-op.
+#[cfg(all(unix, feature = "rocksdb"))]
+pub fn register_rocksdb_batch<P, CURSOR, N>(provider: &P, writer: EitherWriter<'_, CURSOR, N>)
+where
+    P: crate::RocksDBProviderFactory,
+    N: NodePrimitives,
+{
+    if let Some(batch) = writer.into_raw_rocksdb_batch() {
+        provider.set_pending_rocksdb_batch(batch);
+    }
+}
+
+/// Stub for non-`RocksDB` builds.
+#[cfg(not(all(unix, feature = "rocksdb")))]
+pub fn register_rocksdb_batch<P, CURSOR, N>(_provider: &P, _writer: EitherWriter<'_, CURSOR, N>)
+where
+    N: NodePrimitives,
+{
 }
 
 impl<'a> EitherWriter<'a, (), ()> {
@@ -479,6 +605,99 @@ where
             Self::RocksDB(batch) => batch.delete::<tables::StoragesHistory>(key),
         }
     }
+
+    /// Unwinds storage history shards for a given address and storage key.
+    ///
+    /// Walks through all shards for the given key, collecting indices below the unwind point,
+    /// then deletes all shards and reinserts the kept indices as a single sentinel shard.
+    pub fn unwind_storage_history_shards(
+        &mut self,
+        address: Address,
+        storage_key: B256,
+        block_number: BlockNumber,
+    ) -> ProviderResult<()> {
+        let start_key = StorageShardedKey::last(address, storage_key);
+
+        match self {
+            Self::Database(cursor) => {
+                // Walk through shards from highest to lowest, following the same algorithm
+                // as unwind_history_shards in provider.rs
+                let mut item = cursor.seek_exact(start_key.clone())?;
+
+                while let Some((sharded_key, list)) = item {
+                    // Check if shard belongs to this (address, storage_key)
+                    if sharded_key.address != address || sharded_key.sharded_key.key != storage_key
+                    {
+                        break;
+                    }
+
+                    // Delete this shard
+                    cursor.delete_current()?;
+
+                    // Get the first (lowest) block number in this shard
+                    let first = list.iter().next().expect("List can't be empty");
+
+                    // Case 1: Entire shard is at or above the unwinding point
+                    // Keep it deleted (already done above) and continue to next shard
+                    if first >= block_number {
+                        item = cursor.prev()?;
+                        continue;
+                    }
+
+                    // Case 2: Boundary shard - spans across the unwinding point
+                    // Reinsert only indices below unwind point, then STOP
+                    if block_number <= sharded_key.sharded_key.highest_block_number {
+                        let indices_to_keep: Vec<_> =
+                            list.iter().take_while(|i| *i < block_number).collect();
+                        if !indices_to_keep.is_empty() {
+                            cursor.insert(
+                                start_key,
+                                &BlockNumberList::new_pre_sorted(indices_to_keep),
+                            )?;
+                        }
+                        return Ok(());
+                    }
+
+                    // Case 3: Entire shard is below the unwinding point
+                    // Reinsert all indices, then STOP (preserves earlier shards)
+                    let indices_to_keep: Vec<_> = list.iter().collect();
+                    cursor.insert(start_key, &BlockNumberList::new_pre_sorted(indices_to_keep))?;
+                    return Ok(());
+                }
+
+                Ok(())
+            }
+            Self::StaticFile(..) => Err(ProviderError::UnsupportedProvider),
+            #[cfg(all(unix, feature = "rocksdb"))]
+            Self::RocksDB(batch) => {
+                let provider = batch.provider();
+                let iter =
+                    provider.iter_from_reverse::<tables::StoragesHistory>(start_key.clone())?;
+
+                let (shards_to_delete, partial_shard_to_keep) = collect_shards_for_unwind(
+                    iter,
+                    |k: &StorageShardedKey| {
+                        k.address == address && k.sharded_key.key == storage_key
+                    },
+                    |k| k.sharded_key.highest_block_number,
+                    block_number,
+                )?;
+
+                for key in shards_to_delete {
+                    batch.delete::<tables::StoragesHistory>(key)?;
+                }
+
+                if let Some(indices) = partial_shard_to_keep {
+                    batch.put::<tables::StoragesHistory>(
+                        start_key,
+                        &BlockNumberList::new_pre_sorted(indices),
+                    )?;
+                }
+
+                Ok(())
+            }
+        }
+    }
 }
 
 impl<'a, CURSOR, N: NodePrimitives> EitherWriter<'a, CURSOR, N>
@@ -511,6 +730,92 @@ where
             Self::StaticFile(..) => Err(ProviderError::UnsupportedProvider),
             #[cfg(all(unix, feature = "rocksdb"))]
             Self::RocksDB(batch) => batch.delete::<tables::AccountsHistory>(key),
+        }
+    }
+
+    /// Unwinds account history shards for a given address.
+    ///
+    /// Walks through all shards for the given address, following the same algorithm
+    /// as `unwind_history_shards` in provider.rs: only delete/modify shards at or above
+    /// the unwind point, preserving earlier shards.
+    pub fn unwind_account_history_shards(
+        &mut self,
+        address: Address,
+        block_number: BlockNumber,
+    ) -> ProviderResult<()> {
+        let start_key = ShardedKey::last(address);
+
+        match self {
+            Self::Database(cursor) => {
+                // Walk through shards from highest to lowest
+                let mut item = cursor.seek_exact(start_key.clone())?;
+
+                while let Some((sharded_key, list)) = item {
+                    // Check if shard belongs to this address
+                    if sharded_key.key != address {
+                        break;
+                    }
+
+                    // Delete this shard
+                    cursor.delete_current()?;
+
+                    // Get the first (lowest) block number in this shard
+                    let first = list.iter().next().expect("List can't be empty");
+
+                    // Case 1: Entire shard is at or above the unwinding point
+                    if first >= block_number {
+                        item = cursor.prev()?;
+                        continue;
+                    }
+
+                    // Case 2: Boundary shard - spans across the unwinding point
+                    if block_number <= sharded_key.highest_block_number {
+                        let indices_to_keep: Vec<_> =
+                            list.iter().take_while(|i| *i < block_number).collect();
+                        if !indices_to_keep.is_empty() {
+                            cursor.insert(
+                                start_key,
+                                &BlockNumberList::new_pre_sorted(indices_to_keep),
+                            )?;
+                        }
+                        return Ok(());
+                    }
+
+                    // Case 3: Entire shard is below the unwinding point
+                    let indices_to_keep: Vec<_> = list.iter().collect();
+                    cursor.insert(start_key, &BlockNumberList::new_pre_sorted(indices_to_keep))?;
+                    return Ok(());
+                }
+
+                Ok(())
+            }
+            Self::StaticFile(..) => Err(ProviderError::UnsupportedProvider),
+            #[cfg(all(unix, feature = "rocksdb"))]
+            Self::RocksDB(batch) => {
+                let provider = batch.provider();
+                let iter =
+                    provider.iter_from_reverse::<tables::AccountsHistory>(start_key.clone())?;
+
+                let (shards_to_delete, partial_shard_to_keep) = collect_shards_for_unwind(
+                    iter,
+                    |k: &ShardedKey<Address>| k.key == address,
+                    |k| k.highest_block_number,
+                    block_number,
+                )?;
+
+                for key in shards_to_delete {
+                    batch.delete::<tables::AccountsHistory>(key)?;
+                }
+
+                if let Some(indices) = partial_shard_to_keep {
+                    batch.put::<tables::AccountsHistory>(
+                        start_key,
+                        &BlockNumberList::new_pre_sorted(indices),
+                    )?;
+                }
+
+                Ok(())
+            }
         }
     }
 }

--- a/crates/storage/provider/src/either_writer.rs
+++ b/crates/storage/provider/src/either_writer.rs
@@ -274,7 +274,7 @@ impl<'a, CURSOR, N: NodePrimitives> EitherWriter<'a, CURSOR, N> {
     #[cfg(all(unix, feature = "rocksdb"))]
     pub fn into_raw_rocksdb_batch(self) -> Option<rocksdb::WriteBatchWithTransaction<true>> {
         match self {
-            Self::Database(_) | Self::StaticFile(_) => None,
+            Self::Database(_) | Self::StaticFile(..) => None,
             Self::RocksDB(batch) => Some(batch.into_inner()),
         }
     }
@@ -285,7 +285,7 @@ impl<'a, CURSOR, N: NodePrimitives> EitherWriter<'a, CURSOR, N> {
     #[cfg(not(all(unix, feature = "rocksdb")))]
     pub fn into_raw_rocksdb_batch(self) -> Option<RawRocksDBBatch> {
         match self {
-            Self::Database(_) | Self::StaticFile(_) => None,
+            Self::Database(_) | Self::StaticFile(..) => None,
         }
     }
 
@@ -424,7 +424,7 @@ where
                     Ok(cursor.upsert(hash, &tx_num)?)
                 }
             }
-            Self::StaticFile(_) => Err(ProviderError::UnsupportedProvider),
+            Self::StaticFile(..) => Err(ProviderError::UnsupportedProvider),
             #[cfg(all(unix, feature = "rocksdb"))]
             Self::RocksDB(batch) => batch.put::<tables::TransactionHashNumbers>(hash, &tx_num),
         }
@@ -439,7 +439,7 @@ where
                 }
                 Ok(())
             }
-            Self::StaticFile(_) => Err(ProviderError::UnsupportedProvider),
+            Self::StaticFile(..) => Err(ProviderError::UnsupportedProvider),
             #[cfg(all(unix, feature = "rocksdb"))]
             Self::RocksDB(batch) => batch.delete::<tables::TransactionHashNumbers>(hash),
         }
@@ -458,7 +458,7 @@ where
     ) -> ProviderResult<()> {
         match self {
             Self::Database(cursor) => Ok(cursor.upsert(key, value)?),
-            Self::StaticFile(_) => Err(ProviderError::UnsupportedProvider),
+            Self::StaticFile(..) => Err(ProviderError::UnsupportedProvider),
             #[cfg(all(unix, feature = "rocksdb"))]
             Self::RocksDB(batch) => batch.put::<tables::StoragesHistory>(key, value),
         }
@@ -473,7 +473,7 @@ where
                 }
                 Ok(())
             }
-            Self::StaticFile(_) => Err(ProviderError::UnsupportedProvider),
+            Self::StaticFile(..) => Err(ProviderError::UnsupportedProvider),
             #[cfg(all(unix, feature = "rocksdb"))]
             Self::RocksDB(batch) => batch.delete::<tables::StoragesHistory>(key),
         }
@@ -492,7 +492,7 @@ where
     ) -> ProviderResult<()> {
         match self {
             Self::Database(cursor) => Ok(cursor.upsert(key, value)?),
-            Self::StaticFile(_) => Err(ProviderError::UnsupportedProvider),
+            Self::StaticFile(..) => Err(ProviderError::UnsupportedProvider),
             #[cfg(all(unix, feature = "rocksdb"))]
             Self::RocksDB(batch) => batch.put::<tables::AccountsHistory>(key, value),
         }
@@ -507,7 +507,7 @@ where
                 }
                 Ok(())
             }
-            Self::StaticFile(_) => Err(ProviderError::UnsupportedProvider),
+            Self::StaticFile(..) => Err(ProviderError::UnsupportedProvider),
             #[cfg(all(unix, feature = "rocksdb"))]
             Self::RocksDB(batch) => batch.delete::<tables::AccountsHistory>(key),
         }
@@ -546,12 +546,15 @@ where
 }
 
 /// Represents a source for reading data, either from database, static files, or `RocksDB`.
+///
+/// Note: The `StaticFile` variant holds `PhantomData<&'a ()>` to ensure the lifetime `'a`
+/// is used even when the `rocksdb` feature is disabled (where `RocksDB` variant is absent).
 #[derive(Debug, Display)]
 pub enum EitherReader<'a, CURSOR, N> {
     /// Read from database table via cursor
     Database(CURSOR),
     /// Read from static file
-    StaticFile(StaticFileProvider<N>),
+    StaticFile(StaticFileProvider<N>, std::marker::PhantomData<&'a ()>),
     /// Read from `RocksDB` transaction
     #[cfg(all(unix, feature = "rocksdb"))]
     RocksDB(&'a crate::providers::rocksdb::RocksTx<'a>),
@@ -567,7 +570,7 @@ impl<'a> EitherReader<'a, (), ()> {
         P::Tx: DbTx,
     {
         if EitherWriterDestination::senders(provider).is_static_file() {
-            Ok(EitherReader::StaticFile(provider.static_file_provider()))
+            Ok(EitherReader::StaticFile(provider.static_file_provider(), std::marker::PhantomData))
         } else {
             Ok(EitherReader::Database(
                 provider.tx_ref().cursor_read::<tables::TransactionSenders>()?,
@@ -641,7 +644,7 @@ impl<'a> EitherReader<'a, (), ()> {
         P::Tx: DbTx,
     {
         if EitherWriterDestination::account_changesets(provider).is_static_file() {
-            Ok(EitherReader::StaticFile(provider.static_file_provider()))
+            Ok(EitherReader::StaticFile(provider.static_file_provider(), std::marker::PhantomData))
         } else {
             Ok(EitherReader::Database(
                 provider.tx_ref().cursor_dup_read::<tables::AccountChangeSets>()?,
@@ -664,7 +667,7 @@ where
                 .walk_range(range)?
                 .map(|result| result.map_err(ProviderError::from))
                 .collect::<ProviderResult<HashMap<_, _>>>(),
-            Self::StaticFile(provider) => range
+            Self::StaticFile(provider, _) => range
                 .clone()
                 .zip(provider.fetch_range_iter(
                     StaticFileSegment::TransactionSenders,
@@ -693,7 +696,7 @@ where
     ) -> ProviderResult<Option<TxNumber>> {
         match self {
             Self::Database(cursor) => Ok(cursor.seek_exact(hash)?.map(|(_, v)| v)),
-            Self::StaticFile(_) => Err(ProviderError::UnsupportedProvider),
+            Self::StaticFile(..) => Err(ProviderError::UnsupportedProvider),
             #[cfg(all(unix, feature = "rocksdb"))]
             Self::RocksDB(tx) => tx.get::<tables::TransactionHashNumbers>(hash),
         }
@@ -711,7 +714,7 @@ where
     ) -> ProviderResult<Option<BlockNumberList>> {
         match self {
             Self::Database(cursor) => Ok(cursor.seek_exact(key)?.map(|(_, v)| v)),
-            Self::StaticFile(_) => Err(ProviderError::UnsupportedProvider),
+            Self::StaticFile(..) => Err(ProviderError::UnsupportedProvider),
             #[cfg(all(unix, feature = "rocksdb"))]
             Self::RocksDB(tx) => tx.get::<tables::StoragesHistory>(key),
         }
@@ -776,7 +779,7 @@ where
                     Ok(HistoryInfo::NotYetWritten)
                 }
             }
-            Self::StaticFile(_) => Err(ProviderError::UnsupportedProvider),
+            Self::StaticFile(..) => Err(ProviderError::UnsupportedProvider),
             #[cfg(all(unix, feature = "rocksdb"))]
             Self::RocksDB(tx) => tx.storage_history_info(
                 address,
@@ -799,7 +802,7 @@ where
     ) -> ProviderResult<Option<BlockNumberList>> {
         match self {
             Self::Database(cursor) => Ok(cursor.seek_exact(key)?.map(|(_, v)| v)),
-            Self::StaticFile(_) => Err(ProviderError::UnsupportedProvider),
+            Self::StaticFile(..) => Err(ProviderError::UnsupportedProvider),
             #[cfg(all(unix, feature = "rocksdb"))]
             Self::RocksDB(tx) => tx.get::<tables::AccountsHistory>(key),
         }
@@ -859,7 +862,7 @@ where
                     Ok(HistoryInfo::NotYetWritten)
                 }
             }
-            Self::StaticFile(_) => Err(ProviderError::UnsupportedProvider),
+            Self::StaticFile(..) => Err(ProviderError::UnsupportedProvider),
             #[cfg(all(unix, feature = "rocksdb"))]
             Self::RocksDB(tx) => {
                 tx.account_history_info(address, block_number, lowest_available_block_number)
@@ -878,7 +881,7 @@ where
         range: RangeInclusive<BlockNumber>,
     ) -> ProviderResult<BTreeSet<Address>> {
         match self {
-            Self::StaticFile(provider) => {
+            Self::StaticFile(provider, _) => {
                 let highest_static_block =
                     provider.get_highest_static_file_block(StaticFileSegment::AccountChangeSets);
 
@@ -998,7 +1001,7 @@ mod tests {
             if transaction_senders_in_static_files {
                 assert!(matches!(reader, EitherReader::StaticFile(_, _)));
             } else {
-                assert!(matches!(reader, EitherReader::Database(_, _)));
+                assert!(matches!(reader, EitherReader::Database(_)));
             }
 
             assert_eq!(

--- a/crates/storage/provider/src/lib.rs
+++ b/crates/storage/provider/src/lib.rs
@@ -21,7 +21,7 @@ pub mod providers;
 pub use providers::{
     DatabaseProvider, DatabaseProviderRO, DatabaseProviderRW, HistoricalStateProvider,
     HistoricalStateProviderRef, LatestStateProvider, LatestStateProviderRef, ProviderFactory,
-    StaticFileAccess, StaticFileProviderBuilder, StaticFileWriter,
+    SaveBlocksMode, StaticFileAccess, StaticFileProviderBuilder, StaticFileWriter,
 };
 
 pub mod changeset_walker;

--- a/crates/storage/provider/src/lib.rs
+++ b/crates/storage/provider/src/lib.rs
@@ -45,8 +45,8 @@ pub use revm_database::states::OriginalValuesKnown;
 // reexport traits to avoid breaking changes
 pub use reth_static_file_types as static_file;
 pub use reth_storage_api::{
-    HistoryWriter, MetadataProvider, MetadataWriter, StatsReader, StorageSettings,
-    StorageSettingsCache,
+    HistoryWriter, MetadataProvider, MetadataWriter, StateWriteConfig, StatsReader,
+    StorageSettings, StorageSettingsCache,
 };
 /// Re-export provider error.
 pub use reth_storage_errors::provider::{ProviderError, ProviderResult};

--- a/crates/storage/provider/src/lib.rs
+++ b/crates/storage/provider/src/lib.rs
@@ -21,7 +21,8 @@ pub mod providers;
 pub use providers::{
     DatabaseProvider, DatabaseProviderRO, DatabaseProviderRW, HistoricalStateProvider,
     HistoricalStateProviderRef, LatestStateProvider, LatestStateProviderRef, ProviderFactory,
-    SaveBlocksMode, StaticFileAccess, StaticFileProviderBuilder, StaticFileWriter,
+    SaveBlocksMode, StaticFileAccess, StaticFileProviderBuilder, StaticFileWriteTargets,
+    StaticFileWriter,
 };
 
 pub mod changeset_walker;

--- a/crates/storage/provider/src/lib.rs
+++ b/crates/storage/provider/src/lib.rs
@@ -21,7 +21,7 @@ pub mod providers;
 pub use providers::{
     DatabaseProvider, DatabaseProviderRO, DatabaseProviderRW, HistoricalStateProvider,
     HistoricalStateProviderRef, LatestStateProvider, LatestStateProviderRef, ProviderFactory,
-    SaveBlocksMode, StaticFileAccess, StaticFileProviderBuilder, StaticFileWriteTargets,
+    SaveBlocksMode, StaticFileAccess, StaticFileProviderBuilder, StaticFileWriteCtx,
     StaticFileWriter,
 };
 

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -808,8 +808,8 @@ mod tests {
     use reth_storage_api::{
         BlockBodyIndicesProvider, BlockHashReader, BlockIdReader, BlockNumReader, BlockReader,
         BlockReaderIdExt, BlockSource, ChangeSetReader, DBProvider, DatabaseProviderFactory,
-        HeaderProvider, ReceiptProvider, ReceiptProviderIdExt, StateProviderFactory, StateWriter,
-        TransactionVariant, TransactionsProvider,
+        HeaderProvider, ReceiptProvider, ReceiptProviderIdExt, StateProviderFactory,
+        StateWriteConfig, StateWriter, TransactionVariant, TransactionsProvider,
     };
     use reth_testing_utils::generators::{
         self, random_block, random_block_range, random_changeset_range, random_eoa_accounts,
@@ -907,7 +907,7 @@ mod tests {
                     ..Default::default()
                 },
                 OriginalValuesKnown::No,
-                true,
+                StateWriteConfig::default(),
             )?;
         }
 

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -784,9 +784,12 @@ impl<N: ProviderNodeTypes> TrieReader for BlockchainProvider<N> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        BlockWriter, CanonChainTracker, ProviderFactory, SaveBlocksMode, providers::BlockchainProvider, test_utils::{
-            MockNodeTypesWithDB, create_test_provider_factory, create_test_provider_factory_with_chain_spec
-        }
+        providers::BlockchainProvider,
+        test_utils::{
+            create_test_provider_factory, create_test_provider_factory_with_chain_spec,
+            MockNodeTypesWithDB,
+        },
+        BlockWriter, CanonChainTracker, ProviderFactory, SaveBlocksMode,
     };
     use alloy_eips::{BlockHashOrNumber, BlockNumHash, BlockNumberOrTag};
     use alloy_primitives::{BlockNumber, TxNumber, B256};
@@ -904,6 +907,7 @@ mod tests {
                     ..Default::default()
                 },
                 OriginalValuesKnown::No,
+                true,
             )?;
         }
 

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -784,12 +784,9 @@ impl<N: ProviderNodeTypes> TrieReader for BlockchainProvider<N> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        providers::BlockchainProvider,
-        test_utils::{
-            create_test_provider_factory, create_test_provider_factory_with_chain_spec,
-            MockNodeTypesWithDB,
-        },
-        BlockWriter, CanonChainTracker, ProviderFactory,
+        BlockWriter, CanonChainTracker, ProviderFactory, SaveBlocksMode, providers::BlockchainProvider, test_utils::{
+            MockNodeTypesWithDB, create_test_provider_factory, create_test_provider_factory_with_chain_spec
+        }
     };
     use alloy_eips::{BlockHashOrNumber, BlockNumHash, BlockNumberOrTag};
     use alloy_primitives::{BlockNumber, TxNumber, B256};
@@ -997,7 +994,7 @@ mod tests {
 
                 // Push to disk
                 let provider_rw = hook_provider.database_provider_rw().unwrap();
-                provider_rw.save_blocks(vec![lowest_memory_block]).unwrap();
+                provider_rw.save_blocks(vec![lowest_memory_block], SaveBlocksMode::Full).unwrap();
                 provider_rw.commit().unwrap();
 
                 // Remove from memory

--- a/crates/storage/provider/src/providers/database/metrics.rs
+++ b/crates/storage/provider/src/providers/database/metrics.rs
@@ -40,16 +40,8 @@ pub(crate) enum Action {
     InsertHeaderNumbers,
     InsertBlockBodyIndices,
     InsertTransactionBlocks,
-    GetNextTxNum,
     InsertTransactionSenders,
     InsertTransactionHashNumbers,
-    SaveBlocksInsertBlock,
-    SaveBlocksWriteState,
-    SaveBlocksWriteHashedState,
-    SaveBlocksWriteTrieChangesets,
-    SaveBlocksWriteTrieUpdates,
-    SaveBlocksUpdateHistoryIndices,
-    SaveBlocksUpdatePipelineStages,
 }
 
 /// Database provider metrics
@@ -66,19 +58,24 @@ pub(crate) struct DatabaseProviderMetrics {
     insert_history_indices: Histogram,
     /// Duration of update pipeline stages
     update_pipeline_stages: Histogram,
-    /// Duration of insert canonical headers
     /// Duration of insert header numbers
     insert_header_numbers: Histogram,
     /// Duration of insert block body indices
     insert_block_body_indices: Histogram,
     /// Duration of insert transaction blocks
     insert_tx_blocks: Histogram,
-    /// Duration of get next tx num
-    get_next_tx_num: Histogram,
     /// Duration of insert transaction senders
     insert_transaction_senders: Histogram,
     /// Duration of insert transaction hash numbers
     insert_transaction_hash_numbers: Histogram,
+    /// Duration of `save_blocks`
+    save_blocks_total: Histogram,
+    /// Duration of MDBX work in `save_blocks`
+    save_blocks_mdbx: Histogram,
+    /// Duration of static file work in `save_blocks`
+    save_blocks_sf: Histogram,
+    /// Duration of `RocksDB` work in `save_blocks`
+    save_blocks_rocksdb: Histogram,
     /// Duration of `insert_block` in `save_blocks`
     save_blocks_insert_block: Histogram,
     /// Duration of `write_state` in `save_blocks`
@@ -93,6 +90,39 @@ pub(crate) struct DatabaseProviderMetrics {
     save_blocks_update_history_indices: Histogram,
     /// Duration of `update_pipeline_stages` in `save_blocks`
     save_blocks_update_pipeline_stages: Histogram,
+    /// Number of blocks per `save_blocks` call
+    save_blocks_block_count: Histogram,
+    /// Duration of MDBX commit in `save_blocks`
+    save_blocks_commit_mdbx: Histogram,
+    /// Duration of static file commit in `save_blocks`
+    save_blocks_commit_sf: Histogram,
+    /// Duration of `RocksDB` commit in `save_blocks`
+    save_blocks_commit_rocksdb: Histogram,
+}
+
+/// Timings collected during a `save_blocks` call.
+#[derive(Debug, Default)]
+pub(crate) struct SaveBlocksTimings {
+    pub total: Duration,
+    pub mdbx: Duration,
+    pub sf: Duration,
+    pub rocksdb: Duration,
+    pub insert_block: Duration,
+    pub write_state: Duration,
+    pub write_hashed_state: Duration,
+    pub write_trie_changesets: Duration,
+    pub write_trie_updates: Duration,
+    pub update_history_indices: Duration,
+    pub update_pipeline_stages: Duration,
+    pub block_count: u64,
+}
+
+/// Timings collected during a `commit` call.
+#[derive(Debug, Default)]
+pub(crate) struct CommitTimings {
+    pub mdbx: Duration,
+    pub sf: Duration,
+    pub rocksdb: Duration,
 }
 
 impl DatabaseProviderMetrics {
@@ -107,28 +137,33 @@ impl DatabaseProviderMetrics {
             Action::InsertHeaderNumbers => self.insert_header_numbers.record(duration),
             Action::InsertBlockBodyIndices => self.insert_block_body_indices.record(duration),
             Action::InsertTransactionBlocks => self.insert_tx_blocks.record(duration),
-            Action::GetNextTxNum => self.get_next_tx_num.record(duration),
             Action::InsertTransactionSenders => self.insert_transaction_senders.record(duration),
             Action::InsertTransactionHashNumbers => {
                 self.insert_transaction_hash_numbers.record(duration)
             }
-            Action::SaveBlocksInsertBlock => self.save_blocks_insert_block.record(duration),
-            Action::SaveBlocksWriteState => self.save_blocks_write_state.record(duration),
-            Action::SaveBlocksWriteHashedState => {
-                self.save_blocks_write_hashed_state.record(duration)
-            }
-            Action::SaveBlocksWriteTrieChangesets => {
-                self.save_blocks_write_trie_changesets.record(duration)
-            }
-            Action::SaveBlocksWriteTrieUpdates => {
-                self.save_blocks_write_trie_updates.record(duration)
-            }
-            Action::SaveBlocksUpdateHistoryIndices => {
-                self.save_blocks_update_history_indices.record(duration)
-            }
-            Action::SaveBlocksUpdatePipelineStages => {
-                self.save_blocks_update_pipeline_stages.record(duration)
-            }
         }
+    }
+
+    /// Records all `save_blocks` timings.
+    pub(crate) fn record_save_blocks(&self, timings: &SaveBlocksTimings) {
+        self.save_blocks_total.record(timings.total);
+        self.save_blocks_mdbx.record(timings.mdbx);
+        self.save_blocks_sf.record(timings.sf);
+        self.save_blocks_rocksdb.record(timings.rocksdb);
+        self.save_blocks_insert_block.record(timings.insert_block);
+        self.save_blocks_write_state.record(timings.write_state);
+        self.save_blocks_write_hashed_state.record(timings.write_hashed_state);
+        self.save_blocks_write_trie_changesets.record(timings.write_trie_changesets);
+        self.save_blocks_write_trie_updates.record(timings.write_trie_updates);
+        self.save_blocks_update_history_indices.record(timings.update_history_indices);
+        self.save_blocks_update_pipeline_stages.record(timings.update_pipeline_stages);
+        self.save_blocks_block_count.record(timings.block_count as f64);
+    }
+
+    /// Records all commit timings.
+    pub(crate) fn record_commit(&self, timings: &CommitTimings) {
+        self.save_blocks_commit_mdbx.record(timings.mdbx);
+        self.save_blocks_commit_sf.record(timings.sf);
+        self.save_blocks_commit_rocksdb.record(timings.rocksdb);
     }
 }

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -43,7 +43,7 @@ use std::{
 use tracing::trace;
 
 mod provider;
-pub use provider::{DatabaseProvider, DatabaseProviderRO, DatabaseProviderRW};
+pub use provider::{DatabaseProvider, DatabaseProviderRO, DatabaseProviderRW, SaveBlocksMode};
 
 use super::ProviderNodeTypes;
 use reth_trie::KeccakKeyHasher;

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -401,7 +401,7 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
         })
     }
 
-    /// Creates the context for RocksDB writes.
+    /// Creates the context for `RocksDB` writes.
     fn rocksdb_write_ctx(&self, first_block: BlockNumber) -> RocksDBWriteCtx {
         RocksDBWriteCtx {
             first_block_number: first_block,

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -471,7 +471,7 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
                 Ok::<_, ProviderError>(start.elapsed())
             });
 
-            // RocksDB writes
+            // RocksDB writes (batches are pushed to pending_batches inside write_blocks_data)
             let rocksdb_handle = rocksdb_ctx.storage_settings.any_in_rocksdb().then(|| {
                 s.spawn(|| {
                     let start = Instant::now();
@@ -543,10 +543,11 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
                 .join()
                 .map_err(|_| StaticFileWriterError::ThreadPanic("static file"))??;
 
-            // Wait for RocksDB thread
+            // Wait for RocksDB thread (batches already pushed to pending_batches)
             #[cfg(all(unix, feature = "rocksdb"))]
             if let Some(handle) = rocksdb_handle {
-                timings.rocksdb = handle.join().expect("RocksDB thread panicked")?;
+                let elapsed = handle.join().expect("RocksDB thread panicked")?;
+                timings.rocksdb = elapsed;
             }
             #[cfg(not(all(unix, feature = "rocksdb")))]
             let _ = rocksdb_handle;

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -16,8 +16,8 @@ pub use static_file::{
 mod state;
 pub use state::{
     historical::{
-        needs_prev_shard_check, HistoricalStateProvider, HistoricalStateProviderRef, HistoryInfo,
-        LowestAvailableBlocks,
+        compute_history_rank, needs_prev_shard_check, HistoricalStateProvider,
+        HistoricalStateProviderRef, HistoryInfo, LowestAvailableBlocks,
     },
     latest::{LatestStateProvider, LatestStateProviderRef},
     overlay::{OverlayStateProvider, OverlayStateProviderFactory},

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -10,7 +10,7 @@ pub use database::*;
 mod static_file;
 pub use static_file::{
     StaticFileAccess, StaticFileJarProvider, StaticFileProvider, StaticFileProviderBuilder,
-    StaticFileProviderRW, StaticFileProviderRWRefMut, StaticFileWriteTargets, StaticFileWriter,
+    StaticFileProviderRW, StaticFileProviderRWRefMut, StaticFileWriteCtx, StaticFileWriter,
 };
 
 mod state;

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -10,7 +10,7 @@ pub use database::*;
 mod static_file;
 pub use static_file::{
     StaticFileAccess, StaticFileJarProvider, StaticFileProvider, StaticFileProviderBuilder,
-    StaticFileProviderRW, StaticFileProviderRWRefMut, StaticFileWriter,
+    StaticFileProviderRW, StaticFileProviderRWRefMut, StaticFileWriteTargets, StaticFileWriter,
 };
 
 mod state;

--- a/crates/storage/provider/src/providers/rocksdb/invariants.rs
+++ b/crates/storage/provider/src/providers/rocksdb/invariants.rs
@@ -164,15 +164,16 @@ impl RocksDBProvider {
                 self.prune_transaction_hash_numbers_in_range(provider, 0..=highest_tx)?;
             }
             (None, None) => {
-                // Both MDBX and static files are empty.
-                // If checkpoint says we should have data, that's an inconsistency.
+                // Both MDBX and static files are empty - this is expected on first run.
+                // Log a warning but don't require unwind to 0, as the pipeline will
+                // naturally populate the data during sync.
                 if checkpoint > 0 {
                     tracing::warn!(
                         target: "reth::providers::rocksdb",
                         checkpoint,
-                        "Checkpoint set but no transaction data exists, unwind needed"
+                        "TransactionHashNumbers: no transaction data exists but checkpoint is set. \
+                         This is expected on first run with RocksDB enabled."
                     );
-                    return Ok(Some(0));
                 }
             }
         }
@@ -263,14 +264,33 @@ impl RocksDBProvider {
                 }
 
                 // Find the max highest_block_number (excluding u64::MAX sentinel) across all
-                // entries
+                // entries. Also track if we found any non-sentinel entries.
                 let mut max_highest_block = 0u64;
+                let mut found_non_sentinel = false;
                 for result in self.iter::<tables::StoragesHistory>()? {
                     let (key, _) = result?;
                     let highest = key.sharded_key.highest_block_number;
-                    if highest != u64::MAX && highest > max_highest_block {
-                        max_highest_block = highest;
+                    if highest != u64::MAX {
+                        found_non_sentinel = true;
+                        if highest > max_highest_block {
+                            max_highest_block = highest;
+                        }
                     }
+                }
+
+                // If all entries are sentinel entries (u64::MAX), treat as first-run scenario.
+                // Sentinel entries represent "open" shards that haven't been completed yet,
+                // so no actual history has been indexed.
+                if !found_non_sentinel {
+                    if checkpoint > 0 {
+                        tracing::warn!(
+                            target: "reth::providers::rocksdb",
+                            checkpoint,
+                            "StoragesHistory has only sentinel entries but checkpoint is set. \
+                             This is expected on first run with RocksDB enabled."
+                        );
+                    }
+                    return Ok(None);
                 }
 
                 // If any entry has highest_block > checkpoint, prune excess
@@ -383,14 +403,33 @@ impl RocksDBProvider {
                 }
 
                 // Find the max highest_block_number (excluding u64::MAX sentinel) across all
-                // entries
+                // entries. Also track if we found any non-sentinel entries.
                 let mut max_highest_block = 0u64;
+                let mut found_non_sentinel = false;
                 for result in self.iter::<tables::AccountsHistory>()? {
                     let (key, _) = result?;
                     let highest = key.highest_block_number;
-                    if highest != u64::MAX && highest > max_highest_block {
-                        max_highest_block = highest;
+                    if highest != u64::MAX {
+                        found_non_sentinel = true;
+                        if highest > max_highest_block {
+                            max_highest_block = highest;
+                        }
                     }
+                }
+
+                // If all entries are sentinel entries (u64::MAX), treat as first-run scenario.
+                // Sentinel entries represent "open" shards that haven't been completed yet,
+                // so no actual history has been indexed.
+                if !found_non_sentinel {
+                    if checkpoint > 0 {
+                        tracing::warn!(
+                            target: "reth::providers::rocksdb",
+                            checkpoint,
+                            "AccountsHistory has only sentinel entries but checkpoint is set. \
+                             This is expected on first run with RocksDB enabled."
+                        );
+                    }
+                    return Ok(None);
                 }
 
                 // If any entry has highest_block > checkpoint, prune excess
@@ -554,7 +593,7 @@ mod tests {
     }
 
     #[test]
-    fn test_check_consistency_empty_rocksdb_with_checkpoint_needs_unwind() {
+    fn test_check_consistency_empty_rocksdb_with_checkpoint_is_first_run() {
         let temp_dir = TempDir::new().unwrap();
         let rocksdb = RocksDBBuilder::new(temp_dir.path())
             .with_table::<tables::TransactionHashNumbers>()
@@ -578,10 +617,10 @@ mod tests {
 
         let provider = factory.database_provider_ro().unwrap();
 
-        // RocksDB is empty but checkpoint says block 100 was processed
-        // This means RocksDB is missing data and we need to unwind to rebuild
+        // RocksDB is empty but checkpoint says block 100 was processed.
+        // This is treated as a first-run/migration scenario - no unwind needed.
         let result = rocksdb.check_consistency(&provider).unwrap();
-        assert_eq!(result, Some(0), "Should require unwind to block 0 to rebuild RocksDB");
+        assert_eq!(result, None, "Empty data with checkpoint is treated as first run");
     }
 
     #[test]
@@ -988,6 +1027,97 @@ mod tests {
         assert!(
             rocksdb.get::<tables::StoragesHistory>(key_block_max).unwrap().is_some(),
             "Entry with highest_block=u64::MAX (sentinel) should remain"
+        );
+    }
+
+    #[test]
+    fn test_check_consistency_storages_history_sentinel_only_with_checkpoint_is_first_run() {
+        let temp_dir = TempDir::new().unwrap();
+        let rocksdb = RocksDBBuilder::new(temp_dir.path())
+            .with_table::<tables::StoragesHistory>()
+            .build()
+            .unwrap();
+
+        // Insert ONLY sentinel entries (highest_block_number = u64::MAX)
+        // This simulates a scenario where history tracking started but no shards were completed
+        let key_sentinel_1 = StorageShardedKey::new(Address::ZERO, B256::ZERO, u64::MAX);
+        let key_sentinel_2 = StorageShardedKey::new(Address::random(), B256::random(), u64::MAX);
+        let block_list = BlockNumberList::new_pre_sorted([10, 20, 30]);
+        rocksdb.put::<tables::StoragesHistory>(key_sentinel_1, &block_list).unwrap();
+        rocksdb.put::<tables::StoragesHistory>(key_sentinel_2, &block_list).unwrap();
+
+        // Verify entries exist (not empty table)
+        assert!(rocksdb.first::<tables::StoragesHistory>().unwrap().is_some());
+
+        // Create a test provider factory for MDBX
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(
+            StorageSettings::legacy().with_storages_history_in_rocksdb(true),
+        );
+
+        // Set a checkpoint indicating we should have processed up to block 100
+        {
+            let provider = factory.database_provider_rw().unwrap();
+            provider
+                .save_stage_checkpoint(StageId::IndexStorageHistory, StageCheckpoint::new(100))
+                .unwrap();
+            provider.commit().unwrap();
+        }
+
+        let provider = factory.database_provider_ro().unwrap();
+
+        // RocksDB has only sentinel entries (no completed shards) but checkpoint is set.
+        // This is treated as a first-run/migration scenario - no unwind needed.
+        let result = rocksdb.check_consistency(&provider).unwrap();
+        assert_eq!(
+            result, None,
+            "Sentinel-only entries with checkpoint should be treated as first run"
+        );
+    }
+
+    #[test]
+    fn test_check_consistency_accounts_history_sentinel_only_with_checkpoint_is_first_run() {
+        use reth_db_api::models::ShardedKey;
+
+        let temp_dir = TempDir::new().unwrap();
+        let rocksdb = RocksDBBuilder::new(temp_dir.path())
+            .with_table::<tables::AccountsHistory>()
+            .build()
+            .unwrap();
+
+        // Insert ONLY sentinel entries (highest_block_number = u64::MAX)
+        let key_sentinel_1 = ShardedKey::new(Address::ZERO, u64::MAX);
+        let key_sentinel_2 = ShardedKey::new(Address::random(), u64::MAX);
+        let block_list = BlockNumberList::new_pre_sorted([10, 20, 30]);
+        rocksdb.put::<tables::AccountsHistory>(key_sentinel_1, &block_list).unwrap();
+        rocksdb.put::<tables::AccountsHistory>(key_sentinel_2, &block_list).unwrap();
+
+        // Verify entries exist (not empty table)
+        assert!(rocksdb.first::<tables::AccountsHistory>().unwrap().is_some());
+
+        // Create a test provider factory for MDBX
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(
+            StorageSettings::legacy().with_account_history_in_rocksdb(true),
+        );
+
+        // Set a checkpoint indicating we should have processed up to block 100
+        {
+            let provider = factory.database_provider_rw().unwrap();
+            provider
+                .save_stage_checkpoint(StageId::IndexAccountHistory, StageCheckpoint::new(100))
+                .unwrap();
+            provider.commit().unwrap();
+        }
+
+        let provider = factory.database_provider_ro().unwrap();
+
+        // RocksDB has only sentinel entries (no completed shards) but checkpoint is set.
+        // This is treated as a first-run/migration scenario - no unwind needed.
+        let result = rocksdb.check_consistency(&provider).unwrap();
+        assert_eq!(
+            result, None,
+            "Sentinel-only entries with checkpoint should be treated as first run"
         );
     }
 

--- a/crates/storage/provider/src/providers/rocksdb/mod.rs
+++ b/crates/storage/provider/src/providers/rocksdb/mod.rs
@@ -4,6 +4,6 @@ mod invariants;
 mod metrics;
 mod provider;
 
-pub use provider::{
-    PendingRocksDBBatches, RocksDBBatch, RocksDBBuilder, RocksDBProvider, RocksDBWriteCtx, RocksTx,
-};
+pub(crate) use provider::{PendingRocksDBBatches, RocksDBWriteCtx};
+
+pub use provider::{RocksDBBatch, RocksDBBuilder, RocksDBProvider, RocksTx};

--- a/crates/storage/provider/src/providers/rocksdb/mod.rs
+++ b/crates/storage/provider/src/providers/rocksdb/mod.rs
@@ -4,4 +4,6 @@ mod invariants;
 mod metrics;
 mod provider;
 
-pub use provider::{RocksDBBatch, RocksDBBuilder, RocksDBProvider, RocksTx};
+pub use provider::{
+    PendingRocksDBBatches, RocksDBBatch, RocksDBBuilder, RocksDBProvider, RocksDBWriteCtx, RocksTx,
+};

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -57,17 +57,17 @@ impl fmt::Debug for RocksDBWriteCtx {
     }
 }
 
-/// Pending RocksDB batches type alias.
-pub type PendingRocksDBBatches = Arc<Mutex<Vec<WriteBatchWithTransaction<true>>>>;
+/// Pending `RocksDB` batches type alias.
+pub(crate) type PendingRocksDBBatches = Arc<Mutex<Vec<WriteBatchWithTransaction<true>>>>;
 
-/// Context for RocksDB block writes.
+/// Context for `RocksDB` block writes.
 #[derive(Clone)]
-pub struct RocksDBWriteCtx {
+pub(crate) struct RocksDBWriteCtx {
     /// The first block number being written.
     pub first_block_number: BlockNumber,
     /// The prune mode for transaction lookup, if any.
     pub prune_tx_lookup: Option<PruneMode>,
-    /// Storage settings determining what goes to RocksDB.
+    /// Storage settings determining what goes to `RocksDB`.
     pub storage_settings: StorageSettings,
     /// Pending batches to push to after writing.
     pub pending_batches: PendingRocksDBBatches,
@@ -537,13 +537,13 @@ impl RocksDBProvider {
         })
     }
 
-    /// Writes all RocksDB data for multiple blocks in parallel.
+    /// Writes all `RocksDB` data for multiple blocks in parallel.
     ///
     /// This handles transaction hash numbers, account history, and storage history based on
     /// the provided storage settings. Each operation runs in parallel with its own batch,
     /// pushing to `ctx.pending_batches` for later commit.
     #[instrument(level = "debug", target = "providers::db", skip_all)]
-    pub fn write_blocks_data<N: reth_node_types::NodePrimitives>(
+    pub(crate) fn write_blocks_data<N: reth_node_types::NodePrimitives>(
         &self,
         blocks: &[ExecutedBlock<N>],
         tx_nums: &[TxNumber],
@@ -615,7 +615,7 @@ impl RocksDBProvider {
         for (block_idx, block) in blocks.iter().enumerate() {
             let block_number = ctx.first_block_number + block_idx as u64;
             let bundle = &block.execution_outcome().bundle;
-            for (&address, _) in bundle.state() {
+            for &address in bundle.state().keys() {
                 account_history.entry(address).or_default().push(block_number);
             }
         }
@@ -641,7 +641,7 @@ impl RocksDBProvider {
             let block_number = ctx.first_block_number + block_idx as u64;
             let bundle = &block.execution_outcome().bundle;
             for (&address, account) in bundle.state() {
-                for (&slot, _) in &account.storage {
+                for &slot in account.storage.keys() {
                     let key = B256::new(slot.to_be_bytes());
                     storage_history.entry((address, key)).or_default().push(block_number);
                 }

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -2,9 +2,9 @@ use super::metrics::{RocksDBMetrics, RocksDBOperation};
 use crate::providers::{compute_history_rank, needs_prev_shard_check, HistoryInfo};
 use alloy_consensus::transaction::TxHashRef;
 use alloy_primitives::{Address, BlockNumber, TxNumber, B256};
+use itertools::Itertools;
 use parking_lot::Mutex;
 use reth_chain_state::ExecutedBlock;
-use itertools::Itertools;
 use reth_db_api::{
     models::{
         sharded_key::NUM_OF_INDICES_IN_SHARD, storage_sharded_key::StorageShardedKey, ShardedKey,
@@ -512,6 +512,22 @@ impl RocksDBProvider {
                 code: -1,
             }))
         })
+    }
+
+    /// Creates a reverse iterator over a table starting from the given key.
+    ///
+    /// Iterates from the key towards the beginning of the table.
+    pub fn iter_from_reverse<T: Table>(
+        &self,
+        key: T::Key,
+    ) -> ProviderResult<RocksDBIterReverse<'_, T>> {
+        let cf = self.get_cf_handle::<T>()?;
+        let encoded_key = key.encode();
+        let iter = self
+            .0
+            .db
+            .iterator_cf(cf, IteratorMode::From(encoded_key.as_ref(), rocksdb::Direction::Reverse));
+        Ok(RocksDBIterReverse { inner: iter, _marker: std::marker::PhantomData })
     }
 
     /// Writes all `RocksDB` data for multiple blocks in parallel.
@@ -1116,6 +1132,60 @@ impl<T: Table> Iterator for RocksDBIter<'_, T> {
         };
 
         Some(Ok((key, value)))
+    }
+}
+
+/// Result type for raw iterator items.
+type RocksDBRawIterResult = Result<(Box<[u8]>, Box<[u8]>), rocksdb::Error>;
+
+/// Decodes an iterator result from `RocksDB` into a table key-value pair.
+fn decode_iter_result<T: Table>(
+    result: RocksDBRawIterResult,
+) -> Option<ProviderResult<(T::Key, T::Value)>> {
+    let (key_bytes, value_bytes) = match result {
+        Ok(kv) => kv,
+        Err(e) => {
+            return Some(Err(ProviderError::Database(DatabaseError::Read(DatabaseErrorInfo {
+                message: e.to_string().into(),
+                code: -1,
+            }))))
+        }
+    };
+
+    // Decode key
+    let key = match <T::Key as reth_db_api::table::Decode>::decode(&key_bytes) {
+        Ok(k) => k,
+        Err(_) => return Some(Err(ProviderError::Database(DatabaseError::Decode))),
+    };
+
+    // Decompress value
+    let value = match T::Value::decompress(&value_bytes) {
+        Ok(v) => v,
+        Err(_) => return Some(Err(ProviderError::Database(DatabaseError::Decode))),
+    };
+
+    Some(Ok((key, value)))
+}
+
+/// Reverse iterator over a `RocksDB` table (non-transactional).
+///
+/// Yields decoded `(Key, Value)` pairs in reverse key order.
+pub struct RocksDBIterReverse<'db, T: Table> {
+    inner: rocksdb::DBIteratorWithThreadMode<'db, OptimisticTransactionDB>,
+    _marker: std::marker::PhantomData<T>,
+}
+
+impl<T: Table> fmt::Debug for RocksDBIterReverse<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RocksDBIterReverse").field("table", &T::NAME).finish_non_exhaustive()
+    }
+}
+
+impl<T: Table> Iterator for RocksDBIterReverse<'_, T> {
+    type Item = ProviderResult<(T::Key, T::Value)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        decode_iter_result::<T>(self.inner.next()?)
     }
 }
 

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -57,6 +57,33 @@ impl fmt::Debug for RocksDBWriteCtx {
     }
 }
 
+/// Pending RocksDB batches type alias.
+pub type PendingRocksDBBatches = Arc<Mutex<Vec<WriteBatchWithTransaction<true>>>>;
+
+/// Context for RocksDB block writes.
+#[derive(Clone)]
+pub struct RocksDBWriteCtx {
+    /// The first block number being written.
+    pub first_block_number: BlockNumber,
+    /// The prune mode for transaction lookup, if any.
+    pub prune_tx_lookup: Option<PruneMode>,
+    /// Storage settings determining what goes to RocksDB.
+    pub storage_settings: StorageSettings,
+    /// Pending batches to push to after writing.
+    pub pending_batches: PendingRocksDBBatches,
+}
+
+impl fmt::Debug for RocksDBWriteCtx {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RocksDBWriteCtx")
+            .field("first_block_number", &self.first_block_number)
+            .field("prune_tx_lookup", &self.prune_tx_lookup)
+            .field("storage_settings", &self.storage_settings)
+            .field("pending_batches", &"<pending batches>")
+            .finish()
+    }
+}
+
 /// Default cache size for `RocksDB` block cache (128 MB).
 const DEFAULT_CACHE_SIZE: usize = 128 << 20;
 

--- a/crates/storage/provider/src/providers/rocksdb_stub.rs
+++ b/crates/storage/provider/src/providers/rocksdb_stub.rs
@@ -17,17 +17,17 @@ use reth_storage_errors::{
 };
 use std::{path::Path, sync::Arc};
 
-/// Pending RocksDB batches type alias (stub - uses unit type).
-pub type PendingRocksDBBatches = Arc<Mutex<Vec<()>>>;
+/// Pending `RocksDB` batches type alias (stub - uses unit type).
+pub(crate) type PendingRocksDBBatches = Arc<Mutex<Vec<()>>>;
 
-/// Context for RocksDB block writes (stub).
+/// Context for `RocksDB` block writes (stub).
 #[derive(Debug, Clone)]
 pub struct RocksDBWriteCtx {
     /// The first block number being written.
     pub first_block_number: BlockNumber,
     /// The prune mode for transaction lookup, if any.
     pub prune_tx_lookup: Option<PruneMode>,
-    /// Storage settings determining what goes to RocksDB.
+    /// Storage settings determining what goes to `RocksDB`.
     pub storage_settings: StorageSettings,
     /// Pending batches (stub - unused).
     pub pending_batches: PendingRocksDBBatches,
@@ -133,9 +133,9 @@ impl RocksDBProvider {
         Ok(None)
     }
 
-    /// Writes all RocksDB data for multiple blocks (stub implementation).
+    /// Writes all `RocksDB` data for multiple blocks (stub implementation).
     ///
-    /// No-op since RocksDB is not available on this platform.
+    /// No-op since `RocksDB` is not available on this platform.
     pub fn write_blocks_data<N>(
         &self,
         _blocks: &[reth_chain_state::ExecutedBlock<N>],

--- a/crates/storage/provider/src/providers/rocksdb_stub.rs
+++ b/crates/storage/provider/src/providers/rocksdb_stub.rs
@@ -4,12 +4,34 @@
 //! available (either on non-Unix platforms or when the `rocksdb` feature is not enabled).
 //! Operations will produce errors if actually attempted.
 
-use reth_db_api::table::{Encode, Table};
+use alloy_primitives::BlockNumber;
+use parking_lot::Mutex;
+use reth_db_api::{
+    models::StorageSettings,
+    table::{Encode, Table},
+};
+use reth_prune_types::PruneMode;
 use reth_storage_errors::{
     db::LogLevel,
     provider::{ProviderError::UnsupportedProvider, ProviderResult},
 };
-use std::path::Path;
+use std::{path::Path, sync::Arc};
+
+/// Pending RocksDB batches type alias (stub - uses unit type).
+pub type PendingRocksDBBatches = Arc<Mutex<Vec<()>>>;
+
+/// Context for RocksDB block writes (stub).
+#[derive(Debug, Clone)]
+pub struct RocksDBWriteCtx {
+    /// The first block number being written.
+    pub first_block_number: BlockNumber,
+    /// The prune mode for transaction lookup, if any.
+    pub prune_tx_lookup: Option<PruneMode>,
+    /// Storage settings determining what goes to RocksDB.
+    pub storage_settings: StorageSettings,
+    /// Pending batches (stub - unused).
+    pub pending_batches: PendingRocksDBBatches,
+}
 
 /// A stub `RocksDB` provider.
 ///
@@ -109,6 +131,21 @@ impl RocksDBProvider {
         _provider: &Provider,
     ) -> ProviderResult<Option<alloy_primitives::BlockNumber>> {
         Ok(None)
+    }
+
+    /// Writes all RocksDB data for multiple blocks (stub implementation).
+    ///
+    /// No-op since RocksDB is not available on this platform.
+    pub fn write_blocks_data<N>(
+        &self,
+        _blocks: &[reth_chain_state::ExecutedBlock<N>],
+        _tx_nums: &[alloy_primitives::TxNumber],
+        _ctx: RocksDBWriteCtx,
+    ) -> ProviderResult<()>
+    where
+        N: reth_node_types::NodePrimitives,
+    {
+        Ok(())
     }
 }
 

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -130,22 +130,14 @@ impl<'b, Provider: DBProvider + ChangeSetReader + BlockNumReader>
             return Err(ProviderError::StateAtBlockPruned(self.block_number))
         }
 
-        // Create RocksDB tx only when the feature is enabled
-        #[cfg(all(unix, feature = "rocksdb"))]
-        let rocks_provider = self.provider.rocksdb_provider();
-        #[cfg(all(unix, feature = "rocksdb"))]
-        let rocks_tx = rocks_provider.tx();
-        #[cfg(all(unix, feature = "rocksdb"))]
-        let rocks_tx_ref = &rocks_tx;
-        #[cfg(not(all(unix, feature = "rocksdb")))]
-        let rocks_tx_ref = ();
-
-        let mut reader = EitherReader::new_accounts_history(self.provider, rocks_tx_ref)?;
-        reader.account_history_info(
-            address,
-            self.block_number,
-            self.lowest_available_blocks.account_history_block_number,
-        )
+        self.provider.with_rocksdb_tx(|rocks_tx_ref| {
+            let mut reader = EitherReader::new_accounts_history(self.provider, rocks_tx_ref)?;
+            reader.account_history_info(
+                address,
+                self.block_number,
+                self.lowest_available_blocks.account_history_block_number,
+            )
+        })
     }
 
     /// Lookup a storage key in the `StoragesHistory` table using `EitherReader`.
@@ -161,23 +153,15 @@ impl<'b, Provider: DBProvider + ChangeSetReader + BlockNumReader>
             return Err(ProviderError::StateAtBlockPruned(self.block_number))
         }
 
-        // Create RocksDB tx only when the feature is enabled
-        #[cfg(all(unix, feature = "rocksdb"))]
-        let rocks_provider = self.provider.rocksdb_provider();
-        #[cfg(all(unix, feature = "rocksdb"))]
-        let rocks_tx = rocks_provider.tx();
-        #[cfg(all(unix, feature = "rocksdb"))]
-        let rocks_tx_ref = &rocks_tx;
-        #[cfg(not(all(unix, feature = "rocksdb")))]
-        let rocks_tx_ref = ();
-
-        let mut reader = EitherReader::new_storages_history(self.provider, rocks_tx_ref)?;
-        reader.storage_history_info(
-            address,
-            storage_key,
-            self.block_number,
-            self.lowest_available_blocks.storage_history_block_number,
-        )
+        self.provider.with_rocksdb_tx(|rocks_tx_ref| {
+            let mut reader = EitherReader::new_storages_history(self.provider, rocks_tx_ref)?;
+            reader.storage_history_info(
+                address,
+                storage_key,
+                self.block_number,
+                self.lowest_available_blocks.storage_history_block_number,
+            )
+        })
     }
 
     /// Checks and returns `true` if distance to historical block exceeds the provided limit.

--- a/crates/storage/provider/src/providers/static_file/mod.rs
+++ b/crates/storage/provider/src/providers/static_file/mod.rs
@@ -1,6 +1,7 @@
 mod manager;
 pub use manager::{
-    StaticFileAccess, StaticFileProvider, StaticFileProviderBuilder, StaticFileWriter,
+    StaticFileAccess, StaticFileProvider, StaticFileProviderBuilder, StaticFileWriteTargets,
+    StaticFileWriter,
 };
 
 mod jar;

--- a/crates/storage/provider/src/providers/static_file/mod.rs
+++ b/crates/storage/provider/src/providers/static_file/mod.rs
@@ -1,6 +1,6 @@
 mod manager;
 pub use manager::{
-    StaticFileAccess, StaticFileProvider, StaticFileProviderBuilder, StaticFileWriteTargets,
+    StaticFileAccess, StaticFileProvider, StaticFileProviderBuilder, StaticFileWriteCtx,
     StaticFileWriter,
 };
 

--- a/crates/storage/provider/src/traits/rocksdb_provider.rs
+++ b/crates/storage/provider/src/traits/rocksdb_provider.rs
@@ -1,4 +1,5 @@
-use crate::providers::RocksDBProvider;
+use crate::{either_writer::RocksTxRefArg, providers::RocksDBProvider};
+use reth_storage_errors::provider::ProviderResult;
 
 /// `RocksDB` provider factory.
 ///
@@ -13,4 +14,21 @@ pub trait RocksDBProviderFactory {
     /// commits, ensuring atomicity across all storage backends.
     #[cfg(all(unix, feature = "rocksdb"))]
     fn set_pending_rocksdb_batch(&self, batch: rocksdb::WriteBatchWithTransaction<true>);
+
+    /// Executes a closure with a `RocksDB` transaction for reading.
+    ///
+    /// This helper encapsulates all the cfg-gated `RocksDB` transaction handling for reads.
+    fn with_rocksdb_tx<F, R>(&self, f: F) -> ProviderResult<R>
+    where
+        F: FnOnce(RocksTxRefArg<'_>) -> ProviderResult<R>,
+    {
+        #[cfg(all(unix, feature = "rocksdb"))]
+        {
+            let rocksdb = self.rocksdb_provider();
+            let tx = rocksdb.tx();
+            f(&tx)
+        }
+        #[cfg(not(all(unix, feature = "rocksdb")))]
+        f(())
+    }
 }

--- a/crates/storage/provider/src/writer/mod.rs
+++ b/crates/storage/provider/src/writer/mod.rs
@@ -13,7 +13,9 @@ mod tests {
     use reth_ethereum_primitives::Receipt;
     use reth_execution_types::ExecutionOutcome;
     use reth_primitives_traits::{Account, StorageEntry};
-    use reth_storage_api::{DatabaseProviderFactory, HashedPostStateProvider, StateWriter};
+    use reth_storage_api::{
+        DatabaseProviderFactory, HashedPostStateProvider, StateWriteConfig, StateWriter,
+    };
     use reth_trie::{
         test_utils::{state_root, storage_root_prehashed},
         HashedPostState, HashedStorage, StateRoot, StorageRoot, StorageRootProgress,
@@ -135,7 +137,7 @@ mod tests {
         provider.write_state_changes(plain_state).expect("Could not write plain state to DB");
 
         assert_eq!(reverts.storage, [[]]);
-        provider.write_state_reverts(reverts, 1).expect("Could not write reverts to DB");
+        provider.write_state_reverts(reverts, 1, StateWriteConfig::default()).expect("Could not write reverts to DB");
 
         let reth_account_a = account_a.into();
         let reth_account_b = account_b.into();
@@ -201,7 +203,7 @@ mod tests {
             reverts.storage,
             [[PlainStorageRevert { address: address_b, wiped: true, storage_revert: vec![] }]]
         );
-        provider.write_state_reverts(reverts, 2).expect("Could not write reverts to DB");
+        provider.write_state_reverts(reverts, 2, StateWriteConfig::default()).expect("Could not write reverts to DB");
 
         // Check new plain state for account B
         assert_eq!(
@@ -280,7 +282,7 @@ mod tests {
 
         let outcome = ExecutionOutcome::new(state.take_bundle(), Default::default(), 1, Vec::new());
         provider
-            .write_state(&outcome, OriginalValuesKnown::Yes, true)
+            .write_state(&outcome, OriginalValuesKnown::Yes, StateWriteConfig::default())
             .expect("Could not write bundle state to DB");
 
         // Check plain storage state
@@ -380,7 +382,7 @@ mod tests {
         state.merge_transitions(BundleRetention::Reverts);
         let outcome = ExecutionOutcome::new(state.take_bundle(), Default::default(), 2, Vec::new());
         provider
-            .write_state(&outcome, OriginalValuesKnown::Yes, true)
+            .write_state(&outcome, OriginalValuesKnown::Yes, StateWriteConfig::default())
             .expect("Could not write bundle state to DB");
 
         assert_eq!(
@@ -448,7 +450,7 @@ mod tests {
         let outcome =
             ExecutionOutcome::new(init_state.take_bundle(), Default::default(), 0, Vec::new());
         provider
-            .write_state(&outcome, OriginalValuesKnown::Yes, true)
+            .write_state(&outcome, OriginalValuesKnown::Yes, StateWriteConfig::default())
             .expect("Could not write bundle state to DB");
 
         let mut state = State::builder().with_bundle_update().build();
@@ -607,7 +609,7 @@ mod tests {
         let outcome: ExecutionOutcome =
             ExecutionOutcome::new(bundle, Default::default(), 1, Vec::new());
         provider
-            .write_state(&outcome, OriginalValuesKnown::Yes, true)
+            .write_state(&outcome, OriginalValuesKnown::Yes, StateWriteConfig::default())
             .expect("Could not write bundle state to DB");
 
         let mut storage_changeset_cursor = provider
@@ -773,7 +775,7 @@ mod tests {
         let outcome =
             ExecutionOutcome::new(init_state.take_bundle(), Default::default(), 0, Vec::new());
         provider
-            .write_state(&outcome, OriginalValuesKnown::Yes, true)
+            .write_state(&outcome, OriginalValuesKnown::Yes, StateWriteConfig::default())
             .expect("Could not write bundle state to DB");
 
         let mut state = State::builder().with_bundle_update().build();
@@ -822,7 +824,7 @@ mod tests {
         state.merge_transitions(BundleRetention::Reverts);
         let outcome = ExecutionOutcome::new(state.take_bundle(), Default::default(), 1, Vec::new());
         provider
-            .write_state(&outcome, OriginalValuesKnown::Yes, true)
+            .write_state(&outcome, OriginalValuesKnown::Yes, StateWriteConfig::default())
             .expect("Could not write bundle state to DB");
 
         let mut storage_changeset_cursor = provider

--- a/crates/storage/provider/src/writer/mod.rs
+++ b/crates/storage/provider/src/writer/mod.rs
@@ -280,7 +280,7 @@ mod tests {
 
         let outcome = ExecutionOutcome::new(state.take_bundle(), Default::default(), 1, Vec::new());
         provider
-            .write_state(&outcome, OriginalValuesKnown::Yes)
+            .write_state(&outcome, OriginalValuesKnown::Yes, true)
             .expect("Could not write bundle state to DB");
 
         // Check plain storage state
@@ -380,7 +380,7 @@ mod tests {
         state.merge_transitions(BundleRetention::Reverts);
         let outcome = ExecutionOutcome::new(state.take_bundle(), Default::default(), 2, Vec::new());
         provider
-            .write_state(&outcome, OriginalValuesKnown::Yes)
+            .write_state(&outcome, OriginalValuesKnown::Yes, true)
             .expect("Could not write bundle state to DB");
 
         assert_eq!(
@@ -448,7 +448,7 @@ mod tests {
         let outcome =
             ExecutionOutcome::new(init_state.take_bundle(), Default::default(), 0, Vec::new());
         provider
-            .write_state(&outcome, OriginalValuesKnown::Yes)
+            .write_state(&outcome, OriginalValuesKnown::Yes, true)
             .expect("Could not write bundle state to DB");
 
         let mut state = State::builder().with_bundle_update().build();
@@ -607,7 +607,7 @@ mod tests {
         let outcome: ExecutionOutcome =
             ExecutionOutcome::new(bundle, Default::default(), 1, Vec::new());
         provider
-            .write_state(&outcome, OriginalValuesKnown::Yes)
+            .write_state(&outcome, OriginalValuesKnown::Yes, true)
             .expect("Could not write bundle state to DB");
 
         let mut storage_changeset_cursor = provider
@@ -773,7 +773,7 @@ mod tests {
         let outcome =
             ExecutionOutcome::new(init_state.take_bundle(), Default::default(), 0, Vec::new());
         provider
-            .write_state(&outcome, OriginalValuesKnown::Yes)
+            .write_state(&outcome, OriginalValuesKnown::Yes, true)
             .expect("Could not write bundle state to DB");
 
         let mut state = State::builder().with_bundle_update().build();
@@ -822,7 +822,7 @@ mod tests {
         state.merge_transitions(BundleRetention::Reverts);
         let outcome = ExecutionOutcome::new(state.take_bundle(), Default::default(), 1, Vec::new());
         provider
-            .write_state(&outcome, OriginalValuesKnown::Yes)
+            .write_state(&outcome, OriginalValuesKnown::Yes, true)
             .expect("Could not write bundle state to DB");
 
         let mut storage_changeset_cursor = provider

--- a/crates/storage/storage-api/src/state_writer.rs
+++ b/crates/storage/storage-api/src/state_writer.rs
@@ -12,10 +12,10 @@ pub trait StateWriter {
     /// Receipt type included into [`ExecutionOutcome`].
     type Receipt;
 
-    /// Write the state and optionally receipts to the database or static files.
+    /// Write the state and optionally receipts to the database.
     ///
     /// If `write_receipts` is false, receipts are skipped (useful when receipts are written
-    /// separately, e.g., in parallel to static files).
+    /// separately to static files).
     fn write_state(
         &self,
         execution_outcome: &ExecutionOutcome<Self::Receipt>,

--- a/crates/storage/storage-api/src/state_writer.rs
+++ b/crates/storage/storage-api/src/state_writer.rs
@@ -14,22 +14,24 @@ pub trait StateWriter {
 
     /// Write the state and optionally receipts to the database.
     ///
-    /// If `write_receipts` is false, receipts are skipped (useful when receipts are written
-    /// separately to static files).
+    /// Use `config` to skip writing certain data types when they are written elsewhere.
     fn write_state(
         &self,
         execution_outcome: &ExecutionOutcome<Self::Receipt>,
         is_value_known: OriginalValuesKnown,
-        write_receipts: bool,
+        config: StateWriteConfig,
     ) -> ProviderResult<()>;
 
     /// Write state reverts to the database.
     ///
     /// NOTE: Reverts will delete all wiped storage from plain state.
+    ///
+    /// Use `config` to skip writing certain data types when they are written elsewhere.
     fn write_state_reverts(
         &self,
         reverts: PlainStateReverts,
         first_block: BlockNumber,
+        config: StateWriteConfig,
     ) -> ProviderResult<()>;
 
     /// Write state changes to the database.
@@ -48,4 +50,21 @@ pub trait StateWriter {
         &self,
         block: BlockNumber,
     ) -> ProviderResult<ExecutionOutcome<Self::Receipt>>;
+}
+
+/// Configuration for what to write when calling [`StateWriter::write_state`].
+///
+/// Used to skip writing certain data types, when they are being written separately.
+#[derive(Debug, Clone, Copy)]
+pub struct StateWriteConfig {
+    /// Whether to write receipts.
+    pub write_receipts: bool,
+    /// Whether to write account changesets.
+    pub write_account_changesets: bool,
+}
+
+impl Default for StateWriteConfig {
+    fn default() -> Self {
+        Self { write_receipts: true, write_account_changesets: true }
+    }
 }

--- a/crates/storage/storage-api/src/state_writer.rs
+++ b/crates/storage/storage-api/src/state_writer.rs
@@ -12,12 +12,15 @@ pub trait StateWriter {
     /// Receipt type included into [`ExecutionOutcome`].
     type Receipt;
 
-    /// Write the state and receipts to the database or static files if `static_file_producer` is
-    /// `Some`. It should be `None` if there is any kind of pruning/filtering over the receipts.
+    /// Write the state and optionally receipts to the database or static files.
+    ///
+    /// If `write_receipts` is false, receipts are skipped (useful when receipts are written
+    /// separately, e.g., in parallel to static files).
     fn write_state(
         &self,
         execution_outcome: &ExecutionOutcome<Self::Receipt>,
         is_value_known: OriginalValuesKnown,
+        write_receipts: bool,
     ) -> ProviderResult<()>;
 
     /// Write state reverts to the database.

--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -325,7 +325,11 @@ fn run_case(
 
         // Commit the post state/state diff to the database
         provider
-            .write_state(&ExecutionOutcome::single(block.number, output), OriginalValuesKnown::Yes)
+            .write_state(
+                &ExecutionOutcome::single(block.number, output),
+                OriginalValuesKnown::Yes,
+                true,
+            )
             .map_err(|err| Error::block_failed(block_number, program_inputs.clone(), err))?;
 
         provider

--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -17,7 +17,7 @@ use reth_primitives_traits::{Block as BlockTrait, RecoveredBlock, SealedBlock};
 use reth_provider::{
     test_utils::create_test_provider_factory_with_chain_spec, BlockWriter, DatabaseProviderFactory,
     ExecutionOutcome, HeaderProvider, HistoryWriter, OriginalValuesKnown, StateProofProvider,
-    StateWriter, StaticFileProviderFactory, StaticFileSegment, StaticFileWriter,
+    StateWriteConfig, StateWriter, StaticFileProviderFactory, StaticFileSegment, StaticFileWriter,
 };
 use reth_revm::{database::StateProviderDatabase, witness::ExecutionWitnessRecord, State};
 use reth_stateless::{
@@ -328,7 +328,7 @@ fn run_case(
             .write_state(
                 &ExecutionOutcome::single(block.number, output),
                 OriginalValuesKnown::Yes,
-                true,
+                StateWriteConfig::default(),
             )
             .map_err(|err| Error::block_failed(block_number, program_inputs.clone(), err))?;
 


### PR DESCRIPTION
**Summary**
Add RocksDB integration for staged sync operations, combining helper utilities with index history stage unwind support.

**Changes**

Helper functions:
- `make_rocksdb_provider()` - creates RocksDB provider from UnifiedStorageWriter
- `make_rocksdb_batch_arg()` - creates RocksDB batch for EitherWriter
- `register_rocksdb_batch()` - registers batch with pending batches
- `collect_shards_for_unwind()` - shared logic for history shard unwinding
- Add `RocksDBIntegrity` enum variant for metadata

Index history stage unwind:
- IndexAccountHistory: RocksDB batch creation during unwind
- IndexStorageHistory: RocksDB batch creation during unwind
- EitherWriter for history shard operations
- Register batches with pending_batches for atomic commit

Also fixes:
- Register AccountsHistory and StoragesHistory tables in RocksDB metrics
- Fix unresolved RocksDBProviderFactory link in either_writer docs

**Testing**
Stage operations and unwind verified.

---

## PR Stack

```
main
  ↑
#21063 (rocksdb-either-reader)
  ↑
#THIS (rocksdb-stage-utils-combined) ◀ you are here
  ↑
#21068 (rocksdb-init-txlookup)
  ↑
#21069 (rocksdb-cli-testutils)
  ↑
#21070 (rocksdb-cli)
  ↑
#21071 (rocksdb-docs)
```

- https://github.com/paradigmxyz/reth/pull/21063
- #THIS ◀ (combines #21065 + #21066)
- https://github.com/paradigmxyz/reth/pull/21068
- https://github.com/paradigmxyz/reth/pull/21069
- https://github.com/paradigmxyz/reth/pull/21070
- https://github.com/paradigmxyz/reth/pull/21071