### PR TITLE
chore(deps): update alloy-evm and alloy-op-evm to 0.26.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.26.0"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "249337d8316a9ab983784597adfad66b78047ec9522d8b510185bc968c272618"
+checksum = "a96827207397445a919a8adc49289b53cc74e48e460411740bba31cec2fc307d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -404,9 +404,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-op-evm"
-version = "0.26.0"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc9fc7cbe100f7b094428b488225c9aedb835f28a31b74f474ee1c41878e58c6"
+checksum = "54dc5c46a92fc7267055a174d30efb34e2599a0047102a4d38a025ae521435ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -488,7 +488,7 @@ alloy-chains = { version = "0.2.5", default-features = false }
 alloy-dyn-abi = "1.4.3"
 alloy-eip2124 = { version = "0.2.0", default-features = false }
 alloy-eip7928 = { version = "0.3.0", default-features = false }
-alloy-evm = { version = "0.26.0", default-features = false }
+alloy-evm = { version = "0.26.3", default-features = false }
 alloy-primitives = { version = "1.5.0", default-features = false, features = ["map-foldhash"] }
 alloy-rlp = { version = "0.3.10", default-features = false, features = ["core-net"] }
 alloy-sol-macro = "1.5.0"
@@ -526,7 +526,7 @@ alloy-transport-ipc = { version = "1.4.3", default-features = false }
 alloy-transport-ws = { version = "1.4.3", default-features = false }
 
 # op
-alloy-op-evm = { version = "0.26.0", default-features = false }
+alloy-op-evm = { version = "0.26.3", default-features = false }
 alloy-op-hardforks = "0.4.4"
 op-alloy-rpc-types = { version = "0.23.1", default-features = false }
 op-alloy-rpc-types-engine = { version = "0.23.1", default-features = false }

--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -394,6 +394,7 @@ mod tests {
     use reth_evm_ethereum::EthEvm;
     use reth_execution_types::BlockExecutionResult;
     use reth_primitives_traits::RecoveredBlock;
+    use reth_static_file::segments::Receipts;
     use revm::{
         context::result::{ExecutionResult, Output, ResultAndState, SuccessReason},
         database::State,
@@ -408,12 +409,13 @@ mod tests {
     /// A simple mock executor for testing that doesn't require complex EVM setup
     struct MockExecutor {
         state: EvmState,
+        receipts: Vec<Receipt>,
         hook: Option<Box<dyn OnStateHook>>,
     }
 
     impl MockExecutor {
         fn new(state: EvmState) -> Self {
-            Self { state, hook: None }
+            Self { state, receipts: vec![], hook: None }
         }
     }
 
@@ -495,12 +497,16 @@ mod tests {
             self.hook = hook;
         }
 
+        fn evm_mut(&mut self) -> &mut Self::Evm {
+            panic!("Mock executor evm_mut() not implemented")
+        }
+
         fn evm(&self) -> &Self::Evm {
             panic!("Mock executor evm() not implemented")
         }
 
-        fn evm_mut(&mut self) -> &mut Self::Evm {
-            panic!("Mock executor evm_mut() not implemented")
+        fn receipts(&self) -> &[Self::Receipt] {
+            &self.receipts
         }
     }
 

--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -394,7 +394,6 @@ mod tests {
     use reth_evm_ethereum::EthEvm;
     use reth_execution_types::BlockExecutionResult;
     use reth_primitives_traits::RecoveredBlock;
-    use reth_static_file::segments::Receipts;
     use revm::{
         context::result::{ExecutionResult, Output, ResultAndState, SuccessReason},
         database::State,

--- a/crates/ethereum/evm/src/test_utils.rs
+++ b/crates/ethereum/evm/src/test_utils.rs
@@ -65,7 +65,12 @@ impl BlockExecutorFactory for MockEvmConfig {
         DB: Database + 'a,
         I: Inspector<<Self::EvmFactory as EvmFactory>::Context<&'a mut State<DB>>> + 'a,
     {
-        MockExecutor { result: self.exec_results.lock().pop().unwrap(), evm, hook: None }
+        MockExecutor {
+            result: self.exec_results.lock().pop().unwrap(),
+            evm,
+            hook: None,
+            receipts: Vec::new(),
+        }
     }
 }
 
@@ -76,6 +81,7 @@ pub struct MockExecutor<'a, DB: Database, I> {
     evm: EthEvm<&'a mut State<DB>, I, PrecompilesMap>,
     #[debug(skip)]
     hook: Option<Box<dyn reth_evm::OnStateHook>>,
+    receipts: Vec<Receipt>,
 }
 
 impl<'a, DB: Database, I: Inspector<EthEvmContext<&'a mut State<DB>>>> BlockExecutor
@@ -87,6 +93,10 @@ impl<'a, DB: Database, I: Inspector<EthEvmContext<&'a mut State<DB>>>> BlockExec
 
     fn apply_pre_execution_changes(&mut self) -> Result<(), BlockExecutionError> {
         Ok(())
+    }
+
+    fn receipts(&self) -> &[Self::Receipt] {
+        &self.receipts
     }
 
     fn execute_transaction_without_commit(

--- a/examples/custom-beacon-withdrawals/src/main.rs
+++ b/examples/custom-beacon-withdrawals/src/main.rs
@@ -201,6 +201,10 @@ where
         self.inner.apply_pre_execution_changes()
     }
 
+    fn receipts(&self) -> &[Self::Receipt] {
+        self.inner.receipts()
+    }
+
     fn execute_transaction_without_commit(
         &mut self,
         tx: impl ExecutableTx<Self>,

--- a/examples/custom-node/src/evm/executor.rs
+++ b/examples/custom-node/src/evm/executor.rs
@@ -37,6 +37,10 @@ where
         self.inner.apply_pre_execution_changes()
     }
 
+    fn receipts(&self) -> &[Self::Receipt] {
+        self.inner.receipts()
+    }
+
     fn execute_transaction_without_commit(
         &mut self,
         tx: impl ExecutableTx<Self>,


### PR DESCRIPTION
## Summary

Update alloy-evm and alloy-op-evm from 0.26.0 to 0.26.1.

## Breaking Changes

The new version adds a `receipts()` method to the `BlockExecutor` trait. This PR implements the method for:

- `MockExecutor` in reth-evm-ethereum test_utils
- `CustomBlockExecutor` in example-custom-beacon-withdrawals  
- `CustomBlockExecutor` in example-custom-node