### PR TITLE
refactor(provider): make RocksDB tx optional for legacy nodes

### DIFF
--- a/crates/storage/errors/src/provider.rs
+++ b/crates/storage/errors/src/provider.rs
@@ -107,6 +107,12 @@ pub enum ProviderError {
     /// Provider does not support this particular request.
     #[error("this provider does not support this request")]
     UnsupportedProvider,
+    /// RocksDB transaction required but not provided.
+    ///
+    /// This error occurs when storage settings indicate RocksDB should be used for a table,
+    /// but no RocksDB transaction was provided to the reader constructor.
+    #[error("RocksDB transaction required but not provided")]
+    RocksDbTxRequired,
     /// Static File is not found at specified path.
     #[cfg(feature = "std")]
     #[error("not able to find {_0} static file at {_1:?}")]

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -20,14 +20,18 @@ use reth_chain_state::{
     MemoryOverlayStateProvider, PersistedBlockNotifications, PersistedBlockSubscriptions,
 };
 use reth_chainspec::ChainInfo;
-use reth_db_api::models::{AccountBeforeTx, BlockNumberAddress, StoredBlockBodyIndices};
+use reth_db_api::models::{
+    AccountBeforeTx, BlockNumberAddress, StorageSettings, StoredBlockBodyIndices,
+};
 use reth_execution_types::ExecutionOutcome;
 use reth_node_types::{BlockTy, HeaderTy, NodeTypesWithDB, ReceiptTy, TxTy};
 use reth_primitives_traits::{Account, RecoveredBlock, SealedHeader, StorageEntry};
 use reth_prune_types::{PruneCheckpoint, PruneSegment};
 use reth_stages_types::{StageCheckpoint, StageId};
 use reth_static_file_types::StaticFileSegment;
-use reth_storage_api::{BlockBodyIndicesProvider, NodePrimitivesProvider, StorageChangeSetReader};
+use reth_storage_api::{
+    BlockBodyIndicesProvider, NodePrimitivesProvider, StorageChangeSetReader, StorageSettingsCache,
+};
 use reth_storage_errors::provider::ProviderResult;
 use reth_trie::{HashedPostState, KeccakKeyHasher};
 use revm_database::BundleState;
@@ -174,6 +178,16 @@ impl<N: ProviderNodeTypes> StaticFileProviderFactory for BlockchainProvider<N> {
         segment: StaticFileSegment,
     ) -> ProviderResult<StaticFileProviderRWRefMut<'_, Self::Primitives>> {
         self.database.get_static_file_writer(block, segment)
+    }
+}
+
+impl<N: ProviderNodeTypes> StorageSettingsCache for BlockchainProvider<N> {
+    fn cached_storage_settings(&self) -> StorageSettings {
+        self.database.cached_storage_settings()
+    }
+
+    fn set_storage_settings_cache(&self, settings: StorageSettings) {
+        self.database.set_storage_settings_cache(settings)
     }
 }
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -292,7 +292,7 @@ impl<TX, N: NodeTypes> StaticFileProviderFactory for DatabaseProvider<TX, N> {
     }
 }
 
-impl<TX, N: NodeTypes> RocksDBProviderFactory for DatabaseProvider<TX, N> {
+impl<TX: Send, N: NodeTypes> RocksDBProviderFactory for DatabaseProvider<TX, N> {
     /// Returns the `RocksDB` provider.
     fn rocksdb_provider(&self) -> RocksDBProvider {
         self.rocksdb_provider.clone()

--- a/crates/storage/storage-api/src/noop.rs
+++ b/crates/storage/storage-api/src/noop.rs
@@ -6,7 +6,7 @@ use crate::{
     HashedPostStateProvider, HeaderProvider, NodePrimitivesProvider, PruneCheckpointReader,
     ReceiptProvider, ReceiptProviderIdExt, StageCheckpointReader, StateProofProvider,
     StateProvider, StateProviderBox, StateProviderFactory, StateReader, StateRootProvider,
-    StorageRootProvider, TransactionVariant, TransactionsProvider,
+    StorageRootProvider, StorageSettingsCache, TransactionVariant, TransactionsProvider,
 };
 
 #[cfg(feature = "db-api")]
@@ -25,6 +25,7 @@ use core::{
 use reth_chainspec::{ChainInfo, ChainSpecProvider, EthChainSpec, MAINNET};
 #[cfg(feature = "db-api")]
 use reth_db_api::mock::{DatabaseMock, TxMock};
+use reth_db_api::models::StorageSettings;
 use reth_db_models::{AccountBeforeTx, StoredBlockBodyIndices};
 use reth_ethereum_primitives::EthPrimitives;
 use reth_execution_types::ExecutionOutcome;
@@ -603,6 +604,16 @@ impl<C: Send + Sync, N: NodePrimitives> PruneCheckpointReader for NoopProvider<C
 
 impl<C: Send + Sync, N: NodePrimitives> NodePrimitivesProvider for NoopProvider<C, N> {
     type Primitives = N;
+}
+
+impl<C: Send + Sync, N: Send + Sync> StorageSettingsCache for NoopProvider<C, N> {
+    fn cached_storage_settings(&self) -> StorageSettings {
+        StorageSettings::legacy()
+    }
+
+    fn set_storage_settings_cache(&self, _settings: StorageSettings) {
+        // No-op for NoopProvider
+    }
 }
 
 impl<C: Send + Sync, N: Send + Sync> BlockBodyIndicesProvider for NoopProvider<C, N> {


### PR DESCRIPTION
## Summary

Make `RocksTxRefArg` an `Option` type so that `with_rocksdb_tx` only creates a RocksDB transaction when `storage_settings.any_in_rocksdb()` is true. This avoids overhead for legacy MDBX-only nodes.

## Problem

The current implementation always creates a RocksDB transaction via `with_rocksdb_tx` even for legacy MDBX-only nodes where RocksDB isn't used for history indices. This is unnecessary overhead.

## Solution

1. **Change `RocksTxRefArg` from direct reference to `Option<&RocksTx>`** - Allows callers to pass `None` when RocksDB is not configured

2. **Update `with_rocksdb_tx` to check `any_in_rocksdb()`** - Only creates a RocksDB transaction when at least one table is configured to use RocksDB

3. **Add `RocksDbTxRequired` error** - Returns a clear error when RocksDB is configured for a table but no transaction was provided

4. **Add `StorageSettingsCache` supertrait to `RocksDBProviderFactory`** - Allows the trait to access storage settings for the check

5. **Implement `StorageSettingsCache` for `NoopProvider` and `BlockchainProvider`** - Required for the supertrait

## Changes

- `crates/storage/errors/src/provider.rs`: Add `RocksDbTxRequired` error variant
- `crates/storage/provider/src/either_writer.rs`: Update `RocksTxRefArg` type and `EitherReader` constructors
- `crates/storage/provider/src/traits/rocksdb_provider.rs`: Update `with_rocksdb_tx` to check settings
- `crates/storage/provider/src/providers/blockchain_provider.rs`: Implement `StorageSettingsCache`
- `crates/storage/storage-api/src/noop.rs`: Implement `StorageSettingsCache` for `NoopProvider`

## Testing

All existing `either_writer` tests pass.