### PR TITLE
fix: release mutex before dropping ancestors in wait_cloned

### DIFF
--- a/crates/chain-state/src/deferred_trie.rs
+++ b/crates/chain-state/src/deferred_trie.rs
@@ -287,6 +287,11 @@ impl DeferredTrieData {
                     &inputs.ancestors,
                 );
                 *state = DeferredState::Ready(computed.clone());
+
+                // Release lock before inputs (and its ancestors) drop to avoid holding it
+                // while their potential last Arc refs drop (which could trigger recursive locking)
+                drop(state);
+
                 computed
             }
         }


### PR DESCRIPTION
## Summary

In `DeferredTrieData::wait_cloned()`, the mutex guard was being held until the end of the match arm, which meant it was still locked when `inputs.ancestors` went out of scope. If those ancestors contained the last `Arc` reference to other `DeferredTrieData` instances, their drop could trigger recursive locking.

This fix explicitly drops the mutex guard before `inputs` goes out of scope, avoiding potential lock contention during ancestor cleanup.

## Changes

- Add explicit `drop(state)` after updating the state to `Ready`, before `inputs` (and its ancestors) are dropped