### PR TITLE
perf(chain-state): lower MERGE_BATCH_THRESHOLD from 64 to 30

### DIFF
--- a/crates/chain-state/src/lazy_overlay.rs
+++ b/crates/chain-state/src/lazy_overlay.rs
@@ -12,8 +12,9 @@ use tracing::{debug, trace};
 
 /// Threshold for switching from `extend_ref` loop to `merge_batch`.
 ///
-/// Benchmarked crossover: `extend_ref` wins up to ~64 blocks, `merge_batch` wins beyond.
-const MERGE_BATCH_THRESHOLD: usize = 64;
+/// Benchmarked crossover: `extend_ref` wins up to ~30 blocks, `merge_batch` wins beyond.
+/// See: https://github.com/paradigmxyz/reth/pull/21098
+const MERGE_BATCH_THRESHOLD: usize = 30;
 
 /// Inputs captured for lazy overlay computation.
 #[derive(Clone)]


### PR DESCRIPTION
## Summary

Lower `MERGE_BATCH_THRESHOLD` from 64 to 30 based on benchmark analysis from #21098.

## Context

The benchmark results from #21098 show that for `k >= 30` blocks, the k way batch algorithm outperforms the new sorted merge

<img width="876" height="326" alt="image" src="https://github.com/user-attachments/assets/00357da8-2643-47dd-a232-0b2d840ce6bc" />



This change aligns the threshold with the actual algorithmic crossover point.

## Changes

- Changed `MERGE_BATCH_THRESHOLD` from 64 to 30
- Added reference to #21098 in the doc comment