### PR TITLE
fix(`docs/cli`): update `help.rs` to use nightly toolchain

### DIFF
--- a/docs/cli/help.rs
+++ b/docs/cli/help.rs
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S cargo -Zscript
+#!/usr/bin/env -S cargo +nightly -Zscript
 ---
 [package]
 edition = "2021"


### PR DESCRIPTION
smol smol toolchain fix in the docs update script shebang.

The wrong toolchain was causing annoying errors when running `make update-book-cli`, and consequently `make pr`.