### PR TITLE
fix(engine): request head block download when not buffered after backfill

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1676,6 +1676,18 @@ where
                 )));
                 return Ok(());
             }
+        } else {
+            // We don't have the head block or any of its ancestors buffered. Request
+            // a download for the head block which will then trigger further sync.
+            debug!(
+                target: "engine::tree",
+                head_hash = %sync_target_state.head_block_hash,
+                "Backfill complete but head block not buffered, requesting download"
+            );
+            self.emit_event(EngineApiEvent::Download(DownloadRequest::single_block(
+                sync_target_state.head_block_hash,
+            )));
+            return Ok(());
         }
 
         // try to close the gap by executing buffered blocks that are child blocks of the new head

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -1008,6 +1008,15 @@ async fn test_engine_tree_live_sync_transition_required_blocks_requested() {
         _ => panic!("Unexpected event: {event:#?}"),
     }
 
+    // After backfill completes with head not buffered, we also request head download
+    let event = test_harness.from_tree_rx.recv().await.unwrap();
+    match event {
+        EngineApiEvent::Download(DownloadRequest::BlockSet(hash_set)) => {
+            assert_eq!(hash_set, HashSet::from_iter([main_chain_last_hash]));
+        }
+        _ => panic!("Unexpected event: {event:#?}"),
+    }
+
     let _ = test_harness
         .tree
         .on_engine_message(FromEngine::DownloadedBlocks(vec![main_chain


### PR DESCRIPTION
## Problem

When backfill completes, the engine only triggers further sync if:
1. The finalized block is already buffered (for checking if more backfill is needed), OR
2. The head block's lowest ancestor is buffered (for downloading remaining blocks)

If neither condition is met, the function returns early without triggering any download. This causes the node to stall after backfill completes, waiting indefinitely for a new FCU.

## Solution

When the head block (and its ancestors) is not buffered after backfill, request a download for the FCU head block. This kicks off another sync cycle that will eventually connect the chain.

## Related

Fixes sync stall issue where CL and EL were "staring at walls" for hours after backfill.

Ref: [TOOLS-56](https://linear.app/tempoxyz/issue/TOOLS-56/create-nightly-node-crash-and-restore-test-suite)