### PR TITLE
refactor: use ExecutionOutcome::single instead of tuple From

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -954,19 +954,19 @@ impl<N: NodePrimitives<SignedTx: SignedTransaction>> NewCanonicalChain<N> {
             [first, rest @ ..] => {
                 let mut chain = Chain::from_block(
                     first.recovered_block().clone(),
-                    ExecutionOutcome::from((
-                        first.execution_outcome().clone(),
+                    ExecutionOutcome::single(
                         first.block_number(),
-                    )),
+                        first.execution_outcome().clone(),
+                    ),
                     first.trie_data_handle(),
                 );
                 for exec in rest {
                     chain.append_block(
                         exec.recovered_block().clone(),
-                        ExecutionOutcome::from((
-                            exec.execution_outcome().clone(),
+                        ExecutionOutcome::single(
                             exec.block_number(),
-                        )),
+                            exec.execution_outcome().clone(),
+                        ),
                         exec.trie_data_handle(),
                     );
                 }


### PR DESCRIPTION
Replace obfuscating tuple `From` conversions with explicit `ExecutionOutcome::single()` calls in `blocks_to_chain` for better readability.

The tuple `From<(BlockExecutionOutput<T>, BlockNumber)>` implementation just delegates to `Self::single(block_number, output)`, so calling the method directly is clearer.