### PR TITLE
refactor(trie): simplify LazyTrieData with SortedTrieData container

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -958,7 +958,7 @@ impl<N: NodePrimitives<SignedTx: SignedTransaction>> NewCanonicalChain<N> {
                         first.block_number(),
                         first.execution_outcome().clone(),
                     ),
-                    first.trie_data_handle(),
+                    first.trie_data_handle().to_lazy(),
                 );
                 for exec in rest {
                     chain.append_block(
@@ -967,7 +967,7 @@ impl<N: NodePrimitives<SignedTx: SignedTransaction>> NewCanonicalChain<N> {
                             exec.block_number(),
                             exec.execution_outcome().clone(),
                         ),
-                        exec.trie_data_handle(),
+                        exec.trie_data_handle().to_lazy(),
                     );
                 }
                 chain
@@ -1577,14 +1577,14 @@ mod tests {
         // Compare execution outcome
         assert_eq!(*new.execution_outcome(), commit_execution_outcome);
 
-        // Compare trie data by waiting on deferred data
+        // Compare trie data
         for (block_num, expected_updates) in &expected_trie_updates {
-            let actual = new.trie_data_at(*block_num).unwrap().wait_cloned();
-            assert_eq!(actual.trie_updates, *expected_updates);
+            let actual = new.trie_data_at(*block_num).unwrap();
+            assert_eq!(actual.trie_updates(), *expected_updates);
         }
         for (block_num, expected_state) in &expected_hashed_state {
-            let actual = new.trie_data_at(*block_num).unwrap().wait_cloned();
-            assert_eq!(actual.hashed_state, *expected_state);
+            let actual = new.trie_data_at(*block_num).unwrap();
+            assert_eq!(actual.hashed_state(), *expected_state);
         }
 
         // Test reorg notification
@@ -1639,12 +1639,12 @@ mod tests {
 
         // Compare old chain trie data
         for (block_num, expected_updates) in &old_trie_updates {
-            let actual = old.trie_data_at(*block_num).unwrap().wait_cloned();
-            assert_eq!(actual.trie_updates, *expected_updates);
+            let actual = old.trie_data_at(*block_num).unwrap();
+            assert_eq!(actual.trie_updates(), *expected_updates);
         }
         for (block_num, expected_state) in &old_hashed_state {
-            let actual = old.trie_data_at(*block_num).unwrap().wait_cloned();
-            assert_eq!(actual.hashed_state, *expected_state);
+            let actual = old.trie_data_at(*block_num).unwrap();
+            assert_eq!(actual.hashed_state(), *expected_state);
         }
 
         // Compare new chain blocks
@@ -1658,12 +1658,12 @@ mod tests {
 
         // Compare new chain trie data
         for (block_num, expected_updates) in &new_trie_updates {
-            let actual = new.trie_data_at(*block_num).unwrap().wait_cloned();
-            assert_eq!(actual.trie_updates, *expected_updates);
+            let actual = new.trie_data_at(*block_num).unwrap();
+            assert_eq!(actual.trie_updates(), *expected_updates);
         }
         for (block_num, expected_state) in &new_hashed_state {
-            let actual = new.trie_data_at(*block_num).unwrap().wait_cloned();
-            assert_eq!(actual.hashed_state, *expected_state);
+            let actual = new.trie_data_at(*block_num).unwrap();
+            assert_eq!(actual.hashed_state(), *expected_state);
         }
     }
 }

--- a/crates/evm/chain/src/lib.rs
+++ b/crates/evm/chain/src/lib.rs
@@ -1,7 +1,8 @@
-//! Chain and deferred trie data types for reth.
+//! Chain and trie data types for reth.
 //!
 //! This crate contains the [`Chain`] type representing a chain of blocks and their final state,
-//! as well as [`DeferredTrieData`] for handling asynchronously computed trie data.
+//! as well as [`DeferredTrieData`] for handling asynchronously computed trie data and
+//! re-exports [`LazyTrieData`] for lazy initialization.
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
@@ -16,6 +17,9 @@ pub use chain::*;
 
 mod deferred_trie;
 pub use deferred_trie::*;
+
+// Re-export LazyTrieData from trie-common for convenience
+pub use reth_trie_common::LazyTrieData;
 
 /// Bincode-compatible serde implementations for chain types.
 ///

--- a/crates/exex/exex/src/wal/storage.rs
+++ b/crates/exex/exex/src/wal/storage.rs
@@ -357,7 +357,7 @@ mod tests {
                 new: Arc::new(Chain::new(
                     vec![block],
                     Default::default(),
-                    BTreeMap::from([(block_number, trie_data)]),
+                    BTreeMap::from([(block_number, trie_data.to_lazy())]),
                 )),
             };
         Ok(notification)

--- a/crates/trie/common/src/lazy.rs
+++ b/crates/trie/common/src/lazy.rs
@@ -1,0 +1,164 @@
+//! Lazy initialization wrapper for trie data.
+//!
+//! Provides a no-std compatible [`LazyTrieData`] type for lazily initialized
+//! trie-related data containing [`HashedPostStateSorted`] and [`TrieUpdatesSorted`].
+
+use crate::{updates::TrieUpdatesSorted, HashedPostStateSorted};
+use alloc::sync::Arc;
+use core::fmt;
+use reth_primitives_traits::sync::OnceLock;
+
+/// Container for sorted trie data: hashed state and trie updates.
+///
+/// This bundles both [`HashedPostStateSorted`] and [`TrieUpdatesSorted`] together
+/// for convenient passing and storage.
+#[derive(Clone, Debug, Default)]
+pub struct SortedTrieData {
+    /// Sorted hashed post-state produced by execution.
+    pub hashed_state: Arc<HashedPostStateSorted>,
+    /// Sorted trie updates produced by state root computation.
+    pub trie_updates: Arc<TrieUpdatesSorted>,
+}
+
+impl SortedTrieData {
+    /// Creates a new [`SortedTrieData`] with the given values.
+    pub const fn new(
+        hashed_state: Arc<HashedPostStateSorted>,
+        trie_updates: Arc<TrieUpdatesSorted>,
+    ) -> Self {
+        Self { hashed_state, trie_updates }
+    }
+}
+
+/// Lazily initialized trie data containing sorted hashed state and trie updates.
+///
+/// This is a no-std compatible wrapper that supports two modes:
+/// 1. **Ready mode**: Data is available immediately (created via `ready()`)
+/// 2. **Deferred mode**: Data is computed on first access (created via `deferred()`)
+///
+/// In deferred mode, the computation runs on the first call to `get()`, `hashed_state()`,
+/// or `trie_updates()`, and results are cached for subsequent calls.
+///
+/// Cloning is cheap (Arc clone) and clones share the cached state.
+pub struct LazyTrieData {
+    /// Cached sorted trie data, computed on first access.
+    data: Arc<OnceLock<SortedTrieData>>,
+    /// Optional deferred computation function.
+    compute: Option<Arc<dyn Fn() -> SortedTrieData + Send + Sync>>,
+}
+
+impl Clone for LazyTrieData {
+    fn clone(&self) -> Self {
+        Self { data: Arc::clone(&self.data), compute: self.compute.clone() }
+    }
+}
+
+impl fmt::Debug for LazyTrieData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LazyTrieData")
+            .field("data", &if self.data.get().is_some() { "initialized" } else { "pending" })
+            .finish()
+    }
+}
+
+impl LazyTrieData {
+    /// Creates a new [`LazyTrieData`] that is already initialized with the given values.
+    pub fn ready(
+        hashed_state: Arc<HashedPostStateSorted>,
+        trie_updates: Arc<TrieUpdatesSorted>,
+    ) -> Self {
+        let data = OnceLock::new();
+        let _ = data.set(SortedTrieData::new(hashed_state, trie_updates));
+        Self { data: Arc::new(data), compute: None }
+    }
+
+    /// Creates a new [`LazyTrieData`] from pre-computed [`SortedTrieData`].
+    pub fn from_sorted(sorted: SortedTrieData) -> Self {
+        let data = OnceLock::new();
+        let _ = data.set(sorted);
+        Self { data: Arc::new(data), compute: None }
+    }
+
+    /// Creates a new [`LazyTrieData`] with a deferred computation function.
+    ///
+    /// The computation will run on the first call to `get()`, `hashed_state()`,
+    /// or `trie_updates()`. Results are cached for subsequent calls.
+    pub fn deferred(compute: impl Fn() -> SortedTrieData + Send + Sync + 'static) -> Self {
+        Self { data: Arc::new(OnceLock::new()), compute: Some(Arc::new(compute)) }
+    }
+
+    /// Returns a reference to the sorted trie data, computing if necessary.
+    ///
+    /// # Panics
+    ///
+    /// Panics if created via `deferred()` and the computation function was not provided.
+    pub fn get(&self) -> &SortedTrieData {
+        self.data.get_or_init(|| {
+            self.compute.as_ref().expect("LazyTrieData::get called before initialization")()
+        })
+    }
+
+    /// Returns a clone of the hashed state Arc.
+    ///
+    /// If not initialized, computes from the deferred source or panics.
+    pub fn hashed_state(&self) -> Arc<HashedPostStateSorted> {
+        Arc::clone(&self.get().hashed_state)
+    }
+
+    /// Returns a clone of the trie updates Arc.
+    ///
+    /// If not initialized, computes from the deferred source or panics.
+    pub fn trie_updates(&self) -> Arc<TrieUpdatesSorted> {
+        Arc::clone(&self.get().trie_updates)
+    }
+
+    /// Returns a clone of the [`SortedTrieData`].
+    ///
+    /// If not initialized, computes from the deferred source or panics.
+    pub fn sorted_trie_data(&self) -> SortedTrieData {
+        self.get().clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_lazy_ready_is_initialized() {
+        let lazy = LazyTrieData::ready(
+            Arc::new(HashedPostStateSorted::default()),
+            Arc::new(TrieUpdatesSorted::default()),
+        );
+        let _ = lazy.hashed_state();
+        let _ = lazy.trie_updates();
+    }
+
+    #[test]
+    fn test_lazy_clone_shares_state() {
+        let lazy1 = LazyTrieData::ready(
+            Arc::new(HashedPostStateSorted::default()),
+            Arc::new(TrieUpdatesSorted::default()),
+        );
+        let lazy2 = lazy1.clone();
+
+        // Both point to the same data
+        assert!(Arc::ptr_eq(&lazy1.hashed_state(), &lazy2.hashed_state()));
+        assert!(Arc::ptr_eq(&lazy1.trie_updates(), &lazy2.trie_updates()));
+    }
+
+    #[test]
+    fn test_lazy_deferred() {
+        let lazy = LazyTrieData::deferred(SortedTrieData::default);
+        assert!(lazy.hashed_state().is_empty());
+        assert!(lazy.trie_updates().is_empty());
+    }
+
+    #[test]
+    fn test_lazy_from_sorted() {
+        let sorted = SortedTrieData::default();
+        let lazy = LazyTrieData::from_sorted(sorted);
+        assert!(lazy.hashed_state().is_empty());
+        assert!(lazy.trie_updates().is_empty());
+    }
+}

--- a/crates/trie/common/src/lib.rs
+++ b/crates/trie/common/src/lib.rs
@@ -11,6 +11,9 @@
 
 extern crate alloc;
 
+mod lazy;
+pub use lazy::{LazyTrieData, SortedTrieData};
+
 /// In-memory hashed state.
 mod hashed_state;
 pub use hashed_state::*;


### PR DESCRIPTION
## Summary

Simplifies the `LazyTrieData` abstraction introduced in #21139.

## Changes

- Add `SortedTrieData` container bundling `HashedPostStateSorted` + `TrieUpdatesSorted`
- Simplify `LazyTrieData` to use single `Arc<OnceLock<SortedTrieData>>` instead of two separate `OnceLock`s
- Remove `TrieDataCompute` trait - use simple `Arc<dyn Fn() -> SortedTrieData>` instead
- Remove unnecessary `Default` impl for `LazyTrieData`

The previous implementation had two separate `OnceLock` fields and a trait that was only implemented by one type. This consolidates everything into a simpler design while maintaining the same lazy evaluation semantics.