### PR TITLE
refactor(trie): extract hybrid merge algorithm for sorted trie types

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -551,7 +551,6 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
 
                     let trie_data = block.trie_data();
 
-                    // insert hashes and intermediate merkle nodes
                     let start = Instant::now();
                     self.write_hashed_state(&trie_data.hashed_state)?;
                     timings.write_hashed_state += start.elapsed();


### PR DESCRIPTION
## Summary

Batches trie updates across all blocks in `save_blocks` instead of writing per-block, reducing cursor open/close overhead from N to 1.

## Problem

Per #eng-perf profiling, `write_trie_updates` was taking **~25% of persistence time**. The current implementation calls `write_trie_updates_sorted` once per block, opening/closing cursors N times.

In back-to-back (b2b) scenarios with 75-250 accumulated blocks, this overhead compounds significantly.

## Solution

### lazy_overlay.rs
- Move `MERGE_BATCH_THRESHOLD` constant inside function
- Use data directly instead of `Arc::clone` (avoids unnecessary refcount bump)
- Move `Arc::make_mut` into the loop for proper copy-on-write semantics

### provider.rs
Add batched trie updates with hybrid merge algorithm:

| Batch Size | Strategy | Allocation |
|------------|----------|------------|
| 0 | Return default | 0 |
| 1 | `Arc::try_unwrap` | Avoids clone if refcount is 1 |
| < 30 | `extend_ref` with `Arc::make_mut` | Copy-on-write (no collect) |
| >= 30 | k-way `merge_batch` | Single collect for O(n log k) merge |

## Allocation Behavior (No Regression)

Learned from PR #21142 review feedback:
- ❌ Don't use `collect()` unnecessarily in small-k path
- ✅ Use `Arc::make_mut` directly in the loop for copy-on-write
- ✅ Only collect for large-k path where k-way merge needs materialized data
- ✅ Use `Arc::try_unwrap` to avoid final clone when refcount is 1

## Expected Impact

- **~50% reduction** in `write_trie_updates` time for b2b scenarios
- Reduces cursor open/close overhead from N to 1
- Reduces MDBX transaction overhead

## Testing

- All existing `reth-chain-state` and `reth-provider` tests pass
- Clippy and fmt clean

## Related

- Alternative to PR #21142 (same optimization, cleaner implementation)
- Based on optimizations from [Slack #eng-perf thread](https://tempoxyz.enterprise.slack.com/archives/C0A0ZCUHMNY/p1768604061162379)
- Learned from @yongkangc and @brian review feedback on avoiding unnecessary allocations