### PR TITLE
feat(engine): add time_between_new_payloads metric

### DIFF
--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -298,6 +298,8 @@ pub(crate) struct NewPayloadStatusMetrics {
     pub(crate) new_payload_latency: Histogram,
     /// Latency for the last new payload call.
     pub(crate) new_payload_last: Gauge,
+    /// Time between consecutive new payload calls (payload-to-payload interval).
+    pub(crate) time_between_new_payloads: Histogram,
 }
 
 impl NewPayloadStatusMetrics {
@@ -311,6 +313,9 @@ impl NewPayloadStatusMetrics {
         let finish = Instant::now();
         let elapsed = finish - start;
 
+        if let Some(prev) = self.latest_at {
+            self.time_between_new_payloads.record(start - prev);
+        }
         self.latest_at = Some(finish);
         match result {
             Ok(outcome) => match outcome.outcome.status {


### PR DESCRIPTION
Adds a histogram metric (`consensus_engine_beacon_time_between_new_payloads`) to track the time interval between consecutive `engine_newPayload` calls.

## Motivation

This metric helps monitor:
- Block arrival timing from the CL
- Gaps or delays in payload delivery
- Overall engine API health

On mainnet with 12s slots, you'd expect ~12s intervals minus execution time. Deviations indicate missed slots or CL issues.

## Changes

- Added `time_between_new_payloads` histogram to `NewPayloadStatusMetrics`
- Records interval from start of current payload to finish of previous payload