### PR TITLE
feat(engine): add new_payload_interval metric (start-to-start)

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1478,7 +1478,7 @@ where
 
                                 self.metrics.engine.forkchoice_updated.update_response_metrics(
                                     start,
-                                    &mut self.metrics.engine.new_payload.latest_at,
+                                    &mut self.metrics.engine.new_payload.latest_finish_at,
                                     has_attrs,
                                     &output,
                                 );


### PR DESCRIPTION
Follow-up to #21158.

Adds `consensus_engine_beacon_new_payload_interval` histogram to track total time between consecutive `newPayload` calls (start-to-start).

## Metrics Summary

| Metric | Measures | Use Case |
|--------|----------|----------|
| `new_payload_interval` | prev start → current start | Total slot timing, should be ~12s on mainnet |
| `time_between_new_payloads` | prev finish → current start | Idle time waiting for next payload |
| `new_payload_latency` | current start → current finish | Processing time |

Also renames internal field `latest_at` → `latest_finish_at` for clarity.