### PR TITLE
refactor(trie): simplify WorkloadPredictor with reusable WorkloadEma struct

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -225,6 +225,7 @@ where
         multiproof_provider_factory: F,
         config: &TreeConfig,
         bal: Option<Arc<BlockAccessList>>,
+        workload_hint: Option<reth_trie_common::WorkloadHint>,
     ) -> IteratorPayloadHandle<Evm, I, N>
     where
         P: BlockReader + StateProviderFactory + StateReader + Clone + 'static,
@@ -290,6 +291,7 @@ where
             config.multiproof_chunking_enabled().then_some(config.multiproof_chunk_size()),
             to_multi_proof.clone(),
             from_multi_proof,
+            workload_hint,
         );
 
         // spawn multi-proof task

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -231,6 +231,7 @@ where
         F: DatabaseProviderROFactory<Provider: TrieCursorFactory + HashedCursorFactory>
             + Clone
             + Send
+            + Sync
             + 'static,
     {
         // start preparing transactions immediately

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -225,7 +225,7 @@ where
         multiproof_provider_factory: F,
         config: &TreeConfig,
         bal: Option<Arc<BlockAccessList>>,
-        workload_hint: Option<reth_trie_common::WorkloadHint>,
+        workload_hint: Option<reth_trie::WorkloadHint>,
     ) -> IteratorPayloadHandle<Evm, I, N>
     where
         P: BlockReader + StateProviderFactory + StateReader + Clone + 'static,

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -1365,7 +1365,7 @@ mod tests {
         let (to_sparse_trie, _receiver) = std::sync::mpsc::channel();
         let (tx, rx) = crossbeam_channel::unbounded();
 
-        MultiProofTask::new(proof_handle, to_sparse_trie, Some(1), tx, rx)
+        MultiProofTask::new(proof_handle, to_sparse_trie, Some(1), tx, rx, None)
     }
 
     fn create_cached_provider<F>(factory: F) -> CachedStateProvider<StateProviderBox>

--- a/crates/trie/parallel/src/lib.rs
+++ b/crates/trie/parallel/src/lib.rs
@@ -12,7 +12,7 @@ mod storage_root_targets;
 pub use storage_root_targets::StorageRootTargets;
 
 pub mod workload_predictor;
-pub use workload_predictor::WorkloadPredictor;
+pub use workload_predictor::{desired_workers, WorkloadHint, ACCOUNTS_PER_WORKER, SLOTS_PER_WORKER};
 
 /// Parallel trie calculation stats.
 pub mod stats;

--- a/crates/trie/parallel/src/lib.rs
+++ b/crates/trie/parallel/src/lib.rs
@@ -11,6 +11,9 @@
 mod storage_root_targets;
 pub use storage_root_targets::StorageRootTargets;
 
+pub mod workload_predictor;
+pub use workload_predictor::WorkloadPredictor;
+
 /// Parallel trie calculation stats.
 pub mod stats;
 

--- a/crates/trie/parallel/src/workload_predictor.rs
+++ b/crates/trie/parallel/src/workload_predictor.rs
@@ -1,0 +1,132 @@
+//! Workload predictor for parallel trie computation.
+//!
+//! Uses exponential moving average (EMA) to predict the next block's workload,
+//! enabling better resource allocation for parallel state root computation.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Smoothing factor for exponential moving average.
+/// Lower values give more weight to historical data.
+const ALPHA: f64 = 0.3;
+
+/// Headroom multiplier applied to predictions.
+/// Ensures we slightly over-provision to handle workload variance.
+const HEADROOM: f64 = 1.25;
+
+/// Lock-free workload predictor using exponential moving average.
+///
+/// This predictor tracks historical workload patterns and predicts future
+/// resource requirements for parallel trie computation. It uses atomic
+/// operations for thread-safe, lock-free updates.
+///
+/// The struct is cache-line aligned (64 bytes) to prevent false sharing
+/// when accessed from multiple threads.
+#[repr(align(64))]
+#[derive(Debug)]
+pub struct WorkloadPredictor {
+    /// EMA of storage slot count (stores f64 bits as u64).
+    storage_ema: AtomicU64,
+    /// EMA of account count (stores f64 bits as u64).
+    account_ema: AtomicU64,
+}
+
+impl Default for WorkloadPredictor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl WorkloadPredictor {
+    /// Creates a new workload predictor with zero initial estimates.
+    pub const fn new() -> Self {
+        Self { storage_ema: AtomicU64::new(0), account_ema: AtomicU64::new(0) }
+    }
+
+    /// Records observed workload after processing a block.
+    ///
+    /// Updates the internal EMAs with the actual storage and account counts.
+    pub fn record(&self, storage_targets: usize, account_targets: usize) {
+        self.update_ema(&self.storage_ema, storage_targets as f64);
+        self.update_ema(&self.account_ema, account_targets as f64);
+    }
+
+    /// Predicts the next block's workload with headroom.
+    ///
+    /// Returns `(storage_count, account_count)` predictions based on
+    /// historical EMA values multiplied by the headroom factor.
+    pub fn predict(&self) -> (usize, usize) {
+        let storage = f64::from_bits(self.storage_ema.load(Ordering::Relaxed));
+        let accounts = f64::from_bits(self.account_ema.load(Ordering::Relaxed));
+
+        let predicted_storage = (storage * HEADROOM).ceil() as usize;
+        let predicted_accounts = (accounts * HEADROOM).ceil() as usize;
+
+        (predicted_storage, predicted_accounts)
+    }
+
+    /// Updates an EMA atomic using a compare-and-swap loop.
+    fn update_ema(&self, atomic: &AtomicU64, value: f64) {
+        loop {
+            let current_bits = atomic.load(Ordering::Relaxed);
+            let current = f64::from_bits(current_bits);
+
+            // EMA formula: new_ema = alpha * value + (1 - alpha) * current_ema
+            // For first observation (current == 0), use the value directly
+            let new_ema =
+                if current == 0.0 { value } else { ALPHA.mul_add(value, (1.0 - ALPHA) * current) };
+
+            let new_bits = new_ema.to_bits();
+
+            if atomic
+                .compare_exchange_weak(current_bits, new_bits, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+            {
+                break;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_predictor() {
+        let predictor = WorkloadPredictor::new();
+        let (storage, accounts) = predictor.predict();
+        assert_eq!(storage, 0);
+        assert_eq!(accounts, 0);
+    }
+
+    #[test]
+    fn test_first_record() {
+        let predictor = WorkloadPredictor::new();
+        predictor.record(100, 50);
+
+        let (storage, accounts) = predictor.predict();
+        // First record uses value directly, then headroom applied
+        assert_eq!(storage, (100.0 * HEADROOM).ceil() as usize);
+        assert_eq!(accounts, (50.0 * HEADROOM).ceil() as usize);
+    }
+
+    #[test]
+    fn test_ema_convergence() {
+        let predictor = WorkloadPredictor::new();
+
+        // Record same value multiple times
+        for _ in 0..10 {
+            predictor.record(1000, 500);
+        }
+
+        let (storage, accounts) = predictor.predict();
+        // Should converge close to value * headroom
+        assert!((storage as f64 - 1000.0 * HEADROOM).abs() < 10.0);
+        assert!((accounts as f64 - 500.0 * HEADROOM).abs() < 10.0);
+    }
+
+    #[test]
+    fn test_cache_alignment() {
+        assert_eq!(std::mem::align_of::<WorkloadPredictor>(), 64);
+    }
+}

--- a/crates/trie/parallel/src/workload_predictor.rs
+++ b/crates/trie/parallel/src/workload_predictor.rs
@@ -13,6 +13,54 @@ const ALPHA: f64 = 0.3;
 /// Ensures we slightly over-provision to handle workload variance.
 const HEADROOM: f64 = 1.25;
 
+/// Lock-free workload predictor using exponential moving average (stores f64 bits as u64).
+///
+/// This predictor tracks historical workload patterns and predicts future
+/// resource requirements for parallel trie computation. It uses atomic
+/// operations for thread-safe, lock-free updates.
+#[derive(Debug, Default)]
+pub struct WorkloadEma(AtomicU64);
+
+impl WorkloadEma {
+    /// Creates a new workload EMA with zero initial estimate.
+    pub const fn new() -> Self {
+        Self(AtomicU64::new(0))
+    }
+
+    /// Records observed workload and updates the EMA.
+    pub fn record(&self, value: usize) {
+        let value = value as f64;
+        loop {
+            let current_bits = self.0.load(Ordering::Relaxed);
+            let current = f64::from_bits(current_bits);
+
+            // EMA formula: new_ema = alpha * value + (1 - alpha) * current_ema
+            // For first observation (current == 0), use the value directly
+            let new_ema =
+                if current == 0.0 { value } else { ALPHA.mul_add(value, (1.0 - ALPHA) * current) };
+
+            if self
+                .0
+                .compare_exchange_weak(
+                    current_bits,
+                    new_ema.to_bits(),
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                )
+                .is_ok()
+            {
+                break;
+            }
+        }
+    }
+
+    /// Predicts the next workload with headroom applied.
+    pub fn predict(&self) -> usize {
+        let ema = f64::from_bits(self.0.load(Ordering::Relaxed));
+        (ema * HEADROOM).ceil() as usize
+    }
+}
+
 /// Lock-free workload predictor using exponential moving average.
 ///
 /// This predictor tracks historical workload patterns and predicts future
@@ -22,68 +70,31 @@ const HEADROOM: f64 = 1.25;
 /// The struct is cache-line aligned (64 bytes) to prevent false sharing
 /// when accessed from multiple threads.
 #[repr(align(64))]
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct WorkloadPredictor {
-    /// EMA of storage slot count (stores f64 bits as u64).
-    storage_ema: AtomicU64,
-    /// EMA of account count (stores f64 bits as u64).
-    account_ema: AtomicU64,
-}
-
-impl Default for WorkloadPredictor {
-    fn default() -> Self {
-        Self::new()
-    }
+    /// EMA of storage slot count.
+    storage_ema: WorkloadEma,
+    /// EMA of account count.
+    account_ema: WorkloadEma,
 }
 
 impl WorkloadPredictor {
     /// Creates a new workload predictor with zero initial estimates.
     pub const fn new() -> Self {
-        Self { storage_ema: AtomicU64::new(0), account_ema: AtomicU64::new(0) }
+        Self { storage_ema: WorkloadEma::new(), account_ema: WorkloadEma::new() }
     }
 
     /// Records observed workload after processing a block.
-    ///
-    /// Updates the internal EMAs with the actual storage and account counts.
     pub fn record(&self, storage_targets: usize, account_targets: usize) {
-        self.update_ema(&self.storage_ema, storage_targets as f64);
-        self.update_ema(&self.account_ema, account_targets as f64);
+        self.storage_ema.record(storage_targets);
+        self.account_ema.record(account_targets);
     }
 
     /// Predicts the next block's workload with headroom.
     ///
-    /// Returns `(storage_count, account_count)` predictions based on
-    /// historical EMA values multiplied by the headroom factor.
+    /// Returns `(storage_count, account_count)` predictions.
     pub fn predict(&self) -> (usize, usize) {
-        let storage = f64::from_bits(self.storage_ema.load(Ordering::Relaxed));
-        let accounts = f64::from_bits(self.account_ema.load(Ordering::Relaxed));
-
-        let predicted_storage = (storage * HEADROOM).ceil() as usize;
-        let predicted_accounts = (accounts * HEADROOM).ceil() as usize;
-
-        (predicted_storage, predicted_accounts)
-    }
-
-    /// Updates an EMA atomic using a compare-and-swap loop.
-    fn update_ema(&self, atomic: &AtomicU64, value: f64) {
-        loop {
-            let current_bits = atomic.load(Ordering::Relaxed);
-            let current = f64::from_bits(current_bits);
-
-            // EMA formula: new_ema = alpha * value + (1 - alpha) * current_ema
-            // For first observation (current == 0), use the value directly
-            let new_ema =
-                if current == 0.0 { value } else { ALPHA.mul_add(value, (1.0 - ALPHA) * current) };
-
-            let new_bits = new_ema.to_bits();
-
-            if atomic
-                .compare_exchange_weak(current_bits, new_bits, Ordering::Relaxed, Ordering::Relaxed)
-                .is_ok()
-            {
-                break;
-            }
-        }
+        (self.storage_ema.predict(), self.account_ema.predict())
     }
 }
 
@@ -92,37 +103,34 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_new_predictor() {
-        let predictor = WorkloadPredictor::new();
-        let (storage, accounts) = predictor.predict();
-        assert_eq!(storage, 0);
-        assert_eq!(accounts, 0);
+    fn test_new_ema() {
+        let ema = WorkloadEma::new();
+        assert_eq!(ema.predict(), 0);
     }
 
     #[test]
     fn test_first_record() {
-        let predictor = WorkloadPredictor::new();
-        predictor.record(100, 50);
-
-        let (storage, accounts) = predictor.predict();
-        // First record uses value directly, then headroom applied
-        assert_eq!(storage, (100.0 * HEADROOM).ceil() as usize);
-        assert_eq!(accounts, (50.0 * HEADROOM).ceil() as usize);
+        let ema = WorkloadEma::new();
+        ema.record(100);
+        assert_eq!(ema.predict(), (100.0 * HEADROOM).ceil() as usize);
     }
 
     #[test]
     fn test_ema_convergence() {
-        let predictor = WorkloadPredictor::new();
-
-        // Record same value multiple times
+        let ema = WorkloadEma::new();
         for _ in 0..10 {
-            predictor.record(1000, 500);
+            ema.record(1000);
         }
+        assert!((ema.predict() as f64 - 1000.0 * HEADROOM).abs() < 10.0);
+    }
 
+    #[test]
+    fn test_predictor() {
+        let predictor = WorkloadPredictor::new();
+        predictor.record(100, 50);
         let (storage, accounts) = predictor.predict();
-        // Should converge close to value * headroom
-        assert!((storage as f64 - 1000.0 * HEADROOM).abs() < 10.0);
-        assert!((accounts as f64 - 500.0 * HEADROOM).abs() < 10.0);
+        assert_eq!(storage, (100.0 * HEADROOM).ceil() as usize);
+        assert_eq!(accounts, (50.0 * HEADROOM).ceil() as usize);
     }
 
     #[test]


### PR DESCRIPTION
Extracts a reusable `WorkloadEma` struct that encapsulates the atomic EMA logic, removing the duplicated `update_ema` private method.

- `WorkloadEma` - single-variable predictor with `record(value)` and `predict()`
- `WorkloadPredictor` - composes two `WorkloadEma` instances (storage + accounts)