### PR TITLE
feat(stages): add RocksDB support for IndexStorageHistoryStage

### DIFF
--- a/crates/stages/stages/src/stages/utils.rs
+++ b/crates/stages/stages/src/stages/utils.rs
@@ -179,6 +179,7 @@ where
 /// `Address.StorageKey`). It flushes indices to disk when reaching a shard's max length
 /// (`NUM_OF_INDICES_IN_SHARD`) or when the partial key changes, ensuring the last previous partial
 /// key shard is stored.
+#[allow(dead_code)]
 pub(crate) fn load_history_indices<Provider, H, P>(
     provider: &Provider,
     mut collector: Collector<H::Key, H::Value>,
@@ -263,6 +264,7 @@ where
 }
 
 /// Shard and insert the indices list according to [`LoadMode`] and its length.
+#[allow(dead_code)]
 pub(crate) fn load_indices<H, C, P>(
     cursor: &mut C,
     partial_key: P,
@@ -308,6 +310,7 @@ where
 }
 
 /// Mode on how to load index shards into the database.
+#[allow(dead_code)]
 pub(crate) enum LoadMode {
     /// Keep the last shard in memory and don't flush it to the database.
     KeepLast,


### PR DESCRIPTION
## Summary

This PR adds RocksDB support for the `IndexStorageHistoryStage`, following the same pattern established in #21165 for `IndexAccountHistoryStage`.

## Changes

### Stage Implementation
- Add `RocksDBProviderFactory`, `StorageSettingsCache`, and `NodePrimitivesProvider` trait bounds to the `Stage` impl
- Use `EitherWriter::new_storages_history` with explicit `#[cfg(all(unix, feature = "rocksdb"))]` blocks for RocksDB batch creation
- Only clear MDBX table on first sync if not using RocksDB
- Register RocksDB batch for commit at provider level

### Helper Functions
- `load_storage_history_indices_with_writer` - Iterate collector, merge with existing shards during incremental syncs
- `get_last_storage_history_shard` - Read last shard from RocksDB or MDBX based on storage settings
- `write_storage_history_shards_keep_last` - Write full shards to database, keep partial shard in memory
- `flush_storage_history_shards` - Write all remaining shards with `u64::MAX` for the last shard

### Tests
Added `rocksdb_tests` module with:
- `execute_writes_to_rocksdb_when_enabled` - Verify MDBX is empty and RocksDB has data
- `unwind_deletes_from_rocksdb_when_enabled` - Verify unwind checkpoints work
- `execute_incremental_sync` - Verify merging existing and new data works

## Context

This is part of a series of PRs to move secondary indices to RocksDB for better performance. Other related PRs:
- #21165 - IndexAccountHistoryStage (same pattern)
- Related to #20593 (tracking issue)

## Testing

```bash
cargo test -p reth-stages --features rocksdb -- index_storage_history --test-threads=4
```

All 15 tests pass, including 3 new RocksDB-specific tests.