### PR TITLE
docs: add Ethereum section to table of contents and fix heading level

### DIFF
--- a/docs/repo/layout.md
+++ b/docs/repo/layout.md
@@ -23,6 +23,7 @@ Generally, reth is composed of a few components, with supporting crates. The mai
   - [Payloads](#payloads)
   - [Primitives](#primitives)
   - [Optimism](#optimism)
+  - [Ethereum](#ethereum-specific-crates)
   - [Misc](#misc)
 
 The supporting crates are split into two categories: [primitives](#primitives) and [miscellaneous](#misc).
@@ -181,7 +182,7 @@ These crates define primitive types or algorithms.
 
 Crates related to the Optimism rollup live in [optimism](../../crates/optimism/).
 
-#### Ethereum-Specific Crates
+### Ethereum-Specific Crates
 
 Ethereum mainnet-specific implementations and primitives live in `crates/ethereum/`.
 


### PR DESCRIPTION
- Add missing "Ethereum" entry to table of contents
- Change `####` to `###` for Ethereum section heading to match sibling sections (Optimism, Primitives, Misc)
