### PR TITLE
chore(bench): add --disable-tx-gossip to benchmark node args

### DIFF
--- a/bin/reth-bench-compare/src/node.rs
+++ b/bin/reth-bench-compare/src/node.rs
@@ -163,6 +163,7 @@ impl NodeManager {
             "eth,reth".to_string(),
             "--disable-discovery".to_string(),
             "--trusted-only".to_string(),
+            "--disable-tx-gossip".to_string(),
         ]);
 
         // Add tracing arguments if OTLP endpoint is configured


### PR DESCRIPTION
Disable transaction gossip during benchmarks to eliminate p2p noise and reduce resource usage (bandwidth, CPU) from tx broadcasting/fetching.

This complements `--trusted-only` which isolates peers, but still allows tx gossip on established connections. Adding `--disable-tx-gossip` ensures benchmarks run without any transaction propagation overhead.