### PR TITLE
fix: remove redundant usize cast in history pruning

### DIFF
--- a/crates/prune/prune/src/segments/user/history.rs
+++ b/crates/prune/prune/src/segments/user/history.rs
@@ -105,7 +105,7 @@ where
 
         // If there were blocks less than or equal to the target one
         // (so the shard has changed), update the shard.
-        if blocks.len() as usize == higher_blocks.len() {
+        if blocks.len() == higher_blocks.len() {
             return Ok(PruneShardOutcome::Unchanged);
         }
 


### PR DESCRIPTION
Removed redundant as usize cast when comparing BlockNumberList length with Vec length. Rust handles type coercion between u64 and usize in equality comparisons on 64-bit platforms.