### PR TITLE
refactor: remove EthPrimitives re-export from chain-state

### DIFF
--- a/crates/chain-state/src/lib.rs
+++ b/crates/chain-state/src/lib.rs
@@ -36,6 +36,3 @@ pub use memory_overlay::{MemoryOverlayStateProvider, MemoryOverlayStateProviderR
 #[cfg(any(test, feature = "test-utils"))]
 /// Common test helpers
 pub mod test_utils;
-
-// todo: remove when generic data prim integration complete
-pub use reth_ethereum_primitives::EthPrimitives;

--- a/crates/exex/types/Cargo.toml
+++ b/crates/exex/types/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 [dependencies]
 # reth
 reth-chain-state.workspace = true
+reth-ethereum-primitives.workspace = true
 reth-execution-types.workspace = true
 reth-primitives-traits.workspace = true
 

--- a/crates/exex/types/src/notification.rs
+++ b/crates/exex/types/src/notification.rs
@@ -7,7 +7,7 @@ use reth_primitives_traits::NodePrimitives;
 /// Notifications sent to an `ExEx`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum ExExNotification<N: NodePrimitives = reth_chain_state::EthPrimitives> {
+pub enum ExExNotification<N: NodePrimitives = reth_ethereum_primitives::EthPrimitives> {
     /// Chain got committed without a reorg, and only the new chain is returned.
     ChainCommitted {
         /// The new chain after commit.

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -2717,8 +2717,8 @@ where
 mod tests {
     use std::collections::BTreeMap;
 
-    use reth_chain_state::EthPrimitives;
     use reth_db::test_utils::create_test_static_files_dir;
+    use reth_ethereum_primitives::EthPrimitives;
     use reth_static_file_types::{SegmentRangeInclusive, StaticFileSegment};
 
     use crate::{providers::StaticFileProvider, StaticFileProviderBuilder};


### PR DESCRIPTION
Remove the temporary EthPrimitives re-export from reth-chain-state crate.

The generic data primitives integration is complete, so the re-export is no longer needed. 

Update all usages to import directly from reth-ethereum-primitives.