### PR TITLE
feat(engine): add worker utilization logging for Loki visualization

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -48,7 +48,7 @@ use std::{
     collections::BTreeMap,
     ops::Not,
     sync::{
-        atomic::AtomicBool,
+        atomic::{AtomicBool, AtomicUsize},
         mpsc::{self, channel},
         Arc,
     },
@@ -437,6 +437,8 @@ where
             terminate_execution: Arc::new(AtomicBool::new(false)),
             precompile_cache_disabled: self.precompile_cache_disabled,
             precompile_cache_map: self.precompile_cache_map.clone(),
+            active_workers: Arc::new(AtomicUsize::new(0)),
+            total_workers: self.prewarm_max_concurrency,
         };
 
         let (prewarm_task, to_prewarm_task) = PrewarmCacheTask::new(


### PR DESCRIPTION
## Summary

Adds structured debug logs on worker state changes for:
- **Storage proof workers** (target: `trie::worker_utilization`)
- **Account proof workers** (target: `trie::worker_utilization`)
- **Prewarm workers** (target: `prewarm::worker_utilization`)

## Log Format

Each log includes:
```
worker_type = "storage" | "account" | "prewarm"
active = <current active workers>
total = <total workers in pool>
worker_id = <which worker changed state> (proof workers only)
```

## Usage

Logs are emitted when workers start and finish work, enabling millisecond-precision utilization visualization in Loki/Grafana.

**Example LogQL query:**
```logql
{app="reth"} | json | worker_type="storage"
| unwrap active | unwrap total
```

**Utilization calculation:**
```
active / total * 100 = % utilization
```

## Motivation

Enables tracking exact worker utilization at any point in time via log post-processing, which is useful for:
- Identifying bottlenecks in proof computation
- Tuning worker pool sizes
- Understanding prewarm efficiency

cc @shekhirin