### PR TITLE
feat(cli): add RocksDB storage startup flags

### DIFF
--- a/crates/cli/commands/src/common.rs
+++ b/crates/cli/commands/src/common.rs
@@ -19,7 +19,7 @@ use reth_node_builder::{
     Node, NodeComponents, NodeComponentsBuilder, NodeTypes, NodeTypesWithDBAdapter,
 };
 use reth_node_core::{
-    args::{DatabaseArgs, DatadirArgs, StaticFilesArgs},
+    args::{DatabaseArgs, DatadirArgs, StorageArgs},
     dirs::{ChainPath, DataDirPath},
 };
 use reth_provider::{
@@ -63,9 +63,9 @@ pub struct EnvironmentArgs<C: ChainSpecParser> {
     #[command(flatten)]
     pub db: DatabaseArgs,
 
-    /// All static files related arguments
+    /// All storage related arguments (static files + RocksDB tables)
     #[command(flatten)]
-    pub static_files: StaticFilesArgs,
+    pub storage: StorageArgs,
 }
 
 impl<C: ChainSpecParser> EnvironmentArgs<C> {
@@ -131,7 +131,7 @@ impl<C: ChainSpecParser> EnvironmentArgs<C> {
             self.create_provider_factory(&config, db, sfp, rocksdb_provider, access)?;
         if access.is_read_write() {
             debug!(target: "reth::cli", chain=%self.chain.chain(), genesis=?self.chain.genesis_hash(), "Initializing genesis");
-            init_genesis_with_settings(&provider_factory, self.static_files.to_settings())?;
+            init_genesis_with_settings(&provider_factory, self.storage.to_settings())?;
         }
 
         Ok(Environment { config, provider_factory, data_dir })

--- a/crates/cli/commands/src/node.rs
+++ b/crates/cli/commands/src/node.rs
@@ -10,7 +10,7 @@ use reth_node_builder::NodeBuilder;
 use reth_node_core::{
     args::{
         DatabaseArgs, DatadirArgs, DebugArgs, DevArgs, EngineArgs, EraArgs, MetricArgs,
-        NetworkArgs, PayloadBuilderArgs, PruningArgs, RpcServerArgs, StaticFilesArgs, TxPoolArgs,
+        NetworkArgs, PayloadBuilderArgs, PruningArgs, RpcServerArgs, StorageArgs, TxPoolArgs,
     },
     node_config::NodeConfig,
     version,
@@ -110,9 +110,9 @@ pub struct NodeCommand<C: ChainSpecParser, Ext: clap::Args + fmt::Debug = NoArgs
     #[command(flatten, next_help_heading = "ERA")]
     pub era: EraArgs,
 
-    /// All static files related arguments
-    #[command(flatten, next_help_heading = "Static Files")]
-    pub static_files: StaticFilesArgs,
+    /// All storage related arguments (static files + RocksDB tables)
+    #[command(flatten)]
+    pub storage: StorageArgs,
 
     /// Additional cli arguments
     #[command(flatten, next_help_heading = "Extension")]
@@ -168,7 +168,7 @@ where
             pruning,
             engine,
             era,
-            static_files,
+            storage,
             ext,
         } = self;
 
@@ -189,7 +189,7 @@ where
             pruning,
             engine,
             era,
-            static_files,
+            storage,
         };
 
         let data_dir = node_config.datadir();

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -171,8 +171,10 @@ impl LaunchContext {
         toml_config.peers.trusted_nodes_only = config.network.trusted_only;
 
         // Merge static file CLI arguments with config file, giving priority to CLI
-        toml_config.static_files =
-            config.static_files.merge_with_config(toml_config.static_files, config.pruning.minimal);
+        toml_config.static_files = config
+            .storage
+            .static_files
+            .merge_with_config(toml_config.static_files, config.pruning.minimal);
 
         Ok(toml_config)
     }
@@ -678,7 +680,7 @@ where
     pub fn with_genesis(self) -> Result<Self, InitStorageError> {
         init_genesis_with_settings(
             self.provider_factory(),
-            self.node_config().static_files.to_settings(),
+            self.node_config().storage.to_settings(),
         )?;
         Ok(self)
     }
@@ -687,7 +689,7 @@ where
     pub fn init_genesis(&self) -> Result<B256, InitStorageError> {
         init_genesis_with_settings(
             self.provider_factory(),
-            self.node_config().static_files.to_settings(),
+            self.node_config().storage.to_settings(),
         )
     }
 

--- a/crates/node/core/src/args/mod.rs
+++ b/crates/node/core/src/args/mod.rs
@@ -80,5 +80,9 @@ pub use era::{DefaultEraHost, EraArgs, EraSourceArgs};
 mod static_files;
 pub use static_files::{StaticFilesArgs, MINIMAL_BLOCKS_PER_FILE};
 
+/// `StorageArgs` for configuring storage (static files + RocksDB tables).
+mod storage;
+pub use storage::StorageArgs;
+
 mod error;
 pub mod types;

--- a/crates/node/core/src/args/storage.rs
+++ b/crates/node/core/src/args/storage.rs
@@ -1,0 +1,47 @@
+//! clap [Args](clap::Args) for storage configuration (static files + RocksDB tables)
+
+use clap::Args;
+use reth_provider::StorageSettings;
+
+use super::StaticFilesArgs;
+
+/// Parameters for storage configuration
+#[derive(Debug, Args, PartialEq, Eq, Default, Clone, Copy)]
+#[command(next_help_heading = "Storage")]
+pub struct StorageArgs {
+    /// Static files related flags.
+    #[command(flatten)]
+    pub static_files: StaticFilesArgs,
+
+    /// Store transaction hash -> number mapping in `RocksDB` instead of MDBX.
+    ///
+    /// Note: This setting can only be configured at genesis initialization. Once
+    /// the node has been initialized, changing this flag requires re-syncing from scratch.
+    #[arg(long = "storage.tx-hash-in-rocksdb")]
+    pub tx_hash_in_rocksdb: bool,
+
+    /// Store storages history in `RocksDB` instead of MDBX.
+    ///
+    /// Note: This setting can only be configured at genesis initialization. Once
+    /// the node has been initialized, changing this flag requires re-syncing from scratch.
+    #[arg(long = "storage.storages-history-in-rocksdb")]
+    pub storages_history_in_rocksdb: bool,
+
+    /// Store account history in `RocksDB` instead of MDBX.
+    ///
+    /// Note: This setting can only be configured at genesis initialization. Once
+    /// the node has been initialized, changing this flag requires re-syncing from scratch.
+    #[arg(long = "storage.account-history-in-rocksdb")]
+    pub account_history_in_rocksdb: bool,
+}
+
+impl StorageArgs {
+    /// Converts CLI storage arguments into [`StorageSettings`].
+    pub const fn to_settings(&self) -> StorageSettings {
+        self.static_files
+            .to_settings()
+            .with_transaction_hash_numbers_in_rocksdb(self.tx_hash_in_rocksdb)
+            .with_storages_history_in_rocksdb(self.storages_history_in_rocksdb)
+            .with_account_history_in_rocksdb(self.account_history_in_rocksdb)
+    }
+}

--- a/crates/node/core/src/node_config.rs
+++ b/crates/node/core/src/node_config.rs
@@ -3,7 +3,7 @@
 use crate::{
     args::{
         DatabaseArgs, DatadirArgs, DebugArgs, DevArgs, EngineArgs, NetworkArgs, PayloadBuilderArgs,
-        PruningArgs, RpcServerArgs, StaticFilesArgs, TxPoolArgs,
+        PruningArgs, RpcServerArgs, StorageArgs, TxPoolArgs,
     },
     dirs::{ChainPath, DataDirPath},
     utils::get_single_header,
@@ -148,8 +148,8 @@ pub struct NodeConfig<ChainSpec> {
     /// All ERA import related arguments with --era prefix
     pub era: EraArgs,
 
-    /// All static files related arguments
-    pub static_files: StaticFilesArgs,
+    /// All storage related arguments (static files + `RocksDB` tables)
+    pub storage: StorageArgs,
 }
 
 impl NodeConfig<ChainSpec> {
@@ -180,7 +180,7 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
             datadir: DatadirArgs::default(),
             engine: EngineArgs::default(),
             era: EraArgs::default(),
-            static_files: StaticFilesArgs::default(),
+            storage: StorageArgs::default(),
         }
     }
 
@@ -254,7 +254,7 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
             pruning,
             engine,
             era,
-            static_files,
+            storage,
             ..
         } = self;
         NodeConfig {
@@ -273,7 +273,7 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
             pruning,
             engine,
             era,
-            static_files,
+            storage,
         }
     }
 
@@ -543,7 +543,7 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
             pruning: self.pruning,
             engine: self.engine,
             era: self.era,
-            static_files: self.static_files,
+            storage: self.storage,
         }
     }
 
@@ -584,7 +584,7 @@ impl<ChainSpec> Clone for NodeConfig<ChainSpec> {
             datadir: self.datadir.clone(),
             engine: self.engine.clone(),
             era: self.era.clone(),
-            static_files: self.static_files,
+            storage: self.storage,
         }
     }
 }

--- a/docs/vocs/docs/pages/cli/op-reth/db.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/db.mdx
@@ -145,6 +145,21 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
+      --storage.tx-hash-in-rocksdb
+          Store transaction hash -> number mapping in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.storages-history-in-rocksdb
+          Store storages history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.account-history-in-rocksdb
+          Store account history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/docs/vocs/docs/pages/cli/op-reth/import-op.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/import-op.mdx
@@ -129,6 +129,21 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
+      --storage.tx-hash-in-rocksdb
+          Store transaction hash -> number mapping in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.storages-history-in-rocksdb
+          Store storages history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.account-history-in-rocksdb
+          Store account history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
       --chunk-len <CHUNK_LEN>
           Chunk byte length to read from file.
 

--- a/docs/vocs/docs/pages/cli/op-reth/import-receipts-op.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/import-receipts-op.mdx
@@ -129,6 +129,21 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
+      --storage.tx-hash-in-rocksdb
+          Store transaction hash -> number mapping in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.storages-history-in-rocksdb
+          Store storages history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.account-history-in-rocksdb
+          Store account history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
       --chunk-len <CHUNK_LEN>
           Chunk byte length to read from file.
 

--- a/docs/vocs/docs/pages/cli/op-reth/init-state.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/init-state.mdx
@@ -129,6 +129,21 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
+      --storage.tx-hash-in-rocksdb
+          Store transaction hash -> number mapping in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.storages-history-in-rocksdb
+          Store storages history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.account-history-in-rocksdb
+          Store account history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
       --without-evm
           Specifies whether to initialize the state without relying on EVM historical data.
 

--- a/docs/vocs/docs/pages/cli/op-reth/init.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/init.mdx
@@ -129,6 +129,21 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
+      --storage.tx-hash-in-rocksdb
+          Store transaction hash -> number mapping in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.storages-history-in-rocksdb
+          Store storages history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.account-history-in-rocksdb
+          Store account history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/docs/vocs/docs/pages/cli/op-reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/node.mdx
@@ -1024,6 +1024,21 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
+      --storage.tx-hash-in-rocksdb
+          Store transaction hash -> number mapping in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.storages-history-in-rocksdb
+          Store storages history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.account-history-in-rocksdb
+          Store account history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
 Rollup:
       --rollup.sequencer <SEQUENCER>
           Endpoint for the sequencer mempool (can be both HTTP and WS)

--- a/docs/vocs/docs/pages/cli/op-reth/prune.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/prune.mdx
@@ -129,6 +129,21 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
+      --storage.tx-hash-in-rocksdb
+          Store transaction hash -> number mapping in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.storages-history-in-rocksdb
+          Store storages history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.account-history-in-rocksdb
+          Store account history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/docs/vocs/docs/pages/cli/op-reth/re-execute.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/re-execute.mdx
@@ -129,6 +129,21 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
+      --storage.tx-hash-in-rocksdb
+          Store transaction hash -> number mapping in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.storages-history-in-rocksdb
+          Store storages history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.account-history-in-rocksdb
+          Store account history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
       --from <FROM>
           The height to start at
 

--- a/docs/vocs/docs/pages/cli/op-reth/stage/drop.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/stage/drop.mdx
@@ -129,6 +129,21 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
+      --storage.tx-hash-in-rocksdb
+          Store transaction hash -> number mapping in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.storages-history-in-rocksdb
+          Store storages history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.account-history-in-rocksdb
+          Store account history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
   <STAGE>
           Possible values:
           - headers:         The headers stage within the pipeline

--- a/docs/vocs/docs/pages/cli/op-reth/stage/dump.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/stage/dump.mdx
@@ -136,6 +136,21 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
+      --storage.tx-hash-in-rocksdb
+          Store transaction hash -> number mapping in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.storages-history-in-rocksdb
+          Store storages history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.account-history-in-rocksdb
+          Store account history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/docs/vocs/docs/pages/cli/op-reth/stage/run.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/stage/run.mdx
@@ -129,6 +129,21 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
+      --storage.tx-hash-in-rocksdb
+          Store transaction hash -> number mapping in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.storages-history-in-rocksdb
+          Store storages history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.account-history-in-rocksdb
+          Store account history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
       --metrics <SOCKET>
           Enable Prometheus metrics.
 

--- a/docs/vocs/docs/pages/cli/op-reth/stage/unwind.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/stage/unwind.mdx
@@ -134,6 +134,21 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
+      --storage.tx-hash-in-rocksdb
+          Store transaction hash -> number mapping in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.storages-history-in-rocksdb
+          Store storages history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.account-history-in-rocksdb
+          Store account history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
       --offline
           If this is enabled, then all stages except headers, bodies, and sender recovery will be unwound
 

--- a/docs/vocs/docs/pages/cli/reth/db.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db.mdx
@@ -145,6 +145,21 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
+      --storage.tx-hash-in-rocksdb
+          Store transaction hash -> number mapping in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.storages-history-in-rocksdb
+          Store storages history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.account-history-in-rocksdb
+          Store account history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/docs/vocs/docs/pages/cli/reth/download.mdx
+++ b/docs/vocs/docs/pages/cli/reth/download.mdx
@@ -129,6 +129,21 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
+      --storage.tx-hash-in-rocksdb
+          Store transaction hash -> number mapping in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.storages-history-in-rocksdb
+          Store storages history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.account-history-in-rocksdb
+          Store account history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
   -u, --url <URL>
           Specify a snapshot URL or let the command propose a default one.
 

--- a/docs/vocs/docs/pages/cli/reth/export-era.mdx
+++ b/docs/vocs/docs/pages/cli/reth/export-era.mdx
@@ -129,6 +129,21 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
+      --storage.tx-hash-in-rocksdb
+          Store transaction hash -> number mapping in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.storages-history-in-rocksdb
+          Store storages history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.account-history-in-rocksdb
+          Store account history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
       --first-block-number <first-block-number>
           Optional first block number to export from the db.
           It is by default 0.

--- a/docs/vocs/docs/pages/cli/reth/import-era.mdx
+++ b/docs/vocs/docs/pages/cli/reth/import-era.mdx
@@ -129,6 +129,21 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
+      --storage.tx-hash-in-rocksdb
+          Store transaction hash -> number mapping in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.storages-history-in-rocksdb
+          Store storages history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.account-history-in-rocksdb
+          Store account history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
       --path <IMPORT_ERA_PATH>
           The path to a directory for import.
 

--- a/docs/vocs/docs/pages/cli/reth/import.mdx
+++ b/docs/vocs/docs/pages/cli/reth/import.mdx
@@ -129,6 +129,21 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
+      --storage.tx-hash-in-rocksdb
+          Store transaction hash -> number mapping in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.storages-history-in-rocksdb
+          Store storages history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.account-history-in-rocksdb
+          Store account history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
       --no-state
           Disables stages that require state.
 

--- a/docs/vocs/docs/pages/cli/reth/init-state.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init-state.mdx
@@ -129,6 +129,21 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
+      --storage.tx-hash-in-rocksdb
+          Store transaction hash -> number mapping in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.storages-history-in-rocksdb
+          Store storages history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.account-history-in-rocksdb
+          Store account history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
       --without-evm
           Specifies whether to initialize the state without relying on EVM historical data.
 

--- a/docs/vocs/docs/pages/cli/reth/init.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init.mdx
@@ -129,6 +129,21 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
+      --storage.tx-hash-in-rocksdb
+          Store transaction hash -> number mapping in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.storages-history-in-rocksdb
+          Store storages history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.account-history-in-rocksdb
+          Store account history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -1024,6 +1024,21 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
+      --storage.tx-hash-in-rocksdb
+          Store transaction hash -> number mapping in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.storages-history-in-rocksdb
+          Store storages history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.account-history-in-rocksdb
+          Store account history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
 Ress:
       --ress.enable
           Enable support for `ress` subprotocol

--- a/docs/vocs/docs/pages/cli/reth/prune.mdx
+++ b/docs/vocs/docs/pages/cli/reth/prune.mdx
@@ -129,6 +129,21 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
+      --storage.tx-hash-in-rocksdb
+          Store transaction hash -> number mapping in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.storages-history-in-rocksdb
+          Store storages history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.account-history-in-rocksdb
+          Store account history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/docs/vocs/docs/pages/cli/reth/re-execute.mdx
+++ b/docs/vocs/docs/pages/cli/reth/re-execute.mdx
@@ -129,6 +129,21 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
+      --storage.tx-hash-in-rocksdb
+          Store transaction hash -> number mapping in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.storages-history-in-rocksdb
+          Store storages history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.account-history-in-rocksdb
+          Store account history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
       --from <FROM>
           The height to start at
 

--- a/docs/vocs/docs/pages/cli/reth/stage/drop.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/drop.mdx
@@ -129,6 +129,21 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
+      --storage.tx-hash-in-rocksdb
+          Store transaction hash -> number mapping in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.storages-history-in-rocksdb
+          Store storages history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.account-history-in-rocksdb
+          Store account history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
   <STAGE>
           Possible values:
           - headers:         The headers stage within the pipeline

--- a/docs/vocs/docs/pages/cli/reth/stage/dump.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump.mdx
@@ -136,6 +136,21 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
+      --storage.tx-hash-in-rocksdb
+          Store transaction hash -> number mapping in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.storages-history-in-rocksdb
+          Store storages history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.account-history-in-rocksdb
+          Store account history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/docs/vocs/docs/pages/cli/reth/stage/run.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/run.mdx
@@ -129,6 +129,21 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
+      --storage.tx-hash-in-rocksdb
+          Store transaction hash -> number mapping in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.storages-history-in-rocksdb
+          Store storages history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.account-history-in-rocksdb
+          Store account history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
       --metrics <SOCKET>
           Enable Prometheus metrics.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/unwind.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/unwind.mdx
@@ -134,6 +134,21 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
+      --storage.tx-hash-in-rocksdb
+          Store transaction hash -> number mapping in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.storages-history-in-rocksdb
+          Store storages history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
+      --storage.account-history-in-rocksdb
+          Store account history in `RocksDB` instead of MDBX.
+
+          Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
+
       --offline
           If this is enabled, then all stages except headers, bodies, and sender recovery will be unwound
 


### PR DESCRIPTION
## Summary

Add CLI flags to control which storage tables use RocksDB vs MDBX at genesis initialization.

## New Flags

- `--storage.tx-hash-in-rocksdb=<true|false>` - Store transaction hash lookups in RocksDB
- `--storage.storages-history-in-rocksdb=<true|false>` - Store storage history in RocksDB
- `--storage.account-history-in-rocksdb=<true|false>` - Store account history in RocksDB

These flags can only be set during genesis initialization. Once the node is initialized, these settings are persisted to database metadata.

## PR Stack

| PR | Title | Status |
|---|---|---|
| #21181 | feat(cli): add RocksDB storage startup flags | ← **this PR** |
| #21189 | feat(storage): add startup validation for RocksDB CLI flags | depends on #21181 |

Closes https://github.com/paradigmxyz/reth/issues/20393