### PR TITLE
chore: apply spelling and typo fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,7 +249,7 @@ Write comments that remain valuable after the PR is merged. Future readers won't
 unsafe impl GlobalAlloc for LimitedAllocator { ... }
 
 // Binary search requires sorted input. Panics on unsorted slices.
-fn find_index(items: &[Item], target: &Item) -> Option
+fn find_index(items: &[Item], target: &Item) -> Option<usize>
 
 // Timeout set to 5s to match EVM block processing limits
 const TRACER_TIMEOUT: Duration = Duration::from_secs(5);

--- a/crates/ethereum/node/tests/e2e/pool.rs
+++ b/crates/ethereum/node/tests/e2e/pool.rs
@@ -153,7 +153,7 @@ async fn maintain_txpool_reorg() -> eyre::Result<()> {
         w1.address(),
     );
     let pooled_tx1 = EthPooledTransaction::new(tx1.clone(), 200);
-    let tx_hash1 = *pooled_tx1.clone().hash();
+    let tx_hash1 = *pooled_tx1.hash();
 
     // build tx2 from wallet2
     let envelop2 = TransactionTestContext::transfer_tx(1, w2.clone()).await;
@@ -162,7 +162,7 @@ async fn maintain_txpool_reorg() -> eyre::Result<()> {
         w2.address(),
     );
     let pooled_tx2 = EthPooledTransaction::new(tx2.clone(), 200);
-    let tx_hash2 = *pooled_tx2.clone().hash();
+    let tx_hash2 = *pooled_tx2.hash();
 
     let block_info = BlockInfo {
         block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,

--- a/crates/ethereum/primitives/src/transaction.rs
+++ b/crates/ethereum/primitives/src/transaction.rs
@@ -236,7 +236,7 @@ impl reth_codecs::Compact for Transaction {
     // # Panics
     //
     // A panic will be triggered if an identifier larger than 3 is passed from the database. For
-    // optimism a identifier with value [`DEPOSIT_TX_TYPE_ID`] is allowed.
+    // optimism an identifier with value [`DEPOSIT_TX_TYPE_ID`] is allowed.
     fn from_compact(buf: &[u8], identifier: usize) -> (Self, &[u8]) {
         let (tx_type, buf) = TxType::from_compact(buf, identifier);
 

--- a/crates/net/banlist/src/lib.rs
+++ b/crates/net/banlist/src/lib.rs
@@ -106,7 +106,7 @@ impl BanList {
         self.banned_ips.contains_key(ip)
     }
 
-    /// checks the ban list to see if it contains the given ip
+    /// checks the ban list to see if it contains the given peer
     #[inline]
     pub fn is_banned_peer(&self, peer_id: &PeerId) -> bool {
         self.banned_peers.contains_key(peer_id)
@@ -117,7 +117,7 @@ impl BanList {
         self.banned_ips.remove(ip);
     }
 
-    /// Unbans the ip address
+    /// Unbans the peer
     pub fn unban_peer(&mut self, peer_id: &PeerId) {
         self.banned_peers.remove(peer_id);
     }

--- a/crates/storage/codecs/derive/src/compact/generator.rs
+++ b/crates/storage/codecs/derive/src/compact/generator.rs
@@ -69,7 +69,7 @@ pub fn generate_from_to(
     }
 }
 
-/// Generates code to implement the `Compact` trait method `to_compact`.
+/// Generates code to implement the `Compact` trait method `from_compact`.
 fn generate_from_compact(
     fields: &FieldList,
     ident: &Ident,
@@ -155,7 +155,7 @@ fn generate_from_compact(
     }
 }
 
-/// Generates code to implement the `Compact` trait method `from_compact`.
+/// Generates code to implement the `Compact` trait method `to_compact`.
 fn generate_to_compact(
     fields: &FieldList,
     ident: &Ident,

--- a/crates/storage/codecs/derive/src/compact/mod.rs
+++ b/crates/storage/codecs/derive/src/compact/mod.rs
@@ -175,7 +175,7 @@ fn should_use_alt_impl(ftype: &str, segment: &syn::PathSegment) -> bool {
         let syn::PathArguments::AngleBracketed(ref args) = segment.arguments &&
         let Some(syn::GenericArgument::Type(syn::Type::Path(arg_path))) = args.args.last() &&
         let (Some(path), 1) = (arg_path.path.segments.first(), arg_path.path.segments.len()) &&
-        ["B256", "Address", "Address", "Bloom", "TxHash", "BlockHash", "CompactPlaceholder"]
+        ["B256", "Address", "Bloom", "TxHash", "BlockHash", "CompactPlaceholder"]
             .iter()
             .any(|&s| path.ident == s)
     {

--- a/crates/storage/libmdbx-rs/src/cursor.rs
+++ b/crates/storage/libmdbx-rs/src/cursor.rs
@@ -312,7 +312,7 @@ where
     }
 
     /// Position at first key-value pair greater than or equal to specified, return both key and
-    /// data, and the return code depends on a exact match.
+    /// data, and the return code depends on an exact match.
     ///
     /// For non DupSort-ed collections this works the same as [`Self::set_range()`], but returns
     /// [false] if key found exactly and [true] if greater key was found.

--- a/crates/storage/nippy-jar/src/consistency.rs
+++ b/crates/storage/nippy-jar/src/consistency.rs
@@ -37,12 +37,12 @@ impl<H: NippyJarHeader> NippyJarChecker<H> {
         Self { jar, data_file: None, offsets_file: None }
     }
 
-    /// It will throw an error if the [`NippyJar`] is in a inconsistent state.
+    /// It will throw an error if the [`NippyJar`] is in an inconsistent state.
     pub fn check_consistency(&mut self) -> Result<(), NippyJarError> {
         self.handle_consistency(ConsistencyFailStrategy::ThrowError)
     }
 
-    /// It will attempt to heal if the [`NippyJar`] is in a inconsistent state.
+    /// It will attempt to heal if the [`NippyJar`] is in an inconsistent state.
     ///
     /// **ATTENTION**: disk commit should be handled externally by consuming `Self`
     pub fn ensure_consistency(&mut self) -> Result<(), NippyJarError> {

--- a/docs/design/database.md
+++ b/docs/design/database.md
@@ -13,9 +13,9 @@
   - It also enables [out-of-the-box fuzzing](https://github.com/paradigmxyz/reth/blob/main/crates/storage/db-api/src/tables/codecs/fuzz/mod.rs) using [trailofbits/test-fuzz](https://github.com/trailofbits/test-fuzz).
 - We implemented that trait for the following encoding formats:
   - [Ethereum-specific Compact Encoding](https://github.com/paradigmxyz/reth/blob/main/crates/storage/codecs/derive/src/compact/mod.rs): A lot of Ethereum datatypes have unnecessary zeros when serialized, or optional (e.g. on empty hashes) which would be nice not to pay in storage costs.
-    - [Erigon](https://github.com/ledgerwatch/erigon/blob/12ee33a492f5d240458822d052820d9998653a63/docs/programmers_guide/db_walkthrough.MD) achieves that by having a `bitfield` set on Table "PlainState which adds a bitfield to Accounts.
+    - [Erigon](https://github.com/ledgerwatch/erigon/blob/12ee33a492f5d240458822d052820d9998653a63/docs/programmers_guide/db_walkthrough.MD) achieves that by having a `bitfield` set on Table "PlainState" which adds a bitfield to Accounts.
     - [Akula](https://github.com/akula-bft/akula/) expanded it for other tables and datatypes manually. It also saved some more space by storing the length of certain types (U256, u64) using the [`modular_bitfield`](https://docs.rs/modular-bitfield/latest/modular_bitfield/) crate, which compacts this information.
-    - We generalized it for all types, by writing a derive macro that autogenerates code for implementing the trait. It, also generates the interfaces required for fuzzing using ToB/test-fuzz:
+    - We generalized it for all types, by writing a derive macro that autogenerates code for implementing the trait. It also generates the interfaces required for fuzzing using ToB/test-fuzz:
   - [Scale Encoding](https://github.com/paritytech/parity-scale-codec)
   - [Postcard Encoding](https://github.com/jamesmunns/postcard)
   - Passthrough (called `no_codec` in the codebase)

--- a/docs/repo/layout.md
+++ b/docs/repo/layout.md
@@ -23,6 +23,7 @@ Generally, reth is composed of a few components, with supporting crates. The mai
   - [Payloads](#payloads)
   - [Primitives](#primitives)
   - [Optimism](#optimism)
+  - [Ethereum](#ethereum-specific-crates)
   - [Misc](#misc)
 
 The supporting crates are split into two categories: [primitives](#primitives) and [miscellaneous](#misc).
@@ -181,7 +182,7 @@ These crates define primitive types or algorithms.
 
 Crates related to the Optimism rollup live in [optimism](../../crates/optimism/).
 
-#### Ethereum-Specific Crates
+### Ethereum-Specific Crates
 
 Ethereum mainnet-specific implementations and primitives live in `crates/ethereum/`.
 


### PR DESCRIPTION
Combined minor spelling and typo fixes from multiple closed PRs that were labeled 'spelling'. These PRs were closed as individual changes weren't worth separate PRs, but the fixes are still valid.

Fixes from:
- [docs: add Ethereum section to table of contents and fix heading level](https://github.com/paradigmxyz/reth/pull/21170)
- [docs(banlist): fix doc comments referencing ip instead of peer](https://github.com/paradigmxyz/reth/pull/21044)
- [fix: correct comment references and remove duplicate in codecs derive](https://github.com/paradigmxyz/reth/pull/20977)
- [fix: typos and grammatical errors in comments and docstrings](https://github.com/paradigmxyz/reth/pull/20936)
- [fix(rpc): correct parameter name in MinerApi::set_gas_limit](https://github.com/paradigmxyz/reth/pull/20926)
- [chore: remove pooled transaction clones](https://github.com/paradigmxyz/reth/pull/20910)
- [docs: fix grammar in comments](https://github.com/paradigmxyz/reth/pull/20909)
- [fix: typos in error messages and comments](https://github.com/paradigmxyz/reth/pull/20908)
- [docs: fix broken Next Chapter link in reth-db crate docs](https://github.com/paradigmxyz/reth/pull/20907)
- [chore(trie): fix typo in comment](https://github.com/paradigmxyz/reth/pull/20870)
- [docs(storage): fix typos in storage crates](https://github.com/paradigmxyz/reth/pull/20673)