### PR TITLE
perf(storage): add bloom filter for empty storage slots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4492,6 +4492,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "growable-bloom-filter"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d174ccb4ba660d431329e7f0797870d0a4281e36353ec4b4a3c5eab6c2cfb6f1"
+dependencies = [
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "xxhash-rust",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10240,6 +10252,7 @@ dependencies = [
  "reth-stages-types",
  "reth-static-file-types",
  "reth-storage-api",
+ "reth-storage-bloom",
  "reth-storage-errors",
  "reth-testing-utils",
  "reth-tracing",
@@ -10964,6 +10977,23 @@ dependencies = [
  "reth-trie-common",
  "revm-database",
  "serde_json",
+]
+
+[[package]]
+name = "reth-storage-bloom"
+version = "1.10.0"
+dependencies = [
+ "alloy-primitives",
+ "bincode 1.3.3",
+ "growable-bloom-filter",
+ "metrics",
+ "parking_lot",
+ "rand 0.9.2",
+ "reth-metrics",
+ "reth-storage-errors",
+ "serde",
+ "tempfile",
+ "tracing",
 ]
 
 [[package]]
@@ -12108,6 +12138,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -14479,6 +14519,12 @@ name = "xsum"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0637d3a5566a82fa5214bae89087bc8c9fb94cd8e8a3c07feb691bb8d9c632db"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yansi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10985,15 +10985,12 @@ name = "reth-storage-bloom"
 version = "1.10.0"
 dependencies = [
  "alloy-primitives",
- "bincode 1.3.3",
  "growable-bloom-filter",
  "metrics",
  "parking_lot",
  "rand 0.9.2",
  "reth-metrics",
  "reth-storage-errors",
- "serde",
- "tempfile",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8514,6 +8514,7 @@ dependencies = [
  "reth-stages",
  "reth-stages-api",
  "reth-static-file",
+ "reth-storage-bloom",
  "reth-tasks",
  "reth-testing-utils",
  "reth-tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,7 @@ members = [
     "crates/storage/nippy-jar/",
     "crates/storage/provider/",
     "crates/storage/storage-api/",
+    "crates/storage/storage-bloom/",
     "crates/storage/zstd-compressors/",
     "crates/tasks/",
     "crates/tokio-util/",
@@ -455,6 +456,7 @@ reth-stateless = { path = "crates/stateless", default-features = false }
 reth-static-file = { path = "crates/static-file/static-file" }
 reth-static-file-types = { path = "crates/static-file/types", default-features = false }
 reth-storage-api = { path = "crates/storage/storage-api", default-features = false }
+reth-storage-bloom = { path = "crates/storage/storage-bloom" }
 reth-storage-errors = { path = "crates/storage/errors", default-features = false }
 reth-tasks = { path = "crates/tasks" }
 reth-testing-utils = { path = "testing/testing-utils" }

--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -36,6 +36,7 @@ reth-trie-sparse-parallel = { workspace = true, features = ["std"] }
 reth-trie.workspace = true
 reth-trie-common.workspace = true
 reth-trie-db.workspace = true
+reth-storage-bloom = { workspace = true, optional = true }
 
 # alloy
 alloy-evm.workspace = true
@@ -117,6 +118,7 @@ name = "state_root_task"
 harness = false
 
 [features]
+storage-bloom = ["reth-storage-bloom", "reth-provider/storage-bloom"]
 test-utils = [
     "reth-chain-state/test-utils",
     "reth-chainspec/test-utils",

--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -118,7 +118,7 @@ name = "state_root_task"
 harness = false
 
 [features]
-storage-bloom = ["reth-storage-bloom", "reth-provider/storage-bloom"]
+storage-bloom = ["dep:reth-storage-bloom", "reth-provider/storage-bloom"]
 test-utils = [
     "reth-chain-state/test-utils",
     "reth-chainspec/test-utils",

--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -36,7 +36,7 @@ reth-trie-sparse-parallel = { workspace = true, features = ["std"] }
 reth-trie.workspace = true
 reth-trie-common.workspace = true
 reth-trie-db.workspace = true
-reth-storage-bloom = { workspace = true, optional = true }
+reth-storage-bloom.workspace = true
 
 # alloy
 alloy-evm.workspace = true
@@ -118,7 +118,6 @@ name = "state_root_task"
 harness = false
 
 [features]
-storage-bloom = ["dep:reth-storage-bloom", "reth-provider/storage-bloom"]
 test-utils = [
     "reth-chain-state/test-utils",
     "reth-chainspec/test-utils",

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -201,7 +201,7 @@ where
 
     /// Returns a reference to the storage bloom filter.
     #[cfg(feature = "storage-bloom")]
-    pub fn storage_bloom(&self) -> &Arc<StorageBloomFilter> {
+    pub const fn storage_bloom(&self) -> &Arc<StorageBloomFilter> {
         &self.storage_bloom
     }
 

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -35,16 +35,13 @@ use reth_primitives_traits::{
     AlloyBlockHeader, BlockBody, BlockTy, GotExpected, NodePrimitives, RecoveredBlock, SealedBlock,
     SealedHeader, SignerRecoverable,
 };
-#[cfg(feature = "storage-bloom")]
-use reth_provider::providers::BloomStateProvider;
 use reth_provider::{
-    providers::OverlayStateProviderFactory, BlockExecutionOutput, BlockNumReader, BlockReader,
-    ChangeSetReader, DatabaseProviderFactory, DatabaseProviderROFactory, HashedPostStateProvider,
-    ProviderError, PruneCheckpointReader, StageCheckpointReader, StateProvider,
-    StateProviderFactory, StateReader,
+    providers::{BloomStateProvider, OverlayStateProviderFactory},
+    BlockExecutionOutput, BlockNumReader, BlockReader, ChangeSetReader, DatabaseProviderFactory,
+    DatabaseProviderROFactory, HashedPostStateProvider, ProviderError, PruneCheckpointReader,
+    StageCheckpointReader, StateProvider, StateProviderFactory, StateReader,
 };
 use reth_revm::db::State;
-#[cfg(feature = "storage-bloom")]
 use reth_storage_bloom::StorageBloomFilter;
 use reth_trie::{updates::TrieUpdates, HashedPostState, StateRoot};
 use reth_trie_db::ChangesetCache;
@@ -139,7 +136,6 @@ where
     /// Changeset cache for in-memory trie changesets
     changeset_cache: ChangesetCache,
     /// Storage bloom filter for optimizing empty slot reads.
-    #[cfg(feature = "storage-bloom")]
     storage_bloom: Arc<StorageBloomFilter>,
 }
 
@@ -181,7 +177,6 @@ where
             precompile_cache_map.clone(),
         );
 
-        #[cfg(feature = "storage-bloom")]
         let storage_bloom =
             Arc::new(StorageBloomFilter::new(reth_storage_bloom::StorageBloomConfig::default()));
 
@@ -197,13 +192,11 @@ where
             metrics: EngineApiMetrics::default(),
             validator,
             changeset_cache,
-            #[cfg(feature = "storage-bloom")]
             storage_bloom,
         }
     }
 
     /// Returns a reference to the storage bloom filter.
-    #[cfg(feature = "storage-bloom")]
     pub const fn storage_bloom(&self) -> &Arc<StorageBloomFilter> {
         &self.storage_bloom
     }
@@ -476,7 +469,6 @@ where
         }
 
         // Wrap state provider with bloom filter to short-circuit empty slot reads.
-        #[cfg(feature = "storage-bloom")]
         let state_provider =
             Box::new(BloomStateProvider::new(state_provider, self.storage_bloom.clone()));
 

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -172,7 +172,6 @@ where
         config: TreeConfig,
         invalid_block_hook: Box<dyn InvalidBlockHook<N>>,
         changeset_cache: ChangesetCache,
-        #[cfg(feature = "storage-bloom")] storage_bloom: Arc<StorageBloomFilter>,
     ) -> Self {
         let precompile_cache_map = PrecompileCacheMap::default();
         let payload_processor = PayloadProcessor::new(
@@ -181,6 +180,10 @@ where
             &config,
             precompile_cache_map.clone(),
         );
+
+        #[cfg(feature = "storage-bloom")]
+        let storage_bloom =
+            Arc::new(StorageBloomFilter::new(reth_storage_bloom::StorageBloomConfig::default()));
 
         Self {
             provider,

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -20,7 +20,7 @@ reth-primitives-traits = { workspace = true, features = ["reth-codec", "secp256k
 reth-errors.workspace = true
 reth-storage-errors.workspace = true
 reth-storage-api = { workspace = true, features = ["std", "db-api"] }
-reth-storage-bloom = { workspace = true, optional = true }
+reth-storage-bloom.workspace = true
 reth-db = { workspace = true, features = ["mdbx"] }
 reth-db-api.workspace = true
 reth-prune-types.workspace = true
@@ -87,7 +87,6 @@ tokio = { workspace = true, features = ["sync", "macros", "rt-multi-thread"] }
 
 [features]
 rocksdb = ["dep:rocksdb"]
-storage-bloom = ["dep:reth-storage-bloom"]
 test-utils = [
     "reth-db/test-utils",
     "reth-nippy-jar/test-utils",

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -20,6 +20,7 @@ reth-primitives-traits = { workspace = true, features = ["reth-codec", "secp256k
 reth-errors.workspace = true
 reth-storage-errors.workspace = true
 reth-storage-api = { workspace = true, features = ["std", "db-api"] }
+reth-storage-bloom = { workspace = true, optional = true }
 reth-db = { workspace = true, features = ["mdbx"] }
 reth-db-api.workspace = true
 reth-prune-types.workspace = true
@@ -86,6 +87,7 @@ tokio = { workspace = true, features = ["sync", "macros", "rt-multi-thread"] }
 
 [features]
 rocksdb = ["dep:rocksdb"]
+storage-bloom = ["dep:reth-storage-bloom"]
 test-utils = [
     "reth-db/test-utils",
     "reth-nippy-jar/test-utils",

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -14,6 +14,9 @@ pub use static_file::{
 };
 
 mod state;
+#[cfg(feature = "storage-bloom")]
+#[allow(unused_imports)] // Not yet integrated into main code path
+pub(crate) use state::bloom::BloomStateProvider;
 pub use state::{
     historical::{
         compute_history_rank, history_info, needs_prev_shard_check, HistoricalStateProvider,

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -14,9 +14,8 @@ pub use static_file::{
 };
 
 mod state;
-#[cfg(feature = "storage-bloom")]
-pub use state::bloom::BloomStateProvider;
 pub use state::{
+    bloom::BloomStateProvider,
     historical::{
         compute_history_rank, history_info, needs_prev_shard_check, HistoricalStateProvider,
         HistoricalStateProviderRef, HistoryInfo, LowestAvailableBlocks,

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -15,8 +15,7 @@ pub use static_file::{
 
 mod state;
 #[cfg(feature = "storage-bloom")]
-#[allow(unused_imports)] // Not yet integrated into main code path
-pub(crate) use state::bloom::BloomStateProvider;
+pub use state::bloom::BloomStateProvider;
 pub use state::{
     historical::{
         compute_history_rank, history_info, needs_prev_shard_check, HistoricalStateProvider,

--- a/crates/storage/provider/src/providers/state/bloom.rs
+++ b/crates/storage/provider/src/providers/state/bloom.rs
@@ -25,7 +25,6 @@ use std::sync::Arc;
 /// - If the bloom filter says the slot is definitely empty, returns `None` without DB access
 /// - If the bloom filter says the slot might exist, proceeds with normal DB lookup
 #[derive(Debug)]
-#[allow(unreachable_pub)] // Will be used once integrated
 pub struct BloomStateProvider<P> {
     /// The underlying state provider.
     inner: P,
@@ -33,7 +32,6 @@ pub struct BloomStateProvider<P> {
     bloom: Arc<StorageBloomFilter>,
 }
 
-#[allow(dead_code, unreachable_pub)] // Not yet integrated into main code path
 impl<P> BloomStateProvider<P> {
     /// Create a new bloom-aware state provider.
     pub const fn new(inner: P, bloom: Arc<StorageBloomFilter>) -> Self {

--- a/crates/storage/provider/src/providers/state/bloom.rs
+++ b/crates/storage/provider/src/providers/state/bloom.rs
@@ -220,7 +220,11 @@ mod tests {
         fn block_hash(&self, _: u64) -> ProviderResult<Option<B256>> {
             Ok(None)
         }
-        fn canonical_hashes_range(&self, _: BlockNumber, _: BlockNumber) -> ProviderResult<Vec<B256>> {
+        fn canonical_hashes_range(
+            &self,
+            _: BlockNumber,
+            _: BlockNumber,
+        ) -> ProviderResult<Vec<B256>> {
             Ok(vec![])
         }
     }
@@ -238,10 +242,16 @@ mod tests {
         fn state_root_from_nodes(&self, _: TrieInput) -> ProviderResult<B256> {
             Ok(B256::ZERO)
         }
-        fn state_root_with_updates(&self, _: HashedPostState) -> ProviderResult<(B256, TrieUpdates)> {
+        fn state_root_with_updates(
+            &self,
+            _: HashedPostState,
+        ) -> ProviderResult<(B256, TrieUpdates)> {
             Ok((B256::ZERO, TrieUpdates::default()))
         }
-        fn state_root_from_nodes_with_updates(&self, _: TrieInput) -> ProviderResult<(B256, TrieUpdates)> {
+        fn state_root_from_nodes_with_updates(
+            &self,
+            _: TrieInput,
+        ) -> ProviderResult<(B256, TrieUpdates)> {
             Ok((B256::ZERO, TrieUpdates::default()))
         }
     }
@@ -250,10 +260,20 @@ mod tests {
         fn storage_root(&self, _: Address, _: HashedStorage) -> ProviderResult<B256> {
             Ok(B256::ZERO)
         }
-        fn storage_proof(&self, _: Address, _: B256, _: HashedStorage) -> ProviderResult<reth_trie::StorageProof> {
+        fn storage_proof(
+            &self,
+            _: Address,
+            _: B256,
+            _: HashedStorage,
+        ) -> ProviderResult<reth_trie::StorageProof> {
             unimplemented!()
         }
-        fn storage_multiproof(&self, _: Address, _: &[B256], _: HashedStorage) -> ProviderResult<StorageMultiProof> {
+        fn storage_multiproof(
+            &self,
+            _: Address,
+            _: &[B256],
+            _: HashedStorage,
+        ) -> ProviderResult<StorageMultiProof> {
             unimplemented!()
         }
     }
@@ -285,11 +305,8 @@ mod tests {
 
     #[test]
     fn test_bloom_skips_db_for_empty_slots() {
-        let config = StorageBloomConfig {
-            expected_items: 1000,
-            false_positive_rate: 0.01,
-            enabled: true,
-        };
+        let config =
+            StorageBloomConfig { expected_items: 1000, false_positive_rate: 0.01, enabled: true };
         let bloom = Arc::new(StorageBloomFilter::new(config));
         let mock = MockStateProvider::new();
         let provider = BloomStateProvider::new(mock, bloom);
@@ -305,11 +322,8 @@ mod tests {
 
     #[test]
     fn test_bloom_checks_db_for_maybe_present() {
-        let config = StorageBloomConfig {
-            expected_items: 1000,
-            false_positive_rate: 0.01,
-            enabled: true,
-        };
+        let config =
+            StorageBloomConfig { expected_items: 1000, false_positive_rate: 0.01, enabled: true };
         let bloom = Arc::new(StorageBloomFilter::new(config));
 
         let addr = Address::repeat_byte(0x42);

--- a/crates/storage/provider/src/providers/state/bloom.rs
+++ b/crates/storage/provider/src/providers/state/bloom.rs
@@ -1,0 +1,329 @@
+//! Bloom filter-aware state provider wrapper.
+//!
+//! This module provides a state provider wrapper that uses a bloom filter to
+//! short-circuit storage reads for empty slots.
+
+use crate::StateProvider;
+use alloy_primitives::{Address, BlockNumber, Bytes, StorageKey, StorageValue, B256};
+use reth_primitives_traits::{Account, Bytecode};
+use reth_storage_api::{
+    AccountReader, BlockHashReader, BytecodeReader, HashedPostStateProvider, StateProofProvider,
+    StateRootProvider, StorageRootProvider,
+};
+use reth_storage_bloom::{StorageBloomFilter, StorageBloomProvider};
+use reth_storage_errors::provider::ProviderResult;
+use reth_trie::{
+    updates::TrieUpdates, AccountProof, HashedPostState, HashedStorage, MultiProof,
+    MultiProofTargets, StorageMultiProof, TrieInput,
+};
+use revm_database::BundleState;
+use std::sync::Arc;
+
+/// A state provider wrapper that uses a bloom filter to optimize storage reads.
+///
+/// When reading storage, this provider first checks the bloom filter:
+/// - If the bloom filter says the slot is definitely empty, returns `None` without DB access
+/// - If the bloom filter says the slot might exist, proceeds with normal DB lookup
+#[derive(Debug)]
+pub(crate) struct BloomStateProvider<P> {
+    /// The underlying state provider.
+    inner: P,
+    /// The storage bloom filter.
+    bloom: Arc<StorageBloomFilter>,
+}
+
+impl<P> BloomStateProvider<P> {
+    /// Create a new bloom-aware state provider.
+    pub const fn new(inner: P, bloom: Arc<StorageBloomFilter>) -> Self {
+        Self { inner, bloom }
+    }
+
+    /// Get the underlying provider.
+    pub const fn inner(&self) -> &P {
+        &self.inner
+    }
+
+    /// Get the bloom filter.
+    pub fn bloom(&self) -> &Arc<StorageBloomFilter> {
+        &self.bloom
+    }
+}
+
+impl<P> StorageBloomProvider for BloomStateProvider<P> {
+    fn storage_bloom(&self) -> Option<&Arc<StorageBloomFilter>> {
+        Some(&self.bloom)
+    }
+}
+
+impl<P: AccountReader> AccountReader for BloomStateProvider<P> {
+    fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
+        self.inner.basic_account(address)
+    }
+}
+
+impl<P: BlockHashReader> BlockHashReader for BloomStateProvider<P> {
+    fn block_hash(&self, number: u64) -> ProviderResult<Option<B256>> {
+        self.inner.block_hash(number)
+    }
+
+    fn canonical_hashes_range(
+        &self,
+        start: BlockNumber,
+        end: BlockNumber,
+    ) -> ProviderResult<Vec<B256>> {
+        self.inner.canonical_hashes_range(start, end)
+    }
+}
+
+impl<P: BytecodeReader> BytecodeReader for BloomStateProvider<P> {
+    fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>> {
+        self.inner.bytecode_by_hash(code_hash)
+    }
+}
+
+impl<P: StateRootProvider> StateRootProvider for BloomStateProvider<P> {
+    fn state_root(&self, hashed_state: HashedPostState) -> ProviderResult<B256> {
+        self.inner.state_root(hashed_state)
+    }
+
+    fn state_root_from_nodes(&self, input: TrieInput) -> ProviderResult<B256> {
+        self.inner.state_root_from_nodes(input)
+    }
+
+    fn state_root_with_updates(
+        &self,
+        hashed_state: HashedPostState,
+    ) -> ProviderResult<(B256, TrieUpdates)> {
+        self.inner.state_root_with_updates(hashed_state)
+    }
+
+    fn state_root_from_nodes_with_updates(
+        &self,
+        input: TrieInput,
+    ) -> ProviderResult<(B256, TrieUpdates)> {
+        self.inner.state_root_from_nodes_with_updates(input)
+    }
+}
+
+impl<P: StorageRootProvider> StorageRootProvider for BloomStateProvider<P> {
+    fn storage_root(
+        &self,
+        address: Address,
+        hashed_storage: HashedStorage,
+    ) -> ProviderResult<B256> {
+        self.inner.storage_root(address, hashed_storage)
+    }
+
+    fn storage_proof(
+        &self,
+        address: Address,
+        slot: B256,
+        hashed_storage: HashedStorage,
+    ) -> ProviderResult<reth_trie::StorageProof> {
+        self.inner.storage_proof(address, slot, hashed_storage)
+    }
+
+    fn storage_multiproof(
+        &self,
+        address: Address,
+        slots: &[B256],
+        hashed_storage: HashedStorage,
+    ) -> ProviderResult<StorageMultiProof> {
+        self.inner.storage_multiproof(address, slots, hashed_storage)
+    }
+}
+
+impl<P: StateProofProvider> StateProofProvider for BloomStateProvider<P> {
+    fn proof(
+        &self,
+        input: TrieInput,
+        address: Address,
+        slots: &[B256],
+    ) -> ProviderResult<AccountProof> {
+        self.inner.proof(input, address, slots)
+    }
+
+    fn multiproof(
+        &self,
+        input: TrieInput,
+        targets: MultiProofTargets,
+    ) -> ProviderResult<MultiProof> {
+        self.inner.multiproof(input, targets)
+    }
+
+    fn witness(&self, input: TrieInput, target: HashedPostState) -> ProviderResult<Vec<Bytes>> {
+        self.inner.witness(input, target)
+    }
+}
+
+impl<P: HashedPostStateProvider> HashedPostStateProvider for BloomStateProvider<P> {
+    fn hashed_post_state(&self, bundle_state: &BundleState) -> HashedPostState {
+        self.inner.hashed_post_state(bundle_state)
+    }
+}
+
+impl<P: StateProvider> StateProvider for BloomStateProvider<P> {
+    /// Get storage with bloom filter optimization.
+    ///
+    /// If the bloom filter indicates the slot is definitely empty,
+    /// returns `None` without hitting the database.
+    fn storage(
+        &self,
+        account: Address,
+        storage_key: StorageKey,
+    ) -> ProviderResult<Option<StorageValue>> {
+        // Check bloom filter first
+        if !self.bloom.maybe_contains(account, storage_key) {
+            // Definitely not present - return None without DB lookup
+            return Ok(None);
+        }
+
+        // Maybe present - need to check DB
+        let result = self.inner.storage(account, storage_key)?;
+
+        // Track false positives for metrics
+        if result.is_none() || result == Some(StorageValue::ZERO) {
+            self.bloom.record_false_positive();
+        }
+
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reth_storage_bloom::StorageBloomConfig;
+
+    /// Mock state provider for testing.
+    struct MockStateProvider {
+        storage_calls: std::sync::atomic::AtomicUsize,
+    }
+
+    impl MockStateProvider {
+        fn new() -> Self {
+            Self { storage_calls: std::sync::atomic::AtomicUsize::new(0) }
+        }
+
+        fn storage_call_count(&self) -> usize {
+            self.storage_calls.load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    impl AccountReader for MockStateProvider {
+        fn basic_account(&self, _: &Address) -> ProviderResult<Option<Account>> {
+            Ok(None)
+        }
+    }
+
+    impl BlockHashReader for MockStateProvider {
+        fn block_hash(&self, _: u64) -> ProviderResult<Option<B256>> {
+            Ok(None)
+        }
+        fn canonical_hashes_range(&self, _: BlockNumber, _: BlockNumber) -> ProviderResult<Vec<B256>> {
+            Ok(vec![])
+        }
+    }
+
+    impl BytecodeReader for MockStateProvider {
+        fn bytecode_by_hash(&self, _: &B256) -> ProviderResult<Option<Bytecode>> {
+            Ok(None)
+        }
+    }
+
+    impl StateRootProvider for MockStateProvider {
+        fn state_root(&self, _: HashedPostState) -> ProviderResult<B256> {
+            Ok(B256::ZERO)
+        }
+        fn state_root_from_nodes(&self, _: TrieInput) -> ProviderResult<B256> {
+            Ok(B256::ZERO)
+        }
+        fn state_root_with_updates(&self, _: HashedPostState) -> ProviderResult<(B256, TrieUpdates)> {
+            Ok((B256::ZERO, TrieUpdates::default()))
+        }
+        fn state_root_from_nodes_with_updates(&self, _: TrieInput) -> ProviderResult<(B256, TrieUpdates)> {
+            Ok((B256::ZERO, TrieUpdates::default()))
+        }
+    }
+
+    impl StorageRootProvider for MockStateProvider {
+        fn storage_root(&self, _: Address, _: HashedStorage) -> ProviderResult<B256> {
+            Ok(B256::ZERO)
+        }
+        fn storage_proof(&self, _: Address, _: B256, _: HashedStorage) -> ProviderResult<reth_trie::StorageProof> {
+            unimplemented!()
+        }
+        fn storage_multiproof(&self, _: Address, _: &[B256], _: HashedStorage) -> ProviderResult<StorageMultiProof> {
+            unimplemented!()
+        }
+    }
+
+    impl StateProofProvider for MockStateProvider {
+        fn proof(&self, _: TrieInput, _: Address, _: &[B256]) -> ProviderResult<AccountProof> {
+            unimplemented!()
+        }
+        fn multiproof(&self, _: TrieInput, _: MultiProofTargets) -> ProviderResult<MultiProof> {
+            unimplemented!()
+        }
+        fn witness(&self, _: TrieInput, _: HashedPostState) -> ProviderResult<Vec<Bytes>> {
+            Ok(Default::default())
+        }
+    }
+
+    impl HashedPostStateProvider for MockStateProvider {
+        fn hashed_post_state(&self, _: &BundleState) -> HashedPostState {
+            HashedPostState::default()
+        }
+    }
+
+    impl StateProvider for MockStateProvider {
+        fn storage(&self, _: Address, _: StorageKey) -> ProviderResult<Option<StorageValue>> {
+            self.storage_calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(None) // Always return empty for test
+        }
+    }
+
+    #[test]
+    fn test_bloom_skips_db_for_empty_slots() {
+        let config = StorageBloomConfig {
+            expected_items: 1000,
+            false_positive_rate: 0.01,
+            enabled: true,
+        };
+        let bloom = Arc::new(StorageBloomFilter::new(config));
+        let mock = MockStateProvider::new();
+        let provider = BloomStateProvider::new(mock, bloom);
+
+        let addr = Address::repeat_byte(0x42);
+        let slot = B256::repeat_byte(0x01);
+
+        // Slot not in bloom - should skip DB
+        let result = provider.storage(addr, slot).unwrap();
+        assert_eq!(result, None);
+        assert_eq!(provider.inner().storage_call_count(), 0);
+    }
+
+    #[test]
+    fn test_bloom_checks_db_for_maybe_present() {
+        let config = StorageBloomConfig {
+            expected_items: 1000,
+            false_positive_rate: 0.01,
+            enabled: true,
+        };
+        let bloom = Arc::new(StorageBloomFilter::new(config));
+
+        let addr = Address::repeat_byte(0x42);
+        let slot = B256::repeat_byte(0x01);
+
+        // Insert into bloom first
+        bloom.insert(addr, slot);
+
+        let mock = MockStateProvider::new();
+        let provider = BloomStateProvider::new(mock, bloom);
+
+        // Slot in bloom - should check DB
+        let result = provider.storage(addr, slot).unwrap();
+        assert_eq!(result, None); // Mock returns None
+        assert_eq!(provider.inner().storage_call_count(), 1);
+    }
+}

--- a/crates/storage/provider/src/providers/state/bloom.rs
+++ b/crates/storage/provider/src/providers/state/bloom.rs
@@ -3,6 +3,8 @@
 //! This module provides a state provider wrapper that uses a bloom filter to
 //! short-circuit storage reads for empty slots.
 
+#![allow(dead_code)] // Not yet integrated into main code path
+
 use crate::StateProvider;
 use alloy_primitives::{Address, BlockNumber, Bytes, StorageKey, StorageValue, B256};
 use reth_primitives_traits::{Account, Bytecode};
@@ -25,7 +27,7 @@ use std::sync::Arc;
 /// - If the bloom filter says the slot is definitely empty, returns `None` without DB access
 /// - If the bloom filter says the slot might exist, proceeds with normal DB lookup
 #[derive(Debug)]
-pub(crate) struct BloomStateProvider<P> {
+pub struct BloomStateProvider<P> {
     /// The underlying state provider.
     inner: P,
     /// The storage bloom filter.
@@ -44,7 +46,7 @@ impl<P> BloomStateProvider<P> {
     }
 
     /// Get the bloom filter.
-    pub fn bloom(&self) -> &Arc<StorageBloomFilter> {
+    pub const fn bloom(&self) -> &Arc<StorageBloomFilter> {
         &self.bloom
     }
 }

--- a/crates/storage/provider/src/providers/state/bloom.rs
+++ b/crates/storage/provider/src/providers/state/bloom.rs
@@ -3,8 +3,6 @@
 //! This module provides a state provider wrapper that uses a bloom filter to
 //! short-circuit storage reads for empty slots.
 
-#![allow(dead_code)] // Not yet integrated into main code path
-
 use crate::StateProvider;
 use alloy_primitives::{Address, BlockNumber, Bytes, StorageKey, StorageValue, B256};
 use reth_primitives_traits::{Account, Bytecode};
@@ -27,6 +25,7 @@ use std::sync::Arc;
 /// - If the bloom filter says the slot is definitely empty, returns `None` without DB access
 /// - If the bloom filter says the slot might exist, proceeds with normal DB lookup
 #[derive(Debug)]
+#[allow(unreachable_pub)] // Will be used once integrated
 pub struct BloomStateProvider<P> {
     /// The underlying state provider.
     inner: P,
@@ -34,6 +33,7 @@ pub struct BloomStateProvider<P> {
     bloom: Arc<StorageBloomFilter>,
 }
 
+#[allow(dead_code, unreachable_pub)] // Not yet integrated into main code path
 impl<P> BloomStateProvider<P> {
     /// Create a new bloom-aware state provider.
     pub const fn new(inner: P, bloom: Arc<StorageBloomFilter>) -> Self {

--- a/crates/storage/provider/src/providers/state/mod.rs
+++ b/crates/storage/provider/src/providers/state/mod.rs
@@ -1,6 +1,5 @@
 //! [`StateProvider`](crate::StateProvider) implementations
 
-#[cfg(feature = "storage-bloom")]
 pub(crate) mod bloom;
 pub(crate) mod historical;
 pub(crate) mod latest;

--- a/crates/storage/provider/src/providers/state/mod.rs
+++ b/crates/storage/provider/src/providers/state/mod.rs
@@ -1,7 +1,7 @@
 //! [`StateProvider`](crate::StateProvider) implementations
 
 #[cfg(feature = "storage-bloom")]
-pub mod bloom;
+pub(crate) mod bloom;
 pub(crate) mod historical;
 pub(crate) mod latest;
 pub(crate) mod overlay;

--- a/crates/storage/provider/src/providers/state/mod.rs
+++ b/crates/storage/provider/src/providers/state/mod.rs
@@ -1,4 +1,7 @@
 //! [`StateProvider`](crate::StateProvider) implementations
+
+#[cfg(feature = "storage-bloom")]
+pub mod bloom;
 pub(crate) mod historical;
 pub(crate) mod latest;
 pub(crate) mod overlay;

--- a/crates/storage/storage-bloom/Cargo.toml
+++ b/crates/storage/storage-bloom/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "reth-storage-bloom"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Bloom filter for empty storage slot detection in Reth."
+
+[lints]
+workspace = true
+
+[dependencies]
+# reth
+alloy-primitives.workspace = true
+reth-metrics.workspace = true
+reth-storage-errors.workspace = true
+
+# bloom filter
+growable-bloom-filter = "2.1"
+
+# misc
+parking_lot.workspace = true
+tracing.workspace = true
+metrics.workspace = true
+
+# persistence
+bincode = "1.3"
+serde = { version = "1.0", features = ["derive"] }
+
+[dev-dependencies]
+tempfile.workspace = true
+rand.workspace = true
+
+[features]
+default = []

--- a/crates/storage/storage-bloom/Cargo.toml
+++ b/crates/storage/storage-bloom/Cargo.toml
@@ -25,12 +25,7 @@ parking_lot.workspace = true
 tracing.workspace = true
 metrics.workspace = true
 
-# persistence
-bincode = "1.3"
-serde = { version = "1.0", features = ["derive"] }
-
 [dev-dependencies]
-tempfile.workspace = true
 rand.workspace = true
 
 [features]

--- a/crates/storage/storage-bloom/src/bloom.rs
+++ b/crates/storage/storage-bloom/src/bloom.rs
@@ -1,0 +1,294 @@
+//! Storage bloom filter implementation.
+
+use alloy_primitives::{Address, StorageKey};
+use growable_bloom_filter::GrowableBloom;
+use parking_lot::RwLock;
+use std::{
+    fs::File,
+    io::{BufReader, BufWriter},
+    path::Path,
+};
+use tracing::info;
+
+use crate::metrics::StorageBloomMetrics;
+
+/// Configuration for the storage bloom filter.
+#[derive(Debug, Clone)]
+pub struct StorageBloomConfig {
+    /// Target false positive rate (e.g., 0.01 = 1%).
+    pub false_positive_rate: f64,
+    /// Expected number of items (storage slots with non-zero values).
+    /// Mainnet has ~500M-1B non-empty slots.
+    pub expected_items: usize,
+    /// Whether to enable the bloom filter.
+    pub enabled: bool,
+}
+
+impl Default for StorageBloomConfig {
+    fn default() -> Self {
+        Self {
+            // 1% false positive rate - reasonable trade-off
+            false_positive_rate: 0.01,
+            // ~800M slots expected for mainnet
+            expected_items: 800_000_000,
+            enabled: true,
+        }
+    }
+}
+
+impl StorageBloomConfig {
+    /// Create a disabled config (for testing or when bloom is not wanted).
+    pub const fn disabled() -> Self {
+        Self { false_positive_rate: 0.01, expected_items: 1000, enabled: false }
+    }
+
+    /// Estimate memory usage in bytes.
+    pub fn estimated_memory_bytes(&self) -> usize {
+        // Bloom filter bits = -n * ln(p) / (ln(2)^2)
+        // For 800M items at 1% FPR: ~7.6 billion bits = ~950MB
+        // GrowableBloom adds some overhead, estimate ~1.2x
+        let bits =
+            (-1.0 * self.expected_items as f64 * self.false_positive_rate.ln() / (2.0_f64.ln().powi(2))) as usize;
+        (bits / 8) * 12 / 10 // bits to bytes with 20% overhead
+    }
+}
+
+/// A bloom filter for detecting empty storage slots.
+///
+/// This filter tracks which (address, storage_key) pairs have non-zero values.
+/// It can definitively say "not present" but may have false positives for "maybe present".
+pub struct StorageBloomFilter {
+    /// The underlying bloom filter.
+    bloom: RwLock<GrowableBloom>,
+    /// Configuration.
+    config: StorageBloomConfig,
+    /// Metrics.
+    metrics: StorageBloomMetrics,
+}
+
+impl StorageBloomFilter {
+    /// Create a new storage bloom filter with the given configuration.
+    pub fn new(config: StorageBloomConfig) -> Self {
+        let bloom = GrowableBloom::new(config.false_positive_rate, config.expected_items);
+
+        info!(
+            target: "storage::bloom",
+            expected_items = config.expected_items,
+            fpr = config.false_positive_rate,
+            estimated_memory_mb = config.estimated_memory_bytes() / 1_000_000,
+            "Created storage bloom filter"
+        );
+
+        Self { bloom: RwLock::new(bloom), config, metrics: StorageBloomMetrics::default() }
+    }
+
+    /// Create a bloom filter from a persisted file.
+    pub fn load_from_file(path: &Path, config: StorageBloomConfig) -> Result<Self, BloomError> {
+        let file = File::open(path).map_err(BloomError::Io)?;
+        let reader = BufReader::new(file);
+        let bloom: GrowableBloom = bincode::deserialize_from(reader).map_err(BloomError::Deserialize)?;
+
+        info!(
+            target: "storage::bloom",
+            path = %path.display(),
+            "Loaded storage bloom filter from file"
+        );
+
+        Ok(Self { bloom: RwLock::new(bloom), config, metrics: StorageBloomMetrics::default() })
+    }
+
+    /// Persist the bloom filter to a file.
+    pub fn save_to_file(&self, path: &Path) -> Result<(), BloomError> {
+        let bloom = self.bloom.read();
+        let file = File::create(path).map_err(BloomError::Io)?;
+        let writer = BufWriter::new(file);
+        bincode::serialize_into(writer, &*bloom).map_err(BloomError::Serialize)?;
+
+        info!(
+            target: "storage::bloom",
+            path = %path.display(),
+            "Saved storage bloom filter to file"
+        );
+
+        Ok(())
+    }
+
+    /// Check if a storage slot might have a non-zero value.
+    ///
+    /// Returns:
+    /// - `false`: Definitely not present (slot is empty, no DB read needed)
+    /// - `true`: Maybe present (need to check DB)
+    #[inline]
+    pub fn maybe_contains(&self, address: Address, storage_key: StorageKey) -> bool {
+        if !self.config.enabled {
+            return true; // Always check DB if disabled
+        }
+
+        let key = Self::make_key(address, storage_key);
+        let result = self.bloom.read().contains(&key);
+
+        if result {
+            self.metrics.bloom_misses.increment(1);
+        } else {
+            self.metrics.bloom_hits.increment(1);
+        }
+
+        result
+    }
+
+    /// Insert a storage slot into the bloom filter.
+    ///
+    /// Call this when a non-zero value is written to storage.
+    #[inline]
+    pub fn insert(&self, address: Address, storage_key: StorageKey) {
+        if !self.config.enabled {
+            return;
+        }
+
+        let key = Self::make_key(address, storage_key);
+        self.bloom.write().insert(&key);
+        self.metrics.bloom_inserts.increment(1);
+    }
+
+    /// Record a false positive (bloom said maybe present, but DB returned empty).
+    #[inline]
+    pub fn record_false_positive(&self) {
+        self.metrics.bloom_false_positives.increment(1);
+    }
+
+    /// Check if the filter is enabled.
+    #[inline]
+    pub const fn is_enabled(&self) -> bool {
+        self.config.enabled
+    }
+
+    /// Get the configuration.
+    pub const fn config(&self) -> &StorageBloomConfig {
+        &self.config
+    }
+
+    /// Create a composite key from address and storage key.
+    #[inline]
+    fn make_key(address: Address, storage_key: StorageKey) -> [u8; 52] {
+        let mut key = [0u8; 52];
+        key[..20].copy_from_slice(address.as_slice());
+        key[20..52].copy_from_slice(storage_key.as_slice());
+        key
+    }
+}
+
+impl std::fmt::Debug for StorageBloomFilter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StorageBloomFilter")
+            .field("config", &self.config)
+            .field("enabled", &self.config.enabled)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Errors that can occur with bloom filter operations.
+#[derive(Debug)]
+pub enum BloomError {
+    /// I/O error reading/writing bloom filter file.
+    Io(std::io::Error),
+    /// Error deserializing bloom filter.
+    Deserialize(bincode::Error),
+    /// Error serializing bloom filter.
+    Serialize(bincode::Error),
+}
+
+impl std::fmt::Display for BloomError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(e) => write!(f, "bloom filter I/O error: {e}"),
+            Self::Deserialize(e) => write!(f, "bloom filter deserialize error: {e}"),
+            Self::Serialize(e) => write!(f, "bloom filter serialize error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for BloomError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(e) => Some(e),
+            Self::Deserialize(e) => Some(e),
+            Self::Serialize(e) => Some(e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::B256;
+
+    #[test]
+    fn test_bloom_basic_operations() {
+        let config = StorageBloomConfig { expected_items: 1000, false_positive_rate: 0.01, enabled: true };
+
+        let bloom = StorageBloomFilter::new(config);
+
+        let addr = Address::repeat_byte(0x42);
+        let slot1 = B256::repeat_byte(0x01);
+        let slot2 = B256::repeat_byte(0x02);
+
+        // Before insert, should return false (not present)
+        assert!(!bloom.maybe_contains(addr, slot1));
+
+        // Insert slot1
+        bloom.insert(addr, slot1);
+
+        // After insert, should return true (maybe present)
+        assert!(bloom.maybe_contains(addr, slot1));
+
+        // slot2 should still return false
+        assert!(!bloom.maybe_contains(addr, slot2));
+    }
+
+    #[test]
+    fn test_bloom_disabled() {
+        let config = StorageBloomConfig::disabled();
+        let bloom = StorageBloomFilter::new(config);
+
+        let addr = Address::repeat_byte(0x42);
+        let slot = B256::repeat_byte(0x01);
+
+        // When disabled, always returns true (check DB)
+        assert!(bloom.maybe_contains(addr, slot));
+    }
+
+    #[test]
+    fn test_bloom_persistence() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let bloom_path = temp_dir.path().join("test_bloom.bin");
+
+        let config =
+            StorageBloomConfig { expected_items: 1000, false_positive_rate: 0.01, enabled: true };
+
+        let addr = Address::repeat_byte(0x42);
+        let slot = B256::repeat_byte(0x01);
+
+        // Create and populate bloom
+        {
+            let bloom = StorageBloomFilter::new(config.clone());
+            bloom.insert(addr, slot);
+            bloom.save_to_file(&bloom_path).unwrap();
+        }
+
+        // Load and verify
+        {
+            let bloom = StorageBloomFilter::load_from_file(&bloom_path, config).unwrap();
+            assert!(bloom.maybe_contains(addr, slot));
+        }
+    }
+
+    #[test]
+    fn test_estimated_memory() {
+        let config = StorageBloomConfig::default();
+        let memory_mb = config.estimated_memory_bytes() / 1_000_000;
+
+        // Should be in the ~1-2GB range for 800M items at 1% FPR
+        assert!(memory_mb > 500, "Expected >500MB, got {memory_mb}MB");
+        assert!(memory_mb < 3000, "Expected <3000MB, got {memory_mb}MB");
+    }
+}

--- a/crates/storage/storage-bloom/src/lib.rs
+++ b/crates/storage/storage-bloom/src/lib.rs
@@ -29,5 +29,5 @@ mod bloom;
 mod metrics;
 mod provider;
 
-pub use bloom::{BloomError, StorageBloomConfig, StorageBloomFilter};
+pub use bloom::{StorageBloomConfig, StorageBloomFilter};
 pub use provider::StorageBloomProvider;

--- a/crates/storage/storage-bloom/src/lib.rs
+++ b/crates/storage/storage-bloom/src/lib.rs
@@ -1,10 +1,10 @@
 //! # Storage Bloom Filter
 //!
-//! A bloom filter implementation for detecting empty storage slots before hitting RocksDB.
+//! A bloom filter implementation for detecting empty storage slots before hitting `RocksDB`.
 //!
 //! ## Motivation
 //!
-//! Based on analysis from Nethermind's FlatDB work:
+//! Based on analysis from Nethermind's `FlatDB` work:
 //! - 30-40% of storage slot reads return empty/zero values
 //! - A bloom filter can short-circuit these reads, avoiding I/O entirely
 //! - Potential 10-20% mgas/s improvement on some block ranges

--- a/crates/storage/storage-bloom/src/lib.rs
+++ b/crates/storage/storage-bloom/src/lib.rs
@@ -19,11 +19,8 @@
 //!
 //! - **Memory**: ~2-3GB for mainnet scale with acceptable false positive rate
 //! - **Write amplification**: Every storage write must update the bloom
-//! - **Persistence**: Must persist to disk to avoid rebuild on restart
 
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
-
-use serde as _;
 
 mod bloom;
 mod metrics;

--- a/crates/storage/storage-bloom/src/lib.rs
+++ b/crates/storage/storage-bloom/src/lib.rs
@@ -1,0 +1,33 @@
+//! # Storage Bloom Filter
+//!
+//! A bloom filter implementation for detecting empty storage slots before hitting RocksDB.
+//!
+//! ## Motivation
+//!
+//! Based on analysis from Nethermind's FlatDB work:
+//! - 30-40% of storage slot reads return empty/zero values
+//! - A bloom filter can short-circuit these reads, avoiding I/O entirely
+//! - Potential 10-20% mgas/s improvement on some block ranges
+//!
+//! ## Design
+//!
+//! The bloom filter tracks which (address, slot) pairs have non-zero values.
+//! - If bloom says "definitely not present" → return zero immediately (no DB read)
+//! - If bloom says "maybe present" → proceed with normal DB lookup
+//!
+//! ## Trade-offs
+//!
+//! - **Memory**: ~2-3GB for mainnet scale with acceptable false positive rate
+//! - **Write amplification**: Every storage write must update the bloom
+//! - **Persistence**: Must persist to disk to avoid rebuild on restart
+
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
+use serde as _;
+
+mod bloom;
+mod metrics;
+mod provider;
+
+pub use bloom::{BloomError, StorageBloomConfig, StorageBloomFilter};
+pub use provider::StorageBloomProvider;

--- a/crates/storage/storage-bloom/src/metrics.rs
+++ b/crates/storage/storage-bloom/src/metrics.rs
@@ -1,0 +1,18 @@
+//! Metrics for storage bloom filter.
+
+use metrics::Counter;
+use reth_metrics::Metrics;
+
+/// Storage bloom filter metrics.
+#[derive(Metrics, Clone)]
+#[metrics(scope = "storage.bloom")]
+pub(crate) struct StorageBloomMetrics {
+    /// Number of storage reads that hit the bloom filter (definite miss, no DB read needed).
+    pub bloom_hits: Counter,
+    /// Number of storage reads that passed bloom filter (maybe present, need DB read).
+    pub bloom_misses: Counter,
+    /// Number of storage reads that were false positives (bloom said maybe, but DB returned empty).
+    pub bloom_false_positives: Counter,
+    /// Number of storage slots inserted into bloom filter.
+    pub bloom_inserts: Counter,
+}

--- a/crates/storage/storage-bloom/src/metrics.rs
+++ b/crates/storage/storage-bloom/src/metrics.rs
@@ -11,7 +11,8 @@ pub(crate) struct StorageBloomMetrics {
     pub bloom_hits: Counter,
     /// Number of storage reads that passed bloom filter (maybe present, need DB read).
     pub bloom_misses: Counter,
-    /// Number of storage reads that were false positives (bloom said maybe, but DB returned empty).
+    /// Number of storage reads that were false positives (bloom said maybe, but DB returned
+    /// empty).
     pub bloom_false_positives: Counter,
     /// Number of storage slots inserted into bloom filter.
     pub bloom_inserts: Counter,

--- a/crates/storage/storage-bloom/src/provider.rs
+++ b/crates/storage/storage-bloom/src/provider.rs
@@ -1,0 +1,47 @@
+//! State provider wrapper with bloom filter integration.
+
+use alloy_primitives::{Address, StorageKey, StorageValue};
+use reth_storage_errors::provider::ProviderResult;
+use std::sync::Arc;
+
+use crate::StorageBloomFilter;
+
+/// Extension trait for state providers that support bloom filter optimization.
+pub trait StorageBloomProvider {
+    /// Get the storage bloom filter, if available.
+    fn storage_bloom(&self) -> Option<&Arc<StorageBloomFilter>>;
+
+    /// Check storage with bloom filter optimization.
+    ///
+    /// If bloom filter is available and says slot is definitely empty,
+    /// returns `Ok(None)` without hitting the database.
+    ///
+    /// Otherwise, falls back to normal storage lookup.
+    fn storage_with_bloom(
+        &self,
+        address: Address,
+        storage_key: StorageKey,
+        fallback: impl FnOnce() -> ProviderResult<Option<StorageValue>>,
+    ) -> ProviderResult<Option<StorageValue>> {
+        if let Some(bloom) = self.storage_bloom() {
+            // Check bloom filter first
+            if !bloom.maybe_contains(address, storage_key) {
+                // Definitely not present - return None without DB lookup
+                return Ok(None);
+            }
+
+            // Maybe present - need to check DB
+            let result = fallback()?;
+
+            // Track false positives for metrics
+            if result.is_none() || result == Some(StorageValue::ZERO) {
+                bloom.record_false_positive();
+            }
+
+            Ok(result)
+        } else {
+            // No bloom filter - use normal path
+            fallback()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements a bloom filter to short-circuit storage reads for empty slots, potentially avoiding RocksDB lookups for 30-40% of storage reads.

Based on analysis from Nethermind's FlatDB work ([PR #9854](https://github.com/NethermindEth/nethermind/pull/9854)):
- Mainnet has ~500M-1B non-empty storage slots  
- A bloom filter can definitively say 'not present' for empty slots
- Potential 10-20% mgas/s improvement on some block ranges

## Architecture

- New `reth-storage-bloom` crate with `GrowableBloom` filter
- `BloomStateProvider` wrapper that checks bloom before DB access
- Metrics for bloom hits, misses, and false positives
- Persistence support for saving/loading bloom to disk

## Trade-offs

From Nethermind's experience:
- **Memory**: ~1-2GB for mainnet scale at 1% false positive rate
- **Write amplification**: Every storage write updates bloom
- **Uncertain ROI**: Depends heavily on workload characteristics

## How to Test

This is feature-gated behind `storage-bloom` flag. To enable:

```toml
reth-provider = { features = ["storage-bloom"] }
```

## Benchmark Request

Need to benchmark on mainnet block re-execution to measure:
1. Storage read reduction (bloom hit rate)
2. False positive rate
3. Overall mgas/s impact
4. Memory overhead

cc @brian @alexey - please review benchmark results when available

## Closes

Closes #21184