### PR TITLE
chore: bump version to 1.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -181,7 +181,7 @@ dependencies = [
  "futures",
  "futures-util",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -213,7 +213,7 @@ dependencies = [
  "crc",
  "rand 0.8.5",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -244,7 +244,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -282,7 +282,7 @@ dependencies = [
  "serde",
  "serde_with",
  "sha2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -304,7 +304,7 @@ dependencies = [
  "op-alloy",
  "op-revm",
  "revm",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -359,7 +359,7 @@ dependencies = [
  "http",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -386,7 +386,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -417,7 +417,7 @@ dependencies = [
  "op-alloy",
  "op-revm",
  "revm",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -503,7 +503,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -643,7 +643,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tree_hash",
  "tree_hash_derive",
 ]
@@ -700,7 +700,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -729,7 +729,7 @@ dependencies = [
  "alloy-serde",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -768,7 +768,7 @@ dependencies = [
  "either",
  "elliptic-curve",
  "k256",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -786,7 +786,7 @@ dependencies = [
  "coins-bip39",
  "k256",
  "rand 0.8.5",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "zeroize",
 ]
 
@@ -875,7 +875,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tower",
  "tracing",
@@ -1801,7 +1801,7 @@ dependencies = [
  "tag_ptr",
  "tap",
  "thin-vec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "xsum",
 ]
@@ -2085,7 +2085,7 @@ dependencies = [
  "semver 1.0.27",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2099,7 +2099,7 @@ dependencies = [
  "semver 1.0.27",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3331,7 +3331,7 @@ dependencies = [
 
 [[package]]
 name = "ef-test-runner"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "clap",
  "ef-tests",
@@ -3339,7 +3339,7 @@ dependencies = [
 
 [[package]]
 name = "ef-tests"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3366,7 +3366,7 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "walkdir",
 ]
 
@@ -3574,7 +3574,7 @@ dependencies = [
  "reth-ethereum",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3617,7 +3617,7 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -3663,7 +3663,7 @@ dependencies = [
  "reth-payload-builder",
  "reth-tracing",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -3732,7 +3732,7 @@ dependencies = [
  "revm",
  "revm-primitives",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3829,7 +3829,7 @@ dependencies = [
 
 [[package]]
 name = "example-full-contract-state"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "eyre",
  "reth-ethereum",
@@ -3968,7 +3968,7 @@ dependencies = [
 
 [[package]]
 name = "exex-subscription"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -4063,14 +4063,13 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
 dependencies = [
  "cfg-if",
  "libc",
  "libredox",
- "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4216,9 +4215,9 @@ dependencies = [
 
 [[package]]
 name = "futures-concurrency"
-version = "7.7.0"
+version = "7.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69a9561702beff46b705a8ac9c0803ec4c7fc5d01330a99b1feaf86e206e92ba"
+checksum = "175cd8cca9e1d45b87f18ffa75088f2099e3c4fe5e2f83e42de112560bea8ea6"
 dependencies = [
  "fixedbitset",
  "futures-core",
@@ -4637,7 +4636,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tokio",
  "tracing",
@@ -4661,7 +4660,7 @@ dependencies = [
  "resolv-conf",
  "serde",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -5350,7 +5349,7 @@ dependencies = [
  "rustls-pki-types",
  "rustls-platform-verifier",
  "soketto",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -5378,7 +5377,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tower",
@@ -5403,7 +5402,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tower",
  "url",
@@ -5441,7 +5440,7 @@ dependencies = [
  "serde",
  "serde_json",
  "soketto",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -5458,7 +5457,7 @@ dependencies = [
  "http",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5610,7 +5609,7 @@ dependencies = [
  "multihash",
  "quick-protobuf",
  "sha2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "zeroize",
 ]
@@ -5893,7 +5892,7 @@ dependencies = [
  "metrics",
  "metrics-util",
  "quanta",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5945,7 +5944,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -6384,7 +6383,7 @@ dependencies = [
  "derive_more",
  "serde",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6451,7 +6450,7 @@ dependencies = [
  "op-alloy-consensus",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6474,12 +6473,12 @@ dependencies = [
  "serde",
  "sha2",
  "snap",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "op-reth"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "clap",
  "reth-cli-util",
@@ -6528,7 +6527,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -6570,7 +6569,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost 0.14.3",
  "reqwest",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tonic",
  "tracing",
@@ -6607,7 +6606,7 @@ dependencies = [
  "opentelemetry",
  "percent-encoding",
  "rand 0.9.2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7226,7 +7225,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2 0.6.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -7247,7 +7246,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -7512,7 +7511,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7631,7 +7630,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -7678,7 +7677,7 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7701,7 +7700,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bench"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7739,7 +7738,7 @@ dependencies = [
  "reth-tracing",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tower",
  "tracing",
@@ -7748,7 +7747,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bench-compare"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -7776,7 +7775,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7808,7 +7807,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7828,7 +7827,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7841,7 +7840,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7926,7 +7925,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7935,7 +7934,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7949,14 +7948,14 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "snmalloc-rs",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tikv-jemallocator",
  "tracy-client",
 ]
 
 [[package]]
 name = "reth-codecs"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7980,7 +7979,7 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7990,7 +7989,7 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -8008,19 +8007,19 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "auto_impl",
  "reth-execution-types",
  "reth-primitives-traits",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8034,7 +8033,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8059,7 +8058,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8088,12 +8087,12 @@ dependencies = [
  "strum 0.27.2",
  "sysinfo",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-db-api"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8123,7 +8122,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8147,13 +8146,13 @@ dependencies = [
  "reth-trie-db",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "reth-db-models"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8169,7 +8168,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8187,7 +8186,7 @@ dependencies = [
  "schnellru",
  "secp256k1 0.30.0",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -8195,7 +8194,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8213,14 +8212,14 @@ dependencies = [
  "reth-network-peers",
  "reth-tracing",
  "secp256k1 0.30.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8240,7 +8239,7 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -8248,7 +8247,7 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8277,7 +8276,7 @@ dependencies = [
  "reth-testing-utils",
  "reth-tracing",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -8286,7 +8285,7 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8343,7 +8342,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8361,7 +8360,7 @@ dependencies = [
  "reth-network-peers",
  "secp256k1 0.30.0",
  "sha2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -8370,7 +8369,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8394,7 +8393,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8412,13 +8411,13 @@ dependencies = [
  "reth-primitives-traits",
  "reth-trie-common",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
 [[package]]
 name = "reth-engine-service"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-eips",
  "futures",
@@ -8449,7 +8448,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8517,14 +8516,14 @@ dependencies = [
  "schnellru",
  "serde_json",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "reth-engine-util"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8551,7 +8550,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8567,13 +8566,13 @@ dependencies = [
  "snap",
  "tempfile",
  "test-case",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
 [[package]]
 name = "reth-era-downloader"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8591,7 +8590,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8617,17 +8616,17 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
  "reth-storage-errors",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8656,7 +8655,7 @@ dependencies = [
  "serde",
  "snap",
  "test-fuzz",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -8665,7 +8664,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8685,12 +8684,12 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-ethereum"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8730,7 +8729,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "clap",
  "eyre",
@@ -8752,7 +8751,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8768,7 +8767,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8781,12 +8780,12 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8799,7 +8798,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8827,7 +8826,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8854,7 +8853,7 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-primitives",
  "rayon",
@@ -8864,7 +8863,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8889,7 +8888,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8913,19 +8912,19 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
  "nybbles",
  "reth-storage-errors",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-execution-types"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8945,7 +8944,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8982,7 +8981,7 @@ dependencies = [
  "rmp-serde",
  "secp256k1 0.30.0",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
@@ -8990,7 +8989,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-test-utils"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-eips",
  "eyre",
@@ -9015,13 +9014,13 @@ dependencies = [
  "reth-tasks",
  "reth-transaction-pool",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
 [[package]]
 name = "reth-exex-types"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9038,16 +9037,16 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9080,7 +9079,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "bytes",
  "futures",
@@ -9092,7 +9091,7 @@ dependencies = [
  "reth-tracing",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -9102,7 +9101,7 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -9114,13 +9113,13 @@ dependencies = [
  "reth-mdbx-sys",
  "smallvec",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -9128,7 +9127,7 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "futures",
  "metrics",
@@ -9139,7 +9138,7 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9147,21 +9146,21 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "futures-util",
  "if-addrs",
  "reqwest",
  "reth-tracing",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "reth-network"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9212,7 +9211,7 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -9222,7 +9221,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9239,14 +9238,14 @@ dependencies = [
  "reth-network-types",
  "reth-tokio-util",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
 ]
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9268,7 +9267,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9278,14 +9277,14 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde_json",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "url",
 ]
 
 [[package]]
 name = "reth-network-types"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9298,7 +9297,7 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -9309,14 +9308,14 @@ dependencies = [
  "reth-fs-util",
  "serde",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "zstd",
 ]
 
 [[package]]
 name = "reth-node-api"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9339,7 +9338,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9411,7 +9410,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9457,7 +9456,7 @@ dependencies = [
  "serde",
  "shellexpand",
  "strum 0.27.2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "toml",
  "tracing",
@@ -9468,7 +9467,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -9528,7 +9527,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9541,7 +9540,7 @@ dependencies = [
  "reth-transaction-pool",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
@@ -9551,7 +9550,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9574,7 +9573,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "bytes",
  "eyre",
@@ -9603,7 +9602,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9614,7 +9613,7 @@ dependencies = [
 
 [[package]]
 name = "reth-op"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "reth-chainspec",
  "reth-cli-util",
@@ -9654,7 +9653,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-chainspec"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9677,12 +9676,12 @@ dependencies = [
  "serde",
  "serde_json",
  "tar-no-std",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-optimism-cli"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9731,7 +9730,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-consensus"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9756,13 +9755,13 @@ dependencies = [
  "reth-trie",
  "reth-trie-common",
  "revm",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "reth-optimism-evm"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9786,12 +9785,12 @@ dependencies = [
  "reth-rpc-eth-api",
  "reth-storage-errors",
  "revm",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-optimism-flashblocks"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9829,7 +9828,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-forks"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-op-hardforks",
  "alloy-primitives",
@@ -9839,7 +9838,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-node"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9900,7 +9899,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-payload-builder"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9933,13 +9932,13 @@ dependencies = [
  "revm",
  "serde",
  "sha2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "reth-optimism-primitives"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9966,7 +9965,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-rpc"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10019,7 +10018,7 @@ dependencies = [
  "reth-transaction-pool",
  "revm",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tower",
@@ -10028,7 +10027,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-storage"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "reth-codecs",
@@ -10040,7 +10039,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-txpool"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10070,14 +10069,14 @@ dependencies = [
  "reth-storage-api",
  "reth-transaction-pool",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10097,7 +10096,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10108,7 +10107,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10125,13 +10124,13 @@ dependencies = [
  "reth-primitives-traits",
  "reth-trie-common",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
 [[package]]
 name = "reth-payload-util"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10140,7 +10139,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10149,7 +10148,7 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10171,7 +10170,7 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10203,12 +10202,12 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-provider"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10257,7 +10256,7 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10282,18 +10281,18 @@ dependencies = [
  "reth-tokio-util",
  "reth-tracing",
  "rustc-hash",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "reth-prune-db"
-version = "1.10.0"
+version = "1.10.1"
 
 [[package]]
 name = "reth-prune-types"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10306,13 +10305,13 @@ dependencies = [
  "serde",
  "serde_json",
  "strum 0.27.2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "toml",
 ]
 
 [[package]]
 name = "reth-ress-protocol"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10338,7 +10337,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-provider"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10364,7 +10363,7 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10378,7 +10377,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10453,7 +10452,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tower",
@@ -10463,7 +10462,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -10493,7 +10492,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api-testing-util"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10512,7 +10511,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -10558,7 +10557,7 @@ dependencies = [
  "reth-transaction-pool",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tower",
@@ -10568,7 +10567,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10589,12 +10588,12 @@ dependencies = [
  "reth-primitives-traits",
  "reth-storage-api",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-rpc-e2e-tests"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-genesis",
  "alloy-rpc-types-engine",
@@ -10614,7 +10613,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10643,14 +10642,14 @@ dependencies = [
  "reth-testing-utils",
  "reth-transaction-pool",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10693,7 +10692,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10732,7 +10731,7 @@ dependencies = [
  "schnellru",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -10741,7 +10740,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -10758,7 +10757,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10773,7 +10772,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10824,14 +10823,14 @@ dependencies = [
  "reth-trie",
  "reth-trie-db",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "reth-stages-api"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10855,7 +10854,7 @@ dependencies = [
  "reth-static-file-types",
  "reth-testing-utils",
  "reth-tokio-util",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -10863,7 +10862,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10879,7 +10878,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stateless"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -10902,12 +10901,12 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-static-file"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-primitives",
  "assert_matches",
@@ -10930,7 +10929,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10945,7 +10944,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10968,7 +10967,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10979,12 +10978,12 @@ dependencies = [
  "reth-static-file-types",
  "revm-database-interface",
  "revm-state",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-storage-rpc-provider"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11013,7 +11012,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -11022,7 +11021,7 @@ dependencies = [
  "pin-project",
  "rayon",
  "reth-metrics",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-futures",
@@ -11030,7 +11029,7 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11046,7 +11045,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11055,7 +11054,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "clap",
  "eyre",
@@ -11073,7 +11072,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "clap",
  "eyre",
@@ -11090,7 +11089,7 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11130,7 +11129,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -11138,7 +11137,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11172,7 +11171,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -11205,7 +11204,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11236,7 +11235,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11259,14 +11258,14 @@ dependencies = [
  "reth-trie-common",
  "reth-trie-db",
  "reth-trie-sparse",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11299,7 +11298,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse-parallel"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11329,7 +11328,7 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "zstd",
 ]
@@ -11423,7 +11422,7 @@ dependencies = [
  "revm-primitives",
  "revm-state",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11480,7 +11479,7 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -12368,7 +12367,7 @@ checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -12784,11 +12783,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -12804,9 +12803,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13213,7 +13212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
 dependencies = [
  "crossbeam-channel",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tracing-subscriber 0.3.22",
 ]
@@ -13460,7 +13459,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -14449,7 +14448,7 @@ dependencies = [
  "pharos",
  "rustc_version 0.4.1",
  "send_wrapper 0.6.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.10.0"
+version = "1.10.1"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/docs/vocs/vocs.config.ts
+++ b/docs/vocs/vocs.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
     },
     { text: 'GitHub', link: 'https://github.com/paradigmxyz/reth' },
     {
-      text: 'v1.10.0',
+      text: 'v1.10.1',
       items: [
         {
           text: 'Releases',


### PR DESCRIPTION
Bumps version from 1.10.0 to 1.10.1.

Changes:
- `Cargo.toml`: Update workspace.package version
- `docs/vocs/vocs.config.ts`: Update version in navigation
- `Cargo.lock`: Regenerated