### PR TITLE
feat(storage): add startup validation for RocksDB CLI flags

### DIFF
--- a/crates/node/core/src/args/storage.rs
+++ b/crates/node/core/src/args/storage.rs
@@ -1,7 +1,7 @@
 //! clap [Args](clap::Args) for storage configuration (static files + RocksDB tables)
 
-use clap::Args;
-use reth_provider::StorageSettings;
+use clap::{ArgAction, Args};
+use reth_provider::{StorageSettings, StorageSettingsOverrides};
 
 use super::StaticFilesArgs;
 
@@ -17,31 +17,55 @@ pub struct StorageArgs {
     ///
     /// Note: This setting can only be configured at genesis initialization. Once
     /// the node has been initialized, changing this flag requires re-syncing from scratch.
-    #[arg(long = "storage.tx-hash-in-rocksdb")]
-    pub tx_hash_in_rocksdb: bool,
+    #[arg(long = "storage.tx-hash-in-rocksdb", action = ArgAction::Set)]
+    pub tx_hash_in_rocksdb: Option<bool>,
 
     /// Store storages history in `RocksDB` instead of MDBX.
     ///
     /// Note: This setting can only be configured at genesis initialization. Once
     /// the node has been initialized, changing this flag requires re-syncing from scratch.
-    #[arg(long = "storage.storages-history-in-rocksdb")]
-    pub storages_history_in_rocksdb: bool,
+    #[arg(long = "storage.storages-history-in-rocksdb", action = ArgAction::Set)]
+    pub storages_history_in_rocksdb: Option<bool>,
 
     /// Store account history in `RocksDB` instead of MDBX.
     ///
     /// Note: This setting can only be configured at genesis initialization. Once
     /// the node has been initialized, changing this flag requires re-syncing from scratch.
-    #[arg(long = "storage.account-history-in-rocksdb")]
-    pub account_history_in_rocksdb: bool,
+    #[arg(long = "storage.account-history-in-rocksdb", action = ArgAction::Set)]
+    pub account_history_in_rocksdb: Option<bool>,
 }
 
 impl StorageArgs {
     /// Converts CLI storage arguments into [`StorageSettings`].
-    pub const fn to_settings(&self) -> StorageSettings {
-        self.static_files
-            .to_settings()
-            .with_transaction_hash_numbers_in_rocksdb(self.tx_hash_in_rocksdb)
-            .with_storages_history_in_rocksdb(self.storages_history_in_rocksdb)
-            .with_account_history_in_rocksdb(self.account_history_in_rocksdb)
+    ///
+    /// Uses the provided default settings for any flags not explicitly set.
+    pub const fn to_settings(&self, defaults: StorageSettings) -> StorageSettings {
+        let base = self.static_files.to_settings();
+
+        let tx_hash = match self.tx_hash_in_rocksdb {
+            Some(v) => v,
+            None => defaults.transaction_hash_numbers_in_rocksdb,
+        };
+        let storages_history = match self.storages_history_in_rocksdb {
+            Some(v) => v,
+            None => defaults.storages_history_in_rocksdb,
+        };
+        let account_history = match self.account_history_in_rocksdb {
+            Some(v) => v,
+            None => defaults.account_history_in_rocksdb,
+        };
+
+        base.with_transaction_hash_numbers_in_rocksdb(tx_hash)
+            .with_storages_history_in_rocksdb(storages_history)
+            .with_account_history_in_rocksdb(account_history)
+    }
+
+    /// Returns the overrides for RocksDB settings that were explicitly set via CLI.
+    pub const fn to_overrides(&self) -> StorageSettingsOverrides {
+        StorageSettingsOverrides {
+            transaction_hash_numbers_in_rocksdb: self.tx_hash_in_rocksdb,
+            storages_history_in_rocksdb: self.storages_history_in_rocksdb,
+            account_history_in_rocksdb: self.account_history_in_rocksdb,
+        }
     }
 }

--- a/crates/storage/db-api/src/models/metadata.rs
+++ b/crates/storage/db-api/src/models/metadata.rs
@@ -208,15 +208,12 @@ impl std::fmt::Display for StorageSettingsMismatch {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(
             f,
-            "Storage settings mismatch: database was initialized with different RocksDB storage layout.\n"
+            "Storage settings mismatch: database was initialized with different RocksDB storage layout."
         )?;
+        writeln!(f)?;
         writeln!(f, "Conflicts:")?;
         for m in &self.mismatches {
-            writeln!(
-                f,
-                "  - {}: db={}, cli={} ({}={})",
-                m.name, m.db_value, m.cli_value, m.flag, m.cli_value
-            )?;
+            writeln!(f, "  - {} {}: db={}, cli={}", m.flag, m.name, m.db_value, m.cli_value)?;
         }
         writeln!(f)?;
         writeln!(f, "These flags are genesis-only. To proceed:")?;

--- a/crates/storage/provider/src/lib.rs
+++ b/crates/storage/provider/src/lib.rs
@@ -45,8 +45,9 @@ pub use revm_database::states::OriginalValuesKnown;
 // reexport traits to avoid breaking changes
 pub use reth_static_file_types as static_file;
 pub use reth_storage_api::{
-    HistoryWriter, MetadataProvider, MetadataWriter, StateWriteConfig, StatsReader,
-    StorageSettings, StorageSettingsCache,
+    HistoryWriter, MetadataProvider, MetadataWriter, SettingMismatch, StateWriteConfig,
+    StatsReader, StorageSettings, StorageSettingsCache, StorageSettingsMismatch,
+    StorageSettingsOverrides,
 };
 /// Re-export provider error.
 pub use reth_storage_errors::provider::{ProviderError, ProviderResult};

--- a/crates/storage/storage-api/src/lib.rs
+++ b/crates/storage/storage-api/src/lib.rs
@@ -101,7 +101,9 @@ pub mod metadata;
 #[cfg(feature = "db-api")]
 pub use metadata::{MetadataProvider, MetadataWriter, StorageSettingsCache};
 #[cfg(feature = "db-api")]
-pub use reth_db_api::models::StorageSettings;
+pub use reth_db_api::models::{
+    SettingMismatch, StorageSettings, StorageSettingsMismatch, StorageSettingsOverrides,
+};
 
 mod full;
 pub use full::*;


### PR DESCRIPTION
## Summary

Add validation that CLI-provided RocksDB storage flags match the settings stored in the database metadata. This prevents users from accidentally misconfiguring their node after genesis initialization.

## Changes

Split into 3 commits:

1. **Add StorageSettingsOverrides and validation** - Core types and validation logic in db-api
2. **Change StorageArgs bool fields to Option<bool>** - Distinguish explicitly set flags from defaults
3. **Add init_genesis_with_overrides for startup validation** - Wire up validation at node startup

## Behavior

The validation only triggers when the user explicitly passes a flag that differs from what's stored in the database. Existing nodes that don't pass any new flags will continue to work without changes.

## PR Stack

| PR | Title | Status |
|---|---|---|
| #21181 | feat(cli): add RocksDB storage startup flags | base PR |
| #21189 | feat(storage): add startup validation for RocksDB CLI flags | ← **this PR** (depends on #21181) |

Closes #20482