### PR TITLE
docs: add documentation for RocksDB table routing CLI flags

### DIFF
--- a/docs/vocs/docs/pages/run/storage.mdx
+++ b/docs/vocs/docs/pages/run/storage.mdx
@@ -1,0 +1,94 @@
+---
+description: Configure RocksDB table routing for optimal performance.
+---
+
+# Storage Configuration
+
+Reth uses a hybrid storage approach with MDBX as the primary database and optional RocksDB for specific tables. This page documents the `--storage.*` CLI flags that control which tables are stored in RocksDB.
+
+## Overview
+
+By default, all tables are stored in MDBX. However, certain large tables can benefit from RocksDB's performance characteristics. The `--storage.*-in-rocksdb` flags allow you to route specific tables to RocksDB for improved performance on high-throughput workloads.
+
+:::warning
+These settings can only be configured at genesis initialization. Once the node has been initialized, changing these flags requires a full re-sync from scratch.
+:::
+
+## Available Flags
+
+### `--storage.tx-hash-in-rocksdb`
+
+Store the transaction hash to number mapping in RocksDB instead of MDBX.
+
+```bash
+reth node --storage.tx-hash-in-rocksdb=true
+```
+
+**Default:** `false` (stored in MDBX)
+
+**Use case:** This table maps transaction hashes to their sequential transaction IDs. Moving it to RocksDB can improve lookup performance for high-volume transaction queries.
+
+### `--storage.storages-history-in-rocksdb`
+
+Store storage history data in RocksDB instead of MDBX.
+
+```bash
+reth node --storage.storages-history-in-rocksdb=true
+```
+
+**Default:** `false` (stored in MDBX)
+
+**Use case:** Storage history tracks historical values of contract storage slots. This table can grow very large on archive nodes. RocksDB may provide better write performance for this workload.
+
+### `--storage.account-history-in-rocksdb`
+
+Store account history data in RocksDB instead of MDBX.
+
+```bash
+reth node --storage.account-history-in-rocksdb=true
+```
+
+**Default:** `false` (stored in MDBX)
+
+**Use case:** Account history tracks historical account states. Similar to storage history, this table grows significantly on archive nodes and may benefit from RocksDB's handling of large datasets.
+
+## Example Configuration
+
+To initialize a new node with transaction hash lookups and history tables in RocksDB:
+
+```bash
+reth node \
+    --storage.tx-hash-in-rocksdb=true \
+    --storage.storages-history-in-rocksdb=true \
+    --storage.account-history-in-rocksdb=true
+```
+
+## RocksDB Data Directory
+
+When using RocksDB tables, the data is stored in a separate directory. You can customize this location using:
+
+```bash
+reth node --datadir.rocksdb /path/to/rocksdb
+```
+
+If not specified, RocksDB data is stored in a subdirectory of your main data directory.
+
+## When to Use RocksDB Tables
+
+Consider enabling RocksDB for specific tables when:
+
+- Running an **archive node** with full historical data
+- Experiencing **write performance bottlenecks** with large history tables
+- Performing **high-volume transaction lookups** that stress the tx-hash table
+
+For most use cases, the default MDBX configuration provides excellent performance. Only enable RocksDB tables if you have measured performance issues with specific workloads.
+
+## Migration Notes
+
+Since these settings are genesis-only:
+
+1. **New nodes:** Set your desired configuration before first sync
+2. **Existing nodes:** Requires full re-sync to change storage settings
+3. **Backup:** Always backup your data before re-syncing
+
+The storage settings are persisted to ensure consistency across restarts. Attempting to start a node with different storage settings than what was used during initialization will result in an error.

--- a/docs/vocs/docs/pages/run/storage.mdx
+++ b/docs/vocs/docs/pages/run/storage.mdx
@@ -4,48 +4,58 @@ description: Configure RocksDB table routing for optimal performance.
 
 # Storage Configuration
 
-Reth uses a hybrid storage approach with MDBX as the primary database and optional RocksDB for specific tables. This page documents the `--storage.*` CLI flags that control which tables are stored in RocksDB.
+Reth uses a hybrid storage approach with MDBX as the primary database and optional RocksDB for specific tables. This page documents how to configure which tables are stored in RocksDB.
 
 ## Overview
 
-By default, all tables are stored in MDBX. However, certain large tables can benefit from RocksDB's performance characteristics. The `--storage.*-in-rocksdb` flags allow you to route specific tables to RocksDB for improved performance on high-throughput workloads.
+By default, all tables are stored in MDBX. However, certain large tables can benefit from RocksDB's performance characteristics. Storage settings allow you to route specific tables to RocksDB for improved performance on high-throughput workloads.
 
 :::warning
-These settings can only be configured at genesis initialization. Once the node has been initialized, changing these flags requires a full re-sync from scratch.
+These settings can only be configured at genesis initialization. Once the node has been initialized, changing these settings requires a full re-sync from scratch.
 :::
 
-## Available Flags
+## Managing Storage Settings
 
-### `--storage.tx-hash-in-rocksdb`
+Storage settings are managed using the `reth db settings` command.
+
+### Viewing Current Settings
+
+```bash
+reth db settings get
+```
+
+### Available Settings
+
+#### `transaction_hash_numbers`
 
 Store the transaction hash to number mapping in RocksDB instead of MDBX.
 
 ```bash
-reth node --storage.tx-hash-in-rocksdb=true
+reth db settings set transaction_hash_numbers true
 ```
 
 **Default:** `false` (stored in MDBX)
 
 **Use case:** This table maps transaction hashes to their sequential transaction IDs. Moving it to RocksDB can improve lookup performance for high-volume transaction queries.
 
-### `--storage.storages-history-in-rocksdb`
+#### `storages_history`
 
 Store storage history data in RocksDB instead of MDBX.
 
 ```bash
-reth node --storage.storages-history-in-rocksdb=true
+reth db settings set storages_history true
 ```
 
 **Default:** `false` (stored in MDBX)
 
 **Use case:** Storage history tracks historical values of contract storage slots. This table can grow very large on archive nodes. RocksDB may provide better write performance for this workload.
 
-### `--storage.account-history-in-rocksdb`
+#### `account_history`
 
 Store account history data in RocksDB instead of MDBX.
 
 ```bash
-reth node --storage.account-history-in-rocksdb=true
+reth db settings set account_history true
 ```
 
 **Default:** `false` (stored in MDBX)
@@ -54,18 +64,21 @@ reth node --storage.account-history-in-rocksdb=true
 
 ## Example Configuration
 
-To initialize a new node with transaction hash lookups and history tables in RocksDB:
+To configure a new node with transaction hash lookups and history tables in RocksDB before first sync:
 
 ```bash
-reth node \
-    --storage.tx-hash-in-rocksdb=true \
-    --storage.storages-history-in-rocksdb=true \
-    --storage.account-history-in-rocksdb=true
+# Initialize the node first, then configure storage settings
+reth db settings set transaction_hash_numbers true
+reth db settings set storages_history true
+reth db settings set account_history true
+
+# Then start the node
+reth node
 ```
 
 ## RocksDB Data Directory
 
-When using RocksDB tables, the data is stored in a separate directory. You can customize this location using:
+When using RocksDB tables, the data is stored in a separate directory. You can customize this location using the `--datadir.rocksdb` flag:
 
 ```bash
 reth node --datadir.rocksdb /path/to/rocksdb
@@ -79,7 +92,7 @@ Consider enabling RocksDB for specific tables when:
 
 - Running an **archive node** with full historical data
 - Experiencing **write performance bottlenecks** with large history tables
-- Performing **high-volume transaction lookups** that stress the tx-hash table
+- Performing **high-volume transaction lookups** that stress the transaction hash table
 
 For most use cases, the default MDBX configuration provides excellent performance. Only enable RocksDB tables if you have measured performance issues with specific workloads.
 
@@ -87,7 +100,7 @@ For most use cases, the default MDBX configuration provides excellent performanc
 
 Since these settings are genesis-only:
 
-1. **New nodes:** Set your desired configuration before first sync
+1. **New nodes:** Configure storage settings before first sync
 2. **Existing nodes:** Requires full re-sync to change storage settings
 3. **Backup:** Always backup your data before re-syncing
 

--- a/docs/vocs/docs/pages/run/storage.mdx
+++ b/docs/vocs/docs/pages/run/storage.mdx
@@ -14,66 +14,48 @@ By default, all tables are stored in MDBX. However, certain large tables can ben
 These settings can only be configured at genesis initialization. Once the node has been initialized, changing these settings requires a full re-sync from scratch.
 :::
 
-## Managing Storage Settings
+## RocksDB CLI Flags
 
-Storage settings are managed using the `reth db settings` command.
+### `--rocksdb.tx-hash`
 
-### Viewing Current Settings
-
-```bash
-reth db settings get
-```
-
-### Available Settings
-
-#### `transaction_hash_numbers`
-
-Store the transaction hash to number mapping in RocksDB instead of MDBX.
+Route the transaction hash to number mapping table to RocksDB instead of MDBX.
 
 ```bash
-reth db settings set transaction_hash_numbers true
+reth node --rocksdb.tx-hash=true
 ```
 
 **Default:** `false` (stored in MDBX)
 
 **Use case:** This table maps transaction hashes to their sequential transaction IDs. Moving it to RocksDB can improve lookup performance for high-volume transaction queries.
 
-#### `storages_history`
+### `--rocksdb.storages-history`
 
-Store storage history data in RocksDB instead of MDBX.
+Route storage history tables to RocksDB instead of MDBX.
 
 ```bash
-reth db settings set storages_history true
+reth node --rocksdb.storages-history=true
 ```
 
 **Default:** `false` (stored in MDBX)
 
 **Use case:** Storage history tracks historical values of contract storage slots. This table can grow very large on archive nodes. RocksDB may provide better write performance for this workload.
 
-#### `account_history`
+### `--rocksdb.account-history`
 
-Store account history data in RocksDB instead of MDBX.
+Route account history tables to RocksDB instead of MDBX.
 
 ```bash
-reth db settings set account_history true
+reth node --rocksdb.account-history=true
 ```
 
 **Default:** `false` (stored in MDBX)
 
 **Use case:** Account history tracks historical account states. Similar to storage history, this table grows significantly on archive nodes and may benefit from RocksDB's handling of large datasets.
 
-## Example Configuration
-
-To configure a new node with transaction hash lookups and history tables in RocksDB before first sync:
+## Example
 
 ```bash
-# Initialize the node first, then configure storage settings
-reth db settings set transaction_hash_numbers true
-reth db settings set storages_history true
-reth db settings set account_history true
-
-# Then start the node
-reth node
+reth node --rocksdb.tx-hash=true --rocksdb.storages-history=true --rocksdb.account-history=true
 ```
 
 ## RocksDB Data Directory

--- a/docs/vocs/docs/pages/run/storage.mdx
+++ b/docs/vocs/docs/pages/run/storage.mdx
@@ -16,6 +16,8 @@ These settings can only be configured at genesis initialization. Once the node h
 
 ## RocksDB CLI Flags
 
+All RocksDB flags require an explicit boolean value (`true` or `false`). They cannot be used as bare flags.
+
 ### `--rocksdb.tx-hash`
 
 Route the transaction hash to number mapping table to RocksDB instead of MDBX.

--- a/docs/vocs/sidebar.ts
+++ b/docs/vocs/sidebar.ts
@@ -101,6 +101,10 @@ export const sidebar: SidebarItem[] = [
                 link: "/run/configuration"
             },
             {
+                text: "Storage",
+                link: "/run/storage"
+            },
+            {
                 text: "Monitoring",
                 link: "/run/monitoring"
             },


### PR DESCRIPTION
## Summary

Documents the new `--storage.*-in-rocksdb` CLI flags for RocksDB table routing.

## Flags Documented

- `--storage.tx-hash-in-rocksdb`: Route transaction hash lookups to RocksDB
- `--storage.storages-history-in-rocksdb`: Route storage history to RocksDB  
- `--storage.account-history-in-rocksdb`: Route account history to RocksDB

## Documentation Includes

- Overview of hybrid MDBX/RocksDB storage approach
- Genesis-only constraint warning
- Use cases for each flag
- Example configuration
- Migration notes

## PR Stack

This documentation PR is independent and documents the storage flags that will be added to the CLI.