### PR TITLE
feat(storage): add startup validation for RocksDB CLI flags

### DIFF
--- a/crates/cli/commands/src/node.rs
+++ b/crates/cli/commands/src/node.rs
@@ -10,7 +10,8 @@ use reth_node_builder::NodeBuilder;
 use reth_node_core::{
     args::{
         DatabaseArgs, DatadirArgs, DebugArgs, DevArgs, EngineArgs, EraArgs, MetricArgs,
-        NetworkArgs, PayloadBuilderArgs, PruningArgs, RpcServerArgs, StaticFilesArgs, TxPoolArgs,
+        NetworkArgs, PayloadBuilderArgs, PruningArgs, RocksDbArgs, RpcServerArgs, StaticFilesArgs,
+        TxPoolArgs,
     },
     node_config::NodeConfig,
     version,
@@ -102,6 +103,10 @@ pub struct NodeCommand<C: ChainSpecParser, Ext: clap::Args + fmt::Debug = NoArgs
     #[command(flatten)]
     pub pruning: PruningArgs,
 
+    /// All `RocksDB` table routing arguments
+    #[command(flatten)]
+    pub rocksdb: RocksDbArgs,
+
     /// Engine cli arguments
     #[command(flatten, next_help_heading = "Engine")]
     pub engine: EngineArgs,
@@ -166,6 +171,7 @@ where
             db,
             dev,
             pruning,
+            rocksdb,
             engine,
             era,
             static_files,
@@ -187,6 +193,7 @@ where
             db,
             dev,
             pruning,
+            rocksdb,
             engine,
             era,
             static_files,

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -676,19 +676,17 @@ where
 
     /// Convenience function to [`Self::init_genesis`]
     pub fn with_genesis(self) -> Result<Self, InitStorageError> {
-        init_genesis_with_settings(
-            self.provider_factory(),
-            self.node_config().static_files.to_settings(),
-        )?;
+        let base_settings = self.node_config().static_files.to_settings();
+        let settings = self.node_config().rocksdb.apply_to_settings(base_settings);
+        init_genesis_with_settings(self.provider_factory(), settings)?;
         Ok(self)
     }
 
     /// Write the genesis block and state if it has not already been written
     pub fn init_genesis(&self) -> Result<B256, InitStorageError> {
-        init_genesis_with_settings(
-            self.provider_factory(),
-            self.node_config().static_files.to_settings(),
-        )
+        let base_settings = self.node_config().static_files.to_settings();
+        let settings = self.node_config().rocksdb.apply_to_settings(base_settings);
+        init_genesis_with_settings(self.provider_factory(), settings)
     }
 
     /// Creates a new `WithMeteredProvider` container and attaches it to the

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -677,7 +677,13 @@ where
     /// Convenience function to [`Self::init_genesis`]
     pub fn with_genesis(self) -> Result<Self, InitStorageError> {
         let base_settings = self.node_config().static_files.to_settings();
-        let settings = self.node_config().rocksdb.apply_to_settings(base_settings);
+        let (settings, grouped_enabled) =
+            self.node_config().rocksdb.apply_to_settings(base_settings);
+
+        if grouped_enabled {
+            info!(target: "reth::cli", "RocksDB routing enabled for all tables (tx-hash, storages-history, account-history). To disable specific tables, use --rocksdb.<table>=false");
+        }
+
         init_genesis_with_settings(self.provider_factory(), settings)?;
         Ok(self)
     }
@@ -685,7 +691,13 @@ where
     /// Write the genesis block and state if it has not already been written
     pub fn init_genesis(&self) -> Result<B256, InitStorageError> {
         let base_settings = self.node_config().static_files.to_settings();
-        let settings = self.node_config().rocksdb.apply_to_settings(base_settings);
+        let (settings, grouped_enabled) =
+            self.node_config().rocksdb.apply_to_settings(base_settings);
+
+        if grouped_enabled {
+            info!(target: "reth::cli", "RocksDB routing enabled for all tables (tx-hash, storages-history, account-history). To disable specific tables, use --rocksdb.<table>=false");
+        }
+
         init_genesis_with_settings(self.provider_factory(), settings)
     }
 

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -681,7 +681,15 @@ where
             self.node_config().rocksdb.apply_to_settings(base_settings);
 
         if grouped_enabled {
-            info!(target: "reth::cli", "RocksDB routing enabled for all tables (tx-hash, storages-history, account-history). To disable specific tables, use --rocksdb.<table>=false");
+            let enabled: Vec<&str> = [
+                settings.transaction_hash_numbers_in_rocksdb.then_some("tx-hash"),
+                settings.storages_history_in_rocksdb.then_some("storages-history"),
+                settings.account_history_in_rocksdb.then_some("account-history"),
+            ]
+            .into_iter()
+            .flatten()
+            .collect();
+            info!(target: "reth::cli", "RocksDB routing enabled for tables: {}", enabled.join(", "));
         }
 
         init_genesis_with_settings(self.provider_factory(), settings)?;
@@ -695,7 +703,15 @@ where
             self.node_config().rocksdb.apply_to_settings(base_settings);
 
         if grouped_enabled {
-            info!(target: "reth::cli", "RocksDB routing enabled for all tables (tx-hash, storages-history, account-history). To disable specific tables, use --rocksdb.<table>=false");
+            let enabled: Vec<&str> = [
+                settings.transaction_hash_numbers_in_rocksdb.then_some("tx-hash"),
+                settings.storages_history_in_rocksdb.then_some("storages-history"),
+                settings.account_history_in_rocksdb.then_some("account-history"),
+            ]
+            .into_iter()
+            .flatten()
+            .collect();
+            info!(target: "reth::cli", "RocksDB routing enabled for tables: {}", enabled.join(", "));
         }
 
         init_genesis_with_settings(self.provider_factory(), settings)

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -68,7 +68,7 @@ use reth_provider::{
     providers::{NodeTypesForProvider, ProviderNodeTypes, RocksDBProvider, StaticFileProvider},
     BlockHashReader, BlockNumReader, DatabaseProviderFactory, ProviderError, ProviderFactory,
     ProviderResult, RocksDBProviderFactory, StageCheckpointReader, StaticFileProviderBuilder,
-    StaticFileProviderFactory,
+    StaticFileProviderFactory, StorageSettings,
 };
 use reth_prune::{PruneModes, PrunerBuilder};
 use reth_rpc_builder::config::RethRpcServerConfig;
@@ -674,8 +674,8 @@ where
         Ok(())
     }
 
-    /// Convenience function to [`Self::init_genesis`]
-    pub fn with_genesis(self) -> Result<Self, InitStorageError> {
+    /// Computes storage settings from CLI args and logs `RocksDB` routing if enabled.
+    fn storage_settings_with_logging(&self) -> StorageSettings {
         let base_settings = self.node_config().static_files.to_settings();
         let (settings, grouped_enabled) =
             self.node_config().rocksdb.apply_to_settings(base_settings);
@@ -692,28 +692,19 @@ where
             info!(target: "reth::cli", "RocksDB routing enabled for tables: {}", enabled.join(", "));
         }
 
+        settings
+    }
+
+    /// Convenience function to [`Self::init_genesis`]
+    pub fn with_genesis(self) -> Result<Self, InitStorageError> {
+        let settings = self.storage_settings_with_logging();
         init_genesis_with_settings(self.provider_factory(), settings)?;
         Ok(self)
     }
 
     /// Write the genesis block and state if it has not already been written
     pub fn init_genesis(&self) -> Result<B256, InitStorageError> {
-        let base_settings = self.node_config().static_files.to_settings();
-        let (settings, grouped_enabled) =
-            self.node_config().rocksdb.apply_to_settings(base_settings);
-
-        if grouped_enabled {
-            let enabled: Vec<&str> = [
-                settings.transaction_hash_numbers_in_rocksdb.then_some("tx-hash"),
-                settings.storages_history_in_rocksdb.then_some("storages-history"),
-                settings.account_history_in_rocksdb.then_some("account-history"),
-            ]
-            .into_iter()
-            .flatten()
-            .collect();
-            info!(target: "reth::cli", "RocksDB routing enabled for tables: {}", enabled.join(", "));
-        }
-
+        let settings = self.storage_settings_with_logging();
         init_genesis_with_settings(self.provider_factory(), settings)
     }
 

--- a/crates/node/core/src/args/mod.rs
+++ b/crates/node/core/src/args/mod.rs
@@ -82,7 +82,7 @@ pub use static_files::{StaticFilesArgs, MINIMAL_BLOCKS_PER_FILE};
 
 /// `RocksDbArgs` for configuring RocksDB table routing.
 mod rocksdb;
-pub use rocksdb::RocksDbArgs;
+pub use rocksdb::{RocksDbArgs, RocksDbSettingsMismatchError};
 
 mod error;
 pub mod types;

--- a/crates/node/core/src/args/mod.rs
+++ b/crates/node/core/src/args/mod.rs
@@ -80,5 +80,9 @@ pub use era::{DefaultEraHost, EraArgs, EraSourceArgs};
 mod static_files;
 pub use static_files::{StaticFilesArgs, MINIMAL_BLOCKS_PER_FILE};
 
+/// `RocksDbArgs` for configuring RocksDB table routing.
+mod rocksdb;
+pub use rocksdb::RocksDbArgs;
+
 mod error;
 pub mod types;

--- a/crates/node/core/src/args/rocksdb.rs
+++ b/crates/node/core/src/args/rocksdb.rs
@@ -1,28 +1,28 @@
-//! clap [Args](clap::Args) for RocksDB table routing configuration
+//! clap [Args](clap::Args) for `RocksDB` table routing configuration
 
 use clap::{ArgAction, Args};
 use reth_storage_api::StorageSettings;
 
-/// Parameters for RocksDB table routing configuration.
+/// Parameters for `RocksDB` table routing configuration.
 ///
-/// These flags control which database tables are stored in RocksDB instead of MDBX.
+/// These flags control which database tables are stored in `RocksDB` instead of MDBX.
 /// All flags are genesis-initialization-only: changing them after genesis requires a re-sync.
 #[derive(Debug, Args, PartialEq, Eq, Default, Clone, Copy)]
 #[command(next_help_heading = "RocksDB")]
 pub struct RocksDbArgs {
-    /// Route tx hash -> number table to RocksDB instead of MDBX.
+    /// Route tx hash -> number table to `RocksDB` instead of MDBX.
     ///
     /// Note: genesis-initialization-only, changing later requires re-sync.
     #[arg(long = "rocksdb.tx-hash", action = ArgAction::Set)]
     pub tx_hash: Option<bool>,
 
-    /// Route storages history tables to RocksDB instead of MDBX.
+    /// Route storages history tables to `RocksDB` instead of MDBX.
     ///
     /// Note: genesis-initialization-only, changing later requires re-sync.
     #[arg(long = "rocksdb.storages-history", action = ArgAction::Set)]
     pub storages_history: Option<bool>,
 
-    /// Route account history tables to RocksDB instead of MDBX.
+    /// Route account history tables to `RocksDB` instead of MDBX.
     ///
     /// Note: genesis-initialization-only, changing later requires re-sync.
     #[arg(long = "rocksdb.account-history", action = ArgAction::Set)]
@@ -34,7 +34,7 @@ impl RocksDbArgs {
     ///
     /// For each flag that is `Some`, the corresponding field in the defaults is overwritten.
     /// Flags that are `None` preserve the default value.
-    pub fn apply_to_settings(&self, mut defaults: StorageSettings) -> StorageSettings {
+    pub const fn apply_to_settings(&self, mut defaults: StorageSettings) -> StorageSettings {
         if let Some(value) = self.tx_hash {
             defaults.transaction_hash_numbers_in_rocksdb = value;
         }
@@ -47,7 +47,7 @@ impl RocksDbArgs {
         defaults
     }
 
-    /// Returns true if any RocksDB table routing flag was explicitly set.
+    /// Returns true if any `RocksDB` table routing flag was explicitly set.
     pub const fn has_overrides(&self) -> bool {
         self.tx_hash.is_some() || self.storages_history.is_some() || self.account_history.is_some()
     }

--- a/crates/node/core/src/args/rocksdb.rs
+++ b/crates/node/core/src/args/rocksdb.rs
@@ -1,0 +1,168 @@
+//! clap [Args](clap::Args) for RocksDB table routing configuration
+
+use clap::{ArgAction, Args};
+use reth_storage_api::StorageSettings;
+
+/// Parameters for RocksDB table routing configuration.
+///
+/// These flags control which database tables are stored in RocksDB instead of MDBX.
+/// All flags are genesis-initialization-only: changing them after genesis requires a re-sync.
+#[derive(Debug, Args, PartialEq, Eq, Default, Clone, Copy)]
+#[command(next_help_heading = "RocksDB")]
+pub struct RocksDbArgs {
+    /// Route tx hash -> number table to RocksDB instead of MDBX.
+    ///
+    /// Note: genesis-initialization-only, changing later requires re-sync.
+    #[arg(long = "rocksdb.tx-hash", action = ArgAction::Set)]
+    pub tx_hash: Option<bool>,
+
+    /// Route storages history tables to RocksDB instead of MDBX.
+    ///
+    /// Note: genesis-initialization-only, changing later requires re-sync.
+    #[arg(long = "rocksdb.storages-history", action = ArgAction::Set)]
+    pub storages_history: Option<bool>,
+
+    /// Route account history tables to RocksDB instead of MDBX.
+    ///
+    /// Note: genesis-initialization-only, changing later requires re-sync.
+    #[arg(long = "rocksdb.account-history", action = ArgAction::Set)]
+    pub account_history: Option<bool>,
+}
+
+impl RocksDbArgs {
+    /// Applies CLI overrides to the given defaults, returning the resulting settings.
+    ///
+    /// For each flag that is `Some`, the corresponding field in the defaults is overwritten.
+    /// Flags that are `None` preserve the default value.
+    pub fn apply_to_settings(&self, mut defaults: StorageSettings) -> StorageSettings {
+        if let Some(value) = self.tx_hash {
+            defaults.transaction_hash_numbers_in_rocksdb = value;
+        }
+        if let Some(value) = self.storages_history {
+            defaults.storages_history_in_rocksdb = value;
+        }
+        if let Some(value) = self.account_history {
+            defaults.account_history_in_rocksdb = value;
+        }
+        defaults
+    }
+
+    /// Returns true if any RocksDB table routing flag was explicitly set.
+    pub const fn has_overrides(&self) -> bool {
+        self.tx_hash.is_some() || self.storages_history.is_some() || self.account_history.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct CommandParser<T: Args> {
+        #[command(flatten)]
+        args: T,
+    }
+
+    #[test]
+    fn test_default_rocksdb_args() {
+        let default_args = RocksDbArgs::default();
+        let args = CommandParser::<RocksDbArgs>::parse_from(["reth"]).args;
+        assert_eq!(args, default_args);
+        assert_eq!(args.tx_hash, None);
+        assert_eq!(args.storages_history, None);
+        assert_eq!(args.account_history, None);
+    }
+
+    #[test]
+    fn test_rocksdb_tx_hash_true() {
+        let args =
+            CommandParser::<RocksDbArgs>::parse_from(["reth", "--rocksdb.tx-hash=true"]).args;
+        assert_eq!(args.tx_hash, Some(true));
+    }
+
+    #[test]
+    fn test_rocksdb_tx_hash_false() {
+        let args =
+            CommandParser::<RocksDbArgs>::parse_from(["reth", "--rocksdb.tx-hash=false"]).args;
+        assert_eq!(args.tx_hash, Some(false));
+    }
+
+    #[test]
+    fn test_rocksdb_storages_history_true() {
+        let args =
+            CommandParser::<RocksDbArgs>::parse_from(["reth", "--rocksdb.storages-history=true"])
+                .args;
+        assert_eq!(args.storages_history, Some(true));
+    }
+
+    #[test]
+    fn test_rocksdb_storages_history_false() {
+        let args =
+            CommandParser::<RocksDbArgs>::parse_from(["reth", "--rocksdb.storages-history=false"])
+                .args;
+        assert_eq!(args.storages_history, Some(false));
+    }
+
+    #[test]
+    fn test_rocksdb_account_history_true() {
+        let args =
+            CommandParser::<RocksDbArgs>::parse_from(["reth", "--rocksdb.account-history=true"])
+                .args;
+        assert_eq!(args.account_history, Some(true));
+    }
+
+    #[test]
+    fn test_rocksdb_account_history_false() {
+        let args =
+            CommandParser::<RocksDbArgs>::parse_from(["reth", "--rocksdb.account-history=false"])
+                .args;
+        assert_eq!(args.account_history, Some(false));
+    }
+
+    #[test]
+    fn test_all_flags_together() {
+        let args = CommandParser::<RocksDbArgs>::parse_from([
+            "reth",
+            "--rocksdb.tx-hash=true",
+            "--rocksdb.storages-history=false",
+            "--rocksdb.account-history=true",
+        ])
+        .args;
+        assert_eq!(args.tx_hash, Some(true));
+        assert_eq!(args.storages_history, Some(false));
+        assert_eq!(args.account_history, Some(true));
+    }
+
+    #[test]
+    fn test_apply_to_settings() {
+        let args = RocksDbArgs {
+            tx_hash: Some(true),
+            storages_history: None,
+            account_history: Some(false),
+        };
+
+        let defaults = StorageSettings::legacy();
+        let result = args.apply_to_settings(defaults);
+
+        assert!(result.transaction_hash_numbers_in_rocksdb);
+        assert!(!result.storages_history_in_rocksdb);
+        assert!(!result.account_history_in_rocksdb);
+    }
+
+    #[test]
+    fn test_has_overrides() {
+        let empty = RocksDbArgs::default();
+        assert!(!empty.has_overrides());
+
+        let with_tx_hash = RocksDbArgs { tx_hash: Some(true), ..Default::default() };
+        assert!(with_tx_hash.has_overrides());
+
+        let with_all = RocksDbArgs {
+            tx_hash: Some(true),
+            storages_history: Some(false),
+            account_history: Some(true),
+        };
+        assert!(with_all.has_overrides());
+    }
+}

--- a/crates/node/core/src/args/rocksdb.rs
+++ b/crates/node/core/src/args/rocksdb.rs
@@ -66,62 +66,12 @@ mod tests {
 
     #[test]
     fn test_default_rocksdb_args() {
-        let default_args = RocksDbArgs::default();
         let args = CommandParser::<RocksDbArgs>::parse_from(["reth"]).args;
-        assert_eq!(args, default_args);
-        assert_eq!(args.tx_hash, None);
-        assert_eq!(args.storages_history, None);
-        assert_eq!(args.account_history, None);
+        assert_eq!(args, RocksDbArgs::default());
     }
 
     #[test]
-    fn test_rocksdb_tx_hash_true() {
-        let args =
-            CommandParser::<RocksDbArgs>::parse_from(["reth", "--rocksdb.tx-hash=true"]).args;
-        assert_eq!(args.tx_hash, Some(true));
-    }
-
-    #[test]
-    fn test_rocksdb_tx_hash_false() {
-        let args =
-            CommandParser::<RocksDbArgs>::parse_from(["reth", "--rocksdb.tx-hash=false"]).args;
-        assert_eq!(args.tx_hash, Some(false));
-    }
-
-    #[test]
-    fn test_rocksdb_storages_history_true() {
-        let args =
-            CommandParser::<RocksDbArgs>::parse_from(["reth", "--rocksdb.storages-history=true"])
-                .args;
-        assert_eq!(args.storages_history, Some(true));
-    }
-
-    #[test]
-    fn test_rocksdb_storages_history_false() {
-        let args =
-            CommandParser::<RocksDbArgs>::parse_from(["reth", "--rocksdb.storages-history=false"])
-                .args;
-        assert_eq!(args.storages_history, Some(false));
-    }
-
-    #[test]
-    fn test_rocksdb_account_history_true() {
-        let args =
-            CommandParser::<RocksDbArgs>::parse_from(["reth", "--rocksdb.account-history=true"])
-                .args;
-        assert_eq!(args.account_history, Some(true));
-    }
-
-    #[test]
-    fn test_rocksdb_account_history_false() {
-        let args =
-            CommandParser::<RocksDbArgs>::parse_from(["reth", "--rocksdb.account-history=false"])
-                .args;
-        assert_eq!(args.account_history, Some(false));
-    }
-
-    #[test]
-    fn test_all_flags_together() {
+    fn test_parse_all_flags() {
         let args = CommandParser::<RocksDbArgs>::parse_from([
             "reth",
             "--rocksdb.tx-hash=true",
@@ -136,50 +86,10 @@ mod tests {
 
     #[test]
     fn test_apply_to_settings() {
-        let args = RocksDbArgs {
-            tx_hash: Some(true),
-            storages_history: None,
-            account_history: Some(false),
-        };
-
-        let defaults = StorageSettings::legacy();
-        let result = args.apply_to_settings(defaults);
-
+        let args =
+            RocksDbArgs { tx_hash: Some(true), storages_history: None, account_history: None };
+        let result = args.apply_to_settings(StorageSettings::legacy());
         assert!(result.transaction_hash_numbers_in_rocksdb);
         assert!(!result.storages_history_in_rocksdb);
-        assert!(!result.account_history_in_rocksdb);
-    }
-
-    #[test]
-    fn test_has_overrides() {
-        let empty = RocksDbArgs::default();
-        assert!(!empty.has_overrides());
-
-        let with_tx_hash = RocksDbArgs { tx_hash: Some(true), ..Default::default() };
-        assert!(with_tx_hash.has_overrides());
-
-        let with_all = RocksDbArgs {
-            tx_hash: Some(true),
-            storages_history: Some(false),
-            account_history: Some(true),
-        };
-        assert!(with_all.has_overrides());
-    }
-
-    #[test]
-    fn test_bare_flag_requires_value() {
-        let result = CommandParser::<RocksDbArgs>::try_parse_from(["reth", "--rocksdb.tx-hash"]);
-        assert!(result.is_err(), "bare flag without value should require a value");
-    }
-
-    #[test]
-    fn test_space_separated_value() {
-        let args =
-            CommandParser::<RocksDbArgs>::parse_from(["reth", "--rocksdb.tx-hash", "true"]).args;
-        assert_eq!(args.tx_hash, Some(true));
-
-        let args =
-            CommandParser::<RocksDbArgs>::parse_from(["reth", "--rocksdb.tx-hash", "false"]).args;
-        assert_eq!(args.tx_hash, Some(false));
     }
 }

--- a/crates/node/core/src/args/rocksdb.rs
+++ b/crates/node/core/src/args/rocksdb.rs
@@ -11,20 +11,14 @@ use reth_storage_api::StorageSettings;
 #[command(next_help_heading = "RocksDB")]
 pub struct RocksDbArgs {
     /// Route tx hash -> number table to `RocksDB` instead of MDBX.
-    ///
-    /// Note: genesis-initialization-only, changing later requires re-sync.
     #[arg(long = "rocksdb.tx-hash", action = ArgAction::Set)]
     pub tx_hash: Option<bool>,
 
     /// Route storages history tables to `RocksDB` instead of MDBX.
-    ///
-    /// Note: genesis-initialization-only, changing later requires re-sync.
     #[arg(long = "rocksdb.storages-history", action = ArgAction::Set)]
     pub storages_history: Option<bool>,
 
     /// Route account history tables to `RocksDB` instead of MDBX.
-    ///
-    /// Note: genesis-initialization-only, changing later requires re-sync.
     #[arg(long = "rocksdb.account-history", action = ArgAction::Set)]
     pub account_history: Option<bool>,
 }
@@ -32,9 +26,23 @@ pub struct RocksDbArgs {
 impl RocksDbArgs {
     /// Applies CLI overrides to the given defaults, returning the resulting settings.
     ///
-    /// For each flag that is `Some`, the corresponding field in the defaults is overwritten.
-    /// Flags that are `None` preserve the default value.
-    pub const fn apply_to_settings(&self, mut defaults: StorageSettings) -> StorageSettings {
+    /// If any flag is set to `true`, all RocksDB tables are enabled by default, then explicit
+    /// `false` overrides are applied. This grouped behavior ensures users get the full RocksDB
+    /// benefit without needing to specify all flags.
+    ///
+    /// Returns `(settings, grouped_enabled)` where `grouped_enabled` is true if the grouped
+    /// behavior was triggered (any flag was true, enabling all tables).
+    pub fn apply_to_settings(&self, mut defaults: StorageSettings) -> (StorageSettings, bool) {
+        let any_true = self.tx_hash == Some(true) ||
+            self.storages_history == Some(true) ||
+            self.account_history == Some(true);
+
+        if any_true {
+            defaults.transaction_hash_numbers_in_rocksdb = true;
+            defaults.storages_history_in_rocksdb = true;
+            defaults.account_history_in_rocksdb = true;
+        }
+
         if let Some(value) = self.tx_hash {
             defaults.transaction_hash_numbers_in_rocksdb = value;
         }
@@ -44,7 +52,8 @@ impl RocksDbArgs {
         if let Some(value) = self.account_history {
             defaults.account_history_in_rocksdb = value;
         }
-        defaults
+
+        (defaults, any_true)
     }
 
     /// Returns true if any `RocksDB` table routing flag was explicitly set.
@@ -85,11 +94,40 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_to_settings() {
+    fn test_apply_to_settings_grouped_enable() {
         let args =
             RocksDbArgs { tx_hash: Some(true), storages_history: None, account_history: None };
-        let result = args.apply_to_settings(StorageSettings::legacy());
+        let (result, grouped) = args.apply_to_settings(StorageSettings::legacy());
+
+        assert!(grouped, "should trigger grouped behavior when any flag is true");
         assert!(result.transaction_hash_numbers_in_rocksdb);
+        assert!(result.storages_history_in_rocksdb, "grouped: all tables enabled");
+        assert!(result.account_history_in_rocksdb, "grouped: all tables enabled");
+    }
+
+    #[test]
+    fn test_apply_to_settings_explicit_disable() {
+        let args = RocksDbArgs {
+            tx_hash: Some(true),
+            storages_history: Some(false),
+            account_history: None,
+        };
+        let (result, grouped) = args.apply_to_settings(StorageSettings::legacy());
+
+        assert!(grouped);
+        assert!(result.transaction_hash_numbers_in_rocksdb);
+        assert!(!result.storages_history_in_rocksdb, "explicit false overrides grouped enable");
+        assert!(result.account_history_in_rocksdb);
+    }
+
+    #[test]
+    fn test_apply_to_settings_no_grouped_when_all_none() {
+        let args = RocksDbArgs::default();
+        let (result, grouped) = args.apply_to_settings(StorageSettings::legacy());
+
+        assert!(!grouped, "no grouped behavior when no flags set");
+        assert!(!result.transaction_hash_numbers_in_rocksdb);
         assert!(!result.storages_history_in_rocksdb);
+        assert!(!result.account_history_in_rocksdb);
     }
 }

--- a/crates/node/core/src/args/rocksdb.rs
+++ b/crates/node/core/src/args/rocksdb.rs
@@ -73,45 +73,45 @@ impl RocksDbArgs {
     /// - All CLI overrides match the persisted values
     ///
     /// Returns `Err` if any CLI override differs from the persisted value.
-    pub fn validate_against_persisted(
+    pub const fn validate_against_persisted(
         &self,
         persisted: &StorageSettings,
     ) -> Result<(), RocksDbSettingsMismatchError> {
-        if let Some(cli_value) = self.tx_hash {
-            if cli_value != persisted.transaction_hash_numbers_in_rocksdb {
-                return Err(RocksDbSettingsMismatchError {
-                    flag_name: "--rocksdb.tx-hash",
-                    expected: persisted.transaction_hash_numbers_in_rocksdb,
-                    got: cli_value,
-                });
-            }
+        if let Some(cli_value) = self.tx_hash &&
+            cli_value != persisted.transaction_hash_numbers_in_rocksdb
+        {
+            return Err(RocksDbSettingsMismatchError {
+                flag_name: "--rocksdb.tx-hash",
+                expected: persisted.transaction_hash_numbers_in_rocksdb,
+                got: cli_value,
+            });
         }
 
-        if let Some(cli_value) = self.storages_history {
-            if cli_value != persisted.storages_history_in_rocksdb {
-                return Err(RocksDbSettingsMismatchError {
-                    flag_name: "--rocksdb.storages-history",
-                    expected: persisted.storages_history_in_rocksdb,
-                    got: cli_value,
-                });
-            }
+        if let Some(cli_value) = self.storages_history &&
+            cli_value != persisted.storages_history_in_rocksdb
+        {
+            return Err(RocksDbSettingsMismatchError {
+                flag_name: "--rocksdb.storages-history",
+                expected: persisted.storages_history_in_rocksdb,
+                got: cli_value,
+            });
         }
 
-        if let Some(cli_value) = self.account_history {
-            if cli_value != persisted.account_history_in_rocksdb {
-                return Err(RocksDbSettingsMismatchError {
-                    flag_name: "--rocksdb.account-history",
-                    expected: persisted.account_history_in_rocksdb,
-                    got: cli_value,
-                });
-            }
+        if let Some(cli_value) = self.account_history &&
+            cli_value != persisted.account_history_in_rocksdb
+        {
+            return Err(RocksDbSettingsMismatchError {
+                flag_name: "--rocksdb.account-history",
+                expected: persisted.account_history_in_rocksdb,
+                got: cli_value,
+            });
         }
 
         Ok(())
     }
 }
 
-/// Error returned when a CLI RocksDB flag differs from the persisted storage settings.
+/// Error returned when a CLI `RocksDB` flag differs from the persisted storage settings.
 ///
 /// These settings are genesis-initialization-only and cannot be changed after the node
 /// has been initialized.

--- a/crates/node/core/src/args/rocksdb.rs
+++ b/crates/node/core/src/args/rocksdb.rs
@@ -165,4 +165,21 @@ mod tests {
         };
         assert!(with_all.has_overrides());
     }
+
+    #[test]
+    fn test_bare_flag_requires_value() {
+        let result = CommandParser::<RocksDbArgs>::try_parse_from(["reth", "--rocksdb.tx-hash"]);
+        assert!(result.is_err(), "bare flag without value should require a value");
+    }
+
+    #[test]
+    fn test_space_separated_value() {
+        let args =
+            CommandParser::<RocksDbArgs>::parse_from(["reth", "--rocksdb.tx-hash", "true"]).args;
+        assert_eq!(args.tx_hash, Some(true));
+
+        let args =
+            CommandParser::<RocksDbArgs>::parse_from(["reth", "--rocksdb.tx-hash", "false"]).args;
+        assert_eq!(args.tx_hash, Some(false));
+    }
 }

--- a/crates/node/core/src/node_config.rs
+++ b/crates/node/core/src/node_config.rs
@@ -3,7 +3,7 @@
 use crate::{
     args::{
         DatabaseArgs, DatadirArgs, DebugArgs, DevArgs, EngineArgs, NetworkArgs, PayloadBuilderArgs,
-        PruningArgs, RpcServerArgs, StaticFilesArgs, TxPoolArgs,
+        PruningArgs, RocksDbArgs, RpcServerArgs, StaticFilesArgs, TxPoolArgs,
     },
     dirs::{ChainPath, DataDirPath},
     utils::get_single_header,
@@ -150,6 +150,9 @@ pub struct NodeConfig<ChainSpec> {
 
     /// All static files related arguments
     pub static_files: StaticFilesArgs,
+
+    /// All RocksDB table routing arguments
+    pub rocksdb: RocksDbArgs,
 }
 
 impl NodeConfig<ChainSpec> {
@@ -181,6 +184,7 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
             engine: EngineArgs::default(),
             era: EraArgs::default(),
             static_files: StaticFilesArgs::default(),
+            rocksdb: RocksDbArgs::default(),
         }
     }
 
@@ -255,6 +259,7 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
             engine,
             era,
             static_files,
+            rocksdb,
             ..
         } = self;
         NodeConfig {
@@ -274,6 +279,7 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
             engine,
             era,
             static_files,
+            rocksdb,
         }
     }
 
@@ -544,6 +550,7 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
             engine: self.engine,
             era: self.era,
             static_files: self.static_files,
+            rocksdb: self.rocksdb,
         }
     }
 
@@ -585,6 +592,7 @@ impl<ChainSpec> Clone for NodeConfig<ChainSpec> {
             engine: self.engine.clone(),
             era: self.era.clone(),
             static_files: self.static_files,
+            rocksdb: self.rocksdb,
         }
     }
 }

--- a/crates/node/core/src/node_config.rs
+++ b/crates/node/core/src/node_config.rs
@@ -151,7 +151,7 @@ pub struct NodeConfig<ChainSpec> {
     /// All static files related arguments
     pub static_files: StaticFilesArgs,
 
-    /// All RocksDB table routing arguments
+    /// All `RocksDB` table routing arguments
     pub rocksdb: RocksDbArgs,
 }
 

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -75,6 +75,9 @@ pub enum InitStorageError {
     /// State root doesn't match the expected one.
     #[error("state root mismatch: {_0}")]
     StateRootMismatch(GotExpected<B256>),
+    /// `RocksDB` CLI flag differs from persisted storage settings.
+    #[error("{_0}")]
+    RocksDbSettingsMismatch(String),
 }
 
 impl From<DatabaseError> for InitStorageError {

--- a/docs/vocs/docs/pages/cli/op-reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/node.mdx
@@ -897,6 +897,28 @@ Pruning:
       --prune.bodies.before <BLOCK_NUMBER>
           Prune storage history before the specified block number. The specified block number is not pruned
 
+RocksDB:
+      --rocksdb.tx-hash <TX_HASH>
+          Route tx hash -> number table to `RocksDB` instead of MDBX.
+
+          Note: genesis-initialization-only, changing later requires re-sync.
+
+          [possible values: true, false]
+
+      --rocksdb.storages-history <STORAGES_HISTORY>
+          Route storages history tables to `RocksDB` instead of MDBX.
+
+          Note: genesis-initialization-only, changing later requires re-sync.
+
+          [possible values: true, false]
+
+      --rocksdb.account-history <ACCOUNT_HISTORY>
+          Route account history tables to `RocksDB` instead of MDBX.
+
+          Note: genesis-initialization-only, changing later requires re-sync.
+
+          [possible values: true, false]
+
 Engine:
       --engine.persistence-threshold <PERSISTENCE_THRESHOLD>
           Configure persistence threshold for the engine. This determines how many canonical blocks must be in-memory, ahead of the last persisted block, before flushing canonical blocks to disk again.

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -897,6 +897,28 @@ Pruning:
       --prune.bodies.before <BLOCK_NUMBER>
           Prune storage history before the specified block number. The specified block number is not pruned
 
+RocksDB:
+      --rocksdb.tx-hash <TX_HASH>
+          Route tx hash -> number table to `RocksDB` instead of MDBX.
+
+          Note: genesis-initialization-only, changing later requires re-sync.
+
+          [possible values: true, false]
+
+      --rocksdb.storages-history <STORAGES_HISTORY>
+          Route storages history tables to `RocksDB` instead of MDBX.
+
+          Note: genesis-initialization-only, changing later requires re-sync.
+
+          [possible values: true, false]
+
+      --rocksdb.account-history <ACCOUNT_HISTORY>
+          Route account history tables to `RocksDB` instead of MDBX.
+
+          Note: genesis-initialization-only, changing later requires re-sync.
+
+          [possible values: true, false]
+
 Engine:
       --engine.persistence-threshold <PERSISTENCE_THRESHOLD>
           Configure persistence threshold for the engine. This determines how many canonical blocks must be in-memory, ahead of the last persisted block, before flushing canonical blocks to disk again.


### PR DESCRIPTION
## Summary
Adds startup validation to ensure `--rocksdb.*` flags match the persisted storage layout.

## Behavior
- If CLI override differs from initialized layout → startup error with actionable message
- If CLI override matches or is not provided → startup proceeds

## Changes
- Added `validate_against_persisted()` method to `RocksDbArgs` 
- Added `RocksDbSettingsMismatchError` for clear error messages
- Comprehensive tests for validation logic

## Example Error
```
`--rocksdb.tx-hash` differs from initialized layout (expected false, got true). 
This setting is genesis-only; re-sync required (remove datadir or use a new datadir).
```

## PR Stack
1. #21191 - CLI flags ← **base**
2. **This PR** - Validation logic
3. #21190 - Docs (independent)