### PR TITLE
perf(chain-state): parallelize into_sorted with rayon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7789,6 +7789,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "rand 0.9.2",
+ "rayon",
  "reth-chainspec",
  "reth-errors",
  "reth-ethereum-primitives",

--- a/crates/chain-state/Cargo.toml
+++ b/crates/chain-state/Cargo.toml
@@ -41,6 +41,7 @@ derive_more.workspace = true
 metrics.workspace = true
 parking_lot.workspace = true
 pin-project.workspace = true
+rayon = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 
 # optional deps for test-utils
@@ -84,6 +85,7 @@ test-utils = [
     "reth-trie/test-utils",
     "reth-ethereum-primitives/test-utils",
 ]
+rayon = ["dep:rayon"]
 
 [[bench]]
 name = "canonical_hashes_range"

--- a/crates/chain-state/src/deferred_trie.rs
+++ b/crates/chain-state/src/deferred_trie.rs
@@ -163,14 +163,29 @@ impl DeferredTrieData {
         anchor_hash: B256,
         ancestors: &[Self],
     ) -> ComputedTrieData {
-        let sorted_hashed_state = match Arc::try_unwrap(hashed_state) {
-            Ok(state) => state.into_sorted(),
-            Err(arc) => arc.clone_into_sorted(),
-        };
-        let sorted_trie_updates = match Arc::try_unwrap(trie_updates) {
-            Ok(updates) => updates.into_sorted(),
-            Err(arc) => arc.clone_into_sorted(),
-        };
+        #[cfg(feature = "rayon")]
+        let (sorted_hashed_state, sorted_trie_updates) = rayon::join(
+            || match Arc::try_unwrap(hashed_state) {
+                Ok(state) => state.into_sorted(),
+                Err(arc) => arc.clone_into_sorted(),
+            },
+            || match Arc::try_unwrap(trie_updates) {
+                Ok(updates) => updates.into_sorted(),
+                Err(arc) => arc.clone_into_sorted(),
+            },
+        );
+
+        #[cfg(not(feature = "rayon"))]
+        let (sorted_hashed_state, sorted_trie_updates) = (
+            match Arc::try_unwrap(hashed_state) {
+                Ok(state) => state.into_sorted(),
+                Err(arc) => arc.clone_into_sorted(),
+            },
+            match Arc::try_unwrap(trie_updates) {
+                Ok(updates) => updates.into_sorted(),
+                Err(arc) => arc.clone_into_sorted(),
+            },
+        );
 
         // Reuse parent's overlay if available and anchors match.
         // We can only reuse the parent's overlay if it was built on top of the same

--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 
 [dependencies]
 # reth
-reth-chain-state.workspace = true
+reth-chain-state = { workspace = true, features = ["rayon"] }
 reth-chainspec = { workspace = true, optional = true }
 reth-consensus.workspace = true
 reth-db.workspace = true


### PR DESCRIPTION
## Summary

Parallelizes the `into_sorted` conversion for hashed state and trie updates using `rayon::join`.

## Changes

- Use `rayon::join` to convert hashed state and trie updates to sorted form concurrently
- Add `rayon` feature to `reth-chain-state` crate
- Feature-gate parallel implementation with sequential fallback when rayon is disabled

## Follow-up

See #21202 for the parallel merge implementation that builds on this change.