### PR TITLE
fix(engine): separate newPayload finish for FCU timing

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1478,7 +1478,7 @@ where
 
                                 self.metrics.engine.forkchoice_updated.update_response_metrics(
                                     start,
-                                    &mut self.metrics.engine.new_payload.latest_finish_at,
+                                    &mut self.metrics.engine.new_payload.latest_finish_for_fcu,
                                     has_attrs,
                                     &output,
                                 );


### PR DESCRIPTION
`forkchoiceUpdated` metrics consumed `latest_finish_at` via `take()`, which cleared the timestamp used to compute `time_between_new_payloads`. As a result, idle time between consecutive `newPayload` calls was regularly missing after FCU events.
Separated the finish timestamp used for FCU timing from the one used for newPayload intervals, and updated FCU metric handling to consume only the dedicated timestamp.