### PR TITLE
perf(trie): use HashMap reserve heuristic in MultiProof::extend

### DIFF
--- a/crates/trie/common/src/proofs.rs
+++ b/crates/trie/common/src/proofs.rs
@@ -270,7 +270,7 @@ impl MultiProof {
         let reserve = if self.storages.is_empty() {
             other.storages.len()
         } else {
-            (other.storages.len() + 1) / 2
+            other.storages.len().div_ceil(2)
         };
         self.storages.reserve(reserve);
         for (hashed_address, storage) in other.storages {
@@ -399,7 +399,7 @@ impl DecodedMultiProof {
         let reserve = if self.storages.is_empty() {
             other.storages.len()
         } else {
-            (other.storages.len() + 1) / 2
+            other.storages.len().div_ceil(2)
         };
         self.storages.reserve(reserve);
         for (hashed_address, storage) in other.storages {

--- a/crates/trie/common/src/proofs.rs
+++ b/crates/trie/common/src/proofs.rs
@@ -267,6 +267,12 @@ impl MultiProof {
         self.account_subtree.extend_from(other.account_subtree);
         self.branch_node_masks.extend(other.branch_node_masks);
 
+        let reserve = if self.storages.is_empty() {
+            other.storages.len()
+        } else {
+            (other.storages.len() + 1) / 2
+        };
+        self.storages.reserve(reserve);
         for (hashed_address, storage) in other.storages {
             match self.storages.entry(hashed_address) {
                 hash_map::Entry::Occupied(mut entry) => {
@@ -390,6 +396,12 @@ impl DecodedMultiProof {
         self.account_subtree.extend_from(other.account_subtree);
         self.branch_node_masks.extend(other.branch_node_masks);
 
+        let reserve = if self.storages.is_empty() {
+            other.storages.len()
+        } else {
+            (other.storages.len() + 1) / 2
+        };
+        self.storages.reserve(reserve);
         for (hashed_address, storage) in other.storages {
             match self.storages.entry(hashed_address) {
                 hash_map::Entry::Occupied(mut entry) => {


### PR DESCRIPTION
Applies HashMap's extend heuristic for reserving capacity before merging storages in `MultiProof::extend()` and `DecodedMultiProof::extend()`.

The storages loop uses `entry().insert()` rather than `HashMap::extend`, so it doesn't benefit from HashMap's internal reservation logic. This adds the same heuristic: reserve full size when empty, half when non-empty.