### PR TITLE
feat(engine-api): add EIP-7928 BAL stub methods

### DIFF
--- a/crates/rpc/rpc-api/src/engine.rs
+++ b/crates/rpc/rpc-api/src/engine.rs
@@ -252,6 +252,18 @@ pub trait EngineApi<Engine: EngineTypes> {
         &self,
         versioned_hashes: Vec<B256>,
     ) -> RpcResult<Option<Vec<Option<BlobAndProofV2>>>>;
+
+    /// Returns the Block Access Lists for the given block hashes.
+    ///
+    /// See also <https://eips.ethereum.org/EIPS/eip-7928>
+    #[method(name = "getBALsByHashV1")]
+    async fn get_bals_by_hash_v1(&self, block_hashes: Vec<BlockHash>) -> RpcResult<Vec<Bytes>>;
+
+    /// Returns the Block Access Lists for the given block range.
+    ///
+    /// See also <https://eips.ethereum.org/EIPS/eip-7928>
+    #[method(name = "getBALsByRangeV1")]
+    async fn get_bals_by_range_v1(&self, start: U64, count: U64) -> RpcResult<Vec<Bytes>>;
 }
 
 /// A subset of the ETH rpc interface: <https://ethereum.github.io/execution-apis/api-documentation>

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -1161,6 +1161,33 @@ where
         trace!(target: "rpc::engine", "Serving engine_getBlobsV3");
         Ok(self.get_blobs_v3_metered(versioned_hashes)?)
     }
+
+    /// Handler for `engine_getBALsByHashV1`
+    ///
+    /// See also <https://eips.ethereum.org/EIPS/eip-7928>
+    async fn get_bals_by_hash_v1(
+        &self,
+        _block_hashes: Vec<BlockHash>,
+    ) -> RpcResult<Vec<alloy_primitives::Bytes>> {
+        trace!(target: "rpc::engine", "Serving engine_getBALsByHashV1");
+        Err(EngineApiError::EngineObjectValidationError(
+            reth_payload_primitives::EngineObjectValidationError::UnsupportedFork,
+        ))?
+    }
+
+    /// Handler for `engine_getBALsByRangeV1`
+    ///
+    /// See also <https://eips.ethereum.org/EIPS/eip-7928>
+    async fn get_bals_by_range_v1(
+        &self,
+        _start: U64,
+        _count: U64,
+    ) -> RpcResult<Vec<alloy_primitives::Bytes>> {
+        trace!(target: "rpc::engine", "Serving engine_getBALsByRangeV1");
+        Err(EngineApiError::EngineObjectValidationError(
+            reth_payload_primitives::EngineObjectValidationError::UnsupportedFork,
+        ))?
+    }
 }
 
 impl<Provider, EngineT, Pool, Validator, ChainSpec> IntoEngineApiRpcModule

--- a/typos.toml
+++ b/typos.toml
@@ -37,3 +37,4 @@ ONL = "ONL" # Part of base64 encoded ENR
 Iy = "Iy" # Part of base64 encoded ENR
 flate = "flate" # zlib-flate is a valid tool name
 Pn = "Pn" # Part of UPnP (Universal Plug and Play)
+BA = "BA" # Part of BAL - Block Access List (EIP-7928)


### PR DESCRIPTION
## Summary

Add stub implementations for [EIP-7928](https://eips.ethereum.org/EIPS/eip-7928) Block Access Lists:

- `engine_getBALsByHashV1`: retrieve BALs by block hashes
- `engine_getBALsByRangeV1`: retrieve BALs by block range

Both methods currently return `UnsupportedFork` error as the feature is not yet implemented. Capabilities are not advertised yet.

## Changes

- Added trait methods in `reth-rpc-api`
- Added stub implementations in `reth-rpc-engine-api`

Ref: RETH-116