### PR TITLE
fix(node-builder): use edge storage settings for genesis initialization

### DIFF
--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -180,7 +180,7 @@ min-trace-logs = [
     "reth-node-core/min-trace-logs",
 ]
 
-edge = ["reth-ethereum-cli/edge", "reth-node-core/edge"]
+edge = ["reth-ethereum-cli/edge", "reth-node-core/edge", "reth-node-builder/edge"]
 
 [[bin]]
 name = "reth"

--- a/crates/node/builder/Cargo.toml
+++ b/crates/node/builder/Cargo.toml
@@ -128,3 +128,4 @@ op = [
     "reth-evm/op",
     "reth-primitives-traits/op",
 ]
+edge = ["reth-db-common/edge"]

--- a/crates/optimism/cli/Cargo.toml
+++ b/crates/optimism/cli/Cargo.toml
@@ -124,4 +124,4 @@ serde = [
     "reth-optimism-chainspec/serde",
 ]
 
-edge = ["reth-cli-commands/edge", "reth-node-core/edge"]
+edge = ["reth-cli-commands/edge", "reth-node-core/edge", "reth-node-builder/edge"]


### PR DESCRIPTION
## Summary

When compiled with the `edge` feature, the node builder now uses `init_genesis` from `reth-db-common` which enables all static file storage optimizations (receipts, transaction senders, and account changesets in static files).

## Problem

The node builder was calling `init_genesis_with_settings` directly with CLI-derived settings, bypassing the `#[cfg(feature = "edge")]` conditional in `reth-db-common::init::init_genesis` that enables `StorageSettings::edge()`.

This meant that even with the `edge` feature enabled, account changesets were not being stored in static files unless explicitly enabled via `--static-files.account-change-sets`.

## Solution

- Added `edge` feature to `reth-node-builder` that enables `reth-db-common/edge`
- Modified `init_genesis` in launch context to use conditional compilation:
  - With `edge` feature: calls `reth_db_common::init::init_genesis` which uses `StorageSettings::edge()`
  - Without `edge` feature: calls `init_genesis_with_settings` with CLI-provided settings (existing behavior)
- Wired `edge` feature through `bin/reth` and `reth-optimism-cli`

## Testing

Verified that both `cargo check -p reth` and `cargo check -p reth --features edge` compile successfully.