### PR TITLE
chore: use nightly for cargo docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,7 @@ Before submitting changes, ensure:
 1. **Format Check**: `cargo +nightly fmt --all --check`
 2. **Clippy**: No warnings with `RUSTFLAGS="-D warnings"`
 3. **Tests Pass**: All unit and integration tests
-4. **Documentation**: Update relevant docs and add doc comments with `cargo docs --document-private-items`
+4. **Documentation**: Update relevant docs and add doc comments with `cargo +nightly docs --document-private-items`
 5. **Commit Messages**: Follow conventional format (feat:, fix:, chore:, etc.)
 
 
@@ -389,5 +389,5 @@ cargo build --release --features "jemalloc asm-keccak"
 cargo check --workspace --all-features
 
 # Check documentation
-cargo docs --document-private-items 
+cargo +nightly docs --document-private-items 
 ```

--- a/Makefile
+++ b/Makefile
@@ -529,5 +529,5 @@ test:
 pr:
 	make lint && \
 	make update-book-cli && \
-	cargo docs --document-private-items && \
+	cargo +nightly docs --document-private-items && \
 	make test

--- a/docs/vocs/scripts/build-cargo-docs.sh
+++ b/docs/vocs/scripts/build-cargo-docs.sh
@@ -9,6 +9,6 @@ echo "Building cargo docs..."
 
 # Build the documentation
 export RUSTDOCFLAGS="--cfg docsrs --show-type-layout --generate-link-to-definition --enable-index-page -Zunstable-options"
-cargo docs --exclude "example-*"
+cargo +nightly docs --exclude "example-*"
 
 echo "Cargo docs built successfully at ./target/doc"

--- a/docs/vocs/scripts/inject-cargo-docs.ts
+++ b/docs/vocs/scripts/inject-cargo-docs.ts
@@ -13,7 +13,7 @@ async function injectCargoDocs() {
     await fs.access(CARGO_DOCS_PATH);
   } catch {
     console.error(`Error: Cargo docs not found at ${CARGO_DOCS_PATH}`);
-    console.error("Please run: cargo doc --no-deps --workspace --exclude 'example-*'");
+    console.error("Please run: cargo +nightly doc --no-deps --workspace --exclude 'example-*'");
     process.exit(1);
   }
 


### PR DESCRIPTION
Enforce nightly toolchain for cargo docs commands, as unstable options in RUSTDOCFLAGS require it.