### PR TITLE
perf(trie): dispatch storage proofs in lexicographical order

### DIFF
--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -1562,8 +1562,11 @@ fn dispatch_storage_proofs(
     let mut storage_proof_receivers =
         B256Map::with_capacity_and_hasher(targets.len(), Default::default());
 
+    let mut sorted_targets: Vec<_> = targets.iter().collect();
+    sorted_targets.sort_unstable_by_key(|(addr, _)| *addr);
+
     // Dispatch all storage proofs to worker pool
-    for (hashed_address, target_slots) in targets.iter() {
+    for (hashed_address, target_slots) in sorted_targets {
         // Create channel for receiving ProofResultMessage
         let (result_tx, result_rx) = crossbeam_channel::unbounded();
 


### PR DESCRIPTION
Closes #21201 

Sorted the storage proofs in lexicographical order before dispatching so it doesn't dispatch in the arbitrary B256Map iteration order.