### PR TITLE
feat(cli): add `reth db checksum rocksdb` command

### DIFF
--- a/crates/cli/commands/Cargo.toml
+++ b/crates/cli/commands/Cargo.toml
@@ -131,5 +131,4 @@ arbitrary = [
     "reth-ethereum-primitives/arbitrary",
 ]
 
-edge = ["reth-db-common/edge", "reth-stages/rocksdb", "rocksdb"]
-rocksdb = ["reth-provider/rocksdb"]
+edge = ["reth-db-common/edge", "reth-stages/rocksdb", "reth-provider/rocksdb"]

--- a/crates/cli/commands/Cargo.toml
+++ b/crates/cli/commands/Cargo.toml
@@ -131,4 +131,5 @@ arbitrary = [
     "reth-ethereum-primitives/arbitrary",
 ]
 
-edge = ["reth-db-common/edge", "reth-stages/rocksdb"]
+edge = ["reth-db-common/edge", "reth-stages/rocksdb", "rocksdb"]
+rocksdb = ["reth-provider/rocksdb"]

--- a/crates/cli/commands/src/db/checksum.rs
+++ b/crates/cli/commands/src/db/checksum.rs
@@ -4,15 +4,23 @@ use crate::{
 };
 use alloy_primitives::map::foldhash::fast::FixedState;
 use clap::Parser;
+#[cfg(all(unix, feature = "rocksdb"))]
+use clap::ValueEnum;
 use itertools::Itertools;
 use reth_chainspec::EthereumHardforks;
+#[cfg(all(unix, feature = "rocksdb"))]
+use reth_db::tables;
 use reth_db::{static_file::iter_static_files, DatabaseEnv};
+#[cfg(all(unix, feature = "rocksdb"))]
+use reth_db_api::table::{Compress, Encode};
 use reth_db_api::{
     cursor::DbCursorRO, table::Table, transaction::DbTx, RawKey, RawTable, RawValue, TableViewer,
     Tables,
 };
 use reth_db_common::DbTool;
 use reth_node_builder::{NodeTypesWithDB, NodeTypesWithDBAdapter};
+#[cfg(all(unix, feature = "rocksdb"))]
+use reth_provider::RocksDBProviderFactory;
 use reth_provider::{providers::ProviderNodeTypes, DBProvider, StaticFileProviderFactory};
 use reth_static_file_types::StaticFileSegment;
 use std::{
@@ -24,6 +32,30 @@ use tracing::{info, warn};
 
 /// Interval for logging progress during checksum computation.
 const PROGRESS_LOG_INTERVAL: usize = 100_000;
+
+/// RocksDB tables that can be checksummed.
+#[cfg(all(unix, feature = "rocksdb"))]
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum RocksDbTable {
+    /// Transaction hash to transaction number mapping
+    TransactionHashNumbers,
+    /// Account history indices
+    AccountsHistory,
+    /// Storage history indices
+    StoragesHistory,
+}
+
+#[cfg(all(unix, feature = "rocksdb"))]
+impl RocksDbTable {
+    /// Returns the table name as a string
+    const fn name(&self) -> &'static str {
+        match self {
+            Self::TransactionHashNumbers => tables::TransactionHashNumbers::NAME,
+            Self::AccountsHistory => tables::AccountsHistory::NAME,
+            Self::StoragesHistory => tables::StoragesHistory::NAME,
+        }
+    }
+}
 
 #[derive(Parser, Debug)]
 /// The arguments for the `reth db checksum` command
@@ -70,6 +102,17 @@ enum Subcommand {
         #[arg(long)]
         limit: Option<usize>,
     },
+    /// Calculates the checksum of a RocksDB table
+    #[cfg(all(unix, feature = "rocksdb"))]
+    Rocksdb {
+        /// The RocksDB table
+        #[arg(value_enum)]
+        table: RocksDbTable,
+
+        /// The maximum number of records to checksum.
+        #[arg(long)]
+        limit: Option<usize>,
+    },
 }
 
 impl Command {
@@ -86,6 +129,10 @@ impl Command {
             }
             Subcommand::StaticFile { segment, start_block, end_block, limit } => {
                 checksum_static_file(tool, segment, start_block, end_block, limit)?;
+            }
+            #[cfg(all(unix, feature = "rocksdb"))]
+            Subcommand::Rocksdb { table, limit } => {
+                checksum_rocksdb(tool, table, limit)?;
             }
         }
 
@@ -180,6 +227,84 @@ fn checksum_static_file<N: CliNodeTypes<ChainSpec: EthereumHardforks>>(
     );
 
     Ok(())
+}
+
+/// Computes a checksum for a RocksDB table.
+#[cfg(all(unix, feature = "rocksdb"))]
+fn checksum_rocksdb<N: CliNodeTypes<ChainSpec: EthereumHardforks>>(
+    tool: &DbTool<NodeTypesWithDBAdapter<N, Arc<DatabaseEnv>>>,
+    table: RocksDbTable,
+    limit: Option<usize>,
+) -> eyre::Result<()> {
+    let rocksdb = tool.provider_factory.rocksdb_provider();
+
+    let start_time = Instant::now();
+    let limit = limit.unwrap_or(usize::MAX);
+
+    info!(
+        "Computing checksum for RocksDB table `{}`, limit={:?}",
+        table.name(),
+        if limit == usize::MAX { None } else { Some(limit) }
+    );
+
+    let (checksum, total) = match table {
+        RocksDbTable::TransactionHashNumbers => {
+            checksum_rocksdb_table::<tables::TransactionHashNumbers>(&rocksdb, limit)?
+        }
+        RocksDbTable::AccountsHistory => {
+            checksum_rocksdb_table::<tables::AccountsHistory>(&rocksdb, limit)?
+        }
+        RocksDbTable::StoragesHistory => {
+            checksum_rocksdb_table::<tables::StoragesHistory>(&rocksdb, limit)?
+        }
+    };
+
+    let elapsed = start_time.elapsed();
+
+    info!(
+        "Checksum for RocksDB table `{}`: {:#x} ({} entries, elapsed: {:?})",
+        table.name(),
+        checksum,
+        total,
+        elapsed
+    );
+
+    Ok(())
+}
+
+/// Computes checksum for a specific RocksDB table by iterating over all entries.
+#[cfg(all(unix, feature = "rocksdb"))]
+fn checksum_rocksdb_table<T: Table>(
+    rocksdb: &reth_provider::providers::RocksDBProvider,
+    limit: usize,
+) -> eyre::Result<(u64, usize)> {
+    let iter = rocksdb.iter::<T>()?;
+    let mut hasher = checksum_hasher();
+    let mut total = 0usize;
+    let mut compress_buf = Vec::new();
+
+    for entry in iter {
+        let (key, value) = entry?;
+
+        let key_bytes = key.encode();
+        hasher.write(key_bytes.as_ref());
+
+        compress_buf.clear();
+        value.compress_to_buf(&mut compress_buf);
+        hasher.write(&compress_buf);
+
+        total += 1;
+
+        if total.is_multiple_of(PROGRESS_LOG_INTERVAL) {
+            info!("Hashed {total} entries.");
+        }
+
+        if total >= limit {
+            break;
+        }
+    }
+
+    Ok((hasher.finish(), total))
 }
 
 pub(crate) struct ChecksumViewer<'a, N: NodeTypesWithDB> {

--- a/crates/cli/commands/src/db/checksum.rs
+++ b/crates/cli/commands/src/db/checksum.rs
@@ -4,14 +4,14 @@ use crate::{
 };
 use alloy_primitives::map::foldhash::fast::FixedState;
 use clap::Parser;
-#[cfg(all(unix, feature = "rocksdb"))]
+#[cfg(all(unix, feature = "edge"))]
 use clap::ValueEnum;
 use itertools::Itertools;
 use reth_chainspec::EthereumHardforks;
-#[cfg(all(unix, feature = "rocksdb"))]
+#[cfg(all(unix, feature = "edge"))]
 use reth_db::tables;
 use reth_db::{static_file::iter_static_files, DatabaseEnv};
-#[cfg(all(unix, feature = "rocksdb"))]
+#[cfg(all(unix, feature = "edge"))]
 use reth_db_api::table::{Compress, Encode};
 use reth_db_api::{
     cursor::DbCursorRO, table::Table, transaction::DbTx, RawKey, RawTable, RawValue, TableViewer,
@@ -19,7 +19,7 @@ use reth_db_api::{
 };
 use reth_db_common::DbTool;
 use reth_node_builder::{NodeTypesWithDB, NodeTypesWithDBAdapter};
-#[cfg(all(unix, feature = "rocksdb"))]
+#[cfg(all(unix, feature = "edge"))]
 use reth_provider::RocksDBProviderFactory;
 use reth_provider::{providers::ProviderNodeTypes, DBProvider, StaticFileProviderFactory};
 use reth_static_file_types::StaticFileSegment;
@@ -34,7 +34,7 @@ use tracing::{info, warn};
 const PROGRESS_LOG_INTERVAL: usize = 100_000;
 
 /// RocksDB tables that can be checksummed.
-#[cfg(all(unix, feature = "rocksdb"))]
+#[cfg(all(unix, feature = "edge"))]
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum RocksDbTable {
     /// Transaction hash to transaction number mapping
@@ -45,7 +45,7 @@ pub enum RocksDbTable {
     StoragesHistory,
 }
 
-#[cfg(all(unix, feature = "rocksdb"))]
+#[cfg(all(unix, feature = "edge"))]
 impl RocksDbTable {
     /// Returns the table name as a string
     const fn name(&self) -> &'static str {
@@ -103,7 +103,7 @@ enum Subcommand {
         limit: Option<usize>,
     },
     /// Calculates the checksum of a RocksDB table
-    #[cfg(all(unix, feature = "rocksdb"))]
+    #[cfg(all(unix, feature = "edge"))]
     Rocksdb {
         /// The RocksDB table
         #[arg(value_enum)]
@@ -130,7 +130,7 @@ impl Command {
             Subcommand::StaticFile { segment, start_block, end_block, limit } => {
                 checksum_static_file(tool, segment, start_block, end_block, limit)?;
             }
-            #[cfg(all(unix, feature = "rocksdb"))]
+            #[cfg(all(unix, feature = "edge"))]
             Subcommand::Rocksdb { table, limit } => {
                 checksum_rocksdb(tool, table, limit)?;
             }
@@ -230,7 +230,7 @@ fn checksum_static_file<N: CliNodeTypes<ChainSpec: EthereumHardforks>>(
 }
 
 /// Computes a checksum for a RocksDB table.
-#[cfg(all(unix, feature = "rocksdb"))]
+#[cfg(all(unix, feature = "edge"))]
 fn checksum_rocksdb<N: CliNodeTypes<ChainSpec: EthereumHardforks>>(
     tool: &DbTool<NodeTypesWithDBAdapter<N, Arc<DatabaseEnv>>>,
     table: RocksDbTable,
@@ -273,7 +273,7 @@ fn checksum_rocksdb<N: CliNodeTypes<ChainSpec: EthereumHardforks>>(
 }
 
 /// Computes checksum for a specific RocksDB table by iterating over all entries.
-#[cfg(all(unix, feature = "rocksdb"))]
+#[cfg(all(unix, feature = "edge"))]
 fn checksum_rocksdb_table<T: Table>(
     rocksdb: &reth_provider::providers::RocksDBProvider,
     limit: usize,

--- a/crates/cli/commands/src/db/checksum/rocksdb.rs
+++ b/crates/cli/commands/src/db/checksum/rocksdb.rs
@@ -1,0 +1,111 @@
+//! RocksDB checksum implementation.
+
+use super::{checksum_hasher, PROGRESS_LOG_INTERVAL};
+use crate::common::CliNodeTypes;
+use clap::ValueEnum;
+use reth_chainspec::EthereumHardforks;
+use reth_db::{tables, DatabaseEnv};
+use reth_db_api::table::{Compress, Encode, Table};
+use reth_db_common::DbTool;
+use reth_node_builder::NodeTypesWithDBAdapter;
+use reth_provider::RocksDBProviderFactory;
+use std::{hash::Hasher, sync::Arc, time::Instant};
+use tracing::info;
+
+/// RocksDB tables that can be checksummed.
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum RocksDbTable {
+    /// Transaction hash to transaction number mapping
+    TransactionHashNumbers,
+    /// Account history indices
+    AccountsHistory,
+    /// Storage history indices
+    StoragesHistory,
+}
+
+impl RocksDbTable {
+    /// Returns the table name as a string
+    const fn name(&self) -> &'static str {
+        match self {
+            Self::TransactionHashNumbers => tables::TransactionHashNumbers::NAME,
+            Self::AccountsHistory => tables::AccountsHistory::NAME,
+            Self::StoragesHistory => tables::StoragesHistory::NAME,
+        }
+    }
+}
+
+/// Computes a checksum for a RocksDB table.
+pub fn checksum_rocksdb<N: CliNodeTypes<ChainSpec: EthereumHardforks>>(
+    tool: &DbTool<NodeTypesWithDBAdapter<N, Arc<DatabaseEnv>>>,
+    table: RocksDbTable,
+    limit: Option<usize>,
+) -> eyre::Result<()> {
+    let rocksdb = tool.provider_factory.rocksdb_provider();
+
+    let start_time = Instant::now();
+    let limit = limit.unwrap_or(usize::MAX);
+
+    info!(
+        "Computing checksum for RocksDB table `{}`, limit={:?}",
+        table.name(),
+        if limit == usize::MAX { None } else { Some(limit) }
+    );
+
+    let (checksum, total) = match table {
+        RocksDbTable::TransactionHashNumbers => {
+            checksum_rocksdb_table::<tables::TransactionHashNumbers>(&rocksdb, limit)?
+        }
+        RocksDbTable::AccountsHistory => {
+            checksum_rocksdb_table::<tables::AccountsHistory>(&rocksdb, limit)?
+        }
+        RocksDbTable::StoragesHistory => {
+            checksum_rocksdb_table::<tables::StoragesHistory>(&rocksdb, limit)?
+        }
+    };
+
+    let elapsed = start_time.elapsed();
+
+    info!(
+        "Checksum for RocksDB table `{}`: {:#x} ({} entries, elapsed: {:?})",
+        table.name(),
+        checksum,
+        total,
+        elapsed
+    );
+
+    Ok(())
+}
+
+/// Computes checksum for a specific RocksDB table by iterating over all entries.
+fn checksum_rocksdb_table<T: Table>(
+    rocksdb: &reth_provider::providers::RocksDBProvider,
+    limit: usize,
+) -> eyre::Result<(u64, usize)> {
+    let iter = rocksdb.iter::<T>()?;
+    let mut hasher = checksum_hasher();
+    let mut total = 0usize;
+    let mut compress_buf = Vec::new();
+
+    for entry in iter {
+        let (key, value) = entry?;
+
+        let key_bytes = key.encode();
+        hasher.write(key_bytes.as_ref());
+
+        compress_buf.clear();
+        value.compress_to_buf(&mut compress_buf);
+        hasher.write(&compress_buf);
+
+        total += 1;
+
+        if total.is_multiple_of(PROGRESS_LOG_INTERVAL) {
+            info!("Hashed {total} entries.");
+        }
+
+        if total >= limit {
+            break;
+        }
+    }
+
+    Ok((hasher.finish(), total))
+}

--- a/crates/cli/commands/src/db/checksum/rocksdb.rs
+++ b/crates/cli/commands/src/db/checksum/rocksdb.rs
@@ -76,7 +76,7 @@ pub fn checksum_rocksdb<N: CliNodeTypes<ChainSpec: EthereumHardforks>>(
     Ok(())
 }
 
-/// Computes checksum for a specific RocksDB table by iterating over raw bytes.
+/// Computes checksum for a specific RocksDB table by iterating over rows.
 fn checksum_rocksdb_table<T: Table>(
     rocksdb: &reth_provider::providers::RocksDBProvider,
     limit: usize,

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -38,7 +38,7 @@ pub use consistent::ConsistentProvider;
 #[cfg_attr(not(all(unix, feature = "rocksdb")), path = "rocksdb_stub.rs")]
 pub(crate) mod rocksdb;
 
-pub use rocksdb::{RocksDBBatch, RocksDBBuilder, RocksDBProvider, RocksTx};
+pub use rocksdb::{RocksDBBatch, RocksDBBuilder, RocksDBProvider, RocksDBRawIter, RocksTx};
 
 /// Helper trait to bound [`NodeTypes`] so that combined with database they satisfy
 /// [`ProviderNodeTypes`].

--- a/crates/storage/provider/src/providers/rocksdb/mod.rs
+++ b/crates/storage/provider/src/providers/rocksdb/mod.rs
@@ -5,4 +5,4 @@ mod metrics;
 mod provider;
 
 pub(crate) use provider::{PendingRocksDBBatches, RocksDBWriteCtx};
-pub use provider::{RocksDBBatch, RocksDBBuilder, RocksDBProvider, RocksTx};
+pub use provider::{RocksDBBatch, RocksDBBuilder, RocksDBProvider, RocksDBRawIter, RocksTx};

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -656,6 +656,16 @@ impl RocksDBProvider {
         Ok(RocksDBIter { inner: iter, _marker: std::marker::PhantomData })
     }
 
+    /// Creates a raw iterator over all entries in the specified table.
+    ///
+    /// Returns raw `(key_bytes, value_bytes)` pairs without decoding.
+    /// This is more efficient when you need to process raw bytes directly.
+    pub fn raw_iter<T: Table>(&self) -> ProviderResult<RocksDBRawIter<'_>> {
+        let cf = self.get_cf_handle::<T>()?;
+        let iter = self.0.iterator_cf(cf, IteratorMode::Start);
+        Ok(RocksDBRawIter { inner: iter })
+    }
+
     /// Returns all account history shards for the given address in ascending key order.
     ///
     /// This is used for unwind operations where we need to scan all shards for an address
@@ -1514,6 +1524,33 @@ impl<T: Table> Iterator for RocksDBIter<'_, T> {
         };
 
         Some(Ok((key, value)))
+    }
+}
+
+/// Raw iterator over a `RocksDB` table (non-transactional).
+///
+/// Yields raw `(key_bytes, value_bytes)` pairs without decoding.
+pub struct RocksDBRawIter<'db> {
+    inner: RocksDBIterEnum<'db>,
+}
+
+impl fmt::Debug for RocksDBRawIter<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RocksDBRawIter").finish_non_exhaustive()
+    }
+}
+
+impl Iterator for RocksDBRawIter<'_> {
+    type Item = ProviderResult<(Box<[u8]>, Box<[u8]>)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.inner.next()? {
+            Ok(kv) => Some(Ok(kv)),
+            Err(e) => Some(Err(ProviderError::Database(DatabaseError::Read(DatabaseErrorInfo {
+                message: e.to_string().into(),
+                code: -1,
+            })))),
+        }
     }
 }
 

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -659,7 +659,6 @@ impl RocksDBProvider {
     /// Creates a raw iterator over all entries in the specified table.
     ///
     /// Returns raw `(key_bytes, value_bytes)` pairs without decoding.
-    /// This is more efficient when you need to process raw bytes directly.
     pub fn raw_iter<T: Table>(&self) -> ProviderResult<RocksDBRawIter<'_>> {
         let cf = self.get_cf_handle::<T>()?;
         let iter = self.0.iterator_cf(cf, IteratorMode::Start);

--- a/crates/storage/provider/src/providers/rocksdb_stub.rs
+++ b/crates/storage/provider/src/providers/rocksdb_stub.rs
@@ -116,3 +116,7 @@ impl RocksDBBuilder {
 /// A stub transaction for `RocksDB`.
 #[derive(Debug)]
 pub struct RocksTx;
+
+/// A stub raw iterator for `RocksDB`.
+#[derive(Debug)]
+pub struct RocksDBRawIter;


### PR DESCRIPTION
## Summary

Extends the `reth db checksum` command to support RocksDB tables, following the same pattern as the existing `mdbx` and `static-file` subcommands from #21211.

> **Note**: This PR depends on #21211 and should be merged after it.

## Usage

```bash
reth db checksum rocksdb transaction-hash-numbers
reth db checksum rocksdb accounts-history --limit 100000
reth db checksum rocksdb storages-history
```

## Supported RocksDB tables

- `transaction-hash-numbers` - Transaction hash to transaction number mapping
- `accounts-history` - Account history indices  
- `storages-history` - Storage history indices

## Motivation

When data is stored in RocksDB (e.g., TransactionHashNumbers, AccountsHistory, StoragesHistory based on storage settings), there was no way to verify the RocksDB contents match between different nodes. This enables direct comparison using the same hashing approach as the existing mdbx/static-file checksums.

## Implementation

- Adds `RocksDbTable` enum for the three supported tables
- Adds `Rocksdb` subcommand (cfg-gated on `unix` + `rocksdb` feature)
- Uses the same `foldhash` hasher with `RETHRETH` seed for consistency
- Iterates through RocksDB entries using `RocksDBProvider::iter()`
- Adds `rocksdb` feature to `reth-cli-commands` that enables `reth-provider/rocksdb`

