### PR TITLE
fix(reth-bench): replay-payloads prefix

### DIFF
--- a/bin/reth-bench/src/bench/replay_payloads.rs
+++ b/bin/reth-bench/src/bench/replay_payloads.rs
@@ -191,7 +191,7 @@ impl Command {
                 let name = e.file_name();
                 let name_str = name.to_string_lossy();
                 // Extract index from "payload_NNN.json"
-                let index_str = name_str.strip_prefix("payload_")?.strip_suffix(".json")?;
+                let index_str = name_str.strip_prefix("payload_block_")?.strip_suffix(".json")?;
                 let index: u64 = index_str.parse().ok()?;
                 Some((index, e.path()))
             })


### PR DESCRIPTION
We write payloads with `payload_block_` prefix, not `payload_`.