### PR TITLE
perf(db): use Cow::Borrowed in walk_dup to avoid allocation

### DIFF
--- a/crates/storage/db/src/implementation/mdbx/cursor.rs
+++ b/crates/storage/db/src/implementation/mdbx/cursor.rs
@@ -215,27 +215,26 @@ impl<K: TransactionKind, T: DupSort> DbDupCursorRO<T> for Cursor<K, T> {
     ) -> Result<DupWalker<'_, T, Self>, DatabaseError> {
         let start = match (key, subkey) {
             (Some(key), Some(subkey)) => {
-                // encode key and decode it after.
-                let key: Vec<u8> = key.encode().into();
+                let encoded_key = key.encode();
                 self.inner
-                    .get_both_range(key.as_ref(), subkey.encode().as_ref())
+                    .get_both_range(encoded_key.as_ref(), subkey.encode().as_ref())
                     .map_err(|e| DatabaseError::Read(e.into()))?
-                    .map(|val| decoder::<T>((Cow::Owned(key), val)))
+                    .map(|val| decoder::<T>((Cow::Borrowed(encoded_key.as_ref()), val)))
             }
             (Some(key), None) => {
-                let key: Vec<u8> = key.encode().into();
+                let encoded_key = key.encode();
                 self.inner
-                    .set(key.as_ref())
+                    .set(encoded_key.as_ref())
                     .map_err(|e| DatabaseError::Read(e.into()))?
-                    .map(|val| decoder::<T>((Cow::Owned(key), val)))
+                    .map(|val| decoder::<T>((Cow::Borrowed(encoded_key.as_ref()), val)))
             }
             (None, Some(subkey)) => {
                 if let Some((key, _)) = self.first()? {
-                    let key: Vec<u8> = key.encode().into();
+                    let encoded_key = key.encode();
                     self.inner
-                        .get_both_range(key.as_ref(), subkey.encode().as_ref())
+                        .get_both_range(encoded_key.as_ref(), subkey.encode().as_ref())
                         .map_err(|e| DatabaseError::Read(e.into()))?
-                        .map(|val| decoder::<T>((Cow::Owned(key), val)))
+                        .map(|val| decoder::<T>((Cow::Borrowed(encoded_key.as_ref()), val)))
                 } else {
                     Some(Err(DatabaseError::Read(MDBXError::NotFound.into())))
                 }


### PR DESCRIPTION
## Summary

Avoids heap allocation in `walk_dup` by using `Cow::Borrowed` instead of converting the encoded key to `Vec<u8>` with `Cow::Owned`.

For fixed-size key encodings (like `ShardedKey`), the key is already on the stack, so borrowing avoids an unnecessary allocation.

## Changes

- Changed `walk_dup` to keep the encoded key on the stack and use `Cow::Borrowed`
- Removed the intermediate `Vec<u8>` conversion

## Related

Inspired by #21200 and discussion about MDBX cursor allocation optimization.

cc @joshieDo @rakita @mattsse