### PR TITLE
feat(cli): add RocksDB table stats to `reth db stats` command

### DIFF
--- a/crates/cli/commands/Cargo.toml
+++ b/crates/cli/commands/Cargo.toml
@@ -131,4 +131,4 @@ arbitrary = [
     "reth-ethereum-primitives/arbitrary",
 ]
 
-edge = ["reth-db-common/edge", "reth-stages/rocksdb"]
+edge = ["reth-db-common/edge", "reth-stages/rocksdb", "reth-provider/rocksdb"]

--- a/crates/cli/commands/src/db/stats.rs
+++ b/crates/cli/commands/src/db/stats.rs
@@ -11,7 +11,10 @@ use reth_db_common::DbTool;
 use reth_fs_util as fs;
 use reth_node_builder::{NodePrimitives, NodeTypesWithDB, NodeTypesWithDBAdapter};
 use reth_node_core::dirs::{ChainPath, DataDirPath};
-use reth_provider::providers::{ProviderNodeTypes, StaticFileProvider};
+use reth_provider::{
+    providers::{ProviderNodeTypes, StaticFileProvider},
+    RocksDBProviderFactory,
+};
 use reth_static_file_types::SegmentRangeInclusive;
 use std::{sync::Arc, time::Duration};
 
@@ -60,6 +63,11 @@ impl Command {
 
         let db_stats_table = self.db_stats_table(tool)?;
         println!("{db_stats_table}");
+
+        println!("\n");
+
+        let rocksdb_stats_table = self.rocksdb_stats_table(tool);
+        println!("{rocksdb_stats_table}");
 
         Ok(())
     }
@@ -146,6 +154,41 @@ impl Command {
         })??;
 
         Ok(table)
+    }
+
+    fn rocksdb_stats_table<N: NodeTypesWithDB>(&self, tool: &DbTool<N>) -> ComfyTable {
+        let mut table = ComfyTable::new();
+        table.load_preset(comfy_table::presets::ASCII_MARKDOWN);
+        table.set_header(["RocksDB Table Name", "# Entries (est.)", "Total Size (est.)"]);
+
+        let stats = tool.provider_factory.rocksdb_provider().table_stats();
+        let mut total_size: u64 = 0;
+
+        for stat in &stats {
+            total_size += stat.estimated_size_bytes;
+            let mut row = Row::new();
+            row.add_cell(Cell::new(&stat.name))
+                .add_cell(Cell::new(stat.estimated_num_keys))
+                .add_cell(Cell::new(human_bytes(stat.estimated_size_bytes as f64)));
+            table.add_row(row);
+        }
+
+        if !stats.is_empty() {
+            let max_widths = table.column_max_content_widths();
+            let mut separator = Row::new();
+            for width in max_widths {
+                separator.add_cell(Cell::new("-".repeat(width as usize)));
+            }
+            table.add_row(separator);
+
+            let mut row = Row::new();
+            row.add_cell(Cell::new("RocksDB Total"))
+                .add_cell(Cell::new(""))
+                .add_cell(Cell::new(human_bytes(total_size as f64)));
+            table.add_row(row);
+        }
+
+        table
     }
 
     fn static_files_stats_table<N: NodePrimitives>(

--- a/crates/cli/commands/src/db/stats.rs
+++ b/crates/cli/commands/src/db/stats.rs
@@ -159,17 +159,20 @@ impl Command {
     fn rocksdb_stats_table<N: NodeTypesWithDB>(&self, tool: &DbTool<N>) -> ComfyTable {
         let mut table = ComfyTable::new();
         table.load_preset(comfy_table::presets::ASCII_MARKDOWN);
-        table.set_header(["RocksDB Table Name", "# Entries (est.)", "Total Size (est.)"]);
+        table.set_header(["RocksDB Table Name", "# Entries", "Total Size", "Pending Compaction"]);
 
         let stats = tool.provider_factory.rocksdb_provider().table_stats();
         let mut total_size: u64 = 0;
+        let mut total_pending: u64 = 0;
 
         for stat in &stats {
             total_size += stat.estimated_size_bytes;
+            total_pending += stat.pending_compaction_bytes;
             let mut row = Row::new();
             row.add_cell(Cell::new(&stat.name))
                 .add_cell(Cell::new(stat.estimated_num_keys))
-                .add_cell(Cell::new(human_bytes(stat.estimated_size_bytes as f64)));
+                .add_cell(Cell::new(human_bytes(stat.estimated_size_bytes as f64)))
+                .add_cell(Cell::new(human_bytes(stat.pending_compaction_bytes as f64)));
             table.add_row(row);
         }
 
@@ -184,7 +187,8 @@ impl Command {
             let mut row = Row::new();
             row.add_cell(Cell::new("RocksDB Total"))
                 .add_cell(Cell::new(""))
-                .add_cell(Cell::new(human_bytes(total_size as f64)));
+                .add_cell(Cell::new(human_bytes(total_size as f64)))
+                .add_cell(Cell::new(human_bytes(total_pending as f64)));
             table.add_row(row);
         }
 

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -38,7 +38,7 @@ pub use consistent::ConsistentProvider;
 #[cfg_attr(not(all(unix, feature = "rocksdb")), path = "rocksdb_stub.rs")]
 pub(crate) mod rocksdb;
 
-pub use rocksdb::{RocksDBBatch, RocksDBBuilder, RocksDBProvider, RocksTx};
+pub use rocksdb::{RocksDBBatch, RocksDBBuilder, RocksDBProvider, RocksDBTableStats, RocksTx};
 
 /// Helper trait to bound [`NodeTypes`] so that combined with database they satisfy
 /// [`ProviderNodeTypes`].

--- a/crates/storage/provider/src/providers/rocksdb/mod.rs
+++ b/crates/storage/provider/src/providers/rocksdb/mod.rs
@@ -5,4 +5,4 @@ mod metrics;
 mod provider;
 
 pub(crate) use provider::{PendingRocksDBBatches, RocksDBWriteCtx};
-pub use provider::{RocksDBBatch, RocksDBBuilder, RocksDBProvider, RocksTx};
+pub use provider::{RocksDBBatch, RocksDBBuilder, RocksDBProvider, RocksDBTableStats, RocksTx};

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -419,14 +419,6 @@ impl RocksDBProviderInner {
 
     /// Returns statistics for all column families in the database.
     fn table_stats(&self) -> Vec<RocksDBTableStats> {
-        match self {
-            Self::ReadWrite { db, .. } => Self::collect_cf_stats(db),
-            Self::ReadOnly { db, .. } => Self::collect_cf_stats(db),
-        }
-    }
-
-    /// Collects statistics for all column families from a database.
-    fn collect_cf_stats<D: rocksdb::DBAccess>(db: &D) -> Vec<RocksDBTableStats> {
         let cf_names = [
             tables::TransactionHashNumbers::NAME,
             tables::AccountsHistory::NAME,
@@ -435,26 +427,35 @@ impl RocksDBProviderInner {
 
         let mut stats = Vec::new();
 
-        for cf_name in cf_names {
-            if let Some(cf) = db.cf_handle(cf_name) {
-                let estimated_num_keys = db
-                    .property_int_value_cf(cf, rocksdb::properties::ESTIMATE_NUM_KEYS)
-                    .ok()
-                    .flatten()
-                    .unwrap_or(0);
+        macro_rules! collect_stats {
+            ($db:expr) => {
+                for cf_name in cf_names {
+                    if let Some(cf) = $db.cf_handle(cf_name) {
+                        let estimated_num_keys = $db
+                            .property_int_value_cf(cf, rocksdb::properties::ESTIMATE_NUM_KEYS)
+                            .ok()
+                            .flatten()
+                            .unwrap_or(0);
 
-                let estimated_size_bytes = db
-                    .property_int_value_cf(cf, rocksdb::properties::ESTIMATE_LIVE_DATA_SIZE)
-                    .ok()
-                    .flatten()
-                    .unwrap_or(0);
+                        let estimated_size_bytes = $db
+                            .property_int_value_cf(cf, rocksdb::properties::ESTIMATE_LIVE_DATA_SIZE)
+                            .ok()
+                            .flatten()
+                            .unwrap_or(0);
 
-                stats.push(RocksDBTableStats {
-                    name: cf_name.to_string(),
-                    estimated_num_keys,
-                    estimated_size_bytes,
-                });
-            }
+                        stats.push(RocksDBTableStats {
+                            name: cf_name.to_string(),
+                            estimated_num_keys,
+                            estimated_size_bytes,
+                        });
+                    }
+                }
+            };
+        }
+
+        match self {
+            Self::ReadWrite { db, .. } => collect_stats!(db),
+            Self::ReadOnly { db, .. } => collect_stats!(db),
         }
 
         stats

--- a/crates/storage/provider/src/providers/rocksdb_stub.rs
+++ b/crates/storage/provider/src/providers/rocksdb_stub.rs
@@ -71,7 +71,7 @@ impl RocksDBProvider {
     /// Returns statistics for all column families in the database (stub implementation).
     ///
     /// Returns an empty vector since there is no `RocksDB` when the feature is disabled.
-    pub fn table_stats(&self) -> Vec<RocksDBTableStats> {
+    pub const fn table_stats(&self) -> Vec<RocksDBTableStats> {
         Vec::new()
     }
 }

--- a/crates/storage/provider/src/providers/rocksdb_stub.rs
+++ b/crates/storage/provider/src/providers/rocksdb_stub.rs
@@ -14,6 +14,17 @@ use std::{path::Path, sync::Arc};
 /// Pending `RocksDB` batches type alias (stub - uses unit type).
 pub(crate) type PendingRocksDBBatches = Arc<Mutex<Vec<()>>>;
 
+/// Statistics for a single `RocksDB` table (column family) - stub.
+#[derive(Debug, Clone)]
+pub struct RocksDBTableStats {
+    /// Name of the table/column family.
+    pub name: String,
+    /// Estimated number of keys in the table.
+    pub estimated_num_keys: u64,
+    /// Estimated size of live data in bytes.
+    pub estimated_size_bytes: u64,
+}
+
 /// Context for `RocksDB` block writes (stub).
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
@@ -55,6 +66,13 @@ impl RocksDBProvider {
         _provider: &Provider,
     ) -> ProviderResult<Option<BlockNumber>> {
         Ok(None)
+    }
+
+    /// Returns statistics for all column families in the database (stub implementation).
+    ///
+    /// Returns an empty vector since there is no `RocksDB` when the feature is disabled.
+    pub fn table_stats(&self) -> Vec<RocksDBTableStats> {
+        Vec::new()
     }
 }
 

--- a/crates/storage/provider/src/providers/rocksdb_stub.rs
+++ b/crates/storage/provider/src/providers/rocksdb_stub.rs
@@ -21,8 +21,10 @@ pub struct RocksDBTableStats {
     pub name: String,
     /// Estimated number of keys in the table.
     pub estimated_num_keys: u64,
-    /// Estimated size of live data in bytes.
+    /// Estimated size of live data in bytes (SST files + memtables).
     pub estimated_size_bytes: u64,
+    /// Estimated bytes pending compaction (reclaimable space).
+    pub pending_compaction_bytes: u64,
 }
 
 /// Context for `RocksDB` block writes (stub).


### PR DESCRIPTION
## Summary

Adds RocksDB table statistics to the `reth db stats` output, showing:
- Table name
- Entry count
- Data size (SST files + memtables)
- Pending compaction (reclaimable space)

For the 3 RocksDB tables: `TransactionHashNumbers`, `AccountsHistory`, `StoragesHistory`.

## Implementation

- Added `RocksDBTableStats` struct and `table_stats()` method to `RocksDBProvider`
- Uses RocksDB's property API to retrieve stats:
  - `rocksdb.estimate-num-keys` for entry count
  - `rocksdb.live-sst-files-size` + `rocksdb.size-all-mem-tables` for total size
  - `rocksdb.estimate-pending-compaction-bytes` for pending compaction
- Added stub implementation for non-rocksdb builds
- Updated `reth db stats` command to display RocksDB table stats

## Example Output

Hoodi sync (~1K blocks) with `--features edge`:

```
| Segment            | Block Range | Transaction Range | Shape (columns x rows) | Size      |
|--------------------|-------------|-------------------|------------------------|-----------|
| Headers            | 0..=1001    | N/A               | 3 x 1002               | 380.1 KiB |
| Transactions       | 0..=1001    | 0..=9864          | 1 x 9865               | 11.4 MiB  |
| Receipts           | 0..=1001    | 0..=9864          | 1 x 9865               | 533.6 KiB |
| TransactionSenders | 0..=1001    | 0..=9864          | 1 x 9865               | 269.8 KiB |
| AccountChangeSets  | 0..=1001    | N/A               | 1 x 476404             | 12.8 MiB  |
| ------------------ | ----------- | ----------------- | ---------------------- | --------- |
| Total              |             |                   |                        | 25.3 MiB  |

| Table Name                 | # Entries | Branch Pages | Leaf Pages | Overflow Pages | Total Size |
|----------------------------|-----------|--------------|------------|----------------|------------|
| AccountChangeSets          | 0         | 0            | 0          | 0              | 0 B        |
| AccountsHistory            | 473768    | 77           | 8032       | 0              | 31.7 MiB   |
| AccountsTrie               | 52122     | 7            | 1460       | 0              | 5.7 MiB    |
| AccountsTrieChangeSets     | 0         | 0            | 0          | 0              | 0 B        |
| BlockBodyIndices           | 1002      | 1            | 6          | 0              | 28 KiB     |
| BlockOmmers                | 0         | 0            | 0          | 0              | 0 B        |
| BlockWithdrawals           | 941       | 1            | 131        | 0              | 528 KiB    |
| Bytecodes                  | 67        | 1            | 9          | 158            | 672 KiB    |
| CanonicalHeaders           | 0         | 0            | 0          | 0              | 0 B        |
| ChainState                 | 0         | 0            | 0          | 0              | 0 B        |
| HashedAccounts             | 473768    | 67           | 6318       | 0              | 24.9 MiB   |
| HashedStorages             | 2953      | 3            | 50         | 0              | 212 KiB    |
| HeaderNumbers              | 1002      | 1            | 13         | 0              | 56 KiB     |
| HeaderTerminalDifficulties | 0         | 0            | 0          | 0              | 0 B        |
| Headers                    | 0         | 0            | 0          | 0              | 0 B        |
| Metadata                   | 1         | 0            | 1          | 0              | 4 KiB      |
| PlainAccountState          | 473768    | 144          | 9593       | 0              | 38 MiB     |
| PlainStorageState          | 2953      | 3            | 49         | 0              | 208 KiB    |
| PruneCheckpoints           | 1         | 0            | 1          | 0              | 4 KiB      |
| Receipts                   | 0         | 0            | 0          | 0              | 0 B        |
| StageCheckpointProgresses  | 1         | 0            | 1          | 0              | 4 KiB      |
| StageCheckpoints           | 15        | 0            | 1          | 0              | 4 KiB      |
| StorageChangeSets          | 3239      | 2            | 55         | 0              | 228 KiB    |
| StoragesHistory            | 3025      | 3            | 76         | 0              | 316 KiB    |
| StoragesTrie               | 252       | 2            | 13         | 0              | 60 KiB     |
| StoragesTrieChangeSets     | 0         | 0            | 0          | 0              | 0 B        |
| TransactionBlocks          | 689       | 1            | 5          | 0              | 24 KiB     |
| TransactionHashNumbers     | 0         | 0            | 0          | 0              | 0 B        |
| TransactionSenders         | 0         | 0            | 0          | 0              | 0 B        |
| Transactions               | 0         | 0            | 0          | 0              | 0 B        |
| VersionHistory             | 1         | 0            | 1          | 0              | 4 KiB      |
| -------------------------- | --------- | ------------ | ---------- | -------------- | ---------- |
| Tables                     |           |              |            |                | 102.7 MiB  |
| Freelist                   | 7         |              |            |                | 28 KiB     |

| RocksDB Table Name     | # Entries | Total Size | Pending Compaction |
|------------------------|-----------|------------|--------------------|
| TransactionHashNumbers | 9865      | 1 MiB      | 0 B                |
| AccountsHistory        | 0         | 2 KiB      | 0 B                |
| StoragesHistory        | 0         | 2 KiB      | 0 B                |
| ---------------------- | --------- | ---------- | ------------------ |
| RocksDB Total          |           | 1 MiB      | 0 B                |
```

> **Note:** RocksDB tables will show empty unless built with `--features edge` or RocksDB storage settings are manually enabled via:
> ```bash
> reth db settings set account_history true
> reth db settings set storages_history true
> reth db settings set transaction_hash_numbers true
> ```