### PR TITLE
feat(edge): enable transaction_hash_numbers_in_rocksdb for edge builds

### DIFF
--- a/crates/storage/db-api/src/models/metadata.rs
+++ b/crates/storage/db-api/src/models/metadata.rs
@@ -45,7 +45,7 @@ impl StorageSettings {
             transaction_senders_in_static_files: true,
             account_changesets_in_static_files: true,
             storages_history_in_rocksdb: false,
-            transaction_hash_numbers_in_rocksdb: false,
+            transaction_hash_numbers_in_rocksdb: true,
             account_history_in_rocksdb: false,
         }
     }


### PR DESCRIPTION
## Summary

Enables `transaction_hash_numbers_in_rocksdb: true` in the `StorageSettings::edge()` configuration.

This allows edge builds to store `TransactionHashNumbers` in RocksDB for improved transaction hash lookup performance.

## Changes

- Set `transaction_hash_numbers_in_rocksdb: true` in `StorageSettings::edge()`

## Testing

Ran tests with `--features edge,rocksdb` - all pass.