### PR TITLE
refactor: remove static_files.to_settings() and add edge feature to RocksDB flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9442,7 +9442,6 @@ dependencies = [
  "reth-network-p2p",
  "reth-network-peers",
  "reth-primitives-traits",
- "reth-provider",
  "reth-prune-types",
  "reth-rpc-convert",
  "reth-rpc-eth-types",

--- a/crates/cli/commands/src/common.rs
+++ b/crates/cli/commands/src/common.rs
@@ -19,7 +19,7 @@ use reth_node_builder::{
     Node, NodeComponents, NodeComponentsBuilder, NodeTypes, NodeTypesWithDBAdapter,
 };
 use reth_node_core::{
-    args::{DatabaseArgs, DatadirArgs, StaticFilesArgs},
+    args::{DatabaseArgs, DatadirArgs, RocksDbArgs, StaticFilesArgs},
     dirs::{ChainPath, DataDirPath},
 };
 use reth_provider::{
@@ -27,7 +27,7 @@ use reth_provider::{
         BlockchainProvider, NodeTypesForProvider, RocksDBProvider, StaticFileProvider,
         StaticFileProviderBuilder,
     },
-    ProviderFactory, StaticFileProviderFactory,
+    ProviderFactory, StaticFileProviderFactory, StorageSettings,
 };
 use reth_stages::{sets::DefaultStages, Pipeline, PipelineTarget};
 use reth_static_file::StaticFileProducer;
@@ -66,9 +66,24 @@ pub struct EnvironmentArgs<C: ChainSpecParser> {
     /// All static files related arguments
     #[command(flatten)]
     pub static_files: StaticFilesArgs,
+
+    /// All `RocksDB` related arguments
+    #[command(flatten)]
+    pub rocksdb: RocksDbArgs,
 }
 
 impl<C: ChainSpecParser> EnvironmentArgs<C> {
+    /// Returns the effective storage settings derived from static-file and `RocksDB` CLI args.
+    pub fn storage_settings(&self) -> StorageSettings {
+        StorageSettings::base()
+            .with_receipts_in_static_files(self.static_files.receipts)
+            .with_transaction_senders_in_static_files(self.static_files.transaction_senders)
+            .with_account_changesets_in_static_files(self.static_files.account_changesets)
+            .with_transaction_hash_numbers_in_rocksdb(self.rocksdb.all || self.rocksdb.tx_hash)
+            .with_storages_history_in_rocksdb(self.rocksdb.all || self.rocksdb.storages_history)
+            .with_account_history_in_rocksdb(self.rocksdb.all || self.rocksdb.account_history)
+    }
+
     /// Initializes environment according to [`AccessRights`] and returns an instance of
     /// [`Environment`].
     pub fn init<N: CliNodeTypes>(&self, access: AccessRights) -> eyre::Result<Environment<N>>
@@ -131,7 +146,7 @@ impl<C: ChainSpecParser> EnvironmentArgs<C> {
             self.create_provider_factory(&config, db, sfp, rocksdb_provider, access)?;
         if access.is_read_write() {
             debug!(target: "reth::cli", chain=%self.chain.chain(), genesis=?self.chain.genesis_hash(), "Initializing genesis");
-            init_genesis_with_settings(&provider_factory, self.static_files.to_settings())?;
+            init_genesis_with_settings(&provider_factory, self.storage_settings())?;
         }
 
         Ok(Environment { config, provider_factory, data_dir })

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -676,19 +676,13 @@ where
 
     /// Convenience function to [`Self::init_genesis`]
     pub fn with_genesis(self) -> Result<Self, InitStorageError> {
-        init_genesis_with_settings(
-            self.provider_factory(),
-            self.node_config().static_files.to_settings(),
-        )?;
+        init_genesis_with_settings(self.provider_factory(), self.node_config().storage_settings())?;
         Ok(self)
     }
 
     /// Write the genesis block and state if it has not already been written
     pub fn init_genesis(&self) -> Result<B256, InitStorageError> {
-        init_genesis_with_settings(
-            self.provider_factory(),
-            self.node_config().static_files.to_settings(),
-        )
+        init_genesis_with_settings(self.provider_factory(), self.node_config().storage_settings())
     }
 
     /// Creates a new `WithMeteredProvider` container and attaches it to the

--- a/crates/node/core/Cargo.toml
+++ b/crates/node/core/Cargo.toml
@@ -19,7 +19,6 @@ reth-cli-util.workspace = true
 reth-db = { workspace = true, features = ["mdbx"] }
 reth-storage-errors.workspace = true
 reth-storage-api = { workspace = true, features = ["std", "db-api"] }
-reth-provider.workspace = true
 reth-network = { workspace = true, features = ["serde"] }
 reth-network-p2p.workspace = true
 reth-rpc-eth-types.workspace = true
@@ -92,7 +91,7 @@ min-debug-logs = ["tracing/release_max_level_debug"]
 min-trace-logs = ["tracing/release_max_level_trace"]
 
 # Marker feature for edge/unstable builds - captured by vergen in build.rs
-edge = ["reth-provider/edge"]
+edge = ["reth-storage-api/edge"]
 
 [build-dependencies]
 vergen = { workspace = true, features = ["build", "cargo", "emit_and_set"] }

--- a/crates/node/core/src/args/rocksdb.rs
+++ b/crates/node/core/src/args/rocksdb.rs
@@ -2,11 +2,19 @@
 
 use clap::{ArgAction, Args};
 
+/// Default value for `RocksDB` routing flags.
+///
+/// When the `edge` feature is enabled, defaults to `true` to enable edge storage features.
+/// Otherwise defaults to `false` for legacy behavior.
+const fn default_rocksdb_flag() -> bool {
+    cfg!(feature = "edge")
+}
+
 /// Parameters for `RocksDB` table routing configuration.
 ///
 /// These flags control which database tables are stored in `RocksDB` instead of MDBX.
 /// All flags are genesis-initialization-only: changing them after genesis requires a re-sync.
-#[derive(Debug, Args, PartialEq, Eq, Default, Clone, Copy)]
+#[derive(Debug, Args, PartialEq, Eq, Clone, Copy)]
 #[command(next_help_heading = "RocksDB")]
 pub struct RocksDbArgs {
     /// Route all supported tables to `RocksDB` instead of MDBX.
@@ -17,31 +25,51 @@ pub struct RocksDbArgs {
     pub all: bool,
 
     /// Route tx hash -> number table to `RocksDB` instead of MDBX.
-    #[arg(long = "rocksdb.tx-hash", action = ArgAction::Set)]
-    pub tx_hash: Option<bool>,
+    ///
+    /// This is a genesis-initialization-only flag: changing it after genesis requires a re-sync.
+    /// Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+    #[arg(long = "rocksdb.tx-hash", default_value_t = default_rocksdb_flag(), action = ArgAction::Set)]
+    pub tx_hash: bool,
 
     /// Route storages history tables to `RocksDB` instead of MDBX.
-    #[arg(long = "rocksdb.storages-history", action = ArgAction::Set)]
-    pub storages_history: Option<bool>,
+    ///
+    /// This is a genesis-initialization-only flag: changing it after genesis requires a re-sync.
+    /// Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+    #[arg(long = "rocksdb.storages-history", default_value_t = default_rocksdb_flag(), action = ArgAction::Set)]
+    pub storages_history: bool,
 
     /// Route account history tables to `RocksDB` instead of MDBX.
-    #[arg(long = "rocksdb.account-history", action = ArgAction::Set)]
-    pub account_history: Option<bool>,
+    ///
+    /// This is a genesis-initialization-only flag: changing it after genesis requires a re-sync.
+    /// Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+    #[arg(long = "rocksdb.account-history", default_value_t = default_rocksdb_flag(), action = ArgAction::Set)]
+    pub account_history: bool,
+}
+
+impl Default for RocksDbArgs {
+    fn default() -> Self {
+        Self {
+            all: false,
+            tx_hash: default_rocksdb_flag(),
+            storages_history: default_rocksdb_flag(),
+            account_history: default_rocksdb_flag(),
+        }
+    }
 }
 
 impl RocksDbArgs {
     /// Validates the `RocksDB` arguments.
     ///
     /// Returns an error if `--rocksdb.all` is used with any individual flag set to `false`.
-    pub fn validate(&self) -> Result<(), RocksDbArgsError> {
+    pub const fn validate(&self) -> Result<(), RocksDbArgsError> {
         if self.all {
-            if self.tx_hash == Some(false) {
+            if !self.tx_hash {
                 return Err(RocksDbArgsError::ConflictingFlags("tx-hash"));
             }
-            if self.storages_history == Some(false) {
+            if !self.storages_history {
                 return Err(RocksDbArgsError::ConflictingFlags("storages-history"));
             }
-            if self.account_history == Some(false) {
+            if !self.account_history {
                 return Err(RocksDbArgsError::ConflictingFlags("account-history"));
             }
         }
@@ -78,7 +106,7 @@ mod tests {
     fn test_parse_all_flag() {
         let args = CommandParser::<RocksDbArgs>::parse_from(["reth", "--rocksdb.all"]).args;
         assert!(args.all);
-        assert_eq!(args.tx_hash, None);
+        assert_eq!(args.tx_hash, default_rocksdb_flag());
     }
 
     #[test]
@@ -91,32 +119,42 @@ mod tests {
         ])
         .args;
         assert!(!args.all);
-        assert_eq!(args.tx_hash, Some(true));
-        assert_eq!(args.storages_history, Some(false));
-        assert_eq!(args.account_history, Some(true));
-    }
-
-    #[test]
-    fn test_validate_all_alone_ok() {
-        let args = RocksDbArgs { all: true, ..Default::default() };
-        assert!(args.validate().is_ok());
+        assert!(args.tx_hash);
+        assert!(!args.storages_history);
+        assert!(args.account_history);
     }
 
     #[test]
     fn test_validate_all_with_true_ok() {
-        let args = RocksDbArgs { all: true, tx_hash: Some(true), ..Default::default() };
+        let args =
+            RocksDbArgs { all: true, tx_hash: true, storages_history: true, account_history: true };
         assert!(args.validate().is_ok());
     }
 
     #[test]
     fn test_validate_all_with_false_errors() {
-        let args = RocksDbArgs { all: true, tx_hash: Some(false), ..Default::default() };
+        let args = RocksDbArgs {
+            all: true,
+            tx_hash: false,
+            storages_history: true,
+            account_history: true,
+        };
         assert_eq!(args.validate(), Err(RocksDbArgsError::ConflictingFlags("tx-hash")));
 
-        let args = RocksDbArgs { all: true, storages_history: Some(false), ..Default::default() };
+        let args = RocksDbArgs {
+            all: true,
+            tx_hash: true,
+            storages_history: false,
+            account_history: true,
+        };
         assert_eq!(args.validate(), Err(RocksDbArgsError::ConflictingFlags("storages-history")));
 
-        let args = RocksDbArgs { all: true, account_history: Some(false), ..Default::default() };
+        let args = RocksDbArgs {
+            all: true,
+            tx_hash: true,
+            storages_history: true,
+            account_history: false,
+        };
         assert_eq!(args.validate(), Err(RocksDbArgsError::ConflictingFlags("account-history")));
     }
 }

--- a/crates/node/core/src/args/static_files.rs
+++ b/crates/node/core/src/args/static_files.rs
@@ -2,7 +2,6 @@
 
 use clap::Args;
 use reth_config::config::{BlocksPerFileConfig, StaticFilesConfig};
-use reth_provider::StorageSettings;
 
 /// Blocks per static file when running in `--minimal` node.
 ///
@@ -101,18 +100,6 @@ impl StaticFilesArgs {
                     .or(config.blocks_per_file.account_change_sets),
             },
         }
-    }
-
-    /// Converts the static files arguments into [`StorageSettings`].
-    pub const fn to_settings(&self) -> StorageSettings {
-        #[cfg(feature = "edge")]
-        let base = StorageSettings::edge();
-        #[cfg(not(feature = "edge"))]
-        let base = StorageSettings::legacy();
-
-        base.with_receipts_in_static_files(self.receipts)
-            .with_transaction_senders_in_static_files(self.transaction_senders)
-            .with_account_changesets_in_static_files(self.account_changesets)
     }
 }
 

--- a/crates/node/core/src/node_config.rs
+++ b/crates/node/core/src/node_config.rs
@@ -358,19 +358,14 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
     }
 
     /// Returns the effective storage settings derived from static-file and `RocksDB` CLI args.
-    pub fn storage_settings(&self) -> StorageSettings {
-        let tx_hash = self.rocksdb.all || self.rocksdb.tx_hash.unwrap_or(false);
-        let storages_history = self.rocksdb.all || self.rocksdb.storages_history.unwrap_or(false);
-        let account_history = self.rocksdb.all || self.rocksdb.account_history.unwrap_or(false);
-
-        StorageSettings {
-            receipts_in_static_files: self.static_files.receipts,
-            transaction_senders_in_static_files: self.static_files.transaction_senders,
-            account_changesets_in_static_files: self.static_files.account_changesets,
-            transaction_hash_numbers_in_rocksdb: tx_hash,
-            storages_history_in_rocksdb: storages_history,
-            account_history_in_rocksdb: account_history,
-        }
+    pub const fn storage_settings(&self) -> StorageSettings {
+        StorageSettings::base()
+            .with_receipts_in_static_files(self.static_files.receipts)
+            .with_transaction_senders_in_static_files(self.static_files.transaction_senders)
+            .with_account_changesets_in_static_files(self.static_files.account_changesets)
+            .with_transaction_hash_numbers_in_rocksdb(self.rocksdb.all || self.rocksdb.tx_hash)
+            .with_storages_history_in_rocksdb(self.rocksdb.all || self.rocksdb.storages_history)
+            .with_account_history_in_rocksdb(self.rocksdb.all || self.rocksdb.account_history)
     }
 
     /// Returns the max block that the node should run to, looking it up from the network if

--- a/crates/storage/db-api/src/models/metadata.rs
+++ b/crates/storage/db-api/src/models/metadata.rs
@@ -34,6 +34,21 @@ pub struct StorageSettings {
 }
 
 impl StorageSettings {
+    /// Returns the default base `StorageSettings` for this build.
+    ///
+    /// When the `edge` feature is enabled, returns [`Self::edge()`].
+    /// Otherwise, returns [`Self::legacy()`].
+    pub const fn base() -> Self {
+        #[cfg(feature = "edge")]
+        {
+            Self::edge()
+        }
+        #[cfg(not(feature = "edge"))]
+        {
+            Self::legacy()
+        }
+    }
+
     /// Creates `StorageSettings` for edge nodes with all storage features enabled:
     /// - Receipts and transaction senders in static files
     /// - History indices in `RocksDB` (storages, accounts, transaction hashes)

--- a/docs/vocs/docs/pages/cli/op-reth/db.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/db.mdx
@@ -154,6 +154,36 @@ Static Files:
           [default: false]
           [possible values: true, false]
 
+RocksDB:
+      --rocksdb.all
+          Route all supported tables to `RocksDB` instead of MDBX.
+
+          This enables `RocksDB` for `tx-hash`, `storages-history`, and `account-history` tables. Cannot be combined with individual flags set to false.
+
+      --rocksdb.tx-hash <TX_HASH>
+          Route tx hash -> number table to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.storages-history <STORAGES_HISTORY>
+          Route storages history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.account-history <ACCOUNT_HISTORY>
+          Route account history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/docs/vocs/docs/pages/cli/op-reth/import-op.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/import-op.mdx
@@ -138,6 +138,36 @@ Static Files:
           [default: false]
           [possible values: true, false]
 
+RocksDB:
+      --rocksdb.all
+          Route all supported tables to `RocksDB` instead of MDBX.
+
+          This enables `RocksDB` for `tx-hash`, `storages-history`, and `account-history` tables. Cannot be combined with individual flags set to false.
+
+      --rocksdb.tx-hash <TX_HASH>
+          Route tx hash -> number table to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.storages-history <STORAGES_HISTORY>
+          Route storages history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.account-history <ACCOUNT_HISTORY>
+          Route account history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
       --chunk-len <CHUNK_LEN>
           Chunk byte length to read from file.
 

--- a/docs/vocs/docs/pages/cli/op-reth/import-receipts-op.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/import-receipts-op.mdx
@@ -138,6 +138,36 @@ Static Files:
           [default: false]
           [possible values: true, false]
 
+RocksDB:
+      --rocksdb.all
+          Route all supported tables to `RocksDB` instead of MDBX.
+
+          This enables `RocksDB` for `tx-hash`, `storages-history`, and `account-history` tables. Cannot be combined with individual flags set to false.
+
+      --rocksdb.tx-hash <TX_HASH>
+          Route tx hash -> number table to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.storages-history <STORAGES_HISTORY>
+          Route storages history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.account-history <ACCOUNT_HISTORY>
+          Route account history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
       --chunk-len <CHUNK_LEN>
           Chunk byte length to read from file.
 

--- a/docs/vocs/docs/pages/cli/op-reth/init-state.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/init-state.mdx
@@ -138,6 +138,36 @@ Static Files:
           [default: false]
           [possible values: true, false]
 
+RocksDB:
+      --rocksdb.all
+          Route all supported tables to `RocksDB` instead of MDBX.
+
+          This enables `RocksDB` for `tx-hash`, `storages-history`, and `account-history` tables. Cannot be combined with individual flags set to false.
+
+      --rocksdb.tx-hash <TX_HASH>
+          Route tx hash -> number table to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.storages-history <STORAGES_HISTORY>
+          Route storages history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.account-history <ACCOUNT_HISTORY>
+          Route account history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
       --without-evm
           Specifies whether to initialize the state without relying on EVM historical data.
 

--- a/docs/vocs/docs/pages/cli/op-reth/init.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/init.mdx
@@ -138,6 +138,36 @@ Static Files:
           [default: false]
           [possible values: true, false]
 
+RocksDB:
+      --rocksdb.all
+          Route all supported tables to `RocksDB` instead of MDBX.
+
+          This enables `RocksDB` for `tx-hash`, `storages-history`, and `account-history` tables. Cannot be combined with individual flags set to false.
+
+      --rocksdb.tx-hash <TX_HASH>
+          Route tx hash -> number table to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.storages-history <STORAGES_HISTORY>
+          Route storages history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.account-history <ACCOUNT_HISTORY>
+          Route account history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/docs/vocs/docs/pages/cli/op-reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/node.mdx
@@ -904,18 +904,27 @@ RocksDB:
           This enables `RocksDB` for `tx-hash`, `storages-history`, and `account-history` tables. Cannot be combined with individual flags set to false.
 
       --rocksdb.tx-hash <TX_HASH>
-          Route tx hash -> number table to `RocksDB` instead of MDBX
+          Route tx hash -> number table to `RocksDB` instead of MDBX.
 
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
           [possible values: true, false]
 
       --rocksdb.storages-history <STORAGES_HISTORY>
-          Route storages history tables to `RocksDB` instead of MDBX
+          Route storages history tables to `RocksDB` instead of MDBX.
 
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
           [possible values: true, false]
 
       --rocksdb.account-history <ACCOUNT_HISTORY>
-          Route account history tables to `RocksDB` instead of MDBX
+          Route account history tables to `RocksDB` instead of MDBX.
 
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
           [possible values: true, false]
 
 Engine:

--- a/docs/vocs/docs/pages/cli/op-reth/prune.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/prune.mdx
@@ -138,6 +138,36 @@ Static Files:
           [default: false]
           [possible values: true, false]
 
+RocksDB:
+      --rocksdb.all
+          Route all supported tables to `RocksDB` instead of MDBX.
+
+          This enables `RocksDB` for `tx-hash`, `storages-history`, and `account-history` tables. Cannot be combined with individual flags set to false.
+
+      --rocksdb.tx-hash <TX_HASH>
+          Route tx hash -> number table to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.storages-history <STORAGES_HISTORY>
+          Route storages history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.account-history <ACCOUNT_HISTORY>
+          Route account history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/docs/vocs/docs/pages/cli/op-reth/re-execute.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/re-execute.mdx
@@ -138,6 +138,36 @@ Static Files:
           [default: false]
           [possible values: true, false]
 
+RocksDB:
+      --rocksdb.all
+          Route all supported tables to `RocksDB` instead of MDBX.
+
+          This enables `RocksDB` for `tx-hash`, `storages-history`, and `account-history` tables. Cannot be combined with individual flags set to false.
+
+      --rocksdb.tx-hash <TX_HASH>
+          Route tx hash -> number table to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.storages-history <STORAGES_HISTORY>
+          Route storages history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.account-history <ACCOUNT_HISTORY>
+          Route account history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
       --from <FROM>
           The height to start at
 

--- a/docs/vocs/docs/pages/cli/op-reth/stage/drop.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/stage/drop.mdx
@@ -138,6 +138,36 @@ Static Files:
           [default: false]
           [possible values: true, false]
 
+RocksDB:
+      --rocksdb.all
+          Route all supported tables to `RocksDB` instead of MDBX.
+
+          This enables `RocksDB` for `tx-hash`, `storages-history`, and `account-history` tables. Cannot be combined with individual flags set to false.
+
+      --rocksdb.tx-hash <TX_HASH>
+          Route tx hash -> number table to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.storages-history <STORAGES_HISTORY>
+          Route storages history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.account-history <ACCOUNT_HISTORY>
+          Route account history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
   <STAGE>
           Possible values:
           - headers:         The headers stage within the pipeline

--- a/docs/vocs/docs/pages/cli/op-reth/stage/dump.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/stage/dump.mdx
@@ -145,6 +145,36 @@ Static Files:
           [default: false]
           [possible values: true, false]
 
+RocksDB:
+      --rocksdb.all
+          Route all supported tables to `RocksDB` instead of MDBX.
+
+          This enables `RocksDB` for `tx-hash`, `storages-history`, and `account-history` tables. Cannot be combined with individual flags set to false.
+
+      --rocksdb.tx-hash <TX_HASH>
+          Route tx hash -> number table to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.storages-history <STORAGES_HISTORY>
+          Route storages history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.account-history <ACCOUNT_HISTORY>
+          Route account history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/docs/vocs/docs/pages/cli/op-reth/stage/run.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/stage/run.mdx
@@ -138,6 +138,36 @@ Static Files:
           [default: false]
           [possible values: true, false]
 
+RocksDB:
+      --rocksdb.all
+          Route all supported tables to `RocksDB` instead of MDBX.
+
+          This enables `RocksDB` for `tx-hash`, `storages-history`, and `account-history` tables. Cannot be combined with individual flags set to false.
+
+      --rocksdb.tx-hash <TX_HASH>
+          Route tx hash -> number table to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.storages-history <STORAGES_HISTORY>
+          Route storages history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.account-history <ACCOUNT_HISTORY>
+          Route account history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
       --metrics <SOCKET>
           Enable Prometheus metrics.
 

--- a/docs/vocs/docs/pages/cli/op-reth/stage/unwind.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/stage/unwind.mdx
@@ -143,6 +143,36 @@ Static Files:
           [default: false]
           [possible values: true, false]
 
+RocksDB:
+      --rocksdb.all
+          Route all supported tables to `RocksDB` instead of MDBX.
+
+          This enables `RocksDB` for `tx-hash`, `storages-history`, and `account-history` tables. Cannot be combined with individual flags set to false.
+
+      --rocksdb.tx-hash <TX_HASH>
+          Route tx hash -> number table to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.storages-history <STORAGES_HISTORY>
+          Route storages history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.account-history <ACCOUNT_HISTORY>
+          Route account history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
       --offline
           If this is enabled, then all stages except headers, bodies, and sender recovery will be unwound
 

--- a/docs/vocs/docs/pages/cli/reth/db.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db.mdx
@@ -154,6 +154,36 @@ Static Files:
           [default: false]
           [possible values: true, false]
 
+RocksDB:
+      --rocksdb.all
+          Route all supported tables to `RocksDB` instead of MDBX.
+
+          This enables `RocksDB` for `tx-hash`, `storages-history`, and `account-history` tables. Cannot be combined with individual flags set to false.
+
+      --rocksdb.tx-hash <TX_HASH>
+          Route tx hash -> number table to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.storages-history <STORAGES_HISTORY>
+          Route storages history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.account-history <ACCOUNT_HISTORY>
+          Route account history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/docs/vocs/docs/pages/cli/reth/download.mdx
+++ b/docs/vocs/docs/pages/cli/reth/download.mdx
@@ -138,6 +138,36 @@ Static Files:
           [default: false]
           [possible values: true, false]
 
+RocksDB:
+      --rocksdb.all
+          Route all supported tables to `RocksDB` instead of MDBX.
+
+          This enables `RocksDB` for `tx-hash`, `storages-history`, and `account-history` tables. Cannot be combined with individual flags set to false.
+
+      --rocksdb.tx-hash <TX_HASH>
+          Route tx hash -> number table to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.storages-history <STORAGES_HISTORY>
+          Route storages history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.account-history <ACCOUNT_HISTORY>
+          Route account history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
   -u, --url <URL>
           Specify a snapshot URL or let the command propose a default one.
 

--- a/docs/vocs/docs/pages/cli/reth/export-era.mdx
+++ b/docs/vocs/docs/pages/cli/reth/export-era.mdx
@@ -138,6 +138,36 @@ Static Files:
           [default: false]
           [possible values: true, false]
 
+RocksDB:
+      --rocksdb.all
+          Route all supported tables to `RocksDB` instead of MDBX.
+
+          This enables `RocksDB` for `tx-hash`, `storages-history`, and `account-history` tables. Cannot be combined with individual flags set to false.
+
+      --rocksdb.tx-hash <TX_HASH>
+          Route tx hash -> number table to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.storages-history <STORAGES_HISTORY>
+          Route storages history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.account-history <ACCOUNT_HISTORY>
+          Route account history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
       --first-block-number <first-block-number>
           Optional first block number to export from the db.
           It is by default 0.

--- a/docs/vocs/docs/pages/cli/reth/import-era.mdx
+++ b/docs/vocs/docs/pages/cli/reth/import-era.mdx
@@ -138,6 +138,36 @@ Static Files:
           [default: false]
           [possible values: true, false]
 
+RocksDB:
+      --rocksdb.all
+          Route all supported tables to `RocksDB` instead of MDBX.
+
+          This enables `RocksDB` for `tx-hash`, `storages-history`, and `account-history` tables. Cannot be combined with individual flags set to false.
+
+      --rocksdb.tx-hash <TX_HASH>
+          Route tx hash -> number table to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.storages-history <STORAGES_HISTORY>
+          Route storages history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.account-history <ACCOUNT_HISTORY>
+          Route account history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
       --path <IMPORT_ERA_PATH>
           The path to a directory for import.
 

--- a/docs/vocs/docs/pages/cli/reth/import.mdx
+++ b/docs/vocs/docs/pages/cli/reth/import.mdx
@@ -138,6 +138,36 @@ Static Files:
           [default: false]
           [possible values: true, false]
 
+RocksDB:
+      --rocksdb.all
+          Route all supported tables to `RocksDB` instead of MDBX.
+
+          This enables `RocksDB` for `tx-hash`, `storages-history`, and `account-history` tables. Cannot be combined with individual flags set to false.
+
+      --rocksdb.tx-hash <TX_HASH>
+          Route tx hash -> number table to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.storages-history <STORAGES_HISTORY>
+          Route storages history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.account-history <ACCOUNT_HISTORY>
+          Route account history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
       --no-state
           Disables stages that require state.
 

--- a/docs/vocs/docs/pages/cli/reth/init-state.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init-state.mdx
@@ -138,6 +138,36 @@ Static Files:
           [default: false]
           [possible values: true, false]
 
+RocksDB:
+      --rocksdb.all
+          Route all supported tables to `RocksDB` instead of MDBX.
+
+          This enables `RocksDB` for `tx-hash`, `storages-history`, and `account-history` tables. Cannot be combined with individual flags set to false.
+
+      --rocksdb.tx-hash <TX_HASH>
+          Route tx hash -> number table to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.storages-history <STORAGES_HISTORY>
+          Route storages history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.account-history <ACCOUNT_HISTORY>
+          Route account history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
       --without-evm
           Specifies whether to initialize the state without relying on EVM historical data.
 

--- a/docs/vocs/docs/pages/cli/reth/init.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init.mdx
@@ -138,6 +138,36 @@ Static Files:
           [default: false]
           [possible values: true, false]
 
+RocksDB:
+      --rocksdb.all
+          Route all supported tables to `RocksDB` instead of MDBX.
+
+          This enables `RocksDB` for `tx-hash`, `storages-history`, and `account-history` tables. Cannot be combined with individual flags set to false.
+
+      --rocksdb.tx-hash <TX_HASH>
+          Route tx hash -> number table to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.storages-history <STORAGES_HISTORY>
+          Route storages history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.account-history <ACCOUNT_HISTORY>
+          Route account history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -904,18 +904,27 @@ RocksDB:
           This enables `RocksDB` for `tx-hash`, `storages-history`, and `account-history` tables. Cannot be combined with individual flags set to false.
 
       --rocksdb.tx-hash <TX_HASH>
-          Route tx hash -> number table to `RocksDB` instead of MDBX
+          Route tx hash -> number table to `RocksDB` instead of MDBX.
 
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
           [possible values: true, false]
 
       --rocksdb.storages-history <STORAGES_HISTORY>
-          Route storages history tables to `RocksDB` instead of MDBX
+          Route storages history tables to `RocksDB` instead of MDBX.
 
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
           [possible values: true, false]
 
       --rocksdb.account-history <ACCOUNT_HISTORY>
-          Route account history tables to `RocksDB` instead of MDBX
+          Route account history tables to `RocksDB` instead of MDBX.
 
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
           [possible values: true, false]
 
 Engine:

--- a/docs/vocs/docs/pages/cli/reth/prune.mdx
+++ b/docs/vocs/docs/pages/cli/reth/prune.mdx
@@ -138,6 +138,36 @@ Static Files:
           [default: false]
           [possible values: true, false]
 
+RocksDB:
+      --rocksdb.all
+          Route all supported tables to `RocksDB` instead of MDBX.
+
+          This enables `RocksDB` for `tx-hash`, `storages-history`, and `account-history` tables. Cannot be combined with individual flags set to false.
+
+      --rocksdb.tx-hash <TX_HASH>
+          Route tx hash -> number table to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.storages-history <STORAGES_HISTORY>
+          Route storages history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.account-history <ACCOUNT_HISTORY>
+          Route account history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/docs/vocs/docs/pages/cli/reth/re-execute.mdx
+++ b/docs/vocs/docs/pages/cli/reth/re-execute.mdx
@@ -138,6 +138,36 @@ Static Files:
           [default: false]
           [possible values: true, false]
 
+RocksDB:
+      --rocksdb.all
+          Route all supported tables to `RocksDB` instead of MDBX.
+
+          This enables `RocksDB` for `tx-hash`, `storages-history`, and `account-history` tables. Cannot be combined with individual flags set to false.
+
+      --rocksdb.tx-hash <TX_HASH>
+          Route tx hash -> number table to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.storages-history <STORAGES_HISTORY>
+          Route storages history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.account-history <ACCOUNT_HISTORY>
+          Route account history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
       --from <FROM>
           The height to start at
 

--- a/docs/vocs/docs/pages/cli/reth/stage/drop.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/drop.mdx
@@ -138,6 +138,36 @@ Static Files:
           [default: false]
           [possible values: true, false]
 
+RocksDB:
+      --rocksdb.all
+          Route all supported tables to `RocksDB` instead of MDBX.
+
+          This enables `RocksDB` for `tx-hash`, `storages-history`, and `account-history` tables. Cannot be combined with individual flags set to false.
+
+      --rocksdb.tx-hash <TX_HASH>
+          Route tx hash -> number table to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.storages-history <STORAGES_HISTORY>
+          Route storages history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.account-history <ACCOUNT_HISTORY>
+          Route account history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
   <STAGE>
           Possible values:
           - headers:         The headers stage within the pipeline

--- a/docs/vocs/docs/pages/cli/reth/stage/dump.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump.mdx
@@ -145,6 +145,36 @@ Static Files:
           [default: false]
           [possible values: true, false]
 
+RocksDB:
+      --rocksdb.all
+          Route all supported tables to `RocksDB` instead of MDBX.
+
+          This enables `RocksDB` for `tx-hash`, `storages-history`, and `account-history` tables. Cannot be combined with individual flags set to false.
+
+      --rocksdb.tx-hash <TX_HASH>
+          Route tx hash -> number table to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.storages-history <STORAGES_HISTORY>
+          Route storages history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.account-history <ACCOUNT_HISTORY>
+          Route account history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/docs/vocs/docs/pages/cli/reth/stage/run.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/run.mdx
@@ -138,6 +138,36 @@ Static Files:
           [default: false]
           [possible values: true, false]
 
+RocksDB:
+      --rocksdb.all
+          Route all supported tables to `RocksDB` instead of MDBX.
+
+          This enables `RocksDB` for `tx-hash`, `storages-history`, and `account-history` tables. Cannot be combined with individual flags set to false.
+
+      --rocksdb.tx-hash <TX_HASH>
+          Route tx hash -> number table to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.storages-history <STORAGES_HISTORY>
+          Route storages history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.account-history <ACCOUNT_HISTORY>
+          Route account history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
       --metrics <SOCKET>
           Enable Prometheus metrics.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/unwind.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/unwind.mdx
@@ -143,6 +143,36 @@ Static Files:
           [default: false]
           [possible values: true, false]
 
+RocksDB:
+      --rocksdb.all
+          Route all supported tables to `RocksDB` instead of MDBX.
+
+          This enables `RocksDB` for `tx-hash`, `storages-history`, and `account-history` tables. Cannot be combined with individual flags set to false.
+
+      --rocksdb.tx-hash <TX_HASH>
+          Route tx hash -> number table to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.storages-history <STORAGES_HISTORY>
+          Route storages history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
+      --rocksdb.account-history <ACCOUNT_HISTORY>
+          Route account history tables to `RocksDB` instead of MDBX.
+
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+
+          [default: false]
+          [possible values: true, false]
+
       --offline
           If this is enabled, then all stages except headers, bodies, and sender recovery will be unwound
 


### PR DESCRIPTION
## Summary

This PR addresses the review comment from #21191 ([discussion](https://github.com/paradigmxyz/reth/pull/21191#discussion_r2709676364)):

> we can do it in this PR or on a follow-up, but we probably want to remove static_files.to_settings() i think ?
> and we should make sure that the following behaviour introduced here #21208 also applies to rocksdb

## Changes

1. **Remove `StaticFilesArgs::to_settings()`** - This method is now superseded by `NodeConfig::storage_settings()` which handles both static files and RocksDB settings in one place.

2. **Add edge feature behavior to RocksDB flags** - Following the pattern from #21208:
   - Individual RocksDB flags (`tx_hash`, `storages_history`, `account_history`) now default to `true` when the `edge` feature is enabled
   - Changed flags from `Option<bool>` to `bool` with proper defaults using `default_value_t` and `ArgAction::Set`
   - Added consistent doc comments about genesis-initialization-only behavior

3. **Add RocksDbArgs to EnvironmentArgs** - The `EnvironmentArgs` in `cli/commands` now includes `RocksDbArgs` with a `storage_settings()` method for consistent storage settings across all CLI commands.

4. **Update storage_settings() to use edge feature base** - Both `NodeConfig::storage_settings()` and `EnvironmentArgs::storage_settings()` now start from `StorageSettings::edge()` or `StorageSettings::legacy()` based on the feature flag.

## Files Changed

- `crates/node/core/src/args/rocksdb.rs` - Add edge feature defaults, change Option<bool> to bool
- `crates/node/core/src/args/static_files.rs` - Remove `to_settings()` method
- `crates/node/core/src/node_config.rs` - Update `storage_settings()` to use edge feature base
- `crates/cli/commands/src/common.rs` - Add `RocksDbArgs` and `storage_settings()`
- `crates/node/builder/src/launch/common.rs` - Update callers to use `storage_settings()`