### PR TITLE
feat(engine): add --engine.disable-cache-metrics flag

### DIFF
--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -137,6 +137,8 @@ pub struct TreeConfig {
     account_worker_count: usize,
     /// Whether to enable V2 storage proofs.
     enable_proof_v2: bool,
+    /// Whether to disable cache metrics recording (can be expensive with large cached state).
+    disable_cache_metrics: bool,
 }
 
 impl Default for TreeConfig {
@@ -166,6 +168,7 @@ impl Default for TreeConfig {
             storage_worker_count: default_storage_worker_count(),
             account_worker_count: default_account_worker_count(),
             enable_proof_v2: false,
+            disable_cache_metrics: false,
         }
     }
 }
@@ -198,6 +201,7 @@ impl TreeConfig {
         storage_worker_count: usize,
         account_worker_count: usize,
         enable_proof_v2: bool,
+        disable_cache_metrics: bool,
     ) -> Self {
         Self {
             persistence_threshold,
@@ -224,6 +228,7 @@ impl TreeConfig {
             storage_worker_count,
             account_worker_count,
             enable_proof_v2,
+            disable_cache_metrics,
         }
     }
 
@@ -514,6 +519,17 @@ impl TreeConfig {
     /// Setter for whether to enable V2 storage proofs.
     pub const fn with_enable_proof_v2(mut self, enable_proof_v2: bool) -> Self {
         self.enable_proof_v2 = enable_proof_v2;
+        self
+    }
+
+    /// Returns whether cache metrics recording is disabled.
+    pub const fn disable_cache_metrics(&self) -> bool {
+        self.disable_cache_metrics
+    }
+
+    /// Setter for whether to disable cache metrics recording.
+    pub const fn without_cache_metrics(mut self, disable_cache_metrics: bool) -> Self {
+        self.disable_cache_metrics = disable_cache_metrics;
         self
     }
 }

--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -628,7 +628,7 @@ impl SavedCache {
         self.hash
     }
 
-    /// Splits the cache into its caches, metrics, and disable_cache_metrics flag, consuming it.
+    /// Splits the cache into its caches, metrics, and `disable_cache_metrics` flag, consuming it.
     pub(crate) fn split(self) -> (ExecutionCache, CachedStateMetrics, bool) {
         (self.caches, self.metrics, self.disable_cache_metrics)
     }

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -278,8 +278,9 @@ where
             execution_cache.update_with_guard(|cached| {
                 // consumes the `SavedCache` held by the prewarming task, which releases its usage
                 // guard
-                let (caches, cache_metrics) = saved_cache.split();
-                let new_cache = SavedCache::new(hash, caches, cache_metrics);
+                let (caches, cache_metrics, disable_cache_metrics) = saved_cache.split();
+                let new_cache = SavedCache::new(hash, caches, cache_metrics)
+                    .with_disable_cache_metrics(disable_cache_metrics);
 
                 // Insert state into cache while holding the lock
                 // Access the BundleState through the shared ExecutionOutcome

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -473,6 +473,7 @@ mod tests {
             storage_worker_count: Some(16),
             account_worker_count: Some(8),
             enable_proof_v2: false,
+            cache_metrics_disabled: true,
         };
 
         let parsed_args = CommandParser::<EngineArgs>::parse_from([
@@ -503,6 +504,7 @@ mod tests {
             "16",
             "--engine.account-worker-count",
             "8",
+            "--engine.disable-cache-metrics",
         ])
         .args;
 

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -37,6 +37,7 @@ pub struct DefaultEngineValues {
     storage_worker_count: Option<usize>,
     account_worker_count: Option<usize>,
     enable_proof_v2: bool,
+    cache_metrics_disabled: bool,
 }
 
 impl DefaultEngineValues {
@@ -172,6 +173,12 @@ impl DefaultEngineValues {
         self.enable_proof_v2 = v;
         self
     }
+
+    /// Set whether to disable cache metrics by default
+    pub const fn with_cache_metrics_disabled(mut self, v: bool) -> Self {
+        self.cache_metrics_disabled = v;
+        self
+    }
 }
 
 impl Default for DefaultEngineValues {
@@ -197,6 +204,7 @@ impl Default for DefaultEngineValues {
             storage_worker_count: None,
             account_worker_count: None,
             enable_proof_v2: false,
+            cache_metrics_disabled: false,
         }
     }
 }
@@ -320,6 +328,10 @@ pub struct EngineArgs {
     /// Enable V2 storage proofs for state root calculations
     #[arg(long = "engine.enable-proof-v2", default_value_t = DefaultEngineValues::get_global().enable_proof_v2)]
     pub enable_proof_v2: bool,
+
+    /// Disable cache metrics recording, which can take up to 50ms with large cached state.
+    #[arg(long = "engine.disable-cache-metrics", default_value_t = DefaultEngineValues::get_global().cache_metrics_disabled)]
+    pub cache_metrics_disabled: bool,
 }
 
 #[allow(deprecated)]
@@ -346,6 +358,7 @@ impl Default for EngineArgs {
             storage_worker_count,
             account_worker_count,
             enable_proof_v2,
+            cache_metrics_disabled,
         } = DefaultEngineValues::get_global().clone();
         Self {
             persistence_threshold,
@@ -371,6 +384,7 @@ impl Default for EngineArgs {
             storage_worker_count,
             account_worker_count,
             enable_proof_v2,
+            cache_metrics_disabled,
         }
     }
 }
@@ -407,6 +421,7 @@ impl EngineArgs {
         }
 
         config = config.with_enable_proof_v2(self.enable_proof_v2);
+        config = config.without_cache_metrics(self.cache_metrics_disabled);
 
         config
     }

--- a/docs/vocs/docs/pages/cli/op-reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/node.mdx
@@ -972,6 +972,9 @@ Engine:
       --engine.enable-proof-v2
           Enable V2 storage proofs for state root calculations
 
+      --engine.disable-cache-metrics
+          Disable cache metrics recording, which can take up to 50ms with large cached state
+
 ERA:
       --era.enable
           Enable import from ERA1 files

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -972,6 +972,9 @@ Engine:
       --engine.enable-proof-v2
           Enable V2 storage proofs for state root calculations
 
+      --engine.disable-cache-metrics
+          Disable cache metrics recording, which can take up to 50ms with large cached state
+
 ERA:
       --era.enable
           Enable import from ERA1 files


### PR DESCRIPTION
## Summary

Add a flag to disable cache metrics recording in `SavedCache::update_metrics()`.

## Problem

The `update_metrics()` method calls `total_storage_slots()` which iterates over all storage cache entries to count them. With large cached state (millions of entries), this can take on the order of **50ms** per call, adding unnecessary latency to block processing.

## Solution

Add `--engine.disable-cache-metrics` CLI flag (default: `false`) that skips the expensive metrics recording when enabled.

### Changes

- Added `disable_cache_metrics` field to `TreeConfig` with getter/setter
- Added CLI flag to `EngineArgs` and `DefaultEngineValues`  
- Added `disable_cache_metrics` field to `SavedCache` with early return in `update_metrics()`
- Updated `SavedCache::split()` to preserve the flag when caches are transferred
- Wired the config through `PayloadProcessor` to all `SavedCache` creation sites

## Usage

```bash
reth node --engine.disable-cache-metrics
```