### PR TITLE
feat(node): log storage settings after genesis init

### DIFF
--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -32,7 +32,7 @@ use reth_node_core::{
 use reth_node_events::node;
 use reth_provider::{
     providers::{BlockchainProvider, NodeTypesForProvider},
-    BlockNumReader, MetadataProvider, StorageSettingsCache,
+    BlockNumReader, StorageSettingsCache,
 };
 use reth_tasks::TaskExecutor;
 use reth_tokio_util::EventSender;
@@ -41,7 +41,6 @@ use reth_trie_db::ChangesetCache;
 use std::{future::Future, pin::Pin, sync::Arc};
 use tokio::sync::{mpsc::unbounded_channel, oneshot};
 use tokio_stream::wrappers::UnboundedReceiverStream;
-use tracing::warn;
 
 /// The engine node launcher.
 #[derive(Debug)]

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -32,7 +32,7 @@ use reth_node_core::{
 use reth_node_events::node;
 use reth_provider::{
     providers::{BlockchainProvider, NodeTypesForProvider},
-    BlockNumReader, MetadataProvider,
+    BlockNumReader, MetadataProvider, StorageSettingsCache,
 };
 use reth_tasks::TaskExecutor;
 use reth_tokio_util::EventSender;
@@ -104,24 +104,8 @@ impl EngineNodeLauncher {
             .with_adjusted_configs()
             // Create the provider factory with changeset cache
             .with_provider_factory::<_, <CB::Components as NodeComponents<T>>::Evm>(changeset_cache.clone()).await?
-            .inspect(|ctx| {
+            .inspect(|_| {
                 info!(target: "reth::cli", "Database opened");
-                match ctx.provider_factory().storage_settings() {
-                    Ok(settings) => {
-                        info!(
-                            target: "reth::cli",
-                            ?settings,
-                            "Storage settings"
-                        );
-                    },
-                    Err(err) => {
-                        warn!(
-                            target: "reth::cli",
-                            ?err,
-                            "Failed to get storage settings"
-                        );
-                    },
-                }
             })
             .with_prometheus_server().await?
             .inspect(|this| {
@@ -130,6 +114,8 @@ impl EngineNodeLauncher {
             .with_genesis()?
             .inspect(|this: &LaunchContextWith<Attached<WithConfigs<<T::Types as NodeTypes>::ChainSpec>, _>>| {
                 info!(target: "reth::cli", "\n{}", this.chain_spec().display_hardforks());
+                let settings = this.provider_factory().cached_storage_settings();
+                info!(target: "reth::cli", ?settings, "Loaded storage settings");
             })
             .with_metrics_task()
             // passing FullNodeTypes as type parameter here so that we can build


### PR DESCRIPTION
## Summary

Moves storage settings logging to run **after** `with_genesis()` so it correctly logs the effective settings for both:
- **New nodes**: Settings written during `init_genesis_with_settings()`
- **Restarting nodes**: Settings loaded from DB at `ProviderFactory::new()`

Uses `cached_storage_settings()` which is populated correctly in both paths, producing a single log line like:
```
INFO reth::cli: Loaded storage settings settings=StorageSettings { receipts_in_static_files: true, ... }
```

## Changes
- Removed the old storage settings log that ran before genesis (which would show `None` for new nodes)
- Added new log after `with_genesis()` using the cached settings