### PR TITLE
fix: sigsegv handler

### DIFF
--- a/crates/cli/util/src/sigsegv_handler.rs
+++ b/crates/cli/util/src/sigsegv_handler.rs
@@ -123,7 +123,13 @@ pub fn install() {
         let mut alt_stack: libc::stack_t = mem::zeroed();
         // Both SysV AMD64 ABI and aarch64 ABI require 16 bytes alignment. We are going to be
         // generous here and just use a size of a page.
-        let page_sz = libc::sysconf(libc::_SC_PAGESIZE) as usize;
+        let raw_page_sz = libc::sysconf(libc::_SC_PAGESIZE);
+        let page_sz = if raw_page_sz == -1 {
+            // Fallback alignment in case sysconf fails.
+            4096_usize
+        } else {
+            raw_page_sz as usize
+        };
         alt_stack.ss_sp = alloc(Layout::from_size_align(alt_stack_size, page_sz).unwrap()).cast();
         alt_stack.ss_size = alt_stack_size;
         libc::sigaltstack(&raw const alt_stack, ptr::null_mut());

--- a/crates/cli/util/src/sigsegv_handler.rs
+++ b/crates/cli/util/src/sigsegv_handler.rs
@@ -121,7 +121,10 @@ pub fn install() {
     unsafe {
         let alt_stack_size: usize = min_sigstack_size() + 64 * 1024;
         let mut alt_stack: libc::stack_t = mem::zeroed();
-        alt_stack.ss_sp = alloc(Layout::from_size_align(alt_stack_size, 1).unwrap()).cast();
+        // Both SysV AMD64 ABI and aarch64 ABI require 16 bytes alignment. We are going to be
+        // generous here and just use a size of a page.
+        let page_sz = libc::sysconf(libc::_SC_PAGESIZE) as usize;
+        alt_stack.ss_sp = alloc(Layout::from_size_align(alt_stack_size, page_sz).unwrap()).cast();
         alt_stack.ss_size = alt_stack_size;
         libc::sigaltstack(&raw const alt_stack, ptr::null_mut());
 


### PR DESCRIPTION
ABIs have specific requirements on the alignment of the stack. For example, x86-64 SysV ABI requires that it always can spill/reload 128 SIMD registers and thus the compiler would just assume it has that and will just trap if any SSE instructions were emitted in the print_stack_trace routine.

Not sure how plausible that is, and furthermore, it's very likely that the minimum alignment for allocations returned by `alloc` on the most reasonable targets is going to be 16 anyway, but it's better be safe than sorry.