### PR TITLE
chore(trie): remove unnecessary clone in into_sorted_ref

### DIFF
--- a/crates/trie/common/src/updates.rs
+++ b/crates/trie/common/src/updates.rs
@@ -206,7 +206,7 @@ impl TrieUpdates {
     }
 
     /// Converts trie updates into [`TrieUpdatesSortedRef`].
-    pub fn into_sorted_ref<'a>(&'a self) -> TrieUpdatesSortedRef<'a> {
+    pub fn into_sorted_ref(&self) -> TrieUpdatesSortedRef<'_> {
         let mut account_nodes = self.account_nodes.iter().collect::<Vec<_>>();
         account_nodes.sort_unstable_by(|a, b| a.0.cmp(b.0));
 
@@ -216,7 +216,7 @@ impl TrieUpdates {
             storage_tries: self
                 .storage_tries
                 .iter()
-                .map(|m| (*m.0, m.1.into_sorted_ref().clone()))
+                .map(|m| (*m.0, m.1.into_sorted_ref()))
                 .collect(),
         }
     }


### PR DESCRIPTION
Removes an unnecessary `.clone()` call in `TrieUpdates::into_sorted_ref()`.

`into_sorted_ref()` already returns an owned `StorageTrieUpdatesSortedRef`, so cloning it when collecting into the map was redundant.

Also elides the explicit lifetime annotation since it can be inferred.