### PR TITLE
fix(rocksdb): flush memtables before dropping

### DIFF
--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -428,7 +428,8 @@ impl Drop for RocksDBProviderInner {
     fn drop(&mut self) {
         match self {
             Self::ReadWrite { db, .. } => {
-                // Flush all memtables if possible. If not, they will be rebuilt from the WAL on restart
+                // Flush all memtables if possible. If not, they will be rebuilt from the WAL on
+                // restart
                 if let Err(e) = db.flush_wal(true) {
                     tracing::warn!(target: "storage::rocksdb", ?e, "Failed to flush WAL on drop");
                 }

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -428,7 +428,7 @@ impl Drop for RocksDBProviderInner {
     fn drop(&mut self) {
         match self {
             Self::ReadWrite { db, .. } => {
-                // Flush all memtables before shutdown to ensure data durability
+                // Flush all memtables if possible. If not, they will be rebuilt from the WAL on restart
                 if let Err(e) = db.flush_wal(true) {
                     tracing::warn!(target: "storage::rocksdb", ?e, "Failed to flush WAL on drop");
                 }

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -427,7 +427,16 @@ impl fmt::Debug for RocksDBProviderInner {
 impl Drop for RocksDBProviderInner {
     fn drop(&mut self) {
         match self {
-            Self::ReadWrite { db, .. } => db.cancel_all_background_work(true),
+            Self::ReadWrite { db, .. } => {
+                // Flush all memtables before shutdown to ensure data durability
+                if let Err(e) = db.flush_wal(true) {
+                    tracing::warn!(target: "storage::rocksdb", ?e, "Failed to flush WAL on drop");
+                }
+                if let Err(e) = db.flush() {
+                    tracing::warn!(target: "storage::rocksdb", ?e, "Failed to flush memtables on drop");
+                }
+                db.cancel_all_background_work(true);
+            }
             Self::ReadOnly { db, .. } => db.cancel_all_background_work(true),
         }
     }


### PR DESCRIPTION
## Summary

Ensures memtables are flushed before the RocksDB provider is dropped.
## Changes

- Flush WAL and memtables in `Drop` impl before cancelling background work
- Only applies to read-write mode 