### PR TITLE
feat(trie): Add `serde-bincode-compat` feature to `reth-trie`

### DIFF
--- a/crates/trie/trie/Cargo.toml
+++ b/crates/trie/trie/Cargo.toml
@@ -96,6 +96,13 @@ test-utils = [
     "reth-trie-sparse/test-utils",
     "reth-stages-types/test-utils",
 ]
+serde-bincode-compat = [
+    "alloy-consensus/serde-bincode-compat",
+    "alloy-eips/serde-bincode-compat",
+    "reth-ethereum-primitives/serde-bincode-compat",
+    "reth-primitives-traits/serde-bincode-compat",
+    "reth-trie-common/serde-bincode-compat",
+]
 
 [[bench]]
 name = "hash_post_state"


### PR DESCRIPTION
Upstreams part of https://github.com/op-rs/op-reth/pull/250

Exposes `serde-bincode-compat` feature in `reth-trie`