### PR TITLE
perf(pruner): batch pruning with raw iterator optimization

### DIFF
--- a/crates/prune/prune/src/segments/user/account_history.rs
+++ b/crates/prune/prune/src/segments/user/account_history.rs
@@ -238,8 +238,6 @@ impl AccountHistory {
     where
         Provider: DBProvider + StaticFileProviderFactory + ChangeSetReader + RocksDBProviderFactory,
     {
-        use reth_provider::PruneShardOutcome;
-
         // Unlike MDBX path, we don't divide the limit by 2 because RocksDB path only prunes
         // history shards (no separate changeset table to delete from). The changesets are in
         // static files which are deleted separately.
@@ -287,14 +285,15 @@ impl AccountHistory {
         sorted_accounts.sort_unstable_by_key(|(addr, _)| *addr);
 
         provider.with_rocksdb_batch(|mut batch| {
-            for (address, highest_block) in &sorted_accounts {
-                let prune_to = (*highest_block).min(last_changeset_pruned_block);
-                match batch.prune_account_history_to(*address, prune_to)? {
-                    PruneShardOutcome::Deleted => deleted_shards += 1,
-                    PruneShardOutcome::Updated => updated_shards += 1,
-                    PruneShardOutcome::Unchanged => {}
-                }
-            }
+            let targets: Vec<_> = sorted_accounts
+                .iter()
+                .map(|(addr, highest)| (*addr, (*highest).min(last_changeset_pruned_block)))
+                .collect();
+
+            let outcomes = batch.prune_account_history_batch(&targets)?;
+            deleted_shards = outcomes.deleted;
+            updated_shards = outcomes.updated;
+
             Ok(((), Some(batch.into_inner())))
         })?;
         trace!(target: "pruner", deleted = deleted_shards, updated = updated_shards, %done, "Pruned account history (RocksDB indices)");

--- a/crates/storage/provider/src/lib.rs
+++ b/crates/storage/provider/src/lib.rs
@@ -21,7 +21,7 @@ pub mod providers;
 pub use providers::{
     DatabaseProvider, DatabaseProviderRO, DatabaseProviderRW, HistoricalStateProvider,
     HistoricalStateProviderRef, LatestStateProvider, LatestStateProviderRef, ProviderFactory,
-    PruneShardOutcome, SaveBlocksMode, StaticFileAccess, StaticFileProviderBuilder,
+    PruneShardOutcome, PrunedIndices, SaveBlocksMode, StaticFileAccess, StaticFileProviderBuilder,
     StaticFileWriteCtx, StaticFileWriter,
 };
 

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -39,8 +39,8 @@ pub use consistent::ConsistentProvider;
 pub(crate) mod rocksdb;
 
 pub use rocksdb::{
-    PruneShardOutcome, RocksDBBatch, RocksDBBuilder, RocksDBIter, RocksDBProvider, RocksDBRawIter,
-    RocksDBStats, RocksDBTableStats, RocksTx,
+    PruneShardOutcome, PrunedIndices, RocksDBBatch, RocksDBBuilder, RocksDBIter, RocksDBProvider,
+    RocksDBRawIter, RocksDBStats, RocksDBTableStats, RocksTx,
 };
 
 /// Helper trait to bound [`NodeTypes`] so that combined with database they satisfy

--- a/crates/storage/provider/src/providers/rocksdb/mod.rs
+++ b/crates/storage/provider/src/providers/rocksdb/mod.rs
@@ -6,6 +6,6 @@ mod provider;
 
 pub(crate) use provider::{PendingRocksDBBatches, RocksDBWriteCtx};
 pub use provider::{
-    PruneShardOutcome, RocksDBBatch, RocksDBBuilder, RocksDBIter, RocksDBProvider, RocksDBRawIter,
-    RocksDBStats, RocksDBTableStats, RocksTx,
+    PruneShardOutcome, PrunedIndices, RocksDBBatch, RocksDBBuilder, RocksDBIter, RocksDBProvider,
+    RocksDBRawIter, RocksDBStats, RocksDBTableStats, RocksTx,
 };

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -1781,6 +1781,11 @@ impl<'a> RocksDBBatch<'a> {
             return Ok(PrunedIndices::default());
         }
 
+        debug_assert!(
+            targets.windows(2).all(|w| w[0].0 <= w[1].0),
+            "targets must be sorted by address for correctness"
+        );
+
         // ShardedKey<Address> layout: [address: 20][block: 8] = 28 bytes
         // The first 20 bytes are the "prefix" that identifies the address
         const PREFIX_LEN: usize = 20;
@@ -1902,6 +1907,11 @@ impl<'a> RocksDBBatch<'a> {
         if targets.is_empty() {
             return Ok(PrunedIndices::default());
         }
+
+        debug_assert!(
+            targets.windows(2).all(|w| w[0].0 <= w[1].0),
+            "targets must be sorted by (address, storage_key) for correctness"
+        );
 
         // StorageShardedKey layout: [address: 20][storage_key: 32][block: 8] = 60 bytes
         // The first 52 bytes are the "prefix" that identifies (address, storage_key)
@@ -3864,5 +3874,148 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn test_prune_account_history_batch_multiple_sorted_targets() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        let addr1 = Address::from([0x01; 20]);
+        let addr2 = Address::from([0x02; 20]);
+        let addr3 = Address::from([0x03; 20]);
+
+        // Setup shards for each address
+        let mut batch = provider.batch();
+        batch
+            .put::<tables::AccountsHistory>(
+                ShardedKey::new(addr1, u64::MAX),
+                &BlockNumberList::new_pre_sorted([10, 20, 30]),
+            )
+            .unwrap();
+        batch
+            .put::<tables::AccountsHistory>(
+                ShardedKey::new(addr2, u64::MAX),
+                &BlockNumberList::new_pre_sorted([5, 10, 15]),
+            )
+            .unwrap();
+        batch
+            .put::<tables::AccountsHistory>(
+                ShardedKey::new(addr3, u64::MAX),
+                &BlockNumberList::new_pre_sorted([100, 200]),
+            )
+            .unwrap();
+        batch.commit().unwrap();
+
+        // Prune all three (sorted by address)
+        let mut targets = vec![(addr1, 15), (addr2, 10), (addr3, 50)];
+        targets.sort_by_key(|(addr, _)| *addr);
+
+        let mut batch = provider.batch();
+        let outcomes = batch.prune_account_history_batch(&targets).unwrap();
+        batch.commit().unwrap();
+
+        // addr1: prune <=15, keep [20, 30] -> updated
+        // addr2: prune <=10, keep [15] -> updated
+        // addr3: prune <=50, keep [100, 200] -> unchanged
+        assert_eq!(outcomes.updated, 2);
+        assert_eq!(outcomes.unchanged, 1);
+
+        let shards1 = provider.account_history_shards(addr1).unwrap();
+        assert_eq!(shards1[0].1.iter().collect::<Vec<_>>(), vec![20, 30]);
+
+        let shards2 = provider.account_history_shards(addr2).unwrap();
+        assert_eq!(shards2[0].1.iter().collect::<Vec<_>>(), vec![15]);
+
+        let shards3 = provider.account_history_shards(addr3).unwrap();
+        assert_eq!(shards3[0].1.iter().collect::<Vec<_>>(), vec![100, 200]);
+    }
+
+    #[test]
+    fn test_prune_account_history_batch_target_with_no_shards() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        let addr1 = Address::from([0x01; 20]);
+        let addr2 = Address::from([0x02; 20]); // No shards for this one
+        let addr3 = Address::from([0x03; 20]);
+
+        // Only setup shards for addr1 and addr3
+        let mut batch = provider.batch();
+        batch
+            .put::<tables::AccountsHistory>(
+                ShardedKey::new(addr1, u64::MAX),
+                &BlockNumberList::new_pre_sorted([10, 20]),
+            )
+            .unwrap();
+        batch
+            .put::<tables::AccountsHistory>(
+                ShardedKey::new(addr3, u64::MAX),
+                &BlockNumberList::new_pre_sorted([30, 40]),
+            )
+            .unwrap();
+        batch.commit().unwrap();
+
+        // Prune all three (addr2 has no shards - tests p > target_prefix case)
+        let mut targets = vec![(addr1, 15), (addr2, 100), (addr3, 35)];
+        targets.sort_by_key(|(addr, _)| *addr);
+
+        let mut batch = provider.batch();
+        let outcomes = batch.prune_account_history_batch(&targets).unwrap();
+        batch.commit().unwrap();
+
+        // addr1: updated (keep [20])
+        // addr2: unchanged (no shards)
+        // addr3: updated (keep [40])
+        assert_eq!(outcomes.updated, 2);
+        assert_eq!(outcomes.unchanged, 1);
+
+        let shards1 = provider.account_history_shards(addr1).unwrap();
+        assert_eq!(shards1[0].1.iter().collect::<Vec<_>>(), vec![20]);
+
+        let shards3 = provider.account_history_shards(addr3).unwrap();
+        assert_eq!(shards3[0].1.iter().collect::<Vec<_>>(), vec![40]);
+    }
+
+    #[test]
+    fn test_prune_storage_history_batch_multiple_sorted_targets() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        let addr = Address::from([0x42; 20]);
+        let slot1 = B256::from([0x01; 32]);
+        let slot2 = B256::from([0x02; 32]);
+
+        // Setup shards
+        let mut batch = provider.batch();
+        batch
+            .put::<tables::StoragesHistory>(
+                StorageShardedKey::new(addr, slot1, u64::MAX),
+                &BlockNumberList::new_pre_sorted([10, 20, 30]),
+            )
+            .unwrap();
+        batch
+            .put::<tables::StoragesHistory>(
+                StorageShardedKey::new(addr, slot2, u64::MAX),
+                &BlockNumberList::new_pre_sorted([5, 15, 25]),
+            )
+            .unwrap();
+        batch.commit().unwrap();
+
+        // Prune both (sorted)
+        let mut targets = vec![((addr, slot1), 15), ((addr, slot2), 10)];
+        targets.sort_by_key(|((a, s), _)| (*a, *s));
+
+        let mut batch = provider.batch();
+        let outcomes = batch.prune_storage_history_batch(&targets).unwrap();
+        batch.commit().unwrap();
+
+        assert_eq!(outcomes.updated, 2);
+
+        let shards1 = provider.storage_history_shards(addr, slot1).unwrap();
+        assert_eq!(shards1[0].1.iter().collect::<Vec<_>>(), vec![20, 30]);
+
+        let shards2 = provider.storage_history_shards(addr, slot2).unwrap();
+        assert_eq!(shards2[0].1.iter().collect::<Vec<_>>(), vec![15, 25]);
     }
 }

--- a/crates/storage/provider/src/providers/rocksdb_stub.rs
+++ b/crates/storage/provider/src/providers/rocksdb_stub.rs
@@ -221,12 +221,15 @@ pub enum PruneShardOutcome {
 }
 
 /// Tracks pruning outcomes for batch operations (stub).
+///
+/// Each counter represents the number of **targets** (addresses or storage keys)
+/// that had that outcome, not the number of individual shards affected.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct PrunedIndices {
-    /// Number of shards completely deleted.
+    /// Number of targets whose shards were completely deleted.
     pub deleted: usize,
-    /// Number of shards that were updated (filtered but still have entries).
+    /// Number of targets whose shards were updated (filtered but still have entries).
     pub updated: usize,
-    /// Number of shards that were unchanged.
+    /// Number of targets that were unchanged (no blocks <= `to_block`).
     pub unchanged: usize,
 }

--- a/crates/storage/provider/src/providers/rocksdb_stub.rs
+++ b/crates/storage/provider/src/providers/rocksdb_stub.rs
@@ -219,3 +219,14 @@ pub enum PruneShardOutcome {
     /// Shard was unchanged (no blocks <= `to_block`).
     Unchanged,
 }
+
+/// Tracks pruning outcomes for batch operations (stub).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct PrunedIndices {
+    /// Number of shards completely deleted.
+    pub deleted: usize,
+    /// Number of shards that were updated (filtered but still have entries).
+    pub updated: usize,
+    /// Number of shards that were unchanged.
+    pub unchanged: usize,
+}


### PR DESCRIPTION
Adds batch pruning methods for RocksDB history tables that use raw iterators with seek optimization.

## Changes

- Add `prune_account_history_batch()` and `prune_storage_history_batch()` methods
- Use raw iterators with conditional seek to skip seeks when targets are adjacent in key order
- Add `PrunedIndices` struct to track batch outcomes
- Add `RocksDBRawIterEnum` wrapper for raw iterators in both read-write and read-only modes

## Performance

When targets are sorted and adjacent in RocksDB key order, the iterator naturally lands on the next prefix after finishing the previous one, so seeks are skipped. This reduces iterator construction overhead and improves pruning performance.

## Safety

- Debug assertions enforce sorted input with no duplicates  
- Iterator status checked after traversal to catch RocksDB errors
- Reuses existing `prune_history_shards_inner` logic for correctness