### PR TITLE
feat(tree): add persistence backpressure to prevent OOM

### DIFF
--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -204,6 +204,10 @@ pub(crate) struct EngineMetrics {
     pub(crate) failed_forkchoice_updated_response_deliveries: Counter,
     /// block insert duration
     pub(crate) block_insert_total_duration: Histogram,
+    /// Number of blocks currently pending persistence (for backpressure monitoring)
+    pub(crate) pending_persistence_blocks: Gauge,
+    /// Number of times backpressure was applied (validation blocked waiting for persistence)
+    pub(crate) backpressure_events: Counter,
 }
 
 /// Metrics for engine forkchoiceUpdated responses.

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1786,16 +1786,17 @@ where
 
     /// Returns the number of blocks that are pending persistence.
     /// This is the number of canonical blocks in memory that are above the last persisted block.
-    pub fn pending_persistence_blocks(&self) -> u64 {
+    pub const fn pending_persistence_blocks(&self) -> u64 {
         self.state
             .tree_state
-            .canonical_block_number()
+            .current_canonical_head
+            .number
             .saturating_sub(self.persistence_state.last_persisted_block.number)
     }
 
     /// Returns true if backpressure should be applied due to too many blocks pending persistence.
     /// When true, validation should wait for persistence to catch up before processing more blocks.
-    pub fn should_apply_backpressure(&self) -> bool {
+    pub const fn should_apply_backpressure(&self) -> bool {
         self.pending_persistence_blocks() >= self.config.max_pending_persistence_blocks()
     }
 


### PR DESCRIPTION
## Summary

When validation is faster than persistence (e.g., during `reth-bench` or `replay-payloads`), blocks can accumulate in memory faster than they can be written to disk, eventually causing OOM.

This adds a simple backpressure mechanism that prevents OOM by blocking validation when too many blocks are pending persistence.

## Changes

### New Config Option
- `max_pending_persistence_blocks` (default: 128) - Maximum blocks that can be pending persistence before backpressure is applied

### New Methods in `EngineApiTreeHandler`
- `pending_persistence_blocks()` - Returns count of blocks awaiting persistence
- `should_apply_backpressure()` - Returns true if limit is exceeded  
- `wait_for_persistence_if_needed()` - Blocks until persistence catches up

### Metrics
- `pending_persistence_blocks` gauge - Current pending blocks count
- `backpressure_events` counter - Number of times backpressure was applied

## How It Works

1. Before inserting a new payload, check if `pending_persistence_blocks >= max_pending_persistence_blocks`
2. If true, block on the persistence channel until a persistence operation completes
3. This naturally couples validation speed to persistence speed, preventing unbounded memory growth

## Impact

- **Benchmarks**: May show lower peak validation throughput (measures end-to-end including disk, not just CPU)
- **Live sync**: Minimal impact since persistence usually keeps up; reasonable buffer prevents stalls
- **OOM prevention**: No more crashes when running `reth-bench` or `replay-payloads` with many blocks

## Related Discussion

From Slack thread in #eng-perf: validation was outpacing persistence during benchmarking, causing OOM after ~100-150 blocks.

cc @onbjerg @mattsse @joshieDo @gakonst @yk 

---

*This PR was created based on discussion about adding simple backpressure where there should be a max number of blocks to persist. The implementation blocks validation when the persistence queue is too full.*
