### PR TITLE
fix(node): make RocksDbArgs respect edge feature defaults like StaticFilesArgs does

### DIFF
--- a/crates/node/core/src/args/rocksdb.rs
+++ b/crates/node/core/src/args/rocksdb.rs
@@ -171,17 +171,17 @@ mod tests {
         // When edge feature is enabled, tx_hash should default to true
         // When edge feature is disabled, it should default to false
         let args = RocksDbArgs::default();
-        
+
         #[cfg(feature = "edge")]
         {
             assert!(args.tx_hash_with_default());
         }
-        
+
         #[cfg(not(feature = "edge"))]
         {
             assert!(!args.tx_hash_with_default());
         }
-        
+
         // storages_history and account_history always default to false
         assert!(!args.storages_history_with_default());
         assert!(!args.account_history_with_default());
@@ -195,18 +195,18 @@ mod tests {
             storages_history: Some(true),
             account_history: Some(true),
         };
-        
+
         assert!(args.tx_hash_with_default());
         assert!(args.storages_history_with_default());
         assert!(args.account_history_with_default());
-        
+
         let args = RocksDbArgs {
             all: false,
             tx_hash: Some(false),
             storages_history: Some(false),
             account_history: Some(false),
         };
-        
+
         assert!(!args.tx_hash_with_default());
         assert!(!args.storages_history_with_default());
         assert!(!args.account_history_with_default());

--- a/crates/node/core/src/node_config.rs
+++ b/crates/node/core/src/node_config.rs
@@ -358,7 +358,7 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
     }
 
     /// Returns the effective storage settings derived from static-file and `RocksDB` CLI args.
-    pub fn storage_settings(&self) -> StorageSettings {
+    pub const fn storage_settings(&self) -> StorageSettings {
         let tx_hash = self.rocksdb.all || self.rocksdb.tx_hash_with_default();
         let storages_history = self.rocksdb.all || self.rocksdb.storages_history_with_default();
         let account_history = self.rocksdb.all || self.rocksdb.account_history_with_default();


### PR DESCRIPTION
Fixes the inconsistency where StaticFilesArgs properly uses edge feature defaults but RocksDbArgs was always defaulting to false regardless of the feature flag.

Before this, if you compiled with --features edge, you'd still need to manually pass --rocksdb.tx-hash=true to get the actual edge behavior defined in StorageSettings::edge(). Now it just works.