### PR TITLE
feat(txpool): add IntoIterator for AllPoolTransactions

### DIFF
--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -746,6 +746,18 @@ impl<T: PoolTransaction> Default for AllPoolTransactions<T> {
     }
 }
 
+impl<T: PoolTransaction> IntoIterator for AllPoolTransactions<T> {
+    type Item = Arc<ValidPoolTransaction<T>>;
+    type IntoIter = std::iter::Chain<
+        std::vec::IntoIter<Arc<ValidPoolTransaction<T>>>,
+        std::vec::IntoIter<Arc<ValidPoolTransaction<T>>>,
+    >;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.pending.into_iter().chain(self.queued)
+    }
+}
+
 /// Represents transactions that were propagated over the network.
 #[derive(Debug, Clone, Eq, PartialEq, Default)]
 pub struct PropagatedTransactions(pub HashMap<TxHash, Vec<PropagateKind>>);


### PR DESCRIPTION
Adds an `IntoIterator` implementation for `AllPoolTransactions` that chains pending and queued transactions together.

This enables ergonomic iteration patterns like:
```rust
for tx in all_transactions { ... }
```

instead of:
```rust
for tx in all_txs.pending.iter().chain(all_txs.queued.iter()) { ... }
```