### PR TITLE
fix: add latency metrics for getBALsByHash and getBALsByRange methods

### DIFF
--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -1175,9 +1175,12 @@ where
         _block_hashes: Vec<BlockHash>,
     ) -> RpcResult<Vec<alloy_primitives::Bytes>> {
         trace!(target: "rpc::engine", "Serving engine_getBALsByHashV1");
-        Err(EngineApiError::EngineObjectValidationError(
+        let start = std::time::Instant::now();
+        let result = Err(EngineApiError::EngineObjectValidationError(
             reth_payload_primitives::EngineObjectValidationError::UnsupportedFork,
-        ))?
+        ));
+        self.inner.metrics.latency.get_bals_by_hash_v1.record(start.elapsed());
+        result?
     }
 
     /// Handler for `engine_getBALsByRangeV1`
@@ -1189,9 +1192,12 @@ where
         _count: U64,
     ) -> RpcResult<Vec<alloy_primitives::Bytes>> {
         trace!(target: "rpc::engine", "Serving engine_getBALsByRangeV1");
-        Err(EngineApiError::EngineObjectValidationError(
+        let start = std::time::Instant::now();
+        let result = Err(EngineApiError::EngineObjectValidationError(
             reth_payload_primitives::EngineObjectValidationError::UnsupportedFork,
-        ))?
+        ));
+        self.inner.metrics.latency.get_bals_by_range_v1.record(start.elapsed());
+        result?
     }
 }
 

--- a/crates/rpc/rpc-engine-api/src/metrics.rs
+++ b/crates/rpc/rpc-engine-api/src/metrics.rs
@@ -48,6 +48,10 @@ pub(crate) struct EngineApiLatencyMetrics {
     pub(crate) get_blobs_v2: Histogram,
     /// Latency for `engine_getBlobsV3`
     pub(crate) get_blobs_v3: Histogram,
+    /// Latency for `engine_getBALsByHashV1`
+    pub(crate) get_bals_by_hash_v1: Histogram,
+    /// Latency for `engine_getBALsByRangeV1`
+    pub(crate) get_bals_by_range_v1: Histogram,
 }
 
 #[derive(Metrics)]


### PR DESCRIPTION
Adds missing latency metrics for the BAL methods to match the pattern used by other engine API endpoints. Even though these are currently stubs returning UnsupportedFork, tracking metrics lets us monitor CL call frequency and provides baseline data for when we implement the actual functionality.

follow-up #21204