### PR TITLE
fix: fix payload file filter prefix in replay-payloads

### DIFF
--- a/bin/reth-bench/src/bench/replay_payloads.rs
+++ b/bin/reth-bench/src/bench/replay_payloads.rs
@@ -180,7 +180,7 @@ impl Command {
             .filter_map(|e| e.ok())
             .filter(|e| {
                 e.path().extension().and_then(|s| s.to_str()) == Some("json") &&
-                    e.file_name().to_string_lossy().starts_with("payload_")
+                    e.file_name().to_string_lossy().starts_with("payload_block_")
             })
             .collect();
 


### PR DESCRIPTION
File filter used `payload_` prefix but parser expected `payload_block_`, causing silent failures. Changed filter to match actual file format.