### PR TITLE
feat(chainspec): add earliest_block to ChainInfo

### DIFF
--- a/crates/chain-state/src/chain_info.rs
+++ b/crates/chain-state/src/chain_info.rs
@@ -51,7 +51,7 @@ where
     /// Returns the [`ChainInfo`] for the canonical head.
     pub fn chain_info(&self) -> ChainInfo {
         let inner = self.inner.canonical_head.read();
-        ChainInfo { best_hash: inner.hash(), best_number: inner.number() }
+        ChainInfo { best_hash: inner.hash(), best_number: inner.number(), earliest_block: 0 }
     }
 
     /// Update the timestamp when we received a forkchoice update.

--- a/crates/chainspec/src/info.rs
+++ b/crates/chainspec/src/info.rs
@@ -8,6 +8,11 @@ pub struct ChainInfo {
     pub best_hash: B256,
     /// The block number of the highest fully synced block.
     pub best_number: BlockNumber,
+    /// The block number of the earliest block we have available.
+    ///
+    /// This tracks the lowest block height still retained, useful for determining
+    /// what data has expired (e.g., due to pruning).
+    pub earliest_block: BlockNumber,
 }
 
 impl From<ChainInfo> for BlockNumHash {

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -753,7 +753,11 @@ impl<N: ProviderNodeTypes> BlockHashReader for ConsistentProvider<N> {
 impl<N: ProviderNodeTypes> BlockNumReader for ConsistentProvider<N> {
     fn chain_info(&self) -> ProviderResult<ChainInfo> {
         let best_number = self.best_block_number()?;
-        Ok(ChainInfo { best_hash: self.block_hash(best_number)?.unwrap_or_default(), best_number })
+        Ok(ChainInfo {
+            best_hash: self.block_hash(best_number)?.unwrap_or_default(),
+            best_number,
+            earliest_block: 0,
+        })
     }
 
     fn best_block_number(&self) -> ProviderResult<BlockNumber> {

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1463,7 +1463,7 @@ impl<TX: DbTx + 'static, N: NodeTypes> BlockNumReader for DatabaseProvider<TX, N
     fn chain_info(&self) -> ProviderResult<ChainInfo> {
         let best_number = self.best_block_number()?;
         let best_hash = self.block_hash(best_number)?.unwrap_or_default();
-        Ok(ChainInfo { best_hash, best_number })
+        Ok(ChainInfo { best_hash, best_number, earliest_block: 0 })
     }
 
     fn best_block_number(&self) -> ProviderResult<BlockNumber> {

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -573,7 +573,11 @@ impl<T: NodePrimitives, ChainSpec: Send + Sync + 'static> BlockNumReader
         Ok(lock
             .iter()
             .find(|(_, header)| header.number() == best_block_number)
-            .map(|(hash, header)| ChainInfo { best_hash: *hash, best_number: header.number() })
+            .map(|(hash, header)| ChainInfo {
+                best_hash: *hash,
+                best_number: header.number(),
+                earliest_block: 0,
+            })
             .unwrap_or_default())
     }
 

--- a/crates/storage/rpc-provider/src/lib.rs
+++ b/crates/storage/rpc-provider/src/lib.rs
@@ -264,7 +264,11 @@ where
                 .map_err(ProviderError::other)?
                 .ok_or(ProviderError::HeaderNotFound(0.into()))?;
 
-            Ok(ChainInfo { best_hash: block.header().hash(), best_number: block.header().number() })
+            Ok(ChainInfo {
+                best_hash: block.header().hash(),
+                best_number: block.header().number(),
+                earliest_block: 0,
+            })
         })
     }
 
@@ -1381,7 +1385,11 @@ where
                 .map_err(ProviderError::other)?
                 .ok_or(ProviderError::HeaderNotFound(0.into()))?;
 
-            Ok(ChainInfo { best_hash: block.header().hash(), best_number: block.header().number() })
+            Ok(ChainInfo {
+                best_hash: block.header().hash(),
+                best_number: block.header().number(),
+                earliest_block: 0,
+            })
         })
     }
 


### PR DESCRIPTION
Add `earliest_block` field to `ChainInfo` struct to track the lowest block height still retained. This is useful for determining what data has expired (e.g., due to pruning).

## Changes
- Added `earliest_block: BlockNumber` field to `ChainInfo` (defaults to 0)
- Updated all `ChainInfo` construction sites to include the new field

Towards #20038