### PR TITLE
feat(reth-bench): add --target-gas-limit option to gas-limit-ramp

### DIFF
--- a/bin/reth-bench/src/bench/gas_limit_ramp.rs
+++ b/bin/reth-bench/src/bench/gas_limit_ramp.rs
@@ -25,9 +25,14 @@ use tracing::info;
 /// `reth benchmark gas-limit-ramp` command.
 #[derive(Debug, Parser)]
 pub struct Command {
-    /// Number of blocks to generate.
-    #[arg(long, value_name = "BLOCKS")]
-    blocks: u64,
+    /// Number of blocks to generate. Mutually exclusive with --target-gas-limit.
+    #[arg(long, value_name = "BLOCKS", conflicts_with = "target_gas_limit")]
+    blocks: Option<u64>,
+
+    /// Target gas limit to ramp up to. The benchmark will generate blocks until the gas limit
+    /// reaches or exceeds this value. Mutually exclusive with --blocks.
+    #[arg(long, value_name = "TARGET_GAS_LIMIT", conflicts_with = "blocks")]
+    target_gas_limit: Option<u64>,
 
     /// The Engine API RPC URL.
     #[arg(long = "engine-rpc-url", value_name = "ENGINE_RPC_URL")]
@@ -42,12 +47,37 @@ pub struct Command {
     output: PathBuf,
 }
 
+/// Mode for determining when to stop ramping.
+#[derive(Debug, Clone, Copy)]
+enum RampMode {
+    /// Ramp for a fixed number of blocks.
+    Blocks(u64),
+    /// Ramp until reaching or exceeding target gas limit.
+    TargetGasLimit(u64),
+}
+
 impl Command {
     /// Execute `benchmark gas-limit-ramp` command.
     pub async fn execute(self, _ctx: CliContext) -> eyre::Result<()> {
-        if self.blocks == 0 {
-            return Err(eyre::eyre!("--blocks must be greater than 0"));
-        }
+        let mode = match (self.blocks, self.target_gas_limit) {
+            (Some(blocks), None) => {
+                if blocks == 0 {
+                    return Err(eyre::eyre!("--blocks must be greater than 0"));
+                }
+                RampMode::Blocks(blocks)
+            }
+            (None, Some(target)) => {
+                if target == 0 {
+                    return Err(eyre::eyre!("--target-gas-limit must be greater than 0"));
+                }
+                RampMode::TargetGasLimit(target)
+            }
+            _ => {
+                return Err(eyre::eyre!(
+                    "Exactly one of --blocks or --target-gas-limit must be specified"
+                ));
+            }
+        };
 
         // Ensure output directory exists
         if self.output.is_file() {
@@ -84,14 +114,31 @@ impl Command {
 
         let canonical_parent = parent_header.number;
         let start_block = canonical_parent + 1;
-        let end_block = start_block + self.blocks - 1;
 
-        info!(canonical_parent, start_block, end_block, "Starting gas limit ramp benchmark");
+        match mode {
+            RampMode::Blocks(blocks) => {
+                info!(
+                    canonical_parent,
+                    start_block,
+                    end_block = start_block + blocks - 1,
+                    "Starting gas limit ramp benchmark (block count mode)"
+                );
+            }
+            RampMode::TargetGasLimit(target) => {
+                info!(
+                    canonical_parent,
+                    start_block,
+                    current_gas_limit = parent_header.gas_limit,
+                    target_gas_limit = target,
+                    "Starting gas limit ramp benchmark (target gas limit mode)"
+                );
+            }
+        }
 
-        let mut next_block_number = start_block;
+        let mut blocks_processed = 0u64;
         let total_benchmark_duration = Instant::now();
 
-        while next_block_number <= end_block {
+        while !should_stop(mode, blocks_processed, parent_header.gas_limit) {
             let timestamp = parent_header.timestamp.saturating_add(1);
 
             let request = prepare_payload_request(&chain_spec, timestamp, parent_hash);
@@ -140,13 +187,13 @@ impl Command {
 
             parent_header = block.header;
             parent_hash = block_hash;
-            next_block_number += 1;
+            blocks_processed += 1;
         }
 
         let final_gas_limit = parent_header.gas_limit;
         info!(
             total_duration=?total_benchmark_duration.elapsed(),
-            blocks_processed = self.blocks,
+            blocks_processed,
             final_gas_limit,
             "Benchmark complete"
         );
@@ -157,4 +204,11 @@ impl Command {
 
 const fn max_gas_limit_increase(parent_gas_limit: u64) -> u64 {
     (parent_gas_limit / GAS_LIMIT_BOUND_DIVISOR).saturating_sub(1)
+}
+
+const fn should_stop(mode: RampMode, blocks_processed: u64, current_gas_limit: u64) -> bool {
+    match mode {
+        RampMode::Blocks(target_blocks) => blocks_processed >= target_blocks,
+        RampMode::TargetGasLimit(target) => current_gas_limit >= target,
+    }
 }


### PR DESCRIPTION
## Summary

Add `--target-gas-limit` as an alternative to `--blocks` for the `gas-limit-ramp` benchmark. When specified, the benchmark will generate blocks until the gas limit reaches or exceeds the target value, rather than a fixed number of blocks.

## Changes

- Made `--blocks` optional
- Added `--target-gas-limit` option (mutually exclusive with `--blocks`)
- Either one or the other must be specified
- Added `RampMode` enum to cleanly handle both modes

## Usage

```bash
# By block count (existing behavior)
reth-bench gas-limit-ramp --blocks 100 --engine-rpc-url ... --jwt-secret ... --output ...

# By target gas limit (new)
reth-bench gas-limit-ramp --target-gas-limit 100000000 --engine-rpc-url ... --jwt-secret ... --output ...
```