### PR TITLE
feat(engine): add metric for execution cache unavailability due to concurrent use

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -786,18 +786,12 @@ impl<R> Drop for CacheTaskHandle<R> {
 /// - Speculatively loads accounts/storage that might be used in transaction execution
 /// - Prepares data for state root proof computation
 /// - Runs concurrently but must not interfere with cache saves
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 struct ExecutionCache {
     /// Guarded cloneable cache identified by a block hash.
     inner: Arc<RwLock<Option<SavedCache>>>,
     /// Metrics for cache operations.
     metrics: ExecutionCacheMetrics,
-}
-
-impl Default for ExecutionCache {
-    fn default() -> Self {
-        Self { inner: Arc::new(RwLock::new(None)), metrics: ExecutionCacheMetrics::default() }
-    }
 }
 
 impl ExecutionCache {


### PR DESCRIPTION
## Summary

Add a counter metric `execution_cache_in_use` that tracks how often the execution cache cannot be reused because other threads (e.g., prewarming workers) are still using it.

## Motivation

From discussion in [Slack](https://tempoxyz.enterprise.slack.com/archives/C09K7873V4N/p1768949377264679) - when the execution cache hash matches the parent block but other threads are still holding references to it, we currently allocate a new cache. This metric will help us monitor how often this happens and understand the performance impact.

## Changes

- Added `ExecutionCacheMetrics` struct with an `execution_cache_in_use` counter
- The counter increments when `get_cache_for` finds a matching cache that is unavailable due to being held by other tasks
- Metric is exposed under the `consensus.engine.beacon` scope

## Testing

This change adds a metric without altering behavior. The metric can be observed via any metrics endpoint when the execution cache is in use by prewarming workers during block processing.