### PR TITLE
chore(chainspec): use ..Default::default() in create_chain_config

### DIFF
--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -278,6 +278,7 @@ pub fn create_chain_config(
     // Check if DAO fork is supported (it has an activation block)
     let dao_fork_support = hardforks.fork(EthereumHardfork::Dao) != ForkCondition::Never;
 
+    #[allow(clippy::needless_update)]
     ChainConfig {
         chain_id: chain.map(|c| c.id()).unwrap_or(0),
         homestead_block: block_num(EthereumHardfork::Homestead),
@@ -313,6 +314,7 @@ pub fn create_chain_config(
         extra_fields: Default::default(),
         deposit_contract_address,
         blob_schedule,
+        ..Default::default()
     }
 }
 


### PR DESCRIPTION
Adds `..Default::default()` to `ChainConfig` initialization in `create_chain_config` to protect against breaking changes when new fields are added to `ChainConfig`.

Includes `#[allow(clippy::needless_update)]` to silence the lint since the struct is currently exhaustively initialized.