### PR TITLE
ci: add on-demand workflow to check alloy breaking changes

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,3 +5,4 @@ self-hosted-runner:
     - depot-ubuntu-latest-4
     - depot-ubuntu-latest-8
     - depot-ubuntu-latest-16
+    - ubuntu-latest-32

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,4 +5,3 @@ self-hosted-runner:
     - depot-ubuntu-latest-4
     - depot-ubuntu-latest-8
     - depot-ubuntu-latest-16
-    - ubuntu-latest-32

--- a/.github/workflows/check-alloy.yml
+++ b/.github/workflows/check-alloy.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   check:
     name: Check compilation with patched alloy
-    runs-on: ubuntu-latest-32
+    runs-on: depot-ubuntu-latest-16
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/check-alloy.yml
+++ b/.github/workflows/check-alloy.yml
@@ -1,0 +1,110 @@
+# Checks reth compilation against alloy branches to detect breaking changes.
+# Run on-demand via workflow_dispatch.
+
+name: Check Alloy Breaking Changes
+
+on:
+  workflow_dispatch:
+    inputs:
+      alloy_branch:
+        description: 'Branch/rev for alloy-rs/alloy (leave empty to skip)'
+        required: false
+        type: string
+      alloy_evm_branch:
+        description: 'Branch/rev for alloy-rs/evm (alloy-evm, alloy-op-evm) (leave empty to skip)'
+        required: false
+        type: string
+      op_alloy_branch:
+        description: 'Branch/rev for alloy-rs/op-alloy (leave empty to skip)'
+        required: false
+        type: string
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check:
+    name: Check compilation with patched alloy
+    runs-on: ubuntu-latest-32
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - name: Apply alloy patches
+        env:
+          ALLOY_BRANCH: ${{ inputs.alloy_branch }}
+          ALLOY_EVM_BRANCH: ${{ inputs.alloy_evm_branch }}
+          OP_ALLOY_BRANCH: ${{ inputs.op_alloy_branch }}
+        run: |
+          echo "" >> Cargo.toml
+
+          # Patch alloy-rs/alloy crates
+          if [ -n "$ALLOY_BRANCH" ]; then
+            echo "Patching alloy-rs/alloy with branch: $ALLOY_BRANCH"
+            cat >> Cargo.toml << EOF
+          # Patched by check-alloy workflow
+          alloy-consensus = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+          alloy-contract = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+          alloy-eips = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+          alloy-genesis = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+          alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+          alloy-network = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+          alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+          alloy-provider = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+          alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+          alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+          alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+          alloy-rpc-types-admin = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+          alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+          alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+          alloy-rpc-types-debug = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+          alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+          alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+          alloy-rpc-types-mev = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+          alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+          alloy-rpc-types-txpool = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+          alloy-serde = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+          alloy-signer = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+          alloy-signer-local = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+          alloy-transport = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+          alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+          alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+          alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+          EOF
+          fi
+
+          # Patch alloy-rs/evm crates
+          if [ -n "$ALLOY_EVM_BRANCH" ]; then
+            echo "Patching alloy-rs/evm with branch: $ALLOY_EVM_BRANCH"
+            cat >> Cargo.toml << EOF
+          alloy-evm = { git = "https://github.com/alloy-rs/evm", branch = "$ALLOY_EVM_BRANCH" }
+          alloy-op-evm = { git = "https://github.com/alloy-rs/evm", branch = "$ALLOY_EVM_BRANCH" }
+          EOF
+          fi
+
+          # Patch alloy-rs/op-alloy crates
+          if [ -n "$OP_ALLOY_BRANCH" ]; then
+            echo "Patching alloy-rs/op-alloy with branch: $OP_ALLOY_BRANCH"
+            cat >> Cargo.toml << EOF
+          op-alloy-consensus = { git = "https://github.com/alloy-rs/op-alloy", branch = "$OP_ALLOY_BRANCH" }
+          op-alloy-network = { git = "https://github.com/alloy-rs/op-alloy", branch = "$OP_ALLOY_BRANCH" }
+          op-alloy-rpc-types = { git = "https://github.com/alloy-rs/op-alloy", branch = "$OP_ALLOY_BRANCH" }
+          op-alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/op-alloy", branch = "$OP_ALLOY_BRANCH" }
+          op-alloy-rpc-jsonrpsee = { git = "https://github.com/alloy-rs/op-alloy", branch = "$OP_ALLOY_BRANCH" }
+          EOF
+          fi
+
+          echo "=== Final patch section ==="
+          tail -50 Cargo.toml
+
+      - name: Check workspace
+        run: cargo check --workspace --all-features
+
+      - name: Check Optimism
+        run: cargo check -p reth-optimism-node --all-features

--- a/.github/workflows/check-alloy.yml
+++ b/.github/workflows/check-alloy.yml
@@ -37,69 +37,25 @@ jobs:
           cache-on-failure: true
 
       - name: Apply alloy patches
-        env:
-          ALLOY_BRANCH: ${{ inputs.alloy_branch }}
-          ALLOY_EVM_BRANCH: ${{ inputs.alloy_evm_branch }}
-          OP_ALLOY_BRANCH: ${{ inputs.op_alloy_branch }}
         run: |
-          echo "" >> Cargo.toml
-
-          # Patch alloy-rs/alloy crates
-          if [ -n "$ALLOY_BRANCH" ]; then
-            echo "Patching alloy-rs/alloy with branch: $ALLOY_BRANCH"
-            cat >> Cargo.toml << EOF
-          # Patched by check-alloy workflow
-          alloy-consensus = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
-          alloy-contract = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
-          alloy-eips = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
-          alloy-genesis = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
-          alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
-          alloy-network = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
-          alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
-          alloy-provider = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
-          alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
-          alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
-          alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
-          alloy-rpc-types-admin = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
-          alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
-          alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
-          alloy-rpc-types-debug = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
-          alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
-          alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
-          alloy-rpc-types-mev = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
-          alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
-          alloy-rpc-types-txpool = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
-          alloy-serde = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
-          alloy-signer = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
-          alloy-signer-local = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
-          alloy-transport = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
-          alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
-          alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
-          alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
-          EOF
+          ARGS=""
+          if [ -n "${{ inputs.alloy_branch }}" ]; then
+            ARGS="$ARGS --alloy ${{ inputs.alloy_branch }}"
           fi
-
-          # Patch alloy-rs/evm crates
-          if [ -n "$ALLOY_EVM_BRANCH" ]; then
-            echo "Patching alloy-rs/evm with branch: $ALLOY_EVM_BRANCH"
-            cat >> Cargo.toml << EOF
-          alloy-evm = { git = "https://github.com/alloy-rs/evm", branch = "$ALLOY_EVM_BRANCH" }
-          alloy-op-evm = { git = "https://github.com/alloy-rs/evm", branch = "$ALLOY_EVM_BRANCH" }
-          EOF
+          if [ -n "${{ inputs.alloy_evm_branch }}" ]; then
+            ARGS="$ARGS --evm ${{ inputs.alloy_evm_branch }}"
           fi
-
-          # Patch alloy-rs/op-alloy crates
-          if [ -n "$OP_ALLOY_BRANCH" ]; then
-            echo "Patching alloy-rs/op-alloy with branch: $OP_ALLOY_BRANCH"
-            cat >> Cargo.toml << EOF
-          op-alloy-consensus = { git = "https://github.com/alloy-rs/op-alloy", branch = "$OP_ALLOY_BRANCH" }
-          op-alloy-network = { git = "https://github.com/alloy-rs/op-alloy", branch = "$OP_ALLOY_BRANCH" }
-          op-alloy-rpc-types = { git = "https://github.com/alloy-rs/op-alloy", branch = "$OP_ALLOY_BRANCH" }
-          op-alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/op-alloy", branch = "$OP_ALLOY_BRANCH" }
-          op-alloy-rpc-jsonrpsee = { git = "https://github.com/alloy-rs/op-alloy", branch = "$OP_ALLOY_BRANCH" }
-          EOF
+          if [ -n "${{ inputs.op_alloy_branch }}" ]; then
+            ARGS="$ARGS --op ${{ inputs.op_alloy_branch }}"
           fi
-
+          
+          if [ -z "$ARGS" ]; then
+            echo "No branches specified, nothing to patch"
+            exit 1
+          fi
+          
+          ./scripts/patch-alloy.sh $ARGS
+          
           echo "=== Final patch section ==="
           tail -50 Cargo.toml
 

--- a/scripts/patch-alloy.sh
+++ b/scripts/patch-alloy.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Patches alloy dependencies in Cargo.toml for testing breaking changes.
+#
+# Usage:
+#   ./scripts/patch-alloy.sh [--alloy <branch>] [--evm <branch>] [--op <branch>]
+#
+# Examples:
+#   ./scripts/patch-alloy.sh --alloy main
+#   ./scripts/patch-alloy.sh --alloy feat/new-api --evm main
+#   ./scripts/patch-alloy.sh --alloy main --evm main --op main
+
+set -euo pipefail
+
+ALLOY_BRANCH=""
+ALLOY_EVM_BRANCH=""
+OP_ALLOY_BRANCH=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --alloy)
+            ALLOY_BRANCH="$2"
+            shift 2
+            ;;
+        --evm)
+            ALLOY_EVM_BRANCH="$2"
+            shift 2
+            ;;
+        --op)
+            OP_ALLOY_BRANCH="$2"
+            shift 2
+            ;;
+        -h|--help)
+            echo "Usage: $0 [--alloy <branch>] [--evm <branch>] [--op <branch>]"
+            echo ""
+            echo "Options:"
+            echo "  --alloy <branch>  Patch alloy-rs/alloy crates"
+            echo "  --evm <branch>    Patch alloy-rs/evm crates (alloy-evm, alloy-op-evm)"
+            echo "  --op <branch>     Patch alloy-rs/op-alloy crates"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "$ALLOY_BRANCH" && -z "$ALLOY_EVM_BRANCH" && -z "$OP_ALLOY_BRANCH" ]]; then
+    echo "Error: At least one of --alloy, --evm, or --op must be specified"
+    exit 1
+fi
+
+CARGO_TOML="${CARGO_TOML:-Cargo.toml}"
+
+echo "Patching $CARGO_TOML..."
+echo "" >> "$CARGO_TOML"
+
+if [[ -n "$ALLOY_BRANCH" ]]; then
+    echo "Patching alloy-rs/alloy with branch: $ALLOY_BRANCH"
+    cat >> "$CARGO_TOML" << EOF
+# Patched by patch-alloy.sh
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+alloy-contract = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+alloy-eips = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+alloy-genesis = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+alloy-network = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+alloy-provider = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+alloy-rpc-types-admin = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+alloy-rpc-types-debug = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+alloy-rpc-types-mev = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+alloy-rpc-types-txpool = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+alloy-serde = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+alloy-signer = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+alloy-signer-local = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+alloy-transport = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", branch = "$ALLOY_BRANCH" }
+EOF
+fi
+
+if [[ -n "$ALLOY_EVM_BRANCH" ]]; then
+    echo "Patching alloy-rs/evm with branch: $ALLOY_EVM_BRANCH"
+    cat >> "$CARGO_TOML" << EOF
+alloy-evm = { git = "https://github.com/alloy-rs/evm", branch = "$ALLOY_EVM_BRANCH" }
+alloy-op-evm = { git = "https://github.com/alloy-rs/evm", branch = "$ALLOY_EVM_BRANCH" }
+EOF
+fi
+
+if [[ -n "$OP_ALLOY_BRANCH" ]]; then
+    echo "Patching alloy-rs/op-alloy with branch: $OP_ALLOY_BRANCH"
+    cat >> "$CARGO_TOML" << EOF
+op-alloy-consensus = { git = "https://github.com/alloy-rs/op-alloy", branch = "$OP_ALLOY_BRANCH" }
+op-alloy-network = { git = "https://github.com/alloy-rs/op-alloy", branch = "$OP_ALLOY_BRANCH" }
+op-alloy-rpc-types = { git = "https://github.com/alloy-rs/op-alloy", branch = "$OP_ALLOY_BRANCH" }
+op-alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/op-alloy", branch = "$OP_ALLOY_BRANCH" }
+op-alloy-rpc-jsonrpsee = { git = "https://github.com/alloy-rs/op-alloy", branch = "$OP_ALLOY_BRANCH" }
+EOF
+fi
+
+echo "Done. Patches appended to $CARGO_TOML"
+echo ""
+echo "Run 'cargo check --workspace --all-features' to verify compilation."
+echo "Run 'git checkout $CARGO_TOML' to revert changes."


### PR DESCRIPTION
Adds a GitHub Actions workflow that can be run on-demand to check for breaking changes in alloy dependencies.

## Usage

Trigger from Actions → "Check Alloy Breaking Changes" → Run workflow with optional inputs:

- **alloy_branch**: Branch/rev for `alloy-rs/alloy` (patches 27 crates)
- **alloy_evm_branch**: Branch/rev for `alloy-rs/evm` (patches alloy-evm, alloy-op-evm)
- **op_alloy_branch**: Branch/rev for `alloy-rs/op-alloy` (patches 5 crates)

The workflow patches the specified dependencies and compiles the workspace with `--all-features` to detect any breaking changes before they're released.