### PR TITLE
feat(provider): track earliest receipt height separately and respect history expiry

### DIFF
--- a/crates/storage/errors/src/provider.rs
+++ b/crates/storage/errors/src/provider.rs
@@ -104,6 +104,16 @@ pub enum ProviderError {
     /// State is not available for the given block number because it is pruned.
     #[error("state at block #{_0} is pruned")]
     StateAtBlockPruned(BlockNumber),
+    /// Block data is not available because history has expired.
+    ///
+    /// The requested block number is below the earliest available block.
+    #[error("block #{requested} is not available, history has expired (earliest available: #{earliest_available})")]
+    BlockExpired {
+        /// The block number that was requested.
+        requested: BlockNumber,
+        /// The earliest available block number.
+        earliest_available: BlockNumber,
+    },
     /// Provider does not support this particular request.
     #[error("this provider does not support this request")]
     UnsupportedProvider,


### PR DESCRIPTION
## Summary

This PR adds support for properly respecting pruned/expired history in RPC endpoints, addressing #20038.

### Changes

1. **Add separate receipt height tracking** - Adds `earliest_receipt_height` `AtomicU64` to `StaticFileProviderInner` to track receipts independently from transactions (since they can be pruned separately)

2. **Add `BlockExpired` error variant** - New `ProviderError::BlockExpired` variant that includes both the requested block and the earliest available block for clear error messages

3. **Respect `earliest_history_height` in `block()`** - `DatabaseProvider::block()` now checks if the requested block is below `earliest_history_height` and returns `BlockExpired` error instead of silently returning `None`

### Next Steps

- Similar checks should be added to other RPC endpoints like `eth_getLogs` using `earliest_receipt_height()`
- The `BlockExpired` error should be mapped to `PrunedHistoryUnavailable` in the RPC layer

Closes #20038