### PR TITLE
fix(prune): avoid panic in tx lookup

### DIFF
--- a/crates/prune/prune/src/segments/user/transaction_lookup.rs
+++ b/crates/prune/prune/src/segments/user/transaction_lookup.rs
@@ -84,7 +84,14 @@ where
         .into_inner();
         let tx_range = start..=
             Some(end)
-                .min(input.limiter.deleted_entries_limit_left().map(|left| start + left as u64 - 1))
+                .min(
+                    input
+                        .limiter
+                        .deleted_entries_limit_left()
+                        // Use saturating addition here to avoid panicking on
+                        // `deleted_entries_limit == usize::MAX`
+                        .map(|left| start.saturating_add(left as u64) - 1),
+                )
                 .unwrap();
         let tx_range_end = *tx_range.end();
 


### PR DESCRIPTION
We recently started setting `deleted_entries_limit` to `usize::MAX`, this now will overflow `u64` when calculating the upper bound of how many entries we can prune.

This PR fixes it by doing saturating addition.