### PR TITLE
perf(db): use ArrayVec for StoredNibbles key encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8099,6 +8099,7 @@ dependencies = [
  "alloy-genesis",
  "alloy-primitives",
  "arbitrary",
+ "arrayvec",
  "bytes",
  "derive_more",
  "metrics",

--- a/crates/storage/db-api/Cargo.toml
+++ b/crates/storage/db-api/Cargo.toml
@@ -40,6 +40,7 @@ serde = { workspace = true, default-features = false }
 metrics.workspace = true
 
 # misc
+arrayvec.workspace = true
 derive_more.workspace = true
 bytes.workspace = true
 

--- a/crates/storage/db-api/src/models/mod.rs
+++ b/crates/storage/db-api/src/models/mod.rs
@@ -126,13 +126,10 @@ impl Decode for String {
 }
 
 impl Encode for StoredNibbles {
-    type Encoded = Vec<u8>;
+    type Encoded = arrayvec::ArrayVec<u8, 64>;
 
-    // Delegate to the Compact implementation
     fn encode(self) -> Self::Encoded {
-        // NOTE: This used to be `to_compact`, but all it does is append the bytes to the buffer,
-        // so we can just use the implementation of `Into<Vec<u8>>` to reuse the buffer.
-        self.0.to_vec()
+        self.0.iter().collect()
     }
 }
 

--- a/crates/storage/db-api/src/tables/raw.rs
+++ b/crates/storage/db-api/src/tables/raw.rs
@@ -1,5 +1,5 @@
 use crate::{
-    table::{Compress, Decode, Decompress, DupSort, Encode, Key, Table, Value},
+    table::{Compress, Decode, Decompress, DupSort, Encode, IntoVec, Key, Table, Value},
     DatabaseError,
 };
 use serde::{Deserialize, Serialize};
@@ -52,7 +52,7 @@ pub struct RawKey<K: Key> {
 impl<K: Key> RawKey<K> {
     /// Create new raw key.
     pub fn new(key: K) -> Self {
-        Self { key: K::encode(key).into(), _phantom: std::marker::PhantomData }
+        Self { key: K::encode(key).into_vec(), _phantom: std::marker::PhantomData }
     }
 
     /// Creates a raw key from an existing `Vec`. Useful when we already have the encoded

--- a/crates/storage/db/src/implementation/mdbx/cursor.rs
+++ b/crates/storage/db/src/implementation/mdbx/cursor.rs
@@ -11,7 +11,7 @@ use reth_db_api::{
         DbCursorRO, DbCursorRW, DbDupCursorRO, DbDupCursorRW, DupWalker, RangeWalker,
         ReverseWalker, Walker,
     },
-    table::{Compress, Decode, Decompress, DupSort, Encode, Table},
+    table::{Compress, Decode, Decompress, DupSort, Encode, IntoVec, Table},
 };
 use reth_libmdbx::{Error as MDBXError, TransactionKind, WriteFlags, RO, RW};
 use reth_storage_errors::db::{DatabaseErrorInfo, DatabaseWriteError, DatabaseWriteOperation};
@@ -268,7 +268,7 @@ impl<T: Table> DbCursorRW<T> for Cursor<RW, T> {
                             info: e.into(),
                             operation: DatabaseWriteOperation::CursorUpsert,
                             table_name: T::NAME,
-                            key: key.into(),
+                            key: key.into_vec(),
                         }
                         .into()
                     })
@@ -290,7 +290,7 @@ impl<T: Table> DbCursorRW<T> for Cursor<RW, T> {
                             info: e.into(),
                             operation: DatabaseWriteOperation::CursorInsert,
                             table_name: T::NAME,
-                            key: key.into(),
+                            key: key.into_vec(),
                         }
                         .into()
                     })
@@ -314,7 +314,7 @@ impl<T: Table> DbCursorRW<T> for Cursor<RW, T> {
                             info: e.into(),
                             operation: DatabaseWriteOperation::CursorAppend,
                             table_name: T::NAME,
-                            key: key.into(),
+                            key: key.into_vec(),
                         }
                         .into()
                     })
@@ -350,7 +350,7 @@ impl<T: DupSort> DbDupCursorRW<T> for Cursor<RW, T> {
                             info: e.into(),
                             operation: DatabaseWriteOperation::CursorAppendDup,
                             table_name: T::NAME,
-                            key: key.into(),
+                            key: key.into_vec(),
                         }
                         .into()
                     })

--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -6,7 +6,7 @@ use crate::{
     DatabaseError,
 };
 use reth_db_api::{
-    table::{Compress, DupSort, Encode, Table, TableImporter},
+    table::{Compress, DupSort, Encode, IntoVec, Table, TableImporter},
     transaction::{DbTx, DbTxMut},
 };
 use reth_libmdbx::{ffi::MDBX_dbi, CommitLatency, Transaction, TransactionKind, WriteFlags, RW};
@@ -387,7 +387,7 @@ impl Tx<RW> {
                     info: e.into(),
                     operation: write_operation,
                     table_name: T::NAME,
-                    key: key.into(),
+                    key: key.into_vec(),
                 }
                 .into()
             })


### PR DESCRIPTION
Eliminates heap allocation when encoding `StoredNibbles` keys for trie tables (`AccountsTrie`). Nibbles have a max length of 64, so `ArrayVec<u8, 64>` is sufficient and stack-allocated.

## Changes

- Add `IntoVec` trait for converting encoded types to `Vec<u8>`
- Implement `IntoVec` for `Vec<u8>` (no-op), `[u8; N]`, and `ArrayVec<u8, N>`
- Change `StoredNibbles::Encoded` from `Vec<u8>` to `ArrayVec<u8, 64>`
- Update error paths to use `.into_vec()` instead of `.into()`

This follows the same pattern already used in the `Compact` impl:

https://github.com/paradigmxyz/reth/blob/a62f89b0e06a1dd5f2cc1fe1907bb8f8cd14a124/crates/trie/common/src/nibbles.rs#L25-L31

```rust
#[cfg(any(test, feature = "reth-codec"))]
impl reth_codecs::Compact for StoredNibbles {
    fn to_compact<B>(&self, buf: &mut B) -> usize
    where
        B: bytes::BufMut + AsMut<[u8]>,
    {
        let bytes = self.0.iter().collect::<arrayvec::ArrayVec<u8, 64>>();
```