### PR TITLE
fix(engine): clear execution cache when block validation fails

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -297,6 +297,11 @@ where
                     // Replace the shared cache with the new one; the previous cache (if any) is
                     // dropped.
                     *cached = Some(new_cache);
+                } else {
+                    // Block was invalid; caches were already mutated by insert_state above,
+                    // so we must clear to prevent using polluted state
+                    *cached = None;
+                    debug!(target: "engine::caching", "cleared execution cache on invalid block");
                 }
             });
 


### PR DESCRIPTION
Clears the execution cache when `valid_block_rx.recv()` indicates the block was invalid.

Similar to #21233.