### PR TITLE
perf(provider): optimize unwind by dedup & parallel hashing

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -703,7 +703,7 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
         self.unwind_storage_hashing(changed_storages.iter().copied())?;
 
         // Unwind storage history indices.
-        self.unwind_storage_history_indices(changed_storages.iter().copied())?;
+        self.unwind_storage_history_indices(changed_storages.into_iter())?;
 
         // Unwind accounts/storages trie tables using the revert.
         // Get the database tip block number

--- a/crates/storage/storage-api/src/history.rs
+++ b/crates/storage/storage-api/src/history.rs
@@ -10,20 +10,16 @@ use reth_storage_errors::provider::ProviderResult;
 #[auto_impl(&, Box)]
 pub trait HistoryWriter: Send {
     /// Unwind and clear account history indices.
-    ///
-    /// Returns number of changesets walked.
     fn unwind_account_history_indices<'a>(
         &self,
         changesets: impl Iterator<Item = &'a (BlockNumber, AccountBeforeTx)>,
-    ) -> ProviderResult<usize>;
+    ) -> ProviderResult<()>;
 
     /// Unwind and clear account history indices in a given block range.
-    ///
-    /// Returns number of changesets walked.
     fn unwind_account_history_indices_range(
         &self,
         range: impl RangeBounds<BlockNumber>,
-    ) -> ProviderResult<usize>;
+    ) -> ProviderResult<()>;
 
     /// Insert account change index to database. Used inside `AccountHistoryIndex` stage
     fn insert_account_history_index(


### PR DESCRIPTION
  1. Deduplicating by address before hashing - when unwinding multiple blocks, the same address may appear in many changesets, leading to duplicated hashing.
   2. Parallel hashing with rayon