### PR TITLE
fix: handle incomplete receipts gracefully in receipt root task

### DIFF
--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -479,11 +479,15 @@ where
         let block = self.convert_to_block(input)?.with_senders(senders);
 
         // Wait for the receipt root computation to complete.
-        let receipt_root_bloom = Some(
-            receipt_root_rx
-                .blocking_recv()
-                .expect("receipt root task dropped sender without result"),
-        );
+        let receipt_root_bloom = receipt_root_rx
+            .blocking_recv()
+            .inspect_err(|_| {
+                tracing::error!(
+                    target: "engine::tree::payload_validator",
+                    "Receipt root task dropped sender without result, receipt root calculation likely aborted"
+                );
+            })
+            .ok();
 
         let hashed_state = ensure_ok_post_block!(
             self.validate_post_execution(


### PR DESCRIPTION
## Summary

When processing invalid blocks via Engine API, the receipt root task may not receive all expected receipts if execution is aborted early. This previously caused a panic at `receipt_root_task.rs:86`.

## Changes

- **receipt_root_task.rs**: Replace `expect()` with graceful error handling that logs expected vs received receipt counts and returns without sending a result
- **payload_validator.rs**: Use `inspect_err()` + `.ok()` instead of `expect()` when receiving the receipt root result, logging an error if the task failed

## Testing

The existing tests pass. The panic was triggered by malformed `engine_newPayloadV3` requests with invalid block data.

Closes #21281