### PR TITLE
chore(release): prep v1.10.2 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3331,7 +3331,7 @@ dependencies = [
 
 [[package]]
 name = "ef-test-runner"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "clap",
  "ef-tests",
@@ -3339,7 +3339,7 @@ dependencies = [
 
 [[package]]
 name = "ef-tests"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3829,7 +3829,7 @@ dependencies = [
 
 [[package]]
 name = "example-full-contract-state"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "eyre",
  "reth-ethereum",
@@ -3968,7 +3968,7 @@ dependencies = [
 
 [[package]]
 name = "exex-subscription"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -6478,7 +6478,7 @@ dependencies = [
 
 [[package]]
 name = "op-reth"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "clap",
  "reth-cli-util",
@@ -7630,7 +7630,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -7677,7 +7677,7 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7700,7 +7700,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bench"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7747,7 +7747,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bench-compare"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -7775,7 +7775,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7808,7 +7808,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7828,7 +7828,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7841,7 +7841,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7926,7 +7926,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7935,7 +7935,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7956,7 +7956,7 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7980,7 +7980,7 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7990,7 +7990,7 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -8008,7 +8008,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8020,7 +8020,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8034,7 +8034,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8059,7 +8059,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8093,7 +8093,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8124,7 +8124,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8154,7 +8154,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8170,7 +8170,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8196,7 +8196,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8221,7 +8221,7 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8249,7 +8249,7 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8287,7 +8287,7 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8344,7 +8344,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8371,7 +8371,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8395,7 +8395,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8419,7 +8419,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-service"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eips",
  "futures",
@@ -8450,7 +8450,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8525,7 +8525,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8552,7 +8552,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8574,7 +8574,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8592,7 +8592,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8618,7 +8618,7 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8628,7 +8628,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8666,7 +8666,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8691,7 +8691,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8731,7 +8731,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "clap",
  "eyre",
@@ -8753,7 +8753,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8769,7 +8769,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8787,7 +8787,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8800,7 +8800,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8828,7 +8828,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8855,7 +8855,7 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "rayon",
@@ -8865,7 +8865,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8890,7 +8890,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8914,7 +8914,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8926,7 +8926,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8946,7 +8946,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8991,7 +8991,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-test-utils"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eips",
  "eyre",
@@ -9022,7 +9022,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9039,7 +9039,7 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -9048,7 +9048,7 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9081,7 +9081,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "bytes",
  "futures",
@@ -9103,7 +9103,7 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -9121,7 +9121,7 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -9129,7 +9129,7 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "futures",
  "metrics",
@@ -9140,7 +9140,7 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9148,7 +9148,7 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9162,7 +9162,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9223,7 +9223,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9247,7 +9247,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9269,7 +9269,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9286,7 +9286,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9299,7 +9299,7 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -9317,7 +9317,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9340,7 +9340,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9412,7 +9412,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9468,7 +9468,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -9528,7 +9528,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9551,7 +9551,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9574,7 +9574,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "bytes",
  "eyre",
@@ -9603,7 +9603,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9614,7 +9614,7 @@ dependencies = [
 
 [[package]]
 name = "reth-op"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "reth-chainspec",
  "reth-cli-util",
@@ -9654,7 +9654,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-chainspec"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9682,7 +9682,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-cli"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9731,7 +9731,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-consensus"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9762,7 +9762,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-evm"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9791,7 +9791,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-flashblocks"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9829,7 +9829,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-forks"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-op-hardforks",
  "alloy-primitives",
@@ -9839,7 +9839,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-node"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9900,7 +9900,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-payload-builder"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9939,7 +9939,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-primitives"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9966,7 +9966,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-rpc"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10028,7 +10028,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-storage"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "reth-codecs",
@@ -10040,7 +10040,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-txpool"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10077,7 +10077,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10097,7 +10097,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10108,7 +10108,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10131,7 +10131,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-util"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10140,7 +10140,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10149,7 +10149,7 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10171,7 +10171,7 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10208,7 +10208,7 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10257,7 +10257,7 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10289,11 +10289,11 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-db"
-version = "1.10.1"
+version = "1.10.2"
 
 [[package]]
 name = "reth-prune-types"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10312,7 +10312,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-protocol"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10338,7 +10338,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-provider"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10364,7 +10364,7 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10378,7 +10378,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10463,7 +10463,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -10493,7 +10493,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api-testing-util"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10512,7 +10512,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -10568,7 +10568,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10594,7 +10594,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-e2e-tests"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-genesis",
  "alloy-rpc-types-engine",
@@ -10614,7 +10614,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10650,7 +10650,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10693,7 +10693,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10741,7 +10741,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -10758,7 +10758,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10773,7 +10773,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10831,7 +10831,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10863,7 +10863,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10879,7 +10879,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stateless"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -10907,7 +10907,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "assert_matches",
@@ -10930,7 +10930,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10945,7 +10945,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10968,7 +10968,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10984,7 +10984,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-rpc-provider"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11013,7 +11013,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -11030,7 +11030,7 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11046,7 +11046,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11055,7 +11055,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "clap",
  "eyre",
@@ -11073,7 +11073,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "clap",
  "eyre",
@@ -11090,7 +11090,7 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11138,7 +11138,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11172,7 +11172,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -11205,7 +11205,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11236,7 +11236,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11266,7 +11266,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11299,7 +11299,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse-parallel"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11329,7 +11329,7 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.10.1"
+version = "1.10.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/docs/vocs/vocs.config.ts
+++ b/docs/vocs/vocs.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
     },
     { text: 'GitHub', link: 'https://github.com/paradigmxyz/reth' },
     {
-      text: 'v1.10.1',
+      text: 'v1.10.2',
       items: [
         {
           text: 'Releases',


### PR DESCRIPTION
we are going to release some patches for critical bugs on the latest live version 

* updating versions

next steps:
* checkout v1.10.1 
* cherry pick fixes 

https://github.com/paradigmxyz/reth/commit/dbdaf068f0e9481db40e7aa77f9a150242770e57
https://github.com/paradigmxyz/reth/commit/3065a328f9ee9d4b6e90db8f224ee112c565fee3
ideally https://github.com/paradigmxyz/reth/pull/21285 but not critical

* release workflow & cut new tag 