### PR TITLE
perf(prune): sort tx hashes for efficient TransactionLookup pruning

### DIFF
--- a/crates/prune/prune/src/segments/user/transaction_lookup.rs
+++ b/crates/prune/prune/src/segments/user/transaction_lookup.rs
@@ -96,11 +96,16 @@ where
         let tx_range_end = *tx_range.end();
 
         // Retrieve transactions in the range and calculate their hashes in parallel
-        let hashes = provider
+        let mut hashes = provider
             .transactions_by_tx_range(tx_range.clone())?
             .into_par_iter()
             .map(|transaction| transaction.trie_hash())
             .collect::<Vec<_>>();
+
+        // Sort hashes to enable efficient cursor traversal through the TransactionHashNumbers
+        // table, which is keyed by hash. Without sorting, each seek would be O(log n) random
+        // access; with sorting, the cursor advances sequentially through the B+tree.
+        hashes.sort_unstable();
 
         // Number of transactions retrieved from the database should match the tx range count
         let tx_count = tx_range.count();


### PR DESCRIPTION
## Summary

Sort transaction hashes before passing to `prune_table_with_iterator`.

## Problem

The `TransactionHashNumbers` table is a B+tree keyed by `TxHash` (B256). Previously, hashes were passed in transaction number order (from `transactions_by_tx_range`), causing random O(log n) seeks per hash through the tree.

## Solution

Sort hashes before iteration. This enables the cursor to advance sequentially through the B+tree, significantly reducing seek overhead during pruning.

The `prune_table_with_iterator` docstring already expects a "pre-sorted key iterator" - this change fulfills that contract.