### PR TITLE
perf(prune): use bulk table clear for PruneMode::Full

### DIFF
--- a/crates/prune/prune/src/segments/user/transaction_lookup.rs
+++ b/crates/prune/prune/src/segments/user/transaction_lookup.rs
@@ -8,7 +8,7 @@ use rayon::prelude::*;
 use reth_db_api::{tables, transaction::DbTxMut};
 use reth_provider::{BlockReader, DBProvider, PruneCheckpointReader, StaticFileProviderFactory};
 use reth_prune_types::{
-    PruneCheckpoint, PruneMode, PrunePurpose, PruneSegment, SegmentOutputCheckpoint,
+    PruneCheckpoint, PruneMode, PruneProgress, PrunePurpose, PruneSegment, SegmentOutputCheckpoint,
 };
 use reth_static_file_types::StaticFileSegment;
 use tracing::{debug, instrument, trace};
@@ -82,9 +82,36 @@ where
             }
         }
         .into_inner();
+
+        // For PruneMode::Full, clear the entire table in one operation
+        if self.mode.is_full() {
+            let pruned = provider.tx_ref().clear_table::<tables::TransactionHashNumbers>()?;
+            trace!(target: "pruner", %pruned, "Cleared transaction lookup table");
+
+            let last_pruned_block = provider
+                .block_by_transaction_id(end)?
+                .ok_or(PrunerError::InconsistentData("Block for transaction is not found"))?;
+
+            return Ok(SegmentOutput {
+                progress: PruneProgress::Finished,
+                pruned,
+                checkpoint: Some(SegmentOutputCheckpoint {
+                    block_number: Some(last_pruned_block),
+                    tx_number: Some(end),
+                }),
+            });
+        }
+
         let tx_range = start..=
             Some(end)
-                .min(input.limiter.deleted_entries_limit_left().map(|left| start + left as u64 - 1))
+                .min(
+                    input
+                        .limiter
+                        .deleted_entries_limit_left()
+                        // Use saturating addition here to avoid panicking on
+                        // `deleted_entries_limit == usize::MAX`
+                        .map(|left| start.saturating_add(left as u64) - 1),
+                )
                 .unwrap();
         let tx_range_end = *tx_range.end();
 


### PR DESCRIPTION
## Summary

When `PruneMode::Full` is configured for segments with `min_blocks() == 0` (e.g., `SenderRecovery`, `TransactionLookup`), the pruner now clears the entire table in a single MDBX operation instead of iterating entry-by-entry.

## Changes

1. **`db_ext.rs`**: Add `clear_table<T>()` method to `DbTxPruneExt` trait that wraps `DbTxMut::clear()` and returns the entry count

2. **`sender_recovery.rs`**: For `PruneMode::Full`, use bulk `clear_table()` instead of `prune_table_with_range()`

3. **`transaction_lookup.rs`**: For `PruneMode::Full`, use bulk `clear_table()` instead of computing transaction hashes and calling `prune_table_with_iterator()`

## Performance Impact

- **Before**: O(n) - iterate through each entry, check limiter, delete one row at a time
- **After**: O(1) - single MDBX `clear()` operation drops the entire table

This is especially impactful for:
- Starting a node with `--full` prune mode
- Re-syncing with pruning enabled  
- Tables with millions of entries (TransactionHashNumbers, TransactionSenders)

## Notes

- Static files (Bodies, Receipts on static files) already use bulk deletion

Closes #21296