### PR TITLE
fix(cli): clear rocksdb tables in drop-stage command

### DIFF
--- a/crates/storage/provider/src/providers/rocksdb_stub.rs
+++ b/crates/storage/provider/src/providers/rocksdb_stub.rs
@@ -81,6 +81,13 @@ impl RocksDBProvider {
     pub const fn table_stats(&self) -> Vec<RocksDBTableStats> {
         Vec::new()
     }
+
+    /// Clears all entries from the specified table (stub implementation).
+    ///
+    /// This is a no-op since there is no `RocksDB` when the feature is disabled.
+    pub const fn clear<T>(&self) -> ProviderResult<()> {
+        Ok(())
+    }
 }
 
 impl DatabaseMetrics for RocksDBProvider {


### PR DESCRIPTION
## Summary

When dropping stages with `reth drop-stage`, the command now also clears the corresponding tables from RocksDB if the storage settings indicate they are stored there.

Previously, the drop-stage command only cleared MDBX tables, leaving stale data in RocksDB when `--rocksdb.*` flags were used.

## Changes

**TxLookup stage:**
- Clears `TransactionHashNumbers` from RocksDB when `transaction_hash_numbers_in_rocksdb` is enabled

**AccountHistory / StorageHistory stages:**
- Clears `AccountsHistory` from RocksDB when `account_history_in_rocksdb` is enabled
- Clears `StoragesHistory` from RocksDB when `storages_history_in_rocksdb` is enabled

**Stub:**
- Added a `clear<T>()` stub method to the RocksDBProvider stub for non-Unix platforms

## Testing

`cargo clippy -p reth-cli-commands -- -D warnings`