### PR TITLE
perf(prune): use bulk table clear for PruneMode::Full

### DIFF
--- a/crates/prune/prune/src/db_ext.rs
+++ b/crates/prune/prune/src/db_ext.rs
@@ -9,6 +9,16 @@ use std::{fmt::Debug, ops::RangeBounds};
 use tracing::debug;
 
 pub(crate) trait DbTxPruneExt: DbTxMut + DbTx {
+    /// Clear the entire table in a single operation.
+    ///
+    /// This is much faster than iterating entry-by-entry for `PruneMode::Full`.
+    /// Returns the number of entries that were in the table.
+    fn clear_table<T: Table>(&self) -> Result<usize, DatabaseError> {
+        let count = self.entries::<T>()?;
+        <Self as DbTxMut>::clear::<T>(self)?;
+        Ok(count)
+    }
+
     /// Prune the table for the specified pre-sorted key iterator.
     ///
     /// Returns number of rows pruned.


### PR DESCRIPTION
## Summary

When `PruneMode::Full` is configured for segments with `min_blocks() == 0` (e.g., `SenderRecovery`, `TransactionLookup`), the pruner now clears the entire table in a single MDBX operation instead of iterating entry-by-entry.

## Changes

1. **`db_ext.rs`**: Add `clear_table<T>()` method to `DbTxPruneExt` trait that wraps `DbTxMut::clear()` and returns the entry count

2. **`sender_recovery.rs`**: For `PruneMode::Full`, use bulk `clear_table()` instead of `prune_table_with_range()`

3. **`transaction_lookup.rs`**: For `PruneMode::Full`, use bulk `clear_table()` instead of computing transaction hashes and calling `prune_table_with_iterator()`

## Performance Impact

- **Before**: O(n) - iterate through each entry, check limiter, delete one row at a time
- **After**: O(1) - single MDBX `clear()` operation drops the entire table

This is especially impactful for:
- Starting a node with `--full` prune mode
- Re-syncing with pruning enabled  
- Tables with millions of entries (TransactionHashNumbers, TransactionSenders)

## Notes

- Static files (Bodies, Receipts on static files) already use bulk deletion

Closes #21296