### PR TITLE
fix(rocksdb): correct history index divergence causing nonce errors after unwind

### DIFF
--- a/crates/storage/provider/src/either_writer.rs
+++ b/crates/storage/provider/src/either_writer.rs
@@ -1351,7 +1351,8 @@ mod rocksdb_tests {
 
         // Run queries against both backends using EitherReader
         let mdbx_ro = factory.database_provider_ro().unwrap();
-        let rocks_tx = rocks_provider.tx();
+        // Use `with_assume_history_complete()` since both backends have identical data
+        let rocks_tx = rocks_provider.tx().with_assume_history_complete();
 
         for (i, query) in queries.iter().enumerate() {
             // MDBX query via EitherReader
@@ -1443,7 +1444,8 @@ mod rocksdb_tests {
 
         // Run queries against both backends using EitherReader
         let mdbx_ro = factory.database_provider_ro().unwrap();
-        let rocks_tx = rocks_provider.tx();
+        // Use `with_assume_history_complete()` since both backends have identical data
+        let rocks_tx = rocks_provider.tx().with_assume_history_complete();
 
         for (i, query) in queries.iter().enumerate() {
             // MDBX query via EitherReader

--- a/crates/storage/provider/src/providers/rocksdb/invariants.rs
+++ b/crates/storage/provider/src/providers/rocksdb/invariants.rs
@@ -1064,7 +1064,7 @@ mod tests {
         // This simulates a scenario where history tracking started but no shards were completed
         let key_sentinel_1 = StorageShardedKey::new(Address::ZERO, B256::ZERO, u64::MAX);
         let key_sentinel_2 = StorageShardedKey::new(Address::random(), B256::random(), u64::MAX);
-        // Use a checkpoint that matches the sentinel shard contents (max block = 30)
+        // Sentinel shards contain blocks [10, 20, 30], so max block in shard = 30
         let block_list = BlockNumberList::new_pre_sorted([10, 20, 30]);
         rocksdb.put::<tables::StoragesHistory>(key_sentinel_1, &block_list).unwrap();
         rocksdb.put::<tables::StoragesHistory>(key_sentinel_2, &block_list).unwrap();
@@ -1078,8 +1078,8 @@ mod tests {
             StorageSettings::legacy().with_storages_history_in_rocksdb(true),
         );
 
-        // Set a checkpoint that matches the sentinel shard data (max block = 30)
-        // This is a normal scenario where sentinel shards exist and are in sync with checkpoint
+        // Checkpoint = 30 matches sentinel shard max block, simulating "consistent" state
+        // where indexing is complete through the checkpoint block
         {
             let provider = factory.database_provider_rw().unwrap();
             provider
@@ -1108,7 +1108,7 @@ mod tests {
         // Insert ONLY sentinel entries (highest_block_number = u64::MAX)
         let key_sentinel_1 = ShardedKey::new(Address::ZERO, u64::MAX);
         let key_sentinel_2 = ShardedKey::new(Address::random(), u64::MAX);
-        // Use a checkpoint that matches the sentinel shard contents (max block = 30)
+        // Sentinel shards contain blocks [10, 20, 30], so max block in shard = 30
         let block_list = BlockNumberList::new_pre_sorted([10, 20, 30]);
         rocksdb.put::<tables::AccountsHistory>(key_sentinel_1, &block_list).unwrap();
         rocksdb.put::<tables::AccountsHistory>(key_sentinel_2, &block_list).unwrap();
@@ -1122,8 +1122,8 @@ mod tests {
             StorageSettings::legacy().with_account_history_in_rocksdb(true),
         );
 
-        // Set a checkpoint that matches the sentinel shard data (max block = 30)
-        // This is a normal scenario where sentinel shards exist and are in sync with checkpoint
+        // Checkpoint = 30 matches sentinel shard max block, simulating "consistent" state
+        // where indexing is complete through the checkpoint block
         {
             let provider = factory.database_provider_rw().unwrap();
             provider

--- a/crates/storage/provider/src/providers/rocksdb/mod.rs
+++ b/crates/storage/provider/src/providers/rocksdb/mod.rs
@@ -4,7 +4,10 @@ mod invariants;
 mod metrics;
 mod provider;
 
-pub(crate) use provider::{PendingRocksDBBatches, RocksDBWriteCtx};
+#[allow(unused_imports)]
+pub(crate) use provider::{
+    PendingHistory, PendingHistoryWrites, PendingRocksDBBatches, RocksDBWriteCtx,
+};
 pub use provider::{
     RocksDBBatch, RocksDBBuilder, RocksDBProvider, RocksDBRawIter, RocksDBTableStats, RocksTx,
 };

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -1596,7 +1596,7 @@ impl<'a> RocksDBBatch<'a> {
 /// - Iteration over uncommitted data
 ///
 /// Note: `Transaction` is `Send` but NOT `Sync`. This wrapper does not implement
-/// `DbTx`/`DbTxMut` traits directly; use RocksDB-specific methods instead.
+/// `DbTx`/`DbTxMut` traits directly; use `RocksDB`-specific methods instead.
 pub struct RocksTx<'db> {
     inner: Transaction<'db, OptimisticTransactionDB>,
     provider: &'db RocksDBProvider,
@@ -1618,8 +1618,8 @@ impl<'db> RocksTx<'db> {
     /// When enabled, history queries will return `NotYetWritten` (like MDBX) instead of
     /// `MaybeInPlainState` when querying before the first history entry.
     ///
-    /// WARNING: Only use in tests where RocksDB has complete history (identical to MDBX).
-    /// In production, RocksDB may have partial history, so this flag would cause incorrect
+    /// WARNING: Only use in tests where `RocksDB` has complete history (identical to MDBX).
+    /// In production, `RocksDB` may have partial history, so this flag would cause incorrect
     /// behavior (treating accounts as non-existent when they exist in MDBX).
     #[cfg(test)]
     pub const fn with_assume_history_complete(mut self) -> Self {
@@ -2372,7 +2372,7 @@ mod tests {
 
     /// Tests the edge case where block < `lowest_available_block_number`.
     /// This case cannot be tested via `HistoricalStateProviderRef` (which errors before lookup),
-    /// so we keep this RocksDB-specific test to verify the low-level behavior.
+    /// so we keep this `RocksDB`-specific test to verify the low-level behavior.
     #[test]
     fn test_account_history_info_pruned_before_first_entry() {
         let temp_dir = TempDir::new().unwrap();

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -1091,7 +1091,7 @@ impl RocksDBProvider {
     fn write_account_history<N: reth_node_types::NodePrimitives>(
         &self,
         blocks: &[ExecutedBlock<N>],
-        _ctx: &RocksDBWriteCtx,
+        ctx: &RocksDBWriteCtx,
     ) -> ProviderResult<()> {
         let mut local: BTreeMap<Address, Vec<u64>> = BTreeMap::new();
         for block in blocks {
@@ -1107,7 +1107,7 @@ impl RocksDBProvider {
             }
         }
 
-        let mut pending = _ctx.pending_history.lock();
+        let mut pending = ctx.pending_history.lock();
         for (address, mut indices) in local {
             pending.accounts.entry(address).or_default().append(&mut indices);
         }

--- a/crates/storage/provider/src/providers/rocksdb_stub.rs
+++ b/crates/storage/provider/src/providers/rocksdb_stub.rs
@@ -32,6 +32,13 @@ pub struct RocksDBTableStats {
     pub pending_compaction_bytes: u64,
 }
 
+/// Pending history writes (stub - empty struct).
+#[derive(Debug, Default)]
+pub(crate) struct PendingHistoryWrites;
+
+/// Pending history writes type alias (stub).
+pub(crate) type PendingHistory = Arc<Mutex<PendingHistoryWrites>>;
+
 /// Context for `RocksDB` block writes (stub).
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
@@ -44,6 +51,8 @@ pub(crate) struct RocksDBWriteCtx {
     pub storage_settings: StorageSettings,
     /// Pending batches (stub - unused).
     pub pending_batches: PendingRocksDBBatches,
+    /// Pending history writes (stub - unused).
+    pub pending_history: PendingHistory,
 }
 
 /// A stub `RocksDB` provider.


### PR DESCRIPTION
## Summary

This PR fixes RocksDB history indices diverging from MDBX after unwind operations, causing 'max nonce mismatch' errors during block replay.

### Root Causes Fixed

1. **Over-approximation of Account History**: RocksDB was recording history indices for all touched accounts, including those with only storage changes. Now uses `account.is_info_changed() || account.was_destroyed()` to match MDBX semantics.

2. **Over-approximation of Storage History**: Only include slots where `storage_slot.is_changed()`.

3. **Incorrect history_info fallback**: `history_info` in `RocksTx` returned `NotYetWritten` for missing entries instead of `MaybeInPlainState`, incorrectly treating pre-RocksDB accounts as new.

4. **Commit Order Race Condition**: RocksDB history indices were committed before MDBX changesets. Now commits MDBX first, then RocksDB history indices.

### Additional Improvements
- `PendingHistoryWrites` accumulates history across `save_blocks()` calls and materializes once at commit time
- `assume_history_complete` flag for test semantics

### Related
Split from #21216 - this is PR 2 of 2 (contains the main fix).

### Testing
Verified by running `reth-bench new-payload-fcu` for 750 blocks.