### PR TITLE
feat(rpc): add paginated block tracing endpoints

### DIFF
--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -84,6 +84,38 @@ pub trait DebugApi<TxReq: RpcObject> {
         opts: Option<GethDebugTracingOptions>,
     ) -> RpcResult<Vec<TraceResult>>;
 
+    /// Returns traces for a range of transactions within a block by block hash.
+    ///
+    /// This is a paginated version of `debug_traceBlockByHash` that allows tracing a subset of
+    /// transactions. Transactions before `tx_index_start` are replayed without tracing to build
+    /// up state. Transactions from `tx_index_start` to `tx_index_end` (exclusive) are traced.
+    ///
+    /// This is useful for large blocks where full block traces would be too expensive.
+    #[method(name = "traceBlockByHashRange")]
+    async fn debug_trace_block_by_hash_range(
+        &self,
+        block: B256,
+        tx_index_start: u64,
+        tx_index_end: u64,
+        opts: Option<GethDebugTracingOptions>,
+    ) -> RpcResult<Vec<TraceResult>>;
+
+    /// Returns traces for a range of transactions within a block by block number.
+    ///
+    /// This is a paginated version of `debug_traceBlockByNumber` that allows tracing a subset of
+    /// transactions. Transactions before `tx_index_start` are replayed without tracing to build
+    /// up state. Transactions from `tx_index_start` to `tx_index_end` (exclusive) are traced.
+    ///
+    /// This is useful for large blocks where full block traces would be too expensive.
+    #[method(name = "traceBlockByNumberRange")]
+    async fn debug_trace_block_by_number_range(
+        &self,
+        block: BlockNumberOrTag,
+        tx_index_start: u64,
+        tx_index_end: u64,
+        opts: Option<GethDebugTracingOptions>,
+    ) -> RpcResult<Vec<TraceResult>>;
+
     /// The `debug_traceTransaction` debugging method will attempt to run the transaction in the
     /// exact same manner as it was executed on the network. It will replay any transaction that
     /// may have been executed prior to this one before it will finally attempt to execute the

--- a/crates/rpc/rpc-api/src/trace.rs
+++ b/crates/rpc/rpc-api/src/trace.rs
@@ -106,4 +106,19 @@ pub trait TraceApi<TxReq> {
     /// This is the same as `trace_transactionOpcodeGas` but for all transactions in a block.
     #[method(name = "blockOpcodeGas")]
     async fn trace_block_opcode_gas(&self, block_id: BlockId) -> RpcResult<Option<BlockOpcodeGas>>;
+
+    /// Returns traces for a range of transactions within a block.
+    ///
+    /// This is a paginated version of `trace_block` that allows tracing a subset of transactions.
+    /// Transactions before `tx_index_start` are replayed without tracing to build up state.
+    /// Transactions from `tx_index_start` to `tx_index_end` (exclusive) are traced.
+    ///
+    /// This is useful for large blocks where full block traces would be too expensive.
+    #[method(name = "blockRange")]
+    async fn trace_block_range(
+        &self,
+        block_id: BlockId,
+        tx_index_start: u64,
+        tx_index_end: u64,
+    ) -> RpcResult<Option<Vec<LocalizedTransactionTrace>>>;
 }


### PR DESCRIPTION
## Summary

Add new RPC endpoints for paginated block tracing to support large blocks where full block traces would be too expensive in terms of memory and CPU.

## New Endpoints

### trace_blockRange

Parity-style paginated `trace_block`:

```json
{
    "method": "trace_blockRange",
    "params": ["0x123...", 0, 100]  // block_id, tx_index_start, tx_index_end
}
```

### debug_traceBlockByHashRange / debug_traceBlockByNumberRange

Geth-style paginated `debug_traceBlockByHash` and `debug_traceBlockByNumber`:

```json
{
    "method": "debug_traceBlockByHashRange",
    "params": ["0xabc...", 0, 100, {"tracer": "callTracer"}]  // hash, start, end, opts
}
```

## How It Works

1. Transactions before `tx_index_start` are replayed without tracing to build up state
2. Transactions in the range `[tx_index_start, tx_index_end)` are traced
3. The trace response includes `transaction_position` in each trace, allowing callers to derive the next offset for pagination

## Example Usage

To trace a block with 5000 transactions in chunks of 100:

```bash
# First 100 transactions
cast rpc trace_blockRange '"0x123"' 0 100

# Next 100 (transactions 100-199)
cast rpc trace_blockRange '"0x123"' 100 200

# Continue until all transactions are traced...
```

## Motivation

For chains expecting very large blocks (like Tempo), full block tracing via `trace_block` or `debug_traceBlock` can become prohibitively expensive. These paginated endpoints allow clients to:

- Trace blocks incrementally without memory pressure
- Stop early if response becomes too large
- Resume tracing from where they left off

## Testing

- Compiles without warnings
- Clippy passes with `-D warnings`
