### PR TITLE
fix(rocksdb): return MaybeInPlainState for missing history entries

### DIFF
--- a/crates/storage/provider/src/either_writer.rs
+++ b/crates/storage/provider/src/either_writer.rs
@@ -1351,7 +1351,8 @@ mod rocksdb_tests {
 
         // Run queries against both backends using EitherReader
         let mdbx_ro = factory.database_provider_ro().unwrap();
-        let rocks_tx = rocks_provider.tx();
+        // Use `with_assume_history_complete()` since both backends have identical data
+        let rocks_tx = rocks_provider.tx().with_assume_history_complete();
 
         for (i, query) in queries.iter().enumerate() {
             // MDBX query via EitherReader
@@ -1443,7 +1444,8 @@ mod rocksdb_tests {
 
         // Run queries against both backends using EitherReader
         let mdbx_ro = factory.database_provider_ro().unwrap();
-        let rocks_tx = rocks_provider.tx();
+        // Use `with_assume_history_complete()` since both backends have identical data
+        let rocks_tx = rocks_provider.tx().with_assume_history_complete();
 
         for (i, query) in queries.iter().enumerate() {
             // MDBX query via EitherReader

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -1525,7 +1525,7 @@ impl<'a> RocksDBBatch<'a> {
 pub struct RocksTx<'db> {
     inner: Transaction<'db, OptimisticTransactionDB>,
     provider: &'db RocksDBProvider,
-    /// When true, assume RocksDB has complete history (like MDBX) and return `NotYetWritten`
+    /// When true, assume `RocksDB` has complete history (like `MDBX`) and return `NotYetWritten`
     /// when querying before the first history entry. When false (default), return
     /// `MaybeInPlainState` for hybrid storage safety.
     assume_history_complete: bool,
@@ -1540,10 +1540,10 @@ impl fmt::Debug for RocksTx<'_> {
 impl<'db> RocksTx<'db> {
     /// Sets the `assume_history_complete` flag to true.
     ///
-    /// When enabled, history queries will return `NotYetWritten` (like MDBX) instead of
+    /// When enabled, history queries will return `NotYetWritten` (like `MDBX`) instead of
     /// `MaybeInPlainState` when querying before the first history entry. Use this in tests
-    /// where RocksDB and MDBX have identical data.
-    pub fn with_assume_history_complete(mut self) -> Self {
+    /// where `RocksDB` and `MDBX` have identical data.
+    pub const fn with_assume_history_complete(mut self) -> Self {
         self.assume_history_complete = true;
         self
     }
@@ -1717,7 +1717,8 @@ impl<'db> RocksTx<'db> {
         // Determines whether to soften NotYetWritten -> MaybeInPlainState.
         //
         // We soften when:
-        // 1. `assume_history_complete` is false (hybrid storage - RocksDB may not have full history)
+        // 1. `assume_history_complete` is false (hybrid storage - RocksDB may not have full
+        //    history)
         // 2. OR history may be pruned (`lowest_available_block_number.is_some()`)
         //
         // We only return NotYetWritten when we're certain history is complete AND not pruned.


### PR DESCRIPTION
## Summary

RocksDB only has history for blocks AFTER it was enabled. For accounts that existed before RocksDB was enabled, returning `NotYetWritten` incorrectly treats them as non-existent (nonce 0). We now return `MaybeInPlainState` to trigger a plain state lookup.

## Changes

- **`history_info` fallback**: Changed from `NotYetWritten` to `MaybeInPlainState` by default
- **`assume_history_complete` flag**: Added to `RocksTx` for test semantics
  - When `false` (default): returns `MaybeInPlainState` for hybrid storage safety
  - When `true`: returns `NotYetWritten` to match MDBX semantics for tests
- Updated test files to use `.with_assume_history_complete()` where MDBX/RocksDB have identical data

## Why

In hybrid storage (MDBX + RocksDB), RocksDB may not have history for accounts that were written BEFORE RocksDB was enabled. The old behavior returned `NotYetWritten`, which would incorrectly set nonce=0 for such accounts. Now we return `MaybeInPlainState` to ensure a plain state lookup is performed.

## Testing

```
cargo check -p reth-provider --features rocksdb
```