### PR TITLE
fix(cli): handle invalid hex in `db list --search`

### DIFF
--- a/crates/cli/commands/src/db/list.rs
+++ b/crates/cli/commands/src/db/list.rs
@@ -66,7 +66,7 @@ impl Command {
             Some(search) => {
                 if let Some(search) = search.strip_prefix("0x") {
                     hex::decode(search).wrap_err(
-                        "Invalid hex in --search. If using hex, provide it as 0x-prefixed hex (e.g. 0xdeadbeef).",
+                        "Invalid hex content after 0x prefix in --search (expected valid hex like 0xdeadbeef).",
                     )?
                 } else {
                     search.as_bytes().to_vec()

--- a/crates/cli/commands/src/db/list.rs
+++ b/crates/cli/commands/src/db/list.rs
@@ -84,8 +84,8 @@ impl Command {
             min_value_size: self.min_value_size,
             reverse: self.reverse,
             only_count: self.count,
-        }
-    })
+        })
+    }
 }
 
 struct ListTableViewer<'a, N: NodeTypes> {


### PR DESCRIPTION
Replaces a unwrap() in `reth db list` hex search parsing with proper error handling.
Invalid `--search 0x...` values now return a clear eyre error message instead of crashing.