### PR TITLE
fix(rpc): use Default for SimulateError to prepare for alloy breaking change

### DIFF
--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -264,7 +264,7 @@ where
                     error: Some(SimulateError {
                         message: error.to_string(),
                         code: error.into().code(),
-                        ..Default::default()
+                        ..SimulateError::invalid_params()
                     }),
                     gas_used,
                     logs: Vec::new(),
@@ -279,7 +279,7 @@ where
                     error: Some(SimulateError {
                         message: error.to_string(),
                         code: error.into().code(),
-                        ..Default::default()
+                        ..SimulateError::invalid_params()
                     }),
                     gas_used,
                     status: false,

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -258,11 +258,13 @@ where
         let call = match result {
             ExecutionResult::Halt { reason, gas_used } => {
                 let error = Err::from_evm_halt(reason, tx.gas_limit());
+                #[allow(clippy::needless_update)]
                 SimCallResult {
                     return_data: Bytes::new(),
                     error: Some(SimulateError {
                         message: error.to_string(),
                         code: error.into().code(),
+                        ..Default::default()
                     }),
                     gas_used,
                     logs: Vec::new(),
@@ -271,11 +273,13 @@ where
             }
             ExecutionResult::Revert { output, gas_used } => {
                 let error = Err::from_revert(output.clone());
+                #[allow(clippy::needless_update)]
                 SimCallResult {
                     return_data: output,
                     error: Some(SimulateError {
                         message: error.to_string(),
                         code: error.into().code(),
+                        ..Default::default()
                     }),
                     gas_used,
                     status: false,


### PR DESCRIPTION
## Summary

Upcoming alloy change (https://github.com/alloy-rs/alloy/pull/3570) adds a `data` field to `SimulateError`. Using `..Default::default()` makes this non-breaking for reth.

## Changes

- Added `..Default::default()` to both `SimulateError` instantiations in `simulate.rs`
- Added `#[allow(clippy::needless_update)]` to suppress lint until the alloy change lands

## Blocked on

- [ ] https://github.com/alloy-rs/alloy/pull/3570 (adds `#[derive(Default)]` to `SimulateError`)

CI will fail until the alloy PR is merged to main.