### PR TITLE
feat(storage): warn storage settings diff at startup

### DIFF
--- a/crates/e2e-test-utils/src/setup_import.rs
+++ b/crates/e2e-test-utils/src/setup_import.rs
@@ -134,7 +134,7 @@ pub async fn setup_engine_with_chain_import(
             reth_provider::providers::RocksDBProvider::builder(rocksdb_dir_path).build().unwrap(),
         )?;
 
-        // Initialize genesis
+        // Initialize genesis if needed
         reth_db_common::init::init_genesis(&provider_factory)?;
 
         // Import the chain data

--- a/crates/e2e-test-utils/src/setup_import.rs
+++ b/crates/e2e-test-utils/src/setup_import.rs
@@ -99,12 +99,6 @@ pub async fn setup_engine_with_chain_import(
         // Set the datadir
         node_config.datadir.datadir =
             reth_node_core::dirs::MaybePlatformPath::from(datadir.clone());
-
-        // Explicitly set rocksdb args to match StorageSettings used by init_genesis().
-        // Both edge() and legacy() have storages_history_in_rocksdb=false and
-        // account_history_in_rocksdb=false, so we match that here.
-        node_config.rocksdb.storages_history = false;
-        node_config.rocksdb.account_history = false;
         debug!(target: "e2e::import", "Node {idx} datadir: {datadir:?}");
 
         let span = span!(Level::INFO, "node", idx);

--- a/crates/e2e-test-utils/src/setup_import.rs
+++ b/crates/e2e-test-utils/src/setup_import.rs
@@ -99,6 +99,12 @@ pub async fn setup_engine_with_chain_import(
         // Set the datadir
         node_config.datadir.datadir =
             reth_node_core::dirs::MaybePlatformPath::from(datadir.clone());
+
+        // Explicitly set rocksdb args to match StorageSettings used by init_genesis().
+        // Both edge() and legacy() have storages_history_in_rocksdb=false and
+        // account_history_in_rocksdb=false, so we match that here.
+        node_config.rocksdb.storages_history = false;
+        node_config.rocksdb.account_history = false;
         debug!(target: "e2e::import", "Node {idx} datadir: {datadir:?}");
 
         let span = span!(Level::INFO, "node", idx);
@@ -128,7 +134,7 @@ pub async fn setup_engine_with_chain_import(
             reth_provider::providers::RocksDBProvider::builder(rocksdb_dir_path).build().unwrap(),
         )?;
 
-        // Initialize genesis if needed
+        // Initialize genesis
         reth_db_common::init::init_genesis(&provider_factory)?;
 
         // Import the chain data

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -29,7 +29,7 @@ use reth_trie::{
 use reth_trie_db::DatabaseStateRoot;
 use serde::{Deserialize, Serialize};
 use std::io::BufRead;
-use tracing::{debug, error, info, trace};
+use tracing::{debug, error, info, trace, warn};
 
 /// Default soft limit for number of bytes to read from state dump file, before inserting into
 /// database.
@@ -169,9 +169,7 @@ where
                             target: "reth::storage",
                             ?stored,
                             requested = ?genesis_storage_settings,
-                            "Storage settings mismatch: database was initialized with different \
-                             settings than currently configured. To apply new settings, delete \
-                             the datadir and resync."
+                            "Storage settings mismatch detected"
                         );
                     }
                 }


### PR DESCRIPTION
## Summary

Adds validation to detect storage settings mismatches at startup, warning operators when CLI settings differ from stored settings.

Closes #20482

## Changes

- Validate in `init_genesis_with_settings()`: if settings differ from stored, log a warning
- For legacy databases without persisted settings, defaults to `StorageSettings::legacy()` for comparison

## Behavior

| Scenario | Result |
|----------|--------|
| Settings differ from stored | ⚠️ Warning logged, startup proceeds |
| Settings match stored | ✅ OK |
| Legacy DB (no stored settings) | Treated as `legacy()` for comparison |

## Test Plan

2 tests:
- `warn_storage_settings_mismatch` - verifies warning behavior, startup succeeds
- `allow_same_storage_settings` - verifies no warning when settings match