### PR TITLE
refactor: refactor get_idle_peer_for to use Iterator::find

### DIFF
--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -188,13 +188,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
         let TxFetchMetadata { fallback_peers, .. } =
             self.hashes_fetch_inflight_and_pending_fetch.peek(&hash)?;
 
-        for peer_id in fallback_peers.iter() {
-            if self.is_idle(peer_id) {
-                return Some(peer_id)
-            }
-        }
-
-        None
+        fallback_peers.iter().find(|peer_id| self.is_idle(peer_id))
     }
 
     /// Returns any idle peer for any hash pending fetch. If one is found, the corresponding


### PR DESCRIPTION
Clippy reports this loop as a manual Iterator::find implementation (clippy::manual_find). Using find keeps behavior identical and removes the lint failure.