### PR TITLE
feat(rocksdb): pipeline WAL flush on commit

### DIFF
--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -491,7 +491,7 @@ where
                 .with_genesis_block_number(self.chain_spec().genesis().number.unwrap_or_default())
                 .build()?;
 
-        // Initialize RocksDB provider with metrics, statistics, and default tables
+        // Initialize RocksDB provider with metrics, statistics, and default tables.
         let rocksdb_provider = RocksDBProvider::builder(self.data_dir().rocksdb())
             .with_default_tables()
             .with_metrics()

--- a/crates/stages/stages/src/sets.rs
+++ b/crates/stages/stages/src/sets.rs
@@ -51,7 +51,7 @@ use reth_consensus::FullConsensus;
 use reth_evm::ConfigureEvm;
 use reth_network_p2p::{bodies::downloader::BodyDownloader, headers::downloader::HeaderDownloader};
 use reth_primitives_traits::{Block, NodePrimitives};
-use reth_provider::HeaderSyncGapProvider;
+use reth_provider::{HeaderSyncGapProvider, RocksDBProviderFactory};
 use reth_prune_types::PruneModes;
 use reth_stages_api::Stage;
 use std::sync::Arc;
@@ -152,6 +152,7 @@ where
     ) -> StageSetBuilder<Provider>
     where
         OfflineStages<E>: StageSet<Provider>,
+        Provider: RocksDBProviderFactory,
     {
         StageSetBuilder::default()
             .add_set(default_offline)
@@ -168,6 +169,7 @@ where
     E: ConfigureEvm,
     OnlineStages<P, H, B>: StageSet<Provider>,
     OfflineStages<E>: StageSet<Provider>,
+    Provider: RocksDBProviderFactory,
 {
     fn builder(self) -> StageSetBuilder<Provider> {
         Self::add_offline_stages(

--- a/crates/storage/provider/src/providers/rocksdb_stub.rs
+++ b/crates/storage/provider/src/providers/rocksdb_stub.rs
@@ -88,6 +88,13 @@ impl RocksDBProvider {
     pub const fn clear<T>(&self) -> ProviderResult<()> {
         Ok(())
     }
+
+    /// Flushes all column family memtables to SST files (stub implementation).
+    ///
+    /// This is a no-op since there is no `RocksDB` when the feature is disabled.
+    pub const fn flush(&self) -> ProviderResult<()> {
+        Ok(())
+    }
 }
 
 impl DatabaseMetrics for RocksDBProvider {


### PR DESCRIPTION
## Summary

Adds the ability for pipeline providers to schedule WAL flushes on RocksDB commit.

## Problem

RocksDB WAL can grow very large (observed 2.7GB) when pipeline stages write large batches. The TransactionLookup stage writes 65M+ entries, and WAL only flushes on memtable full or shutdown.

This causes:
- Slow `db stats` commands (~10s) due to WAL replay on DB open
- Large disk usage from unflushed WAL
- Potential data loss window

## Proposed Solution

1. Add `flush_on_commit` option to `RocksDBBuilder`
2. Add `flush()` method to `RocksDBProvider`
3. Pipeline calls flush after stage completion if configured
4. Use explicit `db.flush()` calls (not `manual_wal_flush` option)

## Design Doc

See DESIGN-rocksdb-pipeline-wal-flush.md for full design.

## Implementation Status

- [ ] Add `flush_on_commit` to RocksDBBuilder
- [ ] Add `flush()` method to RocksDBProvider
- [ ] Integrate with pipeline stage completion
- [ ] Add tests
- [ ] Benchmark performance impact

---

**Note:** This is a draft for design discussion. Implementation to follow.