### PR TITLE
fix(txpool): bound transaction batcher channel to prevent DoS

### DIFF
--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -271,7 +271,10 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 pub use crate::{
-    batcher::{BatchTxProcessor, BatchTxRequest},
+    batcher::{
+        BatchConfig, BatchTxProcessor, BatchTxRequest, DEFAULT_BATCH_CHANNEL_CAPACITY,
+        DEFAULT_MAX_BATCH_SIZE,
+    },
     blobstore::{BlobStore, BlobStoreError},
     config::{
         LocalTransactionConfig, PoolConfig, PriceBumpConfig, SubPoolLimit,


### PR DESCRIPTION
## Summary

This changes the unbounded channel in the transaction pool batcher to a bounded channel with a default capacity of 2048. This prevents potential denial-of-service attacks where malicious users could blast large transactions and quickly cancel requests to bypass request-level rate limiting, causing unbounded memory growth.

## Changes

- Replace `mpsc::unbounded_channel` with `mpsc::channel(2048)`
- Update RPC layer to use bounded `Sender` and `await` on send
- Fix graceful shutdown when channel is closed (processor now terminates cleanly when all senders drop)
- Update tests to use `try_send` for bounded channel compatibility

## Motivation

The unbounded channel allows unbounded memory growth under sustained load. An attacker could:
1. Blast many large transactions via RPC
2. Quickly cancel the requests
3. Bypass request-level rate limiting since requests complete/cancel quickly
4. Cause unbounded memory allocation in the batcher queue

With a bounded channel:
- Backpressure is applied when the queue reaches capacity
- Memory usage is bounded to ~2048 pending requests
- The RPC layer will block (await) when the queue is full, naturally rate-limiting requests

## Testing

- All existing batcher tests pass
- Verified with clippy and fmt