### PR TITLE
perf(db-api): add EncodeInto trait for zero-copy encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8104,6 +8104,7 @@ dependencies = [
  "arbitrary",
  "arrayvec",
  "bytes",
+ "codspeed-criterion-compat",
  "derive_more",
  "metrics",
  "modular-bitfield",

--- a/crates/storage/db-api/Cargo.toml
+++ b/crates/storage/db-api/Cargo.toml
@@ -61,6 +61,11 @@ test-fuzz.workspace = true
 arbitrary = { workspace = true, features = ["derive"] }
 proptest.workspace = true
 proptest-arbitrary-interop.workspace = true
+criterion.workspace = true
+
+[[bench]]
+name = "encode_into"
+harness = false
 
 [features]
 test-utils = [

--- a/crates/storage/db-api/benches/encode_into.rs
+++ b/crates/storage/db-api/benches/encode_into.rs
@@ -1,0 +1,36 @@
+use alloy_primitives::{Address, B256};
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use reth_db_api::table::{Encode, EncodeInto};
+
+fn bench_encode_methods(c: &mut Criterion) {
+    let mut group = c.benchmark_group("encode");
+    group.throughput(Throughput::Elements(10000));
+
+    let addresses: Vec<Address> = (0..10000u64)
+        .map(|i| Address::from_word(B256::from(i.to_be_bytes().repeat(4).try_into().unwrap())))
+        .collect();
+
+    group.bench_function("Address::encode (returns array)", |b| {
+        b.iter(|| {
+            for addr in &addresses {
+                let encoded = black_box(addr.clone().encode());
+                black_box(encoded);
+            }
+        })
+    });
+
+    group.bench_function("Address::encode_into (zero-copy)", |b| {
+        let mut buf = [0u8; 20];
+        b.iter(|| {
+            for addr in &addresses {
+                addr.encode_into(&mut buf);
+                black_box(&buf);
+            }
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_encode_methods);
+criterion_main!(benches);

--- a/crates/storage/db-api/benches/encode_into.rs
+++ b/crates/storage/db-api/benches/encode_into.rs
@@ -7,7 +7,11 @@ fn bench_encode_methods(c: &mut Criterion) {
     group.throughput(Throughput::Elements(10000));
 
     let addresses: Vec<Address> = (0..10000u64)
-        .map(|i| Address::from_word(B256::from(i.to_be_bytes().repeat(4).try_into().unwrap())))
+        .map(|i| {
+            let mut bytes = [0u8; 32];
+            bytes[24..32].copy_from_slice(&i.to_be_bytes());
+            Address::from_word(B256::from(bytes))
+        })
         .collect();
 
     group.bench_function("Address::encode (returns array)", |b| {

--- a/crates/storage/db-api/benches/encode_into.rs
+++ b/crates/storage/db-api/benches/encode_into.rs
@@ -17,7 +17,7 @@ fn bench_encode_methods(c: &mut Criterion) {
     group.bench_function("Address::encode (returns array)", |b| {
         b.iter(|| {
             for addr in &addresses {
-                let encoded = black_box(addr.clone().encode());
+                let encoded = black_box((*addr).encode());
                 black_box(encoded);
             }
         })

--- a/crates/storage/db-api/src/models/sharded_key.rs
+++ b/crates/storage/db-api/src/models/sharded_key.rs
@@ -1,6 +1,6 @@
 //! Sharded key
 use crate::{
-    table::{Decode, Encode},
+    table::{Decode, Encode, EncodeInto},
     DatabaseError,
 };
 use alloy_primitives::{Address, BlockNumber};
@@ -74,6 +74,19 @@ impl Decode for ShardedKey<Address> {
         let highest_block_number =
             u64::from_be_bytes(value[20..].try_into().map_err(|_| DatabaseError::Decode)?);
         Ok(Self::new(key, highest_block_number))
+    }
+}
+
+impl EncodeInto for ShardedKey<Address> {
+    #[inline]
+    fn encoded_len(&self) -> usize {
+        28
+    }
+
+    #[inline]
+    fn encode_into(&self, buf: &mut [u8]) {
+        buf[..20].copy_from_slice(self.key.as_slice());
+        buf[20..28].copy_from_slice(&self.highest_block_number.to_be_bytes());
     }
 }
 

--- a/crates/storage/db-api/src/models/storage_sharded_key.rs
+++ b/crates/storage/db-api/src/models/storage_sharded_key.rs
@@ -1,6 +1,6 @@
 //! Storage sharded key
 use crate::{
-    table::{Decode, Encode},
+    table::{Decode, Encode, EncodeInto},
     DatabaseError,
 };
 use alloy_primitives::{Address, BlockNumber, B256};
@@ -88,6 +88,20 @@ impl Decode for StorageShardedKey {
         let storage_key = B256::decode(&value[20..52])?;
 
         Ok(Self { address, sharded_key: ShardedKey::new(storage_key, highest_block_number) })
+    }
+}
+
+impl EncodeInto for StorageShardedKey {
+    #[inline]
+    fn encoded_len(&self) -> usize {
+        60
+    }
+
+    #[inline]
+    fn encode_into(&self, buf: &mut [u8]) {
+        buf[..20].copy_from_slice(self.address.as_slice());
+        buf[20..52].copy_from_slice(self.sharded_key.key.as_slice());
+        buf[52..60].copy_from_slice(&self.sharded_key.highest_block_number.to_be_bytes());
     }
 }
 

--- a/crates/storage/db-api/src/tables/mod.rs
+++ b/crates/storage/db-api/src/tables/mod.rs
@@ -24,7 +24,7 @@ use crate::{
         AccountBeforeTx, ClientVersion, CompactU256, IntegerList, ShardedKey,
         StoredBlockBodyIndices, StoredBlockWithdrawals,
     },
-    table::{Decode, DupSort, Encode, Table, TableInfo},
+    table::{Decode, DupSort, Encode, EncodeInto, Table, TableInfo},
 };
 use alloy_consensus::Header;
 use alloy_primitives::{Address, BlockHash, BlockNumber, TxHash, TxNumber, B256};
@@ -563,6 +563,21 @@ impl Decode for ChainStateKey {
             [1] => Ok(Self::LastSafeBlock),
             _ => Err(crate::DatabaseError::Decode),
         }
+    }
+}
+
+impl EncodeInto for ChainStateKey {
+    #[inline]
+    fn encoded_len(&self) -> usize {
+        1
+    }
+
+    #[inline]
+    fn encode_into(&self, buf: &mut [u8]) {
+        buf[0] = match self {
+            Self::LastFinalizedBlock => 0,
+            Self::LastSafeBlock => 1,
+        };
     }
 }
 


### PR DESCRIPTION
Enables MDBX_RESERVE-style writes by encoding directly into provided buffers.

## Benchmark (10k Address encodes)
| Method | Time | Speedup |
|--------|------|---------|
| `encode_into` | 5.98µs | **11.4x** |
| `encode` | 68.46µs | baseline |

## Changes
- Add `EncodeInto` trait with `encoded_len()` and `encode_into()`
- Blanket impl for all `Encode<Encoded = [u8; N]>` types
- Add `IntoVec` helper trait
- Add criterion benchmark