### PR TITLE
ci: align check-alloy workflow with main clippy job

### DIFF
--- a/.github/workflows/check-alloy.yml
+++ b/.github/workflows/check-alloy.yml
@@ -60,7 +60,6 @@ jobs:
           tail -50 Cargo.toml
 
       - name: Check workspace
-        run: cargo check --workspace --all-features
-
-      - name: Check Optimism
-        run: cargo check -p reth-optimism-node --all-features
+        run: cargo clippy --workspace --lib --examples --tests --benches --all-features --locked
+        env:
+          RUSTFLAGS: -D warnings


### PR DESCRIPTION
Aligns the check-alloy CI workflow with the main clippy job to use the same compilation flags.

- Uses `cargo clippy --workspace --lib --examples --tests --benches --all-features --locked`
- Adds `RUSTFLAGS: -D warnings`
- Removes redundant separate Optimism check (already covered by `--workspace`)

was causing failures due to some op feature issues

https://github.com/paradigmxyz/reth/actions/runs/21254547059

now uses regular clippy command we use in ci