### PR TITLE
fix: use unwrap_or_else for lazy evaluation of StorageSettings::legacy

### DIFF
--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -162,7 +162,7 @@ where
                     return Err(InitStorageError::UninitializedDatabase)
                 }
 
-                let stored = factory.storage_settings()?.unwrap_or(StorageSettings::legacy());
+                let stored = factory.storage_settings()?.unwrap_or_else(StorageSettings::legacy);
                 if stored != genesis_storage_settings {
                     warn!(
                         target: "reth::storage",


### PR DESCRIPTION
Addresses review comment from https://github.com/paradigmxyz/reth/pull/21320#discussion_r2717711333

Uses `unwrap_or_else(StorageSettings::legacy)` instead of `unwrap_or(StorageSettings::legacy())` to avoid eagerly evaluating the default when not needed.