### PR TITLE
chore(txpool): explicitly deref RwLockReadGuard in PartialEq impl

### DIFF
--- a/crates/transaction-pool/src/blobstore/mem.rs
+++ b/crates/transaction-pool/src/blobstore/mem.rs
@@ -56,7 +56,7 @@ struct InMemoryBlobStoreInner {
 
 impl PartialEq for InMemoryBlobStoreInner {
     fn eq(&self, other: &Self) -> bool {
-        self.store.read().eq(&other.store.read())
+        self.store.read().eq(&*other.store.read())
     }
 }
 


### PR DESCRIPTION
## Summary                                                                                                                                         
                                                                                                                                         
Fixes a compilation error in `reth-transaction-pool` when `rkyv` with `hashbrown` feature is present in the dependency graph.                      
                                                                                                                                         
## Problem                                                                                                                                         
                                                                                                                                         
The `PartialEq` implementation for `InMemoryBlobStoreInner` uses:                                                                                  
                                                                                                                                         
```rust                                                                                                                                            
self.store.read().eq(&other.store.read())                                                                                                          
```
                                                                                                      
This relies on auto-deref for trait resolution. However, when `rkyv` with `hashbrown-0_15` feature is enabled (which adds `impl PartialEq<ArchivedHashMap> for HashMap`), it causes trait resolution ambiguity so the compiler fails with:                                                                                  
                                                                                                                                         
error[E0277]: can't compare `HashMap<...>` with `RwLockReadGuard<'_, RawRwLock, HashMap<...>>`                                                     
                                                                                                                                         
The issue is that `&other.store.read()` produces `&RwLockReadGuard<HashMap>`, not `&HashMap`.                                                            
                                                                                                                                         
## Solution                                                                                                                                           
                                                                                                                                         
Explicitly dereference the RHS:                                                                                                                    
```rust                                                                                                                                         
self.store.read().eq(&*other.store.read())                                                                                                         
```                                                                                                                             
This ensures we compare `HashMap` with `&HashMap`, which unambiguously resolves to `HashMap::eq`.