### PR TITLE
fix(rocksdb): filter history writes to only changed accounts/storage

### DIFF
--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -1132,7 +1132,10 @@ impl RocksDBProvider {
                 for revert in storage_block_reverts {
                     for (slot, _) in revert.storage_revert {
                         let key = B256::new(slot.to_be_bytes());
-                        storage_history.entry((revert.address, key)).or_default().push(block_number);
+                        storage_history
+                            .entry((revert.address, key))
+                            .or_default()
+                            .push(block_number);
                     }
                 }
             }


### PR DESCRIPTION
**Problem:** RocksDB history index writes included all **touched** accounts/storage from the bundle state, even if only read (not modified). This created false-positive history entries pointing to blocks with no actual changeset, causing `AccountChangesetNotFound` and `StorageChangesetNotFound` errors during historical state queries.

**Root cause:** `write_account_history` iterated `bundle.state().keys()` and `write_storage_history` iterated `account.storage.keys()`. These include all accounts/slots accessed during execution (reads + writes), not just modified ones. History indices must only point to blocks with actual changes, since `HistoricalStateProvider` uses them to look up changesets.

**How found:** During reth-bench historical state queries, `AccountChangesetNotFound` errors surfaced. The history index pointed to blocks with no actual changeset because touched (not just changed) accounts were being indexed.

**Fix:**
- Account history: filter with `account.is_info_changed()`
- Storage history: filter with `slot_value.is_changed()`