### PR TITLE
feat(rocksdb): changeset-based crash recovery healing for history indices

### DIFF
--- a/crates/storage/provider/src/providers/rocksdb/invariants.rs
+++ b/crates/storage/provider/src/providers/rocksdb/invariants.rs
@@ -1154,16 +1154,16 @@ mod tests {
         }
     }
 
-    /// Tests StoragesHistory changeset-based healing with enough blocks to trigger batching.
+    /// Tests `StoragesHistory` changeset-based healing with enough blocks to trigger batching.
     ///
     /// Scenario:
     /// 1. Generate 15,000 blocks worth of storage changeset data (to exceed the 10k batch size)
     /// 2. Each block has 1 storage change (address + slot + value)
     /// 3. Write storage changesets to static files for all 15k blocks
-    /// 4. Set IndexStorageHistory checkpoint to block 5000
-    /// 5. Insert stale StoragesHistory entries in RocksDB for (address, slot) pairs that changed in
-    ///    blocks 5001-15000
-    /// 6. Run check_consistency
+    /// 4. Set `IndexStorageHistory` checkpoint to block 5000
+    /// 5. Insert stale `StoragesHistory` entries in `RocksDB` for (address, slot) pairs that
+    ///    changed in blocks 5001-15000
+    /// 6. Run `check_consistency`
     /// 7. Verify stale entries for blocks > 5000 are pruned and batching worked
     #[test]
     fn test_check_consistency_storages_history_heals_via_changesets_large_range() {
@@ -1286,16 +1286,16 @@ mod tests {
         );
     }
 
-    /// Tests AccountsHistory changeset-based healing with enough blocks to trigger batching.
+    /// Tests `AccountsHistory` changeset-based healing with enough blocks to trigger batching.
     ///
     /// Scenario:
     /// 1. Generate 15,000 blocks worth of account changeset data (to exceed the 10k batch size)
     /// 2. Each block has 1 account change (simple - just random addresses)
     /// 3. Write account changesets to static files for all 15k blocks
-    /// 4. Set IndexAccountHistory checkpoint to block 5000
-    /// 5. Insert stale AccountsHistory entries in RocksDB for addresses that changed in blocks
+    /// 4. Set `IndexAccountHistory` checkpoint to block 5000
+    /// 5. Insert stale `AccountsHistory` entries in `RocksDB` for addresses that changed in blocks
     ///    5001-15000
-    /// 6. Run check_consistency
+    /// 6. Run `check_consistency`
     /// 7. Verify:
     ///    - Stale entries for blocks > 5000 are pruned
     ///    - The batching worked (no OOM, completed successfully)
@@ -1435,8 +1435,8 @@ mod tests {
         let key2 = StorageShardedKey::new(Address::random(), B256::random(), 80);
         let block_list1 = BlockNumberList::new_pre_sorted([10, 20, 30, 50]);
         let block_list2 = BlockNumberList::new_pre_sorted([40, 60, 80]);
-        rocksdb.put::<tables::StoragesHistory>(key1.clone(), &block_list1).unwrap();
-        rocksdb.put::<tables::StoragesHistory>(key2.clone(), &block_list2).unwrap();
+        rocksdb.put::<tables::StoragesHistory>(key1, &block_list1).unwrap();
+        rocksdb.put::<tables::StoragesHistory>(key2, &block_list2).unwrap();
 
         // Capture entries before consistency check
         let entries_before: Vec<_> =

--- a/crates/storage/provider/src/providers/rocksdb/invariants.rs
+++ b/crates/storage/provider/src/providers/rocksdb/invariants.rs
@@ -24,6 +24,118 @@ use std::collections::HashSet;
 /// Balances memory usage against iteration overhead.
 const HEAL_HISTORY_BATCH_SIZE: u64 = 10_000;
 
+/// Generates a `heal_*_history` method for a history table.
+///
+/// This macro deduplicates the common healing logic between `StoragesHistory` and
+/// `AccountsHistory`, which share identical checkpoint/sf_tip handling and batch loop structure.
+macro_rules! impl_heal_history {
+    (
+        $(#[$attr:meta])*
+        fn $fn_name:ident < $provider:ident : $($bound:path),+ $(,)? > (
+            table: $table:ty,
+            stage_id: $stage_id:expr,
+            segment: $segment:expr,
+            table_name: $table_name:literal,
+            get_changesets: |$prov:ident, $range:ident| $get_changesets:expr,
+            extract_indices: |$changesets:ident, $checkpoint:ident| $extract_indices:expr,
+            unwind: |$self:ident, $indices:ident| $unwind:expr $(,)?
+        )
+    ) => {
+        $(#[$attr])*
+        fn $fn_name<$provider>(
+            &self,
+            provider: &$provider,
+        ) -> ProviderResult<Option<BlockNumber>>
+        where
+            $provider: $($bound +)+,
+        {
+            let checkpoint = provider
+                .get_stage_checkpoint($stage_id)?
+                .map(|cp| cp.block_number)
+                .unwrap_or(0);
+
+            // Fast path: if checkpoint is 0 and RocksDB has data, clear everything.
+            if checkpoint == 0 && self.first::<$table>()?.is_some() {
+                tracing::info!(
+                    target: "reth::providers::rocksdb",
+                    concat!($table_name, " has data but checkpoint is 0, clearing all")
+                );
+                self.clear::<$table>()?;
+                return Ok(None);
+            }
+
+            let sf_tip = provider
+                .static_file_provider()
+                .get_highest_static_file_block($segment)
+                .unwrap_or(0);
+
+            if sf_tip < checkpoint {
+                // This should never happen in normal operation - static files are always
+                // committed before RocksDB. If we get here, something is seriously wrong.
+                // The unwind is a best-effort attempt but is probably futile.
+                tracing::warn!(
+                    target: "reth::providers::rocksdb",
+                    sf_tip,
+                    checkpoint,
+                    concat!($table_name, ": static file tip behind checkpoint, unwind needed")
+                );
+                return Ok(Some(sf_tip));
+            }
+
+            if sf_tip == checkpoint {
+                return Ok(None);
+            }
+
+            let total_blocks = sf_tip - checkpoint;
+            tracing::info!(
+                target: "reth::providers::rocksdb",
+                checkpoint,
+                sf_tip,
+                total_blocks,
+                concat!($table_name, ": healing via changesets")
+            );
+
+            let mut batch_start = checkpoint + 1;
+            let mut batch_num = 0u64;
+            let total_batches = total_blocks.div_ceil(HEAL_HISTORY_BATCH_SIZE);
+
+            while batch_start <= sf_tip {
+                let batch_end = (batch_start + HEAL_HISTORY_BATCH_SIZE - 1).min(sf_tip);
+                batch_num += 1;
+
+                let $range = batch_start..=batch_end;
+                let $prov = provider;
+                let changesets = $get_changesets;
+
+                let $changesets = changesets;
+                let $checkpoint = checkpoint;
+                let indices = $extract_indices;
+
+                if !indices.is_empty() {
+                    tracing::info!(
+                        target: "reth::providers::rocksdb",
+                        batch_num,
+                        total_batches,
+                        batch_start,
+                        batch_end,
+                        indices_count = indices.len(),
+                        concat!($table_name, ": unwinding batch")
+                    );
+
+                    let $self = self;
+                    let $indices = &indices;
+                    let batch = $unwind;
+                    self.commit_batch(batch)?;
+                }
+
+                batch_start = batch_end + 1;
+            }
+
+            Ok(None)
+        }
+    };
+}
+
 impl RocksDBProvider {
     /// Checks consistency of `RocksDB` tables against MDBX stage checkpoints.
     ///
@@ -227,197 +339,47 @@ impl RocksDBProvider {
         Ok(())
     }
 
-    /// Heals the `StoragesHistory` table by removing stale entries.
-    ///
-    /// Returns an unwind target if static file tip is behind checkpoint (cannot heal).
-    /// Otherwise iterates changesets in batches to identify and unwind affected keys.
-    fn heal_storages_history<Provider>(
-        &self,
-        provider: &Provider,
-    ) -> ProviderResult<Option<BlockNumber>>
-    where
-        Provider:
-            DBProvider + StageCheckpointReader + StaticFileProviderFactory + StorageChangeSetReader,
-    {
-        let checkpoint = provider
-            .get_stage_checkpoint(StageId::IndexStorageHistory)?
-            .map(|cp| cp.block_number)
-            .unwrap_or(0);
-
-        // Fast path: if checkpoint is 0 and RocksDB has data, clear everything.
-        // Short-circuit: only check has_data when checkpoint == 0 (rare case).
-        if checkpoint == 0 && self.first::<tables::StoragesHistory>()?.is_some() {
-            tracing::info!(
-                target: "reth::providers::rocksdb",
-                "StoragesHistory has data but checkpoint is 0, clearing all"
-            );
-            self.clear::<tables::StoragesHistory>()?;
-            return Ok(None);
-        }
-
-        let sf_tip = provider
-            .static_file_provider()
-            .get_highest_static_file_block(StaticFileSegment::StorageChangeSets)
-            .unwrap_or(0);
-
-        if sf_tip < checkpoint {
-            // This should never happen in normal operation - static files are always committed
-            // before RocksDB. If we get here, something is seriously wrong. The unwind is a
-            // best-effort attempt but is probably futile.
-            tracing::warn!(
-                target: "reth::providers::rocksdb",
-                sf_tip,
-                checkpoint,
-                "StoragesHistory: static file tip behind checkpoint, unwind needed"
-            );
-            return Ok(Some(sf_tip));
-        }
-
-        if sf_tip == checkpoint {
-            return Ok(None);
-        }
-
-        let total_blocks = sf_tip - checkpoint;
-        tracing::info!(
-            target: "reth::providers::rocksdb",
-            checkpoint,
-            sf_tip,
-            total_blocks,
-            "StoragesHistory: healing via changesets"
-        );
-
-        let mut batch_start = checkpoint.saturating_add(1);
-        let mut batch_num = 0u64;
-        let total_batches = total_blocks.div_ceil(HEAL_HISTORY_BATCH_SIZE);
-
-        while batch_start <= sf_tip {
-            let batch_end = batch_start.saturating_add(HEAL_HISTORY_BATCH_SIZE - 1).min(sf_tip);
-            batch_num += 1;
-
-            let changesets = provider.storage_changesets_range(batch_start..=batch_end)?;
-
-            if !changesets.is_empty() {
+    impl_heal_history! {
+        /// Heals the `StoragesHistory` table by removing stale entries.
+        ///
+        /// Returns an unwind target if static file tip is behind checkpoint (cannot heal).
+        /// Otherwise iterates changesets in batches to identify and unwind affected keys.
+        fn heal_storages_history<Provider: DBProvider, StageCheckpointReader, StaticFileProviderFactory, StorageChangeSetReader>(
+            table: tables::StoragesHistory,
+            stage_id: StageId::IndexStorageHistory,
+            segment: StaticFileSegment::StorageChangeSets,
+            table_name: "StoragesHistory",
+            get_changesets: |prov, range| prov.storage_changesets_range(range)?,
+            extract_indices: |changesets, checkpoint| {
                 let unique_keys: HashSet<_> = changesets
                     .into_iter()
                     .map(|(block_addr, entry)| (block_addr.address(), entry.key, checkpoint))
                     .collect();
-
-                let indices: Vec<_> = unique_keys.into_iter().collect();
-
-                tracing::info!(
-                    target: "reth::providers::rocksdb",
-                    batch_num,
-                    total_batches,
-                    batch_start,
-                    batch_end,
-                    indices_count = indices.len(),
-                    "StoragesHistory: unwinding batch"
-                );
-
-                let batch = self.unwind_storage_history_indices(&indices)?;
-                self.commit_batch(batch)?;
-            }
-
-            batch_start = batch_end.saturating_add(1);
-        }
-
-        Ok(None)
+                unique_keys.into_iter().collect::<Vec<_>>()
+            },
+            unwind: |this, indices| this.unwind_storage_history_indices(indices)?,
+        )
     }
 
-    /// Heals the `AccountsHistory` table by removing stale entries.
-    ///
-    /// Returns an unwind target if static file tip is behind checkpoint (cannot heal).
-    /// Otherwise iterates changesets in batches to identify and unwind affected keys.
-    fn heal_accounts_history<Provider>(
-        &self,
-        provider: &Provider,
-    ) -> ProviderResult<Option<BlockNumber>>
-    where
-        Provider: DBProvider + StageCheckpointReader + StaticFileProviderFactory + ChangeSetReader,
-    {
-        let checkpoint = provider
-            .get_stage_checkpoint(StageId::IndexAccountHistory)?
-            .map(|cp| cp.block_number)
-            .unwrap_or(0);
-
-        // Fast path: if checkpoint is 0 and RocksDB has data, clear everything.
-        // Short-circuit: only check has_data when checkpoint == 0 (rare case).
-        if checkpoint == 0 && self.first::<tables::AccountsHistory>()?.is_some() {
-            tracing::info!(
-                target: "reth::providers::rocksdb",
-                "AccountsHistory has data but checkpoint is 0, clearing all"
-            );
-            self.clear::<tables::AccountsHistory>()?;
-            return Ok(None);
-        }
-
-        let sf_tip = provider
-            .static_file_provider()
-            .get_highest_static_file_block(StaticFileSegment::AccountChangeSets)
-            .unwrap_or(0);
-
-        if sf_tip < checkpoint {
-            // This should never happen in normal operation - static files are always committed
-            // before RocksDB. If we get here, something is seriously wrong. The unwind is a
-            // best-effort attempt but is probably futile.
-            tracing::warn!(
-                target: "reth::providers::rocksdb",
-                sf_tip,
-                checkpoint,
-                "AccountsHistory: static file tip behind checkpoint, unwind needed"
-            );
-            return Ok(Some(sf_tip));
-        }
-
-        if sf_tip == checkpoint {
-            return Ok(None);
-        }
-
-        let total_blocks = sf_tip - checkpoint;
-        tracing::info!(
-            target: "reth::providers::rocksdb",
-            sf_tip,
-            checkpoint,
-            total_blocks,
-            "AccountsHistory: healing via changesets"
-        );
-
-        let mut batch_start = checkpoint + 1;
-        let mut batch_num = 0u64;
-        let total_batches = total_blocks.div_ceil(HEAL_HISTORY_BATCH_SIZE);
-
-        while batch_start <= sf_tip {
-            let batch_end = (batch_start + HEAL_HISTORY_BATCH_SIZE - 1).min(sf_tip);
-            batch_num += 1;
-
-            let changesets = provider.account_changesets_range(batch_start..=batch_end)?;
-
-            if !changesets.is_empty() {
+    impl_heal_history! {
+        /// Heals the `AccountsHistory` table by removing stale entries.
+        ///
+        /// Returns an unwind target if static file tip is behind checkpoint (cannot heal).
+        /// Otherwise iterates changesets in batches to identify and unwind affected keys.
+        fn heal_accounts_history<Provider: DBProvider, StageCheckpointReader, StaticFileProviderFactory, ChangeSetReader>(
+            table: tables::AccountsHistory,
+            stage_id: StageId::IndexAccountHistory,
+            segment: StaticFileSegment::AccountChangeSets,
+            table_name: "AccountsHistory",
+            get_changesets: |prov, range| prov.account_changesets_range(range)?,
+            extract_indices: |changesets, checkpoint| {
                 let mut addresses = HashSet::with_capacity(changesets.len());
                 addresses.extend(changesets.iter().map(|(_, cs)| cs.address));
-
                 let unwind_from = checkpoint + 1;
-                let indices: Vec<_> =
-                    addresses.into_iter().map(|addr| (addr, unwind_from)).collect();
-
-                tracing::info!(
-                    target: "reth::providers::rocksdb",
-                    batch_num,
-                    total_batches,
-                    batch_start,
-                    batch_end,
-                    indices_count = indices.len(),
-                    "AccountsHistory: unwinding batch"
-                );
-
-                let batch = self.unwind_account_history_indices(&indices)?;
-                self.commit_batch(batch)?;
-            }
-
-            batch_start = batch_end + 1;
-        }
-
-        Ok(None)
+                addresses.into_iter().map(|addr| (addr, unwind_from)).collect::<Vec<_>>()
+            },
+            unwind: |this, indices| this.unwind_account_history_indices(indices)?,
+        )
     }
 }
 

--- a/crates/storage/provider/src/providers/rocksdb/invariants.rs
+++ b/crates/storage/provider/src/providers/rocksdb/invariants.rs
@@ -386,7 +386,8 @@ impl RocksDBProvider {
 mod tests {
     use super::*;
     use crate::{
-        providers::rocksdb::RocksDBBuilder, test_utils::create_test_provider_factory, BlockWriter,
+        providers::{rocksdb::RocksDBBuilder, static_file::StaticFileWriter},
+        test_utils::create_test_provider_factory, BlockWriter,
         DatabaseProviderFactory, StageCheckpointWriter, TransactionsProvider,
     };
     use alloy_primitives::{Address, B256};
@@ -1070,6 +1071,476 @@ mod tests {
             rocksdb.last::<tables::AccountsHistory>().unwrap().is_none(),
             "RocksDB should be empty after pruning"
         );
+    }
+
+    #[test]
+    fn test_check_consistency_accounts_history_sf_tip_equals_checkpoint_no_action() {
+        use reth_db::models::AccountBeforeTx;
+        use reth_db_api::models::ShardedKey;
+        use reth_static_file_types::StaticFileSegment;
+
+        let temp_dir = TempDir::new().unwrap();
+        let rocksdb = RocksDBBuilder::new(temp_dir.path())
+            .with_table::<tables::AccountsHistory>()
+            .build()
+            .unwrap();
+
+        // Insert some AccountsHistory entries with various highest_block_numbers
+        let key1 = ShardedKey::new(Address::ZERO, 50);
+        let key2 = ShardedKey::new(Address::random(), 75);
+        let key3 = ShardedKey::new(Address::random(), u64::MAX); // sentinel
+        let block_list1 = BlockNumberList::new_pre_sorted([10, 20, 30, 50]);
+        let block_list2 = BlockNumberList::new_pre_sorted([40, 60, 75]);
+        let block_list3 = BlockNumberList::new_pre_sorted([80, 90, 100]);
+        rocksdb.put::<tables::AccountsHistory>(key1, &block_list1).unwrap();
+        rocksdb.put::<tables::AccountsHistory>(key2, &block_list2).unwrap();
+        rocksdb.put::<tables::AccountsHistory>(key3, &block_list3).unwrap();
+
+        // Capture RocksDB state before consistency check
+        let entries_before: Vec<_> = rocksdb
+            .iter::<tables::AccountsHistory>()
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+        assert_eq!(entries_before.len(), 3, "Should have 3 entries before check");
+
+        // Create a test provider factory for MDBX
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(
+            StorageSettings::legacy().with_account_history_in_rocksdb(true),
+        );
+
+        // Write account changesets to static files for blocks 0-100
+        {
+            let sf_provider = factory.static_file_provider();
+            let mut writer = sf_provider
+                .latest_writer(StaticFileSegment::AccountChangeSets)
+                .unwrap();
+
+            for block_num in 0..=100 {
+                let changeset = vec![AccountBeforeTx {
+                    address: Address::random(),
+                    info: None,
+                }];
+                writer.append_account_changeset(changeset, block_num).unwrap();
+            }
+
+            writer.commit().unwrap();
+        }
+
+        // Set IndexAccountHistory checkpoint to block 100 (same as sf_tip)
+        {
+            let provider = factory.database_provider_rw().unwrap();
+            provider
+                .save_stage_checkpoint(StageId::IndexAccountHistory, StageCheckpoint::new(100))
+                .unwrap();
+            provider.commit().unwrap();
+        }
+
+        let provider = factory.database_provider_ro().unwrap();
+
+        // Verify sf_tip equals checkpoint (both at 100)
+        let sf_tip = provider
+            .static_file_provider()
+            .get_highest_static_file_block(StaticFileSegment::AccountChangeSets)
+            .unwrap();
+        assert_eq!(sf_tip, 100, "Static file tip should be 100");
+
+        // Run check_consistency - should return None (no unwind needed)
+        let result = rocksdb.check_consistency(&provider).unwrap();
+        assert_eq!(result, None, "sf_tip == checkpoint should not require unwind");
+
+        // Verify NO entries are deleted - RocksDB state unchanged
+        let entries_after: Vec<_> = rocksdb
+            .iter::<tables::AccountsHistory>()
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+
+        assert_eq!(
+            entries_after.len(),
+            entries_before.len(),
+            "RocksDB entry count should be unchanged when sf_tip == checkpoint"
+        );
+
+        // Verify exact entries are preserved
+        for (before, after) in entries_before.iter().zip(entries_after.iter()) {
+            assert_eq!(
+                before.0.key, after.0.key,
+                "Entry key should be unchanged"
+            );
+            assert_eq!(
+                before.0.highest_block_number, after.0.highest_block_number,
+                "Entry highest_block_number should be unchanged"
+            );
+            assert_eq!(
+                before.1, after.1,
+                "Entry block list should be unchanged"
+            );
+        }
+    }
+
+    /// Tests StoragesHistory changeset-based healing with enough blocks to trigger batching.
+    ///
+    /// Scenario:
+    /// 1. Generate 15,000 blocks worth of storage changeset data (to exceed the 10k batch size)
+    /// 2. Each block has 1 storage change (address + slot + value)
+    /// 3. Write storage changesets to static files for all 15k blocks
+    /// 4. Set IndexStorageHistory checkpoint to block 5000
+    /// 5. Insert stale StoragesHistory entries in RocksDB for (address, slot) pairs
+    ///    that changed in blocks 5001-15000
+    /// 6. Run check_consistency
+    /// 7. Verify stale entries for blocks > 5000 are pruned and batching worked
+    #[test]
+    fn test_check_consistency_storages_history_heals_via_changesets_large_range() {
+        use alloy_primitives::U256;
+        use reth_db_api::models::StorageBeforeTx;
+
+        const TOTAL_BLOCKS: u64 = 15_000;
+        const CHECKPOINT_BLOCK: u64 = 5_000;
+
+        let temp_dir = TempDir::new().unwrap();
+        let rocksdb = RocksDBBuilder::new(temp_dir.path())
+            .with_table::<tables::StoragesHistory>()
+            .build()
+            .unwrap();
+
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(
+            StorageSettings::legacy()
+                .with_storages_history_in_rocksdb(true)
+                .with_storage_changesets_in_static_files(true),
+        );
+
+        // Write storage changesets to static files for 15k blocks.
+        // Each block has 1 storage change with a unique (address, slot) pair.
+        {
+            let sf_provider = factory.static_file_provider();
+            let mut writer =
+                sf_provider.latest_writer(StaticFileSegment::StorageChangeSets).unwrap();
+
+            for block_num in 0..TOTAL_BLOCKS {
+                // Generate unique address and slot for each block
+                let mut addr_bytes = [0u8; 20];
+                addr_bytes[0..8].copy_from_slice(&block_num.to_le_bytes());
+                let address = Address::from(addr_bytes);
+
+                let mut slot_bytes = [0u8; 32];
+                slot_bytes[0..8].copy_from_slice(&block_num.to_le_bytes());
+                let slot = B256::from(slot_bytes);
+
+                let changeset = vec![StorageBeforeTx {
+                    address,
+                    key: slot,
+                    value: U256::from(block_num),
+                }];
+
+                writer.append_storage_changeset(changeset, block_num).unwrap();
+            }
+
+            writer.commit().unwrap();
+        }
+
+        // Verify static files have data up to block 14999
+        {
+            let sf_provider = factory.static_file_provider();
+            let highest = sf_provider
+                .get_highest_static_file_block(StaticFileSegment::StorageChangeSets)
+                .unwrap();
+            assert_eq!(
+                highest,
+                TOTAL_BLOCKS - 1,
+                "Static files should have blocks 0..14999"
+            );
+        }
+
+        // Set IndexStorageHistory checkpoint to block 5000
+        {
+            let provider = factory.database_provider_rw().unwrap();
+            provider
+                .save_stage_checkpoint(
+                    StageId::IndexStorageHistory,
+                    StageCheckpoint::new(CHECKPOINT_BLOCK),
+                )
+                .unwrap();
+            provider.commit().unwrap();
+        }
+
+        // Insert stale StoragesHistory entries for blocks 5001-14999
+        // These are (address, slot) pairs that changed after the checkpoint
+        for block_num in (CHECKPOINT_BLOCK + 1)..TOTAL_BLOCKS {
+            let mut addr_bytes = [0u8; 20];
+            addr_bytes[0..8].copy_from_slice(&block_num.to_le_bytes());
+            let address = Address::from(addr_bytes);
+
+            let mut slot_bytes = [0u8; 32];
+            slot_bytes[0..8].copy_from_slice(&block_num.to_le_bytes());
+            let slot = B256::from(slot_bytes);
+
+            // Create a stale entry with highest_block_number = block_num
+            let key = StorageShardedKey::new(address, slot, block_num);
+            let block_list = BlockNumberList::new_pre_sorted([block_num]);
+            rocksdb.put::<tables::StoragesHistory>(key, &block_list).unwrap();
+        }
+
+        // Verify RocksDB has stale entries before healing
+        let count_before: usize = rocksdb.iter::<tables::StoragesHistory>().unwrap().count();
+        assert_eq!(
+            count_before,
+            (TOTAL_BLOCKS - CHECKPOINT_BLOCK - 1) as usize,
+            "Should have {} stale entries before healing",
+            TOTAL_BLOCKS - CHECKPOINT_BLOCK - 1
+        );
+
+        // Run check_consistency - this should heal by pruning stale entries
+        let provider = factory.database_provider_ro().unwrap();
+        let result = rocksdb.check_consistency(&provider).unwrap();
+        assert_eq!(result, None, "Should heal via changesets, no unwind needed");
+
+        // Verify all stale entries were pruned
+        // After healing, entries with highest_block_number > checkpoint should be gone
+        let mut remaining_stale = 0;
+        for result in rocksdb.iter::<tables::StoragesHistory>().unwrap() {
+            let (key, _) = result.unwrap();
+            if key.sharded_key.highest_block_number > CHECKPOINT_BLOCK {
+                remaining_stale += 1;
+            }
+        }
+        assert_eq!(
+            remaining_stale, 0,
+            "All stale entries (block > {}) should be pruned",
+            CHECKPOINT_BLOCK
+        );
+    }
+
+    /// Tests AccountsHistory changeset-based healing with enough blocks to trigger batching.
+    ///
+    /// Scenario:
+    /// 1. Generate 15,000 blocks worth of account changeset data (to exceed the 10k batch size)
+    /// 2. Each block has 1 account change (simple - just random addresses)
+    /// 3. Write account changesets to static files for all 15k blocks
+    /// 4. Set IndexAccountHistory checkpoint to block 5000
+    /// 5. Insert stale AccountsHistory entries in RocksDB for addresses that changed
+    ///    in blocks 5001-15000
+    /// 6. Run check_consistency
+    /// 7. Verify:
+    ///    - Stale entries for blocks > 5000 are pruned
+    ///    - The batching worked (no OOM, completed successfully)
+    #[test]
+    fn test_check_consistency_accounts_history_heals_via_changesets_large_range() {
+        use reth_db::models::AccountBeforeTx;
+        use reth_db_api::models::ShardedKey;
+        use reth_static_file_types::StaticFileSegment;
+
+        let temp_dir = TempDir::new().unwrap();
+        let rocksdb = RocksDBBuilder::new(temp_dir.path())
+            .with_table::<tables::AccountsHistory>()
+            .build()
+            .unwrap();
+
+        // Create test provider factory
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(
+            StorageSettings::legacy()
+                .with_account_history_in_rocksdb(true)
+                .with_account_changesets_in_static_files(true),
+        );
+
+        const TOTAL_BLOCKS: u64 = 15_000;
+        const CHECKPOINT_BLOCK: u64 = 5_000;
+
+        // Generate unique addresses for each block
+        let addresses: Vec<Address> = (0..TOTAL_BLOCKS)
+            .map(|i| {
+                let mut addr = Address::ZERO;
+                addr.0[0..8].copy_from_slice(&i.to_le_bytes());
+                addr
+            })
+            .collect();
+
+        // Write account changesets to static files for all 15k blocks
+        {
+            let sf_provider = factory.static_file_provider();
+            let mut writer = sf_provider
+                .latest_writer(StaticFileSegment::AccountChangeSets)
+                .unwrap();
+
+            for block_num in 0..TOTAL_BLOCKS {
+                let changeset = vec![AccountBeforeTx {
+                    address: addresses[block_num as usize],
+                    info: None,
+                }];
+                writer.append_account_changeset(changeset, block_num).unwrap();
+            }
+
+            writer.commit().unwrap();
+        }
+
+        // Insert stale AccountsHistory entries in RocksDB for addresses that changed
+        // in blocks 5001-15000 (i.e., blocks after the checkpoint)
+        // These should be pruned by check_consistency
+        for block_num in (CHECKPOINT_BLOCK + 1)..TOTAL_BLOCKS {
+            let addr = addresses[block_num as usize];
+            // Create a shard with highest_block_number = block_num
+            let key = ShardedKey::new(addr, block_num);
+            let block_list = BlockNumberList::new_pre_sorted([block_num]);
+            rocksdb.put::<tables::AccountsHistory>(key, &block_list).unwrap();
+        }
+
+        // Also insert some valid entries for blocks <= 5000 that should NOT be pruned
+        for block_num in [100u64, 500, 1000, 2500, 5000] {
+            let addr = addresses[block_num as usize];
+            let key = ShardedKey::new(addr, block_num);
+            let block_list = BlockNumberList::new_pre_sorted([block_num]);
+            rocksdb.put::<tables::AccountsHistory>(key, &block_list).unwrap();
+        }
+
+        // Verify we have entries before healing
+        let entries_before: usize = rocksdb
+            .iter::<tables::AccountsHistory>()
+            .unwrap()
+            .count();
+        let stale_count = (TOTAL_BLOCKS - CHECKPOINT_BLOCK - 1) as usize;
+        let valid_count = 5usize;
+        assert_eq!(
+            entries_before,
+            stale_count + valid_count,
+            "Should have {} stale + {} valid entries before healing",
+            stale_count,
+            valid_count
+        );
+
+        // Set IndexAccountHistory checkpoint to block 5000
+        {
+            let provider = factory.database_provider_rw().unwrap();
+            provider
+                .save_stage_checkpoint(
+                    StageId::IndexAccountHistory,
+                    StageCheckpoint::new(CHECKPOINT_BLOCK),
+                )
+                .unwrap();
+            provider.commit().unwrap();
+        }
+
+        let provider = factory.database_provider_ro().unwrap();
+
+        // Verify sf_tip > checkpoint
+        let sf_tip = provider
+            .static_file_provider()
+            .get_highest_static_file_block(StaticFileSegment::AccountChangeSets)
+            .unwrap();
+        assert_eq!(sf_tip, TOTAL_BLOCKS - 1, "Static file tip should be 14999");
+        assert!(sf_tip > CHECKPOINT_BLOCK, "sf_tip should be > checkpoint to trigger healing");
+
+        // Run check_consistency - this should trigger batched changeset-based healing
+        let result = rocksdb.check_consistency(&provider).unwrap();
+        assert_eq!(result, None, "Healing should succeed without requiring unwind");
+
+        // Verify: all stale entries for blocks > 5000 should be pruned
+        // Count remaining entries with highest_block_number > checkpoint
+        let mut remaining_stale = 0;
+        for result in rocksdb.iter::<tables::AccountsHistory>().unwrap() {
+            let (key, _) = result.unwrap();
+            if key.highest_block_number > CHECKPOINT_BLOCK && key.highest_block_number != u64::MAX {
+                remaining_stale += 1;
+            }
+        }
+        assert_eq!(
+            remaining_stale, 0,
+            "All stale entries (block > {}) should be pruned",
+            CHECKPOINT_BLOCK
+        );
+    }
+
+    #[test]
+    fn test_check_consistency_storages_history_sf_tip_equals_checkpoint_no_action() {
+        use alloy_primitives::U256;
+        use reth_db::models::StorageBeforeTx;
+        use reth_static_file_types::StaticFileSegment;
+
+        let temp_dir = TempDir::new().unwrap();
+        let rocksdb = RocksDBBuilder::new(temp_dir.path())
+            .with_table::<tables::StoragesHistory>()
+            .build()
+            .unwrap();
+
+        // Insert StoragesHistory entries into RocksDB
+        let key1 = StorageShardedKey::new(Address::ZERO, B256::ZERO, 50);
+        let key2 = StorageShardedKey::new(Address::random(), B256::random(), 80);
+        let block_list1 = BlockNumberList::new_pre_sorted([10, 20, 30, 50]);
+        let block_list2 = BlockNumberList::new_pre_sorted([40, 60, 80]);
+        rocksdb.put::<tables::StoragesHistory>(key1.clone(), &block_list1).unwrap();
+        rocksdb.put::<tables::StoragesHistory>(key2.clone(), &block_list2).unwrap();
+
+        // Capture entries before consistency check
+        let entries_before: Vec<_> = rocksdb
+            .iter::<tables::StoragesHistory>()
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+
+        // Create a test provider factory
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(
+            StorageSettings::legacy().with_storages_history_in_rocksdb(true),
+        );
+
+        // Write storage changesets to static files for blocks 0-100
+        {
+            let sf_provider = factory.static_file_provider();
+            let mut writer = sf_provider.latest_writer(StaticFileSegment::StorageChangeSets).unwrap();
+
+            for block_num in 0..=100u64 {
+                let changeset = vec![StorageBeforeTx {
+                    address: Address::ZERO,
+                    key: B256::with_last_byte(block_num as u8),
+                    value: U256::from(block_num),
+                }];
+                writer.append_storage_changeset(changeset, block_num).unwrap();
+            }
+            writer.commit().unwrap();
+        }
+
+        // Set IndexStorageHistory checkpoint to block 100 (same as sf_tip)
+        {
+            let provider = factory.database_provider_rw().unwrap();
+            provider
+                .save_stage_checkpoint(StageId::IndexStorageHistory, StageCheckpoint::new(100))
+                .unwrap();
+            provider.commit().unwrap();
+        }
+
+        let provider = factory.database_provider_ro().unwrap();
+
+        // Verify sf_tip equals checkpoint (both at 100)
+        let sf_tip = provider
+            .static_file_provider()
+            .get_highest_static_file_block(StaticFileSegment::StorageChangeSets)
+            .unwrap();
+        assert_eq!(sf_tip, 100, "Static file tip should be 100");
+
+        // Run check_consistency - should return None (no unwind needed)
+        let result = rocksdb.check_consistency(&provider).unwrap();
+        assert_eq!(result, None, "sf_tip == checkpoint should not require unwind");
+
+        // Verify NO entries are deleted - RocksDB state unchanged
+        let entries_after: Vec<_> = rocksdb
+            .iter::<tables::StoragesHistory>()
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+
+        assert_eq!(
+            entries_after.len(),
+            entries_before.len(),
+            "RocksDB entry count should be unchanged when sf_tip == checkpoint"
+        );
+
+        // Verify exact entries are preserved
+        for (before, after) in entries_before.iter().zip(entries_after.iter()) {
+            assert_eq!(before.0, after.0, "Entry key should be unchanged");
+            assert_eq!(before.1, after.1, "Entry block list should be unchanged");
+        }
     }
 
 }

--- a/crates/storage/provider/src/providers/rocksdb/invariants.rs
+++ b/crates/storage/provider/src/providers/rocksdb/invariants.rs
@@ -27,7 +27,7 @@ const HEAL_HISTORY_BATCH_SIZE: u64 = 10_000;
 /// Generates a `heal_*_history` method for a history table.
 ///
 /// This macro deduplicates the common healing logic between `StoragesHistory` and
-/// `AccountsHistory`, which share identical checkpoint/sf_tip handling and batch loop structure.
+/// `AccountsHistory`, which share identical `checkpoint/sf_tip` handling and batch loop structure.
 macro_rules! impl_heal_history {
     (
         $(#[$attr:meta])*


### PR DESCRIPTION
## Summary

Replaces O(n) table scan with changeset-based healing for RocksDB history tables.

## Problem

After a crash with auto-commit mid-stage (PR #21334), RocksDB may have stale data beyond the MDBX checkpoint. Previous approach scanned ALL entries to detect this.

## Solution

1. **Fast path**: `checkpoint == 0` + has data → clear entire table
2. **Slow path**: iterate changesets in `(checkpoint, sf_tip]` batches of 10k, prune via `unwind_*_history_indices()`

## Why not a RocksDB watermark?

History index stages sort data by address (for shard merging), not by block. During writes:
- Address 0x0001 touches blocks [5, 100, 5000]
- Address 0x0002 touches blocks [3, 7, 50000]
- Address 0xFFFF touches blocks [10, 20]

At any point mid-write, there's no consistent block boundary—we've touched a mix of blocks across addresses. A watermark like "committed up to block X" is meaningless because unwritten addresses may reference blocks < X.

## Changes

| Before | After |
|--------|-------|
| `check_accounts_history`: O(n) scan | O(changesets in stale range) |
| `check_storages_history`: O(n) scan | O(changesets in stale range) |
| `prune_*_history_above` functions | Removed (use unwind instead) |

## Tests

18 tests including 15k-block batching tests.

Closes #21313, #21294, #21342