### PR TITLE
chore(etc): update ethereum-metrics-exporter GitHub URL

### DIFF
--- a/etc/grafana/dashboards/metrics-exporter.json
+++ b/etc/grafana/dashboards/metrics-exporter.json
@@ -21,7 +21,7 @@
         }
       ]
     },
-    "description": "Companion dashboard for https://github.com/samcm/ethereum-metrics-exporter",
+    "description": "Companion dashboard for https://github.com/ethpandaops/ethereum-metrics-exporter",
     "editable": true,
     "fiscalYearStartMonth": 0,
     "gnetId": 16277,


### PR DESCRIPTION
The ethereum-metrics-exporter project has moved from `samcm` to `ethpandaops` organization. While the old URL still redirects automatically, this change:
- Avoids potential confusion for users clicking the link
- Maintains consistency with the Docker image reference (`ethpandaops/ethereum-metrics-exporter`) used in `lighthouse.yml`