### PR TITLE
feat(net): add memory-bounded channel for transaction events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3869,6 +3869,7 @@ dependencies = [
  "eyre",
  "futures",
  "reth-ethereum",
+ "reth-metrics",
  "reth-tracing",
  "tokio",
 ]
@@ -9137,6 +9138,7 @@ dependencies = [
  "futures",
  "metrics",
  "metrics-derive",
+ "reth-primitives-traits",
  "tokio",
  "tokio-util",
 ]

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -16,10 +16,13 @@ workspace = true
 metrics.workspace = true
 metrics-derive.workspace = true
 
+# reth
+reth-primitives-traits = { workspace = true, optional = true }
+
 # async
 tokio = { workspace = true, features = ["full"], optional = true }
 futures = { workspace = true, optional = true }
 tokio-util = { workspace = true, optional = true }
 
 [features]
-common = ["tokio", "futures", "tokio-util"]
+common = ["tokio", "futures", "tokio-util", "reth-primitives-traits"]

--- a/crates/net/eth-wire-types/src/broadcast.rs
+++ b/crates/net/eth-wire-types/src/broadcast.rs
@@ -13,7 +13,7 @@ use core::{fmt::Debug, mem};
 use derive_more::{Constructor, Deref, DerefMut, From, IntoIterator};
 use reth_codecs_derive::{add_arbitrary_tests, generate_tests};
 use reth_ethereum_primitives::TransactionSigned;
-use reth_primitives_traits::{Block, SignedTransaction};
+use reth_primitives_traits::{Block, InMemorySize, SignedTransaction};
 
 /// This informs peers of new blocks that have appeared on the network.
 #[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Default)]
@@ -803,6 +803,19 @@ pub struct BlockRangeUpdate {
     pub latest: u64,
     /// Latest available block's hash.
     pub latest_hash: B256,
+}
+
+impl InMemorySize for NewPooledTransactionHashes {
+    fn size(&self) -> usize {
+        match self {
+            Self::Eth66(msg) => msg.0.len() * core::mem::size_of::<B256>(),
+            Self::Eth68(msg) => {
+                msg.types.len() * core::mem::size_of::<u8>() +
+                    msg.sizes.len() * core::mem::size_of::<usize>() +
+                    msg.hashes.len() * core::mem::size_of::<B256>()
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/net/eth-wire-types/src/transactions.rs
+++ b/crates/net/eth-wire-types/src/transactions.rs
@@ -7,6 +7,7 @@ use alloy_primitives::B256;
 use alloy_rlp::{RlpDecodableWrapper, RlpEncodableWrapper};
 use derive_more::{Constructor, Deref, IntoIterator};
 use reth_codecs_derive::add_arbitrary_tests;
+use reth_primitives_traits::InMemorySize;
 
 /// A list of transaction hashes that the peer would like transaction bodies for.
 #[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Default)]
@@ -24,6 +25,12 @@ where
 {
     fn from(hashes: Vec<T>) -> Self {
         Self(hashes.into_iter().map(|h| h.into()).collect())
+    }
+}
+
+impl InMemorySize for GetPooledTransactions {
+    fn size(&self) -> usize {
+        self.0.len() * core::mem::size_of::<B256>()
     }
 }
 

--- a/crates/net/network/src/metrics.rs
+++ b/crates/net/network/src/metrics.rs
@@ -52,6 +52,9 @@ pub struct NetworkMetrics {
     /// Number of Eth Requests dropped due to channel being at full capacity
     pub(crate) total_dropped_eth_requests_at_full_capacity: Counter,
 
+    /// Number of transaction events dropped due to the tx manager channel being at full capacity
+    pub(crate) total_dropped_tx_events_at_full_capacity: Counter,
+
     /* ================ POLL DURATION ================ */
 
     /* -- Total poll duration of `NetworksManager` future -- */

--- a/examples/network-proxy/Cargo.toml
+++ b/examples/network-proxy/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 
 [dependencies]
 reth-ethereum = { workspace = true, features = ["network"] }
+reth-metrics.workspace = true
 reth-tracing.workspace = true
 futures.workspace = true
 tokio.workspace = true


### PR DESCRIPTION
## Summary

Implement a semaphore-based memory-bounded channel between `NetworkManager` and `TransactionsManager` to prevent unbounded memory growth when transaction events queue up faster than they can be processed.

## Problem

The current `to_transactions_manager` channel is unbounded, which means during heavy network activity (e.g., transaction announcement floods), messages can accumulate without limit, potentially consuming all available memory.

## Solution

Use a **byte-budget semaphore** pattern:
- Each message must "acquire" semaphore permits equal to its in-memory size before being sent
- Permits are held in a `Budgeted<T>` envelope until the message is dropped by the receiver
- When the budget (default 1GB) is exhausted, `try_send` returns `Full` and the event is dropped with a metric counter

### Key Changes

1. **`reth-metrics`**: Added `MemoryBoundedSender<T>` and `MemoryBoundedReceiver<T>` wrappers
   - `Budgeted<T>` envelope holds owned semaphore permits (RAII pattern)
   - Per-message overhead of 256 bytes added for envelope/permit costs
   
2. **`reth-eth-wire-types`**: Added `InMemorySize` implementations for:
   - `NewPooledTransactionHashes`
   - `GetPooledTransactions`

3. **`reth-network`**:
   - `NetworkTransactionEvent<N>` now implements `InMemorySize`
   - Control plane messages (`GetTransactionsHandle`) return size 0 to avoid blocking
   - `notify_tx_manager` uses `try_send` with backpressure - drops events when at capacity
   - Added `total_dropped_tx_events_at_full_capacity` metric
   - `TransactionsManager` receives `Budgeted<NetworkTransactionEvent<N>>` and unwraps

## Testing

All 119 existing tests in `reth-network` pass.

## Configuration

The memory limit is set to 1GB via:
```rust
const TX_MANAGER_CHANNEL_MEMORY_LIMIT_BYTES: usize = 1024 * 1024 * 1024; // 1GB
```
