### PR TITLE
feat: add ReceiptExt for backwards-compatible receipt field extensions

### DIFF
--- a/crates/ethereum/primitives/src/receipt.rs
+++ b/crates/ethereum/primitives/src/receipt.rs
@@ -490,8 +490,7 @@ mod compact {
     /// All new fields should be added here in the form of a `Option<T>`, since `Option<ReceiptExt>`
     /// is used as an extension field for backwards compatibility.
     ///
-    /// More information: <https://github.com/paradigmxyz/reth/issues/7820> &
-    /// [`reth_codecs_derive::Compact`].
+    /// More information: <https://github.com/paradigmxyz/reth/issues/7820>
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
     #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Compact)]

--- a/crates/ethereum/primitives/src/receipt.rs
+++ b/crates/ethereum/primitives/src/receipt.rs
@@ -635,7 +635,7 @@ mod tests {
     }
 
     /// Test vectors generated from main branch to ensure backwards compatibility.
-    /// These test that receipts encoded before ReceiptExt was added can still be decoded.
+    /// These test that receipts encoded before [`ReceiptExt`] was added can still be decoded.
     #[test]
     #[cfg(feature = "reth-codec")]
     fn test_backwards_compat_decode_legacy_receipt() {


### PR DESCRIPTION
## Summary

Adds `ReceiptExt` struct following the [`HeaderExt` pattern](https://github.com/paradigmxyz/reth/blob/main/crates/storage/codecs/src/alloy/header.rs#L48-L76) to enable adding new receipt fields (e.g., for Glamsterdam hardfork) without breaking backwards compatibility.

## Problem

The `Receipt` compact encoding uses all 8 bits in its flags byte (0 unused bits):
- `tx_type_len`: 2 bits
- `success_len`: 1 bit
- `cumulative_gas_used_len`: 4 bits
- `__zstd`: 1 bit

This means new fields cannot be added directly to Receipt without a breaking change.

## Solution

Following the established pattern from `HeaderExt` ([#7820](https://github.com/paradigmxyz/reth/issues/7820)), this PR adds:
- `ReceiptExt` struct with `#[derive(Compact)]`
- `into_option()` helper for conditional serialization
- Backwards compatibility test for the bitflags
- **Comprehensive test vectors** generated from main branch to verify old receipts decode correctly

### Test Vectors

Test vectors were generated on `main` branch and verify:
- Legacy receipt (small, no logs)
- EIP-1559 receipt (no logs)  
- EIP-4844 failed receipt (success=false)
- Receipt with logs (zstd compressed)
- All tx types roundtrip

## Next Steps

When the glam field is known:
1. Add the field as `Option<T>` to `ReceiptExt`
2. Update `ReceiptExt::into_option()` to check the new field
3. Wire `extra_fields: Option<ReceiptExt>` into the Compact impl
4. Update the test to expect `UnusedBits::NotZero`

## For OP Receipts

`CompactOpReceipt` already has unused bits (`UnusedBits::NotZero`), so glam fields can be added directly there as `Option<T>` or use a shared `ReceiptExt` for consistency.

cc @mattsse