### PR TITLE
feat(cli): add `reth db get rocksdb` subcommand

### DIFF
--- a/crates/cli/commands/src/db/checksum/mod.rs
+++ b/crates/cli/commands/src/db/checksum/mod.rs
@@ -24,6 +24,8 @@ use tracing::{info, warn};
 
 #[cfg(all(unix, feature = "edge"))]
 mod rocksdb;
+#[cfg(all(unix, feature = "edge"))]
+pub use rocksdb::RocksDbTable;
 
 /// Interval for logging progress during checksum computation.
 const PROGRESS_LOG_INTERVAL: usize = 100_000;

--- a/crates/cli/commands/src/db/get.rs
+++ b/crates/cli/commands/src/db/get.rs
@@ -35,44 +35,58 @@ pub struct Command {
 
 #[derive(clap::Subcommand, Debug)]
 enum Subcommand {
+    /// Gets the content of a database table for the given key
     Mdbx {
         table: tables::Tables,
 
+        /// The key to get content for
         #[arg(value_parser = maybe_json_value_parser)]
         key: String,
 
+        /// The subkey to get content for
         #[arg(value_parser = maybe_json_value_parser)]
         subkey: Option<String>,
 
+        /// Optional end key for range query (exclusive upper bound)
         #[arg(value_parser = maybe_json_value_parser)]
         end_key: Option<String>,
 
+        /// Optional end subkey for range query (exclusive upper bound)
         #[arg(value_parser = maybe_json_value_parser)]
         end_subkey: Option<String>,
 
+        /// Output bytes instead of human-readable decoded value
         #[arg(long)]
         raw: bool,
     },
+    /// Gets the content of a static file segment for the given key
     StaticFile {
         segment: StaticFileSegment,
 
+        /// The key to get content for
         #[arg(value_parser = maybe_json_value_parser)]
         key: String,
 
+        /// The subkey to get content for, for example address in changeset
         #[arg(value_parser = maybe_json_value_parser)]
         subkey: Option<String>,
 
+        /// Output bytes instead of human-readable decoded value
         #[arg(long)]
         raw: bool,
     },
+    /// Gets the content of a RocksDB table for the given key
     #[cfg(all(unix, feature = "edge"))]
     Rocksdb {
+        /// The RocksDB table
         #[arg(value_enum)]
         table: RocksDbTable,
 
+        /// The key to get content for
         #[arg(value_parser = maybe_json_value_parser)]
         key: String,
 
+        /// Output bytes instead of human-readable decoded value
         #[arg(long)]
         raw: bool,
     },


### PR DESCRIPTION
Adds RocksDB support to the `reth db get` command, completing the tooling for RocksDB tables alongside MDBX and static files.

Usage:
```
  reth db get rocksdb transaction-hash-numbers '"0xabc..."'
  reth db get rocksdb accounts-history '{ "key": "0x...", "highest_block_number": 12345 }'
  reth db get rocksdb storages-history '...' --raw
```

This was the last missing piece - we now have checksum (#21217), list(#21364), and get(this) for RocksDB. Users can finally look up specific entries without iterating through the entire table.