### PR TITLE
feat(stages): flush RocksDB in FinishStage with edge feature

### DIFF
--- a/crates/stages/stages/Cargo.toml
+++ b/crates/stages/stages/Cargo.toml
@@ -119,6 +119,7 @@ test-utils = [
     "reth-evm-ethereum/test-utils",
 ]
 rocksdb = ["reth-provider/rocksdb"]
+edge = ["reth-provider/edge", "rocksdb"]
 
 [[bench]]
 name = "criterion"

--- a/crates/storage/errors/src/db.rs
+++ b/crates/storage/errors/src/db.rs
@@ -115,6 +115,8 @@ pub enum DatabaseWriteOperation {
     PutUpsert,
     /// Put append.
     PutAppend,
+    /// Flush operation (WAL/memtable).
+    Flush,
 }
 
 /// Database log level.


### PR DESCRIPTION
## Summary

Add RocksDB flush (WAL and memtables) in the `FinishStage` to ensure data durability at sync boundaries.

When the `rocksdb` or `edge` feature is enabled:
- Flushes the WAL with sync to ensure durability
- Flushes all column family memtables to SST files

This ensures all pending writes are persisted to disk before marking a sync checkpoint as complete.

## Changes

- Add `flush()` method to `RocksDBProvider` with tracing instrumentation
- Add `Flush` variant to `DatabaseWriteOperation` enum
- Add `edge` feature to `reth-stages` (enables `reth-provider/edge` + `rocksdb`)
- Modify `FinishStage` to call `flush()` when the `rocksdb` feature is enabled

## Usage

Enable the `edge` or `rocksdb` feature in `reth-stages`:

```toml
reth-stages = { version = "...", features = ["edge"] }
```

## Testing

The flush is guarded by `!rocksdb.is_read_only()` to avoid panics in read-only scenarios.