### PR TITLE
feat(stages): flush RocksDB at end of history and tx_lookup stages

### DIFF
--- a/crates/stages/stages/src/stages/index_account_history.rs
+++ b/crates/stages/stages/src/stages/index_account_history.rs
@@ -1,6 +1,8 @@
 use super::collect_account_history_indices;
 use crate::stages::utils::{collect_history_indices, load_account_history};
 use reth_config::config::{EtlConfig, IndexHistoryConfig};
+#[cfg(all(unix, feature = "rocksdb"))]
+use reth_db_api::table::Table;
 use reth_db_api::{models::ShardedKey, tables, transaction::DbTxMut};
 use reth_provider::{
     DBProvider, EitherWriter, HistoryWriter, PruneCheckpointReader, PruneCheckpointWriter,
@@ -142,6 +144,11 @@ where
                 .map_err(|e| reth_provider::ProviderError::other(Box::new(e)))?;
             Ok(((), writer.into_raw_rocksdb_batch()))
         })?;
+
+        #[cfg(all(unix, feature = "rocksdb"))]
+        if use_rocksdb {
+            provider.rocksdb_provider().flush(&[tables::AccountsHistory::NAME])?;
+        }
 
         Ok(ExecOutput { checkpoint: StageCheckpoint::new(*range.end()), done: true })
     }

--- a/crates/stages/stages/src/stages/index_account_history.rs
+++ b/crates/stages/stages/src/stages/index_account_history.rs
@@ -1,9 +1,7 @@
 use super::collect_account_history_indices;
 use crate::stages::utils::{collect_history_indices, load_account_history};
 use reth_config::config::{EtlConfig, IndexHistoryConfig};
-#[cfg(all(unix, feature = "rocksdb"))]
-use reth_db_api::table::Table;
-use reth_db_api::{models::ShardedKey, tables, transaction::DbTxMut};
+use reth_db_api::{models::ShardedKey, table::Table, tables, transaction::DbTxMut};
 use reth_provider::{
     DBProvider, EitherWriter, HistoryWriter, PruneCheckpointReader, PruneCheckpointWriter,
     RocksDBProviderFactory, StorageSettingsCache,
@@ -113,7 +111,6 @@ where
                 // but this is safe for first_sync because if we crash before commit, the
                 // checkpoint stays at 0 and we'll just clear and rebuild again on restart. The
                 // source data (changesets) is intact.
-                #[cfg(all(unix, feature = "rocksdb"))]
                 provider.rocksdb_provider().clear::<tables::AccountsHistory>()?;
             } else {
                 provider.tx_ref().clear::<tables::AccountsHistory>()?;
@@ -145,7 +142,6 @@ where
             Ok(((), writer.into_raw_rocksdb_batch()))
         })?;
 
-        #[cfg(all(unix, feature = "rocksdb"))]
         if use_rocksdb {
             provider.rocksdb_provider().flush(&[tables::AccountsHistory::NAME])?;
         }

--- a/crates/stages/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/stages/src/stages/index_storage_history.rs
@@ -1,6 +1,8 @@
 use super::{collect_history_indices, collect_storage_history_indices};
 use crate::{stages::utils::load_storage_history, StageCheckpoint, StageId};
 use reth_config::config::{EtlConfig, IndexHistoryConfig};
+#[cfg(all(unix, feature = "rocksdb"))]
+use reth_db_api::table::Table;
 use reth_db_api::{
     models::{storage_sharded_key::StorageShardedKey, AddressStorageKey, BlockNumberAddress},
     tables,
@@ -146,6 +148,11 @@ where
                 .map_err(|e| reth_provider::ProviderError::other(Box::new(e)))?;
             Ok(((), writer.into_raw_rocksdb_batch()))
         })?;
+
+        #[cfg(all(unix, feature = "rocksdb"))]
+        if use_rocksdb {
+            provider.rocksdb_provider().flush(&[tables::StoragesHistory::NAME])?;
+        }
 
         Ok(ExecOutput { checkpoint: StageCheckpoint::new(*range.end()), done: true })
     }

--- a/crates/stages/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/stages/src/stages/index_storage_history.rs
@@ -1,10 +1,9 @@
 use super::{collect_history_indices, collect_storage_history_indices};
 use crate::{stages::utils::load_storage_history, StageCheckpoint, StageId};
 use reth_config::config::{EtlConfig, IndexHistoryConfig};
-#[cfg(all(unix, feature = "rocksdb"))]
-use reth_db_api::table::Table;
 use reth_db_api::{
     models::{storage_sharded_key::StorageShardedKey, AddressStorageKey, BlockNumberAddress},
+    table::Table,
     tables,
     transaction::DbTxMut,
 };
@@ -117,7 +116,6 @@ where
                 // but this is safe for first_sync because if we crash before commit, the
                 // checkpoint stays at 0 and we'll just clear and rebuild again on restart. The
                 // source data (changesets) is intact.
-                #[cfg(all(unix, feature = "rocksdb"))]
                 provider.rocksdb_provider().clear::<tables::StoragesHistory>()?;
             } else {
                 provider.tx_ref().clear::<tables::StoragesHistory>()?;
@@ -149,7 +147,6 @@ where
             Ok(((), writer.into_raw_rocksdb_batch()))
         })?;
 
-        #[cfg(all(unix, feature = "rocksdb"))]
         if use_rocksdb {
             provider.rocksdb_provider().flush(&[tables::StoragesHistory::NAME])?;
         }

--- a/crates/stages/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/stages/src/stages/tx_lookup.rs
@@ -2,10 +2,8 @@ use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{TxHash, TxNumber};
 use num_traits::Zero;
 use reth_config::config::{EtlConfig, TransactionLookupConfig};
-#[cfg(all(unix, feature = "rocksdb"))]
-use reth_db_api::table::Table;
 use reth_db_api::{
-    table::{Decode, Decompress, Value},
+    table::{Decode, Decompress, Table, Value},
     tables,
     transaction::DbTxMut,
 };
@@ -202,7 +200,6 @@ where
             }
         }
 
-        #[cfg(all(unix, feature = "rocksdb"))]
         provider.rocksdb_provider().flush(&[tables::TransactionHashNumbers::NAME])?;
 
         Ok(ExecOutput {

--- a/crates/stages/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/stages/src/stages/tx_lookup.rs
@@ -200,7 +200,9 @@ where
             }
         }
 
-        provider.rocksdb_provider().flush(&[tables::TransactionHashNumbers::NAME])?;
+        if provider.cached_storage_settings().transaction_hash_numbers_in_rocksdb {
+            provider.rocksdb_provider().flush(&[tables::TransactionHashNumbers::NAME])?;
+        }
 
         Ok(ExecOutput {
             checkpoint: StageCheckpoint::new(input.target())

--- a/crates/stages/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/stages/src/stages/tx_lookup.rs
@@ -2,6 +2,8 @@ use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{TxHash, TxNumber};
 use num_traits::Zero;
 use reth_config::config::{EtlConfig, TransactionLookupConfig};
+#[cfg(all(unix, feature = "rocksdb"))]
+use reth_db_api::table::Table;
 use reth_db_api::{
     table::{Decode, Decompress, Value},
     tables,
@@ -199,6 +201,9 @@ where
                 break;
             }
         }
+
+        #[cfg(all(unix, feature = "rocksdb"))]
+        provider.rocksdb_provider().flush(&[tables::TransactionHashNumbers::NAME])?;
 
         Ok(ExecOutput {
             checkpoint: StageCheckpoint::new(input.target())

--- a/crates/storage/errors/src/db.rs
+++ b/crates/storage/errors/src/db.rs
@@ -115,6 +115,8 @@ pub enum DatabaseWriteOperation {
     PutUpsert,
     /// Put append.
     PutAppend,
+    /// Flush to disk.
+    Flush,
 }
 
 /// Database log level.

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -1260,9 +1260,6 @@ impl<'a> RocksDBBatch<'a> {
     ///
     /// This is called after each `put` or `delete` operation to prevent unbounded memory growth.
     /// Returns immediately if auto-commit is disabled or threshold not reached.
-    ///
-    /// This also flushes the WAL and memtables to disk after committing.
-    #[instrument(level = "debug", target = "providers::rocksdb", skip_all, fields(batch_size = self.inner.size_in_bytes()))]
     fn maybe_auto_commit(&mut self) -> ProviderResult<()> {
         if let Some(threshold) = self.auto_commit_threshold &&
             self.inner.size_in_bytes() >= threshold
@@ -1282,13 +1279,6 @@ impl<'a> RocksDBBatch<'a> {
                     }))
                 },
             )?;
-
-            self.provider.flush(ROCKSDB_TABLES)?;
-
-            tracing::info!(
-                target: "providers::rocksdb",
-                "Flushed RocksDB WAL and memtables after auto-commit"
-            );
         }
         Ok(())
     }

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -1274,12 +1274,14 @@ impl<'a> RocksDBBatch<'a> {
                 "Auto-committing RocksDB batch"
             );
             let old_batch = std::mem::take(&mut self.inner);
-            self.provider.0.db_rw().write_opt(old_batch, &WriteOptions::default()).map_err(|e| {
-                ProviderError::Database(DatabaseError::Commit(DatabaseErrorInfo {
-                    message: e.to_string().into(),
-                    code: -1,
-                }))
-            })?;
+            self.provider.0.db_rw().write_opt(old_batch, &WriteOptions::default()).map_err(
+                |e| {
+                    ProviderError::Database(DatabaseError::Commit(DatabaseErrorInfo {
+                        message: e.to_string().into(),
+                        code: -1,
+                    }))
+                },
+            )?;
 
             self.provider.flush(ROCKSDB_TABLES)?;
 

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -1261,9 +1261,7 @@ impl<'a> RocksDBBatch<'a> {
     /// This is called after each `put` or `delete` operation to prevent unbounded memory growth.
     /// Returns immediately if auto-commit is disabled or threshold not reached.
     ///
-    /// This also flushes the WAL and memtables to disk after committing. Since data is inserted
-    /// in sorted order, this results in trivial compaction moves rather than expensive merge
-    /// operations.
+    /// This also flushes the WAL and memtables to disk after committing.
     #[instrument(level = "debug", target = "providers::rocksdb", skip_all, fields(batch_size = self.inner.size_in_bytes()))]
     fn maybe_auto_commit(&mut self) -> ProviderResult<()> {
         if let Some(threshold) = self.auto_commit_threshold &&

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -1274,8 +1274,7 @@ impl<'a> RocksDBBatch<'a> {
                 "Auto-committing RocksDB batch"
             );
             let old_batch = std::mem::take(&mut self.inner);
-            let db = self.provider.0.db_rw();
-            db.write_opt(old_batch, &WriteOptions::default()).map_err(|e| {
+            self.provider.0.db_rw().write_opt(old_batch, &WriteOptions::default()).map_err(|e| {
                 ProviderError::Database(DatabaseError::Commit(DatabaseErrorInfo {
                     message: e.to_string().into(),
                     code: -1,

--- a/crates/storage/provider/src/providers/rocksdb_stub.rs
+++ b/crates/storage/provider/src/providers/rocksdb_stub.rs
@@ -88,6 +88,13 @@ impl RocksDBProvider {
     pub const fn clear<T>(&self) -> ProviderResult<()> {
         Ok(())
     }
+
+    /// Flushes all pending writes to disk (stub implementation).
+    ///
+    /// This is a no-op since there is no `RocksDB` when the feature is disabled.
+    pub const fn flush(&self) -> ProviderResult<()> {
+        Ok(())
+    }
 }
 
 impl DatabaseMetrics for RocksDBProvider {

--- a/crates/storage/provider/src/providers/rocksdb_stub.rs
+++ b/crates/storage/provider/src/providers/rocksdb_stub.rs
@@ -92,7 +92,7 @@ impl RocksDBProvider {
     /// Flushes all pending writes to disk (stub implementation).
     ///
     /// This is a no-op since there is no `RocksDB` when the feature is disabled.
-    pub const fn flush(&self) -> ProviderResult<()> {
+    pub const fn flush(&self, _tables: &[&'static str]) -> ProviderResult<()> {
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

Added RocksDB flush support at the end of specific sync stages to improve data durability and WAL management.

## Changes

1. **Added `flush(tables)` method to `RocksDBProvider`** - Flushes the WAL and specified column family memtables to SST files on disk.

2. **Added `Flush` variant to `DatabaseWriteOperation`** - Enables proper error handling and context for flush operations.

3. **Flush called at end of `execute()` for:**
   - `TransactionLookupStage` → flushes `TransactionHashNumbers` table
   - `IndexAccountHistoryStage` → flushes `AccountsHistory` table
   - `IndexStorageHistoryStage` → flushes `StoragesHistory` table

4. **Flush only happens when the stage completes** (i.e., reaches target block) - not on partial progress.

## Benefits

- **Data durability** - Ensures data is persisted to SST files before the pipeline moves to the next stage
- **Bounded WAL size** - Prevents unbounded WAL growth during long-running stages
- **Faster crash recovery** - Less WAL replay needed on restart since data is already in SST files