### PR TITLE
fix(libmdbx): handle errors gracefully in TransactionInner::drop

### DIFF
--- a/crates/storage/libmdbx-rs/src/transaction.rs
+++ b/crates/storage/libmdbx-rs/src/transaction.rs
@@ -339,26 +339,31 @@ where
     fn drop(&mut self) {
         // To be able to abort a timed out transaction, we need to renew it first.
         // Hence the usage of `txn_execute_renew_on_timeout` here.
-        self.txn
-            .txn_execute_renew_on_timeout(|txn| {
-                if !self.has_committed() {
-                    if K::IS_READ_ONLY {
-                        #[cfg(feature = "read-tx-timeouts")]
-                        self.env.txn_manager().remove_active_read_transaction(txn);
+        //
+        // We intentionally ignore errors here because Drop should never panic.
+        // MDBX can return errors (e.g., MDBX_PANIC) during abort if the environment
+        // is in a fatal state, but panicking in Drop can cause double-panics during
+        // unwinding which terminates the process.
+        let _ = self.txn.txn_execute_renew_on_timeout(|txn| {
+            if !self.has_committed() {
+                if K::IS_READ_ONLY {
+                    #[cfg(feature = "read-tx-timeouts")]
+                    self.env.txn_manager().remove_active_read_transaction(txn);
 
-                        unsafe {
-                            ffi::mdbx_txn_abort(txn);
-                        }
-                    } else {
-                        let (sender, rx) = sync_channel(0);
-                        self.env
-                            .txn_manager()
-                            .send_message(TxnManagerMessage::Abort { tx: TxnPtr(txn), sender });
-                        rx.recv().unwrap().unwrap();
+                    unsafe {
+                        ffi::mdbx_txn_abort(txn);
+                    }
+                } else {
+                    let (sender, rx) = sync_channel(0);
+                    self.env
+                        .txn_manager()
+                        .send_message(TxnManagerMessage::Abort { tx: TxnPtr(txn), sender });
+                    if let Ok(Err(e)) = rx.recv() {
+                        tracing::error!(target: "libmdbx", %e, "failed to abort transaction in drop");
                     }
                 }
-            })
-            .unwrap();
+            }
+        });
     }
 }
 


### PR DESCRIPTION
## Summary

Drop implementations should never panic as this can cause double-panics during stack unwinding which terminates the process. When MDBX is in a fatal state (e.g., meta page corruption, IO errors), it returns `MDBX_PANIC` during transaction abort. Previously, this would panic due to `unwrap()` calls on the abort result.

## Problem

During heavy load (e.g., big block processing with 10k+ transactions while pruning), MDBX can enter a fatal state. When `TransactionInner` is dropped:

1. `mdbx_txn_abort()` returns `MDBX_PANIC` (-30795)
2. The code at line 357 does `rx.recv().unwrap().unwrap()`
3. The inner `.unwrap()` on `Err(Panic)` causes a panic
4. If already unwinding from another panic → double-panic → process abort

```
thread 'Persistence Service' panicked at crates/storage/libmdbx-rs/src/transaction.rs:357:44:
called \`Result::unwrap()\` on an \`Err\` value: Panic
```

## Solution

- Replace `.unwrap().unwrap()` with graceful error handling
- Log errors using `tracing::error!` instead of panicking
- Use `let _ =` on outer result to ignore timeout errors

This allows the process to continue or unwind gracefully rather than aborting.

## Testing

Observed during reth-bench big block benchmarking with `--minimal` mode where the Persistence Service would panic after processing ~17 blocks.