### PR TITLE
fix: removes a redundant return

### DIFF
--- a/crates/cli/commands/src/test_vectors/compact.rs
+++ b/crates/cli/commands/src/test_vectors/compact.rs
@@ -214,7 +214,7 @@ where
                         tries += 1;
                         bytes.extend(std::iter::repeat_n(0u8, 256));
                     } else {
-                        return Err(err)?
+                        Err(err)?;
                     }
                 }
             }


### PR DESCRIPTION
`return Err(err)?` is equivalent to `Err(err)?` and triggers clippy::needless_return_with_question_mark