### PR TITLE
revert: perf(trie): parallelize merge_ancestors_into_overlay (#21202)

### DIFF
--- a/crates/trie/common/src/updates.rs
+++ b/crates/trie/common/src/updates.rs
@@ -4,7 +4,6 @@ use crate::{
 };
 use alloc::{
     collections::{btree_map::BTreeMap, btree_set::BTreeSet},
-    sync::Arc,
     vec::Vec,
 };
 use alloy_primitives::{
@@ -697,36 +696,6 @@ impl TrieUpdatesSorted {
             .collect();
 
         Self { account_nodes, storage_tries }.into()
-    }
-
-    /// Parallel batch-merge sorted trie updates. Slice is **oldest to newest**.
-    ///
-    /// This is more efficient than sequential `extend_ref` calls when merging many updates,
-    /// as it processes all updates in parallel with tree reduction using divide-and-conquer.
-    #[cfg(feature = "rayon")]
-    pub fn merge_parallel(updates: &[Arc<Self>]) -> Self {
-        fn parallel_merge_tree(updates: &[Arc<TrieUpdatesSorted>]) -> TrieUpdatesSorted {
-            match updates.len() {
-                0 => TrieUpdatesSorted::default(),
-                1 => updates[0].as_ref().clone(),
-                2 => {
-                    let mut acc = updates[0].as_ref().clone();
-                    acc.extend_ref_and_sort(&updates[1]);
-                    acc
-                }
-                n => {
-                    let mid = n / 2;
-                    let (mut left, right) = rayon::join(
-                        || parallel_merge_tree(&updates[..mid]),
-                        || parallel_merge_tree(&updates[mid..]),
-                    );
-                    left.extend_ref_and_sort(&right);
-                    left
-                }
-            }
-        }
-
-        parallel_merge_tree(updates)
     }
 }
 


### PR DESCRIPTION
Reverts #21202 for benchmarking to investigate potential perf regression in execution Gas/s.

