### PR TITLE
feat(engine): add metric for state root task fallback success

### DIFF
--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -331,6 +331,8 @@ pub(crate) struct BlockValidationMetrics {
     pub(crate) state_root_storage_tries_updated_total: Counter,
     /// Total number of times the parallel state root computation fell back to regular.
     pub(crate) state_root_parallel_fallback_total: Counter,
+    /// Total number of times the state root task failed but the fallback succeeded.
+    pub(crate) state_root_task_fallback_success_total: Counter,
     /// Latest state root duration, ie the time spent blocked waiting for the state root.
     pub(crate) state_root_duration: Gauge,
     /// Histogram for state root duration ie the time spent blocked waiting for the state root


### PR DESCRIPTION
## Summary

Adds a new counter metric `sync.block_validation.state_root_task_fallback_success_total` that is incremented when the state root task fails to validate the state root (either by returning an error or a mismatched root) but the synchronous fallback subsequently succeeds.

## Motivation

This helps track reliability issues with the sparse trie state root algorithm and identify when the fallback is saving block validation. The existing `state_root_parallel_fallback_total` metric tracks all fallbacks, but doesn't distinguish between StateRootTask failures specifically.

## Changes

- Added `state_root_task_fallback_success_total` counter to `BlockValidationMetrics`
- Track when StateRootTask returns an error or incorrect state root
- Increment the new metric only when the fallback succeeds after StateRootTask failure