### PR TITLE
fix(stages): commit RocksDB batches before flush and configure immediate WAL cleanup

### DIFF
--- a/crates/stages/stages/src/stages/index_account_history.rs
+++ b/crates/stages/stages/src/stages/index_account_history.rs
@@ -143,6 +143,7 @@ where
         })?;
 
         if use_rocksdb {
+            provider.commit_pending_rocksdb_batches()?;
             provider.rocksdb_provider().flush(&[tables::AccountsHistory::NAME])?;
         }
 

--- a/crates/stages/stages/src/stages/index_account_history.rs
+++ b/crates/stages/stages/src/stages/index_account_history.rs
@@ -1,6 +1,8 @@
 use super::collect_account_history_indices;
 use crate::stages::utils::{collect_history_indices, load_account_history};
 use reth_config::config::{EtlConfig, IndexHistoryConfig};
+#[cfg(all(unix, feature = "rocksdb"))]
+use reth_db_api::Tables;
 use reth_db_api::{models::ShardedKey, tables, transaction::DbTxMut};
 use reth_provider::{
     DBProvider, EitherWriter, HistoryWriter, PruneCheckpointReader, PruneCheckpointWriter,
@@ -145,7 +147,7 @@ where
         #[cfg(all(unix, feature = "rocksdb"))]
         if use_rocksdb {
             provider.commit_pending_rocksdb_batches()?;
-            provider.rocksdb_provider().flush(&[tables::AccountsHistory::NAME])?;
+            provider.rocksdb_provider().flush(&[Tables::AccountsHistory.name()])?;
         }
 
         Ok(ExecOutput { checkpoint: StageCheckpoint::new(*range.end()), done: true })

--- a/crates/stages/stages/src/stages/index_account_history.rs
+++ b/crates/stages/stages/src/stages/index_account_history.rs
@@ -1,7 +1,7 @@
 use super::collect_account_history_indices;
 use crate::stages::utils::{collect_history_indices, load_account_history};
 use reth_config::config::{EtlConfig, IndexHistoryConfig};
-use reth_db_api::{models::ShardedKey, table::Table, tables, transaction::DbTxMut};
+use reth_db_api::{models::ShardedKey, tables, transaction::DbTxMut};
 use reth_provider::{
     DBProvider, EitherWriter, HistoryWriter, PruneCheckpointReader, PruneCheckpointWriter,
     RocksDBProviderFactory, StorageSettingsCache,

--- a/crates/stages/stages/src/stages/index_account_history.rs
+++ b/crates/stages/stages/src/stages/index_account_history.rs
@@ -142,6 +142,7 @@ where
             Ok(((), writer.into_raw_rocksdb_batch()))
         })?;
 
+        #[cfg(all(unix, feature = "rocksdb"))]
         if use_rocksdb {
             provider.commit_pending_rocksdb_batches()?;
             provider.rocksdb_provider().flush(&[tables::AccountsHistory::NAME])?;

--- a/crates/stages/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/stages/src/stages/index_storage_history.rs
@@ -148,6 +148,7 @@ where
         })?;
 
         if use_rocksdb {
+            provider.commit_pending_rocksdb_batches()?;
             provider.rocksdb_provider().flush(&[tables::StoragesHistory::NAME])?;
         }
 

--- a/crates/stages/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/stages/src/stages/index_storage_history.rs
@@ -147,6 +147,7 @@ where
             Ok(((), writer.into_raw_rocksdb_batch()))
         })?;
 
+        #[cfg(all(unix, feature = "rocksdb"))]
         if use_rocksdb {
             provider.commit_pending_rocksdb_batches()?;
             provider.rocksdb_provider().flush(&[tables::StoragesHistory::NAME])?;

--- a/crates/stages/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/stages/src/stages/index_storage_history.rs
@@ -3,7 +3,6 @@ use crate::{stages::utils::load_storage_history, StageCheckpoint, StageId};
 use reth_config::config::{EtlConfig, IndexHistoryConfig};
 use reth_db_api::{
     models::{storage_sharded_key::StorageShardedKey, AddressStorageKey, BlockNumberAddress},
-    table::Table,
     tables,
     transaction::DbTxMut,
 };

--- a/crates/stages/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/stages/src/stages/index_storage_history.rs
@@ -1,6 +1,8 @@
 use super::{collect_history_indices, collect_storage_history_indices};
 use crate::{stages::utils::load_storage_history, StageCheckpoint, StageId};
 use reth_config::config::{EtlConfig, IndexHistoryConfig};
+#[cfg(all(unix, feature = "rocksdb"))]
+use reth_db_api::Tables;
 use reth_db_api::{
     models::{storage_sharded_key::StorageShardedKey, AddressStorageKey, BlockNumberAddress},
     tables,
@@ -149,7 +151,7 @@ where
         #[cfg(all(unix, feature = "rocksdb"))]
         if use_rocksdb {
             provider.commit_pending_rocksdb_batches()?;
-            provider.rocksdb_provider().flush(&[tables::StoragesHistory::NAME])?;
+            provider.rocksdb_provider().flush(&[Tables::StoragesHistory.name()])?;
         }
 
         Ok(ExecOutput { checkpoint: StageCheckpoint::new(*range.end()), done: true })

--- a/crates/stages/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/stages/src/stages/tx_lookup.rs
@@ -3,7 +3,7 @@ use alloy_primitives::{TxHash, TxNumber};
 use num_traits::Zero;
 use reth_config::config::{EtlConfig, TransactionLookupConfig};
 use reth_db_api::{
-    table::{Decode, Decompress, Table, Value},
+    table::{Decode, Decompress, Value},
     tables,
     transaction::DbTxMut,
 };

--- a/crates/stages/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/stages/src/stages/tx_lookup.rs
@@ -200,6 +200,7 @@ where
             }
         }
 
+        #[cfg(all(unix, feature = "rocksdb"))]
         if provider.cached_storage_settings().transaction_hash_numbers_in_rocksdb {
             provider.commit_pending_rocksdb_batches()?;
             provider.rocksdb_provider().flush(&[tables::TransactionHashNumbers::NAME])?;

--- a/crates/stages/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/stages/src/stages/tx_lookup.rs
@@ -201,6 +201,7 @@ where
         }
 
         if provider.cached_storage_settings().transaction_hash_numbers_in_rocksdb {
+            provider.commit_pending_rocksdb_batches()?;
             provider.rocksdb_provider().flush(&[tables::TransactionHashNumbers::NAME])?;
         }
 

--- a/crates/stages/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/stages/src/stages/tx_lookup.rs
@@ -2,6 +2,8 @@ use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{TxHash, TxNumber};
 use num_traits::Zero;
 use reth_config::config::{EtlConfig, TransactionLookupConfig};
+#[cfg(all(unix, feature = "rocksdb"))]
+use reth_db_api::Tables;
 use reth_db_api::{
     table::{Decode, Decompress, Value},
     tables,
@@ -203,7 +205,7 @@ where
         #[cfg(all(unix, feature = "rocksdb"))]
         if provider.cached_storage_settings().transaction_hash_numbers_in_rocksdb {
             provider.commit_pending_rocksdb_batches()?;
-            provider.rocksdb_provider().flush(&[tables::TransactionHashNumbers::NAME])?;
+            provider.rocksdb_provider().flush(&[Tables::TransactionHashNumbers.name()])?;
         }
 
         Ok(ExecOutput {

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -186,6 +186,11 @@ impl<N: ProviderNodeTypes> RocksDBProviderFactory for BlockchainProvider<N> {
     fn set_pending_rocksdb_batch(&self, _batch: rocksdb::WriteBatchWithTransaction<true>) {
         unimplemented!("BlockchainProvider wraps ProviderFactory - use DatabaseProvider::set_pending_rocksdb_batch instead")
     }
+
+    #[cfg(all(unix, feature = "rocksdb"))]
+    fn commit_pending_rocksdb_batches(&self) -> ProviderResult<()> {
+        unimplemented!("BlockchainProvider wraps ProviderFactory - use DatabaseProvider::commit_pending_rocksdb_batches instead")
+    }
 }
 
 impl<N: ProviderNodeTypes> HeaderProvider for BlockchainProvider<N> {

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -171,6 +171,11 @@ impl<N: NodeTypesWithDB> RocksDBProviderFactory for ProviderFactory<N> {
     fn set_pending_rocksdb_batch(&self, _batch: rocksdb::WriteBatchWithTransaction<true>) {
         unimplemented!("ProviderFactory is a factory, not a provider - use DatabaseProvider::set_pending_rocksdb_batch instead")
     }
+
+    #[cfg(all(unix, feature = "rocksdb"))]
+    fn commit_pending_rocksdb_batches(&self) -> ProviderResult<()> {
+        unimplemented!("ProviderFactory is a factory, not a provider - use DatabaseProvider::commit_pending_rocksdb_batches instead")
+    }
 }
 
 impl<N: ProviderNodeTypes<DB = Arc<DatabaseEnv>>> ProviderFactory<N> {

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -175,6 +175,11 @@ impl RocksDBBuilder {
 
         options.set_log_level(log_level);
 
+        // Delete obsolete WAL files immediately after all column families have flushed.
+        // Both set to 0 means "delete ASAP, no archival".
+        options.set_wal_ttl_seconds(0);
+        options.set_wal_size_limit_mb(0);
+
         // Statistics can view from RocksDB log file
         if enable_statistics {
             options.enable_statistics();

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -33,6 +33,7 @@ impl<C: Send + Sync, N: NodePrimitives> RocksDBProviderFactory for NoopProvider<
     #[cfg(all(unix, feature = "rocksdb"))]
     fn set_pending_rocksdb_batch(&self, _batch: rocksdb::WriteBatchWithTransaction<true>) {}
 
+    #[cfg(all(unix, feature = "rocksdb"))]
     fn commit_pending_rocksdb_batches(&self) -> ProviderResult<()> {
         Ok(())
     }

--- a/crates/storage/provider/src/test_utils/noop.rs
+++ b/crates/storage/provider/src/test_utils/noop.rs
@@ -31,7 +31,9 @@ impl<C: Send + Sync, N: NodePrimitives> RocksDBProviderFactory for NoopProvider<
     }
 
     #[cfg(all(unix, feature = "rocksdb"))]
-    fn set_pending_rocksdb_batch(&self, _batch: rocksdb::WriteBatchWithTransaction<true>) {
-        // No-op for NoopProvider
+    fn set_pending_rocksdb_batch(&self, _batch: rocksdb::WriteBatchWithTransaction<true>) {}
+
+    fn commit_pending_rocksdb_batches(&self) -> ProviderResult<()> {
+        Ok(())
     }
 }

--- a/crates/storage/provider/src/traits/rocksdb_provider.rs
+++ b/crates/storage/provider/src/traits/rocksdb_provider.rs
@@ -19,6 +19,14 @@ pub trait RocksDBProviderFactory {
     #[cfg(all(unix, feature = "rocksdb"))]
     fn set_pending_rocksdb_batch(&self, batch: rocksdb::WriteBatchWithTransaction<true>);
 
+    /// Takes all pending `RocksDB` batches and commits them.
+    ///
+    /// This drains the pending batches from the lock and commits each one using the `RocksDB`
+    /// provider. Can be called before flush to persist `RocksDB` writes independently of the
+    /// full commit path.
+    #[cfg(all(unix, feature = "rocksdb"))]
+    fn commit_pending_rocksdb_batches(&self) -> ProviderResult<()>;
+
     /// Executes a closure with a `RocksDB` transaction for reading.
     ///
     /// This helper encapsulates all the cfg-gated `RocksDB` transaction handling for reads.
@@ -154,6 +162,10 @@ mod tests {
         }
 
         fn set_pending_rocksdb_batch(&self, _batch: rocksdb::WriteBatchWithTransaction<true>) {}
+
+        fn commit_pending_rocksdb_batches(&self) -> ProviderResult<()> {
+            Ok(())
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This PR fixes RocksDB flush ordering and WAL cleanup issues in the stages.

## Changes

### 1. Fixed flush order
Changed the flush sequence to: `flush_cf()` first (memtable → SST), then `flush_wal()`. Previously the order was reversed, which was incorrect.

### 2. Added `commit_pending_rocksdb_batches()` method
Added this method to the `RocksDBProviderFactory` trait to allow stages to commit any pending batches before flushing.

### 3. Updated stages to commit pending batches before flushing
The following stages now call `commit_pending_rocksdb_batches()` before flushing:
- `tx_lookup`
- `index_account_history`
- `index_storage_history`

### 4. Configured immediate WAL cleanup
Set `wal_ttl_seconds=0` and `wal_size_limit_mb=0` to delete WAL files immediately after they are no longer needed.

## Why these changes are needed

- **Flush before commit**: The flush was happening before the pending batch was committed, so the final batch data wasn't being flushed to SST files
- **Wrong flush order**: WAL was being flushed first, then memtables - this is incorrect because memtables should be flushed to SST files before syncing the WAL
- **WAL file accumulation**: WAL files were not being cleaned up promptly, leading to unnecessary disk usage