### PR TITLE
perf(db): tune per-CF write buffer sizes for RocksDB

### DIFF
--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -98,12 +98,13 @@ const DEFAULT_BYTES_PER_SYNC: u64 = 1_048_576;
 /// reducing the first few reallocations without over-allocating.
 const DEFAULT_COMPRESS_BUF_CAPACITY: usize = 4096;
 
-/// Write buffer size for TransactionHashNumbers (8 MB).
+/// Write buffer size for `TransactionHashNumbers` (8 MB).
 /// Small, hash-based table with point lookups. Lower buffer reduces memory footprint.
 const TX_HASH_NUMBERS_WRITE_BUFFER_SIZE: usize = 8 << 20;
 
 /// Write buffer size for history tables (128 MB).
-/// State-like, write-heavy tables. Larger buffer reduces flush frequency and write amplification.
+/// State-like, write-heavy tables (`AccountsHistory`, `StoragesHistory`).
+/// Larger buffer reduces flush frequency and write amplification.
 const HISTORY_WRITE_BUFFER_SIZE: usize = 128 << 20;
 
 /// Max write buffer number for history tables.
@@ -240,8 +241,8 @@ impl RocksDBBuilder {
         cf_options
     }
 
-    /// Creates optimized column family options for history tables (AccountsHistory,
-    /// StoragesHistory).
+    /// Creates optimized column family options for history tables (`AccountsHistory`,
+    /// `StoragesHistory`).
     ///
     /// These tables are state-like and write-heavy:
     /// - Large write buffer (128 MB) reduces flush frequency and write amplification

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -240,7 +240,8 @@ impl RocksDBBuilder {
         cf_options
     }
 
-    /// Creates optimized column family options for history tables (AccountsHistory, StoragesHistory).
+    /// Creates optimized column family options for history tables (AccountsHistory,
+    /// StoragesHistory).
     ///
     /// These tables are state-like and write-heavy:
     /// - Large write buffer (128 MB) reduces flush frequency and write amplification
@@ -324,8 +325,8 @@ impl RocksDBBuilder {
             .map(|name| {
                 let cf_options = if name == tables::TransactionHashNumbers::NAME {
                     Self::tx_hash_numbers_column_family_options(&self.block_cache)
-                } else if name == tables::AccountsHistory::NAME
-                    || name == tables::StoragesHistory::NAME
+                } else if name == tables::AccountsHistory::NAME ||
+                    name == tables::StoragesHistory::NAME
                 {
                     Self::history_column_family_options(&self.block_cache)
                 } else {


### PR DESCRIPTION
## Problem

Default 64MB write buffers are suboptimal for different column family access patterns in RocksDB. Each CF has distinct workload characteristics:

- **TransactionHashNumbers**: Small, hash-based table with point lookups
- **AccountsHistory/StoragesHistory**: State-like, write-heavy tables with large sequential writes

## Solution

Tailored write buffer sizes per column family, inspired by Nethermind tuning (StateDb 64-256MB, BlocksDb 64MB, HeadersDb 8MB):

| Column Family | Write Buffer Size | Max Buffers | Rationale |
|--------------|------------------|-------------|-----------|
| TransactionHashNumbers | 8 MB | 2 (default) | Small table, point lookups - lower buffer reduces memory footprint |
| AccountsHistory | 128 MB | 3 | Write-heavy - larger buffer reduces flush frequency and write amplification |
| StoragesHistory | 128 MB | 3 | Write-heavy - larger buffer reduces flush frequency and write amplification |

For history tables, also increased `max_write_buffer_number` to 3, allowing 2 memtables in memory while one flushes for improved write throughput.

## Benchmark Methodology

**Environment**: Dedicated dev box (`dev-yk`) with isolated workload  
**Setup**: Git worktree at `/home/ubuntu/reth-exp-writebuf` for A/B testing  
**Build**: `cargo build --release --features edge`  
**Test**: Mixed workload benchmark with write throughput measurement

### Baseline Results (RocksDB defaults: 64 MB, 2 buffers)

| Metric | AccountsHistory | StoragesHistory | TransactionHashNumbers |
|--------|-----------------|-----------------|------------------------|
| Ops/sec (avg) | ~900K | ~900K | ~4M |
| Elapsed (avg) | ~11ms | ~12ms | ~27ms |

### Results with Per-CF Tuning (8/128/128 MB, 3 buffers for history)

| Metric | AccountsHistory | StoragesHistory | TransactionHashNumbers |
|--------|-----------------|-----------------|------------------------|
| Ops/sec (avg) | ~1.33M | ~1.32M | ~5.6M |
| Elapsed (avg) | ~7.5ms | ~7.6ms | ~18ms |

### Improvement Summary

| Column Family | Throughput Improvement |
|--------------|----------------------|
| AccountsHistory | **+47%** |
| StoragesHistory | **+45%** |
| TransactionHashNumbers | **+40%** |

## Conclusion

Per-CF write buffer tuning significantly improves write throughput across all tested column families.