### PR TITLE
feat(db): add bloom filters to RocksDB history tables

### DIFF
--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -315,8 +315,8 @@ impl RocksDBBuilder {
             .map(|name| {
                 let cf_options = if name == tables::TransactionHashNumbers::NAME {
                     Self::tx_hash_numbers_column_family_options(&self.block_cache)
-                } else if name == tables::AccountsHistory::NAME
-                    || name == tables::StoragesHistory::NAME
+                } else if name == tables::AccountsHistory::NAME ||
+                    name == tables::StoragesHistory::NAME
                 {
                     Self::history_column_family_options(&self.block_cache)
                 } else {
@@ -2940,4 +2940,3 @@ mod tests {
         }
     }
 }
-

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -228,7 +228,7 @@ impl RocksDBBuilder {
 
     /// Creates optimized column family options for history tables with Bloom filters.
     ///
-    /// AccountsHistory and StoragesHistory tables use sharded keys and frequently
+    /// `AccountsHistory` and `StoragesHistory` tables use sharded keys and frequently
     /// perform point lookups. Adding a 15-bit Bloom filter reduces unnecessary disk reads
     /// when a key does not exist in a shard (common during historical queries).
     ///


### PR DESCRIPTION
## Summary

Adds 15-bit Bloom filters to `AccountsHistory` and `StoragesHistory` column families in RocksDB to reduce disk I/O for point lookups.

## Problem

History table lookups frequently check for non-existing keys (e.g., "did this account exist at block N?"). Without Bloom filters, every lookup traverses all SST levels, incurring disk I/O at each level.

## Solution

Configure 15-bit Bloom filters (~1.875 bytes/key) for history CFs. Bloom filters provide a fast in-memory check: if the filter says "not present", skip disk I/O entirely.

## Benchmark Results

**Setup**: 500K accounts, 50K lookups, 4MB block cache

| Metric | Baseline (no bloom) | With 15-bit Bloom | Improvement |
|--------|---------------------|-------------------|-------------|
| **Non-existing keys** ||||
| p50 | 4.99 µs | 0.53 µs | **-89%** |
| p99 | 7.32 µs | 0.86 µs | **-88%** |
| mean | 5.06 µs | 0.55 µs | **-89%** |
| **Existing keys** ||||
| p50 | 3.73 µs | 3.32 µs | -11% |
| p99 | 7.32 µs | 5.08 µs | -31% |
| mean | 4.24 µs | 3.24 µs | -24% |

## Memory Overhead

- 15 bits per key ≈ 1.875 bytes/key
- For 10M keys: ~18 MB additional RAM
- False positive rate: ~0.6%

## Why History Tables

`AccountsHistory` and `StoragesHistory` are frequently queried with negative lookups (checking historical state that does not exist), making Bloom filters highly effective.
