### PR TITLE
feat(engine): add metric for forkchoiceUpdated response -> newPayload

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1514,10 +1514,12 @@ where
                                 let gas_used = payload.gas_used();
                                 let num_hash = payload.num_hash();
                                 let mut output = self.on_new_payload(payload);
-                                self.metrics
-                                    .engine
-                                    .new_payload
-                                    .update_response_metrics(start, &output, gas_used);
+                                self.metrics.engine.new_payload.update_response_metrics(
+                                    start,
+                                    &mut self.metrics.engine.forkchoice_updated.latest_finish_at,
+                                    &output,
+                                    gas_used,
+                                );
 
                                 let maybe_event =
                                     output.as_mut().ok().and_then(|out| out.event.take());


### PR DESCRIPTION
This is the opposite of `new_payload_forkchoice_updated_time_diff`, letting us measure the time between the forkchoice updated response, and the newPayload request