### PR TITLE
chore: removed needless collect

### DIFF
--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -1985,13 +1985,11 @@ mod tests {
                     database_state.into_iter().map(|(address, (account, _))| {
                         (address, None, Some(account.into()), Default::default())
                     }),
-                    database_changesets
-                        .iter()
-                        .map(|block_changesets| {
-                            block_changesets.iter().map(|(address, account, _)| {
-                                (*address, Some(Some((*account).into())), [])
-                            })
-                        }),
+                    database_changesets.iter().map(|block_changesets| {
+                        block_changesets.iter().map(|(address, account, _)| {
+                            (*address, Some(Some((*account).into())), [])
+                        })
+                    }),
                     Vec::new(),
                 ),
                 first_block: first_database_block,

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -1991,8 +1991,7 @@ mod tests {
                             block_changesets.iter().map(|(address, account, _)| {
                                 (*address, Some(Some((*account).into())), [])
                             })
-                        })
-                        .collect::<Vec<_>>(),
+                        }),
                     Vec::new(),
                 ),
                 first_block: first_database_block,


### PR DESCRIPTION
Passes the iterator directly to BundleState::new instead of collecting into an intermediate Vec.