### PR TITLE
fix(docker): pass vergen git vars as build args

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,6 +50,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Get git info for vergen
+        id: git
+        run: |
+          echo "sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          echo "describe=$(git describe --always --tags)" >> "$GITHUB_OUTPUT"
+          echo "dirty=false" >> "$GITHUB_OUTPUT"
+
       - name: Determine build parameters
         id: params
         run: |
@@ -82,6 +89,10 @@ jobs:
 
       - name: Build and push images
         uses: depot/bake-action@v1
+        env:
+          VERGEN_GIT_SHA: ${{ steps.git.outputs.sha }}
+          VERGEN_GIT_DESCRIBE: ${{ steps.git.outputs.describe }}
+          VERGEN_GIT_DIRTY: ${{ steps.git.outputs.dirty }}
         with:
           project: ${{ vars.DEPOT_PROJECT_ID }}
           files: docker-bake.hcl

--- a/Dockerfile.depot
+++ b/Dockerfile.depot
@@ -44,6 +44,14 @@ ENV RUSTFLAGS="$RUSTFLAGS"
 ARG FEATURES=""
 ENV FEATURES=$FEATURES
 
+# Git info for vergen (since .git is excluded from Docker context)
+ARG VERGEN_GIT_SHA=""
+ARG VERGEN_GIT_DESCRIBE=""
+ARG VERGEN_GIT_DIRTY="false"
+ENV VERGEN_GIT_SHA=$VERGEN_GIT_SHA
+ENV VERGEN_GIT_DESCRIBE=$VERGEN_GIT_DESCRIBE
+ENV VERGEN_GIT_DIRTY=$VERGEN_GIT_DIRTY
+
 # Build dependencies with cache mounts
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -20,6 +20,19 @@ variable "FEATURES" {
   default = "jemalloc asm-keccak min-debug-logs"
 }
 
+// Git info for vergen (since .git is excluded from Docker context)
+variable "VERGEN_GIT_SHA" {
+  default = ""
+}
+
+variable "VERGEN_GIT_DESCRIBE" {
+  default = ""
+}
+
+variable "VERGEN_GIT_DIRTY" {
+  default = "false"
+}
+
 // Common settings for all targets
 group "default" {
   targets = ["ethereum", "optimism"]
@@ -34,8 +47,11 @@ target "_base" {
   dockerfile = "Dockerfile.depot"
   platforms  = ["linux/amd64", "linux/arm64"]
   args = {
-    BUILD_PROFILE = "${BUILD_PROFILE}"
-    FEATURES      = "${FEATURES}"
+    BUILD_PROFILE      = "${BUILD_PROFILE}"
+    FEATURES           = "${FEATURES}"
+    VERGEN_GIT_SHA     = "${VERGEN_GIT_SHA}"
+    VERGEN_GIT_DESCRIBE = "${VERGEN_GIT_DESCRIBE}"
+    VERGEN_GIT_DIRTY   = "${VERGEN_GIT_DIRTY}"
   }
 }
 


### PR DESCRIPTION
## Summary
The Docker build excludes `.git` directory for cache efficiency (`COPY --exclude=.git`), which causes vergen to fall back to `VERGEN_IDEMPOTENT_OUTPUT` instead of the actual git SHA.

Current nightly images show:
```
Commit SHA: VERGEN_IDEMPOTENT_OUTPUT
```

## Fix
Pass `VERGEN_GIT_SHA`, `VERGEN_GIT_DESCRIBE`, and `VERGEN_GIT_DIRTY` as build args from the CI workflow where git info is available. The vergen library reads these from environment variables as fallback when `.git` is not present.

## Changes
- `docker-bake.hcl`: Add variables for git info and pass them to build args
- `Dockerfile.depot`: Accept git info as ARGs and set them as ENVs for the build
- `.github/workflows/docker.yml`: Compute git info and export as env vars for bake

## Testing
Verified with `docker buildx bake --print` that variables are properly passed through.