### PR TITLE
chore: fix clippy unnecessary_sort_by lint

### DIFF
--- a/crates/era-downloader/src/fs.rs
+++ b/crates/era-downloader/src/fs.rs
@@ -52,7 +52,7 @@ pub fn read_dir(
         checksums.next().transpose()?.ok_or_eyre("Got less checksums than ERA files")?;
     }
 
-    entries.sort_by(|(left, _), (right, _)| left.cmp(right));
+    entries.sort_by_key(|(left, _)| *left);
 
     Ok(stream::iter(entries.into_iter().skip_while(move |(n, _)| *n < start_index).map(
         move |(_, path)| {

--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -1631,7 +1631,7 @@ impl Discv4Service {
             .filter(|entry| entry.node.value.is_expired())
             .map(|n| n.node.value)
             .collect::<Vec<_>>();
-        nodes.sort_by(|a, b| a.last_seen.cmp(&b.last_seen));
+        nodes.sort_by_key(|a| a.last_seen);
         let to_ping = nodes.into_iter().map(|n| n.record).take(MAX_NODES_PING).collect::<Vec<_>>();
         for node in to_ping {
             self.try_ping(node, PingReason::RePing)

--- a/crates/stages/stages/src/stages/hashing_account.rs
+++ b/crates/stages/stages/src/stages/hashing_account.rs
@@ -99,7 +99,7 @@ impl AccountHashingStage {
             // Account State generator
             let mut account_cursor =
                 provider.tx_ref().cursor_write::<tables::PlainAccountState>()?;
-            accounts.sort_by(|a, b| a.0.cmp(&b.0));
+            accounts.sort_by_key(|a| a.0);
             for (addr, acc) in &accounts {
                 account_cursor.append(*addr, acc)?;
             }

--- a/crates/trie/common/src/updates.rs
+++ b/crates/trie/common/src/updates.rs
@@ -169,7 +169,7 @@ impl TrieUpdates {
             .collect::<Vec<_>>();
 
         account_nodes.extend(self.removed_nodes.drain().map(|path| (path, None)));
-        account_nodes.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+        account_nodes.sort_unstable_by_key(|a| a.0);
 
         let storage_tries = self
             .storage_tries
@@ -195,7 +195,7 @@ impl TrieUpdates {
                 .filter(|path| !self.account_nodes.contains_key(*path))
                 .map(|path| (*path, None)),
         );
-        account_nodes.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+        account_nodes.sort_unstable_by_key(|a| a.0);
 
         let storage_tries = self
             .storage_tries
@@ -373,7 +373,7 @@ impl StorageTrieUpdates {
             .collect::<Vec<_>>();
 
         storage_nodes.extend(self.removed_nodes.into_iter().map(|path| (path, None)));
-        storage_nodes.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+        storage_nodes.sort_unstable_by_key(|a| a.0);
 
         StorageTrieUpdatesSorted { is_deleted: self.is_deleted, storage_nodes }
     }
@@ -394,7 +394,7 @@ impl StorageTrieUpdates {
                 .filter(|path| !self.storage_nodes.contains_key(*path))
                 .map(|path| (*path, None)),
         );
-        storage_nodes.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+        storage_nodes.sort_unstable_by_key(|a| a.0);
 
         StorageTrieUpdatesSorted { is_deleted: self.is_deleted, storage_nodes }
     }

--- a/crates/trie/trie/src/hashed_cursor/post_state.rs
+++ b/crates/trie/trie/src/hashed_cursor/post_state.rs
@@ -420,7 +420,7 @@ mod tests {
                     .into_iter()
                     .map(|(byte, value)| (B256::repeat_byte(byte), value))
                     .collect();
-                result.sort_by(|a, b| a.0.cmp(&b.0));
+                result.sort_by_key(|a| a.0);
                 result.dedup_by(|a, b| a.0 == b.0);
                 result
             })
@@ -438,7 +438,7 @@ mod tests {
                             (B256::repeat_byte(byte), effective_value)
                         })
                         .collect();
-                    result.sort_by(|a, b| a.0.cmp(&b.0));
+                    result.sort_by_key(|a| a.0);
                     result.dedup_by(|a, b| a.0 == b.0);
                     result
                 },

--- a/crates/trie/trie/src/trie_cursor/in_memory.rs
+++ b/crates/trie/trie/src/trie_cursor/in_memory.rs
@@ -758,7 +758,7 @@ mod tests {
                     .into_iter()
                     .map(|(bytes, node)| (Nibbles::from_nibbles_unchecked(bytes), node))
                     .collect();
-                result.sort_by(|a, b| a.0.cmp(&b.0));
+                result.sort_by_key(|a| a.0);
                 result.dedup_by(|a, b| a.0 == b.0);
                 result
             })
@@ -780,7 +780,7 @@ mod tests {
                     .into_iter()
                     .map(|(bytes, node)| (Nibbles::from_nibbles_unchecked(bytes), node))
                     .collect();
-                result.sort_by(|a, b| a.0.cmp(&b.0));
+                result.sort_by_key(|a| a.0);
                 result.dedup_by(|a, b| a.0 == b.0);
                 result
             })

--- a/crates/trie/trie/src/verify.rs
+++ b/crates/trie/trie/src/verify.rs
@@ -13,7 +13,7 @@ use alloy_primitives::B256;
 use alloy_trie::BranchNodeCompact;
 use reth_execution_errors::StateRootError;
 use reth_storage_errors::db::DatabaseError;
-use std::cmp::Ordering;
+use std::cmp::{Ordering, Reverse};
 use tracing::trace;
 
 /// Used by [`StateRootBranchNodesIter`] to iterate over branch nodes in a state root.
@@ -141,7 +141,7 @@ impl<H: HashedCursorFactory + Clone> Iterator for StateRootBranchNodesIter<H> {
             // By sorting by the account we ensure that we continue with the partially processed
             // trie (the last of the previous run) first. We sort in reverse order because we pop
             // off of this Vec.
-            self.storage_tries.sort_unstable_by(|a, b| b.0.cmp(&a.0));
+            self.storage_tries.sort_unstable_by_key(|a| Reverse(a.0));
 
             // loop back to the top.
         }


### PR DESCRIPTION
Fixes the new `clippy::unnecessary_sort_by` lint from nightly-2026-01-24.

Changes `sort_by(|a, b| a.X.cmp(&b.X))` to `sort_by_key(|a| a.X)` and `sort_unstable_by(|a, b| b.X.cmp(&a.X))` to `sort_unstable_by_key(|a| Reverse(a.X))`.