### PR TITLE
feat(static-file): add metrics tracking to StaticFileProducer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10848,10 +10848,12 @@ version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "assert_matches",
+ "metrics",
  "parking_lot",
  "rayon",
  "reth-codecs",
  "reth-db-api",
+ "reth-metrics",
  "reth-primitives-traits",
  "reth-provider",
  "reth-prune-types",

--- a/crates/static-file/static-file/Cargo.toml
+++ b/crates/static-file/static-file/Cargo.toml
@@ -25,6 +25,10 @@ reth-stages-types.workspace = true
 
 alloy-primitives.workspace = true
 
+# metrics
+reth-metrics.workspace = true
+metrics.workspace = true
+
 # misc
 tracing.workspace = true
 rayon.workspace = true

--- a/crates/static-file/static-file/src/lib.rs
+++ b/crates/static-file/static-file/src/lib.rs
@@ -8,6 +8,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
+mod metrics;
 pub mod segments;
 mod static_file_producer;
 

--- a/crates/static-file/static-file/src/metrics.rs
+++ b/crates/static-file/static-file/src/metrics.rs
@@ -2,13 +2,17 @@
 
 use metrics::Histogram;
 use reth_metrics::Metrics;
+use reth_static_file_types::StaticFileSegment;
 
 /// Metrics for the static file producer.
 #[derive(Metrics, Clone)]
 #[metrics(scope = "static_file_producer")]
 pub(crate) struct StaticFileProducerMetrics {
-    /// Histogram of segment copy durations in seconds.
-    pub segment_duration_seconds: Histogram,
     /// Histogram of total static file production durations in seconds.
     pub run_duration_seconds: Histogram,
+}
+
+/// Returns a histogram for recording segment copy durations.
+pub(crate) fn segment_duration_histogram(segment: StaticFileSegment) -> Histogram {
+    metrics::histogram!("static_file_producer.segment_duration_seconds", "segment" => segment.to_string())
 }

--- a/crates/static-file/static-file/src/metrics.rs
+++ b/crates/static-file/static-file/src/metrics.rs
@@ -1,0 +1,14 @@
+//! Static file producer metrics.
+
+use metrics::Histogram;
+use reth_metrics::Metrics;
+
+/// Metrics for the static file producer.
+#[derive(Metrics, Clone)]
+#[metrics(scope = "static_file_producer")]
+pub(crate) struct StaticFileProducerMetrics {
+    /// Histogram of segment copy durations in seconds.
+    pub segment_duration_seconds: Histogram,
+    /// Histogram of total static file production durations in seconds.
+    pub run_duration_seconds: Histogram,
+}

--- a/crates/static-file/static-file/src/static_file_producer.rs
+++ b/crates/static-file/static-file/src/static_file_producer.rs
@@ -1,7 +1,10 @@
 //! Support for producing static files.
 
 use crate::{
-    metrics::StaticFileProducerMetrics, segments, segments::Segment, StaticFileProducerEvent,
+    metrics::{segment_duration_histogram, StaticFileProducerMetrics},
+    segments,
+    segments::Segment,
+    StaticFileProducerEvent,
 };
 use alloy_primitives::BlockNumber;
 use parking_lot::Mutex;
@@ -149,7 +152,7 @@ where
             segment.copy_to_static_files(provider,  block_range.clone())?;
 
             let elapsed = start.elapsed();
-            metrics.segment_duration_seconds.record(elapsed.as_secs_f64());
+            segment_duration_histogram(segment.segment()).record(elapsed.as_secs_f64());
             debug!(target: "static_file", segment = %segment.segment(), ?block_range, ?elapsed, "Finished StaticFileProducer segment");
 
             Ok(())


### PR DESCRIPTION
## Summary

- Add histogram metrics to track StaticFileProducer durations
- Resolve TODO comments from **alexey** in `static_file_producer.rs`

## Test plan

- `cargo check -p reth-static-file`
- `cargo +nightly fmt --all`
- `cargo clippy -p reth-static-file --all-features`
- `cargo test -p reth-static-file`