### PR TITLE
fix(provider): replace panic with proper error handling in remove_blocks_above

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -3260,7 +3260,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> BlockWriter
         let highest_static_file_block = self
             .static_file_provider()
             .get_highest_static_file_block(StaticFileSegment::Headers)
-            .expect("todo: error handling, headers should exist");
+            .ok_or(ProviderError::MissingHighestStaticFileBlock(StaticFileSegment::Headers))?;
 
         // IMPORTANT: we use `highest_static_file_block.saturating_sub(block_number)` to make sure
         // we remove only what is ABOVE the block.


### PR DESCRIPTION
## Summary

- Replace `.expect("todo: error handling, headers should exist")` with proper error handling using `ProviderError::MissingHighestStaticFileBlock`

## Motivation

The original code used `.expect()` which would panic if the highest static file block was not found. This is problematic because:

1. **Node reliability**: A panic crashes the node unexpectedly, which is unacceptable for production blockchain infrastructure
 2. **Technical debt**: The `expect` message explicitly said "todo: error handling", indicating this was always intended to be fixed
 3. **Error propagation**: Callers should be able to handle this error gracefully rather than facing an unrecoverable crash

 ## Changes

 Replaced:
 ```rust
 .expect("todo: error handling, headers should exist");
```
 With:
```rust
 .ok_or(ProviderError::MissingHighestStaticFileBlock(StaticFileSegment::Headers))?;
```

 This follows the existing pattern used elsewhere in the same function (e.g., ProviderError::BlockBodyIndicesNotFound) and uses an error variant that was already defined in the codebase for this exact scenario.

## Test plan

- cargo test -p reth-provider passes
- cargo +nightly clippy -p reth-provider --all-features passes