### PR TITLE
fix: remove redundant `.clone()` in proptest code generation

### DIFF
--- a/crates/storage/codecs/derive/src/arbitrary.rs
+++ b/crates/storage/codecs/derive/src/arbitrary.rs
@@ -41,7 +41,7 @@ pub fn maybe_generate_tests(
             roundtrips.push(quote! {
                 {
                     let mut buf = vec![];
-                    let len = field.clone().to_compact(&mut buf);
+                    let len = field.to_compact(&mut buf);
                     let (decoded, _): (super::#type_ident, _) = Compact::from_compact(&buf, len);
                     assert_eq!(field, decoded, "maybe_generate_tests::compact");
                 }


### PR DESCRIPTION

Removes an unnecessary `.clone()` call in the generated proptest code for `Compact` trait roundtrip tests. The `to_compact` method takes `&self`, so cloning the value before calling it is redundant and adds unnecessary performance overhead.

