### PR TITLE
fix(rpc): add block number validation in eth_simulateV1

### DIFF
--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -37,8 +37,13 @@ pub enum EthSimulateError {
     #[error("Client adjustable limit reached")]
     GasLimitReached,
     /// Block number in sequence did not increase.
-    #[error("Block number in sequence did not increase")]
-    BlockNumberInvalid,
+    #[error("block numbers must be in order: {got} <= {parent}")]
+    BlockNumberInvalid {
+        /// The block number that was provided.
+        got: u64,
+        /// The parent block number.
+        parent: u64,
+    },
     /// Block timestamp in sequence did not increase or stay the same.
     #[error("Block timestamp in sequence did not increase")]
     BlockTimestampInvalid,
@@ -91,7 +96,7 @@ impl EthSimulateError {
             Self::IntrinsicGasTooLow => -38013,
             Self::InsufficientFunds { .. } => -38014,
             Self::BlockGasLimitExceeded => -38015,
-            Self::BlockNumberInvalid => -38020,
+            Self::BlockNumberInvalid { .. } => -38020,
             Self::BlockTimestampInvalid => -38021,
             Self::PrecompileSelfReference => -38022,
             Self::PrecompileDuplicateAddress => -38023,


### PR DESCRIPTION
## Summary

Adds block number validation for `eth_simulateV1` to ensure block numbers are strictly increasing when overridden.

### Changes

- Updated `EthSimulateError::BlockNumberInvalid` to include `got` and `parent` fields for detailed error messages
- Added validation in `simulate_v1` to check block number ordering
- Returns error code `-38020` with message matching geth format: `"block numbers must be in order: X <= Y"`

### Motivation

Fixes failing Hive `rpc-compat` test: `ethSimulate-block-num-order-38020.io`

The [execution-apis spec](https://github.com/ethereum/execution-apis/tree/main/tests/eth_simulateV1) requires that block numbers in `eth_simulateV1` must be strictly increasing. This aligns reth with geth's behavior.

### Test

The fix can be verified by running the Hive rpc-compat tests for eth_simulateV1.