### PR TITLE
fix(rpc): add block timestamp validation in eth_simulateV1

### DIFF
--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -46,9 +46,14 @@ pub enum EthSimulateError {
         /// The parent block number.
         parent: u64,
     },
-    /// Block timestamp in sequence did not increase or stay the same.
-    #[error("Block timestamp in sequence did not increase")]
-    BlockTimestampInvalid,
+    /// Block timestamp in sequence did not increase.
+    #[error("block timestamps must be in order: {got} <= {parent}")]
+    BlockTimestampInvalid {
+        /// The block timestamp that was provided.
+        got: u64,
+        /// The parent block timestamp.
+        parent: u64,
+    },
     /// Transaction nonce is too low.
     #[error("nonce too low: next nonce {state}, tx nonce {tx}")]
     NonceTooLow {
@@ -102,7 +107,7 @@ impl EthSimulateError {
             Self::InsufficientFunds { .. } => -38014,
             Self::BlockGasLimitExceeded => -38015,
             Self::BlockNumberInvalid { .. } => -38020,
-            Self::BlockTimestampInvalid => -38021,
+            Self::BlockTimestampInvalid { .. } => -38021,
             Self::PrecompileSelfReference => -38022,
             Self::PrecompileDuplicateAddress => -38023,
             Self::SenderNotEOA => -38024,


### PR DESCRIPTION
## Summary

Adds block timestamp validation for `eth_simulateV1` to ensure timestamps are strictly increasing when overridden.

### Changes

- Updated `EthSimulateError::BlockTimestampInvalid` to include `got` and `parent` fields for detailed error messages
- Added validation in `simulate_v1` to check timestamp ordering
- Returns error code `-38021` with message matching geth format: `"block timestamps must be in order: X <= Y"`

### Motivation

Fixes failing Hive `rpc-compat` test: `ethSimulate-block-timestamp-order-38021.io`

The [execution-apis spec](https://github.com/ethereum/execution-apis/tree/main/tests/eth_simulateV1) requires that block timestamps in `eth_simulateV1` must be strictly increasing. This aligns reth with geth's behavior.

### Dependencies

Builds on #21396 (block number validation).

### Test

The fix can be verified by running the Hive rpc-compat tests for eth_simulateV1.