### PR TITLE
fix(rpc): set prevrandao to zero for eth_simulateV1 simulated blocks

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -116,6 +116,11 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
 
                     let SimBlock { block_overrides, state_overrides, calls } = block;
 
+                    // Set prevrandao to zero for simulated blocks by default,
+                    // matching spec behavior where MixDigest is zero-initialized.
+                    // If user provides an override, it will be applied by apply_block_overrides.
+                    evm_env.block_env.inner_mut().prevrandao = Some(B256::ZERO);
+
                     if let Some(block_overrides) = block_overrides {
                         // ensure we don't allow uncapped gas limit per block
                         if let Some(gas_limit_override) = block_overrides.gas_limit &&


### PR DESCRIPTION
## Summary

In geth, simulated block headers are created with `MixDigest` (prevrandao) zero-initialized by default. Only when a `prevRandao`/`random` override is explicitly provided does it get set to a non-zero value.

Reth was inheriting `prevrandao` from the parent block's environment, causing `mixHash` in the response to differ from geth's output.

This fix sets `prevrandao` to `B256::ZERO` before applying block overrides, matching geth's behavior. If user provides a `random` override, it will be applied by `apply_block_overrides`.

## Test Plan

Fixes failing Hive rpc-compat tests for `eth_simulateV1`, specifically `ethSimulate-blockhash-simple` which expects `mixHash` to be `0x0000...0000`.

## Related

- Part of ongoing `eth_simulateV1` compatibility work
- Related to #21396 and #21397