### PR TITLE
chore: remove unused imports in storage-api

### DIFF
--- a/crates/storage/storage-api/src/noop.rs
+++ b/crates/storage/storage-api/src/noop.rs
@@ -28,9 +28,7 @@ use reth_db_api::mock::{DatabaseMock, TxMock};
 use reth_db_models::{AccountBeforeTx, StoredBlockBodyIndices};
 use reth_ethereum_primitives::EthPrimitives;
 use reth_execution_types::ExecutionOutcome;
-use reth_primitives_traits::{
-    Account, Bytecode, NodePrimitives, RecoveredBlock, SealedHeader, StorageEntry,
-};
+use reth_primitives_traits::{Account, Bytecode, NodePrimitives, RecoveredBlock, SealedHeader};
 #[cfg(feature = "db-api")]
 use reth_prune_types::PruneModes;
 use reth_prune_types::{PruneCheckpoint, PruneSegment};
@@ -415,7 +413,9 @@ impl<C: Send + Sync, N: NodePrimitives> StorageChangeSetReader for NoopProvider<
     fn storage_changeset(
         &self,
         _block_number: BlockNumber,
-    ) -> ProviderResult<Vec<(reth_db_api::models::BlockNumberAddress, StorageEntry)>> {
+    ) -> ProviderResult<
+        Vec<(reth_db_api::models::BlockNumberAddress, reth_primitives_traits::StorageEntry)>,
+    > {
         Ok(Vec::default())
     }
 
@@ -424,14 +424,16 @@ impl<C: Send + Sync, N: NodePrimitives> StorageChangeSetReader for NoopProvider<
         _block_number: BlockNumber,
         _address: Address,
         _storage_key: B256,
-    ) -> ProviderResult<Option<StorageEntry>> {
+    ) -> ProviderResult<Option<reth_primitives_traits::StorageEntry>> {
         Ok(None)
     }
 
     fn storage_changesets_range(
         &self,
         _range: RangeInclusive<BlockNumber>,
-    ) -> ProviderResult<Vec<(reth_db_api::models::BlockNumberAddress, StorageEntry)>> {
+    ) -> ProviderResult<
+        Vec<(reth_db_api::models::BlockNumberAddress, reth_primitives_traits::StorageEntry)>,
+    > {
         Ok(Vec::default())
     }
 

--- a/crates/storage/storage-api/src/storage.rs
+++ b/crates/storage/storage-api/src/storage.rs
@@ -4,7 +4,6 @@ use alloc::{
 };
 use alloy_primitives::{Address, BlockNumber, B256};
 use core::ops::RangeInclusive;
-use reth_db_models::StorageBeforeTx;
 use reth_primitives_traits::StorageEntry;
 use reth_storage_errors::provider::ProviderResult;
 
@@ -70,11 +69,11 @@ pub trait StorageChangeSetReader: Send {
     fn storage_block_changeset(
         &self,
         block_number: BlockNumber,
-    ) -> ProviderResult<Vec<StorageBeforeTx>> {
+    ) -> ProviderResult<Vec<reth_db_models::StorageBeforeTx>> {
         self.storage_changeset(block_number).map(|changesets| {
             changesets
                 .into_iter()
-                .map(|(block_address, entry)| StorageBeforeTx {
+                .map(|(block_address, entry)| reth_db_models::StorageBeforeTx {
                     address: block_address.address(),
                     key: entry.key,
                     value: entry.value,


### PR DESCRIPTION
Removes unused imports:
- `StorageBeforeTx` from `storage.rs`
- `StorageEntry` from `noop.rs`