### PR TITLE
refactor(db): use slice instead of Vec reference in benchmark utils

### DIFF
--- a/crates/storage/db/benches/utils.rs
+++ b/crates/storage/db/benches/utils.rs
@@ -47,11 +47,10 @@ where
 }
 
 /// Sets up a clear database at `bench_db_path`.
-#[expect(clippy::ptr_arg)]
 #[allow(dead_code)]
 pub(crate) fn set_up_db<T>(
     bench_db_path: &Path,
-    pair: &Vec<(<T as Table>::Key, Bytes, <T as Table>::Value, Bytes)>,
+    pair: &[(<T as Table>::Key, Bytes, <T as Table>::Value, Bytes)],
 ) -> DatabaseEnv
 where
     T: Table,


### PR DESCRIPTION
Removes unnecessary `#[expect(clippy::ptr_arg)]` attribute by fixing the underlying issue.