### PR TITLE
feat(payload): add fn for system transaction check

### DIFF
--- a/crates/optimism/primitives/src/transaction/signed.rs
+++ b/crates/optimism/primitives/src/transaction/signed.rs
@@ -155,6 +155,10 @@ impl IsTyped2718 for OpTransactionSigned {
 }
 
 impl SignedTransaction for OpTransactionSigned {
+    fn is_system_tx(&self) -> bool {
+        self.is_deposit()
+    }
+
     fn recalculate_hash(&self) -> B256 {
         keccak256(self.encoded_2718())
     }

--- a/crates/primitives-traits/src/transaction/signed.rs
+++ b/crates/primitives-traits/src/transaction/signed.rs
@@ -48,20 +48,12 @@ pub trait SignedTransaction:
     + TxHashRef
     + IsTyped2718
 {
-    /// Returns whether this transaction is a system transaction
+    /// Returns whether this is a system transaction.
     ///
-    /// Maximum standard Ethereum transaction type value.
-    ///
-    /// Standard transaction types are:
-    /// - Type 0: Legacy transactions (original Ethereum)
-    /// - Type 1: EIP-2930 (access list transactions)
-    /// - Type 2: EIP-1559 (dynamic fee transactions)
-    /// - Type 3: EIP-4844 (blob transactions)
-    /// - Type 4: EIP-7702 (set code authorization transactions)
-    ///
-    /// Any transaction with a type > 4 is considered a non-standard/system transaction,
-    /// typically used by L2s for special purposes (e.g., Optimism deposit transactions use type
-    /// 126).
+    /// System transactions are created at the protocol level rather than by users. They are
+    /// typically used by L2s for special purposes (e.g., Optimism deposit transactions with type
+    /// 126) and may have different validation rules or fee handling compared to standard
+    /// user-initiated transactions.
     fn is_system_tx(&self) -> bool {
         false
     }

--- a/crates/primitives-traits/src/transaction/signed.rs
+++ b/crates/primitives-traits/src/transaction/signed.rs
@@ -48,6 +48,24 @@ pub trait SignedTransaction:
     + TxHashRef
     + IsTyped2718
 {
+    /// Returns whether this transaction is a system transaction
+    ///
+    /// Maximum standard Ethereum transaction type value.
+    ///
+    /// Standard transaction types are:
+    /// - Type 0: Legacy transactions (original Ethereum)
+    /// - Type 1: EIP-2930 (access list transactions)
+    /// - Type 2: EIP-1559 (dynamic fee transactions)
+    /// - Type 3: EIP-4844 (blob transactions)
+    /// - Type 4: EIP-7702 (set code authorization transactions)
+    ///
+    /// Any transaction with a type > 4 is considered a non-standard/system transaction,
+    /// typically used by L2s for special purposes (e.g., Optimism deposit transactions use type
+    /// 126).
+    fn is_system_tx(&self) -> bool {
+        false
+    }
+
     /// Returns whether this transaction type can be __broadcasted__ as full transaction over the
     /// network.
     ///


### PR DESCRIPTION
Fixes second part of #20431 

- Add is_system_tx method in SignedTransaction trait
    - by default returns false
    - for OP it returns if the tx is a deposit