### PR TITLE
perf(rocksdb): reduce default block size from 16KB to 4KB

### DIFF
--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -97,8 +97,8 @@ impl fmt::Debug for RocksDBWriteCtx {
 /// Default cache size for `RocksDB` block cache (128 MB).
 const DEFAULT_CACHE_SIZE: usize = 128 << 20;
 
-/// Default block size for `RocksDB` tables (16 KB).
-const DEFAULT_BLOCK_SIZE: usize = 16 * 1024;
+/// Default block size for `RocksDB` tables (4 KB).
+const DEFAULT_BLOCK_SIZE: usize = 4 * 1024;
 
 /// Default max background jobs for `RocksDB` compaction and flushing.
 const DEFAULT_MAX_BACKGROUND_JOBS: i32 = 6;


### PR DESCRIPTION
## Summary

Reduces `DEFAULT_BLOCK_SIZE` from 16 KiB to 4 KiB for RocksDB tables.

## Motivation

As noted by @pepyakin , with a 16 KiB block size:

> Theoretically it could be less optimal for the case of point reads, because a point read will have to read 4 pages instead of one. I guess for seeks it might be as well.

Since OS pages are typically 4 KiB, a single key lookup with 16 KiB blocks loads 4 pages into cache when only 1 page worth of data is needed. This wastes I/O bandwidth and cache space, especially for random point lookups like transaction hash lookups (`TransactionHashNumbers` table).

Reducing to 4 KiB aligns RocksDB blocks with OS page size, improving:
- **Point read efficiency**: Read exactly what's needed
- **Cache utilization**: More granular caching, less wasted memory
- **Write tail latency**: Smaller blocks commit faster

## Benchmark Results (500K keys)

| Metric | 4 KiB | 16 KiB | Difference |
|--------|-------|--------|------------|
| **Write ops/sec** | 1,611 | 1,487 | **+8.3% for 4KiB** |
| Write p50 | 589μs | 688μs | 4KiB is 14% faster |
| Write p99 | 831μs | 983μs | 4KiB is 15% faster |
| **Point read ops/sec** | 35,440 | 35,188 | ~same (+0.7%) |
| Point read p99 | 31μs | 32μs | ~same |
| **Range scan ops/sec** | 57,556 | 60,121 | -4.3% for 4KiB |
| Range scan p99 | 26μs | 44μs | **4KiB 41% faster p99** |

### Full Benchmark Results (100K keys, all block sizes)

| Block Size | Operation | ops/sec | p50 (μs) | p99 (μs) | p999 (μs) |
|------------|-----------|---------|----------|----------|-----------|
| 4 KiB | write | 2,180 | 438 | 650 | 757 |
| 4 KiB | point_read | 565,276 | 1 | 4 | 4 |
| 4 KiB | range_scan | 56,500 | 18 | 22 | 53 |
| 8 KiB | write | 2,171 | 443 | 681 | 745 |
| 8 KiB | point_read | 567,711 | 1 | 4 | 5 |
| 8 KiB | range_scan | 59,946 | 15 | 33 | 57 |
| 16 KiB | write | 2,221 | 426 | 782 | 917 |
| 16 KiB | point_read | 569,529 | 1 | 3 | 7 |
| 16 KiB | range_scan | 59,242 | 18 | 38 | 53 |
| 32 KiB | write | 2,283 | 418 | 493 | 563 |
| 32 KiB | point_read | 576,566 | 1 | 2 | 10 |
| 32 KiB | range_scan | 52,316 | 17 | 33 | 51 |

## Key Observations

1. **Write performance**: 4 KiB has significantly better tail latency (p99: 831μs vs 983μs)
2. **Point reads**: Essentially identical across all block sizes (within noise)
3. **Range scans**: 4 KiB has ~4% lower throughput but **41% better p99 latency**
4. **Memory efficiency**: Smaller blocks = less wasted I/O for point lookups (only 1 page vs 4)

## Benchmark Code

https://gist.github.com/yongkangc/b2c749c18a1907ea77187788bf01a507

cc @pepyakin  @Joshiedo