### PR TITLE
fix(era-utils): export correct era1 CompressedBody payload

### DIFF
--- a/crates/era-utils/src/export.rs
+++ b/crates/era-utils/src/export.rs
@@ -20,6 +20,7 @@ use reth_era::{
     },
 };
 use reth_fs_util as fs;
+use reth_primitives_traits::Block;
 use reth_storage_api::{BlockNumReader, BlockReader, HeaderProvider};
 use std::{
     path::PathBuf,
@@ -295,9 +296,11 @@ where
         return Err(eyre!("Expected block {expected_block_number}, got {actual_block_number}"));
     }
 
+    // CompressedBody must contain the block *body* (rlp(body)), not the full block (rlp(block)).
     let body = provider
         .block_by_number(actual_block_number)?
-        .ok_or_else(|| eyre!("Block body not found for block {}", actual_block_number))?;
+        .ok_or_else(|| eyre!("Block not found for block {}", actual_block_number))?
+        .into_body();
 
     let receipts = provider
         .receipts_by_block(actual_block_number.into())?


### PR DESCRIPTION
Export was encoding the full block into the ERA1 CompressedBody record. This breaks the era1 format because CompressedBody is defined as rlp(body), not rlp(block). Update export to extract block body before compression and import the Block trait to use into_body().