### PR TITLE
fix(rpc): populate block_hash in eth_simulateV1 logs

### DIFF
--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -299,6 +299,7 @@ where
                             log_index: Some(log_index - 1),
                             transaction_index: Some(index as u64),
                             transaction_hash: Some(*tx.tx_hash()),
+                            block_hash: Some(block.hash()),
                             block_number: Some(block.header().number()),
                             block_timestamp: Some(block.header().timestamp()),
                             ..Default::default()


### PR DESCRIPTION
## Summary

The logs in `eth_simulateV1` response were missing the `block_hash` field, returning `null` instead of the simulated block's hash.

## Test

Fixes hive test `eth_simulateV1/ethSimulate-eth-send-should-produce-logs`:

```diff
"blockHash": -- null ++ "0xd568b74dd9ae10031741a45a142f7dcb2625d2e31b552a6fef3a87542daef335"
```