### PR TITLE
docs(tracing): fix incorrect example description in lib.rs

### DIFF
--- a/crates/tracing/src/lib.rs
+++ b/crates/tracing/src/lib.rs
@@ -32,8 +32,7 @@
 //!  }
 //!  ```
 //!
-//!  This example sets up a tracer with JSON format logging for journald and terminal-friendly
-//! format  for file logging.
+//! This example sets up a tracer with JSON format logging to stdout.
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",


### PR DESCRIPTION
 Fixed misleading doc comment in `crates/tracing/src/lib.rs` that incorrectly described the example code.
