### PR TITLE
test: add E2E test for RocksDB provider functionality

### DIFF
--- a/crates/e2e-test-utils/Cargo.toml
+++ b/crates/e2e-test-utils/Cargo.toml
@@ -72,3 +72,11 @@ derive_more.workspace = true
 [[test]]
 name = "e2e_testsuite"
 path = "tests/e2e-testsuite/main.rs"
+
+[[test]]
+name = "rocksdb"
+path = "tests/rocksdb/main.rs"
+required-features = ["edge"]
+
+[features]
+edge = ["reth-node-core/edge"]

--- a/crates/e2e-test-utils/tests/rocksdb/main.rs
+++ b/crates/e2e-test-utils/tests/rocksdb/main.rs
@@ -1,7 +1,7 @@
-//! E2E tests for `RocksDB` provider functionality.
+//! `E2E` tests for `RocksDB` provider functionality.
 //!
 //! These tests verify that reth can start and operate correctly with `RocksDB`
-//! enabled for various tables instead of the default `MDBX` storage.
+//! enabled for various tables instead of the default MDBX storage.
 
 #![cfg(all(feature = "edge", unix))]
 
@@ -20,9 +20,9 @@ use std::sync::Arc;
 
 /// Helper function to enable `RocksDB` for all supported tables.
 ///
-/// This modifies the node configuration to route tx-hash, storages-history,
-/// and account-history tables to `RocksDB` instead of `MDBX`.
-fn with_rocksdb_enabled<C>(mut config: NodeConfig<C>) -> NodeConfig<C> {
+/// This modifies the node configuration to route `tx-hash`, `storages-history`,
+/// and `account-history` tables to `RocksDB` instead of MDBX.
+const fn with_rocksdb_enabled<C>(mut config: NodeConfig<C>) -> NodeConfig<C> {
     config.rocksdb =
         RocksDbArgs { all: true, tx_hash: true, storages_history: true, account_history: true };
     config

--- a/crates/e2e-test-utils/tests/rocksdb/main.rs
+++ b/crates/e2e-test-utils/tests/rocksdb/main.rs
@@ -1,7 +1,7 @@
-//! E2E tests for RocksDB provider functionality.
+//! E2E tests for `RocksDB` provider functionality.
 //!
-//! These tests verify that reth can start and operate correctly with RocksDB
-//! enabled for various tables instead of the default MDBX storage.
+//! These tests verify that reth can start and operate correctly with `RocksDB`
+//! enabled for various tables instead of the default `MDBX` storage.
 
 #![cfg(all(feature = "edge", unix))]
 
@@ -18,19 +18,19 @@ use reth_node_ethereum::EthereumNode;
 use reth_payload_builder::EthPayloadBuilderAttributes;
 use std::sync::Arc;
 
-/// Helper function to enable RocksDB for all supported tables.
+/// Helper function to enable `RocksDB` for all supported tables.
 ///
 /// This modifies the node configuration to route tx-hash, storages-history,
-/// and account-history tables to RocksDB instead of MDBX.
+/// and account-history tables to `RocksDB` instead of `MDBX`.
 fn with_rocksdb_enabled<C>(mut config: NodeConfig<C>) -> NodeConfig<C> {
     config.rocksdb =
         RocksDbArgs { all: true, tx_hash: true, storages_history: true, account_history: true };
     config
 }
 
-/// Test that a node with RocksDB enabled can start up and shut down cleanly.
+/// Test that a node with `RocksDB` enabled can start up and shut down cleanly.
 ///
-/// This is a minimal smoke test to verify that the RocksDB provider integration
+/// This is a minimal smoke test to verify that the `RocksDB` provider integration
 /// works correctly at a basic level.
 #[tokio::test]
 async fn test_rocksdb_node_startup() -> Result<()> {
@@ -72,9 +72,9 @@ async fn test_rocksdb_node_startup() -> Result<()> {
     Ok(())
 }
 
-/// Test that a node with RocksDB enabled can mine blocks and advance the chain.
+/// Test that a node with `RocksDB` enabled can mine blocks and advance the chain.
 ///
-/// This verifies that block production works correctly when using RocksDB
+/// This verifies that block production works correctly when using `RocksDB`
 /// for storage, including proper state transitions and block persistence.
 #[tokio::test]
 async fn test_rocksdb_block_mining() -> Result<()> {
@@ -131,9 +131,9 @@ async fn test_rocksdb_block_mining() -> Result<()> {
     Ok(())
 }
 
-/// Test that a node with RocksDB enabled correctly stores and retrieves transactions.
+/// Test that a node with `RocksDB` enabled correctly stores and retrieves transactions.
 ///
-/// This verifies that the TransactionHashNumbers RocksDB table works correctly
+/// This verifies that the `TransactionHashNumbers` `RocksDB` table works correctly
 /// by injecting transactions, mining blocks, and then querying the transactions
 /// via RPC to ensure they can be looked up by hash.
 #[tokio::test]

--- a/crates/e2e-test-utils/tests/rocksdb/main.rs
+++ b/crates/e2e-test-utils/tests/rocksdb/main.rs
@@ -1,0 +1,230 @@
+//! E2E tests for RocksDB provider functionality.
+//!
+//! These tests verify that reth can start and operate correctly with RocksDB
+//! enabled for various tables instead of the default MDBX storage.
+
+#![cfg(all(feature = "edge", unix))]
+
+use alloy_consensus::BlockHeader;
+use alloy_primitives::B256;
+use alloy_rpc_types_eth::{Transaction, TransactionReceipt};
+use eyre::Result;
+use jsonrpsee::core::client::ClientT;
+use reth_chainspec::{ChainSpecBuilder, MAINNET};
+use reth_e2e_test_utils::{transaction::TransactionTestContext, E2ETestSetupBuilder};
+use reth_node_builder::NodeConfig;
+use reth_node_core::args::RocksDbArgs;
+use reth_node_ethereum::EthereumNode;
+use reth_payload_builder::EthPayloadBuilderAttributes;
+use std::sync::Arc;
+
+/// Helper function to enable RocksDB for all supported tables.
+///
+/// This modifies the node configuration to route tx-hash, storages-history,
+/// and account-history tables to RocksDB instead of MDBX.
+fn with_rocksdb_enabled<C>(mut config: NodeConfig<C>) -> NodeConfig<C> {
+    config.rocksdb =
+        RocksDbArgs { all: true, tx_hash: true, storages_history: true, account_history: true };
+    config
+}
+
+/// Test that a node with RocksDB enabled can start up and shut down cleanly.
+///
+/// This is a minimal smoke test to verify that the RocksDB provider integration
+/// works correctly at a basic level.
+#[tokio::test]
+async fn test_rocksdb_node_startup() -> Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let chain_spec = Arc::new(
+        ChainSpecBuilder::default()
+            .chain(MAINNET.chain)
+            .genesis(
+                serde_json::from_str(include_str!("../../src/testsuite/assets/genesis.json"))
+                    .unwrap(),
+            )
+            .cancun_activated()
+            .build(),
+    );
+
+    let attributes_generator = |timestamp| {
+        let attributes = alloy_rpc_types_engine::PayloadAttributes {
+            timestamp,
+            prev_randao: B256::ZERO,
+            suggested_fee_recipient: alloy_primitives::Address::ZERO,
+            withdrawals: Some(vec![]),
+            parent_beacon_block_root: Some(B256::ZERO),
+        };
+        EthPayloadBuilderAttributes::new(B256::ZERO, attributes)
+    };
+
+    let (nodes, _tasks, _wallet) =
+        E2ETestSetupBuilder::<EthereumNode, _>::new(1, chain_spec, attributes_generator)
+            .with_node_config_modifier(with_rocksdb_enabled)
+            .build()
+            .await?;
+
+    assert_eq!(nodes.len(), 1, "Expected exactly one node to be created");
+
+    let genesis_hash = nodes[0].block_hash(0);
+    assert_ne!(genesis_hash, B256::ZERO, "Genesis hash should not be zero");
+
+    Ok(())
+}
+
+/// Test that a node with RocksDB enabled can mine blocks and advance the chain.
+///
+/// This verifies that block production works correctly when using RocksDB
+/// for storage, including proper state transitions and block persistence.
+#[tokio::test]
+async fn test_rocksdb_block_mining() -> Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let chain_spec = Arc::new(
+        ChainSpecBuilder::default()
+            .chain(MAINNET.chain)
+            .genesis(
+                serde_json::from_str(include_str!("../../src/testsuite/assets/genesis.json"))
+                    .unwrap(),
+            )
+            .cancun_activated()
+            .build(),
+    );
+
+    let attributes_generator = |timestamp| {
+        let attributes = alloy_rpc_types_engine::PayloadAttributes {
+            timestamp,
+            prev_randao: B256::ZERO,
+            suggested_fee_recipient: alloy_primitives::Address::ZERO,
+            withdrawals: Some(vec![]),
+            parent_beacon_block_root: Some(B256::ZERO),
+        };
+        EthPayloadBuilderAttributes::new(B256::ZERO, attributes)
+    };
+
+    let (mut nodes, _tasks, _wallet) =
+        E2ETestSetupBuilder::<EthereumNode, _>::new(1, chain_spec, attributes_generator)
+            .with_node_config_modifier(with_rocksdb_enabled)
+            .build()
+            .await?;
+
+    assert_eq!(nodes.len(), 1, "Expected exactly one node to be created");
+
+    let genesis_hash = nodes[0].block_hash(0);
+    assert_ne!(genesis_hash, B256::ZERO, "Genesis hash should not be zero");
+
+    // Mine 3 blocks
+    for i in 1..=3 {
+        let payload = nodes[0].advance_block().await?;
+        let block = payload.block();
+
+        assert_eq!(block.number(), i, "Block number should be {i}");
+        assert_ne!(block.hash(), B256::ZERO, "Block {i} hash should not be zero");
+    }
+
+    // Verify all blocks are stored correctly
+    for i in 0..=3 {
+        let block_hash = nodes[0].block_hash(i);
+        assert_ne!(block_hash, B256::ZERO, "Block {i} should be stored with non-zero hash");
+    }
+
+    Ok(())
+}
+
+/// Test that a node with RocksDB enabled correctly stores and retrieves transactions.
+///
+/// This verifies that the TransactionHashNumbers RocksDB table works correctly
+/// by injecting transactions, mining blocks, and then querying the transactions
+/// via RPC to ensure they can be looked up by hash.
+#[tokio::test]
+async fn test_rocksdb_transaction_queries() -> Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let chain_spec = Arc::new(
+        ChainSpecBuilder::default()
+            .chain(MAINNET.chain)
+            .genesis(
+                serde_json::from_str(include_str!("../../src/testsuite/assets/genesis.json"))
+                    .unwrap(),
+            )
+            .cancun_activated()
+            .build(),
+    );
+
+    let attributes_generator = |timestamp| {
+        let attributes = alloy_rpc_types_engine::PayloadAttributes {
+            timestamp,
+            prev_randao: B256::ZERO,
+            suggested_fee_recipient: alloy_primitives::Address::ZERO,
+            withdrawals: Some(vec![]),
+            parent_beacon_block_root: Some(B256::ZERO),
+        };
+        EthPayloadBuilderAttributes::new(B256::ZERO, attributes)
+    };
+
+    let (mut nodes, _tasks, wallet) =
+        E2ETestSetupBuilder::<EthereumNode, _>::new(1, chain_spec.clone(), attributes_generator)
+            .with_node_config_modifier(with_rocksdb_enabled)
+            .build()
+            .await?;
+
+    assert_eq!(nodes.len(), 1, "Expected exactly one node to be created");
+
+    let chain_id = chain_spec.chain().id();
+    let mut tx_hashes = Vec::new();
+
+    // Inject and mine 3 transactions
+    for i in 0..3 {
+        // Create a new wallet for each tx to avoid nonce issues
+        let wallets = wallet.wallet_gen();
+        let signer = wallets[0].clone();
+
+        // Create and sign a transfer transaction
+        let raw_tx = TransactionTestContext::transfer_tx_bytes(chain_id, signer).await;
+
+        // Inject the transaction into the mempool
+        let tx_hash = nodes[0].rpc.inject_tx(raw_tx).await?;
+        tx_hashes.push(tx_hash);
+
+        // Mine a block containing the transaction
+        let payload = nodes[0].advance_block().await?;
+        let block = payload.block();
+        assert_eq!(block.number(), i + 1, "Block number should be {}", i + 1);
+    }
+
+    // Get the RPC client to query transactions
+    let client = nodes[0].rpc_client().expect("RPC client should be available");
+
+    // Query each transaction by hash and verify the responses
+    for (i, tx_hash) in tx_hashes.iter().enumerate() {
+        let expected_block_number = (i + 1) as u64;
+
+        // Query eth_getTransactionByHash
+        let tx: Option<Transaction> = client.request("eth_getTransactionByHash", [tx_hash]).await?;
+
+        let tx = tx.expect("Transaction should be found by hash");
+        assert_eq!(
+            tx.block_number,
+            Some(expected_block_number),
+            "Transaction {} should be in block {}",
+            tx_hash,
+            expected_block_number
+        );
+
+        // Query eth_getTransactionReceipt
+        let receipt: Option<TransactionReceipt> =
+            client.request("eth_getTransactionReceipt", [tx_hash]).await?;
+
+        let receipt = receipt.expect("Transaction receipt should be found by hash");
+        assert_eq!(
+            receipt.block_number,
+            Some(expected_block_number),
+            "Receipt for {} should be in block {}",
+            tx_hash,
+            expected_block_number
+        );
+        assert!(receipt.status(), "Transaction {} should have succeeded", tx_hash);
+    }
+
+    Ok(())
+}

--- a/crates/e2e-test-utils/tests/rocksdb/main.rs
+++ b/crates/e2e-test-utils/tests/rocksdb/main.rs
@@ -1,7 +1,4 @@
-//! `E2E` tests for `RocksDB` provider functionality.
-//!
-//! These tests verify that reth can start and operate correctly with `RocksDB`
-//! enabled for various tables instead of the default MDBX storage.
+//! E2E tests for `RocksDB` provider functionality.
 
 #![cfg(all(feature = "edge", unix))]
 
@@ -10,7 +7,7 @@ use alloy_primitives::B256;
 use alloy_rpc_types_eth::{Transaction, TransactionReceipt};
 use eyre::Result;
 use jsonrpsee::core::client::ClientT;
-use reth_chainspec::{ChainSpecBuilder, MAINNET};
+use reth_chainspec::{ChainSpec, ChainSpecBuilder, MAINNET};
 use reth_e2e_test_utils::{transaction::TransactionTestContext, E2ETestSetupBuilder};
 use reth_node_builder::NodeConfig;
 use reth_node_core::args::RocksDbArgs;
@@ -18,213 +15,155 @@ use reth_node_ethereum::EthereumNode;
 use reth_payload_builder::EthPayloadBuilderAttributes;
 use std::sync::Arc;
 
-/// Helper function to enable `RocksDB` for all supported tables.
-///
-/// This modifies the node configuration to route `tx-hash`, `storages-history`,
-/// and `account-history` tables to `RocksDB` instead of MDBX.
-const fn with_rocksdb_enabled<C>(mut config: NodeConfig<C>) -> NodeConfig<C> {
-    config.rocksdb =
-        RocksDbArgs { all: true, tx_hash: true, storages_history: true, account_history: true };
+/// Returns the test chain spec for `RocksDB` tests.
+fn test_chain_spec() -> Arc<ChainSpec> {
+    Arc::new(
+        ChainSpecBuilder::default()
+            .chain(MAINNET.chain)
+            .genesis(
+                serde_json::from_str(include_str!("../../src/testsuite/assets/genesis.json"))
+                    .unwrap(),
+            )
+            .cancun_activated()
+            .build(),
+    )
+}
+
+/// Returns test payload attributes for the given timestamp.
+fn test_attributes_generator(timestamp: u64) -> EthPayloadBuilderAttributes {
+    let attributes = alloy_rpc_types_engine::PayloadAttributes {
+        timestamp,
+        prev_randao: B256::ZERO,
+        suggested_fee_recipient: alloy_primitives::Address::ZERO,
+        withdrawals: Some(vec![]),
+        parent_beacon_block_root: Some(B256::ZERO),
+    };
+    EthPayloadBuilderAttributes::new(B256::ZERO, attributes)
+}
+
+/// Enables `RocksDB` for all supported tables.
+fn with_rocksdb_enabled<C>(mut config: NodeConfig<C>) -> NodeConfig<C> {
+    config.rocksdb = RocksDbArgs { all: true, ..Default::default() };
     config
 }
 
-/// Test that a node with `RocksDB` enabled can start up and shut down cleanly.
-///
-/// This is a minimal smoke test to verify that the `RocksDB` provider integration
-/// works correctly at a basic level.
+/// Smoke test: node boots with `RocksDB` routing enabled.
 #[tokio::test]
 async fn test_rocksdb_node_startup() -> Result<()> {
     reth_tracing::init_test_tracing();
 
-    let chain_spec = Arc::new(
-        ChainSpecBuilder::default()
-            .chain(MAINNET.chain)
-            .genesis(
-                serde_json::from_str(include_str!("../../src/testsuite/assets/genesis.json"))
-                    .unwrap(),
-            )
-            .cancun_activated()
-            .build(),
-    );
-
-    let attributes_generator = |timestamp| {
-        let attributes = alloy_rpc_types_engine::PayloadAttributes {
-            timestamp,
-            prev_randao: B256::ZERO,
-            suggested_fee_recipient: alloy_primitives::Address::ZERO,
-            withdrawals: Some(vec![]),
-            parent_beacon_block_root: Some(B256::ZERO),
-        };
-        EthPayloadBuilderAttributes::new(B256::ZERO, attributes)
-    };
+    let chain_spec = test_chain_spec();
 
     let (nodes, _tasks, _wallet) =
-        E2ETestSetupBuilder::<EthereumNode, _>::new(1, chain_spec, attributes_generator)
+        E2ETestSetupBuilder::<EthereumNode, _>::new(1, chain_spec, test_attributes_generator)
             .with_node_config_modifier(with_rocksdb_enabled)
             .build()
             .await?;
 
-    assert_eq!(nodes.len(), 1, "Expected exactly one node to be created");
+    assert_eq!(nodes.len(), 1);
+
+    // Verify RocksDB directory exists
+    let rocksdb_path = nodes[0].inner.data_dir.rocksdb();
+    assert!(rocksdb_path.exists(), "RocksDB directory should exist at {rocksdb_path:?}");
+    assert!(
+        std::fs::read_dir(&rocksdb_path).map(|mut d| d.next().is_some()).unwrap_or(false),
+        "RocksDB directory should be non-empty"
+    );
 
     let genesis_hash = nodes[0].block_hash(0);
-    assert_ne!(genesis_hash, B256::ZERO, "Genesis hash should not be zero");
+    assert_ne!(genesis_hash, B256::ZERO);
 
     Ok(())
 }
 
-/// Test that a node with `RocksDB` enabled can mine blocks and advance the chain.
-///
-/// This verifies that block production works correctly when using `RocksDB`
-/// for storage, including proper state transitions and block persistence.
+/// Block mining works with `RocksDB` storage.
 #[tokio::test]
 async fn test_rocksdb_block_mining() -> Result<()> {
     reth_tracing::init_test_tracing();
 
-    let chain_spec = Arc::new(
-        ChainSpecBuilder::default()
-            .chain(MAINNET.chain)
-            .genesis(
-                serde_json::from_str(include_str!("../../src/testsuite/assets/genesis.json"))
-                    .unwrap(),
-            )
-            .cancun_activated()
-            .build(),
-    );
-
-    let attributes_generator = |timestamp| {
-        let attributes = alloy_rpc_types_engine::PayloadAttributes {
-            timestamp,
-            prev_randao: B256::ZERO,
-            suggested_fee_recipient: alloy_primitives::Address::ZERO,
-            withdrawals: Some(vec![]),
-            parent_beacon_block_root: Some(B256::ZERO),
-        };
-        EthPayloadBuilderAttributes::new(B256::ZERO, attributes)
-    };
+    let chain_spec = test_chain_spec();
 
     let (mut nodes, _tasks, _wallet) =
-        E2ETestSetupBuilder::<EthereumNode, _>::new(1, chain_spec, attributes_generator)
+        E2ETestSetupBuilder::<EthereumNode, _>::new(1, chain_spec, test_attributes_generator)
             .with_node_config_modifier(with_rocksdb_enabled)
             .build()
             .await?;
 
-    assert_eq!(nodes.len(), 1, "Expected exactly one node to be created");
+    assert_eq!(nodes.len(), 1);
 
     let genesis_hash = nodes[0].block_hash(0);
-    assert_ne!(genesis_hash, B256::ZERO, "Genesis hash should not be zero");
+    assert_ne!(genesis_hash, B256::ZERO);
 
     // Mine 3 blocks
     for i in 1..=3 {
         let payload = nodes[0].advance_block().await?;
         let block = payload.block();
-
-        assert_eq!(block.number(), i, "Block number should be {i}");
-        assert_ne!(block.hash(), B256::ZERO, "Block {i} hash should not be zero");
+        assert_eq!(block.number(), i);
+        assert_ne!(block.hash(), B256::ZERO);
     }
 
-    // Verify all blocks are stored correctly
+    // Verify all blocks are stored
     for i in 0..=3 {
         let block_hash = nodes[0].block_hash(i);
-        assert_ne!(block_hash, B256::ZERO, "Block {i} should be stored with non-zero hash");
+        assert_ne!(block_hash, B256::ZERO);
     }
 
     Ok(())
 }
 
-/// Test that a node with `RocksDB` enabled correctly stores and retrieves transactions.
-///
-/// This verifies that the `TransactionHashNumbers` `RocksDB` table works correctly
-/// by injecting transactions, mining blocks, and then querying the transactions
-/// via RPC to ensure they can be looked up by hash.
+/// Tx hash lookup exercises `TransactionHashNumbers` table.
 #[tokio::test]
 async fn test_rocksdb_transaction_queries() -> Result<()> {
     reth_tracing::init_test_tracing();
 
-    let chain_spec = Arc::new(
-        ChainSpecBuilder::default()
-            .chain(MAINNET.chain)
-            .genesis(
-                serde_json::from_str(include_str!("../../src/testsuite/assets/genesis.json"))
-                    .unwrap(),
-            )
-            .cancun_activated()
-            .build(),
-    );
-
-    let attributes_generator = |timestamp| {
-        let attributes = alloy_rpc_types_engine::PayloadAttributes {
-            timestamp,
-            prev_randao: B256::ZERO,
-            suggested_fee_recipient: alloy_primitives::Address::ZERO,
-            withdrawals: Some(vec![]),
-            parent_beacon_block_root: Some(B256::ZERO),
-        };
-        EthPayloadBuilderAttributes::new(B256::ZERO, attributes)
-    };
+    let chain_spec = test_chain_spec();
+    let chain_id = chain_spec.chain().id();
 
     let (mut nodes, _tasks, wallet) =
-        E2ETestSetupBuilder::<EthereumNode, _>::new(1, chain_spec.clone(), attributes_generator)
+        E2ETestSetupBuilder::<EthereumNode, _>::new(1, chain_spec, test_attributes_generator)
             .with_node_config_modifier(with_rocksdb_enabled)
             .build()
             .await?;
 
-    assert_eq!(nodes.len(), 1, "Expected exactly one node to be created");
+    assert_eq!(nodes.len(), 1);
 
-    let chain_id = chain_spec.chain().id();
     let mut tx_hashes = Vec::new();
 
-    // Inject and mine 3 transactions
+    // Inject and mine 3 transactions (new wallet per tx to avoid nonce tracking)
     for i in 0..3 {
-        // Create a new wallet for each tx to avoid nonce issues
         let wallets = wallet.wallet_gen();
         let signer = wallets[0].clone();
 
-        // Create and sign a transfer transaction
         let raw_tx = TransactionTestContext::transfer_tx_bytes(chain_id, signer).await;
-
-        // Inject the transaction into the mempool
         let tx_hash = nodes[0].rpc.inject_tx(raw_tx).await?;
         tx_hashes.push(tx_hash);
 
-        // Mine a block containing the transaction
         let payload = nodes[0].advance_block().await?;
-        let block = payload.block();
-        assert_eq!(block.number(), i + 1, "Block number should be {}", i + 1);
+        assert_eq!(payload.block().number(), i + 1);
     }
 
-    // Get the RPC client to query transactions
     let client = nodes[0].rpc_client().expect("RPC client should be available");
 
-    // Query each transaction by hash and verify the responses
+    // Query each transaction by hash
     for (i, tx_hash) in tx_hashes.iter().enumerate() {
         let expected_block_number = (i + 1) as u64;
 
-        // Query eth_getTransactionByHash
         let tx: Option<Transaction> = client.request("eth_getTransactionByHash", [tx_hash]).await?;
+        let tx = tx.expect("Transaction should be found");
+        assert_eq!(tx.block_number, Some(expected_block_number));
 
-        let tx = tx.expect("Transaction should be found by hash");
-        assert_eq!(
-            tx.block_number,
-            Some(expected_block_number),
-            "Transaction {} should be in block {}",
-            tx_hash,
-            expected_block_number
-        );
-
-        // Query eth_getTransactionReceipt
         let receipt: Option<TransactionReceipt> =
             client.request("eth_getTransactionReceipt", [tx_hash]).await?;
-
-        let receipt = receipt.expect("Transaction receipt should be found by hash");
-        assert_eq!(
-            receipt.block_number,
-            Some(expected_block_number),
-            "Receipt for {} should be in block {}",
-            tx_hash,
-            expected_block_number
-        );
-        assert!(receipt.status(), "Transaction {} should have succeeded", tx_hash);
+        let receipt = receipt.expect("Receipt should be found");
+        assert_eq!(receipt.block_number, Some(expected_block_number));
+        assert!(receipt.status());
     }
+
+    // Negative test: querying a non-existent tx hash returns None
+    let random_hash = B256::random();
+    let missing_tx: Option<Transaction> =
+        client.request("eth_getTransactionByHash", [random_hash]).await?;
+    assert!(missing_tx.is_none(), "Random tx hash should not exist");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Implements #20424

This adds E2E tests to verify RocksDB provider integration works correctly.

## Tests Added

| Test | Purpose |
|------|---------|
| `test_rocksdb_node_startup` | Verifies node starts with RocksDB enabled |
| `test_rocksdb_block_mining` | Mines 3 blocks and verifies chain advances |
| `test_rocksdb_transaction_queries` | Injects transactions, mines blocks, queries via `eth_getTransactionByHash`/`eth_getTransactionReceipt` |

## Key Implementation Details

- Tests are feature-gated behind `#[cfg(all(feature = "edge", unix))]`
- Uses `with_rocksdb_enabled()` helper to configure `NodeConfig.rocksdb` with all tables enabled
- Transaction query test exercises the `TransactionHashNumbers` RocksDB table

## Run Tests

```bash
cargo test -p reth-e2e-test-utils --features edge --test rocksdb
```

## related to

- #20384 (RocksDB routing must be merged for tests to be meaningful)

---

Closes #20424