### PR TITLE
fix(stages): retain RocksDB TempDir in TestStageDB to prevent premature deletion

### DIFF
--- a/crates/stages/stages/src/test_utils/test_db.rs
+++ b/crates/stages/stages/src/test_utils/test_db.rs
@@ -38,15 +38,17 @@ use tempfile::TempDir;
 pub struct TestStageDB {
     pub factory: ProviderFactory<MockNodeTypesWithDB>,
     pub temp_static_files_dir: TempDir,
+    pub temp_rocksdb_dir: TempDir,
 }
 
 impl Default for TestStageDB {
     /// Create a new instance of [`TestStageDB`]
     fn default() -> Self {
         let (static_dir, static_dir_path) = create_test_static_files_dir();
-        let (_, rocksdb_dir_path) = create_test_rocksdb_dir();
+        let (rocksdb_dir, rocksdb_dir_path) = create_test_rocksdb_dir();
         Self {
             temp_static_files_dir: static_dir,
+            temp_rocksdb_dir: rocksdb_dir,
             factory: ProviderFactory::new(
                 create_test_rw_db(),
                 MAINNET.clone(),
@@ -61,10 +63,11 @@ impl Default for TestStageDB {
 impl TestStageDB {
     pub fn new(path: &Path) -> Self {
         let (static_dir, static_dir_path) = create_test_static_files_dir();
-        let (_, rocksdb_dir_path) = create_test_rocksdb_dir();
+        let (rocksdb_dir, rocksdb_dir_path) = create_test_rocksdb_dir();
 
         Self {
             temp_static_files_dir: static_dir,
+            temp_rocksdb_dir: rocksdb_dir,
             factory: ProviderFactory::new(
                 create_test_rw_db_with_path(path),
                 MAINNET.clone(),


### PR DESCRIPTION
The RocksDB temp directory was being dropped immediately after creation in both `TestStageDB::default()` and `TestStageDB::new()`, while the path was still being used by RocksDBProvider. This could cause the directory to be deleted before RocksDB finished using it, leading to undefined behavior.                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                       Added `temp_rocksdb_dir` field to TestStageDB to keep the TempDir alive for the struct's lifetime, matching how we already handle `temp_static_files_dir`. Also matches the pattern used in `provider/src/test_utils/mod.rs` and `exex/test-utils/src/lib.rs`. 