### PR TITLE
refactor(storage): remove dead test helper functions from LatestStateProvider

### DIFF
--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -195,14 +195,3 @@ impl<Provider: DBProvider> LatestStateProvider<Provider> {
 
 // Delegates all provider impls to [LatestStateProviderRef]
 reth_storage_api::macros::delegate_provider_impls!(LatestStateProvider<Provider> where [Provider: DBProvider + BlockHashReader ]);
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    const fn assert_state_provider<T: StateProvider>() {}
-    #[expect(dead_code)]
-    const fn assert_latest_state_provider<T: DBProvider + BlockHashReader>() {
-        assert_state_provider::<LatestStateProvider<T>>();
-    }
-}


### PR DESCRIPTION
Removes unused compile-time test helpers from `LatestStateProvider` that were marked with `#[expect(dead_code)]` and never invoked.