### PR TITLE
perf(docker): use shared cache mounts for parallel builds

### DIFF
--- a/Dockerfile.depot
+++ b/Dockerfile.depot
@@ -55,17 +55,17 @@ ENV VERGEN_GIT_DIRTY=$VERGEN_GIT_DIRTY
 
 # Build dependencies
 RUN --mount=type=secret,id=DEPOT_TOKEN,env=SCCACHE_WEBDAV_TOKEN \
-    --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
-    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/registry,sharing=shared \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=shared \
+    --mount=type=cache,target=$SCCACHE_DIR,sharing=shared \
     cargo chef cook --profile $BUILD_PROFILE --features "$FEATURES" --locked --recipe-path recipe.json --manifest-path $MANIFEST_PATH/Cargo.toml
 
 # Build application
 COPY --exclude=.git . .
 RUN --mount=type=secret,id=DEPOT_TOKEN,env=SCCACHE_WEBDAV_TOKEN \
-    --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
-    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/registry,sharing=shared \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=shared \
+    --mount=type=cache,target=$SCCACHE_DIR,sharing=shared \
     cargo build --profile $BUILD_PROFILE --features "$FEATURES" --locked --bin $BINARY --manifest-path $MANIFEST_PATH/Cargo.toml
 
 # Copy binary to a known location (ARG not resolved in COPY)


### PR DESCRIPTION
## Summary

Change cache mount sharing mode from `locked` to `shared` for cargo registry, git, and sccache directories.

## Problem

With `sharing=locked`, parallel builds (7 total for nightly: 5 targets, some multi-arch) must wait for exclusive access to each cache. This causes builds to queue up even when compilation itself completes quickly—leading to 40+ minute Docker jobs despite fast individual builds.

## Solution

Use `sharing=shared` instead. Both cargo and sccache are designed to handle concurrent access correctly, so this is safe and allows parallel builds to proceed without blocking on cache locks.

## Testing

Will be validated by the next nightly Docker build—expect significant time reduction.