### PR TITLE
chore: use Default::default() for TransactionInfo for forward compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11407,9 +11407,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.34.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1ce3f52a052d78cc251714d57bf05dc8bc75e269677de11805d3153300a2cd"
+checksum = "a24ca988ae1f7a0bb5688630579c00e867cd9f1df0a2f040623887f63d3b414c"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -481,7 +481,7 @@ revm-primitives = { version = "22.0.0", default-features = false }
 revm-interpreter = { version = "32.0.0", default-features = false }
 revm-database-interface = { version = "9.0.0", default-features = false }
 op-revm = { version = "15.0.0", default-features = false }
-revm-inspectors = "0.34.0"
+revm-inspectors = "0.34.1"
 
 # eth
 alloy-chains = { version = "0.2.5", default-features = false }

--- a/crates/primitives-traits/src/block/recovered.rs
+++ b/crates/primitives-traits/src/block/recovered.rs
@@ -798,12 +798,14 @@ mod rpc_compat {
                 .zip(senders)
                 .enumerate()
                 .map(|(idx, (tx, sender))| {
+                    #[allow(clippy::needless_update)]
                     let tx_info = TransactionInfo {
                         hash: Some(*tx.tx_hash()),
                         block_hash,
                         block_number: Some(block_number),
                         base_fee,
                         index: Some(idx as u64),
+                        ..Default::default()
                     };
 
                     converter(Recovered::new_unchecked(tx, sender), tx_info)

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -310,12 +310,14 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
                     .evm_factory()
                     .create_tracer(&mut db, evm_env, inspector_setup())
                     .try_trace_many(block.transactions_recovered().take(max_transactions), |ctx| {
+                        #[allow(clippy::needless_update)]
                         let tx_info = TransactionInfo {
                             hash: Some(*ctx.tx.tx_hash()),
                             index: Some(idx),
                             block_hash: Some(block_hash),
                             block_number: Some(block_number),
                             base_fee: Some(base_fee),
+                            ..Default::default()
                         };
                         idx += 1;
 

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -290,12 +290,14 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
                 let block_number = block.number();
                 let base_fee_per_gas = block.base_fee_per_gas();
                 if let Some((signer, tx)) = block.transactions_with_sender().nth(index) {
+                    #[allow(clippy::needless_update)]
                     let tx_info = TransactionInfo {
                         hash: Some(*tx.tx_hash()),
                         block_hash: Some(block_hash),
                         block_number: Some(block_number),
                         base_fee: base_fee_per_gas,
                         index: Some(index as u64),
+                        ..Default::default()
                     };
 
                     return Ok(Some(
@@ -366,12 +368,14 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
                         .enumerate()
                         .find(|(_, (signer, tx))| **signer == sender && (*tx).nonce() == nonce)
                         .map(|(index, (signer, tx))| {
+                            #[allow(clippy::needless_update)]
                             let tx_info = TransactionInfo {
                                 hash: Some(*tx.tx_hash()),
                                 block_hash: Some(block_hash),
                                 block_number: Some(block_number),
                                 base_fee: base_fee_per_gas,
                                 index: Some(index as u64),
+                                ..Default::default()
                             };
                             Ok(self.converter().fill(tx.clone().with_signer(*signer), tx_info)?)
                         })

--- a/crates/rpc/rpc-eth-types/src/transaction.rs
+++ b/crates/rpc/rpc-eth-types/src/transaction.rs
@@ -49,12 +49,14 @@ impl<T: SignedTransaction> TransactionSource<T> {
         match self {
             Self::Pool(tx) => resp_builder.fill_pending(tx),
             Self::Block { transaction, index, block_hash, block_number, base_fee } => {
+                #[allow(clippy::needless_update)]
                 let tx_info = TransactionInfo {
                     hash: Some(transaction.trie_hash()),
                     index: Some(index),
                     block_hash: Some(block_hash),
                     block_number: Some(block_number),
                     base_fee,
+                    ..Default::default()
                 };
 
                 resp_builder.fill(transaction, tx_info)
@@ -69,6 +71,7 @@ impl<T: SignedTransaction> TransactionSource<T> {
                 let hash = tx.trie_hash();
                 (tx, TransactionInfo { hash: Some(hash), ..Default::default() })
             }
+            #[allow(clippy::needless_update)]
             Self::Block { transaction, index, block_hash, block_number, base_fee } => {
                 let hash = transaction.trie_hash();
                 (
@@ -79,6 +82,7 @@ impl<T: SignedTransaction> TransactionSource<T> {
                         block_hash: Some(block_hash),
                         block_number: Some(block_number),
                         base_fee,
+                        ..Default::default()
                     },
                 )
             }


### PR DESCRIPTION
Prepares for alloy adding a `block_timestamp` field to `TransactionInfo`.

This PR uses `..Default::default()` pattern when constructing `TransactionInfo` to ensure forward compatibility when new fields are added.

## Patches
- alloy: `feat/transaction-timestamp` branch - https://github.com/alloy-rs/alloy/pull/3606
- revm-inspectors: `feat/alloy-timestamp` branch - https://github.com/paradigmxyz/revm-inspectors/pull/401
- alloy-evm: main (already uses `..Default` pattern)

Related: https://github.com/ethereum/execution-apis/issues/729