### PR TITLE
perf(trie): use is_zero() check to avoid copy in is_storage_empty

### DIFF
--- a/crates/trie/trie/src/hashed_cursor/post_state.rs
+++ b/crates/trie/trie/src/hashed_cursor/post_state.rs
@@ -79,7 +79,7 @@ impl HashedPostStateCursorValue for U256 {
     type NonZero = Self;
 
     fn into_option(self) -> Option<Self::NonZero> {
-        (self != Self::ZERO).then_some(self)
+        (!self.is_zero()).then_some(self)
     }
 }
 
@@ -351,7 +351,7 @@ where
     /// [`HashedCursor::next`].
     fn is_storage_empty(&mut self) -> Result<bool, DatabaseError> {
         // Storage is not empty if it has non-zero slots.
-        if self.post_state_cursor.has_any(|(_, value)| value.into_option().is_some()) {
+        if self.post_state_cursor.has_any(|(_, value)| !value.is_zero()) {
             return Ok(false);
         }
 


### PR DESCRIPTION
Replaces `value.into_option().is_some()` with `!value.is_zero()` in `is_storage_empty` to avoid an unnecessary U256 copy.

Also simplifies the U256 impl of `into_option` to use `is_zero()` for consistency.

based on https://github.com/paradigmxyz/reth/pull/21439 findings cc @figtracer 

independent of #21439 this change we can easily do