### PR TITLE
chore: replace Option::map().unwrap_or(false) with is_some_and

### DIFF
--- a/crates/node/core/src/args/types.rs
+++ b/crates/node/core/src/args/types.rs
@@ -126,7 +126,7 @@ where
         arg: Option<&clap::Arg>,
         value: &std::ffi::OsStr,
     ) -> Result<Self::Value, clap::Error> {
-        if value.to_str().map(|s| s.eq_ignore_ascii_case("max")).unwrap_or(false) {
+        if value.to_str().is_some_and(|s| s.eq_ignore_ascii_case("max")) {
             Ok(u64::MAX)
         } else {
             self.inner.parse_ref(cmd, arg, value).map(Into::into)

--- a/crates/storage/errors/src/provider.rs
+++ b/crates/storage/errors/src/provider.rs
@@ -203,7 +203,7 @@ impl ProviderError {
     /// Returns true if this type is a [`ProviderError::Other`] of that error
     /// type. Returns false otherwise.
     pub fn is_other<T: core::error::Error + 'static>(&self) -> bool {
-        self.as_other().map(|err| err.is::<T>()).unwrap_or(false)
+        self.as_other().is_some_and(|err| err.is::<T>())
     }
 }
 

--- a/crates/storage/provider/src/providers/static_file/mod.rs
+++ b/crates/storage/provider/src/providers/static_file/mod.rs
@@ -590,9 +590,8 @@ mod tests {
 
     /// Returns the number of files in the provided path, excluding ".lock" files.
     fn count_files_without_lockfile(path: impl AsRef<Path>) -> eyre::Result<usize> {
-        let is_lockfile = |entry: &fs::DirEntry| {
-            entry.path().file_name().is_some_and(|name| name == "lock")
-        };
+        let is_lockfile =
+            |entry: &fs::DirEntry| entry.path().file_name().is_some_and(|name| name == "lock");
         let count = fs::read_dir(path)?
             .filter_map(|entry| entry.ok())
             .filter(|entry| !is_lockfile(entry))

--- a/crates/storage/provider/src/providers/static_file/mod.rs
+++ b/crates/storage/provider/src/providers/static_file/mod.rs
@@ -591,7 +591,7 @@ mod tests {
     /// Returns the number of files in the provided path, excluding ".lock" files.
     fn count_files_without_lockfile(path: impl AsRef<Path>) -> eyre::Result<usize> {
         let is_lockfile = |entry: &fs::DirEntry| {
-            entry.path().file_name().map(|name| name == "lock").unwrap_or(false)
+            entry.path().file_name().is_some_and(|name| name == "lock")
         };
         let count = fs::read_dir(path)?
             .filter_map(|entry| entry.ok())

--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -243,7 +243,7 @@ impl TaskManager {
         drop(self.signal);
         let when = timeout.map(|t| std::time::Instant::now() + t);
         while self.graceful_tasks.load(Ordering::Relaxed) > 0 {
-            if when.map(|when| std::time::Instant::now() > when).unwrap_or(false) {
+            if when.is_some_and(|when| std::time::Instant::now() > when) {
                 debug!("graceful shutdown timed out");
                 return false
             }

--- a/crates/transaction-pool/src/error.rs
+++ b/crates/transaction-pool/src/error.rs
@@ -442,7 +442,7 @@ impl InvalidPoolTransactionError {
     /// Returns true if the this type is a [`InvalidPoolTransactionError::Other`] of that error
     /// type. Returns false otherwise.
     pub fn is_other<T: core::error::Error + 'static>(&self) -> bool {
-        self.as_other().map(|err| err.as_any().is::<T>()).unwrap_or(false)
+        self.as_other().is_some_and(|err| err.as_any().is::<T>())
     }
 }
 


### PR DESCRIPTION
Simplify boolean checks on `Option` using `is_some_and`, aligning with existing codebase style.