### PR TITLE
fix(provider): skip storage changeset writes when routed to static files

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,3 +44,24 @@ jobs:
             --exclude 'op-reth' \
             --exclude 'reth' \
             -E 'binary(e2e_testsuite)'
+
+  rocksdb:
+    name: e2e-rocksdb
+    runs-on: depot-ubuntu-latest-4
+    env:
+      RUST_BACKTRACE: 1
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: taiki-e/install-action@nextest
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - name: Run RocksDB e2e tests
+        run: |
+          cargo nextest run \
+            --locked --features "edge" \
+            -p reth-e2e-test-utils \
+            -E 'binary(rocksdb)'

--- a/crates/e2e-test-utils/tests/rocksdb/main.rs
+++ b/crates/e2e-test-utils/tests/rocksdb/main.rs
@@ -98,14 +98,12 @@ fn test_attributes_generator(timestamp: u64) -> EthPayloadBuilderAttributes {
 }
 
 /// Enables `RocksDB` for `TransactionHashNumbers` table.
-///
-/// Note: Static file changesets are disabled because `persistence_threshold(0)` causes
-/// a race where the static file writer expects sequential block numbers but receives
-/// them out of order, resulting in `UnexpectedStaticFileBlockNumber` errors.
-fn with_rocksdb_enabled<C>(mut config: NodeConfig<C>) -> NodeConfig<C> {
-    config.rocksdb = RocksDbArgs { tx_hash: true, ..Default::default() };
-    config.static_files.storage_changesets = false;
-    config.static_files.account_changesets = false;
+/// Explicitly enables static file changesets to test the fix for double-write bug.
+const fn with_rocksdb_enabled<C>(mut config: NodeConfig<C>) -> NodeConfig<C> {
+    config.rocksdb =
+        RocksDbArgs { all: true, tx_hash: true, storages_history: true, account_history: true };
+    config.static_files.storage_changesets = true;
+    config.static_files.account_changesets = true;
     config
 }
 

--- a/crates/storage/storage-api/src/state_writer.rs
+++ b/crates/storage/storage-api/src/state_writer.rs
@@ -136,10 +136,16 @@ pub struct StateWriteConfig {
     pub write_receipts: bool,
     /// Whether to write account changesets.
     pub write_account_changesets: bool,
+    /// Whether to write storage changesets.
+    pub write_storage_changesets: bool,
 }
 
 impl Default for StateWriteConfig {
     fn default() -> Self {
-        Self { write_receipts: true, write_account_changesets: true }
+        Self {
+            write_receipts: true,
+            write_account_changesets: true,
+            write_storage_changesets: true,
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixed a bug where storage changesets were written twice when static file storage changesets are enabled, causing `UnexpectedStaticFileBlockNumber` errors.

## Problem

PR #20896 added static file routing for storage changesets but forgot to add `write_storage_changesets` to `StateWriteConfig`. This caused storage changesets to be written twice:

1. First write: via `write_blocks_data` → static file manager
2. Second write: via `write_state` → `write_state_reverts` → `EitherWriter::new_storage_changesets` (also routed to static files)

The second write fails because block N was already written:
```
ProviderError(UnexpectedStaticFileBlockNumber(StorageChangeSets, 1, 2))
```

This manifests with `persistence_threshold(0)` and static file changesets enabled.

## Solution

1. Add `write_storage_changesets` field to `StateWriteConfig`
2. Pass `!sf_ctx.write_storage_changesets` to the config in `save_blocks`
3. Guard storage changeset writes in `write_state_reverts` with the config

This matches the existing pattern for `write_receipts` and `write_account_changesets`.

Closes #21467