### PR TITLE
refactor(e2e): remove redundant with_rocksdb_enabled helper

### DIFF
--- a/crates/e2e-test-utils/tests/rocksdb/main.rs
+++ b/crates/e2e-test-utils/tests/rocksdb/main.rs
@@ -102,7 +102,7 @@ fn test_attributes_generator(timestamp: u64) -> EthPayloadBuilderAttributes {
 /// a race where the static file writer expects sequential block numbers but receives
 /// them out of order, resulting in `UnexpectedStaticFileBlockNumber` errors.
 ///
-/// RocksDB routing is automatically enabled by default when the `edge` feature is set
+/// `RocksDB` routing is automatically enabled by default when the `edge` feature is set
 /// (see `default_rocksdb_flag()` in `reth-node-core`), so no explicit configuration is needed.
 fn without_static_file_changesets<C>(mut config: NodeConfig<C>) -> NodeConfig<C> {
     config.static_files.storage_changesets = false;


### PR DESCRIPTION
## Summary

The `with_rocksdb_enabled` helper was explicitly setting `config.rocksdb.tx_hash = true`, but this is now redundant since the `edge` feature (which these tests require via `#![cfg(all(feature = "edge", unix))]`) already makes RocksDB routing the default through `default_rocksdb_flag()` returning `true`.

## Changes

- Renamed the helper to `without_static_file_changesets` to accurately reflect its remaining purpose
- Removed the now-redundant `RocksDbArgs { tx_hash: true, ..Default::default() }` setting
- Updated the docstring to explain that RocksDB routing is automatically enabled by the `edge` feature

## Rationale

When the `edge` feature is enabled:
- `default_rocksdb_flag()` returns `true`
- `RocksDbArgs::default()` sets `tx_hash: true`, `storages_history: true`, `account_history: true`

The static file changeset disabling is still needed due to the race condition with `persistence_threshold(0)` documented in the comment.

## Testing

These tests only run with the `edge` feature (`required-features = ["edge"]` in Cargo.toml), so the RocksDB defaults are guaranteed to be enabled.