### PR TITLE
fix(db): write genesis history to correct storage backend

### DIFF
--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -15,9 +15,10 @@ use reth_primitives_traits::{
 use reth_provider::{
     errors::provider::ProviderResult, providers::StaticFileWriter, BlockHashReader, BlockNumReader,
     BundleStateInit, ChainSpecProvider, DBProvider, DatabaseProviderFactory, ExecutionOutcome,
-    HashingWriter, HeaderProvider, HistoryWriter, MetadataWriter, OriginalValuesKnown,
-    ProviderError, RevertsInit, StageCheckpointReader, StageCheckpointWriter, StateWriter,
-    StaticFileProviderFactory, StorageSettings, StorageSettingsCache, TrieWriter,
+    HashingWriter, HeaderProvider, HistoryWriter, MetadataWriter, NodePrimitivesProvider,
+    OriginalValuesKnown, ProviderError, RevertsInit, RocksDBProviderFactory, StageCheckpointReader,
+    StageCheckpointWriter, StateWriter, StaticFileProviderFactory, StorageSettings,
+    StorageSettingsCache, TrieWriter,
 };
 use reth_stages_types::{StageCheckpoint, StageId};
 use reth_static_file_types::StaticFileSegment;
@@ -369,37 +370,71 @@ where
 }
 
 /// Inserts history indices for genesis accounts and storage.
+///
+/// Writes to either MDBX or RocksDB based on storage settings configuration,
+/// using [`EitherWriter`] to abstract over the storage backend.
 pub fn insert_genesis_history<'a, 'b, Provider>(
     provider: &Provider,
     alloc: impl Iterator<Item = (&'a Address, &'b GenesisAccount)> + Clone,
 ) -> ProviderResult<()>
 where
-    Provider: DBProvider<Tx: DbTxMut> + HistoryWriter + ChainSpecProvider,
+    Provider: DBProvider<Tx: DbTxMut>
+        + HistoryWriter
+        + ChainSpecProvider
+        + StorageSettingsCache
+        + RocksDBProviderFactory,
 {
     let genesis_block_number = provider.chain_spec().genesis_header().number();
     insert_history(provider, alloc, genesis_block_number)
 }
 
 /// Inserts history indices for genesis accounts and storage.
+///
+/// Writes to either MDBX or RocksDB based on storage settings configuration,
+/// using [`EitherWriter`] to abstract over the storage backend.
 pub fn insert_history<'a, 'b, Provider>(
     provider: &Provider,
     alloc: impl Iterator<Item = (&'a Address, &'b GenesisAccount)> + Clone,
     block: u64,
 ) -> ProviderResult<()>
 where
-    Provider: DBProvider<Tx: DbTxMut> + HistoryWriter,
+    Provider: DBProvider<Tx: DbTxMut>
+        + HistoryWriter
+        + StorageSettingsCache
+        + RocksDBProviderFactory
+        + NodePrimitivesProvider,
 {
-    let account_transitions = alloc.clone().map(|(addr, _)| (*addr, [block]));
-    provider.insert_account_history_index(account_transitions)?;
+    use reth_db_api::{
+        models::{storage_sharded_key::StorageShardedKey, ShardedKey},
+        BlockNumberList,
+    };
+    use reth_provider::EitherWriter;
 
-    trace!(target: "reth::cli", "Inserted account history");
+    // Write account history using EitherWriter
+    provider.with_rocksdb_batch(|batch| {
+        let mut writer = EitherWriter::new_accounts_history(provider, batch)?;
+        let list = BlockNumberList::new([block]).expect("single block always fits");
+        for (addr, _) in alloc.clone() {
+            writer.put_account_history(ShardedKey::last(*addr), &list)?;
+        }
+        trace!(target: "reth::cli", "Inserted account history");
+        Ok(((), writer.into_raw_rocksdb_batch()))
+    })?;
 
-    let storage_transitions = alloc
-        .filter_map(|(addr, account)| account.storage.as_ref().map(|storage| (addr, storage)))
-        .flat_map(|(addr, storage)| storage.keys().map(|key| ((*addr, *key), [block])));
-    provider.insert_storage_history_index(storage_transitions)?;
-
-    trace!(target: "reth::cli", "Inserted storage history");
+    // Write storage history using EitherWriter
+    provider.with_rocksdb_batch(|batch| {
+        let mut writer = EitherWriter::new_storages_history(provider, batch)?;
+        let list = BlockNumberList::new([block]).expect("single block always fits");
+        for (addr, account) in alloc {
+            if let Some(storage) = &account.storage {
+                for key in storage.keys() {
+                    writer.put_storage_history(StorageShardedKey::last(*addr, *key), &list)?;
+                }
+            }
+        }
+        trace!(target: "reth::cli", "Inserted storage history");
+        Ok(((), writer.into_raw_rocksdb_batch()))
+    })?;
 
     Ok(())
 }

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -420,7 +420,6 @@ where
         Ok(((), writer.into_raw_rocksdb_batch()))
     })?;
 
-    // Write storage history using EitherWriter
     provider.with_rocksdb_batch(|batch| {
         let mut writer = EitherWriter::new_storages_history(provider, batch)?;
         let list = BlockNumberList::new([block]).expect("single block always fits");

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -410,7 +410,6 @@ where
     };
     use reth_provider::EitherWriter;
 
-    // Write account history using EitherWriter
     provider.with_rocksdb_batch(|batch| {
         let mut writer = EitherWriter::new_accounts_history(provider, batch)?;
         let list = BlockNumberList::new([block]).expect("single block always fits");


### PR DESCRIPTION
## Summary

When `account_history_in_rocksdb` or `storages_history_in_rocksdb` is enabled, `insert_genesis_history` now writes to RocksDB instead of MDBX.

## Problem

Previously, genesis account/storage history was always written to MDBX regardless of storage settings. This caused ~8893 stale entries in MDBX `AccountsHistory` table on reth-edge nodes configured for RocksDB history (the ~8893 entries correspond to Ethereum mainnet genesis allocation accounts).

## Solution

Updated `insert_genesis_history` and `insert_history` to check storage settings and write to the appropriate backend:
- When `account_history_in_rocksdb` is true → write to RocksDB
- When `account_history_in_rocksdb` is false → write to MDBX (existing behavior)
- Same logic for `storages_history_in_rocksdb`

This ensures history indices are written to exactly one location based on the storage configuration.