### PR TITLE
refactor: align RocksDbArgs defaults with StorageSettings::base()

### DIFF
--- a/crates/e2e-test-utils/tests/rocksdb/main.rs
+++ b/crates/e2e-test-utils/tests/rocksdb/main.rs
@@ -96,13 +96,26 @@ fn test_attributes_generator(timestamp: u64) -> EthPayloadBuilderAttributes {
     EthPayloadBuilderAttributes::new(B256::ZERO, attributes)
 }
 
-/// Verifies that RocksDB defaults are enabled when the `edge` feature is active.
+/// Verifies that RocksDB CLI defaults match `StorageSettings::base()`.
 #[test]
-fn test_rocksdb_defaults_match_edge_feature() {
+fn test_rocksdb_defaults_match_storage_settings() {
+    use reth_provider::StorageSettings;
+
     let args = RocksDbArgs::default();
-    assert!(args.tx_hash, "tx_hash should default to true with edge feature");
-    assert!(args.storages_history, "storages_history should default to true with edge feature");
-    assert!(args.account_history, "account_history should default to true with edge feature");
+    let settings = StorageSettings::base();
+
+    assert_eq!(
+        args.tx_hash, settings.transaction_hash_numbers_in_rocksdb,
+        "tx_hash default should match StorageSettings::base()"
+    );
+    assert_eq!(
+        args.storages_history, settings.storages_history_in_rocksdb,
+        "storages_history default should match StorageSettings::base()"
+    );
+    assert_eq!(
+        args.account_history, settings.account_history_in_rocksdb,
+        "account_history default should match StorageSettings::base()"
+    );
 }
 
 /// Smoke test: node boots with `RocksDB` routing enabled.

--- a/crates/e2e-test-utils/tests/rocksdb/main.rs
+++ b/crates/e2e-test-utils/tests/rocksdb/main.rs
@@ -13,7 +13,7 @@ use reth_e2e_test_utils::{transaction::TransactionTestContext, wallet, E2ETestSe
 use reth_node_core::args::RocksDbArgs;
 use reth_node_ethereum::EthereumNode;
 use reth_payload_builder::EthPayloadBuilderAttributes;
-use reth_provider::RocksDBProviderFactory;
+use reth_provider::{RocksDBProviderFactory, StorageSettings};
 use std::{sync::Arc, time::Duration};
 
 const ROCKSDB_POLL_TIMEOUT: Duration = Duration::from_secs(60);
@@ -99,8 +99,6 @@ fn test_attributes_generator(timestamp: u64) -> EthPayloadBuilderAttributes {
 /// Verifies that `RocksDB` CLI defaults match `StorageSettings::base()`.
 #[test]
 fn test_rocksdb_defaults_match_storage_settings() {
-    use reth_provider::StorageSettings;
-
     let args = RocksDbArgs::default();
     let settings = StorageSettings::base();
 

--- a/crates/e2e-test-utils/tests/rocksdb/main.rs
+++ b/crates/e2e-test-utils/tests/rocksdb/main.rs
@@ -96,7 +96,7 @@ fn test_attributes_generator(timestamp: u64) -> EthPayloadBuilderAttributes {
     EthPayloadBuilderAttributes::new(B256::ZERO, attributes)
 }
 
-/// Verifies that RocksDB CLI defaults match `StorageSettings::base()`.
+/// Verifies that `RocksDB` CLI defaults match `StorageSettings::base()`.
 #[test]
 fn test_rocksdb_defaults_match_storage_settings() {
     use reth_provider::StorageSettings;

--- a/crates/node/core/src/args/rocksdb.rs
+++ b/crates/node/core/src/args/rocksdb.rs
@@ -41,21 +41,19 @@ pub struct RocksDbArgs {
     /// Route tx hash -> number table to `RocksDB` instead of MDBX.
     ///
     /// This is a genesis-initialization-only flag: changing it after genesis requires a re-sync.
-    /// Defaults to match [`StorageSettings::base()`].
+    /// Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
     #[arg(long = "rocksdb.tx-hash", default_value_t = default_tx_hash_in_rocksdb(), action = ArgAction::Set)]
     pub tx_hash: bool,
 
     /// Route storages history tables to `RocksDB` instead of MDBX.
     ///
     /// This is a genesis-initialization-only flag: changing it after genesis requires a re-sync.
-    /// Defaults to match [`StorageSettings::base()`].
     #[arg(long = "rocksdb.storages-history", default_value_t = default_storages_history_in_rocksdb(), action = ArgAction::Set)]
     pub storages_history: bool,
 
     /// Route account history tables to `RocksDB` instead of MDBX.
     ///
     /// This is a genesis-initialization-only flag: changing it after genesis requires a re-sync.
-    /// Defaults to match [`StorageSettings::base()`].
     #[arg(long = "rocksdb.account-history", default_value_t = default_account_history_in_rocksdb(), action = ArgAction::Set)]
     pub account_history: bool,
 }

--- a/crates/node/core/src/args/rocksdb.rs
+++ b/crates/node/core/src/args/rocksdb.rs
@@ -48,12 +48,14 @@ pub struct RocksDbArgs {
     /// Route storages history tables to `RocksDB` instead of MDBX.
     ///
     /// This is a genesis-initialization-only flag: changing it after genesis requires a re-sync.
+    /// Defaults to `false`.
     #[arg(long = "rocksdb.storages-history", default_value_t = default_storages_history_in_rocksdb(), action = ArgAction::Set)]
     pub storages_history: bool,
 
     /// Route account history tables to `RocksDB` instead of MDBX.
     ///
     /// This is a genesis-initialization-only flag: changing it after genesis requires a re-sync.
+    /// Defaults to `false`.
     #[arg(long = "rocksdb.account-history", default_value_t = default_account_history_in_rocksdb(), action = ArgAction::Set)]
     pub account_history: bool,
 }

--- a/docs/vocs/docs/pages/cli/op-reth/db.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/db.mdx
@@ -184,7 +184,7 @@ RocksDB:
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]
@@ -192,7 +192,7 @@ RocksDB:
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]

--- a/docs/vocs/docs/pages/cli/op-reth/import-op.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/import-op.mdx
@@ -168,7 +168,7 @@ RocksDB:
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]
@@ -176,7 +176,7 @@ RocksDB:
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]

--- a/docs/vocs/docs/pages/cli/op-reth/import-receipts-op.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/import-receipts-op.mdx
@@ -168,7 +168,7 @@ RocksDB:
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]
@@ -176,7 +176,7 @@ RocksDB:
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]

--- a/docs/vocs/docs/pages/cli/op-reth/init-state.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/init-state.mdx
@@ -168,7 +168,7 @@ RocksDB:
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]
@@ -176,7 +176,7 @@ RocksDB:
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]

--- a/docs/vocs/docs/pages/cli/op-reth/init.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/init.mdx
@@ -168,7 +168,7 @@ RocksDB:
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]
@@ -176,7 +176,7 @@ RocksDB:
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]

--- a/docs/vocs/docs/pages/cli/op-reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/node.mdx
@@ -919,7 +919,7 @@ RocksDB:
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]
@@ -927,7 +927,7 @@ RocksDB:
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]

--- a/docs/vocs/docs/pages/cli/op-reth/prune.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/prune.mdx
@@ -168,7 +168,7 @@ RocksDB:
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]
@@ -176,7 +176,7 @@ RocksDB:
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]

--- a/docs/vocs/docs/pages/cli/op-reth/re-execute.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/re-execute.mdx
@@ -168,7 +168,7 @@ RocksDB:
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]
@@ -176,7 +176,7 @@ RocksDB:
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]

--- a/docs/vocs/docs/pages/cli/op-reth/stage/drop.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/stage/drop.mdx
@@ -168,7 +168,7 @@ RocksDB:
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]
@@ -176,7 +176,7 @@ RocksDB:
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]

--- a/docs/vocs/docs/pages/cli/op-reth/stage/dump.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/stage/dump.mdx
@@ -175,7 +175,7 @@ RocksDB:
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]
@@ -183,7 +183,7 @@ RocksDB:
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]

--- a/docs/vocs/docs/pages/cli/op-reth/stage/run.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/stage/run.mdx
@@ -168,7 +168,7 @@ RocksDB:
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]
@@ -176,7 +176,7 @@ RocksDB:
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]

--- a/docs/vocs/docs/pages/cli/op-reth/stage/unwind.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/stage/unwind.mdx
@@ -173,7 +173,7 @@ RocksDB:
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]
@@ -181,7 +181,7 @@ RocksDB:
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]

--- a/docs/vocs/docs/pages/cli/reth/db.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db.mdx
@@ -184,7 +184,7 @@ RocksDB:
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]
@@ -192,7 +192,7 @@ RocksDB:
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]

--- a/docs/vocs/docs/pages/cli/reth/download.mdx
+++ b/docs/vocs/docs/pages/cli/reth/download.mdx
@@ -168,7 +168,7 @@ RocksDB:
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]
@@ -176,7 +176,7 @@ RocksDB:
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]

--- a/docs/vocs/docs/pages/cli/reth/export-era.mdx
+++ b/docs/vocs/docs/pages/cli/reth/export-era.mdx
@@ -168,7 +168,7 @@ RocksDB:
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]
@@ -176,7 +176,7 @@ RocksDB:
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]

--- a/docs/vocs/docs/pages/cli/reth/import-era.mdx
+++ b/docs/vocs/docs/pages/cli/reth/import-era.mdx
@@ -168,7 +168,7 @@ RocksDB:
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]
@@ -176,7 +176,7 @@ RocksDB:
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]

--- a/docs/vocs/docs/pages/cli/reth/import.mdx
+++ b/docs/vocs/docs/pages/cli/reth/import.mdx
@@ -168,7 +168,7 @@ RocksDB:
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]
@@ -176,7 +176,7 @@ RocksDB:
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]

--- a/docs/vocs/docs/pages/cli/reth/init-state.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init-state.mdx
@@ -168,7 +168,7 @@ RocksDB:
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]
@@ -176,7 +176,7 @@ RocksDB:
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]

--- a/docs/vocs/docs/pages/cli/reth/init.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init.mdx
@@ -168,7 +168,7 @@ RocksDB:
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]
@@ -176,7 +176,7 @@ RocksDB:
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -919,7 +919,7 @@ RocksDB:
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]
@@ -927,7 +927,7 @@ RocksDB:
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]

--- a/docs/vocs/docs/pages/cli/reth/prune.mdx
+++ b/docs/vocs/docs/pages/cli/reth/prune.mdx
@@ -168,7 +168,7 @@ RocksDB:
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]
@@ -176,7 +176,7 @@ RocksDB:
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]

--- a/docs/vocs/docs/pages/cli/reth/re-execute.mdx
+++ b/docs/vocs/docs/pages/cli/reth/re-execute.mdx
@@ -168,7 +168,7 @@ RocksDB:
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]
@@ -176,7 +176,7 @@ RocksDB:
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]

--- a/docs/vocs/docs/pages/cli/reth/stage/drop.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/drop.mdx
@@ -168,7 +168,7 @@ RocksDB:
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]
@@ -176,7 +176,7 @@ RocksDB:
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]

--- a/docs/vocs/docs/pages/cli/reth/stage/dump.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump.mdx
@@ -175,7 +175,7 @@ RocksDB:
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]
@@ -183,7 +183,7 @@ RocksDB:
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]

--- a/docs/vocs/docs/pages/cli/reth/stage/run.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/run.mdx
@@ -168,7 +168,7 @@ RocksDB:
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]
@@ -176,7 +176,7 @@ RocksDB:
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]

--- a/docs/vocs/docs/pages/cli/reth/stage/unwind.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/unwind.mdx
@@ -173,7 +173,7 @@ RocksDB:
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]
@@ -181,7 +181,7 @@ RocksDB:
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
 
           [default: false]
           [possible values: true, false]


### PR DESCRIPTION
## Summary

Removes the redundant `with_rocksdb_enabled` test helper and aligns RocksDB CLI argument defaults with `StorageSettings::base()` to ensure a single source of truth for storage configuration.

## Problem

Previously there was a mismatch:
- `RocksDbArgs::default()` with `edge` feature set **all three** RocksDB flags to `true`
- But `StorageSettings::edge()` only enables `transaction_hash_numbers_in_rocksdb: true`

This meant CLI defaults didn't match the canonical storage configuration.

## Solution

Replace `default_rocksdb_flag()` (which used `cfg!(feature = "edge")`) with per-field defaults derived from `StorageSettings::base()`:

```rust
const fn default_tx_hash_in_rocksdb() -> bool {
    StorageSettings::base().transaction_hash_numbers_in_rocksdb
}

const fn default_storages_history_in_rocksdb() -> bool {
    StorageSettings::base().storages_history_in_rocksdb
}

const fn default_account_history_in_rocksdb() -> bool {
    StorageSettings::base().account_history_in_rocksdb
}
```

## Changes

### crates/node/core/src/args/rocksdb.rs
- Replace `default_rocksdb_flag()` with per-field defaults from `StorageSettings::base()`
- Update CLI arg annotations to use new default functions
- Add `test_defaults_match_storage_settings` test to validate alignment

### crates/e2e-test-utils/tests/rocksdb/main.rs
- Remove `with_rocksdb_enabled` helper function (was redundant)
- Remove all `.with_node_config_modifier(with_rocksdb_enabled)` calls from 6 tests
- Replace test with `test_rocksdb_defaults_match_storage_settings`
- Remove unused `NodeConfig` import

## Behavior Change

With the `edge` feature enabled:
- **Before**: `tx_hash=true`, `storages_history=true`, `account_history=true`
- **After**: `tx_hash=true`, `storages_history=false`, `account_history=false`

This aligns with `StorageSettings::edge()` which is the canonical source of truth.