### PR TITLE
perf(tree): optimistically prepare canonical overlay

### DIFF
--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1103,16 +1103,30 @@ where
     /// while the trie input computation is deferred until the overlay is actually needed.
     ///
     /// If parent is on disk (no in-memory blocks), returns `None` for the lazy overlay.
+    ///
+    /// Uses a cached overlay if available for the canonical head (the common case).
     fn get_parent_lazy_overlay(
         parent_hash: B256,
         state: &EngineApiTreeState<N>,
     ) -> (Option<LazyOverlay>, B256) {
+        // Get blocks leading to the parent to determine the anchor
         let (anchor_hash, blocks) =
             state.tree_state.blocks_by_hash(parent_hash).unwrap_or_else(|| (parent_hash, vec![]));
 
         if blocks.is_empty() {
             debug!(target: "engine::tree::payload_validator", "Parent found on disk, no lazy overlay needed");
             return (None, anchor_hash);
+        }
+
+        // Try to use the cached overlay if it matches both parent hash and anchor
+        if let Some(cached) = state.tree_state.get_cached_overlay(parent_hash, anchor_hash) {
+            debug!(
+                target: "engine::tree::payload_validator",
+                %parent_hash,
+                %anchor_hash,
+                "Using cached canonical overlay"
+            );
+            return (Some(cached.overlay.clone()), cached.anchor_hash);
         }
 
         debug!(

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -259,6 +259,7 @@ impl TestHarness {
             current_canonical_head: blocks.last().unwrap().recovered_block().num_hash(),
             parent_to_child,
             engine_kind: EngineApiKind::Ethereum,
+            cached_canonical_overlay: None,
         };
 
         let last_executed_block = blocks.last().unwrap().clone();


### PR DESCRIPTION
## Summary

Pre-compute the `LazyOverlay` for the canonical head after persistence completes, so subsequent payloads building on the canonical head can reuse the cached overlay immediately without re-traversing in-memory blocks.

## Changes

- Add `PreparedCanonicalOverlay` struct to `TreeState` to cache the overlay with parent and anchor hashes
- Add `prepare_canonical_overlay()` that returns the overlay clone for background computation  
- Spawn rayon task to trigger `overlay.get()` for eager computation
- Add anchor hash verification in `get_cached_overlay()` to prevent using stale overlays after persistence advances
- Invalidate overlay in `remove_until()` and after persistence changes the anchor

## How it works

1. After persistence completes, `prepare_canonical_overlay()` is called
2. It creates a `LazyOverlay` with handles to deferred trie data from in-memory blocks
3. A rayon task is spawned to call `.get()` which triggers the actual overlay computation
4. When the next payload arrives building on the canonical head, `get_parent_lazy_overlay()` checks the cache
5. If parent hash and anchor hash match, the pre-computed overlay is reused

## Safety

- Both `parent_hash` and `anchor_hash` must match for cache hit (prevents stale overlay usage)
- Overlay is invalidated on `reset()`, `remove_until()`, and after persistence
- `LazyOverlay` uses `Arc<OnceLock>` so the spawned task and cached copy share the same result