### PR TITLE
fix(static-files): apply minimal blocks per file to all segments

### DIFF
--- a/crates/node/core/src/args/static_files.rs
+++ b/crates/node/core/src/args/static_files.rs
@@ -90,7 +90,7 @@ impl StaticFilesArgs {
     /// args.
     ///
     /// If `minimal` is true, uses [`MINIMAL_BLOCKS_PER_FILE`] blocks per file as the default for
-    /// headers, transactions, and receipts segments.
+    /// all segments.
     pub fn merge_with_config(&self, config: StaticFilesConfig, minimal: bool) -> StaticFilesConfig {
         let minimal_blocks_per_file = minimal.then_some(MINIMAL_BLOCKS_PER_FILE);
         StaticFilesConfig {
@@ -109,12 +109,15 @@ impl StaticFilesArgs {
                     .or(config.blocks_per_file.receipts),
                 transaction_senders: self
                     .blocks_per_file_transaction_senders
+                    .or(minimal_blocks_per_file)
                     .or(config.blocks_per_file.transaction_senders),
                 account_change_sets: self
                     .blocks_per_file_account_change_sets
+                    .or(minimal_blocks_per_file)
                     .or(config.blocks_per_file.account_change_sets),
                 storage_change_sets: self
                     .blocks_per_file_storage_change_sets
+                    .or(minimal_blocks_per_file)
                     .or(config.blocks_per_file.storage_change_sets),
             },
         }


### PR DESCRIPTION
Extends `--minimal` flag's 10k blocks per file setting to all static file segments.

Previously only applied to headers, transactions, and receipts. Now also applies to transaction_senders, account_change_sets, and storage_change_sets for consistency.