### PR TITLE
fix(config): save static files config to reth.toml

### DIFF
--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -443,6 +443,11 @@ pub struct BlocksPerFileConfig {
 }
 
 impl StaticFilesConfig {
+    /// Returns whether this configuration is the default one.
+    pub fn is_default(&self) -> bool {
+        self == &Self::default()
+    }
+
     /// Validates the static files configuration.
     ///
     /// Returns an error if any blocks per file value is zero.

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -219,11 +219,17 @@ impl LaunchContext {
 
         let mut should_save = false;
 
-        // Save if the merged config differs from what's in the file and is not default
-        if reth_config.static_files != merged_config && !merged_config.is_default() {
-            reth_config.static_files = merged_config;
-            should_save = true;
+        if !config.static_files.is_empty() || config.pruning.minimal {
+            // Save if the merged config differs from what's in the file and is not default
+            if reth_config.static_files != merged_config && !merged_config.is_default() {
+                should_save = true;
+            }
+        } else if !reth_config.static_files.is_default() {
+            warn!(target: "reth::cli", "Static files configuration is present in the config file, but no CLI arguments are provided. Using config from file.");
         }
+
+        // Always apply the merged config
+        reth_config.static_files = merged_config;
 
         if should_save {
             info!(target: "reth::cli", "Saving static files config to toml file");

--- a/crates/node/core/src/args/static_files.rs
+++ b/crates/node/core/src/args/static_files.rs
@@ -86,6 +86,16 @@ pub struct StaticFilesArgs {
 }
 
 impl StaticFilesArgs {
+    /// Returns `true` if no blocks-per-file CLI arguments are set.
+    pub const fn is_empty(&self) -> bool {
+        self.blocks_per_file_headers.is_none() &&
+            self.blocks_per_file_transactions.is_none() &&
+            self.blocks_per_file_receipts.is_none() &&
+            self.blocks_per_file_transaction_senders.is_none() &&
+            self.blocks_per_file_account_change_sets.is_none() &&
+            self.blocks_per_file_storage_change_sets.is_none()
+    }
+
     /// Merges the CLI arguments with an existing [`StaticFilesConfig`], giving priority to CLI
     /// args.
     ///


### PR DESCRIPTION
Persists static files configuration from CLI to reth.toml, matching the existing behavior for pruning config.

Previously, `--minimal` and explicit `--static-files.blocks-per-file.*` flags were only applied in memory and users had to specify them on every restart.

Now the configuration is automatically saved to reth.toml when it differs from the file and is non-default, providing the same persistent behavior as pruning configuration.