### PR TITLE
chore: remove Sync bound from cursor associated types

### DIFF
--- a/crates/storage/db-api/src/transaction.rs
+++ b/crates/storage/db-api/src/transaction.rs
@@ -20,9 +20,9 @@ pub type DupCursorMutTy<TX, T> = <TX as DbTxMut>::DupCursorMut<T>;
 /// Read only transaction
 pub trait DbTx: Debug + Send {
     /// Cursor type for this read-only transaction
-    type Cursor<T: Table>: DbCursorRO<T> + Send + Sync;
+    type Cursor<T: Table>: DbCursorRO<T> + Send;
     /// `DupCursor` type for this read-only transaction
-    type DupCursor<T: DupSort>: DbDupCursorRO<T> + DbCursorRO<T> + Send + Sync;
+    type DupCursor<T: DupSort>: DbDupCursorRO<T> + DbCursorRO<T> + Send;
 
     /// Get value by an owned key
     fn get<T: Table>(&self, key: T::Key) -> Result<Option<T::Value>, DatabaseError>;
@@ -51,14 +51,13 @@ pub trait DbTx: Debug + Send {
 /// Read write transaction that allows writing to database
 pub trait DbTxMut: Send {
     /// Read-Write Cursor type
-    type CursorMut<T: Table>: DbCursorRW<T> + DbCursorRO<T> + Send + Sync;
+    type CursorMut<T: Table>: DbCursorRW<T> + DbCursorRO<T> + Send;
     /// Read-Write `DupCursor` type
     type DupCursorMut<T: DupSort>: DbDupCursorRW<T>
         + DbCursorRW<T>
         + DbDupCursorRO<T>
         + DbCursorRO<T>
-        + Send
-        + Sync;
+        + Send;
 
     /// Put value to database
     fn put<T: Table>(&self, key: T::Key, value: T::Value) -> Result<(), DatabaseError>;

--- a/crates/trie/db/src/trie_cursor.rs
+++ b/crates/trie/db/src/trie_cursor.rs
@@ -64,7 +64,7 @@ impl<C> DatabaseAccountTrieCursor<C> {
 
 impl<C> TrieCursor for DatabaseAccountTrieCursor<C>
 where
-    C: DbCursorRO<tables::AccountsTrie> + Send + Sync,
+    C: DbCursorRO<tables::AccountsTrie> + Send,
 {
     /// Seeks an exact match for the provided key in the account trie.
     fn seek_exact(
@@ -160,7 +160,7 @@ where
 
 impl<C> TrieCursor for DatabaseStorageTrieCursor<C>
 where
-    C: DbCursorRO<tables::StoragesTrie> + DbDupCursorRO<tables::StoragesTrie> + Send + Sync,
+    C: DbCursorRO<tables::StoragesTrie> + DbDupCursorRO<tables::StoragesTrie> + Send,
 {
     /// Seeks an exact match for the given key in the storage trie.
     fn seek_exact(
@@ -202,7 +202,7 @@ where
 
 impl<C> TrieStorageCursor for DatabaseStorageTrieCursor<C>
 where
-    C: DbCursorRO<tables::StoragesTrie> + DbDupCursorRO<tables::StoragesTrie> + Send + Sync,
+    C: DbCursorRO<tables::StoragesTrie> + DbDupCursorRO<tables::StoragesTrie> + Send,
 {
     fn set_hashed_address(&mut self, hashed_address: B256) {
         self.hashed_address = hashed_address;


### PR DESCRIPTION
### Summary

Removes the unnecessary `Sync` bound from cursor associated types in `DbTx` and `DbTxMut` traits.

### Changes

- Remove `Sync` bound from `Cursor`, `DupCursor`, `CursorMut`, and `DupCursorMut` associated types
- Update `DatabaseAccountTrieCursor` and `DatabaseStorageTrieCursor` impl bounds accordingly

The MDBX cursors already implement `Sync` (via `unsafe impl`), so existing code is unaffected. This change allows for non-`Sync` cursor implementations in the future.