### PR TITLE
feat(engine): add --engine.trie-metrics flag to gate cursor timing

### DIFF
--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -147,6 +147,8 @@ pub struct TreeConfig {
     enable_proof_v2: bool,
     /// Whether to disable cache metrics recording (can be expensive with large cached state).
     disable_cache_metrics: bool,
+    /// Whether to enable trie cursor metrics (adds overhead from timing every cursor operation).
+    trie_metrics: bool,
 }
 
 impl Default for TreeConfig {
@@ -176,6 +178,7 @@ impl Default for TreeConfig {
             account_worker_count: default_account_worker_count(),
             enable_proof_v2: false,
             disable_cache_metrics: false,
+            trie_metrics: false,
         }
     }
 }
@@ -208,6 +211,7 @@ impl TreeConfig {
         account_worker_count: usize,
         enable_proof_v2: bool,
         disable_cache_metrics: bool,
+        trie_metrics: bool,
     ) -> Self {
         Self {
             persistence_threshold,
@@ -234,6 +238,7 @@ impl TreeConfig {
             account_worker_count,
             enable_proof_v2,
             disable_cache_metrics,
+            trie_metrics,
         }
     }
 
@@ -521,6 +526,17 @@ impl TreeConfig {
     /// Setter for whether to disable cache metrics recording.
     pub const fn without_cache_metrics(mut self, disable_cache_metrics: bool) -> Self {
         self.disable_cache_metrics = disable_cache_metrics;
+        self
+    }
+
+    /// Returns whether trie cursor metrics are enabled.
+    pub const fn trie_metrics(&self) -> bool {
+        self.trie_metrics
+    }
+
+    /// Setter for whether to enable trie cursor metrics.
+    pub const fn with_trie_metrics(mut self, trie_metrics: bool) -> Self {
+        self.trie_metrics = trie_metrics;
         self
     }
 }

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -275,12 +275,14 @@ where
         let task_ctx = ProofTaskCtx::new(multiproof_provider_factory);
         let storage_worker_count = config.storage_worker_count();
         let account_worker_count = config.account_worker_count();
+        let trie_metrics_enabled = config.trie_metrics();
         let proof_handle = ProofWorkerHandle::new(
             self.executor.handle().clone(),
             task_ctx,
             storage_worker_count,
             account_worker_count,
             v2_proofs_enabled,
+            trie_metrics_enabled,
         );
 
         let multi_proof_task = MultiProofTask::new(

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -1572,7 +1572,7 @@ mod tests {
         let changeset_cache = ChangesetCache::new();
         let overlay_factory = OverlayStateProviderFactory::new(factory, changeset_cache);
         let task_ctx = ProofTaskCtx::new(overlay_factory);
-        let proof_handle = ProofWorkerHandle::new(rt_handle, task_ctx, 1, 1, false);
+        let proof_handle = ProofWorkerHandle::new(rt_handle, task_ctx, 1, 1, false, false);
         let (to_sparse_trie, _receiver) = std::sync::mpsc::channel();
         let (tx, rx) = crossbeam_channel::unbounded();
 

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -37,6 +37,7 @@ pub struct DefaultEngineValues {
     account_worker_count: Option<usize>,
     enable_proof_v2: bool,
     cache_metrics_disabled: bool,
+    trie_metrics: bool,
 }
 
 impl DefaultEngineValues {
@@ -172,6 +173,12 @@ impl DefaultEngineValues {
         self.cache_metrics_disabled = v;
         self
     }
+
+    /// Set whether to enable trie cursor metrics by default
+    pub const fn with_trie_metrics(mut self, v: bool) -> Self {
+        self.trie_metrics = v;
+        self
+    }
 }
 
 impl Default for DefaultEngineValues {
@@ -197,6 +204,7 @@ impl Default for DefaultEngineValues {
             account_worker_count: None,
             enable_proof_v2: false,
             cache_metrics_disabled: false,
+            trie_metrics: false,
         }
     }
 }
@@ -324,6 +332,11 @@ pub struct EngineArgs {
     /// Disable cache metrics recording, which can take up to 50ms with large cached state.
     #[arg(long = "engine.disable-cache-metrics", default_value_t = DefaultEngineValues::get_global().cache_metrics_disabled)]
     pub cache_metrics_disabled: bool,
+
+    /// Enable trie cursor metrics recording. This adds overhead from timing every cursor
+    /// operation in hot paths.
+    #[arg(long = "engine.trie-metrics", default_value_t = DefaultEngineValues::get_global().trie_metrics)]
+    pub trie_metrics: bool,
 }
 
 #[allow(deprecated)]
@@ -350,6 +363,7 @@ impl Default for EngineArgs {
             account_worker_count,
             enable_proof_v2,
             cache_metrics_disabled,
+            trie_metrics,
         } = DefaultEngineValues::get_global().clone();
         Self {
             persistence_threshold,
@@ -376,6 +390,7 @@ impl Default for EngineArgs {
             account_worker_count,
             enable_proof_v2,
             cache_metrics_disabled,
+            trie_metrics,
         }
     }
 }
@@ -412,6 +427,7 @@ impl EngineArgs {
 
         config = config.with_enable_proof_v2(self.enable_proof_v2);
         config = config.without_cache_metrics(self.cache_metrics_disabled);
+        config = config.with_trie_metrics(self.trie_metrics);
 
         config
     }
@@ -464,6 +480,7 @@ mod tests {
             account_worker_count: Some(8),
             enable_proof_v2: false,
             cache_metrics_disabled: true,
+            trie_metrics: true,
         };
 
         let parsed_args = CommandParser::<EngineArgs>::parse_from([
@@ -494,6 +511,7 @@ mod tests {
             "--engine.account-worker-count",
             "8",
             "--engine.disable-cache-metrics",
+            "--engine.trie-metrics",
         ])
         .args;
 

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -328,7 +328,7 @@ mod tests {
             reth_provider::providers::OverlayStateProviderFactory::new(factory, changeset_cache);
         let task_ctx = ProofTaskCtx::new(factory);
         let proof_worker_handle =
-            ProofWorkerHandle::new(rt.handle().clone(), task_ctx, 1, 1, false);
+            ProofWorkerHandle::new(rt.handle().clone(), task_ctx, 1, 1, false, false);
 
         let parallel_result = ParallelProof::new(Default::default(), proof_worker_handle.clone())
             .decoded_multiproof(targets.clone())

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -123,6 +123,8 @@ pub struct ProofWorkerHandle {
     account_worker_count: usize,
     /// Whether V2 storage proofs are enabled
     v2_proofs_enabled: bool,
+    /// Whether trie cursor metrics are enabled
+    trie_metrics_enabled: bool,
 }
 
 impl ProofWorkerHandle {
@@ -137,12 +139,14 @@ impl ProofWorkerHandle {
     /// - `storage_worker_count`: Number of storage workers to spawn
     /// - `account_worker_count`: Number of account workers to spawn
     /// - `v2_proofs_enabled`: Whether to enable V2 storage proofs
+    /// - `trie_metrics_enabled`: Whether to enable trie cursor metrics
     pub fn new<Factory>(
         executor: Handle,
         task_ctx: ProofTaskCtx<Factory>,
         storage_worker_count: usize,
         account_worker_count: usize,
         v2_proofs_enabled: bool,
+        trie_metrics_enabled: bool,
     ) -> Self
     where
         Factory: DatabaseProviderROFactory<Provider: TrieCursorFactory + HashedCursorFactory>
@@ -262,7 +266,13 @@ impl ProofWorkerHandle {
             storage_worker_count,
             account_worker_count,
             v2_proofs_enabled,
+            trie_metrics_enabled,
         }
+    }
+
+    /// Returns whether trie cursor metrics are enabled.
+    pub const fn trie_metrics_enabled(&self) -> bool {
+        self.trie_metrics_enabled
     }
 
     /// Returns whether V2 storage proofs are enabled for this worker pool.
@@ -2010,7 +2020,7 @@ mod tests {
             );
             let ctx = test_ctx(factory);
 
-            let proof_handle = ProofWorkerHandle::new(handle.clone(), ctx, 5, 3, false);
+            let proof_handle = ProofWorkerHandle::new(handle.clone(), ctx, 5, 3, false, false);
 
             // Verify handle can be cloned
             let _cloned_handle = proof_handle.clone();

--- a/docs/vocs/docs/pages/cli/op-reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/node.mdx
@@ -1007,6 +1007,9 @@ Engine:
       --engine.disable-cache-metrics
           Disable cache metrics recording, which can take up to 50ms with large cached state
 
+      --engine.trie-metrics
+          Enable trie cursor metrics recording. This adds overhead from timing every cursor operation in hot paths
+
 ERA:
       --era.enable
           Enable import from ERA1 files

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -1007,6 +1007,9 @@ Engine:
       --engine.disable-cache-metrics
           Disable cache metrics recording, which can take up to 50ms with large cached state
 
+      --engine.trie-metrics
+          Enable trie cursor metrics recording. This adds overhead from timing every cursor operation in hot paths
+
 ERA:
       --era.enable
           Enable import from ERA1 files


### PR DESCRIPTION
## Summary

Adds a new CLI flag `--engine.trie-metrics` (default: false) that controls whether trie cursor metrics are collected in hot paths.

## Changes

### InstrumentedTrieCursor / InstrumentedHashedCursor

Modified to support a passthrough mode that skips timing overhead when metrics are not needed:
- Added `new_passthrough()` constructor that creates a cursor wrapper without metrics
- When `metrics` is `None`, cursor operations pass through directly without `Instant::now()` calls

### StorageProof

Updated `storage_multiproof` to use passthrough cursors when metrics are not provided via `with_trie_cursor_metrics()` / `with_hashed_cursor_metrics()`.

### TreeConfig / EngineArgs

Added:
- `trie_metrics: bool` field to `TreeConfig`
- `--engine.trie-metrics` CLI flag to `EngineArgs`
- `trie_metrics_enabled` parameter to `ProofWorkerHandle::new()`

## Why?

The current implementation always wraps cursors with instrumentation even when metrics aren't being collected. This adds unnecessary overhead from `Instant::now()` calls on every cursor operation (seek, seek_exact, next) in the proof generation hot path.

With this change, when `--engine.trie-metrics` is not set (default), the proof path skips the timing overhead entirely.

## Testing

- [x] `cargo check` passes for all affected crates
- [x] Unit tests in `reth-node-core` pass
- [x] `cargo +nightly fmt --all`

Related: https://github.com/paradigmxyz/reth/blob/af3601c65d2b1cbf0ffa04d3f3390c18c997bfb5/crates/trie/trie/src/proof/mod.rs#L374