### PR TITLE
refactor(db): make Tx::inner field private with accessor

### DIFF
--- a/crates/cli/commands/src/db/list.rs
+++ b/crates/cli/commands/src/db/list.rs
@@ -101,8 +101,8 @@ impl<N: NodeTypes> TableViewer<()> for ListTableViewer<'_, N> {
             // We may be using the tui for a long time
             tx.disable_long_read_transaction_safety();
 
-            let table_db = tx.inner.open_db(Some(self.args.table.name())).wrap_err("Could not open db.")?;
-            let stats = tx.inner.db_stat(table_db.dbi()).wrap_err(format!("Could not find table: {}", self.args.table.name()))?;
+            let table_db = tx.inner().open_db(Some(self.args.table.name())).wrap_err("Could not open db.")?;
+                    let stats = tx.inner().db_stat(table_db.dbi()).wrap_err(format!("Could not find table: {}", self.args.table.name()))?;
             let total_entries = stats.entries();
             let final_entry_idx = total_entries.saturating_sub(1);
             if self.args.skip > final_entry_idx {

--- a/crates/cli/commands/src/db/stats.rs
+++ b/crates/cli/commands/src/db/stats.rs
@@ -92,10 +92,10 @@ impl Command {
             db_tables.sort();
             let mut total_size = 0;
             for db_table in db_tables {
-                let table_db = tx.inner.open_db(Some(db_table)).wrap_err("Could not open db.")?;
+                let table_db = tx.inner().open_db(Some(db_table)).wrap_err("Could not open db.")?;
 
                 let stats = tx
-                    .inner
+                    .inner()
                     .db_stat(table_db.dbi())
                     .wrap_err(format!("Could not find table: {db_table}"))?;
 
@@ -136,9 +136,9 @@ impl Command {
                 .add_cell(Cell::new(human_bytes(total_size as f64)));
             table.add_row(row);
 
-            let freelist = tx.inner.env().freelist()?;
+            let freelist = tx.inner().env().freelist()?;
             let pagesize =
-                tx.inner.db_stat(mdbx::Database::freelist_db().dbi())?.page_size() as usize;
+                tx.inner().db_stat(mdbx::Database::freelist_db().dbi())?.page_size() as usize;
             let freelist_size = freelist * pagesize;
 
             let mut row = Row::new();

--- a/crates/storage/db/benches/criterion.rs
+++ b/crates/storage/db/benches/criterion.rs
@@ -137,6 +137,7 @@ where
                 for (k, _, v, _) in input {
                     crsr.append(k, &v).expect("submit");
                 }
+                drop(crsr);
                 tx.commit().unwrap()
             },
         )
@@ -157,7 +158,7 @@ where
                     let (k, _, v, _) = input.get(index).unwrap().clone();
                     crsr.insert(k, &v).expect("submit");
                 }
-
+                drop(crsr);
                 tx.commit().unwrap()
             },
         )
@@ -219,6 +220,7 @@ where
                 for (k, _, v, _) in input {
                     crsr.append_dup(k, v).expect("submit");
                 }
+                drop(crsr);
                 tx.commit().unwrap()
             },
         )

--- a/crates/storage/db/benches/criterion.rs
+++ b/crates/storage/db/benches/criterion.rs
@@ -137,7 +137,7 @@ where
                 for (k, _, v, _) in input {
                     crsr.append(k, &v).expect("submit");
                 }
-                tx.inner().commit().unwrap()
+                tx.commit().unwrap()
             },
         )
     });
@@ -158,7 +158,7 @@ where
                     crsr.insert(k, &v).expect("submit");
                 }
 
-                tx.inner().commit().unwrap()
+                tx.commit().unwrap()
             },
         )
     });
@@ -219,7 +219,7 @@ where
                 for (k, _, v, _) in input {
                     crsr.append_dup(k, v).expect("submit");
                 }
-                tx.inner().commit().unwrap()
+                tx.commit().unwrap()
             },
         )
     });
@@ -239,7 +239,7 @@ where
                     let (k, _, v, _) = input.get(index).unwrap().clone();
                     tx.put::<T>(k, v).unwrap();
                 }
-                tx.commit().unwrap();
+                tx.commit().unwrap()
             },
         )
     });

--- a/crates/storage/db/benches/criterion.rs
+++ b/crates/storage/db/benches/criterion.rs
@@ -137,7 +137,7 @@ where
                 for (k, _, v, _) in input {
                     crsr.append(k, &v).expect("submit");
                 }
-                tx.inner.commit().unwrap()
+                tx.inner().commit().unwrap()
             },
         )
     });
@@ -158,7 +158,7 @@ where
                     crsr.insert(k, &v).expect("submit");
                 }
 
-                tx.inner.commit().unwrap()
+                tx.inner().commit().unwrap()
             },
         )
     });
@@ -219,7 +219,7 @@ where
                 for (k, _, v, _) in input {
                     crsr.append_dup(k, v).expect("submit");
                 }
-                tx.inner.commit().unwrap()
+                tx.inner().commit().unwrap()
             },
         )
     });
@@ -239,7 +239,7 @@ where
                     let (k, _, v, _) = input.get(index).unwrap().clone();
                     tx.put::<T>(k, v).unwrap();
                 }
-                tx.inner.commit().unwrap();
+                tx.inner().commit().unwrap();
             },
         )
     });

--- a/crates/storage/db/benches/criterion.rs
+++ b/crates/storage/db/benches/criterion.rs
@@ -239,7 +239,7 @@ where
                     let (k, _, v, _) = input.get(index).unwrap().clone();
                     tx.put::<T>(k, v).unwrap();
                 }
-                tx.inner().commit().unwrap();
+                tx.commit().unwrap();
             },
         )
     });

--- a/crates/storage/db/benches/hash_keys.rs
+++ b/crates/storage/db/benches/hash_keys.rs
@@ -16,7 +16,7 @@ use reth_db_api::{
     cursor::DbCursorRW,
     database::Database,
     table::{Table, TableRow},
-    transaction::DbTxMut,
+    transaction::{DbTx, DbTxMut},
 };
 use reth_fs_util as fs;
 use std::hint::black_box;
@@ -185,9 +185,9 @@ where
             for (k, v) in input {
                 crsr.append(k, &v).expect("submit");
             }
-
-            tx.commit().unwrap()
         });
+        drop(crsr);
+        tx.commit().unwrap();
     }
     db
 }
@@ -203,9 +203,9 @@ where
             for (k, v) in input {
                 crsr.insert(k, &v).expect("submit");
             }
-
-            tx.commit().unwrap()
         });
+        drop(crsr);
+        tx.commit().unwrap();
     }
     db
 }
@@ -220,9 +220,8 @@ where
             for (k, v) in input {
                 tx.put::<T>(k, v).expect("submit");
             }
-
-            tx.commit().unwrap()
         });
+        tx.commit().unwrap();
     }
     db
 }

--- a/crates/storage/db/benches/hash_keys.rs
+++ b/crates/storage/db/benches/hash_keys.rs
@@ -19,7 +19,6 @@ use reth_db_api::{
     transaction::{DbTx, DbTxMut},
 };
 use reth_fs_util as fs;
-use std::hint::black_box;
 
 mod utils;
 use utils::*;
@@ -178,17 +177,13 @@ fn append<T>(db: DatabaseEnv, input: Vec<(<T as Table>::Key, <T as Table>::Value
 where
     T: Table,
 {
-    {
-        let tx = db.tx_mut().expect("tx");
-        let mut crsr = tx.cursor_write::<T>().expect("cursor");
-        black_box({
-            for (k, v) in input {
-                crsr.append(k, &v).expect("submit");
-            }
-        });
-        drop(crsr);
-        tx.commit().unwrap();
+    let tx = db.tx_mut().expect("tx");
+    let mut crsr = tx.cursor_write::<T>().expect("cursor");
+    for (k, v) in input {
+        crsr.append(k, &v).expect("submit");
     }
+    drop(crsr);
+    tx.commit().unwrap();
     db
 }
 
@@ -196,17 +191,13 @@ fn insert<T>(db: DatabaseEnv, input: Vec<(<T as Table>::Key, <T as Table>::Value
 where
     T: Table,
 {
-    {
-        let tx = db.tx_mut().expect("tx");
-        let mut crsr = tx.cursor_write::<T>().expect("cursor");
-        black_box({
-            for (k, v) in input {
-                crsr.insert(k, &v).expect("submit");
-            }
-        });
-        drop(crsr);
-        tx.commit().unwrap();
+    let tx = db.tx_mut().expect("tx");
+    let mut crsr = tx.cursor_write::<T>().expect("cursor");
+    for (k, v) in input {
+        crsr.insert(k, &v).expect("submit");
     }
+    drop(crsr);
+    tx.commit().unwrap();
     db
 }
 
@@ -214,15 +205,11 @@ fn put<T>(db: DatabaseEnv, input: Vec<(<T as Table>::Key, <T as Table>::Value)>)
 where
     T: Table,
 {
-    {
-        let tx = db.tx_mut().expect("tx");
-        black_box({
-            for (k, v) in input {
-                tx.put::<T>(k, v).expect("submit");
-            }
-        });
-        tx.commit().unwrap();
+    let tx = db.tx_mut().expect("tx");
+    for (k, v) in input {
+        tx.put::<T>(k, v).expect("submit");
     }
+    tx.commit().unwrap();
     db
 }
 

--- a/crates/storage/db/benches/hash_keys.rs
+++ b/crates/storage/db/benches/hash_keys.rs
@@ -186,7 +186,7 @@ where
                 crsr.append(k, &v).expect("submit");
             }
 
-            tx.inner.commit().unwrap()
+            tx.inner().commit().unwrap()
         });
     }
     db
@@ -204,7 +204,7 @@ where
                 crsr.insert(k, &v).expect("submit");
             }
 
-            tx.inner.commit().unwrap()
+            tx.inner().commit().unwrap()
         });
     }
     db
@@ -221,7 +221,7 @@ where
                 tx.put::<T>(k, v).expect("submit");
             }
 
-            tx.inner.commit().unwrap()
+            tx.inner().commit().unwrap()
         });
     }
     db
@@ -243,11 +243,11 @@ where
     T: Table,
 {
     db.view(|tx| {
-        let table_db = tx.inner.open_db(Some(T::NAME)).map_err(|_| "Could not open db.").unwrap();
+        let table_db = tx.inner().open_db(Some(T::NAME)).map_err(|_| "Could not open db.").unwrap();
 
         println!(
             "{:?}\n",
-            tx.inner
+            tx.inner()
                 .db_stat(table_db.dbi())
                 .map_err(|_| format!("Could not find table: {}", T::NAME))
                 .map(|stats| {

--- a/crates/storage/db/benches/hash_keys.rs
+++ b/crates/storage/db/benches/hash_keys.rs
@@ -186,7 +186,7 @@ where
                 crsr.append(k, &v).expect("submit");
             }
 
-            tx.inner().commit().unwrap()
+            tx.commit().unwrap()
         });
     }
     db
@@ -204,7 +204,7 @@ where
                 crsr.insert(k, &v).expect("submit");
             }
 
-            tx.inner().commit().unwrap()
+            tx.commit().unwrap()
         });
     }
     db
@@ -221,7 +221,7 @@ where
                 tx.put::<T>(k, v).expect("submit");
             }
 
-            tx.inner().commit().unwrap()
+            tx.commit().unwrap()
         });
     }
     db

--- a/crates/storage/db/benches/utils.rs
+++ b/crates/storage/db/benches/utils.rs
@@ -5,7 +5,7 @@ use alloy_primitives::Bytes;
 use reth_db::{test_utils::create_test_rw_db_with_path, DatabaseEnv};
 use reth_db_api::{
     table::{Compress, Encode, Table, TableRow},
-    transaction::DbTxMut,
+    transaction::{DbTx, DbTxMut},
     Database,
 };
 use reth_fs_util as fs;
@@ -68,7 +68,7 @@ where
         for (k, _, v, _) in pair.clone() {
             tx.put::<T>(k, v).expect("submit");
         }
-        tx.inner().commit().unwrap();
+        tx.commit().unwrap();
     }
 
     db.into_inner_db()

--- a/crates/storage/db/benches/utils.rs
+++ b/crates/storage/db/benches/utils.rs
@@ -68,7 +68,7 @@ where
         for (k, _, v, _) in pair.clone() {
             tx.put::<T>(k, v).expect("submit");
         }
-        tx.inner.commit().unwrap();
+        tx.inner().commit().unwrap();
     }
 
     db.into_inner_db()

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -274,10 +274,10 @@ impl DatabaseMetrics for DatabaseEnv {
         let _ = self
             .view(|tx| {
                 for table in Tables::ALL.iter().map(Tables::name) {
-                    let table_db = tx.inner.open_db(Some(table)).wrap_err("Could not open db.")?;
+                    let table_db = tx.inner().open_db(Some(table)).wrap_err("Could not open db.")?;
 
                     let stats = tx
-                        .inner
+                        .inner()
                         .db_stat(table_db.dbi())
                         .wrap_err(format!("Could not find table: {table}"))?;
 

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -274,7 +274,8 @@ impl DatabaseMetrics for DatabaseEnv {
         let _ = self
             .view(|tx| {
                 for table in Tables::ALL.iter().map(Tables::name) {
-                    let table_db = tx.inner().open_db(Some(table)).wrap_err("Could not open db.")?;
+                    let table_db =
+                        tx.inner().open_db(Some(table)).wrap_err("Could not open db.")?;
 
                     let stats = tx
                         .inner()

--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -30,7 +30,7 @@ const LONG_TRANSACTION_DURATION: Duration = Duration::from_secs(60);
 #[derive(Debug)]
 pub struct Tx<K: TransactionKind> {
     /// Libmdbx-sys transaction.
-    pub inner: Transaction<K>,
+    inner: Transaction<K>,
 
     /// Cached MDBX DBIs for reuse.
     dbis: Arc<HashMap<&'static str, MDBX_dbi>>,
@@ -60,6 +60,11 @@ impl<K: TransactionKind> Tx<K> {
             })
             .transpose()?;
         Ok(Self { inner, dbis, metrics_handler })
+    }
+
+    /// Returns a reference to the inner libmdbx transaction.
+    pub const fn inner(&self) -> &Transaction<K> {
+        &self.inner
     }
 
     /// Gets this transaction ID.


### PR DESCRIPTION
Makes the `Tx::inner` field private and exposes a `pub const fn inner()` accessor instead.

This improves encapsulation while maintaining the same functionality.