### PR TITLE
fix(rpc): populate block fields in mev_simBundle logs

### DIFF
--- a/crates/rpc/rpc/src/eth/sim_bundle.rs
+++ b/crates/rpc/rpc/src/eth/sim_bundle.rs
@@ -318,9 +318,9 @@ where
                             .map(|inner| {
                                 let full_log = alloy_rpc_types_eth::Log {
                                     inner,
-                                    block_hash: None,
-                                    block_number: None,
-                                    block_timestamp: None,
+                                    block_hash: Some(current_block.hash()),
+                                    block_number: Some(current_block.number()),
+                                    block_timestamp: Some(current_block.timestamp()),
                                     transaction_hash: Some(*item.tx.tx_hash()),
                                     transaction_index: Some(tx_index as u64),
                                     log_index: Some(log_index),


### PR DESCRIPTION
Fill in block_hash, block_number, block_timestamp in log objects returned by mev_simBundle.                                                                                                                                                                                                                                                                                                                                                                                                                                                      These fields were set to None even though current_block is already available in the closure. matches the behavior of `eth_simulateV1` which properly populates these fields. 