### PR TITLE
chore(metrics): add persistence_duration_last and block_insert_total_duration_last gauges

### DIFF
--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -120,6 +120,8 @@ pub(crate) struct EngineMetrics {
     pub(crate) executed_new_block_cache_miss: Counter,
     /// Histogram of persistence operation durations (in seconds)
     pub(crate) persistence_duration: Histogram,
+    /// Duration of the last persistence operation (in seconds)
+    pub(crate) persistence_duration_last: Gauge,
     /// Tracks the how often we failed to deliver a newPayload response.
     ///
     /// This effectively tracks how often the message sender dropped the channel and indicates a CL
@@ -130,6 +132,8 @@ pub(crate) struct EngineMetrics {
     pub(crate) failed_forkchoice_updated_response_deliveries: Counter,
     /// block insert duration
     pub(crate) block_insert_total_duration: Histogram,
+    /// Duration of the last block insert operation (in seconds)
+    pub(crate) block_insert_total_duration_last: Gauge,
 }
 
 /// Metrics for engine forkchoiceUpdated responses.

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1369,7 +1369,9 @@ where
         last_persisted_hash_num: Option<BlockNumHash>,
         start_time: Instant,
     ) -> Result<(), AdvancePersistenceError> {
-        self.metrics.engine.persistence_duration.record(start_time.elapsed());
+        let elapsed = start_time.elapsed();
+        self.metrics.engine.persistence_duration.record(elapsed);
+        self.metrics.engine.persistence_duration_last.set(elapsed.as_secs_f64());
 
         let Some(BlockNumHash {
             hash: last_persisted_block_hash,
@@ -2662,10 +2664,9 @@ where
         };
         self.emit_event(EngineApiEvent::BeaconConsensus(engine_event));
 
-        self.metrics
-            .engine
-            .block_insert_total_duration
-            .record(block_insert_start.elapsed().as_secs_f64());
+        let block_insert_elapsed = block_insert_start.elapsed().as_secs_f64();
+        self.metrics.engine.block_insert_total_duration.record(block_insert_elapsed);
+        self.metrics.engine.block_insert_total_duration_last.set(block_insert_elapsed);
         debug!(target: "engine::tree", block=?block_num_hash, "Finished inserting block");
         Ok(InsertPayloadOk::Inserted(BlockStatus::Valid))
     }


### PR DESCRIPTION
Add _last gauges for persistence_duration and block_insert_total_duration to match the pattern used by forkchoice_updated_last and new_payload_last