### PR TITLE
refactor(trie): consolidate StorageTries parallel maps into one

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -177,20 +177,20 @@ where
     let results: Vec<_> = state
         .storages
         .into_iter()
-        .map(|(address, storage)| (address, storage, trie.take_storage_trie(&address)))
+        .map(|(address, storage)| (address, storage, trie.take_storage_trie_entry(&address)))
         .par_bridge()
-        .map(|(address, storage, storage_trie)| {
+        .map(|(address, storage, storage_entry)| {
             let _enter =
                 debug_span!(target: "engine::tree::payload_processor::sparse_trie", parent: &span, "storage trie", ?address)
                     .entered();
 
             trace!(target: "engine::tree::payload_processor::sparse_trie", "Updating storage");
             let storage_provider = blinded_provider_factory.storage_node_provider(address);
-            let mut storage_trie = storage_trie.ok_or(SparseTrieErrorKind::Blind)?;
+            let mut storage_entry = storage_entry.ok_or(SparseTrieErrorKind::Blind)?;
 
             if storage.wiped {
                 trace!(target: "engine::tree::payload_processor::sparse_trie", "Wiping storage");
-                storage_trie.wipe()?;
+                storage_entry.trie.wipe()?;
             }
 
             // Defer leaf removals until after updates/additions, so that we don't delete an
@@ -208,7 +208,7 @@ where
                 }
 
                 trace!(target: "engine::tree::payload_processor::sparse_trie", ?slot_nibbles, "Updating storage slot");
-                storage_trie.update_leaf(
+                storage_entry.trie.update_leaf(
                     slot_nibbles,
                     alloy_rlp::encode_fixed_size(&value).to_vec(),
                     &storage_provider,
@@ -217,12 +217,12 @@ where
 
             for slot_nibbles in removed_slots {
                 trace!(target: "engine::root::sparse", ?slot_nibbles, "Removing storage slot");
-                storage_trie.remove_leaf(&slot_nibbles, &storage_provider)?;
+                storage_entry.trie.remove_leaf(&slot_nibbles, &storage_provider)?;
             }
 
-            storage_trie.root();
+            storage_entry.trie.root();
 
-            SparseStateTrieResult::Ok((address, storage_trie))
+            SparseStateTrieResult::Ok((address, storage_entry))
         })
         .collect();
 
@@ -237,8 +237,8 @@ where
         tracing::debug_span!(target: "engine::tree::payload_processor::sparse_trie", "account trie")
             .entered();
     for result in results {
-        let (address, storage_trie) = result?;
-        trie.insert_storage_trie(address, storage_trie);
+        let (address, storage_entry) = result?;
+        trie.insert_storage_trie_entry(address, storage_entry);
 
         if let Some(account) = state.accounts.remove(&address) {
             // If the account itself has an update, remove it from the state update and update in

--- a/crates/stateless/src/trie.rs
+++ b/crates/stateless/src/trie.rs
@@ -11,7 +11,7 @@ use reth_trie_common::{HashedPostState, Nibbles, TRIE_ACCOUNT_RLP_MAX_SIZE};
 use reth_trie_sparse::{
     errors::SparseStateTrieResult,
     provider::{DefaultTrieNodeProvider, DefaultTrieNodeProviderFactory},
-    RevealableSparseTrie, SparseStateTrie, SparseTrie,
+    RevealableSparseTrie, SparseStateTrie, SparseTrie, StorageTrieEntry,
 };
 
 /// Trait for stateless trie implementations that can be used for stateless validation.
@@ -243,12 +243,15 @@ fn calculate_state_root(
     let storage_provider = DefaultTrieNodeProvider;
 
     for (address, storage) in state.storages.into_iter().sorted_unstable_by_key(|(addr, _)| *addr) {
-        // Take the existing storage trie (or create an empty, “revealed” one)
-        let mut storage_trie =
-            trie.take_storage_trie(&address).unwrap_or_else(RevealableSparseTrie::revealed_empty);
+        // Take the existing storage entry (or create an empty, “revealed” one)
+        let mut storage_entry =
+            trie.take_storage_trie_entry(&address).unwrap_or_else(|| StorageTrieEntry {
+                trie: RevealableSparseTrie::revealed_empty(),
+                revealed_paths: Default::default(),
+            });
 
         if storage.wiped {
-            storage_trie.wipe()?;
+            storage_entry.trie.wipe()?;
         }
 
         // Apply slot‑level changes
@@ -257,9 +260,9 @@ fn calculate_state_root(
         {
             let nibbles = Nibbles::unpack(hashed_slot);
             if value.is_zero() {
-                storage_trie.remove_leaf(&nibbles, &storage_provider)?;
+                storage_entry.trie.remove_leaf(&nibbles, &storage_provider)?;
             } else {
-                storage_trie.update_leaf(
+                storage_entry.trie.update_leaf(
                     nibbles,
                     alloy_rlp::encode_fixed_size(&value).to_vec(),
                     &storage_provider,
@@ -268,13 +271,13 @@ fn calculate_state_root(
         }
 
         // Finalise the storage‑trie root before pushing the result
-        storage_trie.root();
-        storage_results.push((address, storage_trie));
+        storage_entry.trie.root();
+        storage_results.push((address, storage_entry));
     }
 
     // Insert every updated storage trie back into the outer state trie
-    for (address, storage_trie) in storage_results {
-        trie.insert_storage_trie(address, storage_trie);
+    for (address, storage_entry) in storage_results {
+        trie.insert_storage_trie_entry(address, storage_entry);
     }
 
     // 2. Apply account‑level updates and (re)encode the account nodes


### PR DESCRIPTION
reopens #20714

- created new struct StorageTrieEntry for better cache locality
- updated all calling sites to use this new struct

this makes storage related lookups in the sparse trie 2x faster and we also save 48 bytes per StorageTrie instance