### PR TITLE
perf: use FxHashMap in BlockBuffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8452,6 +8452,7 @@ dependencies = [
  "revm",
  "revm-primitives",
  "revm-state",
+ "rustc-hash",
  "schnellru",
  "serde_json",
  "smallvec",

--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -69,6 +69,7 @@ tracing.workspace = true
 derive_more.workspace = true
 parking_lot.workspace = true
 crossbeam-channel.workspace = true
+rustc-hash.workspace = true
 
 # optional deps for test-utils
 reth-prune-types = { workspace = true, optional = true }


### PR DESCRIPTION
Replaced std HashMap/HashSet with FxHashMap/FxHashSet in BlockBuffer. Added with_capacity() to avoid reallocations during buffer initialization and in hot paths (remove_old_blocks, remove_children).

This pattern is already used across the codebase in txpool, network, and storage layers. BlockHash keys are ideal for FxHash.