### PR TITLE
feat(trie): add update_leaves method to SparseTrie

### DIFF
--- a/crates/trie/common/src/lib.rs
+++ b/crates/trie/common/src/lib.rs
@@ -39,6 +39,9 @@ pub use key::{KeccakKeyHasher, KeyHasher};
 mod nibbles;
 pub use nibbles::{Nibbles, StoredNibbles, StoredNibblesSubKey};
 
+mod target;
+pub use target::Target;
+
 mod storage;
 pub use storage::StorageTrieEntry;
 

--- a/crates/trie/common/src/target.rs
+++ b/crates/trie/common/src/target.rs
@@ -1,0 +1,68 @@
+use alloy_primitives::B256;
+
+use crate::Nibbles;
+
+/// Target describes a proof target for trie operations.
+///
+/// For every proof target given, the proof calculator will return all nodes
+/// whose path is a prefix of the target's `key`.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct Target {
+    /// The full key path (64 nibbles).
+    pub key: Nibbles,
+    /// Minimum path length required for the proof.
+    /// Only match trie nodes whose path is at least this long.
+    pub min_len: u8,
+}
+
+impl Target {
+    /// Returns a new [`Target`] which matches all trie nodes whose path is a prefix of this key.
+    pub fn new(key: B256) -> Self {
+        // SAFETY: key is a B256 and so is exactly 32-bytes.
+        let key = unsafe { Nibbles::unpack_unchecked(key.as_slice()) };
+        Self { key, min_len: 0 }
+    }
+
+    /// Creates a new target from nibbles with a specific min_len.
+    #[inline]
+    pub const fn from_nibbles(key: Nibbles, min_len: u8) -> Self {
+        Self { key, min_len }
+    }
+
+    /// Returns the key the target was initialized with.
+    pub fn key(&self) -> B256 {
+        B256::from_slice(&self.key.pack())
+    }
+
+    /// Only match trie nodes whose path is at least this long.
+    ///
+    /// # Panics
+    ///
+    /// This method panics if `min_len` is greater than 64.
+    pub fn with_min_len(mut self, min_len: u8) -> Self {
+        debug_assert!(min_len <= 64);
+        self.min_len = min_len;
+        self
+    }
+
+    /// Returns the sub-trie prefix for this target.
+    ///
+    /// A target will only match nodes which share the target's prefix, where the target's prefix
+    /// is the first `min_len` nibbles of its key. E.g. a target with `key` 0xabcd and `min_len` 2
+    /// will only match nodes with prefix 0xab.
+    ///
+    /// The sub-trie prefix is the target prefix with a nibble truncated, because a branch node
+    /// must be constructed at the parent level to know the node exists at that path.
+    #[inline]
+    pub fn sub_trie_prefix(&self) -> Nibbles {
+        let mut sub_trie_prefix = self.key;
+        sub_trie_prefix.truncate(self.min_len.saturating_sub(1) as usize);
+        sub_trie_prefix
+    }
+}
+
+impl From<B256> for Target {
+    fn from(key: B256) -> Self {
+        Self::new(key)
+    }
+}

--- a/crates/trie/sparse/src/lib.rs
+++ b/crates/trie/sparse/src/lib.rs
@@ -14,6 +14,8 @@ pub use trie::*;
 mod traits;
 pub use traits::*;
 
+pub use reth_trie_common::Target;
+
 pub mod provider;
 
 #[cfg(feature = "metrics")]

--- a/crates/trie/sparse/src/provider.rs
+++ b/crates/trie/sparse/src/provider.rs
@@ -64,6 +64,22 @@ impl TrieNodeProvider for DefaultTrieNodeProvider {
     }
 }
 
+/// A trie node provider that always returns `Ok(None)`.
+///
+/// This is used by [`update_leaves`](crate::SparseTrie::update_leaves) to force
+/// [`BlindedNode`](reth_execution_errors::SparseTrieErrorKind::BlindedNode) errors
+/// when the trie traversal hits a hash node, rather than attempting to fetch from a database.
+/// This enables a "short-circuit" pattern where blinded nodes are detected and collected
+/// for batch proof fetching instead of being resolved one-at-a-time.
+#[derive(PartialEq, Eq, Clone, Copy, Default, Debug)]
+pub struct ShortCircuitTrieNodeProvider;
+
+impl TrieNodeProvider for ShortCircuitTrieNodeProvider {
+    fn trie_node(&self, _path: &Nibbles) -> Result<Option<RevealedNode>, SparseTrieError> {
+        Ok(None)
+    }
+}
+
 /// Right pad the path with 0s and return as [`B256`].
 #[inline]
 pub fn pad_path_to_key(path: &Nibbles) -> B256 {

--- a/crates/trie/trie/src/proof_v2/target.rs
+++ b/crates/trie/trie/src/proof_v2/target.rs
@@ -1,71 +1,7 @@
 use crate::proof_v2::increment_and_strip_trailing_zeros;
-use alloy_primitives::B256;
 use reth_trie_common::Nibbles;
 
-/// Target describes a proof target. For every proof target given, the
-/// [`crate::proof_v2::ProofCalculator`] will calculate and return all nodes whose path is a prefix
-/// of the target's `key`.
-#[derive(Debug, Copy, Clone)]
-pub struct Target {
-    pub(crate) key: Nibbles,
-    pub(crate) min_len: u8,
-}
-
-impl Target {
-    /// Returns a new [`Target`] which matches all trie nodes whose path is a prefix of this key.
-    pub fn new(key: B256) -> Self {
-        // SAFETY: key is a B256 and so is exactly 32-bytes.
-        let key = unsafe { Nibbles::unpack_unchecked(key.as_slice()) };
-        Self { key, min_len: 0 }
-    }
-
-    /// Returns the key the target was initialized with.
-    pub fn key(&self) -> B256 {
-        B256::from_slice(&self.key.pack())
-    }
-
-    /// Only match trie nodes whose path is at least this long.
-    ///
-    /// # Panics
-    ///
-    /// This method panics if `min_len` is greater than 64.
-    pub fn with_min_len(mut self, min_len: u8) -> Self {
-        debug_assert!(min_len <= 64);
-        self.min_len = min_len;
-        self
-    }
-
-    // A helper function for getting the largest prefix of the sub-trie which contains a particular
-    // target, based on its `min_len`.
-    //
-    // A target will only match nodes which share the target's prefix, where the target's prefix is
-    // the first `min_len` nibbles of its key. E.g. a target with `key` 0xabcd and `min_len` 2 will
-    // only match nodes with prefix 0xab.
-    //
-    // In general the target will only match within the sub-trie whose prefix is identical to the
-    // target's. However there is an exception:
-    //
-    // Given a trie with a node at 0xabc, there must be a branch at 0xab. A target with prefix 0xabc
-    // needs to match that node, but the branch at 0xab must be constructed order to know the node
-    // is at that path. Therefore the sub-trie prefix is the target prefix with a nibble truncated.
-    //
-    // For a target with an empty prefix (`min_len` of 0) we still use an empty sub-trie prefix;
-    // this will still construct the branch at the root node (if there is one). Targets with
-    // `min_len` of both 0 and 1 will therefore construct the root node, but only those with
-    // `min_len` of 0 will retain it.
-    #[inline]
-    fn sub_trie_prefix(&self) -> Nibbles {
-        let mut sub_trie_prefix = self.key;
-        sub_trie_prefix.truncate(self.min_len.saturating_sub(1) as usize);
-        sub_trie_prefix
-    }
-}
-
-impl From<B256> for Target {
-    fn from(key: B256) -> Self {
-        Self::new(key)
-    }
-}
+pub use reth_trie_common::Target;
 
 // A helper function which returns the first path following a sub-trie in lexicographical order.
 #[inline]
@@ -153,6 +89,7 @@ pub(crate) fn iter_sub_trie_targets<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_primitives::B256;
 
     #[test]
     fn test_iter_sub_trie_targets() {


### PR DESCRIPTION
## Summary

Add batch `update_leaves` method to `SparseTrie` trait that collects proof targets for blinded nodes instead of fetching proofs one-at-a-time. This enables batch proof fetching with a single database call.

## Changes

**New Types (`traits.rs`)**
- **`ProofTarget`**: Identifies a blinded node that needs proof fetching (key + min_len)
- **`LeafUpdate`**: Represents an update operation (`Upsert(value)` or `Deleted`)

**New Method (`SparseTrie::update_leaves`)**
```rust
fn update_leaves<F>(
    &mut self,
    updates: &mut HashMap<Nibbles, LeafUpdate>,
    on_blinded: F,
) -> SparseTrieResult<()>
where
    F: FnMut(ProofTarget);
```

- Processes updates in lexicographic order for cache efficiency
- Successfully applied updates are removed from the map
- Blinded nodes are reported via callback (not errors)
- Supports both upserts and deletions

**Transactional `update_leaf` Fix**

Made `update_leaf` transactional by deferring all mutations to the end:
- Uses local `NodeOp` buffer to stage all node changes
- Mutations only applied after successful traversal
- If `BlindedNode` error occurs, trie state is unchanged
- Safe for retry after fetching proofs

Closes RETH-177