### PR TITLE
feat(db): add unsynchronized transaction variants for improved performance

### DIFF
--- a/crates/storage/db-api/src/database.rs
+++ b/crates/storage/db-api/src/database.rs
@@ -9,10 +9,15 @@ use std::{fmt::Debug, sync::Arc};
 ///
 /// Sealed trait which cannot be implemented by 3rd parties, exposed only for consumption.
 pub trait Database: Send + Sync + Debug {
-    /// Read-Only database transaction
+    /// Read-Only database transaction (thread-safe, synchronized)
     type TX: DbTx + Send + Sync + Debug + 'static;
-    /// Read-Write database transaction
+    /// Read-Write database transaction (thread-safe, synchronized)
     type TXMut: DbTxMut + DbTx + TableImporter + Send + Sync + Debug + 'static;
+
+    /// Read-Only database transaction (unsynchronized, faster for single-threaded use)
+    type TXUnsync: DbTx + Send + Debug + 'static;
+    /// Read-Write database transaction (unsynchronized, faster for single-threaded use)
+    type TXMutUnsync: DbTxMut + DbTx + TableImporter + Send + Debug + 'static;
 
     /// Create read only transaction.
     #[track_caller]
@@ -21,6 +26,20 @@ pub trait Database: Send + Sync + Debug {
     /// Create read write transaction only possible if database is open with write access.
     #[track_caller]
     fn tx_mut(&self) -> Result<Self::TXMut, DatabaseError>;
+
+    /// Create read only transaction (unsynchronized, faster for single-threaded use).
+    ///
+    /// The returned transaction is not `Sync` and not `Clone`, but avoids `Arc` and `Mutex`
+    /// overhead for faster single-threaded access.
+    #[track_caller]
+    fn tx_unsync(&self) -> Result<Self::TXUnsync, DatabaseError>;
+
+    /// Create read write transaction (unsynchronized, faster for single-threaded use).
+    ///
+    /// The returned transaction is not `Sync` and not `Clone`, but avoids `Arc` and `Mutex`
+    /// overhead for faster single-threaded access.
+    #[track_caller]
+    fn tx_mut_unsync(&self) -> Result<Self::TXMutUnsync, DatabaseError>;
 
     /// Takes a function and passes a read-only transaction into it, making sure it's closed in the
     /// end of the execution.
@@ -54,6 +73,8 @@ pub trait Database: Send + Sync + Debug {
 impl<DB: Database> Database for Arc<DB> {
     type TX = <DB as Database>::TX;
     type TXMut = <DB as Database>::TXMut;
+    type TXUnsync = <DB as Database>::TXUnsync;
+    type TXMutUnsync = <DB as Database>::TXMutUnsync;
 
     fn tx(&self) -> Result<Self::TX, DatabaseError> {
         <DB as Database>::tx(self)
@@ -61,12 +82,22 @@ impl<DB: Database> Database for Arc<DB> {
 
     fn tx_mut(&self) -> Result<Self::TXMut, DatabaseError> {
         <DB as Database>::tx_mut(self)
+    }
+
+    fn tx_unsync(&self) -> Result<Self::TXUnsync, DatabaseError> {
+        <DB as Database>::tx_unsync(self)
+    }
+
+    fn tx_mut_unsync(&self) -> Result<Self::TXMutUnsync, DatabaseError> {
+        <DB as Database>::tx_mut_unsync(self)
     }
 }
 
 impl<DB: Database> Database for &DB {
     type TX = <DB as Database>::TX;
     type TXMut = <DB as Database>::TXMut;
+    type TXUnsync = <DB as Database>::TXUnsync;
+    type TXMutUnsync = <DB as Database>::TXMutUnsync;
 
     fn tx(&self) -> Result<Self::TX, DatabaseError> {
         <DB as Database>::tx(self)
@@ -74,5 +105,13 @@ impl<DB: Database> Database for &DB {
 
     fn tx_mut(&self) -> Result<Self::TXMut, DatabaseError> {
         <DB as Database>::tx_mut(self)
+    }
+
+    fn tx_unsync(&self) -> Result<Self::TXUnsync, DatabaseError> {
+        <DB as Database>::tx_unsync(self)
+    }
+
+    fn tx_mut_unsync(&self) -> Result<Self::TXMutUnsync, DatabaseError> {
+        <DB as Database>::tx_mut_unsync(self)
     }
 }

--- a/crates/storage/db-api/src/mock.rs
+++ b/crates/storage/db-api/src/mock.rs
@@ -34,6 +34,8 @@ pub struct DatabaseMock {
 impl Database for DatabaseMock {
     type TX = TxMock;
     type TXMut = TxMock;
+    type TXUnsync = TxMock;
+    type TXMutUnsync = TxMock;
 
     /// Creates a new read-only transaction.
     ///
@@ -48,6 +50,14 @@ impl Database for DatabaseMock {
     /// This always succeeds and returns a default [`TxMock`] instance.
     /// The mock transaction doesn't actually perform any database operations.
     fn tx_mut(&self) -> Result<Self::TXMut, DatabaseError> {
+        Ok(TxMock::default())
+    }
+
+    fn tx_unsync(&self) -> Result<Self::TXUnsync, DatabaseError> {
+        Ok(TxMock::default())
+    }
+
+    fn tx_mut_unsync(&self) -> Result<Self::TXMutUnsync, DatabaseError> {
         Ok(TxMock::default())
     }
 }

--- a/crates/storage/db/src/implementation/mdbx/cursor.rs
+++ b/crates/storage/db/src/implementation/mdbx/cursor.rs
@@ -13,7 +13,9 @@ use reth_db_api::{
     },
     table::{Compress, Decode, Decompress, DupSort, Encode, IntoVec, Table},
 };
-use reth_libmdbx::{Error as MDBXError, TransactionKind, WriteFlags, RO, RW};
+use reth_libmdbx::{
+    CursorUnsync as LibmdbxCursorUnsync, Error as MDBXError, TransactionKind, WriteFlags, RO, RW,
+};
 use reth_storage_errors::db::{DatabaseErrorInfo, DatabaseWriteError, DatabaseWriteOperation};
 use std::{borrow::Cow, collections::Bound, marker::PhantomData, ops::RangeBounds, sync::Arc};
 
@@ -354,6 +356,267 @@ impl<T: DupSort> DbDupCursorRW<T> for Cursor<RW, T> {
                         }
                         .into()
                     })
+            },
+        )
+    }
+}
+
+/// Unsynchronized cursor wrapper to access KV items.
+///
+/// This is a faster variant of [`Cursor`] that works with unsynchronized transactions.
+#[derive(Debug)]
+pub struct CursorUnsync<'tx, K: TransactionKind, T: Table> {
+    /// Inner `libmdbx` unsynchronized cursor.
+    inner: LibmdbxCursorUnsync<'tx, K>,
+    /// Cache buffer that receives compressed values.
+    buf: Vec<u8>,
+    /// Phantom data to enforce encoding/decoding.
+    _dbi: PhantomData<T>,
+}
+
+impl<'tx, K: TransactionKind, T: Table> CursorUnsync<'tx, K, T> {
+    pub(crate) const fn new(inner: LibmdbxCursorUnsync<'tx, K>) -> Self {
+        Self { inner, buf: Vec::new(), _dbi: PhantomData }
+    }
+}
+
+/// Decodes a `(key, value)` pair from an unsynchronized cursor.
+#[allow(clippy::type_complexity)]
+fn decode_unsync<T>(
+    res: Result<Option<(Cow<'_, [u8]>, Cow<'_, [u8]>)>, impl Into<DatabaseErrorInfo>>,
+) -> PairResult<T>
+where
+    T: Table,
+    T::Key: Decode,
+    T::Value: Decompress,
+{
+    res.map_err(|e| DatabaseError::Read(e.into()))?.map(decoder::<T>).transpose()
+}
+
+impl<K: TransactionKind, T: Table> DbCursorRO<T> for CursorUnsync<'_, K, T> {
+    fn first(&mut self) -> PairResult<T> {
+        decode_unsync::<T>(self.inner.first())
+    }
+
+    fn seek_exact(&mut self, key: <T as Table>::Key) -> PairResult<T> {
+        decode_unsync::<T>(self.inner.set_key(key.encode().as_ref()))
+    }
+
+    fn seek(&mut self, key: <T as Table>::Key) -> PairResult<T> {
+        decode_unsync::<T>(self.inner.set_range(key.encode().as_ref()))
+    }
+
+    fn next(&mut self) -> PairResult<T> {
+        decode_unsync::<T>(self.inner.next())
+    }
+
+    fn prev(&mut self) -> PairResult<T> {
+        decode_unsync::<T>(self.inner.prev())
+    }
+
+    fn last(&mut self) -> PairResult<T> {
+        decode_unsync::<T>(self.inner.last())
+    }
+
+    fn current(&mut self) -> PairResult<T> {
+        decode_unsync::<T>(self.inner.get_current())
+    }
+
+    fn walk(&mut self, start_key: Option<T::Key>) -> Result<Walker<'_, T, Self>, DatabaseError> {
+        let start = if let Some(start_key) = start_key {
+            decode_unsync::<T>(self.inner.set_range(start_key.encode().as_ref())).transpose()
+        } else {
+            self.first().transpose()
+        };
+
+        Ok(Walker::new(self, start))
+    }
+
+    fn walk_range(
+        &mut self,
+        range: impl RangeBounds<T::Key>,
+    ) -> Result<RangeWalker<'_, T, Self>, DatabaseError> {
+        let start = match range.start_bound().cloned() {
+            Bound::Included(key) => self.inner.set_range(key.encode().as_ref()),
+            Bound::Excluded(_key) => {
+                unreachable!("Rust doesn't allow for Bound::Excluded in starting bounds");
+            }
+            Bound::Unbounded => self.inner.first(),
+        };
+        let start = decode_unsync::<T>(start).transpose();
+        Ok(RangeWalker::new(self, start, range.end_bound().cloned()))
+    }
+
+    fn walk_back(
+        &mut self,
+        start_key: Option<T::Key>,
+    ) -> Result<ReverseWalker<'_, T, Self>, DatabaseError> {
+        let start = if let Some(start_key) = start_key {
+            decode_unsync::<T>(self.inner.set_range(start_key.encode().as_ref()))
+        } else {
+            self.last()
+        }
+        .transpose();
+
+        Ok(ReverseWalker::new(self, start))
+    }
+}
+
+impl<K: TransactionKind, T: DupSort> DbDupCursorRO<T> for CursorUnsync<'_, K, T> {
+    fn prev_dup(&mut self) -> PairResult<T> {
+        decode_unsync::<T>(self.inner.prev_dup())
+    }
+
+    fn next_dup(&mut self) -> PairResult<T> {
+        decode_unsync::<T>(self.inner.next_dup())
+    }
+
+    fn last_dup(&mut self) -> ValueOnlyResult<T> {
+        self.inner
+            .last_dup()
+            .map_err(|e| DatabaseError::Read(e.into()))?
+            .map(|v| match v {
+                Cow::Borrowed(v) => Decompress::decompress(v),
+                Cow::Owned(v) => Decompress::decompress_owned(v),
+            })
+            .transpose()
+    }
+
+    fn next_no_dup(&mut self) -> PairResult<T> {
+        decode_unsync::<T>(self.inner.next_nodup())
+    }
+
+    fn next_dup_val(&mut self) -> ValueOnlyResult<T> {
+        self.inner
+            .next_dup::<Cow<'_, [u8]>, Cow<'_, [u8]>>()
+            .map_err(|e| DatabaseError::Read(e.into()))?
+            .map(|(_, v)| match v {
+                Cow::Borrowed(v) => Decompress::decompress(v),
+                Cow::Owned(v) => Decompress::decompress_owned(v),
+            })
+            .transpose()
+    }
+
+    fn seek_by_key_subkey(
+        &mut self,
+        key: <T as Table>::Key,
+        subkey: <T as DupSort>::SubKey,
+    ) -> ValueOnlyResult<T> {
+        self.inner
+            .get_both_range(key.encode().as_ref(), subkey.encode().as_ref())
+            .map_err(|e| DatabaseError::Read(e.into()))?
+            .map(|v| match v {
+                Cow::Borrowed(v) => Decompress::decompress(v),
+                Cow::Owned(v) => Decompress::decompress_owned(v),
+            })
+            .transpose()
+    }
+
+    fn walk_dup(
+        &mut self,
+        key: Option<T::Key>,
+        subkey: Option<T::SubKey>,
+    ) -> Result<DupWalker<'_, T, Self>, DatabaseError> {
+        let start = match (key, subkey) {
+            (Some(key), Some(subkey)) => {
+                let encoded_key = key.encode();
+                self.inner
+                    .get_both_range(encoded_key.as_ref(), subkey.encode().as_ref())
+                    .map_err(|e| DatabaseError::Read(e.into()))?
+                    .map(|val| decoder::<T>((Cow::Borrowed(encoded_key.as_ref()), val)))
+            }
+            (Some(key), None) => {
+                let encoded_key = key.encode();
+                self.inner
+                    .set(encoded_key.as_ref())
+                    .map_err(|e| DatabaseError::Read(e.into()))?
+                    .map(|val| decoder::<T>((Cow::Borrowed(encoded_key.as_ref()), val)))
+            }
+            (None, Some(subkey)) => {
+                if let Some((key, _)) = self.first()? {
+                    let encoded_key = key.encode();
+                    self.inner
+                        .get_both_range(encoded_key.as_ref(), subkey.encode().as_ref())
+                        .map_err(|e| DatabaseError::Read(e.into()))?
+                        .map(|val| decoder::<T>((Cow::Borrowed(encoded_key.as_ref()), val)))
+                } else {
+                    Some(Err(DatabaseError::Read(MDBXError::NotFound.into())))
+                }
+            }
+            (None, None) => self.first().transpose(),
+        };
+
+        Ok(DupWalker::<'_, T, Self> { cursor: self, start })
+    }
+}
+
+impl<T: Table> DbCursorRW<T> for CursorUnsync<'_, RW, T> {
+    fn upsert(&mut self, key: T::Key, value: &T::Value) -> Result<(), DatabaseError> {
+        let key = key.encode();
+        let value = compress_to_buf_or_ref!(self, value);
+        self.inner.put(key.as_ref(), value.unwrap_or(&self.buf), WriteFlags::UPSERT).map_err(|e| {
+            DatabaseWriteError {
+                info: e.into(),
+                operation: DatabaseWriteOperation::CursorUpsert,
+                table_name: T::NAME,
+                key: key.into_vec(),
+            }
+            .into()
+        })
+    }
+
+    fn insert(&mut self, key: T::Key, value: &T::Value) -> Result<(), DatabaseError> {
+        let key = key.encode();
+        let value = compress_to_buf_or_ref!(self, value);
+        self.inner.put(key.as_ref(), value.unwrap_or(&self.buf), WriteFlags::NO_OVERWRITE).map_err(
+            |e| {
+                DatabaseWriteError {
+                    info: e.into(),
+                    operation: DatabaseWriteOperation::CursorInsert,
+                    table_name: T::NAME,
+                    key: key.into_vec(),
+                }
+                .into()
+            },
+        )
+    }
+
+    fn append(&mut self, key: T::Key, value: &T::Value) -> Result<(), DatabaseError> {
+        let key = key.encode();
+        let value = compress_to_buf_or_ref!(self, value);
+        self.inner.put(key.as_ref(), value.unwrap_or(&self.buf), WriteFlags::APPEND).map_err(|e| {
+            DatabaseWriteError {
+                info: e.into(),
+                operation: DatabaseWriteOperation::CursorAppend,
+                table_name: T::NAME,
+                key: key.into_vec(),
+            }
+            .into()
+        })
+    }
+
+    fn delete_current(&mut self) -> Result<(), DatabaseError> {
+        self.inner.del(WriteFlags::CURRENT).map_err(|e| DatabaseError::Delete(e.into()))
+    }
+}
+
+impl<T: DupSort> DbDupCursorRW<T> for CursorUnsync<'_, RW, T> {
+    fn delete_current_duplicates(&mut self) -> Result<(), DatabaseError> {
+        self.inner.del(WriteFlags::NO_DUP_DATA).map_err(|e| DatabaseError::Delete(e.into()))
+    }
+
+    fn append_dup(&mut self, key: T::Key, value: T::Value) -> Result<(), DatabaseError> {
+        let key = key.encode();
+        let value = compress_to_buf_or_ref!(self, value);
+        self.inner.put(key.as_ref(), value.unwrap_or(&self.buf), WriteFlags::APPEND_DUP).map_err(
+            |e| {
+                DatabaseWriteError {
+                    info: e.into(),
+                    operation: DatabaseWriteOperation::CursorAppendDup,
+                    table_name: T::NAME,
+                    key: key.into_vec(),
+                }
+                .into()
             },
         )
     }

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -241,6 +241,8 @@ pub struct DatabaseEnv {
 impl Database for DatabaseEnv {
     type TX = tx::Tx<RO>;
     type TXMut = tx::Tx<RW>;
+    type TXUnsync = tx::TxUnsync<RO>;
+    type TXMutUnsync = tx::TxUnsync<RW>;
 
     fn tx(&self) -> Result<Self::TX, DatabaseError> {
         Tx::new(
@@ -258,6 +260,18 @@ impl Database for DatabaseEnv {
             self.metrics.clone(),
         )
         .map_err(|e| DatabaseError::InitTx(e.into()))
+    }
+
+    fn tx_unsync(&self) -> Result<Self::TXUnsync, DatabaseError> {
+        let inner =
+            self.inner.begin_ro_txn_unsync().map_err(|e| DatabaseError::InitTx(e.into()))?;
+        Ok(tx::TxUnsync::new(inner, self.dbis.clone()))
+    }
+
+    fn tx_mut_unsync(&self) -> Result<Self::TXMutUnsync, DatabaseError> {
+        let inner =
+            self.inner.begin_rw_txn_unsync().map_err(|e| DatabaseError::InitTx(e.into()))?;
+        Ok(tx::TxUnsync::new(inner, self.dbis.clone()))
     }
 }
 

--- a/crates/storage/db/src/lib.rs
+++ b/crates/storage/db/src/lib.rs
@@ -133,6 +133,9 @@ pub mod test_utils {
     impl<DB: Database> Database for TempDatabase<DB> {
         type TX = <DB as Database>::TX;
         type TXMut = <DB as Database>::TXMut;
+        type TXUnsync = <DB as Database>::TXUnsync;
+        type TXMutUnsync = <DB as Database>::TXMutUnsync;
+
         fn tx(&self) -> Result<Self::TX, DatabaseError> {
             self.pre_tx_hook.read()();
             let tx = self.db().tx()?;
@@ -142,6 +145,17 @@ pub mod test_utils {
 
         fn tx_mut(&self) -> Result<Self::TXMut, DatabaseError> {
             self.db().tx_mut()
+        }
+
+        fn tx_unsync(&self) -> Result<Self::TXUnsync, DatabaseError> {
+            self.pre_tx_hook.read()();
+            let tx = self.db().tx_unsync()?;
+            self.post_tx_hook.read()();
+            Ok(tx)
+        }
+
+        fn tx_mut_unsync(&self) -> Result<Self::TXMutUnsync, DatabaseError> {
+            self.db().tx_mut_unsync()
         }
     }
 

--- a/crates/storage/libmdbx-rs/src/lib.rs
+++ b/crates/storage/libmdbx-rs/src/lib.rs
@@ -21,7 +21,9 @@ pub use crate::{
     },
     error::{Error, Result},
     flags::*,
-    transaction::{CommitLatency, Transaction, TransactionKind, RO, RW},
+    transaction::{
+        CommitLatency, CursorUnsync, Transaction, TransactionKind, TransactionUnsync, RO, RW,
+    },
 };
 
 #[cfg(feature = "read-tx-timeouts")]


### PR DESCRIPTION
## Summary

This PR adds `TXUnsync` and `TXMutUnsync` associated types to the `Database` trait, providing faster transaction and cursor implementations that avoid `Arc` and `Mutex` overhead at the cost of not being `Sync`.

## Motivation

The synchronized transaction variants (`Transaction<K>`) use `Arc<Mutex<()>>` for thread-safety, which adds overhead even in single-threaded scenarios. For use cases where transactions are used within a single thread (which is common), these unsynchronized variants provide better performance.

## Key Changes

### reth-libmdbx
- Added `TransactionUnsync<K>` - unsynchronized transaction without Arc/Mutex overhead
- Added `CursorUnsync<'tx, K>` - unsynchronized cursor with proper lifetime tracking
- Added `begin_ro_txn_unsync()` and `begin_rw_txn_unsync()` methods to `Environment`

### reth-db
- Added `TxUnsync<K>` wrapper implementing `DbTx`/`DbTxMut` traits
- Added `CursorUnsync<'tx, K, T>` wrapper implementing cursor traits

### reth-db-api
- Added `TXUnsync` and `TXMutUnsync` associated types to `Database` trait
- Added `tx_unsync()` and `tx_mut_unsync()` methods to `Database` trait
- Updated `DatabaseMock` implementation

## Trade-offs

- **Pro**: Faster transaction operations in single-threaded contexts
- **Con**: Not `Sync`, cannot be shared across threads
- The unsync variants are not tracked by the read transaction timeout manager

## Testing

All existing tests pass. The new types reuse the same underlying MDBX operations.