### PR TITLE
fix: remove redundant clone

### DIFF
--- a/crates/trie/db/tests/walker.rs
+++ b/crates/trie/db/tests/walker.rs
@@ -37,7 +37,7 @@ fn walk_nodes_with_common_prefix() {
 
     let mut account_cursor = tx.tx_ref().cursor_write::<tables::AccountsTrie>().unwrap();
     for (k, v) in &inputs {
-        account_cursor.upsert(k.clone().into(), &v.clone()).unwrap();
+        account_cursor.upsert(k.clone().into(), v).unwrap();
     }
     let account_trie = DatabaseAccountTrieCursor::new(account_cursor);
     test_cursor(account_trie, &expected);


### PR DESCRIPTION
In `walk_nodes_with_common_prefix`, the loop iterates over `&inputs`, so `v` is already a reference to the value type. Calling `v.clone()` and then immediately taking a reference `&v.clone()` performs an unnecessary copy that does not affect ownership, borrowing, or the data written to the database.

