### PR TITLE
fix(prune): set min_blocks=64 for receipts and bodies segments

### DIFF
--- a/crates/prune/types/src/segment.rs
+++ b/crates/prune/types/src/segment.rs
@@ -62,10 +62,15 @@ impl PruneSegment {
         Self::iter()
     }
 
+    /// Minimum number of blocks to keep for receipts and bodies to handle reorgs safely.
+    /// 2 epochs (32 blocks each) ensures we have data for any consensus-valid reorg.
+    const MIN_RECEIPTS_BODIES_BLOCKS: u64 = 64;
+
     /// Returns minimum number of blocks to keep in the database for this segment.
     pub const fn min_blocks(&self) -> u64 {
         match self {
-            Self::SenderRecovery | Self::TransactionLookup | Self::Receipts | Self::Bodies => 0,
+            Self::SenderRecovery | Self::TransactionLookup => 0,
+            Self::Receipts | Self::Bodies => Self::MIN_RECEIPTS_BODIES_BLOCKS,
             Self::ContractLogs | Self::AccountHistory | Self::StorageHistory => {
                 MINIMUM_PRUNING_DISTANCE
             }


### PR DESCRIPTION
## Summary

Prevents aggressive pruning of receipts and bodies that can cause FCU errors when the node needs receipt data for blocks that were pruned.

## Problem

With `PruneMode::Full` on minimal nodes, receipts were being pruned right up to the tip. When a forkchoice update needs to look up receipts for recently pruned blocks, this causes:

```
ERROR engine::tree: Error processing forkchoice update err=no receipt found for Number(3223619873)
```

Once this error occurs, the node stops persisting blocks and they pile up in memory until OOM.

## Solution

Set `min_blocks` to 64 (2 epochs × 32 blocks/epoch) for `Receipts` and `Bodies` segments. This ensures we retain enough data to handle any consensus-valid reorg while still allowing aggressive pruning for minimal nodes.

## Testing

- [x] Compiles
- [x] Clippy passes