### PR TITLE
feat(log): disable file logging by default for non-node commands

### DIFF
--- a/crates/ethereum/cli/src/app.rs
+++ b/crates/ethereum/cli/src/app.rs
@@ -106,6 +106,11 @@ where
                 self.cli.logs.log_file_directory.join(chain_spec.chain().to_string());
         }
 
+        // Apply node-specific log defaults before initializing tracing
+        if matches!(self.cli.command, Commands::Node(_)) {
+            self.cli.logs.apply_node_defaults();
+        }
+
         self.init_tracing(&runner)?;
 
         // Install the prometheus recorder to be sure to record all metrics

--- a/crates/ethereum/cli/src/interface.rs
+++ b/crates/ethereum/cli/src/interface.rs
@@ -209,6 +209,12 @@ impl<
             self.logs.log_file_directory =
                 self.logs.log_file_directory.join(chain_spec.chain().to_string());
         }
+
+        // Apply node-specific log defaults before initializing tracing
+        if matches!(self.command, Commands::Node(_)) {
+            self.logs.apply_node_defaults();
+        }
+
         let _guard = self.init_tracing(&runner, Layers::new())?;
 
         // Install the prometheus recorder to be sure to record all metrics
@@ -443,6 +449,42 @@ mod tests {
         let end = "reth/logs".to_string();
         println!("{log_dir:?}");
         assert!(log_dir.as_ref().ends_with(end), "{log_dir:?}");
+    }
+
+    #[test]
+    fn log_file_max_files_defaults() {
+        use reth_node_core::args::LogArgs;
+
+        // Node command without explicit --log.file.max-files should get Some(5) after
+        // apply_node_defaults
+        let mut cli = Cli::try_parse_args_from(["reth", "node"]).unwrap();
+        assert!(cli.logs.log_file_max_files.is_none());
+        cli.logs.apply_node_defaults();
+        assert_eq!(cli.logs.log_file_max_files, Some(LogArgs::DEFAULT_MAX_LOG_FILES_NODE));
+
+        // Non-node command without explicit --log.file.max-files should be None and
+        // effective_log_file_max_files returns 0
+        let cli = Cli::try_parse_args_from(["reth", "config"]).unwrap();
+        assert!(cli.logs.log_file_max_files.is_none());
+        assert_eq!(cli.logs.effective_log_file_max_files(), 0);
+
+        // Explicitly set value should be preserved for node command
+        let mut cli =
+            Cli::try_parse_args_from(["reth", "node", "--log.file.max-files", "10"]).unwrap();
+        assert_eq!(cli.logs.log_file_max_files, Some(10));
+        cli.logs.apply_node_defaults();
+        assert_eq!(cli.logs.log_file_max_files, Some(10));
+
+        // Explicitly set value should be preserved for non-node command
+        let cli =
+            Cli::try_parse_args_from(["reth", "config", "--log.file.max-files", "3"]).unwrap();
+        assert_eq!(cli.logs.log_file_max_files, Some(3));
+        assert_eq!(cli.logs.effective_log_file_max_files(), 3);
+
+        // Setting to 0 explicitly should work
+        let cli = Cli::try_parse_args_from(["reth", "node", "--log.file.max-files", "0"]).unwrap();
+        assert_eq!(cli.logs.log_file_max_files, Some(0));
+        assert_eq!(cli.logs.effective_log_file_max_files(), 0);
     }
 
     #[test]

--- a/docs/vocs/docs/pages/cli/reth.mdx
+++ b/docs/vocs/docs/pages/cli/reth.mdx
@@ -79,9 +79,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/config.mdx
+++ b/docs/vocs/docs/pages/cli/reth/config.mdx
@@ -65,9 +65,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db.mdx
@@ -187,9 +187,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/account-storage.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/account-storage.mdx
@@ -73,9 +73,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/checksum.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/checksum.mdx
@@ -75,9 +75,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/checksum/mdbx.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/checksum/mdbx.mdx
@@ -82,9 +82,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/checksum/rocksdb.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/checksum/rocksdb.mdx
@@ -81,9 +81,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/checksum/static-file.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/checksum/static-file.mdx
@@ -90,9 +90,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/checksum/use_hashed_state.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/checksum/use_hashed_state.mdx
@@ -73,9 +73,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/clear.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/clear.mdx
@@ -74,9 +74,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/clear/mdbx.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/clear/mdbx.mdx
@@ -73,9 +73,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/clear/static-file.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/clear/static-file.mdx
@@ -79,9 +79,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/copy.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/copy.mdx
@@ -82,9 +82,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/diff.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/diff.mdx
@@ -125,9 +125,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/drop.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/drop.mdx
@@ -72,9 +72,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/get.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/get.mdx
@@ -74,9 +74,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/get/mdbx.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/get/mdbx.mdx
@@ -88,9 +88,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/get/static-file.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/get/static-file.mdx
@@ -88,9 +88,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/list.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/list.mdx
@@ -115,9 +115,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/path.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/path.mdx
@@ -69,9 +69,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/prune-checkpoints.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/prune-checkpoints.mdx
@@ -74,9 +74,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/prune-checkpoints/get.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/prune-checkpoints/get.mdx
@@ -74,9 +74,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/prune-checkpoints/set.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/prune-checkpoints/set.mdx
@@ -91,9 +91,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/repair-trie.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/repair-trie.mdx
@@ -77,9 +77,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/settings.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/settings.mdx
@@ -74,9 +74,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/settings/get.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/settings/get.mdx
@@ -69,9 +69,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/settings/set.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/settings/set.mdx
@@ -73,9 +73,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/settings/set/account_changesets.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/settings/set/account_changesets.mdx
@@ -73,9 +73,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/settings/set/account_history.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/settings/set/account_history.mdx
@@ -73,9 +73,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/settings/set/receipts.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/settings/set/receipts.mdx
@@ -73,9 +73,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/settings/set/receipts_in_static_files.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/settings/set/receipts_in_static_files.mdx
@@ -73,9 +73,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/settings/set/storage_changesets.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/settings/set/storage_changesets.mdx
@@ -73,9 +73,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/settings/set/storages_history.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/settings/set/storages_history.mdx
@@ -73,9 +73,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/settings/set/transaction_hash_numbers.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/settings/set/transaction_hash_numbers.mdx
@@ -73,9 +73,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/settings/set/transaction_senders.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/settings/set/transaction_senders.mdx
@@ -73,9 +73,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/settings/set/transaction_senders_in_static_files.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/settings/set/transaction_senders_in_static_files.mdx
@@ -73,9 +73,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/settings/set/use_hashed_state.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/settings/set/use_hashed_state.mdx
@@ -73,9 +73,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/settings/set/v2.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/settings/set/v2.mdx
@@ -73,9 +73,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/state.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/state.mdx
@@ -87,9 +87,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/static-file-header.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/static-file-header.mdx
@@ -74,9 +74,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/static-file-header/block.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/static-file-header/block.mdx
@@ -84,9 +84,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/static-file-header/path.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/static-file-header/path.mdx
@@ -73,9 +73,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/stats.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/stats.mdx
@@ -85,9 +85,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/db/version.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/version.mdx
@@ -69,9 +69,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/download.mdx
+++ b/docs/vocs/docs/pages/cli/reth/download.mdx
@@ -180,9 +180,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/dump-genesis.mdx
+++ b/docs/vocs/docs/pages/cli/reth/dump-genesis.mdx
@@ -68,9 +68,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/export-era.mdx
+++ b/docs/vocs/docs/pages/cli/reth/export-era.mdx
@@ -184,9 +184,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/import-era.mdx
+++ b/docs/vocs/docs/pages/cli/reth/import-era.mdx
@@ -179,9 +179,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/import.mdx
+++ b/docs/vocs/docs/pages/cli/reth/import.mdx
@@ -187,9 +187,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/init-state.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init-state.mdx
@@ -200,9 +200,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/init.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init.mdx
@@ -168,9 +168,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -1100,9 +1100,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/p2p.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p.mdx
@@ -67,9 +67,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/p2p/body.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/body.mdx
@@ -321,9 +321,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/p2p/bootnode.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/bootnode.mdx
@@ -77,9 +77,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/p2p/enode.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/enode.mdx
@@ -68,9 +68,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/p2p/header.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/header.mdx
@@ -321,9 +321,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/p2p/rlpx.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/rlpx.mdx
@@ -63,9 +63,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/p2p/rlpx/ping.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/rlpx/ping.mdx
@@ -63,9 +63,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/prune.mdx
+++ b/docs/vocs/docs/pages/cli/reth/prune.mdx
@@ -186,9 +186,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/re-execute.mdx
+++ b/docs/vocs/docs/pages/cli/reth/re-execute.mdx
@@ -182,9 +182,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/stage.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage.mdx
@@ -66,9 +66,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/stage/drop.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/drop.mdx
@@ -182,9 +182,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/stage/dump.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump.mdx
@@ -175,9 +175,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/stage/dump/account-hashing.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump/account-hashing.mdx
@@ -81,9 +81,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/stage/dump/execution.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump/execution.mdx
@@ -81,9 +81,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/stage/dump/merkle.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump/merkle.mdx
@@ -81,9 +81,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/stage/dump/storage-hashing.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump/storage-hashing.mdx
@@ -81,9 +81,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/stage/run.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/run.mdx
@@ -434,9 +434,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/stage/unwind.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/unwind.mdx
@@ -176,9 +176,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/stage/unwind/num-blocks.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/unwind/num-blocks.mdx
@@ -73,9 +73,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/stage/unwind/to-block.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/unwind/to-block.mdx
@@ -73,9 +73,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald

--- a/docs/vocs/docs/pages/cli/reth/test-vectors/tables.mdx
+++ b/docs/vocs/docs/pages/cli/reth/test-vectors/tables.mdx
@@ -76,9 +76,9 @@ Logging:
           [default: 200]
 
       --log.file.max-files <COUNT>
-          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
 
-          [default: 5]
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
 
       --log.journald
           Write logs to journald


### PR DESCRIPTION
## Summary

Changes `log_file_max_files` from a hardcoded default of 5 to being command-dependent:
- **node** subcommand: defaults to 5 log files (preserves existing behavior)
- **utility** subcommands (config, db, etc.): defaults to 0 (file logging disabled)

## Motivation

Utility commands like `reth config`, `reth db`, etc. should not create log files by default since they are short-lived operations. Previously, every command would create log files which cluttered the logs directory.

## Changes

- Changed `log_file_max_files` from `usize` with default 5 to `Option<usize>` with no default
- Added `apply_node_defaults()` method that sets the default to 5 for node command
- Added `effective_log_file_max_files()` to return 0 when not explicitly set
- Updated both Ethereum and Optimism CLI entry points to apply node defaults before tracing init
- Added unit tests for the new behavior