### PR TITLE
fix(prune): improve pruner log readability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10248,6 +10248,7 @@ dependencies = [
  "strum 0.27.2",
  "thiserror 2.0.18",
  "toml",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/prune/prune/src/pruner.rs
+++ b/crates/prune/prune/src/pruner.rs
@@ -149,11 +149,7 @@ where
         let elapsed = start.elapsed();
         self.metrics.duration_seconds.record(elapsed);
 
-        debug!(
-            target: "pruner",
-            "{}",
-            output.to_log_message(tip_block_number, deleted_entries, elapsed.as_millis() as u64),
-        );
+        output.debug_log(tip_block_number, deleted_entries, elapsed);
 
         self.event_sender.notify(PrunerEvent::Finished { tip_block_number, elapsed, stats });
 

--- a/crates/prune/prune/src/pruner.rs
+++ b/crates/prune/prune/src/pruner.rs
@@ -154,14 +154,18 @@ where
             PruneProgress::Finished => "Pruner finished",
         };
 
+        let segments_summary: Vec<_> = stats
+            .iter()
+            .filter(|s| s.pruned > 0)
+            .map(|s| format!("{}={}", s.segment, s.pruned))
+            .collect();
+
         debug!(
             target: "pruner",
-            %tip_block_number,
-            ?elapsed,
-            ?deleted_entries,
-            ?limiter,
-            ?output,
-            ?stats,
+            tip_block_number,
+            deleted_entries,
+            elapsed_ms = elapsed.as_millis() as u64,
+            segments = %segments_summary.join(", "),
             "{message}",
         );
 

--- a/crates/prune/prune/src/pruner.rs
+++ b/crates/prune/prune/src/pruner.rs
@@ -15,7 +15,7 @@ use reth_stages_types::StageId;
 use reth_tokio_util::{EventSender, EventStream};
 use std::time::{Duration, Instant};
 use tokio::sync::watch;
-use tracing::{debug, trace};
+use tracing::debug;
 
 /// Result of [`Pruner::run`] execution.
 pub type PrunerResult = Result<PrunerOutput, PrunerError>;
@@ -175,17 +175,6 @@ where
             deleted_entries,
             elapsed_ms = elapsed.as_millis() as u64,
             segments = %segments_summary.join(" "),
-            "{message}",
-        );
-
-        trace!(
-            target: "pruner",
-            %tip_block_number,
-            ?elapsed,
-            ?deleted_entries,
-            ?limiter,
-            ?output,
-            ?stats,
             "{message}",
         );
 

--- a/crates/prune/prune/src/pruner.rs
+++ b/crates/prune/prune/src/pruner.rs
@@ -151,10 +151,8 @@ where
 
         debug!(
             target: "pruner",
-            tip_block_number,
-            deleted_entries,
             "{}",
-            output.to_log_message(elapsed.as_millis() as u64),
+            output.to_log_message(tip_block_number, deleted_entries, elapsed.as_millis() as u64),
         );
 
         self.event_sender.notify(PrunerEvent::Finished { tip_block_number, elapsed, stats });

--- a/crates/prune/prune/src/pruner.rs
+++ b/crates/prune/prune/src/pruner.rs
@@ -160,9 +160,17 @@ where
             .map(|s| format!("{}={}", s.segment, s.pruned))
             .collect();
 
+        let highest_pruned_block = output
+            .segments
+            .iter()
+            .filter(|(_, seg)| seg.pruned > 0)
+            .filter_map(|(_, seg)| seg.checkpoint.and_then(|c| c.block_number))
+            .max();
+
         debug!(
             target: "pruner",
             tip_block_number,
+            ?highest_pruned_block,
             deleted_entries,
             elapsed_ms = elapsed.as_millis() as u64,
             segments = %segments_summary.join(", "),

--- a/crates/prune/prune/src/pruner.rs
+++ b/crates/prune/prune/src/pruner.rs
@@ -164,8 +164,8 @@ where
                     .and_then(|c| c.block_number)
                     .map(|b| b.to_string())
                     .unwrap_or_else(|| "?".to_string());
-                let status = if seg.progress.is_finished() { "" } else { "..." };
-                format!("{segment}={pruned}@{block}{status}", pruned = seg.pruned)
+                let status = if seg.progress.is_finished() { "done" } else { "more" };
+                format!("{segment}({} rows to block {}, {})", seg.pruned, block, status)
             })
             .collect();
 
@@ -174,7 +174,7 @@ where
             tip_block_number,
             deleted_entries,
             elapsed_ms = elapsed.as_millis() as u64,
-            segments = %segments_summary.join(" "),
+            segments = %segments_summary.join(", "),
             "{message}",
         );
 

--- a/crates/prune/types/Cargo.toml
+++ b/crates/prune/types/Cargo.toml
@@ -43,8 +43,9 @@ std = [
     "derive_more/std",
     "serde?/std",
     "serde_json/std",
-    "thiserror/std",
     "strum/std",
+    "thiserror/std",
+    "tracing/std",
 ]
 test-utils = [
     "std",

--- a/crates/prune/types/Cargo.toml
+++ b/crates/prune/types/Cargo.toml
@@ -18,6 +18,7 @@ alloy-primitives.workspace = true
 derive_more.workspace = true
 strum = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
+tracing.workspace = true
 
 modular-bitfield = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"], optional = true }

--- a/crates/prune/types/src/pruner.rs
+++ b/crates/prune/types/src/pruner.rs
@@ -23,6 +23,7 @@ impl PrunerOutput {
     ///
     /// Format: `"Pruner finished tip=24328929 deleted=10886 in 148ms
     /// segments=AccountHistory[24318865, done] ..."`
+    #[inline]
     pub fn to_log_message(
         &self,
         tip_block_number: BlockNumber,

--- a/crates/prune/types/src/pruner.rs
+++ b/crates/prune/types/src/pruner.rs
@@ -21,8 +21,14 @@ impl From<PruneProgress> for PrunerOutput {
 impl PrunerOutput {
     /// Returns a human-readable log message summarizing the pruner run.
     ///
-    /// Format: `"Pruner finished in 148ms segments=AccountHistory[24318865, done] ..."`
-    pub fn to_log_message(&self, elapsed_ms: u64) -> alloc::string::String {
+    /// Format: `"Pruner finished tip=24328929 deleted=10886 in 148ms
+    /// segments=AccountHistory[24318865, done] ..."`
+    pub fn to_log_message(
+        &self,
+        tip_block_number: BlockNumber,
+        deleted_entries: usize,
+        elapsed_ms: u64,
+    ) -> alloc::string::String {
         use alloc::string::ToString;
 
         let status = match self.progress {
@@ -45,7 +51,10 @@ impl PrunerOutput {
             })
             .collect();
 
-        alloc::format!("{status} in {elapsed_ms}ms segments={}", segments.join(" "))
+        alloc::format!(
+            "{status} tip={tip_block_number} deleted={deleted_entries} in {elapsed_ms}ms segments={}",
+            segments.join(" ")
+        )
     }
 }
 

--- a/crates/prune/types/src/pruner.rs
+++ b/crates/prune/types/src/pruner.rs
@@ -19,18 +19,20 @@ impl From<PruneProgress> for PrunerOutput {
 }
 
 impl PrunerOutput {
-    /// Returns a human-readable log message summarizing the pruner run.
+    /// Logs a human-readable summary of the pruner run at DEBUG level.
     ///
     /// Format: `"Pruner finished tip=24328929 deleted=10886 in 148ms
     /// segments=AccountHistory[24318865, done] ..."`
     #[inline]
-    pub fn to_log_message(
+    pub fn debug_log(
         &self,
         tip_block_number: BlockNumber,
         deleted_entries: usize,
-        elapsed_ms: u64,
-    ) -> alloc::string::String {
+        elapsed: core::time::Duration,
+    ) {
         use alloc::string::ToString;
+
+        let elapsed_ms = elapsed.as_millis() as u64;
 
         let status = match self.progress {
             PruneProgress::HasMoreData(_) => "Pruner interrupted, has more data",
@@ -52,10 +54,11 @@ impl PrunerOutput {
             })
             .collect();
 
-        alloc::format!(
+        tracing::debug!(
+            target: "pruner",
             "{status} tip={tip_block_number} deleted={deleted_entries} in {elapsed_ms}ms segments={}",
             segments.join(" ")
-        )
+        );
     }
 }
 


### PR DESCRIPTION
Simplify the pruner 'Pruner finished' debug log to be readable at a glance.

**Before:**
```
DEBUG pruner: Pruner finished tip_block_number=24328929 elapsed=148.298392ms
deleted_entries=10886 limiter=PruneLimiter { deleted_entries_limit: Some(PruneDeletedEntriesLimit {
limit: 18446744073709551615, deleted: 10886 }), time_limit: None }
output=PrunerOutput { progress: Finished, segments: [(Bodies, SegmentOutput {...
```

**After:**
```
DEBUG pruner: Pruner finished tip_block_number=24328929 deleted_entries=10886 elapsed=148.298392ms
segments="AccountHistory[24318865, done] StorageHistory[24318865, done] Receipts[24328929, done]"
```

Changes:
- Add `PrunerOutput::debug_log()` method that formats and logs the pruner summary
- Compact segment format: `Segment[checkpoint_block, done|in_progress]`
- Remove verbose struct dumps (`limiter`, `output`, `stats`)