### PR TITLE
fix: simplify UTF-8 decoding in `StreamCodec` by using `Result::ok`

### DIFF
--- a/crates/rpc/ipc/src/stream_codec.rs
+++ b/crates/rpc/ipc/src/stream_codec.rs
@@ -117,10 +117,7 @@ impl tokio_util::codec::Decoder for StreamCodec {
                         buf.advance(start_idx);
                     }
                     let bts = buf.split_to(idx + 1 - start_idx);
-                    return match String::from_utf8(bts.into()) {
-                        Ok(val) => Ok(Some(val)),
-                        Err(_) => Ok(None),
-                    }
+                    return Ok(String::from_utf8(bts.into()).ok())
                 }
             }
             Ok(None)


### PR DESCRIPTION
The previous code manually mapped `Ok(val)` to `Ok(Some(val))` and any `Err(_)` to `Ok(None)`.  
`Result::ok()` already encodes this behavior, so the explicit `match` was redundant and added noise without changing semantics.

