### PR TITLE
refactor: refactor bootstrap network handling

### DIFF
--- a/crates/net/dns/src/lib.rs
+++ b/crates/net/dns/src/lib.rs
@@ -165,7 +165,7 @@ impl<R: Resolver> DnsDiscoveryService<R> {
 
     /// Starts discovery with all configured bootstrap links
     pub fn bootstrap(&mut self) {
-        let links = self.bootstrap_dns_networks.iter().copied().collect::<Vec<_>>();
+        let links = self.bootstrap_dns_networks.iter().cloned().collect::<Vec<_>>();
         for link in links {
             self.sync_tree_with_link(link);
         }

--- a/crates/net/dns/src/lib.rs
+++ b/crates/net/dns/src/lib.rs
@@ -165,7 +165,8 @@ impl<R: Resolver> DnsDiscoveryService<R> {
 
     /// Starts discovery with all configured bootstrap links
     pub fn bootstrap(&mut self) {
-        for link in self.bootstrap_dns_networks.clone() {
+        let links = self.bootstrap_dns_networks.iter().copied().collect::<Vec<_>>();
+        for link in links {
             self.sync_tree_with_link(link);
         }
     }


### PR DESCRIPTION
Updates the bootstrap method to use a more efficient iteration pattern.
Removed the most expensive part - cloning the entire HashSet along with the buckets