### PR TITLE
fix(provider): read changesets from static files during unwind

### DIFF
--- a/crates/stages/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/stages/src/stages/hashing_storage.rs
@@ -3,7 +3,7 @@ use itertools::Itertools;
 use reth_config::config::{EtlConfig, HashingConfig};
 use reth_db_api::{
     cursor::{DbCursorRO, DbDupCursorRW},
-    models::{BlockNumberAddress, CompactU256},
+    models::CompactU256,
     table::Decompress,
     tables,
     transaction::{DbTx, DbTxMut},
@@ -179,7 +179,7 @@ where
         let (range, unwind_progress, _) =
             input.unwind_block_range_with_threshold(self.commit_threshold);
 
-        provider.unwind_storage_hashing_range(BlockNumberAddress::range(range))?;
+        provider.unwind_storage_hashing_range(range)?;
 
         let mut stage_checkpoint =
             input.checkpoint.storage_hashing_stage_checkpoint().unwrap_or_default();
@@ -227,7 +227,7 @@ mod tests {
     use rand::Rng;
     use reth_db_api::{
         cursor::{DbCursorRW, DbDupCursorRO},
-        models::StoredBlockBodyIndices,
+        models::{BlockNumberAddress, StoredBlockBodyIndices},
     };
     use reth_ethereum_primitives::Block;
     use reth_primitives_traits::SealedBlock;

--- a/crates/stages/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/stages/src/stages/index_storage_history.rs
@@ -166,7 +166,7 @@ where
         let (range, unwind_progress, _) =
             input.unwind_block_range_with_threshold(self.commit_threshold);
 
-        provider.unwind_storage_history_indices_range(BlockNumberAddress::range(range))?;
+        provider.unwind_storage_history_indices_range(range)?;
 
         Ok(UnwindOutput { checkpoint: StageCheckpoint::new(unwind_progress) })
     }

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -728,7 +728,7 @@ impl<N: ProviderNodeTypes> StorageChangeSetReader for BlockchainProvider<N> {
 
     fn storage_changesets_range(
         &self,
-        range: RangeInclusive<BlockNumber>,
+        range: impl RangeBounds<BlockNumber>,
     ) -> ProviderResult<Vec<(BlockNumberAddress, StorageEntry)>> {
         self.consistent_provider()?.storage_changesets_range(range)
     }

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -1397,7 +1397,7 @@ impl<N: ProviderNodeTypes> StorageChangeSetReader for ConsistentProvider<N> {
 
     fn storage_changesets_range(
         &self,
-        range: RangeInclusive<BlockNumber>,
+        range: impl RangeBounds<BlockNumber>,
     ) -> ProviderResult<Vec<(BlockNumberAddress, StorageEntry)>> {
         let range = to_range(range);
         let mut changesets = Vec::new();

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -2499,7 +2499,7 @@ impl<N: NodePrimitives> StorageChangeSetReader for StaticFileProvider<N> {
 
     fn storage_changesets_range(
         &self,
-        range: RangeInclusive<BlockNumber>,
+        range: impl RangeBounds<BlockNumber>,
     ) -> ProviderResult<Vec<(BlockNumberAddress, StorageEntry)>> {
         let range = self.bound_range(range, StaticFileSegment::StorageChangeSets);
         self.walk_storage_changeset_range(range).collect()

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -1025,7 +1025,7 @@ impl<T: NodePrimitives, ChainSpec: Send + Sync> StorageChangeSetReader
 
     fn storage_changesets_range(
         &self,
-        _range: RangeInclusive<BlockNumber>,
+        _range: impl RangeBounds<BlockNumber>,
     ) -> ProviderResult<Vec<(reth_db_api::models::BlockNumberAddress, StorageEntry)>> {
         Ok(Vec::default())
     }

--- a/crates/storage/storage-api/src/hashing.rs
+++ b/crates/storage/storage-api/src/hashing.rs
@@ -57,7 +57,7 @@ pub trait HashingWriter: Send {
     /// Mapping of hashed keys of updated accounts to their respective updated hashed slots.
     fn unwind_storage_hashing_range(
         &self,
-        range: impl RangeBounds<BlockNumberAddress>,
+        range: impl RangeBounds<BlockNumber>,
     ) -> ProviderResult<HashMap<B256, BTreeSet<B256>>>;
 
     /// Iterates over storages and inserts them to hashing table.

--- a/crates/storage/storage-api/src/history.rs
+++ b/crates/storage/storage-api/src/history.rs
@@ -44,7 +44,7 @@ pub trait HistoryWriter: Send {
     /// Returns number of changesets walked.
     fn unwind_storage_history_indices_range(
         &self,
-        range: impl RangeBounds<BlockNumberAddress>,
+        range: impl RangeBounds<BlockNumber>,
     ) -> ProviderResult<usize>;
 
     /// Insert storage change index to database. Used inside `StorageHistoryIndex` stage

--- a/crates/storage/storage-api/src/noop.rs
+++ b/crates/storage/storage-api/src/noop.rs
@@ -430,7 +430,7 @@ impl<C: Send + Sync, N: NodePrimitives> StorageChangeSetReader for NoopProvider<
 
     fn storage_changesets_range(
         &self,
-        _range: RangeInclusive<BlockNumber>,
+        _range: impl core::ops::RangeBounds<BlockNumber>,
     ) -> ProviderResult<
         Vec<(reth_db_api::models::BlockNumberAddress, reth_primitives_traits::StorageEntry)>,
     > {

--- a/crates/storage/storage-api/src/storage.rs
+++ b/crates/storage/storage-api/src/storage.rs
@@ -3,7 +3,7 @@ use alloc::{
     vec::Vec,
 };
 use alloy_primitives::{Address, BlockNumber, B256};
-use core::ops::RangeInclusive;
+use core::ops::{RangeBounds, RangeInclusive};
 use reth_primitives_traits::StorageEntry;
 use reth_storage_errors::provider::ProviderResult;
 
@@ -53,11 +53,9 @@ pub trait StorageChangeSetReader: Send {
     ) -> ProviderResult<Option<StorageEntry>>;
 
     /// Get all storage changesets in a range of blocks.
-    ///
-    /// NOTE: Get inclusive range of blocks.
     fn storage_changesets_range(
         &self,
-        range: RangeInclusive<BlockNumber>,
+        range: impl RangeBounds<BlockNumber>,
     ) -> ProviderResult<Vec<(reth_db_api::models::BlockNumberAddress, StorageEntry)>>;
 
     /// Get the total count of all storage changes.


### PR DESCRIPTION
## Summary

Fixes state root mismatch errors during chain reorganizations on nodes running with `--features edge`.

## Problem

The following functions in `DatabaseProvider` were reading changesets directly from database tables (`AccountChangeSets` / `StorageChangeSets`):

- `unwind_account_hashing_range`
- `unwind_storage_hashing_range`
- `unwind_account_history_indices_range`
- `unwind_storage_history_indices_range`

With the edge feature enabled, changesets are stored in **static files**, not in the database tables. This caused these unwind functions to read empty data.

During a chain reorg unwind:
1. `MerkleUnwind` stage correctly identified changed accounts/storages by reading from static files (via `load_prefix_sets_with_provider`)
2. `AccountHashingStage` and `StorageHashingStage` unwinds read from empty DB tables
3. `HashedAccounts` / `HashedStorages` tables were **not properly reverted**
4. `MerkleUnwind` computed state root from incorrectly unwound hashed state → **mismatch**

## Solution

Use the existing `account_changesets_range` and `storage_changesets_range` methods which already handle reading from static files when the edge feature is enabled.

Also updates `storage_changesets_range`, `unwind_storage_hashing_range`, and `unwind_storage_history_indices_range` to accept `impl RangeBounds<BlockNumber>` instead of `RangeInclusive`/`BlockNumberAddress` for consistency with the account variants.
