### PR TITLE
fix(rpc): update broken execution-apis documentation links

### DIFF
--- a/crates/rpc/rpc-api/src/engine.rs
+++ b/crates/rpc/rpc-api/src/engine.rs
@@ -292,7 +292,7 @@ pub trait EngineApi<Engine: EngineTypes> {
     async fn get_bals_by_range_v1(&self, start: U64, count: U64) -> RpcResult<Vec<Bytes>>;
 }
 
-/// A subset of the ETH rpc interface: <https://ethereum.github.io/execution-apis/api-documentation>
+/// A subset of the ETH rpc interface: <https://ethereum.github.io/execution-apis/eth/>
 ///
 /// This also includes additional eth functions required by optimism.
 ///

--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -50,7 +50,7 @@ impl<T> FullEthApiServer for T where
 {
 }
 
-/// Eth rpc interface: <https://ethereum.github.io/execution-apis/api-documentation>
+/// Eth rpc interface: <https://ethereum.github.io/execution-apis/eth/>
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "eth"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "eth"))]
 pub trait EthApi<


### PR DESCRIPTION
The old /api-documentation links are dead and return 404. Replaced them with the current execution-apis ETH RPC docs.
