### PR TITLE
fix: avoid redundant allocation when formatting invalid block hook values

### DIFF
--- a/crates/node/core/src/args/debug.rs
+++ b/crates/node/core/src/args/debug.rs
@@ -267,7 +267,7 @@ impl TypedValueParser for InvalidBlockSelectionValueParser {
             value.to_str().ok_or_else(|| clap::Error::new(clap::error::ErrorKind::InvalidUtf8))?;
         val.parse::<InvalidBlockSelection>().map_err(|err| {
             let arg = arg.map(|a| a.to_string()).unwrap_or_else(|| "...".to_owned());
-            let possible_values = InvalidBlockHookType::all_variant_names().to_vec().join(",");
+            let possible_values = InvalidBlockHookType::all_variant_names().join(",");
             let msg = format!(
                 "Invalid value '{val}' for {arg}: {err}.\n    [possible values: {possible_values}]"
             );


### PR DESCRIPTION
Replaced `InvalidBlockHookType::all_variant_names().to_vec().join(",")` with `InvalidBlockHookType::all_variant_names().join(",")` in `InvalidBlockSelectionValueParser::parse_ref`.

`all_variant_names()` already returns a slice of static strings; calling `to_vec()` allocates a temporary `Vec` that is only used for `join`, without changing the resulting error message.
