### PR TITLE
fix(prune): respect rocksdb storage settings for history pruning

### DIFF
--- a/crates/prune/prune/Cargo.toml
+++ b/crates/prune/prune/Cargo.toml
@@ -51,3 +51,7 @@ reth-testing-utils.workspace = true
 reth-tracing.workspace = true
 
 assert_matches.workspace = true
+
+[features]
+default = []
+rocksdb = ["reth-provider/rocksdb"]


### PR DESCRIPTION
 History pruning was hardcoded to use MDBX cursors, ignoring `account_history_in_rocksdb` and `storages_history_in_rocksdb` settings. This meant RocksDB history data would never get cleaned up when pruning was enabled.                                                            
                                                                                                                                                                                                                                                                                       Added `prune_account_history_up_to` and `prune_storage_history_up_to` to RocksDBBatch, and updated the prune segments to check storage settings before choosing the backend.