### PR TITLE
chore: avoid eager evaluation in base_fee_params_at_timestamp

### DIFF
--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -541,7 +541,7 @@ impl<H: BlockHeader> ChainSpec<H> {
                     }
                 }
 
-                bf_params.first().map(|(_, params)| *params).unwrap_or(BaseFeeParams::ethereum())
+                bf_params.first().map(|(_, params)| *params).unwrap_or_else(BaseFeeParams::ethereum)
             }
         }
     }


### PR DESCRIPTION
Uses `unwrap_or_else(BaseFeeParams::ethereum)` instead of `unwrap_or(BaseFeeParams::ethereum())` to avoid eagerly evaluating the default when not needed. This method is called during block processing.                                                                                 