### PR TITLE
fix: address CI issues for cursor lifetimes PR

### DIFF
--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -602,14 +602,14 @@ impl DatabaseEnv {
             let mut version_cursor = tx.cursor_write::<tables::VersionHistory>()?;
 
             let last_version = version_cursor.last()?.map(|(_, v)| v);
-            if Some(&version) != last_version.as_ref() {
+            if Some(&version) == last_version.as_ref() {
+                false
+            } else {
                 version_cursor.upsert(
                     SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs(),
                     &version,
                 )?;
                 true
-            } else {
-                false
             }
         };
 

--- a/crates/storage/libmdbx-rs/benches/cursor.rs
+++ b/crates/storage/libmdbx-rs/benches/cursor.rs
@@ -32,7 +32,7 @@ fn bench_get_seq_iter(c: &mut Criterion) {
                 count += 1;
             }
 
-            fn iterate<K: TransactionKind>(cursor: &mut Cursor<K>) -> Result<()> {
+            fn iterate<K: TransactionKind>(cursor: &mut Cursor<'_, K>) -> Result<()> {
                 let mut i = 0;
                 for result in cursor.iter::<ObjectLength, ObjectLength>() {
                     let (key_len, data_len) = result?;


### PR DESCRIPTION
Stacks on #21531

Fixes CI issues:
- **Clippy**: Fixed `if-not-else` lint in `record_client_version`
- **Udeps/bench**: Added explicit `'_` lifetime to `Cursor` in benchmarks to fix `elided-lifetimes-in-paths`
- **Test compile**: Scoped cursor usage in `test_write_trie_updates_sorted` to drop cursors before `commit()` - this is the correct fix as cursor lifetimes now properly enforce that cursors must not outlive transaction operations

The test fix demonstrates the value of cursor lifetimes: the borrow checker now correctly catches cases where cursors would have dangled references during commit.