### PR TITLE
fix: CI fixes for cursor lifetimes PR

### DIFF
--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -602,14 +602,14 @@ impl DatabaseEnv {
             let mut version_cursor = tx.cursor_write::<tables::VersionHistory>()?;
 
             let last_version = version_cursor.last()?.map(|(_, v)| v);
-            if Some(&version) != last_version.as_ref() {
+            if Some(&version) == last_version.as_ref() {
+                false
+            } else {
                 version_cursor.upsert(
                     SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs(),
                     &version,
                 )?;
                 true
-            } else {
-                false
             }
         };
 

--- a/crates/storage/libmdbx-rs/benches/cursor.rs
+++ b/crates/storage/libmdbx-rs/benches/cursor.rs
@@ -32,7 +32,7 @@ fn bench_get_seq_iter(c: &mut Criterion) {
                 count += 1;
             }
 
-            fn iterate<K: TransactionKind>(cursor: &mut Cursor<K>) -> Result<()> {
+            fn iterate<K: TransactionKind>(cursor: &mut Cursor<'_, K>) -> Result<()> {
                 let mut i = 0;
                 for result in cursor.iter::<ObjectLength, ObjectLength>() {
                     let (key_len, data_len) = result?;


### PR DESCRIPTION
## Summary

Stacked on #21531. Fixes CI failures:

1. **Clippy**: Fix `if-not-else` lint in `record_client_version` by inverting the condition
2. **Elided lifetimes**: Add explicit `'_` lifetime to `Cursor` in benchmark
3. **Borrow checker**: Scope cursor usage in tests to drop before `tx.commit()`

The new cursor lifetime parameters correctly catch cases where cursors would outlive their transaction. These were previously undetected bugs that could lead to use-after-free in unsafe code.

## Test Plan

CI should pass with these fixes.

---

Stacked on: #21531