### PR TITLE
chore: release 1.10.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3300,7 +3300,7 @@ dependencies = [
 
 [[package]]
 name = "ef-test-runner"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "clap",
  "ef-tests",
@@ -3308,7 +3308,7 @@ dependencies = [
 
 [[package]]
 name = "ef-tests"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3788,7 +3788,7 @@ dependencies = [
 
 [[package]]
 name = "example-full-contract-state"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "eyre",
  "reth-ethereum",
@@ -3927,7 +3927,7 @@ dependencies = [
 
 [[package]]
 name = "exex-subscription"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -6426,7 +6426,7 @@ dependencies = [
 
 [[package]]
 name = "op-reth"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "clap",
  "reth-cli-util",
@@ -7567,7 +7567,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -7614,7 +7614,7 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7637,7 +7637,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bench"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7684,7 +7684,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bench-compare"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -7712,7 +7712,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7745,7 +7745,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7765,7 +7765,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7778,7 +7778,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7864,7 +7864,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7873,7 +7873,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7894,7 +7894,7 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7918,7 +7918,7 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7928,7 +7928,7 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -7946,7 +7946,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7958,7 +7958,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7972,7 +7972,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7997,7 +7997,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8031,7 +8031,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8062,7 +8062,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8092,7 +8092,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8108,7 +8108,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8134,7 +8134,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8159,7 +8159,7 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8187,7 +8187,7 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8225,7 +8225,7 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8282,7 +8282,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8309,7 +8309,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8332,7 +8332,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8356,7 +8356,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-service"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-eips",
  "futures",
@@ -8387,7 +8387,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8462,7 +8462,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8489,7 +8489,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8511,7 +8511,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8529,7 +8529,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8555,7 +8555,7 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8565,7 +8565,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8603,7 +8603,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8628,7 +8628,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8668,7 +8668,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "clap",
  "eyre",
@@ -8690,7 +8690,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8706,7 +8706,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8724,7 +8724,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8737,7 +8737,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8765,7 +8765,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8792,7 +8792,7 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-primitives",
  "rayon",
@@ -8802,7 +8802,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8827,7 +8827,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8851,7 +8851,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8863,7 +8863,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8883,7 +8883,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8928,7 +8928,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-test-utils"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-eips",
  "eyre",
@@ -8959,7 +8959,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8976,7 +8976,7 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -8985,7 +8985,7 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9018,7 +9018,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "bytes",
  "futures",
@@ -9040,7 +9040,7 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -9058,7 +9058,7 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -9066,7 +9066,7 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "futures",
  "metrics",
@@ -9077,7 +9077,7 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9085,7 +9085,7 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9099,7 +9099,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9161,7 +9161,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9185,7 +9185,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9207,7 +9207,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9224,7 +9224,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9237,7 +9237,7 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -9255,7 +9255,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9278,7 +9278,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9350,7 +9350,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9406,7 +9406,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -9466,7 +9466,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9489,7 +9489,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9512,7 +9512,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "bytes",
  "eyre",
@@ -9541,7 +9541,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9552,7 +9552,7 @@ dependencies = [
 
 [[package]]
 name = "reth-op"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "reth-chainspec",
  "reth-cli-util",
@@ -9592,7 +9592,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-chainspec"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9620,7 +9620,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-cli"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9669,7 +9669,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-consensus"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9700,7 +9700,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-evm"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9729,7 +9729,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-flashblocks"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9767,7 +9767,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-forks"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-op-hardforks",
  "alloy-primitives",
@@ -9777,7 +9777,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-node"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9838,7 +9838,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-payload-builder"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9877,7 +9877,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-primitives"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9904,7 +9904,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-rpc"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9966,7 +9966,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-storage"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "reth-codecs",
@@ -9978,7 +9978,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-txpool"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10016,7 +10016,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10036,7 +10036,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10047,7 +10047,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10070,7 +10070,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-util"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10079,7 +10079,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10088,7 +10088,7 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10110,7 +10110,7 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10147,7 +10147,7 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10196,7 +10196,7 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10229,11 +10229,11 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-db"
-version = "1.10.2"
+version = "1.10.3"
 
 [[package]]
 name = "reth-prune-types"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10253,7 +10253,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-protocol"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10279,7 +10279,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-provider"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10305,7 +10305,7 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10319,7 +10319,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10404,7 +10404,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -10434,7 +10434,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api-testing-util"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10453,7 +10453,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -10509,7 +10509,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10533,7 +10533,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-e2e-tests"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-genesis",
  "alloy-rpc-types-engine",
@@ -10553,7 +10553,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10589,7 +10589,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10632,7 +10632,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10680,7 +10680,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -10697,7 +10697,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10712,7 +10712,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10770,7 +10770,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10802,7 +10802,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10818,7 +10818,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stateless"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -10846,7 +10846,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-primitives",
  "assert_matches",
@@ -10869,7 +10869,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10884,7 +10884,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10907,7 +10907,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10923,7 +10923,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-rpc-provider"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10952,7 +10952,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -10969,7 +10969,7 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10985,7 +10985,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10994,7 +10994,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "clap",
  "eyre",
@@ -11012,7 +11012,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "clap",
  "eyre",
@@ -11029,7 +11029,7 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11080,7 +11080,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11114,7 +11114,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -11147,7 +11147,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11178,7 +11178,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11208,7 +11208,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11241,7 +11241,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse-parallel"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11271,7 +11271,7 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.10.2"
+version = "1.10.3"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/docs/vocs/vocs.config.ts
+++ b/docs/vocs/vocs.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
     },
     { text: 'GitHub', link: 'https://github.com/paradigmxyz/reth' },
     {
-      text: 'v1.10.2',
+      text: 'v1.10.3',
       items: [
         {
           text: 'Releases',


### PR DESCRIPTION
Prepare release candidate and tag for v1.10.3 nightly.

## Changes
- Bump workspace version to 1.10.3
- Update docs version in vocs.config.ts
- Update Cargo.lock