### PR TITLE
fix(reth-bench): return error instead of panic on invalid payload

### DIFF
--- a/bin/reth-bench/src/valid_payload.rs
+++ b/bin/reth-bench/src/valid_payload.rs
@@ -260,7 +260,9 @@ pub(crate) async fn call_new_payload<N: Network, P: Provider<N>>(
     while !status.is_valid() {
         if status.is_invalid() {
             error!(?status, ?params, "Invalid {method}",);
-            panic!("Invalid {method}: {status:?}");
+            return Err(alloy_json_rpc::RpcError::LocalUsageError(Box::new(std::io::Error::other(
+                format!("Invalid {method}: {status:?}"),
+            ))))
         }
         if status.is_syncing() {
             return Err(alloy_json_rpc::RpcError::UnsupportedFeature(


### PR DESCRIPTION
## Description

reth-bench `new-payload-fcu` currently panics when receiving an Invalid payload status from `engine_newPayload`. This replaces the panic with a proper error return, allowing the benchmark to handle invalid payloads gracefully.

## Changes

- Replace `panic!` with `RpcError::LocalUsageError` in `call_new_payload`

## Example error before this fix:
```
The application panicked (crashed).
Message:  Invalid engine_newPayloadV4: PayloadStatus { status: Invalid { validation_error: "mismatched block state root: got 0xf76..., expected 0xec0..." }, latest_valid_hash: Some(0x106...) }
Location: bin/reth-bench/src/valid_payload.rs:263
```