### PR TITLE
feat: add reth-db-tune migrate CLI for RocksDB tuning experimentation

### DIFF
--- a/.github/scripts/check_wasm.sh
+++ b/.github/scripts/check_wasm.sh
@@ -82,6 +82,7 @@ exclude_crates=(
   reth-era-utils # tokio
   reth-tracing-otlp
   reth-node-ethstats
+  reth-db-tune # rocksdb
 )
 
 # Array to hold the results

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8112,7 +8112,6 @@ version = "1.10.2"
 dependencies = [
  "clap",
  "eyre",
- "humantime",
  "reth-tracing",
  "rocksdb",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8107,6 +8107,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-db-tune"
+version = "1.10.2"
+dependencies = [
+ "clap",
+ "eyre",
+ "humantime",
+ "reth-tracing",
+ "rocksdb",
+ "serde",
+ "serde_json",
+ "toml",
+ "tracing",
+]
+
+[[package]]
 name = "reth-discv4"
 version = "1.10.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ exclude = [".github/"]
 members = [
     "bin/reth-bench/",
     "bin/reth-bench-compare/",
+    "bin/reth-db-tune/",
     "bin/reth/",
     "crates/storage/rpc-provider/",
     "crates/chain-state/",

--- a/bin/reth-db-tune/Cargo.toml
+++ b/bin/reth-db-tune/Cargo.toml
@@ -27,7 +27,6 @@ toml.workspace = true
 # misc
 eyre.workspace = true
 tracing.workspace = true
-humantime.workspace = true
 
 # reth
 reth-tracing.workspace = true

--- a/bin/reth-db-tune/Cargo.toml
+++ b/bin/reth-db-tune/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "reth-db-tune"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "RocksDB tuning experimentation tool for reth"
+default-run = "reth-db-tune"
+
+[lints]
+workspace = true
+
+[dependencies]
+# rocksdb
+rocksdb.workspace = true
+
+# cli
+clap = { workspace = true, features = ["derive"] }
+
+# config parsing
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+toml.workspace = true
+
+# misc
+eyre.workspace = true
+tracing.workspace = true
+humantime.workspace = true
+
+# reth
+reth-tracing.workspace = true
+
+[[bin]]
+name = "reth-db-tune"
+path = "src/main.rs"

--- a/bin/reth-db-tune/src/config.rs
+++ b/bin/reth-db-tune/src/config.rs
@@ -1,0 +1,137 @@
+use serde::Deserialize;
+use std::collections::HashMap;
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct TuningConfig {
+    #[serde(default)]
+    pub default: CfOptions,
+    #[serde(default)]
+    pub cf: HashMap<String, CfOptions>,
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+pub(crate) struct CfOptions {
+    pub write_buffer_size: Option<String>,
+    pub max_write_buffer_number: Option<i32>,
+    pub compression: Option<CompressionType>,
+    pub block_size: Option<String>,
+    pub bloom_filter_bits: Option<i32>,
+    pub max_background_jobs: Option<i32>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum CompressionType {
+    None,
+    Snappy,
+    Lz4,
+    Zstd,
+}
+
+impl From<CompressionType> for rocksdb::DBCompressionType {
+    fn from(ct: CompressionType) -> Self {
+        match ct {
+            CompressionType::None => Self::None,
+            CompressionType::Snappy => Self::Snappy,
+            CompressionType::Lz4 => Self::Lz4,
+            CompressionType::Zstd => Self::Zstd,
+        }
+    }
+}
+
+pub(crate) fn parse_size(s: &str) -> eyre::Result<usize> {
+    let s = s.trim();
+    let (num_str, multiplier) = if let Some(n) = s.strip_suffix("GiB") {
+        (n, 1024 * 1024 * 1024)
+    } else if let Some(n) = s.strip_suffix("MiB") {
+        (n, 1024 * 1024)
+    } else if let Some(n) = s.strip_suffix("KiB") {
+        (n, 1024)
+    } else if let Some(n) = s.strip_suffix("GB") {
+        (n, 1_000_000_000)
+    } else if let Some(n) = s.strip_suffix("MB") {
+        (n, 1_000_000)
+    } else if let Some(n) = s.strip_suffix("KB") {
+        (n, 1000)
+    } else {
+        (s, 1)
+    };
+
+    let num: usize = num_str.trim().parse()?;
+    Ok(num * multiplier)
+}
+
+impl TuningConfig {
+    pub(crate) fn get_cf_options(&self, cf_name: &str) -> CfOptions {
+        let mut opts = self.default.clone();
+
+        if let Some(cf_opts) = self.cf.get(cf_name) {
+            if cf_opts.write_buffer_size.is_some() {
+                opts.write_buffer_size = cf_opts.write_buffer_size.clone();
+            }
+            if cf_opts.max_write_buffer_number.is_some() {
+                opts.max_write_buffer_number = cf_opts.max_write_buffer_number;
+            }
+            if cf_opts.compression.is_some() {
+                opts.compression = cf_opts.compression;
+            }
+            if cf_opts.block_size.is_some() {
+                opts.block_size = cf_opts.block_size.clone();
+            }
+            if cf_opts.bloom_filter_bits.is_some() {
+                opts.bloom_filter_bits = cf_opts.bloom_filter_bits;
+            }
+            if cf_opts.max_background_jobs.is_some() {
+                opts.max_background_jobs = cf_opts.max_background_jobs;
+            }
+        }
+
+        opts
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_config() {
+        let toml_str = r#"
+[default]
+write_buffer_size = "256MiB"
+max_write_buffer_number = 4
+compression = "lz4"
+block_size = "16KiB"
+bloom_filter_bits = 10
+max_background_jobs = 16
+
+[cf.Headers]
+compression = "zstd"
+bloom_filter_bits = 12
+
+[cf.TransactionLookup]
+write_buffer_size = "512MiB"
+"#;
+
+        let config: TuningConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.default.max_write_buffer_number, Some(4));
+        assert_eq!(config.default.compression, Some(CompressionType::Lz4));
+
+        let headers_opts = config.get_cf_options("Headers");
+        assert_eq!(headers_opts.compression, Some(CompressionType::Zstd));
+        assert_eq!(headers_opts.bloom_filter_bits, Some(12));
+        assert_eq!(headers_opts.max_write_buffer_number, Some(4));
+
+        let tx_opts = config.get_cf_options("TransactionLookup");
+        assert_eq!(tx_opts.write_buffer_size, Some("512MiB".to_string()));
+        assert_eq!(tx_opts.compression, Some(CompressionType::Lz4));
+    }
+
+    #[test]
+    fn test_parse_size() {
+        assert_eq!(parse_size("256MiB").unwrap(), 256 * 1024 * 1024);
+        assert_eq!(parse_size("16KiB").unwrap(), 16 * 1024);
+        assert_eq!(parse_size("1GiB").unwrap(), 1024 * 1024 * 1024);
+        assert_eq!(parse_size("1000").unwrap(), 1000);
+    }
+}

--- a/bin/reth-db-tune/src/main.rs
+++ b/bin/reth-db-tune/src/main.rs
@@ -1,0 +1,108 @@
+//! `RocksDB` tuning experimentation tool for reth.
+
+use clap::{Parser, Subcommand};
+use eyre::{bail, Context, Result};
+use reth_tracing::{LayerInfo, LogFormat, RethTracer, Tracer};
+use std::{fs, path::PathBuf};
+use tracing::info;
+
+mod config;
+mod migrate;
+
+use config::TuningConfig;
+use migrate::{run_migration, MigrateOptions};
+
+#[derive(Parser)]
+#[command(name = "reth-db-tune")]
+#[command(about = "RocksDB tuning experimentation tool for reth")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    Migrate {
+        #[arg(long)]
+        src: PathBuf,
+
+        #[arg(long)]
+        dst: PathBuf,
+
+        #[arg(long)]
+        config: PathBuf,
+
+        #[arg(long)]
+        jobs: Option<i32>,
+
+        #[arg(long, default_value = "true")]
+        compact: bool,
+
+        #[arg(long, default_value = "false")]
+        verify: bool,
+
+        #[arg(long, default_value = "false")]
+        overwrite: bool,
+    },
+}
+
+fn main() -> Result<()> {
+    let tracer = RethTracer::new().with_stdout(LayerInfo::new(
+        LogFormat::Terminal,
+        "info".into(),
+        String::new(),
+        None,
+    ));
+    tracer.init()?;
+
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::Migrate { src, dst, config, jobs, compact, verify, overwrite } => {
+            if !src.exists() {
+                bail!("source directory does not exist: {:?}", src);
+            }
+
+            if dst.exists() && !overwrite {
+                bail!("destination directory already exists: {:?}. Use --overwrite to allow.", dst);
+            }
+
+            if dst.exists() && overwrite {
+                info!(path = %dst.display(), "removing existing destination directory");
+                fs::remove_dir_all(&dst)?;
+            }
+
+            let config_content =
+                fs::read_to_string(&config).wrap_err("failed to read config file")?;
+            let tuning_config: TuningConfig =
+                toml::from_str(&config_content).wrap_err("failed to parse config file")?;
+
+            info!(src = %src.display(), dst = %dst.display(), "starting migration");
+
+            let report = run_migration(MigrateOptions {
+                src: &src,
+                dst: &dst,
+                config: &tuning_config,
+                jobs_override: jobs,
+                compact,
+                verify,
+            })?;
+
+            info!(
+                duration_secs = report.total_duration_secs,
+                cfs = report.column_families.len(),
+                "migration complete"
+            );
+
+            if let Some(passed) = report.verify_passed {
+                if passed {
+                    info!("verification: PASSED");
+                } else {
+                    bail!("verification: FAILED");
+                }
+            }
+
+            Ok(())
+        }
+    }
+}

--- a/bin/reth-db-tune/src/migrate.rs
+++ b/bin/reth-db-tune/src/migrate.rs
@@ -1,0 +1,276 @@
+use crate::config::{parse_size, TuningConfig};
+use eyre::{bail, Context, Result};
+use rocksdb::{
+    BlockBasedOptions, ColumnFamilyDescriptor, DBCompressionType, Options, WriteBatch, DB,
+};
+use serde::Serialize;
+use std::{fs, path::Path, time::Instant};
+use tracing::{info, warn};
+
+const BATCH_SIZE: usize = 32 * 1024 * 1024;
+
+#[derive(Debug, Serialize)]
+pub(crate) struct MigrationReport {
+    pub source_path: String,
+    pub destination_path: String,
+    pub column_families: Vec<CfMigrationStats>,
+    pub total_duration_secs: f64,
+    pub compact_performed: bool,
+    pub verify_performed: bool,
+    pub verify_passed: Option<bool>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct CfMigrationStats {
+    pub name: String,
+    pub keys_copied: u64,
+    pub bytes_copied: u64,
+    pub duration_secs: f64,
+}
+
+pub(crate) struct MigrateOptions<'a> {
+    pub src: &'a Path,
+    pub dst: &'a Path,
+    pub config: &'a TuningConfig,
+    pub jobs_override: Option<i32>,
+    pub compact: bool,
+    pub verify: bool,
+}
+
+pub(crate) fn run_migration(opts: MigrateOptions<'_>) -> Result<MigrationReport> {
+    let start = Instant::now();
+
+    let src_opts = Options::default();
+    let cf_names = DB::list_cf(&src_opts, opts.src)
+        .wrap_err_with(|| format!("failed to list column families from {:?}", opts.src))?;
+
+    info!(cfs = ?cf_names, "discovered column families");
+
+    let src_cf_descriptors: Vec<ColumnFamilyDescriptor> = cf_names
+        .iter()
+        .map(|name| ColumnFamilyDescriptor::new(name.clone(), Options::default()))
+        .collect();
+
+    let src_db = DB::open_cf_descriptors_read_only(&src_opts, opts.src, src_cf_descriptors, false)
+        .wrap_err("failed to open source database")?;
+
+    if !opts.dst.exists() {
+        fs::create_dir_all(opts.dst)?;
+    }
+
+    let dst_db = open_destination_db(opts.dst, &cf_names, opts.config, opts.jobs_override)?;
+
+    let mut cf_stats = Vec::new();
+
+    for cf_name in &cf_names {
+        let stats = copy_column_family(&src_db, &dst_db, cf_name)?;
+        cf_stats.push(stats);
+    }
+
+    drop(src_db);
+
+    if opts.compact {
+        info!("running compaction on destination database");
+        for cf_name in &cf_names {
+            if let Some(cf) = dst_db.cf_handle(cf_name) {
+                dst_db.compact_range_cf(cf, None::<&[u8]>, None::<&[u8]>);
+            }
+        }
+    }
+
+    let verify_passed = if opts.verify {
+        info!("verifying migration");
+        let src_db_verify = DB::open_cf_descriptors_read_only(
+            &src_opts,
+            opts.src,
+            cf_names
+                .iter()
+                .map(|name| ColumnFamilyDescriptor::new(name.clone(), Options::default()))
+                .collect::<Vec<_>>(),
+            false,
+        )?;
+        Some(verify_databases(&src_db_verify, &dst_db, &cf_names)?)
+    } else {
+        None
+    };
+
+    let report = MigrationReport {
+        source_path: opts.src.display().to_string(),
+        destination_path: opts.dst.display().to_string(),
+        column_families: cf_stats,
+        total_duration_secs: start.elapsed().as_secs_f64(),
+        compact_performed: opts.compact,
+        verify_performed: opts.verify,
+        verify_passed,
+    };
+
+    let report_path = opts.dst.join("migration_report.json");
+    let report_json = serde_json::to_string_pretty(&report)?;
+    fs::write(&report_path, &report_json)?;
+    info!(path = %report_path.display(), "wrote migration report");
+
+    Ok(report)
+}
+
+fn open_destination_db(
+    path: &Path,
+    cf_names: &[String],
+    config: &TuningConfig,
+    jobs_override: Option<i32>,
+) -> Result<DB> {
+    let mut db_opts = Options::default();
+    db_opts.create_if_missing(true);
+    db_opts.create_missing_column_families(true);
+
+    let jobs = jobs_override.or(config.default.max_background_jobs).unwrap_or(6);
+    db_opts.set_max_background_jobs(jobs);
+
+    let cf_descriptors: Vec<ColumnFamilyDescriptor> = cf_names
+        .iter()
+        .map(|name| {
+            let cf_config = config.get_cf_options(name);
+            let cf_opts = build_cf_options(&cf_config);
+            ColumnFamilyDescriptor::new(name.clone(), cf_opts)
+        })
+        .collect();
+
+    DB::open_cf_descriptors(&db_opts, path, cf_descriptors).wrap_err("failed to open destination")
+}
+
+fn build_cf_options(cf_config: &crate::config::CfOptions) -> Options {
+    let mut opts = Options::default();
+
+    if let Some(ref size_str) = cf_config.write_buffer_size &&
+        let Ok(size) = parse_size(size_str)
+    {
+        opts.set_write_buffer_size(size);
+    }
+
+    if let Some(n) = cf_config.max_write_buffer_number {
+        opts.set_max_write_buffer_number(n);
+    }
+
+    if let Some(ct) = cf_config.compression {
+        opts.set_compression_type(ct.into());
+    } else {
+        opts.set_compression_type(DBCompressionType::Lz4);
+    }
+
+    let mut block_opts = BlockBasedOptions::default();
+
+    if let Some(ref size_str) = cf_config.block_size &&
+        let Ok(size) = parse_size(size_str)
+    {
+        block_opts.set_block_size(size);
+    }
+
+    if let Some(bits) = cf_config.bloom_filter_bits {
+        block_opts.set_bloom_filter(bits as f64, false);
+    }
+
+    opts.set_block_based_table_factory(&block_opts);
+    opts
+}
+
+fn copy_column_family(src_db: &DB, dst_db: &DB, cf_name: &str) -> Result<CfMigrationStats> {
+    let start = Instant::now();
+    let mut keys_copied = 0u64;
+    let mut bytes_copied = 0u64;
+
+    let src_cf =
+        src_db.cf_handle(cf_name).ok_or_else(|| eyre::eyre!("source CF {} not found", cf_name))?;
+    let dst_cf = dst_db
+        .cf_handle(cf_name)
+        .ok_or_else(|| eyre::eyre!("destination CF {} not found", cf_name))?;
+
+    let mut batch = WriteBatch::default();
+    let mut batch_bytes = 0usize;
+
+    let iter = src_db.iterator_cf(src_cf, rocksdb::IteratorMode::Start);
+
+    for item in iter {
+        let (key, value) = item?;
+        let entry_size = key.len() + value.len();
+
+        batch.put_cf(dst_cf, &key, &value);
+        batch_bytes += entry_size;
+        keys_copied += 1;
+        bytes_copied += entry_size as u64;
+
+        if batch_bytes >= BATCH_SIZE {
+            dst_db.write(batch)?;
+            batch = WriteBatch::default();
+            batch_bytes = 0;
+
+            if keys_copied.is_multiple_of(1_000_000) {
+                info!(cf = cf_name, keys = keys_copied, "migration progress");
+            }
+        }
+    }
+
+    if !batch.is_empty() {
+        dst_db.write(batch)?;
+    }
+
+    let duration = start.elapsed();
+    info!(
+        cf = cf_name,
+        keys = keys_copied,
+        bytes = bytes_copied,
+        duration_secs = duration.as_secs_f64(),
+        "completed CF migration"
+    );
+
+    Ok(CfMigrationStats {
+        name: cf_name.to_string(),
+        keys_copied,
+        bytes_copied,
+        duration_secs: duration.as_secs_f64(),
+    })
+}
+
+fn verify_databases(src_db: &DB, dst_db: &DB, cf_names: &[String]) -> Result<bool> {
+    for cf_name in cf_names {
+        let src_cf = match src_db.cf_handle(cf_name) {
+            Some(cf) => cf,
+            None => continue,
+        };
+        let dst_cf = match dst_db.cf_handle(cf_name) {
+            Some(cf) => cf,
+            None => {
+                warn!(cf = cf_name, "CF missing in destination");
+                return Ok(false);
+            }
+        };
+
+        let mut src_iter = src_db.iterator_cf(src_cf, rocksdb::IteratorMode::Start);
+        let mut dst_iter = dst_db.iterator_cf(dst_cf, rocksdb::IteratorMode::Start);
+
+        loop {
+            match (src_iter.next(), dst_iter.next()) {
+                (Some(Ok((sk, sv))), Some(Ok((dk, dv)))) => {
+                    if sk != dk || sv != dv {
+                        warn!(cf = cf_name, "key/value mismatch");
+                        return Ok(false);
+                    }
+                }
+                (None, None) => break,
+                (Some(_), None) => {
+                    warn!(cf = cf_name, "destination has fewer keys");
+                    return Ok(false);
+                }
+                (None, Some(_)) => {
+                    warn!(cf = cf_name, "destination has more keys");
+                    return Ok(false);
+                }
+                (Some(Err(e)), _) | (_, Some(Err(e))) => {
+                    bail!("iterator error during verification: {}", e);
+                }
+            }
+        }
+
+        info!(cf = cf_name, "verification passed");
+    }
+
+    Ok(true)
+}


### PR DESCRIPTION
## Summary

Adds a new `reth-db-tune` binary with a `migrate` subcommand that migrates an existing RocksDB to a new directory with different tuning options.

**Part of RETH-269**

### CLI Usage

```bash
reth-db-tune migrate \
  --src <path>           # Source RocksDB directory
  --dst <path>           # Destination directory (must not exist unless --overwrite)
  --config <config.toml> # Per-CF tuning config
  [--jobs N]             # Background jobs override
  [--verify]             # Verify after migration
  [--compact]            # Run CompactRange (default: true)
  [--overwrite]          # Allow overwriting dst
```

### TOML Config Format

```toml
[default]
write_buffer_size = "256MiB"
max_write_buffer_number = 4
compression = "lz4"              # none|snappy|lz4|zstd
block_size = "16KiB"
bloom_filter_bits = 10
max_background_jobs = 16

[cf.Headers]
compression = "zstd"
bloom_filter_bits = 12

[cf.TransactionLookup]
write_buffer_size = "512MiB"
```

### Features

- Migrates RocksDB databases with custom per-CF tuning options
- Copies data CF-by-CF using batched WriteBatch operations (32MB chunks)
- Optionally runs CompactRange on destination to rewrite SSTs with new options
- Optionally verifies migration by comparing all keys/values
- Outputs `migration_report.json` with detailed stats including:
  - Keys copied per CF
  - Bytes copied per CF
  - Duration per CF and total

## Testing

```bash
cargo build -p reth-db-tune
cargo test -p reth-db-tune
```

### Example tuning result:
https://gist.github.com/gakonst/1c22b7eb7cc1e14f19d2253a6a8fe32b