### PR TITLE
fix(rocksdb): prevent UnsortedInput error on multiple history shard appends

### DIFF
--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -1302,7 +1302,7 @@ pub struct RocksDBBatch<'a> {
     /// Used to handle multiple calls to `append_account_history_shard` for the same address
     /// within a single batch, since the batch cannot read its own pending writes.
     pending_account_history: HashMap<Address, BlockNumberList>,
-    /// Pending storage history shards ((address, storage_key) -> merged indices).
+    /// Pending storage history shards ((address, `storage_key`) -> merged indices).
     /// Used to handle multiple calls to `append_storage_history_shard` for the same key
     /// within a single batch, since the batch cannot read its own pending writes.
     pending_storage_history: HashMap<(Address, B256), BlockNumberList>,
@@ -1575,7 +1575,7 @@ impl<'a> RocksDBBatch<'a> {
     /// Appends indices to a storage history shard with proper shard management.
     ///
     /// Indices are accumulated in memory and written to the database when `commit()` is called.
-    /// This allows multiple calls for the same (address, storage_key) pair within a single batch.
+    /// This allows multiple calls for the same (address, `storage_key`) pair within a single batch.
     ///
     /// # Requirements
     ///


### PR DESCRIPTION
## Summary

Fix UnsortedInput error when `append_storage_history_shard` or `append_account_history_shard` is called multiple times for the same key within a single RocksDB batch.

## Motivation

The `RocksDBBatch` cannot read its own pending writes (WriteBatch does not support read-your-writes). When `append_storage_history_shard` was called twice for the same `(address, storage_key)`:

1. First call: reads committed DB shard, appends indices `[10, 20, 30]`, puts to batch
2. Second call: reads SAME committed shard (can't see batch), tries to append `[40, 50, 60]` which are higher than what's in committed but the batch already has higher indices
3. `last_shard.append(indices)` fails with `UnsortedInput`

The doc comment at lines 1492-1494 explicitly warned about this limitation but it was still triggering in production.

## Changes

- Add `pending_account_history: HashMap<Address, BlockNumberList>` and `pending_storage_history: HashMap<(Address, B256), BlockNumberList>` to `RocksDBBatch`
- Modify `append_*_history_shard` to accumulate indices in pending maps instead of writing to batch immediately
- Add `flush_pending_history()` called on `commit()` to write all pending shards with proper rechunking
- Add `write_*_history_shard()` helpers for the actual shard writing logic
- Add 3 tests covering:
  - Multiple appends to same storage history key in one batch
  - Multiple appends to same account history key in one batch
  - Merging with previously committed data

## Testing

```bash
cargo test -p reth-provider --features rocksdb test_append_storage_history_shard_multiple_calls_same_key
cargo test -p reth-provider --features rocksdb test_append_account_history_shard_multiple_calls_same_key
cargo test -p reth-provider --features rocksdb test_append_storage_history_shard_merges_with_committed
```
