### PR TITLE
fix(trie): retain revealed paths for surviving leaves after prune

### DIFF
--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -1090,10 +1090,10 @@ where
 
         // Retain only revealed storage paths for leaves that still exist after pruning.
         for hash in &tries_to_keep {
-            if let Some(trie) = self.storage.tries.get(hash).and_then(|t| t.as_revealed_ref()) {
-                if let Some(paths) = self.storage.revealed_paths.get_mut(hash) {
-                    paths.retain(|path| trie.get_leaf_value(path).is_some());
-                }
+            if let Some(trie) = self.storage.tries.get(hash).and_then(|t| t.as_revealed_ref()) &&
+                let Some(paths) = self.storage.revealed_paths.get_mut(hash)
+            {
+                paths.retain(|path| trie.get_leaf_value(path).is_some());
             }
         }
     }


### PR DESCRIPTION
## Summary
Fixes root mismatch issue when using sparse trie cache with prune.

## Problem
`prune()` unconditionally cleared `revealed_account_paths` and revealed storage paths even though leaf nodes survive pruning (only internal nodes deeper than `max_depth` are converted to hash stubs).

This caused:
1. `is_account_revealed()` returns false for still-revealed accounts
2. Storage root updates skipped for accounts with only storage changes
3. State root mismatch on subsequent blocks

## Solution
Replace unconditional `clear()` with `retain()` that keeps paths for accounts/slots whose leaves still exist after pruning.

## Testing
- Repro: Send 3 payloads via reth-bench → previously failed on 3rd block due to stale storage roots

Relates to #21534