### PR TITLE
fix(provider): use storage-aware methods in unwind_trie_state_from

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -761,11 +761,7 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
     /// This includes calculating the resulted state root and comparing it with the parent block
     /// state root.
     pub fn unwind_trie_state_from(&self, from: BlockNumber) -> ProviderResult<()> {
-        let changed_accounts = self
-            .tx
-            .cursor_read::<tables::AccountChangeSets>()?
-            .walk_range(from..)?
-            .collect::<Result<Vec<_>, _>>()?;
+        let changed_accounts = self.account_changesets_range(from..)?;
 
         // Unwind account hashes.
         self.unwind_account_hashing(changed_accounts.iter())?;
@@ -773,12 +769,7 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
         // Unwind account history indices.
         self.unwind_account_history_indices(changed_accounts.iter())?;
 
-        let storage_start = BlockNumberAddress((from, Address::ZERO));
-        let changed_storages = self
-            .tx
-            .cursor_read::<tables::StorageChangeSets>()?
-            .walk_range(storage_start..)?
-            .collect::<Result<Vec<_>, _>>()?;
+        let changed_storages = self.storage_changesets_range(from..)?;
 
         // Unwind storage hashes.
         self.unwind_storage_hashing(changed_storages.iter().copied())?;


### PR DESCRIPTION
## Summary

Fixes UnsortedInput error in `write_storage_history` after stage unwind on RocksDB hot/cold nodes.

## Problem

`unwind_trie_state_from` reads changesets directly from MDBX tables:
```rust
let changed_accounts = self.tx.cursor_read::<tables::AccountChangeSets>()?...
let changed_storages = self.tx.cursor_read::<tables::StorageChangeSets>()?...
```

On RocksDB hot/cold nodes where changesets are stored in **static files**, this returns empty results. This causes:
- History indices not unwound
- Stale keys remain in database
- `UnsortedInput` error when replaying payloads

## Solution

Replace direct MDBX reads with storage-aware trait methods:
- `account_changesets_range(from..)`
- `storage_changesets_range(from..)`

These methods check `storage_changesets_in_static_files` and read from the appropriate source (static files vs MDBX).

RETH-285