### PR TITLE
fix(engine): add progress detection to persistence loop

### DIFF
--- a/crates/engine/tree/src/tree/error.rs
+++ b/crates/engine/tree/src/tree/error.rs
@@ -13,6 +13,9 @@ pub enum AdvancePersistenceError {
     /// The persistence channel was closed unexpectedly
     #[error("persistence channel closed")]
     ChannelClosed,
+    /// No progress was made after multiple persistence attempts
+    #[error("no progress in persistence after multiple attempts")]
+    NoProgress,
     /// A provider error
     #[error(transparent)]
     Provider(#[from] ProviderError),


### PR DESCRIPTION
The `persist_until_complete` function could loop indefinitely if persistence tasks fail silently. Add progress tracking to detect when the same number of blocks need to be persisted after multiple iterations, indicating the persistence task is not making progress. Return error after 3 iterations without progress to prevent infinite loops during shutdown.