### PR TITLE
refactor(engine): simplify iter_transactions implementation

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -688,7 +688,8 @@ impl<Tx, Err, R: Send + Sync + 'static> PayloadHandle<Tx, Err, R> {
     }
 
     /// Returns iterator yielding transactions from the stream.
-            core::iter::repeat_with(|| self.transactions.recv()).filter_map(Result::ok)
+    pub fn iter_transactions(&mut self) -> impl Iterator<Item = Result<Tx, Err>> + '_ {
+        core::iter::repeat_with(|| self.transactions.recv()).filter_map(Result::ok)
     }
 }
 

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -688,10 +688,7 @@ impl<Tx, Err, R: Send + Sync + 'static> PayloadHandle<Tx, Err, R> {
     }
 
     /// Returns iterator yielding transactions from the stream.
-    pub fn iter_transactions(&mut self) -> impl Iterator<Item = Result<Tx, Err>> + '_ {
-        core::iter::repeat_with(|| self.transactions.recv())
-            .take_while(|res| res.is_ok())
-            .map(|res| res.unwrap())
+            core::iter::repeat_with(|| self.transactions.recv()).filter_map(Result::ok)
     }
 }
 


### PR DESCRIPTION
Replaces `.take_while(|res| res.is_ok()).map(|res| res.unwrap())` with `.filter_map(Result::ok)`.

More idiomatic, removes unwrap