### PR TITLE
chore: remove redundant deref in in-memory blob store equality

### DIFF
--- a/crates/transaction-pool/src/blobstore/mem.rs
+++ b/crates/transaction-pool/src/blobstore/mem.rs
@@ -56,7 +56,7 @@ struct InMemoryBlobStoreInner {
 
 impl PartialEq for InMemoryBlobStoreInner {
     fn eq(&self, other: &Self) -> bool {
-        self.store.read().eq(&*other.store.read())
+        self.store.read().eq(&other.store.read())
     }
 }
 


### PR DESCRIPTION
Remove a redundant `&*` deref in the `InMemoryBlobStoreInner` `PartialEq` implementation.

