### PR TITLE
fix(reth-bench): stop fetcher when reaching chain tip

### DIFF
--- a/bin/reth-bench/src/bench/generate_big_block.rs
+++ b/bin/reth-bench/src/bench/generate_big_block.rs
@@ -543,6 +543,11 @@ impl Command {
             let mut current_block = start_block;
 
             while let Some(batch) = fetch_batch_with_retry(&collector, current_block).await {
+                if batch.transactions.is_empty() {
+                    info!(block = current_block, "Reached chain tip, stopping fetcher");
+                    break;
+                }
+
                 info!(
                     tx_count = batch.transactions.len(),
                     gas_sent = batch.gas_sent,


### PR DESCRIPTION
Stop when reached the tip to prevent looping

```
2026-01-29T11:23:03.172842Z  WARN Block not found, stopping block=24340185
2026-01-29T11:23:03.172853Z  INFO Finished collecting transactions total_txs=264 gas_sent=45593368 next_block=24340185
2026-01-29T11:23:03.172862Z  INFO Fetched transaction batch tx_count=264 gas_sent=45593368 blocks="24340184..24340185"
2026-01-29T11:23:04.487154Z  INFO Underfilled, collecting more transactions for retry payload=61 gas_used=130677084 gas_sent=999999016 ratio="0.1307" additional_gas=6652444591
2026-01-29T11:23:04.501940Z  WARN Block not found, stopping block=24340185
2026-01-29T11:23:04.501950Z  INFO Finished collecting transactions total_txs=0 gas_sent=0 next_block=24340185
2026-01-29T11:23:04.501958Z  INFO Fetched transaction batch tx_count=0 gas_sent=0 blocks="24340185..24340185"
2026-01-29T11:23:04.515025Z  WARN Block not found, stopping block=24340185
2026-01-29T11:23:04.515036Z  INFO Finished collecting transactions total_txs=0 gas_sent=0 next_block=24340185
2026-01-29T11:23:04.515039Z  INFO Fetched transaction batch tx_count=0 gas_sent=0 blocks="24340185..24340185"
2026-01-29T11:23:04.528454Z  WARN Block not found, stopping block=24340185
2026-01-29T11:23:04.528467Z  INFO Finished collecting transactions total_txs=0 gas_sent=0 next_block=24340185
2026-01-29T11:23:04.528473Z  INFO Fetched transaction batch tx_count=0 gas_sent=0 blocks="24340185..24340185"
2026-01-29T11:23:04.547831Z  WARN Block not found, stopping block=24340185
2026-01-29T11:23:04.547842Z  INFO Finished collecting transactions total_txs=0 gas_sent=0 next_block=24340185
2026-01-29T11:23:04.547851Z  INFO Fetched transaction batch tx_count=0 gas_sent=0 blocks="24340185..24340185"
```