### PR TITLE
refactor(stages): simplify Option plumbing in opt::max/min

### DIFF
--- a/crates/stages/api/src/util.rs
+++ b/crates/stages/api/src/util.rs
@@ -3,14 +3,14 @@ pub(crate) mod opt {
     /// value of the [Option]. If the [Option] is `None`, then an option containing the passed in
     /// value will be returned.
     pub(crate) fn max<T: Ord + Copy>(a: Option<T>, b: T) -> Option<T> {
-        a.map_or(Some(b), |v| Some(std::cmp::max(v, b)))
+        Some(a.map_or(b, |v| std::cmp::max(v, b)))
     }
 
     /// Get an [Option] with the minimum value, compared between the passed in value and the inner
     /// value of the [Option]. If the [Option] is `None`, then an option containing the passed in
     /// value will be returned.
     pub(crate) fn min<T: Ord + Copy>(a: Option<T>, b: T) -> Option<T> {
-        a.map_or(Some(b), |v| Some(std::cmp::min(v, b)))
+        Some(a.map_or(b, |v| std::cmp::min(v, b)))
     }
 
     #[cfg(test)]


### PR DESCRIPTION
Removes redundant `Option` wrapping in `opt::max` and `opt::min` functions. Both functions always return `Some(_)`, so wrapping the result once is sufficient instead of wrapping in both branches of `map_or`.

- **Before**: `a.map_or(Some(b), |v| Some(std::cmp::max(v, b)))`
- **After**: `Some(a.map_or(b, |v| std::cmp::max(v, b)))`

