### PR TITLE
fix(provider): check executed block before returning historical state

### DIFF
--- a/crates/storage/errors/src/provider.rs
+++ b/crates/storage/errors/src/provider.rs
@@ -104,6 +104,14 @@ pub enum ProviderError {
     /// State is not available for the given block number because it is pruned.
     #[error("state at block #{_0} is pruned")]
     StateAtBlockPruned(BlockNumber),
+    /// State is not available because the block has not been executed yet.
+    #[error("state at block #{requested} is not available, block has not been executed yet (latest executed: #{executed})")]
+    BlockNotExecuted {
+        /// The block number that was requested.
+        requested: BlockNumber,
+        /// The latest executed block number.
+        executed: BlockNumber,
+    },
     /// Block data is not available because history has expired.
     ///
     /// The requested block number is below the earliest available block.

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -834,14 +834,13 @@ impl<TX: DbTx + 'static, N: NodeTypes> TryIntoHistoricalStateProvider for Databa
         // Ensure the requested block has been executed. Without this check, we could return
         // stale or invalid state for blocks that exist in the database but haven't been
         // executed yet (e.g., during pipeline sync when headers/bodies are ahead of execution).
-        let execution_checkpoint = self.get_stage_checkpoint(StageId::Execution)?;
-        if let Some(checkpoint) = execution_checkpoint {
-            if block_number > checkpoint.block_number {
-                return Err(ProviderError::BlockNotExecuted {
-                    requested: block_number,
-                    executed: checkpoint.block_number,
-                });
-            }
+        if let Some(checkpoint) = self.get_stage_checkpoint(StageId::Execution)? &&
+            block_number > checkpoint.block_number
+        {
+            return Err(ProviderError::BlockNotExecuted {
+                requested: block_number,
+                executed: checkpoint.block_number,
+            });
         }
 
         // +1 as the changeset that we want is the one that was applied after this block.

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -831,6 +831,19 @@ impl<TX: DbTx + 'static, N: NodeTypes> TryIntoHistoricalStateProvider for Databa
             return Ok(Box::new(LatestStateProvider::new(self)))
         }
 
+        // Ensure the requested block has been executed. Without this check, we could return
+        // stale or invalid state for blocks that exist in the database but haven't been
+        // executed yet (e.g., during pipeline sync when headers/bodies are ahead of execution).
+        let execution_checkpoint = self.get_stage_checkpoint(StageId::Execution)?;
+        if let Some(checkpoint) = execution_checkpoint {
+            if block_number > checkpoint.block_number {
+                return Err(ProviderError::BlockNotExecuted {
+                    requested: block_number,
+                    executed: checkpoint.block_number,
+                });
+            }
+        }
+
         // +1 as the changeset that we want is the one that was applied after this block.
         block_number += 1;
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -3614,7 +3614,7 @@ mod tests {
         let data = BlockchainTestData::default();
 
         let provider_rw = factory.provider_rw().unwrap();
-        provider_rw.insert_block(&data.genesis.clone().try_recover().unwrap()).unwrap();
+        provider_rw.insert_block(&data.genesis.try_recover().unwrap()).unwrap();
         provider_rw
             .write_state(
                 &ExecutionOutcome { first_block: 0, receipts: vec![vec![]], ..Default::default() },
@@ -3647,7 +3647,7 @@ mod tests {
         let data = BlockchainTestData::default();
 
         let provider_rw = factory.provider_rw().unwrap();
-        provider_rw.insert_block(&data.genesis.clone().try_recover().unwrap()).unwrap();
+        provider_rw.insert_block(&data.genesis.try_recover().unwrap()).unwrap();
         provider_rw
             .write_state(
                 &ExecutionOutcome { first_block: 0, receipts: vec![vec![]], ..Default::default() },
@@ -3684,7 +3684,7 @@ mod tests {
         let data = BlockchainTestData::default();
 
         let provider_rw = factory.provider_rw().unwrap();
-        provider_rw.insert_block(&data.genesis.clone().try_recover().unwrap()).unwrap();
+        provider_rw.insert_block(&data.genesis.try_recover().unwrap()).unwrap();
         provider_rw
             .write_state(
                 &ExecutionOutcome { first_block: 0, receipts: vec![vec![]], ..Default::default() },
@@ -3722,7 +3722,7 @@ mod tests {
         let data = BlockchainTestData::default();
 
         let provider_rw = factory.provider_rw().unwrap();
-        provider_rw.insert_block(&data.genesis.clone().try_recover().unwrap()).unwrap();
+        provider_rw.insert_block(&data.genesis.try_recover().unwrap()).unwrap();
         provider_rw
             .write_state(
                 &ExecutionOutcome { first_block: 0, receipts: vec![vec![]], ..Default::default() },
@@ -3792,7 +3792,7 @@ mod tests {
         let data = BlockchainTestData::default();
 
         let provider_rw = factory.provider_rw().unwrap();
-        provider_rw.insert_block(&data.genesis.clone().try_recover().unwrap()).unwrap();
+        provider_rw.insert_block(&data.genesis.try_recover().unwrap()).unwrap();
         provider_rw
             .write_state(
                 &ExecutionOutcome { first_block: 0, receipts: vec![vec![]], ..Default::default() },
@@ -4197,7 +4197,7 @@ mod tests {
         // Insert genesis block to have some data
         let data = BlockchainTestData::default();
         let provider_rw = factory.provider_rw().unwrap();
-        provider_rw.insert_block(&data.genesis.clone().try_recover().unwrap()).unwrap();
+        provider_rw.insert_block(&data.genesis.try_recover().unwrap()).unwrap();
         provider_rw
             .write_state(
                 &ExecutionOutcome { first_block: 0, receipts: vec![vec![]], ..Default::default() },

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -825,36 +825,19 @@ impl<TX: DbTx + 'static, N: NodeTypes> TryIntoHistoricalStateProvider for Databa
         self,
         mut block_number: BlockNumber,
     ) -> ProviderResult<StateProviderBox> {
-        // Determine the highest block with valid state on disk. State is valid when execution
-        // has completed and receipts are written. We use two sources:
-        //
-        // 1. Execution checkpoint: Updated by pipeline's Execution stage
-        // 2. Receipts static file: Written by both pipeline Execution stage AND engine persistence
-        //
-        // Taking max handles both cases:
-        // - Pipeline sync: Execution checkpoint is authoritative
-        // - Engine sync: Receipts segment reflects engine-persisted blocks (checkpoint stale)
-        let execution_checkpoint = self
-            .get_stage_checkpoint(StageId::Execution)?
-            .map(|c| c.block_number)
-            .unwrap_or_default();
-        let receipts_block = self
-            .static_file_provider
-            .get_highest_static_file_block(StaticFileSegment::Receipts)
-            .unwrap_or_default();
-        let state_tip = execution_checkpoint.max(receipts_block);
+        let best_block = self.best_block_number()?;
 
-        // If requesting state at the tip, use the latest state provider
-        if block_number == state_tip {
-            return Ok(Box::new(LatestStateProvider::new(self)));
-        }
-
-        // Reject requests for blocks that don't have valid state yet
-        if block_number > state_tip {
+        // Reject requests for blocks beyond the best block
+        if block_number > best_block {
             return Err(ProviderError::BlockNotExecuted {
                 requested: block_number,
-                executed: state_tip,
+                executed: best_block,
             });
+        }
+
+        // If requesting state at the best block, use the latest state provider
+        if block_number == best_block {
+            return Ok(Box::new(LatestStateProvider::new(self)));
         }
 
         // +1 as the changeset that we want is the one that was applied after this block.

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -825,7 +825,7 @@ impl<TX: DbTx + 'static, N: NodeTypes> TryIntoHistoricalStateProvider for Databa
         self,
         mut block_number: BlockNumber,
     ) -> ProviderResult<StateProviderBox> {
-        let best_block = self.best_block_number()?;
+        let best_block = self.best_block_number().unwrap_or_default();
 
         // Reject requests for blocks beyond the best block
         if block_number > best_block {


### PR DESCRIPTION
## Summary

Fixes state provider returning invalid data for blocks that haven't been executed yet.

## Problem

During pipeline sync, `HistoricalStateProvider` could return wrong state for blocks where headers/bodies exist but execution hasn't run. The lookup falls through to `HistoryInfo::InPlainState` and reads from `PlainAccountState` - returning **current** state instead of erroring.
