### PR TITLE
chore: update RPC URLs from ithaca.xyz to reth.rs

### DIFF
--- a/bin/reth-bench-compare/src/cli.rs
+++ b/bin/reth-bench-compare/src/cli.rs
@@ -274,10 +274,10 @@ impl Args {
     /// Get the default RPC URL for a given chain
     const fn get_default_rpc_url(chain: &Chain) -> &'static str {
         match chain.id() {
-            8453 => "https://base-mainnet.rpc.ithaca.xyz",  // base
+            8453 => "https://base.reth.rs/rpc",  // base
             84532 => "https://base-sepolia.rpc.ithaca.xyz", // base-sepolia
             27082 => "https://rpc.hoodi.ethpandaops.io",    // hoodi
-            _ => "https://reth-ethereum.ithaca.xyz/rpc",    // mainnet and fallback
+            _ => "https://ethereum.reth.rs/rpc",    // mainnet and fallback
         }
     }
 

--- a/bin/reth-bench-compare/src/cli.rs
+++ b/bin/reth-bench-compare/src/cli.rs
@@ -274,10 +274,10 @@ impl Args {
     /// Get the default RPC URL for a given chain
     const fn get_default_rpc_url(chain: &Chain) -> &'static str {
         match chain.id() {
-            8453 => "https://base.reth.rs/rpc",  // base
+            8453 => "https://base.reth.rs/rpc",             // base
             84532 => "https://base-sepolia.rpc.ithaca.xyz", // base-sepolia
             27082 => "https://rpc.hoodi.ethpandaops.io",    // hoodi
-            _ => "https://ethereum.reth.rs/rpc",    // mainnet and fallback
+            _ => "https://ethereum.reth.rs/rpc",            // mainnet and fallback
         }
     }
 

--- a/docs/vocs/docs/pages/run/overview.mdx
+++ b/docs/vocs/docs/pages/run/overview.mdx
@@ -37,9 +37,9 @@ Find answers to common questions and troubleshooting tips:
 
 | Network         | Chain ID | RPC URL                              |
 | --------------- | -------- | ------------------------------------ |
-| Ethereum        | 1        | https://reth-ethereum.ithaca.xyz/rpc |
+| Ethereum        | 1        | https://ethereum.reth.rs/rpc |
 | Sepolia Testnet | 11155111 | https://sepolia.drpc.org             |
-| Base            | 8453     | https://base-mainnet.rpc.ithaca.xyz  |
+| Base            | 8453     | https://base.reth.rs/rpc  |
 | Base Sepolia    | 84532    | https://base-sepolia.drpc.org        |
 
 :::tip


### PR DESCRIPTION
## Summary
Updates RPC endpoint URLs from `ithaca.xyz` to `reth.rs`.

## Changes
- `reth-ethereum.ithaca.xyz/rpc` -> `ethereum.reth.rs/rpc`
- `base-mainnet.rpc.ithaca.xyz` -> `base.reth.rs/rpc`