### PR TITLE
fix(trie): replace panic with error return for invalid branch node

### DIFF
--- a/crates/trie/trie/src/walker.rs
+++ b/crates/trie/trie/src/walker.rs
@@ -290,7 +290,9 @@ impl<C: TrieCursor, K: AsRef<AddedRemovedKeys>> TrieWalker<C, K> {
         self.metrics.inc_branch_nodes_seeked();
 
         if let Some((_, node)) = &entry {
-            assert!(!node.state_mask.is_empty());
+            if node.state_mask.is_empty() {
+                return Err(DatabaseError::Other("branch node state_mask is empty".to_string()))
+            }
         }
 
         Ok(entry)


### PR DESCRIPTION
The `TrieWalker::node()` method used `assert!(!node.state_mask.is_empty())` to validate branch nodes retrieved from the database. This causes a panic on corrupted or unexpected database state, crashing the node process.
