### PR TITLE
fix(engine): Try to always compute storage root in V2 proofs when account proof is present, fallback if not

### DIFF
--- a/crates/trie/parallel/src/proof_task_metrics.rs
+++ b/crates/trie/parallel/src/proof_task_metrics.rs
@@ -26,6 +26,8 @@ pub struct ProofTaskTrieMetrics {
     deferred_encoder_from_cache: Histogram,
     /// Histogram for `Sync` deferred encoder variant count.
     deferred_encoder_sync: Histogram,
+    /// Histogram for dispatched storage proofs that fell back to sync due to missing root.
+    deferred_encoder_dispatched_missing_root: Histogram,
 }
 
 impl ProofTaskTrieMetrics {
@@ -54,6 +56,8 @@ impl ProofTaskTrieMetrics {
         self.deferred_encoder_dispatched.record(stats.dispatched_count as f64);
         self.deferred_encoder_from_cache.record(stats.from_cache_count as f64);
         self.deferred_encoder_sync.record(stats.sync_count as f64);
+        self.deferred_encoder_dispatched_missing_root
+            .record(stats.dispatched_missing_root_count as f64);
     }
 }
 


### PR DESCRIPTION
The `AsyncAccountValueEncoder` checks for the presence of a dispatched storage proof channel when it's encoding the storage root for an account. However with partial proofs the storage proof's results might not contain the root node to compute the storage root with. The fix is two-part:

* When the multiproof contains an account proof and storage proof for the same account, ensure the storage proof has at least one proof with min_len == 0 (which will guarantee that the root node is included)

* For cases where an account needs to be encoded but there is not an account proof for it, and there _is_ a storage proof for it which does not include the root, fallback to a synchronous storage proof just to get that proof. A metric is added to track this, it should only happen rarely.