### PR TITLE
chore(trie): remove unused direct MDBX changeset readers

### DIFF
--- a/crates/trie/db/src/lib.rs
+++ b/crates/trie/db/src/lib.rs
@@ -15,12 +15,10 @@ mod witness;
 pub use hashed_cursor::{
     DatabaseHashedAccountCursor, DatabaseHashedCursorFactory, DatabaseHashedStorageCursor,
 };
-pub use prefix_set::{load_prefix_sets_with_provider, PrefixSetLoader};
+pub use prefix_set::load_prefix_sets_with_provider;
 pub use proof::{DatabaseProof, DatabaseStorageProof};
 pub use state::{DatabaseHashedPostState, DatabaseStateRoot};
-pub use storage::{
-    hashed_storage_from_reverts_with_provider, DatabaseHashedStorage, DatabaseStorageRoot,
-};
+pub use storage::{hashed_storage_from_reverts_with_provider, DatabaseStorageRoot};
 pub use trie_cursor::{
     DatabaseAccountTrieCursor, DatabaseStorageTrieCursor, DatabaseTrieCursorFactory,
 };

--- a/crates/trie/db/src/prefix_set.rs
+++ b/crates/trie/db/src/prefix_set.rs
@@ -2,17 +2,8 @@ use alloy_primitives::{
     map::{HashMap, HashSet},
     BlockNumber, B256,
 };
-use core::{
-    marker::PhantomData,
-    ops::{Deref, RangeInclusive},
-};
-use reth_db_api::{
-    cursor::DbCursorRO,
-    models::{AccountBeforeTx, BlockNumberAddress},
-    tables,
-    transaction::DbTx,
-    DatabaseError,
-};
+use core::ops::RangeInclusive;
+use reth_db_api::{cursor::DbCursorRO, models::BlockNumberAddress, tables, transaction::DbTx};
 use reth_primitives_traits::StorageEntry;
 use reth_storage_api::{ChangeSetReader, DBProvider, StorageChangeSetReader};
 use reth_storage_errors::provider::ProviderError;
@@ -20,71 +11,6 @@ use reth_trie::{
     prefix_set::{PrefixSetMut, TriePrefixSets},
     KeyHasher, Nibbles,
 };
-
-/// A wrapper around a database transaction that loads prefix sets within a given block range.
-#[derive(Debug)]
-pub struct PrefixSetLoader<'a, TX, KH>(&'a TX, PhantomData<KH>);
-
-impl<'a, TX, KH> PrefixSetLoader<'a, TX, KH> {
-    /// Create a new loader.
-    pub const fn new(tx: &'a TX) -> Self {
-        Self(tx, PhantomData)
-    }
-}
-
-impl<TX, KH> Deref for PrefixSetLoader<'_, TX, KH> {
-    type Target = TX;
-
-    fn deref(&self) -> &Self::Target {
-        self.0
-    }
-}
-
-impl<TX: DbTx, KH: KeyHasher> PrefixSetLoader<'_, TX, KH> {
-    /// Load all account and storage changes for the given block range.
-    pub fn load(self, range: RangeInclusive<BlockNumber>) -> Result<TriePrefixSets, DatabaseError> {
-        // Initialize prefix sets.
-        let mut account_prefix_set = PrefixSetMut::default();
-        let mut storage_prefix_sets = HashMap::<B256, PrefixSetMut>::default();
-        let mut destroyed_accounts = HashSet::default();
-
-        // Walk account changeset and insert account prefixes.
-        let mut account_changeset_cursor = self.cursor_read::<tables::AccountChangeSets>()?;
-        let mut account_hashed_state_cursor = self.cursor_read::<tables::HashedAccounts>()?;
-        for account_entry in account_changeset_cursor.walk_range(range.clone())? {
-            let (_, AccountBeforeTx { address, .. }) = account_entry?;
-            let hashed_address = KH::hash_key(address);
-            account_prefix_set.insert(Nibbles::unpack(hashed_address));
-
-            if account_hashed_state_cursor.seek_exact(hashed_address)?.is_none() {
-                destroyed_accounts.insert(hashed_address);
-            }
-        }
-
-        // Walk storage changeset and insert storage prefixes as well as account prefixes if missing
-        // from the account prefix set.
-        let mut storage_cursor = self.cursor_dup_read::<tables::StorageChangeSets>()?;
-        let storage_range = BlockNumberAddress::range(range);
-        for storage_entry in storage_cursor.walk_range(storage_range)? {
-            let (BlockNumberAddress((_, address)), StorageEntry { key, .. }) = storage_entry?;
-            let hashed_address = KH::hash_key(address);
-            account_prefix_set.insert(Nibbles::unpack(hashed_address));
-            storage_prefix_sets
-                .entry(hashed_address)
-                .or_default()
-                .insert(Nibbles::unpack(KH::hash_key(key)));
-        }
-
-        Ok(TriePrefixSets {
-            account_prefix_set: account_prefix_set.freeze(),
-            storage_prefix_sets: storage_prefix_sets
-                .into_iter()
-                .map(|(k, v)| (k, v.freeze()))
-                .collect(),
-            destroyed_accounts,
-        })
-    }
-}
 
 /// Load prefix sets using a provider that implements [`ChangeSetReader`]. This function can read
 /// changesets from both static files and database.
@@ -109,8 +35,8 @@ where
     // We still need direct access to HashedAccounts table
     let mut account_hashed_state_cursor = tx.cursor_read::<tables::HashedAccounts>()?;
 
-    for (_, AccountBeforeTx { address, .. }) in account_changesets {
-        let hashed_address = KH::hash_key(address);
+    for (_, account_before_tx) in account_changesets {
+        let hashed_address = KH::hash_key(account_before_tx.address);
         account_prefix_set.insert(Nibbles::unpack(hashed_address));
 
         if account_hashed_state_cursor.seek_exact(hashed_address)?.is_none() {

--- a/crates/trie/db/src/prefix_set.rs
+++ b/crates/trie/db/src/prefix_set.rs
@@ -3,7 +3,12 @@ use alloy_primitives::{
     BlockNumber, B256,
 };
 use core::ops::RangeInclusive;
-use reth_db_api::{cursor::DbCursorRO, models::BlockNumberAddress, tables, transaction::DbTx};
+use reth_db_api::{
+    cursor::DbCursorRO,
+    models::{AccountBeforeTx, BlockNumberAddress},
+    tables,
+    transaction::DbTx,
+};
 use reth_primitives_traits::StorageEntry;
 use reth_storage_api::{ChangeSetReader, DBProvider, StorageChangeSetReader};
 use reth_storage_errors::provider::ProviderError;

--- a/crates/trie/db/src/prefix_set.rs
+++ b/crates/trie/db/src/prefix_set.rs
@@ -35,8 +35,8 @@ where
     // We still need direct access to HashedAccounts table
     let mut account_hashed_state_cursor = tx.cursor_read::<tables::HashedAccounts>()?;
 
-    for (_, account_before_tx) in account_changesets {
-        let hashed_address = KH::hash_key(account_before_tx.address);
+    for (_, AccountBeforeTx { address, .. }) in account_changesets {
+        let hashed_address = KH::hash_key(address);
         account_prefix_set.insert(Nibbles::unpack(hashed_address));
 
         if account_hashed_state_cursor.seek_exact(hashed_address)?.is_none() {

--- a/crates/trie/db/src/storage.rs
+++ b/crates/trie/db/src/storage.rs
@@ -1,6 +1,6 @@
 use crate::{DatabaseHashedCursorFactory, DatabaseTrieCursorFactory};
 use alloy_primitives::{keccak256, map::hash_map, Address, BlockNumber, B256};
-use reth_db_api::transaction::DbTx;
+use reth_db_api::{models::BlockNumberAddress, transaction::DbTx};
 use reth_execution_errors::StorageRootError;
 use reth_storage_api::{BlockNumReader, StorageChangeSetReader};
 use reth_storage_errors::provider::ProviderResult;

--- a/crates/trie/db/src/storage.rs
+++ b/crates/trie/db/src/storage.rs
@@ -43,8 +43,10 @@ where
         return Ok(storage)
     }
 
-    for (block_num_addr, storage_change) in provider.storage_changesets_range(from..=tip)? {
-        if block_num_addr.address() == address {
+    for (BlockNumberAddress((_, storage_address)), storage_change) in
+        provider.storage_changesets_range(from..=tip)?
+    {
+        if storage_address == address {
             let hashed_slot = keccak256(storage_change.key);
             if let hash_map::Entry::Vacant(entry) = storage.storage.entry(hashed_slot) {
                 entry.insert(storage_change.value);


### PR DESCRIPTION
## Summary

Remove dead code that reads changesets directly from MDBX tables:

- `PrefixSetLoader` struct (unused, `load_prefix_sets_with_provider` is used instead)
- `DatabaseHashedStorage` trait (unused, `hashed_storage_from_reverts_with_provider` is used instead)

These were superseded by storage-aware functions that respect `StorageSettings` and can read from either MDBX or static files.

## Changes

- Removed `PrefixSetLoader` struct and its impl from `crates/trie/db/src/prefix_set.rs`
- Removed `DatabaseHashedStorage` trait and its impl for `HashedStorage` from `crates/trie/db/src/storage.rs`
- Updated `crates/trie/db/src/lib.rs` to remove exports of the deleted items
- Added documentation to test code that reads directly from MDBX tables, clarifying that this is acceptable for tests that control the storage location