### PR TITLE
fix(grafana): order MerkleChangeSets checkpoint after MerkleExecute

### DIFF
--- a/etc/grafana/dashboards/overview.json
+++ b/etc/grafana/dashboards/overview.json
@@ -714,18 +714,19 @@
               "AccountHashing": 6,
               "Bodies": 1,
               "Execution": 3,
-              "Finish": 13,
+              "Finish": 14,
               "Headers": 0,
-              "IndexAccountHistory": 11,
-              "IndexStorageHistory": 10,
+              "IndexAccountHistory": 12,
+              "IndexStorageHistory": 11,
+              "MerkleChangeSets": 9,
               "MerkleExecute": 8,
               "MerkleUnwind": 5,
-              "Prune": 12,
+              "Prune": 13,
               "PruneSenderRecovery": 4,
               "SenderRecovery": 2,
               "StorageHashing": 7,
-              "Time": 14,
-              "TransactionLookup": 9
+              "Time": 15,
+              "TransactionLookup": 10
             },
             "renameByName": {}
           }


### PR DESCRIPTION
## Summary
MerkleChangeSets stage checkpoint was showing at the end of the grafana dashboard instead of being right after MerkleExecute.

## Changes
- Added explicit `MerkleChangeSets` index (9) in the stage ordering to position it after `MerkleExecute` (8)
- Shifted subsequent stage indices accordingly

## Context
MerkleChangeSets is deprecated but databases may still have the checkpoint from before the stage was removed. Without an explicit index, it defaults to appearing at the end of the chart.