### PR TITLE
refactor(bench): share CSV row types between reth-bench and reth-bench-compare

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7713,6 +7713,7 @@ dependencies = [
  "ctrlc",
  "eyre",
  "nix 0.29.0",
+ "reth-bench",
  "reth-chainspec",
  "reth-cli-runner",
  "reth-cli-util",

--- a/bin/reth-bench-compare/Cargo.toml
+++ b/bin/reth-bench-compare/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # reth
+reth-bench = { path = "../reth-bench", default-features = false }
 reth-cli-runner.workspace = true
 reth-cli-util.workspace = true
 reth-node-core.workspace = true
@@ -62,40 +63,55 @@ nix = { version = "0.29", features = ["signal", "process"] }
 default = ["jemalloc"]
 
 asm-keccak = [
-    "reth-node-core/asm-keccak",
-    "alloy-primitives/asm-keccak",
+	"reth-node-core/asm-keccak",
+	"alloy-primitives/asm-keccak",
+	"reth-bench/asm-keccak"
 ]
 
 jemalloc = [
-    "reth-cli-util/jemalloc",
-    "reth-node-core/jemalloc",
+	"reth-cli-util/jemalloc",
+	"reth-node-core/jemalloc",
+	"reth-bench/jemalloc"
 ]
-jemalloc-prof = ["reth-cli-util/jemalloc-prof"]
-tracy-allocator = ["reth-cli-util/tracy-allocator", "tracy"]
+jemalloc-prof = [
+	"reth-cli-util/jemalloc-prof",
+	"reth-bench/jemalloc-prof"
+]
+tracy-allocator = [
+	"reth-cli-util/tracy-allocator",
+	"tracy",
+	"reth-bench/tracy-allocator"
+]
 tracy = [
-    "reth-node-core/tracy",
-    "reth-tracing/tracy",
+	"reth-node-core/tracy",
+	"reth-tracing/tracy",
+	"reth-bench/tracy"
 ]
 
 min-error-logs = [
-    "tracing/release_max_level_error",
-    "reth-node-core/min-error-logs",
+	"tracing/release_max_level_error",
+	"reth-node-core/min-error-logs",
+	"reth-bench/min-error-logs"
 ]
 min-warn-logs = [
-    "tracing/release_max_level_warn",
-    "reth-node-core/min-warn-logs",
+	"tracing/release_max_level_warn",
+	"reth-node-core/min-warn-logs",
+	"reth-bench/min-warn-logs"
 ]
 min-info-logs = [
-    "tracing/release_max_level_info",
-    "reth-node-core/min-info-logs",
+	"tracing/release_max_level_info",
+	"reth-node-core/min-info-logs",
+	"reth-bench/min-info-logs"
 ]
 min-debug-logs = [
-    "tracing/release_max_level_debug",
-    "reth-node-core/min-debug-logs",
+	"tracing/release_max_level_debug",
+	"reth-node-core/min-debug-logs",
+	"reth-bench/min-debug-logs"
 ]
 min-trace-logs = [
-    "tracing/release_max_level_trace",
-    "reth-node-core/min-trace-logs",
+	"tracing/release_max_level_trace",
+	"reth-node-core/min-trace-logs",
+	"reth-bench/min-trace-logs"
 ]
 
 # no-op feature flag for switching between the `optimism` and default functionality in CI matrices

--- a/bin/reth-bench-compare/Cargo.toml
+++ b/bin/reth-bench-compare/Cargo.toml
@@ -63,55 +63,55 @@ nix = { version = "0.29", features = ["signal", "process"] }
 default = ["jemalloc"]
 
 asm-keccak = [
-	"reth-node-core/asm-keccak",
-	"alloy-primitives/asm-keccak",
-	"reth-bench/asm-keccak"
+    "reth-node-core/asm-keccak",
+    "alloy-primitives/asm-keccak",
+    "reth-bench/asm-keccak",
 ]
 
 jemalloc = [
-	"reth-cli-util/jemalloc",
-	"reth-node-core/jemalloc",
-	"reth-bench/jemalloc"
+    "reth-cli-util/jemalloc",
+    "reth-node-core/jemalloc",
+    "reth-bench/jemalloc",
 ]
 jemalloc-prof = [
-	"reth-cli-util/jemalloc-prof",
-	"reth-bench/jemalloc-prof"
+    "reth-cli-util/jemalloc-prof",
+    "reth-bench/jemalloc-prof",
 ]
 tracy-allocator = [
-	"reth-cli-util/tracy-allocator",
-	"tracy",
-	"reth-bench/tracy-allocator"
+    "reth-cli-util/tracy-allocator",
+    "tracy",
+    "reth-bench/tracy-allocator",
 ]
 tracy = [
-	"reth-node-core/tracy",
-	"reth-tracing/tracy",
-	"reth-bench/tracy"
+    "reth-node-core/tracy",
+    "reth-tracing/tracy",
+    "reth-bench/tracy",
 ]
 
 min-error-logs = [
-	"tracing/release_max_level_error",
-	"reth-node-core/min-error-logs",
-	"reth-bench/min-error-logs"
+    "tracing/release_max_level_error",
+    "reth-node-core/min-error-logs",
+    "reth-bench/min-error-logs",
 ]
 min-warn-logs = [
-	"tracing/release_max_level_warn",
-	"reth-node-core/min-warn-logs",
-	"reth-bench/min-warn-logs"
+    "tracing/release_max_level_warn",
+    "reth-node-core/min-warn-logs",
+    "reth-bench/min-warn-logs",
 ]
 min-info-logs = [
-	"tracing/release_max_level_info",
-	"reth-node-core/min-info-logs",
-	"reth-bench/min-info-logs"
+    "tracing/release_max_level_info",
+    "reth-node-core/min-info-logs",
+    "reth-bench/min-info-logs",
 ]
 min-debug-logs = [
-	"tracing/release_max_level_debug",
-	"reth-node-core/min-debug-logs",
-	"reth-bench/min-debug-logs"
+    "tracing/release_max_level_debug",
+    "reth-node-core/min-debug-logs",
+    "reth-bench/min-debug-logs",
 ]
 min-trace-logs = [
-	"tracing/release_max_level_trace",
-	"reth-node-core/min-trace-logs",
-	"reth-bench/min-trace-logs"
+    "tracing/release_max_level_trace",
+    "reth-node-core/min-trace-logs",
+    "reth-bench/min-trace-logs",
 ]
 
 # no-op feature flag for switching between the `optimism` and default functionality in CI matrices

--- a/bin/reth-bench/Cargo.toml
+++ b/bin/reth-bench/Cargo.toml
@@ -9,6 +9,10 @@ repository.workspace = true
 description = "Benchmarking for ethereum nodes"
 default-run = "reth-bench"
 
+[lib]
+name = "reth_bench"
+path = "src/lib.rs"
+
 [lints]
 workspace = true
 

--- a/bin/reth-bench/src/authenticated_transport.rs
+++ b/bin/reth-bench/src/authenticated_transport.rs
@@ -22,7 +22,7 @@ use tower::Service;
 /// An enum representing the different transports that can be used to connect to a runtime.
 /// Only meant to be used internally by [`AuthenticatedTransport`].
 #[derive(Clone, Debug)]
-pub enum InnerTransport {
+pub(crate) enum InnerTransport {
     /// HTTP transport
     Http(ReqwestTransport),
     /// `WebSocket` transport
@@ -196,7 +196,7 @@ fn build_auth(secret: JwtSecret) -> eyre::Result<(Authorization, Claims)> {
 
 /// This specifies how to connect to an authenticated transport.
 #[derive(Clone, Debug)]
-pub struct AuthenticatedTransportConnect {
+pub(crate) struct AuthenticatedTransportConnect {
     /// The URL to connect to.
     url: Url,
     /// The JWT secret is used to authenticate the transport.
@@ -205,7 +205,7 @@ pub struct AuthenticatedTransportConnect {
 
 impl AuthenticatedTransportConnect {
     /// Create a new builder with the given URL.
-    pub const fn new(url: Url, jwt: JwtSecret) -> Self {
+    pub(crate) const fn new(url: Url, jwt: JwtSecret) -> Self {
         Self { url, jwt }
     }
 }

--- a/bin/reth-bench/src/bench/mod.rs
+++ b/bin/reth-bench/src/bench/mod.rs
@@ -14,7 +14,7 @@ pub use generate_big_block::{
 };
 mod new_payload_fcu;
 mod new_payload_only;
-mod output;
+pub mod output;
 mod persistence_waiter;
 mod replay_payloads;
 mod send_invalid_payload;

--- a/bin/reth-bench/src/bench/output.rs
+++ b/bin/reth-bench/src/bench/output.rs
@@ -10,13 +10,13 @@ use std::{fs, path::Path, time::Duration};
 use tracing::info;
 
 /// This is the suffix for gas output csv files.
-pub(crate) const GAS_OUTPUT_SUFFIX: &str = "total_gas.csv";
+pub const GAS_OUTPUT_SUFFIX: &str = "total_gas.csv";
 
 /// This is the suffix for combined output csv files.
-pub(crate) const COMBINED_OUTPUT_SUFFIX: &str = "combined_latency.csv";
+pub const COMBINED_OUTPUT_SUFFIX: &str = "combined_latency.csv";
 
 /// This is the suffix for new payload output csv files.
-pub(crate) const NEW_PAYLOAD_OUTPUT_SUFFIX: &str = "new_payload_latency.csv";
+pub const NEW_PAYLOAD_OUTPUT_SUFFIX: &str = "new_payload_latency.csv";
 
 /// Serialized format for gas ramp payloads on disk.
 #[derive(Debug, Serialize, Deserialize)]
@@ -151,6 +151,49 @@ pub(crate) struct TotalGasRow {
     pub(crate) gas_used: u64,
     /// Time since the start of the benchmark.
     pub(crate) time: Duration,
+}
+
+/// CSV row structure for total gas data.
+///
+/// This is the flattened representation used for CSV serialization/deserialization,
+/// with time stored as microseconds for CSV compatibility.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct TotalGasCsvRow {
+    /// The block number of the block being processed.
+    pub block_number: u64,
+    /// The number of transactions in the block.
+    #[serde(default)]
+    pub transaction_count: Option<u64>,
+    /// The total gas used in the block.
+    pub gas_used: u64,
+    /// Time since the start of the benchmark, in microseconds.
+    pub time: u128,
+}
+
+/// CSV row structure for combined latency data.
+///
+/// This is the flattened representation used for CSV serialization/deserialization,
+/// with latencies stored as microseconds for CSV compatibility.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CombinedLatencyCsvRow {
+    /// The block number of the block being processed.
+    pub block_number: u64,
+    /// The gas limit of the block.
+    #[serde(default)]
+    pub gas_limit: Option<u64>,
+    /// The number of transactions in the block.
+    #[serde(default)]
+    pub transaction_count: Option<u64>,
+    /// The gas used in the `newPayload` call.
+    pub gas_used: u64,
+    /// The latency of the `newPayload` call, in microseconds.
+    pub new_payload_latency: u128,
+    /// The latency of the `forkchoiceUpdated` call, in microseconds.
+    #[serde(default)]
+    pub fcu_latency: Option<u128>,
+    /// The total latency of both calls combined, in microseconds.
+    #[serde(default)]
+    pub total_latency: Option<u128>,
 }
 
 /// This represents the aggregated output, meant to show gas per second metrics, of a benchmark run.

--- a/bin/reth-bench/src/bench_mode.rs
+++ b/bin/reth-bench/src/bench_mode.rs
@@ -4,7 +4,7 @@ use std::ops::RangeInclusive;
 
 /// Whether or not the benchmark should run as a continuous stream of payloads.
 #[derive(Debug, PartialEq, Eq)]
-pub enum BenchMode {
+pub(crate) enum BenchMode {
     /// Run the benchmark as a continuous stream of payloads, until the benchmark is interrupted.
     Continuous(u64),
     /// Run the benchmark for a specific range of blocks.
@@ -13,7 +13,7 @@ pub enum BenchMode {
 
 impl BenchMode {
     /// Check if the block number is in the range
-    pub fn contains(&self, block_number: u64) -> bool {
+    pub(crate) fn contains(&self, block_number: u64) -> bool {
         match self {
             Self::Continuous(start) => block_number >= *start,
             Self::Range(range) => range.contains(&block_number),
@@ -21,7 +21,7 @@ impl BenchMode {
     }
 
     /// Create a [`BenchMode`] from optional `from` and `to` fields.
-    pub fn new(from: Option<u64>, to: Option<u64>, latest_block: u64) -> Result<Self, eyre::Error> {
+    pub(crate) fn new(from: Option<u64>, to: Option<u64>, latest_block: u64) -> Result<Self, eyre::Error> {
         // If neither `--from` nor `--to` are provided, we will run the benchmark continuously,
         // starting at the latest block.
         match (from, to) {

--- a/bin/reth-bench/src/bench_mode.rs
+++ b/bin/reth-bench/src/bench_mode.rs
@@ -21,7 +21,11 @@ impl BenchMode {
     }
 
     /// Create a [`BenchMode`] from optional `from` and `to` fields.
-    pub(crate) fn new(from: Option<u64>, to: Option<u64>, latest_block: u64) -> Result<Self, eyre::Error> {
+    pub(crate) fn new(
+        from: Option<u64>,
+        to: Option<u64>,
+        latest_block: u64,
+    ) -> Result<Self, eyre::Error> {
         // If neither `--from` nor `--to` are provided, we will run the benchmark continuously,
         // starting at the latest block.
         match (from, to) {

--- a/bin/reth-bench/src/lib.rs
+++ b/bin/reth-bench/src/lib.rs
@@ -8,9 +8,13 @@
     issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
-mod authenticated_transport;
+// Used by main.rs only
+use color_eyre as _;
+use reth_cli_util as _;
+
+pub(crate) mod authenticated_transport;
 pub mod bench;
-mod bench_mode;
+pub(crate) mod bench_mode;
 pub mod valid_payload;

--- a/bin/reth-bench/src/lib.rs
+++ b/bin/reth-bench/src/lib.rs
@@ -1,0 +1,16 @@
+//! reth-bench library
+//!
+//! Provides benchmarking utilities for Ethereum execution clients.
+
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
+    html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",
+    issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
+)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+
+mod authenticated_transport;
+pub mod bench;
+mod bench_mode;
+pub mod valid_payload;

--- a/bin/reth-bench/src/main.rs
+++ b/bin/reth-bench/src/main.rs
@@ -3,24 +3,11 @@
 //! This is a tool that converts existing blocks into a stream of blocks for benchmarking purposes.
 //! These blocks are then fed into reth as a stream of execution payloads.
 
-#![doc(
-    html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
-    html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",
-    issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
-)]
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
-#![cfg_attr(docsrs, feature(doc_cfg))]
-
 #[global_allocator]
 static ALLOC: reth_cli_util::allocator::Allocator = reth_cli_util::allocator::new_allocator();
 
-pub mod authenticated_transport;
-pub mod bench;
-pub mod bench_mode;
-pub mod valid_payload;
-
-use bench::BenchmarkCommand;
 use clap::Parser;
+use reth_bench::bench::BenchmarkCommand;
 use reth_cli_runner::CliRunner;
 
 fn main() -> eyre::Result<()> {


### PR DESCRIPTION
Extract `TotalGasCsvRow` and `CombinedLatencyCsvRow` into reth-bench as shared types, removing duplicate struct definitions from reth-bench-compare. This ensures type safety between CSV writer and reader.