### PR TITLE
feat(metrics): add commit_space_dirty_bytes metric for MDBX

### DIFF
--- a/crates/storage/db/src/metrics.rs
+++ b/crates/storage/db/src/metrics.rs
@@ -302,6 +302,8 @@ pub(crate) struct TransactionOutcomeMetrics {
     commit_whole_duration_seconds: Histogram,
     /// User-mode CPU time spent on GC update during transaction commit
     commit_gc_cputime_duration_seconds: Histogram,
+    /// Size in bytes of dirty pages written during transaction commit
+    commit_space_dirty_bytes: Histogram,
 }
 
 impl TransactionOutcomeMetrics {
@@ -329,6 +331,7 @@ impl TransactionOutcomeMetrics {
             self.commit_ending_duration_seconds.record(commit_latency.ending());
             self.commit_whole_duration_seconds.record(commit_latency.whole());
             self.commit_gc_cputime_duration_seconds.record(commit_latency.gc_cputime());
+            self.commit_space_dirty_bytes.record(commit_latency.space_dirty() as f64);
         }
     }
 }

--- a/crates/storage/libmdbx-rs/src/lib.rs
+++ b/crates/storage/libmdbx-rs/src/lib.rs
@@ -21,7 +21,7 @@ pub use crate::{
     },
     error::{Error, Result},
     flags::*,
-    transaction::{CommitLatency, Transaction, TransactionKind, RO, RW},
+    transaction::{CommitLatency, Transaction, TransactionKind, TxnInfo, RO, RW},
 };
 
 #[cfg(feature = "read-tx-timeouts")]

--- a/crates/storage/libmdbx-rs/src/txn_manager.rs
+++ b/crates/storage/libmdbx-rs/src/txn_manager.rs
@@ -1,7 +1,7 @@
 use crate::{
     environment::EnvPtr,
     error::{mdbx_result, Result},
-    CommitLatency,
+    CommitLatency, TxnInfo,
 };
 use std::{
     ptr,
@@ -84,11 +84,26 @@ impl TxnManager {
                                 tracing::debug_span!(target: "libmdbx::txn", "commit").entered();
                             sender
                                 .send({
+                                    // Capture dirty page size before commit
+                                    let mut txn_info = TxnInfo::new();
+                                    let space_dirty = if mdbx_result(unsafe {
+                                        ffi::mdbx_txn_info(tx.0, txn_info.mdb_txn_info(), false)
+                                    })
+                                    .is_ok()
+                                    {
+                                        txn_info.space_dirty()
+                                    } else {
+                                        0
+                                    };
+
                                     let mut latency = CommitLatency::new();
                                     mdbx_result(unsafe {
                                         ffi::mdbx_txn_commit_ex(tx.0, latency.mdb_commit_latency())
                                     })
-                                    .map(|v| (v, latency))
+                                    .map(|v| {
+                                        latency.set_space_dirty(space_dirty);
+                                        (v, latency)
+                                    })
                                 })
                                 .unwrap();
                         }


### PR DESCRIPTION
## Summary

Adds a new histogram metric `reth_database_transaction_commit_space_dirty_bytes` to track bytes written per MDBX commit, enabling p50/p99 monitoring for capacity planning.

## Motivation

There was no way to monitor how many bytes are written on each MDBX commit. This metric enables:
- Performance analysis of write amplification
- Capacity planning based on actual data written
- Debugging high-write scenarios

## Changes

- Extended `CommitLatency` to capture `txn_space_dirty` from `mdbx_txn_info`
- Added `TxnInfo` struct to wrap `MDBX_txn_info` for querying transaction state
- Call `mdbx_txn_info` before commit to capture dirty page size (best-effort, doesn't fail commit if info unavailable)
- Added `commit_space_dirty_bytes` histogram to `TransactionOutcomeMetrics`

## Implementation Notes

- `mdbx_txn_info()` is called before `mdbx_txn_commit_ex()` since the txn handle is invalid after commit
- The space_dirty value is only recorded on successful commits
- If `mdbx_txn_info()` fails, we continue with commit (best-effort metrics)

## Testing

```bash
cargo test -p reth-libmdbx --all-features
cargo test -p reth-db
```