### PR TITLE
feat(metrics): add bytes_written metric for static file commits

### DIFF
--- a/crates/storage/provider/src/providers/rocksdb/metrics.rs
+++ b/crates/storage/provider/src/providers/rocksdb/metrics.rs
@@ -62,6 +62,16 @@ impl RocksDBMetrics {
         metrics.calls_total.increment(1);
         metrics.duration_seconds.record(duration.as_secs_f64());
     }
+
+    /// Records bytes written for a batch commit operation.
+    pub(crate) fn record_commit_bytes_written(&self, bytes_written: usize) {
+        let metrics = self
+            .operations
+            .get(&("Batch", RocksDBOperation::BatchWrite))
+            .expect("batch operation metrics should exist");
+
+        metrics.commit_bytes_written.record(bytes_written as f64);
+    }
 }
 
 /// `RocksDB` operations that are tracked
@@ -92,4 +102,6 @@ pub(crate) struct RocksDBOperationMetrics {
     calls_total: Counter,
     /// Duration of operations
     duration_seconds: Histogram,
+    /// Bytes written per commit (only recorded for `BatchWrite` operations)
+    commit_bytes_written: Histogram,
 }

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -1131,12 +1131,19 @@ impl RocksDBProvider {
     /// Panics if the provider is in read-only mode.
     #[instrument(level = "debug", target = "providers::rocksdb", skip_all, fields(batch_len = batch.len(), batch_size = batch.size_in_bytes()))]
     pub fn commit_batch(&self, batch: WriteBatchWithTransaction<true>) -> ProviderResult<()> {
+        let bytes_written = batch.size_in_bytes();
         self.0.db_rw().write_opt(batch, &WriteOptions::default()).map_err(|e| {
             ProviderError::Database(DatabaseError::Commit(DatabaseErrorInfo {
                 message: e.to_string().into(),
                 code: -1,
             }))
-        })
+        })?;
+
+        if let Some(metrics) = self.0.metrics() {
+            metrics.record_commit_bytes_written(bytes_written);
+        }
+
+        Ok(())
     }
 
     /// Writes all `RocksDB` data for multiple blocks in parallel.
@@ -1350,9 +1357,10 @@ impl<'a> RocksDBBatch<'a> {
         if let Some(threshold) = self.auto_commit_threshold &&
             self.inner.size_in_bytes() >= threshold
         {
+            let bytes_written = self.inner.size_in_bytes();
             tracing::debug!(
                 target: "providers::rocksdb",
-                batch_size = self.inner.size_in_bytes(),
+                batch_size = bytes_written,
                 threshold,
                 "Auto-committing RocksDB batch"
             );
@@ -1365,6 +1373,10 @@ impl<'a> RocksDBBatch<'a> {
                     }))
                 },
             )?;
+
+            if let Some(metrics) = self.provider.0.metrics() {
+                metrics.record_commit_bytes_written(bytes_written);
+            }
         }
         Ok(())
     }
@@ -1377,12 +1389,19 @@ impl<'a> RocksDBBatch<'a> {
     /// Panics if the provider is in read-only mode.
     #[instrument(level = "debug", target = "providers::rocksdb", skip_all, fields(batch_len = self.inner.len(), batch_size = self.inner.size_in_bytes()))]
     pub fn commit(self) -> ProviderResult<()> {
+        let bytes_written = self.inner.size_in_bytes();
         self.provider.0.db_rw().write_opt(self.inner, &WriteOptions::default()).map_err(|e| {
             ProviderError::Database(DatabaseError::Commit(DatabaseErrorInfo {
                 message: e.to_string().into(),
                 code: -1,
             }))
-        })
+        })?;
+
+        if let Some(metrics) = self.provider.0.metrics() {
+            metrics.record_commit_bytes_written(bytes_written);
+        }
+
+        Ok(())
     }
 
     /// Returns the number of write operations (puts + deletes) queued in this batch.

--- a/crates/storage/provider/src/providers/static_file/metrics.rs
+++ b/crates/storage/provider/src/providers/static_file/metrics.rs
@@ -104,6 +104,18 @@ impl StaticFileProviderMetrics {
                 .record(duration.as_secs_f64() / count as f64);
         }
     }
+
+    pub(crate) fn record_commit_bytes_written(
+        &self,
+        segment: StaticFileSegment,
+        bytes_written: u64,
+    ) {
+        self.segment_operations
+            .get(&(segment, StaticFileProviderOperation::CommitWriter))
+            .expect("segment operation metrics should exist")
+            .commit_bytes_written
+            .record(bytes_written as f64);
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EnumIter)]
@@ -148,4 +160,6 @@ pub(crate) struct StaticFileProviderOperationMetrics {
     calls_total: Counter,
     /// The time it took to execute the static file jar provider operation that writes data.
     write_duration_seconds: Histogram,
+    /// The number of bytes written during a commit operation.
+    commit_bytes_written: Histogram,
 }


### PR DESCRIPTION
## Summary
Adds a `commit_bytes_written` histogram metric for static file commits, mirroring the existing `commit_space_dirty_bytes` metric for MDBX commits.

## Changes
- Added `bytes_written` field to `NippyJarWriter` to track bytes written during the session
- Added `take_bytes_written()` method to get and reset the counter
- Added `commit_bytes_written` histogram to `StaticFileProviderOperationMetrics`
- Record bytes written during `CommitWriter` operations in both `commit()` and `commit_without_sync_all()`

## Testing
```
cargo check -p reth-nippy-jar -p reth-provider
```