### PR TITLE
feat(static-file): incremental changeset offset storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10896,6 +10896,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum 0.27.2",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/static-file/types/Cargo.toml
+++ b/crates/static-file/types/Cargo.toml
@@ -24,6 +24,7 @@ strum = { workspace = true, features = ["derive"] }
 reth-nippy-jar.workspace = true
 serde_json.workspace = true
 insta.workspace = true
+tempfile.workspace = true
 
 [features]
 default = ["std"]

--- a/crates/static-file/types/src/changeset_offsets.rs
+++ b/crates/static-file/types/src/changeset_offsets.rs
@@ -1,0 +1,215 @@
+//! Changeset offset sidecar file I/O.
+//!
+//! Provides append-only writing and O(1) random-access reading for changeset offsets.
+//! The file format is fixed-width 16-byte records: `[offset: u64 LE][num_changes: u64 LE]`.
+
+use crate::ChangesetOffset;
+use std::{
+    fs::{File, OpenOptions},
+    io::{self, Read, Seek, SeekFrom, Write},
+    path::Path,
+};
+
+/// Writer for appending changeset offsets to a sidecar file.
+#[derive(Debug)]
+pub struct ChangesetOffsetWriter {
+    file: File,
+    /// Number of records written (tracked separately for sync)
+    records_written: u64,
+}
+
+impl ChangesetOffsetWriter {
+    /// Record size in bytes (u64 offset + u64 num_changes).
+    const RECORD_SIZE: usize = 16;
+
+    /// Opens or creates the changeset offset file for appending.
+    pub fn new(path: impl AsRef<Path>) -> io::Result<Self> {
+        let file = OpenOptions::new().create(true).read(true).append(true).open(path)?;
+
+        let records_written = file.metadata()?.len() / Self::RECORD_SIZE as u64;
+
+        Ok(Self { file, records_written })
+    }
+
+    /// Appends a single changeset offset record.
+    pub fn append(&mut self, offset: &ChangesetOffset) -> io::Result<()> {
+        let mut buf = [0u8; Self::RECORD_SIZE];
+        buf[..8].copy_from_slice(&offset.offset().to_le_bytes());
+        buf[8..].copy_from_slice(&offset.num_changes().to_le_bytes());
+        self.file.write_all(&buf)?;
+        self.records_written += 1;
+        Ok(())
+    }
+
+    /// Appends multiple changeset offset records.
+    pub fn append_many(&mut self, offsets: &[ChangesetOffset]) -> io::Result<()> {
+        for offset in offsets {
+            self.append(offset)?;
+        }
+        Ok(())
+    }
+
+    /// Syncs all data to disk. Must be called before committing the header.
+    pub fn sync(&mut self) -> io::Result<()> {
+        self.file.sync_all()
+    }
+
+    /// Truncates the file to contain exactly `len` records.
+    /// Used after prune operations to reclaim space.
+    pub fn truncate(&mut self, len: u64) -> io::Result<()> {
+        self.file.set_len(len * Self::RECORD_SIZE as u64)?;
+        self.records_written = len;
+        Ok(())
+    }
+
+    /// Returns the number of records in the file.
+    pub fn len(&self) -> u64 {
+        self.records_written
+    }
+
+    /// Returns true if the file is empty.
+    pub fn is_empty(&self) -> bool {
+        self.records_written == 0
+    }
+}
+
+/// Reader for changeset offsets with O(1) random access.
+#[derive(Debug)]
+pub struct ChangesetOffsetReader {
+    file: File,
+    /// Cached file length in records
+    len: u64,
+}
+
+impl ChangesetOffsetReader {
+    /// Record size in bytes.
+    const RECORD_SIZE: usize = 16;
+
+    /// Opens the changeset offset file for reading.
+    pub fn new(path: impl AsRef<Path>) -> io::Result<Self> {
+        let file = File::open(path)?;
+        let len = file.metadata()?.len() / Self::RECORD_SIZE as u64;
+        Ok(Self { file, len })
+    }
+
+    /// Opens with an explicit length (from header metadata).
+    /// Any records beyond `len` are ignored.
+    pub fn with_len(path: impl AsRef<Path>, len: u64) -> io::Result<Self> {
+        let file = File::open(path)?;
+        Ok(Self { file, len })
+    }
+
+    /// Reads a single changeset offset by block index.
+    /// Returns None if index is out of bounds.
+    pub fn get(&mut self, block_index: u64) -> io::Result<Option<ChangesetOffset>> {
+        if block_index >= self.len {
+            return Ok(None);
+        }
+
+        let byte_pos = block_index * Self::RECORD_SIZE as u64;
+        self.file.seek(SeekFrom::Start(byte_pos))?;
+
+        let mut buf = [0u8; Self::RECORD_SIZE];
+        self.file.read_exact(&mut buf)?;
+
+        let offset = u64::from_le_bytes(buf[..8].try_into().unwrap());
+        let num_changes = u64::from_le_bytes(buf[8..].try_into().unwrap());
+
+        Ok(Some(ChangesetOffset::new(offset, num_changes)))
+    }
+
+    /// Reads a range of changeset offsets.
+    pub fn get_range(&mut self, start: u64, end: u64) -> io::Result<Vec<ChangesetOffset>> {
+        let end = end.min(self.len);
+        if start >= end {
+            return Ok(Vec::new());
+        }
+
+        let count = (end - start) as usize;
+        let byte_pos = start * Self::RECORD_SIZE as u64;
+        self.file.seek(SeekFrom::Start(byte_pos))?;
+
+        let mut result = Vec::with_capacity(count);
+        let mut buf = [0u8; Self::RECORD_SIZE];
+
+        for _ in 0..count {
+            self.file.read_exact(&mut buf)?;
+            let offset = u64::from_le_bytes(buf[..8].try_into().unwrap());
+            let num_changes = u64::from_le_bytes(buf[8..].try_into().unwrap());
+            result.push(ChangesetOffset::new(offset, num_changes));
+        }
+
+        Ok(result)
+    }
+
+    /// Returns the number of valid records.
+    pub fn len(&self) -> u64 {
+        self.len
+    }
+
+    /// Returns true if there are no records.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_write_and_read() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.csoff");
+
+        // Write
+        {
+            let mut writer = ChangesetOffsetWriter::new(&path).unwrap();
+            writer.append(&ChangesetOffset::new(0, 5)).unwrap();
+            writer.append(&ChangesetOffset::new(5, 3)).unwrap();
+            writer.append(&ChangesetOffset::new(8, 10)).unwrap();
+            writer.sync().unwrap();
+            assert_eq!(writer.len(), 3);
+        }
+
+        // Read
+        {
+            let mut reader = ChangesetOffsetReader::new(&path).unwrap();
+            assert_eq!(reader.len(), 3);
+
+            let entry = reader.get(0).unwrap().unwrap();
+            assert_eq!(entry.offset(), 0);
+            assert_eq!(entry.num_changes(), 5);
+
+            let entry = reader.get(1).unwrap().unwrap();
+            assert_eq!(entry.offset(), 5);
+            assert_eq!(entry.num_changes(), 3);
+
+            let entry = reader.get(2).unwrap().unwrap();
+            assert_eq!(entry.offset(), 8);
+            assert_eq!(entry.num_changes(), 10);
+
+            assert!(reader.get(3).unwrap().is_none());
+        }
+    }
+
+    #[test]
+    fn test_truncate() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.csoff");
+
+        let mut writer = ChangesetOffsetWriter::new(&path).unwrap();
+        writer.append(&ChangesetOffset::new(0, 1)).unwrap();
+        writer.append(&ChangesetOffset::new(1, 2)).unwrap();
+        writer.append(&ChangesetOffset::new(3, 3)).unwrap();
+        writer.sync().unwrap();
+
+        writer.truncate(2).unwrap();
+        assert_eq!(writer.len(), 2);
+
+        let mut reader = ChangesetOffsetReader::new(&path).unwrap();
+        assert_eq!(reader.len(), 2);
+        assert!(reader.get(2).unwrap().is_none());
+    }
+}

--- a/crates/static-file/types/src/lib.rs
+++ b/crates/static-file/types/src/lib.rs
@@ -15,11 +15,18 @@ mod compression;
 mod event;
 mod segment;
 
+#[cfg(feature = "std")]
+mod changeset_offsets;
+#[cfg(feature = "std")]
+pub use changeset_offsets::{ChangesetOffsetReader, ChangesetOffsetWriter};
+
 use alloy_primitives::BlockNumber;
 pub use compression::Compression;
 use core::ops::RangeInclusive;
 pub use event::StaticFileProducerEvent;
-pub use segment::{SegmentConfig, SegmentHeader, SegmentRangeInclusive, StaticFileSegment};
+pub use segment::{
+    ChangesetOffset, SegmentConfig, SegmentHeader, SegmentRangeInclusive, StaticFileSegment,
+};
 
 /// Map keyed by [`StaticFileSegment`].
 pub type StaticFileMap<T> = alloc::boxed::Box<fixed_map::Map<StaticFileSegment, T>>;

--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -59,6 +59,9 @@ const INDEX_FILE_EXTENSION: &str = "idx";
 const OFFSETS_FILE_EXTENSION: &str = "off";
 /// The file extension used for configuration files.
 pub const CONFIG_FILE_EXTENSION: &str = "conf";
+/// The file extension used for changeset offset sidecar files.
+#[allow(dead_code)] // Used in upcoming integration
+pub const CHANGESET_OFFSETS_FILE_EXTENSION: &str = "csoff";
 
 /// A [`RefRow`] is a list of column value slices pointing to either an internal buffer or a
 /// memory-mapped file.

--- a/docs/design/incremental-changeset-offsets.md
+++ b/docs/design/incremental-changeset-offsets.md
@@ -1,0 +1,171 @@
+# Incremental Changeset Offset Storage
+
+## Problem
+
+Currently, `SegmentHeader.changeset_offsets` stores a `Vec<ChangesetOffset>` that gets fully serialized and written to the NippyJar config file on **every commit**:
+
+```rust
+pub struct SegmentHeader {
+    // ...
+    changeset_offsets: Option<Vec<ChangesetOffset>>,  // 16 bytes per block
+}
+```
+
+For a segment with 500k blocks, this means **~8MB rewritten on every commit** - even when only appending a single block.
+
+### Current Write Path
+```
+commit() 
+  → NippyJarWriter::commit()
+    → sync_all()           // flush data + row offsets
+    → finalize()
+      → freeze_config()    // atomic_write_file of ENTIRE NippyJar config
+        → bincode serialize entire SegmentHeader (including Vec<ChangesetOffset>)
+```
+
+## Solution
+
+Move changeset offsets to a **separate append-only sidecar file** with fixed-width records, keeping only a small descriptor in `SegmentHeader`.
+
+### New Data Layout
+
+```
+segment_xxx.nippy      # existing data file
+segment_xxx.off        # existing row offsets  
+segment_xxx.conf       # config (now smaller - no Vec<ChangesetOffset>)
+segment_xxx.csoff      # NEW: changeset offsets sidecar (fixed 16-byte records)
+```
+
+### New SegmentHeader Structure
+
+```rust
+pub struct SegmentHeader {
+    expected_block_range: SegmentRangeInclusive,
+    block_range: Option<SegmentRangeInclusive>,
+    tx_range: Option<SegmentRangeInclusive>,
+    segment: StaticFileSegment,
+    // REMOVED: changeset_offsets: Option<Vec<ChangesetOffset>>
+    // NEW: metadata only
+    changeset_offsets_meta: Option<ChangesetOffsetsMeta>,
+}
+
+pub struct ChangesetOffsetsMeta {
+    /// Number of valid entries (blocks) in the sidecar file
+    len: u64,
+    /// Format version for future compatibility
+    version: u8,
+}
+```
+
+### Sidecar File Format
+
+Fixed-width binary records (16 bytes each):
+```
+[offset: u64 LE][num_changes: u64 LE]  // block N
+[offset: u64 LE][num_changes: u64 LE]  // block N+1
+...
+```
+
+Random access: `byte_position = block_index * 16`
+
+## New Commit Protocol
+
+### Append Path (adding blocks)
+
+```
+1. Write data rows to .nippy
+2. Write row offsets to .off  
+3. Append new ChangesetOffset records to .csoff
+4. fdatasync(.csoff)                    // ensure offsets durable
+5. Update SegmentHeader.changeset_offsets_meta.len += N
+6. atomic_write_file(.conf)             // commit header last
+```
+
+**Crash safety**: If crash occurs:
+- After step 3 but before 6: extra bytes in .csoff ignored (header has old len)
+- After step 6: all data consistent
+
+### Prune Path (removing blocks from tail)
+
+```
+1. Update SegmentHeader.changeset_offsets_meta.len = new_len
+2. atomic_write_file(.conf)             // commit header
+3. (Optional) Truncate .csoff to len * 16 bytes
+```
+
+**Crash safety**: Header is source of truth for valid length. Garbage beyond `len * 16` is ignored.
+
+## Implementation Plan
+
+### Phase 1: Add sidecar infrastructure
+- [ ] Add `ChangesetOffsetsMeta` struct in `segment.rs`
+- [ ] Add `.csoff` file path helpers in `NippyJar`
+- [ ] Add `ChangesetOffsetWriter` for append-only writes
+- [ ] Add `ChangesetOffsetReader` for O(1) lookups
+
+### Phase 2: Modify SegmentHeader
+- [ ] Replace `changeset_offsets: Option<Vec<ChangesetOffset>>` with `changeset_offsets_meta`
+- [ ] Update serialize/deserialize with backwards compatibility
+- [ ] Migrate existing data on open (one-time conversion)
+
+### Phase 3: Update write path
+- [ ] Modify `StaticFileProviderRW::commit()` to use new protocol
+- [ ] Ensure fdatasync ordering: data → offsets → header
+- [ ] Update prune logic to shrink `len` instead of rewriting
+
+### Phase 4: Update read path  
+- [ ] Modify `changeset_offsets()` to read from sidecar
+- [ ] Cache hot entries in memory if needed
+- [ ] Add mmap support for large segments
+
+## API Changes
+
+### Before
+```rust
+impl SegmentHeader {
+    pub fn changeset_offsets(&self) -> Option<&Vec<ChangesetOffset>>;
+}
+```
+
+### After
+```rust
+impl SegmentHeader {
+    pub fn changeset_offsets_meta(&self) -> Option<&ChangesetOffsetsMeta>;
+}
+
+// New reader for lookups
+pub struct ChangesetOffsetReader { ... }
+
+impl ChangesetOffsetReader {
+    pub fn get(&self, block_index: u64) -> Option<ChangesetOffset>;
+    pub fn get_range(&self, range: Range<u64>) -> Vec<ChangesetOffset>;
+}
+```
+
+## Performance Impact
+
+| Operation | Before | After |
+|-----------|--------|-------|
+| Append 1 block | O(total_blocks) write | O(1) write (16 bytes) |
+| Commit overhead | ~8MB for 500k blocks | ~100 bytes (header only) |
+| Random lookup | O(1) from memory | O(1) from mmap/pread |
+| Prune | O(remaining_blocks) | O(1) (len update only) |
+
+## Migration Strategy
+
+On segment open, if `changeset_offsets` (old Vec) is present and `changeset_offsets_meta` is absent:
+1. Write Vec contents to new `.csoff` file
+2. Set `changeset_offsets_meta.len = vec.len()`
+3. Clear old `changeset_offsets` field
+4. Commit header
+
+This is a one-time migration per segment file.
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Commit ordering bug (header before offsets) | Enforce fdatasync on .csoff before header commit |
+| Crash during append leaves partial record | Only advance `len` after fdatasync; validate `file_size >= len * 16` on open |
+| Prune from middle (not just tail) | Currently unsupported; would need tombstones or compaction |
+| Platform fsync semantics | Fsync directory after rename on Linux for full durability |


### PR DESCRIPTION
## Summary

Replace inline `Vec<ChangesetOffset>` in `SegmentHeader` with a separate `.csoff` sidecar file for **incremental append/prune operations**.

## Problem

Previously, changeset offsets were stored as `Vec<ChangesetOffset>` in `SegmentHeader` and fully rewritten on every commit. For segments with 500k+ blocks, this meant **~8MB rewritten per commit** even when appending a single block.

## Solution

- Store offsets in a separate `.csoff` sidecar file (fixed 16-byte records)
- `SegmentHeader` now stores only `changeset_offsets_len: u64` (count)
- Crash consistency: sidecar is synced before header commit

## Performance Impact

| Operation | Before | After |
|-----------|--------|-------|
| Append 1 block | O(total_blocks) | O(1) (16 bytes) |
| Commit overhead | ~8MB (500k blocks) | ~100 bytes |
| Prune | O(remaining_blocks) | O(1) |
| Lookup | O(1) from memory | O(1) from mmap/pread |

## Changes

### reth-static-file-types
- Add `ChangesetOffsetsWriter`/`ChangesetOffsetsReader` for sidecar I/O
- Replace `changeset_offsets: Vec` with `changeset_offsets_len: u64` in `SegmentHeader`
- Update serialization to write u64 count instead of Vec

### reth-nippy-jar
- Add `changeset_offsets_path()` for `.csoff` file paths
- Update `delete()` to clean up sidecar files

### reth-provider
- Add `ChangesetOffsetsWriter` to `StaticFileProviderRW`
- Track current block offset during writes, write to sidecar on block completion
- Sync sidecar before header commit (crash consistency)
- Add `read_changeset_offset()`/`read_changeset_offsets()` to `StaticFileJarProvider`
- Update `manager.rs` to read offsets from sidecar file
- Update `truncate_changesets` to truncate sidecar file

## Breaking Change

This changes the static file format for changeset segments. Existing changeset static files are not backwards compatible and must be regenerated.

## Testing

```bash
cargo test -p reth-static-file-types
cargo check -p reth-provider
```

cc @joshieDo @mattsse