### PR TITLE
feat(metrics): add _last gauge metrics for save_blocks timings

### DIFF
--- a/crates/storage/provider/src/providers/database/metrics.rs
+++ b/crates/storage/provider/src/providers/database/metrics.rs
@@ -1,4 +1,4 @@
-use metrics::Histogram;
+use metrics::{Gauge, Histogram};
 use reth_metrics::Metrics;
 use std::time::{Duration, Instant};
 
@@ -96,6 +96,34 @@ pub(crate) struct DatabaseProviderMetrics {
     save_blocks_commit_sf: Histogram,
     /// Duration of `RocksDB` commit in `save_blocks`
     save_blocks_commit_rocksdb: Histogram,
+    /// Last duration of `save_blocks`
+    save_blocks_total_last: Gauge,
+    /// Last duration of MDBX work in `save_blocks`
+    save_blocks_mdbx_last: Gauge,
+    /// Last duration of static file work in `save_blocks`
+    save_blocks_sf_last: Gauge,
+    /// Last duration of `RocksDB` work in `save_blocks`
+    save_blocks_rocksdb_last: Gauge,
+    /// Last duration of `insert_block` in `save_blocks`
+    save_blocks_insert_block_last: Gauge,
+    /// Last duration of `write_state` in `save_blocks`
+    save_blocks_write_state_last: Gauge,
+    /// Last duration of `write_hashed_state` in `save_blocks`
+    save_blocks_write_hashed_state_last: Gauge,
+    /// Last duration of `write_trie_updates` in `save_blocks`
+    save_blocks_write_trie_updates_last: Gauge,
+    /// Last duration of `update_history_indices` in `save_blocks`
+    save_blocks_update_history_indices_last: Gauge,
+    /// Last duration of `update_pipeline_stages` in `save_blocks`
+    save_blocks_update_pipeline_stages_last: Gauge,
+    /// Last number of blocks per `save_blocks` call
+    save_blocks_block_count_last: Gauge,
+    /// Last duration of MDBX commit in `save_blocks`
+    save_blocks_commit_mdbx_last: Gauge,
+    /// Last duration of static file commit in `save_blocks`
+    save_blocks_commit_sf_last: Gauge,
+    /// Last duration of `RocksDB` commit in `save_blocks`
+    save_blocks_commit_rocksdb_last: Gauge,
 }
 
 /// Timings collected during a `save_blocks` call.
@@ -154,6 +182,20 @@ impl DatabaseProviderMetrics {
         self.save_blocks_update_history_indices.record(timings.update_history_indices);
         self.save_blocks_update_pipeline_stages.record(timings.update_pipeline_stages);
         self.save_blocks_block_count.record(timings.block_count as f64);
+
+        self.save_blocks_total_last.set(timings.total.as_secs_f64());
+        self.save_blocks_mdbx_last.set(timings.mdbx.as_secs_f64());
+        self.save_blocks_sf_last.set(timings.sf.as_secs_f64());
+        self.save_blocks_rocksdb_last.set(timings.rocksdb.as_secs_f64());
+        self.save_blocks_insert_block_last.set(timings.insert_block.as_secs_f64());
+        self.save_blocks_write_state_last.set(timings.write_state.as_secs_f64());
+        self.save_blocks_write_hashed_state_last.set(timings.write_hashed_state.as_secs_f64());
+        self.save_blocks_write_trie_updates_last.set(timings.write_trie_updates.as_secs_f64());
+        self.save_blocks_update_history_indices_last
+            .set(timings.update_history_indices.as_secs_f64());
+        self.save_blocks_update_pipeline_stages_last
+            .set(timings.update_pipeline_stages.as_secs_f64());
+        self.save_blocks_block_count_last.set(timings.block_count as f64);
     }
 
     /// Records all commit timings.
@@ -161,5 +203,9 @@ impl DatabaseProviderMetrics {
         self.save_blocks_commit_mdbx.record(timings.mdbx);
         self.save_blocks_commit_sf.record(timings.sf);
         self.save_blocks_commit_rocksdb.record(timings.rocksdb);
+
+        self.save_blocks_commit_mdbx_last.set(timings.mdbx.as_secs_f64());
+        self.save_blocks_commit_sf_last.set(timings.sf.as_secs_f64());
+        self.save_blocks_commit_rocksdb_last.set(timings.rocksdb.as_secs_f64());
     }
 }


### PR DESCRIPTION
## Summary
Adds gauge metrics with `_last` suffix for all `save_blocks` histogram metrics.

## Motivation
The [reth-persistence dashboard](https://github.com/paradigmxyz/reth/pull/21594) needs to display the most recent values for each timing metric. Histograms only provide bucket distributions, but gauges allow directly querying the last observed value.

## Changes
- Added 14 new gauge metrics in `DatabaseProviderMetrics`:
  - `save_blocks_total_last`
  - `save_blocks_mdbx_last`
  - `save_blocks_sf_last`
  - `save_blocks_rocksdb_last`
  - `save_blocks_insert_block_last`
  - `save_blocks_write_state_last`
  - `save_blocks_write_hashed_state_last`
  - `save_blocks_write_trie_updates_last`
  - `save_blocks_update_history_indices_last`
  - `save_blocks_update_pipeline_stages_last`
  - `save_blocks_block_count_last`
  - `save_blocks_commit_mdbx_last`
  - `save_blocks_commit_sf_last`
  - `save_blocks_commit_rocksdb_last`

## Testing
`cargo check -p reth-provider` passes.