### PR TITLE
feat(prune): add static file pruning support for sender recovery

### DIFF
--- a/crates/prune/prune/src/segments/user/sender_recovery.rs
+++ b/crates/prune/prune/src/segments/user/sender_recovery.rs
@@ -1,14 +1,18 @@
 use crate::{
     db_ext::DbTxPruneExt,
-    segments::{PruneInput, Segment},
+    segments::{self, PruneInput, Segment},
     PrunerError,
 };
 use reth_db_api::{tables, transaction::DbTxMut};
-use reth_provider::{BlockReader, DBProvider, TransactionsProvider};
+use reth_provider::{
+    BlockReader, DBProvider, EitherWriterDestination, StaticFileProviderFactory,
+    StorageSettingsCache, TransactionsProvider,
+};
 use reth_prune_types::{
     PruneMode, PruneProgress, PrunePurpose, PruneSegment, SegmentOutput, SegmentOutputCheckpoint,
 };
-use tracing::{instrument, trace};
+use reth_static_file_types::StaticFileSegment;
+use tracing::{debug, instrument, trace};
 
 #[derive(Debug)]
 pub struct SenderRecovery {
@@ -23,7 +27,11 @@ impl SenderRecovery {
 
 impl<Provider> Segment<Provider> for SenderRecovery
 where
-    Provider: DBProvider<Tx: DbTxMut> + TransactionsProvider + BlockReader,
+    Provider: DBProvider<Tx: DbTxMut>
+        + TransactionsProvider
+        + BlockReader
+        + StorageSettingsCache
+        + StaticFileProviderFactory,
 {
     fn segment(&self) -> PruneSegment {
         PruneSegment::SenderRecovery
@@ -39,6 +47,16 @@ where
 
     #[instrument(target = "pruner", skip(self, provider), ret(level = "trace"))]
     fn prune(&self, provider: &Provider, input: PruneInput) -> Result<SegmentOutput, PrunerError> {
+        if EitherWriterDestination::senders(provider).is_static_file() {
+            debug!(target: "pruner", "Pruning transaction senders from static files.");
+            return segments::prune_static_files(
+                provider,
+                input,
+                StaticFileSegment::TransactionSenders,
+            )
+        }
+        debug!(target: "pruner", "Pruning transaction senders from database.");
+
         let tx_range = match input.get_next_tx_num_range(provider)? {
             Some(range) => range,
             None => {


### PR DESCRIPTION
## Summary

Adds support for pruning transaction senders from static files when they are stored there (via the `transaction_senders_in_static_files` storage setting).

## Motivation

Previously, the `SenderRecovery` pruner only handled pruning from the database (`TransactionSenders` table). When senders are configured to be stored in static files, the pruner would not delete them, leaving stale data.

This affects both:
- The `SenderRecovery` segment used by the main `Pruner` task
- The `PruneSenderRecoveryStage` which wraps `PruneStage` and uses the same segment

## Changes

- Updated `SenderRecovery::prune()` to check `EitherWriterDestination::senders()` to determine storage location
- When senders are in static files, delegates to `segments::prune_static_files()` with `StaticFileSegment::TransactionSenders`
- Added required trait bounds (`StorageSettingsCache`, `StaticFileProviderFactory`) to the `Segment` impl
- Follows the same pattern used by receipts pruning

## Testing

- Existing tests continue to pass (they test database pruning)
- Static file pruning uses the shared `prune_static_files()` helper that is already well-tested via bodies/receipts segments