### PR TITLE
feat(rpc): default --testing.skip-invalid-transactions to true

### DIFF
--- a/crates/node/core/src/args/rpc_server.rs
+++ b/crates/node/core/src/args/rpc_server.rs
@@ -859,7 +859,7 @@ impl Default for RpcServerArgs {
             rpc_state_cache,
             gas_price_oracle,
             rpc_send_raw_transaction_sync_timeout,
-            testing_skip_invalid_transactions: false,
+            testing_skip_invalid_transactions: true,
         }
     }
 }

--- a/crates/node/core/src/args/rpc_server.rs
+++ b/crates/node/core/src/args/rpc_server.rs
@@ -645,7 +645,7 @@ pub struct RpcServerArgs {
     ///
     /// When enabled, transactions that fail execution will be skipped, and all subsequent
     /// transactions from the same sender will also be skipped.
-    #[arg(long = "testing.skip-invalid-transactions", default_value_t = false)]
+    #[arg(long = "testing.skip-invalid-transactions", default_value_t = true)]
     pub testing_skip_invalid_transactions: bool,
 }
 


### PR DESCRIPTION
## Summary

Changes the default value of `--testing.skip-invalid-transactions` from `false` to `true`.

## Motivation

When using `testing_buildBlockV1`, it's more convenient to skip invalid transactions by default rather than failing the entire block build. This saves users from having to pass the flag explicitly every time.

## Changes

- Updated default value in `RpcServerArgs` from `false` to `true`

## Testing

N/A - default value change only, existing test already expects `true` when flag is passed