### PR TITLE
feat(grafana): add gauge panels for save_blocks _last metrics

### DIFF
--- a/etc/grafana/dashboards/reth-persistence.json
+++ b/etc/grafana/dashboards/reth-persistence.json
@@ -677,6 +677,646 @@
       ],
       "title": "Blocks per Save",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 36
+      },
+      "id": 100,
+      "panels": [],
+      "title": "Last Values (Gauges)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 100,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "percent"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 16,
+        "w": 24,
+        "x": 0,
+        "y": 37
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "avg(reth_storage_providers_database_save_blocks_insert_block_last{$instance_label=\"$instance\"})",
+          "legendFormat": "block",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "avg(reth_storage_providers_database_save_blocks_write_state_last{$instance_label=\"$instance\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "state",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "avg(reth_storage_providers_database_save_blocks_write_hashed_state_last{$instance_label=\"$instance\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "hashed state",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "avg(reth_storage_providers_database_save_blocks_write_trie_updates_last{$instance_label=\"$instance\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "trie updates",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "avg(reth_storage_providers_database_save_blocks_update_history_indices_last{$instance_label=\"$instance\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "history indices",
+          "range": true,
+          "refId": "F"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "avg(reth_storage_providers_database_save_blocks_update_pipeline_stages_last{$instance_label=\"$instance\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "pipeline stages",
+          "range": true,
+          "refId": "G"
+        }
+      ],
+      "title": "Save Blocks - Write Operations (Last)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 100,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "percent"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 53
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "avg(reth_storage_providers_database_save_blocks_mdbx_last{$instance_label=\"$instance\"})",
+          "legendFormat": "MDBX",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "avg(reth_storage_providers_database_save_blocks_sf_last{$instance_label=\"$instance\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Static Files",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "avg(reth_storage_providers_database_save_blocks_rocksdb_last{$instance_label=\"$instance\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "RocksDB",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Storage Backend - Write Time (Last)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 100,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "percent"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 53
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "avg(reth_storage_providers_database_save_blocks_commit_mdbx_last{$instance_label=\"$instance\"})",
+          "legendFormat": "MDBX Commit",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "avg(reth_storage_providers_database_save_blocks_commit_sf_last{$instance_label=\"$instance\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Static Files Commit",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "avg(reth_storage_providers_database_save_blocks_commit_rocksdb_last{$instance_label=\"$instance\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "RocksDB Commit",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Storage Backend - Commit Time (Last)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 63
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "avg(reth_storage_providers_database_save_blocks_total_last{$instance_label=\"$instance\"})",
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Save Blocks - Total Time (Last)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 63
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "avg(reth_storage_providers_database_save_blocks_block_count_last{$instance_label=\"$instance\"})",
+          "legendFormat": "Blocks per save_blocks call",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Blocks per Save (Last)",
+      "type": "timeseries"
     }
   ],
   "refresh": "",

--- a/etc/grafana/dashboards/reth-persistence.json
+++ b/etc/grafana/dashboards/reth-persistence.json
@@ -784,7 +784,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(reth_storage_providers_database_save_blocks_insert_block_last{$instance_label=\"$instance\"})",
+          "expr": "reth_storage_providers_database_save_blocks_insert_block_last{$instance_label=\"$instance\"}",
           "legendFormat": "block",
           "range": true,
           "refId": "A"
@@ -795,7 +795,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(reth_storage_providers_database_save_blocks_write_state_last{$instance_label=\"$instance\"})",
+          "expr": "reth_storage_providers_database_save_blocks_write_state_last{$instance_label=\"$instance\"}",
           "hide": false,
           "instant": false,
           "legendFormat": "state",
@@ -808,7 +808,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(reth_storage_providers_database_save_blocks_write_hashed_state_last{$instance_label=\"$instance\"})",
+          "expr": "reth_storage_providers_database_save_blocks_write_hashed_state_last{$instance_label=\"$instance\"}",
           "hide": false,
           "instant": false,
           "legendFormat": "hashed state",
@@ -821,7 +821,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(reth_storage_providers_database_save_blocks_write_trie_updates_last{$instance_label=\"$instance\"})",
+          "expr": "reth_storage_providers_database_save_blocks_write_trie_updates_last{$instance_label=\"$instance\"}",
           "hide": false,
           "instant": false,
           "legendFormat": "trie updates",
@@ -834,7 +834,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(reth_storage_providers_database_save_blocks_update_history_indices_last{$instance_label=\"$instance\"})",
+          "expr": "reth_storage_providers_database_save_blocks_update_history_indices_last{$instance_label=\"$instance\"}",
           "hide": false,
           "instant": false,
           "legendFormat": "history indices",
@@ -847,7 +847,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(reth_storage_providers_database_save_blocks_update_pipeline_stages_last{$instance_label=\"$instance\"})",
+          "expr": "reth_storage_providers_database_save_blocks_update_pipeline_stages_last{$instance_label=\"$instance\"}",
           "hide": false,
           "instant": false,
           "legendFormat": "pipeline stages",
@@ -951,7 +951,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(reth_storage_providers_database_save_blocks_mdbx_last{$instance_label=\"$instance\"})",
+          "expr": "reth_storage_providers_database_save_blocks_mdbx_last{$instance_label=\"$instance\"}",
           "legendFormat": "MDBX",
           "range": true,
           "refId": "A"
@@ -962,7 +962,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(reth_storage_providers_database_save_blocks_sf_last{$instance_label=\"$instance\"})",
+          "expr": "reth_storage_providers_database_save_blocks_sf_last{$instance_label=\"$instance\"}",
           "hide": false,
           "instant": false,
           "legendFormat": "Static Files",
@@ -975,7 +975,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(reth_storage_providers_database_save_blocks_rocksdb_last{$instance_label=\"$instance\"})",
+          "expr": "reth_storage_providers_database_save_blocks_rocksdb_last{$instance_label=\"$instance\"}",
           "hide": false,
           "instant": false,
           "legendFormat": "RocksDB",
@@ -1079,7 +1079,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(reth_storage_providers_database_save_blocks_commit_mdbx_last{$instance_label=\"$instance\"})",
+          "expr": "reth_storage_providers_database_save_blocks_commit_mdbx_last{$instance_label=\"$instance\"}",
           "legendFormat": "MDBX Commit",
           "range": true,
           "refId": "A"


### PR DESCRIPTION
## Summary
Adds panels to the reth-persistence Grafana dashboard using the new `_last` gauge metrics from #21597.

## Motivation
The histogram-based panels show quantile distributions but can't display the most recent values directly. The new gauge metrics allow querying the last observed timing values.

## Changes
Added a new "Last Values (Gauges)" section with 5 panels mirroring the existing histogram panels:
- Save Blocks - Write Operations (Last)
- Storage Backend - Write Time (Last)
- Storage Backend - Commit Time (Last)
- Save Blocks - Total Time (Last)
- Blocks per Save (Last)

## Testing
Validated JSON syntax.

<img width="1382" height="605" alt="Screenshot 2026-01-29 at 5 32 40 PM" src="https://github.com/user-attachments/assets/a8329f6e-fb0d-4f15-ab42-ba7f6b370de9" />
<img width="1382" height="764" alt="Screenshot 2026-01-29 at 5 32 50 PM" src="https://github.com/user-attachments/assets/ab6d2e4b-3579-44e7-84d4-1973f8e7c60d" />
