### PR TITLE
feat(stages): add parallel merkle stage for staged sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10778,6 +10778,7 @@ dependencies = [
  "reth-testing-utils",
  "reth-trie",
  "reth-trie-db",
+ "reth-trie-parallel",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/node/builder/src/setup.rs
+++ b/crates/node/builder/src/setup.rs
@@ -18,7 +18,7 @@ use reth_network_p2p::{
 use reth_node_api::HeaderTy;
 use reth_provider::{providers::ProviderNodeTypes, ProviderFactory};
 use reth_stages::{
-    prelude::DefaultStages,
+    prelude::ParallelDefaultStages,
     stages::{EraImportSource, ExecutionStage},
     Pipeline, StageSet,
 };
@@ -110,7 +110,7 @@ where
         .with_tip_sender(tip_tx)
         .with_metrics_tx(metrics_tx)
         .add_stages(
-            DefaultStages::new(
+            ParallelDefaultStages::new(
                 provider_factory.clone(),
                 tip_rx,
                 Arc::clone(&consensus),
@@ -120,6 +120,7 @@ where
                 stage_config.clone(),
                 prune_config.segments,
                 era_import_source,
+                provider_factory.clone(),
             )
             .set(ExecutionStage::new(
                 evm_config,

--- a/crates/stages/stages/Cargo.toml
+++ b/crates/stages/stages/Cargo.toml
@@ -114,6 +114,7 @@ test-utils = [
     "reth-db-api/test-utils",
     "reth-trie-db/test-utils",
     "reth-trie/test-utils",
+    "reth-trie-parallel/test-utils",
     "reth-prune-types/test-utils",
     "dep:reth-ethereum-primitives",
     "reth-ethereum-primitives?/test-utils",

--- a/crates/stages/stages/Cargo.toml
+++ b/crates/stages/stages/Cargo.toml
@@ -40,6 +40,7 @@ reth-stages-api.workspace = true
 reth-static-file-types.workspace = true
 reth-trie = { workspace = true, features = ["metrics"] }
 reth-trie-db = { workspace = true, features = ["metrics"] }
+reth-trie-parallel = { workspace = true, features = ["metrics"] }
 
 reth-testing-utils = { workspace = true, optional = true }
 

--- a/crates/stages/stages/src/prelude.rs
+++ b/crates/stages/stages/src/prelude.rs
@@ -1,4 +1,4 @@
 pub use crate::sets::{
     DefaultStages, ExecutionStages, HashingStages, HistoryIndexingStages, OfflineStages,
-    OnlineStages,
+    OnlineStages, ParallelDefaultStages, ParallelHashingStages, ParallelOfflineStages,
 };

--- a/crates/stages/stages/src/sets.rs
+++ b/crates/stages/stages/src/sets.rs
@@ -555,11 +555,9 @@ where
 /// - [`MerkleStage`] (unwind)
 /// - [`AccountHashingStage`]
 /// - [`StorageHashingStage`]
-/// - [`MerkleStage`] or [`ParallelMerkleStage`] (execute)
+/// - [`MerkleStage`] (execute)
 ///
-/// When a provider factory is supplied via [`HashingStages::with_parallel_merkle`], the
-/// [`ParallelMerkleStage`] is used for incremental state root computation, which calculates
-/// storage roots in parallel across multiple threads.
+/// For parallel state root computation, use [`ParallelHashingStages`] instead.
 #[derive(Debug, Default)]
 #[non_exhaustive]
 pub struct HashingStages {

--- a/crates/stages/stages/src/sets.rs
+++ b/crates/stages/stages/src/sets.rs
@@ -40,8 +40,8 @@ use crate::{
     stages::{
         AccountHashingStage, BodyStage, EraImportSource, EraStage, ExecutionStage, FinishStage,
         HeaderStage, IndexAccountHistoryStage, IndexStorageHistoryStage, MerkleStage,
-        ParallelMerkleStage, PruneSenderRecoveryStage, PruneStage, SenderRecoveryStage,
-        StorageHashingStage, TransactionLookupStage,
+        ParallelMerkleStage, ParallelMerkleUnwindStage, PruneSenderRecoveryStage, PruneStage,
+        SenderRecoveryStage, StorageHashingStage, TransactionLookupStage,
     },
     StageSet, StageSetBuilder,
 };

--- a/crates/stages/stages/src/sets.rs
+++ b/crates/stages/stages/src/sets.rs
@@ -40,8 +40,8 @@ use crate::{
     stages::{
         AccountHashingStage, BodyStage, EraImportSource, EraStage, ExecutionStage, FinishStage,
         HeaderStage, IndexAccountHistoryStage, IndexStorageHistoryStage, MerkleStage,
-        PruneSenderRecoveryStage, PruneStage, SenderRecoveryStage, StorageHashingStage,
-        TransactionLookupStage,
+        ParallelMerkleStage, PruneSenderRecoveryStage, PruneStage, SenderRecoveryStage,
+        StorageHashingStage, TransactionLookupStage,
     },
     StageSet, StageSetBuilder,
 };
@@ -177,6 +177,99 @@ where
             self.stages_config.clone(),
             self.prune_modes,
         )
+    }
+}
+
+/// Default stages with parallel merkle stage support.
+///
+/// This is identical to [`DefaultStages`] but uses [`ParallelMerkleStage`] for incremental
+/// state root computation, providing better performance by computing storage roots in parallel.
+#[derive(Debug)]
+pub struct ParallelDefaultStages<Provider, H, B, E, F>
+where
+    H: HeaderDownloader,
+    B: BodyDownloader,
+    E: ConfigureEvm,
+{
+    /// Configuration for the online stages
+    online: OnlineStages<Provider, H, B>,
+    /// Executor factory needs for execution stage
+    evm_config: E,
+    /// Consensus instance
+    consensus: Arc<dyn FullConsensus<E::Primitives>>,
+    /// Configuration for each stage in the pipeline
+    stages_config: StageConfig,
+    /// Prune configuration for every segment that can be pruned
+    prune_modes: PruneModes,
+    /// Provider factory for parallel merkle stage
+    provider_factory: F,
+}
+
+impl<Provider, H, B, E, F: Clone> ParallelDefaultStages<Provider, H, B, E, F>
+where
+    H: HeaderDownloader,
+    B: BodyDownloader,
+    E: ConfigureEvm<Primitives: NodePrimitives<BlockHeader = H::Header, Block = B::Block>>,
+{
+    /// Create a new set of default stages with parallel merkle support.
+    #[expect(clippy::too_many_arguments)]
+    pub fn new(
+        provider: Provider,
+        tip: watch::Receiver<B256>,
+        consensus: Arc<dyn FullConsensus<E::Primitives>>,
+        header_downloader: H,
+        body_downloader: B,
+        evm_config: E,
+        stages_config: StageConfig,
+        prune_modes: PruneModes,
+        era_import_source: Option<EraImportSource>,
+        provider_factory: F,
+    ) -> Self {
+        Self {
+            online: OnlineStages::new(
+                provider,
+                tip,
+                header_downloader,
+                body_downloader,
+                stages_config.clone(),
+                era_import_source,
+            ),
+            evm_config,
+            consensus,
+            stages_config,
+            prune_modes,
+            provider_factory,
+        }
+    }
+}
+
+impl<P, H, B, E, F, StageProvider> StageSet<StageProvider> for ParallelDefaultStages<P, H, B, E, F>
+where
+    P: HeaderSyncGapProvider + 'static,
+    H: HeaderDownloader + 'static,
+    B: BodyDownloader + 'static,
+    E: ConfigureEvm,
+    F: reth_provider::DatabaseProviderFactory + Clone + Send + Sync + 'static,
+    F::Provider: reth_provider::StageCheckpointReader
+        + reth_provider::PruneCheckpointReader
+        + reth_provider::BlockNumReader
+        + reth_provider::ChangeSetReader
+        + reth_provider::StorageChangeSetReader
+        + reth_provider::DBProvider,
+    OnlineStages<P, H, B>: StageSet<StageProvider>,
+    ParallelOfflineStages<E, F>: StageSet<StageProvider>,
+{
+    fn builder(self) -> StageSetBuilder<StageProvider> {
+        StageSetBuilder::default()
+            .add_set(self.online)
+            .add_set(ParallelOfflineStages::new(
+                self.evm_config,
+                self.consensus,
+                self.stages_config,
+                self.prune_modes,
+                self.provider_factory,
+            ))
+            .add_stage(FinishStage)
     }
 }
 
@@ -334,7 +427,6 @@ where
     fn builder(self) -> StageSetBuilder<Provider> {
         ExecutionStages::new(self.evm_config, self.consensus, self.stages_config.clone())
             .builder()
-            // If sender recovery prune mode is set, add the prune sender recovery stage.
             .add_stage_opt(self.prune_modes.sender_recovery.map(|prune_mode| {
                 PruneSenderRecoveryStage::new(prune_mode, self.stages_config.prune.commit_threshold)
             }))
@@ -343,8 +435,72 @@ where
                 stages_config: self.stages_config.clone(),
                 prune_modes: self.prune_modes.clone(),
             })
-            // Prune stage should be added after all hashing stages, because otherwise it will
-            // delete
+            .add_stage(PruneStage::new(
+                self.prune_modes.clone(),
+                self.stages_config.prune.commit_threshold,
+            ))
+    }
+}
+
+/// Offline stages with parallel merkle stage support.
+///
+/// This is the same as [`OfflineStages`] but uses [`ParallelMerkleStage`] for incremental
+/// state root computation, providing better performance by computing storage roots in parallel.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct ParallelOfflineStages<E: ConfigureEvm, F> {
+    /// Executor factory needs for execution stage
+    evm_config: E,
+    /// Consensus instance for validating blocks.
+    consensus: Arc<dyn FullConsensus<E::Primitives>>,
+    /// Configuration for each stage in the pipeline
+    stages_config: StageConfig,
+    /// Prune configuration for every segment that can be pruned
+    prune_modes: PruneModes,
+    /// Provider factory for parallel merkle stage
+    provider_factory: F,
+}
+
+impl<E: ConfigureEvm, F: Clone> ParallelOfflineStages<E, F> {
+    /// Create a new set of offline stages with parallel merkle support.
+    pub fn new(
+        evm_config: E,
+        consensus: Arc<dyn FullConsensus<E::Primitives>>,
+        stages_config: StageConfig,
+        prune_modes: PruneModes,
+        provider_factory: F,
+    ) -> Self {
+        Self { evm_config, consensus, stages_config, prune_modes, provider_factory }
+    }
+}
+
+impl<E, F, Provider> StageSet<Provider> for ParallelOfflineStages<E, F>
+where
+    E: ConfigureEvm,
+    F: reth_provider::DatabaseProviderFactory + Clone + Send + Sync + 'static,
+    F::Provider: reth_provider::StageCheckpointReader
+        + reth_provider::PruneCheckpointReader
+        + reth_provider::BlockNumReader
+        + reth_provider::ChangeSetReader
+        + reth_provider::StorageChangeSetReader
+        + reth_provider::DBProvider,
+    ExecutionStages<E>: StageSet<Provider>,
+    PruneSenderRecoveryStage: Stage<Provider>,
+    ParallelHashingStages<F>: StageSet<Provider>,
+    HistoryIndexingStages: StageSet<Provider>,
+    PruneStage: Stage<Provider>,
+{
+    fn builder(self) -> StageSetBuilder<Provider> {
+        ExecutionStages::new(self.evm_config, self.consensus, self.stages_config.clone())
+            .builder()
+            .add_stage_opt(self.prune_modes.sender_recovery.map(|prune_mode| {
+                PruneSenderRecoveryStage::new(prune_mode, self.stages_config.prune.commit_threshold)
+            }))
+            .add_set(ParallelHashingStages::new(self.stages_config.clone(), self.provider_factory))
+            .add_set(HistoryIndexingStages {
+                stages_config: self.stages_config.clone(),
+                prune_modes: self.prune_modes.clone(),
+            })
             .add_stage(PruneStage::new(
                 self.prune_modes.clone(),
                 self.stages_config.prune.commit_threshold,
@@ -399,12 +555,23 @@ where
 /// - [`MerkleStage`] (unwind)
 /// - [`AccountHashingStage`]
 /// - [`StorageHashingStage`]
-/// - [`MerkleStage`] (execute)
+/// - [`MerkleStage`] or [`ParallelMerkleStage`] (execute)
+///
+/// When a provider factory is supplied via [`HashingStages::with_parallel_merkle`], the
+/// [`ParallelMerkleStage`] is used for incremental state root computation, which calculates
+/// storage roots in parallel across multiple threads.
 #[derive(Debug, Default)]
 #[non_exhaustive]
 pub struct HashingStages {
     /// Configuration for each stage in the pipeline
     stages_config: StageConfig,
+}
+
+impl HashingStages {
+    /// Creates a new `HashingStages` with the given configuration.
+    pub const fn new(stages_config: StageConfig) -> Self {
+        Self { stages_config }
+    }
 }
 
 impl<Provider> StageSet<Provider> for HashingStages
@@ -425,6 +592,59 @@ where
                 self.stages_config.etl.clone(),
             ))
             .add_stage(MerkleStage::new_execution(
+                self.stages_config.merkle.rebuild_threshold,
+                self.stages_config.merkle.incremental_threshold,
+            ))
+    }
+}
+
+/// A set containing all stages that hash account state with parallel merkle stage support.
+///
+/// This is similar to [`HashingStages`] but uses [`ParallelMerkleStage`] for incremental state
+/// root computation, which provides better performance by computing storage roots in parallel.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct ParallelHashingStages<F> {
+    /// Configuration for each stage in the pipeline
+    stages_config: StageConfig,
+    /// The provider factory for parallel state root computation
+    provider_factory: F,
+}
+
+impl<F> ParallelHashingStages<F> {
+    /// Creates a new `ParallelHashingStages` with parallel merkle stage support.
+    pub const fn new(stages_config: StageConfig, provider_factory: F) -> Self {
+        Self { stages_config, provider_factory }
+    }
+}
+
+impl<F, Provider> StageSet<Provider> for ParallelHashingStages<F>
+where
+    F: reth_provider::DatabaseProviderFactory + Clone + Send + Sync + 'static,
+    F::Provider: reth_provider::StageCheckpointReader
+        + reth_provider::PruneCheckpointReader
+        + reth_provider::BlockNumReader
+        + reth_provider::ChangeSetReader
+        + reth_provider::StorageChangeSetReader
+        + reth_provider::DBProvider,
+    ParallelMerkleStage<F>: Stage<Provider>,
+    MerkleStage: Stage<Provider>,
+    AccountHashingStage: Stage<Provider>,
+    StorageHashingStage: Stage<Provider>,
+{
+    fn builder(self) -> StageSetBuilder<Provider> {
+        StageSetBuilder::default()
+            .add_stage(MerkleStage::default_unwind())
+            .add_stage(AccountHashingStage::new(
+                self.stages_config.account_hashing,
+                self.stages_config.etl.clone(),
+            ))
+            .add_stage(StorageHashingStage::new(
+                self.stages_config.storage_hashing,
+                self.stages_config.etl.clone(),
+            ))
+            .add_stage(ParallelMerkleStage::with_thresholds(
+                self.provider_factory,
                 self.stages_config.merkle.rebuild_threshold,
                 self.stages_config.merkle.incremental_threshold,
             ))

--- a/crates/stages/stages/src/sets.rs
+++ b/crates/stages/stages/src/sets.rs
@@ -626,13 +626,13 @@ where
         + reth_provider::StorageChangeSetReader
         + reth_provider::DBProvider,
     ParallelMerkleStage<F>: Stage<Provider>,
-    MerkleStage: Stage<Provider>,
+    ParallelMerkleUnwindStage<F>: Stage<Provider>,
     AccountHashingStage: Stage<Provider>,
     StorageHashingStage: Stage<Provider>,
 {
     fn builder(self) -> StageSetBuilder<Provider> {
         StageSetBuilder::default()
-            .add_stage(MerkleStage::default_unwind())
+            .add_stage(ParallelMerkleUnwindStage::new(self.provider_factory.clone()))
             .add_stage(AccountHashingStage::new(
                 self.stages_config.account_hashing,
                 self.stages_config.etl.clone(),

--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -741,11 +741,10 @@ where
             info!(target: "sync::stages::merkle::unwind", "Nothing to unwind");
         } else {
             // Load the hashed post state from the database for the unwind range
-            let hashed_state =
-                reth_trie::HashedPostStateSorted::from_reverts::<reth_trie::KeccakKeyHasher>(
-                    provider, range,
-                )
-                .map_err(|e| StageError::Fatal(Box::new(e)))?;
+            let hashed_state = reth_trie::HashedPostStateSorted::from_reverts::<
+                reth_trie::KeccakKeyHasher,
+            >(provider, range)
+            .map_err(|e| StageError::Fatal(Box::new(e)))?;
 
             let prefix_sets = hashed_state.construct_prefix_sets().freeze();
 

--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -16,11 +16,10 @@ use reth_stages_api::{
     BlockErrorKind, EntitiesCheckpoint, ExecInput, ExecOutput, MerkleCheckpoint, Stage,
     StageCheckpoint, StageError, StageId, StorageRootMerkleCheckpoint, UnwindInput, UnwindOutput,
 };
-use reth_trie::{IntermediateStateRootState, StateRoot, StateRootProgress, StoredSubNode};
-use reth_trie_db::{
-    load_prefix_sets_with_provider, ChangesetCache, DatabaseHashedPostState, DatabaseStateRoot,
-    KeccakKeyHasher,
+use reth_trie::{
+    IntermediateStateRootState, KeccakKeyHasher, StateRoot, StateRootProgress, StoredSubNode,
 };
+use reth_trie_db::{load_prefix_sets_with_provider, ChangesetCache, DatabaseStateRoot};
 use reth_trie_parallel::root::ParallelStateRoot;
 use std::fmt::Debug;
 use tracing::*;

--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -467,7 +467,7 @@ pub struct ParallelMerkleStage<F> {
 
 impl<F> ParallelMerkleStage<F> {
     /// Create a new parallel merkle stage with the given provider factory.
-    pub fn new(factory: F) -> Self {
+    pub const fn new(factory: F) -> Self {
         Self {
             factory,
             rebuild_threshold: MERKLE_STAGE_DEFAULT_REBUILD_THRESHOLD,
@@ -476,7 +476,11 @@ impl<F> ParallelMerkleStage<F> {
     }
 
     /// Create a new parallel merkle stage with custom thresholds.
-    pub fn with_thresholds(factory: F, rebuild_threshold: u64, incremental_threshold: u64) -> Self {
+    pub const fn with_thresholds(
+        factory: F,
+        rebuild_threshold: u64,
+        incremental_threshold: u64,
+    ) -> Self {
         Self { factory, rebuild_threshold, incremental_threshold }
     }
 

--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -449,7 +449,7 @@ fn validate_state_root<H: BlockHeader + Sealable + Debug>(
 /// during staged sync.
 ///
 /// Internally, it creates an [`OverlayStateProviderFactory`] that provides the necessary
-/// [`TrieCursorFactory`] and [`HashedCursorFactory`] implementations for [`ParallelStateRoot`].
+/// trie cursor factory and hashed cursor factory implementations for [`ParallelStateRoot`].
 #[derive(Debug, Clone)]
 pub struct ParallelMerkleStage<F> {
     /// The overlay factory that wraps the database provider factory.

--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -804,9 +804,8 @@ where
             info!(target: "sync::stages::merkle::unwind", "Nothing to unwind");
         } else {
             // Load prefix sets from changesets for the unwind range
-            let prefix_sets =
-                load_prefix_sets_with_provider::<_, KeccakKeyHasher>(provider, range)
-                    .map_err(|e| StageError::Fatal(Box::new(e)))?;
+            let prefix_sets = load_prefix_sets_with_provider::<_, KeccakKeyHasher>(provider, range)
+                .map_err(|e| StageError::Fatal(Box::new(e)))?;
 
             // Create a fresh overlay factory for unwind to ensure we have the latest
             // database state.


### PR DESCRIPTION
## Summary

Introduces `ParallelMerkleStage` that uses `ParallelStateRoot` for incremental state root computation during staged sync. This enables parallel storage root calculation across multiple threads, improving performance for the merkle hashing stage.

## Motivation

The existing `MerkleStage` computes state roots serially. By leveraging `ParallelStateRoot` (already used in the engine tree for payload validation), we can significantly speed up incremental state root computation during staged sync by calculating storage roots in parallel.

## Changes

- **`crates/stages/stages/src/stages/merkle.rs`**: Added `ParallelMerkleStage<F>` that wraps the provider factory in an `OverlayStateProviderFactory` internally. This satisfies the `TrieCursorFactory + HashedCursorFactory` trait bounds required by `ParallelStateRoot`.

- **`crates/stages/stages/src/sets.rs`**: Added new stage sets:
  - `ParallelHashingStages<F>` - uses `ParallelMerkleStage` instead of `MerkleStage`
  - `ParallelOfflineStages<E, F>` - offline stages with parallel merkle support
  - `ParallelDefaultStages<P, H, B, E, F>` - full stage set with parallel merkle

- **`crates/node/builder/src/setup.rs`**: Wired `ParallelDefaultStages` into the default pipeline, enabling parallel merkle computation for all reth nodes.

- **`crates/stages/stages/src/prelude.rs`**: Exported the new parallel stage set types.

## Testing

- Compiled successfully with `cargo check -p reth`
- Passes `cargo +nightly fmt --all --check`
- Passes `cargo clippy` with `-D warnings`

Next steps: Test by syncing a Hoodi node to block 1000, unwinding to 100, and syncing back to 1000.