### PR TITLE
chore: fix unused parallel trie const without std

### DIFF
--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -994,6 +994,7 @@ where
     S: SparseTrieTrait + SparseTrieExt + Default + Clone,
 {
     /// Minimum number of storage tries before parallel pruning is enabled.
+    #[cfg(feature = "std")]
     const PARALLEL_PRUNE_THRESHOLD: usize = 16;
 
     /// Returns true if parallelism should be enabled for pruning the given number of tries.


### PR DESCRIPTION
was throwing an unused warning when sparse trie was used but `std` was not enabled