### PR TITLE
perf: cache fetched proof targets in `SparseTrieCacheTask`

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -178,6 +178,12 @@ pub(super) struct SparseTrieCacheTask<A = SerialSparseTrie, S = SerialSparseTrie
     ///   - Some(_): account was changed/destroyed and is awaiting storage root calculation/reveal
     ///     to complete.
     pending_account_updates: B256Map<Option<Option<Account>>>,
+    /// Cache of account proof targets that were already fetched/requested from the proof workers.
+    /// account -> lowest min_len requested.
+    fetched_account_targets: B256Map<u8>,
+    /// Cache of storage proof targets that have already been fetched/requested from the proof
+    /// workers. account -> slot -> lowest min_len requested.
+    fetched_storage_targets: B256Map<B256Map<u8>>,
     /// Metrics for the sparse trie.
     metrics: MultiProofTaskMetrics,
 }
@@ -204,6 +210,8 @@ where
             account_updates: Default::default(),
             storage_updates: Default::default(),
             pending_account_updates: Default::default(),
+            fetched_account_targets: Default::default(),
+            fetched_storage_targets: Default::default(),
             metrics,
         }
     }
@@ -397,13 +405,27 @@ where
 
         for (addr, updates) in &mut self.storage_updates {
             let trie = self.trie.get_or_create_storage_trie_mut(*addr);
+            let fetched_storage = self.fetched_storage_targets.entry(*addr).or_default();
 
-            trie.update_leaves(updates, |path, min_len| {
-                targets
-                    .storage_targets
-                    .entry(*addr)
-                    .or_default()
-                    .push(Target::new(path).with_min_len(min_len));
+            trie.update_leaves(updates, |path, min_len| match fetched_storage.entry(path) {
+                Entry::Occupied(mut entry) => {
+                    if min_len < *entry.get() {
+                        entry.insert(min_len);
+                        targets
+                            .storage_targets
+                            .entry(*addr)
+                            .or_default()
+                            .push(Target::new(path).with_min_len(min_len));
+                    }
+                }
+                Entry::Vacant(entry) => {
+                    entry.insert(min_len);
+                    targets
+                        .storage_targets
+                        .entry(*addr)
+                        .or_default()
+                        .push(Target::new(path).with_min_len(min_len));
+                }
             })
             .map_err(ProviderError::other)?;
 
@@ -481,7 +503,18 @@ where
         self.trie
             .trie_mut()
             .update_leaves(&mut self.account_updates, |target, min_len| {
-                targets.account_targets.push(Target::new(target).with_min_len(min_len));
+                match self.fetched_account_targets.entry(target) {
+                    Entry::Occupied(mut entry) => {
+                        if min_len < *entry.get() {
+                            entry.insert(min_len);
+                            targets.account_targets.push(Target::new(target).with_min_len(min_len));
+                        }
+                    }
+                    Entry::Vacant(entry) => {
+                        entry.insert(min_len);
+                        targets.account_targets.push(Target::new(target).with_min_len(min_len));
+                    }
+                }
             })
             .map_err(ProviderError::other)?;
 

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -179,10 +179,10 @@ pub(super) struct SparseTrieCacheTask<A = SerialSparseTrie, S = SerialSparseTrie
     ///     to complete.
     pending_account_updates: B256Map<Option<Option<Account>>>,
     /// Cache of account proof targets that were already fetched/requested from the proof workers.
-    /// account -> lowest min_len requested.
+    /// account -> lowest `min_len` requested.
     fetched_account_targets: B256Map<u8>,
     /// Cache of storage proof targets that have already been fetched/requested from the proof
-    /// workers. account -> slot -> lowest min_len requested.
+    /// workers. account -> slot -> lowest `min_len` requested.
     fetched_storage_targets: B256Map<B256Map<u8>>,
     /// Metrics for the sparse trie.
     metrics: MultiProofTaskMetrics,

--- a/crates/trie/parallel/src/value_encoder.rs
+++ b/crates/trie/parallel/src/value_encoder.rs
@@ -54,7 +54,9 @@ pub(crate) enum AsyncAccountDeferredValueEncoder<TC, HC> {
     Dispatched {
         hashed_address: B256,
         account: Account,
-        proof_result_rx: Result<CrossbeamReceiver<StorageProofResultMessage>, DatabaseError>,
+        /// Shared dispatched receivers - the receiver for this address will be removed and
+        /// consumed in encode(). If encode() is never called, finalize() will collect it.
+        dispatched: Rc<RefCell<B256Map<CrossbeamReceiver<StorageProofResultMessage>>>>,
         /// Shared storage proof results.
         storage_proof_results: Rc<RefCell<B256Map<Vec<ProofTrieNode>>>>,
         /// Shared stats for tracking wait time and counts.
@@ -88,14 +90,21 @@ where
             Self::Dispatched {
                 hashed_address,
                 account,
-                proof_result_rx,
+                dispatched,
                 storage_proof_results,
                 stats,
                 storage_calculator,
                 cached_storage_roots,
             } => {
+                // Remove the receiver from dispatched and consume it
+                let rx = dispatched.borrow_mut().remove(&hashed_address).ok_or_else(|| {
+                    StateProofError::Database(DatabaseError::Other(format!(
+                        "No dispatched receiver found for {hashed_address:?}",
+                    )))
+                })?;
+
                 let wait_start = Instant::now();
-                let result = proof_result_rx?
+                let result = rx
                     .recv()
                     .map_err(|_| {
                         StateProofError::Database(DatabaseError::Other(format!(
@@ -164,8 +173,9 @@ where
 /// [`StorageProofCalculator`] to compute storage roots synchronously, reusing cursors across
 /// multiple accounts.
 pub(crate) struct AsyncAccountValueEncoder<TC, HC> {
-    /// Storage proof jobs which were dispatched ahead of time.
-    dispatched: B256Map<CrossbeamReceiver<StorageProofResultMessage>>,
+    /// Storage proof jobs which were dispatched ahead of time. Shared so that `encode()` can
+    /// remove consumed receivers. Any remaining receivers are collected in `finalize()`.
+    dispatched: Rc<RefCell<B256Map<CrossbeamReceiver<StorageProofResultMessage>>>>,
     /// Storage roots which have already been computed. This can be used only if a storage proof
     /// wasn't dispatched for an account, otherwise we must consume the proof result.
     cached_storage_roots: Arc<DashMap<B256, B256>>,
@@ -193,7 +203,7 @@ impl<TC, HC> AsyncAccountValueEncoder<TC, HC> {
         storage_calculator: Rc<RefCell<StorageProofCalculator<TC, HC>>>,
     ) -> Self {
         Self {
-            dispatched,
+            dispatched: Rc::new(RefCell::new(dispatched)),
             cached_storage_roots,
             storage_proof_results: Default::default(),
             storage_calculator,
@@ -221,9 +231,14 @@ impl<TC, HC> AsyncAccountValueEncoder<TC, HC> {
             .expect("no deferred encoders are still allocated")
             .into_inner();
 
-        // Any remaining dispatched proofs need to have their results collected.
-        // These are proofs that were pre-dispatched but not consumed during proof calculation.
-        for (hashed_address, rx) in &self.dispatched {
+        // Collect any remaining dispatched proofs. These include:
+        // - Proofs that were pre-dispatched but never had deferred_encoder() called
+        // - Proofs where deferred_encoder() was called but encode() wasn't (account filtered out)
+        let dispatched = Rc::into_inner(self.dispatched)
+            .expect("no deferred encoders are still allocated")
+            .into_inner();
+
+        for (hashed_address, rx) in dispatched {
             let wait_start = Instant::now();
             let result = rx
                 .recv()
@@ -239,7 +254,7 @@ impl<TC, HC> AsyncAccountValueEncoder<TC, HC> {
                 panic!("StorageProofResult is not V2: {result:?}")
             };
 
-            storage_proof_results.insert(*hashed_address, proof);
+            storage_proof_results.insert(hashed_address, proof);
         }
 
         Ok((storage_proof_results, stats))
@@ -259,14 +274,15 @@ where
         hashed_address: B256,
         account: Self::Value,
     ) -> Self::DeferredEncoder {
-        // If the proof job has already been dispatched for this account then it's not necessary to
-        // dispatch another.
-        if let Some(rx) = self.dispatched.remove(&hashed_address) {
+        // If a proof job was dispatched for this account, return a Dispatched encoder.
+        // The receiver will be removed from dispatched when encode() is called.
+        // If encode() is never called, finalize() will collect it.
+        if self.dispatched.borrow().contains_key(&hashed_address) {
             self.stats.borrow_mut().dispatched_count += 1;
             return AsyncAccountDeferredValueEncoder::Dispatched {
                 hashed_address,
                 account,
-                proof_result_rx: Ok(rx),
+                dispatched: self.dispatched.clone(),
                 storage_proof_results: self.storage_proof_results.clone(),
                 stats: self.stats.clone(),
                 storage_calculator: self.storage_calculator.clone(),

--- a/crates/trie/parallel/src/value_encoder.rs
+++ b/crates/trie/parallel/src/value_encoder.rs
@@ -103,7 +103,7 @@ where
                     })?;
 
                 let wait_start = Instant::now();
-                let result = rx
+                let result = proof_result_rx
                     .recv()
                     .map_err(|_| {
                         StateProofError::Database(DatabaseError::Other(format!(


### PR DESCRIPTION
Based on https://github.com/paradigmxyz/reth/pull/21611

Implements cache for fetched proof targets so that we don't fetch same account/storage proofs over and over.