### PR TITLE
feat(prune): add --delete-limit flag to control memory usage (temp fix for prune)

### DIFF
--- a/crates/cli/commands/src/prune.rs
+++ b/crates/cli/commands/src/prune.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use tracing::{info, warn};
 
 /// Default delete limit per prune run to prevent OOM when static files are involved.
+#[cfg(feature = "edge")]
 const DEFAULT_DELETE_LIMIT: usize = 100_000;
 
 /// Prunes according to the configuration with a configurable delete limit.

--- a/crates/prune/prune/src/pruner.rs
+++ b/crates/prune/prune/src/pruner.rs
@@ -177,6 +177,7 @@ where
 
         for segment in &self.segments {
             if limiter.is_limit_reached() {
+                output.progress = limiter.progress(false);
                 break
             }
 

--- a/docs/vocs/docs/pages/cli/op-reth/prune.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/prune.mdx
@@ -181,6 +181,11 @@ RocksDB:
           [default: false]
           [possible values: true, false]
 
+      --delete-limit <DELETE_LIMIT>
+          Maximum number of entries to delete per pruner run (across all segments).
+
+          For edge builds, defaults to 100,000 to prevent OOM. For legacy builds, defaults to unlimited. Set to 0 for unlimited deletions per run.
+
 Metrics:
       --metrics <PROMETHEUS>
           Enable Prometheus metrics.

--- a/docs/vocs/docs/pages/cli/reth/prune.mdx
+++ b/docs/vocs/docs/pages/cli/reth/prune.mdx
@@ -181,6 +181,11 @@ RocksDB:
           [default: false]
           [possible values: true, false]
 
+      --delete-limit <DELETE_LIMIT>
+          Maximum number of entries to delete per pruner run (across all segments).
+
+          For edge builds, defaults to 100,000 to prevent OOM. For legacy builds, defaults to unlimited. Set to 0 for unlimited deletions per run.
+
 Metrics:
       --metrics <PROMETHEUS>
           Enable Prometheus metrics.


### PR DESCRIPTION
## Summary

Adds a configurable `--delete-limit` flag to the `reth prune` command to control memory usage during pruning operations.

## Motivation

The `reth prune` command causes OOM with ~50GB RSS on archive nodes. The root cause is that `delete_limit(usize::MAX)` causes walker loops to collect all entries into memory before processing, which is problematic for nodes with hundreds of millions of entries.

## Solution

- Add `--delete-limit` CLI argument with a sensible default of 100,000 entries per segment
- Use `0` to mean unlimited (backwards compatible with legacy behavior)
- Log the delete limit for visibility during pruning

## Changes

- Added `const DEFAULT_DELETE_LIMIT: usize = 100_000`
- Added `--delete-limit` CLI argument with documentation
- Updated pruner builder to use configurable limit
- Enhanced logging to show the configured delete limit

## Testing

Tested on dev-yk with 2.5TB RocksDB datadir - memory usage stayed under control with the new default limit.