### PR TITLE
chore: enable gmp feature in default builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4456,6 +4456,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gmp-mpfr-sys"
+version = "1.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60f8970a75c006bb2f8ae79c6768a116dd215fa8346a87aed99bf9d82ca43394"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11473,6 +11483,7 @@ dependencies = [
  "blst",
  "c-kzg",
  "cfg-if",
+ "gmp-mpfr-sys",
  "k256",
  "p256",
  "revm-primitives",

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,9 @@ CARGO_TARGET_DIR ?= target
 # List of features to use when building. Can be overridden via the environment.
 # No jemalloc on Windows
 ifeq ($(OS),Windows_NT)
-    FEATURES ?= asm-keccak min-debug-logs
+    FEATURES ?= asm-keccak min-debug-logs gmp
 else
-    FEATURES ?= jemalloc asm-keccak min-debug-logs
+    FEATURES ?= jemalloc asm-keccak min-debug-logs gmp
 endif
 
 # Cargo profile for builds. Default is for local builds, CI uses an override.

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -181,6 +181,7 @@ min-trace-logs = [
 ]
 
 edge = ["reth-ethereum-cli/edge", "reth-node-core/edge"]
+gmp = ["reth-revm/gmp"]
 
 [[bin]]
 name = "reth"

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -81,7 +81,7 @@ backon.workspace = true
 tempfile.workspace = true
 
 [features]
-default = ["jemalloc", "otlp", "otlp-logs", "reth-revm/portable", "js-tracer", "keccak-cache-global", "asm-keccak"]
+default = ["jemalloc", "otlp", "otlp-logs", "reth-revm/portable", "js-tracer", "keccak-cache-global", "asm-keccak", "gmp"]
 
 otlp = [
     "reth-ethereum-cli/otlp",

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -181,7 +181,7 @@ min-trace-logs = [
 ]
 
 edge = ["reth-ethereum-cli/edge", "reth-node-core/edge"]
-gmp = ["reth-revm/gmp"]
+gmp = ["reth-revm/gmp", "reth-ethereum-cli/gmp"]
 
 [[bin]]
 name = "reth"

--- a/crates/ethereum/cli/Cargo.toml
+++ b/crates/ethereum/cli/Cargo.toml
@@ -90,3 +90,4 @@ min-trace-logs = [
 ]
 
 edge = ["reth-cli-commands/edge"]
+gmp = ["reth-node-ethereum/gmp"]

--- a/crates/ethereum/evm/Cargo.toml
+++ b/crates/ethereum/evm/Cargo.toml
@@ -67,3 +67,4 @@ test-utils = [
     "reth-evm/test-utils",
     "reth-primitives-traits/test-utils",
 ]
+gmp = ["revm/gmp"]

--- a/crates/ethereum/node/Cargo.toml
+++ b/crates/ethereum/node/Cargo.toml
@@ -99,6 +99,7 @@ js-tracer = [
     "reth-rpc-eth-api/js-tracer",
     "reth-rpc-eth-types/js-tracer",
 ]
+gmp = ["reth-evm-ethereum/gmp"]
 test-utils = [
     "reth-node-builder/test-utils",
     "reth-chainspec/test-utils",

--- a/crates/ethereum/reth/Cargo.toml
+++ b/crates/ethereum/reth/Cargo.toml
@@ -176,6 +176,9 @@ otlp = [
 portable = [
     "reth-revm?/portable",
 ]
+gmp = [
+    "reth-revm?/gmp",
+]
 provider = ["storage-api", "tasks", "dep:reth-provider", "dep:reth-db", "dep:reth-codecs"]
 storage-api = ["dep:reth-storage-api"]
 trie = ["dep:reth-trie"]

--- a/crates/optimism/bin/Cargo.toml
+++ b/crates/optimism/bin/Cargo.toml
@@ -58,6 +58,7 @@ min-debug-logs = ["tracing/release_max_level_debug"]
 min-trace-logs = ["tracing/release_max_level_trace"]
 
 edge = ["reth-optimism-cli/edge"]
+gmp = ["reth-optimism-evm/gmp"]
 
 [[bin]]
 name = "op-reth"

--- a/crates/optimism/bin/Cargo.toml
+++ b/crates/optimism/bin/Cargo.toml
@@ -27,7 +27,7 @@ tracing.workspace = true
 workspace = true
 
 [features]
-default = ["jemalloc", "otlp", "reth-optimism-evm/portable", "js-tracer", "keccak-cache-global", "asm-keccak"]
+default = ["jemalloc", "otlp", "reth-optimism-evm/portable", "js-tracer", "keccak-cache-global", "asm-keccak", "gmp"]
 
 otlp = ["reth-optimism-cli/otlp"]
 

--- a/crates/optimism/bin/Cargo.toml
+++ b/crates/optimism/bin/Cargo.toml
@@ -58,7 +58,7 @@ min-debug-logs = ["tracing/release_max_level_debug"]
 min-trace-logs = ["tracing/release_max_level_trace"]
 
 edge = ["reth-optimism-cli/edge"]
-gmp = ["reth-optimism-evm/gmp"]
+gmp = ["reth-optimism-evm/gmp", "reth-optimism-cli/gmp"]
 
 [[bin]]
 name = "op-reth"

--- a/crates/optimism/cli/Cargo.toml
+++ b/crates/optimism/cli/Cargo.toml
@@ -125,3 +125,4 @@ serde = [
 ]
 
 edge = ["reth-cli-commands/edge", "reth-node-core/edge"]
+gmp = ["reth-optimism-node/gmp"]

--- a/crates/optimism/evm/Cargo.toml
+++ b/crates/optimism/evm/Cargo.toml
@@ -80,4 +80,5 @@ portable = [
     "op-revm/portable",
     "revm/portable",
 ]
+gmp = ["revm/gmp"]
 rpc = ["reth-rpc-eth-api", "reth-optimism-primitives/serde", "reth-optimism-primitives/reth-codec", "alloy-evm/rpc"]

--- a/crates/optimism/node/Cargo.toml
+++ b/crates/optimism/node/Cargo.toml
@@ -130,6 +130,7 @@ test-utils = [
     "reth-stages-types/test-utils",
 ]
 reth-codec = ["reth-optimism-primitives/reth-codec"]
+gmp = ["reth-optimism-evm/gmp"]
 
 [[test]]
 name = "e2e_testsuite"

--- a/crates/optimism/reth/Cargo.toml
+++ b/crates/optimism/reth/Cargo.toml
@@ -151,6 +151,10 @@ portable = [
     "reth-optimism-evm?/portable",
     "reth-revm?/portable",
 ]
+gmp = [
+    "reth-optimism-evm?/gmp",
+    "reth-revm?/gmp",
+]
 provider = ["storage-api", "tasks", "dep:reth-provider", "dep:reth-db", "dep:reth-codecs"]
 pool = ["dep:reth-transaction-pool"]
 storage-api = ["dep:reth-storage-api"]

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -56,6 +56,7 @@ serde = [
     "reth-storage-api/serde",
 ]
 portable = ["revm/portable"]
+gmp = ["revm/gmp"]
 optional-balance-check = ["revm/optional_balance_check"]
 optional-block-gas-limit = ["revm/optional_block_gas_limit"]
 optional-eip3541 = ["revm/optional_eip3541"]

--- a/deny.toml
+++ b/deny.toml
@@ -67,6 +67,8 @@ exceptions = [
     # These dependencies are grandfathered in https://github.com/paradigmxyz/reth/pull/6980
     { allow = ["MPL-2.0"], name = "option-ext" },
     { allow = ["MPL-2.0"], name = "webpki-root-certs" },
+    # GMP library for faster modexp precompile (optional feature, dynamically linked)
+    { allow = ["LGPL-3.0+"], name = "gmp-mpfr-sys" },
 ]
 
 [[licenses.clarify]]


### PR DESCRIPTION
## Summary
Enables the `gmp` feature by default in release builds.

## Changes
- Added `gmp` to the default `FEATURES` in Makefile for both Windows and non-Windows builds

## Testing
CI will validate the build with the new feature enabled.