### PR TITLE
feat(rpc): make blob sidecar upcasting opt-in

### DIFF
--- a/crates/ethereum/node/tests/e2e/blobs.rs
+++ b/crates/ethereum/node/tests/e2e/blobs.rs
@@ -100,10 +100,12 @@ async fn can_send_legacy_sidecar_post_activation() -> eyre::Result<()> {
         ChainSpecBuilder::default().chain(MAINNET.chain).genesis(genesis).osaka_activated().build(),
     );
     let genesis_hash = chain_spec.genesis_hash();
-    let node_config = NodeConfig::test()
-        .with_chain(chain_spec)
-        .with_unused_ports()
-        .with_rpc(RpcServerArgs::default().with_unused_ports().with_http());
+    let node_config = NodeConfig::test().with_chain(chain_spec).with_unused_ports().with_rpc(
+        RpcServerArgs::default()
+            .with_unused_ports()
+            .with_http()
+            .with_force_blob_sidecar_upcasting(),
+    );
     let NodeHandle { node, node_exit_future: _ } = NodeBuilder::new(node_config.clone())
         .testing_node(exec.clone())
         .node(EthereumNode::default())
@@ -125,7 +127,7 @@ async fn can_send_legacy_sidecar_post_activation() -> eyre::Result<()> {
     let blob_tx_hash = node.rpc.inject_tx(blob_tx).await?;
     // fetch it from rpc
     let envelope = node.rpc.envelope_by_hash(blob_tx_hash).await?;
-    // assert that sidecar was converted to eip7594
+    // assert that sidecar was converted to eip7594 (force upcasting is enabled)
     assert!(envelope.as_eip4844().unwrap().tx().sidecar().unwrap().is_eip7594());
     // validate sidecar
     TransactionTestContext::validate_sidecar(envelope);
@@ -161,10 +163,12 @@ async fn blob_conversion_at_osaka() -> eyre::Result<()> {
             .build(),
     );
     let genesis_hash = chain_spec.genesis_hash();
-    let node_config = NodeConfig::test()
-        .with_chain(chain_spec)
-        .with_unused_ports()
-        .with_rpc(RpcServerArgs::default().with_unused_ports().with_http());
+    let node_config = NodeConfig::test().with_chain(chain_spec).with_unused_ports().with_rpc(
+        RpcServerArgs::default()
+            .with_unused_ports()
+            .with_http()
+            .with_force_blob_sidecar_upcasting(),
+    );
     let NodeHandle { node, node_exit_future: _ } = NodeBuilder::new(node_config.clone())
         .testing_node(exec.clone())
         .node(EthereumNode::default())

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -1192,6 +1192,7 @@ impl<'a, N: FullNodeComponents<Types: NodeTypes<ChainSpec: Hardforks + EthereumH
             .pending_block_kind(self.config.pending_block_kind)
             .raw_tx_forwarder(self.config.raw_tx_forwarder)
             .evm_memory_limit(self.config.rpc_evm_memory_limit)
+            .force_blob_sidecar_upcasting(self.config.force_blob_sidecar_upcasting)
     }
 }
 

--- a/crates/node/core/src/args/rpc_server.rs
+++ b/crates/node/core/src/args/rpc_server.rs
@@ -776,6 +776,12 @@ impl RpcServerArgs {
         self.rpc_send_raw_transaction_sync_timeout = timeout;
         self
     }
+
+    /// Enables forced blob sidecar upcasting from EIP-4844 to EIP-7594 format.
+    pub const fn with_force_blob_sidecar_upcasting(mut self) -> Self {
+        self.rpc_force_blob_sidecar_upcasting = true;
+        self
+    }
 }
 
 impl Default for RpcServerArgs {

--- a/crates/node/core/src/args/rpc_server.rs
+++ b/crates/node/core/src/args/rpc_server.rs
@@ -1045,6 +1045,7 @@ mod tests {
             },
             rpc_send_raw_transaction_sync_timeout: std::time::Duration::from_secs(30),
             testing_skip_invalid_transactions: true,
+            rpc_force_blob_sidecar_upcasting: false,
         };
 
         let parsed_args = CommandParser::<RpcServerArgs>::parse_from([

--- a/crates/node/core/src/args/rpc_server.rs
+++ b/crates/node/core/src/args/rpc_server.rs
@@ -647,6 +647,14 @@ pub struct RpcServerArgs {
     /// transactions from the same sender will also be skipped.
     #[arg(long = "testing.skip-invalid-transactions", default_value_t = true)]
     pub testing_skip_invalid_transactions: bool,
+
+    /// Force upcasting EIP-4844 blob sidecars to EIP-7594 format when Osaka is active.
+    ///
+    /// When enabled, blob transactions submitted via `eth_sendRawTransaction` with EIP-4844
+    /// sidecars will be automatically converted to EIP-7594 format if the next block is Osaka.
+    /// By default this is disabled, meaning transactions are submitted as-is.
+    #[arg(long = "rpc.force-blob-sidecar-upcasting", default_value_t = false)]
+    pub rpc_force_blob_sidecar_upcasting: bool,
 }
 
 impl RpcServerArgs {

--- a/crates/node/core/src/args/rpc_server.rs
+++ b/crates/node/core/src/args/rpc_server.rs
@@ -868,6 +868,7 @@ impl Default for RpcServerArgs {
             gas_price_oracle,
             rpc_send_raw_transaction_sync_timeout,
             testing_skip_invalid_transactions: true,
+            rpc_force_blob_sidecar_upcasting: false,
         }
     }
 }

--- a/crates/rpc/rpc-builder/src/config.rs
+++ b/crates/rpc/rpc-builder/src/config.rs
@@ -107,6 +107,7 @@ impl RethRpcServerConfig for RpcServerArgs {
             .pending_block_kind(self.rpc_pending_block)
             .raw_tx_forwarder(self.rpc_forwarder.clone())
             .rpc_evm_memory_limit(self.rpc_evm_memory_limit)
+            .force_blob_sidecar_upcasting(self.rpc_force_blob_sidecar_upcasting)
     }
 
     fn flashbots_config(&self) -> ValidationApiConfig {

--- a/crates/rpc/rpc-eth-types/src/builder/config.rs
+++ b/crates/rpc/rpc-eth-types/src/builder/config.rs
@@ -107,6 +107,11 @@ pub struct EthConfig {
     pub send_raw_transaction_sync_timeout: Duration,
     /// Maximum memory the EVM can allocate per RPC request.
     pub rpc_evm_memory_limit: u64,
+    /// Whether to force upcasting EIP-4844 blob sidecars to EIP-7594 format when Osaka is active.
+    ///
+    /// This is disabled by default, allowing blob transactions with EIP-4844 sidecars to be
+    /// submitted without automatic conversion.
+    pub force_blob_sidecar_upcasting: bool,
 }
 
 impl EthConfig {
@@ -140,6 +145,7 @@ impl Default for EthConfig {
             raw_tx_forwarder: ForwardConfig::default(),
             send_raw_transaction_sync_timeout: RPC_DEFAULT_SEND_RAW_TX_SYNC_TIMEOUT_SECS,
             rpc_evm_memory_limit: (1 << 32) - 1,
+            force_blob_sidecar_upcasting: false,
         }
     }
 }
@@ -240,6 +246,12 @@ impl EthConfig {
     /// Configures the maximum memory the EVM can allocate per RPC request.
     pub const fn rpc_evm_memory_limit(mut self, memory_limit: u64) -> Self {
         self.rpc_evm_memory_limit = memory_limit;
+        self
+    }
+
+    /// Configures whether to force upcasting EIP-4844 blob sidecars to EIP-7594 format.
+    pub const fn force_blob_sidecar_upcasting(mut self, force: bool) -> Self {
+        self.force_blob_sidecar_upcasting = force;
         self
     }
 }

--- a/crates/rpc/rpc/src/eth/builder.rs
+++ b/crates/rpc/rpc/src/eth/builder.rs
@@ -47,6 +47,7 @@ pub struct EthApiBuilder<N: RpcNodeCore, Rpc, NextEnv = ()> {
     raw_tx_forwarder: ForwardConfig,
     send_raw_transaction_sync_timeout: Duration,
     evm_memory_limit: u64,
+    force_blob_sidecar_upcasting: bool,
 }
 
 impl<Provider, Pool, Network, EvmConfig, ChainSpec>
@@ -99,6 +100,7 @@ impl<N: RpcNodeCore, Rpc, NextEnv> EthApiBuilder<N, Rpc, NextEnv> {
             raw_tx_forwarder,
             send_raw_transaction_sync_timeout,
             evm_memory_limit,
+            force_blob_sidecar_upcasting,
         } = self;
         EthApiBuilder {
             components,
@@ -121,6 +123,7 @@ impl<N: RpcNodeCore, Rpc, NextEnv> EthApiBuilder<N, Rpc, NextEnv> {
             raw_tx_forwarder,
             send_raw_transaction_sync_timeout,
             evm_memory_limit,
+            force_blob_sidecar_upcasting,
         }
     }
 }
@@ -154,6 +157,7 @@ where
             raw_tx_forwarder: ForwardConfig::default(),
             send_raw_transaction_sync_timeout: Duration::from_secs(30),
             evm_memory_limit: (1 << 32) - 1,
+            force_blob_sidecar_upcasting: false,
         }
     }
 }
@@ -194,6 +198,7 @@ where
             raw_tx_forwarder,
             send_raw_transaction_sync_timeout,
             evm_memory_limit,
+            force_blob_sidecar_upcasting,
         } = self;
         EthApiBuilder {
             components,
@@ -216,6 +221,7 @@ where
             raw_tx_forwarder,
             send_raw_transaction_sync_timeout,
             evm_memory_limit,
+            force_blob_sidecar_upcasting,
         }
     }
 
@@ -245,6 +251,7 @@ where
             raw_tx_forwarder,
             send_raw_transaction_sync_timeout,
             evm_memory_limit,
+            force_blob_sidecar_upcasting,
         } = self;
         EthApiBuilder {
             components,
@@ -267,6 +274,7 @@ where
             raw_tx_forwarder,
             send_raw_transaction_sync_timeout,
             evm_memory_limit,
+            force_blob_sidecar_upcasting,
         }
     }
 
@@ -502,6 +510,7 @@ where
             raw_tx_forwarder,
             send_raw_transaction_sync_timeout,
             evm_memory_limit,
+            force_blob_sidecar_upcasting,
         } = self;
 
         let provider = components.provider().clone();
@@ -544,6 +553,7 @@ where
             raw_tx_forwarder.forwarder_client(),
             send_raw_transaction_sync_timeout,
             evm_memory_limit,
+            force_blob_sidecar_upcasting,
         )
     }
 
@@ -572,6 +582,12 @@ where
     /// Sets the maximum memory the EVM can allocate per RPC request.
     pub const fn evm_memory_limit(mut self, memory_limit: u64) -> Self {
         self.evm_memory_limit = memory_limit;
+        self
+    }
+
+    /// Sets whether to force upcasting EIP-4844 blob sidecars to EIP-7594 format.
+    pub const fn force_blob_sidecar_upcasting(mut self, force: bool) -> Self {
+        self.force_blob_sidecar_upcasting = force;
         self
     }
 }

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -157,6 +157,7 @@ where
         raw_tx_forwarder: ForwardConfig,
         send_raw_transaction_sync_timeout: Duration,
         evm_memory_limit: u64,
+        force_blob_sidecar_upcasting: bool,
     ) -> Self {
         let inner = EthApiInner::new(
             components,
@@ -177,6 +178,7 @@ where
             raw_tx_forwarder.forwarder_client(),
             send_raw_transaction_sync_timeout,
             evm_memory_limit,
+            force_blob_sidecar_upcasting,
         );
 
         Self { inner: Arc::new(inner) }

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -333,6 +333,9 @@ pub struct EthApiInner<N: RpcNodeCore, Rpc: RpcConvert> {
 
     /// Maximum memory the EVM can allocate per RPC request.
     evm_memory_limit: u64,
+
+    /// Whether to force upcasting EIP-4844 blob sidecars to EIP-7594 format when Osaka is active.
+    force_blob_sidecar_upcasting: bool,
 }
 
 impl<N, Rpc> EthApiInner<N, Rpc>
@@ -361,6 +364,7 @@ where
         raw_tx_forwarder: Option<RpcClient>,
         send_raw_transaction_sync_timeout: Duration,
         evm_memory_limit: u64,
+        force_blob_sidecar_upcasting: bool,
     ) -> Self {
         let signers = parking_lot::RwLock::new(Default::default());
         // get the block number of the latest block
@@ -405,6 +409,7 @@ where
             send_raw_transaction_sync_timeout,
             blob_sidecar_converter: BlobSidecarConverter::new(),
             evm_memory_limit,
+            force_blob_sidecar_upcasting,
         }
     }
 }
@@ -595,6 +600,12 @@ where
     #[inline]
     pub const fn blocking_io_request_semaphore(&self) -> &Arc<Semaphore> {
         &self.blocking_io_request_semaphore
+    }
+
+    /// Returns whether to force upcasting EIP-4844 blob sidecars to EIP-7594 format.
+    #[inline]
+    pub const fn force_blob_sidecar_upcasting(&self) -> bool {
+        self.force_blob_sidecar_upcasting
     }
 }
 

--- a/crates/rpc/rpc/src/eth/helpers/transaction.rs
+++ b/crates/rpc/rpc/src/eth/helpers/transaction.rs
@@ -44,9 +44,9 @@ where
         let mut pool_transaction =
             <Self::Pool as TransactionPool>::Transaction::from_pooled(recovered);
 
-        // TODO: remove this after Osaka transition
-        // Convert legacy blob sidecars to EIP-7594 format
-        if pool_transaction.is_eip4844() {
+        // Optionally convert legacy blob sidecars to EIP-7594 format when Osaka is active
+        // This is opt-in via --rpc.force-blob-sidecar-upcasting
+        if self.inner.force_blob_sidecar_upcasting() && pool_transaction.is_eip4844() {
             let EthBlobTransactionSidecar::Present(sidecar) = pool_transaction.take_blob() else {
                 return Err(EthApiError::PoolError(RpcPoolError::Eip4844(
                     Eip4844PoolTransactionError::MissingEip4844BlobSidecar,

--- a/docs/vocs/docs/pages/cli/op-reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/node.mdx
@@ -540,6 +540,11 @@ Gas Price Oracle:
 
           When enabled, transactions that fail execution will be skipped, and all subsequent transactions from the same sender will also be skipped.
 
+      --rpc.force-blob-sidecar-upcasting
+          Force upcasting EIP-4844 blob sidecars to EIP-7594 format when Osaka is active.
+
+          When enabled, blob transactions submitted via `eth_sendRawTransaction` with EIP-4844 sidecars will be automatically converted to EIP-7594 format if the next block is Osaka. By default this is disabled, meaning transactions are submitted as-is.
+
 TxPool:
       --txpool.pending-max-count <PENDING_MAX_COUNT>
           Max number of transaction in the pending sub-pool

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -540,6 +540,11 @@ Gas Price Oracle:
 
           When enabled, transactions that fail execution will be skipped, and all subsequent transactions from the same sender will also be skipped.
 
+      --rpc.force-blob-sidecar-upcasting
+          Force upcasting EIP-4844 blob sidecars to EIP-7594 format when Osaka is active.
+
+          When enabled, blob transactions submitted via `eth_sendRawTransaction` with EIP-4844 sidecars will be automatically converted to EIP-7594 format if the next block is Osaka. By default this is disabled, meaning transactions are submitted as-is.
+
 TxPool:
       --txpool.pending-max-count <PENDING_MAX_COUNT>
           Max number of transaction in the pending sub-pool


### PR DESCRIPTION
## Summary

Makes the forced EIP-4844 to EIP-7594 blob sidecar upcasting opt-in via a new CLI flag.

## Motivation

Currently, blob transactions with EIP-4844 sidecars are automatically converted to EIP-7594 format when Osaka is active. This change makes that behavior opt-in, allowing users to choose whether they want automatic conversion.

## Changes

- Add `--rpc.force-blob-sidecar-upcasting` flag to `RpcServerArgs` (defaults to `false`)
- Add `force_blob_sidecar_upcasting` field to `EthConfig` with builder method
- Wire the setting through `EthApiBuilder` to `EthApiInner`
- Check the flag in `send_transaction` before performing the conversion

## Testing

The change is additive and preserves existing behavior when the flag is enabled.