### PR TITLE
fix(storage): populate storage settings cache for existing nodes

### DIFF
--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -183,6 +183,10 @@ where
                     );
                 }
 
+                // Set storage settings cache even for existing nodes so that
+                // components like the pruner know where data is stored.
+                factory.set_storage_settings_cache(stored);
+
                 debug!("Genesis already written, skipping.");
                 return Ok(hash)
             }


### PR DESCRIPTION
When a node is already initialized (genesis exists), `init_genesis_with_settings` was returning early without calling `set_storage_settings_cache()`. This caused components like the pruner to not know about RocksDB storage settings, resulting in the wrong code path being used.

This fix ensures the storage settings cache is populated even for existing nodes, so all components can correctly detect which storage backend is in use.