### PR TITLE
feat: add metrics tracking for static file producer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10870,10 +10870,12 @@ version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "assert_matches",
+ "metrics",
  "parking_lot",
  "rayon",
  "reth-codecs",
  "reth-db-api",
+ "reth-metrics",
  "reth-primitives-traits",
  "reth-provider",
  "reth-prune-types",

--- a/crates/static-file/static-file/Cargo.toml
+++ b/crates/static-file/static-file/Cargo.toml
@@ -15,20 +15,22 @@ workspace = true
 # reth
 reth-codecs.workspace = true
 reth-db-api.workspace = true
+reth-metrics.workspace = true
+reth-primitives-traits.workspace = true
 reth-provider.workspace = true
+reth-prune-types.workspace = true
+reth-stages-types.workspace = true
+reth-static-file-types.workspace = true
 reth-storage-errors.workspace = true
 reth-tokio-util.workspace = true
-reth-prune-types.workspace = true
-reth-primitives-traits.workspace = true
-reth-static-file-types.workspace = true
-reth-stages-types.workspace = true
 
 alloy-primitives.workspace = true
 
 # misc
-tracing.workspace = true
-rayon.workspace = true
+metrics.workspace = true
 parking_lot = { workspace = true, features = ["send_guard", "arc_lock"] }
+rayon.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 reth-stages = { workspace = true, features = ["test-utils"] }

--- a/crates/static-file/static-file/src/lib.rs
+++ b/crates/static-file/static-file/src/lib.rs
@@ -8,6 +8,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
+mod metrics;
 pub mod segments;
 mod static_file_producer;
 

--- a/crates/static-file/static-file/src/metrics.rs
+++ b/crates/static-file/static-file/src/metrics.rs
@@ -1,0 +1,14 @@
+//! Static file producer metrics.
+
+use metrics::Histogram;
+use reth_metrics::Metrics;
+
+/// Static file producer metrics.
+#[derive(Metrics, Clone)]
+#[metrics(scope = "static_file.producer")]
+pub(crate) struct StaticFileProducerMetrics {
+    /// Histogram for the time taken to produce static files for a single segment (in seconds).
+    pub(crate) segment_production_duration: Histogram,
+    /// Histogram for the total time taken to produce all static files (in seconds).
+    pub(crate) total_production_duration: Histogram,
+}


### PR DESCRIPTION
Adds histogram metrics to track segment and total production duration, resolves TODOs at static_file_producer.rs.