### PR TITLE
chore(db-api): simplify DatabaseMetrics impl for Arc

### DIFF
--- a/crates/storage/db-api/src/database_metrics.rs
+++ b/crates/storage/db-api/src/database_metrics.rs
@@ -37,18 +37,18 @@ pub trait DatabaseMetrics {
 
 impl<DB: DatabaseMetrics> DatabaseMetrics for Arc<DB> {
     fn report_metrics(&self) {
-        <DB as DatabaseMetrics>::report_metrics(self)
+        DB::report_metrics(self)
     }
 
     fn gauge_metrics(&self) -> Vec<(&'static str, f64, Vec<Label>)> {
-        <DB as DatabaseMetrics>::gauge_metrics(self)
+        DB::gauge_metrics(self)
     }
 
     fn counter_metrics(&self) -> Vec<(&'static str, u64, Vec<Label>)> {
-        <DB as DatabaseMetrics>::counter_metrics(self)
+        DB::counter_metrics(self)
     }
 
     fn histogram_metrics(&self) -> Vec<(&'static str, f64, Vec<Label>)> {
-        <DB as DatabaseMetrics>::histogram_metrics(self)
+        DB::histogram_metrics(self)
     }
 }


### PR DESCRIPTION
Replace `<DB as DatabaseMetrics>::method(self)` with `DB::method(self)` since the trait bound is already declared on the impl block.