### PR TITLE
refactor(trie): replace SmallVec with Vec in sparse trie buffers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11255,7 +11255,6 @@ dependencies = [
  "reth-trie",
  "reth-trie-common",
  "reth-trie-db",
- "smallvec",
  "tracing",
 ]
 

--- a/crates/trie/sparse-parallel/Cargo.toml
+++ b/crates/trie/sparse-parallel/Cargo.toml
@@ -28,8 +28,8 @@ reth-metrics = { workspace = true, optional = true }
 metrics = { workspace = true, optional = true }
 
 # misc
-smallvec.workspace = true
 rayon = { workspace = true, optional = true }
+smallvec.workspace = true
 
 [dev-dependencies]
 # reth

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -17,7 +17,6 @@ use reth_trie_sparse::{
     LeafLookup, LeafLookupError, RlpNodeStackItem, SparseNode, SparseNodeType, SparseTrie,
     SparseTrieExt, SparseTrieUpdates,
 };
-
 use smallvec::SmallVec;
 use std::cmp::{Ord, Ordering, PartialOrd};
 use tracing::{debug, instrument, trace};

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -17,6 +17,7 @@ use reth_trie_sparse::{
     LeafLookup, LeafLookupError, RlpNodeStackItem, SparseNode, SparseNodeType, SparseTrie,
     SparseTrieExt, SparseTrieUpdates,
 };
+
 use smallvec::SmallVec;
 use std::cmp::{Ord, Ordering, PartialOrd};
 use tracing::{debug, instrument, trace};
@@ -3123,9 +3124,9 @@ pub struct SparseSubtrieBuffers {
     /// Stack of RLP nodes
     rlp_node_stack: Vec<RlpNodeStackItem>,
     /// Reusable branch child path
-    branch_child_buf: SmallVec<[Nibbles; 16]>,
+    branch_child_buf: Vec<Nibbles>,
     /// Reusable branch value stack
-    branch_value_stack_buf: SmallVec<[RlpNode; 16]>,
+    branch_value_stack_buf: Vec<RlpNode>,
     /// Reusable RLP buffer
     rlp_buf: Vec<u8>,
 }

--- a/crates/trie/sparse/Cargo.toml
+++ b/crates/trie/sparse/Cargo.toml
@@ -26,7 +26,6 @@ alloy-rlp.workspace = true
 # misc
 auto_impl.workspace = true
 rayon = { workspace = true, optional = true }
-smallvec = { workspace = true, features = ["const_new"] }
 
 # metrics
 reth-metrics = { workspace = true, optional = true }
@@ -80,7 +79,6 @@ arbitrary = [
     "alloy-trie/arbitrary",
     "reth-primitives-traits/arbitrary",
     "reth-trie-common/arbitrary",
-    "smallvec/arbitrary",
 ]
 
 [[bench]]

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -24,7 +24,6 @@ use reth_trie_common::{
     LeafNodeRef, Nibbles, ProofTrieNode, RlpNode, TrieMask, TrieNode, CHILD_INDEX_RANGE,
     EMPTY_ROOT_HASH,
 };
-use smallvec::SmallVec;
 use tracing::{debug, instrument, trace};
 
 /// The level below which the sparse trie hashes are calculated in
@@ -1993,9 +1992,9 @@ pub struct RlpNodeBuffers {
     /// Stack of RLP nodes
     rlp_node_stack: Vec<RlpNodeStackItem>,
     /// Reusable branch child path
-    branch_child_buf: SmallVec<[Nibbles; 16]>,
+    branch_child_buf: Vec<Nibbles>,
     /// Reusable branch value stack
-    branch_value_stack_buf: SmallVec<[RlpNode; 16]>,
+    branch_value_stack_buf: Vec<RlpNode>,
 }
 
 impl RlpNodeBuffers {
@@ -2008,8 +2007,8 @@ impl RlpNodeBuffers {
                 is_in_prefix_set: None,
             }],
             rlp_node_stack: Vec::new(),
-            branch_child_buf: SmallVec::<[Nibbles; 16]>::new_const(),
-            branch_value_stack_buf: SmallVec::<[RlpNode; 16]>::new_const(),
+            branch_child_buf: Vec::new(),
+            branch_value_stack_buf: Vec::new(),
         }
     }
 }


### PR DESCRIPTION
## Summary
Replaces `SmallVec` with `Vec` in sparse trie buffer structs (`RlpNodeBuffers`, `SparseSubtrieBuffers`).

## Changes
- Remove `smallvec` dependency from `reth-trie-sparse` and `reth-trie-sparse-parallel`
- Replace `SmallVec<[Nibbles; 16]>` and `SmallVec<[RlpNode; 16]>` with `Vec<Nibbles>` and `Vec<RlpNode>` in buffer structs
- Update DFS stack in `prune_upper_subtrie` to use `Vec`