### PR TITLE
chore(trie): clear RevealableSparseTrie in place

### DIFF
--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -995,7 +995,7 @@ where
     /// This resets the trie to an empty state but keeps the underlying memory allocations,
     /// which can significantly reduce allocation overhead when the trie is reused.
     pub fn clear(&mut self) {
-        self.state = core::mem::take(&mut self.state).clear();
+        self.state.clear();
         self.revealed_account_paths.clear();
         self.storage.clear();
         self.account_rlp_buf.clear();
@@ -1127,8 +1127,9 @@ impl<S: SparseTrieTrait + SparseTrieExt> StorageTries<S> {
 
         // Evict storage tries that exceeded limit, saving cleared allocations for reuse
         for address in &tries_to_clear {
-            if let Some(trie) = self.tries.remove(address) {
-                self.cleared_tries.push(trie.clear());
+            if let Some(mut trie) = self.tries.remove(address) {
+                trie.clear();
+                self.cleared_tries.push(trie);
             }
             if let Some(mut paths) = self.revealed_paths.remove(address) {
                 paths.clear();
@@ -1193,7 +1194,10 @@ impl<S: SparseTrieTrait> StorageTries<S> {
     /// Returns all fields to a cleared state, equivalent to the default state, keeping cleared
     /// collections for re-use later when possible.
     fn clear(&mut self) {
-        self.cleared_tries.extend(self.tries.drain().map(|(_, trie)| trie.clear()));
+        self.cleared_tries.extend(self.tries.drain().map(|(_, mut trie)| {
+            trie.clear();
+            trie
+        }));
         self.cleared_revealed_paths.extend(self.revealed_paths.drain().map(|(_, mut set)| {
             set.clear();
             set

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -39,7 +39,7 @@ where
     /// Creates a [`ClearedSparseStateTrie`] by clearing all the existing internal state of a
     /// [`SparseStateTrie`] and then storing that instance for later re-use.
     pub fn from_state_trie(mut trie: SparseStateTrie<A, S>) -> Self {
-        trie.state = trie.state.clear();
+        trie.state.clear();
         trie.revealed_account_paths.clear();
         trie.storage.clear();
         trie.account_rlp_buf.clear();

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -217,18 +217,20 @@ impl<T: SparseTrieTrait> RevealableSparseTrie<T> {
         Some((revealed.root(), revealed.take_updates()))
     }
 
-    /// Returns a [`RevealableSparseTrie::Blind`] based on this one. If this instance was revealed,
-    /// or was itself a `Blind` with a pre-allocated [`RevealableSparseTrie`](SparseTrieTrait),
-    /// this will return a `Blind` carrying a cleared pre-allocated
-    /// [`RevealableSparseTrie`](SparseTrieTrait).
-    pub fn clear(self) -> Self {
-        match self {
-            Self::Blind(_) => self,
+    /// Clears this trie, setting it to a blind state.
+    ///
+    /// If this instance was revealed, or was itself a `Blind` with a pre-allocated
+    /// [`RevealableSparseTrie`](SparseTrieTrait), this will set to `Blind` carrying a cleared
+    /// pre-allocated [`RevealableSparseTrie`](SparseTrieTrait).
+    #[inline]
+    pub fn clear(&mut self) {
+        *self = match std::mem::replace(self, Self::blind()) {
+            s @ Self::Blind(_) => s,
             Self::Revealed(mut trie) => {
                 trie.clear();
                 Self::Blind(Some(trie))
             }
-        }
+        };
     }
 
     /// Updates (or inserts) a leaf at the given key path with the specified RLP-encoded value.

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -224,7 +224,7 @@ impl<T: SparseTrieTrait> RevealableSparseTrie<T> {
     /// pre-allocated [`RevealableSparseTrie`](SparseTrieTrait).
     #[inline]
     pub fn clear(&mut self) {
-        *self = match std::mem::replace(self, Self::blind()) {
+        *self = match core::mem::replace(self, Self::blind()) {
             s @ Self::Blind(_) => s,
             Self::Revealed(mut trie) => {
                 trie.clear();


### PR DESCRIPTION
Changes `RevealableSparseTrie::clear` from taking `self` by value and returning `Self` to taking `&mut self`, avoiding an unnecessary move when clearing the trie state.