### PR TITLE
fix(engine): wait for persistence service thread before RocksDB drop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8384,7 +8384,6 @@ dependencies = [
  "reth-engine-tree",
  "reth-ethereum-consensus",
  "reth-ethereum-engine-primitives",
- "reth-ethereum-primitives",
  "reth-evm",
  "reth-evm-ethereum",
  "reth-exex-types",

--- a/crates/engine/service/Cargo.toml
+++ b/crates/engine/service/Cargo.toml
@@ -17,7 +17,6 @@ reth-engine-tree.workspace = true
 reth-evm.workspace = true
 reth-network-p2p.workspace = true
 reth-payload-builder.workspace = true
-reth-ethereum-primitives.workspace = true
 reth-provider.workspace = true
 reth-prune.workspace = true
 reth-stages-api.workspace = true

--- a/crates/engine/service/src/service.rs
+++ b/crates/engine/service/src/service.rs
@@ -61,9 +61,6 @@ where
     Client: BlockClient<Block = BlockTy<N>> + 'static,
 {
     orchestrator: EngineServiceType<N, Client>,
-    /// Handle to the persistence service - kept to ensure graceful shutdown.
-    /// The handle joins the service thread when dropped.
-    _persistence_handle: PersistenceHandle<N::Primitives>,
 }
 
 impl<N, Client> EngineService<N, Client>
@@ -108,7 +105,7 @@ where
             blockchain_db,
             consensus,
             payload_validator,
-            persistence_handle.clone(),
+            persistence_handle,
             payload_builder,
             canonical_in_memory_state,
             tree_config,
@@ -122,10 +119,7 @@ where
 
         let backfill_sync = PipelineSync::new(pipeline, pipeline_task_spawner);
 
-        Self {
-            orchestrator: ChainOrchestrator::new(handler, backfill_sync),
-            _persistence_handle: persistence_handle,
-        }
+        Self { orchestrator: ChainOrchestrator::new(handler, backfill_sync) }
     }
 
     /// Returns a mutable reference to the orchestrator.

--- a/crates/engine/service/src/service.rs
+++ b/crates/engine/service/src/service.rs
@@ -14,7 +14,6 @@ pub use reth_engine_tree::{
     chain::{ChainEvent, ChainOrchestrator},
     engine::EngineApiEvent,
 };
-
 use reth_evm::ConfigureEvm;
 use reth_network_p2p::BlockClient;
 use reth_node_types::{BlockTy, NodeTypes};

--- a/crates/engine/service/src/service.rs
+++ b/crates/engine/service/src/service.rs
@@ -96,7 +96,7 @@ where
 
         let downloader = BasicBlockDownloader::new(client, consensus.clone());
 
-        let persistence_handle =
+        let (persistence_handle, _) =
             PersistenceHandle::<EthPrimitives>::spawn_service(provider, pruner, sync_metrics_tx);
 
         let canonical_in_memory_state = blockchain_db.canonical_in_memory_state();

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -214,6 +214,14 @@ pub struct PersistenceHandle<N: NodePrimitives = EthPrimitives> {
 }
 
 impl<T: NodePrimitives> PersistenceHandle<T> {
+    /// Create a new [`PersistenceHandle`] from a [`Sender<PersistenceAction>`].
+    ///
+    /// This is intended for testing purposes where you want to mock the persistence service.
+    /// For production use, prefer [`spawn_service`](Self::spawn_service).
+    pub fn new(sender: Sender<PersistenceAction<T>>) -> Self {
+        Self { sender, _service_guard: Arc::new(ServiceGuard(None)) }
+    }
+
     /// Create a new [`PersistenceHandle`], and spawn the persistence service.
     ///
     /// The returned handle can be cloned and shared. When all clones are dropped, the service


### PR DESCRIPTION
## Summary

Fixes flaky persistence tests with `pthread lock: Invalid argument` errors on the `edge` feature (RocksDB backend).

## Root Cause

Race condition during test cleanup:
1. Test ends, `PersistenceHandle` (sender) is dropped
2. `ProviderFactory` gets dropped, triggering RocksDB destructor  
3. RocksDB calls `cancel_all_background_work(true)`
4. Meanwhile the persistence service thread is still winding down
5. Race between RocksDB shutdown and persistence thread accessing mutexes -> pthread error

## Solution

`PersistenceHandle` now holds an `Arc<ServiceGuard>` that joins the service thread when dropped:

```rust
pub struct PersistenceHandle<N: NodePrimitives = EthPrimitives> {
    sender: Sender<PersistenceAction<N>>,
    _service_guard: Arc<ServiceGuard>,
}

struct ServiceGuard(Option<JoinHandle<()>>);

impl Drop for ServiceGuard {
    fn drop(&mut self) {
        if let Some(join_handle) = self.0.take() {
            let _ = join_handle.join();
        }
    }
}
```

When all clones of `PersistenceHandle` are dropped (e.g., when the tree handler that holds it is dropped), the `Arc` refcount hits zero, `ServiceGuard::drop` runs, and the service thread is joined before RocksDB is released.

## Caveat

`join()` can block indefinitely if the persistence service hangs, and thread panics are silently ignored. This is acceptable since a hung service indicates a bug, but could be improved by logging panics.

## Changes

- Added `ServiceGuard` struct that joins the thread on drop
- `PersistenceHandle` now holds `Arc<ServiceGuard>` (remains `Clone`)
- `spawn_service` returns `PersistenceHandle` directly (no wrapper type)
- `PersistenceHandle::new()` preserved for test mocking (creates empty guard)

Closes the flaky test issue in https://github.com/paradigmxyz/reth/actions/runs/21525951607/job/62029485190#step:9:1240