### PR TITLE
fix(cli): use StorageReader for db state command to support static files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7814,7 +7814,6 @@ dependencies = [
  "itertools 0.14.0",
  "lz4",
  "metrics",
- "parking_lot",
  "proptest",
  "proptest-arbitrary-interop",
  "ratatui",

--- a/crates/cli/commands/Cargo.toml
+++ b/crates/cli/commands/Cargo.toml
@@ -78,7 +78,6 @@ lz4.workspace = true
 zstd.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-parking_lot.workspace = true
 tar.workspace = true
 tracing.workspace = true
 backon.workspace = true


### PR DESCRIPTION
Replace direct MDBX cursor access with `changed_storages_with_range()` in `reth db state --block` to properly read storage changesets from static files when edge mode is enabled. Also removed unused `parking_lot` dependency.