### PR TITLE
perf(trie): use Entry API to avoid empty Vec allocation in extend

### DIFF
--- a/crates/trie/common/src/proofs.rs
+++ b/crates/trie/common/src/proofs.rs
@@ -465,7 +465,14 @@ impl DecodedMultiProofV2 {
     pub fn extend(&mut self, other: Self) {
         self.account_proofs.extend(other.account_proofs);
         for (hashed_address, other_storage_proofs) in other.storage_proofs {
-            self.storage_proofs.entry(hashed_address).or_default().extend(other_storage_proofs);
+            match self.storage_proofs.entry(hashed_address) {
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    entry.insert(other_storage_proofs);
+                }
+                std::collections::hash_map::Entry::Occupied(mut entry) => {
+                    entry.get_mut().extend(other_storage_proofs);
+                }
+            }
         }
     }
 }

--- a/crates/trie/common/src/proofs.rs
+++ b/crates/trie/common/src/proofs.rs
@@ -466,10 +466,10 @@ impl DecodedMultiProofV2 {
         self.account_proofs.extend(other.account_proofs);
         for (hashed_address, other_storage_proofs) in other.storage_proofs {
             match self.storage_proofs.entry(hashed_address) {
-                std::collections::hash_map::Entry::Vacant(entry) => {
+                hash_map::Entry::Vacant(entry) => {
                     entry.insert(other_storage_proofs);
                 }
-                std::collections::hash_map::Entry::Occupied(mut entry) => {
+                hash_map::Entry::Occupied(mut entry) => {
                     entry.get_mut().extend(other_storage_proofs);
                 }
             }


### PR DESCRIPTION
Replaces `.or_default().extend()` with a match on `Entry` in `DecodedMultiProofV2::extend`. For vacant entries, the Vec is inserted directly instead of allocating an empty Vec first and then extending it.

## Changes
- `DecodedMultiProofV2::extend`: Use `Entry::Vacant` to insert directly, `Entry::Occupied` to extend

## Testing
Compiles and passes clippy.