### PR TITLE
perf(trie): reuse proof nodes buffer in `reveal_nodes`

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -587,14 +587,11 @@ where
                     target: "engine::tree::payload_processor",
                     "State root receiver dropped, clearing trie"
                 );
-                let (trie, deferred) = task.into_cleared_trie(
+                let trie = task.into_cleared_trie(
                     SPARSE_TRIE_MAX_NODES_SHRINK_CAPACITY,
                     SPARSE_TRIE_MAX_VALUES_SHRINK_CAPACITY,
                 );
                 guard.store(PreservedSparseTrie::cleared(trie));
-                // Drop guard before deferred to release lock before expensive deallocations
-                drop(guard);
-                drop(deferred);
                 return;
             }
 
@@ -602,9 +599,9 @@ where
             // A failed computation may have left the trie in a partially updated state.
             let _enter =
                 debug_span!(target: "engine::tree::payload_processor", "preserve").entered();
-            let deferred = if let Some(state_root) = computed_state_root {
+            if let Some(state_root) = computed_state_root {
                 let start = std::time::Instant::now();
-                let (trie, deferred) = task.into_trie_for_reuse(
+                let trie = task.into_trie_for_reuse(
                     prune_depth,
                     max_storage_tries,
                     SPARSE_TRIE_MAX_NODES_SHRINK_CAPACITY,
@@ -614,22 +611,17 @@ where
                     .into_trie_for_reuse_duration_histogram
                     .record(start.elapsed().as_secs_f64());
                 guard.store(PreservedSparseTrie::anchored(trie, state_root));
-                deferred
             } else {
                 debug!(
                     target: "engine::tree::payload_processor",
                     "State root computation failed, clearing trie"
                 );
-                let (trie, deferred) = task.into_cleared_trie(
+                let trie = task.into_cleared_trie(
                     SPARSE_TRIE_MAX_NODES_SHRINK_CAPACITY,
                     SPARSE_TRIE_MAX_VALUES_SHRINK_CAPACITY,
                 );
                 guard.store(PreservedSparseTrie::cleared(trie));
-                deferred
-            };
-            // Drop guard before deferred to release lock before expensive deallocations
-            drop(guard);
-            drop(deferred);
+            }
         });
     }
 

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -587,11 +587,14 @@ where
                     target: "engine::tree::payload_processor",
                     "State root receiver dropped, clearing trie"
                 );
-                let trie = task.into_cleared_trie(
+                let (trie, deferred) = task.into_cleared_trie(
                     SPARSE_TRIE_MAX_NODES_SHRINK_CAPACITY,
                     SPARSE_TRIE_MAX_VALUES_SHRINK_CAPACITY,
                 );
                 guard.store(PreservedSparseTrie::cleared(trie));
+                // Drop guard before deferred to release lock before expensive deallocations
+                drop(guard);
+                drop(deferred);
                 return;
             }
 
@@ -599,9 +602,9 @@ where
             // A failed computation may have left the trie in a partially updated state.
             let _enter =
                 debug_span!(target: "engine::tree::payload_processor", "preserve").entered();
-            if let Some(state_root) = computed_state_root {
+            let deferred = if let Some(state_root) = computed_state_root {
                 let start = std::time::Instant::now();
-                let trie = task.into_trie_for_reuse(
+                let (trie, deferred) = task.into_trie_for_reuse(
                     prune_depth,
                     max_storage_tries,
                     SPARSE_TRIE_MAX_NODES_SHRINK_CAPACITY,
@@ -611,17 +614,22 @@ where
                     .into_trie_for_reuse_duration_histogram
                     .record(start.elapsed().as_secs_f64());
                 guard.store(PreservedSparseTrie::anchored(trie, state_root));
+                deferred
             } else {
                 debug!(
                     target: "engine::tree::payload_processor",
                     "State root computation failed, clearing trie"
                 );
-                let trie = task.into_cleared_trie(
+                let (trie, deferred) = task.into_cleared_trie(
                     SPARSE_TRIE_MAX_NODES_SHRINK_CAPACITY,
                     SPARSE_TRIE_MAX_VALUES_SHRINK_CAPACITY,
                 );
                 guard.store(PreservedSparseTrie::cleared(trie));
-            }
+                deferred
+            };
+            // Drop guard before deferred to release lock before expensive deallocations
+            drop(guard);
+            drop(deferred);
         });
     }
 

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -28,7 +28,7 @@ use reth_trie_parallel::{
 use reth_trie_sparse::{
     errors::{SparseStateTrieResult, SparseTrieErrorKind, SparseTrieResult},
     provider::{TrieNodeProvider, TrieNodeProviderFactory},
-    ClearedSparseStateTrie, DeferredDrops, LeafUpdate, SerialSparseTrie, SparseStateTrie,
+     DeferredDrops, LeafUpdate, SerialSparseTrie, SparseStateTrie,
     SparseTrie, SparseTrieExt,
 };
 use revm_primitives::{hash_map::Entry, B256Map};

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -28,7 +28,7 @@ use reth_trie_parallel::{
 use reth_trie_sparse::{
     errors::{SparseStateTrieResult, SparseTrieErrorKind, SparseTrieResult},
     provider::{TrieNodeProvider, TrieNodeProviderFactory},
-    LeafUpdate, SerialSparseTrie, SparseStateTrie, SparseTrie, SparseTrieExt,
+    DeferredDrops, LeafUpdate, SerialSparseTrie, SparseStateTrie, SparseTrie, SparseTrieExt,
 };
 use revm_primitives::{hash_map::Entry, B256Map};
 use smallvec::SmallVec;
@@ -72,7 +72,7 @@ where
         max_storage_tries: usize,
         max_nodes_capacity: usize,
         max_values_capacity: usize,
-    ) -> SparseStateTrie<A, S> {
+    ) -> (SparseStateTrie<A, S>, DeferredDrops) {
         match self {
             Self::Cleared(task) => task.into_cleared_trie(max_nodes_capacity, max_values_capacity),
             Self::Cached(task) => task.into_trie_for_reuse(
@@ -88,7 +88,7 @@ where
         self,
         max_nodes_capacity: usize,
         max_values_capacity: usize,
-    ) -> SparseStateTrie<A, S> {
+    ) -> (SparseStateTrie<A, S>, DeferredDrops) {
         match self {
             Self::Cleared(task) => task.into_cleared_trie(max_nodes_capacity, max_values_capacity),
             Self::Cached(task) => task.into_cleared_trie(max_nodes_capacity, max_values_capacity),
@@ -198,10 +198,11 @@ where
         mut self,
         max_nodes_capacity: usize,
         max_values_capacity: usize,
-    ) -> SparseStateTrie<A, S> {
+    ) -> (SparseStateTrie<A, S>, DeferredDrops) {
         self.trie.clear();
         self.trie.shrink_to(max_nodes_capacity, max_values_capacity);
-        self.trie
+        let deferred = self.trie.take_deferred_drops();
+        (self.trie, deferred)
     }
 }
 
@@ -311,10 +312,11 @@ where
         max_storage_tries: usize,
         max_nodes_capacity: usize,
         max_values_capacity: usize,
-    ) -> SparseStateTrie<A, S> {
+    ) -> (SparseStateTrie<A, S>, DeferredDrops) {
         self.trie.prune(prune_depth, max_storage_tries);
         self.trie.shrink_to(max_nodes_capacity, max_values_capacity);
-        self.trie
+        let deferred = self.trie.take_deferred_drops();
+        (self.trie, deferred)
     }
 
     /// Clears and shrinks the trie, discarding all state.
@@ -325,10 +327,11 @@ where
         mut self,
         max_nodes_capacity: usize,
         max_values_capacity: usize,
-    ) -> SparseStateTrie<A, S> {
+    ) -> (SparseStateTrie<A, S>, DeferredDrops) {
         self.trie.clear();
         self.trie.shrink_to(max_nodes_capacity, max_values_capacity);
-        self.trie
+        let deferred = self.trie.take_deferred_drops();
+        (self.trie, deferred)
     }
 
     /// Runs the sparse trie task to completion.

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -28,8 +28,7 @@ use reth_trie_parallel::{
 use reth_trie_sparse::{
     errors::{SparseStateTrieResult, SparseTrieErrorKind, SparseTrieResult},
     provider::{TrieNodeProvider, TrieNodeProviderFactory},
-     DeferredDrops, LeafUpdate, SerialSparseTrie, SparseStateTrie,
-    SparseTrie, SparseTrieExt,
+    LeafUpdate, SerialSparseTrie, SparseStateTrie, SparseTrie, SparseTrieExt,
 };
 use revm_primitives::{hash_map::Entry, B256Map};
 use smallvec::SmallVec;
@@ -73,7 +72,7 @@ where
         max_storage_tries: usize,
         max_nodes_capacity: usize,
         max_values_capacity: usize,
-    ) -> (SparseStateTrie<A, S>, DeferredDrops) {
+    ) -> SparseStateTrie<A, S> {
         match self {
             Self::Cleared(task) => task.into_cleared_trie(max_nodes_capacity, max_values_capacity),
             Self::Cached(task) => task.into_trie_for_reuse(
@@ -89,7 +88,7 @@ where
         self,
         max_nodes_capacity: usize,
         max_values_capacity: usize,
-    ) -> (SparseStateTrie<A, S>, DeferredDrops) {
+    ) -> SparseStateTrie<A, S> {
         match self {
             Self::Cleared(task) => task.into_cleared_trie(max_nodes_capacity, max_values_capacity),
             Self::Cached(task) => task.into_cleared_trie(max_nodes_capacity, max_values_capacity),
@@ -199,11 +198,10 @@ where
         mut self,
         max_nodes_capacity: usize,
         max_values_capacity: usize,
-    ) -> (SparseStateTrie<A, S>, DeferredDrops) {
+    ) -> SparseStateTrie<A, S> {
         self.trie.clear();
         self.trie.shrink_to(max_nodes_capacity, max_values_capacity);
-        let deferred = self.trie.take_deferred_drops();
-        (self.trie, deferred)
+        self.trie
     }
 }
 
@@ -313,11 +311,10 @@ where
         max_storage_tries: usize,
         max_nodes_capacity: usize,
         max_values_capacity: usize,
-    ) -> (SparseStateTrie<A, S>, DeferredDrops) {
+    ) -> SparseStateTrie<A, S> {
         self.trie.prune(prune_depth, max_storage_tries);
         self.trie.shrink_to(max_nodes_capacity, max_values_capacity);
-        let deferred = self.trie.take_deferred_drops();
-        (self.trie, deferred)
+        self.trie
     }
 
     /// Clears and shrinks the trie, discarding all state.
@@ -328,11 +325,10 @@ where
         mut self,
         max_nodes_capacity: usize,
         max_values_capacity: usize,
-    ) -> (SparseStateTrie<A, S>, DeferredDrops) {
+    ) -> SparseStateTrie<A, S> {
         self.trie.clear();
         self.trie.shrink_to(max_nodes_capacity, max_values_capacity);
-        let deferred = self.trie.take_deferred_drops();
-        (self.trie, deferred)
+        self.trie
     }
 
     /// Runs the sparse trie task to completion.

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -8999,7 +8999,7 @@ mod tests {
 
         // Create a trie with some data
         let mut trie = ParallelSparseTrie::default();
-        let nodes = vec![
+        let mut nodes = vec![
             ProofTrieNode {
                 path: Nibbles::from_nibbles_unchecked([0x1, 0x2]),
                 node: TrieNode::Leaf(LeafNode {
@@ -9017,7 +9017,7 @@ mod tests {
                 masks: None,
             },
         ];
-        trie.reveal_nodes(nodes).unwrap();
+        trie.reveal_nodes(&mut nodes).unwrap();
 
         let populated_size = trie.memory_size();
 

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -175,7 +175,7 @@ impl SparseTrie for ParallelSparseTrie {
         self.updates = retain_updates.then(Default::default);
     }
 
-    fn reveal_nodes(&mut self, mut nodes: Vec<ProofTrieNode>) -> SparseTrieResult<()> {
+    fn reveal_nodes(&mut self, nodes: &mut [ProofTrieNode]) -> SparseTrieResult<()> {
         if nodes.is_empty() {
             return Ok(())
         }
@@ -192,7 +192,7 @@ impl SparseTrie for ParallelSparseTrie {
 
         // Update the top-level branch node masks. This is simple and can't be done in parallel.
         self.branch_node_masks.reserve(nodes.len());
-        for ProofTrieNode { path, masks, .. } in &nodes {
+        for ProofTrieNode { path, masks, .. } in nodes.iter() {
             if let Some(branch_masks) = masks {
                 self.branch_node_masks.insert(*path, *branch_masks);
             }
@@ -4095,7 +4095,7 @@ mod tests {
             let node = create_leaf_node([0x2, 0x3], 42);
             let masks = None;
 
-            trie.reveal_nodes(vec![ProofTrieNode { path, node, masks }]).unwrap();
+            trie.reveal_nodes(&mut [ProofTrieNode { path, node, masks }]).unwrap();
 
             assert_matches!(
                 trie.upper_subtrie.nodes.get(&path),
@@ -4116,7 +4116,7 @@ mod tests {
             let node = create_leaf_node([0x3, 0x4], 42);
             let masks = None;
 
-            trie.reveal_nodes(vec![ProofTrieNode { path, node, masks }]).unwrap();
+            trie.reveal_nodes(&mut [ProofTrieNode { path, node, masks }]).unwrap();
 
             // Check that the lower subtrie was created
             let idx = path_subtrie_index_unchecked(&path);
@@ -4140,7 +4140,7 @@ mod tests {
             let node = create_leaf_node([0x4, 0x5], 42);
             let masks = None;
 
-            trie.reveal_nodes(vec![ProofTrieNode { path, node, masks }]).unwrap();
+            trie.reveal_nodes(&mut [ProofTrieNode { path, node, masks }]).unwrap();
 
             // Check that the lower subtrie's path hasn't changed
             let idx = path_subtrie_index_unchecked(&path);
@@ -4201,7 +4201,7 @@ mod tests {
         let node = create_extension_node([0x2], child_hash);
         let masks = None;
 
-        trie.reveal_nodes(vec![ProofTrieNode { path, node, masks }]).unwrap();
+        trie.reveal_nodes(&mut [ProofTrieNode { path, node, masks }]).unwrap();
 
         // Extension node should be in upper trie
         assert_matches!(
@@ -4263,7 +4263,7 @@ mod tests {
         let node = create_branch_node_with_children(&[0x0, 0x7, 0xf], child_hashes.clone());
         let masks = None;
 
-        trie.reveal_nodes(vec![ProofTrieNode { path, node, masks }]).unwrap();
+        trie.reveal_nodes(&mut [ProofTrieNode { path, node, masks }]).unwrap();
 
         // Branch node should be in upper trie
         assert_matches!(
@@ -4319,7 +4319,7 @@ mod tests {
         let branch_node = create_branch_node_with_children(&[0x0, 0x1, 0x2], child_hashes);
 
         // Reveal nodes using reveal_nodes
-        trie.reveal_nodes(vec![
+        trie.reveal_nodes(&mut [
             ProofTrieNode { path: branch_path, node: branch_node, masks: None },
             ProofTrieNode { path: leaf_1_path, node: leaf_1, masks: None },
             ProofTrieNode { path: leaf_2_path, node: leaf_2, masks: None },
@@ -5022,7 +5022,7 @@ mod tests {
         let removed_branch_path = Nibbles::from_nibbles([0x4, 0xf, 0x8, 0x8, 0x0, 0x7, 0x2]);
 
         // Convert the logs into reveal_nodes call on a fresh ParallelSparseTrie
-        let nodes = vec![
+        let mut nodes = vec![
             // Branch at 0x4f8807
             ProofTrieNode {
                 path: branch_path,
@@ -5153,7 +5153,7 @@ mod tests {
         .unwrap();
 
         // Call reveal_nodes
-        trie.reveal_nodes(nodes).unwrap();
+        trie.reveal_nodes(&mut nodes).unwrap();
 
         // Remove the leaf at "0x4f88072c077f86613088dfcae648abe831fadca55ad43ab165d1680dd567b5d6"
         let leaf_key = Nibbles::from_nibbles([
@@ -5239,7 +5239,7 @@ mod tests {
 
         // Step 2: Reveal nodes in the trie
         let mut trie = ParallelSparseTrie::from_root(extension, None, true).unwrap();
-        trie.reveal_nodes(vec![
+        trie.reveal_nodes(&mut [
             ProofTrieNode { path: branch_path, node: branch, masks: None },
             ProofTrieNode { path: leaf_1_path, node: leaf_1, masks: None },
             ProofTrieNode { path: leaf_2_path, node: leaf_2, masks: None },
@@ -5779,7 +5779,7 @@ mod tests {
         // ├── 0 -> Hash (Path = 0)
         // └── 1 -> Leaf (Path = 1)
         sparse
-            .reveal_nodes(vec![
+            .reveal_nodes(&mut [
                 ProofTrieNode {
                     path: Nibbles::default(),
                     node: branch,
@@ -5834,7 +5834,7 @@ mod tests {
         // ├── 0 -> Hash (Path = 0)
         // └── 1 -> Leaf (Path = 1)
         sparse
-            .reveal_nodes(vec![
+            .reveal_nodes(&mut [
                 ProofTrieNode {
                     path: Nibbles::default(),
                     node: branch,
@@ -6200,7 +6200,7 @@ mod tests {
                 Default::default(),
                 [key1()],
             );
-        let revealed_nodes: Vec<ProofTrieNode> = hash_builder_proof_nodes
+        let mut revealed_nodes: Vec<ProofTrieNode> = hash_builder_proof_nodes
             .nodes_sorted()
             .into_iter()
             .map(|(path, node)| {
@@ -6210,7 +6210,7 @@ mod tests {
                 ProofTrieNode { path, node: TrieNode::decode(&mut &node[..]).unwrap(), masks }
             })
             .collect();
-        sparse.reveal_nodes(revealed_nodes).unwrap();
+        sparse.reveal_nodes(&mut revealed_nodes).unwrap();
 
         // Check that the branch node exists with only two nibbles set
         assert_eq!(
@@ -6235,7 +6235,7 @@ mod tests {
                 Default::default(),
                 [key3()],
             );
-        let revealed_nodes: Vec<ProofTrieNode> = hash_builder_proof_nodes
+        let mut revealed_nodes: Vec<ProofTrieNode> = hash_builder_proof_nodes
             .nodes_sorted()
             .into_iter()
             .map(|(path, node)| {
@@ -6245,7 +6245,7 @@ mod tests {
                 ProofTrieNode { path, node: TrieNode::decode(&mut &node[..]).unwrap(), masks }
             })
             .collect();
-        sparse.reveal_nodes(revealed_nodes).unwrap();
+        sparse.reveal_nodes(&mut revealed_nodes).unwrap();
 
         // Check that nothing changed in the branch node
         assert_eq!(
@@ -6321,7 +6321,7 @@ mod tests {
                 Default::default(),
                 [key1(), Nibbles::from_nibbles_unchecked([0x01])],
             );
-        let revealed_nodes: Vec<ProofTrieNode> = hash_builder_proof_nodes
+        let mut revealed_nodes: Vec<ProofTrieNode> = hash_builder_proof_nodes
             .nodes_sorted()
             .into_iter()
             .map(|(path, node)| {
@@ -6331,7 +6331,7 @@ mod tests {
                 ProofTrieNode { path, node: TrieNode::decode(&mut &node[..]).unwrap(), masks }
             })
             .collect();
-        sparse.reveal_nodes(revealed_nodes).unwrap();
+        sparse.reveal_nodes(&mut revealed_nodes).unwrap();
 
         // Check that the branch node exists
         assert_eq!(
@@ -6356,7 +6356,7 @@ mod tests {
                 Default::default(),
                 [key2()],
             );
-        let revealed_nodes: Vec<ProofTrieNode> = hash_builder_proof_nodes
+        let mut revealed_nodes: Vec<ProofTrieNode> = hash_builder_proof_nodes
             .nodes_sorted()
             .into_iter()
             .map(|(path, node)| {
@@ -6366,7 +6366,7 @@ mod tests {
                 ProofTrieNode { path, node: TrieNode::decode(&mut &node[..]).unwrap(), masks }
             })
             .collect();
-        sparse.reveal_nodes(revealed_nodes).unwrap();
+        sparse.reveal_nodes(&mut revealed_nodes).unwrap();
 
         // Check that nothing changed in the extension node
         assert_eq!(
@@ -6448,7 +6448,7 @@ mod tests {
                 Default::default(),
                 [key1()],
             );
-        let revealed_nodes: Vec<ProofTrieNode> = hash_builder_proof_nodes
+        let mut revealed_nodes: Vec<ProofTrieNode> = hash_builder_proof_nodes
             .nodes_sorted()
             .into_iter()
             .map(|(path, node)| {
@@ -6458,7 +6458,7 @@ mod tests {
                 ProofTrieNode { path, node: TrieNode::decode(&mut &node[..]).unwrap(), masks }
             })
             .collect();
-        sparse.reveal_nodes(revealed_nodes).unwrap();
+        sparse.reveal_nodes(&mut revealed_nodes).unwrap();
 
         // Check that the branch node wasn't overwritten by the extension node in the proof
         assert_matches!(
@@ -7422,7 +7422,7 @@ mod tests {
         let leaf_node = LeafNode::new(leaf_key, leaf_value);
         let leaf_masks = None;
 
-        trie.reveal_nodes(vec![
+        trie.reveal_nodes(&mut [
             ProofTrieNode {
                 path: Nibbles::from_nibbles([0x3]),
                 node: TrieNode::Branch(branch_0x3_node),
@@ -7732,7 +7732,7 @@ mod tests {
         );
 
         // Reveal the trie structure using ProofTrieNode
-        let proof_nodes = vec![
+        let mut proof_nodes = vec![
             ProofTrieNode {
                 path: Nibbles::from_nibbles([0x3]),
                 node: branch_0x3_node,
@@ -7763,7 +7763,7 @@ mod tests {
             )
             .expect("root revealed");
 
-        trie.reveal_nodes(proof_nodes).unwrap();
+        trie.reveal_nodes(&mut proof_nodes).unwrap();
 
         // Update the leaf in order to reveal it in the trie
         trie.update_leaf(leaf_nibbles, leaf_value, &provider).unwrap();
@@ -7811,7 +7811,7 @@ mod tests {
         let leaf_node = create_leaf_node(leaf_key.to_vec(), 42);
 
         // Reveal the leaf node
-        trie.reveal_nodes(vec![ProofTrieNode { path: leaf_path, node: leaf_node, masks: None }])
+        trie.reveal_nodes(&mut [ProofTrieNode { path: leaf_path, node: leaf_node, masks: None }])
             .unwrap();
 
         // The full path is leaf_path + leaf_key

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -25,8 +25,8 @@ use tracing::{instrument, trace};
 
 /// Holds data that should be dropped after any locks are released.
 ///
-/// This is used to defer expensive deallocations (like proof node buffers)
-/// until after the `preserved_sparse_trie` lock is released.
+/// This is used to defer expensive deallocations (like proof node buffers) until after final state
+/// root is calculated
 #[derive(Debug, Default)]
 pub struct DeferredDrops {
     /// Each nodes reveal operation creates a new buffer, uses it, and pushes it here.
@@ -49,7 +49,7 @@ pub struct SparseStateTrie<
     retain_updates: bool,
     /// Reusable buffer for RLP encoding of trie accounts.
     account_rlp_buf: Vec<u8>,
-    /// Holds data that should be dropped after any locks are released.
+    /// Holds data that should be dropped after final state root is calculated.
     deferred_drops: DeferredDrops,
     /// Metrics for the sparse state trie.
     #[cfg(feature = "metrics")]
@@ -121,8 +121,8 @@ impl<A, S> SparseStateTrie<A, S> {
 
     /// Takes the data structures for deferred dropping.
     ///
-    /// This allows the caller to drop the buffers after releasing any locks,
-    /// avoiding expensive deallocations while holding locks.
+    /// This allows the caller to drop the buffers later, avoiding expensive deallocations while
+    /// calculating the state root.
     pub fn take_deferred_drops(&mut self) -> DeferredDrops {
         core::mem::take(&mut self.deferred_drops)
     }

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -1417,6 +1417,8 @@ struct FilterMappedProofNodes {
 /// Filters the decoded nodes that are already revealed, maps them to `SparseTrieNode`s,
 /// separates the root node if present, and returns additional information about the number of
 /// total, skipped, and new nodes.
+///
+/// Resulting [trie nodes](`ProofTrieNode`) are pushed to the input `nodes` buffer.
 fn filter_map_revealed_nodes(
     proof_nodes: DecodedProofNodes,
     revealed_nodes: &mut HashSet<Nibbles>,

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -1454,7 +1454,7 @@ fn filter_map_revealed_nodes(
 ) -> SparseStateTrieResult<FilterMappedProofNodes> {
     let mut result = FilterMappedProofNodes {
         root_node: None,
-        nodes: Vec::new(),
+        nodes: Vec::with_capacity(proof_nodes.len()),
         new_nodes: 0,
         metric_values: Default::default(),
     };
@@ -1539,7 +1539,7 @@ fn filter_revealed_v2_proof_nodes(
 ) -> SparseStateTrieResult<FilteredV2ProofNodes> {
     let mut result = FilteredV2ProofNodes {
         root_node: None,
-        nodes: Vec::new(),
+        nodes: Vec::with_capacity(proof_nodes.len()),
         new_nodes: 0,
         metric_values: Default::default(),
     };
@@ -2077,7 +2077,7 @@ mod tests {
                 nodes: vec![ProofTrieNode {
                     path: Nibbles::from_nibbles([0x1]),
                     node: leaf,
-                    masks: None
+                    masks: None,
                 }],
                 // Branch, two of its children, one leaf
                 new_nodes: 4,

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -42,6 +42,9 @@ pub struct SparseStateTrie<
     /// Reusable buffer for proof nodes.
     proof_nodes_buf: Vec<ProofTrieNode>,
     /// Reuseable buffers for storage trie proof nodes.
+    ///
+    /// The buffer grows up to the number of storage tries present in one multiproof. Even without
+    /// chunking, this is up to the number of contracts modified in one transaction.
     storage_proof_nodes_bufs: Vec<Vec<ProofTrieNode>>,
     /// Metrics for the sparse state trie.
     #[cfg(feature = "metrics")]

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -23,49 +23,6 @@ use reth_trie_common::{
 use tracing::debug;
 use tracing::{instrument, trace};
 
-/// Provides type-safe re-use of cleared [`SparseStateTrie`]s, which helps to save allocations
-/// across payload runs.
-#[derive(Debug)]
-pub struct ClearedSparseStateTrie<
-    A = SerialSparseTrie, // Account trie implementation
-    S = SerialSparseTrie, // Storage trie implementation
->(SparseStateTrie<A, S>);
-
-impl<A, S> ClearedSparseStateTrie<A, S>
-where
-    A: SparseTrieTrait,
-    S: SparseTrieTrait,
-{
-    /// Creates a [`ClearedSparseStateTrie`] by clearing all the existing internal state of a
-    /// [`SparseStateTrie`] and then storing that instance for later re-use.
-    pub fn from_state_trie(mut trie: SparseStateTrie<A, S>) -> Self {
-        trie.state.clear();
-        trie.revealed_account_paths.clear();
-        trie.storage.clear();
-        trie.account_rlp_buf.clear();
-        trie.proof_nodes_buf.clear();
-        Self(trie)
-    }
-
-    /// Returns the cleared [`SparseStateTrie`], consuming this instance.
-    pub fn into_inner(self) -> SparseStateTrie<A, S> {
-        self.0
-    }
-}
-
-impl<A, S> ClearedSparseStateTrie<A, S>
-where
-    A: SparseTrieTrait + SparseTrieExt + Default,
-    S: SparseTrieTrait + SparseTrieExt + Default + Clone,
-{
-    /// Shrink the cleared sparse trie's capacity to the given node and value size.
-    ///
-    /// Delegates to the inner `SparseStateTrie::shrink_to`.
-    pub fn shrink_to(&mut self, max_nodes: usize, max_values: usize) {
-        self.0.shrink_to(max_nodes, max_values);
-    }
-}
-
 /// Holds data that should be dropped after any locks are released.
 ///
 /// This is used to defer expensive deallocations (like proof node buffers)

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -23,6 +23,59 @@ use reth_trie_common::{
 use tracing::debug;
 use tracing::{instrument, trace};
 
+/// Provides type-safe re-use of cleared [`SparseStateTrie`]s, which helps to save allocations
+/// across payload runs.
+#[derive(Debug)]
+pub struct ClearedSparseStateTrie<
+    A = SerialSparseTrie, // Account trie implementation
+    S = SerialSparseTrie, // Storage trie implementation
+>(SparseStateTrie<A, S>);
+
+impl<A, S> ClearedSparseStateTrie<A, S>
+where
+    A: SparseTrieTrait,
+    S: SparseTrieTrait,
+{
+    /// Creates a [`ClearedSparseStateTrie`] by clearing all the existing internal state of a
+    /// [`SparseStateTrie`] and then storing that instance for later re-use.
+    pub fn from_state_trie(mut trie: SparseStateTrie<A, S>) -> Self {
+        trie.state.clear();
+        trie.revealed_account_paths.clear();
+        trie.storage.clear();
+        trie.account_rlp_buf.clear();
+        trie.proof_nodes_buf.clear();
+        Self(trie)
+    }
+
+    /// Returns the cleared [`SparseStateTrie`], consuming this instance.
+    pub fn into_inner(self) -> SparseStateTrie<A, S> {
+        self.0
+    }
+}
+
+impl<A, S> ClearedSparseStateTrie<A, S>
+where
+    A: SparseTrieTrait + SparseTrieExt + Default,
+    S: SparseTrieTrait + SparseTrieExt + Default + Clone,
+{
+    /// Shrink the cleared sparse trie's capacity to the given node and value size.
+    ///
+    /// Delegates to the inner `SparseStateTrie::shrink_to`.
+    pub fn shrink_to(&mut self, max_nodes: usize, max_values: usize) {
+        self.0.shrink_to(max_nodes, max_values);
+    }
+}
+
+/// Holds data that should be dropped after any locks are released.
+///
+/// This is used to defer expensive deallocations (like proof node buffers)
+/// until after the `preserved_sparse_trie` lock is released.
+#[derive(Debug, Default)]
+pub struct DeferredDrops {
+    /// Proof nodes buffer that can be dropped after lock release.
+    pub proof_nodes_buf: Vec<ProofTrieNode>,
+}
+
 #[derive(Debug)]
 /// Sparse state trie representing lazy-loaded Ethereum state trie.
 pub struct SparseStateTrie<
@@ -39,6 +92,8 @@ pub struct SparseStateTrie<
     retain_updates: bool,
     /// Reusable buffer for RLP encoding of trie accounts.
     account_rlp_buf: Vec<u8>,
+    /// Reusable buffer for proof nodes, to avoid allocations across payload runs.
+    proof_nodes_buf: Vec<ProofTrieNode>,
     /// Metrics for the sparse state trie.
     #[cfg(feature = "metrics")]
     metrics: crate::metrics::SparseStateTrieMetrics,
@@ -56,6 +111,7 @@ where
             storage: Default::default(),
             retain_updates: false,
             account_rlp_buf: Vec::with_capacity(TRIE_ACCOUNT_RLP_MAX_SIZE),
+            proof_nodes_buf: Vec::new(),
             #[cfg(feature = "metrics")]
             metrics: Default::default(),
         }
@@ -104,6 +160,14 @@ impl<A, S> SparseStateTrie<A, S> {
     pub fn with_default_storage_trie(mut self, trie: RevealableSparseTrie<S>) -> Self {
         self.set_default_storage_trie(trie);
         self
+    }
+
+    /// Takes the proof nodes buffer for deferred dropping.
+    ///
+    /// This allows the caller to drop the buffer after releasing any locks,
+    /// avoiding expensive deallocations while holding locks.
+    pub fn take_deferred_drops(&mut self) -> DeferredDrops {
+        DeferredDrops { proof_nodes_buf: core::mem::take(&mut self.proof_nodes_buf) }
     }
 }
 
@@ -420,12 +484,16 @@ where
         account_subtree: DecodedProofNodes,
         branch_node_masks: BranchNodeMasksMap,
     ) -> SparseStateTrieResult<()> {
-        let FilterMappedProofNodes { root_node, nodes, new_nodes, metric_values: _metric_values } =
-            filter_map_revealed_nodes(
-                account_subtree,
-                &mut self.revealed_account_paths,
-                &branch_node_masks,
-            )?;
+        let FilterMappedProofNodes {
+            root_node,
+            mut nodes,
+            new_nodes,
+            metric_values: _metric_values,
+        } = filter_map_revealed_nodes(
+            account_subtree,
+            &mut self.revealed_account_paths,
+            &branch_node_masks,
+        )?;
         #[cfg(feature = "metrics")]
         {
             self.metrics.increment_total_account_nodes(_metric_values.total_nodes as u64);
@@ -443,7 +511,7 @@ where
             trie.reserve_nodes(new_nodes);
 
             trace!(target: "trie::sparse", total_nodes = ?nodes.len(), "Revealing account nodes");
-            trie.reveal_nodes(nodes)?;
+            trie.reveal_nodes(&mut nodes)?;
         }
 
         Ok(())
@@ -457,7 +525,7 @@ where
         &mut self,
         nodes: Vec<ProofTrieNode>,
     ) -> SparseStateTrieResult<()> {
-        let FilteredV2ProofNodes { root_node, nodes, new_nodes, metric_values: _metric_values } =
+        let FilteredV2ProofNodes { root_node, mut nodes, new_nodes, metric_values: _metric_values } =
             filter_revealed_v2_proof_nodes(nodes, &mut self.revealed_account_paths)?;
 
         #[cfg(feature = "metrics")]
@@ -476,7 +544,7 @@ where
         trie.reserve_nodes(new_nodes);
 
         trace!(target: "trie::sparse", total_nodes = ?nodes.len(), "Revealing account nodes from V2 proof");
-        trie.reveal_nodes(nodes)?;
+        trie.reveal_nodes(&mut nodes)?;
 
         Ok(())
     }
@@ -517,7 +585,7 @@ where
         trie: &mut RevealableSparseTrie<S>,
         retain_updates: bool,
     ) -> SparseStateTrieResult<ProofNodesMetricValues> {
-        let FilteredV2ProofNodes { root_node, nodes, new_nodes, metric_values } =
+        let FilteredV2ProofNodes { root_node, mut nodes, new_nodes, metric_values } =
             filter_revealed_v2_proof_nodes(nodes, revealed_nodes)?;
 
         let trie = if let Some(root_node) = root_node {
@@ -530,7 +598,7 @@ where
         trie.reserve_nodes(new_nodes);
 
         trace!(target: "trie::sparse", ?account, total_nodes = ?nodes.len(), "Revealing storage nodes from V2 proof");
-        trie.reveal_nodes(nodes)?;
+        trie.reveal_nodes(&mut nodes)?;
 
         Ok(metric_values)
     }
@@ -579,7 +647,7 @@ where
         trie: &mut RevealableSparseTrie<S>,
         retain_updates: bool,
     ) -> SparseStateTrieResult<ProofNodesMetricValues> {
-        let FilterMappedProofNodes { root_node, nodes, new_nodes, metric_values } =
+        let FilterMappedProofNodes { root_node, mut nodes, new_nodes, metric_values } =
             filter_map_revealed_nodes(
                 storage_subtree.subtree,
                 revealed_nodes,
@@ -596,7 +664,7 @@ where
             trie.reserve_nodes(new_nodes);
 
             trace!(target: "trie::sparse", ?account, total_nodes = ?nodes.len(), "Revealing storage nodes");
-            trie.reveal_nodes(nodes)?;
+            trie.reveal_nodes(&mut nodes)?;
         }
 
         Ok(metric_values)

--- a/crates/trie/sparse/src/traits.rs
+++ b/crates/trie/sparse/src/traits.rs
@@ -2,7 +2,7 @@
 
 use core::fmt::Debug;
 
-use alloc::{borrow::Cow, vec, vec::Vec};
+use alloc::{borrow::Cow, vec::Vec};
 use alloy_primitives::{
     map::{B256Map, HashMap, HashSet},
     B256,
@@ -102,7 +102,7 @@ pub trait SparseTrie: Sized + Debug + Send + Sync {
         node: TrieNode,
         masks: Option<BranchNodeMasks>,
     ) -> SparseTrieResult<()> {
-        self.reveal_nodes(vec![ProofTrieNode { path, node, masks }])
+        self.reveal_nodes(&mut [ProofTrieNode { path, node, masks }])
     }
 
     /// Reveals one or more trie nodes if they have not been revealed before.
@@ -119,7 +119,7 @@ pub trait SparseTrie: Sized + Debug + Send + Sync {
     /// # Returns
     ///
     /// `Ok(())` if successful, or an error if any of the nodes was not revealed.
-    fn reveal_nodes(&mut self, nodes: Vec<ProofTrieNode>) -> SparseTrieResult<()>;
+    fn reveal_nodes(&mut self, nodes: &mut [ProofTrieNode]) -> SparseTrieResult<()>;
 
     /// Updates the value of a leaf node at the specified path.
     ///

--- a/crates/trie/sparse/src/traits.rs
+++ b/crates/trie/sparse/src/traits.rs
@@ -119,6 +119,11 @@ pub trait SparseTrie: Sized + Debug + Send + Sync {
     /// # Returns
     ///
     /// `Ok(())` if successful, or an error if any of the nodes was not revealed.
+    ///
+    /// # Note
+    ///
+    /// The implementation may modify the input nodes. A common thing to do is [`std::mem::replace`]
+    /// each node with [`TrieNode::EmptyRoot`] to avoid cloning.
     fn reveal_nodes(&mut self, nodes: &mut [ProofTrieNode]) -> SparseTrieResult<()>;
 
     /// Updates the value of a leaf node at the specified path.

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -476,6 +476,7 @@ impl SparseTrieTrait for SerialSparseTrie {
     fn reserve_nodes(&mut self, additional: usize) {
         self.nodes.reserve(additional);
     }
+
     fn reveal_node(
         &mut self,
         path: Nibbles,

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -618,10 +618,14 @@ impl SparseTrieTrait for SerialSparseTrie {
         Ok(())
     }
 
-    fn reveal_nodes(&mut self, mut nodes: Vec<ProofTrieNode>) -> SparseTrieResult<()> {
+    fn reveal_nodes(&mut self, nodes: &mut [ProofTrieNode]) -> SparseTrieResult<()> {
         nodes.sort_unstable_by_key(|node| node.path);
-        for node in nodes {
-            self.reveal_node(node.path, node.node, node.masks)?;
+        for node in nodes.iter_mut() {
+            self.reveal_node(
+                node.path,
+                core::mem::replace(&mut node.node, TrieNode::EmptyRoot),
+                node.masks.take(),
+            )?;
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary

Changes `reveal_nodes` signature from `Vec<ProofTrieNode>` to `&mut [ProofTrieNode]` to enable caller-side buffer preservation and ensures expensive drops happen after lock release.

Adds `DeferredDrops` struct that collects all `Vec<ProofTrieNode>` accumulated during the block, and drops them all at once between blocks.

## Motivation

The previous signature required callers to pass owned Vec<ProofTrieNode>, which meant:
* No buffer reuse across payload runs
* Expensive deallocations happened while holding the `preserved_sparse_trie` lock

## Lock/drop ordering

`into_trie_for_reuse` and `into_cleared_trie` now return `(SparseStateTrie, DeferredDrops)`.

The guard is explicitly dropped before `DeferredDrops`, ensuring expensive deallocations happen outside the lock.

## Benchmark
```
Metric        | Baseline         | Feature          | Change    | Threshold
--------------+------------------+------------------+-----------+-----------
Mean Latency  |          33.07ms |          32.24ms |   -2.5% ≈ |    ±2.97%
Std Dev       |          15.83ms |          15.23ms |           |
P50 Latency   |          29.04ms |          28.57ms |  -1.65% ≈ |    ±4.24%
P90 Latency   |          54.99ms |          52.65ms |  -4.25%   |
P99 Latency   |          79.17ms |          77.16ms |  -2.53%   |
--------------+------------------+------------------+-----------+-----------
Gas/sec       |    921.51 Mgas/s |     945.1 Mgas/s |  +2.56% ≈ |    ±2.97%
```