### PR TITLE
fix(metrics): rename save_blocks_block_count to save_blocks_batch_size

### DIFF
--- a/crates/engine/tree/src/metrics.rs
+++ b/crates/engine/tree/src/metrics.rs
@@ -20,7 +20,7 @@ pub(crate) struct PersistenceMetrics {
     /// How long it took for blocks to be saved
     pub(crate) save_blocks_duration_seconds: Histogram,
     /// How many blocks we persist at once.
-    pub(crate) save_blocks_block_count: Histogram,
+    pub(crate) save_blocks_batch_size: Histogram,
     /// How long it took for blocks to be pruned
     pub(crate) prune_before_duration_seconds: Histogram,
 }

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -157,7 +157,7 @@ where
 
         debug!(target: "engine::persistence", first=?first_block, last=?last_block, "Saved range of blocks");
 
-        self.metrics.save_blocks_block_count.record(block_count as f64);
+        self.metrics.save_blocks_batch_size.record(block_count as f64);
         self.metrics.save_blocks_duration_seconds.record(start_time.elapsed());
 
         Ok(last_block)


### PR DESCRIPTION
## Summary

Fixes #21482

The `save_blocks_block_count` metric in `PersistenceMetrics` was causing Prometheus scrapers to fail because the metric name ending in `_count` conflicts with Prometheus summary conventions.

When histograms are exported as summaries, Prometheus automatically adds `_count` and `_sum` suffixes. Having a base metric named `save_blocks_block_count` caused the exporter to emit a bare sample without a quantile label:

```
# TYPE reth_consensus_engine_persistence_save_blocks_block_count summary
reth_consensus_engine_persistence_save_blocks_block_count{quantile="0"} 0
...
reth_consensus_engine_persistence_save_blocks_block_count 0  <- breaks Prometheus
```

This caused scrapers like Vector to fail with:
```
error: ExpectedQuantileTag
```

## Solution

Renamed the metric from `save_blocks_block_count` to `save_blocks_batch_size` to avoid the `_count` suffix collision while preserving the `Histogram` type for distribution analysis.

## Dashboard Impact

No dashboard updates needed. The existing references in `reth-persistence.json` are for `reth_storage_providers_database_save_blocks_block_count` (storage provider scope), not this consensus engine metric.

## Test Plan

- `cargo check -p reth-engine-tree` passes
- `cargo +nightly clippy -p reth-engine-tree --all-features` passes