### PR TITLE
fix: remove unnecessary alloc

### DIFF
--- a/crates/stages/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/stages/src/stages/tx_lookup.rs
@@ -232,11 +232,8 @@ where
         let mut writer = EitherWriter::new_transaction_hash_numbers(provider, rocksdb_batch)?;
 
         let static_file_provider = provider.static_file_provider();
-        let rev_walker = provider
-            .block_body_indices_range(range.clone())?
-            .into_iter()
-            .zip(range) 
-            .rev();
+        let rev_walker =
+            provider.block_body_indices_range(range.clone())?.into_iter().zip(range).rev();
 
         for (body, number) in rev_walker {
             if number <= unwind_to {

--- a/crates/stages/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/stages/src/stages/tx_lookup.rs
@@ -233,7 +233,7 @@ where
 
         let static_file_provider = provider.static_file_provider();
         let rev_walker =
-            provider.block_body_indices_range(range.clone())?.into_iter().zip(range).rev();
+            provider.block_body_indices_range(range.clone())?.into_iter().rev().zip(range.rev());;
 
         for (body, number) in rev_walker {
             if number <= unwind_to {

--- a/crates/stages/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/stages/src/stages/tx_lookup.rs
@@ -233,7 +233,7 @@ where
 
         let static_file_provider = provider.static_file_provider();
         let rev_walker =
-            provider.block_body_indices_range(range.clone())?.into_iter().rev().zip(range.rev());;
+            provider.block_body_indices_range(range.clone())?.into_iter().rev().zip(range.rev());
 
         for (body, number) in rev_walker {
             if number <= unwind_to {

--- a/crates/stages/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/stages/src/stages/tx_lookup.rs
@@ -235,7 +235,7 @@ where
         let rev_walker = provider
             .block_body_indices_range(range.clone())?
             .into_iter()
-            .zip(range.collect::<Vec<_>>())
+            .zip(range) 
             .rev();
 
         for (body, number) in rev_walker {


### PR DESCRIPTION
Streamline iterator chain by zipping directly with the range instead of materializing it into a `Vec` first. 