### PR TITLE
perf(provider): remove redundant clone in static file test iteration

### DIFF
--- a/crates/storage/provider/src/providers/static_file/mod.rs
+++ b/crates/storage/provider/src/providers/static_file/mod.rs
@@ -115,7 +115,7 @@ mod tests {
 
         let mut provider_rw = factory.provider_rw().unwrap();
         let tx = provider_rw.tx_mut();
-        for header in headers.clone() {
+        for header in &headers {
             let hash = header.hash();
 
             tx.put::<CanonicalHeaders>(header.number, hash).unwrap();


### PR DESCRIPTION
Removes unnecessary Vec::clone() when iterating over headers in the test_static_files test. The vector is only read during iteration, so borrowing is sufficient and avoids an unnecessary heap allocation of the entire Vec<SealedHeader>.