### PR TITLE
perf(trie): remove unnecessary clones in test_account_trie_order

### DIFF
--- a/crates/trie/db/src/trie_cursor.rs
+++ b/crates/trie/db/src/trie_cursor.rs
@@ -229,7 +229,7 @@ mod tests {
             hex!("0303050a").to_vec(),
         ];
 
-        for key in data.clone() {
+        for key in &data {
             cursor
                 .upsert(
                     key.into(),
@@ -252,7 +252,7 @@ mod tests {
 
         assert_eq!(
             cursor.seek(hex!("0303040f").to_vec().into()).unwrap().map(|(k, _)| k.0.to_vec()),
-            Some(data[1].clone())
+            Some(data[1].to_vec())
         );
     }
 


### PR DESCRIPTION
Removes redundant allocations in `test_account_trie_order` test function:
