### PR TITLE
fix(provider): replace expect with safe pattern matching in ConsistentProvider

### DIFF
--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -334,10 +334,13 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
         // necessary drop it early.
         //
         // The last block of `in_memory_chain` is the lowest block number.
-        let (in_memory, storage_range) = match in_memory_chain.last().as_ref().map(|b| b.number()) {
-            Some(lowest_memory_block) if lowest_memory_block <= end => {
-                let highest_memory_block =
-                    in_memory_chain.first().as_ref().map(|b| b.number()).expect("qed");
+        let (in_memory, storage_range) = match (
+            in_memory_chain.first().as_ref().map(|b| b.number()),
+            in_memory_chain.last().as_ref().map(|b| b.number()),
+        ) {
+            (Some(highest_memory_block), Some(lowest_memory_block))
+                if lowest_memory_block <= end =>
+            {
 
                 // Database will for a time overlap with in-memory-chain blocks. In
                 // case of a re-org, it can mean that the database blocks are of a forked chain, and


### PR DESCRIPTION
Replaces `.expect("qed")` with safe tuple pattern matching in `ConsistentProvider::get_in_memory_or_storage_by_block_range_while` to eliminate panic risk in production code.