### PR TITLE
refactor(provider): deduplicate segment-to-stage mapping in static file manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10945,6 +10945,7 @@ dependencies = [
  "fixed-map",
  "insta",
  "reth-nippy-jar",
+ "reth-stages-types",
  "serde",
  "serde_json",
  "strum",

--- a/crates/static-file/types/Cargo.toml
+++ b/crates/static-file/types/Cargo.toml
@@ -18,6 +18,7 @@ clap = { workspace = true, features = ["derive"], optional = true }
 fixed-map.workspace = true
 derive_more.workspace = true
 serde = { workspace = true, features = ["alloc", "derive"] }
+reth-stages-types.workspace = true
 strum = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
@@ -30,6 +31,7 @@ default = ["std"]
 std = [
     "alloy-primitives/std",
     "derive_more/std",
+    "reth-stages-types/std",
     "serde/std",
     "strum/std",
     "serde_json/std",

--- a/crates/static-file/types/Cargo.toml
+++ b/crates/static-file/types/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 alloy-primitives.workspace = true
+reth-stages-types.workspace = true
 
 clap = { workspace = true, features = ["derive"], optional = true }
 fixed-map.workspace = true
@@ -29,6 +30,7 @@ insta.workspace = true
 default = ["std"]
 std = [
     "alloy-primitives/std",
+    "reth-stages-types/std",
     "derive_more/std",
     "serde/std",
     "strum/std",

--- a/crates/static-file/types/Cargo.toml
+++ b/crates/static-file/types/Cargo.toml
@@ -13,7 +13,6 @@ workspace = true
 
 [dependencies]
 alloy-primitives.workspace = true
-reth-stages-types.workspace = true
 
 clap = { workspace = true, features = ["derive"], optional = true }
 fixed-map.workspace = true
@@ -30,7 +29,6 @@ insta.workspace = true
 default = ["std"]
 std = [
     "alloy-primitives/std",
-    "reth-stages-types/std",
     "derive_more/std",
     "serde/std",
     "strum/std",

--- a/crates/static-file/types/src/segment.rs
+++ b/crates/static-file/types/src/segment.rs
@@ -199,7 +199,7 @@ impl StaticFileSegment {
         self.is_block_based() || self.is_change_based()
     }
 
-    /// Maps this segment to the [`StageId`] responsible for it.                              
+    /// Maps this segment to the [`reth_stages_types::StageId`] responsible for it.                              
     pub const fn to_stage_id(&self) -> reth_stages_types::StageId {
         use reth_stages_types::StageId;
         match self {

--- a/crates/static-file/types/src/segment.rs
+++ b/crates/static-file/types/src/segment.rs
@@ -79,18 +79,6 @@ impl StaticFileSegment {
             Self::StorageChangeSets => "storage-change-sets",
         }
     }
-        /// Maps this segment to the [`StageId`] responsible for it.                              
-    pub const fn to_stage_id(&self) -> reth_stages_types::StageId {                           
-        use reth_stages_types::StageId;                                                       
-        match self {                                                                          
-            Self::Headers => StageId::Headers,                                                
-            Self::Transactions => StageId::Bodies,                                            
-            Self::Receipts | Self::AccountChangeSets | Self::StorageChangeSets => {           
-                StageId::Execution                                                            
-            }                                                                                 
-            Self::TransactionSenders => StageId::SenderRecovery,                              
-        }                                                                                     
-    }
 
     /// Returns an iterator over all segments.
     pub fn iter() -> impl Iterator<Item = Self> {
@@ -209,6 +197,19 @@ impl StaticFileSegment {
     /// that the user header contains a block range or a max block
     pub const fn is_block_or_change_based(&self) -> bool {
         self.is_block_based() || self.is_change_based()
+    }
+    
+    /// Maps this segment to the [`StageId`] responsible for it.                              
+    pub const fn to_stage_id(&self) -> reth_stages_types::StageId {                           
+        use reth_stages_types::StageId;                                                       
+        match self {                                                                          
+            Self::Headers => StageId::Headers,                                                
+            Self::Transactions => StageId::Bodies,                                            
+            Self::Receipts | Self::AccountChangeSets | Self::StorageChangeSets => {           
+                StageId::Execution                                                            
+            }                                                                                 
+            Self::TransactionSenders => StageId::SenderRecovery,                              
+        }                                                                                     
     }
 }
 

--- a/crates/static-file/types/src/segment.rs
+++ b/crates/static-file/types/src/segment.rs
@@ -199,7 +199,8 @@ impl StaticFileSegment {
         self.is_block_based() || self.is_change_based()
     }
 
-    /// Maps this segment to the [`reth_stages_types::StageId`] responsible for it.                              
+    /// Maps this segment to the [`reth_stages_types::StageId`] responsible for it.
+    ///
     pub const fn to_stage_id(&self) -> reth_stages_types::StageId {
         use reth_stages_types::StageId;
         match self {
@@ -209,7 +210,7 @@ impl StaticFileSegment {
                 StageId::Execution
             }
             Self::TransactionSenders => StageId::SenderRecovery,
-        }                                
+        }
     }
 }
 

--- a/crates/static-file/types/src/segment.rs
+++ b/crates/static-file/types/src/segment.rs
@@ -79,6 +79,18 @@ impl StaticFileSegment {
             Self::StorageChangeSets => "storage-change-sets",
         }
     }
+        /// Maps this segment to the [`StageId`] responsible for it.                              
+    pub const fn to_stage_id(&self) -> reth_stages_types::StageId {                           
+        use reth_stages_types::StageId;                                                       
+        match self {                                                                          
+            Self::Headers => StageId::Headers,                                                
+            Self::Transactions => StageId::Bodies,                                            
+            Self::Receipts | Self::AccountChangeSets | Self::StorageChangeSets => {           
+                StageId::Execution                                                            
+            }                                                                                 
+            Self::TransactionSenders => StageId::SenderRecovery,                              
+        }                                                                                     
+    }
 
     /// Returns an iterator over all segments.
     pub fn iter() -> impl Iterator<Item = Self> {

--- a/crates/static-file/types/src/segment.rs
+++ b/crates/static-file/types/src/segment.rs
@@ -1,4 +1,5 @@
 use crate::{find_fixed_range, BlockNumber, Compression};
+use reth_stages_types::StageId;
 use alloc::{format, string::String, vec::Vec};
 use alloy_primitives::TxNumber;
 use core::{
@@ -199,9 +200,8 @@ impl StaticFileSegment {
         self.is_block_based() || self.is_change_based()
     }
 
-    /// Maps this segment to the [`reth_stages_types::StageId`] responsible for it.
-    pub const fn to_stage_id(&self) -> reth_stages_types::StageId {
-        use reth_stages_types::StageId;
+    /// Maps this segment to the [`StageId`] responsible for it.
+    pub const fn to_stage_id(&self) -> StageId {
         match self {
             Self::Headers => StageId::Headers,
             Self::Transactions => StageId::Bodies,

--- a/crates/static-file/types/src/segment.rs
+++ b/crates/static-file/types/src/segment.rs
@@ -200,7 +200,6 @@ impl StaticFileSegment {
     }
 
     /// Maps this segment to the [`reth_stages_types::StageId`] responsible for it.
-    ///
     pub const fn to_stage_id(&self) -> reth_stages_types::StageId {
         use reth_stages_types::StageId;
         match self {

--- a/crates/static-file/types/src/segment.rs
+++ b/crates/static-file/types/src/segment.rs
@@ -1,11 +1,11 @@
 use crate::{find_fixed_range, BlockNumber, Compression};
-use reth_stages_types::StageId;
 use alloc::{format, string::String, vec::Vec};
 use alloy_primitives::TxNumber;
 use core::{
     ops::{Range, RangeInclusive},
     str::FromStr,
 };
+use reth_stages_types::StageId;
 use serde::{de::Visitor, ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer};
 use strum::{EnumIs, EnumString};
 

--- a/crates/static-file/types/src/segment.rs
+++ b/crates/static-file/types/src/segment.rs
@@ -198,7 +198,7 @@ impl StaticFileSegment {
     pub const fn is_block_or_change_based(&self) -> bool {
         self.is_block_based() || self.is_change_based()
     }
-    
+
     /// Maps this segment to the [`StageId`] responsible for it.                              
     pub const fn to_stage_id(&self) -> reth_stages_types::StageId {
         use reth_stages_types::StageId;
@@ -209,7 +209,7 @@ impl StaticFileSegment {
                 StageId::Execution
             }
             Self::TransactionSenders => StageId::SenderRecovery,
-        }                                                                                 
+        }                                
     }
 }
 

--- a/crates/static-file/types/src/segment.rs
+++ b/crates/static-file/types/src/segment.rs
@@ -200,16 +200,16 @@ impl StaticFileSegment {
     }
     
     /// Maps this segment to the [`StageId`] responsible for it.                              
-    pub const fn to_stage_id(&self) -> reth_stages_types::StageId {                           
-        use reth_stages_types::StageId;                                                       
-        match self {                                                                          
-            Self::Headers => StageId::Headers,                                                
-            Self::Transactions => StageId::Bodies,                                            
-            Self::Receipts | Self::AccountChangeSets | Self::StorageChangeSets => {           
-                StageId::Execution                                                            
-            }                                                                                 
-            Self::TransactionSenders => StageId::SenderRecovery,                              
-        }                                                                                     
+    pub const fn to_stage_id(&self) -> reth_stages_types::StageId {
+        use reth_stages_types::StageId;
+        match self {
+            Self::Headers => StageId::Headers,
+            Self::Transactions => StageId::Bodies,
+            Self::Receipts | Self::AccountChangeSets | Self::StorageChangeSets => {
+                StageId::Execution
+            }
+            Self::TransactionSenders => StageId::SenderRecovery,
+        }                                                                                 
     }
 }
 

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -3018,19 +3018,6 @@ where
     Ok((keccak256(rlp_buf), tx_id))
 }
 
-/// Maps this segment to the [`StageId`] responsible for it.                                  
-pub const fn to_stage_id(&self) -> reth_stages_types::StageId {                               
-    use reth_stages_types::StageId;                                                           
-    match self {                                                                              
-        Self::Headers => StageId::Headers,                                                    
-        Self::Transactions => StageId::Bodies,                                                
-        Self::Receipts | Self::AccountChangeSets | Self::StorageChangeSets => {               
-            StageId::Execution                                                                
-        }                                                                                     
-        Self::TransactionSenders => StageId::SenderRecovery,                                  
-    }                                                                                         
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;


### PR DESCRIPTION
Replace two identical match expressions in `ensure_unwind_consistency` and `stage_checkpoint_matches_static_file`