### PR TITLE
fix(cli): correct `--trusted-peer` to `--trusted-peers` in error message

### DIFF
--- a/crates/cli/commands/src/p2p/mod.rs
+++ b/crates/cli/commands/src/p2p/mod.rs
@@ -183,7 +183,7 @@ impl<C: ChainSpecParser> DownloadArgs<C> {
 
         if config.peers.trusted_nodes.is_empty() && self.network.trusted_only {
             eyre::bail!(
-                "No trusted nodes. Set trusted peer with `--trusted-peer <enode record>` or set `--trusted-only` to `false`"
+                "No trusted nodes. Set trusted peer with `--trusted-peers <enode record>` or set `--trusted-only` to `false`"
             )
         }
 


### PR DESCRIPTION
Hi when I run the error message in p2p command referenced `--trusted-peer` but dosent work, And the actual CLI flag is `--trusted-peers`. This caused confusion......