### PR TITLE
chore(deps): update metrics-derive 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5852,13 +5852,12 @@ dependencies = [
 
 [[package]]
 name = "metrics-derive"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3dbdd96ed57d565ec744cba02862d707acf373c5772d152abae6ec5c4e24f6c"
+checksum = "37a87f4b19620e4c561f7b48f5e6ca085b1780def671696a6a3d9d0c137360ec"
 dependencies = [
  "proc-macro2",
  "quote",
- "regex",
  "syn 2.0.114",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -595,7 +595,7 @@ chrono = "0.4.41"
 
 # metrics
 metrics = "0.24.0"
-metrics-derive = "0.1"
+metrics-derive = "0.1.1"
 metrics-exporter-prometheus = { version = "0.18.0", default-features = false }
 metrics-process = "2.1.0"
 metrics-util = { default-features = false, version = "0.20.0" }


### PR DESCRIPTION
- Cached `describe` and `default` calls
- Less generated code