### PR TITLE
trie: replace panic with error handling in walker node lookup

### DIFF
--- a/crates/trie/trie/src/walker.rs
+++ b/crates/trie/trie/src/walker.rs
@@ -284,7 +284,9 @@ impl<C: TrieCursor, K: AsRef<AddedRemovedKeys>> TrieWalker<C, K> {
 
     /// Retrieves the current root node from the DB, seeking either the exact node or the next one.
     fn node(&mut self, exact: bool) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
-        let key = self.key().expect("key must exist");
+        let Some(key) = self.key() else {
+            return Err(DatabaseError::Other("trie walker key missing".to_string()))
+        };
         let entry = if exact { self.cursor.seek_exact(*key)? } else { self.cursor.seek(*key)? };
         #[cfg(feature = "metrics")]
         self.metrics.inc_branch_nodes_seeked();


### PR DESCRIPTION
The TrieWalker::node method used .expect("key must exist") when retrieving the current key from the stack. This causes a panic if the walker is in an inconsistent state or the stack is unexpectedly empty, leading to uncontrolled process termination in production.