### PR TITLE
fix(prune): migrate invalid receipts prune config to Distance(64)

### DIFF
--- a/crates/node/core/src/args/pruning.rs
+++ b/crates/node/core/src/args/pruning.rs
@@ -6,7 +6,7 @@ use clap::{builder::RangedU64ValueParser, Args};
 use reth_chainspec::EthereumHardforks;
 use reth_config::config::PruneConfig;
 use reth_prune_types::{
-    PruneMode, PruneModes, ReceiptsLogPruneConfig, MINIMUM_UNWIND_SAFE_DISTANCE,
+    PruneMode, PruneModes, ReceiptsLogPruneConfig, MINIMUM_DISTANCE, MINIMUM_UNWIND_SAFE_DISTANCE,
 };
 use std::{collections::BTreeMap, ops::Not, sync::OnceLock};
 
@@ -81,7 +81,7 @@ impl Default for DefaultPruningValues {
             minimal_prune_modes: PruneModes {
                 sender_recovery: Some(PruneMode::Full),
                 transaction_lookup: Some(PruneMode::Full),
-                receipts: Some(PruneMode::Full),
+                receipts: Some(PruneMode::Distance(MINIMUM_DISTANCE)),
                 account_history: Some(PruneMode::Distance(MINIMUM_UNWIND_SAFE_DISTANCE)),
                 storage_history: Some(PruneMode::Distance(MINIMUM_UNWIND_SAFE_DISTANCE)),
                 bodies_history: Some(PruneMode::Distance(MINIMUM_UNWIND_SAFE_DISTANCE)),

--- a/crates/prune/types/src/target.rs
+++ b/crates/prune/types/src/target.rs
@@ -54,7 +54,7 @@ pub struct PruneModes {
     pub transaction_lookup: Option<PruneMode>,
     /// Receipts pruning configuration. This setting overrides `receipts_log_filter`
     /// and offers improved performance.
-    #[cfg_attr(any(test, feature = "serde"), serde(skip_serializing_if = "Option::is_none",))]
+    #[cfg_attr(any(test, feature = "serde"), serde(skip_serializing_if = "Option::is_none"))]
     pub receipts: Option<PruneMode>,
     /// Account History pruning configuration.
     #[cfg_attr(
@@ -75,7 +75,7 @@ pub struct PruneModes {
     )]
     pub storage_history: Option<PruneMode>,
     /// Bodies History pruning configuration.
-    #[cfg_attr(any(test, feature = "serde"), serde(skip_serializing_if = "Option::is_none",))]
+    #[cfg_attr(any(test, feature = "serde"), serde(skip_serializing_if = "Option::is_none"))]
     pub bodies_history: Option<PruneMode>,
     /// Receipts pruning configuration by retaining only those receipts that contain logs emitted
     /// by the specified addresses, discarding others. This setting is overridden by `receipts`.
@@ -112,7 +112,13 @@ impl PruneModes {
     ///
     /// Returns `true` if any migration was performed.
     pub const fn migrate(&mut self) -> bool {
-        false
+        match &self.receipts {
+            Some(PruneMode::Full | PruneMode::Distance(0..MINIMUM_DISTANCE)) => {
+                self.receipts = Some(PruneMode::Distance(MINIMUM_DISTANCE));
+                true
+            }
+            _ => false,
+        }
     }
 
     /// Returns an error if we can't unwind to the targeted block because the target block is


### PR DESCRIPTION
Updates `minimal_prune_modes.receipts` from `Full` to `Distance(MINIMUM_DISTANCE)`.

Extends `migrate()` to convert invalid receipts configs (`Full` or `Distance < 64`) to `Distance(64)` at startup. Migrated config is persisted to `reth.toml`.