### PR TITLE
Fix bal fcu validation

### DIFF
--- a/crates/payload/primitives/src/lib.rs
+++ b/crates/payload/primitives/src/lib.rs
@@ -418,13 +418,16 @@ where
     Type: PayloadAttributes,
     T: EthereumHardforks,
 {
-    validate_block_access_list_presence(
-        chain_spec,
-        version,
-        payload_or_attrs.message_validation_kind(),
-        payload_or_attrs.timestamp(),
-        payload_or_attrs.block_access_list().is_some(),
-    )?;
+    // BAL only exists in ExecutionPayload, not PayloadAttributes (EIP-7928)
+    if let PayloadOrAttributes::ExecutionPayload(_) = payload_or_attrs {
+        validate_block_access_list_presence(
+            chain_spec,
+            version,
+            payload_or_attrs.message_validation_kind(),
+            payload_or_attrs.timestamp(),
+            payload_or_attrs.block_access_list().is_some(),
+        )?;
+    }
 
     validate_withdrawals_presence(
         chain_spec,


### PR DESCRIPTION
#### Problem & Root cause

`engine_forkchoiceUpdatedV4` fails with NoBlockAccessListPostAmsterdam when Amsterdam is active. `validate_block_access_list_presence()` was called for both ExecutionPayload and PayloadAttributes. Per EIP-7928, blockAccessList only exists in ExecutionPayloadV4 (used by newPayload), not in PayloadAttributes (used by FCU).

Raised on [discord](https://discord.com/channels/1359927674746835211/1422938484573732926/1466600091732279470) 

#### Solution 
Only validate BAL presence for ExecutionPayload