### PR TITLE
refactor: add with_* compressor utility methods

### DIFF
--- a/crates/ethereum/primitives/src/receipt.rs
+++ b/crates/ethereum/primitives/src/receipt.rs
@@ -511,9 +511,8 @@ mod compact {
             total_length += flags.len() + buffer.len();
             buf.put_slice(&flags);
             if zstd {
-                reth_zstd_compressors::RECEIPT_COMPRESSOR.with(|compressor| {
-                    let compressed =
-                        compressor.borrow_mut().compress(&buffer).expect("Failed to compress.");
+                reth_zstd_compressors::with_receipt_compressor(|compressor| {
+                    let compressed = compressor.compress(&buffer).expect("Failed to compress.");
                     buf.put(compressed.as_slice());
                 });
             } else {
@@ -525,8 +524,7 @@ mod compact {
         fn from_compact(buf: &[u8], _len: usize) -> (Self, &[u8]) {
             let (flags, mut buf) = ReceiptFlags::from(buf);
             if flags.__zstd() != 0 {
-                reth_zstd_compressors::RECEIPT_DECOMPRESSOR.with(|decompressor| {
-                    let decompressor = &mut decompressor.borrow_mut();
+                reth_zstd_compressors::with_receipt_decompressor(|decompressor| {
                     let decompressed = decompressor.decompress(buf);
                     let original_buf = buf;
                     let mut buf: &[u8] = decompressed;

--- a/crates/ethereum/primitives/src/transaction.rs
+++ b/crates/ethereum/primitives/src/transaction.rs
@@ -577,19 +577,11 @@ impl reth_codecs::Compact for TransactionSigned {
 
         let tx_bits = if zstd_bit {
             let mut tmp = Vec::with_capacity(256);
-            if cfg!(feature = "std") {
-                reth_zstd_compressors::TRANSACTION_COMPRESSOR.with(|compressor| {
-                    let mut compressor = compressor.borrow_mut();
-                    let tx_bits = self.transaction.to_compact(&mut tmp);
-                    buf.put_slice(&compressor.compress(&tmp).expect("Failed to compress"));
-                    tx_bits as u8
-                })
-            } else {
-                let mut compressor = reth_zstd_compressors::create_tx_compressor();
+            reth_zstd_compressors::with_tx_compressor(|compressor| {
                 let tx_bits = self.transaction.to_compact(&mut tmp);
                 buf.put_slice(&compressor.compress(&tmp).expect("Failed to compress"));
                 tx_bits as u8
-            }
+            })
         } else {
             self.transaction.to_compact(buf) as u8
         };
@@ -611,26 +603,13 @@ impl reth_codecs::Compact for TransactionSigned {
 
         let zstd_bit = bitflags >> 3;
         let (transaction, buf) = if zstd_bit != 0 {
-            if cfg!(feature = "std") {
-                reth_zstd_compressors::TRANSACTION_DECOMPRESSOR.with(|decompressor| {
-                    let mut decompressor = decompressor.borrow_mut();
-
-                    // TODO: enforce that zstd is only present at a "top" level type
-
-                    let transaction_type = (bitflags & 0b110) >> 1;
-                    let (transaction, _) =
-                        Transaction::from_compact(decompressor.decompress(buf), transaction_type);
-
-                    (transaction, buf)
-                })
-            } else {
-                let mut decompressor = reth_zstd_compressors::create_tx_decompressor();
+            reth_zstd_compressors::with_tx_decompressor(|decompressor| {
+                // TODO: enforce that zstd is only present at a "top" level type
                 let transaction_type = (bitflags & 0b110) >> 1;
                 let (transaction, _) =
                     Transaction::from_compact(decompressor.decompress(buf), transaction_type);
-
                 (transaction, buf)
-            }
+            })
         } else {
             let transaction_type = bitflags >> 1;
             Transaction::from_compact(buf, transaction_type)

--- a/crates/optimism/primitives/src/transaction/signed.rs
+++ b/crates/optimism/primitives/src/transaction/signed.rs
@@ -435,19 +435,11 @@ impl reth_codecs::Compact for OpTransactionSigned {
 
         let tx_bits = if zstd_bit {
             let mut tmp = Vec::with_capacity(256);
-            if cfg!(feature = "std") {
-                reth_zstd_compressors::TRANSACTION_COMPRESSOR.with(|compressor| {
-                    let mut compressor = compressor.borrow_mut();
-                    let tx_bits = self.transaction.to_compact(&mut tmp);
-                    buf.put_slice(&compressor.compress(&tmp).expect("Failed to compress"));
-                    tx_bits as u8
-                })
-            } else {
-                let mut compressor = reth_zstd_compressors::create_tx_compressor();
+            reth_zstd_compressors::with_tx_compressor(|compressor| {
                 let tx_bits = self.transaction.to_compact(&mut tmp);
                 buf.put_slice(&compressor.compress(&tmp).expect("Failed to compress"));
                 tx_bits as u8
-            }
+            })
         } else {
             self.transaction.to_compact(buf) as u8
         };
@@ -469,29 +461,15 @@ impl reth_codecs::Compact for OpTransactionSigned {
 
         let zstd_bit = bitflags >> 3;
         let (transaction, buf) = if zstd_bit != 0 {
-            if cfg!(feature = "std") {
-                reth_zstd_compressors::TRANSACTION_DECOMPRESSOR.with(|decompressor| {
-                    let mut decompressor = decompressor.borrow_mut();
-
-                    // TODO: enforce that zstd is only present at a "top" level type
-                    let transaction_type = (bitflags & 0b110) >> 1;
-                    let (transaction, _) = OpTypedTransaction::from_compact(
-                        decompressor.decompress(buf),
-                        transaction_type,
-                    );
-
-                    (transaction, buf)
-                })
-            } else {
-                let mut decompressor = reth_zstd_compressors::create_tx_decompressor();
+            reth_zstd_compressors::with_tx_decompressor(|decompressor| {
+                // TODO: enforce that zstd is only present at a "top" level type
                 let transaction_type = (bitflags & 0b110) >> 1;
                 let (transaction, _) = OpTypedTransaction::from_compact(
                     decompressor.decompress(buf),
                     transaction_type,
                 );
-
                 (transaction, buf)
-            }
+            })
         } else {
             let transaction_type = bitflags >> 1;
             OpTypedTransaction::from_compact(buf, transaction_type)

--- a/crates/storage/codecs/derive/src/compact/generator.rs
+++ b/crates/storage/codecs/derive/src/compact/generator.rs
@@ -133,8 +133,7 @@ fn generate_from_compact(
         let decompressor = zstd.decompressor;
         quote! {
             if flags.__zstd() != 0 {
-                #decompressor.with(|decompressor| {
-                    let decompressor = &mut decompressor.borrow_mut();
+                #decompressor(|decompressor| {
                     let decompressed = decompressor.decompress(buf);
                     let mut original_buf = buf;
 
@@ -203,9 +202,7 @@ fn generate_to_compact(
         let compressor = zstd.compressor;
         lines.push(quote! {
             if zstd {
-                #compressor.with(|compressor| {
-                    let mut compressor = compressor.borrow_mut();
-
+                #compressor(|compressor| {
                     let compressed = compressor.compress(&buffer).expect("Failed to compress.");
                     buf.put(compressed.as_slice());
                 });

--- a/crates/storage/codecs/src/alloy/optimism.rs
+++ b/crates/storage/codecs/src/alloy/optimism.rs
@@ -10,8 +10,8 @@ use reth_codecs_derive::CompactZstd;
 #[derive(CompactZstd)]
 #[reth_codecs(crate = "crate")]
 #[reth_zstd(
-    compressor = reth_zstd_compressors::RECEIPT_COMPRESSOR,
-    decompressor = reth_zstd_compressors::RECEIPT_DECOMPRESSOR
+    compressor = reth_zstd_compressors::with_receipt_compressor,
+    decompressor = reth_zstd_compressors::with_receipt_decompressor
 )]
 struct CompactOpReceipt<'a> {
     tx_type: OpTxType,

--- a/crates/storage/zstd-compressors/src/lib.rs
+++ b/crates/storage/zstd-compressors/src/lib.rs
@@ -85,6 +85,59 @@ pub fn create_receipt_decompressor() -> ReusableDecompressor {
     )
 }
 
+/// Executes `f` with the thread-local transaction compressor on `std`, otherwise creates a new one.
+#[inline]
+pub fn with_tx_compressor<R>(f: impl FnOnce(&mut Compressor<'static>) -> R) -> R {
+    #[cfg(feature = "std")]
+    {
+        TRANSACTION_COMPRESSOR.with(|c| f(&mut c.borrow_mut()))
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        f(&mut create_tx_compressor())
+    }
+}
+
+/// Executes `f` with the thread-local transaction decompressor on `std`, otherwise creates a new
+/// one.
+#[inline]
+pub fn with_tx_decompressor<R>(f: impl FnOnce(&mut ReusableDecompressor) -> R) -> R {
+    #[cfg(feature = "std")]
+    {
+        TRANSACTION_DECOMPRESSOR.with(|c| f(&mut c.borrow_mut()))
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        f(&mut create_tx_decompressor())
+    }
+}
+
+/// Executes `f` with the thread-local receipt compressor on `std`, otherwise creates a new one.
+#[inline]
+pub fn with_receipt_compressor<R>(f: impl FnOnce(&mut Compressor<'static>) -> R) -> R {
+    #[cfg(feature = "std")]
+    {
+        RECEIPT_COMPRESSOR.with(|c| f(&mut c.borrow_mut()))
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        f(&mut create_receipt_compressor())
+    }
+}
+
+/// Executes `f` with the thread-local receipt decompressor on `std`, otherwise creates a new one.
+#[inline]
+pub fn with_receipt_decompressor<R>(f: impl FnOnce(&mut ReusableDecompressor) -> R) -> R {
+    #[cfg(feature = "std")]
+    {
+        RECEIPT_DECOMPRESSOR.with(|c| f(&mut c.borrow_mut()))
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        f(&mut create_receipt_decompressor())
+    }
+}
+
 /// Reusable decompressor that uses its own internal buffer.
 #[expect(missing_debug_implementations)]
 pub struct ReusableDecompressor {

--- a/crates/storage/zstd-compressors/src/lib.rs
+++ b/crates/storage/zstd-compressors/src/lib.rs
@@ -90,7 +90,7 @@ pub fn create_receipt_decompressor() -> ReusableDecompressor {
 pub fn with_tx_compressor<R>(f: impl FnOnce(&mut Compressor<'static>) -> R) -> R {
     #[cfg(feature = "std")]
     {
-        TRANSACTION_COMPRESSOR.with(|c| f(&mut c.borrow_mut()))
+        TRANSACTION_COMPRESSOR.with_borrow_mut(f)
     }
     #[cfg(not(feature = "std"))]
     {
@@ -104,7 +104,7 @@ pub fn with_tx_compressor<R>(f: impl FnOnce(&mut Compressor<'static>) -> R) -> R
 pub fn with_tx_decompressor<R>(f: impl FnOnce(&mut ReusableDecompressor) -> R) -> R {
     #[cfg(feature = "std")]
     {
-        TRANSACTION_DECOMPRESSOR.with(|c| f(&mut c.borrow_mut()))
+        TRANSACTION_DECOMPRESSOR.with_borrow_mut(f)
     }
     #[cfg(not(feature = "std"))]
     {
@@ -117,7 +117,7 @@ pub fn with_tx_decompressor<R>(f: impl FnOnce(&mut ReusableDecompressor) -> R) -
 pub fn with_receipt_compressor<R>(f: impl FnOnce(&mut Compressor<'static>) -> R) -> R {
     #[cfg(feature = "std")]
     {
-        RECEIPT_COMPRESSOR.with(|c| f(&mut c.borrow_mut()))
+        RECEIPT_COMPRESSOR.with_borrow_mut(f)
     }
     #[cfg(not(feature = "std"))]
     {
@@ -130,7 +130,7 @@ pub fn with_receipt_compressor<R>(f: impl FnOnce(&mut Compressor<'static>) -> R)
 pub fn with_receipt_decompressor<R>(f: impl FnOnce(&mut ReusableDecompressor) -> R) -> R {
     #[cfg(feature = "std")]
     {
-        RECEIPT_DECOMPRESSOR.with(|c| f(&mut c.borrow_mut()))
+        RECEIPT_DECOMPRESSOR.with_borrow_mut(f)
     }
     #[cfg(not(feature = "std"))]
     {

--- a/crates/storage/zstd-compressors/src/lib.rs
+++ b/crates/storage/zstd-compressors/src/lib.rs
@@ -87,7 +87,7 @@ pub fn create_receipt_decompressor() -> ReusableDecompressor {
 
 /// Executes `f` with the thread-local transaction compressor on `std`, otherwise creates a new one.
 #[inline]
-pub fn with_tx_compressor<R>(f: impl FnOnce(&mut Compressor<'static>) -> R) -> R {
+pub fn with_tx_compressor<R>(f: impl FnOnce(&mut Compressor<'_>) -> R) -> R {
     #[cfg(feature = "std")]
     {
         TRANSACTION_COMPRESSOR.with_borrow_mut(f)
@@ -114,7 +114,7 @@ pub fn with_tx_decompressor<R>(f: impl FnOnce(&mut ReusableDecompressor) -> R) -
 
 /// Executes `f` with the thread-local receipt compressor on `std`, otherwise creates a new one.
 #[inline]
-pub fn with_receipt_compressor<R>(f: impl FnOnce(&mut Compressor<'static>) -> R) -> R {
+pub fn with_receipt_compressor<R>(f: impl FnOnce(&mut Compressor<'_>) -> R) -> R {
     #[cfg(feature = "std")]
     {
         RECEIPT_COMPRESSOR.with_borrow_mut(f)


### PR DESCRIPTION
Add utility functions in `reth-zstd-compressors` that abstract away the `#[cfg(feature = "std")]` / `cfg!(feature = "std")` branching:

- `with_tx_compressor`
- `with_tx_decompressor`
- `with_receipt_compressor`
- `with_receipt_decompressor`

These functions use thread-local compressors on `std` and create new instances on `no_std`.

Updated all call sites and the `CompactZstd` derive macro to use the new pattern.