### PR TITLE
feat(zstd): add option to omit dictionary ID from compressed frames

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9410,6 +9410,7 @@ dependencies = [
  "reth-tracing",
  "reth-transaction-pool",
  "reth-trie-db",
+ "reth-zstd-compressors",
  "secp256k1 0.30.0",
  "serde_json",
  "tempfile",

--- a/crates/ethereum/primitives/src/transaction.rs
+++ b/crates/ethereum/primitives/src/transaction.rs
@@ -585,7 +585,7 @@ impl reth_codecs::Compact for TransactionSigned {
                     tx_bits as u8
                 })
             } else {
-                let mut compressor = reth_zstd_compressors::create_tx_compressor();
+                let mut compressor = reth_zstd_compressors::create_tx_compressor(false);
                 let tx_bits = self.transaction.to_compact(&mut tmp);
                 buf.put_slice(&compressor.compress(&tmp).expect("Failed to compress"));
                 tx_bits as u8

--- a/crates/node/builder/Cargo.toml
+++ b/crates/node/builder/Cargo.toml
@@ -57,6 +57,7 @@ reth-transaction-pool.workspace = true
 reth-trie-db = { workspace = true, features = ["metrics"] }
 reth-basic-payload-builder.workspace = true
 reth-node-ethstats.workspace = true
+reth-zstd-compressors.workspace = true
 
 ## ethereum
 alloy-consensus.workspace = true

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -115,6 +115,9 @@ impl EngineNodeLauncher {
                 info!(target: "reth::cli", "\n{}", this.chain_spec().display_hardforks());
                 let settings = this.provider_factory().cached_storage_settings();
                 info!(target: "reth::cli", ?settings, "Loaded storage settings");
+
+                // Configure zstd compression based on storage settings
+                reth_zstd_compressors::set_omit_dictionary_id(settings.zstd_omit_dictionary_id);
             })
             .with_metrics_task()
             // passing FullNodeTypes as type parameter here so that we can build

--- a/crates/optimism/primitives/src/transaction/signed.rs
+++ b/crates/optimism/primitives/src/transaction/signed.rs
@@ -443,7 +443,7 @@ impl reth_codecs::Compact for OpTransactionSigned {
                     tx_bits as u8
                 })
             } else {
-                let mut compressor = reth_zstd_compressors::create_tx_compressor();
+                let mut compressor = reth_zstd_compressors::create_tx_compressor(false);
                 let tx_bits = self.transaction.to_compact(&mut tmp);
                 buf.put_slice(&compressor.compress(&tmp).expect("Failed to compress"));
                 tx_bits as u8

--- a/crates/storage/codecs/src/alloy/transaction/ethereum.rs
+++ b/crates/storage/codecs/src/alloy/transaction/ethereum.rs
@@ -159,7 +159,7 @@ impl<T: Envelope + ToTxCompact + Transaction + Send + Sync> CompactEnvelope for 
                     }
                     #[cfg(not(feature = "std"))]
                     {
-                        let mut compressor = reth_zstd_compressors::create_tx_compressor();
+                        let mut compressor = reth_zstd_compressors::create_tx_compressor(false);
                         compressor.compress(&tx_buf)
                     }
                 }

--- a/crates/storage/db-api/src/models/metadata.rs
+++ b/crates/storage/db-api/src/models/metadata.rs
@@ -34,6 +34,12 @@ pub struct StorageSettings {
     /// Whether this node should read and write storage changesets from static files.
     #[serde(default)]
     pub storage_changesets_in_static_files: bool,
+    /// Whether to omit the dictionary ID from zstd compressed frames.
+    ///
+    /// When enabled, saves 4 bytes per compressed transaction/receipt by not writing
+    /// the dictionary ID to the frame header. Safe because reth uses hardcoded dictionaries.
+    #[serde(default)]
+    pub zstd_omit_dictionary_id: bool,
 }
 
 impl StorageSettings {
@@ -56,6 +62,7 @@ impl StorageSettings {
     /// - Receipts and transaction senders in static files
     /// - History indices in `RocksDB` (storages, accounts, transaction hashes)
     /// - Account changesets in static files
+    /// - Omit dictionary ID from zstd frames (saves ~4 bytes per tx/receipt)
     #[cfg(feature = "edge")]
     pub const fn edge() -> Self {
         Self {
@@ -66,6 +73,7 @@ impl StorageSettings {
             storages_history_in_rocksdb: true,
             transaction_hash_numbers_in_rocksdb: true,
             account_history_in_rocksdb: true,
+            zstd_omit_dictionary_id: true,
         }
     }
 
@@ -83,6 +91,7 @@ impl StorageSettings {
             account_history_in_rocksdb: false,
             account_changesets_in_static_files: false,
             storage_changesets_in_static_files: false,
+            zstd_omit_dictionary_id: false,
         }
     }
 
@@ -125,6 +134,12 @@ impl StorageSettings {
     /// Sets the `storage_changesets_in_static_files` flag to the provided value.
     pub const fn with_storage_changesets_in_static_files(mut self, value: bool) -> Self {
         self.storage_changesets_in_static_files = value;
+        self
+    }
+
+    /// Sets the `zstd_omit_dictionary_id` flag to the provided value.
+    pub const fn with_zstd_omit_dictionary_id(mut self, value: bool) -> Self {
+        self.zstd_omit_dictionary_id = value;
         self
     }
 


### PR DESCRIPTION
## Summary

Add `zstd_omit_dictionary_id` setting to `StorageSettings` that saves 4 bytes per compressed transaction/receipt by not writing the dictionary ID to zstd frame headers.

## Motivation

Ethereum mainnet has ~3.2 billion transactions. Each compressed tx/receipt includes a 4-byte dictionary ID in the zstd frame header. Since reth uses hardcoded dictionaries, this ID is redundant - the decompressor always knows which dictionary to use.

**Estimated savings:**
- ~13 GB on mainnet (3.2B txs × 4 bytes)
- Growing ~9 MB/day at current ~2.3M tx/day rate

## Changes

- Add `zstd_omit_dictionary_id` flag to `StorageSettings`
- Update `create_tx_compressor` and `create_receipt_compressor` to accept `omit_dictionary_id` parameter
- Add global `set_omit_dictionary_id()` function to configure at startup
- Configure zstd compression from storage settings at node launch
- **Bug fix**: `create_tx_compressor` was using `RECEIPT_DICTIONARY` instead of `TRANSACTION_DICTIONARY` (no-std only path)
- Add tests for roundtrip compression with and without dictionary ID

## Compatibility

- **New nodes** with `edge` feature: Dictionary ID omitted by default (saves space)
- **Legacy nodes**: Dictionary ID included (backward compatible)
- Decompression works in both cases since the dictionary is known

## Testing

```
cargo test -p reth-zstd-compressors
```

All 4 tests pass:
- `test_tx_roundtrip_with_dict_id`
- `test_tx_roundtrip_without_dict_id`
- `test_omitting_dict_id_saves_bytes`
- `test_receipt_roundtrip`