### PR TITLE
fix(prune): migrate invalid bodies_history config to Distance(64)

### DIFF
--- a/crates/prune/types/src/target.rs
+++ b/crates/prune/types/src/target.rs
@@ -112,13 +112,27 @@ impl PruneModes {
     ///
     /// Returns `true` if any migration was performed.
     pub const fn migrate(&mut self) -> bool {
-        match &self.receipts {
-            Some(PruneMode::Full | PruneMode::Distance(0..MINIMUM_DISTANCE)) => {
-                self.receipts = Some(PruneMode::Distance(MINIMUM_DISTANCE));
-                true
-            }
-            _ => false,
-        }
+        let migrated_receipts = if matches!(
+            &self.receipts,
+            Some(PruneMode::Full | PruneMode::Distance(0..MINIMUM_DISTANCE))
+        ) {
+            self.receipts = Some(PruneMode::Distance(MINIMUM_DISTANCE));
+            true
+        } else {
+            false
+        };
+
+        let migrated_bodies = if matches!(
+            &self.bodies_history,
+            Some(PruneMode::Full | PruneMode::Distance(0..MINIMUM_DISTANCE))
+        ) {
+            self.bodies_history = Some(PruneMode::Distance(MINIMUM_DISTANCE));
+            true
+        } else {
+            false
+        };
+
+        migrated_receipts || migrated_bodies
     }
 
     /// Returns an error if we can't unwind to the targeted block because the target block is


### PR DESCRIPTION
Extend migrate() from https://github.com/paradigmxyz/reth/pull/21677 to also fix invalid bodies_history configurations at startup. Both receipts and bodies_history have MINIMUM_DISTANCE (64) constraint as defined in PruneSegment::min_blocks()."

I think this is not low value?  BTW some of my rocksDB contribution has been hold for a while like #20851 #21365 #21535, couple of the times I really trying to help but not get review and when they finally got review seems all my work overlap with some new merged commit and be closed really frustrated..