### PR TITLE
perf(trie): dispatch V2 storage proofs in lexicographical order

### DIFF
--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -1828,8 +1828,14 @@ fn dispatch_v2_storage_proofs(
         }
     }
 
+    // Sort storage targets by address for optimal dispatch order.
+    // Since trie walk processes accounts in lexicographical order, dispatching in the same order
+    // reduces head-of-line blocking when consuming results.
+    let mut sorted_storage_targets: Vec<_> = storage_targets.into_iter().collect();
+    sorted_storage_targets.sort_unstable_by_key(|(addr, _)| *addr);
+
     // Dispatch all proofs for targeted storage slots
-    for (hashed_address, targets) in storage_targets {
+    for (hashed_address, targets) in sorted_storage_targets {
         // Create channel for receiving StorageProofResultMessage
         let (result_tx, result_rx) = crossbeam_channel::unbounded();
         let input = StorageProofInput::new(hashed_address, targets);


### PR DESCRIPTION
dispatch_v2_storage_proofs iterates over B256Map in arbitrary order, but storage proofs are consumed in lexicographical order during the account trie walk. This mismatch causes head-of-line blocking. This sorts storage_targets by hashed address before dispatching to align production order with consumption order.

References:
Dispatch: crates/trie/parallel/src/proof_task.rs#L1810
Consumption: crates/trie/parallel/src/proof_task.rs#L1379

Dont think this is low value? All refer to existing patten.