### PR TITLE
refactor: deduplicate `compare_receipts_root_and_logs_bloom` into `reth-consensus-common`

### DIFF
--- a/crates/consensus/common/Cargo.toml
+++ b/crates/consensus/common/Cargo.toml
@@ -19,6 +19,7 @@ reth-consensus.workspace = true
 reth-primitives-traits.workspace = true
 alloy-consensus.workspace = true
 alloy-eips.workspace = true
+alloy-primitives.workspace = true 
 
 [dev-dependencies]
 alloy-primitives = { workspace = true, features = ["rand"] }

--- a/crates/consensus/common/Cargo.toml
+++ b/crates/consensus/common/Cargo.toml
@@ -19,7 +19,7 @@ reth-consensus.workspace = true
 reth-primitives-traits.workspace = true
 alloy-consensus.workspace = true
 alloy-eips.workspace = true
-alloy-primitives.workspace = true 
+alloy-primitives.workspace = true
 
 [dev-dependencies]
 alloy-primitives = { workspace = true, features = ["rand"] }

--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -423,6 +423,29 @@ pub fn validate_against_parent_4844<H: BlockHeader>(
     Ok(())
 }
 
+/// Compare the calculated receipts root with the expected receipts root, also compare
+/// the calculated logs bloom with the expected logs bloom.
+pub fn compare_receipts_root_and_logs_bloom(
+    calculated_receipts_root: B256,
+    calculated_logs_bloom: Bloom,
+    expected_receipts_root: B256,
+    expected_logs_bloom: Bloom,
+) -> Result<(), ConsensusError> {
+    if calculated_receipts_root != expected_receipts_root {
+        return Err(ConsensusError::BodyReceiptRootDiff(
+            GotExpected { got: calculated_receipts_root, expected: expected_receipts_root }.into(),
+        ))
+    }
+
+    if calculated_logs_bloom != expected_logs_bloom {
+        return Err(ConsensusError::BodyBloomLogDiff(
+            GotExpected { got: calculated_logs_bloom, expected: expected_logs_bloom }.into(),
+        ))
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -2,6 +2,7 @@
 
 use alloy_consensus::{BlockHeader as _, EMPTY_OMMER_ROOT_HASH};
 use alloy_eips::{eip4844::DATA_GAS_PER_BLOB, eip7840::BlobParams};
+use alloy_primitives::{Bloom, B256};
 use reth_chainspec::{EthChainSpec, EthereumHardfork, EthereumHardforks};
 use reth_consensus::ConsensusError;
 use reth_primitives_traits::{

--- a/crates/ethereum/consensus/src/validation.rs
+++ b/crates/ethereum/consensus/src/validation.rs
@@ -4,6 +4,7 @@ use alloy_eips::{eip7685::Requests, Encodable2718};
 use alloy_primitives::{Bloom, Bytes, B256};
 use reth_chainspec::EthereumHardforks;
 use reth_consensus::ConsensusError;
+use reth_consensus_common::validation::compare_receipts_root_and_logs_bloom;
 use reth_primitives_traits::{
     receipt::gas_spent_by_transactions, Block, GotExpected, Receipt, RecoveredBlock,
 };
@@ -99,29 +100,6 @@ fn verify_receipts<R: Receipt>(
         expected_receipts_root,
         expected_logs_bloom,
     )
-}
-
-/// Compare the calculated receipts root with the expected receipts root, also compare
-/// the calculated logs bloom with the expected logs bloom.
-fn compare_receipts_root_and_logs_bloom(
-    calculated_receipts_root: B256,
-    calculated_logs_bloom: Bloom,
-    expected_receipts_root: B256,
-    expected_logs_bloom: Bloom,
-) -> Result<(), ConsensusError> {
-    if calculated_receipts_root != expected_receipts_root {
-        return Err(ConsensusError::BodyReceiptRootDiff(
-            GotExpected { got: calculated_receipts_root, expected: expected_receipts_root }.into(),
-        ))
-    }
-
-    if calculated_logs_bloom != expected_logs_bloom {
-        return Err(ConsensusError::BodyBloomLogDiff(
-            GotExpected { got: calculated_logs_bloom, expected: expected_logs_bloom }.into(),
-        ))
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/optimism/consensus/src/validation/mod.rs
+++ b/crates/optimism/consensus/src/validation/mod.rs
@@ -14,6 +14,7 @@ use alloy_eips::Encodable2718;
 use alloy_primitives::{Bloom, Bytes, B256};
 use alloy_trie::EMPTY_ROOT_HASH;
 use reth_consensus::ConsensusError;
+use reth_consensus_common::validation::compare_receipts_root_and_logs_bloom;
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_primitives::DepositReceipt;
 use reth_primitives_traits::{receipt::gas_spent_by_transactions, BlockBody, GotExpected};
@@ -177,29 +178,6 @@ fn verify_receipts_optimism<R: DepositReceipt>(
         expected_receipts_root,
         expected_logs_bloom,
     )?;
-
-    Ok(())
-}
-
-/// Compare the calculated receipts root with the expected receipts root, also compare
-/// the calculated logs bloom with the expected logs bloom.
-fn compare_receipts_root_and_logs_bloom(
-    calculated_receipts_root: B256,
-    calculated_logs_bloom: Bloom,
-    expected_receipts_root: B256,
-    expected_logs_bloom: Bloom,
-) -> Result<(), ConsensusError> {
-    if calculated_receipts_root != expected_receipts_root {
-        return Err(ConsensusError::BodyReceiptRootDiff(
-            GotExpected { got: calculated_receipts_root, expected: expected_receipts_root }.into(),
-        ))
-    }
-
-    if calculated_logs_bloom != expected_logs_bloom {
-        return Err(ConsensusError::BodyBloomLogDiff(
-            GotExpected { got: calculated_logs_bloom, expected: expected_logs_bloom }.into(),
-        ))
-    }
 
     Ok(())
 }


### PR DESCRIPTION
Moves the `compare_receipts_root_and_logs_bloom` function from both `reth-ethereum-consensus` and `reth-optimism-consensus` into `reth-consensus-common`, eliminating an identical 20-line copy-paste.