### PR TITLE
perf(rocksdb): increase write buffer size to 128 MB

### DIFF
--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -106,6 +106,13 @@ const DEFAULT_MAX_BACKGROUND_JOBS: i32 = 6;
 /// Default bytes per sync for `RocksDB` WAL writes (1 MB).
 const DEFAULT_BYTES_PER_SYNC: u64 = 1_048_576;
 
+/// Default write buffer size for `RocksDB` memtables (128 MB).
+///
+/// Larger memtables reduce flush frequency during burst writes, providing more consistent
+/// tail latency. Benchmarks showed 128 MB reduces p99 latency variance by ~80% compared
+/// to 64 MB default, with negligible impact on mean throughput.
+const DEFAULT_WRITE_BUFFER_SIZE: usize = 128 << 20;
+
 /// Default buffer capacity for compression in batches.
 /// 4 KiB matches common block/page sizes and comfortably holds typical history values,
 /// reducing the first few reallocations without over-allocating.
@@ -214,6 +221,7 @@ impl RocksDBBuilder {
         cf_options.set_bottommost_compression_type(DBCompressionType::Zstd);
         // Only use Zstd compression, disable dictionary training
         cf_options.set_bottommost_zstd_max_train_bytes(0, true);
+        cf_options.set_write_buffer_size(DEFAULT_WRITE_BUFFER_SIZE);
 
         cf_options
     }


### PR DESCRIPTION
## Summary

Increases RocksDB memtable write buffer from 64 MB to 128 MB for more consistent tail latency. Closes RETH-220

## Benchmark Results

### Big Blocks (100 blocks @ 60M gas)

| Metric | 64 MB | 128 MB | Δ% |
|--------|-------|--------|-----|
| Total | 423.3s | 397.6s | **-6.1%** |

### Standard Blocks (1000 blocks @ ~30M gas, 5-run avg)

| Metric | 64 MB | 128 MB | Δ% |
|--------|-------|--------|-----|
| Mean | 28.50 ms | 27.10 ms | **-4.9%** |
| p50 | 25.63 ms | 25.81 ms | +0.7% |
| p90 | 39.95 ms | 37.74 ms | **-5.5%** |
| p99 | 83.77 ms | 50.40 ms | **-39.8%** |
| p99 σ | 40.17 ms | 7.04 ms | **-82.5%** |
| Ggas/s | 1.036 | 1.075 | **+3.8%** |

### Internal Metrics (median per save_blocks)

| Component | Time | % |
|-----------|------|---|
| trie_updates | 226.5 ms | 53.5% |
| write_state | 106.0 ms | 25.0% |
| hashed_state | 90.2 ms | 21.3% |
| RocksDB write | 33.0 ms | 7.8% |

## Why It Works

Larger memtables = fewer flushes = fewer blocks hit flush window = lower p99.

The p99 drops 40% while p50 stays flat—most blocks are unaffected, but the "unlucky" ones that hit a flush are now rare.

## Tradeoffs

+64 MB memory per column family. 