### PR TITLE
fix(trie): Return full_key from update_leaves unless it is not a child of the missing path

### DIFF
--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -1237,8 +1237,8 @@ impl SparseTrieExt for ParallelSparseTrie {
                             Ok(()) => {}
                             Err(e) => {
                                 if let Some(path) = Self::get_retriable_path(&e) {
-                                    let target_key = Self::nibbles_to_padded_b256(&path);
-                                    let min_len = (path.len() as u8).min(64);
+                                    let (target_key, min_len) =
+                                        Self::proof_target_for_path(key, &full_path, &path);
                                     proof_required_fn(target_key, min_len);
                                     updates.insert(key, LeafUpdate::Changed(value));
                                 } else {
@@ -1251,8 +1251,8 @@ impl SparseTrieExt for ParallelSparseTrie {
                         if let Err(e) = self.update_leaf(full_path, value.clone(), NoRevealProvider)
                         {
                             if let Some(path) = Self::get_retriable_path(&e) {
-                                let target_key = Self::nibbles_to_padded_b256(&path);
-                                let min_len = (path.len() as u8).min(64);
+                                let (target_key, min_len) =
+                                    Self::proof_target_for_path(key, &full_path, &path);
                                 proof_required_fn(target_key, min_len);
                                 updates.insert(key, LeafUpdate::Changed(value));
                             } else {
@@ -1265,8 +1265,8 @@ impl SparseTrieExt for ParallelSparseTrie {
                     // Touched is read-only: check if path is accessible, request proof if blinded.
                     match self.find_leaf(&full_path, None) {
                         Err(LeafLookupError::BlindedNode { path, .. }) => {
-                            let target_key = Self::nibbles_to_padded_b256(&path);
-                            let min_len = (path.len() as u8).min(64);
+                            let (target_key, min_len) =
+                                Self::proof_target_for_path(key, &full_path, &path);
                             proof_required_fn(target_key, min_len);
                             updates.insert(key, LeafUpdate::Touched);
                         }
@@ -1343,6 +1343,18 @@ impl ParallelSparseTrie {
         let mut bytes = [0u8; 32];
         bytes[..packed.len()].copy_from_slice(&packed);
         B256::from(bytes)
+    }
+
+    /// Computes the proof target key and `min_len` for a blinded node error.
+    ///
+    /// Returns `(target_key, min_len)` where:
+    /// - `target_key` is `full_key` if `path` is a prefix of `full_path`, otherwise the padded path
+    /// - `min_len` is always based on `path.len()`
+    fn proof_target_for_path(full_key: B256, full_path: &Nibbles, path: &Nibbles) -> (B256, u8) {
+        let min_len = (path.len() as u8).min(64);
+        let target_key =
+            if full_path.starts_with(path) { full_key } else { Self::nibbles_to_padded_b256(path) };
+        (target_key, min_len)
     }
 
     /// Rolls back a partial update by removing the value, removing any inserted nodes,


### PR DESCRIPTION
In general we want to return the `full_key` from update_leaves when we need to reveal a blinded section of the trie, as that will reveal most of the trie in one go. The exception is when the node which needs to be revealed is not a parent of the full key, ie its a sibling of some branch along the full_key's path. This can happen when creating branches in update_leaf and when deleting branches in remove_leaf.

This also includes a perf fix to the `nibbles_to_padded_b256` implementation.