### PR TITLE
fix: short-circuit in reveal_account_v2_proof_nodes on empty nodes

### DIFF
--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -357,7 +357,11 @@ where
     ) -> SparseStateTrieResult<()> {
         // Reveal the account proof nodes.
         //
-        // Skip revealing account proof nodes if this result only contains storage proofs.
+        // Skip revealing account nodes if this result only contains storage proofs.
+        // `reveal_account_v2_proof_nodes` will return an error if empty `nodes` are passed into it
+        // before the accounts trie root was revealed. This might happen in cases when first account
+        // trie proof arrives later than first storage trie proof even though the account trie proof
+        // was requested first.
         if !multiproof.account_proofs.is_empty() {
             self.reveal_account_v2_proof_nodes(multiproof.account_proofs)?;
         }

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -479,6 +479,11 @@ where
         &mut self,
         nodes: Vec<ProofTrieNode>,
     ) -> SparseStateTrieResult<()> {
+        // Short-circuit if there are no nodes to reveal.
+        if nodes.is_empty() {
+            return Ok(());
+        }
+
         let FilteredV2ProofNodes { root_node, nodes, new_nodes, metric_values: _metric_values } =
             filter_revealed_v2_proof_nodes(nodes, &mut self.revealed_account_paths)?;
 

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -355,8 +355,12 @@ where
         &mut self,
         multiproof: reth_trie_common::DecodedMultiProofV2,
     ) -> SparseStateTrieResult<()> {
-        // Reveal the account proof nodes
-        self.reveal_account_v2_proof_nodes(multiproof.account_proofs)?;
+        // Reveal the account proof nodes.
+        //
+        // Skip revealing account proof nodes if this result only contains storage proofs.
+        if !multiproof.account_proofs.is_empty() {
+            self.reveal_account_v2_proof_nodes(multiproof.account_proofs)?;
+        }
 
         #[cfg(not(feature = "std"))]
         // If nostd then serially reveal storage proof nodes for each storage trie
@@ -479,11 +483,6 @@ where
         &mut self,
         nodes: Vec<ProofTrieNode>,
     ) -> SparseStateTrieResult<()> {
-        // Short-circuit if there are no nodes to reveal.
-        if nodes.is_empty() {
-            return Ok(());
-        }
-
         let FilteredV2ProofNodes { root_node, nodes, new_nodes, metric_values: _metric_values } =
             filter_revealed_v2_proof_nodes(nodes, &mut self.revealed_account_paths)?;
 


### PR DESCRIPTION
Right now if `reveal_account_v2_proof_nodes` will receive an empty vec of nodes before the root node was revealed, it will always fail in else branch here https://github.com/paradigmxyz/reth/blob/ecf3fbec219c886e242ac52f2731a7494dfc5488/crates/trie/sparse/src/state.rs#L496-L501