### PR TITLE
feat(engine): add CLI args for sparse trie pruning configuration

### DIFF
--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -528,8 +528,12 @@ impl TreeConfig {
     }
 
     /// Setter for the number of storage proof worker threads.
-    pub fn with_storage_worker_count(mut self, storage_worker_count: usize) -> Self {
-        self.storage_worker_count = storage_worker_count.max(MIN_WORKER_COUNT);
+    ///
+    /// No-op if it's [`None`].
+    pub fn with_storage_worker_count_opt(mut self, storage_worker_count: Option<usize>) -> Self {
+        if let Some(count) = storage_worker_count {
+            self.storage_worker_count = count.max(MIN_WORKER_COUNT);
+        }
         self
     }
 
@@ -539,8 +543,12 @@ impl TreeConfig {
     }
 
     /// Setter for the number of account proof worker threads.
-    pub fn with_account_worker_count(mut self, account_worker_count: usize) -> Self {
-        self.account_worker_count = account_worker_count.max(MIN_WORKER_COUNT);
+    ///
+    /// No-op if it's [`None`].
+    pub fn with_account_worker_count_opt(mut self, account_worker_count: Option<usize>) -> Self {
+        if let Some(count) = account_worker_count {
+            self.account_worker_count = count.max(MIN_WORKER_COUNT);
+        }
         self
     }
 

--- a/docs/vocs/docs/pages/cli/op-reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/node.mdx
@@ -1015,6 +1015,16 @@ Engine:
       --engine.enable-sparse-trie-as-cache
           Enable sparse trie as cache
 
+      --engine.sparse-trie-prune-depth <SPARSE_TRIE_PRUNE_DEPTH>
+          Sparse trie prune depth
+
+          [default: 4]
+
+      --engine.sparse-trie-max-storage-tries <SPARSE_TRIE_MAX_STORAGE_TRIES>
+          Maximum number of storage tries to retain after sparse trie pruning
+
+          [default: 100]
+
 ERA:
       --era.enable
           Enable import from ERA1 files

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -1015,6 +1015,16 @@ Engine:
       --engine.enable-sparse-trie-as-cache
           Enable sparse trie as cache
 
+      --engine.sparse-trie-prune-depth <SPARSE_TRIE_PRUNE_DEPTH>
+          Sparse trie prune depth
+
+          [default: 4]
+
+      --engine.sparse-trie-max-storage-tries <SPARSE_TRIE_MAX_STORAGE_TRIES>
+          Maximum number of storage tries to retain after sparse trie pruning
+
+          [default: 100]
+
 ERA:
       --era.enable
           Enable import from ERA1 files


### PR DESCRIPTION
Adds two new engine CLI arguments:
- `--engine.sparse-trie-prune-depth`
- `--engine.sparse-trie-max-storage-tries`

These allow configuring sparse trie pruning behavior when `--engine.enable-sparse-trie-as-cache` is enabled.