### PR TITLE
perf: optimize `SparseTrieCacheTask`

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -517,6 +517,8 @@ where
         let disable_sparse_trie_as_cache = !config.enable_sparse_trie_as_cache();
         let prune_depth = self.sparse_trie_prune_depth;
         let max_storage_tries = self.sparse_trie_max_storage_tries;
+        let chunk_size =
+            config.multiproof_chunking_enabled().then_some(config.multiproof_chunk_size());
 
         self.executor.spawn_blocking(move || {
             let _enter = span.entered();
@@ -557,6 +559,7 @@ where
                     proof_worker_handle,
                     trie_metrics.clone(),
                     sparse_state_trie,
+                    chunk_size,
                 ))
             };
 

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -63,7 +63,7 @@ const PREFETCH_MAX_BATCH_MESSAGES: usize = 16;
 
 /// The default max targets, for limiting the number of account and storage proof targets to be
 /// fetched by a single worker. If exceeded, chunking is forced regardless of worker availability.
-const DEFAULT_MAX_TARGETS_FOR_CHUNKING: usize = 300;
+pub(crate) const DEFAULT_MAX_TARGETS_FOR_CHUNKING: usize = 300;
 
 /// A trie update that can be applied to sparse trie alongside the proofs for touched parts of the
 /// state.
@@ -311,11 +311,7 @@ impl VersionedMultiProofTargets {
     fn chunking_length(&self) -> usize {
         match self {
             Self::Legacy(targets) => targets.chunking_length(),
-            Self::V2(targets) => {
-                // For V2, count accounts + storage slots
-                targets.account_targets.len() +
-                    targets.storage_targets.values().map(|slots| slots.len()).sum::<usize>()
-            }
+            Self::V2(targets) => targets.chunking_length(),
         }
     }
 

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -22,7 +22,7 @@ use reth_trie_parallel::{
         AccountMultiproofInput, ProofResult, ProofResultContext, ProofResultMessage,
         ProofWorkerHandle,
     },
-    targets_v2::{ChunkedMultiProofTargetsV2, MultiProofTargetsV2},
+    targets_v2::MultiProofTargetsV2,
 };
 use revm_primitives::map::{hash_map, B256Map};
 use std::{collections::BTreeMap, sync::Arc, time::Instant};
@@ -367,9 +367,7 @@ impl VersionedMultiProofTargets {
             Self::Legacy(targets) => {
                 Box::new(MultiProofTargets::chunks(targets, chunk_size).map(Self::Legacy))
             }
-            Self::V2(targets) => {
-                Box::new(ChunkedMultiProofTargetsV2::new(targets, chunk_size).map(Self::V2))
-            }
+            Self::V2(targets) => Box::new(targets.chunks(chunk_size).map(Self::V2)),
         }
     }
 }
@@ -1494,7 +1492,7 @@ fn get_proof_targets(
 /// Dispatches work items as a single unit or in chunks based on target size and worker
 /// availability.
 #[allow(clippy::too_many_arguments)]
-fn dispatch_with_chunking<T, I>(
+pub(crate) fn dispatch_with_chunking<T, I>(
     items: T,
     chunking_len: usize,
     chunk_size: Option<usize>,

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -353,6 +353,7 @@ where
                     };
 
                     self.on_multiproof_message(update);
+                    self.pending_updates += 1;
                 }
                 recv(self.proof_result_rx) -> message => {
                     let Ok(result) = message else {

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -567,30 +567,30 @@ where
     }
 
     /// Invokes `update_leaves` for the accounts trie and collects any new targets.
-    /// 
+    ///
     /// Returns whether any updates were drained (applied to the trie).
     fn process_account_leaf_updates(&mut self) -> SparseTrieResult<bool> {
         let updates_len_before = self.account_updates.len();
 
-        self.trie.trie_mut().update_leaves(&mut self.account_updates, |target, min_len| match self
-            .fetched_account_targets
-            .entry(target)
-        {
-            Entry::Occupied(mut entry) => {
-                if min_len < *entry.get() {
+        self.trie.trie_mut().update_leaves(
+            &mut self.account_updates,
+            |target, min_len| match self.fetched_account_targets.entry(target) {
+                Entry::Occupied(mut entry) => {
+                    if min_len < *entry.get() {
+                        entry.insert(min_len);
+                        self.pending_targets
+                            .account_targets
+                            .push(Target::new(target).with_min_len(min_len));
+                    }
+                }
+                Entry::Vacant(entry) => {
                     entry.insert(min_len);
                     self.pending_targets
                         .account_targets
                         .push(Target::new(target).with_min_len(min_len));
                 }
-            }
-            Entry::Vacant(entry) => {
-                entry.insert(min_len);
-                self.pending_targets
-                    .account_targets
-                    .push(Target::new(target).with_min_len(min_len));
-            }
-        })?;
+            },
+        )?;
 
         Ok(self.account_updates.len() < updates_len_before)
     }
@@ -701,7 +701,6 @@ where
                 break
             }
         }
-            
 
         Ok(())
     }

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -375,13 +375,19 @@ where
             }
 
             if self.updates.is_empty() && self.proof_result_rx.is_empty() {
+                // If we don't have any pending messages, we can spend some time on computing
+                // storage roots and promoting account updates.
                 self.dispatch_pending_targets();
                 self.promote_pending_account_updates()?;
                 self.dispatch_pending_targets();
             } else if self.updates.is_empty() || self.pending_updates > 100 {
+                // If we don't have any pending updates OR we've accumulated a lot already, apply
+                // them to the trie,
                 self.process_leaf_updates()?;
                 self.dispatch_pending_targets();
             } else if self.updates.is_empty() || self.pending_targets.chunking_length() > 100 {
+                // Make sure to dispatch targets if we don't have any updates or if we've
+                // accumulated a lot of them.
                 self.dispatch_pending_targets();
             }
 

--- a/crates/trie/parallel/src/root.rs
+++ b/crates/trie/parallel/src/root.rs
@@ -4,7 +4,7 @@ use crate::{stats::ParallelTrieTracker, storage_root_targets::StorageRootTargets
 use alloy_primitives::B256;
 use alloy_rlp::{BufMut, Encodable};
 use itertools::Itertools;
-use reth_execution_errors::{StateProofError, StorageRootError};
+use reth_execution_errors::{SparseTrieError, StateProofError, StorageRootError};
 use reth_provider::{DatabaseProviderROFactory, ProviderError};
 use reth_storage_errors::db::DatabaseError;
 use reth_trie::{
@@ -232,6 +232,9 @@ pub enum ParallelStateRootError {
     /// Provider error.
     #[error(transparent)]
     Provider(#[from] ProviderError),
+    /// Sparse trie error.
+    #[error(transparent)]
+    SparseTrie(#[from] SparseTrieError),
     /// Other unspecified error.
     #[error("{_0}")]
     Other(String),
@@ -244,6 +247,7 @@ impl From<ParallelStateRootError> for ProviderError {
             ParallelStateRootError::StorageRoot(StorageRootError::Database(error)) => {
                 Self::Database(error)
             }
+            ParallelStateRootError::SparseTrie(error) => Self::other(error),
             ParallelStateRootError::Other(other) => Self::Database(DatabaseError::Other(other)),
         }
     }

--- a/crates/trie/parallel/src/targets_v2.rs
+++ b/crates/trie/parallel/src/targets_v2.rs
@@ -18,6 +18,17 @@ impl MultiProofTargetsV2 {
     pub fn is_empty(&self) -> bool {
         self.account_targets.is_empty() && self.storage_targets.is_empty()
     }
+
+    /// Returns the number of items that will be considered during chunking.
+    pub fn chunking_length(&self) -> usize {
+        self.account_targets.len() +
+            self.storage_targets.values().map(|slots| slots.len()).sum::<usize>()
+    }
+
+    /// Returns an iterator that yields chunks of the specified size.
+    pub fn chunks(self, chunk_size: usize) -> impl Iterator<Item = Self> {
+        ChunkedMultiProofTargetsV2::new(self, chunk_size)
+    }
 }
 
 /// An iterator that yields chunks of V2 proof targets of at most `size` account and storage

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -182,9 +182,21 @@ where
         self.storage.tries.get_mut(address).and_then(|e| e.as_revealed_mut())
     }
 
+    /// Returns mutable reference to storage tries.
+    pub const fn storage_tries_mut(&mut self) -> &mut B256Map<RevealableSparseTrie<S>> {
+        &mut self.storage.tries
+    }
+
     /// Takes the storage trie for the provided address.
     pub fn take_storage_trie(&mut self, address: &B256) -> Option<RevealableSparseTrie<S>> {
         self.storage.tries.remove(address)
+    }
+
+    /// Takes the storage trie for the provided address, creating a blind one if it doesn't exist.
+    pub fn take_or_create_storage_trie(&mut self, address: &B256) -> RevealableSparseTrie<S> {
+        self.storage.tries.remove(address).unwrap_or_else(|| {
+            self.storage.cleared_tries.pop().unwrap_or_else(|| self.storage.default_trie.clone())
+        })
     }
 
     /// Inserts storage trie for the provided address.


### PR DESCRIPTION
This PR introduces various refactors and perf optimizations for `SparseTrieCacheTask`, including
- Batching of state/prewarm updates and multiproof v2 results
- Decoupling of storage roots computation and storage updates processing (the latter is cheaper and can be done more often)
- Parallelization of storage updates processing and storage roots computation
- Batching and chunking of multiproof updates