### PR TITLE
chore(ci): add `consts` to typos allowlist

### DIFF
--- a/typos.toml
+++ b/typos.toml
@@ -38,3 +38,5 @@ Iy = "Iy" # Part of base64 encoded ENR
 flate = "flate" # zlib-flate is a valid tool name
 Pn = "Pn" # Part of UPnP (Universal Plug and Play)
 BA = "BA" # Part of BAL - Block Access List (EIP-7928)
+consts = "consts" # std::env::consts is a valid Rust module
+Consts = "Consts" # Valid identifier suffix (e.g., RethCliVersionConsts)


### PR DESCRIPTION
found this from previous [PR CI check failed](https://github.com/paradigmxyz/reth/actions/runs/21595099280/job/62225260312?pr=21705)
Add `consts` and `Consts` to typos allowlist to fix CI failures caused by typos v1.43.0

typos v1.43.0 (released 2026-02-02) added `consts -> constants` to its dictionary via [PR #1489](https://github.com/crate-ci/typos/pull/1489). This causes false positives for:                                                                                                      
                                                                                                                                                                                                                                                                                       
  - `std::env::consts` - Rust standard library module                                                                                                                                                                                                                                  
  - `RethCliVersionConsts` - existing reth struct name                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                       
Since reth CI uses `crate-ci/typos@v1` (floating version), all PRs now fail the typos check.   
                                                                                                                                                                                      
  - typos dictionary update: https://github.com/crate-ci/typos/pull/1489                                                                                                                                                                                                               
  - Affected files: `crates/node/ethstats/src/ethstats.rs`, `crates/node/core/src/version.rs`                                                                                                                                                                                          
                                                                                               