### PR TITLE
fix: properly drain pending account updates

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -595,7 +595,7 @@ where
                 // Only exit when no new updates are processed.
                 //
                 // We need to keep iterating if any updates are being drained because that might
-                //indicate that more pending account updates can be promoted.
+                // indicate that more pending account updates can be promoted.
                 break;
             }
         }


### PR DESCRIPTION
easier to rewiew with hide whitespace

right now the code was assuming that all pending updates can be processed via a single `process_updates` call after the loop that will promote update to `Changed` and apply it to the trie in one go. however, in some cases this is not possible and requires fetching more proofs which in that case are going to be dispatched but never received