### PR TITLE
fix: handle payload builder stream termination gracefully

### DIFF
--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -9,7 +9,7 @@ use crate::{
     NodeBuilderWithComponents, NodeComponents, NodeComponentsBuilder, NodeHandle, NodeTypesAdapter,
 };
 use alloy_consensus::BlockHeader;
-use futures::{stream_select, FutureExt, StreamExt};
+use futures::{stream::FusedStream, stream_select, FutureExt, StreamExt};
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_engine_service::service::{ChainEvent, EngineService};
 use reth_engine_tree::{
@@ -352,7 +352,7 @@ impl EngineNodeLauncher {
                             }
                         }
                     }
-                    payload = built_payloads.select_next_some() => {
+                    payload = built_payloads.select_next_some(), if !built_payloads.is_terminated() => {
                         if let Some(executed_block) = payload.executed_block() {
                             debug!(target: "reth::cli", block=?executed_block.recovered_block.num_hash(),  "inserting built payload");
                             engine_service.orchestrator_mut().handler_mut().handler_mut().on_event(EngineApiRequest::InsertExecutedBlock(executed_block.into_executed_payload()).into());


### PR DESCRIPTION
Was running into this when shutting down the node:
```
thread 'tokio-runtime-worker' (3222032) panicked at /home/ubuntu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-util-0.3.31/src/stream/stream/select_next_some.rs:32:9:
SelectNextSome polled after terminated
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/254b59607d4417e9dffbc307138ae5c86280fe4c/library/std/src/panicking.rs:689:5
   1: core::panicking::panic_fmt
             at /rustc/254b59607d4417e9dffbc307138ae5c86280fe4c/library/core/src/panicking.rs:80:14
   2: core::panicking::panic
             at /rustc/254b59607d4417e9dffbc307138ae5c86280fe4c/library/core/src/panicking.rs:150:5
2026-02-02T17:23:07.171855Z  INFO Wrote network peers to file peers_file="/home/ubuntu/rocksdb-snapshot/known-peers.json"
   3: <futures_util::stream::stream::select_next_some::SelectNextSome<St> as core::future::future::Future>::poll
             at /home/ubuntu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-util-0.3.31/src/stream/stream/select_next_some.rs:32:9
   4: reth_node_builder::launch::engine::EngineNodeLauncher::launch_node::{{closure}}::{{closure}}::{{closure}}
             at /home/ubuntu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/macros/select.rs:707:49
   5: <core::future::poll_fn::PollFn<F> as core::future::future::Future>::poll
             at /rustc/254b59607d4417e9dffbc307138ae5c86280fe4c/library/core/src/future/poll_fn.rs:151:9
   6: reth_node_builder::launch::engine::EngineNodeLauncher::launch_node::{{closure}}::{{closure}}
             at ./crates/node/builder/src/launch/engine.rs:305:17
   7: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /rustc/254b59607d4417e9dffbc307138ae5c86280fe4c/library/core/src/future/future.rs:133:9
   8: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::future::future::Future>::poll
             at /rustc/254b59607d4417e9dffbc307138ae5c86280fe4c/library/core/src/panic/unwind_safe.rs:299:9
   9: <futures_util::future::future::catch_unwind::CatchUnwind<Fut> as core::future::future::Future>::poll::{{closure}}
             at /home/ubuntu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-util-0.3.31/src/future/future/catch_unwind.rs:37:44
  10: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/254b59607d4417e9dffbc307138ae5c86280fe4c/library/core/src/panic/unwind_safe.rs:274:9
  11: std::panicking::catch_unwind::do_call
             at /rustc/254b59607d4417e9dffbc307138ae5c86280fe4c/library/std/src/panicking.rs:581:40
  12: std::panicking::catch_unwind
             at /rustc/254b59607d4417e9dffbc307138ae5c86280fe4c/library/std/src/panicking.rs:544:19
  13: std::panic::catch_unwind
             at /rustc/254b59607d4417e9dffbc307138ae5c86280fe4c/library/std/src/panic.rs:359:14
  14: <futures_util::future::future::catch_unwind::CatchUnwind<Fut> as core::future::future::Future>::poll
             at /home/ubuntu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-util-0.3.31/src/future/future/catch_unwind.rs:37:9
  15: <F as futures_core::future::TryFuture>::try_poll
             at /home/ubuntu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-core-0.3.31/src/future.rs:92:14
  16: <futures_util::future::try_future::into_future::IntoFuture<Fut> as core::future::future::Future>::poll
             at /home/ubuntu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-util-0.3.31/src/future/try_future/into_future.rs:34:31
  17: <futures_util::future::future::map::Map<Fut,F> as core::future::future::Future>::poll
             at /home/ubuntu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-util-0.3.31/src/future/future/map.rs:55:44
  18: <futures_util::future::future::Map<Fut,F> as core::future::future::Future>::poll
             at /home/ubuntu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-util-0.3.31/src/lib.rs:86:35
  19: <futures_util::future::try_future::MapErr<Fut,F> as core::future::future::Future>::poll
             at /home/ubuntu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-util-0.3.31/src/lib.rs:86:35
  20: <tracing_futures::Instrumented<T> as core::future::future::Future>::poll
             at /home/ubuntu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tracing-futures-0.2.5/src/lib.rs:283:20
  21: <core::pin::Pin<P> as core::future::future::Future>::poll
```

So now this just checks if the stream is terminated and otherwise shouldn't poll a completed `SelectNextSome`