### PR TITLE
fix: compute hashed post state in RpcBlockchainStateProvider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3331,7 +3331,7 @@ dependencies = [
 
 [[package]]
 name = "ef-test-runner"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "clap",
  "ef-tests",
@@ -3339,7 +3339,7 @@ dependencies = [
 
 [[package]]
 name = "ef-tests"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3829,7 +3829,7 @@ dependencies = [
 
 [[package]]
 name = "example-full-contract-state"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "eyre",
  "reth-ethereum",
@@ -3968,7 +3968,7 @@ dependencies = [
 
 [[package]]
 name = "exex-subscription"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -6478,7 +6478,7 @@ dependencies = [
 
 [[package]]
 name = "op-reth"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "clap",
  "reth-cli-util",
@@ -7630,7 +7630,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -7677,7 +7677,7 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7700,7 +7700,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bench"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7747,7 +7747,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bench-compare"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -7775,7 +7775,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7807,7 +7807,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7827,7 +7827,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7840,7 +7840,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7925,7 +7925,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7934,7 +7934,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7955,7 +7955,7 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7979,7 +7979,7 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7989,7 +7989,7 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -8007,7 +8007,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8019,7 +8019,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8033,7 +8033,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8058,7 +8058,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8092,7 +8092,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8122,7 +8122,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8152,7 +8152,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8168,7 +8168,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8194,7 +8194,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8219,7 +8219,7 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8247,7 +8247,7 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8285,7 +8285,7 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8342,7 +8342,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8369,7 +8369,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8393,7 +8393,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8417,7 +8417,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-service"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eips",
  "futures",
@@ -8448,7 +8448,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8523,7 +8523,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8550,7 +8550,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8572,7 +8572,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8590,7 +8590,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8616,7 +8616,7 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8626,7 +8626,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8664,7 +8664,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8689,7 +8689,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8729,7 +8729,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "clap",
  "eyre",
@@ -8751,7 +8751,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8767,7 +8767,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8785,7 +8785,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8798,7 +8798,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8826,7 +8826,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8853,7 +8853,7 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "rayon",
@@ -8863,7 +8863,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8888,7 +8888,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8912,7 +8912,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8924,7 +8924,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8944,7 +8944,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8989,7 +8989,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-test-utils"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eips",
  "eyre",
@@ -9020,7 +9020,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9037,7 +9037,7 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -9046,7 +9046,7 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9079,7 +9079,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "bytes",
  "futures",
@@ -9101,7 +9101,7 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -9119,7 +9119,7 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -9127,7 +9127,7 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "futures",
  "metrics",
@@ -9138,7 +9138,7 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9146,7 +9146,7 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9160,7 +9160,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9221,7 +9221,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9245,7 +9245,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9267,7 +9267,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9284,7 +9284,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9297,7 +9297,7 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -9315,7 +9315,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9338,7 +9338,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9410,7 +9410,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9467,7 +9467,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -9527,7 +9527,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9550,7 +9550,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9573,7 +9573,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "bytes",
  "eyre",
@@ -9602,7 +9602,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9613,7 +9613,7 @@ dependencies = [
 
 [[package]]
 name = "reth-op"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "reth-chainspec",
  "reth-cli-util",
@@ -9653,7 +9653,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-chainspec"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9681,7 +9681,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-cli"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9730,7 +9730,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-consensus"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9761,7 +9761,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-evm"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9790,7 +9790,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-flashblocks"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9828,7 +9828,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-forks"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-op-hardforks",
  "alloy-primitives",
@@ -9838,7 +9838,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-node"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9899,7 +9899,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-payload-builder"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9938,7 +9938,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-primitives"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9965,7 +9965,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-rpc"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10027,7 +10027,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-storage"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "reth-codecs",
@@ -10039,7 +10039,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-txpool"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10076,7 +10076,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10096,7 +10096,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10107,7 +10107,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10130,7 +10130,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-util"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10139,7 +10139,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10148,7 +10148,7 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10170,7 +10170,7 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10207,7 +10207,7 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10256,7 +10256,7 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10288,11 +10288,11 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-db"
-version = "1.10.1"
+version = "1.10.2"
 
 [[package]]
 name = "reth-prune-types"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10311,7 +10311,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-protocol"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10337,7 +10337,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-provider"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10363,7 +10363,7 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10377,7 +10377,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10462,7 +10462,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -10492,7 +10492,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api-testing-util"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10511,7 +10511,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -10567,7 +10567,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10593,7 +10593,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-e2e-tests"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-genesis",
  "alloy-rpc-types-engine",
@@ -10613,7 +10613,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10649,7 +10649,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10692,7 +10692,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10740,7 +10740,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -10757,7 +10757,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10772,7 +10772,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10830,7 +10830,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10862,7 +10862,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10878,7 +10878,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stateless"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -10906,7 +10906,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "assert_matches",
@@ -10929,7 +10929,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10944,7 +10944,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10967,7 +10967,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10983,7 +10983,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-rpc-provider"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11012,7 +11012,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -11029,7 +11029,7 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11045,7 +11045,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11054,7 +11054,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "clap",
  "eyre",
@@ -11072,7 +11072,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "clap",
  "eyre",
@@ -11089,7 +11089,7 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11137,7 +11137,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11171,7 +11171,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -11204,7 +11204,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11235,7 +11235,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11265,7 +11265,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11298,7 +11298,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse-parallel"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11328,7 +11328,7 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.10.1"
+version = "1.10.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -296,6 +296,11 @@ where
                     // Replace the shared cache with the new one; the previous cache (if any) is
                     // dropped.
                     *cached = Some(new_cache);
+                } else {
+                    // Block was invalid; caches were already mutated by insert_state above,
+                    // so we must clear to prevent using polluted state
+                    *cached = None;
+                    debug!(target: "engine::caching", "cleared execution cache on invalid block");
                 }
             });
 

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -479,11 +479,15 @@ where
         let block = self.convert_to_block(input)?.with_senders(senders);
 
         // Wait for the receipt root computation to complete.
-        let receipt_root_bloom = Some(
-            receipt_root_rx
-                .blocking_recv()
-                .expect("receipt root task dropped sender without result"),
-        );
+        let receipt_root_bloom = receipt_root_rx
+            .blocking_recv()
+            .inspect_err(|_| {
+                tracing::error!(
+                    target: "engine::tree::payload_validator",
+                    "Receipt root task dropped sender without result, receipt root calculation likely aborted"
+                );
+            })
+            .ok();
 
         let hashed_state = ensure_ok_post_block!(
             self.validate_post_execution(

--- a/crates/storage/provider/src/providers/state/overlay.rs
+++ b/crates/storage/provider/src/providers/state/overlay.rs
@@ -129,6 +129,8 @@ impl<F> OverlayStateProviderFactory<F> {
     /// This overlay will be applied on top of any reverts applied via `with_block_hash`.
     pub fn with_overlay_source(mut self, source: Option<OverlaySource>) -> Self {
         self.overlay_source = source;
+        // Clear the overlay cache since we've updated the source.
+        self.overlay_cache = Default::default();
         self
     }
 
@@ -137,6 +139,8 @@ impl<F> OverlayStateProviderFactory<F> {
     /// Convenience method that wraps the lazy overlay in `OverlaySource::Lazy`.
     pub fn with_lazy_overlay(mut self, lazy_overlay: Option<LazyOverlay>) -> Self {
         self.overlay_source = lazy_overlay.map(OverlaySource::Lazy);
+        // Clear the overlay cache since we've updated the source.
+        self.overlay_cache = Default::default();
         self
     }
 
@@ -152,6 +156,8 @@ impl<F> OverlayStateProviderFactory<F> {
                 trie: Arc::new(TrieUpdatesSorted::default()),
                 state,
             });
+            // Clear the overlay cache since we've updated the source.
+            self.overlay_cache = Default::default();
         }
         self
     }
@@ -178,6 +184,8 @@ impl<F> OverlayStateProviderFactory<F> {
                 });
             }
         }
+        // Clear the overlay cache since we've updated the source.
+        self.overlay_cache = Default::default();
         self
     }
 }

--- a/crates/storage/rpc-provider/src/lib.rs
+++ b/crates/storage/rpc-provider/src/lib.rs
@@ -59,7 +59,9 @@ use reth_storage_api::{
     BlockBodyIndicesProvider, BlockReaderIdExt, BlockSource, DBProvider, NodePrimitivesProvider,
     ReceiptProviderIdExt, StatsReader,
 };
-use reth_trie::{updates::TrieUpdates, AccountProof, HashedPostState, MultiProof, TrieInput};
+use reth_trie::{
+    updates::TrieUpdates, AccountProof, HashedPostState, KeccakKeyHasher, MultiProof, TrieInput,
+};
 use std::{
     collections::BTreeMap,
     future::{Future, IntoFuture},
@@ -1307,9 +1309,8 @@ where
     N: Network,
     Node: NodeTypes,
 {
-    fn hashed_post_state(&self, _bundle_state: &revm::database::BundleState) -> HashedPostState {
-        // Return empty hashed post state for RPC provider
-        HashedPostState::default()
+    fn hashed_post_state(&self, bundle_state: &revm::database::BundleState) -> HashedPostState {
+        HashedPostState::from_bundle_state::<KeccakKeyHasher>(bundle_state.state())
     }
 }
 

--- a/docs/vocs/vocs.config.ts
+++ b/docs/vocs/vocs.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
     },
     { text: 'GitHub', link: 'https://github.com/paradigmxyz/reth' },
     {
-      text: 'v1.10.1',
+      text: 'v1.10.2',
       items: [
         {
           text: 'Releases',


### PR DESCRIPTION
The `RpcBlockchainStateProvider` was returning an empty `HashedPostState`, causing incorrect state roots when used with `debug_stateRootWithUpdates`