### PR TITLE
fix(cli): actually enable reth-prune rocksdb feature in cli

### DIFF
--- a/crates/cli/commands/Cargo.toml
+++ b/crates/cli/commands/Cargo.toml
@@ -133,4 +133,4 @@ arbitrary = [
     "reth-ethereum-primitives/arbitrary",
 ]
 
-edge = ["reth-db-common/edge", "reth-stages/rocksdb", "reth-provider/rocksdb"]
+edge = ["reth-db-common/edge", "reth-stages/rocksdb", "reth-provider/rocksdb", "reth-prune/rocksdb"]


### PR DESCRIPTION
We were not enabling the pruner's `rocksdb` feature when the `edge` feature was enabled, so whenever we would compile with `edge` the pruner would be a no-op on all rocksdb tables