### PR TITLE
fix(rpc): validate toBlock in trace_filter

### DIFF
--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -353,6 +353,9 @@ where
             return Err(EthApiError::HeaderNotFound(start.into()).into());
         }
         let end = to_block.unwrap_or(latest_block);
+        if end > latest_block {
+            return Err(EthApiError::HeaderNotFound(end.into()).into());
+        }
 
         if start > end {
             return Err(EthApiError::InvalidParams(


### PR DESCRIPTION
## Summary
Add validation for `toBlock` parameter in `trace_filter` to return `HeaderNotFound` error when it exceeds the latest block.

## Problem
When `toBlock > latest_block`, `recovered_block_range` silently returns partial results instead of an error.

Example (latest_block = 1000):
- Request: `trace_filter({ fromBlock: 950, toBlock: 1050 })`  
- Before: Returns traces for 950-1000 only, **no error**
- After: Returns `HeaderNotFound(1050)` error
