### PR TITLE
feat(rpc): add EIP-7928 eth_getBalanceWithProof and eth_getAccountWithProof

### DIFF
--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -394,6 +394,17 @@ pub trait EthApi<
         address: Address,
         block: BlockId,
     ) -> RpcResult<alloy_rpc_types_eth::AccountInfo>;
+
+    /// Returns the EIP-7928 block access list for a block by hash.
+    #[method(name = "getBlockAccessListByBlockHash")]
+    async fn block_access_list_by_block_hash(&self, hash: B256) -> RpcResult<Option<Bytes>>;
+
+    /// Returns the EIP-7928 block access list for a block by number.
+    #[method(name = "getBlockAccessListByBlockNumber")]
+    async fn block_access_list_by_block_number(
+        &self,
+        number: BlockNumberOrTag,
+    ) -> RpcResult<Option<Bytes>>;
 }
 
 #[async_trait::async_trait]
@@ -880,5 +891,20 @@ where
     ) -> RpcResult<alloy_rpc_types_eth::AccountInfo> {
         trace!(target: "rpc::eth", "Serving eth_getAccountInfo");
         Ok(EthState::get_account_info(self, address, block).await?)
+    }
+
+    /// Handler for: `eth_getBlockAccessListByBlockHash`
+    async fn block_access_list_by_block_hash(&self, hash: B256) -> RpcResult<Option<Bytes>> {
+        trace!(target: "rpc::eth", ?hash, "Serving eth_getBlockAccessListByBlockHash");
+        Err(internal_rpc_err("unimplemented"))
+    }
+
+    /// Handler for: `eth_getBlockAccessListByBlockNumber`
+    async fn block_access_list_by_block_number(
+        &self,
+        number: BlockNumberOrTag,
+    ) -> RpcResult<Option<Bytes>> {
+        trace!(target: "rpc::eth", ?number, "Serving eth_getBlockAccessListByBlockNumber");
+        Err(internal_rpc_err("unimplemented"))
     }
 }


### PR DESCRIPTION
Adds trait definitions for the two new RPC endpoints from [ethereum/execution-apis#726](https://github.com/ethereum/execution-apis/pull/726):

- `eth_getBalanceWithProof` - returns account balance with merkle proof
- `eth_getAccountWithProof` - returns full account info with merkle proof

Both implementations currently return an unimplemented RPC error as placeholders.

Related: EIP-7928