### PR TITLE
chore: move TransactionLookup as first option

### DIFF
--- a/crates/prune/prune/src/segments/set.rs
+++ b/crates/prune/prune/src/segments/set.rs
@@ -76,6 +76,8 @@ where
         } = prune_modes;
 
         Self::default()
+            // Transaction lookup
+            .segment_opt(transaction_lookup.map(TransactionLookup::new))
             // Bodies - run first since file deletion is fast
             .segment_opt(bodies_history.map(Bodies::new))
             // Account history
@@ -89,8 +91,6 @@ where
                 (!receipts_log_filter.is_empty())
                     .then(|| ReceiptsByLogs::new(receipts_log_filter.clone())),
             )
-            // Transaction lookup
-            .segment_opt(transaction_lookup.map(TransactionLookup::new))
             // Sender recovery
             .segment_opt(sender_recovery.map(SenderRecovery::new))
     }


### PR DESCRIPTION
Move txlookup to the first option, before bodies history, so it's pushed before bodies. This is so we prune bodies _after_ txlookup, we will be first deleting from rocksdb then deleting the static files