### PR TITLE
perf(rocksdb): batch tx reads in TransactionLookupStage unwind

### DIFF
--- a/crates/stages/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/stages/src/stages/tx_lookup.rs
@@ -223,36 +223,31 @@ where
     ) -> Result<UnwindOutput, StageError> {
         let (range, unwind_to, _) = input.unwind_block_range_with_threshold(self.chunk_size);
 
-        #[cfg(all(unix, feature = "rocksdb"))]
-        let rocksdb = provider.rocksdb_provider();
-        #[cfg(all(unix, feature = "rocksdb"))]
-        let rocksdb_batch = rocksdb.batch();
-        #[cfg(not(all(unix, feature = "rocksdb")))]
-        let rocksdb_batch = ();
-        let mut writer = EitherWriter::new_transaction_hash_numbers(provider, rocksdb_batch)?;
+        provider.with_rocksdb_batch(|rocksdb_batch| {
+            let mut writer = EitherWriter::new_transaction_hash_numbers(provider, rocksdb_batch)?;
 
-        let static_file_provider = provider.static_file_provider();
-        let rev_walker =
-            provider.block_body_indices_range(range.clone())?.into_iter().rev().zip(range.rev());
+            let static_file_provider = provider.static_file_provider();
+            let rev_walker = provider
+                .block_body_indices_range(range.clone())?
+                .into_iter()
+                .rev()
+                .zip(range.rev());
 
-        for (body, number) in rev_walker {
-            if number <= unwind_to {
-                break;
-            }
+            for (body, number) in rev_walker {
+                if number <= unwind_to {
+                    break;
+                }
 
-            // Delete all transactions that belong to this block
-            for tx_id in body.tx_num_range() {
-                if let Some(transaction) = static_file_provider.transaction_by_id(tx_id)? {
+                // Delete all transactions that belong to this block
+                for transaction in
+                    static_file_provider.transactions_by_tx_range(body.tx_num_range())?
+                {
                     writer.delete_transaction_hash_number(transaction.trie_hash())?;
                 }
             }
-        }
 
-        // Extract and register RocksDB batch for commit at provider level
-        #[cfg(all(unix, feature = "rocksdb"))]
-        if let Some(batch) = writer.into_raw_rocksdb_batch() {
-            provider.set_pending_rocksdb_batch(batch);
-        }
+            Ok(((), writer.into_raw_rocksdb_batch()))
+        })?;
 
         Ok(UnwindOutput {
             checkpoint: StageCheckpoint::new(unwind_to)


### PR DESCRIPTION
Replace per-tx `transaction_by_id()` with batch `transactions_by_tx_range()` in unwind. Both gracefully handle missing transactions by returning partial results.

