### PR TITLE
perf(nippy-jar): reduce initial buffer allocation

### DIFF
--- a/crates/storage/nippy-jar/src/writer.rs
+++ b/crates/storage/nippy-jar/src/writer.rs
@@ -74,9 +74,9 @@ impl<H: NippyJarHeader> NippyJarWriter<H> {
             jar,
             data_file,
             offsets_file,
-            tmp_buf: Vec::with_capacity(1_000_000),
+            tmp_buf: Vec::with_capacity(65536),
             uncompressed_row_size: 0,
-            offsets: Vec::with_capacity(1_000_000),
+            offsets: Vec::with_capacity(65536),
             column: 0,
             dirty: false,
         };


### PR DESCRIPTION
## Summary

Reduces the initial buffer allocations in `NippyJarWriter` from 1MB to 64KB:
- `tmp_buf`: 1,000,000 → 65,536 bytes
- `offsets`: 1,000,000 → 65,536 entries

## Rationale

The 1MB pre-allocations were unnecessarily large for typical usage. Rust's `Vec` exponential growth strategy will efficiently handle cases that need more capacity, while the smaller initial size reduces memory pressure and speeds up writer instantiation.

## Testing

All existing tests pass (`cargo test -p reth-nippy-jar`).