### PR TITLE
perf(static-file): hoist cursor creation outside block loop

### DIFF
--- a/crates/static-file/static-file/src/segments/receipts.rs
+++ b/crates/static-file/static-file/src/segments/receipts.rs
@@ -30,6 +30,10 @@ where
         let mut static_file_writer =
             provider.get_static_file_writer(*block_range.start(), StaticFileSegment::Receipts)?;
 
+        let mut receipts_cursor = provider
+            .tx_ref()
+            .cursor_read::<tables::Receipts<<Provider::Primitives as NodePrimitives>::Receipt>>()?;
+
         for block in block_range {
             static_file_writer.increment_block(block)?;
 
@@ -37,10 +41,6 @@ where
                 .block_body_indices(block)?
                 .ok_or(ProviderError::BlockBodyIndicesNotFound(block))?;
 
-            let mut receipts_cursor = provider
-                .tx_ref()
-                .cursor_read::<tables::Receipts<<Provider::Primitives as NodePrimitives>::Receipt>>(
-                )?;
             let receipts_walker = receipts_cursor.walk_range(block_body_indices.tx_num_range())?;
 
             static_file_writer.append_receipts(


### PR DESCRIPTION
The receipts cursor was being recreated on every iteration of the block loop in `copy_to_static_files`. This hoists the cursor creation outside the loop, creating it once and reusing it across all blocks.

This is a small optimization that reduces overhead when copying receipts to static files.