### PR TITLE
chore(db): remove duplicate cursor method

### DIFF
--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -95,7 +95,7 @@ impl<K: TransactionKind> Tx<K> {
     pub fn new_cursor<T: Table>(&self) -> Result<Cursor<K, T>, DatabaseError> {
         let inner = self
             .inner
-            .cursor_with_dbi(self.get_dbi::<T>()?)
+            .cursor(self.get_dbi::<T>()?)
             .map_err(|e| DatabaseError::InitCursor(e.into()))?;
 
         Ok(Cursor::new_with_metrics(

--- a/crates/storage/libmdbx-rs/src/transaction.rs
+++ b/crates/storage/libmdbx-rs/src/transaction.rs
@@ -257,11 +257,6 @@ where
         Cursor::new(self.clone(), dbi)
     }
 
-    /// Open a new cursor on the given dbi.
-    pub fn cursor_with_dbi(&self, dbi: ffi::MDBX_dbi) -> Result<Cursor<K>> {
-        Cursor::new(self.clone(), dbi)
-    }
-
     /// Disables a timeout for this read transaction.
     #[cfg(feature = "read-tx-timeouts")]
     pub fn disable_timeout(&self) {


### PR DESCRIPTION
## Summary
Remove duplicate `cursor_with_dbi()` method from `Transaction` that was identical to `cursor()`.

Both methods called `Cursor::new(self.clone(), dbi)` with the same implementation. This consolidates to a single `cursor()` method.

## Changes
- Remove `cursor_with_dbi()` from `Transaction<K>`
- Update the single call site in `tx.rs` to use `cursor()` instead