### PR TITLE
perf(static-file): hoist cursor creation outside block loop

### DIFF
--- a/crates/static-file/static-file/src/segments/receipts.rs
+++ b/crates/static-file/static-file/src/segments/receipts.rs
@@ -30,6 +30,10 @@ where
         let mut static_file_writer =
             provider.get_static_file_writer(*block_range.start(), StaticFileSegment::Receipts)?;
 
+        let mut receipts_cursor = provider
+            .tx_ref()
+            .cursor_read::<tables::Receipts<<Provider::Primitives as NodePrimitives>::Receipt>>()?;
+
         for block in block_range {
             static_file_writer.increment_block(block)?;
 
@@ -37,10 +41,6 @@ where
                 .block_body_indices(block)?
                 .ok_or(ProviderError::BlockBodyIndicesNotFound(block))?;
 
-            let mut receipts_cursor = provider
-                .tx_ref()
-                .cursor_read::<tables::Receipts<<Provider::Primitives as NodePrimitives>::Receipt>>(
-                )?;
             let receipts_walker = receipts_cursor.walk_range(block_body_indices.tx_num_range())?;
 
             static_file_writer.append_receipts(


### PR DESCRIPTION
Hoists the MDBX cursor creation outside the block loop in the receipts segment to avoid creating a new cursor for each block.

For a range of 500k blocks, this reduces cursor creations from 500k to 1.

## Changes
- Move `receipts_cursor` creation outside the `for block in block_range` loop
- Reuse the same cursor across all iterations via `walk_range()`