### PR TITLE
docs: improve RocksDB block cache size method documentation

### DIFF
--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -283,6 +283,19 @@ impl RocksDBBuilder {
     }
 
     /// Sets a custom block cache size.
+    ///
+    /// The block cache is shared across all column families and caches uncompressed data blocks.
+    /// For large databases, setting this to 25-50% of available RAM can significantly improve
+    /// read performance by reducing disk I/O.
+    ///
+    /// Default: 128 MB ([`DEFAULT_CACHE_SIZE`]).
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // Set cache to 1 GB
+    /// builder.with_block_cache_size(1 << 30)
+    /// ```
     pub fn with_block_cache_size(mut self, capacity_bytes: usize) -> Self {
         self.block_cache = Cache::new_lru_cache(capacity_bytes);
         self


### PR DESCRIPTION
## Summary

Improves documentation for `RocksDBBuilder::with_block_cache_size()` method.

## Changes

- Added comprehensive documentation explaining the purpose of the block cache
- Documented recommended sizing guidelines (25-50% of RAM for large databases)
- Referenced the DEFAULT_CACHE_SIZE constant for default value
- Added usage example

## Related

Lane 3 of RocksDB improvements - Task 1399