### PR TITLE
refactor(rocksdb): deduplicate first()/last() implementations

### DIFF
--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -818,6 +818,7 @@ impl RocksDBProvider {
         Ok(())
     }
 
+    /// Retrieves the first or last entry from a table based on the iterator mode.
     #[inline]
     fn get_boundary<T: Table>(
         &self,

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -819,7 +819,6 @@ impl RocksDBProvider {
     }
 
     /// Retrieves the first or last entry from a table based on the iterator mode.
-    #[inline]
     fn get_boundary<T: Table>(
         &self,
         mode: IteratorMode<'_>,
@@ -848,11 +847,13 @@ impl RocksDBProvider {
     }
 
     /// Gets the first (smallest key) entry from the specified table.
+    #[inline]
     pub fn first<T: Table>(&self) -> ProviderResult<Option<(T::Key, T::Value)>> {
         self.get_boundary::<T>(IteratorMode::Start)
     }
 
     /// Gets the last (largest key) entry from the specified table.
+    #[inline]
     pub fn last<T: Table>(&self) -> ProviderResult<Option<(T::Key, T::Value)>> {
         self.get_boundary::<T>(IteratorMode::End)
     }

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -818,6 +818,7 @@ impl RocksDBProvider {
         Ok(())
     }
 
+    #[inline]
     fn get_boundary<T: Table>(
         &self,
         mode: IteratorMode<'_>,


### PR DESCRIPTION
## Summary

Extract shared logic from `first()` and `last()` into a private `get_boundary()` helper method that accepts an `IteratorMode` parameter.

## Changes

Both methods had identical implementations differing only by `IteratorMode::Start` vs `IteratorMode::End`. This refactor:

- Creates a private `get_boundary<T: Table>(mode: IteratorMode)` helper
- Simplifies `first()` and `last()` to one-line delegations

## Before

~22 lines each for `first()` and `last()` with duplicated decode/error-handling logic.

## After

- `get_boundary()`: ~22 lines (shared)
- `first()`: 3 lines
- `last()`: 3 lines