### PR TITLE
refactor(rocksdb): add #[inline] to get_boundary helper

### DIFF
--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -818,6 +818,7 @@ impl RocksDBProvider {
         Ok(())
     }
 
+    /// Retrieves the first or last entry from a table based on the iterator mode.
     #[inline]
     fn get_boundary<T: Table>(
         &self,

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -818,6 +818,7 @@ impl RocksDBProvider {
         Ok(())
     }
 
+    #[inline]
     fn get_boundary<T: Table>(
         &self,
         mode: IteratorMode<'_>,


### PR DESCRIPTION
Follow-up to #21738 - adds `#[inline]` to the `get_boundary` helper since `first()` and `last()` are now thin wrappers that delegate to it.

Doc comments were already correctly placed on the public methods.