### PR TITLE
fix: enable reth-prune rocksdb feature in edge builds

### DIFF
--- a/crates/optimism/cli/Cargo.toml
+++ b/crates/optimism/cli/Cargo.toml
@@ -124,4 +124,4 @@ serde = [
     "reth-optimism-chainspec/serde",
 ]
 
-edge = ["reth-cli-commands/edge", "reth-node-core/edge"]
+edge = ["reth-cli-commands/edge", "reth-node-core/edge", "reth-db-common/edge", "reth-stages/rocksdb", "reth-provider/rocksdb", "reth-prune/rocksdb"]

--- a/crates/stages/stages/Cargo.toml
+++ b/crates/stages/stages/Cargo.toml
@@ -122,7 +122,7 @@ test-utils = [
     "reth-evm-ethereum/test-utils",
 ]
 rocksdb = ["reth-provider/rocksdb"]
-edge = ["reth-provider/edge", "reth-db-common/edge", "rocksdb"]
+edge = ["reth-provider/edge", "reth-db-common/edge", "rocksdb", "reth-prune/rocksdb"]
 
 [[bench]]
 name = "criterion"


### PR DESCRIPTION
Fixes missing rocksdb feature propagation in edge builds.  Similar to #21715, the edge feature was not enabling reth-prune's rocksdb feature in reth-stages and reth-optimism-cli, causing the pruner to be a no-op on rocksdb tables when edge is enabled.