### PR TITLE
feat(txpool): add `is_transaction_ready` to `TransactionPool` trait

### DIFF
--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -615,14 +615,7 @@ where
         sender: Address,
         nonce: u64,
     ) -> Option<Arc<ValidPoolTransaction<Self::Transaction>>> {
-        let sender_id = self.pool.get_sender_id(sender);
-        self.pool
-            .get_pool_data()
-            .pending()
-            .independent_transactions()
-            .get(&sender_id)
-            .filter(|tx| tx.transaction.nonce() == nonce)
-            .map(|tx| tx.transaction.clone())
+        self.pool.get_pending_transaction_by_sender_and_nonce(sender, nonce)
     }
 
     fn pending_transactions_max(

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -610,6 +610,15 @@ where
         self.pool.pending_transactions()
     }
 
+    fn is_transaction_ready(&self, sender: &Address, nonce: u64) -> bool {
+        let pool_data = self.pool.get_pool_data();
+        pool_data
+            .pending()
+            .independent_transactions()
+            .values()
+            .any(|tx| tx.transaction.sender() == *sender && tx.transaction.nonce() == nonce)
+    }
+
     fn pending_transactions_max(
         &self,
         max: usize,

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -610,13 +610,19 @@ where
         self.pool.pending_transactions()
     }
 
-    fn is_transaction_ready(&self, sender: &Address, nonce: u64) -> bool {
-        let pool_data = self.pool.get_pool_data();
-        pool_data
+    fn get_pending_transaction_by_sender_and_nonce(
+        &self,
+        sender: Address,
+        nonce: u64,
+    ) -> Option<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        let sender_id = self.pool.get_sender_id(sender);
+        self.pool
+            .get_pool_data()
             .pending()
             .independent_transactions()
-            .values()
-            .any(|tx| tx.transaction.sender() == *sender && tx.transaction.nonce() == nonce)
+            .get(&sender_id)
+            .filter(|tx| tx.transaction.nonce() == nonce)
+            .map(|tx| tx.transaction.clone())
     }
 
     fn pending_transactions_max(

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -1090,6 +1090,16 @@ where
         self.get_pool_data().get_transactions_by_sender(sender_id)
     }
 
+    /// Returns a pending transaction sent by the given sender with the given nonce.
+    pub fn get_pending_transaction_by_sender_and_nonce(
+        &self,
+        sender: Address,
+        nonce: u64,
+    ) -> Option<Arc<ValidPoolTransaction<T::Transaction>>> {
+        let sender_id = self.get_sender_id(sender);
+        self.get_pool_data().get_pending_transaction_by_sender_and_nonce(sender_id, nonce)
+    }
+
     /// Returns all queued transactions of the address by sender
     pub fn get_queued_transactions_by_sender(
         &self,

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -560,6 +560,18 @@ impl<T: TransactionOrdering> TxPool<T> {
         self.all_transactions.txs_iter(sender).map(|(_, tx)| Arc::clone(&tx.transaction)).collect()
     }
 
+    /// Returns a pending transaction sent by the given sender with the given nonce.
+    pub(crate) fn get_pending_transaction_by_sender_and_nonce(
+        &self,
+        sender: SenderId,
+        nonce: u64,
+    ) -> Option<Arc<ValidPoolTransaction<T::Transaction>>> {
+        self.all_transactions
+            .txs_iter(sender)
+            .find(|(id, tx)| id.nonce == nonce && tx.subpool == SubPool::Pending)
+            .map(|(_, tx)| Arc::clone(&tx.transaction))
+    }
+
     /// Updates only the pending fees without triggering subpool updates.
     /// Returns the previous base fee and blob fee values.
     const fn update_pending_fees_only(

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -405,6 +405,26 @@ pub trait TransactionPool: Clone + Debug + Send + Sync {
     /// Consumer: RPC
     fn pending_transactions(&self) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
 
+    /// Returns `true` if the transaction with the given sender and nonce is ready to be executed.
+    ///
+    /// A transaction is "nonce-ready" if it is the next expected transaction for its sender,
+    /// meaning all prior nonces have already been consumed or are not required.
+    ///
+    /// This is useful for checking whether a transaction can be directly included in a block
+    /// without violating nonce ordering constraints.
+    ///
+    /// The default implementation scans pending transactions to find the lowest nonce for the
+    /// sender and checks if it matches the given nonce.
+    fn is_transaction_ready(&self, sender: &Address, nonce: u64) -> bool {
+        use alloy_consensus::Transaction;
+        self.pending_transactions()
+            .iter()
+            .filter(|tx| tx.sender() == *sender)
+            .map(|tx| tx.transaction.nonce())
+            .min() ==
+            Some(nonce)
+    }
+
     /// Returns first `max` transactions that can be included in the next block.
     /// See <https://github.com/paradigmxyz/reth/issues/12767#issuecomment-2493223579>
     ///


### PR DESCRIPTION
Adds `is_transaction_ready(&self, sender: &Address, nonce: u64) -> bool` to the `TransactionPool` trait.

## Motivation
External builder implementation needs to check whether a specific transaction is ready for inclusion. The existing `best_transactions()` iterator only supports sequential consumption - there's no API to check if a specific transaction is ready to be included. This can be easily done by using the `independent_transactions` set that the txpool is managing internally. 

## Solution
- Add `is_transaction_ready` to `TransactionPool` trait with a default implementation that scans `pending_transactions()` for the sender's minimum nonce (preserve backwards compatibility of trait).
- Override in `Pool<V,T,S>` with an implementation that checks the pending pool's `independent_transactions` set directly

The `independent_transactions` set contains exactly the transactions whose nonce is next-expected for their sender, making this an `O(k)` lookup where k is the number of unique senders with pending txs.
