### PR TITLE
perf(db): disable prefault_write to avoid mincore() syscall overhead

### DIFF
--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -488,6 +488,10 @@ impl DatabaseEnv {
             inner_env.set_max_read_transaction_duration(max_read_transaction_duration);
         }
 
+        // Disable prefault writes: avoids mincore() syscall overhead since pages are likely
+        // already warm from Engine Task reads in WRITEMAP mode.
+        inner_env.set_prefault_write(false);
+
         let env = Self {
             inner: inner_env.open(path).map_err(|e| DatabaseError::Open(e.into()))?,
             dbis: Arc::default(),


### PR DESCRIPTION
## Summary

In WRITEMAP mode, MDBX by default calls `mincore()` before each page write to check if the page is resident in memory. Profiling shows this accounts for **~20-22% of persistence time**, yet pages are usually already warm from Engine Task reads.

This PR:
1. Adds `set_prefault_write()` method to `EnvironmentBuilder` in libmdbx-rs to control the `MDBX_opt_prefault_write_enable` option
2. Disables prefault writes in reth-db by default

## Rationale

From [profiling data](https://profiler.firefox.com/public/3sz87dp8x7g47yr4hnxwncnhkdg01zrnapr05z0/flame-graph/?globalTrackOrder=201&hiddenGlobalTracks=01):

| mincore overhead | ~20-22% |
|------------------|---------|
| Actual page faults | ~4-5% |

Since pages are likely resident (warmed by Engine Task reads), the `mincore()` syscall is mostly overhead. Disabling prefault_write:
- Eliminates syscall overhead when pages are already warm
- Lets the kernel handle the occasional page fault directly
- Expected net improvement given the warm cache assumption

## Testing

- Verified compilation with `cargo check -p reth-libmdbx -p reth-db`
- Ran clippy and fmt

Benchmark results needed to validate the performance improvement.