### PR TITLE
chore: disable changelog workflow on PRs

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,8 +1,7 @@
 name: Changelog
 
 on:
-  pull_request:
-    types: [opened, synchronize]
+  workflow_dispatch:
 
 jobs:
   changelog:


### PR DESCRIPTION
Disables the automatic changelog generation workflow on pull requests. The workflow can still be triggered manually via workflow_dispatch if needed.