### PR TITLE
fix(discv5): add missing `rand` feature for test compilation

### DIFF
--- a/crates/net/discv5/Cargo.toml
+++ b/crates/net/discv5/Cargo.toml
@@ -41,6 +41,7 @@ metrics.workspace = true
 
 [dev-dependencies]
 reth-tracing.workspace = true
+alloy-primitives = { workspace = true, features = ["rand"] }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 secp256k1 = { workspace = true, features = ["std", "rand"] }
 rand_08.workspace = true


### PR DESCRIPTION
Hi there, there is a compile issue on my end.

Add `alloy-primitives` with `rand` feature to dev-dependencies to fix test compilation error.

The `PeerId::random()` call in tests requires the `rand` feature from `alloy-primitives`, which was not enabled.