### PR TITLE
chore: enable changelog check on PRs

### DIFF
--- a/.changelog/lively-deer-shout.md
+++ b/.changelog/lively-deer-shout.md
@@ -1,0 +1,5 @@
+---
+reth: patch
+---
+
+Re-enabled changelog workflow to run automatically on pull requests.

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -9,13 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref }}
       - run: npm install -g @anthropic-ai/claude-code
-      - uses: wevm/changelogs-rs/gen@master
+      - uses: wevm/changelogs/check@master
         with:
           ai: 'claude -p'
         env:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,7 +1,8 @@
 name: Changelog
 
 on:
-  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize]
 
 jobs:
   changelog:


### PR DESCRIPTION
Enables the `wevm/changelogs/check` GitHub Action to enforce changelog entries on PRs.

## What it does
- Runs on every PR (opened/synchronized)
- Checks if a changelog entry exists for the PR
- If missing, the bot comments with a warning and provides a suggested changelog entry with an "Add changelog" link to commit it directly

This replaces the previous `wevm/changelogs-rs/gen` action with the updated `wevm/changelogs/check` action.


Example:
<img width="1850" height="594" alt="CleanShot 2026-02-04 at 10 32 05@2x" src="https://github.com/user-attachments/assets/a0acc75c-667a-417d-ad9d-b6cb6f8dcd23" />
