### PR TITLE
chore: shorten thread names

### DIFF
--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -236,7 +236,7 @@ impl LaunchContext {
             .map_or(0, |num| num.get().saturating_sub(reserved_cpu_cores).max(1));
         if let Err(err) = ThreadPoolBuilder::new()
             .num_threads(num_threads)
-            .thread_name(|i| format!("reth-rayon-{i}"))
+            .thread_name(|i| format!("rayon-{i}"))
             .build_global()
         {
             warn!(%err, "Failed to build global thread pool")

--- a/crates/rpc/rpc/src/eth/builder.rs
+++ b/crates/rpc/rpc/src/eth/builder.rs
@@ -541,7 +541,7 @@ where
             eth_proof_window,
             blocking_task_pool.unwrap_or_else(|| {
                 BlockingTaskPool::builder()
-                    .thread_name(|i| format!("reth-blocking-{i}"))
+                    .thread_name(|i| format!("blocking-{i}"))
                     .build()
                     .map(BlockingTaskPool::new)
                     .expect("failed to build blocking task pool")

--- a/crates/rpc/rpc/src/eth/builder.rs
+++ b/crates/rpc/rpc/src/eth/builder.rs
@@ -540,7 +540,11 @@ where
             max_simulate_blocks,
             eth_proof_window,
             blocking_task_pool.unwrap_or_else(|| {
-                BlockingTaskPool::build().expect("failed to build blocking task pool")
+                BlockingTaskPool::builder()
+                    .thread_name(|i| format!("reth-blocking-{i}"))
+                    .build()
+                    .map(BlockingTaskPool::new)
+                    .expect("failed to build blocking task pool")
             }),
             fee_history_cache,
             task_spawner,

--- a/crates/storage/libmdbx-rs/src/txn_manager.rs
+++ b/crates/storage/libmdbx-rs/src/txn_manager.rs
@@ -97,7 +97,7 @@ impl TxnManager {
                 }
             }
         };
-        std::thread::Builder::new().name("mdbx-rs-txn-manager".to_string()).spawn(task).unwrap();
+        std::thread::Builder::new().name("mdbx-rs-txn-mgr".to_string()).spawn(task).unwrap();
     }
 
     pub(crate) fn send_message(&self, message: TxnManagerMessage) {


### PR DESCRIPTION
The RPC blocking task pool (used for tracing/proof calls) was using rayon's default thread naming which inherits the process name. This made profiling confusing as these threads appeared as generic "reth" threads rather than something descriptive.

Names them "blocking-{i}" to distinguish from the global rayon pool ("rayon-{i}").