### PR TITLE
chore(deps): bump bytes 1.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1986,9 +1986,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -543,7 +543,7 @@ backon = { version = "1.2", default-features = false, features = ["std-blocking-
 bincode = "1.3"
 bitflags = "2.4"
 boyer-moore-magiclen = "0.2.16"
-bytes = { version = "1.5", default-features = false }
+bytes = { version = "1.11.1", default-features = false }
 brotli = "8"
 cfg-if = "1.0"
 clap = "4"


### PR DESCRIPTION
[rustsec.org/advisories/RUSTSEC-2026-0007](https://rustsec.org/advisories/RUSTSEC-2026-0007)