### PR TITLE
perf(docker): set default target-cpu to x86-64-v3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ARG BUILD_PROFILE=maxperf
 ENV BUILD_PROFILE=$BUILD_PROFILE
 
 # Extra Cargo flags
-ARG RUSTFLAGS=""
+ARG RUSTFLAGS="-C target-cpu=x86-64-v3"
 ENV RUSTFLAGS="$RUSTFLAGS"
 
 # Extra Cargo features


### PR DESCRIPTION
Sets RUSTFLAGS default to `-C target-cpu=x86-64-v3` in the Dockerfile for better performance on modern CPUs.

x86-64-v3 enables AVX, AVX2, BMI1/2, F16C, FMA, LZCNT, MOVBE, and XSAVE instructions available on Intel Haswell (2013+) and AMD Excavator (2015+) processors.