### PR TITLE
chore(prune): increase reth prune DELETE_LIMIT to 20M

### DIFF
--- a/crates/cli/commands/src/prune.rs
+++ b/crates/cli/commands/src/prune.rs
@@ -71,7 +71,9 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> PruneComma
             info!(target: "reth::cli", ?prune_tip, ?config, "Pruning data from database...");
 
             // Use batched pruning with a limit to bound memory, running in a loop until complete.
-            const DELETE_LIMIT: usize = 200_000;
+            //
+            // A limit of 20_000_000 results in a max memory usage of ~5G.
+            const DELETE_LIMIT: usize = 20_000_000;
             let mut pruner = PrunerBuilder::new(config)
                 .delete_limit(DELETE_LIMIT)
                 .build_with_provider_factory(provider_factory);


### PR DESCRIPTION
The previous limit would result in very slow pruning, this makes it faster but still not quite as fast as we would need it.

Memory usage from running this:
<img width="1384" height="757" alt="Screenshot 2026-02-03 at 12 29 51 PM" src="https://github.com/user-attachments/assets/cf06c38c-fd6d-4f6c-ace6-8fb66d2f62d0" />
