### PR TITLE
fix(rpc): use consistent sidecar check in fill_transaction for EIP-7594 support

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -494,7 +494,9 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
                 request.as_mut().set_max_fee_per_blob_gas(blob_fee.to());
             }
 
-            if request.as_ref().blob_sidecar().is_some() &&
+            // Use `sidecar.is_some()` instead of `blob_sidecar().is_some()` to handle
+            // both EIP-4844 (v0) and EIP-7594 (v1) sidecar formats
+            if request.as_ref().sidecar.is_some() &&
                 request.as_ref().blob_versioned_hashes.is_none()
             {
                 request.as_mut().populate_blob_hashes();


### PR DESCRIPTION
## Summary

- Fix `populate_blob_hashes()` not being called when EIP-7594 (v1) sidecar is provided
- Change condition from `blob_sidecar().is_some()` to `sidecar.is_some()`

## Problem

In `fill_transaction`, the condition for populating blob hashes used `blob_sidecar().is_some()`, which only returns `Some` for EIP-4844 (v0) sidecars. When users provide an EIP-7594 (v1) sidecar, this check returns `false`, causing `populate_blob_hashes()` to be skipped.

## Solution

Use `sidecar.is_some()` which checks the raw `Option<BlobTransactionSidecarVariant>` field directly, correctly handling both v0 and v1 formats.