### PR TITLE
feat: add a public `prune_transactions` method to the TransactionPool

### DIFF
--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -519,7 +519,7 @@ where
         transactions: Vec<Self::Transaction>,
     ) -> Vec<PoolResult<AddedTransactionOutcome>> {
         if transactions.is_empty() {
-            return Vec::new()
+            return Vec::new();
         }
         let validated = self.validate_all(origin, transactions).await;
 
@@ -663,6 +663,13 @@ where
         sender: Address,
     ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
         self.pool.remove_transactions_by_sender(sender)
+    }
+
+    fn prune_transactions(
+        &self,
+        hashes: Vec<TxHash>,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.pool.prune_transactions(hashes)
     }
 
     fn retain_unknown<A>(&self, announcement: &mut A)

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -519,7 +519,7 @@ where
         transactions: Vec<Self::Transaction>,
     ) -> Vec<PoolResult<AddedTransactionOutcome>> {
         if transactions.is_empty() {
-            return Vec::new();
+            return Vec::new()
         }
         let validated = self.validate_all(origin, transactions).await;
 

--- a/crates/transaction-pool/src/noop.rs
+++ b/crates/transaction-pool/src/noop.rs
@@ -231,6 +231,13 @@ impl<T: EthPoolTransaction> TransactionPool for NoopTransactionPool<T> {
         vec![]
     }
 
+    fn prune_transactions(
+        &self,
+        _hashes: Vec<TxHash>,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        vec![]
+    }
+
     fn retain_unknown<A>(&self, _announcement: &mut A)
     where
         A: HandleMempoolData,
@@ -335,7 +342,7 @@ impl<T: EthPoolTransaction> TransactionPool for NoopTransactionPool<T> {
         tx_hashes: Vec<TxHash>,
     ) -> Result<Vec<Arc<BlobTransactionSidecarVariant>>, BlobStoreError> {
         if tx_hashes.is_empty() {
-            return Ok(vec![])
+            return Ok(vec![]);
         }
         Err(BlobStoreError::MissingSidecar(tx_hashes[0]))
     }

--- a/crates/transaction-pool/src/noop.rs
+++ b/crates/transaction-pool/src/noop.rs
@@ -342,7 +342,7 @@ impl<T: EthPoolTransaction> TransactionPool for NoopTransactionPool<T> {
         tx_hashes: Vec<TxHash>,
     ) -> Result<Vec<Arc<BlobTransactionSidecarVariant>>, BlobStoreError> {
         if tx_hashes.is_empty() {
-            return Ok(vec![]);
+            return Ok(vec![])
         }
         Err(BlobStoreError::MissingSidecar(tx_hashes[0]))
     }

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -644,8 +644,8 @@ where
                     let (result, meta) = self.add_transaction(&mut pool, origin, tx);
 
                     // Only collect metadata for successful insertions
-                    if result.is_ok()
-                        && let Some(meta) = meta
+                    if result.is_ok() &&
+                        let Some(meta) = meta
                     {
                         added_metas.push(meta);
                     }
@@ -679,8 +679,8 @@ where
             // A newly added transaction may be immediately discarded, so we need to
             // adjust the result here
             for res in &mut results {
-                if let Ok(AddedTransactionOutcome { hash, .. }) = res
-                    && discarded_hashes.contains(hash)
+                if let Ok(AddedTransactionOutcome { hash, .. }) = res &&
+                    discarded_hashes.contains(hash)
                 {
                     *res = Err(PoolError::new(*hash, PoolErrorKind::DiscardedOnInsert))
                 }

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -1072,9 +1072,8 @@ where
         if hashes.is_empty() {
             return Vec::new();
         }
-        let removed = self.pool.write().prune_transactions(hashes);
 
-        removed
+        self.pool.write().prune_transactions(hashes)
     }
 
     /// Removes and returns all transactions that are present in the pool.

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -774,7 +774,7 @@ where
                         needs_cleanup = true;
                     }
                     // Skip non-propagate transactions for propagate-only listeners
-                    continue;
+                    continue
                 }
 
                 if !listener.send(event.clone()) {
@@ -793,7 +793,7 @@ where
     fn on_new_blob_sidecar(&self, tx_hash: &TxHash, sidecar: &BlobTransactionSidecarVariant) {
         let mut sidecar_listeners = self.blob_transaction_sidecar_listener.lock();
         if sidecar_listeners.is_empty() {
-            return;
+            return
         }
         let sidecar = Arc::new(sidecar.clone());
         sidecar_listeners.retain_mut(|listener| {
@@ -1024,7 +1024,7 @@ where
         hashes: Vec<TxHash>,
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
         if hashes.is_empty() {
-            return Vec::new();
+            return Vec::new()
         }
         let removed = self.pool.write().remove_transactions(hashes);
 
@@ -1040,7 +1040,7 @@ where
         hashes: Vec<TxHash>,
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
         if hashes.is_empty() {
-            return Vec::new();
+            return Vec::new()
         }
         let removed = self.pool.write().remove_transactions_and_descendants(hashes);
 
@@ -1067,12 +1067,15 @@ where
     }
 
     /// Prunes and returns all matching transactions from the pool.
+    ///
+    /// This removes the transactions as if they were mined: descendant transactions are **not**
+    /// parked and remain eligible for inclusion.
     pub fn prune_transactions(
         &self,
         hashes: Vec<TxHash>,
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
         if hashes.is_empty() {
-            return Vec::new();
+            return Vec::new()
         }
 
         self.pool.write().prune_transactions(hashes)
@@ -1084,7 +1087,7 @@ where
         A: HandleMempoolData,
     {
         if announcement.is_empty() {
-            return;
+            return
         }
         let pool = self.get_pool_data();
         announcement.retain_by_hash(|tx| !pool.contains(tx))
@@ -1195,7 +1198,7 @@ where
     /// If no transaction exists, it is skipped.
     pub fn get_all(&self, txs: Vec<TxHash>) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
         if txs.is_empty() {
-            return Vec::new();
+            return Vec::new()
         }
         self.get_pool_data().get_all(txs).collect()
     }
@@ -1208,7 +1211,7 @@ where
         txs: &[TxHash],
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
         if txs.is_empty() {
-            return Vec::new();
+            return Vec::new()
         }
         let pool = self.get_pool_data();
         txs.iter().filter_map(|tx| pool.get(tx).filter(|tx| tx.propagate)).collect()
@@ -1217,7 +1220,7 @@ where
     /// Notify about propagated transactions.
     pub fn on_propagated(&self, txs: PropagatedTransactions) {
         if txs.0.is_empty() {
-            return;
+            return
         }
         self.with_event_listener(|listener| {
             txs.0.into_iter().for_each(|(hash, peers)| listener.propagated(&hash, peers));
@@ -1349,9 +1352,9 @@ where
         loop {
             let next = self.iter.next()?;
             if self.kind.is_propagate_only() && !next.propagate {
-                continue;
+                continue
             }
-            return Some(*next.hash());
+            return Some(*next.hash())
         }
     }
 }
@@ -1373,12 +1376,12 @@ where
         loop {
             let next = self.iter.next()?;
             if self.kind.is_propagate_only() && !next.propagate {
-                continue;
+                continue
             }
             return Some(NewTransactionEvent {
                 subpool: SubPool::Pending,
                 transaction: next.clone(),
-            });
+            })
         }
     }
 }

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -169,7 +169,7 @@ impl<T: TransactionOrdering> TxPool<T> {
         let mut next_expected_nonce = on_chain.nonce;
         for (id, tx) in self.all().descendant_txs_inclusive(&on_chain) {
             if next_expected_nonce != id.nonce {
-                break
+                break;
             }
             next_expected_nonce = id.next_nonce();
             last_consecutive_tx = Some(tx);
@@ -746,7 +746,7 @@ impl<T: TransactionOrdering> TxPool<T> {
         on_chain_code_hash: Option<B256>,
     ) -> PoolResult<AddedTransaction<T::Transaction>> {
         if self.contains(tx.hash()) {
-            return Err(PoolError::new(*tx.hash(), PoolErrorKind::AlreadyImported))
+            return Err(PoolError::new(*tx.hash(), PoolErrorKind::AlreadyImported));
         }
 
         self.validate_auth(&tx, on_chain_nonce, on_chain_code_hash)?;
@@ -860,10 +860,10 @@ impl<T: TransactionOrdering> TxPool<T> {
         on_chain_code_hash: Option<B256>,
     ) -> Result<(), PoolError> {
         // Short circuit if the sender has neither delegation nor pending delegation.
-        if (on_chain_code_hash.is_none() || on_chain_code_hash == Some(KECCAK_EMPTY)) &&
-            !self.all_transactions.auths.contains_key(&transaction.sender_id())
+        if (on_chain_code_hash.is_none() || on_chain_code_hash == Some(KECCAK_EMPTY))
+            && !self.all_transactions.auths.contains_key(&transaction.sender_id())
         {
-            return Ok(())
+            return Ok(());
         }
 
         let mut txs_by_sender =
@@ -881,23 +881,23 @@ impl<T: TransactionOrdering> TxPool<T> {
                     PoolErrorKind::InvalidTransaction(InvalidPoolTransactionError::Eip7702(
                         Eip7702PoolTransactionError::OutOfOrderTxFromDelegated,
                     )),
-                ))
+                ));
             }
-            return Ok(())
+            return Ok(());
         }
 
         let mut count = 0;
         for id in txs_by_sender {
             if id == &transaction.transaction_id {
                 // Transaction replacement is supported
-                return Ok(())
+                return Ok(());
             }
             count += 1;
         }
 
         if count < self.config.max_inflight_delegated_slot_limit {
             // account still has an available slot
-            return Ok(())
+            return Ok(());
         }
 
         Err(PoolError::new(
@@ -935,7 +935,7 @@ impl<T: TransactionOrdering> TxPool<T> {
                         PoolErrorKind::InvalidTransaction(InvalidPoolTransactionError::Eip7702(
                             Eip7702PoolTransactionError::AuthorityReserved,
                         )),
-                    ))
+                    ));
                 }
             }
         }
@@ -961,8 +961,8 @@ impl<T: TransactionOrdering> TxPool<T> {
                 Destination::Pool(move_to) => {
                     debug_assert_ne!(&move_to, &current, "destination must be different");
                     let moved = self.move_transaction(current, move_to, &id);
-                    if matches!(move_to, SubPool::Pending) &&
-                        let Some(tx) = moved
+                    if matches!(move_to, SubPool::Pending)
+                        && let Some(tx) = moved
                     {
                         trace!(target: "txpool", hash=%tx.transaction.hash(), "Promoted transaction to pending");
                         outcome.promoted.push(tx);
@@ -1037,6 +1037,17 @@ impl<T: TransactionOrdering> TxPool<T> {
         }
         self.update_size_metrics();
         removed
+    }
+
+    /// Prunes and returns all matching transactions from the pool.
+    pub(crate) fn prune_transactions(
+        &mut self,
+        hashes: Vec<TxHash>,
+    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        let txs =
+            hashes.into_iter().filter_map(|hash| self.prune_transaction_by_hash(&hash)).collect();
+        self.update_size_metrics();
+        txs
     }
 
     /// Remove the transaction from the __entire__ pool.
@@ -1137,7 +1148,7 @@ impl<T: TransactionOrdering> TxPool<T> {
                 }
                 id = descendant;
             } else {
-                return
+                return;
             }
         }
     }
@@ -1410,7 +1421,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
                 entry.remove();
                 self.sender_info.remove(&sender);
                 self.metrics.all_transactions_by_all_senders.decrement(1.0);
-                return
+                return;
             }
             *count -= 1;
             self.metrics.all_transactions_by_all_senders.decrement(1.0);
@@ -1485,7 +1496,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
                 ($iter:ident) => {
                     'this: while let Some((peek, _)) = iter.peek() {
                         if peek.sender != id.sender {
-                            break 'this
+                            break 'this;
                         }
                         iter.next();
                     }
@@ -1502,7 +1513,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
                         current: tx.subpool,
                         destination: Destination::Discard,
                     });
-                    continue 'transactions
+                    continue 'transactions;
                 }
 
                 let ancestor = TransactionId::ancestor(id.nonce, info.state_nonce, id.sender);
@@ -1527,7 +1538,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
             // If there's a nonce gap, we can shortcircuit, because there's nothing to update yet.
             if tx.state.has_nonce_gap() {
                 next_sender!(iter);
-                continue 'transactions
+                continue 'transactions;
             }
 
             // Since this is the first transaction of the sender, it has no parked ancestors
@@ -1550,7 +1561,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
             while let Some((peek, tx)) = iter.peek_mut() {
                 if peek.sender != id.sender {
                     // Found the next sender we need to check
-                    continue 'transactions
+                    continue 'transactions;
                 }
 
                 if tx.transaction.nonce() == next_nonce_in_line {
@@ -1559,7 +1570,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
                 } else {
                     // can short circuit if there's still a nonce gap
                     next_sender!(iter);
-                    continue 'transactions
+                    continue 'transactions;
                 }
 
                 // update for next iteration of this sender's loop
@@ -1814,7 +1825,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
             if current_txs >= self.max_account_slots && transaction.nonce() > on_chain_nonce {
                 return Err(InsertErr::ExceededSenderTransactionsCapacity {
                     transaction: Arc::new(transaction),
-                })
+                });
             }
         }
         if transaction.gas_limit() > self.block_gas_limit {
@@ -1822,12 +1833,12 @@ impl<T: PoolTransaction> AllTransactions<T> {
                 block_gas_limit: self.block_gas_limit,
                 tx_gas_limit: transaction.gas_limit(),
                 transaction: Arc::new(transaction),
-            })
+            });
         }
 
         if self.contains_conflicting_transaction(&transaction) {
             // blob vs non blob transactions are mutually exclusive for the same sender
-            return Err(InsertErr::TxTypeConflict { transaction: Arc::new(transaction) })
+            return Err(InsertErr::TxTypeConflict { transaction: Arc::new(transaction) });
         }
 
         Ok(transaction)
@@ -1848,13 +1859,13 @@ impl<T: PoolTransaction> AllTransactions<T> {
             let Some(ancestor_tx) = self.txs.get(&ancestor) else {
                 // ancestor tx is missing, so we can't insert the new blob
                 self.metrics.blob_transactions_nonce_gaps.increment(1);
-                return Err(InsertErr::BlobTxHasNonceGap { transaction: Arc::new(new_blob_tx) })
+                return Err(InsertErr::BlobTxHasNonceGap { transaction: Arc::new(new_blob_tx) });
             };
             if ancestor_tx.state.has_nonce_gap() {
                 // the ancestor transaction already has a nonce gap, so we can't insert the new
                 // blob
                 self.metrics.blob_transactions_nonce_gaps.increment(1);
-                return Err(InsertErr::BlobTxHasNonceGap { transaction: Arc::new(new_blob_tx) })
+                return Err(InsertErr::BlobTxHasNonceGap { transaction: Arc::new(new_blob_tx) });
             }
 
             // the max cost executing this transaction requires
@@ -1863,15 +1874,15 @@ impl<T: PoolTransaction> AllTransactions<T> {
             // check if the new blob would go into overdraft
             if cumulative_cost > on_chain_balance {
                 // the transaction would go into overdraft
-                return Err(InsertErr::Overdraft { transaction: Arc::new(new_blob_tx) })
+                return Err(InsertErr::Overdraft { transaction: Arc::new(new_blob_tx) });
             }
 
             // ensure that a replacement would not shift already propagated blob transactions into
             // overdraft
             let id = new_blob_tx.transaction_id;
             let mut descendants = self.descendant_txs_inclusive(&id).peekable();
-            if let Some((maybe_replacement, _)) = descendants.peek() &&
-                **maybe_replacement == new_blob_tx.transaction_id
+            if let Some((maybe_replacement, _)) = descendants.peek()
+                && **maybe_replacement == new_blob_tx.transaction_id
             {
                 // replacement transaction
                 descendants.next();
@@ -1881,13 +1892,13 @@ impl<T: PoolTransaction> AllTransactions<T> {
                     cumulative_cost += tx.transaction.cost();
                     if tx.transaction.is_eip4844() && cumulative_cost > on_chain_balance {
                         // the transaction would shift
-                        return Err(InsertErr::Overdraft { transaction: Arc::new(new_blob_tx) })
+                        return Err(InsertErr::Overdraft { transaction: Arc::new(new_blob_tx) });
                     }
                 }
             }
         } else if new_blob_tx.cost() > &on_chain_balance {
             // the transaction would go into overdraft
-            return Err(InsertErr::Overdraft { transaction: Arc::new(new_blob_tx) })
+            return Err(InsertErr::Overdraft { transaction: Arc::new(new_blob_tx) });
         }
 
         Ok(new_blob_tx)
@@ -1978,7 +1989,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
         let fee_cap = transaction.max_fee_per_gas();
 
         if fee_cap < self.minimal_protocol_basefee as u128 {
-            return Err(InsertErr::FeeCapBelowMinimumProtocolFeeCap { transaction, fee_cap })
+            return Err(InsertErr::FeeCapBelowMinimumProtocolFeeCap { transaction, fee_cap });
         }
         if fee_cap >= self.pending_fees.base_fee as u128 {
             state.insert(TxState::ENOUGH_FEE_CAP_BLOCK);
@@ -2011,7 +2022,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
                     return Err(InsertErr::Underpriced {
                         transaction: pool_tx.transaction,
                         existing: *entry.get().transaction.hash(),
-                    })
+                    });
                 }
                 let new_hash = *pool_tx.transaction.hash();
                 let new_transaction = pool_tx.transaction.clone();
@@ -2051,7 +2062,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
 
                 // If there's a nonce gap, we can shortcircuit
                 if next_nonce != id.nonce {
-                    break
+                    break;
                 }
 
                 // close the nonce gap

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -171,7 +171,7 @@ impl<T: TransactionOrdering> TxPool<T> {
         let mut next_expected_nonce = on_chain.nonce;
         for (id, tx) in self.all().descendant_txs_inclusive(&on_chain) {
             if next_expected_nonce != id.nonce {
-                break;
+                break
             }
             next_expected_nonce = id.next_nonce();
             last_consecutive_tx = Some(tx);
@@ -748,7 +748,7 @@ impl<T: TransactionOrdering> TxPool<T> {
         on_chain_code_hash: Option<B256>,
     ) -> PoolResult<AddedTransaction<T::Transaction>> {
         if self.contains(tx.hash()) {
-            return Err(PoolError::new(*tx.hash(), PoolErrorKind::AlreadyImported));
+            return Err(PoolError::new(*tx.hash(), PoolErrorKind::AlreadyImported))
         }
 
         self.validate_auth(&tx, on_chain_nonce, on_chain_code_hash)?;
@@ -865,7 +865,7 @@ impl<T: TransactionOrdering> TxPool<T> {
         if (on_chain_code_hash.is_none() || on_chain_code_hash == Some(KECCAK_EMPTY)) &&
             !self.all_transactions.auths.contains_key(&transaction.sender_id())
         {
-            return Ok(());
+            return Ok(())
         }
 
         let mut txs_by_sender =
@@ -883,23 +883,23 @@ impl<T: TransactionOrdering> TxPool<T> {
                     PoolErrorKind::InvalidTransaction(InvalidPoolTransactionError::Eip7702(
                         Eip7702PoolTransactionError::OutOfOrderTxFromDelegated,
                     )),
-                ));
+                ))
             }
-            return Ok(());
+            return Ok(())
         }
 
         let mut count = 0;
         for id in txs_by_sender {
             if id == &transaction.transaction_id {
                 // Transaction replacement is supported
-                return Ok(());
+                return Ok(())
             }
             count += 1;
         }
 
         if count < self.config.max_inflight_delegated_slot_limit {
             // account still has an available slot
-            return Ok(());
+            return Ok(())
         }
 
         Err(PoolError::new(
@@ -937,7 +937,7 @@ impl<T: TransactionOrdering> TxPool<T> {
                         PoolErrorKind::InvalidTransaction(InvalidPoolTransactionError::Eip7702(
                             Eip7702PoolTransactionError::AuthorityReserved,
                         )),
-                    ));
+                    ))
                 }
             }
         }
@@ -1042,6 +1042,10 @@ impl<T: TransactionOrdering> TxPool<T> {
     }
 
     /// Prunes and returns all matching transactions from the pool.
+    ///
+    /// This uses [`Self::prune_transaction_by_hash`] which does **not** park descendant
+    /// transactions, so they remain in their current sub-pool and can be included in subsequent
+    /// blocks.
     pub(crate) fn prune_transactions(
         &mut self,
         hashes: Vec<TxHash>,
@@ -1150,7 +1154,7 @@ impl<T: TransactionOrdering> TxPool<T> {
                 }
                 id = descendant;
             } else {
-                return;
+                return
             }
         }
     }
@@ -1423,7 +1427,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
                 entry.remove();
                 self.sender_info.remove(&sender);
                 self.metrics.all_transactions_by_all_senders.decrement(1.0);
-                return;
+                return
             }
             *count -= 1;
             self.metrics.all_transactions_by_all_senders.decrement(1.0);
@@ -1498,7 +1502,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
                 ($iter:ident) => {
                     'this: while let Some((peek, _)) = iter.peek() {
                         if peek.sender != id.sender {
-                            break 'this;
+                            break 'this
                         }
                         iter.next();
                     }
@@ -1515,7 +1519,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
                         current: tx.subpool,
                         destination: Destination::Discard,
                     });
-                    continue 'transactions;
+                    continue 'transactions
                 }
 
                 let ancestor = TransactionId::ancestor(id.nonce, info.state_nonce, id.sender);
@@ -1540,7 +1544,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
             // If there's a nonce gap, we can shortcircuit, because there's nothing to update yet.
             if tx.state.has_nonce_gap() {
                 next_sender!(iter);
-                continue 'transactions;
+                continue 'transactions
             }
 
             // Since this is the first transaction of the sender, it has no parked ancestors
@@ -1563,7 +1567,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
             while let Some((peek, tx)) = iter.peek_mut() {
                 if peek.sender != id.sender {
                     // Found the next sender we need to check
-                    continue 'transactions;
+                    continue 'transactions
                 }
 
                 if tx.transaction.nonce() == next_nonce_in_line {
@@ -1572,7 +1576,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
                 } else {
                     // can short circuit if there's still a nonce gap
                     next_sender!(iter);
-                    continue 'transactions;
+                    continue 'transactions
                 }
 
                 // update for next iteration of this sender's loop
@@ -1827,7 +1831,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
             if current_txs >= self.max_account_slots && transaction.nonce() > on_chain_nonce {
                 return Err(InsertErr::ExceededSenderTransactionsCapacity {
                     transaction: Arc::new(transaction),
-                });
+                })
             }
         }
         if transaction.gas_limit() > self.block_gas_limit {
@@ -1835,12 +1839,12 @@ impl<T: PoolTransaction> AllTransactions<T> {
                 block_gas_limit: self.block_gas_limit,
                 tx_gas_limit: transaction.gas_limit(),
                 transaction: Arc::new(transaction),
-            });
+            })
         }
 
         if self.contains_conflicting_transaction(&transaction) {
             // blob vs non blob transactions are mutually exclusive for the same sender
-            return Err(InsertErr::TxTypeConflict { transaction: Arc::new(transaction) });
+            return Err(InsertErr::TxTypeConflict { transaction: Arc::new(transaction) })
         }
 
         Ok(transaction)
@@ -1861,13 +1865,13 @@ impl<T: PoolTransaction> AllTransactions<T> {
             let Some(ancestor_tx) = self.txs.get(&ancestor) else {
                 // ancestor tx is missing, so we can't insert the new blob
                 self.metrics.blob_transactions_nonce_gaps.increment(1);
-                return Err(InsertErr::BlobTxHasNonceGap { transaction: Arc::new(new_blob_tx) });
+                return Err(InsertErr::BlobTxHasNonceGap { transaction: Arc::new(new_blob_tx) })
             };
             if ancestor_tx.state.has_nonce_gap() {
                 // the ancestor transaction already has a nonce gap, so we can't insert the new
                 // blob
                 self.metrics.blob_transactions_nonce_gaps.increment(1);
-                return Err(InsertErr::BlobTxHasNonceGap { transaction: Arc::new(new_blob_tx) });
+                return Err(InsertErr::BlobTxHasNonceGap { transaction: Arc::new(new_blob_tx) })
             }
 
             // the max cost executing this transaction requires
@@ -1876,7 +1880,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
             // check if the new blob would go into overdraft
             if cumulative_cost > on_chain_balance {
                 // the transaction would go into overdraft
-                return Err(InsertErr::Overdraft { transaction: Arc::new(new_blob_tx) });
+                return Err(InsertErr::Overdraft { transaction: Arc::new(new_blob_tx) })
             }
 
             // ensure that a replacement would not shift already propagated blob transactions into
@@ -1894,13 +1898,13 @@ impl<T: PoolTransaction> AllTransactions<T> {
                     cumulative_cost += tx.transaction.cost();
                     if tx.transaction.is_eip4844() && cumulative_cost > on_chain_balance {
                         // the transaction would shift
-                        return Err(InsertErr::Overdraft { transaction: Arc::new(new_blob_tx) });
+                        return Err(InsertErr::Overdraft { transaction: Arc::new(new_blob_tx) })
                     }
                 }
             }
         } else if new_blob_tx.cost() > &on_chain_balance {
             // the transaction would go into overdraft
-            return Err(InsertErr::Overdraft { transaction: Arc::new(new_blob_tx) });
+            return Err(InsertErr::Overdraft { transaction: Arc::new(new_blob_tx) })
         }
 
         Ok(new_blob_tx)
@@ -1991,7 +1995,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
         let fee_cap = transaction.max_fee_per_gas();
 
         if fee_cap < self.minimal_protocol_basefee as u128 {
-            return Err(InsertErr::FeeCapBelowMinimumProtocolFeeCap { transaction, fee_cap });
+            return Err(InsertErr::FeeCapBelowMinimumProtocolFeeCap { transaction, fee_cap })
         }
         if fee_cap >= self.pending_fees.base_fee as u128 {
             state.insert(TxState::ENOUGH_FEE_CAP_BLOCK);
@@ -2024,7 +2028,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
                     return Err(InsertErr::Underpriced {
                         transaction: pool_tx.transaction,
                         existing: *entry.get().transaction.hash(),
-                    });
+                    })
                 }
                 let new_hash = *pool_tx.transaction.hash();
                 let new_transaction = pool_tx.transaction.clone();
@@ -2064,7 +2068,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
 
                 // If there's a nonce gap, we can shortcircuit
                 if next_nonce != id.nonce {
-                    break;
+                    break
                 }
 
                 // close the nonce gap

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -860,8 +860,8 @@ impl<T: TransactionOrdering> TxPool<T> {
         on_chain_code_hash: Option<B256>,
     ) -> Result<(), PoolError> {
         // Short circuit if the sender has neither delegation nor pending delegation.
-        if (on_chain_code_hash.is_none() || on_chain_code_hash == Some(KECCAK_EMPTY))
-            && !self.all_transactions.auths.contains_key(&transaction.sender_id())
+        if (on_chain_code_hash.is_none() || on_chain_code_hash == Some(KECCAK_EMPTY)) &&
+            !self.all_transactions.auths.contains_key(&transaction.sender_id())
         {
             return Ok(());
         }
@@ -961,8 +961,8 @@ impl<T: TransactionOrdering> TxPool<T> {
                 Destination::Pool(move_to) => {
                     debug_assert_ne!(&move_to, &current, "destination must be different");
                     let moved = self.move_transaction(current, move_to, &id);
-                    if matches!(move_to, SubPool::Pending)
-                        && let Some(tx) = moved
+                    if matches!(move_to, SubPool::Pending) &&
+                        let Some(tx) = moved
                     {
                         trace!(target: "txpool", hash=%tx.transaction.hash(), "Promoted transaction to pending");
                         outcome.promoted.push(tx);
@@ -1881,8 +1881,8 @@ impl<T: PoolTransaction> AllTransactions<T> {
             // overdraft
             let id = new_blob_tx.transaction_id;
             let mut descendants = self.descendant_txs_inclusive(&id).peekable();
-            if let Some((maybe_replacement, _)) = descendants.peek()
-                && **maybe_replacement == new_blob_tx.transaction_id
+            if let Some((maybe_replacement, _)) = descendants.peek() &&
+                **maybe_replacement == new_blob_tx.transaction_id
             {
                 // replacement transaction
                 descendants.next();

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -496,6 +496,26 @@ pub trait TransactionPool: Clone + Debug + Send + Sync {
         sender: Address,
     ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
 
+    /// Prunes a single transaction corresponding to the given hash.
+    ///
+    /// Returns the pruned transaction if it was found in the pool.
+    ///
+    /// Consumer: Utility
+    fn prune_transaction(
+        &self,
+        hash: TxHash,
+    ) -> Option<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.prune_transactions(vec![hash]).pop()
+    }
+
+    /// Prunes and returns transactions corresponding to the given hashes.
+    ///
+    /// Consumer: Utility
+    fn prune_transactions(
+        &self,
+        hashes: Vec<TxHash>,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
+
     /// Retains only those hashes that are unknown to the pool.
     /// In other words, removes all transactions from the given set that are currently present in
     /// the pool. Returns hashes already known to the pool.
@@ -1719,7 +1739,7 @@ impl<Tx: PoolTransaction> NewSubpoolTransactionStream<Tx> {
             match self.st.try_recv() {
                 Ok(event) => {
                     if event.subpool == self.subpool {
-                        return Ok(event)
+                        return Ok(event);
                     }
                 }
                 Err(e) => return Err(e),
@@ -1736,7 +1756,7 @@ impl<Tx: PoolTransaction> Stream for NewSubpoolTransactionStream<Tx> {
             match ready!(self.st.poll_recv(cx)) {
                 Some(event) => {
                     if event.subpool == self.subpool {
-                        return Poll::Ready(Some(event))
+                        return Poll::Ready(Some(event));
                     }
                 }
                 None => return Poll::Ready(None),


### PR DESCRIPTION
For Flashblocks built beyond the first one, we need to reset the best transactions iterator over the TxPool on a per flashblock basis to reset the priority boundaries. However, since the TxPool has no idea of which transactions have already been committed in past flashblocks, the new iterator has all the same transactions again.

While we can trivially skip transactions that have already been committed, it does mess up the ordering of best transactions since descendant txns of previously committed txns can have different priority fees and should have been yielded earlier in the new flashblock building process but weren't because we were waiting on it's ancestor to first be yielded and skipped before it even moves the descendant to the independent set.

This PR adds a public `prune_transactions` method to the trait that will allow consumers of the Reth SDK to manually prune a transaction from the transaction pool even if a canonical state update has not been received, allowing us to cleanly mark previously committed txns as pruned and bump their descendants in the middle of the Flashblocks building process.