### PR TITLE
perf(pruner): do not create an iterator_cf for every address

### DIFF
--- a/crates/prune/prune/src/segments/user/account_history.rs
+++ b/crates/prune/prune/src/segments/user/account_history.rs
@@ -238,8 +238,6 @@ impl AccountHistory {
     where
         Provider: DBProvider + StaticFileProviderFactory + ChangeSetReader + RocksDBProviderFactory,
     {
-        use reth_provider::PruneShardOutcome;
-
         // Unlike MDBX path, we don't divide the limit by 2 because RocksDB path only prunes
         // history shards (no separate changeset table to delete from). The changesets are in
         // static files which are deleted separately.
@@ -287,14 +285,15 @@ impl AccountHistory {
         sorted_accounts.sort_unstable_by_key(|(addr, _)| *addr);
 
         provider.with_rocksdb_batch(|mut batch| {
-            for (address, highest_block) in &sorted_accounts {
-                let prune_to = (*highest_block).min(last_changeset_pruned_block);
-                match batch.prune_account_history_to(*address, prune_to)? {
-                    PruneShardOutcome::Deleted => deleted_shards += 1,
-                    PruneShardOutcome::Updated => updated_shards += 1,
-                    PruneShardOutcome::Unchanged => {}
-                }
-            }
+            let targets: Vec<_> = sorted_accounts
+                .iter()
+                .map(|(addr, highest)| (*addr, (*highest).min(last_changeset_pruned_block)))
+                .collect();
+
+            let outcomes = batch.prune_account_history_batch(&targets)?;
+            deleted_shards = outcomes.deleted;
+            updated_shards = outcomes.updated;
+
             Ok(((), Some(batch.into_inner())))
         })?;
         trace!(target: "pruner", deleted = deleted_shards, updated = updated_shards, %done, "Pruned account history (RocksDB indices)");

--- a/crates/storage/provider/src/lib.rs
+++ b/crates/storage/provider/src/lib.rs
@@ -21,7 +21,7 @@ pub mod providers;
 pub use providers::{
     DatabaseProvider, DatabaseProviderRO, DatabaseProviderRW, HistoricalStateProvider,
     HistoricalStateProviderRef, LatestStateProvider, LatestStateProviderRef, ProviderFactory,
-    PruneShardOutcome, SaveBlocksMode, StaticFileAccess, StaticFileProviderBuilder,
+    PruneShardOutcome, PrunedIndices, SaveBlocksMode, StaticFileAccess, StaticFileProviderBuilder,
     StaticFileWriteCtx, StaticFileWriter,
 };
 

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -39,8 +39,8 @@ pub use consistent::ConsistentProvider;
 pub(crate) mod rocksdb;
 
 pub use rocksdb::{
-    PruneShardOutcome, RocksDBBatch, RocksDBBuilder, RocksDBIter, RocksDBProvider, RocksDBRawIter,
-    RocksDBStats, RocksDBTableStats, RocksTx,
+    PruneShardOutcome, PrunedIndices, RocksDBBatch, RocksDBBuilder, RocksDBIter, RocksDBProvider,
+    RocksDBRawIter, RocksDBStats, RocksDBTableStats, RocksTx,
 };
 
 /// Helper trait to bound [`NodeTypes`] so that combined with database they satisfy

--- a/crates/storage/provider/src/providers/rocksdb/mod.rs
+++ b/crates/storage/provider/src/providers/rocksdb/mod.rs
@@ -6,6 +6,6 @@ mod provider;
 
 pub(crate) use provider::{PendingRocksDBBatches, RocksDBWriteCtx};
 pub use provider::{
-    PruneShardOutcome, RocksDBBatch, RocksDBBuilder, RocksDBIter, RocksDBProvider, RocksDBRawIter,
-    RocksDBStats, RocksDBTableStats, RocksTx,
+    PruneShardOutcome, PrunedIndices, RocksDBBatch, RocksDBBuilder, RocksDBIter, RocksDBProvider,
+    RocksDBRawIter, RocksDBStats, RocksDBTableStats, RocksTx,
 };

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -1781,11 +1781,10 @@ impl<'a> RocksDBBatch<'a> {
             return Ok(PrunedIndices::default());
         }
 
-        if !targets.windows(2).all(|w| w[0].0 <= w[1].0) {
-            return Err(ProviderError::other(std::io::Error::other(
-                "prune_account_history_batch: targets must be sorted by address",
-            )));
-        }
+        debug_assert!(
+            targets.windows(2).all(|w| w[0].0 <= w[1].0),
+            "prune_account_history_batch: targets must be sorted by address"
+        );
 
         // ShardedKey<Address> layout: [address: 20][block: 8] = 28 bytes
         // The first 20 bytes are the "prefix" that identifies the address
@@ -1909,11 +1908,10 @@ impl<'a> RocksDBBatch<'a> {
             return Ok(PrunedIndices::default());
         }
 
-        if !targets.windows(2).all(|w| w[0].0 <= w[1].0) {
-            return Err(ProviderError::other(std::io::Error::other(
-                "prune_storage_history_batch: targets must be sorted by (address, storage_key)",
-            )));
-        }
+        debug_assert!(
+            targets.windows(2).all(|w| w[0].0 <= w[1].0),
+            "prune_storage_history_batch: targets must be sorted by (address, storage_key)"
+        );
 
         // StorageShardedKey layout: [address: 20][storage_key: 32][block: 8] = 60 bytes
         // The first 52 bytes are the "prefix" that identifies (address, storage_key)

--- a/crates/storage/provider/src/providers/rocksdb_stub.rs
+++ b/crates/storage/provider/src/providers/rocksdb_stub.rs
@@ -219,3 +219,14 @@ pub enum PruneShardOutcome {
     /// Shard was unchanged (no blocks <= `to_block`).
     Unchanged,
 }
+
+/// Tracks pruning outcomes for batch operations (stub).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct PrunedIndices {
+    /// Number of shards completely deleted.
+    pub deleted: usize,
+    /// Number of shards that were updated (filtered but still have entries).
+    pub updated: usize,
+    /// Number of shards that were unchanged.
+    pub unchanged: usize,
+}


### PR DESCRIPTION
right now we create an iterator_cf for every single address, this causes us to seek the entire rocksdb for each address (more or less), now this creates one iterator / cursor for the entire pruning operation and seek as needed