### PR TITLE
perf(trie): process new updates from state/prewarm update directly

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -357,7 +357,10 @@ where
 
                     self.on_multiproof_message(update);
                     self.process_new_updates()?;
-                    self.dispatch_pending_targets();
+
+                    if self.updates.is_empty() || self.pending_targets.chunking_length() >= self.chunk_size.unwrap_or_default() {
+                        self.dispatch_pending_targets();
+                    }
                 }
                 recv(self.proof_result_rx) -> message => {
                     let Ok(result) = message else {

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -529,6 +529,8 @@ where
         skip_all
     )]
     fn process_new_updates(&mut self) -> SparseTrieResult<()> {
+        self.pending_updates = 0;
+
         // Firstly apply all new storage and account updates to the tries.
         self.process_leaf_updates(true)?;
 

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -587,8 +587,7 @@ where
             if new { &mut self.new_storage_updates } else { &mut self.storage_updates };
 
         // Process all storage updates in parallel, skipping tries with no pending updates.
-        let storage_results = self
-            .storage_updates
+        let storage_results = storage_updates
             .iter_mut()
             .filter(|(_, updates)| !updates.is_empty())
             .map(|(address, updates)| {

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -206,7 +206,7 @@ where
 }
 
 /// Maximum number of pending/prewarm updates that we accumulate in memory before actually applying.
-const MAX_PENDING_UPDATES: usize = 10;
+const MAX_PENDING_UPDATES: usize = 100;
 
 /// Sparse trie task implementation that uses in-memory sparse trie data to schedule proof fetching.
 pub(super) struct SparseTrieCacheTask<A = SerialSparseTrie, S = SerialSparseTrie> {

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -304,7 +304,7 @@ where
             account_rlp_buf: Vec::with_capacity(TRIE_ACCOUNT_RLP_MAX_SIZE),
             finished_state_updates: Default::default(),
             pending_targets: Default::default(),
-            pending_updates: 0,
+            pending_updates: Default::default(),
             metrics,
         }
     }

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -360,6 +360,7 @@ where
 
                     let mut num_drained = 0;
 
+                    self.on_multiproof_message(update);
                     while let Ok(next) = self.updates.try_recv() {
                         self.on_multiproof_message(next);
                         num_drained += 1;

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -356,11 +356,6 @@ where
                     };
 
                     self.on_multiproof_message(update);
-
-                    while let Ok(update) = self.updates.try_recv() {
-                        self.on_multiproof_message(update);
-                    }
-
                     self.process_new_updates()?;
                     self.dispatch_pending_targets();
                 }

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -477,6 +477,9 @@ where
                     .entry(address)
                     .or_default()
                     .insert(slot, LeafUpdate::Changed(encoded));
+
+                // Remove an existing storage update if it exists.
+                self.storage_updates.get_mut(&address).and_then(|updates| updates.remove(&slot));
             }
 
             // Make sure account is tracked in `account_updates` so that it is revealed in accounts
@@ -636,9 +639,7 @@ where
             }
         })?;
 
-        let applied_updates = account_updates.len() < updates_len_before;
-
-        Ok(applied_updates)
+        Ok(account_updates.len() < updates_len_before)
     }
 
     /// Iterates through all storage tries for which all updates were processed, computes their

--- a/crates/trie/sparse/src/traits.rs
+++ b/crates/trie/sparse/src/traits.rs
@@ -24,6 +24,18 @@ pub enum LeafUpdate {
     Touched,
 }
 
+impl LeafUpdate {
+    /// Returns true if the leaf update is a change.
+    pub const fn is_changed(&self) -> bool {
+        matches!(self, Self::Changed(_))
+    }
+
+    /// Returns true if the leaf update is a touched update.
+    pub const fn is_touched(&self) -> bool {
+        matches!(self, Self::Touched)
+    }
+}
+
 /// Trait defining common operations for revealed sparse trie implementations.
 ///
 /// This trait abstracts over different sparse trie implementations (serial vs parallel)


### PR DESCRIPTION
One problem of sparse trie task we have right now is that it's basically never idle because of `update_leaves` calls taking long time. One of the reasons for this is that every time we end up iterating over the same leaves again even if the only difference since last time are several state updates.

This PR addresses this by buffering _new_ state updates into separate sets of updates that are applied to the trie separately and merged into regular updates after.

That way, we can process any new updates ~immediately and leave "follow-up" updates for later when we've drained the channels

```
Metric        | Baseline         | Feature          | Change    | Threshold
--------------+------------------+------------------+-----------+-----------
Mean Latency  |          29.42ms |          28.55ms |  -2.95% ✅ |    ±2.91%
Std Dev       |           13.8ms |          13.22ms |           |
P50 Latency   |          26.39ms |          25.54ms |  -3.19% ≈ |    ±4.06%
P90 Latency   |          47.58ms |          45.73ms |  -3.89%   |
P99 Latency   |          75.56ms |          67.31ms | -10.92%   |
--------------+------------------+------------------+-----------+-----------
Gas/sec       |    1033.3 Mgas/s |   1064.75 Mgas/s |  +3.04% ✅ |    ±2.91%
```

While this does improve perf ideally we should be able to fix the root cause (slow `update_leaves`) which I'm looking into right now