### PR TITLE
chore(cli): expose static file metrics in cli

### DIFF
--- a/crates/cli/commands/src/common.rs
+++ b/crates/cli/commands/src/common.rs
@@ -123,12 +123,14 @@ impl<C: ChainSpecParser> EnvironmentArgs<C> {
             AccessRights::RW => (
                 init_db(db_path, self.db.database_args())?,
                 StaticFileProviderBuilder::read_write(sf_path)
+                    .with_metrics()
                     .with_genesis_block_number(genesis_block_number)
                     .build()?,
             ),
             AccessRights::RO | AccessRights::RoInconsistent => {
                 (open_db_read_only(&db_path, self.db.database_args())?, {
                     let provider = StaticFileProviderBuilder::read_only(sf_path)
+                        .with_metrics()
                         .with_genesis_block_number(genesis_block_number)
                         .build()?;
                     provider.watch_directory();


### PR DESCRIPTION
These were not being exposed with `reth prune`