### PR TITLE
fix(test): clean up test temp directories on drop

### DIFF
--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -1370,7 +1370,7 @@ mod tests {
             .expect(ERROR_ETH_ADDRESS);
 
         {
-            let env = create_test_db_with_path(DatabaseEnvKind::RW, &path);
+            let env = create_test_db_with_path(DatabaseEnvKind::RW, path);
 
             // PUT
             let result = env.update(|tx| {
@@ -1381,7 +1381,7 @@ mod tests {
         }
 
         let env = DatabaseEnv::open(
-            &path,
+            path,
             DatabaseEnvKind::RO,
             DatabaseArguments::new(ClientVersion::default()),
         )

--- a/crates/storage/provider/src/test_utils/mod.rs
+++ b/crates/storage/provider/src/test_utils/mod.rs
@@ -4,12 +4,7 @@ use crate::{
 };
 use alloy_primitives::B256;
 use reth_chainspec::{ChainSpec, MAINNET};
-use reth_db::{
-    test_utils::{
-        create_test_rocksdb_dir, create_test_rw_db, create_test_static_files_dir, TempDatabase,
-    },
-    DatabaseEnv,
-};
+use reth_db::{test_utils::TempDatabase, DatabaseEnv};
 use reth_errors::ProviderResult;
 use reth_ethereum_engine_primitives::EthEngineTypes;
 use reth_node_types::NodeTypesWithDBAdapter;
@@ -55,14 +50,23 @@ pub fn create_test_provider_factory_with_chain_spec(
 pub fn create_test_provider_factory_with_node_types<N: NodeTypesForProvider>(
     chain_spec: Arc<N::ChainSpec>,
 ) -> ProviderFactory<NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>> {
-    let (static_dir, _) = create_test_static_files_dir();
-    let (rocksdb_dir, _) = create_test_rocksdb_dir();
-    let db = create_test_rw_db();
-    let rocksdb_path = rocksdb_dir.keep();
+    // Create a single temp directory that contains all data dirs (db, static_files, rocksdb).
+    // TempDatabase will clean up the entire directory on drop.
+    let datadir_path = reth_db::test_utils::tempdir_path();
+
+    let static_files_path = datadir_path.join("static_files");
+    let rocksdb_path = datadir_path.join("rocksdb");
+
+    // Create static_files directory
+    std::fs::create_dir_all(&static_files_path).expect("failed to create static_files dir");
+
+    // Create database with the datadir path so TempDatabase cleans up everything on drop
+    let db = reth_db::test_utils::create_test_rw_db_with_datadir(&datadir_path);
+
     ProviderFactory::new(
         db,
         chain_spec,
-        StaticFileProvider::read_write(static_dir.keep()).expect("static file provider"),
+        StaticFileProvider::read_write(static_files_path).expect("static file provider"),
         RocksDBBuilder::new(&rocksdb_path)
             .with_default_tables()
             .build()


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/21769 cc @DaniPopes 

The test helper `create_test_provider_factory_with_node_types` was creating three separate temp directories and calling `.keep()` on each, which tells tempfile not to delete them. This meant running tests a few times would leave hundreds of directories in /tmp.

Changed it to use a single parent directory containing db/, static_files/, and rocksdb/ subdirs. Now TempDatabase cleans up the whole thing when it's dropped.

Also fixed a test that was accidentally dropping the factory too early - it was doing `factory.with_prune_modes(...).provider_rw()` which consumes the factory, so TempDatabase got dropped while the provider was still in use.

Oh and thanks to Claude, help to located the key point quickly.
