### PR TITLE
fix(test): break circular reference in persist_block_after_db_tx_creation

### DIFF
--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -995,17 +995,31 @@ mod tests {
         )
     }
 
+    /// Guard that clears the post-transaction hook when dropped.
+    ///
+    /// This prevents circular references between the hook closure and the provider.
+    struct PostTxHookGuard(Arc<reth_db::test_utils::TempDatabase<reth_db::DatabaseEnv>>);
+
+    impl Drop for PostTxHookGuard {
+        fn drop(&mut self) {
+            self.0.set_post_transaction_hook(Box::new(|| ()));
+        }
+    }
+
     /// This will persist the last block in-memory and delete it from
     /// `canonical_in_memory_state` right after a database read transaction is created.
     ///
     /// This simulates a RPC method having a different view than when its database transaction was
     /// created.
+    ///
+    /// Returns a guard that clears the hook when dropped to prevent circular references.
     fn persist_block_after_db_tx_creation(
         provider: BlockchainProvider<MockNodeTypesWithDB>,
         block_number: BlockNumber,
-    ) {
+    ) -> PostTxHookGuard {
         let hook_provider = provider.clone();
-        provider.database.db_ref().set_post_transaction_hook(Box::new(move || {
+        let db = Arc::clone(provider.database.db_ref());
+        db.set_post_transaction_hook(Box::new(move || {
             if let Some(state) = hook_provider.canonical_in_memory_state.head_state() &&
                 state.anchor().number + 1 == block_number
             {
@@ -1025,6 +1039,7 @@ mod tests {
                 hook_provider.canonical_in_memory_state.remove_persisted_blocks(num_hash);
             }
         }));
+        PostTxHookGuard(db)
     }
 
     #[test]
@@ -2059,7 +2074,7 @@ mod tests {
                 // Test range that spans database and in-memory
                 {
                     // This block will be persisted to disk and removed from memory AFTER the first database query. This ensures that we query the in-memory state before the database avoiding any race condition.
-                    persist_block_after_db_tx_creation(provider.clone(), in_memory_blocks[0].number);
+                    let _hook_guard = persist_block_after_db_tx_creation(provider.clone(), in_memory_blocks[0].number);
 
                     assert_eq!(
                         provider.$method(in_mem_range.start() - 2..=in_mem_range.end() - 1)?,
@@ -2151,7 +2166,7 @@ mod tests {
                 {
 
                     // This block will be persisted to disk and removed from memory AFTER the first database query. This ensures that we query the in-memory state before the database avoiding any race condition.
-                    persist_block_after_db_tx_creation(provider.clone(), in_memory_blocks[0].number);
+                    let _hook_guard = persist_block_after_db_tx_creation(provider.clone(), in_memory_blocks[0].number);
 
                     assert_eq!(
                         provider.$method(in_mem_range.start() - 2..=in_mem_range.end() - 1)?,
@@ -2268,7 +2283,7 @@ mod tests {
             // Ensure that the first generated in-memory block exists
             {
                 // This block will be persisted to disk and removed from memory AFTER the first database query. This ensures that we query the in-memory state before the database avoiding any race condition.
-                persist_block_after_db_tx_creation(provider.clone(), in_memory_blocks[0].number);
+                let _hook_guard = persist_block_after_db_tx_creation(provider.clone(), in_memory_blocks[0].number);
 
                 call_method!($arg_count, provider, $method, $item_extractor, tx_num, tx_hash, &in_memory_blocks[0], &receipts);
 
@@ -2580,7 +2595,8 @@ mod tests {
         {
             // This will persist block 1 AFTER a database is created. Moving it from memory to
             // storage.
-            persist_block_after_db_tx_creation(provider.clone(), in_memory_blocks[0].number);
+            let _hook_guard =
+                persist_block_after_db_tx_creation(provider.clone(), in_memory_blocks[0].number);
             let to_be_persisted_tx = in_memory_blocks[0].body().transactions[0].clone();
 
             // Even though the block exists, given the order of provider queries done in the method
@@ -2599,7 +2615,8 @@ mod tests {
         {
             // This will persist block 1 AFTER a database is created. Moving it from memory to
             // storage.
-            persist_block_after_db_tx_creation(provider.clone(), in_memory_blocks[1].number);
+            let _hook_guard =
+                persist_block_after_db_tx_creation(provider.clone(), in_memory_blocks[1].number);
             let to_be_persisted_tx = in_memory_blocks[1].body().transactions[0].clone();
 
             assert_eq!(


### PR DESCRIPTION
`persist_block_after_db_tx_creation` had a circular reference: the hook closure captures a cloned provider holding `Arc<TempDatabase>`, while the hook is stored in that same `TempDatabase`. This prevents temp directories from being cleaned up.
                                                                                                                                                                                                                                                                                       
Added `PostTxHookGuard` that clears the hook on drop, breaking the cycle.