### PR TITLE
fix(pruner): implement pruning for rocksdb TransactionHashNumbers

### DIFF
--- a/crates/prune/prune/src/segments/user/transaction_lookup.rs
+++ b/crates/prune/prune/src/segments/user/transaction_lookup.rs
@@ -6,11 +6,15 @@ use crate::{
 use alloy_eips::eip2718::Encodable2718;
 use rayon::prelude::*;
 use reth_db_api::{tables, transaction::DbTxMut};
-use reth_provider::{BlockReader, DBProvider, PruneCheckpointReader, StaticFileProviderFactory};
+use reth_provider::{
+    BlockReader, DBProvider, PruneCheckpointReader, RocksDBProviderFactory,
+    StaticFileProviderFactory,
+};
 use reth_prune_types::{
     PruneCheckpoint, PruneMode, PruneProgress, PrunePurpose, PruneSegment, SegmentOutputCheckpoint,
 };
 use reth_static_file_types::StaticFileSegment;
+use reth_storage_api::StorageSettingsCache;
 use tracing::{debug, instrument, trace};
 
 #[derive(Debug)]
@@ -29,7 +33,9 @@ where
     Provider: DBProvider<Tx: DbTxMut>
         + BlockReader<Transaction: Encodable2718>
         + PruneCheckpointReader
-        + StaticFileProviderFactory,
+        + StaticFileProviderFactory
+        + StorageSettingsCache
+        + RocksDBProviderFactory,
 {
     fn segment(&self) -> PruneSegment {
         PruneSegment::TransactionLookup
@@ -82,6 +88,12 @@ where
             }
         }
         .into_inner();
+
+        // Check where transaction hash numbers are stored
+        #[cfg(all(unix, feature = "rocksdb"))]
+        if provider.cached_storage_settings().transaction_hash_numbers_in_rocksdb {
+            return self.prune_rocksdb(provider, input, start, end);
+        }
 
         // For PruneMode::Full, clear the entire table in one operation
         if self.mode.is_full() {
@@ -166,6 +178,106 @@ where
         Ok(SegmentOutput {
             progress,
             pruned,
+            checkpoint: Some(SegmentOutputCheckpoint {
+                block_number: last_pruned_block,
+                tx_number: Some(last_pruned_transaction),
+            }),
+        })
+    }
+}
+
+impl TransactionLookup {
+    /// Prunes transaction lookup when indices are stored in `RocksDB`.
+    ///
+    /// Reads transactions from static files and deletes corresponding entries
+    /// from the `RocksDB` `TransactionHashNumbers` table.
+    #[cfg(all(unix, feature = "rocksdb"))]
+    fn prune_rocksdb<Provider>(
+        &self,
+        provider: &Provider,
+        input: PruneInput,
+        start: alloy_primitives::TxNumber,
+        end: alloy_primitives::TxNumber,
+    ) -> Result<SegmentOutput, PrunerError>
+    where
+        Provider: DBProvider
+            + BlockReader<Transaction: Encodable2718>
+            + StaticFileProviderFactory
+            + RocksDBProviderFactory,
+    {
+        // For PruneMode::Full, clear the entire RocksDB table in one operation
+        if self.mode.is_full() {
+            let rocksdb = provider.rocksdb_provider();
+            rocksdb.clear::<tables::TransactionHashNumbers>()?;
+            trace!(target: "pruner", "Cleared transaction lookup table (RocksDB)");
+
+            let last_pruned_block = provider
+                .block_by_transaction_id(end)?
+                .ok_or(PrunerError::InconsistentData("Block for transaction is not found"))?;
+
+            return Ok(SegmentOutput {
+                progress: PruneProgress::Finished,
+                pruned: 0, // RocksDB clear doesn't return count
+                checkpoint: Some(SegmentOutputCheckpoint {
+                    block_number: Some(last_pruned_block),
+                    tx_number: Some(end),
+                }),
+            });
+        }
+
+        let tx_range_end = input
+            .limiter
+            .deleted_entries_limit_left()
+            .map(|left| start.saturating_add(left as u64).saturating_sub(1))
+            .map_or(end, |limited| limited.min(end));
+        let tx_range = start..=tx_range_end;
+
+        // Retrieve transactions in the range and calculate their hashes in parallel
+        let hashes: Vec<_> = provider
+            .transactions_by_tx_range(tx_range.clone())?
+            .into_par_iter()
+            .map(|transaction| transaction.trie_hash())
+            .collect();
+
+        // Number of transactions retrieved from the database should match the tx range count
+        let tx_count = tx_range.count();
+        if hashes.len() != tx_count {
+            return Err(PrunerError::InconsistentData(
+                "Unexpected number of transaction hashes retrieved by transaction number range",
+            ))
+        }
+
+        let mut limiter = input.limiter;
+
+        // Delete transaction hash -> number mappings from RocksDB
+        let mut deleted = 0usize;
+        provider.with_rocksdb_batch(|mut batch| {
+            for hash in &hashes {
+                if limiter.is_limit_reached() {
+                    break;
+                }
+                batch.delete::<tables::TransactionHashNumbers>(*hash)?;
+                limiter.increment_deleted_entries_count();
+                deleted += 1;
+            }
+            Ok(((), Some(batch.into_inner())))
+        })?;
+
+        let done = deleted == hashes.len() && tx_range_end == end;
+        trace!(target: "pruner", %deleted, %done, "Pruned transaction lookup (RocksDB)");
+
+        let last_pruned_transaction = if deleted > 0 { start + deleted as u64 - 1 } else { start };
+
+        let last_pruned_block = provider
+            .block_by_transaction_id(last_pruned_transaction)?
+            .ok_or(PrunerError::InconsistentData("Block for transaction is not found"))?
+            .checked_sub(if done { 0 } else { 1 });
+
+        let progress = limiter.progress(done);
+
+        Ok(SegmentOutput {
+            progress,
+            pruned: deleted,
             checkpoint: Some(SegmentOutputCheckpoint {
                 block_number: last_pruned_block,
                 tx_number: Some(last_pruned_transaction),
@@ -318,5 +430,101 @@ mod tests {
         );
         test_prune(6, (PruneProgress::Finished, 2));
         test_prune(10, (PruneProgress::Finished, 8));
+    }
+
+    #[cfg(all(unix, feature = "rocksdb"))]
+    #[test]
+    fn prune_rocksdb() {
+        use reth_db_api::models::StorageSettings;
+        use reth_provider::RocksDBProviderFactory;
+        use reth_storage_api::StorageSettingsCache;
+
+        let db = TestStageDB::default();
+        let mut rng = generators::rng();
+
+        let blocks = random_block_range(
+            &mut rng,
+            1..=10,
+            BlockRangeParams { parent: Some(B256::ZERO), tx_count: 2..3, ..Default::default() },
+        );
+        db.insert_blocks(blocks.iter(), StorageKind::Static).expect("insert blocks");
+
+        // Collect transaction hashes and their tx numbers
+        let mut tx_hash_numbers = Vec::new();
+        for block in &blocks {
+            tx_hash_numbers.reserve_exact(block.transaction_count());
+            for transaction in &block.body().transactions {
+                tx_hash_numbers.push((*transaction.tx_hash(), tx_hash_numbers.len() as u64));
+            }
+        }
+        let tx_hash_numbers_len = tx_hash_numbers.len();
+
+        // Insert into RocksDB instead of MDBX
+        {
+            let rocksdb = db.factory.rocksdb_provider();
+            let mut batch = rocksdb.batch();
+            for (hash, tx_num) in &tx_hash_numbers {
+                batch.put::<tables::TransactionHashNumbers>(*hash, tx_num).unwrap();
+            }
+            batch.commit().expect("commit rocksdb batch");
+        }
+
+        // Verify RocksDB has all entries
+        {
+            let rocksdb = db.factory.rocksdb_provider();
+            for (hash, expected_tx_num) in &tx_hash_numbers {
+                let actual = rocksdb.get::<tables::TransactionHashNumbers>(*hash).unwrap();
+                assert_eq!(actual, Some(*expected_tx_num));
+            }
+        }
+
+        let to_block: BlockNumber = 6;
+        let prune_mode = PruneMode::Before(to_block);
+        let input =
+            PruneInput { previous_checkpoint: None, to_block, limiter: PruneLimiter::default() };
+        let segment = TransactionLookup::new(prune_mode);
+
+        // Enable RocksDB storage for transaction hash numbers
+        db.factory.set_storage_settings_cache(
+            StorageSettings::legacy().with_transaction_hash_numbers_in_rocksdb(true),
+        );
+
+        let provider = db.factory.database_provider_rw().unwrap();
+        let result = segment.prune(&provider, input).unwrap();
+        provider.commit().expect("commit");
+
+        assert_matches!(
+            result,
+            SegmentOutput { progress: PruneProgress::Finished, pruned, checkpoint: Some(_) }
+                if pruned > 0
+        );
+
+        // Calculate expected: blocks 1-6 should have their tx hashes pruned
+        let txs_up_to_block_6: usize = blocks.iter().take(6).map(|b| b.transaction_count()).sum();
+
+        // Verify RocksDB entries: first `txs_up_to_block_6` should be gone
+        {
+            let rocksdb = db.factory.rocksdb_provider();
+            for (i, (hash, _)) in tx_hash_numbers.iter().enumerate() {
+                let entry = rocksdb.get::<tables::TransactionHashNumbers>(*hash).unwrap();
+                if i < txs_up_to_block_6 {
+                    assert!(entry.is_none(), "Entry {} (hash {:?}) should be pruned", i, hash);
+                } else {
+                    assert!(entry.is_some(), "Entry {} (hash {:?}) should still exist", i, hash);
+                }
+            }
+        }
+
+        // Verify remaining count
+        {
+            let rocksdb = db.factory.rocksdb_provider();
+            let remaining: Vec<_> =
+                rocksdb.iter::<tables::TransactionHashNumbers>().unwrap().collect();
+            assert_eq!(
+                remaining.len(),
+                tx_hash_numbers_len - txs_up_to_block_6,
+                "Remaining RocksDB entries should match expected"
+            );
+        }
     }
 }


### PR DESCRIPTION
We did not actually implement pruning for `TxLookup` / `TransactionHashNumbers`, so it wasn't being pruned