### PR TITLE
perf(rocksdb): use single iterator for batch history unwind

### DIFF
--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -944,9 +944,14 @@ impl RocksDBProvider {
         Ok(())
     }
 
-    /// Flushes and compacts all tables to reclaim disk space.
+    /// Flushes and compacts all tables in `RocksDB`.
     ///
-    /// Use after large delete operations like pruning.
+    /// This:
+    /// 1. Flushes all column family memtables to SST files
+    /// 2. Flushes the Write-Ahead Log (WAL) with sync
+    /// 3. Triggers manual compaction on all column families to reclaim disk space
+    ///
+    /// Use this after large delete operations (like pruning) to reclaim disk space.
     ///
     /// # Panics
     /// Panics if the provider is in read-only mode.

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -1741,6 +1741,13 @@ impl<'a> RocksDBBatch<'a> {
                 iter.next();
             }
 
+            iter.status().map_err(|e| {
+                ProviderError::Database(DatabaseError::Read(DatabaseErrorInfo {
+                    message: e.to_string().into(),
+                    code: -1,
+                }))
+            })?;
+
             if shards.is_empty() {
                 continue;
             }
@@ -1883,6 +1890,13 @@ impl<'a> RocksDBBatch<'a> {
                 shards.push((key, value));
                 iter.next();
             }
+
+            iter.status().map_err(|e| {
+                ProviderError::Database(DatabaseError::Read(DatabaseErrorInfo {
+                    message: e.to_string().into(),
+                    code: -1,
+                }))
+            })?;
 
             if shards.is_empty() {
                 continue;


### PR DESCRIPTION
## Summary

Applies the same optimization from #21767 to the `unwind_*` methods.

Previously, `unwind_account_history_indices` and `unwind_storage_history_indices` created a new `iterator_cf` for every address/storage key by calling `account_history_shards`/`storage_history_shards` in a loop.

The batch methods reuse a single raw iterator and skip seeks when the iterator is already positioned correctly (for sorted targets in key order). This reduces RocksDB seek overhead for large unwind operations.
