### PR TITLE
fix(trie): Guard against infinite loop in proof_v2

### DIFF
--- a/crates/evm/execution-errors/src/trie.rs
+++ b/crates/evm/execution-errors/src/trie.rs
@@ -57,6 +57,12 @@ pub enum StateProofError {
     /// RLP decoding error.
     #[error(transparent)]
     Rlp(#[from] alloy_rlp::Error),
+    /// Trie inconsistency detected during proof calculation.
+    ///
+    /// This occurs when cached trie nodes disagree with the leaf data, causing
+    /// proof calculation to be unable to make forward progress.
+    #[error("trie inconsistency: {0}")]
+    TrieInconsistency(alloc::string::String),
 }
 
 impl From<StateProofError> for ProviderError {
@@ -64,6 +70,7 @@ impl From<StateProofError> for ProviderError {
         match value {
             StateProofError::Database(error) => Self::Database(error),
             StateProofError::Rlp(error) => Self::Rlp(error),
+            StateProofError::TrieInconsistency(msg) => Self::Database(DatabaseError::Other(msg)),
         }
     }
 }

--- a/crates/trie/parallel/src/root.rs
+++ b/crates/trie/parallel/src/root.rs
@@ -264,6 +264,9 @@ impl From<StateProofError> for ParallelStateRootError {
         match error {
             StateProofError::Database(err) => Self::Provider(ProviderError::Database(err)),
             StateProofError::Rlp(err) => Self::Provider(ProviderError::Rlp(err)),
+            StateProofError::TrieInconsistency(msg) => {
+                Self::Provider(ProviderError::TrieWitnessError(msg))
+            }
         }
     }
 }


### PR DESCRIPTION
When cached branch nodes in the db are in an inconsistent state we want to error out rather than infinite looping or silently completing the proof.