### PR TITLE
ci: set `RUSTFLAGS` in Dockerfile instead of bake

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -100,7 +100,5 @@ jobs:
           targets: ${{ steps.params.outputs.targets }}
           push: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
           set: |
-            ethereum-amd64.tags=${{ steps.params.outputs.ethereum_tags }}
-            ethereum-arm64.tags=${{ steps.params.outputs.ethereum_tags }}
-            optimism-amd64.tags=${{ steps.params.outputs.optimism_tags }}
-            optimism-arm64.tags=${{ steps.params.outputs.optimism_tags }}
+            ethereum.tags=${{ steps.params.outputs.ethereum_tags }}
+            optimism.tags=${{ steps.params.outputs.optimism_tags }}

--- a/Dockerfile.depot
+++ b/Dockerfile.depot
@@ -29,9 +29,8 @@ ARG MANIFEST_PATH=bin/reth
 ARG BUILD_PROFILE=release
 ENV BUILD_PROFILE=$BUILD_PROFILE
 
-# Extra Cargo flags
+# Extra Cargo flags (can be overridden, otherwise set per-platform below)
 ARG RUSTFLAGS=""
-ENV RUSTFLAGS="$RUSTFLAGS"
 
 # Extra Cargo features
 ARG FEATURES=""
@@ -46,11 +45,18 @@ ENV VERGEN_GIT_DESCRIBE=$VERGEN_GIT_DESCRIBE
 ENV VERGEN_GIT_DIRTY=$VERGEN_GIT_DIRTY
 
 # Build application
+# Platform-specific RUSTFLAGS: amd64 uses x86-64-v3 (Haswell+) with pclmulqdq for rocksdb
+ARG TARGETPLATFORM
 COPY --exclude=.git . .
 RUN --mount=type=secret,id=DEPOT_TOKEN,env=SCCACHE_WEBDAV_TOKEN \
     --mount=type=cache,target=/usr/local/cargo/registry,sharing=shared \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=shared \
     --mount=type=cache,target=$SCCACHE_DIR,sharing=shared \
+    if [ -n "$RUSTFLAGS" ]; then \
+        export RUSTFLAGS="$RUSTFLAGS"; \
+    elif [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
+        export RUSTFLAGS="-C target-cpu=x86-64-v3 -C target-feature=+pclmulqdq"; \
+    fi && \
     cargo build --profile $BUILD_PROFILE --features "$FEATURES" --locked --bin $BINARY --manifest-path $MANIFEST_PATH/Cargo.toml
 
 RUN sccache --show-stats || true

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -32,22 +32,31 @@ variable "VERGEN_GIT_DIRTY" {
 // Common settings for all targets
 group "default" {
   targets = [
-    "ethereum-amd64",
-    "ethereum-arm64",
-    "optimism-amd64",
-    "optimism-arm64"
+    "ethereum",
+    "optimism"
+  ]
+}
+
+group "ethereum" {
+  targets = [
+    "ethereum"
+  ]
+}
+
+group "optimism" {
+  targets = [
+    "optimism"
   ]
 }
 
 group "nightly" {
   targets = [
-    "ethereum-amd64",
-    "ethereum-arm64",
+    "ethereum",
     "ethereum-profiling",
     "ethereum-edge-profiling",
-    "optimism-amd64",
-    "optimism-arm64",
-    "optimism-profiling"
+    "optimism",
+    "optimism-profiling",
+    "optimism-edge-profiling"
   ]
 }
 
@@ -90,20 +99,13 @@ target "_base_arm64" {
 
 target "_base_profiling" {
   inherits  = ["_base_amd64"]
+  platforms = ["linux/amd64"]
 }
 
-// Ethereum (reth)
-target "ethereum-amd64" {
-  inherits = ["_base_amd64"]
-  args = {
-    BINARY        = "reth"
-    MANIFEST_PATH = "bin/reth"
-  }
-  tags = ["${REGISTRY}/reth:${TAG}"]
-}
-
-target "ethereum-arm64" {
-  inherits = ["_base_arm64"]
+// Ethereum (reth) - multi-platform
+target "ethereum" {
+  inherits  = ["_base"]
+  platforms = ["linux/amd64", "linux/arm64"]
   args = {
     BINARY        = "reth"
     MANIFEST_PATH = "bin/reth"
@@ -112,7 +114,8 @@ target "ethereum-arm64" {
 }
 
 target "ethereum-profiling" {
-  inherits = ["_base_profiling"]
+  inherits  = ["_base_profiling"]
+  platforms = ["linux/amd64"]
   args = {
     BINARY        = "reth"
     MANIFEST_PATH = "bin/reth"
@@ -123,7 +126,8 @@ target "ethereum-profiling" {
 }
 
 target "ethereum-edge-profiling" {
-  inherits = ["_base_profiling"]
+  inherits  = ["_base_profiling"]
+  platforms = ["linux/amd64"]
   args = {
     BINARY        = "reth"
     MANIFEST_PATH = "bin/reth"
@@ -133,18 +137,10 @@ target "ethereum-edge-profiling" {
   tags = ["${REGISTRY}/reth:nightly-edge-profiling"]
 }
 
-// Optimism (op-reth)
-target "optimism-amd64" {
-  inherits = ["_base_amd64"]
-  args = {
-    BINARY        = "op-reth"
-    MANIFEST_PATH = "crates/optimism/bin"
-  }
-  tags = ["${REGISTRY}/op-reth:${TAG}"]
-}
-
-target "optimism-arm64" {
-  inherits = ["_base_arm64"]
+// Optimism (op-reth) - multi-platform
+target "optimism" {
+  inherits  = ["_base"]
+  platforms = ["linux/amd64", "linux/arm64"]
   args = {
     BINARY        = "op-reth"
     MANIFEST_PATH = "crates/optimism/bin"
@@ -153,7 +149,8 @@ target "optimism-arm64" {
 }
 
 target "optimism-profiling" {
-  inherits = ["_base_profiling"]
+  inherits  = ["_base_profiling"]
+  platforms = ["linux/amd64"]
   args = {
     BINARY        = "op-reth"
     MANIFEST_PATH = "crates/optimism/bin"
@@ -164,7 +161,8 @@ target "optimism-profiling" {
 }
 
 target "optimism-edge-profiling" {
-  inherits = ["_base_profiling"]
+  inherits  = ["_base_profiling"]
+  platforms = ["linux/amd64"]
   args = {
     BINARY        = "op-reth"
     MANIFEST_PATH = "crates/optimism/bin"


### PR DESCRIPTION
Setting it in `docker-bake.hcl` didn't work for some reason and only pushed `linux/arm64` target. To unblock nightly Docker builds, this PR moves the `linux/amd64` detection to Dockerfile, and applies necessary `RUSTFLAGS` there.

Now nightly image has both platforms: https://github.com/paradigmxyz/reth/pkgs/container/reth/670687305?tag=nightly

<img width="705" height="274" alt="image" src="https://github.com/user-attachments/assets/eabdea4a-d542-47f4-ba21-635e86a9db6b" />
