### PR TITLE
fix(prune): auto-enable transaction_lookup pruning for RocksDB storage

### DIFF
--- a/crates/node/core/src/args/pruning.rs
+++ b/crates/node/core/src/args/pruning.rs
@@ -66,10 +66,17 @@ impl DefaultPruningValues {
 
 impl Default for DefaultPruningValues {
     fn default() -> Self {
+        // In edge mode, transaction hash numbers are stored in RocksDB and should be pruned
+        // by default when running with --full, similar to account/storage history.
+        #[cfg(feature = "edge")]
+        let transaction_lookup = Some(PruneMode::Full);
+        #[cfg(not(feature = "edge"))]
+        let transaction_lookup = None;
+
         Self {
             full_prune_modes: PruneModes {
                 sender_recovery: Some(PruneMode::Full),
-                transaction_lookup: None,
+                transaction_lookup,
                 receipts: Some(PruneMode::Distance(MINIMUM_UNWIND_SAFE_DISTANCE)),
                 account_history: Some(PruneMode::Distance(MINIMUM_UNWIND_SAFE_DISTANCE)),
                 storage_history: Some(PruneMode::Distance(MINIMUM_UNWIND_SAFE_DISTANCE)),


### PR DESCRIPTION
## Summary

Enable `transaction_lookup` pruning by default when running with `--full` flag in edge mode, similar to how `account_history` and `storage_history` are already enabled by default.

## Problem

In edge mode, transaction hash numbers are stored in RocksDB. However, running `reth node --full` or `reth prune` would not prune the TransactionHashNumbers table because `transaction_lookup` was not included in the default `full_prune_modes`.

This is inconsistent with `account_history` and `storage_history`, which ARE enabled by default in `--full` mode.

## Solution

When the `edge` feature is enabled, include `transaction_lookup: Some(PruneMode::Full)` in the default `full_prune_modes`. This matches the behavior of other RocksDB-stored data like account and storage history.

```rust
#[cfg(feature = "edge")]
let transaction_lookup = Some(PruneMode::Full);
#[cfg(not(feature = "edge"))]
let transaction_lookup = None;
```

## Testing

- Verified build with `cargo check -p reth-node-core --features edge`
- Verified build without edge feature
- Both compile successfully