### PR TITLE
fix: add engine_forkchoiceUpdatedV4 to capabilities list

### DIFF
--- a/crates/rpc/rpc-engine-api/src/capabilities.rs
+++ b/crates/rpc/rpc-engine-api/src/capabilities.rs
@@ -17,6 +17,7 @@ pub const CAPABILITIES: &[&str] = &[
     "engine_forkchoiceUpdatedV1",
     "engine_forkchoiceUpdatedV2",
     "engine_forkchoiceUpdatedV3",
+    "engine_forkchoiceUpdatedV4",
     "engine_getClientVersionV1",
     "engine_getPayloadV1",
     "engine_getPayloadV2",


### PR DESCRIPTION
## Summary

- `engine_forkchoiceUpdatedV4` handler was implemented in #21567 but was never added to the `CAPABILITIES` constant in `capabilities.rs`
- This causes `engine_exchangeCapabilities` to omit `forkchoiceUpdatedV4` from the response
- Lighthouse checks this capability list and refuses to call V4 when missing, causing all Lighthouse-proposed blocks to fail after the Gloas fork with: `engine_forkchoiceUpdatedV4 is required for Gloas/Amsterdam fork`
- Lodestar is unaffected because it falls back to V3 gracefully

## Test plan

- [x] Verified reth responds to `engine_forkchoiceUpdatedV4` calls (method exists, just not advertised)
- [ ] Build local image and verify `engine_exchangeCapabilities` includes V4
- [ ] Run Kurtosis enclave with lighthouse+reth and confirm no missed blocks after Gloas fork

🤖 Generated with [Claude Code](https://claude.com/claude-code)