### PR TITLE
fix(prune): handle RocksDB TransactionHashNumbers pruning when MDBX has no data

### DIFF
--- a/crates/prune/prune/src/segments/user/transaction_lookup.rs
+++ b/crates/prune/prune/src/segments/user/transaction_lookup.rs
@@ -205,6 +205,10 @@ impl TransactionLookup {
     /// This is called when MDBX has no `BlockBodyIndices` for `to_block` (e.g., data only
     /// exists in static files) but `RocksDB` still contains transaction hash mappings that
     /// need to be cleared. The checkpoint is derived from static files.
+    ///
+    /// Note: There's a similar MDBX `clear_table` call in the main `prune()` function (line ~115),
+    /// but that path is unreachable when using `RocksDB` storage because `get_next_tx_num_range()`
+    /// returns `None` and we return early. This method handles that case for `RocksDB`.
     #[cfg(all(unix, feature = "rocksdb"))]
     fn prune_rocksdb_full<Provider>(
         &self,


### PR DESCRIPTION
## Summary

Fixes RocksDB `TransactionHashNumbers` entries never being pruned when MDBX has no transaction data.

## Problem

When `get_next_tx_num_range()` returns `None` (MDBX `BlockBodyIndices` empty/pruned), the function returns early **before** reaching the RocksDB pruning check.

## Solution

Move the RocksDB check inside the `None` branch. For `PruneMode::Full`, add `prune_rocksdb_full()` that clears the table using static files for checkpoint data.
