### PR TITLE
revert: undo last two changes to docker-bake.hcl

### DIFF
--- a/.github/scripts/verify_image_arch.sh
+++ b/.github/scripts/verify_image_arch.sh
@@ -47,7 +47,6 @@ if [[ "$TARGETS" == *"nightly"* ]]; then
     verify_image "${REGISTRY}/reth:nightly-profiling" amd64
     verify_image "${REGISTRY}/reth:nightly-edge-profiling" amd64
     verify_image "${REGISTRY}/op-reth:nightly-profiling" amd64
-    verify_image "${REGISTRY}/op-reth:nightly-edge-profiling" amd64
 else
     for tag in $(echo "$ETHEREUM_TAGS" | tr ',' ' '); do
         verify_image "$tag" amd64 arm64

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -31,44 +31,23 @@ variable "VERGEN_GIT_DIRTY" {
 
 // Common settings for all targets
 group "default" {
-  targets = [
-    "ethereum",
-    "optimism"
-  ]
-}
-
-group "ethereum" {
-  targets = [
-    "ethereum"
-  ]
-}
-
-group "optimism" {
-  targets = [
-    "optimism"
-  ]
+  targets = ["ethereum", "optimism"]
 }
 
 group "nightly" {
-  targets = [
-    "ethereum",
-    "ethereum-profiling",
-    "ethereum-edge-profiling",
-    "optimism",
-    "optimism-profiling",
-    "optimism-edge-profiling"
-  ]
+  targets = ["ethereum", "ethereum-profiling", "ethereum-edge-profiling", "optimism", "optimism-profiling"]
 }
 
 // Base target with shared configuration
 target "_base" {
   dockerfile = "Dockerfile.depot"
+  platforms  = ["linux/amd64", "linux/arm64"]
   args = {
-    BUILD_PROFILE       = "${BUILD_PROFILE}"
-    FEATURES            = "${FEATURES}"
-    VERGEN_GIT_SHA      = "${VERGEN_GIT_SHA}"
+    BUILD_PROFILE      = "${BUILD_PROFILE}"
+    FEATURES           = "${FEATURES}"
+    VERGEN_GIT_SHA     = "${VERGEN_GIT_SHA}"
     VERGEN_GIT_DESCRIBE = "${VERGEN_GIT_DESCRIBE}"
-    VERGEN_GIT_DIRTY    = "${VERGEN_GIT_DIRTY}"
+    VERGEN_GIT_DIRTY   = "${VERGEN_GIT_DIRTY}"
   }
   secret = [
     {
@@ -77,35 +56,14 @@ target "_base" {
     }
   ]
 }
-
-// amd64 base with x86-64-v3 optimizations
-target "_base_amd64" {
-  inherits  = ["_base"]
-  platforms = ["linux/amd64"]
-  args = {
-    # `x86-64-v3` features match the 2013 Intel Haswell architecture, excluding Intel-specific instructions;
-    # see: https://en.wikipedia.org/wiki/X86-64
-    #
-    # `pclmulqdq` is required for rocksdb: https://github.com/rust-rocksdb/rust-rocksdb/issues/1069
-    RUSTFLAGS = "-C target-cpu=x86-64-v3 -C target-feature=+pclmulqdq"
-  }
-}
-
-// arm64 base
-target "_base_arm64" {
-  inherits  = ["_base"]
-  platforms = ["linux/arm64"]
-}
-
 target "_base_profiling" {
-  inherits  = ["_base_amd64"]
-  platforms = ["linux/amd64"]
+  inherits = ["_base"]
+  platforms  = ["linux/amd64"]
 }
 
-// Ethereum (reth) - multi-platform
+// Ethereum (reth)
 target "ethereum" {
-  inherits  = ["_base"]
-  platforms = ["linux/amd64", "linux/arm64"]
+  inherits = ["_base"]
   args = {
     BINARY        = "reth"
     MANIFEST_PATH = "bin/reth"
@@ -114,8 +72,7 @@ target "ethereum" {
 }
 
 target "ethereum-profiling" {
-  inherits  = ["_base_profiling"]
-  platforms = ["linux/amd64"]
+  inherits = ["_base_profiling"]
   args = {
     BINARY        = "reth"
     MANIFEST_PATH = "bin/reth"
@@ -126,8 +83,7 @@ target "ethereum-profiling" {
 }
 
 target "ethereum-edge-profiling" {
-  inherits  = ["_base_profiling"]
-  platforms = ["linux/amd64"]
+  inherits = ["_base_profiling"]
   args = {
     BINARY        = "reth"
     MANIFEST_PATH = "bin/reth"
@@ -137,10 +93,9 @@ target "ethereum-edge-profiling" {
   tags = ["${REGISTRY}/reth:nightly-edge-profiling"]
 }
 
-// Optimism (op-reth) - multi-platform
+// Optimism (op-reth)
 target "optimism" {
-  inherits  = ["_base"]
-  platforms = ["linux/amd64", "linux/arm64"]
+  inherits = ["_base"]
   args = {
     BINARY        = "op-reth"
     MANIFEST_PATH = "crates/optimism/bin"
@@ -149,8 +104,7 @@ target "optimism" {
 }
 
 target "optimism-profiling" {
-  inherits  = ["_base_profiling"]
-  platforms = ["linux/amd64"]
+  inherits = ["_base_profiling"]
   args = {
     BINARY        = "op-reth"
     MANIFEST_PATH = "crates/optimism/bin"
@@ -161,8 +115,7 @@ target "optimism-profiling" {
 }
 
 target "optimism-edge-profiling" {
-  inherits  = ["_base_profiling"]
-  platforms = ["linux/amd64"]
+  inherits = ["_base_profiling"]
   args = {
     BINARY        = "op-reth"
     MANIFEST_PATH = "crates/optimism/bin"


### PR DESCRIPTION
Reverts changes from:
- 819d6b6 ci: set RUSTFLAGS in Dockerfile instead of bake (#21790)
- 648f19f perf: build for target-cpu=x86-64-v3 in docker by default (#21761)

This restores docker-bake.hcl to its state before these two commits.