### PR TITLE
perf(dns): avoid cloning entire HashSet in bootstrap method

### DIFF
--- a/crates/net/dns/src/lib.rs
+++ b/crates/net/dns/src/lib.rs
@@ -165,7 +165,7 @@ impl<R: Resolver> DnsDiscoveryService<R> {
 
     /// Starts discovery with all configured bootstrap links
     pub fn bootstrap(&mut self) {
-        for link in self.bootstrap_dns_networks.clone() {
+        for link in self.bootstrap_dns_networks.iter().cloned() {
             self.sync_tree_with_link(link);
         }
     }


### PR DESCRIPTION
Optimizes memory allocation in `DnsDiscoveryService::bootstrap` by replacing collection cloning with iterator-based element cloning.
