### PR TITLE
chore(deps): bump revm inspectors, handle case where revm-inspectors js-tracer is enabled but reth's js-tracer is not

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -480,7 +480,7 @@ revm-primitives = { version = "22.0.0", default-features = false }
 revm-interpreter = { version = "32.0.0", default-features = false }
 revm-database-interface = { version = "9.0.0", default-features = false }
 op-revm = { version = "15.0.0", default-features = false }
-revm-inspectors = "0.34.1"
+revm-inspectors = "0.34.2"
 
 # eth
 alloy-dyn-abi = "1.5.4"

--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -453,8 +453,8 @@ where
             DebugInspectorError::Database(err) => Self::Internal(RethError::other(err)),
             #[cfg(feature = "js-tracer")]
             DebugInspectorError::JsInspector(err) => err.into(),
-            #[cfg(not(feature = "js-tracer"))]
-            DebugInspectorError::JsInspector(_) => Self::Unsupported("JS Tracer is not enabled"),
+            #[allow(unreachable_patterns)]
+            _ => Self::Unsupported("unsupported tracer error"),
         }
     }
 }

--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -202,7 +202,7 @@ pub enum EthApiError {
     CallManyError {
         /// Bundle index where the error occurred
         bundle_index: usize,
-        /// Transaction index within the bundle where the error occurred  
+        /// Transaction index within the bundle where the error occurred
         tx_index: usize,
         /// The underlying error object
         error: jsonrpsee_types::ErrorObject<'static>,
@@ -453,6 +453,8 @@ where
             DebugInspectorError::Database(err) => Self::Internal(RethError::other(err)),
             #[cfg(feature = "js-tracer")]
             DebugInspectorError::JsInspector(err) => err.into(),
+            #[cfg(not(feature = "js-tracer"))]
+            DebugInspectorError::JsInspector(_) => Self::Unsupported("JS Tracer is not enabled"),
         }
     }
 }


### PR DESCRIPTION
Fixes a JS tracer compilation issue downstream in `tempo` + `tempo-foundry` due to feature unification

```
error[E0004]: non-exhaustive patterns: `DebugInspectorError::JsInspector(_)` not covered
   --> /home/zerosnacks/.cargo/git/checkouts/reth-e231042ee7db3fb7/c59a120/crates/rpc/rpc-eth-types/src/error/mod.rs:446:15
    |
446 |         match error {
    |               ^^^^^ pattern `DebugInspectorError::JsInspector(_)` not covered
    |
note: `DebugInspectorError<Err>` defined here
   --> /home/zerosnacks/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/revm-inspectors-0.34.2/src/tracing/debug.rs:335:1
    |
335 | pub enum DebugInspectorError<DBError = core::convert::Infallible> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
351 |     JsInspector(#[from] crate::tracing::js::JsInspectorError),
    |     ----------- not covered
    = note: the matched value is of type `DebugInspectorError<Err>`
help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
453 ~             DebugInspectorError::Database(err) => Self::Internal(RethError::other(err)),
454 ~             DebugInspectorError::JsInspector(_) => todo!(),
    |
```