### PR TITLE
perf(trie): Don't filter proofs in v2 if sparse trie as cache is enabled

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -563,7 +563,7 @@ where
                     from_multi_proof,
                     proof_worker_handle,
                     trie_metrics.clone(),
-                    sparse_state_trie,
+                    sparse_state_trie.with_skip_proof_node_filtering(true),
                     chunk_size,
                 ))
             };


### PR DESCRIPTION
The sparse trie will already ignore already-revealed nodes, so there's no need for an extra filtering step.

Closes RETH-326