### PR TITLE
fix(ef-tests): add Amsterdam fork and BAL header fields for devnet-2 testing

### DIFF
--- a/testing/ef-tests/src/models.rs
+++ b/testing/ef-tests/src/models.rs
@@ -85,6 +85,10 @@ pub struct Header {
     pub requests_hash: Option<B256>,
     /// Target blobs per block.
     pub target_blobs_per_block: Option<U256>,
+    /// Block access list hash (EIP-7928).
+    pub block_access_list_hash: Option<B256>,
+    /// Slot number (EIP-7928).
+    pub slot_number: Option<U256>,
 }
 
 impl From<Header> for SealedHeader {
@@ -111,8 +115,8 @@ impl From<Header> for SealedHeader {
             excess_blob_gas: value.excess_blob_gas.map(|v| v.to::<u64>()),
             parent_beacon_block_root: value.parent_beacon_block_root,
             requests_hash: value.requests_hash,
-            block_access_list_hash: None,
-            slot_number: None,
+            block_access_list_hash: value.block_access_list_hash,
+            slot_number: value.slot_number.map(|v| v.to::<u64>()),
         };
         Self::new(header, value.hash)
     }
@@ -321,6 +325,8 @@ pub enum ForkSpec {
     Prague,
     /// Osaka
     Osaka,
+    /// Amsterdam
+    Amsterdam,
 }
 
 impl From<ForkSpec> for ChainSpec {
@@ -376,6 +382,7 @@ impl From<ForkSpec> for ChainSpec {
                 .with_fork(EthereumHardfork::Prague, ForkCondition::Timestamp(15_000)),
             ForkSpec::Prague => spec_builder.prague_activated(),
             ForkSpec::Osaka => spec_builder.osaka_activated(),
+            ForkSpec::Amsterdam => spec_builder.amsterdam_activated(),
         }
         .build()
     }


### PR DESCRIPTION
## Summary

Adds support for BAL (Block Access Lists) testing in ef-tests for Ethereum devnet-2.

### Changes
- Added `Amsterdam` variant to `ForkSpec` enum with `amsterdam_activated()` chain spec
- Added BAL header fields to `Header` struct:
  - `block_access_list_hash: Option<B256>` (EIP-7928)
  - `slot_number: Option<U256>` (EIP-7928)
- Updated `From<Header> for SealedHeader` to use these fields

### Test Status (with bal@v5.1.0 fixtures)
- ✅ State tests (st_attack, st_chain_id, st_bugs) all pass
- ✅ 2/3 Constantinople blockchain tests pass
- ❌ 1 blockchain test fails: `test_create2_return_data.json` with receipt root mismatch

The failing test is a BAL execution issue (warm/cold access gas differences from BAL pre-warming), not a test setup issue - requires upstream BAL implementation fixes.

### Testing
```bash
# Download v5.1.0 BAL fixtures
wget https://github.com/ethereum/execution-spec-tests/releases/download/bal%40v5.1.0/fixtures_bal.tar.gz
tar -xzf fixtures_bal.tar.gz -C testing/ef-tests/execution-spec-tests/

# Run tests
cargo nextest run -p ef-tests --release --features ef-tests
```