### PR TITLE
feat(metrics): add execution and state root duration metrics grouped by gas limit

### DIFF
--- a/crates/engine/primitives/src/event.rs
+++ b/crates/engine/primitives/src/event.rs
@@ -9,6 +9,7 @@ use core::{
     fmt::{Display, Formatter, Result},
     time::Duration,
 };
+pub use reth_chain_state::BlockValidationTiming;
 use reth_chain_state::ExecutedBlock;
 use reth_ethereum_primitives::EthPrimitives;
 use reth_primitives_traits::{NodePrimitives, SealedBlock, SealedHeader};
@@ -26,8 +27,8 @@ pub enum ConsensusEngineEvent<N: NodePrimitives = EthPrimitives> {
     ForkBlockAdded(ExecutedBlock<N>, Duration),
     /// A new block was received from the consensus engine
     BlockReceived(BlockNumHash),
-    /// A block was added to the canonical chain, and the elapsed time validating the block
-    CanonicalBlockAdded(ExecutedBlock<N>, Duration),
+    /// A block was added to the canonical chain, with timing information for validation.
+    CanonicalBlockAdded(ExecutedBlock<N>, BlockValidationTiming),
     /// A canonical chain was committed, and the elapsed time committing the data
     CanonicalChainCommitted(Box<SealedHeader<N::BlockHeader>>, Duration),
     /// The consensus engine processed an invalid block.
@@ -57,11 +58,13 @@ where
             Self::ForkBlockAdded(block, duration) => {
                 write!(f, "ForkBlockAdded({:?}, {duration:?})", block.recovered_block.num_hash())
             }
-            Self::CanonicalBlockAdded(block, duration) => {
+            Self::CanonicalBlockAdded(block, timing) => {
                 write!(
                     f,
-                    "CanonicalBlockAdded({:?}, {duration:?})",
-                    block.recovered_block.num_hash()
+                    "CanonicalBlockAdded({:?}, exec={:?}, state_root={:?})",
+                    block.recovered_block.num_hash(),
+                    timing.execution_elapsed,
+                    timing.state_root_elapsed,
                 )
             }
             Self::CanonicalChainCommitted(block, duration) => {

--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -360,12 +360,12 @@ pub(crate) struct BalMetrics {
 /// Converts a gas limit to a bucket label for metrics.
 ///
 /// Buckets are designed to cover historical and current Ethereum mainnet gas limits:
-/// - "30M": gas_limit < 33M (covers the 30M era, 2021-2024)
-/// - "36M": 33M <= gas_limit < 40M (covers the 36M era, early 2025)
-/// - "45M": 40M <= gas_limit < 52M (covers the 45M era, mid 2025)
-/// - "60M": 52M <= gas_limit < 75M (covers the 60M era, late 2025+)
-/// - "90M+": gas_limit >= 75M (future growth)
-fn gas_limit_bucket(gas_limit: u64) -> &'static str {
+/// - "30M": `gas_limit` < 33M (covers the 30M era, 2021-2024)
+/// - "36M": 33M <= `gas_limit` < 40M (covers the 36M era, early 2025)
+/// - "45M": 40M <= `gas_limit` < 52M (covers the 45M era, mid 2025)
+/// - "60M": 52M <= `gas_limit` < 75M (covers the 60M era, late 2025+)
+/// - "90M+": `gas_limit` >= 75M (future growth)
+const fn gas_limit_bucket(gas_limit: u64) -> &'static str {
     match gas_limit {
         0..33_000_000 => "30M",
         33_000_000..40_000_000 => "36M",

--- a/crates/node/events/src/node.rs
+++ b/crates/node/events/src/node.rs
@@ -231,25 +231,28 @@ impl NodeState {
                 self.safe_block_hash = Some(safe_block_hash);
                 self.finalized_block_hash = Some(finalized_block_hash);
             }
-            ConsensusEngineEvent::CanonicalBlockAdded(executed, elapsed) => {
+            ConsensusEngineEvent::CanonicalBlockAdded(executed, timing) => {
                 let block = executed.sealed_block();
                 let mut full = block.gas_used() as f64 * 100.0 / block.gas_limit() as f64;
                 if full.is_nan() {
                     full = 0.0;
                 }
+                let execution_elapsed = timing.execution_elapsed;
+                let state_root_elapsed = timing.state_root_elapsed;
                 info!(
                     number=block.number(),
                     hash=?block.hash(),
                     peers=self.num_connected_peers(),
                     txs=block.body().transactions().len(),
                     gas_used=%format_gas(block.gas_used()),
-                    gas_throughput=%format_gas_throughput(block.gas_used(), elapsed),
+                    gas_throughput=%format_gas_throughput(block.gas_used(), execution_elapsed),
                     gas_limit=%format_gas(block.gas_limit()),
                     full=%format!("{:.1}%", full),
                     base_fee=%format!("{:.2}Gwei", block.base_fee_per_gas().unwrap_or(0) as f64 / GWEI_TO_WEI as f64),
                     blobs=block.blob_gas_used().unwrap_or(0) / alloy_eips::eip4844::DATA_GAS_PER_BLOB,
                     excess_blobs=block.excess_blob_gas().unwrap_or(0) / alloy_eips::eip4844::DATA_GAS_PER_BLOB,
-                    ?elapsed,
+                    ?execution_elapsed,
+                    ?state_root_elapsed,
                     "Block added to canonical chain"
                 );
             }

--- a/crates/optimism/examples/custom-node/src/engine.rs
+++ b/crates/optimism/examples/custom-node/src/engine.rs
@@ -71,6 +71,10 @@ impl ExecutionPayload for CustomExecutionData {
         self.inner.gas_used()
     }
 
+    fn gas_limit(&self) -> u64 {
+        self.inner.gas_limit()
+    }
+
     fn transaction_count(&self) -> usize {
         self.inner.payload.as_v1().transactions.len()
     }

--- a/crates/payload/primitives/src/payload.rs
+++ b/crates/payload/primitives/src/payload.rs
@@ -56,6 +56,9 @@ pub trait ExecutionPayload:
     /// Returns the total gas consumed by all transactions in this block.
     fn gas_used(&self) -> u64;
 
+    /// Returns the maximum gas allowed in this block.
+    fn gas_limit(&self) -> u64;
+
     /// Returns the number of transactions in the payload.
     fn transaction_count(&self) -> usize;
 }
@@ -91,6 +94,10 @@ impl ExecutionPayload for ExecutionData {
 
     fn gas_used(&self) -> u64 {
         self.payload.as_v1().gas_used
+    }
+
+    fn gas_limit(&self) -> u64 {
+        self.payload.as_v1().gas_limit
     }
 
     fn transaction_count(&self) -> usize {
@@ -202,6 +209,10 @@ impl ExecutionPayload for op_alloy_rpc_types_engine::OpExecutionData {
 
     fn gas_used(&self) -> u64 {
         self.payload.as_v1().gas_used
+    }
+
+    fn gas_limit(&self) -> u64 {
+        self.payload.as_v1().gas_limit
     }
 
     fn transaction_count(&self) -> usize {


### PR DESCRIPTION
## Summary

This PR adds new metrics that track block execution and state root calculation durations, grouped by gas limit buckets (30M, 36M, 45M, 60M, 90M+).

These metrics allow analyzing performance across different gas limit eras and understanding how execution time scales with block capacity.

## New Metrics

- `sync.execution.duration_by_gas_limit{gas_limit="X"}` - Execution duration histogram by gas limit bucket
- `sync.execution.gas_per_second_by_gas_limit{gas_limit="X"}` - Gas per second histogram by gas limit bucket  
- `sync.block_validation.state_root_duration_by_gas_limit{gas_limit="X"}` - State root duration histogram by gas limit bucket

## Gas Limit Buckets

| Bucket | Range | Era |
|--------|-------|-----|
| 30M | < 33M | 2021-2024 |
| 36M | 33M - 40M | Early 2025 |
| 45M | 40M - 52M | Mid 2025 |
| 60M | 52M - 75M | Late 2025+ |
| 90M+ | >= 75M | Future |

## Changes

- Added `ExecutionPayload::gas_limit()` trait method
- Added `ExecutionTimingMetrics` struct for gas-limit-grouped execution metrics
- Added `BlockValidationMetrics::record_state_root_by_gas_limit()` method
- Updated `execute_block` to return duration for gas-limit-grouped recording
- Updated `EngineApiMetrics` to include execution timing metrics

## Testing

Compiles successfully with `cargo check`