### PR TITLE
perf: use separate rayon pool for save_blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10250,7 +10250,6 @@ dependencies = [
  "reth-static-file-types",
  "reth-storage-api",
  "reth-storage-errors",
- "reth-tasks",
  "reth-testing-utils",
  "reth-tracing",
  "reth-trie",

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -31,7 +31,6 @@ reth-codecs.workspace = true
 reth-chain-state.workspace = true
 reth-node-types.workspace = true
 reth-static-file-types.workspace = true
-reth-tasks.workspace = true
 # ethereum
 alloy-eips.workspace = true
 alloy-primitives.workspace = true

--- a/crates/storage/provider/src/lib.rs
+++ b/crates/storage/provider/src/lib.rs
@@ -28,6 +28,9 @@ pub use providers::{
 pub mod changeset_walker;
 pub mod changesets_utils;
 
+mod storage_threadpool;
+use storage_threadpool::STORAGE_POOL;
+
 #[cfg(any(test, feature = "test-utils"))]
 /// Common test helpers for mocking the Provider.
 pub mod test_utils;

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -18,7 +18,7 @@ use crate::{
     PruneCheckpointReader, PruneCheckpointWriter, RawRocksDBBatch, RevertsInit, RocksBatchArg,
     RocksDBProviderFactory, StageCheckpointReader, StateProviderBox, StateWriter,
     StaticFileProviderFactory, StatsReader, StorageReader, StorageTrieWriter, TransactionVariant,
-    TransactionsProvider, TransactionsProviderExt, TrieWriter,
+    TransactionsProvider, TransactionsProviderExt, TrieWriter, STORAGE_POOL,
 };
 use alloy_consensus::{
     transaction::{SignerRecoverable, TransactionMeta, TxHashRef},
@@ -64,7 +64,6 @@ use reth_storage_api::{
     StorageSettingsCache, TryIntoHistoricalStateProvider, WriteStateInput,
 };
 use reth_storage_errors::provider::{ProviderResult, StaticFileWriterError};
-use reth_tasks::spawn_scoped_os_thread;
 use reth_trie::{
     updates::{StorageTrieUpdatesSorted, TrieUpdatesSorted},
     HashedPostStateSorted, StoredNibbles,
@@ -79,7 +78,6 @@ use std::{
     fmt::Debug,
     ops::{Deref, DerefMut, Range, RangeBounds, RangeInclusive},
     sync::Arc,
-    thread,
     time::Instant,
 };
 use tracing::{debug, instrument, trace};
@@ -550,24 +548,39 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
         let rocksdb_provider = self.rocksdb_provider.clone();
         #[cfg(all(unix, feature = "rocksdb"))]
         let rocksdb_ctx = self.rocksdb_write_ctx(first_number);
+        #[cfg(all(unix, feature = "rocksdb"))]
+        let rocksdb_enabled = rocksdb_ctx.storage_settings.any_in_rocksdb();
 
-        thread::scope(|s| {
+        // Results from spawned tasks (set before in_place_scope returns).
+        let mut sf_result = None;
+        #[cfg(all(unix, feature = "rocksdb"))]
+        let mut rocksdb_result = None;
+
+        // Spawn SF and RocksDB writes on the storage pool.
+        // MDBX writes happen on the calling thread (within this scope) because &self isn't Sync.
+        STORAGE_POOL.in_place_scope(|s| {
             // SF writes
-            let sf_handle = spawn_scoped_os_thread(s, "static-files", || {
+            s.spawn(|_| {
                 let start = Instant::now();
-                sf_provider.write_blocks_data(&blocks, &tx_nums, sf_ctx)?;
-                Ok::<_, ProviderError>(start.elapsed())
+                sf_result = Some(
+                    sf_provider
+                        .write_blocks_data(&blocks, &tx_nums, sf_ctx)
+                        .map(|()| start.elapsed()),
+                );
             });
 
             // RocksDB writes
             #[cfg(all(unix, feature = "rocksdb"))]
-            let rocksdb_handle = rocksdb_ctx.storage_settings.any_in_rocksdb().then(|| {
-                spawn_scoped_os_thread(s, "rocksdb", || {
+            if rocksdb_enabled {
+                s.spawn(|_| {
                     let start = Instant::now();
-                    rocksdb_provider.write_blocks_data(&blocks, &tx_nums, rocksdb_ctx)?;
-                    Ok::<_, ProviderError>(start.elapsed())
-                })
-            });
+                    rocksdb_result = Some(
+                        rocksdb_provider
+                            .write_blocks_data(&blocks, &tx_nums, rocksdb_ctx)
+                            .map(|()| start.elapsed()),
+                    );
+                });
+            }
 
             // MDBX writes
             let mdbx_start = Instant::now();
@@ -672,24 +685,27 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
 
             timings.mdbx = mdbx_start.elapsed();
 
-            // Wait for SF thread
-            timings.sf = sf_handle
-                .join()
-                .map_err(|_| StaticFileWriterError::ThreadPanic("static file"))??;
+            Ok::<_, ProviderError>(())
+        })?;
 
-            // Wait for RocksDB thread
-            #[cfg(all(unix, feature = "rocksdb"))]
-            if let Some(handle) = rocksdb_handle {
-                timings.rocksdb = handle.join().expect("RocksDB thread panicked")?;
-            }
+        // Collect results from spawned tasks
+        timings.sf = sf_result.ok_or(StaticFileWriterError::ThreadPanic("static file"))??;
 
-            timings.total = total_start.elapsed();
+        #[cfg(all(unix, feature = "rocksdb"))]
+        if rocksdb_enabled {
+            timings.rocksdb = rocksdb_result.ok_or_else(|| {
+                ProviderError::Database(reth_db_api::DatabaseError::Other(
+                    "RocksDB thread panicked".into(),
+                ))
+            })??;
+        }
 
-            self.metrics.record_save_blocks(&timings);
-            debug!(target: "providers::db", range = ?first_number..=last_block_number, "Appended block data");
+        timings.total = total_start.elapsed();
 
-            Ok(())
-        })
+        self.metrics.record_save_blocks(&timings);
+        debug!(target: "providers::db", range = ?first_number..=last_block_number, "Appended block data");
+
+        Ok(())
     }
 
     /// Writes MDBX-only data for a block (indices, lookups, and senders if configured for MDBX).

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -1,5 +1,8 @@
 use super::metrics::{RocksDBMetrics, RocksDBOperation, ROCKSDB_TABLES};
-use crate::providers::{compute_history_rank, needs_prev_shard_check, HistoryInfo};
+use crate::{
+    providers::{compute_history_rank, needs_prev_shard_check, HistoryInfo},
+    STORAGE_POOL,
+};
 use alloy_consensus::transaction::TxHashRef;
 use alloy_primitives::{
     map::{AddressMap, HashMap},
@@ -24,7 +27,6 @@ use reth_storage_errors::{
     db::{DatabaseErrorInfo, DatabaseWriteError, DatabaseWriteOperation, LogLevel},
     provider::{ProviderError, ProviderResult},
 };
-use reth_tasks::spawn_scoped_os_thread;
 use rocksdb::{
     BlockBasedOptions, Cache, ColumnFamilyDescriptor, CompactionPri, DBCompressionType,
     DBRawIteratorWithThreadMode, IteratorMode, OptimisticTransactionDB,
@@ -36,7 +38,6 @@ use std::{
     fmt,
     path::{Path, PathBuf},
     sync::Arc,
-    thread,
     time::Instant,
 };
 use tracing::instrument;
@@ -1189,41 +1190,58 @@ impl RocksDBProvider {
             return Ok(());
         }
 
-        thread::scope(|s| {
-            let handles: Vec<_> = [
-                (ctx.storage_settings.transaction_hash_numbers_in_rocksdb &&
-                    ctx.prune_tx_lookup.is_none_or(|m| !m.is_full()))
-                .then(|| {
-                    spawn_scoped_os_thread(s, "rocksdb-tx-hash", || {
-                        self.write_tx_hash_numbers(blocks, tx_nums, &ctx)
-                    })
-                }),
-                ctx.storage_settings.account_history_in_rocksdb.then(|| {
-                    spawn_scoped_os_thread(s, "rocksdb-account-history", || {
-                        self.write_account_history(blocks, &ctx)
-                    })
-                }),
-                ctx.storage_settings.storages_history_in_rocksdb.then(|| {
-                    spawn_scoped_os_thread(s, "rocksdb-storage-history", || {
-                        self.write_storage_history(blocks, &ctx)
-                    })
-                }),
-            ]
-            .into_iter()
-            .enumerate()
-            .filter_map(|(i, h)| h.map(|h| (i, h)))
-            .collect();
+        let mut r_tx_hash = None;
+        let mut r_account_history = None;
+        let mut r_storage_history = None;
 
-            for (i, handle) in handles {
-                handle.join().map_err(|_| {
-                    ProviderError::Database(DatabaseError::Other(format!(
-                        "rocksdb write thread {i} panicked"
-                    )))
-                })??;
+        let write_tx_hash = ctx.storage_settings.transaction_hash_numbers_in_rocksdb &&
+            ctx.prune_tx_lookup.is_none_or(|m| !m.is_full());
+        let write_account_history = ctx.storage_settings.account_history_in_rocksdb;
+        let write_storage_history = ctx.storage_settings.storages_history_in_rocksdb;
+
+        STORAGE_POOL.in_place_scope(|s| {
+            if write_tx_hash {
+                s.spawn(|_| {
+                    r_tx_hash = Some(self.write_tx_hash_numbers(blocks, tx_nums, &ctx));
+                });
             }
 
-            Ok(())
-        })
+            if write_account_history {
+                s.spawn(|_| {
+                    r_account_history = Some(self.write_account_history(blocks, &ctx));
+                });
+            }
+
+            if write_storage_history {
+                s.spawn(|_| {
+                    r_storage_history = Some(self.write_storage_history(blocks, &ctx));
+                });
+            }
+        });
+
+        if write_tx_hash {
+            r_tx_hash.ok_or_else(|| {
+                ProviderError::Database(DatabaseError::Other(
+                    "rocksdb tx-hash write thread panicked".into(),
+                ))
+            })??;
+        }
+        if write_account_history {
+            r_account_history.ok_or_else(|| {
+                ProviderError::Database(DatabaseError::Other(
+                    "rocksdb account-history write thread panicked".into(),
+                ))
+            })??;
+        }
+        if write_storage_history {
+            r_storage_history.ok_or_else(|| {
+                ProviderError::Database(DatabaseError::Other(
+                    "rocksdb storage-history write thread panicked".into(),
+                ))
+            })??;
+        }
+
+        Ok(())
     }
 
     /// Writes transaction hash to number mappings for the given blocks.

--- a/crates/storage/provider/src/storage_threadpool.rs
+++ b/crates/storage/provider/src/storage_threadpool.rs
@@ -1,0 +1,22 @@
+//! Dedicated thread pool for storage I/O operations.
+//!
+//! This module provides a static rayon thread pool used for parallel writes to static files,
+//! `RocksDB`, and other storage backends during block persistence.
+
+use rayon::{ThreadPool, ThreadPoolBuilder};
+use std::sync::LazyLock;
+
+/// Number of threads in the storage I/O thread pool.
+const STORAGE_POOL_THREADS: usize = 16;
+
+/// Static thread pool for storage I/O operations.
+///
+/// This pool is used by [`save_blocks`](crate::DatabaseProvider::save_blocks) and related
+/// methods to parallelize writes to different storage backends (static files, `RocksDB`).
+pub(crate) static STORAGE_POOL: LazyLock<ThreadPool> = LazyLock::new(|| {
+    ThreadPoolBuilder::new()
+        .num_threads(STORAGE_POOL_THREADS)
+        .thread_name(|idx| format!("save-blocks-{idx}"))
+        .build()
+        .expect("failed to create storage thread pool")
+});


### PR DESCRIPTION
## Description

Use a dedicated 16-thread rayon pool for `save_blocks` I/O operations instead of the global pool. This prevents storage I/O from competing with other parallel tasks (trie computation, transaction processing) for rayon threads.

The `STORAGE_POOL` is used for:
- Static file writes (headers, receipts, transactions, changesets)
- RocksDB writes (tx hash lookups, account/storage history)
- Parallel write coordination within `save_blocks`

---

Clean cherry-pick of the core change from #21764, excluding CI fix attempts.

Co-authored-by: DaniPopes <57450786+DaniPopes@users.noreply.github.com>