### PR TITLE
fix(storage): add skip(provider) to check_consistency instrument

### DIFF
--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -1314,7 +1314,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
     ///
     /// WARNING: No static file writer should be held before calling this function, otherwise it
     /// will deadlock.
-    #[instrument(skip(self), fields(read_only = self.is_read_only()))]
+    #[instrument(skip(self, provider), fields(read_only = self.is_read_only()))]
     pub fn check_consistency<Provider>(
         &self,
         provider: &Provider,


### PR DESCRIPTION
Follow-up to https://github.com/paradigmxyz/reth/commit/543c77a37408a64720adbf34c1e400380a158887

Adds `provider` to the `skip()` list in the `#[instrument]` attribute for `check_consistency` to avoid logging the provider type.