### PR TITLE
ci(docker): notify Slack on nightly build failure

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -112,3 +112,16 @@ jobs:
             "ghcr.io/${{ github.repository_owner }}" \
             "${{ steps.params.outputs.ethereum_tags }}" \
             "${{ steps.params.outputs.optimism_tags }}"
+
+  notify:
+    name: Notify on failure
+    runs-on: ubuntu-latest
+    needs: build
+    if: failure() && github.event_name == 'schedule'
+    steps:
+      - name: Slack Webhook Action
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_MESSAGE: "Failed run: https://github.com/paradigmxyz/reth/actions/runs/${{ github.run_id }}"
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Adds Slack notification when scheduled nightly Docker builds fail.

## Changes
- New `notify` job that runs only on schedule trigger failures
- Posts workflow name, run URL, trigger type, and last 30 lines of failure logs

## Requirements
- `SLACK_WEBHOOK_URL` secret (already configured)