### PR TITLE
fix: EIP-7778 gas accounting in receipts and block validation

### DIFF
--- a/crates/ethereum/evm/src/receipt.rs
+++ b/crates/ethereum/evm/src/receipt.rs
@@ -15,14 +15,16 @@ impl ReceiptBuilder for RethReceiptBuilder {
 
     fn build_receipt<E: Evm>(&self, ctx: ReceiptBuilderCtx<'_, TxType, E>) -> Self::Receipt {
         let ReceiptBuilderCtx { tx_type, result, cumulative_gas_used, gas_spent, .. } = ctx;
-        tracing::debug!("Building receipt with cumulative gas used: {:?}", cumulative_gas_used);
-        tracing::debug!("Gas spent in receipt builder: {:?}", gas_spent);
+        // EIP-7778: when active, `cumulative_gas_used` tracks gas before refunds (for block
+        // accounting), but receipts must use gas after refunds (unchanged). `gas_spent` holds the
+        // after-refund cumulative gas when EIP-7778 is active.
+        let receipt_gas = gas_spent.unwrap_or(cumulative_gas_used);
         Receipt {
             tx_type,
             // Success flag was added in `EIP-658: Embedding transaction status code in
             // receipts`.
             success: result.is_success(),
-            cumulative_gas_used,
+            cumulative_gas_used: receipt_gas,
             logs: result.into_logs(),
         }
     }

--- a/crates/stateless/src/validation.rs
+++ b/crates/stateless/src/validation.rs
@@ -237,7 +237,7 @@ where
         &output.receipts,
         &output.requests,
         None,
-        None,
+        Some(output.gas_used),
     )
     .map_err(StatelessValidationError::ConsensusValidationFailed)?;
 

--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -283,7 +283,7 @@ fn run_case(
             &output.receipts,
             &output.requests,
             None,
-            None,
+            Some(output.gas_used),
         )
         .map_err(|err| Error::block_failed(block_number, program_inputs.clone(), err))?;
 


### PR DESCRIPTION
## Summary

- **Receipt gas fix**: `RethReceiptBuilder` now uses `gas_spent` (after-refund cumulative gas) for `cumulative_gas_used` when EIP-7778 is active, matching the alloy-evm fix in alloy-rs/evm#279
- **Block validation fix**: `validate_block_post_execution` now accepts `execution_gas_used` from `BlockExecutionResult` and uses it for the header gas check when Amsterdam is active — post-EIP-7778, `header.gas_used` (before-refund) diverges from `receipt.cumulative_gas_used` (after-refund) by design

Without these fixes, reth rejects valid post-Amsterdam blocks due to gas_used mismatches at the fork boundary.

## Dependencies

- Requires alloy-rs/evm#279 for the matching `AlloyReceiptBuilder` fix

## Test plan

- [x] Tested locally with Kurtosis (geth+lighthouse supernode, reth+lodestar under test)
- [x] Pre-fork blocks sync correctly between geth and reth
- [ ] Verify post-fork blocks accepted by both clients
- [ ] Verify receipt roots match across clients

🤖 Generated with [Claude Code](https://claude.com/claude-code)