### PR TITLE
chore: use cargo nextest run in CLAUDE.md example

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -352,7 +352,7 @@ Let's say you want to fix a bug where external IP resolution fails on startup:
    ```bash
    cargo +nightly fmt --all
    cargo clippy --workspace --all-features # Make sure WHOLE WORKSPACE compiles!
-   cargo test -p reth-discv4
+   cargo nextest run -p reth-discv4
    ```
 
 6. **Commit with clear message**:


### PR DESCRIPTION
Updates the example workflow in CLAUDE.md to use `cargo nextest run` instead of `cargo test`, consistent with the recommended testing approach documented earlier in the file.