### PR TITLE
perf: use num_threads for prewarm concurrency

### DIFF
--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -44,8 +44,17 @@ pub const DEFAULT_MULTIPROOF_TASK_CHUNK_SIZE_V2: usize = DEFAULT_MULTIPROOF_TASK
 /// This will be deducted from the thread count of main reth global threadpool.
 pub const DEFAULT_RESERVED_CPU_CORES: usize = 1;
 
-/// Default maximum concurrency for prewarm task.
-pub const DEFAULT_PREWARM_MAX_CONCURRENCY: usize = 16;
+/// Returns the default maximum concurrency for prewarm task based on available parallelism.
+fn default_prewarm_max_concurrency() -> usize {
+    #[cfg(feature = "std")]
+    {
+        std::thread::available_parallelism().map_or(16, |n| n.get())
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        16
+    }
+}
 
 /// Default depth for sparse trie pruning.
 ///
@@ -192,7 +201,7 @@ impl Default for TreeConfig {
             precompile_cache_disabled: false,
             state_root_fallback: false,
             always_process_payload_attributes_on_canonical_head: false,
-            prewarm_max_concurrency: DEFAULT_PREWARM_MAX_CONCURRENCY,
+            prewarm_max_concurrency: default_prewarm_max_concurrency(),
             allow_unwind_canonical_header: false,
             storage_worker_count: default_storage_worker_count(),
             account_worker_count: default_account_worker_count(),


### PR DESCRIPTION
```markdown
Metric        | Baseline         | Feature          | Change    | Threshold
--------------+------------------+------------------+-----------+-----------
Mean Latency  |          39.52ms |           38.1ms |   -3.6% ✅ |    ±2.58%
Std Dev       |          16.62ms |          15.57ms |           |
P50 Latency   |          35.78ms |          34.67ms |  -3.09% ≈ |    ±3.57%
P90 Latency   |          61.41ms |          57.64ms |  -6.14%   |
P99 Latency   |           95.1ms |          90.95ms |  -4.37%   |
--------------+------------------+------------------+-----------+-----------
Gas/sec       |    770.95 Mgas/s |    799.76 Mgas/s |  +3.74% ✅ |    ±2.58%
```

```markdown
Metric        | Baseline         | Feature          | Change    | Threshold
--------------+------------------+------------------+-----------+-----------
Mean Latency  |          39.63ms |          38.42ms |  -3.08% ✅ |    ±2.63%
Std Dev       |          17.52ms |           15.3ms |           |
P50 Latency   |          35.29ms |          35.21ms |  -0.23% ≈ |    ±3.69%
P90 Latency   |          63.89ms |           56.8ms |  -11.1%   |
P99 Latency   |          97.44ms |           88.0ms |  -9.69%   |
--------------+------------------+------------------+-----------+-----------
Gas/sec       |     768.8 Mgas/s |    793.21 Mgas/s |  +3.18% ✅ |    ±2.63%
```