### PR TITLE
chore(engine): remove MIN_WORKER_COUNT

### DIFF
--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -527,7 +527,10 @@ impl TreeConfig {
     /// Setter for the number of storage proof worker threads.
     ///
     /// No-op if it's [`None`].
-    pub fn with_storage_worker_count_opt(mut self, storage_worker_count: Option<usize>) -> Self {
+    pub const fn with_storage_worker_count_opt(
+        mut self,
+        storage_worker_count: Option<usize>,
+    ) -> Self {
         if let Some(count) = storage_worker_count {
             self.storage_worker_count = count;
         }
@@ -542,7 +545,10 @@ impl TreeConfig {
     /// Setter for the number of account proof worker threads.
     ///
     /// No-op if it's [`None`].
-    pub fn with_account_worker_count_opt(mut self, account_worker_count: Option<usize>) -> Self {
+    pub const fn with_account_worker_count_opt(
+        mut self,
+        account_worker_count: Option<usize>,
+    ) -> Self {
         if let Some(count) = account_worker_count {
             self.account_worker_count = count;
         }

--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -8,14 +8,11 @@ pub const DEFAULT_PERSISTENCE_THRESHOLD: u64 = 2;
 /// How close to the canonical head we persist blocks.
 pub const DEFAULT_MEMORY_BLOCK_BUFFER_TARGET: u64 = 0;
 
-/// Minimum number of workers we allow configuring explicitly.
-pub const MIN_WORKER_COUNT: usize = 32;
-
 /// Returns the default number of storage worker threads based on available parallelism.
 fn default_storage_worker_count() -> usize {
     #[cfg(feature = "std")]
     {
-        std::thread::available_parallelism().map_or(8, |n| n.get() * 2).min(MIN_WORKER_COUNT)
+        std::thread::available_parallelism().map_or(8, |n| n.get() * 2)
     }
     #[cfg(not(feature = "std"))]
     {
@@ -532,7 +529,7 @@ impl TreeConfig {
     /// No-op if it's [`None`].
     pub fn with_storage_worker_count_opt(mut self, storage_worker_count: Option<usize>) -> Self {
         if let Some(count) = storage_worker_count {
-            self.storage_worker_count = count.max(MIN_WORKER_COUNT);
+            self.storage_worker_count = count;
         }
         self
     }
@@ -547,7 +544,7 @@ impl TreeConfig {
     /// No-op if it's [`None`].
     pub fn with_account_worker_count_opt(mut self, account_worker_count: Option<usize>) -> Self {
         if let Some(count) = account_worker_count {
-            self.account_worker_count = count.max(MIN_WORKER_COUNT);
+            self.account_worker_count = count;
         }
         self
     }

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -335,7 +335,7 @@ pub struct EngineArgs {
     pub allow_unwind_canonical_header: bool,
 
     /// Configure the number of storage proof workers in the Tokio blocking pool.
-    /// If not specified, defaults to 2x available parallelism, clamped between 2 and 64.
+    /// If not specified, defaults to 2x available parallelism.
     #[arg(long = "engine.storage-worker-count", default_value = Resettable::from(DefaultEngineValues::get_global().storage_worker_count.map(|v| v.to_string().into())))]
     pub storage_worker_count: Option<usize>,
 

--- a/docs/vocs/docs/pages/cli/op-reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/node.mdx
@@ -1001,7 +1001,7 @@ Engine:
           Allow unwinding canonical header to ancestor during forkchoice updates. See `TreeConfig::unwind_canonical_header` for more details
 
       --engine.storage-worker-count <STORAGE_WORKER_COUNT>
-          Configure the number of storage proof workers in the Tokio blocking pool. If not specified, defaults to 2x available parallelism, clamped between 2 and 64
+          Configure the number of storage proof workers in the Tokio blocking pool. If not specified, defaults to 2x available parallelism
 
       --engine.account-worker-count <ACCOUNT_WORKER_COUNT>
           Configure the number of account proof workers in the Tokio blocking pool. If not specified, defaults to the same count as storage workers

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -1001,7 +1001,7 @@ Engine:
           Allow unwinding canonical header to ancestor during forkchoice updates. See `TreeConfig::unwind_canonical_header` for more details
 
       --engine.storage-worker-count <STORAGE_WORKER_COUNT>
-          Configure the number of storage proof workers in the Tokio blocking pool. If not specified, defaults to 2x available parallelism, clamped between 2 and 64
+          Configure the number of storage proof workers in the Tokio blocking pool. If not specified, defaults to 2x available parallelism
 
       --engine.account-worker-count <ACCOUNT_WORKER_COUNT>
           Configure the number of account proof workers in the Tokio blocking pool. If not specified, defaults to the same count as storage workers


### PR DESCRIPTION
It is used both as .min and .max, and also we don't actually need this