### PR TITLE
perf(net): remove unnecessary collect in transaction propagation

### DIFF
--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -954,8 +954,7 @@ where
                 .pool
                 .get_all(hashes)
                 .into_iter()
-                .map(PropagateTransaction::pool_tx)
-                .collect::<Vec<_>>();
+                .map(PropagateTransaction::pool_tx);
 
             let mut propagated = PropagatedTransactions::default();
 

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -950,11 +950,8 @@ where
                 return
             };
 
-            let to_propagate = self
-                .pool
-                .get_all(hashes)
-                .into_iter()
-                .map(PropagateTransaction::pool_tx);
+            let to_propagate =
+                self.pool.get_all(hashes).into_iter().map(PropagateTransaction::pool_tx);
 
             let mut propagated = PropagatedTransactions::default();
 


### PR DESCRIPTION
The `.collect::<Vec<_>>()` is unnecessary since the iterator is consumed exactly once in either the `extend` call or the `for` loop.