### PR TITLE
fix(rocksdb): speed up shutdown on edge nodes

### DIFF
--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -180,7 +180,7 @@ min-trace-logs = [
     "reth-node-core/min-trace-logs",
 ]
 
-edge = ["reth-ethereum-cli/edge", "reth-node-core/edge"]
+edge = ["reth-ethereum-cli/edge", "reth-node-core/edge", "reth-node-builder/rocksdb"]
 
 [[bin]]
 name = "reth"

--- a/crates/node/builder/Cargo.toml
+++ b/crates/node/builder/Cargo.toml
@@ -128,3 +128,4 @@ op = [
     "reth-evm/op",
     "reth-primitives-traits/op",
 ]
+rocksdb = ["reth-provider/rocksdb"]

--- a/crates/optimism/cli/Cargo.toml
+++ b/crates/optimism/cli/Cargo.toml
@@ -124,4 +124,4 @@ serde = [
     "reth-optimism-chainspec/serde",
 ]
 
-edge = ["reth-cli-commands/edge", "reth-node-core/edge"]
+edge = ["reth-cli-commands/edge", "reth-node-core/edge", "reth-node-builder/rocksdb"]


### PR DESCRIPTION
**Summary**
Ctrl+C was slow on edge (RocksDB) nodes because `RocksDBProviderInner::Drop` did expensive synchronous operations (`flush_wal(true)` + 3x `flush_cf` + blocking `cancel_all_background_work(true)`). Additionally, the Drop wasn't even being called because Arc references weren't released before process exit. This PR adds an explicit `shutdown()` method called during graceful shutdown, and simplifies Drop to be non-blocking.

Closes RETH-361

**Changes**
- Add idempotent `RocksDBProvider::shutdown()` method with AtomicBool guard
- Wire shutdown into engine launch via `spawn_critical_with_graceful_shutdown_signal`
- Simplify Drop to skip expensive `flush_wal(true)` and `flush_cf` calls
- Use `cancel_all_background_work(false)` for non-blocking cleanup
- Propagate `rocksdb` feature through `reth-node-builder` and `edge` features

**Expected Impact**
Fast Ctrl+C exit on edge nodes. RocksDB will replay WAL on next startup if needed (correct behavior, no data loss).

**Notes**
- The previous flush-on-drop was primarily an optimization for faster restart / WAL cleanup, not a correctness requirement
- RocksDB's WAL exists specifically so memtables don't need to be flushed to SST for correctness