### PR TITLE
fix(provider): off-by-one error in static file range calculation

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1315,7 +1315,7 @@ impl<TX: DbTx + 'static, N: NodeTypes> AccountExtReader for DatabaseProvider<TX,
             self.cached_storage_settings().account_changesets_in_static_files
         {
             let start = *range.start();
-            let static_end = (*range.end()).min(highest + 1);
+            let static_end = (*range.end()).min(highest);
 
             let mut changed_accounts_and_blocks: BTreeMap<_, Vec<u64>> = BTreeMap::default();
             if start <= static_end {


### PR DESCRIPTION
Fix off-by-one error in `changed_accounts_and_blocks_with_range` and `EitherReader::changed_accounts_in_range`.

The calculation `(*range.end()).min(highest + 1)` allowed querying block `highest + 1` which doesn't exist in static files. Changed to `min(highest)` to match the correct pattern in `StaticFileProviderRW::bound_range`.