### PR TITLE
test: fix temp directory cleanup to prevent /tmp pollution

### DIFF
--- a/crates/exex/test-utils/src/lib.rs
+++ b/crates/exex/test-utils/src/lib.rs
@@ -244,15 +244,17 @@ pub async fn test_exex_context_with_chain_spec(
     let evm_config = MockEvmConfig::default();
     let consensus = Arc::new(TestConsensus::default());
 
-    let (static_dir, _) = create_test_static_files_dir();
-    let (rocksdb_dir, _) = create_test_rocksdb_dir();
+    let (static_dir, static_path) = create_test_static_files_dir();
+    let (rocksdb_dir, rocksdb_path) = create_test_rocksdb_dir();
     let db = create_test_rw_db();
     let provider_factory = ProviderFactory::<NodeTypesWithDBAdapter<TestNode, _>>::new(
         db,
         chain_spec.clone(),
-        StaticFileProvider::read_write(static_dir.keep()).expect("static file provider"),
-        RocksDBProvider::builder(rocksdb_dir.keep()).with_default_tables().build().unwrap(),
+        StaticFileProvider::read_write(static_path).expect("static file provider"),
+        RocksDBProvider::builder(rocksdb_path).with_default_tables().build().unwrap(),
     )?;
+    // Keep temp dirs alive until context is dropped
+    let _temp_dirs = (static_dir, rocksdb_dir);
 
     let genesis_hash = init_genesis(&provider_factory)?;
     let provider = BlockchainProvider::new(provider_factory.clone())?;

--- a/crates/stages/api/src/stage.rs
+++ b/crates/stages/api/src/stage.rs
@@ -340,16 +340,20 @@ mod tests {
     #[test]
     fn test_exec_input_next_block_range_with_transaction_threshold() {
         let mut rng = generators::rng();
+        let (static_dir, static_path) = create_test_static_files_dir();
+        let (rocksdb_dir, rocksdb_path) = create_test_rocksdb_dir();
         let provider_factory = ProviderFactory::<MockNodeTypesWithDB>::new(
             create_test_rw_db(),
             MAINNET.clone(),
-            StaticFileProviderBuilder::read_write(create_test_static_files_dir().0.keep())
+            StaticFileProviderBuilder::read_write(static_path)
                 .with_blocks_per_file(1)
                 .build()
                 .unwrap(),
-            RocksDBProvider::builder(create_test_rocksdb_dir().0.keep()).build().unwrap(),
+            RocksDBProvider::builder(rocksdb_path).build().unwrap(),
         )
         .unwrap();
+        // Keep temp dirs alive until test ends
+        let _temp_dirs = (static_dir, rocksdb_dir);
 
         // Without checkpoint, without transactions in static files
         {


### PR DESCRIPTION
Fixes #21769

Test helpers were calling .keep() on temp directories leaving them in /tmp after tests, apply the same fix from #21772 to remaining test files.