### PR TITLE
perf(engine): single-pass fold for EvmState metrics collection

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -232,11 +232,11 @@ impl OnStateHook for MeteredStateHook {
     fn on_state(&mut self, source: StateChangeSource, state: &EvmState) {
         // Update the metrics for the number of accounts, storage slots and bytecodes loaded
         let (accounts, storage_slots, bytecodes) =
-            state.values().fold((0, 0, 0), |(acc, slots, codes), account| {
+            state.values().fold((0, 0, 0), |(accounts, storage_slots, bytecodes), account| {
                 (
-                    acc + 1,
-                    slots + account.storage.len(),
-                    codes + usize::from(!account.info.is_empty_code_hash()),
+                    accounts + 1,
+                    storage_slots + account.storage.len(),
+                    bytecodes + usize::from(!account.info.is_empty_code_hash()),
                 )
             });
 

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -230,6 +230,7 @@ struct MeteredStateHook {
 
 impl OnStateHook for MeteredStateHook {
     fn on_state(&mut self, source: StateChangeSource, state: &EvmState) {
+        // Update the metrics for the number of accounts, storage slots and bytecodes loaded
         let (accounts, storage_slots, bytecodes) =
             state.values().fold((0, 0, 0), |(acc, slots, codes), account| {
                 (

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -244,6 +244,7 @@ impl OnStateHook for MeteredStateHook {
         self.metrics.storage_slots_loaded_histogram.record(storage_slots as f64);
         self.metrics.bytecodes_loaded_histogram.record(bytecodes as f64);
 
+        // Call the original state hook
         self.inner_hook.on_state(source, state);
     }
 }

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -231,10 +231,10 @@ struct MeteredStateHook {
 impl OnStateHook for MeteredStateHook {
     fn on_state(&mut self, source: StateChangeSource, state: &EvmState) {
         // Update the metrics for the number of accounts, storage slots and bytecodes loaded
-        let (accounts, storage_slots, bytecodes) =
-            state.values().fold((0, 0, 0), |(accounts, storage_slots, bytecodes), account| {
+        let accounts = state.len();
+        let (storage_slots, bytecodes) =
+            state.values().fold((0, 0), |(storage_slots, bytecodes), account| {
                 (
-                    accounts + 1,
                     storage_slots + account.storage.len(),
                     bytecodes + usize::from(!account.info.is_empty_code_hash()),
                 )


### PR DESCRIPTION
## Summary

Replace three separate iterations over EvmState HashMap in `MeteredStateHook::on_state()` with a single `fold()` pass plus O(1) `len()` call.


## Performance Analysis

### What changed at the low level

| Aspect | Before | After |
|--------|--------|-------|
| HashMap iterations | 2 full passes (`values()` x2) | 1 pass |
| Iterator constructions | 3 (`keys()`, `values()`, `values()`) | 1 (`values()`) |
| Account count | `keys().len()` iterator | `state.len()` O(1) field access |
| Pointer chasing | 2x through HashMap buckets | 1x |
| Cache line loads | Each account touched twice | Each account touched once |

### Why LLVM cannot optimize this automatically

The original code uses different iterator types and operations:
- `state.keys().len()` - iterates keys, returns count
- `state.values().map().sum()` - iterates values with map combinator
- `state.values().filter().count()` - iterates values with filter combinator

LLVM cannot fuse these because:
1. Different iterator adapters (`map` vs `filter`) produce different types
2. The `keys()` vs `values()` iterators are distinct
3. No guarantee the iterations are side-effect-free from the compiler's perspective

### Expected impact

- **Call frequency**: ~200 times per block (once per transaction)
- **Typical state size**: 2-20 accounts per transaction
- **Savings**: Eliminates redundant HashMap bucket traversal and pointer dereferences