### PR TITLE
fix(engine): propagate tracing span to rayon task in payload processor

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -379,7 +379,9 @@ where
         let (execute_tx, execute_rx) = mpsc::channel();
 
         // Spawn a task that `convert`s all transactions in parallel and sends them out-of-order.
+        let parent_span = Span::current();
         rayon::spawn(move || {
+            let _enter = parent_span.entered();
             let (transactions, convert) = transactions.into();
             transactions.into_par_iter().enumerate().for_each_with(ooo_tx, |ooo_tx, (idx, tx)| {
                 let tx = convert(tx);


### PR DESCRIPTION
Propagate parent span context to the `rayon::spawn` task in `spawn_tx_iterator` for consistent tracing hierarchy                                                                                                                                                                   
                                 
Cleanup from #21830.