### PR TITLE
fix: support EIP-1559 params configuration for Optimism dev mode

### DIFF
--- a/crates/engine/local/src/payload.rs
+++ b/crates/engine/local/src/payload.rs
@@ -83,8 +83,11 @@ where
             "7ef8f8a0683079df94aa5b9cf86687d739a60a9b4f0835e520ec4d664e2e415dca17a6df94deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8a4440a5e200000146b000f79c500000000000000040000000066d052e700000000013ad8a3000000000000000000000000000000000000000000000000000000003ef1278700000000000000000000000000000000000000000000000000000000000000012fdf87b89884a61e74b322bbcf60386f543bfae7827725efaaf0ab1de2294a590000000000000000000000006887246668a3b87f54deb3b94ba47a6f63f32985"
         );
 
+        // Configure EIP-1559 parameters for dev mode. These can be overridden via environment
+        // variables (OP_DEV_EIP1559_DENOMINATOR, OP_DEV_EIP1559_ELASTICITY, OP_DEV_GAS_LIMIT),
+        // otherwise defaults from Optimism's BaseFeeParams are used. The parameters are encoded
+        // as an 8-byte value (denominator + elasticity) required by Optimism's Jovian fork.
         let default_eip_1559_params = BaseFeeParams::optimism();
-
         let denominator = env::var("OP_DEV_EIP1559_DENOMINATOR")
             .ok()
             .and_then(|v| v.parse::<u32>().ok())

--- a/crates/engine/local/src/payload.rs
+++ b/crates/engine/local/src/payload.rs
@@ -72,6 +72,9 @@ where
         &self,
         parent: &SealedHeader<ChainSpec::Header>,
     ) -> op_alloy_rpc_types_engine::OpPayloadAttributes {
+        use alloy_primitives::B64;
+        use reth_chainspec::BaseFeeParams;
+        use std::env;
         /// Dummy system transaction for dev mode.
         /// OP Mainnet transaction at index 0 in block 124665056.
         ///
@@ -80,14 +83,30 @@ where
             "7ef8f8a0683079df94aa5b9cf86687d739a60a9b4f0835e520ec4d664e2e415dca17a6df94deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8a4440a5e200000146b000f79c500000000000000040000000066d052e700000000013ad8a3000000000000000000000000000000000000000000000000000000003ef1278700000000000000000000000000000000000000000000000000000000000000012fdf87b89884a61e74b322bbcf60386f543bfae7827725efaaf0ab1de2294a590000000000000000000000006887246668a3b87f54deb3b94ba47a6f63f32985"
         );
 
+        let default_eip_1559_params = BaseFeeParams::optimism();
+
+        let denominator = env::var("OP_DEV_EIP1559_DENOMINATOR")
+            .ok()
+            .and_then(|v| v.parse::<u32>().ok())
+            .unwrap_or(default_eip_1559_params.max_change_denominator as u32);
+        let elasticity = env::var("OP_DEV_EIP1559_ELASTICITY")
+            .ok()
+            .and_then(|v| v.parse::<u32>().ok())
+            .unwrap_or(default_eip_1559_params.elasticity_multiplier as u32);
+        let gas_limit = env::var("OP_DEV_GAS_LIMIT").ok().and_then(|v| v.parse::<u64>().ok());
+
+        let mut eip1559_bytes = [0u8; 8];
+        eip1559_bytes[0..4].copy_from_slice(&denominator.to_be_bytes());
+        eip1559_bytes[4..8].copy_from_slice(&elasticity.to_be_bytes());
+        let eip_1559_params = Some(B64::from(eip1559_bytes));
+
         op_alloy_rpc_types_engine::OpPayloadAttributes {
             payload_attributes: self.build(parent),
-            // Add dummy system transaction
             transactions: Some(vec![TX_SET_L1_BLOCK_OP_MAINNET_BLOCK_124665056.into()]),
             no_tx_pool: None,
-            gas_limit: None,
-            eip_1559_params: None,
-            min_base_fee: None,
+            gas_limit,
+            eip_1559_params,
+            min_base_fee: Some(0),
         }
     }
 }

--- a/crates/ethereum/hardforks/src/hardforks/dev.rs
+++ b/crates/ethereum/hardforks/src/hardforks/dev.rs
@@ -35,5 +35,6 @@ pub static DEV_HARDFORKS: LazyLock<ChainHardforks> = LazyLock::new(|| {
         (EthereumHardfork::Shanghai.boxed(), ForkCondition::Timestamp(0)),
         (EthereumHardfork::Cancun.boxed(), ForkCondition::Timestamp(0)),
         (EthereumHardfork::Prague.boxed(), ForkCondition::Timestamp(0)),
+        (EthereumHardfork::Osaka.boxed(), ForkCondition::Timestamp(0)),
     ])
 });

--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -512,6 +512,14 @@ pub fn make_op_genesis_header(genesis: &Genesis, hardforks: &ChainHardforks) -> 
             })));
     }
 
+    // If Jovian is active at genesis, encode the base fee parameters in extra_data
+    if hardforks.fork(OpHardfork::Jovian).active_at_timestamp(header.timestamp) {
+        use op_alloy_consensus::encode_jovian_extra_data;
+        // Encode with empty nonce (8 zero bytes)
+        header.extra_data =
+            encode_jovian_extra_data([0u8; 8].into(), BaseFeeParams::optimism(), 0).unwrap();
+    }
+
     header
 }
 

--- a/crates/optimism/hardforks/src/lib.rs
+++ b/crates/optimism/hardforks/src/lib.rs
@@ -32,7 +32,6 @@ use reth_ethereum_forks::{ChainHardforks, EthereumHardfork, ForkCondition, Hardf
 
 /// Dev hardforks
 pub static DEV_HARDFORKS: LazyLock<ChainHardforks> = LazyLock::new(|| {
-    const JOVIAN_TIMESTAMP: ForkCondition = ForkCondition::Timestamp(1761840000);
     ChainHardforks::new(vec![
         (EthereumHardfork::Frontier.boxed(), ForkCondition::Block(0)),
         (EthereumHardfork::Homestead.boxed(), ForkCondition::Block(0)),
@@ -64,7 +63,7 @@ pub static DEV_HARDFORKS: LazyLock<ChainHardforks> = LazyLock::new(|| {
         (OpHardfork::Holocene.boxed(), ForkCondition::Timestamp(0)),
         (EthereumHardfork::Prague.boxed(), ForkCondition::Timestamp(0)),
         (OpHardfork::Isthmus.boxed(), ForkCondition::Timestamp(0)),
-        (OpHardfork::Jovian.boxed(), JOVIAN_TIMESTAMP),
+        (OpHardfork::Jovian.boxed(), ForkCondition::Timestamp(0)),
     ])
 });
 


### PR DESCRIPTION
## Description

Fixes Optimism dev mode startup issue by properly configuring EIP-1559 parameters required after Jovian fork activation.

## Problem

Running `op-reth node --dev --dev.block-time 1s` fails with error:
```
failed to resolve pending payload err=Minimum base fee cannot be None after Jovian
Error advancing the chain: No payload

Location:
    /data/reth/crates/engine/local/src/miner.rs:217:13
```

This occurs because Jovian fork requires EIP-1559 parameters and minimum base fee to be set, but they were missing in dev mode.

## Changes

- Add environment variable support for EIP-1559 params (`OP_DEV_EIP1559_DENOMINATOR`, `OP_DEV_EIP1559_ELASTICITY`, `OP_DEV_GAS_LIMIT`)
- Encode base fee parameters in genesis header `extra_data` when Jovian fork is active at genesis
- Activate Jovian fork at timestamp 0 in dev mode
- Set `min_base_fee` in payload attributes (required after Jovian)
- Add Osaka fork to Ethereum dev hardforks
