### PR TITLE
fix(nippy-jar): refine InconsistentState error into specific variants

### DIFF
--- a/crates/storage/nippy-jar/src/consistency.rs
+++ b/crates/storage/nippy-jar/src/consistency.rs
@@ -67,7 +67,10 @@ impl<H: NippyJarHeader> NippyJarChecker<H> {
         if mode.should_err() &&
             expected_offsets_file_size.cmp(&actual_offsets_file_size) != Ordering::Equal
         {
-            return Err(NippyJarError::InconsistentState)
+            return Err(NippyJarError::OffsetFileSizeMismatch {
+                expected: expected_offsets_file_size,
+                actual: actual_offsets_file_size,
+            })
         }
 
         // Offsets configuration wasn't properly committed
@@ -103,7 +106,10 @@ impl<H: NippyJarHeader> NippyJarChecker<H> {
         let data_file_len = self.data_file().get_ref().metadata()?.len();
 
         if mode.should_err() && last_offset.cmp(&data_file_len) != Ordering::Equal {
-            return Err(NippyJarError::InconsistentState)
+            return Err(NippyJarError::DataFileSizeMismatch {
+                expected: last_offset,
+                actual: data_file_len,
+            })
         }
 
         // Offset list wasn't properly committed

--- a/crates/storage/nippy-jar/src/error.rs
+++ b/crates/storage/nippy-jar/src/error.rs
@@ -85,9 +85,23 @@ pub enum NippyJarError {
     #[error("jar has been frozen and cannot be modified.")]
     FrozenJar,
 
-    /// The file is in an inconsistent state.
-    #[error("File is in an inconsistent state.")]
-    InconsistentState,
+    /// The offset file size does not match the expected size based on row/column configuration.
+    #[error("Offset file size mismatch: expected {expected} bytes, actual {actual} bytes")]
+    OffsetFileSizeMismatch {
+        /// Expected file size in bytes.
+        expected: u64,
+        /// Actual file size in bytes.
+        actual: u64,
+    },
+
+    /// The data file size does not match the last offset value.
+    #[error("Data file size mismatch: expected {expected} bytes (from last offset), actual {actual} bytes")]
+    DataFileSizeMismatch {
+        /// Expected file size in bytes (from last offset).
+        expected: u64,
+        /// Actual file size in bytes.
+        actual: u64,
+    },
 
     /// A specified file is missing.
     #[error("Missing file: {}", .0.display())]


### PR DESCRIPTION
Debugging a node startup failure and got hit with "File is in an inconsistent state" -  figure out it was the offset file that was corrupted, not the data file. Turns out the same error is used for both cases. Split it into `OffsetFileSizeMismatch` and `DataFileSizeMismatch` with actual byte values so next time it's obvious what went wrong.