### PR TITLE
fix(ci): use commit SHA instead of branch ref in changelog workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   changelog:
+    # Skip for fork PRs since they can't access secrets
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -14,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       - run: npm install -g @anthropic-ai/claude-code
       - uses: wevm/changelogs/check@master
         with:


### PR DESCRIPTION
The changelog workflow fails for fork PRs because they can't access repository secrets (GitHub security policy), causing "Invalid API key" error. This adds a condition to skip the job for fork PRs.

Also switched from `github.head_ref` to `github.event.pull_request.head.sha` for more reliable checkout.
