### PR TITLE
chore: introduce v2 storage flag and remove edge flag

### DIFF
--- a/.changelog/cute-bears-paint.md
+++ b/.changelog/cute-bears-paint.md
@@ -1,0 +1,17 @@
+---
+reth: minor
+reth-cli-commands: minor
+reth-e2e-test-utils: minor
+reth-ethereum-cli: minor
+reth-node-core: minor
+reth-optimism-bin: minor
+reth-optimism-cli: minor
+reth-prune: patch
+reth-stages: patch
+reth-storage-api: minor
+reth-storage-db-api: minor
+reth-storage-db-common: patch
+reth-storage-provider: patch
+---
+
+Introduced `--storage.v2` flag to control storage mode defaults, replacing the `edge` feature flag with `rocksdb` feature. The new flag enables v2 storage settings (static files + RocksDB routing) while individual `--static-files.*` and `--rocksdb.*` flags can still override defaults. Updated feature gates from `edge` to `rocksdb` across all affected crates.

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -81,7 +81,16 @@ backon.workspace = true
 tempfile.workspace = true
 
 [features]
-default = ["jemalloc", "otlp", "otlp-logs", "reth-revm/portable", "js-tracer", "keccak-cache-global", "asm-keccak"]
+default = [
+    "jemalloc",
+    "otlp",
+    "otlp-logs",
+    "reth-revm/portable",
+    "js-tracer",
+    "keccak-cache-global",
+    "asm-keccak",
+    "rocksdb",
+]
 
 otlp = [
     "reth-ethereum-cli/otlp",
@@ -180,7 +189,8 @@ min-trace-logs = [
     "reth-node-core/min-trace-logs",
 ]
 
-edge = ["reth-ethereum-cli/edge", "reth-node-core/edge"]
+rocksdb = ["reth-ethereum-cli/rocksdb", "reth-node-core/rocksdb"]
+edge = ["rocksdb"]
 
 [[bin]]
 name = "reth"

--- a/crates/cli/commands/Cargo.toml
+++ b/crates/cli/commands/Cargo.toml
@@ -133,4 +133,5 @@ arbitrary = [
     "reth-ethereum-primitives/arbitrary",
 ]
 
-edge = ["reth-db-common/edge", "reth-stages/rocksdb", "reth-provider/rocksdb", "reth-prune/rocksdb"]
+rocksdb = ["reth-db-common/rocksdb", "reth-stages/rocksdb", "reth-provider/rocksdb", "reth-prune/rocksdb"]
+edge = ["rocksdb"]

--- a/crates/cli/commands/src/common.rs
+++ b/crates/cli/commands/src/common.rs
@@ -71,7 +71,7 @@ pub struct EnvironmentArgs<C: ChainSpecParser> {
     #[command(flatten)]
     pub rocksdb: RocksDbArgs,
 
-    /// Storage mode configuration (edge vs legacy)
+    /// Storage mode configuration (v2 vs v1/legacy)
     #[command(flatten)]
     pub storage: StorageArgs,
 }

--- a/crates/cli/commands/src/common.rs
+++ b/crates/cli/commands/src/common.rs
@@ -19,7 +19,7 @@ use reth_node_builder::{
     Node, NodeComponents, NodeComponentsBuilder, NodeTypes, NodeTypesWithDBAdapter,
 };
 use reth_node_core::{
-    args::{DatabaseArgs, DatadirArgs, RocksDbArgs, StaticFilesArgs},
+    args::{DatabaseArgs, DatadirArgs, RocksDbArgs, StaticFilesArgs, StorageArgs},
     dirs::{ChainPath, DataDirPath},
 };
 use reth_provider::{
@@ -70,18 +70,59 @@ pub struct EnvironmentArgs<C: ChainSpecParser> {
     /// All `RocksDB` related arguments
     #[command(flatten)]
     pub rocksdb: RocksDbArgs,
+
+    /// Storage mode configuration (edge vs legacy)
+    #[command(flatten)]
+    pub storage: StorageArgs,
 }
 
 impl<C: ChainSpecParser> EnvironmentArgs<C> {
-    /// Returns the effective storage settings derived from static-file and `RocksDB` CLI args.
+    /// Returns the effective storage settings derived from `--storage.v2`, static-file, and
+    /// `RocksDB` CLI args.
+    ///
+    /// The base storage mode is determined by `--storage.v2`:
+    /// - When `--storage.v2` is set: uses [`StorageSettings::v2()`] defaults
+    /// - Otherwise: uses [`StorageSettings::v1()`] defaults
+    ///
+    /// Individual `--static-files.*` and `--rocksdb.*` flags override the base when explicitly set.
     pub fn storage_settings(&self) -> StorageSettings {
-        StorageSettings::base()
-            .with_receipts_in_static_files(self.static_files.receipts)
-            .with_transaction_senders_in_static_files(self.static_files.transaction_senders)
-            .with_account_changesets_in_static_files(self.static_files.account_changesets)
-            .with_transaction_hash_numbers_in_rocksdb(self.rocksdb.all || self.rocksdb.tx_hash)
-            .with_storages_history_in_rocksdb(self.rocksdb.all || self.rocksdb.storages_history)
-            .with_account_history_in_rocksdb(self.rocksdb.all || self.rocksdb.account_history)
+        let mut s = if self.storage.v2 { StorageSettings::v2() } else { StorageSettings::base() };
+
+        // Apply static files overrides (only when explicitly set)
+        if let Some(v) = self.static_files.receipts {
+            s = s.with_receipts_in_static_files(v);
+        }
+        if let Some(v) = self.static_files.transaction_senders {
+            s = s.with_transaction_senders_in_static_files(v);
+        }
+        if let Some(v) = self.static_files.account_changesets {
+            s = s.with_account_changesets_in_static_files(v);
+        }
+        if let Some(v) = self.static_files.storage_changesets {
+            s = s.with_storage_changesets_in_static_files(v);
+        }
+
+        // Apply rocksdb overrides
+        // --rocksdb.all sets all rocksdb flags to true
+        if self.rocksdb.all {
+            s = s
+                .with_transaction_hash_numbers_in_rocksdb(true)
+                .with_storages_history_in_rocksdb(true)
+                .with_account_history_in_rocksdb(true);
+        }
+
+        // Individual rocksdb flags override --rocksdb.all when explicitly set
+        if let Some(v) = self.rocksdb.tx_hash {
+            s = s.with_transaction_hash_numbers_in_rocksdb(v);
+        }
+        if let Some(v) = self.rocksdb.storages_history {
+            s = s.with_storages_history_in_rocksdb(v);
+        }
+        if let Some(v) = self.rocksdb.account_history {
+            s = s.with_account_history_in_rocksdb(v);
+        }
+
+        s
     }
 
     /// Initializes environment according to [`AccessRights`] and returns an instance of

--- a/crates/cli/commands/src/db/checksum/mod.rs
+++ b/crates/cli/commands/src/db/checksum/mod.rs
@@ -21,7 +21,7 @@ use std::{
 };
 use tracing::{info, warn};
 
-#[cfg(all(unix, feature = "edge"))]
+#[cfg(all(unix, feature = "rocksdb"))]
 mod rocksdb;
 
 /// Interval for logging progress during checksum computation.
@@ -73,7 +73,7 @@ enum Subcommand {
         limit: Option<usize>,
     },
     /// Calculates the checksum of a RocksDB table
-    #[cfg(all(unix, feature = "edge"))]
+    #[cfg(all(unix, feature = "rocksdb"))]
     Rocksdb {
         /// The RocksDB table
         #[arg(value_enum)]
@@ -100,7 +100,7 @@ impl Command {
             Subcommand::StaticFile { segment, start_block, end_block, limit } => {
                 checksum_static_file(tool, segment, start_block, end_block, limit)?;
             }
-            #[cfg(all(unix, feature = "edge"))]
+            #[cfg(all(unix, feature = "rocksdb"))]
             Subcommand::Rocksdb { table, limit } => {
                 rocksdb::checksum_rocksdb(tool, table, limit)?;
             }

--- a/crates/cli/commands/src/db/settings.rs
+++ b/crates/cli/commands/src/db/settings.rs
@@ -121,7 +121,7 @@ impl Command {
             account_history_in_rocksdb: _,
             account_changesets_in_static_files: _,
             storage_changesets_in_static_files: _,
-        } = settings.unwrap_or_else(StorageSettings::legacy);
+        } = settings.unwrap_or_else(StorageSettings::v1);
 
         // Update the setting based on the key
         match cmd {

--- a/crates/cli/commands/src/node.rs
+++ b/crates/cli/commands/src/node.rs
@@ -119,7 +119,7 @@ pub struct NodeCommand<C: ChainSpecParser, Ext: clap::Args + fmt::Debug = NoArgs
     #[command(flatten, next_help_heading = "Static Files")]
     pub static_files: StaticFilesArgs,
 
-    /// Storage mode configuration (edge vs legacy)
+    /// Storage mode configuration (v2 vs v1/legacy)
     #[command(flatten)]
     pub storage: StorageArgs,
 

--- a/crates/cli/commands/src/node.rs
+++ b/crates/cli/commands/src/node.rs
@@ -11,7 +11,7 @@ use reth_node_core::{
     args::{
         DatabaseArgs, DatadirArgs, DebugArgs, DevArgs, EngineArgs, EraArgs, MetricArgs,
         NetworkArgs, PayloadBuilderArgs, PruningArgs, RocksDbArgs, RpcServerArgs, StaticFilesArgs,
-        TxPoolArgs,
+        StorageArgs, TxPoolArgs,
     },
     node_config::NodeConfig,
     version,
@@ -119,6 +119,10 @@ pub struct NodeCommand<C: ChainSpecParser, Ext: clap::Args + fmt::Debug = NoArgs
     #[command(flatten, next_help_heading = "Static Files")]
     pub static_files: StaticFilesArgs,
 
+    /// Storage mode configuration (edge vs legacy)
+    #[command(flatten)]
+    pub storage: StorageArgs,
+
     /// Additional cli arguments
     #[command(flatten, next_help_heading = "Extension")]
     pub ext: Ext,
@@ -175,6 +179,7 @@ where
             engine,
             era,
             static_files,
+            storage,
             ext,
         } = self;
 
@@ -200,6 +205,7 @@ where
             engine,
             era,
             static_files,
+            storage,
         };
 
         let data_dir = node_config.datadir();

--- a/crates/cli/commands/src/prune.rs
+++ b/crates/cli/commands/src/prune.rs
@@ -12,7 +12,7 @@ use reth_node_metrics::{
     server::{MetricServer, MetricServerConfig},
     version::VersionInfo,
 };
-#[cfg(all(unix, feature = "edge"))]
+#[cfg(all(unix, feature = "rocksdb"))]
 use reth_provider::RocksDBProviderFactory;
 use reth_prune::PrunerBuilder;
 use reth_static_file::StaticFileProducer;
@@ -122,7 +122,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> PruneComma
         }
 
         // Flush and compact RocksDB to reclaim disk space after pruning
-        #[cfg(all(unix, feature = "edge"))]
+        #[cfg(all(unix, feature = "rocksdb"))]
         {
             info!(target: "reth::cli", "Flushing and compacting RocksDB...");
             provider_factory.rocksdb_provider().flush_and_compact()?;

--- a/crates/e2e-test-utils/Cargo.toml
+++ b/crates/e2e-test-utils/Cargo.toml
@@ -76,7 +76,8 @@ path = "tests/e2e-testsuite/main.rs"
 [[test]]
 name = "rocksdb"
 path = "tests/rocksdb/main.rs"
-required-features = ["edge"]
+required-features = ["rocksdb"]
 
 [features]
-edge = ["reth-node-core/edge", "reth-provider/rocksdb", "reth-cli-commands/edge"]
+rocksdb = ["reth-node-core/rocksdb", "reth-provider/rocksdb", "reth-cli-commands/rocksdb"]
+edge = ["rocksdb"]

--- a/crates/e2e-test-utils/src/setup_builder.rs
+++ b/crates/e2e-test-utils/src/setup_builder.rs
@@ -96,6 +96,15 @@ where
         self
     }
 
+    /// Enables v2 storage defaults (`--storage.v2`), routing tx hashes, history
+    /// indices, etc. to `RocksDB` and changesets/senders to static files.
+    pub fn with_storage_v2(self) -> Self {
+        self.with_node_config_modifier(|mut config| {
+            config.storage.v2 = true;
+            config
+        })
+    }
+
     /// Builds and launches the test nodes.
     pub async fn build(
         self,

--- a/crates/e2e-test-utils/tests/rocksdb/main.rs
+++ b/crates/e2e-test-utils/tests/rocksdb/main.rs
@@ -13,7 +13,7 @@ use reth_e2e_test_utils::{transaction::TransactionTestContext, wallet, E2ETestSe
 use reth_node_core::args::RocksDbArgs;
 use reth_node_ethereum::EthereumNode;
 use reth_payload_builder::EthPayloadBuilderAttributes;
-use reth_provider::{RocksDBProviderFactory, StorageSettings};
+use reth_provider::RocksDBProviderFactory;
 use std::{sync::Arc, time::Duration};
 
 const ROCKSDB_POLL_TIMEOUT: Duration = Duration::from_secs(60);

--- a/crates/e2e-test-utils/tests/rocksdb/main.rs
+++ b/crates/e2e-test-utils/tests/rocksdb/main.rs
@@ -121,6 +121,7 @@ async fn test_rocksdb_node_startup() -> Result<()> {
 
     let (nodes, _tasks, _wallet) =
         E2ETestSetupBuilder::<EthereumNode, _>::new(1, chain_spec, test_attributes_generator)
+            .with_storage_v2()
             .build()
             .await?;
 
@@ -148,6 +149,7 @@ async fn test_rocksdb_block_mining() -> Result<()> {
 
     let (mut nodes, _tasks, _wallet) =
         E2ETestSetupBuilder::<EthereumNode, _>::new(1, chain_spec, test_attributes_generator)
+            .with_storage_v2()
             .build()
             .await?;
 
@@ -204,6 +206,7 @@ async fn test_rocksdb_transaction_queries() -> Result<()> {
         chain_spec.clone(),
         test_attributes_generator,
     )
+    .with_storage_v2()
     .with_tree_config_modifier(|config| config.with_persistence_threshold(0))
     .build()
     .await?;
@@ -270,6 +273,7 @@ async fn test_rocksdb_multi_tx_same_block() -> Result<()> {
         chain_spec.clone(),
         test_attributes_generator,
     )
+    .with_storage_v2()
     .with_tree_config_modifier(|config| config.with_persistence_threshold(0))
     .build()
     .await?;
@@ -337,6 +341,7 @@ async fn test_rocksdb_txs_across_blocks() -> Result<()> {
         chain_spec.clone(),
         test_attributes_generator,
     )
+    .with_storage_v2()
     .with_tree_config_modifier(|config| config.with_persistence_threshold(0))
     .build()
     .await?;
@@ -421,6 +426,7 @@ async fn test_rocksdb_pending_tx_not_in_storage() -> Result<()> {
         chain_spec.clone(),
         test_attributes_generator,
     )
+    .with_storage_v2()
     .with_tree_config_modifier(|config| config.with_persistence_threshold(0))
     .build()
     .await?;
@@ -484,6 +490,7 @@ async fn test_rocksdb_reorg_unwind() -> Result<()> {
         chain_spec.clone(),
         test_attributes_generator,
     )
+    .with_storage_v2()
     .with_tree_config_modifier(|config| config.with_persistence_threshold(0))
     .build()
     .await?;

--- a/crates/e2e-test-utils/tests/rocksdb/main.rs
+++ b/crates/e2e-test-utils/tests/rocksdb/main.rs
@@ -1,6 +1,6 @@
 //! E2E tests for `RocksDB` provider functionality.
 
-#![cfg(all(feature = "edge", unix))]
+#![cfg(all(feature = "rocksdb", unix))]
 
 use alloy_consensus::BlockHeader;
 use alloy_primitives::B256;
@@ -96,23 +96,19 @@ fn test_attributes_generator(timestamp: u64) -> EthPayloadBuilderAttributes {
     EthPayloadBuilderAttributes::new(B256::ZERO, attributes)
 }
 
-/// Verifies that `RocksDB` CLI defaults match `StorageSettings::base()`.
+/// Verifies that `RocksDB` CLI defaults are `None` (deferred to storage mode).
 #[test]
-fn test_rocksdb_defaults_match_storage_settings() {
+fn test_rocksdb_defaults_are_none() {
     let args = RocksDbArgs::default();
-    let settings = StorageSettings::base();
 
-    assert_eq!(
-        args.tx_hash, settings.transaction_hash_numbers_in_rocksdb,
-        "tx_hash default should match StorageSettings::base()"
+    assert!(args.tx_hash.is_none(), "tx_hash default should be None (deferred to --storage.v2)");
+    assert!(
+        args.storages_history.is_none(),
+        "storages_history default should be None (deferred to --storage.v2)"
     );
-    assert_eq!(
-        args.storages_history, settings.storages_history_in_rocksdb,
-        "storages_history default should match StorageSettings::base()"
-    );
-    assert_eq!(
-        args.account_history, settings.account_history_in_rocksdb,
-        "account_history default should match StorageSettings::base()"
+    assert!(
+        args.account_history.is_none(),
+        "account_history default should be None (deferred to --storage.v2)"
     );
 }
 

--- a/crates/ethereum/cli/Cargo.toml
+++ b/crates/ethereum/cli/Cargo.toml
@@ -89,4 +89,5 @@ min-trace-logs = [
     "reth-node-core/min-trace-logs",
 ]
 
-edge = ["reth-cli-commands/edge"]
+rocksdb = ["reth-cli-commands/rocksdb"]
+edge = ["rocksdb"]

--- a/crates/node/core/Cargo.toml
+++ b/crates/node/core/Cargo.toml
@@ -90,8 +90,11 @@ min-info-logs = ["tracing/release_max_level_info"]
 min-debug-logs = ["tracing/release_max_level_debug"]
 min-trace-logs = ["tracing/release_max_level_trace"]
 
-# Marker feature for edge/unstable builds - captured by vergen in build.rs
-edge = ["reth-storage-api/edge"]
+# Route supported tables to RocksDB instead of MDBX
+rocksdb = ["reth-storage-api/rocksdb"]
+
+# Marker feature for edge/unstable builds - enables rocksdb and sets v2 defaults
+edge = ["rocksdb"]
 
 [build-dependencies]
 vergen = { workspace = true, features = ["build", "cargo", "emit_and_set"] }

--- a/crates/node/core/src/args/mod.rs
+++ b/crates/node/core/src/args/mod.rs
@@ -84,5 +84,9 @@ pub use static_files::{StaticFilesArgs, MINIMAL_BLOCKS_PER_FILE};
 mod rocksdb;
 pub use rocksdb::{RocksDbArgs, RocksDbArgsError};
 
+/// `StorageArgs` for configuring storage mode (v2 vs v1/legacy).
+mod storage;
+pub use storage::StorageArgs;
+
 mod error;
 pub mod types;

--- a/crates/node/core/src/args/rocksdb.rs
+++ b/crates/node/core/src/args/rocksdb.rs
@@ -7,7 +7,7 @@ use clap::{ArgAction, Args};
 /// These flags control which database tables are stored in `RocksDB` instead of MDBX.
 /// All flags are genesis-initialization-only: changing them after genesis requires a re-sync.
 ///
-/// When `--storage.v2` is used, the defaults for these flags change to enable RocksDB routing.
+/// When `--storage.v2` is used, the defaults for these flags change to enable `RocksDB` routing.
 /// Individual flags can still override those defaults when explicitly set.
 #[derive(Debug, Args, PartialEq, Eq, Clone, Copy, Default)]
 #[command(next_help_heading = "RocksDB")]

--- a/crates/node/core/src/args/static_files.rs
+++ b/crates/node/core/src/args/static_files.rs
@@ -2,23 +2,17 @@
 
 use clap::Args;
 use reth_config::config::{BlocksPerFileConfig, StaticFilesConfig};
-use reth_storage_api::StorageSettings;
 
 /// Blocks per static file when running in `--minimal` node.
 ///
 /// 10000 blocks per static file allows us to prune all history every 10k blocks.
 pub const MINIMAL_BLOCKS_PER_FILE: u64 = 10000;
 
-/// Default value for static file storage flags.
-///
-/// When the `edge` feature is enabled, defaults to `true` to enable edge storage features.
-/// Otherwise defaults to `false` for legacy behavior.
-const fn default_static_file_flag() -> bool {
-    cfg!(feature = "edge")
-}
-
 /// Parameters for static files configuration
-#[derive(Debug, Args, PartialEq, Eq, Clone, Copy)]
+///
+/// When `--storage.v2` is used, the defaults for the storage flags change to enable static file
+/// storage. Individual flags can still override those defaults when explicitly set.
+#[derive(Debug, Args, PartialEq, Eq, Clone, Copy, Default)]
 #[command(next_help_heading = "Static Files")]
 pub struct StaticFilesArgs {
     /// Number of blocks per file for the headers segment.
@@ -51,8 +45,10 @@ pub struct StaticFilesArgs {
     ///
     /// Note: This setting can only be configured at genesis initialization. Once
     /// the node has been initialized, changing this flag requires re-syncing from scratch.
-    #[arg(long = "static-files.receipts", default_value_t = default_static_file_flag(), action = clap::ArgAction::Set)]
-    pub receipts: bool,
+    ///
+    /// Defaults to the base storage mode (v1: false, v2: true).
+    #[arg(long = "static-files.receipts", action = clap::ArgAction::Set)]
+    pub receipts: Option<bool>,
 
     /// Store transaction senders in static files instead of the database.
     ///
@@ -61,8 +57,10 @@ pub struct StaticFilesArgs {
     ///
     /// Note: This setting can only be configured at genesis initialization. Once
     /// the node has been initialized, changing this flag requires re-syncing from scratch.
-    #[arg(long = "static-files.transaction-senders", default_value_t = default_static_file_flag(), action = clap::ArgAction::Set)]
-    pub transaction_senders: bool,
+    ///
+    /// Defaults to the base storage mode (v1: false, v2: true).
+    #[arg(long = "static-files.transaction-senders", action = clap::ArgAction::Set)]
+    pub transaction_senders: Option<bool>,
 
     /// Store account changesets in static files.
     ///
@@ -71,8 +69,10 @@ pub struct StaticFilesArgs {
     ///
     /// Note: This setting can only be configured at genesis initialization. Once
     /// the node has been initialized, changing this flag requires re-syncing from scratch.
-    #[arg(long = "static-files.account-change-sets", default_value_t = default_static_file_flag(), action = clap::ArgAction::Set)]
-    pub account_changesets: bool,
+    ///
+    /// Defaults to the base storage mode (v1: false, v2: true).
+    #[arg(long = "static-files.account-change-sets", action = clap::ArgAction::Set)]
+    pub account_changesets: Option<bool>,
 
     /// Store storage changesets in static files.
     ///
@@ -81,8 +81,10 @@ pub struct StaticFilesArgs {
     ///
     /// Note: This setting can only be configured at genesis initialization. Once
     /// the node has been initialized, changing this flag requires re-syncing from scratch.
-    #[arg(long = "static-files.storage-change-sets", default_value_t = default_static_file_flag(), action = clap::ArgAction::Set)]
-    pub storage_changesets: bool,
+    ///
+    /// Defaults to the base storage mode (v1: false, v2: true).
+    #[arg(long = "static-files.storage-change-sets", action = clap::ArgAction::Set)]
+    pub storage_changesets: Option<bool>,
 }
 
 impl StaticFilesArgs {
@@ -120,36 +122,6 @@ impl StaticFilesArgs {
                     .or(minimal_blocks_per_file)
                     .or(config.blocks_per_file.storage_change_sets),
             },
-        }
-    }
-
-    /// Converts the static files arguments into [`StorageSettings`].
-    pub const fn to_settings(&self) -> StorageSettings {
-        #[cfg(feature = "edge")]
-        let base = StorageSettings::edge();
-        #[cfg(not(feature = "edge"))]
-        let base = StorageSettings::legacy();
-
-        base.with_receipts_in_static_files(self.receipts)
-            .with_transaction_senders_in_static_files(self.transaction_senders)
-            .with_account_changesets_in_static_files(self.account_changesets)
-            .with_storage_changesets_in_static_files(self.storage_changesets)
-    }
-}
-
-impl Default for StaticFilesArgs {
-    fn default() -> Self {
-        Self {
-            blocks_per_file_headers: None,
-            blocks_per_file_transactions: None,
-            blocks_per_file_receipts: None,
-            blocks_per_file_transaction_senders: None,
-            blocks_per_file_account_change_sets: None,
-            blocks_per_file_storage_change_sets: None,
-            receipts: default_static_file_flag(),
-            transaction_senders: default_static_file_flag(),
-            account_changesets: default_static_file_flag(),
-            storage_changesets: default_static_file_flag(),
         }
     }
 }

--- a/crates/node/core/src/args/storage.rs
+++ b/crates/node/core/src/args/storage.rs
@@ -4,16 +4,16 @@ use clap::{ArgAction, Args};
 
 /// Parameters for storage mode configuration.
 ///
-/// This controls whether the node uses v2 storage defaults (with RocksDB and static file
+/// This controls whether the node uses v2 storage defaults (with `RocksDB` and static file
 /// optimizations) or v1/legacy storage defaults.
 #[derive(Debug, Args, PartialEq, Eq, Clone, Copy, Default)]
 #[command(next_help_heading = "Storage")]
 pub struct StorageArgs {
-    /// Enable v2 storage defaults (static files + RocksDB routing).
+    /// Enable v2 storage defaults (static files + `RocksDB` routing).
     ///
     /// When enabled, the node uses optimized storage settings:
     /// - Receipts and transaction senders in static files
-    /// - History indices in RocksDB (accounts, storages, transaction hashes)
+    /// - History indices in `RocksDB` (accounts, storages, transaction hashes)
     /// - Account and storage changesets in static files
     ///
     /// This is a genesis-initialization-only setting: changing it after genesis requires a

--- a/crates/node/core/src/args/storage.rs
+++ b/crates/node/core/src/args/storage.rs
@@ -1,0 +1,50 @@
+//! clap [Args](clap::Args) for storage mode configuration
+
+use clap::{ArgAction, Args};
+
+/// Parameters for storage mode configuration.
+///
+/// This controls whether the node uses v2 storage defaults (with RocksDB and static file
+/// optimizations) or v1/legacy storage defaults.
+#[derive(Debug, Args, PartialEq, Eq, Clone, Copy, Default)]
+#[command(next_help_heading = "Storage")]
+pub struct StorageArgs {
+    /// Enable v2 storage defaults (static files + RocksDB routing).
+    ///
+    /// When enabled, the node uses optimized storage settings:
+    /// - Receipts and transaction senders in static files
+    /// - History indices in RocksDB (accounts, storages, transaction hashes)
+    /// - Account and storage changesets in static files
+    ///
+    /// This is a genesis-initialization-only setting: changing it after genesis requires a
+    /// re-sync.
+    ///
+    /// Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*`
+    /// flags.
+    #[arg(long = "storage.v2", action = ArgAction::SetTrue)]
+    pub v2: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct CommandParser {
+        #[command(flatten)]
+        args: StorageArgs,
+    }
+
+    #[test]
+    fn test_default_storage_args() {
+        let args = CommandParser::parse_from(["reth"]).args;
+        assert!(!args.v2);
+    }
+
+    #[test]
+    fn test_parse_v2_flag() {
+        let args = CommandParser::parse_from(["reth", "--storage.v2"]).args;
+        assert!(args.v2);
+    }
+}

--- a/crates/node/core/src/node_config.rs
+++ b/crates/node/core/src/node_config.rs
@@ -3,7 +3,7 @@
 use crate::{
     args::{
         DatabaseArgs, DatadirArgs, DebugArgs, DevArgs, EngineArgs, NetworkArgs, PayloadBuilderArgs,
-        PruningArgs, RocksDbArgs, RpcServerArgs, StaticFilesArgs, TxPoolArgs,
+        PruningArgs, RocksDbArgs, RpcServerArgs, StaticFilesArgs, StorageArgs, TxPoolArgs,
     },
     dirs::{ChainPath, DataDirPath},
     utils::get_single_header,
@@ -154,6 +154,9 @@ pub struct NodeConfig<ChainSpec> {
 
     /// All `RocksDB` table routing arguments
     pub rocksdb: RocksDbArgs,
+
+    /// Storage mode configuration (v2 vs v1/legacy)
+    pub storage: StorageArgs,
 }
 
 impl NodeConfig<ChainSpec> {
@@ -186,6 +189,7 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
             era: EraArgs::default(),
             static_files: StaticFilesArgs::default(),
             rocksdb: RocksDbArgs::default(),
+            storage: StorageArgs::default(),
         }
     }
 
@@ -261,6 +265,7 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
             era,
             static_files,
             rocksdb,
+            storage,
             ..
         } = self;
         NodeConfig {
@@ -281,6 +286,7 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
             era,
             static_files,
             rocksdb,
+            storage,
         }
     }
 
@@ -357,16 +363,52 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
         self.pruning.prune_config(&self.chain)
     }
 
-    /// Returns the effective storage settings derived from static-file and `RocksDB` CLI args.
-    pub const fn storage_settings(&self) -> StorageSettings {
-        StorageSettings::base()
-            .with_receipts_in_static_files(self.static_files.receipts)
-            .with_transaction_senders_in_static_files(self.static_files.transaction_senders)
-            .with_account_changesets_in_static_files(self.static_files.account_changesets)
-            .with_storage_changesets_in_static_files(self.static_files.storage_changesets)
-            .with_transaction_hash_numbers_in_rocksdb(self.rocksdb.all || self.rocksdb.tx_hash)
-            .with_storages_history_in_rocksdb(self.rocksdb.all || self.rocksdb.storages_history)
-            .with_account_history_in_rocksdb(self.rocksdb.all || self.rocksdb.account_history)
+    /// Returns the effective storage settings derived from `--storage.v2`, static-file, and
+    /// `RocksDB` CLI args.
+    ///
+    /// The base storage mode is determined by `--storage.v2`:
+    /// - When `--storage.v2` is set: uses [`StorageSettings::v2()`] defaults
+    /// - Otherwise: uses [`StorageSettings::v1()`] defaults
+    ///
+    /// Individual `--static-files.*` and `--rocksdb.*` flags override the base when explicitly set.
+    pub fn storage_settings(&self) -> StorageSettings {
+        let mut s = if self.storage.v2 { StorageSettings::v2() } else { StorageSettings::base() };
+
+        // Apply static files overrides (only when explicitly set)
+        if let Some(v) = self.static_files.receipts {
+            s = s.with_receipts_in_static_files(v);
+        }
+        if let Some(v) = self.static_files.transaction_senders {
+            s = s.with_transaction_senders_in_static_files(v);
+        }
+        if let Some(v) = self.static_files.account_changesets {
+            s = s.with_account_changesets_in_static_files(v);
+        }
+        if let Some(v) = self.static_files.storage_changesets {
+            s = s.with_storage_changesets_in_static_files(v);
+        }
+
+        // Apply rocksdb overrides
+        // --rocksdb.all sets all rocksdb flags to true
+        if self.rocksdb.all {
+            s = s
+                .with_transaction_hash_numbers_in_rocksdb(true)
+                .with_storages_history_in_rocksdb(true)
+                .with_account_history_in_rocksdb(true);
+        }
+
+        // Individual rocksdb flags override --rocksdb.all when explicitly set
+        if let Some(v) = self.rocksdb.tx_hash {
+            s = s.with_transaction_hash_numbers_in_rocksdb(v);
+        }
+        if let Some(v) = self.rocksdb.storages_history {
+            s = s.with_storages_history_in_rocksdb(v);
+        }
+        if let Some(v) = self.rocksdb.account_history {
+            s = s.with_account_history_in_rocksdb(v);
+        }
+
+        s
     }
 
     /// Returns the max block that the node should run to, looking it up from the network if
@@ -564,6 +606,7 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
             era: self.era,
             static_files: self.static_files,
             rocksdb: self.rocksdb,
+            storage: self.storage,
         }
     }
 
@@ -606,6 +649,7 @@ impl<ChainSpec> Clone for NodeConfig<ChainSpec> {
             era: self.era.clone(),
             static_files: self.static_files,
             rocksdb: self.rocksdb,
+            storage: self.storage,
         }
     }
 }

--- a/crates/node/core/src/node_config.rs
+++ b/crates/node/core/src/node_config.rs
@@ -371,7 +371,7 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
     /// - Otherwise: uses [`StorageSettings::v1()`] defaults
     ///
     /// Individual `--static-files.*` and `--rocksdb.*` flags override the base when explicitly set.
-    pub fn storage_settings(&self) -> StorageSettings {
+    pub const fn storage_settings(&self) -> StorageSettings {
         let mut s = if self.storage.v2 { StorageSettings::v2() } else { StorageSettings::base() };
 
         // Apply static files overrides (only when explicitly set)

--- a/crates/prune/prune/src/segments/user/transaction_lookup.rs
+++ b/crates/prune/prune/src/segments/user/transaction_lookup.rs
@@ -492,7 +492,7 @@ mod tests {
 
         // Enable RocksDB storage for transaction hash numbers
         db.factory.set_storage_settings_cache(
-            StorageSettings::legacy().with_transaction_hash_numbers_in_rocksdb(true),
+            StorageSettings::v1().with_transaction_hash_numbers_in_rocksdb(true),
         );
 
         let provider = db.factory.database_provider_rw().unwrap();

--- a/crates/prune/prune/src/segments/user/transaction_lookup.rs
+++ b/crates/prune/prune/src/segments/user/transaction_lookup.rs
@@ -579,7 +579,7 @@ mod tests {
 
         // Enable RocksDB storage for transaction hash numbers
         db.factory.set_storage_settings_cache(
-            StorageSettings::legacy().with_transaction_hash_numbers_in_rocksdb(true),
+            StorageSettings::v1().with_transaction_hash_numbers_in_rocksdb(true),
         );
 
         let to_block: BlockNumber = 6;

--- a/crates/stages/stages/Cargo.toml
+++ b/crates/stages/stages/Cargo.toml
@@ -122,8 +122,8 @@ test-utils = [
     "reth-ethereum-primitives?/test-utils",
     "reth-evm-ethereum/test-utils",
 ]
-rocksdb = ["reth-provider/rocksdb"]
-edge = ["reth-provider/edge", "reth-db-common/edge", "rocksdb"]
+rocksdb = ["reth-provider/rocksdb", "reth-db-common/rocksdb"]
+edge = ["rocksdb"]
 
 [[bench]]
 name = "criterion"

--- a/crates/stages/stages/src/stages/execution.rs
+++ b/crates/stages/stages/src/stages/execution.rs
@@ -1261,9 +1261,8 @@ mod tests {
         // but no receipt data is written.
 
         let factory = create_test_provider_factory();
-        factory.set_storage_settings_cache(
-            StorageSettings::legacy().with_receipts_in_static_files(true),
-        );
+        factory
+            .set_storage_settings_cache(StorageSettings::v1().with_receipts_in_static_files(true));
 
         // Setup with block 1
         let provider_rw = factory.database_provider_rw().unwrap();

--- a/crates/stages/stages/src/stages/index_account_history.rs
+++ b/crates/stages/stages/src/stages/index_account_history.rs
@@ -678,7 +678,7 @@ mod tests {
 
             // Enable RocksDB for account history
             db.factory.set_storage_settings_cache(
-                StorageSettings::legacy().with_account_history_in_rocksdb(true),
+                StorageSettings::v1().with_account_history_in_rocksdb(true),
             );
 
             db.commit(|tx| {
@@ -723,7 +723,7 @@ mod tests {
             let db = TestStageDB::default();
 
             db.factory.set_storage_settings_cache(
-                StorageSettings::legacy().with_account_history_in_rocksdb(true),
+                StorageSettings::v1().with_account_history_in_rocksdb(true),
             );
 
             db.commit(|tx| {
@@ -774,7 +774,7 @@ mod tests {
             let db = TestStageDB::default();
 
             db.factory.set_storage_settings_cache(
-                StorageSettings::legacy().with_account_history_in_rocksdb(true),
+                StorageSettings::v1().with_account_history_in_rocksdb(true),
             );
 
             db.commit(|tx| {

--- a/crates/stages/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/stages/src/stages/index_storage_history.rs
@@ -704,7 +704,7 @@ mod tests {
             let db = TestStageDB::default();
 
             db.factory.set_storage_settings_cache(
-                StorageSettings::legacy().with_storages_history_in_rocksdb(true),
+                StorageSettings::v1().with_storages_history_in_rocksdb(true),
             );
 
             db.commit(|tx| {
@@ -750,7 +750,7 @@ mod tests {
             let db = TestStageDB::default();
 
             db.factory.set_storage_settings_cache(
-                StorageSettings::legacy().with_storages_history_in_rocksdb(true),
+                StorageSettings::v1().with_storages_history_in_rocksdb(true),
             );
 
             db.commit(|tx| {
@@ -805,7 +805,7 @@ mod tests {
             let db = TestStageDB::default();
 
             db.factory.set_storage_settings_cache(
-                StorageSettings::legacy().with_storages_history_in_rocksdb(true),
+                StorageSettings::v1().with_storages_history_in_rocksdb(true),
             );
 
             db.commit(|tx| {
@@ -854,7 +854,7 @@ mod tests {
             let db = TestStageDB::default();
 
             db.factory.set_storage_settings_cache(
-                StorageSettings::legacy().with_storages_history_in_rocksdb(true),
+                StorageSettings::v1().with_storages_history_in_rocksdb(true),
             );
 
             db.commit(|tx| {
@@ -921,7 +921,7 @@ mod tests {
             let db = TestStageDB::default();
 
             db.factory.set_storage_settings_cache(
-                StorageSettings::legacy().with_storages_history_in_rocksdb(true),
+                StorageSettings::v1().with_storages_history_in_rocksdb(true),
             );
 
             let num_blocks = (NUM_OF_INDICES_IN_SHARD * 2 + 100) as u64;

--- a/crates/stages/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/stages/src/stages/sender_recovery.rs
@@ -494,7 +494,7 @@ mod tests {
 
         let runner = SenderRecoveryTestRunner::default();
         runner.db.factory.set_storage_settings_cache(
-            StorageSettings::legacy().with_transaction_senders_in_static_files(true),
+            StorageSettings::v1().with_transaction_senders_in_static_files(true),
         );
         let input = ExecInput {
             target: Some(target),

--- a/crates/stages/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/stages/src/stages/tx_lookup.rs
@@ -619,7 +619,7 @@ mod tests {
 
             // Enable RocksDB for transaction hash numbers
             runner.db.factory.set_storage_settings_cache(
-                StorageSettings::legacy().with_transaction_hash_numbers_in_rocksdb(true),
+                StorageSettings::v1().with_transaction_hash_numbers_in_rocksdb(true),
             );
 
             let input = ExecInput {
@@ -687,7 +687,7 @@ mod tests {
 
             // Enable RocksDB for transaction hash numbers
             runner.db.factory.set_storage_settings_cache(
-                StorageSettings::legacy().with_transaction_hash_numbers_in_rocksdb(true),
+                StorageSettings::v1().with_transaction_hash_numbers_in_rocksdb(true),
             );
 
             // Insert blocks with transactions

--- a/crates/storage/db-api/Cargo.toml
+++ b/crates/storage/db-api/Cargo.toml
@@ -94,4 +94,5 @@ op = [
     "reth-primitives-traits/op",
 ]
 bench = []
-edge = []
+rocksdb = []
+edge = ["rocksdb"]

--- a/crates/storage/db-api/src/models/metadata.rs
+++ b/crates/storage/db-api/src/models/metadata.rs
@@ -39,25 +39,26 @@ pub struct StorageSettings {
 impl StorageSettings {
     /// Returns the default base `StorageSettings` for this build.
     ///
-    /// When the `edge` feature is enabled, returns `Self::edge()`.
-    /// Otherwise, returns [`Self::legacy()`].
+    /// When the `edge` feature is enabled, returns `Self::v2()`.
+    /// Otherwise, returns [`Self::v1()`]. Use `--storage.v2` CLI flag for runtime override.
     pub const fn base() -> Self {
         #[cfg(feature = "edge")]
         {
-            Self::edge()
+            Self::v2()
         }
         #[cfg(not(feature = "edge"))]
         {
-            Self::legacy()
+            Self::v1()
         }
     }
 
-    /// Creates `StorageSettings` for edge nodes with all storage features enabled:
+    /// Creates `StorageSettings` for v2 nodes with all storage features enabled:
     /// - Receipts and transaction senders in static files
     /// - History indices in `RocksDB` (storages, accounts, transaction hashes)
-    /// - Account changesets in static files
-    #[cfg(feature = "edge")]
-    pub const fn edge() -> Self {
+    /// - Account and storage changesets in static files
+    ///
+    /// Use this when the `--storage.v2` CLI flag is set.
+    pub const fn v2() -> Self {
         Self {
             receipts_in_static_files: true,
             transaction_senders_in_static_files: true,
@@ -69,12 +70,12 @@ impl StorageSettings {
         }
     }
 
-    /// Creates `StorageSettings` for legacy nodes.
+    /// Creates `StorageSettings` for v1/legacy nodes.
     ///
     /// This explicitly sets `receipts_in_static_files` and `transaction_senders_in_static_files` to
     /// `false`, ensuring older nodes continue writing receipts and transaction senders to the
     /// database when receipt pruning is enabled.
-    pub const fn legacy() -> Self {
+    pub const fn v1() -> Self {
         Self {
             receipts_in_static_files: false,
             transaction_senders_in_static_files: false,

--- a/crates/storage/db-api/src/models/metadata.rs
+++ b/crates/storage/db-api/src/models/metadata.rs
@@ -37,19 +37,13 @@ pub struct StorageSettings {
 }
 
 impl StorageSettings {
-    /// Returns the default base `StorageSettings` for this build.
+    /// Returns the default base `StorageSettings`.
     ///
-    /// When the `rocksdb` feature is enabled, returns `Self::v2()`.
-    /// Otherwise, returns [`Self::v1()`]. Use `--storage.v2` CLI flag for runtime override.
+    /// Always returns [`Self::v1()`]. Use the `--storage.v2` CLI flag to opt into
+    /// [`Self::v2()`] at runtime. The `rocksdb` feature only makes the v2 backend
+    /// *available*; it does not activate it by default.
     pub const fn base() -> Self {
-        #[cfg(feature = "rocksdb")]
-        {
-            Self::v2()
-        }
-        #[cfg(not(feature = "rocksdb"))]
-        {
-            Self::v1()
-        }
+        Self::v1()
     }
 
     /// Creates `StorageSettings` for v2 nodes with all storage features enabled:

--- a/crates/storage/db-api/src/models/metadata.rs
+++ b/crates/storage/db-api/src/models/metadata.rs
@@ -39,14 +39,14 @@ pub struct StorageSettings {
 impl StorageSettings {
     /// Returns the default base `StorageSettings` for this build.
     ///
-    /// When the `edge` feature is enabled, returns `Self::v2()`.
+    /// When the `rocksdb` feature is enabled, returns `Self::v2()`.
     /// Otherwise, returns [`Self::v1()`]. Use `--storage.v2` CLI flag for runtime override.
     pub const fn base() -> Self {
-        #[cfg(feature = "edge")]
+        #[cfg(feature = "rocksdb")]
         {
             Self::v2()
         }
-        #[cfg(not(feature = "edge"))]
+        #[cfg(not(feature = "rocksdb"))]
         {
             Self::v1()
         }

--- a/crates/storage/db-common/Cargo.toml
+++ b/crates/storage/db-common/Cargo.toml
@@ -46,7 +46,8 @@ reth-db = { workspace = true, features = ["mdbx"] }
 reth-provider = { workspace = true, features = ["test-utils"] }
 
 [features]
-edge = ["reth-db-api/edge", "reth-provider/rocksdb"]
+rocksdb = ["reth-db-api/rocksdb", "reth-provider/rocksdb"]
+edge = ["rocksdb"]
 
 [lints]
 workspace = true

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -963,7 +963,7 @@ mod tests {
             )
         };
 
-        #[cfg(feature = "edge")]
+        #[cfg(feature = "rocksdb")]
         {
             let settings = factory.cached_storage_settings();
             let rocksdb = factory.rocksdb_provider();
@@ -992,7 +992,7 @@ mod tests {
             assert_eq!(storages, expected_storages);
         }
 
-        #[cfg(not(feature = "edge"))]
+        #[cfg(not(feature = "rocksdb"))]
         {
             let (accounts, storages) = collect_from_mdbx(&factory);
             assert_eq!(accounts, expected_accounts);

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -118,14 +118,7 @@ where
         + AsRef<PF::ProviderRW>,
     PF::ChainSpec: EthChainSpec<Header = <PF::Primitives as NodePrimitives>::BlockHeader>,
 {
-    #[cfg(feature = "edge")]
-    {
-        init_genesis_with_settings(factory, StorageSettings::edge())
-    }
-    #[cfg(not(feature = "edge"))]
-    {
-        init_genesis_with_settings(factory, StorageSettings::legacy())
-    }
+    init_genesis_with_settings(factory, StorageSettings::base())
 }
 
 /// Write the genesis block if it has not already been written with [`StorageSettings`].
@@ -177,7 +170,7 @@ where
                     return Err(InitStorageError::UninitializedDatabase)
                 }
 
-                let stored = factory.storage_settings()?.unwrap_or_else(StorageSettings::legacy);
+                let stored = factory.storage_settings()?.unwrap_or_else(StorageSettings::v1);
                 if stored != genesis_storage_settings {
                     warn!(
                         target: "reth::storage",
@@ -1010,12 +1003,12 @@ mod tests {
     #[test]
     fn warn_storage_settings_mismatch() {
         let factory = create_test_provider_factory_with_chain_spec(MAINNET.clone());
-        init_genesis_with_settings(&factory, StorageSettings::legacy()).unwrap();
+        init_genesis_with_settings(&factory, StorageSettings::v1()).unwrap();
 
         // Request different settings - should warn but succeed
         let result = init_genesis_with_settings(
             &factory,
-            StorageSettings::legacy().with_receipts_in_static_files(true),
+            StorageSettings::v1().with_receipts_in_static_files(true),
         );
 
         // Should succeed (warning is logged, not an error)
@@ -1025,7 +1018,7 @@ mod tests {
     #[test]
     fn allow_same_storage_settings() {
         let factory = create_test_provider_factory_with_chain_spec(MAINNET.clone());
-        let settings = StorageSettings::legacy().with_receipts_in_static_files(true);
+        let settings = StorageSettings::v1().with_receipts_in_static_files(true);
         init_genesis_with_settings(&factory, settings).unwrap();
 
         let result = init_genesis_with_settings(&factory, settings);

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -87,8 +87,8 @@ rand.workspace = true
 tokio = { workspace = true, features = ["sync", "macros", "rt-multi-thread"] }
 
 [features]
-edge = ["reth-storage-api/edge", "rocksdb"]
-rocksdb = ["dep:rocksdb"]
+rocksdb = ["reth-storage-api/rocksdb", "dep:rocksdb"]
+edge = ["rocksdb"]
 test-utils = [
     "reth-db/test-utils",
     "reth-nippy-jar/test-utils",

--- a/crates/storage/provider/src/either_writer.rs
+++ b/crates/storage/provider/src/either_writer.rs
@@ -1162,7 +1162,7 @@ mod tests {
 
         for transaction_senders_in_static_files in [false, true] {
             factory.set_storage_settings_cache(
-                StorageSettings::legacy()
+                StorageSettings::v1()
                     .with_transaction_senders_in_static_files(transaction_senders_in_static_files),
             );
 
@@ -1235,7 +1235,7 @@ mod rocksdb_tests {
 
         // Enable RocksDB for transaction hash numbers
         factory.set_storage_settings_cache(
-            StorageSettings::legacy().with_transaction_hash_numbers_in_rocksdb(true),
+            StorageSettings::v1().with_transaction_hash_numbers_in_rocksdb(true),
         );
 
         let hash1 = B256::from([1u8; 32]);
@@ -1279,7 +1279,7 @@ mod rocksdb_tests {
 
         // Enable RocksDB for transaction hash numbers
         factory.set_storage_settings_cache(
-            StorageSettings::legacy().with_transaction_hash_numbers_in_rocksdb(true),
+            StorageSettings::v1().with_transaction_hash_numbers_in_rocksdb(true),
         );
 
         let hash = B256::from([1u8; 32]);
@@ -1833,7 +1833,7 @@ mod rocksdb_tests {
 
         // Enable RocksDB for transaction hash numbers
         factory.set_storage_settings_cache(
-            StorageSettings::legacy().with_transaction_hash_numbers_in_rocksdb(true),
+            StorageSettings::v1().with_transaction_hash_numbers_in_rocksdb(true),
         );
 
         let hash1 = B256::from([1u8; 32]);
@@ -1893,7 +1893,7 @@ mod rocksdb_tests {
         let factory = create_test_provider_factory();
 
         factory.set_storage_settings_cache(
-            StorageSettings::legacy().with_account_history_in_rocksdb(true),
+            StorageSettings::v1().with_account_history_in_rocksdb(true),
         );
 
         let provider = factory.database_provider_ro().unwrap();

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -105,7 +105,7 @@ impl<N: ProviderNodeTypes> ProviderFactory<N> {
         // to read persisted settings, falling back to legacy defaults if none exist.
         //
         // Both factory and all providers it creates should share these cached settings.
-        let legacy_settings = StorageSettings::legacy();
+        let legacy_settings = StorageSettings::v1();
         let storage_settings = DatabaseProvider::<_, N>::new(
             db.tx()?,
             chain_spec.clone(),

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -4110,7 +4110,7 @@ mod tests {
         // Legacy mode (receipts in DB) - should be prunable
         {
             let factory = create_test_provider_factory();
-            let storage_settings = StorageSettings::legacy();
+            let storage_settings = StorageSettings::v1();
             factory.set_storage_settings_cache(storage_settings);
             let factory = factory.with_prune_modes(PruneModes {
                 receipts: Some(PruneMode::Before(100)),
@@ -4147,7 +4147,7 @@ mod tests {
         // Static files mode
         {
             let factory = create_test_provider_factory();
-            let storage_settings = StorageSettings::legacy().with_receipts_in_static_files(true);
+            let storage_settings = StorageSettings::v1().with_receipts_in_static_files(true);
             factory.set_storage_settings_cache(storage_settings);
             let factory = factory.with_prune_modes(PruneModes {
                 receipts: Some(PruneMode::Before(2)),

--- a/crates/storage/provider/src/providers/rocksdb/invariants.rs
+++ b/crates/storage/provider/src/providers/rocksdb/invariants.rs
@@ -502,7 +502,7 @@ mod tests {
         // Create a test provider factory for MDBX
         let factory = create_test_provider_factory();
         factory.set_storage_settings_cache(
-            StorageSettings::legacy()
+            StorageSettings::v1()
                 .with_transaction_hash_numbers_in_rocksdb(true)
                 .with_storages_history_in_rocksdb(true),
         );
@@ -525,7 +525,7 @@ mod tests {
         // Create a test provider factory for MDBX
         let factory = create_test_provider_factory();
         factory.set_storage_settings_cache(
-            StorageSettings::legacy().with_transaction_hash_numbers_in_rocksdb(true),
+            StorageSettings::v1().with_transaction_hash_numbers_in_rocksdb(true),
         );
 
         // Set a checkpoint indicating we should have processed up to block 100
@@ -557,7 +557,7 @@ mod tests {
 
         let factory = create_test_provider_factory();
         factory.set_storage_settings_cache(
-            StorageSettings::legacy().with_transaction_hash_numbers_in_rocksdb(true),
+            StorageSettings::v1().with_transaction_hash_numbers_in_rocksdb(true),
         );
 
         // Generate blocks with real transactions and insert them
@@ -625,7 +625,7 @@ mod tests {
         // Create a test provider factory for MDBX
         let factory = create_test_provider_factory();
         factory.set_storage_settings_cache(
-            StorageSettings::legacy().with_storages_history_in_rocksdb(true),
+            StorageSettings::v1().with_storages_history_in_rocksdb(true),
         );
 
         // Set a checkpoint indicating we should have processed up to block 100
@@ -665,7 +665,7 @@ mod tests {
         // Create a test provider factory for MDBX with NO checkpoint
         let factory = create_test_provider_factory();
         factory.set_storage_settings_cache(
-            StorageSettings::legacy().with_storages_history_in_rocksdb(true),
+            StorageSettings::v1().with_storages_history_in_rocksdb(true),
         );
 
         let provider = factory.database_provider_ro().unwrap();
@@ -691,7 +691,7 @@ mod tests {
 
         let factory = create_test_provider_factory();
         factory.set_storage_settings_cache(
-            StorageSettings::legacy().with_transaction_hash_numbers_in_rocksdb(true),
+            StorageSettings::v1().with_transaction_hash_numbers_in_rocksdb(true),
         );
 
         // Generate blocks with real transactions (blocks 0-2, 6 transactions total)
@@ -747,7 +747,7 @@ mod tests {
         // Create a test provider factory for MDBX
         let factory = create_test_provider_factory();
         factory.set_storage_settings_cache(
-            StorageSettings::legacy().with_transaction_hash_numbers_in_rocksdb(true),
+            StorageSettings::v1().with_transaction_hash_numbers_in_rocksdb(true),
         );
 
         // Generate blocks with real transactions:
@@ -859,7 +859,7 @@ mod tests {
         // Create a test provider factory for MDBX
         let factory = create_test_provider_factory();
         factory.set_storage_settings_cache(
-            StorageSettings::legacy().with_storages_history_in_rocksdb(true),
+            StorageSettings::v1().with_storages_history_in_rocksdb(true),
         );
 
         // Set a checkpoint indicating we should have processed up to block 100
@@ -903,7 +903,7 @@ mod tests {
         // Create a test provider factory for MDBX
         let factory = create_test_provider_factory();
         factory.set_storage_settings_cache(
-            StorageSettings::legacy().with_account_history_in_rocksdb(true),
+            StorageSettings::v1().with_account_history_in_rocksdb(true),
         );
 
         // Set a checkpoint indicating we should have processed up to block 100
@@ -938,7 +938,7 @@ mod tests {
         // Create a test provider factory for MDBX
         let factory = create_test_provider_factory();
         factory.set_storage_settings_cache(
-            StorageSettings::legacy().with_transaction_hash_numbers_in_rocksdb(true),
+            StorageSettings::v1().with_transaction_hash_numbers_in_rocksdb(true),
         );
 
         // Generate random blocks with unique transactions
@@ -1051,7 +1051,7 @@ mod tests {
         // Create a test provider factory for MDBX
         let factory = create_test_provider_factory();
         factory.set_storage_settings_cache(
-            StorageSettings::legacy().with_account_history_in_rocksdb(true),
+            StorageSettings::v1().with_account_history_in_rocksdb(true),
         );
 
         // Set a checkpoint indicating we should have processed up to block 100
@@ -1093,7 +1093,7 @@ mod tests {
         // Create a test provider factory for MDBX with NO checkpoint
         let factory = create_test_provider_factory();
         factory.set_storage_settings_cache(
-            StorageSettings::legacy().with_account_history_in_rocksdb(true),
+            StorageSettings::v1().with_account_history_in_rocksdb(true),
         );
 
         let provider = factory.database_provider_ro().unwrap();
@@ -1141,7 +1141,7 @@ mod tests {
         // Create a test provider factory for MDBX
         let factory = create_test_provider_factory();
         factory.set_storage_settings_cache(
-            StorageSettings::legacy().with_account_history_in_rocksdb(true),
+            StorageSettings::v1().with_account_history_in_rocksdb(true),
         );
 
         // Write account changesets to static files for blocks 0-100
@@ -1228,7 +1228,7 @@ mod tests {
 
         let factory = create_test_provider_factory();
         factory.set_storage_settings_cache(
-            StorageSettings::legacy()
+            StorageSettings::v1()
                 .with_storages_history_in_rocksdb(true)
                 .with_storage_changesets_in_static_files(true),
         );
@@ -1352,7 +1352,7 @@ mod tests {
 
         let factory = create_test_provider_factory();
         factory.set_storage_settings_cache(
-            StorageSettings::legacy()
+            StorageSettings::v1()
                 .with_storages_history_in_rocksdb(true)
                 .with_storage_changesets_in_static_files(true),
         );
@@ -1458,7 +1458,7 @@ mod tests {
         // Create test provider factory
         let factory = create_test_provider_factory();
         factory.set_storage_settings_cache(
-            StorageSettings::legacy()
+            StorageSettings::v1()
                 .with_account_history_in_rocksdb(true)
                 .with_account_changesets_in_static_files(true),
         );
@@ -1579,7 +1579,7 @@ mod tests {
 
         let factory = create_test_provider_factory();
         factory.set_storage_settings_cache(
-            StorageSettings::legacy()
+            StorageSettings::v1()
                 .with_account_history_in_rocksdb(true)
                 .with_account_changesets_in_static_files(true),
         );
@@ -1669,7 +1669,7 @@ mod tests {
         // Create a test provider factory
         let factory = create_test_provider_factory();
         factory.set_storage_settings_cache(
-            StorageSettings::legacy().with_storages_history_in_rocksdb(true),
+            StorageSettings::v1().with_storages_history_in_rocksdb(true),
         );
 
         // Write storage changesets to static files for blocks 0-100

--- a/crates/storage/provider/src/traits/rocksdb_provider.rs
+++ b/crates/storage/provider/src/traits/rocksdb_provider.rs
@@ -170,7 +170,7 @@ mod tests {
 
     #[test]
     fn test_legacy_settings_skip_rocksdb_tx_creation() {
-        let provider = TestProvider::new(StorageSettings::legacy());
+        let provider = TestProvider::new(StorageSettings::v1());
 
         let result = provider.with_rocksdb_tx(|tx| {
             assert!(tx.is_none(), "legacy settings should pass None tx");
@@ -184,7 +184,7 @@ mod tests {
     #[test]
     fn test_rocksdb_settings_create_tx() {
         let settings =
-            StorageSettings { account_history_in_rocksdb: true, ..StorageSettings::legacy() };
+            StorageSettings { account_history_in_rocksdb: true, ..StorageSettings::v1() };
         let provider = TestProvider::new(settings);
 
         let result = provider.with_rocksdb_tx(|tx| {

--- a/crates/storage/storage-api/Cargo.toml
+++ b/crates/storage/storage-api/Cargo.toml
@@ -36,7 +36,8 @@ serde_json = { workspace = true, optional = true }
 
 [features]
 default = ["std"]
-edge = ["reth-db-api/edge"]
+rocksdb = ["reth-db-api/rocksdb"]
+edge = ["rocksdb"]
 std = [
     "reth-chainspec/std",
     "alloy-consensus/std",

--- a/docs/vocs/docs/pages/cli/SUMMARY.mdx
+++ b/docs/vocs/docs/pages/cli/SUMMARY.mdx
@@ -12,6 +12,7 @@
       - [`reth db checksum`](./reth/db/checksum.mdx)
         - [`reth db checksum mdbx`](./reth/db/checksum/mdbx.mdx)
         - [`reth db checksum static-file`](./reth/db/checksum/static-file.mdx)
+        - [`reth db checksum rocksdb`](./reth/db/checksum/rocksdb.mdx)
       - [`reth db diff`](./reth/db/diff.mdx)
       - [`reth db get`](./reth/db/get.mdx)
         - [`reth db get mdbx`](./reth/db/get/mdbx.mdx)

--- a/docs/vocs/docs/pages/cli/reth/db.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db.mdx
@@ -201,9 +201,9 @@ RocksDB:
 
 Storage:
       --storage.v2
-          Enable v2 storage defaults (static files + RocksDB routing).
+          Enable v2 storage defaults (static files + `RocksDB` routing).
 
-          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in RocksDB (accounts, storages, transaction hashes) - Account and storage changesets in static files
+          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in `RocksDB` (accounts, storages, transaction hashes) - Account and storage changesets in static files
 
           This is a genesis-initialization-only setting: changing it after genesis requires a re-sync.
 

--- a/docs/vocs/docs/pages/cli/reth/db.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db.mdx
@@ -135,7 +135,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.transaction-senders <TRANSACTION_SENDERS>
@@ -145,7 +146,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.account-change-sets <ACCOUNT_CHANGESETS>
@@ -155,7 +157,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.storage-change-sets <STORAGE_CHANGESETS>
@@ -165,7 +168,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
 RocksDB:
@@ -177,26 +181,33 @@ RocksDB:
       --rocksdb.tx-hash <TX_HASH>
           Route tx hash -> number table to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
 
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
 
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
+
+Storage:
+      --storage.v2
+          Enable v2 storage defaults (static files + RocksDB routing).
+
+          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in RocksDB (accounts, storages, transaction hashes) - Account and storage changesets in static files
+
+          This is a genesis-initialization-only setting: changing it after genesis requires a re-sync.
+
+          Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
 Logging:
       --log.stdout.format <FORMAT>

--- a/docs/vocs/docs/pages/cli/reth/db/checksum/rocksdb.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/checksum/rocksdb.mdx
@@ -1,20 +1,26 @@
-# reth db checksum
+# reth db checksum rocksdb
 
-Calculates the content checksum of a table or static file segment
+Calculates the checksum of a RocksDB table
 
 ```bash
-$ reth db checksum --help
+$ reth db checksum rocksdb --help
 ```
 ```txt
-Usage: reth db checksum [OPTIONS] <COMMAND>
+Usage: reth db checksum rocksdb [OPTIONS] <TABLE>
 
-Commands:
-  mdbx         Calculates the checksum of a database table
-  static-file  Calculates the checksum of a static file segment
-  rocksdb      Calculates the checksum of a RocksDB table
-  help         Print this message or the help of the given subcommand(s)
+Arguments:
+  <TABLE>
+          The RocksDB table
+
+          Possible values:
+          - transaction-hash-numbers: Transaction hash to transaction number mapping
+          - accounts-history:         Account history indices
+          - storages-history:         Storage history indices
 
 Options:
+      --limit <LIMIT>
+          The maximum number of records to checksum
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/docs/vocs/docs/pages/cli/reth/download.mdx
+++ b/docs/vocs/docs/pages/cli/reth/download.mdx
@@ -118,7 +118,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.transaction-senders <TRANSACTION_SENDERS>
@@ -128,7 +129,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.account-change-sets <ACCOUNT_CHANGESETS>
@@ -138,7 +140,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.storage-change-sets <STORAGE_CHANGESETS>
@@ -148,7 +151,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
 RocksDB:
@@ -160,26 +164,33 @@ RocksDB:
       --rocksdb.tx-hash <TX_HASH>
           Route tx hash -> number table to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
 
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
 
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
+
+Storage:
+      --storage.v2
+          Enable v2 storage defaults (static files + RocksDB routing).
+
+          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in RocksDB (accounts, storages, transaction hashes) - Account and storage changesets in static files
+
+          This is a genesis-initialization-only setting: changing it after genesis requires a re-sync.
+
+          Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
   -u, --url <URL>
           Specify a snapshot URL or let the command propose a default one.

--- a/docs/vocs/docs/pages/cli/reth/download.mdx
+++ b/docs/vocs/docs/pages/cli/reth/download.mdx
@@ -184,9 +184,9 @@ RocksDB:
 
 Storage:
       --storage.v2
-          Enable v2 storage defaults (static files + RocksDB routing).
+          Enable v2 storage defaults (static files + `RocksDB` routing).
 
-          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in RocksDB (accounts, storages, transaction hashes) - Account and storage changesets in static files
+          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in `RocksDB` (accounts, storages, transaction hashes) - Account and storage changesets in static files
 
           This is a genesis-initialization-only setting: changing it after genesis requires a re-sync.
 

--- a/docs/vocs/docs/pages/cli/reth/export-era.mdx
+++ b/docs/vocs/docs/pages/cli/reth/export-era.mdx
@@ -118,7 +118,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.transaction-senders <TRANSACTION_SENDERS>
@@ -128,7 +129,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.account-change-sets <ACCOUNT_CHANGESETS>
@@ -138,7 +140,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.storage-change-sets <STORAGE_CHANGESETS>
@@ -148,7 +151,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
 RocksDB:
@@ -160,26 +164,33 @@ RocksDB:
       --rocksdb.tx-hash <TX_HASH>
           Route tx hash -> number table to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
 
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
 
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
+
+Storage:
+      --storage.v2
+          Enable v2 storage defaults (static files + RocksDB routing).
+
+          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in RocksDB (accounts, storages, transaction hashes) - Account and storage changesets in static files
+
+          This is a genesis-initialization-only setting: changing it after genesis requires a re-sync.
+
+          Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
       --first-block-number <first-block-number>
           Optional first block number to export from the db.

--- a/docs/vocs/docs/pages/cli/reth/export-era.mdx
+++ b/docs/vocs/docs/pages/cli/reth/export-era.mdx
@@ -184,9 +184,9 @@ RocksDB:
 
 Storage:
       --storage.v2
-          Enable v2 storage defaults (static files + RocksDB routing).
+          Enable v2 storage defaults (static files + `RocksDB` routing).
 
-          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in RocksDB (accounts, storages, transaction hashes) - Account and storage changesets in static files
+          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in `RocksDB` (accounts, storages, transaction hashes) - Account and storage changesets in static files
 
           This is a genesis-initialization-only setting: changing it after genesis requires a re-sync.
 

--- a/docs/vocs/docs/pages/cli/reth/import-era.mdx
+++ b/docs/vocs/docs/pages/cli/reth/import-era.mdx
@@ -118,7 +118,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.transaction-senders <TRANSACTION_SENDERS>
@@ -128,7 +129,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.account-change-sets <ACCOUNT_CHANGESETS>
@@ -138,7 +140,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.storage-change-sets <STORAGE_CHANGESETS>
@@ -148,7 +151,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
 RocksDB:
@@ -160,26 +164,33 @@ RocksDB:
       --rocksdb.tx-hash <TX_HASH>
           Route tx hash -> number table to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
 
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
 
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
+
+Storage:
+      --storage.v2
+          Enable v2 storage defaults (static files + RocksDB routing).
+
+          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in RocksDB (accounts, storages, transaction hashes) - Account and storage changesets in static files
+
+          This is a genesis-initialization-only setting: changing it after genesis requires a re-sync.
+
+          Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
       --path <IMPORT_ERA_PATH>
           The path to a directory for import.

--- a/docs/vocs/docs/pages/cli/reth/import-era.mdx
+++ b/docs/vocs/docs/pages/cli/reth/import-era.mdx
@@ -184,9 +184,9 @@ RocksDB:
 
 Storage:
       --storage.v2
-          Enable v2 storage defaults (static files + RocksDB routing).
+          Enable v2 storage defaults (static files + `RocksDB` routing).
 
-          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in RocksDB (accounts, storages, transaction hashes) - Account and storage changesets in static files
+          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in `RocksDB` (accounts, storages, transaction hashes) - Account and storage changesets in static files
 
           This is a genesis-initialization-only setting: changing it after genesis requires a re-sync.
 

--- a/docs/vocs/docs/pages/cli/reth/import.mdx
+++ b/docs/vocs/docs/pages/cli/reth/import.mdx
@@ -118,7 +118,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.transaction-senders <TRANSACTION_SENDERS>
@@ -128,7 +129,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.account-change-sets <ACCOUNT_CHANGESETS>
@@ -138,7 +140,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.storage-change-sets <STORAGE_CHANGESETS>
@@ -148,7 +151,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
 RocksDB:
@@ -160,26 +164,33 @@ RocksDB:
       --rocksdb.tx-hash <TX_HASH>
           Route tx hash -> number table to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
 
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
 
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
+
+Storage:
+      --storage.v2
+          Enable v2 storage defaults (static files + RocksDB routing).
+
+          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in RocksDB (accounts, storages, transaction hashes) - Account and storage changesets in static files
+
+          This is a genesis-initialization-only setting: changing it after genesis requires a re-sync.
+
+          Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
       --no-state
           Disables stages that require state.

--- a/docs/vocs/docs/pages/cli/reth/import.mdx
+++ b/docs/vocs/docs/pages/cli/reth/import.mdx
@@ -184,9 +184,9 @@ RocksDB:
 
 Storage:
       --storage.v2
-          Enable v2 storage defaults (static files + RocksDB routing).
+          Enable v2 storage defaults (static files + `RocksDB` routing).
 
-          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in RocksDB (accounts, storages, transaction hashes) - Account and storage changesets in static files
+          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in `RocksDB` (accounts, storages, transaction hashes) - Account and storage changesets in static files
 
           This is a genesis-initialization-only setting: changing it after genesis requires a re-sync.
 

--- a/docs/vocs/docs/pages/cli/reth/init-state.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init-state.mdx
@@ -118,7 +118,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.transaction-senders <TRANSACTION_SENDERS>
@@ -128,7 +129,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.account-change-sets <ACCOUNT_CHANGESETS>
@@ -138,7 +140,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.storage-change-sets <STORAGE_CHANGESETS>
@@ -148,7 +151,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
 RocksDB:
@@ -160,26 +164,33 @@ RocksDB:
       --rocksdb.tx-hash <TX_HASH>
           Route tx hash -> number table to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
 
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
 
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
+
+Storage:
+      --storage.v2
+          Enable v2 storage defaults (static files + RocksDB routing).
+
+          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in RocksDB (accounts, storages, transaction hashes) - Account and storage changesets in static files
+
+          This is a genesis-initialization-only setting: changing it after genesis requires a re-sync.
+
+          Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
       --without-evm
           Specifies whether to initialize the state without relying on EVM historical data.

--- a/docs/vocs/docs/pages/cli/reth/init-state.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init-state.mdx
@@ -184,9 +184,9 @@ RocksDB:
 
 Storage:
       --storage.v2
-          Enable v2 storage defaults (static files + RocksDB routing).
+          Enable v2 storage defaults (static files + `RocksDB` routing).
 
-          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in RocksDB (accounts, storages, transaction hashes) - Account and storage changesets in static files
+          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in `RocksDB` (accounts, storages, transaction hashes) - Account and storage changesets in static files
 
           This is a genesis-initialization-only setting: changing it after genesis requires a re-sync.
 

--- a/docs/vocs/docs/pages/cli/reth/init.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init.mdx
@@ -118,7 +118,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.transaction-senders <TRANSACTION_SENDERS>
@@ -128,7 +129,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.account-change-sets <ACCOUNT_CHANGESETS>
@@ -138,7 +140,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.storage-change-sets <STORAGE_CHANGESETS>
@@ -148,7 +151,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
 RocksDB:
@@ -160,26 +164,33 @@ RocksDB:
       --rocksdb.tx-hash <TX_HASH>
           Route tx hash -> number table to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
 
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
 
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
+
+Storage:
+      --storage.v2
+          Enable v2 storage defaults (static files + RocksDB routing).
+
+          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in RocksDB (accounts, storages, transaction hashes) - Account and storage changesets in static files
+
+          This is a genesis-initialization-only setting: changing it after genesis requires a re-sync.
+
+          Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
 Logging:
       --log.stdout.format <FORMAT>

--- a/docs/vocs/docs/pages/cli/reth/init.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init.mdx
@@ -184,9 +184,9 @@ RocksDB:
 
 Storage:
       --storage.v2
-          Enable v2 storage defaults (static files + RocksDB routing).
+          Enable v2 storage defaults (static files + `RocksDB` routing).
 
-          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in RocksDB (accounts, storages, transaction hashes) - Account and storage changesets in static files
+          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in `RocksDB` (accounts, storages, transaction hashes) - Account and storage changesets in static files
 
           This is a genesis-initialization-only setting: changing it after genesis requires a re-sync.
 

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -916,25 +916,22 @@ RocksDB:
       --rocksdb.tx-hash <TX_HASH>
           Route tx hash -> number table to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
 
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
 
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
 
 Engine:
@@ -1066,7 +1063,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.transaction-senders <TRANSACTION_SENDERS>
@@ -1076,7 +1074,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.account-change-sets <ACCOUNT_CHANGESETS>
@@ -1086,7 +1085,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.storage-change-sets <STORAGE_CHANGESETS>
@@ -1096,8 +1096,19 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
+
+Storage:
+      --storage.v2
+          Enable v2 storage defaults (static files + RocksDB routing).
+
+          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in RocksDB (accounts, storages, transaction hashes) - Account and storage changesets in static files
+
+          This is a genesis-initialization-only setting: changing it after genesis requires a re-sync.
+
+          Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
 Ress:
       --ress.enable

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -1102,9 +1102,9 @@ Static Files:
 
 Storage:
       --storage.v2
-          Enable v2 storage defaults (static files + RocksDB routing).
+          Enable v2 storage defaults (static files + `RocksDB` routing).
 
-          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in RocksDB (accounts, storages, transaction hashes) - Account and storage changesets in static files
+          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in `RocksDB` (accounts, storages, transaction hashes) - Account and storage changesets in static files
 
           This is a genesis-initialization-only setting: changing it after genesis requires a re-sync.
 

--- a/docs/vocs/docs/pages/cli/reth/prune.mdx
+++ b/docs/vocs/docs/pages/cli/reth/prune.mdx
@@ -118,7 +118,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.transaction-senders <TRANSACTION_SENDERS>
@@ -128,7 +129,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.account-change-sets <ACCOUNT_CHANGESETS>
@@ -138,7 +140,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.storage-change-sets <STORAGE_CHANGESETS>
@@ -148,7 +151,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
 RocksDB:
@@ -160,26 +164,33 @@ RocksDB:
       --rocksdb.tx-hash <TX_HASH>
           Route tx hash -> number table to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
 
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
 
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
+
+Storage:
+      --storage.v2
+          Enable v2 storage defaults (static files + RocksDB routing).
+
+          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in RocksDB (accounts, storages, transaction hashes) - Account and storage changesets in static files
+
+          This is a genesis-initialization-only setting: changing it after genesis requires a re-sync.
+
+          Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
 Metrics:
       --metrics <PROMETHEUS>

--- a/docs/vocs/docs/pages/cli/reth/prune.mdx
+++ b/docs/vocs/docs/pages/cli/reth/prune.mdx
@@ -184,9 +184,9 @@ RocksDB:
 
 Storage:
       --storage.v2
-          Enable v2 storage defaults (static files + RocksDB routing).
+          Enable v2 storage defaults (static files + `RocksDB` routing).
 
-          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in RocksDB (accounts, storages, transaction hashes) - Account and storage changesets in static files
+          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in `RocksDB` (accounts, storages, transaction hashes) - Account and storage changesets in static files
 
           This is a genesis-initialization-only setting: changing it after genesis requires a re-sync.
 

--- a/docs/vocs/docs/pages/cli/reth/re-execute.mdx
+++ b/docs/vocs/docs/pages/cli/reth/re-execute.mdx
@@ -118,7 +118,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.transaction-senders <TRANSACTION_SENDERS>
@@ -128,7 +129,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.account-change-sets <ACCOUNT_CHANGESETS>
@@ -138,7 +140,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.storage-change-sets <STORAGE_CHANGESETS>
@@ -148,7 +151,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
 RocksDB:
@@ -160,26 +164,33 @@ RocksDB:
       --rocksdb.tx-hash <TX_HASH>
           Route tx hash -> number table to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
 
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
 
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
+
+Storage:
+      --storage.v2
+          Enable v2 storage defaults (static files + RocksDB routing).
+
+          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in RocksDB (accounts, storages, transaction hashes) - Account and storage changesets in static files
+
+          This is a genesis-initialization-only setting: changing it after genesis requires a re-sync.
+
+          Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
       --from <FROM>
           The height to start at

--- a/docs/vocs/docs/pages/cli/reth/re-execute.mdx
+++ b/docs/vocs/docs/pages/cli/reth/re-execute.mdx
@@ -184,9 +184,9 @@ RocksDB:
 
 Storage:
       --storage.v2
-          Enable v2 storage defaults (static files + RocksDB routing).
+          Enable v2 storage defaults (static files + `RocksDB` routing).
 
-          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in RocksDB (accounts, storages, transaction hashes) - Account and storage changesets in static files
+          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in `RocksDB` (accounts, storages, transaction hashes) - Account and storage changesets in static files
 
           This is a genesis-initialization-only setting: changing it after genesis requires a re-sync.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/drop.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/drop.mdx
@@ -118,7 +118,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.transaction-senders <TRANSACTION_SENDERS>
@@ -128,7 +129,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.account-change-sets <ACCOUNT_CHANGESETS>
@@ -138,7 +140,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.storage-change-sets <STORAGE_CHANGESETS>
@@ -148,7 +151,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
 RocksDB:
@@ -160,26 +164,33 @@ RocksDB:
       --rocksdb.tx-hash <TX_HASH>
           Route tx hash -> number table to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
 
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
 
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
+
+Storage:
+      --storage.v2
+          Enable v2 storage defaults (static files + RocksDB routing).
+
+          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in RocksDB (accounts, storages, transaction hashes) - Account and storage changesets in static files
+
+          This is a genesis-initialization-only setting: changing it after genesis requires a re-sync.
+
+          Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
   <STAGE>
           Possible values:

--- a/docs/vocs/docs/pages/cli/reth/stage/drop.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/drop.mdx
@@ -184,9 +184,9 @@ RocksDB:
 
 Storage:
       --storage.v2
-          Enable v2 storage defaults (static files + RocksDB routing).
+          Enable v2 storage defaults (static files + `RocksDB` routing).
 
-          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in RocksDB (accounts, storages, transaction hashes) - Account and storage changesets in static files
+          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in `RocksDB` (accounts, storages, transaction hashes) - Account and storage changesets in static files
 
           This is a genesis-initialization-only setting: changing it after genesis requires a re-sync.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/dump.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump.mdx
@@ -125,7 +125,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.transaction-senders <TRANSACTION_SENDERS>
@@ -135,7 +136,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.account-change-sets <ACCOUNT_CHANGESETS>
@@ -145,7 +147,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.storage-change-sets <STORAGE_CHANGESETS>
@@ -155,7 +158,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
 RocksDB:
@@ -167,26 +171,33 @@ RocksDB:
       --rocksdb.tx-hash <TX_HASH>
           Route tx hash -> number table to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
 
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
 
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
+
+Storage:
+      --storage.v2
+          Enable v2 storage defaults (static files + RocksDB routing).
+
+          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in RocksDB (accounts, storages, transaction hashes) - Account and storage changesets in static files
+
+          This is a genesis-initialization-only setting: changing it after genesis requires a re-sync.
+
+          Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
 Logging:
       --log.stdout.format <FORMAT>

--- a/docs/vocs/docs/pages/cli/reth/stage/dump.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump.mdx
@@ -191,9 +191,9 @@ RocksDB:
 
 Storage:
       --storage.v2
-          Enable v2 storage defaults (static files + RocksDB routing).
+          Enable v2 storage defaults (static files + `RocksDB` routing).
 
-          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in RocksDB (accounts, storages, transaction hashes) - Account and storage changesets in static files
+          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in `RocksDB` (accounts, storages, transaction hashes) - Account and storage changesets in static files
 
           This is a genesis-initialization-only setting: changing it after genesis requires a re-sync.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/run.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/run.mdx
@@ -118,7 +118,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.transaction-senders <TRANSACTION_SENDERS>
@@ -128,7 +129,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.account-change-sets <ACCOUNT_CHANGESETS>
@@ -138,7 +140,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.storage-change-sets <STORAGE_CHANGESETS>
@@ -148,7 +151,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
 RocksDB:
@@ -160,26 +164,33 @@ RocksDB:
       --rocksdb.tx-hash <TX_HASH>
           Route tx hash -> number table to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
 
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
 
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
+
+Storage:
+      --storage.v2
+          Enable v2 storage defaults (static files + RocksDB routing).
+
+          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in RocksDB (accounts, storages, transaction hashes) - Account and storage changesets in static files
+
+          This is a genesis-initialization-only setting: changing it after genesis requires a re-sync.
+
+          Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
       --metrics <SOCKET>
           Enable Prometheus metrics.

--- a/docs/vocs/docs/pages/cli/reth/stage/run.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/run.mdx
@@ -184,9 +184,9 @@ RocksDB:
 
 Storage:
       --storage.v2
-          Enable v2 storage defaults (static files + RocksDB routing).
+          Enable v2 storage defaults (static files + `RocksDB` routing).
 
-          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in RocksDB (accounts, storages, transaction hashes) - Account and storage changesets in static files
+          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in `RocksDB` (accounts, storages, transaction hashes) - Account and storage changesets in static files
 
           This is a genesis-initialization-only setting: changing it after genesis requires a re-sync.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/unwind.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/unwind.mdx
@@ -189,9 +189,9 @@ RocksDB:
 
 Storage:
       --storage.v2
-          Enable v2 storage defaults (static files + RocksDB routing).
+          Enable v2 storage defaults (static files + `RocksDB` routing).
 
-          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in RocksDB (accounts, storages, transaction hashes) - Account and storage changesets in static files
+          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in `RocksDB` (accounts, storages, transaction hashes) - Account and storage changesets in static files
 
           This is a genesis-initialization-only setting: changing it after genesis requires a re-sync.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/unwind.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/unwind.mdx
@@ -123,7 +123,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.transaction-senders <TRANSACTION_SENDERS>
@@ -133,7 +134,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.account-change-sets <ACCOUNT_CHANGESETS>
@@ -143,7 +145,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
       --static-files.storage-change-sets <STORAGE_CHANGESETS>
@@ -153,7 +156,8 @@ Static Files:
 
           Note: This setting can only be configured at genesis initialization. Once the node has been initialized, changing this flag requires re-syncing from scratch.
 
-          [default: false]
+          Defaults to the base storage mode (v1: false, v2: true).
+
           [possible values: true, false]
 
 RocksDB:
@@ -165,26 +169,33 @@ RocksDB:
       --rocksdb.tx-hash <TX_HASH>
           Route tx hash -> number table to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `true` when the `edge` feature is enabled, `false` otherwise.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
 
       --rocksdb.storages-history <STORAGES_HISTORY>
           Route storages history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
 
       --rocksdb.account-history <ACCOUNT_HISTORY>
           Route account history tables to `RocksDB` instead of MDBX.
 
-          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to `false`.
+          This is a genesis-initialization-only flag: changing it after genesis requires a re-sync. Defaults to the base storage mode (v1: false, v2: true).
 
-          [default: false]
           [possible values: true, false]
+
+Storage:
+      --storage.v2
+          Enable v2 storage defaults (static files + RocksDB routing).
+
+          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in RocksDB (accounts, storages, transaction hashes) - Account and storage changesets in static files
+
+          This is a genesis-initialization-only setting: changing it after genesis requires a re-sync.
+
+          Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
       --offline
           If this is enabled, then all stages except headers, bodies, and sender recovery will be unwound

--- a/docs/vocs/sidebar-cli-reth.ts
+++ b/docs/vocs/sidebar-cli-reth.ts
@@ -58,6 +58,10 @@ export const rethCliSidebar: SidebarItem = {
                         {
                             text: "reth db checksum static-file",
                             link: "/cli/reth/db/checksum/static-file"
+                        },
+                        {
+                            text: "reth db checksum rocksdb",
+                            link: "/cli/reth/db/checksum/rocksdb"
                         }
                     ]
                 },


### PR DESCRIPTION
Removes the `edge` feature flag. Adds `rocksdb` as a default feature for `reth`. Adds a v2 storage flag so that we can enable this via cli.