### PR TITLE
chore(reth-bench): use "reth-bench" log target

### DIFF
--- a/bin/reth-bench/src/bench/context.rs
+++ b/bin/reth-bench/src/bench/context.rs
@@ -35,7 +35,7 @@ impl BenchContext {
     /// This is the initialization code for most benchmarks, taking in a [`BenchmarkArgs`] and
     /// returning the providers needed to run a benchmark.
     pub(crate) async fn new(bench_args: &BenchmarkArgs, rpc_url: String) -> eyre::Result<Self> {
-        info!("Running benchmark using data from RPC URL: {}", rpc_url);
+        info!(target: "reth-bench", "Running benchmark using data from RPC URL: {}", rpc_url);
 
         // Ensure that output directory exists and is a directory
         if let Some(output) = &bench_args.output {
@@ -45,7 +45,7 @@ impl BenchContext {
             // Create the directory if it doesn't exist
             if !output.exists() {
                 std::fs::create_dir_all(output)?;
-                info!("Created output directory: {:?}", output);
+                info!(target: "reth-bench", "Created output directory: {:?}", output);
             }
         }
 
@@ -77,7 +77,7 @@ impl BenchContext {
         let auth_url = Url::parse(&bench_args.engine_rpc_url)?;
 
         // construct the authed transport
-        info!("Connecting to Engine RPC at {} for replay", auth_url);
+        info!(target: "reth-bench", "Connecting to Engine RPC at {} for replay", auth_url);
         let auth_transport = AuthenticatedTransportConnect::new(auth_url, jwt);
         let client = ClientBuilder::default().connect_with(auth_transport).await?;
         let auth_provider = RootProvider::<AnyNetwork>::new(client);

--- a/bin/reth-bench/src/bench/gas_limit_ramp.rs
+++ b/bin/reth-bench/src/bench/gas_limit_ramp.rs
@@ -87,7 +87,7 @@ impl Command {
         }
         if !self.output.exists() {
             std::fs::create_dir_all(&self.output)?;
-            info!("Created output directory: {:?}", self.output);
+            info!(target: "reth-bench", "Created output directory: {:?}", self.output);
         }
 
         // Set up authenticated provider (used for both Engine API and eth_ methods)
@@ -95,7 +95,7 @@ impl Command {
         let jwt = JwtSecret::from_hex(jwt)?;
         let auth_url = Url::parse(&self.engine_rpc_url)?;
 
-        info!("Connecting to Engine RPC at {}", auth_url);
+        info!(target: "reth-bench", "Connecting to Engine RPC at {}", auth_url);
         let auth_transport = AuthenticatedTransportConnect::new(auth_url, jwt);
         let client = ClientBuilder::default().connect_with(auth_transport).await?;
         let provider = RootProvider::<AnyNetwork>::new(client);
@@ -120,6 +120,7 @@ impl Command {
         match mode {
             RampMode::Blocks(blocks) => {
                 info!(
+                    target: "reth-bench",
                     canonical_parent,
                     start_block,
                     end_block = start_block + blocks - 1,
@@ -128,6 +129,7 @@ impl Command {
             }
             RampMode::TargetGasLimit(target) => {
                 info!(
+                    target: "reth-bench",
                     canonical_parent,
                     start_block,
                     current_gas_limit = parent_header.gas_limit,
@@ -176,7 +178,7 @@ impl Command {
                 GasRampPayloadFile { version: version as u8, block_hash, params: params.clone() };
             let payload_json = serde_json::to_string_pretty(&file)?;
             std::fs::write(&payload_path, &payload_json)?;
-            info!(block_number = block.header.number, path = %payload_path.display(), "Saved payload");
+            info!(target: "reth-bench", block_number = block.header.number, path = %payload_path.display(), "Saved payload");
 
             call_new_payload(&provider, version, params).await?;
 
@@ -194,6 +196,7 @@ impl Command {
 
         let final_gas_limit = parent_header.gas_limit;
         info!(
+            target: "reth-bench",
             total_duration=?total_benchmark_duration.elapsed(),
             blocks_processed,
             final_gas_limit,

--- a/bin/reth-bench/src/bench/helpers.rs
+++ b/bin/reth-bench/src/bench/helpers.rs
@@ -180,7 +180,7 @@ pub(crate) async fn get_payload_with_sidecar(
     payload_id: PayloadId,
     parent_beacon_block_root: Option<B256>,
 ) -> eyre::Result<(ExecutionPayload, ExecutionPayloadSidecar)> {
-    debug!(get_payload_version = ?version, ?payload_id, "Sending getPayload");
+    debug!(target: "reth-bench", get_payload_version = ?version, ?payload_id, "Sending getPayload");
 
     match version {
         1 => {

--- a/bin/reth-bench/src/bench/mod.rs
+++ b/bin/reth-bench/src/bench/mod.rs
@@ -111,7 +111,18 @@ impl BenchmarkCommand {
     ///
     /// If file logging is enabled, this function returns a guard that must be kept alive to ensure
     /// that all logs are flushed to disk.
+    ///
+    /// Always enables log target display (`RUST_LOG_TARGET=1`) so that the `reth-bench` target
+    /// is visible in output, making it easy to distinguish reth-bench logs from reth logs when
+    /// both are streamed to the same console or file.
     pub fn init_tracing(&self) -> eyre::Result<Option<FileWorkerGuard>> {
+        // Always show the log target so "reth-bench" is visible in the output.
+        if std::env::var_os("RUST_LOG_TARGET").is_none() {
+            // SAFETY: This is called early during single-threaded initialization, before any
+            // threads are spawned and before the tracing subscriber is set up.
+            unsafe { std::env::set_var("RUST_LOG_TARGET", "1") };
+        }
+
         let guard = self.logs.init_tracing()?;
         Ok(guard)
     }

--- a/bin/reth-bench/src/bench/new_payload_only.rs
+++ b/bin/reth-bench/src/bench/new_payload_only.rs
@@ -68,7 +68,7 @@ impl Command {
                 let block = match block_res.and_then(|opt| opt.ok_or_eyre("Block not found")) {
                     Ok(block) => block,
                     Err(e) => {
-                        tracing::error!("Failed to fetch block {next_block}: {e}");
+                        tracing::error!(target: "reth-bench", "Failed to fetch block {next_block}: {e}");
                         let _ = error_sender.send(e);
                         break;
                     }
@@ -76,7 +76,7 @@ impl Command {
 
                 next_block += 1;
                 if let Err(e) = sender.send(block).await {
-                    tracing::error!("Failed to send block data: {e}");
+                    tracing::error!(target: "reth-bench", "Failed to send block data: {e}");
                     break;
                 }
             }
@@ -97,7 +97,7 @@ impl Command {
             let transaction_count = block.transactions.len() as u64;
             let gas_used = block.header.gas_used;
 
-            debug!(number=?block.header.number, "Sending payload to engine");
+            debug!(target: "reth-bench", number=?block.header.number, "Sending payload to engine");
 
             let (version, params) = block_to_new_payload(block, is_optimism)?;
 
@@ -105,7 +105,7 @@ impl Command {
             call_new_payload(&auth_provider, version, params).await?;
 
             let new_payload_result = NewPayloadResult { gas_used, latency: start.elapsed() };
-            info!(%new_payload_result);
+            info!(target: "reth-bench", %new_payload_result);
 
             // current duration since the start of the benchmark minus the time
             // waiting for blocks
@@ -129,7 +129,7 @@ impl Command {
         if let Some(path) = self.benchmark.output {
             // first write the new payload results to a file
             let output_path = path.join(NEW_PAYLOAD_OUTPUT_SUFFIX);
-            info!("Writing newPayload call latency output to file: {:?}", output_path);
+            info!(target: "reth-bench", "Writing newPayload call latency output to file: {:?}", output_path);
             let mut writer = Writer::from_path(output_path)?;
             for result in new_payload_results {
                 writer.serialize(result)?;
@@ -138,19 +138,20 @@ impl Command {
 
             // now write the gas output to a file
             let output_path = path.join(GAS_OUTPUT_SUFFIX);
-            info!("Writing total gas output to file: {:?}", output_path);
+            info!(target: "reth-bench", "Writing total gas output to file: {:?}", output_path);
             let mut writer = Writer::from_path(output_path)?;
             for row in &gas_output_results {
                 writer.serialize(row)?;
             }
             writer.flush()?;
 
-            info!("Finished writing benchmark output files to {:?}.", path);
+            info!(target: "reth-bench", "Finished writing benchmark output files to {:?}.", path);
         }
 
         // accumulate the results and calculate the overall Ggas/s
         let gas_output = TotalGasOutput::new(gas_output_results)?;
         info!(
+            target: "reth-bench",
             total_duration=?gas_output.total_duration,
             total_gas_used=?gas_output.total_gas_used,
             blocks_processed=?gas_output.blocks_processed,

--- a/bin/reth-bench/src/bench/output.rs
+++ b/bin/reth-bench/src/bench/output.rs
@@ -226,7 +226,7 @@ pub(crate) fn write_benchmark_results(
     fs::create_dir_all(output_dir)?;
 
     let output_path = output_dir.join(COMBINED_OUTPUT_SUFFIX);
-    info!("Writing engine api call latency output to file: {:?}", output_path);
+    info!(target: "reth-bench", "Writing engine api call latency output to file: {:?}", output_path);
     let mut writer = Writer::from_path(&output_path)?;
     for result in combined_results {
         writer.serialize(result)?;
@@ -234,14 +234,14 @@ pub(crate) fn write_benchmark_results(
     writer.flush()?;
 
     let output_path = output_dir.join(GAS_OUTPUT_SUFFIX);
-    info!("Writing total gas output to file: {:?}", output_path);
+    info!(target: "reth-bench", "Writing total gas output to file: {:?}", output_path);
     let mut writer = Writer::from_path(&output_path)?;
     for row in gas_results {
         writer.serialize(row)?;
     }
     writer.flush()?;
 
-    info!("Finished writing benchmark output files to {:?}.", output_dir);
+    info!(target: "reth-bench", "Finished writing benchmark output files to {:?}.", output_dir);
     Ok(())
 }
 

--- a/bin/reth-bench/src/bench/persistence_waiter.rs
+++ b/bin/reth-bench/src/bench/persistence_waiter.rs
@@ -160,7 +160,7 @@ impl PersistenceSubscription {
 pub(crate) async fn setup_persistence_subscription(
     ws_url: Url,
 ) -> eyre::Result<PersistenceSubscription> {
-    info!("Connecting to WebSocket at {} for persistence subscription", ws_url);
+    info!(target: "reth-bench", "Connecting to WebSocket at {} for persistence subscription", ws_url);
 
     let ws_connect = WsConnect::new(ws_url.to_string());
     let client = RpcClient::connect_pubsub(ws_connect)
@@ -173,7 +173,7 @@ pub(crate) async fn setup_persistence_subscription(
         .await
         .wrap_err("Failed to subscribe to persistence notifications")?;
 
-    info!("Subscribed to persistence notifications");
+    info!(target: "reth-bench", "Subscribed to persistence notifications");
 
     Ok(PersistenceSubscription::new(provider, subscription.into_stream()))
 }

--- a/bin/reth-bench/src/valid_payload.rs
+++ b/bin/reth-bench/src/valid_payload.rs
@@ -54,6 +54,7 @@ where
         payload_attributes: Option<PayloadAttributes>,
     ) -> TransportResult<ForkchoiceUpdated> {
         debug!(
+            target: "reth-bench",
             method = "engine_forkchoiceUpdatedV1",
             ?fork_choice_state,
             ?payload_attributes,
@@ -66,6 +67,7 @@ where
         while !status.is_valid() {
             if status.is_invalid() {
                 error!(
+                    target: "reth-bench",
                     ?status,
                     ?fork_choice_state,
                     ?payload_attributes,
@@ -91,6 +93,7 @@ where
         payload_attributes: Option<PayloadAttributes>,
     ) -> TransportResult<ForkchoiceUpdated> {
         debug!(
+            target: "reth-bench",
             method = "engine_forkchoiceUpdatedV2",
             ?fork_choice_state,
             ?payload_attributes,
@@ -103,6 +106,7 @@ where
         while !status.is_valid() {
             if status.is_invalid() {
                 error!(
+                    target: "reth-bench",
                     ?status,
                     ?fork_choice_state,
                     ?payload_attributes,
@@ -128,6 +132,7 @@ where
         payload_attributes: Option<PayloadAttributes>,
     ) -> TransportResult<ForkchoiceUpdated> {
         debug!(
+            target: "reth-bench",
             method = "engine_forkchoiceUpdatedV3",
             ?fork_choice_state,
             ?payload_attributes,
@@ -140,6 +145,7 @@ where
         while !status.is_valid() {
             if status.is_invalid() {
                 error!(
+                    target: "reth-bench",
                     ?status,
                     ?fork_choice_state,
                     ?payload_attributes,
@@ -253,13 +259,13 @@ pub(crate) async fn call_new_payload<N: Network, P: Provider<N>>(
 ) -> TransportResult<()> {
     let method = version.method_name();
 
-    debug!(method, "Sending newPayload");
+    debug!(target: "reth-bench", method, "Sending newPayload");
 
     let mut status: PayloadStatus = provider.client().request(method, &params).await?;
 
     while !status.is_valid() {
         if status.is_invalid() {
-            error!(?status, ?params, "Invalid {method}",);
+            error!(target: "reth-bench", ?status, ?params, "Invalid {method}",);
             return Err(alloy_json_rpc::RpcError::LocalUsageError(Box::new(std::io::Error::other(
                 format!("Invalid {method}: {status:?}"),
             ))))


### PR DESCRIPTION
Use `target: "reth-bench"` for all log statements in reth-bench for easier differentiation when both reth and reth-bench logs are streamed to the same console/file.