### PR TITLE
fix(engine): include pending updates in STaC task exit condition

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -449,7 +449,10 @@ where
 
             if self.finished_state_updates &&
                 self.account_updates.is_empty() &&
-                self.storage_updates.iter().all(|(_, updates)| updates.is_empty())
+                self.storage_updates.iter().all(|(_, updates)| updates.is_empty()) &&
+                self.pending_account_updates.is_empty() &&
+                self.new_account_updates.is_empty() &&
+                self.new_storage_updates.iter().all(|(_, updates)| updates.is_empty())
             {
                 break;
             }


### PR DESCRIPTION
## Summary

The `SparseTrieCacheTask::run` loop was exiting too early when `finished_state_updates` was true but there were still pending account updates or uncommitted new updates that hadn't been processed yet.

This caused the task to return the **previous block's state root** instead of computing the new one, resulting in state root mismatches.

## Problem

The exit condition only checked:
- `finished_state_updates`
- `account_updates.is_empty()`
- `storage_updates` all empty

But was **missing** checks for:
- `pending_account_updates` - accounts awaiting storage root calculation
- `new_account_updates` - buffered account updates not yet applied
- `new_storage_updates` - buffered storage updates not yet applied

## Reproduction

```bash
cargo run --bin reth -- node --dev --dev.block-time 1s --engine.enable-sparse-trie-as-cache --engine.state-root-task-compare-updates
```

Then spam transactions:
```bash
cast send --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --create 0x608060405260f6806100105f395ff3fe6080604052348015600e575f5ffd5b50600436106026575f3560e01c8063d09de08a14602a575b5f5ffd5b60306032565b005b5f5f815480929190604190607e565b9190505550565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52601160045260245ffd5b5f819050919050565b5f6086826075565b91507fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff820360b55760b46048565b5b60018201905091905056fea26469706673582212207704dd25fe11bd37cd976c36098b1540d9d13de669981d8ca8df68e6c1a44e2864736f6c63430008210033 && for i in {1..100}; do sleep 0.1s && cast send '0x5FbDB2315678afecb367f032d93F642f64180aa3' 'increment()' --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --async --nonce $i ; done
```

Before fix: 4 state root mismatches in first 12 blocks
After fix: Zero mismatches

## Fix

Added three additional checks to ensure all pending work is complete before exiting:

```diff
 if self.finished_state_updates &&
     self.account_updates.is_empty() &&
-    self.storage_updates.iter().all(|(_, updates)| updates.is_empty())
+    self.storage_updates.iter().all(|(_, updates)| updates.is_empty()) &&
+    self.pending_account_updates.is_empty() &&
+    self.new_account_updates.is_empty() &&
+    self.new_storage_updates.iter().all(|(_, updates)| updates.is_empty())
 {
     break;
 }
```