### PR TITLE
chore: improve persistence spans

### DIFF
--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -187,7 +187,7 @@ impl<'b, Provider: DBProvider + ChangeSetReader + StorageChangeSetReader + Block
 
         if self.check_distance_against_limit(EPOCH_SLOTS)? {
             tracing::warn!(
-                target: "provider::historical_sp",
+                target: "providers::historical_sp",
                 target = self.block_number,
                 "Attempt to calculate state root for an old block might result in OOM"
             );
@@ -204,7 +204,7 @@ impl<'b, Provider: DBProvider + ChangeSetReader + StorageChangeSetReader + Block
 
         if self.check_distance_against_limit(EPOCH_SLOTS * 10)? {
             tracing::warn!(
-                target: "provider::historical_sp",
+                target: "providers::historical_sp",
                 target = self.block_number,
                 "Attempt to calculate storage root for an old block might result in OOM"
             );

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -932,7 +932,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
             }
 
             debug!(
-                target: "provider::static_file",
+                target: "providers::static_file",
                 ?segment,
                 ?block_height,
                 "Deleting static file below block"
@@ -941,7 +941,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
             // now we need to wipe the static file, this will take care of updating the index and
             // advance the lowest tracked block height for the segment.
             let header = self.delete_jar(segment, block_height).inspect_err(|err| {
-                warn!( target: "provider::static_file", ?segment, %block_height, ?err, "Failed to delete static file below block")
+                warn!( target: "providers::static_file", ?segment, %block_height, ?err, "Failed to delete static file below block")
             })?;
 
             deleted_headers.push(header);
@@ -967,7 +967,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         } else {
             let file = self.path.join(segment.filename(&fixed_block_range));
             debug!(
-                target: "provider::static_file",
+                target: "providers::static_file",
                 ?file,
                 ?fixed_block_range,
                 ?block,
@@ -998,14 +998,14 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
 
         while let Some(block_height) = self.get_highest_static_file_block(segment) {
             debug!(
-                target: "provider::static_file",
+                target: "providers::static_file",
                 ?segment,
                 ?block_height,
                 "Deleting static file jar"
             );
 
             let header = self.delete_jar(segment, block_height).inspect_err(|err| {
-                warn!(target: "provider::static_file", ?segment, %block_height, ?err, "Failed to delete static file jar")
+                warn!(target: "providers::static_file", ?segment, %block_height, ?err, "Failed to delete static file jar")
             })?;
 
             deleted_headers.push(header);
@@ -1025,12 +1025,12 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         let key = (fixed_block_range.end(), segment);
 
         // Avoid using `entry` directly to avoid a write lock in the common case.
-        trace!(target: "provider::static_file", ?segment, ?fixed_block_range, "Getting provider");
+        trace!(target: "providers::static_file", ?segment, ?fixed_block_range, "Getting provider");
         let mut provider: StaticFileJarProvider<'_, N> = if let Some(jar) = self.map.get(&key) {
-            trace!(target: "provider::static_file", ?segment, ?fixed_block_range, "Jar found in cache");
+            trace!(target: "providers::static_file", ?segment, ?fixed_block_range, "Jar found in cache");
             jar.into()
         } else {
-            trace!(target: "provider::static_file", ?segment, ?fixed_block_range, "Creating jar from scratch");
+            trace!(target: "providers::static_file", ?segment, ?fixed_block_range, "Creating jar from scratch");
             let path = self.path.join(segment.filename(fixed_block_range));
             let jar = NippyJar::load(&path).map_err(ProviderError::other)?;
             self.map.entry(key).insert(LoadedJar::new(jar)?).downgrade().into()
@@ -1105,7 +1105,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         segment_max_block: Option<BlockNumber>,
     ) -> ProviderResult<()> {
         debug!(
-            target: "provider::static_file",
+            target: "providers::static_file",
             ?segment,
             ?segment_max_block,
             "Updating provider index"
@@ -1217,20 +1217,20 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                 }
 
                 // Update the cached provider.
-                debug!(target: "provider::static_file", ?segment, "Inserting updated jar into cache");
+                debug!(target: "providers::static_file", ?segment, "Inserting updated jar into cache");
                 self.map.insert((fixed_range.end(), segment), LoadedJar::new(jar)?);
 
                 // Delete any cached provider that no longer has an associated jar.
-                debug!(target: "provider::static_file", ?segment, "Cleaning up jar map");
+                debug!(target: "providers::static_file", ?segment, "Cleaning up jar map");
                 self.map.retain(|(end, seg), _| !(*seg == segment && *end > fixed_range.end()));
             }
             None => {
-                debug!(target: "provider::static_file", ?segment, "Removing segment from index");
+                debug!(target: "providers::static_file", ?segment, "Removing segment from index");
                 indexes.remove(segment);
             }
         };
 
-        debug!(target: "provider::static_file", ?segment, "Updated provider index");
+        debug!(target: "providers::static_file", ?segment, "Updated provider index");
         Ok(())
     }
 
@@ -2335,7 +2335,7 @@ impl<N: NodePrimitives> StaticFileWriter for StaticFileProvider<N> {
             return Err(ProviderError::ReadOnlyStaticFileAccess);
         }
 
-        trace!(target: "provider::static_file", ?block, ?segment, "Getting static file writer.");
+        trace!(target: "providers::static_file", ?block, ?segment, "Getting static file writer.");
         self.writers.get_or_create(segment, || {
             StaticFileProviderRW::new(segment, block, Arc::downgrade(&self.0), self.metrics.clone())
         })
@@ -2437,7 +2437,7 @@ impl<N: NodePrimitives> ChangeSetReader for StaticFileProvider<N> {
                 // This is not expected but means we are out of the range / file somehow, and can't
                 // continue
                 debug!(
-                    target: "provider::static_file",
+                    target: "providers::static_file",
                     ?low,
                     ?mid,
                     ?high,
@@ -2556,7 +2556,7 @@ impl<N: NodePrimitives> StorageChangeSetReader for StaticFileProvider<N> {
                 }
             } else {
                 debug!(
-                    target: "provider::static_file",
+                    target: "providers::static_file",
                     ?low,
                     ?mid,
                     ?high,

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -115,11 +115,11 @@ impl<N: NodePrimitives> StaticFileWriters<N> {
     #[instrument(
         name = "StaticFileWriters::commit",
         level = "debug",
-        target = "provider::static_file",
+        target = "providers::static_file",
         skip_all
     )]
     pub(crate) fn commit(&self) -> ProviderResult<()> {
-        debug!(target: "provider::static_file", "Committing all static file segments");
+        debug!(target: "providers::static_file", "Committing all static file segments");
 
         for writer_lock in [
             &self.headers,
@@ -135,7 +135,7 @@ impl<N: NodePrimitives> StaticFileWriters<N> {
             }
         }
 
-        debug!(target: "provider::static_file", "Committed all static file segments");
+        debug!(target: "providers::static_file", "Committed all static file segments");
         Ok(())
     }
 
@@ -165,11 +165,11 @@ impl<N: NodePrimitives> StaticFileWriters<N> {
     #[instrument(
         name = "StaticFileWriters::finalize",
         level = "debug",
-        target = "provider::static_file",
+        target = "providers::static_file",
         skip_all
     )]
     pub(crate) fn finalize(&self) -> ProviderResult<()> {
-        debug!(target: "provider::static_file", "Finalizing all static file segments into disk");
+        debug!(target: "providers::static_file", "Finalizing all static file segments into disk");
 
         for writer_lock in [
             &self.headers,
@@ -185,7 +185,7 @@ impl<N: NodePrimitives> StaticFileWriters<N> {
             }
         }
 
-        debug!(target: "provider::static_file", "Finalized all static file segments into disk");
+        debug!(target: "providers::static_file", "Finalized all static file segments into disk");
         Ok(())
     }
 }
@@ -330,7 +330,7 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
         }
 
         debug!(
-            target: "provider::static_file",
+            target: "providers::static_file",
             segment = ?self.writer.user_header().segment(),
             path = ?self.data_path,
             pruned_rows,
@@ -374,7 +374,7 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
     #[instrument(
         name = "StaticFileProviderRW::finalize",
         level = "debug",
-        target = "provider::static_file",
+        target = "providers::static_file",
         skip_all
     )]
     pub fn finalize(&mut self) -> ProviderResult<()> {
@@ -397,7 +397,7 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
     #[instrument(
         name = "StaticFileProviderRW::commit",
         level = "debug",
-        target = "provider::static_file",
+        target = "providers::static_file",
         skip_all
     )]
     pub fn commit(&mut self) -> ProviderResult<()> {
@@ -406,7 +406,7 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
         // Truncates the data file if instructed to.
         if let Some(strategy) = self.prune_on_commit.take() {
             debug!(
-                target: "provider::static_file",
+                target: "providers::static_file",
                 segment = ?self.writer.user_header().segment(),
                 "Pruning data on commit"
             );
@@ -432,7 +432,7 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
 
         if self.writer.is_dirty() {
             debug!(
-                target: "provider::static_file",
+                target: "providers::static_file",
                 segment = ?self.writer.user_header().segment(),
                 "Committing writer to disk"
             );
@@ -449,7 +449,7 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
             }
 
             debug!(
-                target: "provider::static_file",
+                target: "providers::static_file",
                 segment = ?self.writer.user_header().segment(),
                 path = ?self.data_path,
                 duration = ?start.elapsed(),
@@ -470,7 +470,7 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
         let start = Instant::now();
 
         debug!(
-            target: "provider::static_file",
+            target: "providers::static_file",
             segment = ?self.writer.user_header().segment(),
             "Committing writer to disk (without sync)"
         );
@@ -487,7 +487,7 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
         }
 
         debug!(
-            target: "provider::static_file",
+            target: "providers::static_file",
             segment = ?self.writer.user_header().segment(),
             path = ?self.data_path,
             duration = ?start.elapsed(),


### PR DESCRIPTION
Fix static file provider logs and spans using `provider::` instead of `providers::` target like everywhere else.

Stacked on #21875.