### PR TITLE
fix: only exit when both channels are drained

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -436,6 +436,14 @@ where
                 self.dispatch_pending_targets();
                 self.process_new_updates()?;
                 self.promote_pending_account_updates()?;
+
+                if self.finished_state_updates &&
+                    self.account_updates.is_empty() &&
+                    self.storage_updates.iter().all(|(_, updates)| updates.is_empty())
+                {
+                    break;
+                }
+
                 self.dispatch_pending_targets();
             } else if self.updates.is_empty() || self.pending_updates > MAX_PENDING_UPDATES {
                 // If we don't have any pending updates OR we've accumulated a lot already, apply
@@ -445,13 +453,6 @@ where
             } else if self.pending_targets.chunking_length() > self.chunk_size.unwrap_or_default() {
                 // Make sure to dispatch targets if we've accumulated a lot of them.
                 self.dispatch_pending_targets();
-            }
-
-            if self.finished_state_updates &&
-                self.account_updates.is_empty() &&
-                self.storage_updates.iter().all(|(_, updates)| updates.is_empty())
-            {
-                break;
             }
         }
 


### PR DESCRIPTION
With https://github.com/paradigmxyz/reth/pull/21768 it might rarely happen that accounts present in `pending_account_updates` are ending up revealed in the accounts trie but not promoted to a proper update immediately

This in combination with `updates` or `proof_result_rx` channels not being fully drained might result in those account updates never being applied to the trie

With this PR we will only exit the loop if both channels are drained