### PR TITLE
perf(storage): Static file provider delete_segment should use unwind_queue logic

### DIFF
--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -2411,7 +2411,7 @@ impl<N: NodePrimitives> StaticFileWriter for StaticFileProvider<N> {
 
     /// Commits all pending writes and executes any queued jar deletions.
     ///
-    /// 1. Flush pending writer data via [`StaticFileWriters::commit`].
+    /// 1. Flush pending writer data.
     /// 2. Drain the deferred delete queue (populated by [`Self::delete_segment`] /
     ///    [`Self::delete_segment_below_block`]).
     /// 3. Reset writers for affected segments so they release file handles.

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -2421,16 +2421,16 @@ impl<N: NodePrimitives> StaticFileWriter for StaticFileProvider<N> {
     /// If a deletion fails mid-way, unprocessed operations are re-queued so a
     /// subsequent `commit()` can retry them.
     fn commit(&self) -> ProviderResult<()> {
-        // Step 1: flush pending writer data.
+        // Flush pending writer data.
         self.writers.commit()?;
 
-        // Step 2: drain the delete queue (sorted + deduped).
+        // Drain the delete queue (sorted + deduped).
         let mut ops = self.take_delete_queue();
         if ops.is_empty() {
             return Ok(());
         }
 
-        // Step 3: reset writers for segments about to be deleted so file handles are released.
+        // Reset writers for segments about to be deleted so file handles are released.
         let mut last_reset = None;
         for &(segment, _) in &ops {
             if last_reset != Some(segment) {
@@ -2439,7 +2439,7 @@ impl<N: NodePrimitives> StaticFileWriter for StaticFileProvider<N> {
             }
         }
 
-        // Step 4: delete jar files from disk.
+        // Delete jar files from disk.
         let mut delete_err = None;
         let mut completed = 0;
         for &(segment, range_end) in &ops {
@@ -2456,7 +2456,7 @@ impl<N: NodePrimitives> StaticFileWriter for StaticFileProvider<N> {
             self.0.queue_delete_raw(remaining);
         }
 
-        // Step 5: rebuild the index once after all deletions.
+        // Rebuild the index once after all deletions.
         self.initialize_index()?;
 
         if let Some(err) = delete_err {

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -188,6 +188,18 @@ impl<N: NodePrimitives> StaticFileWriters<N> {
         debug!(target: "providers::static_file", "Finalized all static file segments into disk");
         Ok(())
     }
+
+    pub(crate) fn reset(&self, segment: StaticFileSegment) {
+        let mut writer = match segment {
+            StaticFileSegment::Headers => self.headers.write(),
+            StaticFileSegment::Transactions => self.transactions.write(),
+            StaticFileSegment::Receipts => self.receipts.write(),
+            StaticFileSegment::TransactionSenders => self.transaction_senders.write(),
+            StaticFileSegment::AccountChangeSets => self.account_change_sets.write(),
+            StaticFileSegment::StorageChangeSets => self.storage_change_sets.write(),
+        };
+        *writer = None;
+    }
 }
 
 /// Mutable reference to a [`StaticFileProviderRW`] behind a [`RwLockWriteGuard`].

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -189,6 +189,7 @@ impl<N: NodePrimitives> StaticFileWriters<N> {
         Ok(())
     }
 
+    /// Drops the writer for `segment`, releasing its file handle so the jar can be deleted.
     pub(crate) fn reset(&self, segment: StaticFileSegment) {
         let mut writer = match segment {
             StaticFileSegment::Headers => self.headers.write(),


### PR DESCRIPTION
**Summary**
`delete_segment` and `delete_segment_below_block` previously deleted static file jars immediately during the pruner run, before `DatabaseProvider::commit()`. 

This bypassed the unwind commit ordering (DB first, then static files) that ensures crash consistency, a crash after jar deletion but before DB commit left the database referencing jars that no longer existed on disk.

**Solution:**
This PR defers jar deletions to `commit()` time, matching the existing `prune_on_commit` pattern. `has_unwind_queued()` now returns `true` when deletions are queued, routing `DatabaseProvider::commit()` through the unwind path (DB commits first, then static files are deleted). 

A single `initialize_index()` call replaces the per-jar reindex loop.


**Expected Impact**
Crash-consistent commit ordering for segment deletions, and O(1) reindexing instead of O(n) per-jar reindex during pruning.

Resolves [RETH-343](https://linear.app/tempoxyz/issue/RETH-343)