### PR TITLE
fix(net): correct backed_off_peers metric calculation

### DIFF
--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -877,7 +877,6 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
                             .state()
                             .peers()
                             .num_backed_off_peers()
-                            .saturating_sub(1)
                             as f64,
                     );
                 self.event_sender
@@ -915,7 +914,6 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
                             .state()
                             .peers()
                             .num_backed_off_peers()
-                            .saturating_sub(1)
                             as f64,
                     );
             }
@@ -952,7 +950,6 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
                             .state()
                             .peers()
                             .num_backed_off_peers()
-                            .saturating_sub(1)
                             as f64,
                     );
             }
@@ -976,7 +973,6 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
                             .state()
                             .peers()
                             .num_backed_off_peers()
-                            .saturating_sub(1)
                             as f64,
                     );
                 self.update_pending_connection_metrics();

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -872,13 +872,9 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
                 if let Some(reason) = reason {
                     self.disconnect_metrics.increment(reason);
                 }
-                self.metrics.backed_off_peers.set(
-                        self.swarm
-                            .state()
-                            .peers()
-                            .num_backed_off_peers()
-                            as f64,
-                    );
+                self.metrics
+                    .backed_off_peers
+                    .set(self.swarm.state().peers().num_backed_off_peers() as f64);
                 self.event_sender
                     .notify(NetworkEvent::Peer(PeerEvent::SessionClosed { peer_id, reason }));
             }
@@ -909,13 +905,9 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
                 self.metrics
                     .incoming_connections
                     .set(self.swarm.state().peers().num_inbound_connections() as f64);
-                self.metrics.backed_off_peers.set(
-                        self.swarm
-                            .state()
-                            .peers()
-                            .num_backed_off_peers()
-                            as f64,
-                    );
+                self.metrics
+                    .backed_off_peers
+                    .set(self.swarm.state().peers().num_backed_off_peers() as f64);
             }
             SwarmEvent::OutgoingPendingSessionClosed { remote_addr, peer_id, error } => {
                 trace!(
@@ -945,13 +937,9 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
                 self.metrics.closed_sessions.increment(1);
                 self.update_pending_connection_metrics();
 
-                self.metrics.backed_off_peers.set(
-                        self.swarm
-                            .state()
-                            .peers()
-                            .num_backed_off_peers()
-                            as f64,
-                    );
+                self.metrics
+                    .backed_off_peers
+                    .set(self.swarm.state().peers().num_backed_off_peers() as f64);
             }
             SwarmEvent::OutgoingConnectionError { remote_addr, peer_id, error } => {
                 trace!(
@@ -968,13 +956,9 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
                     &error,
                 );
 
-                self.metrics.backed_off_peers.set(
-                        self.swarm
-                            .state()
-                            .peers()
-                            .num_backed_off_peers()
-                            as f64,
-                    );
+                self.metrics
+                    .backed_off_peers
+                    .set(self.swarm.state().peers().num_backed_off_peers() as f64);
                 self.update_pending_connection_metrics();
             }
             SwarmEvent::BadMessage { peer_id } => {


### PR DESCRIPTION
Removed the `.saturating_sub(1)` call and now the metric directly reflects the actual number returned by `num_backed_off_peers()`, ensuring accurate monitoring of backed-off peers.