### PR TITLE
perf(engine): merge pruning into save_blocks write transaction

### DIFF
--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -708,6 +708,7 @@ impl ExecutionCache {
                 }
 
                 self.account_cache.remove(addr);
+                self.account_stats.decrement_size();
                 continue
             }
 

--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -827,6 +827,11 @@ impl SavedCache {
         &self.metrics
     }
 
+    /// Returns whether cache metrics recording is disabled.
+    pub const fn disable_cache_metrics(&self) -> bool {
+        self.disable_cache_metrics
+    }
+
     /// Updates the cache metrics (size/capacity/collisions) from the stats handlers.
     ///
     /// Note: This can be expensive with large cached state. Use

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -286,6 +286,12 @@ where
                     } else {
                         *cached = None;
                     }
+                } else {
+                    debug!(
+                        target: "engine::caching",
+                        expected=?expected_parent_hash,
+                        "Skipped cache save due to parent-hash mismatch"
+                    );
                 }
             });
 


### PR DESCRIPTION
**Summary**
After `on_save_blocks` committed blocks (fsync #1), the persistence thread ran pruning in a separate MDBX write transaction with its own commit (fsync #2). During this entire pruning pass, the persistence thread could not process new requests. This merges pruning into the same write transaction by calling `Pruner::run_with_provider()` with the existing `provider_rw` before `commit()`, eliminating the second fsync entirely.

**Changes**
- Move pruning into `on_save_blocks` before `provider_rw.commit()` using the existing `run_with_provider` API
- Catch and log prune errors without preventing block persistence (preserves existing guarantee)
- Remove standalone `prune_before` method and post-save pruning from `run()` loop
- Clean up unused `PrunerOutput` import

**Expected Impact**
Eliminates ~128ms of redundant fsync latency on every prune cycle (fires every other save). Based on bench metrics: prune accounts for 14.9% of total persistence wall time (53s / 356s). Each persistence cycle becomes a single atomic DB update with one fsync instead of two.

**Notes**
The `PersistenceError::PrunerError` variant is retained for API compatibility even though it is no longer constructed in this code path. The pruner's built-in `delete_limit` and `timeout` bound the additional transaction duration.