### PR TITLE
perf(engine): pipeline persistence batch preparation

### DIFF
--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -708,6 +708,7 @@ impl ExecutionCache {
                 }
 
                 self.account_cache.remove(addr);
+                self.account_stats.decrement_size();
                 continue
             }
 

--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -827,6 +827,11 @@ impl SavedCache {
         &self.metrics
     }
 
+    /// Returns whether cache metrics recording is disabled.
+    pub const fn disable_cache_metrics(&self) -> bool {
+        self.disable_cache_metrics
+    }
+
     /// Updates the cache metrics (size/capacity/collisions) from the stats handlers.
     ///
     /// Note: This can be expensive with large cached state. Use

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -286,6 +286,12 @@ where
                     } else {
                         *cached = None;
                     }
+                } else {
+                    debug!(
+                        target: "engine::caching",
+                        expected=?expected_parent_hash,
+                        "Skipped cache save due to parent-hash mismatch"
+                    );
                 }
             });
 

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -213,7 +213,7 @@ impl TestHarness {
             engine_api_tree_state,
             canonical_in_memory_state,
             persistence_handle,
-            PersistenceState { last_persisted_block: BlockNumHash::default(), rx: None },
+            PersistenceState { last_persisted_block: BlockNumHash::default(), rx: None, queued_save: None },
             payload_builder,
             // always assume enough parallelism for tests
             TreeConfig::default().with_legacy_state_root(false).with_has_enough_parallelism(true),


### PR DESCRIPTION
Allows the engine tree to pre-prepare the next persistence batch while the current one is being written to disk. Previously, `advance_persistence()` did nothing while a persist was in-flight, then had to walk the chain and collect blocks before dispatching the next batch.

Changes:
- `advance_persistence()` now calls `prepare_persist_batch()` while persistence is running
- On completion, the queued batch is dispatched immediately with validation: checks contiguity with last persisted block and verifies the batch is still on the canonical chain
- Queue cleared on reorgs (both `advance_persistence` and `on_new_persisted_block`)
- Single-item queue; `ExecutedBlock` clones are Arc-wrapped so memory overhead is minimal

### Measurement

Impact should be measured on `engine_newPayload` latency during sustained sync:
- `engine.persistence.save_blocks_duration` — gap between consecutive persist dispatches should shrink
- `engine.new_payload.duration` — reduced p99 when batch preparation previously added latency between persists
- Look for reduced time between `persistence_state.finish()` and next `persistence_state.start_save()` in traces

The win is proportional to the time spent collecting blocks (chain walk + clone) relative to the persist I/O time.