### PR TITLE
perf(engine): move pruning to dedicated background thread

### DIFF
--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -708,6 +708,7 @@ impl ExecutionCache {
                 }
 
                 self.account_cache.remove(addr);
+                self.account_stats.decrement_size();
                 continue
             }
 

--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -827,6 +827,11 @@ impl SavedCache {
         &self.metrics
     }
 
+    /// Returns whether cache metrics recording is disabled.
+    pub const fn disable_cache_metrics(&self) -> bool {
+        self.disable_cache_metrics
+    }
+
     /// Updates the cache metrics (size/capacity/collisions) from the stats handlers.
     ///
     /// Note: This can be expensive with large cached state. Use

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -286,6 +286,12 @@ where
                     } else {
                         *cached = None;
                     }
+                } else {
+                    debug!(
+                        target: "engine::caching",
+                        expected=?expected_parent_hash,
+                        "Skipped cache save due to parent-hash mismatch"
+                    );
                 }
             });
 


### PR DESCRIPTION
Moves pruning from the persistence service thread to a dedicated `PruneWorker` OS thread. Previously, pruning ran inline after `save_blocks`, blocking the persistence thread from processing new requests during the prune transaction + fsync.

Changes:
- `PruneWorker` runs on its own OS thread, receives block numbers via `mpsc` channel
- Coalesces pending requests via `try_recv` drain to skip redundant prune runs
- `Arc<Mutex<()>>` writer gate ensures MDBX single-writer safety between persist and prune threads
- After acquiring the gate, clamps prune target to `min(requested, best_block_number())` to handle reorgs that occurred between send and receive
- `ServiceGuard` joins both threads on shutdown

### Measurement

Impact should be measured on `engine_newPayload` latency under sustained load:
- `engine.persistence.save_blocks_duration` — should decrease since pruning no longer adds to it
- `engine.new_payload.duration` — reduced tail latency when pruning previously delayed the next persist
- `engine.persistence.prune_before_duration` — now recorded separately on the prune thread

The win is most visible when pruning is active (every N blocks per config) and blocks arrive back-to-back.