### PR TITLE
perf(engine): filter dirty state in state_hook instead of full clone

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -733,7 +733,10 @@ impl<Tx, Err, R: Send + Sync + 'static> PayloadHandle<Tx, Err, R> {
 
         move |source: StateChangeSource, state: &EvmState| {
             if let Some(sender) = &to_multi_proof {
-                let _ = sender.send(MultiProofMessage::StateUpdate(source.into(), state.clone()));
+                let _ = sender.send(MultiProofMessage::StateUpdate(
+                    source.into(),
+                    extract_dirty_state(state),
+                ));
             }
         }
     }


### PR DESCRIPTION
Replaces `state.clone()` with `extract_dirty_state()` in the payload processor state hook. Instead of cloning the entire `EvmState` (which includes all loaded accounts), this filters to only `is_touched()` accounts and `is_changed()` storage slots before sending to the multiproof task.

The downstream consumer (`evm_state_to_hashed_post_state`) already applies these same filters, so pre-filtering is semantically equivalent. Uses `Box::default()` for `original_info` since it's never read downstream.

### Measurement

Impact should be measured on `engine_newPayload` latency. Key metrics:
- `tree.root.multiproof_task_total_duration` — less time spent deserializing oversized state updates
- `engine.new_payload.duration` — overall newPayload improvement
- Memory allocation pressure during block execution (fewer large HashMap clones per tx)

Biggest wins expected on blocks with many read-only account accesses (e.g. DEX blocks touching many token contracts).