### PR TITLE
perf(db): default MDBX sync mode to safe-no-sync

### DIFF
--- a/crates/node/core/src/args/database.rs
+++ b/crates/node/core/src/args/database.rs
@@ -55,6 +55,12 @@ pub struct DatabaseArgs {
     #[arg(long = "db.max-readers")]
     pub max_readers: Option<u64>,
     /// Controls how aggressively the database synchronizes data to disk.
+    ///
+    /// Defaults to `safe-no-sync` which skips per-commit fsync for significantly faster
+    /// persistence. Database integrity is preserved on any crash; only the most recent
+    /// transactions may be lost on power failure (reth recovers these from peers on restart).
+    ///
+    /// Use `durable` for per-commit fsync if strict durability is required.
     #[arg(
         long = "db.sync-mode",
         value_parser = value_parser!(SyncMode),

--- a/crates/storage/libmdbx-rs/src/flags.rs
+++ b/crates/storage/libmdbx-rs/src/flags.rs
@@ -6,10 +6,9 @@ use ffi::*;
 /// MDBX sync mode
 #[derive(PartialEq, Eq, Clone, Copy, Debug, Default)]
 pub enum SyncMode {
-    /// Default robust and durable sync mode.
+    /// Robust and durable sync mode.
     /// Metadata is written and flushed to disk after a data is written and flushed, which
     /// guarantees the integrity of the database in the event of a crash at any time.
-    #[default]
     Durable,
 
     /// Don't sync the meta-page after commit.
@@ -63,6 +62,7 @@ pub enum SyncMode {
     /// as without any no-sync flags. However, you should expect a larger process's work set
     /// and significantly worse a locality of reference, due to the more intensive allocation
     /// of previously unused pages and increase the size of the database.
+    #[default]
     SafeNoSync,
 
     /// Don't sync anything and wipe previous steady commits.


### PR DESCRIPTION
## Summary

Changes the default MDBX sync mode from `Durable` to `SafeNoSync`, removing per-commit `fsync` from the persistence hot path. This targets the MDBX commit latency bottleneck in `save_blocks()`.

## Motivation

MDBX commit is the persistence bottleneck in the engine tree pipeline (`advance_persistence` → `save_blocks` → MDBX commit). Under `Durable` mode, every commit triggers an `fsync`, which dominates commit wall time.  `SafeNoSync` eliminates this per-commit fsync, providing up to **10x faster commit latency** (per libmdbx docs).

## Safety

`SafeNoSync` guarantees:
- **No database corruption** on any crash — MDBX preserves the B-tree of the last "steady" (synced) transaction
- **App crash**: no data loss — OS eventually flushes dirty mmap pages
- **Power loss / kernel crash**: rolls back to last steady commit; reth recovers missing blocks by re-executing from peers

This is already a first-class CLI option (`--db.sync-mode safe-no-sync`) and is used in production by downstream forks.

## Changes

| File | Change |
|------|--------|
| `crates/storage/libmdbx-rs/src/flags.rs` | Move `#[default]` from `Durable` to `SafeNoSync` |
| `crates/storage/db/src/implementation/mdbx/mod.rs` | Default to `SyncMode::SafeNoSync` in `DatabaseArguments::new()` |
| `crates/node/core/src/args/database.rs` | Update `--db.sync-mode` help text to document new default |

## Override

To restore previous behavior:
```bash
reth node --db.sync-mode=durable
```

## How to measure

Key Prometheus metrics to compare before/after:

| Metric | What it shows |
|--------|--------------|
| `reth_database_transaction_commit_sync_duration_seconds` | fsync phase of MDBX commit (expect near-zero with SafeNoSync) |
| `reth_database_transaction_commit_whole_duration_seconds` | Total MDBX commit time |
| `reth_storage_providers_database_save_blocks_commit_mdbx` | MDBX commit within save_blocks |
| `reth_consensus_engine_persistence_save_blocks_duration_seconds` | Total persistence duration |
| `reth_consensus_engine_beacon_persistence_duration` | End-to-end persistence round-trip |
