### PR TITLE
docs: add Signature Verification to sidebar under Running a Node

### DIFF
--- a/docs/vocs/sidebar.ts
+++ b/docs/vocs/sidebar.ts
@@ -63,6 +63,10 @@ export const sidebar: SidebarItem[] = [
                         link: "/run/overview",
                     },
                     {
+                        text: "Signature Verification",
+                        link: "/installation/binaries#signature-verification",
+                    },
+                    {
                         text: "Networks",
                         // link: "/run/networks",
                         items: [


### PR DESCRIPTION
Adds a link to the Signature Verification section in the sidebar under "Running a Node" for easier discoverability.

The content already exists at `/installation/binaries#signature-verification` - this just adds a sidebar entry linking to it.