### PR TITLE
perf(engine): send proofs directly from prewarming to multiproof task

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -551,8 +551,7 @@ where
             // create the tx env
             let start = Instant::now();
 
-            // If the task was cancelled, stop execution, send an empty result to notify the task,
-            // and exit.
+            // If the task was cancelled, stop execution, and exit.
             if terminate_execution.load(Ordering::Relaxed) {
                 break
             }
@@ -582,8 +581,7 @@ where
 
             drop(enter);
 
-            // If the task was cancelled, stop execution, send an empty result to notify the task,
-            // and exit.
+            // If the task was cancelled, stop execution, and exit.
             if terminate_execution.load(Ordering::Relaxed) {
                 break
             }


### PR DESCRIPTION
Instead of routing proofs from prewarming through prewarm task, send them directly to multiproof task.

```
Metric        | Baseline         | Feature          | Change    | Threshold
--------------+------------------+------------------+-----------+-----------
Mean Latency  |          39.74ms |          39.25ms |  -1.24% ≈ |    ±2.52%
Std Dev       |          15.97ms |          15.64ms |           |
P50 Latency   |          36.29ms |          35.91ms |  -1.03% ≈ |    ±3.45%
P90 Latency   |          59.27ms |          58.62ms |  -1.08%   |
P99 Latency   |          93.18ms |          88.81ms |   -4.7%   |
--------------+------------------+------------------+-----------+-----------
Gas/sec       |    766.72 Mgas/s |    776.33 Mgas/s |  +1.25% ≈ |    ±2.52%
```