### PR TITLE
docs: add site-level meta description for SEO

### DIFF
--- a/.changelog/big-mules-cook.md
+++ b/.changelog/big-mules-cook.md
@@ -1,0 +1,4 @@
+---
+---
+
+Added site-level meta description for SEO.

--- a/docs/vocs/vocs.config.ts
+++ b/docs/vocs/vocs.config.ts
@@ -5,6 +5,7 @@ import { basePath } from './redirects.config'
 
 export default defineConfig({
   title: 'Reth',
+  description: 'Reth is a secure, performant, and modular Ethereum execution client built in Rust.',
   logoUrl: '/logo.png',
   iconUrl: '/logo.png',
   ogImageUrl: '/reth-prod.png',


### PR DESCRIPTION
## Problem

Google search results for reth.rs show garbled navigation text as the page description:

> RunSDKRustdocsGitHub; v1.10.2. RunSDKRustdocsGitHub; v1.10.2. Reth. Reth. Secure, performant, and modular blockchain SDK and node. Run a NodeBuild a NodeWhy ...

This happens because there is no site-level `<meta name="description">` tag, so Google scrapes and concatenates sidebar/nav text instead.

## Fix

Adds a `description` field to the Vocs config, which renders as a proper meta description tag. Google will prefer this over scraped page content.

After deployment, re-indexing can be triggered via [Google Search Console](https://search.google.com/search-console).