### PR TITLE
fix(evm): add range validation in ExecutionOutcome::split_at

### DIFF
--- a/crates/evm/execution-types/src/execution_outcome.rs
+++ b/crates/evm/execution-types/src/execution_outcome.rs
@@ -320,6 +320,14 @@ impl<T> ExecutionOutcome<T> {
             return (None, self)
         }
 
+        let last_block = self.last_block();
+        if at < self.first_block || at > last_block {
+            panic!(
+                "target block number {} is not included in the state block range [{}, {}]",
+                at, self.first_block, last_block
+            );
+        }
+
         let (mut lower_state, mut higher_state) = (self.clone(), self);
 
         // Revert lower state to [..at].


### PR DESCRIPTION
When calling `split_at(at)` with `at < self.first_block`, a panic occurred in `at.checked_sub(1).unwrap()` before range validation. This resulted in an uninformative error message and violated the method's contract documented in the docstring.