### PR TITLE
feat(trie): Add root_node method to v2 ProofCalculator

### DIFF
--- a/.changelog/zesty-birds-smile.md
+++ b/.changelog/zesty-birds-smile.md
@@ -1,0 +1,6 @@
+---
+reth-trie: minor
+reth-trie-parallel: minor
+---
+
+Added `root_node` and `storage_root_node` methods to proof calculators for efficient root-only calculations. These methods directly return the root node without requiring dummy targets, replacing the previous workaround of passing fake targets to proof generation.

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -539,9 +539,11 @@ where
 
         let proof_start = Instant::now();
 
-        // If targets is empty it means the caller only wants the root hash.
+        // If targets is empty it means the caller only wants the root node.
         let (proof, root) = if targets.is_empty() {
-            (Vec::new(), Some(calculator.storage_root(hashed_address)?))
+            let root_node = calculator.storage_root_node(hashed_address)?;
+            let root = calculator.compute_root_hash(std::slice::from_ref(&root_node))?;
+            (vec![root_node], root)
         } else {
             let proof = calculator.storage_proof(hashed_address, &mut targets)?;
             let root = calculator.compute_root_hash(&proof)?;

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -540,15 +540,14 @@ where
         let proof_start = Instant::now();
 
         // If targets is empty it means the caller only wants the root node.
-        let (proof, root) = if targets.is_empty() {
+        let proof = if targets.is_empty() {
             let root_node = calculator.storage_root_node(hashed_address)?;
-            let root = calculator.compute_root_hash(std::slice::from_ref(&root_node))?;
-            (vec![root_node], root)
+            vec![root_node]
         } else {
-            let proof = calculator.storage_proof(hashed_address, &mut targets)?;
-            let root = calculator.compute_root_hash(&proof)?;
-            (proof, root)
+            calculator.storage_proof(hashed_address, &mut targets)?
         };
+
+        let root = calculator.compute_root_hash(&proof)?;
 
         trace!(
             target: "trie::proof_task",

--- a/crates/trie/parallel/src/value_encoder.rs
+++ b/crates/trie/parallel/src/value_encoder.rs
@@ -177,7 +177,10 @@ where
                         stats.borrow_mut().dispatched_missing_root_count += 1;
 
                         let mut calculator = storage_calculator.borrow_mut();
-                        let storage_root = calculator.storage_root(hashed_address)?;
+                        let root_node = calculator.storage_root_node(hashed_address)?;
+                        let storage_root = calculator
+                            .compute_root_hash(std::slice::from_ref(&root_node))?
+                            .expect("storage_root_node returns a node at empty path");
 
                         cached_storage_roots.insert(hashed_address, storage_root);
                         storage_root
@@ -191,7 +194,10 @@ where
                 let hashed_address = *hashed_address;
                 let account = *account;
                 let mut calculator = storage_calculator.borrow_mut();
-                let storage_root = calculator.storage_root(hashed_address)?;
+                let root_node = calculator.storage_root_node(hashed_address)?;
+                let storage_root = calculator
+                    .compute_root_hash(std::slice::from_ref(&root_node))?
+                    .expect("storage_root_node returns a node at empty path");
 
                 cached_storage_roots.insert(hashed_address, storage_root);
                 (account, storage_root)

--- a/crates/trie/parallel/src/value_encoder.rs
+++ b/crates/trie/parallel/src/value_encoder.rs
@@ -179,7 +179,7 @@ where
                         let mut calculator = storage_calculator.borrow_mut();
                         let root_node = calculator.storage_root_node(hashed_address)?;
                         let storage_root = calculator
-                            .compute_root_hash(std::slice::from_ref(&root_node))?
+                            .compute_root_hash(&[root_node])?
                             .expect("storage_root_node returns a node at empty path");
 
                         cached_storage_roots.insert(hashed_address, storage_root);
@@ -196,7 +196,7 @@ where
                 let mut calculator = storage_calculator.borrow_mut();
                 let root_node = calculator.storage_root_node(hashed_address)?;
                 let storage_root = calculator
-                    .compute_root_hash(std::slice::from_ref(&root_node))?
+                    .compute_root_hash(&[root_node])?
                     .expect("storage_root_node returns a node at empty path");
 
                 cached_storage_roots.insert(hashed_address, storage_root);

--- a/crates/trie/parallel/src/value_encoder.rs
+++ b/crates/trie/parallel/src/value_encoder.rs
@@ -177,11 +177,7 @@ where
                         stats.borrow_mut().dispatched_missing_root_count += 1;
 
                         let mut calculator = storage_calculator.borrow_mut();
-                        let proof =
-                            calculator.storage_proof(hashed_address, &mut [B256::ZERO.into()])?;
-                        let storage_root = calculator
-                            .compute_root_hash(&proof)?
-                            .expect("storage_proof with dummy target always returns root");
+                        let storage_root = calculator.storage_root(hashed_address)?;
 
                         cached_storage_roots.insert(hashed_address, storage_root);
                         storage_root
@@ -195,10 +191,7 @@ where
                 let hashed_address = *hashed_address;
                 let account = *account;
                 let mut calculator = storage_calculator.borrow_mut();
-                let proof = calculator.storage_proof(hashed_address, &mut [B256::ZERO.into()])?;
-                let storage_root = calculator
-                    .compute_root_hash(&proof)?
-                    .expect("storage_proof with dummy target always returns root");
+                let storage_root = calculator.storage_root(hashed_address)?;
 
                 cached_storage_roots.insert(hashed_address, storage_root);
                 (account, storage_root)

--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -1807,7 +1807,7 @@ mod tests {
 
             // The hash of the root node should match the expected root from legacy StateRoot
             let root_hash = proof_calculator
-                .compute_root_hash(std::slice::from_ref(&root_node))?
+                .compute_root_hash(&[root_node])?
                 .expect("root_node returns a node at empty path");
             pretty_assertions::assert_eq!(self.expected_root, root_hash);
 

--- a/crates/trie/trie/src/proof_v2/value.rs
+++ b/crates/trie/trie/src/proof_v2/value.rs
@@ -115,7 +115,10 @@ where
             self.hashed_cursor_factory.hashed_storage_cursor(self.hashed_address)?;
 
         let mut storage_proof_calculator = ProofCalculator::new_storage(trie_cursor, hashed_cursor);
-        let storage_root = storage_proof_calculator.storage_root(self.hashed_address)?;
+        let root_node = storage_proof_calculator.storage_root_node(self.hashed_address)?;
+        let storage_root = storage_proof_calculator
+            .compute_root_hash(std::slice::from_ref(&root_node))?
+            .expect("storage_root_node returns a node at empty path");
 
         let trie_account = self.account.into_trie_account(storage_root);
         trie_account.encode(buf);

--- a/crates/trie/trie/src/proof_v2/value.rs
+++ b/crates/trie/trie/src/proof_v2/value.rs
@@ -117,7 +117,7 @@ where
         let mut storage_proof_calculator = ProofCalculator::new_storage(trie_cursor, hashed_cursor);
         let root_node = storage_proof_calculator.storage_root_node(self.hashed_address)?;
         let storage_root = storage_proof_calculator
-            .compute_root_hash(std::slice::from_ref(&root_node))?
+            .compute_root_hash(&[root_node])?
             .expect("storage_root_node returns a node at empty path");
 
         let trie_account = self.account.into_trie_account(storage_root);

--- a/crates/trie/trie/src/proof_v2/value.rs
+++ b/crates/trie/trie/src/proof_v2/value.rs
@@ -115,12 +115,7 @@ where
             self.hashed_cursor_factory.hashed_storage_cursor(self.hashed_address)?;
 
         let mut storage_proof_calculator = ProofCalculator::new_storage(trie_cursor, hashed_cursor);
-
-        let proof = storage_proof_calculator
-            .storage_proof(self.hashed_address, &mut [B256::ZERO.into()])?;
-        let storage_root = storage_proof_calculator
-            .compute_root_hash(&proof)?
-            .expect("storage_proof with dummy target always returns root");
+        let storage_root = storage_proof_calculator.storage_root(self.hashed_address)?;
 
         let trie_account = self.account.into_trie_account(storage_root);
         trie_account.encode(buf);


### PR DESCRIPTION
We were previously using a bit of a hack to calculate the root hash of the tries using proof v2, passing in `B256::ZERO` as a target. This ended up being a contributor to SR mismatches we were seeing. This PR properly implements a `root_node` method on the ProofCalculator, and a `storage_root_node` method for the StorageProofCalculator, and uses those instead of the hack.

We return the node and not just the hash because we need the node itself to reveal the storage tries, in cases where the account has been updated but no slots have been.