### PR TITLE
perf(batch-stark): Hoist lookup data allocations out of parallel quotient loop

### DIFF
--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -694,7 +694,7 @@ impl Discv4Service {
     ///
     /// **Note:** This is a noop if there are no bootnodes.
     pub fn bootstrap(&mut self) {
-        for record in self.config.bootstrap_nodes.clone() {
+        for record in self.config.bootstrap_nodes.iter().cloned() {
             debug!(target: "discv4", ?record, "pinging boot node");
             let key = kad_key(record.id);
             let entry = NodeEntry::new(record);


### PR DESCRIPTION
Eliminates redundant allocations and clones in the hot path of quotient polynomial computation by hoisting packed_perm_challenges and packed_lookup_data preparation outside the parallel iterator loop.