### PR TITLE
fix(provider): add history expiry checks to receipt query methods

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1922,6 +1922,16 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> ReceiptProvider for DatabasePr
 
     fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Self::Receipt>> {
         if let Some(id) = self.transaction_id(hash)? {
+            // Check if the receipt's block has been pruned
+            if let Some(block_number) = self.block_by_transaction_id(id)? {
+                let earliest_available = self.static_file_provider.earliest_history_height();
+                if block_number < earliest_available {
+                    return Err(ProviderError::BlockExpired {
+                        requested: block_number,
+                        earliest_available,
+                    })
+                }
+            }
             self.receipt(id)
         } else {
             Ok(None)
@@ -1932,14 +1942,20 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> ReceiptProvider for DatabasePr
         &self,
         block: BlockHashOrNumber,
     ) -> ProviderResult<Option<Vec<Self::Receipt>>> {
-        if let Some(number) = self.convert_hash_or_number(block)? &&
-            let Some(body) = self.block_body_indices(number)?
-        {
-            let tx_range = body.tx_num_range();
-            return if tx_range.is_empty() {
-                Ok(Some(Vec::new()))
-            } else {
-                self.receipts_by_tx_range(tx_range).map(Some)
+        if let Some(number) = self.convert_hash_or_number(block)? {
+            // Check if the block has been pruned
+            let earliest_available = self.static_file_provider.earliest_history_height();
+            if number < earliest_available {
+                return Err(ProviderError::BlockExpired { requested: number, earliest_available })
+            }
+
+            if let Some(body) = self.block_body_indices(number)? {
+                let tx_range = body.tx_num_range();
+                return if tx_range.is_empty() {
+                    Ok(Some(Vec::new()))
+                } else {
+                    self.receipts_by_tx_range(tx_range).map(Some)
+                }
             }
         }
         Ok(None)
@@ -1964,6 +1980,15 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> ReceiptProvider for DatabasePr
     ) -> ProviderResult<Vec<Vec<Self::Receipt>>> {
         if block_range.is_empty() {
             return Ok(Vec::new());
+        }
+
+        // Check if the start of the range has been pruned
+        let earliest_available = self.static_file_provider.earliest_history_height();
+        if *block_range.start() < earliest_available {
+            return Err(ProviderError::BlockExpired {
+                requested: *block_range.start(),
+                earliest_available,
+            })
         }
 
         // collect block body indices for each block in the range


### PR DESCRIPTION
The`receipts_by_block()` and `receipt_by_hash()` return `None` when querying pruned history, while `block()` returns a proper `BlockExpired` error. This inconsistency is confusing for RPC callers - they can't tell if a receipt doesn't exist or was just pruned.

Added the same `earliest_history_height` check to:
- `receipt_by_hash()`
- `receipts_by_block()` 
- `receipts_by_block_range()`

Now they return `BlockExpired` which maps to RPC error code 4444 (EIP-4444).
