### PR TITLE
perf(tracing): add granular spans to save_blocks, proof workers, and on_new_payload

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -551,7 +551,7 @@ where
         level = "debug",
         target = "engine::tree",
         skip_all,
-        fields(block_hash = %payload.block_hash(), block_num = %payload.block_number()),
+        fields(block_hash = %payload.block_hash(), block_num = %payload.block_number(), gas_used = %payload.gas_used()),
     )]
     fn on_new_payload(
         &mut self,

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -988,6 +988,12 @@ where
         let mut hashed_cursor_metrics = HashedCursorMetricsCache::default();
         let hashed_address = input.hashed_address();
         let proof_start = Instant::now();
+        let _span = debug_span!(
+            target: "trie::proof_task",
+            "storage_proof",
+            worker_id = self.worker_id,
+            ?hashed_address,
+        ).entered();
 
         let result = match &input {
             StorageProofInput::Legacy { hashed_address, prefix_set, target_slots, .. } => {
@@ -1085,6 +1091,12 @@ where
         );
 
         let start = Instant::now();
+        let _span = debug_span!(
+            target: "trie::proof_task",
+            "blinded_storage_node",
+            worker_id,
+            ?account,
+        ).entered();
         let result = proof_tx.process_blinded_storage_node(account, &path);
         let elapsed = start.elapsed();
 
@@ -1423,6 +1435,11 @@ where
     {
         let mut proof_cursor_metrics = ProofTaskCursorMetricsCache::default();
         let proof_start = Instant::now();
+        let _span = debug_span!(
+            target: "trie::proof_task",
+            "account_multiproof",
+            worker_id = self.worker_id,
+        ).entered();
 
         let (proof_result_sender, result, value_encoder_stats) = match input {
             AccountMultiproofInput::Legacy {


### PR DESCRIPTION
## Summary

Adds debug-level tracing spans to the three hottest paths identified via production Tempo traces, so distributed tracing can show sub-operation breakdowns without reading source code.

## Motivation

Our auto-optimizer tooling queries Tempo traces to find performance bottlenecks. Currently, `on_save_blocks` appears as a single 265ms-1174ms blob, and proof worker spans lack per-job granularity. This makes it impossible to determine _which sub-operation_ inside these spans is the bottleneck without reading source code every time.

## Changes

### `save_blocks` (265ms-1174ms in production)
New child spans:
- `save_blocks::static_file_writes`
- `save_blocks::rocksdb_writes`  
- `save_blocks::insert_tx_hash_numbers` (with `total_tx_count` attribute)
- `save_blocks::write_hashed_state`
- `save_blocks::write_trie_updates`
- `save_blocks::update_history_indices` (with block range)
- Added `first_block`/`last_block` fields to the parent span

### Proof workers (200-377ms in production)
New per-job spans:
- `storage_proof` per proof (with `worker_id`, `hashed_address`)
- `account_multiproof` per multiproof (with `worker_id`)
- `blinded_storage_node` per node lookup (with `worker_id`, `account`)

### `on_new_payload`
- Added `gas_used` field to enable gas/s-per-span analysis

## Impact
- All spans are `debug` level — zero cost when debug tracing is disabled
- No behavioral changes, only observability improvements
- Enables automated bottleneck identification through distributed tracing