### PR TITLE
fix(trie): Do not reveal disconnected leaves

### DIFF
--- a/.changelog/eager-mules-fold.md
+++ b/.changelog/eager-mules-fold.md
@@ -1,0 +1,5 @@
+---
+reth-trie-sparse-parallel: patch
+---
+
+Fixed parallel sparse trie to skip revealing disconnected leaves by checking parent branch reachability before inserting leaf nodes.

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -235,6 +235,11 @@ impl SparseTrie for ParallelSparseTrie {
                         &node.node,
                     )
                 {
+                    trace!(
+                        target: "trie::parallel_sparse",
+                        path = ?node.path,
+                        "Boundary leaf not reachable from upper subtrie, skipping",
+                    );
                     continue;
                 }
                 self.lower_subtries[idx].reveal(&node.path);
@@ -318,6 +323,11 @@ impl SparseTrie for ParallelSparseTrie {
                                 &node.node,
                             )
                         {
+                            trace!(
+                                target: "trie::parallel_sparse",
+                                path = ?node.path,
+                                "Boundary leaf not reachable from upper subtrie, skipping",
+                            );
                             continue;
                         }
                         // Reveal each node in the subtrie, returning early on any errors
@@ -2856,6 +2866,11 @@ impl SparseSubtrie {
                 if path.len() != UPPER_TRIE_MAX_DEPTH &&
                     !self.is_leaf_reachable_from_parent(&path, node)
                 {
+                    trace!(
+                        target: "trie::parallel_sparse",
+                        ?path,
+                        "Leaf not reachable from parent branch, skipping",
+                    );
                     return Ok(false)
                 }
 

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -227,6 +227,16 @@ impl SparseTrie for ParallelSparseTrie {
                     );
                     continue;
                 }
+                // For boundary leaves, check reachability from upper subtrie's parent branch
+                if node.path.len() == UPPER_TRIE_MAX_DEPTH &&
+                    !Self::is_boundary_leaf_reachable(
+                        &self.upper_subtrie.nodes,
+                        &node.path,
+                        &node.node,
+                    )
+                {
+                    continue;
+                }
                 self.lower_subtries[idx].reveal(&node.path);
                 self.subtrie_heat.mark_modified(idx);
                 self.lower_subtries[idx]
@@ -244,6 +254,9 @@ impl SparseTrie for ParallelSparseTrie {
         // Reveal lower subtrie nodes in parallel
         {
             use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
+
+            // Capture reference to upper subtrie nodes for boundary leaf reachability checks
+            let upper_nodes = &self.upper_subtrie.nodes;
 
             // Group the nodes by lower subtrie. This must be collected into a Vec in order for
             // rayon's `zip` to be happy.
@@ -296,6 +309,17 @@ impl SparseTrie for ParallelSparseTrie {
                     subtrie.nodes.reserve(nodes.len());
 
                     for node in nodes {
+                        // For boundary leaves, check reachability from upper subtrie's parent
+                        // branch
+                        if node.path.len() == UPPER_TRIE_MAX_DEPTH &&
+                            !Self::is_boundary_leaf_reachable(
+                                upper_nodes,
+                                &node.path,
+                                &node.node,
+                            )
+                        {
+                            continue;
+                        }
                         // Reveal each node in the subtrie, returning early on any errors
                         let res = subtrie.reveal_node(node.path, &node.node, node.masks);
                         if res.is_err() {
@@ -2224,6 +2248,31 @@ impl ParallelSparseTrie {
         true
     }
 
+    /// Checks if a boundary leaf (at `path.len() == UPPER_TRIE_MAX_DEPTH`) is reachable from its
+    /// parent branch in the upper subtrie.
+    ///
+    /// This is used for leaves that sit at the upper/lower subtrie boundary, where the leaf is
+    /// in a lower subtrie but its parent branch is in the upper subtrie.
+    fn is_boundary_leaf_reachable(
+        upper_nodes: &HashMap<Nibbles, SparseNode>,
+        path: &Nibbles,
+        node: &TrieNode,
+    ) -> bool {
+        debug_assert_eq!(path.len(), UPPER_TRIE_MAX_DEPTH);
+
+        if !matches!(node, TrieNode::Leaf(_)) {
+            return true
+        }
+
+        let parent_path = path.slice(..path.len() - 1);
+        let leaf_nibble = path.get_unchecked(path.len() - 1);
+
+        match upper_nodes.get(&parent_path) {
+            Some(SparseNode::Branch { state_mask, .. }) => state_mask.is_bit_set(leaf_nibble),
+            _ => false,
+        }
+    }
+
     /// Returns a bitset of all subtries that are reachable from the upper trie. If subtrie is not
     /// reachable it means that it does not exist.
     fn reachable_subtries(&self) -> SubtriesBitmap {
@@ -2394,6 +2443,28 @@ impl SparseSubtrie {
         let current_level = core::mem::discriminant(&SparseSubtrieType::from_path(current_path));
         let child_level = core::mem::discriminant(&SparseSubtrieType::from_path(child_path));
         current_level == child_level
+    }
+
+    /// Checks if a leaf node at the given path is reachable from its parent branch node.
+    ///
+    /// Returns `true` if:
+    /// - The path is at the root (no parent to check)
+    /// - The parent branch node has the corresponding `state_mask` bit set for this leaf
+    ///
+    /// Returns `false` if the parent is a branch node that doesn't have the `state_mask` bit set
+    /// for this leaf's nibble, meaning the leaf is not reachable.
+    fn is_leaf_reachable_from_parent(&self, path: &Nibbles, _node: &TrieNode) -> bool {
+        if path.is_empty() {
+            return true
+        }
+
+        let parent_path = path.slice(..path.len() - 1);
+        let leaf_nibble = path.get_unchecked(path.len() - 1);
+
+        match self.nodes.get(&parent_path) {
+            Some(SparseNode::Branch { state_mask, .. }) => state_mask.is_bit_set(leaf_nibble),
+            _ => false,
+        }
     }
 
     /// Updates or inserts a leaf node at the specified key path with the provided RLP-encoded
@@ -2777,29 +2848,41 @@ impl SparseSubtrie {
                     }
                 }
             },
-            TrieNode::Leaf(leaf) => match self.nodes.entry(path) {
-                Entry::Occupied(mut entry) => match entry.get() {
-                    // Replace a hash node with a revealed leaf node and store leaf node value.
-                    SparseNode::Hash(hash) => {
+            TrieNode::Leaf(leaf) => {
+                // Skip the reachability check when path.len() == UPPER_TRIE_MAX_DEPTH because
+                // at that boundary the leaf is in the lower subtrie but its parent branch is in
+                // the upper subtrie. The subtrie cannot check connectivity across the upper/lower
+                // boundary, so that check happens in `reveal_nodes` instead.
+                if path.len() != UPPER_TRIE_MAX_DEPTH &&
+                    !self.is_leaf_reachable_from_parent(&path, node)
+                {
+                    return Ok(false)
+                }
+
+                match self.nodes.entry(path) {
+                    Entry::Occupied(mut entry) => match entry.get() {
+                        // Replace a hash node with a revealed leaf node and store leaf node value.
+                        SparseNode::Hash(hash) => {
+                            let mut full = *entry.key();
+                            full.extend(&leaf.key);
+                            self.inner.values.insert(full, leaf.value.clone());
+                            entry.insert(SparseNode::Leaf {
+                                key: leaf.key,
+                                // Memoize the hash of a previously blinded node in a new leaf
+                                // node.
+                                hash: Some(*hash),
+                            });
+                        }
+                        _ => unreachable!("checked that node is either a hash or non-existent"),
+                    },
+                    Entry::Vacant(entry) => {
                         let mut full = *entry.key();
                         full.extend(&leaf.key);
+                        entry.insert(SparseNode::new_leaf(leaf.key));
                         self.inner.values.insert(full, leaf.value.clone());
-                        entry.insert(SparseNode::Leaf {
-                            key: leaf.key,
-                            // Memoize the hash of a previously blinded node in a new leaf
-                            // node.
-                            hash: Some(*hash),
-                        });
                     }
-                    _ => unreachable!("checked that node is either a hash or non-existent"),
-                },
-                Entry::Vacant(entry) => {
-                    let mut full = *entry.key();
-                    full.extend(&leaf.key);
-                    entry.insert(SparseNode::new_leaf(leaf.key));
-                    self.inner.values.insert(full, leaf.value.clone());
                 }
-            },
+            }
         }
 
         Ok(true)


### PR DESCRIPTION
When a leaf is revealed, and then later it's path changes (e.g. due to a branch node collapse) we need to prevent re-reveals of the original leaf from overwriting the `values` HashMap. To do this we check that all leaves are connectable from their branch prior to revealing them.

This check has to be done in a special way for leaves sitting on the upper/lower border, as they will be on the lower subtrie and their branch on the upper, so for these we can't easily do the check from the SparseSubtrie.