### PR TITLE
perf(evm): replace moka precompile cache with schnellru LRU

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8344,7 +8344,6 @@ dependencies = [
  "futures",
  "metrics",
  "metrics-util",
- "moka",
  "parking_lot",
  "proptest",
  "rand 0.8.5",

--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -54,7 +54,6 @@ futures.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "sync", "macros"] }
 fixed-cache.workspace = true
-moka = { workspace = true, features = ["sync"] }
 smallvec.workspace = true
 
 # metrics


### PR DESCRIPTION
## Summary
Replaces `moka::sync::Cache` (concurrent cache using crossbeam-epoch GC) with `Arc<Mutex<schnellru::LruMap>>` in the precompile cache, eliminating 5.5% CPU overhead from epoch-based garbage collection.

## Motivation
Pyroscope shows `crossbeam_epoch` functions consuming 5.5% CPU combined:
- `try_advance`: 1.5%
- `with_handle`: 1.3%
- `Iter::next`: 2.7%

All from moka's internal concurrent hash table. Individual precompile cache access during EVM execution is single-threaded per transaction, so the concurrent data structure overhead is unnecessary.

## Changes
- Replaced `moka::sync::Cache<Bytes, CacheEntry<S>>` with `Arc<Mutex<LruMap<Bytes, CacheEntry<S>, ByLength>>>`
- Removed `moka` dependency from `reth-engine-tree`
- `schnellru` already used widely in reth (`reth-net-dns`, `reth-network`, etc.)

## Testing
- `cargo check -p reth-engine-tree` passes
- Existing precompile cache tests pass
- CI benchmark submitted (run `b73add5d`)

Thread: https://tempoxyz.slack.com/archives/C0A87C21805/p1770428917299909