### PR TITLE
perf(trie): reduce allocations in sparse trie hot paths

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -936,7 +936,7 @@ where
                 trace!(target: "engine::tree::payload_processor::sparse_trie", ?slot_nibbles, "Updating storage slot");
                 storage_trie.update_leaf(
                     slot_nibbles,
-                    alloy_rlp::encode_fixed_size(&value).to_vec(),
+                    &alloy_rlp::encode_fixed_size(&value),
                     &storage_provider,
                 )?;
             }

--- a/crates/stateless/src/trie.rs
+++ b/crates/stateless/src/trie.rs
@@ -261,7 +261,7 @@ fn calculate_state_root(
             } else {
                 storage_trie.update_leaf(
                     nibbles,
-                    alloy_rlp::encode_fixed_size(&value).to_vec(),
+                    &alloy_rlp::encode_fixed_size(&value),
                     &storage_provider,
                 )?;
             }
@@ -300,7 +300,7 @@ fn calculate_state_root(
         if let Some(account) = account {
             account_rlp_buf.clear();
             account.into_trie_account(storage_root).encode(&mut account_rlp_buf);
-            trie.update_account_leaf(nibbles, account_rlp_buf.clone(), &provider_factory)?;
+            trie.update_account_leaf(nibbles, &account_rlp_buf, &provider_factory)?;
         } else {
             trie.remove_account_leaf(&nibbles, &provider_factory)?;
         }

--- a/crates/trie/sparse/benches/rlp_node.rs
+++ b/crates/trie/sparse/benches/rlp_node.rs
@@ -26,11 +26,7 @@ fn update_rlp_node_level(c: &mut Criterion) {
         let mut sparse = SerialSparseTrie::default();
         for (key, value) in &state {
             sparse
-                .update_leaf(
-                    Nibbles::unpack(key),
-                    alloy_rlp::encode_fixed_size(value).to_vec(),
-                    &provider,
-                )
+                .update_leaf(Nibbles::unpack(key), &alloy_rlp::encode_fixed_size(value), &provider)
                 .unwrap();
         }
         sparse.root();
@@ -43,7 +39,7 @@ fn update_rlp_node_level(c: &mut Criterion) {
                 sparse
                     .update_leaf(
                         Nibbles::unpack(key),
-                        alloy_rlp::encode_fixed_size(&rng.random::<U256>()).to_vec(),
+                        &alloy_rlp::encode_fixed_size(&rng.random::<U256>()),
                         &provider,
                     )
                     .unwrap();

--- a/crates/trie/sparse/benches/root.rs
+++ b/crates/trie/sparse/benches/root.rs
@@ -49,7 +49,7 @@ fn calculate_root_from_leaves(c: &mut Criterion) {
                         sparse
                             .update_leaf(
                                 Nibbles::unpack(key),
-                                alloy_rlp::encode_fixed_size(value).to_vec(),
+                                &alloy_rlp::encode_fixed_size(value),
                                 &provider,
                             )
                             .unwrap();
@@ -215,7 +215,7 @@ fn calculate_root_from_leaves_repeated(c: &mut Criterion) {
                                 sparse
                                     .update_leaf(
                                         Nibbles::unpack(key),
-                                        alloy_rlp::encode_fixed_size(value).to_vec(),
+                                        &alloy_rlp::encode_fixed_size(value),
                                         &provider,
                                     )
                                     .unwrap();
@@ -229,7 +229,7 @@ fn calculate_root_from_leaves_repeated(c: &mut Criterion) {
                                     sparse
                                         .update_leaf(
                                             Nibbles::unpack(key),
-                                            alloy_rlp::encode_fixed_size(value).to_vec(),
+                                            &alloy_rlp::encode_fixed_size(value),
                                             &provider,
                                         )
                                         .unwrap();

--- a/crates/trie/sparse/src/traits.rs
+++ b/crates/trie/sparse/src/traits.rs
@@ -155,7 +155,7 @@ pub trait SparseTrie: Sized + Debug + Send + Sync {
     fn update_leaf<P: TrieNodeProvider>(
         &mut self,
         full_path: Nibbles,
-        value: Vec<u8>,
+        value: &[u8],
         provider: P,
     ) -> SparseTrieResult<()>;
 

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -175,9 +175,14 @@ where
                     .map(|v| alloy_rlp::encode_fixed_size(v).to_vec());
 
                 if let Some(value) = maybe_leaf_value {
-                    storage_trie.update_leaf(storage_nibbles, value, &provider).map_err(|err| {
-                        SparseStateTrieErrorKind::SparseStorageTrie(hashed_address, err.into_kind())
-                    })?;
+                    storage_trie.update_leaf(storage_nibbles, &value, &provider).map_err(
+                        |err| {
+                            SparseStateTrieErrorKind::SparseStorageTrie(
+                                hashed_address,
+                                err.into_kind(),
+                            )
+                        },
+                    )?;
                 } else {
                     storage_trie.remove_leaf(&storage_nibbles, &provider).map_err(|err| {
                         SparseStateTrieErrorKind::SparseStorageTrie(hashed_address, err.into_kind())


### PR DESCRIPTION
## Summary

Reduce per-node heap allocations in the sparse trie's hot paths.

## Motivation

Profiling shows two allocation bottlenecks during state root computation:
1. `update_leaf` / `update_account_leaf` / `update_storage_leaf` take `Vec<u8>`, forcing callers to `.clone()` the RLP buffer even though the callee only needs a read
2. `rlp_node()` allocates a fresh `Vec<B256>` per branch node to collect child hashes

## Changes

- Changed `update_leaf`, `update_account_leaf`, and `update_storage_leaf` signatures from `Vec<u8>` to `&[u8]`, eliminating clone at `update_account` and `update_account_storage_root` call sites (`crates/trie/sparse/src/state.rs`)
- Added `hashes_buf: Vec<B256>` to `RlpNodeBuffers` so branch node hash collection reuses the same buffer across iterations instead of allocating per branch node (`crates/trie/sparse/src/trie.rs`)
- Updated all call sites across serial trie, parallel trie, engine tree, stateless, witness, and benchmarks

## Testing

```
cargo test -p reth-trie-sparse --lib  # 37/37 passed
cargo check -p reth-trie-sparse-parallel -p reth-engine-tree -p reth-stateless -p reth-trie
```

Thread: https://tempoxyz.slack.com/archives/C0A87C21805/p1770435825158049