### PR TITLE
perf(rpc): cache execution witnesses in debug_executionWitness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9862,6 +9862,7 @@ dependencies = [
  "revm",
  "revm-inspectors",
  "revm-primitives",
+ "schnellru",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -82,6 +82,7 @@ pin-project.workspace = true
 parking_lot.workspace = true
 
 # misc
+schnellru.workspace = true
 dyn-clone.workspace = true
 tracing.workspace = true
 tracing-futures.workspace = true


### PR DESCRIPTION
## Summary

Add an LRU cache for `debug_executionWitness` results to avoid redundant block re-execution.

## Motivation

Every call to `debug_executionWitness` currently re-executes the entire block and recomputes the trie witness from scratch. This is expensive (100ms+ per call). When the same block is queried repeatedly (common pattern for CL<->EL workflows and debugging), this wastes significant CPU.

## Changes

- Add a bounded LRU cache (128 entries, keyed by block hash) to `DebugApiInner`
- On cache hit, return the cached `ExecutionWitness` directly
- On cache miss, execute as before and store the result

## Testing

```
cargo check -p reth-rpc
cargo +nightly clippy -p reth-rpc --all-features
```