### PR TITLE
perf(engine): skip precompile cache for identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,8 +290,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ccfe6d724ceabd5518350cfb34f17dd3a6c3cc33579eee94d98101d3a511ff"
+source = "git+https://github.com/alloy-rs/evm?rev=80d15a8#80d15a865757fd93607d743c0c0019a753d526cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13941,3 +13940,8 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "alloy-op-evm"
+version = "0.27.2"
+source = "git+https://github.com/alloy-rs/evm?rev=80d15a8#80d15a865757fd93607d743c0c0019a753d526cf"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,7 +290,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.27.2"
-source = "git+https://github.com/alloy-rs/evm?rev=80d15a8#80d15a865757fd93607d743c0c0019a753d526cf"
+source = "git+https://github.com/alloy-rs/evm?rev=72b2121#72b21219f6bbb15805488f3f6f944b423737835f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13944,4 +13944,4 @@ dependencies = [
 [[patch.unused]]
 name = "alloy-op-evm"
 version = "0.27.2"
-source = "git+https://github.com/alloy-rs/evm?rev=80d15a8#80d15a865757fd93607d743c0c0019a753d526cf"
+source = "git+https://github.com/alloy-rs/evm?rev=72b2121#72b21219f6bbb15805488f3f6f944b423737835f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -763,3 +763,6 @@ ipnet = "2.11"
 
 # alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "072c248" }
 # alloy-op-evm = { git = "https://github.com/alloy-rs/evm", rev = "072c248" }
+
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "80d15a8" }
+alloy-op-evm = { git = "https://github.com/alloy-rs/evm", rev = "80d15a8" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -764,5 +764,5 @@ ipnet = "2.11"
 # alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "072c248" }
 # alloy-op-evm = { git = "https://github.com/alloy-rs/evm", rev = "072c248" }
 
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "80d15a8" }
-alloy-op-evm = { git = "https://github.com/alloy-rs/evm", rev = "80d15a8" }
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "72b2121" }
+alloy-op-evm = { git = "https://github.com/alloy-rs/evm", rev = "72b2121" }

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -19,7 +19,7 @@ use crate::tree::{
         multiproof::{MultiProofMessage, VersionedMultiProofTargets},
         PayloadExecutionCache,
     },
-    precompile_cache::{supports_caching, CachedPrecompile, PrecompileCacheMap},
+    precompile_cache::{CachedPrecompile, PrecompileCacheMap},
     ExecutionEnv, StateProviderBuilder,
 };
 use alloy_consensus::transaction::TxHashRef;
@@ -495,12 +495,7 @@ where
         let mut evm = evm_config.evm_with_env(state_provider, evm_env);
 
         if !precompile_cache_disabled {
-            // Only cache pure precompiles to avoid issues with stateful precompiles.
-            // Additionally skip precompiles where caching overhead exceeds benefit (e.g. identity).
-            evm.precompiles_mut().map_pure_precompiles(|address, precompile| {
-                if !supports_caching(address) {
-                    return precompile;
-                }
+            evm.precompiles_mut().map_cacheable_precompiles(|address, precompile| {
                 CachedPrecompile::wrap(
                     precompile,
                     precompile_cache_map.cache_for_address(*address),

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -5,9 +5,7 @@ use crate::tree::{
     error::{InsertBlockError, InsertBlockErrorKind, InsertPayloadError},
     instrumented_state::InstrumentedStateProvider,
     payload_processor::{executor::WorkloadExecutor, PayloadProcessor},
-    precompile_cache::{
-        supports_caching, CachedPrecompile, CachedPrecompileMetrics, PrecompileCacheMap,
-    },
+    precompile_cache::{CachedPrecompile, CachedPrecompileMetrics, PrecompileCacheMap},
     sparse_trie::StateRootComputeOutcome,
     EngineApiMetrics, EngineApiTreeState, ExecutionEnv, PayloadHandle, StateProviderBuilder,
     StateProviderDatabase, TreeConfig,
@@ -714,24 +712,21 @@ where
         let mut executor = self.evm_config.create_executor(evm, ctx);
 
         if !self.config.precompile_cache_disabled() {
-            // Only cache pure precompiles to avoid issues with stateful precompiles.
-            // Additionally skip precompiles where caching overhead exceeds benefit (e.g. identity).
-            executor.evm_mut().precompiles_mut().map_pure_precompiles(|address, precompile| {
-                if !supports_caching(address) {
-                    return precompile;
-                }
-                let metrics = self
-                    .precompile_cache_metrics
-                    .entry(*address)
-                    .or_insert_with(|| CachedPrecompileMetrics::new_with_address(*address))
-                    .clone();
-                CachedPrecompile::wrap(
-                    precompile,
-                    self.precompile_cache_map.cache_for_address(*address),
-                    spec_id,
-                    Some(metrics),
-                )
-            });
+            executor.evm_mut().precompiles_mut().map_cacheable_precompiles(
+                |address, precompile| {
+                    let metrics = self
+                        .precompile_cache_metrics
+                        .entry(*address)
+                        .or_insert_with(|| CachedPrecompileMetrics::new_with_address(*address))
+                        .clone();
+                    CachedPrecompile::wrap(
+                        precompile,
+                        self.precompile_cache_map.cache_for_address(*address),
+                        spec_id,
+                        Some(metrics),
+                    )
+                },
+            );
         }
 
         // Spawn background task to compute receipt root and logs bloom incrementally.

--- a/crates/engine/tree/src/tree/precompile_cache.rs
+++ b/crates/engine/tree/src/tree/precompile_cache.rs
@@ -11,24 +11,6 @@ use std::{hash::Hash, sync::Arc};
 /// Default max cache size for [`PrecompileCache`]
 const MAX_CACHE_SIZE: u32 = 10_000;
 
-/// Identity precompile address (0x04).
-///
-/// The identity precompile simply copies its input to output, which is an O(n) operation.
-/// Caching it is counterproductive because computing the cache key hash is also O(n),
-/// so we'd be doing O(n) work to potentially save O(n) work with no net benefit.
-const IDENTITY_PRECOMPILE: Address =
-    Address::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x04]);
-
-/// Returns `true` if caching should be enabled for the precompile at the given address.
-///
-/// Some precompiles are not worth caching because the overhead of computing the cache key
-/// (hashing the input) is comparable to or greater than the cost of simply re-executing
-/// the precompile.
-#[inline]
-pub fn supports_caching(address: &Address) -> bool {
-    *address != IDENTITY_PRECOMPILE
-}
-
 /// Stores caches for each precompile.
 #[derive(Debug, Clone, Default)]
 pub struct PrecompileCacheMap<S>(Arc<DashMap<Address, PrecompileCache<S>>>)
@@ -384,24 +366,5 @@ mod tests {
             .into_output()
             .unwrap();
         assert_eq!(result3.as_ref(), b"output_from_precompile_1");
-    }
-
-    #[test]
-    fn test_supports_caching() {
-        use super::{supports_caching, IDENTITY_PRECOMPILE};
-
-        // Identity precompile should NOT support caching
-        assert!(!supports_caching(&IDENTITY_PRECOMPILE));
-        assert!(!supports_caching(&Address::with_last_byte(0x04)));
-
-        // Other precompiles should support caching
-        assert!(supports_caching(&Address::with_last_byte(0x01))); // ecrecover
-        assert!(supports_caching(&Address::with_last_byte(0x02))); // sha256
-        assert!(supports_caching(&Address::with_last_byte(0x03))); // ripemd160
-        assert!(supports_caching(&Address::with_last_byte(0x05))); // modexp
-        assert!(supports_caching(&Address::with_last_byte(0x06))); // bn254 add
-        assert!(supports_caching(&Address::with_last_byte(0x07))); // bn254 mul
-        assert!(supports_caching(&Address::with_last_byte(0x08))); // bn254 pairing
-        assert!(supports_caching(&Address::with_last_byte(0x09))); // blake2f
     }
 }


### PR DESCRIPTION
## Summary

Skip caching for the identity precompile by using the new `Precompile::supports_caching` trait method and `map_cacheable_precompiles` from alloy-evm.

## Motivation

The identity precompile simply copies its input to output, which is an O(n) operation. Caching it is counterproductive because computing the cache key hash is also O(n), so we'd be doing O(n) work to potentially save O(n) work with no net benefit.

## Changes

- Patched alloy-evm to use `map_cacheable_precompiles` (replaces `map_pure_precompiles`)
- Updated `payload_validator.rs` and `prewarm.rs` to use new API
- Removed reth-side `supports_caching` helper (now handled by the trait)

## Dependencies

- alloy-rs/evm#284

## Testing

```
cargo test -p reth-engine-tree precompile_cache
```