### PR TITLE
chore(trie): move revm-database to dev-dependencies

### DIFF
--- a/crates/trie/trie/Cargo.toml
+++ b/crates/trie/trie/Cargo.toml
@@ -20,8 +20,6 @@ reth-storage-errors.workspace = true
 reth-trie-sparse.workspace = true
 reth-trie-common = { workspace = true, features = ["rayon"] }
 
-revm-database.workspace = true
-
 # alloy
 alloy-eips.workspace = true
 alloy-rlp.workspace = true
@@ -52,6 +50,7 @@ reth-tracing.workspace = true
 reth-trie-common = { workspace = true, features = ["test-utils", "arbitrary"] }
 
 # revm
+revm-database.workspace = true
 revm-state.workspace = true
 
 # trie
@@ -75,17 +74,12 @@ serde = [
     "alloy-eips/serde",
     "reth-trie-common/serde",
     "reth-primitives-traits/serde",
-    "alloy-primitives/serde",
-    "alloy-consensus/serde",
-    "alloy-trie/serde",
-    "alloy-eips/serde",
-    "reth-trie-common/serde",
-    "revm-database/serde",
     "reth-stages-types/serde",
-    "revm-state/serde",
-    "parking_lot/serde",
-    "reth-ethereum-primitives/serde",
+    "parking_lot?/serde",
     "rand/serde",
+    "reth-ethereum-primitives/serde",
+    "revm-database/serde",
+    "revm-state/serde",
 ]
 test-utils = [
     "triehash",


### PR DESCRIPTION
`revm-database` is only used in `benches/hash_post_state.rs`, so it should be a dev-dependency.

Also removes duplicate entries in the `serde` feature and fixes `parking_lot?/serde` syntax for optional dep.