### PR TITLE
perf(prewarm): disable balance check for prewarming transactions

### DIFF
--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -27,7 +27,7 @@ reth-primitives-traits = { workspace = true, features = ["rayon", "dashmap"] }
 reth-ethereum-primitives.workspace = true
 reth-provider.workspace = true
 reth-prune.workspace = true
-reth-revm.workspace = true
+reth-revm = { workspace = true, features = ["optional-balance-check"] }
 reth-stages-api.workspace = true
 reth-tasks.workspace = true
 reth-trie-parallel.workspace = true

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -490,6 +490,10 @@ where
         // doesn't match what's on chain.
         evm_env.cfg_env.disable_nonce_check = true;
 
+        // disable the balance check so that transactions from senders who were funded by earlier
+        // transactions in the block can still be prewarmed
+        evm_env.cfg_env.disable_balance_check = true;
+
         // create a new executor and disable nonce checks in the env
         let spec_id = *evm_env.spec_id();
         let mut evm = evm_config.evm_with_env(state_provider, evm_env);


### PR DESCRIPTION
Disables the EVM balance check during prewarming by setting `cfg_env.disable_balance_check = true` alongside the existing `disable_nonce_check = true`.

Prewarming executes transactions in parallel without sequential state updates, so senders with multiple transactions in the same block fail validation with "lack of funds" errors. This primarily affects MEV bots and sandwich bundles that submit multiple transactions per block and whose later transactions depend on balance changes from earlier ones. Contract wallets funded mid-block via internal transfers are also affected.

These failures are harmless but waste work since the failed transactions don't warm the cache. With the balance check disabled, revm uses saturating arithmetic for balance deductions instead of rejecting the transaction, allowing all transactions to execute and warm the cache.