### PR TITLE
perf(engine/tree): avoid redundant hash lookups in tree state and block buffer

### DIFF
--- a/crates/engine/tree/src/tree/block_buffer.rs
+++ b/crates/engine/tree/src/tree/block_buffer.rs
@@ -2,7 +2,7 @@ use crate::tree::metrics::BlockBufferMetrics;
 use alloy_consensus::BlockHeader;
 use alloy_primitives::{BlockHash, BlockNumber};
 use reth_primitives_traits::{Block, SealedBlock};
-use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
+use std::collections::{hash_map, BTreeMap, HashMap, HashSet, VecDeque};
 
 /// Contains the tree of pending blocks that cannot be executed due to missing parent.
 /// It allows to store unconnected blocks for potential future inclusion.
@@ -137,12 +137,10 @@ impl<B: Block> BlockBuffer<B> {
 
     /// Remove from parent child connection. This method does not remove children.
     fn remove_from_parent(&mut self, parent_hash: BlockHash, hash: &BlockHash) {
-        // remove from parent to child connection, but only for this block parent.
-        if let Some(entry) = self.parent_to_child.get_mut(&parent_hash) {
-            entry.remove(hash);
-            // if set is empty remove block entry.
-            if entry.is_empty() {
-                self.parent_to_child.remove(&parent_hash);
+        if let hash_map::Entry::Occupied(mut entry) = self.parent_to_child.entry(parent_hash) {
+            entry.get_mut().remove(hash);
+            if entry.get().is_empty() {
+                entry.remove();
             }
         }
     }

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1259,8 +1259,7 @@ where
 
         // NOTE: checked non-empty above
         let highest_num_hash = blocks_to_persist
-            .iter()
-            .max_by_key(|block| block.recovered_block().number())
+            .last()
             .map(|b| b.recovered_block().num_hash())
             .expect("Checked non-empty persisting blocks");
 

--- a/crates/engine/tree/src/tree/state.rs
+++ b/crates/engine/tree/src/tree/state.rs
@@ -162,11 +162,12 @@ impl<N: NodePrimitives> TreeState<N> {
         let parent_hash = executed.recovered_block().parent_hash();
         let block_number = executed.recovered_block().number();
 
-        if self.blocks_by_hash.contains_key(&hash) {
-            return;
+        match self.blocks_by_hash.entry(hash) {
+            hash_map::Entry::Occupied(_) => return,
+            hash_map::Entry::Vacant(entry) => {
+                entry.insert(executed.clone());
+            }
         }
-
-        self.blocks_by_hash.insert(hash, executed.clone());
 
         self.blocks_by_number.entry(block_number).or_default().push(executed);
 


### PR DESCRIPTION
## Summary                                                                                                                              
 - Replace `max_by_key` with `last()` in `persist_blocks` , input is always ascending from `get_canonical_blocks_to_persist`, so `last()` is O(1) instead of O(n)                                                                                                                         
 - Use entry API in `TreeState::insert_executed` to avoid double hash+probe on `B256Map` (`contains_key` + `insert` → single                                                                                              `entry`)                                                                                                                                                 
 - Use entry API in `BlockBuffer::remove_from_parent` to avoid redundant HashMap lookup on empty-set cleanup path                                                                                                       
                                                                                                                                                                          
## Test plan                                                                                                                                               
- [x] Existing tests pass (`cargo nextest run -p reth-engine-tree`)                                                                                        
- [x] No behavior change, only fewer hash computations per call