### PR TITLE
chore: add libmdbx to default tracing filter

### DIFF
--- a/crates/node/core/src/args/log.rs
+++ b/crates/node/core/src/args/log.rs
@@ -13,7 +13,7 @@ use tracing::{level_filters::LevelFilter, Level};
 const MB_TO_BYTES: u64 = 1024 * 1024;
 
 const PROFILER_TRACING_FILTER: &str =
-    "info,engine=debug,trie=debug,providers=debug,rpc=debug,sync=debug,pruner=debug";
+    "info,engine=debug,trie=debug,providers=debug,rpc=debug,sync=debug,pruner=debug,libmdbx=debug";
 
 /// The log configuration.
 #[derive(Debug, Args)]


### PR DESCRIPTION
Txn manager uses this