### PR TITLE
refactor(discv4): replace unwrap with unwrap_or_default for UNIX_EPOCH calls

### DIFF
--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -1675,22 +1675,22 @@ impl Discv4Service {
     }
 
     fn ping_expiration(&self) -> u64 {
-        (SystemTime::now().duration_since(UNIX_EPOCH).unwrap() + self.config.ping_expiration)
+        (SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default() + self.config.ping_expiration)
             .as_secs()
     }
 
     fn find_node_expiration(&self) -> u64 {
-        (SystemTime::now().duration_since(UNIX_EPOCH).unwrap() + self.config.request_timeout)
+        (SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default() + self.config.request_timeout)
             .as_secs()
     }
 
     fn enr_request_expiration(&self) -> u64 {
-        (SystemTime::now().duration_since(UNIX_EPOCH).unwrap() + self.config.enr_expiration)
+        (SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default() + self.config.enr_expiration)
             .as_secs()
     }
 
     fn send_neighbours_expiration(&self) -> u64 {
-        (SystemTime::now().duration_since(UNIX_EPOCH).unwrap() + self.config.neighbours_expiration)
+        (SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default() + self.config.neighbours_expiration)
             .as_secs()
     }
 


### PR DESCRIPTION
Replaced `.unwrap()` with `.unwrap_or_default()` in four expiration timestamp methods to prevent potential panics when system time is before UNIX epoch.
