### PR TITLE
fix: return None for pruned blocks in transactions_by_block and receipts_by_block

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1871,6 +1871,14 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> TransactionsProvider for Datab
         if let Some(block_number) = self.convert_hash_or_number(id)? &&
             let Some(body) = self.block_body_indices(block_number)?
         {
+            // If the block's transactions have been pruned, return None
+            if let Some(checkpoint) = self.get_prune_checkpoint(PruneSegment::Bodies)? &&
+                let Some(pruned_block) = checkpoint.block_number &&
+                block_number <= pruned_block
+            {
+                return Ok(None);
+            }
+
             let tx_range = body.tx_num_range();
             return if tx_range.is_empty() {
                 Ok(Some(Vec::new()))
@@ -1954,6 +1962,14 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> ReceiptProvider for DatabasePr
         if let Some(number) = self.convert_hash_or_number(block)? &&
             let Some(body) = self.block_body_indices(number)?
         {
+            // If the block's receipts have been pruned, return None
+            if let Some(checkpoint) = self.get_prune_checkpoint(PruneSegment::Receipts)? &&
+                let Some(pruned_block) = checkpoint.block_number &&
+                number <= pruned_block
+            {
+                return Ok(None);
+            }
+
             let tx_range = body.tx_num_range();
             return if tx_range.is_empty() {
                 Ok(Some(Vec::new()))


### PR DESCRIPTION
Ran into a weird issue on a pruned node where `eth_getBlockByNumber` was returning blocks with empty tx lists for old blocks instead of treating them as unavailable. Turns out block_body_indices entries stick around in MDBX after bodies pruning, so both `transactions_by_block` and `receipts_by_block` happily find the indices and end up returning Some(vec![]) when the actual data is long gone from static files. Added prune checkpoint checks for Bodies/Receipts segments before attempting to read, consistent with how AccountHistory/StorageHistory already handle this.