### PR TITLE
chore(ci): improve wasm and riscv check output

### DIFF
--- a/.github/scripts/check_rv32imac.sh
+++ b/.github/scripts/check_rv32imac.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-set +e  # Disable immediate exit on error
+set -uo pipefail
 
-# Array of crates to check
 crates_to_check=(
     reth-codecs-derive
     reth-primitives
@@ -31,51 +30,20 @@ crates_to_check=(
     reth-stateless
 )
 
-# Array to hold the results
-results=()
-# Flag to track if any command fails
 any_failed=0
+tmpdir=$(mktemp -d 2>/dev/null || mktemp -d -t reth-check)
+trap 'rm -rf -- "$tmpdir"' EXIT INT TERM
 
 for crate in "${crates_to_check[@]}"; do
-  cmd="cargo +stable build -p $crate --target riscv32imac-unknown-none-elf --no-default-features"
-
-  if [ -n "$CI" ]; then
-    echo "::group::$cmd"
+  outfile="$tmpdir/$crate.log"
+  if cargo +stable build -p "$crate" --target riscv32imac-unknown-none-elf --no-default-features --color never >"$outfile" 2>&1; then
+    echo "✅ $crate"
   else
-    printf "\n%s:\n  %s\n" "$crate" "$cmd"
-  fi
-
-  set +e  # Disable immediate exit on error
-  # Run the command and capture the return code
-  $cmd
-  ret_code=$?
-  set -e  # Re-enable immediate exit on error
-
-  # Store the result in the dictionary
-  if [ $ret_code -eq 0 ]; then
-    results+=("1:✅:$crate")
-  else
-    results+=("2:❌:$crate")
+    echo "❌ $crate"
+    sed 's/^/   /' "$outfile"
+    echo ""
     any_failed=1
   fi
-
-  if [ -n "$CI" ]; then
-    echo "::endgroup::"
-  fi
 done
 
-# Sort the results by status and then by crate name
-IFS=$'\n' sorted_results=($(sort <<<"${results[*]}"))
-unset IFS
-
-# Print summary
-echo -e "\nSummary of build results:"
-for result in "${sorted_results[@]}"; do
-  status="${result#*:}"
-  status="${status%%:*}"
-  crate="${result##*:}"
-  echo "$status $crate"
-done
-
-# Exit with a non-zero status if any command fails
 exit $any_failed

--- a/.github/scripts/check_wasm.sh
+++ b/.github/scripts/check_wasm.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
-set +e  # Disable immediate exit on error
+set -uo pipefail
 
-# Array of crates to compile
-crates=($(cargo metadata --format-version=1 --no-deps | jq -r '.packages[].name' | grep '^reth' | sort))
+readarray -t crates < <(
+  cargo metadata --format-version=1 --no-deps | jq -r '.packages[].name' | grep '^reth' | sort
+)
 
-# Array of crates to exclude
-# Used with the `contains` function.
 # shellcheck disable=SC2034
 exclude_crates=(
   # The following require investigation if they can be fixed
@@ -77,70 +76,35 @@ exclude_crates=(
   reth-node-ethstats
 )
 
-# Array to hold the results
-results=()
-# Flag to track if any command fails
 any_failed=0
+tmpdir=$(mktemp -d 2>/dev/null || mktemp -d -t reth-check)
+trap 'rm -rf -- "$tmpdir"' EXIT INT TERM
 
-# Function to check if a value exists in an array
 contains() {
   local array="$1[@]"
-  local seeking=$2
-  local in=1
+  local seeking="$2"
+  local element
   for element in "${!array}"; do
-    if [[ "$element" == "$seeking" ]]; then
-      in=0
-      break
-    fi
+    [[ "$element" == "$seeking" ]] && return 0
   done
-  return $in
+  return 1
 }
 
 for crate in "${crates[@]}"; do
   if contains exclude_crates "$crate"; then
-    results+=("3:⏭️:$crate")
+    echo "⏭️ $crate"
     continue
   fi
 
-  cmd="cargo +stable build -p $crate --target wasm32-wasip1 --no-default-features"
-
-  if [ -n "$CI" ]; then
-    echo "::group::$cmd"
+  outfile="$tmpdir/$crate.log"
+  if cargo +stable build -p "$crate" --target wasm32-wasip1 --no-default-features --color never >"$outfile" 2>&1; then
+    echo "✅ $crate"
   else
-    printf "\n%s:\n  %s\n" "$crate" "$cmd"
-  fi
-
-  set +e  # Disable immediate exit on error
-  # Run the command and capture the return code
-  $cmd
-  ret_code=$?
-  set -e  # Re-enable immediate exit on error
-
-  # Store the result in the dictionary
-  if [ $ret_code -eq 0 ]; then
-    results+=("1:✅:$crate")
-  else
-    results+=("2:❌:$crate")
+    echo "❌ $crate"
+    sed 's/^/   /' "$outfile"
+    echo ""
     any_failed=1
   fi
-
-  if [ -n "$CI" ]; then
-    echo "::endgroup::"
-  fi
 done
 
-# Sort the results by status and then by crate name
-IFS=$'\n' sorted_results=($(sort <<<"${results[*]}"))
-unset IFS
-
-# Print summary
-echo -e "\nSummary of build results:"
-for result in "${sorted_results[@]}"; do
-  status="${result#*:}"
-  status="${status%%:*}"
-  crate="${result##*:}"
-  echo "$status $crate"
-done
-
-# Exit with a non-zero status if any command fails
 exit $any_failed


### PR DESCRIPTION
## Summary

Make wasm/riscv check output human-readable by merging the two separate sections into one unified output.

## Motivation

Previously the scripts had two disconnected sections: a wall of streaming build output, then a summary with emoji statuses. Figuring out which error output corresponded to which failing crate was painful.

## Changes

- Capture each crate's build output into a temp file, suppress during build
- Print `✅ crate` / `❌ crate` immediately, with indented error output below failures
- Remove the separate summary section and CI `::group::` markers
- Use `readarray` instead of word-splitting for crate list
- Use `set -uo pipefail` and proper quoting
- Use `--color never` for clean captured output

**Before:**
```
... 500 lines of cargo output ...
... 500 more lines ...

Summary of build results:
✅ reth-alloy-provider
❌ reth-chainspec     <-- which error was this??
✅ reth-cli-util
```

**After:**
```
✅ reth-alloy-provider
❌ reth-chainspec
   error[E0433]: failed to resolve: use of undeclared crate
    --> crates/chainspec/src/lib.rs:5:5
     |
   5 | use std::net::SocketAddr;
     |     ^^^ use of undeclared crate
✅ reth-cli-util
```

## Testing

N/A - CI script changes, will be validated by the lint workflow.