### PR TITLE
fix(engine): Cap persistence batch size for threshold=0 to prevent memory accumulation

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1809,6 +1809,7 @@ where
         debug_assert!(!self.persistence_state.in_progress());
 
         let mut blocks_to_persist = Vec::new();
+        let max_batch_size = if self.config.persistence_threshold() == 0 { 1 } else { usize::MAX };
         let mut current_hash = self.state.tree_state.canonical_block_hash();
         let last_persisted_number = self.persistence_state.last_persisted_block.number;
         let canonical_head_number = self.state.tree_state.canonical_block_number();
@@ -1838,6 +1839,9 @@ where
             }
 
             current_hash = block.recovered_block().parent_hash();
+            if blocks_to_persist.len() >= max_batch_size {
+                break;
+            }
         }
 
         // Reverse the order so that the oldest block comes first


### PR DESCRIPTION
**This is a Draft PR** – Tests incoming in follow-up commits.

### Description

This PR addresses the open issue where `--engine.persistence-threshold=0` combined with `--engine.memory-block-buffer-target=0` causes indefinite memory accumulation during live sync (#21093).

`get_canonical_blocks_to_persist` may be batches **all** unsaved blocks.

large batches → slow writes → lag snowballs → no new tasks queued → memory grows indefinitely.

The reported "self-resolve" (flush after high memory) may be due to giant batch completing during low activity.

### Fix
- Introduce a batch size when `persistence_threshold == 0` in `get_canonical_blocks_to_persist`.
- Forces small, fast DB writes → persistence keeps up → bounded gap/memory.
- Low-risk workaround; makes threshold=0 reliable.
- Please note I have limited local setup and was not able to reproduce the issue. This is based on code analysis + issue description.

Fixes #21093 (or contributes toward it).

Thanks for reviewing—happy to iterate!