### PR TITLE
perf(storage): skip redundant storage writes and use NO_OVERWRITE for bytecodes

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -46,7 +46,7 @@ use reth_db_api::{
     table::Table,
     tables,
     transaction::{DbTx, DbTxMut},
-    BlockNumberList, PlainAccountState, PlainStorageState,
+    BlockNumberList, DatabaseError, DatabaseWriteOperation, PlainAccountState, PlainStorageState,
 };
 use reth_execution_types::{BlockExecutionOutput, BlockExecutionResult, Chain, ExecutionOutcome};
 use reth_node_types::{BlockTy, BodyTy, HeaderTy, NodeTypes, ReceiptTy, TxTy};
@@ -2416,11 +2416,17 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
             }
         }
 
-        // Write bytecode
+        // Write bytecode using NO_OVERWRITE: bytecodes are content-addressed, so if the hash
+        // already exists the value is guaranteed identical. This avoids dirtying MDBX pages for
+        // already-known bytecodes.
         tracing::trace!(len = changes.contracts.len(), "Writing bytecodes");
         let mut bytecodes_cursor = self.tx_ref().cursor_write::<tables::Bytecodes>()?;
         for (hash, bytecode) in changes.contracts {
-            bytecodes_cursor.upsert(hash, &Bytecode(bytecode))?;
+            if let Err(e) = bytecodes_cursor.insert(hash, &Bytecode(bytecode))
+                && !matches!(&e, DatabaseError::Write(err) if err.operation == DatabaseWriteOperation::CursorInsert)
+            {
+                return Err(e.into());
+            }
         }
 
         // Write new storage state and wipe storage if needed.
@@ -2444,6 +2450,9 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
                 if let Some(db_entry) = storages_cursor.seek_by_key_subkey(address, entry.key)? &&
                     db_entry.key == entry.key
                 {
+                    if db_entry.value == entry.value && !entry.value.is_zero() {
+                        continue;
+                    }
                     storages_cursor.delete_current()?;
                 }
 
@@ -2484,6 +2493,9 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
                     hashed_storage_cursor.seek_by_key_subkey(*hashed_address, entry.key)? &&
                     db_entry.key == entry.key
                 {
+                    if db_entry.value == entry.value && !entry.value.is_zero() {
+                        continue;
+                    }
                     hashed_storage_cursor.delete_current()?;
                 }
 


### PR DESCRIPTION
## Summary
Skip MDBX writes when the DB already contains the identical value, reducing dirty pages and write amplification.

## Motivation
With `OriginalValuesKnown::No`, `to_plain_state()` emits ALL touched storage slots including read-only SLOADs. Many slots have values identical to what's already in the DB. The current code does seek → delete → upsert for every slot regardless, dirtying MDBX pages unnecessarily.

Profiling showed reth writes ~18x more data/s to disk than nethermind on the same blocks. While not all of that gap is from this issue, eliminating no-op writes is a direct reduction in write amplification.

## Changes
- `write_state_changes`: after `seek_by_key_subkey` finds an existing `PlainStorageState` entry, compare values before proceeding with delete+upsert. If identical (and non-zero), skip both operations. The seek is already happening so this adds only a cheap `U256` comparison.
- `write_hashed_state`: same skip-unchanged optimization for `HashedStorages`.
- `write_state_changes`: use `cursor.insert()` (`NO_OVERWRITE`) instead of `cursor.upsert()` for bytecodes. Since bytecodes are content-addressed by hash, if the key exists the value is guaranteed identical.

## Testing
`cargo test -p reth-provider --lib` — 88 tests pass
`cargo clippy -p reth-provider -- -D warnings` — clean

## Results
Run ID: `df8abc67-a8d5-4a36-b0ec-cb350ea3823b`

| Metric | Normal | Big Blocks |
|--------|--------|------------|
| Gas/s | 368.5 MGas/s | 368.5 MGas/s |
| Gas/s delta | +2.2% | +2.2% |
| Verdict | improved | improved |