### PR TITLE
ci: use cargo-rail for selective crate testing on PRs

### DIFF
--- a/.changelog/swift-rails-run.md
+++ b/.changelog/swift-rails-run.md
@@ -1,0 +1,4 @@
+---
+---
+
+Use cargo-rail for selective crate testing on PRs to speed up CI by only testing affected crates.

--- a/.config/rail.toml
+++ b/.config/rail.toml
@@ -1,0 +1,13 @@
+targets = ["x86_64-unknown-linux-gnu"]
+
+[change-detection]
+infrastructure = [
+    ".github/**",
+    "Cargo.lock",
+    "Cargo.toml",
+    "rust-toolchain.toml",
+    "deny.toml",
+    "dprint.json",
+    "clippy.toml",
+    "rustfmt.toml",
+]

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -21,9 +21,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  detect:
+    name: detect affected crates
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      cargo-args: ${{ steps.rail.outputs.cargo-args }}
+      count: ${{ steps.rail.outputs.count }}
+      rebuild-all: ${{ steps.rail.outputs.rebuild-all }}
+      docs-only: ${{ steps.rail.outputs.docs-only }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: loadingalias/cargo-rail-action@v2
+        id: rail
+
   test:
     name: test / ${{ matrix.network }} / ${{ matrix.storage }}
-    if: github.event_name != 'schedule'
+    needs: [detect]
+    if: |
+      always() &&
+      github.event_name != 'schedule' &&
+      (needs.detect.result == 'skipped' ||
+       (needs.detect.result == 'success' &&
+        (needs.detect.outputs.rebuild-all == 'true' ||
+         (needs.detect.outputs.count != '0' && needs.detect.outputs.docs-only != 'true'))))
     runs-on: depot-ubuntu-latest-4
     env:
       RUST_BACKTRACE: 1
@@ -45,21 +68,26 @@ jobs:
           cache-on-failure: true
       - name: Run tests
         run: |
+          SCOPE="${{ needs.detect.outputs.cargo-args }}"
+          if [ -z "$SCOPE" ] || [ "${{ needs.detect.outputs.rebuild-all }}" == "true" ]; then
+            SCOPE="--workspace"
+          fi
           cargo nextest run \
             --locked --features "asm-keccak ${{ matrix.network }} ${{ matrix.storage == 'edge' && 'edge' || '' }}" \
-            --workspace --exclude ef-tests \
+            $SCOPE --exclude ef-tests \
             -E "kind(test) and not binary(e2e_testsuite)"
 
   integration-success:
     name: integration success
     runs-on: ubuntu-latest
     if: always() && github.event_name != 'schedule'
-    needs: [test]
+    needs: [detect, test]
     timeout-minutes: 30
     steps:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@release/v1
         with:
+          allowed-skips: detect, test
           jobs: ${{ toJSON(needs) }}
 
   era-files:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,6 +25,8 @@ jobs:
     name: detect affected crates
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    env:
+      RUSTC_WRAPPER: ""
     outputs:
       cargo-args: ${{ steps.rail.outputs.cargo-args }}
       count: ${{ steps.rail.outputs.count }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,15 +11,37 @@ env:
   RUSTC_WRAPPER: "sccache"
 
 jobs:
+  detect:
+    name: detect affected crates
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      cargo-args: ${{ steps.rail.outputs.cargo-args }}
+      count: ${{ steps.rail.outputs.count }}
+      rebuild-all: ${{ steps.rail.outputs.rebuild-all }}
+      docs-only: ${{ steps.rail.outputs.docs-only }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: loadingalias/cargo-rail-action@v2
+        id: rail
+
   clippy-binaries:
     name: clippy binaries / ${{ matrix.type }}
+    needs: [detect]
+    if: |
+      always() &&
+      (needs.detect.result == 'skipped' ||
+       (needs.detect.result == 'success' &&
+        (needs.detect.outputs.rebuild-all == 'true' ||
+         (needs.detect.outputs.count != '0' && needs.detect.outputs.docs-only != 'true'))))
     runs-on: depot-ubuntu-latest
     timeout-minutes: 30
     strategy:
       matrix:
         include:
           - type: ethereum
-            args: --workspace --lib --examples --tests --benches --locked
             features: "ethereum asm-keccak jemalloc jemalloc-prof min-error-logs min-warn-logs min-info-logs min-debug-logs min-trace-logs"
     steps:
       - uses: actions/checkout@v6
@@ -36,12 +58,24 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run clippy on binaries
-        run: cargo clippy ${{ matrix.args }} --features "${{ matrix.features }}"
+        run: |
+          SCOPE="${{ needs.detect.outputs.cargo-args }}"
+          if [ -z "$SCOPE" ] || [ "${{ needs.detect.outputs.rebuild-all }}" == "true" ]; then
+            SCOPE="--workspace"
+          fi
+          cargo clippy $SCOPE --lib --examples --tests --benches --locked --features "${{ matrix.features }}"
         env:
           RUSTFLAGS: -D warnings
 
   clippy:
     name: clippy
+    needs: [detect]
+    if: |
+      always() &&
+      (needs.detect.result == 'skipped' ||
+       (needs.detect.result == 'success' &&
+        (needs.detect.outputs.rebuild-all == 'true' ||
+         (needs.detect.outputs.count != '0' && needs.detect.outputs.docs-only != 'true'))))
     runs-on: depot-ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -54,11 +88,24 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-      - run: cargo clippy --workspace --lib --examples --tests --benches --all-features --locked
+      - name: Run clippy
+        run: |
+          SCOPE="${{ needs.detect.outputs.cargo-args }}"
+          if [ -z "$SCOPE" ] || [ "${{ needs.detect.outputs.rebuild-all }}" == "true" ]; then
+            SCOPE="--workspace"
+          fi
+          cargo clippy $SCOPE --lib --examples --tests --benches --all-features --locked
         env:
           RUSTFLAGS: -D warnings
 
   wasm:
+    needs: [detect]
+    if: |
+      always() &&
+      (needs.detect.result == 'skipped' ||
+       (needs.detect.result == 'success' &&
+        (needs.detect.outputs.rebuild-all == 'true' ||
+         (needs.detect.outputs.count != '0' && needs.detect.outputs.docs-only != 'true'))))
     runs-on: depot-ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -79,6 +126,13 @@ jobs:
           .github/scripts/check_wasm.sh
 
   riscv:
+    needs: [detect]
+    if: |
+      always() &&
+      (needs.detect.result == 'skipped' ||
+       (needs.detect.result == 'success' &&
+        (needs.detect.outputs.rebuild-all == 'true' ||
+         (needs.detect.outputs.count != '0' && needs.detect.outputs.docs-only != 'true'))))
     runs-on: depot-ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -98,6 +152,13 @@ jobs:
 
   crate-checks:
     name: crate-checks (${{ matrix.partition }}/${{ matrix.total_partitions }})
+    needs: [detect]
+    if: |
+      always() &&
+      (needs.detect.result == 'skipped' ||
+       (needs.detect.result == 'success' &&
+        (needs.detect.outputs.rebuild-all == 'true' ||
+         (needs.detect.outputs.count != '0' && needs.detect.outputs.docs-only != 'true'))))
     runs-on: depot-ubuntu-latest-4
     strategy:
       matrix:
@@ -135,6 +196,13 @@ jobs:
 
   docs:
     name: docs
+    needs: [detect]
+    if: |
+      always() &&
+      (needs.detect.result == 'skipped' ||
+       (needs.detect.result == 'success' &&
+        (needs.detect.outputs.rebuild-all == 'true' ||
+         (needs.detect.outputs.count != '0' && needs.detect.outputs.docs-only != 'true'))))
     runs-on: depot-ubuntu-latest-4
     timeout-minutes: 30
     steps:
@@ -167,6 +235,13 @@ jobs:
 
   udeps:
     name: udeps
+    needs: [detect]
+    if: |
+      always() &&
+      (needs.detect.result == 'skipped' ||
+       (needs.detect.result == 'success' &&
+        (needs.detect.outputs.rebuild-all == 'true' ||
+         (needs.detect.outputs.count != '0' && needs.detect.outputs.docs-only != 'true'))))
     runs-on: depot-ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -178,7 +253,13 @@ jobs:
         with:
           cache-on-failure: true
       - uses: taiki-e/install-action@cargo-udeps
-      - run: cargo udeps --workspace --lib --examples --tests --benches --all-features --locked
+      - name: Run udeps
+        run: |
+          SCOPE="${{ needs.detect.outputs.cargo-args }}"
+          if [ -z "$SCOPE" ] || [ "${{ needs.detect.outputs.rebuild-all }}" == "true" ]; then
+            SCOPE="--workspace"
+          fi
+          cargo udeps $SCOPE --lib --examples --tests --benches --all-features --locked
 
   book:
     name: book
@@ -286,9 +367,11 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     needs:
+      - detect
       - clippy-binaries
       - clippy
       - wasm
+      - riscv
       - crate-checks
       - docs
       - fmt
@@ -305,4 +388,5 @@ jobs:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@release/v1
         with:
+          allowed-skips: detect, clippy-binaries, clippy, wasm, riscv, crate-checks, docs, udeps
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -213,7 +213,14 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-      - run: cargo docs --document-private-items
+      - name: Run doc build
+        run: |
+          SCOPE="${{ needs.detect.outputs.cargo-args }}"
+          if [ -z "$SCOPE" ] || [ "${{ needs.detect.outputs.rebuild-all }}" == "true" ]; then
+            cargo docs --document-private-items
+          else
+            cargo doc $SCOPE --all-features --no-deps --document-private-items
+          fi
         env:
           # Keep in sync with ./book.yml:jobs.build
           # This should only add `-D warnings`

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,8 @@ jobs:
     name: detect affected crates
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    env:
+      RUSTC_WRAPPER: ""
     outputs:
       cargo-args: ${{ steps.rail.outputs.cargo-args }}
       count: ${{ steps.rail.outputs.count }}

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -18,8 +18,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  detect:
+    name: detect affected crates
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      cargo-args: ${{ steps.rail.outputs.cargo-args }}
+      count: ${{ steps.rail.outputs.count }}
+      rebuild-all: ${{ steps.rail.outputs.rebuild-all }}
+      docs-only: ${{ steps.rail.outputs.docs-only }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: loadingalias/cargo-rail-action@v2
+        id: rail
+
   test:
     name: test / ${{ matrix.type }} / ${{ matrix.storage }}
+    needs: [detect]
+    if: |
+      always() &&
+      (needs.detect.result == 'skipped' ||
+       (needs.detect.result == 'success' &&
+        (needs.detect.outputs.rebuild-all == 'true' ||
+         (needs.detect.outputs.count != '0' && needs.detect.outputs.docs-only != 'true'))))
     runs-on: depot-ubuntu-latest-4
     env:
       RUST_BACKTRACE: 1
@@ -48,9 +71,13 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run tests
         run: |
+          SCOPE="${{ needs.detect.outputs.cargo-args }}"
+          if [ -z "$SCOPE" ] || [ "${{ needs.detect.outputs.rebuild-all }}" == "true" ]; then
+            SCOPE="--workspace"
+          fi
           cargo nextest run \
             --features "${{ matrix.features }} $EDGE_FEATURES" --locked \
-            ${{ matrix.exclude_args }} --workspace \
+            ${{ matrix.exclude_args }} $SCOPE \
             --exclude ef-tests --no-tests=warn \
             -E "!kind(test) and not binary(e2e_testsuite)"
 
@@ -110,10 +137,11 @@ jobs:
     name: unit success
     runs-on: ubuntu-latest
     if: always()
-    needs: [test, state, doc]
+    needs: [detect, test, state, doc]
     timeout-minutes: 30
     steps:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@release/v1
         with:
+          allowed-skips: detect, test
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -22,6 +22,8 @@ jobs:
     name: detect affected crates
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    env:
+      RUSTC_WRAPPER: ""
     outputs:
       cargo-args: ${{ steps.rail.outputs.cargo-args }}
       count: ${{ steps.rail.outputs.count }}


### PR DESCRIPTION
On PRs, only test crates affected by the changes (and their transitive dependents) using cargo-rail's graph-aware change detection. Merge queue and main pushes continue to run the full `--workspace` test suite.

## Changes

- Add `.config/rail.toml` with infrastructure file patterns
- Add `detect` job using `cargo-rail-action` to unit.yml, integration.yml, and lint.yml
- Test/lint jobs fall back to `--workspace` when detect is skipped (merge_group/push) or when infrastructure files changed (rebuild-all)
- Skip jobs entirely when no crates are affected or only docs changed
- Scope clippy and udeps to affected crates on PRs

## How it works

1. On `pull_request` events, the `detect` job runs `cargo-rail` to determine which crates are affected by the PR
2. Jobs use the `cargo-args` output (e.g., `-p reth-primitives -p reth-provider`) to scope their commands
3. If detect is skipped (merge_group/push) or rebuild-all is triggered, jobs run with `--workspace`
4. Jobs skip entirely if no crates are affected or only docs changed

## Infrastructure triggers

Changes to these files trigger a full rebuild:
- `.github/**`
- `Cargo.lock`, `Cargo.toml`
- `rust-toolchain.toml`, `deny.toml`, `dprint.json`, `clippy.toml`, `rustfmt.toml`