### PR TITLE
fix(trie): correct tracing target in SerialSparseTrie

### DIFF
--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -1343,7 +1343,7 @@ impl SerialSparseTrie {
         let remaining_child_node = match self.nodes.get(remaining_child_path).unwrap() {
             SparseNode::Hash(_) => {
                 debug!(
-                    target: "trie::parallel_sparse",
+                    target: "trie::sparse",
                     child_path = ?remaining_child_path,
                     leaf_full_path = ?full_path,
                     "Node child not revealed in remove_leaf, falling back to db",
@@ -1353,7 +1353,7 @@ impl SerialSparseTrie {
                 {
                     let decoded = TrieNode::decode(&mut &node[..])?;
                     trace!(
-                        target: "trie::parallel_sparse",
+                        target: "trie::sparse",
                         ?remaining_child_path,
                         ?decoded,
                         ?tree_mask,
@@ -1384,7 +1384,7 @@ impl SerialSparseTrie {
             remaining_grandchild_path.extend(key);
 
             trace!(
-                target: "trie::parallel_sparse",
+                target: "trie::sparse",
                 remaining_grandchild_path = ?remaining_grandchild_path,
                 child_path = ?remaining_child_path,
                 leaf_full_path = ?full_path,


### PR DESCRIPTION
The `reveal_remaining_child_on_leaf_removal`https://github.com/paradigmxyz/reth/blob/a8b9c9a9dcf89aae9e4c9f5a4a4f98d9d01d9c46/crates/trie/sparse/src/trie.rs#L1327-L1403 function in `SerialSparseTrie`https://github.com/paradigmxyz/reth/blob/a8b9c9a9dcf89aae9e4c9f5a4a4f98d9d01d9c46/crates/trie/sparse/src/trie.rs#L334-L354 used `"trie::parallel_sparse"` as the tracing target in 3 places. This was a copy-paste from the parallel trie implementation — every other trace in this file uses `"trie::sparse"`, making these logs invisible when filtering by the serial trie target.

Changed all 3 occurrences to `"trie::sparse"` to match the rest of `SerialSparseTrie`