### PR TITLE
perf(engine): move sparse trie prune/shrink outside preserved_sparse_trie lock

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -571,40 +571,14 @@ where
             };
 
             let result = task.run();
-            // Capture the computed state_root before sending the result
             let computed_state_root = result.as_ref().ok().map(|outcome| outcome.state_root);
 
-            // Acquire the guard before sending the result to prevent a race condition:
-            // Without this, the next block could start after send() but before store(),
-            // causing take() to return None and forcing it to create a new empty trie
-            // instead of reusing the preserved one. Holding the guard ensures the next
-            // block's take() blocks until we've stored the trie for reuse.
-            let mut guard = preserved_sparse_trie.lock();
-
-            // Send state root computation result - next block may start but will block on take()
-            if state_root_tx.send(result).is_err() {
-                // Receiver dropped - payload was likely invalid or cancelled.
-                // Clear the trie instead of preserving potentially invalid state.
-                debug!(
-                    target: "engine::tree::payload_processor",
-                    "State root receiver dropped, clearing trie"
-                );
-                let (trie, deferred) = task.into_cleared_trie(
-                    SPARSE_TRIE_MAX_NODES_SHRINK_CAPACITY,
-                    SPARSE_TRIE_MAX_VALUES_SHRINK_CAPACITY,
-                );
-                guard.store(PreservedSparseTrie::cleared(trie));
-                // Drop guard before deferred to release lock before expensive deallocations
-                drop(guard);
-                drop(deferred);
-                return;
-            }
-
-            // Only preserve the trie as anchored if computation succeeded.
-            // A failed computation may have left the trie in a partially updated state.
+            // Prepare the trie for reuse BEFORE acquiring the lock.
+            // prune + shrink is expensive (~45ms) and would block the next block's
+            // trie take() if done under the lock.
             let _enter =
                 debug_span!(target: "engine::tree::payload_processor", "preserve").entered();
-            let deferred = if let Some(state_root) = computed_state_root {
+            let (mut trie, deferred, preserve_state_root) = if let Some(state_root) = computed_state_root {
                 let start = std::time::Instant::now();
                 let (trie, deferred) = task.into_trie_for_reuse(
                     prune_depth,
@@ -615,8 +589,7 @@ where
                 trie_metrics
                     .into_trie_for_reuse_duration_histogram
                     .record(start.elapsed().as_secs_f64());
-                guard.store(PreservedSparseTrie::anchored(trie, state_root));
-                deferred
+                (trie, deferred, Some(state_root))
             } else {
                 debug!(
                     target: "engine::tree::payload_processor",
@@ -626,10 +599,29 @@ where
                     SPARSE_TRIE_MAX_NODES_SHRINK_CAPACITY,
                     SPARSE_TRIE_MAX_VALUES_SHRINK_CAPACITY,
                 );
-                guard.store(PreservedSparseTrie::cleared(trie));
-                deferred
+                (trie, deferred, None)
             };
-            // Drop guard before deferred to release lock before expensive deallocations
+            drop(_enter);
+
+            // Now acquire the lock briefly: send result + store trie.
+            let mut guard = preserved_sparse_trie.lock();
+            if state_root_tx.send(result).is_err() {
+                debug!(
+                    target: "engine::tree::payload_processor",
+                    "State root receiver dropped, clearing trie"
+                );
+                trie.clear();
+                guard.store(PreservedSparseTrie::cleared(trie));
+                drop(guard);
+                drop(deferred);
+                return;
+            }
+
+            if let Some(state_root) = preserve_state_root {
+                guard.store(PreservedSparseTrie::anchored(trie, state_root));
+            } else {
+                guard.store(PreservedSparseTrie::cleared(trie));
+            }
             drop(guard);
             drop(deferred);
         });

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -352,7 +352,7 @@ where
 
     /// Prunes and shrinks the trie for reuse in the next payload built on top of this one.
     ///
-    /// Should be called after the state root result has been sent.
+    /// Called before storing the trie into the preserved slot.
     pub(super) fn into_trie_for_reuse(
         self,
         prune_depth: usize,


### PR DESCRIPTION
## Summary

Move the expensive `into_trie_for_reuse` (prune + shrink) outside the `preserved_sparse_trie` mutex to eliminate lock contention between consecutive blocks.

## Motivation

Tracy profiling on mainnet showed that `into_trie_for_reuse` (prune + shrink) takes ~45ms mean and was done while holding the `preserved_sparse_trie` lock. The next block's sparse trie task calls `take()` on this same mutex, so it was blocked for the entire duration of prune/shrink — adding ~29ms p50 of pure lock contention to every block.

## Changes

- Move `into_trie_for_reuse` / `into_cleared_trie` to run **before** acquiring the lock
- Acquire the lock only briefly for `send(result)` + `store(trie)`
- In the error path (`send` fails), call `trie.clear()` on the already-prepared trie instead of re-extracting from the task
- Update doc comment on `SparseTrieCacheTask::into_trie_for_reuse` to reflect new call ordering

## Testing

Measured on mainnet over 41 blocks on dev-georgios:

| Metric | Before | After | Delta |
|---|---|---|---|
| newPayload p50 | 93ms | **22ms** | **-76%** |
| newPayload p90 | 115ms | **32ms** | **-72%** |
| state root p50 | 58ms | **2.8ms** | **-95%** |
| Ggas/s p50 | 0.35 | **0.80** | **+129%** |

Note: "before" numbers include Tracy instrumentation overhead.