### PR TITLE
chore(trie): Spans and traces for sparse trie

### DIFF
--- a/.changelog/evil-pigs-cry.md
+++ b/.changelog/evil-pigs-cry.md
@@ -1,0 +1,6 @@
+---
+reth-engine-tree: patch
+reth-trie-sparse-parallel: patch
+---
+
+Added tracing spans and debug logs to sparse trie operations for better observability during parallel state root computation.

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -623,6 +623,7 @@ where
             if new { &mut self.new_storage_updates } else { &mut self.storage_updates };
 
         // Process all storage updates in parallel, skipping tries with no pending updates.
+        let span = tracing::Span::current();
         let storage_results = storage_updates
             .iter_mut()
             .filter(|(_, updates)| !updates.is_empty())
@@ -634,6 +635,7 @@ where
             })
             .par_bridge_buffered()
             .map(|(address, updates, mut fetched, mut trie)| {
+                let _enter = debug_span!(target: "engine::tree::payload_processor::sparse_trie", parent: &span, "storage trie leaf updates", ?address).entered();
                 let mut targets = Vec::new();
 
                 trie.update_leaves(updates, |path, min_len| match fetched.entry(path) {
@@ -714,6 +716,7 @@ where
             return Ok(());
         }
 
+        let span = tracing::Span::current();
         let roots = self
             .trie
             .storage_tries_mut()
@@ -722,6 +725,7 @@ where
                 self.storage_updates.get(*address).is_some_and(|updates| updates.is_empty())
             })
             .map(|(address, trie)| {
+                let _enter = debug_span!(target: "engine::tree::payload_processor::sparse_trie", parent: &span, "storage root", ?address).entered();
                 let root =
                     trie.root().expect("updates are drained, trie should be revealed by now");
 

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -655,6 +655,8 @@ where
             })
             .collect::<Result<Vec<_>, _>>()?;
 
+        drop(span);
+
         for (address, targets, fetched, trie) in storage_results {
             self.fetched_storage_targets.insert(*address, fetched);
             self.trie.insert_storage_trie(*address, trie);


### PR DESCRIPTION
* Propagate spans to storage trie rayon threads in SparseTrieCacheTask, so that the hashed address of the storage trie shows up in its traces.

* Add traces to ParallelSparseTrie which are useful when debugging. These are the traces I end up adding to the codebase manually everytime I have to debug something, imo we should just commit them.