### PR TITLE
perf: reuse decoded transactions in engine tree to avoid double-decode

### DIFF
--- a/crates/ethereum/node/src/engine.rs
+++ b/crates/ethereum/node/src/engine.rs
@@ -49,6 +49,18 @@ where
     ) -> Result<SealedBlock<Self::Block>, NewPayloadError> {
         self.inner.ensure_well_formed_payload(payload).map_err(Into::into)
     }
+
+    fn convert_payload_to_block_with_transactions(
+        &self,
+        payload: ExecutionData,
+        transactions: Vec<
+            <<Self::Block as reth_primitives_traits::Block>::Body as reth_primitives_traits::BlockBody>::Transaction,
+        >,
+    ) -> Result<SealedBlock<Self::Block>, NewPayloadError> {
+        self.inner
+            .ensure_well_formed_payload_with_transactions(payload, transactions)
+            .map_err(Into::into)
+    }
 }
 
 impl<ChainSpec, Types> EngineApiValidator<Types> for EthereumEngineValidator<ChainSpec>


### PR DESCRIPTION
## Summary

During `newPayload` processing, transactions were decoded twice:
1. In `tx_iterator_for_payload` (parallel decode + recover for execution)
2. In `convert_to_block` → `ensure_well_formed_payload` (sequential re-decode from raw bytes)

This PR eliminates the second decode by reusing the already-decoded transactions from execution.

## Changes

- **`execute_transactions`**: Now returns `Vec<Recovered<N::SignedTx>>` instead of `Vec<Address>`. Clones the inner transaction (cheap for types like `TransactionSigned`) before execution to retain them.
- **`PayloadValidator` trait**: Adds `convert_payload_to_block_with_transactions` with a default fallback to the existing decode path.
- **`EthereumEngineValidator`**: Overrides the new method to use `try_into_block_with_sidecar_with` with a closure that consumes pre-decoded transactions instead of calling `decode_2718`.
- **`PayloadBlockValidator::convert_to_recovered_block`**: New method that wires everything together, splitting recovered txs into `(transactions, senders)` and constructing the block.

## Impact

Eliminates redundant sequential RLP decoding of all transactions in the `newPayload` hot path. The clone cost (copying the decoded tx struct before execution) is significantly cheaper than re-decoding from raw bytes.