### PR TITLE
ci: use depot for hive and kurtosis image builds, run daily

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -25,6 +25,12 @@ jobs:
       - uses: actions/checkout@v6
       - run: mkdir -p artifacts
 
+      - name: Get git info
+        id: git
+        run: |
+          echo "sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          echo "describe=$(git describe --always --tags)" >> "$GITHUB_OUTPUT"
+
       - name: Set up Depot CLI
         uses: depot/setup-action@v1
 
@@ -32,6 +38,8 @@ jobs:
         uses: depot/bake-action@v1
         env:
           DEPOT_TOKEN: ${{ secrets.DEPOT_TOKEN }}
+          VERGEN_GIT_SHA: ${{ steps.git.outputs.sha }}
+          VERGEN_GIT_DESCRIBE: ${{ steps.git.outputs.describe }}
         with:
           project: ${{ vars.DEPOT_PROJECT_ID }}
           files: docker-bake.hcl

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     if: github.repository == 'paradigmxyz/reth'
     timeout-minutes: 45
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -14,7 +14,7 @@ on:
         description: "Name for the uploaded artifact"
 
 jobs:
-  prepare-reth:
+  build:
     if: github.repository == 'paradigmxyz/reth'
     timeout-minutes: 45
     runs-on: ubuntu-24.04

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     if: github.repository == 'paradigmxyz/reth'
     timeout-minutes: 45
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest-4
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -1,4 +1,4 @@
-name: Prepare Reth Image
+name: Build test Docker image
 
 on:
   workflow_call:

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     if: github.repository == 'paradigmxyz/reth'
     timeout-minutes: 45
-    runs-on: depot-ubuntu-latest-4
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -23,6 +23,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
+      - run: mkdir -p artifacts
 
       - name: Set up Depot CLI
         uses: depot/setup-action@v1

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -15,14 +15,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  prepare-reth-stable:
+  build-reth-stable:
     uses: ./.github/workflows/docker-test.yml
     with:
       hive_target: hive-stable
       artifact_name: "reth-stable"
     secrets: inherit
 
-  prepare-reth-edge:
+  build-reth-edge:
     uses: ./.github/workflows/docker-test.yml
     with:
       hive_target: hive-edge
@@ -185,8 +185,8 @@ jobs:
           - sim: ethereum/eels/consume-rlp
             limit: .*tests/paris.*
     needs:
-      - prepare-reth-stable
-      - prepare-reth-edge
+      - build-reth-stable
+      - build-reth-edge
       - prepare-hive
     name: ${{ matrix.storage }} / ${{ matrix.scenario.sim }}${{ matrix.scenario.limit && format(' - {0}', matrix.scenario.limit) }}
     runs-on:

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -32,8 +32,7 @@ jobs:
   prepare-hive:
     if: github.repository == 'paradigmxyz/reth'
     timeout-minutes: 45
-    runs-on:
-      group: Reth
+    runs-on: depot-ubuntu-latest-4
     steps:
       - uses: actions/checkout@v6
       - name: Checkout hive tests
@@ -189,8 +188,7 @@ jobs:
       - build-reth-edge
       - prepare-hive
     name: ${{ matrix.storage }} / ${{ matrix.scenario.sim }}${{ matrix.scenario.limit && format(' - {0}', matrix.scenario.limit) }}
-    runs-on:
-      group: Reth
+    runs-on: depot-ubuntu-latest-4
     permissions:
       issues: write
     steps:

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -18,18 +18,16 @@ jobs:
   prepare-reth-stable:
     uses: ./.github/workflows/prepare-reth.yml
     with:
-      image_tag: ghcr.io/paradigmxyz/reth:latest
-      binary_name: reth
-      cargo_features: "asm-keccak"
+      hive_target: hive-stable
       artifact_name: "reth-stable"
+    secrets: inherit
 
   prepare-reth-edge:
     uses: ./.github/workflows/prepare-reth.yml
     with:
-      image_tag: ghcr.io/paradigmxyz/reth:latest
-      binary_name: reth
-      cargo_features: "asm-keccak edge"
+      hive_target: hive-edge
       artifact_name: "reth-edge"
+    secrets: inherit
 
   prepare-hive:
     if: github.repository == 'paradigmxyz/reth'

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -5,7 +5,7 @@ name: hive
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 */6 * * *"
+    - cron: "0 0 * * *"
 
 env:
   CARGO_TERM_COLOR: always
@@ -16,14 +16,14 @@ concurrency:
 
 jobs:
   prepare-reth-stable:
-    uses: ./.github/workflows/prepare-reth.yml
+    uses: ./.github/workflows/docker-test.yml
     with:
       hive_target: hive-stable
       artifact_name: "reth-stable"
     secrets: inherit
 
   prepare-reth-edge:
-    uses: ./.github/workflows/prepare-reth.yml
+    uses: ./.github/workflows/docker-test.yml
     with:
       hive_target: hive-edge
       artifact_name: "reth-edge"

--- a/.github/workflows/kurtosis.yml
+++ b/.github/workflows/kurtosis.yml
@@ -22,8 +22,8 @@ jobs:
   prepare-reth:
     uses: ./.github/workflows/prepare-reth.yml
     with:
-      image_tag: ghcr.io/paradigmxyz/reth:kurtosis-ci
-      binary_name: reth
+      hive_target: kurtosis
+    secrets: inherit
 
   test:
     timeout-minutes: 60

--- a/.github/workflows/kurtosis.yml
+++ b/.github/workflows/kurtosis.yml
@@ -5,7 +5,7 @@ name: kurtosis
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 */6 * * *"
+    - cron: "0 0 * * *"
 
   push:
     tags:
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   prepare-reth:
-    uses: ./.github/workflows/prepare-reth.yml
+    uses: ./.github/workflows/docker-test.yml
     with:
       hive_target: kurtosis
     secrets: inherit

--- a/.github/workflows/kurtosis.yml
+++ b/.github/workflows/kurtosis.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  prepare-reth:
+  build-reth:
     uses: ./.github/workflows/docker-test.yml
     with:
       hive_target: kurtosis
@@ -32,7 +32,7 @@ jobs:
     name: run kurtosis
     runs-on: depot-ubuntu-latest
     needs:
-      - prepare-reth
+      - build-reth
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/prepare-reth.yml
+++ b/.github/workflows/prepare-reth.yml
@@ -3,24 +3,10 @@ name: Prepare Reth Image
 on:
   workflow_call:
     inputs:
-      image_tag:
+      hive_target:
         required: true
         type: string
-        description: "Docker image tag to use"
-      binary_name:
-        required: false
-        type: string
-        default: "reth"
-        description: "Binary name to build"
-      cargo_features:
-        required: false
-        type: string
-        default: "asm-keccak"
-        description: "Cargo features to enable"
-      cargo_package:
-        required: false
-        type: string
-        description: "Optional cargo package path"
+        description: "Docker bake target to build (e.g. hive-stable, hive-edge)"
       artifact_name:
         required: false
         type: string
@@ -31,30 +17,27 @@ jobs:
   prepare-reth:
     if: github.repository == 'paradigmxyz/reth'
     timeout-minutes: 45
-    runs-on: depot-ubuntu-latest
+    runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v6
-      - run: mkdir artifacts
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Set up Depot CLI
+        uses: depot/setup-action@v1
 
-      - name: Build and export reth image
-        uses: docker/build-push-action@v6
+      - name: Build reth image
+        uses: depot/bake-action@v1
+        env:
+          DEPOT_TOKEN: ${{ secrets.DEPOT_TOKEN }}
         with:
-          context: .
-          file: .github/scripts/hive/Dockerfile
-          tags: ${{ inputs.image_tag }}
-          outputs: type=docker,dest=./artifacts/reth_image.tar
-          build-args: |
-            CARGO_BIN=${{ inputs.binary_name }}
-            MANIFEST_PATH=${{ inputs.cargo_package }}
-            FEATURES=${{ inputs.cargo_features }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          project: ${{ vars.DEPOT_PROJECT_ID }}
+          files: docker-bake.hcl
+          targets: ${{ inputs.hive_target }}
+          push: false
 
       - name: Upload reth image
-        id: upload
         uses: actions/upload-artifact@v6
         with:
           name: ${{ inputs.artifact_name }}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -113,7 +113,7 @@ target "hive-stable" {
     MANIFEST_PATH = "bin/reth"
     FEATURES      = "asm-keccak"
   }
-  tags   = ["ghcr.io/paradigmxyz/reth:latest"]
+  tags   = ["reth:local"]
   output = ["type=docker,dest=${HIVE_OUTPUT_DIR}/reth_image.tar"]
 }
 
@@ -124,7 +124,7 @@ target "hive-edge" {
     MANIFEST_PATH = "bin/reth"
     FEATURES      = "asm-keccak edge"
   }
-  tags   = ["ghcr.io/paradigmxyz/reth:latest"]
+  tags   = ["reth:local"]
   output = ["type=docker,dest=${HIVE_OUTPUT_DIR}/reth_image.tar"]
 }
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -93,3 +93,50 @@ target "ethereum-edge-profiling" {
   tags = ["${REGISTRY}/reth:nightly-edge-profiling"]
 }
 
+// Hive test targets — single-platform, hivetests profile, tar output
+target "_base_hive" {
+  inherits  = ["_base"]
+  platforms = ["linux/amd64"]
+  args = {
+    BUILD_PROFILE = "hivetests"
+  }
+}
+
+variable "HIVE_OUTPUT_DIR" {
+  default = "./artifacts"
+}
+
+target "hive-stable" {
+  inherits = ["_base_hive"]
+  args = {
+    BINARY        = "reth"
+    MANIFEST_PATH = "bin/reth"
+    FEATURES      = "asm-keccak"
+  }
+  tags   = ["ghcr.io/paradigmxyz/reth:latest"]
+  output = ["type=docker,dest=${HIVE_OUTPUT_DIR}/reth_image.tar"]
+}
+
+target "hive-edge" {
+  inherits = ["_base_hive"]
+  args = {
+    BINARY        = "reth"
+    MANIFEST_PATH = "bin/reth"
+    FEATURES      = "asm-keccak edge"
+  }
+  tags   = ["ghcr.io/paradigmxyz/reth:latest"]
+  output = ["type=docker,dest=${HIVE_OUTPUT_DIR}/reth_image.tar"]
+}
+
+// Kurtosis test target
+target "kurtosis" {
+  inherits  = ["_base_hive"]
+  args = {
+    BINARY        = "reth"
+    MANIFEST_PATH = "bin/reth"
+    FEATURES      = "asm-keccak"
+  }
+  tags   = ["ghcr.io/paradigmxyz/reth:kurtosis-ci"]
+  output = ["type=docker,dest=${HIVE_OUTPUT_DIR}/reth_image.tar"]
+}
+


### PR DESCRIPTION
Switches `prepare-reth.yml` from `docker/build-push-action` with cargo-chef to `depot/bake-action` with `Dockerfile.depot` and sccache, matching the approach already used in the main `docker.yml` workflow.

Changes:
- Rewrote `prepare-reth.yml` to use `depot/bake-action` instead of `docker/build-push-action`
- Added `hive-stable`, `hive-edge`, and `kurtosis` targets to `docker-bake.hcl` using the `hivetests` build profile with single-platform (linux/amd64) tar output
- Updated `hive.yml` and `kurtosis.yml` to pass the new bake target inputs
- Builds now run on Depot's cloud builders with sccache instead of cargo-chef on `depot-ubuntu-latest` runners