### PR TITLE
docs: fix typos and comment inaccuracies in cli crates

### DIFF
--- a/crates/cli/cli/src/lib.rs
+++ b/crates/cli/cli/src/lib.rs
@@ -21,7 +21,7 @@ use crate::chainspec::ChainSpecParser;
 ///
 /// This trait is supposed to be implemented by the main struct of the CLI.
 ///
-/// It provides commonly used functionality for running commands and information about the CL, such
+/// It provides commonly used functionality for running commands and information about the CLI, such
 /// as the name and version.
 pub trait RethCli: Sized {
     /// The associated `ChainSpecParser` type

--- a/crates/cli/commands/src/db/mod.rs
+++ b/crates/cli/commands/src/db/mod.rs
@@ -92,14 +92,14 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
         let static_files_path = data_dir.static_files();
         let exex_wal_path = data_dir.exex_wal();
 
-        // ensure the provided datadir exist
+        // ensure the provided datadir exists
         eyre::ensure!(
             data_dir.data_dir().is_dir(),
             "Datadir does not exist: {:?}",
             data_dir.data_dir()
         );
 
-        // ensure the provided database exist
+        // ensure the provided database exists
         eyre::ensure!(db_path.is_dir(), "Database does not exist: {:?}", db_path);
 
         match self.command {

--- a/crates/cli/commands/src/db/state.rs
+++ b/crates/cli/commands/src/db/state.rs
@@ -19,7 +19,7 @@ use std::{
 };
 use tracing::{error, info};
 
-/// Log progress every 5 seconds
+/// Log progress every 30 seconds
 const LOG_INTERVAL: Duration = Duration::from_secs(30);
 
 /// The arguments for the `reth db state` command

--- a/crates/cli/commands/src/init_state/mod.rs
+++ b/crates/cli/commands/src/init_state/mod.rs
@@ -47,7 +47,7 @@ pub struct InitStateCommand<C: ChainSpecParser> {
     /// Specifies whether to initialize the state without relying on EVM historical data.
     ///
     /// When enabled, and before inserting the state, it creates a dummy chain up to the last EVM
-    /// block specified. It then, appends the first block provided block.
+    /// block specified. It then appends the first provided block.
     ///
     /// - **Note**: **Do not** import receipts and blocks beforehand, or this will fail or be
     ///   ignored.

--- a/crates/cli/commands/src/node.rs
+++ b/crates/cli/commands/src/node.rs
@@ -129,12 +129,12 @@ pub struct NodeCommand<C: ChainSpecParser, Ext: clap::Args + fmt::Debug = NoArgs
 }
 
 impl<C: ChainSpecParser> NodeCommand<C> {
-    /// Parsers only the default CLI arguments
+    /// Parses only the default CLI arguments
     pub fn parse_args() -> Self {
         Self::parse()
     }
 
-    /// Parsers only the default [`NodeCommand`] arguments from the given iterator
+    /// Parses only the default [`NodeCommand`] arguments from the given iterator
     pub fn try_parse_args_from<I, T>(itr: I) -> Result<Self, clap::error::Error>
     where
         I: IntoIterator<Item = T>,

--- a/crates/cli/commands/src/stage/run.rs
+++ b/crates/cli/commands/src/stage/run.rs
@@ -107,7 +107,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
         Comp: CliNodeComponents<N>,
         F: FnOnce(Arc<C::ChainSpec>) -> Comp,
     {
-        // Quit early if the stages requires a commit and `--commit` is not provided.
+        // Quit early if the stage requires a commit and `--commit` is not provided.
         if self.requires_commit() && !self.commit {
             return Err(eyre::eyre!(
                 "The stage {} requires overwriting existing static files and must commit, but `--commit` was not provided. Please pass `--commit` and try again.",

--- a/docs/vocs/docs/pages/cli/reth/init-state.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init-state.mdx
@@ -195,7 +195,7 @@ Storage:
       --without-evm
           Specifies whether to initialize the state without relying on EVM historical data.
 
-          When enabled, and before inserting the state, it creates a dummy chain up to the last EVM block specified. It then, appends the first block provided block.
+          When enabled, and before inserting the state, it creates a dummy chain up to the last EVM block specified. It then appends the first provided block.
 
           - **Note**: **Do not** import receipts and blocks beforehand, or this will fail or be ignored.
 


### PR DESCRIPTION
  - Fix "CL" → "CLI" in `RethCli` trait doc comment
  - Fix "exist" → "exists" in db command comments (2 occurrences)
  - Fix "Parsers" → "Parses" in `NodeCommand` doc comments (2 occurrences)
  - Fix garbled "the first block provided block" → "the first provided block" in init_state
  - Fix "stages requires" → "stage requires" in stage run comment
  - Fix stale comment "5 seconds" → "30 seconds" for `LOG_INTERVAL` constant