### PR TITLE
ci: update all workflows to depot-ubuntu-latest-32

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -16,7 +16,7 @@ env:
 name: bench
 jobs:
   codspeed:
-    runs-on: depot-ubuntu-latest
+    runs-on: depot-ubuntu-latest-32
     strategy:
       matrix:
         partition: [1, 2]

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build:
-    runs-on: depot-ubuntu-latest-8
+    runs-on: depot-ubuntu-latest-32
     timeout-minutes: 90
     steps:
       - name: Checkout

--- a/.github/workflows/check-alloy.yml
+++ b/.github/workflows/check-alloy.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   check:
     name: Check compilation with patched alloy
-    runs-on: depot-ubuntu-latest-16
+    runs-on: depot-ubuntu-latest-32
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/compact.yml
+++ b/.github/workflows/compact.yml
@@ -18,7 +18,7 @@ env:
 name: compact-codec
 jobs:
   compact-codec:
-    runs-on: depot-ubuntu-latest
+    runs-on: depot-ubuntu-latest-32
     strategy:
       matrix:
         bin:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   test:
     name: e2e-testsuite
-    runs-on: depot-ubuntu-latest-4
+    runs-on: depot-ubuntu-latest-32
     env:
       RUST_BACKTRACE: 1
     timeout-minutes: 90
@@ -46,7 +46,7 @@ jobs:
 
   rocksdb:
     name: e2e-rocksdb
-    runs-on: depot-ubuntu-latest-4
+    runs-on: depot-ubuntu-latest-32
     env:
       RUST_BACKTRACE: 1
     timeout-minutes: 60

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,7 +24,7 @@ jobs:
   test:
     name: test / ${{ matrix.network }} / ${{ matrix.storage }}
     if: github.event_name != 'schedule'
-    runs-on: depot-ubuntu-latest-4
+    runs-on: depot-ubuntu-latest-32
     env:
       RUST_BACKTRACE: 1
     strategy:

--- a/.github/workflows/kurtosis.yml
+++ b/.github/workflows/kurtosis.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
     name: run kurtosis
-    runs-on: depot-ubuntu-latest
+    runs-on: depot-ubuntu-latest-32
     needs:
       - prepare-reth
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   clippy-binaries:
     name: clippy binaries / ${{ matrix.type }}
-    runs-on: depot-ubuntu-latest
+    runs-on: depot-ubuntu-latest-32
     timeout-minutes: 30
     strategy:
       matrix:
@@ -42,7 +42,7 @@ jobs:
 
   clippy:
     name: clippy
-    runs-on: depot-ubuntu-latest
+    runs-on: depot-ubuntu-latest-32
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -59,7 +59,7 @@ jobs:
           RUSTFLAGS: -D warnings
 
   wasm:
-    runs-on: depot-ubuntu-latest
+    runs-on: depot-ubuntu-latest-32
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -79,7 +79,7 @@ jobs:
           .github/scripts/check_wasm.sh
 
   riscv:
-    runs-on: depot-ubuntu-latest
+    runs-on: depot-ubuntu-latest-32
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
@@ -98,7 +98,7 @@ jobs:
 
   crate-checks:
     name: crate-checks (${{ matrix.partition }}/${{ matrix.total_partitions }})
-    runs-on: depot-ubuntu-latest-4
+    runs-on: depot-ubuntu-latest-32
     strategy:
       matrix:
         partition: [1, 2, 3]
@@ -117,7 +117,7 @@ jobs:
 
   msrv:
     name: MSRV
-    runs-on: depot-ubuntu-latest
+    runs-on: depot-ubuntu-latest-32
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -135,7 +135,7 @@ jobs:
 
   docs:
     name: docs
-    runs-on: depot-ubuntu-latest-4
+    runs-on: depot-ubuntu-latest-32
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -153,7 +153,7 @@ jobs:
 
   fmt:
     name: fmt
-    runs-on: depot-ubuntu-latest
+    runs-on: depot-ubuntu-latest-32
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -167,7 +167,7 @@ jobs:
 
   udeps:
     name: udeps
-    runs-on: depot-ubuntu-latest
+    runs-on: depot-ubuntu-latest-32
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -182,7 +182,7 @@ jobs:
 
   book:
     name: book
-    runs-on: depot-ubuntu-latest
+    runs-on: depot-ubuntu-latest-32
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -240,7 +240,7 @@ jobs:
   # Checks that selected crates can compile with power set of features
   features:
     name: features
-    runs-on: depot-ubuntu-latest
+    runs-on: depot-ubuntu-latest-32
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -264,7 +264,7 @@ jobs:
 
   # Check crates correctly propagate features
   feature-propagation:
-    runs-on: depot-ubuntu-latest
+    runs-on: depot-ubuntu-latest-32
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/prepare-reth.yml
+++ b/.github/workflows/prepare-reth.yml
@@ -31,7 +31,7 @@ jobs:
   prepare-reth:
     if: github.repository == 'paradigmxyz/reth'
     timeout-minutes: 45
-    runs-on: depot-ubuntu-latest
+    runs-on: depot-ubuntu-latest-32
     steps:
       - uses: actions/checkout@v6
       - run: mkdir artifacts

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -23,7 +23,7 @@ jobs:
     name: stage-run-test
     # Only run stage commands test in merge groups
     if: github.event_name == 'merge_group'
-    runs-on: depot-ubuntu-latest
+    runs-on: depot-ubuntu-latest-32
     env:
       RUST_LOG: info,sync=error
       RUST_BACKTRACE: 1

--- a/.github/workflows/sync-era.yml
+++ b/.github/workflows/sync-era.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   sync:
     name: sync (${{ matrix.chain.bin }})
-    runs-on: depot-ubuntu-latest
+    runs-on: depot-ubuntu-latest-32
     env:
       RUST_LOG: info,sync=error
       RUST_BACKTRACE: 1

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   sync:
     name: sync (${{ matrix.chain.bin }})
-    runs-on: depot-ubuntu-latest
+    runs-on: depot-ubuntu-latest-32
     env:
       RUST_LOG: info,sync=error
       RUST_BACKTRACE: 1

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   test:
     name: test / ${{ matrix.type }} / ${{ matrix.storage }}
-    runs-on: depot-ubuntu-latest-4
+    runs-on: depot-ubuntu-latest-32
     env:
       RUST_BACKTRACE: 1
       EDGE_FEATURES: ${{ matrix.storage == 'edge' && 'edge' || '' }}
@@ -56,7 +56,7 @@ jobs:
 
   state:
     name: Ethereum state tests
-    runs-on: depot-ubuntu-latest-4
+    runs-on: depot-ubuntu-latest-32
     env:
       RUST_LOG: info,sync=error
       RUST_BACKTRACE: 1
@@ -91,7 +91,7 @@ jobs:
 
   doc:
     name: doc tests
-    runs-on: depot-ubuntu-latest
+    runs-on: depot-ubuntu-latest-32
     env:
       RUST_BACKTRACE: 1
     timeout-minutes: 30


### PR DESCRIPTION
Update all 27 `runs-on: depot-ubuntu-latest*` entries across 13 workflow files to use `depot-ubuntu-latest-32` (32 cores).

## Changes
- `depot-ubuntu-latest` (18 occurrences) → `depot-ubuntu-latest-32`
- `depot-ubuntu-latest-4` (7 occurrences) → `depot-ubuntu-latest-32`
- `depot-ubuntu-latest-8` (1 occurrence) → `depot-ubuntu-latest-32`
- `depot-ubuntu-latest-16` (1 occurrence) → `depot-ubuntu-latest-32`

Thread: https://tempoxyz.slack.com/archives/C0A8PR5CZLM/p1770640860748119