### PR TITLE
feat(tracing): add jsonrpsee targets to profiling filter

### DIFF
--- a/crates/node/core/src/args/log.rs
+++ b/crates/node/core/src/args/log.rs
@@ -13,7 +13,7 @@ use tracing::{level_filters::LevelFilter, Level};
 const MB_TO_BYTES: u64 = 1024 * 1024;
 
 const PROFILER_TRACING_FILTER: &str =
-    "info,engine=debug,trie=debug,providers=debug,rpc=debug,sync=debug,pruner=debug,libmdbx=debug";
+    "info,engine=debug,trie=debug,providers=debug,rpc=debug,sync=debug,pruner=debug,libmdbx=debug,jsonrpsee-server=debug,jsonrpsee-core=debug,jsonrpsee-http=debug,jsonrpsee=debug";
 
 /// The log configuration.
 #[derive(Debug, Args)]

--- a/crates/node/core/src/args/log.rs
+++ b/crates/node/core/src/args/log.rs
@@ -12,8 +12,20 @@ use tracing::{level_filters::LevelFilter, Level};
 /// Constant to convert megabytes to bytes
 const MB_TO_BYTES: u64 = 1024 * 1024;
 
-const PROFILER_TRACING_FILTER: &str =
-    "info,engine=debug,trie=debug,providers=debug,rpc=debug,sync=debug,pruner=debug,libmdbx=debug,jsonrpsee-server=debug,jsonrpsee-core=debug,jsonrpsee-http=debug,jsonrpsee=debug";
+const PROFILER_TRACING_FILTER: &str = concat!(
+    "info",
+    ",engine=debug",
+    ",trie=debug",
+    ",providers=debug",
+    ",rpc=debug",
+    ",sync=debug",
+    ",pruner=debug",
+    ",libmdbx=debug",
+    ",jsonrpsee-server=debug",
+    ",jsonrpsee-core=debug",
+    ",jsonrpsee-http=debug",
+    ",jsonrpsee=debug",
+);
 
 /// The log configuration.
 #[derive(Debug, Args)]


### PR DESCRIPTION
## Summary
Add jsonrpsee tracing targets to the default profiling filter so they show up in Tracy/Samply profiles.

## Motivation
jsonrpsee uses the `tracing` crate with several targets (`jsonrpsee-server`, `jsonrpsee-core`, `jsonrpsee-http`, `jsonrpsee`) and instrumented spans (`method_call`, `batch`, `notification`). These are currently invisible in profiling sessions because `PROFILER_TRACING_FILTER` doesn't include them. Adding them at debug level lets us see JSON-RPC overhead like serialization, request dispatch, and connection management in profiles.

## Changes
- `crates/node/core/src/args/log.rs`: Added `jsonrpsee-server=debug,jsonrpsee-core=debug,jsonrpsee-http=debug,jsonrpsee=debug` to `PROFILER_TRACING_FILTER`

## Testing
`cargo check -p reth-node-core` passes.