### PR TITLE
fix(trie): subtrie root node too small to have hash

### DIFF
--- a/.changelog/good-rats-pack.md
+++ b/.changelog/good-rats-pack.md
@@ -1,0 +1,6 @@
+---
+reth-trie: patch
+reth-trie-sparse-parallel: patch
+---
+
+Fixed caching of RLP node in SparseSubtrie root and optimized root hash computation to reuse cached lower subtrie hashes. Changed default witness builder to use ParallelSparseTrie for improved performance.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10582,6 +10582,7 @@ dependencies = [
  "reth-tracing",
  "reth-trie-common",
  "reth-trie-sparse",
+ "reth-trie-sparse-parallel",
  "revm-database",
  "revm-state",
  "tracing",

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -2014,7 +2014,7 @@ impl ParallelSparseTrie {
     fn lower_subtrie_rlp_node(&mut self, path: Nibbles) -> RlpNodeStackItem {
         let index = path_subtrie_index_unchecked(&path);
         let lower_subtrie =
-            self.lower_subtries[index].as_revealed_ref().expect("lower subtrie must exist");
+            self.lower_subtries[index].as_revealed_mut().expect("lower subtrie must exist");
 
         // Check for pre-computed root_rlp_node from changed subtries
         if let Some((rlp_node, node_type)) = lower_subtrie.root_rlp_node.clone() {
@@ -2023,8 +2023,6 @@ impl ParallelSparseTrie {
 
         // No pre-computed value - call update_hashes with empty prefix set.
         // This will use cached hashes where available, and compute only where needed.
-        let lower_subtrie =
-            self.lower_subtries[index].as_revealed_mut().expect("lower subtrie must exist");
         let mut empty_prefix_set = PrefixSetMut::default().freeze();
         lower_subtrie.update_hashes(&mut empty_prefix_set, &mut None, &self.branch_node_masks);
 

--- a/crates/trie/trie/Cargo.toml
+++ b/crates/trie/trie/Cargo.toml
@@ -18,6 +18,7 @@ reth-primitives-traits.workspace = true
 reth-stages-types.workspace = true
 reth-storage-errors.workspace = true
 reth-trie-sparse.workspace = true
+reth-trie-sparse-parallel.workspace = true
 reth-trie-common = { workspace = true, features = ["rayon"] }
 
 revm-database.workspace = true

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -22,8 +22,9 @@ use reth_execution_errors::{
 use reth_trie_common::{MultiProofTargets, Nibbles};
 use reth_trie_sparse::{
     provider::{RevealedNode, TrieNodeProvider, TrieNodeProviderFactory},
-    SerialSparseTrie, SparseStateTrie,
+    SparseStateTrie,
 };
+use reth_trie_sparse_parallel::ParallelSparseTrie;
 use std::sync::mpsc;
 
 /// State transition witness for the trie.
@@ -151,7 +152,7 @@ where
             ProofTrieNodeProviderFactory::new(self.trie_cursor_factory, self.hashed_cursor_factory),
             tx,
         );
-        let mut sparse_trie = SparseStateTrie::<SerialSparseTrie>::new();
+        let mut sparse_trie = SparseStateTrie::<ParallelSparseTrie>::new();
         sparse_trie.reveal_multiproof(multiproof)?;
 
         // Attempt to update state trie to gather additional information for the witness.


### PR DESCRIPTION
We encountered a PST bug in one of the trie witness tests given the
following scenario:

* Leafs 0x000...01 and 0x000..02 updated
* `root()` called
* Panic due to `Lower subtrie root node at path Nibbles(0x000000000000000000000000000000000000000000000000000000000000000) has no hash`

In this scenario we have the following nodes:

* 0x (root): extension node with short key 0x000000000000000000000000000000000000000000000000000000000000000
* 0x0x000000000000000000000000000000000000000000000000000000000000000: branch
* 0x0000000000000000000000000000000000000000000000000000000000000001: leaf w/ value 0x1
* 0x0000000000000000000000000000000000000000000000000000000000000002: leaf w/ value 0x2

The branch node is interesting because it is simultaneously the root of its lower subtrie, and its RLP encoding is <32 bytes and is therefore inlined into the parent extension rather than being hashed.

Our implementation of `update_upper_subtrie_hashes` was incorrectly assuming that the root node of lower subtries would always have its `hash` field populated, but that field only gets populated if the node is actually hashed.

The solution is to cache the root RLP node of each SparseSubtrie, and for cases where that cached node is not present (because that subtrie was not modified) we fallback to calling rlp_node which will use the hash if it's available, or calculate from scratch if not.