### PR TITLE
fix(trie): use `hashed_entries_walked` in StorageRoot complete path

### DIFF
--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -716,8 +716,7 @@ where
             "calculated storage root"
         );
 
-        let storage_slots_walked = stats.leaves_added() as usize;
-        Ok(StorageRootProgress::Complete(root, storage_slots_walked, trie_updates))
+        Ok(StorageRootProgress::Complete(root, hashed_entries_walked, trie_updates))
     }
 }
 


### PR DESCRIPTION
StorageRoot::calculate used stats.leaves_added() from the tracker to return the walked count in the Complete path, while the Progress path used hashed_entries_walked. Both values are always equal, but this is inconsistent with how StateRoot::calculate handles the same thing — where tracker is solely for metrics/tracing and hashed_entries_walked is solely for the return value.

Use hashed_entries_walked in both return paths of StorageRoot::calculate, removing the redundant storage_slots_walked variable. This aligns with the StateRoot::calculate pattern and keeps the roles of tracker vs walked counter cleanly separated.