### PR TITLE
ci: set CARGO_BUILD_JOBS=16, drop rust-cache

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_BUILD_JOBS: 32
   BASELINE: base
   SEED: reth
   RUSTC_WRAPPER: "sccache"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_BUILD_JOBS: 32
+  CARGO_BUILD_JOBS: 16
   BASELINE: base
   SEED: reth
   RUSTC_WRAPPER: "sccache"
@@ -35,9 +35,6 @@ jobs:
       - uses: rui314/setup-mold@v1
       - uses: dtolnay/rust-toolchain@stable
       - uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
       - name: Install cargo-codspeed
         uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -11,7 +11,7 @@ on:
   merge_group:
 
 env:
-  CARGO_BUILD_JOBS: 32
+  CARGO_BUILD_JOBS: 16
   RUSTC_WRAPPER: "sccache"
 
 jobs:

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -11,6 +11,7 @@ on:
   merge_group:
 
 env:
+  CARGO_BUILD_JOBS: 32
   RUSTC_WRAPPER: "sccache"
 
 jobs:

--- a/.github/workflows/check-alloy.yml
+++ b/.github/workflows/check-alloy.yml
@@ -21,6 +21,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_BUILD_JOBS: 32
 
 jobs:
   check:

--- a/.github/workflows/check-alloy.yml
+++ b/.github/workflows/check-alloy.yml
@@ -21,7 +21,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_BUILD_JOBS: 32
+  CARGO_BUILD_JOBS: 16
 
 jobs:
   check:
@@ -32,10 +32,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
 
       - name: Apply alloy patches
         run: |

--- a/.github/workflows/compact.yml
+++ b/.github/workflows/compact.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_BUILD_JOBS: 32
+  CARGO_BUILD_JOBS: 16
   RUSTC_WRAPPER: "sccache"
 
 name: compact-codec
@@ -28,9 +28,6 @@ jobs:
       - uses: rui314/setup-mold@v1
       - uses: dtolnay/rust-toolchain@stable
       - uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
       - name: Checkout base
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/compact.yml
+++ b/.github/workflows/compact.yml
@@ -13,6 +13,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_BUILD_JOBS: 32
   RUSTC_WRAPPER: "sccache"
 
 name: compact-codec

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_BUILD_JOBS: 32
+  CARGO_BUILD_JOBS: 16
   SEED: rustethereumethereumrust
   RUSTC_WRAPPER: "sccache"
 
@@ -30,9 +30,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: taiki-e/install-action@nextest
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
       - name: Run e2e tests
         run: |
           cargo nextest run \
@@ -56,9 +53,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: taiki-e/install-action@nextest
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
       - name: Run RocksDB e2e tests
         run: |
           cargo nextest run \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_BUILD_JOBS: 32
   SEED: rustethereumethereumrust
   RUSTC_WRAPPER: "sccache"
 

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_BUILD_JOBS: 32
+  CARGO_BUILD_JOBS: 16
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_BUILD_JOBS: 32
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,6 +13,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_BUILD_JOBS: 32
   SEED: rustethereumethereumrust
   RUSTC_WRAPPER: "sccache"
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_BUILD_JOBS: 32
+  CARGO_BUILD_JOBS: 16
   SEED: rustethereumethereumrust
   RUSTC_WRAPPER: "sccache"
 
@@ -41,9 +41,6 @@ jobs:
         run: .github/scripts/install_geth.sh
       - uses: taiki-e/install-action@nextest
       - uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
       - name: Run tests
         run: |
           cargo nextest run \
@@ -73,8 +70,5 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@nextest
       - uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
       - name: run era1 files integration tests
         run: cargo nextest run --release --package reth-era --test it -- --ignored

--- a/.github/workflows/kurtosis.yml
+++ b/.github/workflows/kurtosis.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_BUILD_JOBS: 32
+  CARGO_BUILD_JOBS: 16
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/kurtosis.yml
+++ b/.github/workflows/kurtosis.yml
@@ -13,6 +13,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_BUILD_JOBS: 32
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_BUILD_JOBS: 32
   RUSTC_WRAPPER: "sccache"
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_BUILD_JOBS: 32
+  CARGO_BUILD_JOBS: 16
   RUSTC_WRAPPER: "sccache"
 
 jobs:
@@ -29,9 +29,6 @@ jobs:
         with:
           components: clippy
       - uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
       - if: "${{ matrix.type == 'book' }}"
         uses: arduino/setup-protoc@v3
         with:
@@ -52,9 +49,6 @@ jobs:
         with:
           components: clippy
       - uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
       - run: cargo clippy --workspace --lib --examples --tests --benches --all-features --locked
         env:
           RUSTFLAGS: -D warnings
@@ -70,9 +64,6 @@ jobs:
           target: wasm32-wasip1
       - uses: taiki-e/install-action@cargo-hack
       - uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
       - uses: dcarbone/install-jq-action@v3
       - name: Run Wasm checks
         run: |
@@ -90,9 +81,6 @@ jobs:
           target: riscv32imac-unknown-none-elf
       - uses: taiki-e/install-action@cargo-hack
       - uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
       - uses: dcarbone/install-jq-action@v3
       - name: Run RISC-V checks
         run: .github/scripts/check_rv32imac.sh
@@ -111,9 +99,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@cargo-hack
       - uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
       - run: cargo hack check --workspace --partition ${{ matrix.partition }}/${{ matrix.total_partitions }}
 
   msrv:
@@ -127,9 +112,6 @@ jobs:
         with:
           toolchain: "1.88" # MSRV
       - uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
       - run: cargo build --bin reth --workspace
         env:
           RUSTFLAGS: -D warnings
@@ -143,9 +125,6 @@ jobs:
       - uses: rui314/setup-mold@v1
       - uses: dtolnay/rust-toolchain@nightly
       - uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
       - run: cargo docs --document-private-items
         env:
           # Keep in sync with ./book.yml:jobs.build
@@ -175,9 +154,6 @@ jobs:
       - uses: rui314/setup-mold@v1
       - uses: dtolnay/rust-toolchain@nightly
       - uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
       - uses: taiki-e/install-action@cargo-udeps
       - run: cargo udeps --workspace --lib --examples --tests --benches --all-features --locked
 
@@ -190,9 +166,6 @@ jobs:
       - uses: rui314/setup-mold@v1
       - uses: dtolnay/rust-toolchain@nightly
       - uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
       - run: cargo build --bin reth --workspace
         env:
           RUSTFLAGS: -D warnings
@@ -248,9 +221,6 @@ jobs:
       - uses: rui314/setup-mold@v1
       - uses: dtolnay/rust-toolchain@clippy
       - uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
       - name: cargo install cargo-hack
         uses: taiki-e/install-action@cargo-hack
       - run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ env:
   IMAGE_NAME: ${{ github.repository_owner }}/reth
   REPRODUCIBLE_IMAGE_NAME: ${{ github.repository_owner }}/reth-reproducible
   CARGO_TERM_COLOR: always
-  CARGO_BUILD_JOBS: 32
+  CARGO_BUILD_JOBS: 16
   DOCKER_IMAGE_NAME_URL: https://ghcr.io/${{ github.repository_owner }}/reth
   RUSTC_WRAPPER: "sccache"
 
@@ -104,10 +104,6 @@ jobs:
         id: cross_main
         run: |
           cargo install cross --git https://github.com/cross-rs/cross
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-
       - name: Apple M1 setup
         if: matrix.configs.target == 'aarch64-apple-darwin'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ env:
   IMAGE_NAME: ${{ github.repository_owner }}/reth
   REPRODUCIBLE_IMAGE_NAME: ${{ github.repository_owner }}/reth-reproducible
   CARGO_TERM_COLOR: always
+  CARGO_BUILD_JOBS: 32
   DOCKER_IMAGE_NAME_URL: https://ghcr.io/${{ github.repository_owner }}/reth
   RUSTC_WRAPPER: "sccache"
 

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_BUILD_JOBS: 32
+  CARGO_BUILD_JOBS: 16
   FROM_BLOCK: 0
   TO_BLOCK: 50000
   RUSTC_WRAPPER: "sccache"
@@ -34,9 +34,6 @@ jobs:
       - uses: rui314/setup-mold@v1
       - uses: dtolnay/rust-toolchain@stable
       - uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
       - name: Build reth
         run: |
           cargo install --features asm-keccak,jemalloc --path bin/reth

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_BUILD_JOBS: 32
   FROM_BLOCK: 0
   TO_BLOCK: 50000
   RUSTC_WRAPPER: "sccache"

--- a/.github/workflows/sync-era.yml
+++ b/.github/workflows/sync-era.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_BUILD_JOBS: 32
+  CARGO_BUILD_JOBS: 16
   RUSTC_WRAPPER: "sccache"
 
 concurrency:
@@ -38,9 +38,6 @@ jobs:
       - uses: rui314/setup-mold@v1
       - uses: dtolnay/rust-toolchain@stable
       - uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
       - name: Build ${{ matrix.chain.bin }}
         run: make ${{ matrix.chain.build }}
       - name: Run sync with ERA enabled

--- a/.github/workflows/sync-era.yml
+++ b/.github/workflows/sync-era.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_BUILD_JOBS: 32
   RUSTC_WRAPPER: "sccache"
 
 concurrency:

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_BUILD_JOBS: 32
+  CARGO_BUILD_JOBS: 16
   RUSTC_WRAPPER: "sccache"
 
 concurrency:
@@ -38,9 +38,6 @@ jobs:
       - uses: rui314/setup-mold@v1
       - uses: dtolnay/rust-toolchain@stable
       - uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
       - name: Build ${{ matrix.chain.bin }}
         run: make ${{ matrix.chain.build }}
       - name: Run sync

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_BUILD_JOBS: 32
   RUSTC_WRAPPER: "sccache"
 
 concurrency:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_BUILD_JOBS: 32
   SEED: rustethereumethereumrust
   RUSTC_WRAPPER: "sccache"
 

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_BUILD_JOBS: 32
+  CARGO_BUILD_JOBS: 16
   SEED: rustethereumethereumrust
   RUSTC_WRAPPER: "sccache"
 
@@ -39,9 +39,6 @@ jobs:
       - uses: rui314/setup-mold@v1
       - uses: dtolnay/rust-toolchain@stable
       - uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
       - uses: taiki-e/install-action@nextest
       - if: "${{ matrix.type == 'book' }}"
         uses: arduino/setup-protoc@v3
@@ -85,9 +82,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@nextest
       - uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
       - run: cargo nextest run --cargo-profile hivetests -p ef-tests --features "asm-keccak ef-tests"
 
   doc:
@@ -101,9 +95,6 @@ jobs:
       - uses: rui314/setup-mold@v1
       - uses: dtolnay/rust-toolchain@stable
       - uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
       - name: Run doctests
         run: cargo test --doc --workspace --all-features
 


### PR DESCRIPTION
## Summary
Sets `CARGO_BUILD_JOBS=16` and removes `Swatinem/rust-cache` from all CI workflows.

## Motivation
Most crates are fetched from sccache remote cache, not compiled locally. Cache hits are network-bound (not CPU-bound), so limiting parallelism to core count is inefficient when cache fetch time exceeds compile time. More parallel jobs = more concurrent cache fetches.

`rust-cache` is redundant with sccache and just adds save/restore overhead on every run.

## Changes
- Set `CARGO_BUILD_JOBS: 16` in top-level `env:` of all 14 workflows that compile Rust
- Removed all 22 `Swatinem/rust-cache@v2` steps across 11 workflow files

## Testing
CI will validate on this PR. Comparing wall-clock times against main baselines.

Thread: https://tempoxyz.slack.com/archives/C0A87C21805/p1770662330739469