### PR TITLE
refactor(stages): replace tuple return with UnwindBlockRangeOutput struct

### DIFF
--- a/crates/stages/stages/src/stages/hashing_account.rs
+++ b/crates/stages/stages/src/stages/hashing_account.rs
@@ -234,11 +234,10 @@ where
         provider: &Provider,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
-        let (range, unwind_progress, _) =
-            input.unwind_block_range_with_threshold(self.commit_threshold);
+        let output = input.unwind_block_range_with_threshold(self.commit_threshold);
 
         // Aggregate all transition changesets and make a list of accounts that have been changed.
-        provider.unwind_account_hashing_range(range)?;
+        provider.unwind_account_hashing_range(output.block_range)?;
 
         let mut stage_checkpoint =
             input.checkpoint.account_hashing_stage_checkpoint().unwrap_or_default();
@@ -246,7 +245,7 @@ where
         stage_checkpoint.progress = stage_checkpoint_progress(provider)?;
 
         Ok(UnwindOutput {
-            checkpoint: StageCheckpoint::new(unwind_progress)
+            checkpoint: StageCheckpoint::new(output.unwind_to)
                 .with_account_hashing_stage_checkpoint(stage_checkpoint),
         })
     }

--- a/crates/stages/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/stages/src/stages/hashing_storage.rs
@@ -176,10 +176,9 @@ where
         provider: &Provider,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
-        let (range, unwind_progress, _) =
-            input.unwind_block_range_with_threshold(self.commit_threshold);
+        let output = input.unwind_block_range_with_threshold(self.commit_threshold);
 
-        provider.unwind_storage_hashing_range(range)?;
+        provider.unwind_storage_hashing_range(output.block_range)?;
 
         let mut stage_checkpoint =
             input.checkpoint.storage_hashing_stage_checkpoint().unwrap_or_default();
@@ -187,7 +186,7 @@ where
         stage_checkpoint.progress = stage_checkpoint_progress(provider)?;
 
         Ok(UnwindOutput {
-            checkpoint: StageCheckpoint::new(unwind_progress)
+            checkpoint: StageCheckpoint::new(output.unwind_to)
                 .with_storage_hashing_stage_checkpoint(stage_checkpoint),
         })
     }

--- a/crates/stages/stages/src/stages/index_account_history.rs
+++ b/crates/stages/stages/src/stages/index_account_history.rs
@@ -159,13 +159,12 @@ where
         provider: &Provider,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
-        let (range, unwind_progress, _) =
-            input.unwind_block_range_with_threshold(self.commit_threshold);
+        let output = input.unwind_block_range_with_threshold(self.commit_threshold);
 
-        provider.unwind_account_history_indices_range(range)?;
+        provider.unwind_account_history_indices_range(output.block_range)?;
 
         // from HistoryIndex higher than that number.
-        Ok(UnwindOutput { checkpoint: StageCheckpoint::new(unwind_progress) })
+        Ok(UnwindOutput { checkpoint: StageCheckpoint::new(output.unwind_to) })
     }
 }
 

--- a/crates/stages/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/stages/src/stages/index_storage_history.rs
@@ -163,12 +163,11 @@ where
         provider: &Provider,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
-        let (range, unwind_progress, _) =
-            input.unwind_block_range_with_threshold(self.commit_threshold);
+        let output = input.unwind_block_range_with_threshold(self.commit_threshold);
 
-        provider.unwind_storage_history_indices_range(range)?;
+        provider.unwind_storage_history_indices_range(output.block_range)?;
 
-        Ok(UnwindOutput { checkpoint: StageCheckpoint::new(unwind_progress) })
+        Ok(UnwindOutput { checkpoint: StageCheckpoint::new(output.unwind_to) })
     }
 }
 

--- a/crates/stages/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/stages/src/stages/sender_recovery.rs
@@ -200,7 +200,7 @@ where
         provider: &Provider,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
-        let (_, unwind_to, _) = input.unwind_block_range_with_threshold(self.commit_threshold);
+        let unwind_to = input.unwind_block_range_with_threshold(self.commit_threshold).unwind_to;
 
         if self.prune_mode.is_none_or(|mode| !mode.is_full()) {
             // Lookup the next tx id after unwind_to block (first tx to remove)


### PR DESCRIPTION
The previous 3-tuple return type `(RangeInclusive<BlockNumber>, BlockNumber, bool)`
from `unwind_block_range_with_threshold` had poor ergonomics:

- Field meanings were unclear without checking the implementation
- All 8 call sites discarded the third value with `let (range, unwind_to, _) = ...`
- Inconsistent with `BlockRangeOutput` and `TransactionRangeOutput` in the same file

The new `UnwindBlockRangeOutput` struct provides:

- Self-documenting field names: `block_range`, `unwind_to`, `is_final_range`
- Consistent API style with sibling types
- Better IDE support for field discovery
