### PR TITLE
feat(storage): add use_hashed_state storage setting

### DIFF
--- a/crates/cli/commands/src/db/settings.rs
+++ b/crates/cli/commands/src/db/settings.rs
@@ -74,6 +74,18 @@ pub enum SetCommand {
         #[clap(action(ArgAction::Set))]
         value: bool,
     },
+    /// Use hashed state tables (HashedAccounts/HashedStorages) as canonical state
+    ///
+    /// When enabled, execution writes directly to hashed tables, eliminating need for
+    /// separate hashing stages. State reads come from hashed tables.
+    ///
+    /// WARNING: Changing this setting in either direction requires re-syncing the database.
+    /// Enabling on an existing plain-state database leaves hashed tables empty.
+    /// Disabling on an existing hashed-state database leaves plain tables empty.
+    UseHashedState {
+        #[clap(action(ArgAction::Set))]
+        value: bool,
+    },
 }
 
 impl Command {
@@ -121,6 +133,7 @@ impl Command {
             account_history_in_rocksdb: _,
             account_changesets_in_static_files: _,
             storage_changesets_in_static_files: _,
+            use_hashed_state: _,
         } = settings.unwrap_or_else(StorageSettings::v1);
 
         // Update the setting based on the key
@@ -180,6 +193,19 @@ impl Command {
                 }
                 settings.storage_changesets_in_static_files = value;
                 println!("Set storage_changesets_in_static_files = {}", value);
+            }
+            SetCommand::UseHashedState { value } => {
+                if settings.use_hashed_state == value {
+                    println!("use_hashed_state is already set to {}", value);
+                    return Ok(());
+                }
+                if settings.use_hashed_state && !value {
+                    println!("WARNING: Disabling use_hashed_state on an existing hashed-state database requires a full resync.");
+                } else {
+                    println!("WARNING: Enabling use_hashed_state on an existing plain-state database requires a full resync.");
+                }
+                settings.use_hashed_state = value;
+                println!("Set use_hashed_state = {}", value);
             }
         }
 

--- a/crates/node/core/src/args/storage.rs
+++ b/crates/node/core/src/args/storage.rs
@@ -23,6 +23,16 @@ pub struct StorageArgs {
     /// flags.
     #[arg(long = "storage.v2", action = ArgAction::SetTrue)]
     pub v2: bool,
+
+    /// Use hashed state tables (`HashedAccounts`/`HashedStorages`) as canonical state
+    /// representation instead of plain state tables.
+    ///
+    /// When enabled, execution writes directly to hashed tables, eliminating the need for
+    /// separate hashing stages. This should only be enabled for new databases.
+    ///
+    /// WARNING: Changing this setting on an existing database requires a full resync.
+    #[arg(long = "storage.use-hashed-state", default_value_t = false)]
+    pub use_hashed_state: bool,
 }
 
 #[cfg(test)]

--- a/crates/node/core/src/node_config.rs
+++ b/crates/node/core/src/node_config.rs
@@ -408,6 +408,8 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
             s = s.with_account_history_in_rocksdb(v);
         }
 
+        s = s.with_use_hashed_state(self.storage.use_hashed_state);
+
         s
     }
 

--- a/crates/storage/db-api/src/models/metadata.rs
+++ b/crates/storage/db-api/src/models/metadata.rs
@@ -34,6 +34,10 @@ pub struct StorageSettings {
     /// Whether this node should read and write storage changesets from static files.
     #[serde(default)]
     pub storage_changesets_in_static_files: bool,
+    /// Whether to use hashed state tables (`HashedAccounts`/`HashedStorages`) as the canonical
+    /// state representation instead of plain state tables.
+    #[serde(default)]
+    pub use_hashed_state: bool,
 }
 
 impl StorageSettings {
@@ -61,6 +65,7 @@ impl StorageSettings {
             storages_history_in_rocksdb: true,
             transaction_hash_numbers_in_rocksdb: true,
             account_history_in_rocksdb: true,
+            use_hashed_state: false,
         }
     }
 
@@ -78,6 +83,7 @@ impl StorageSettings {
             account_history_in_rocksdb: false,
             account_changesets_in_static_files: false,
             storage_changesets_in_static_files: false,
+            use_hashed_state: false,
         }
     }
 
@@ -120,6 +126,12 @@ impl StorageSettings {
     /// Sets the `storage_changesets_in_static_files` flag to the provided value.
     pub const fn with_storage_changesets_in_static_files(mut self, value: bool) -> Self {
         self.storage_changesets_in_static_files = value;
+        self
+    }
+
+    /// Sets the `use_hashed_state` flag to the provided value.
+    pub const fn with_use_hashed_state(mut self, value: bool) -> Self {
+        self.use_hashed_state = value;
         self
     }
 

--- a/docs/vocs/docs/pages/cli/SUMMARY.mdx
+++ b/docs/vocs/docs/pages/cli/SUMMARY.mdx
@@ -37,6 +37,7 @@
           - [`reth db settings set transaction_hash_numbers`](./reth/db/settings/set/transaction_hash_numbers.mdx)
           - [`reth db settings set account_history`](./reth/db/settings/set/account_history.mdx)
           - [`reth db settings set storage_changesets`](./reth/db/settings/set/storage_changesets.mdx)
+          - [`reth db settings set use_hashed_state`](./reth/db/settings/set/use_hashed_state.mdx)
       - [`reth db account-storage`](./reth/db/account-storage.mdx)
       - [`reth db state`](./reth/db/state.mdx)
     - [`reth download`](./reth/download.mdx)

--- a/docs/vocs/docs/pages/cli/reth/db.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db.mdx
@@ -209,6 +209,13 @@ Storage:
 
           Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
+      --storage.use-hashed-state
+          Use hashed state tables (`HashedAccounts`/`HashedStorages`) as canonical state representation instead of plain state tables.
+
+          When enabled, execution writes directly to hashed tables, eliminating the need for separate hashing stages. This should only be enabled for new databases.
+
+          WARNING: Changing this setting on an existing database requires a full resync.
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/docs/vocs/docs/pages/cli/reth/db/settings/set/use_hashed_state.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/settings/set/use_hashed_state.mdx
@@ -1,23 +1,16 @@
-# reth db settings set
+# reth db settings set use_hashed_state
 
-Set storage settings in database
+Use hashed state tables (HashedAccounts/HashedStorages) as canonical state
 
 ```bash
-$ reth db settings set --help
+$ reth db settings set use_hashed_state --help
 ```
 ```txt
-Usage: reth db settings set [OPTIONS] <COMMAND>
+Usage: reth db settings set use_hashed_state [OPTIONS] <VALUE>
 
-Commands:
-  receipts                  Store receipts in static files instead of the database
-  transaction_senders       Store transaction senders in static files instead of the database
-  account_changesets        Store account changesets in static files instead of the database
-  storages_history          Store storage history in rocksdb instead of MDBX
-  transaction_hash_numbers  Store transaction hash to number mapping in rocksdb instead of MDBX
-  account_history           Store account history in rocksdb instead of MDBX
-  storage_changesets        Store storage changesets in static files instead of the database
-  use_hashed_state          Use hashed state tables (HashedAccounts/HashedStorages) as canonical state
-  help                      Print this message or the help of the given subcommand(s)
+Arguments:
+  <VALUE>
+          [possible values: true, false]
 
 Options:
   -h, --help

--- a/docs/vocs/docs/pages/cli/reth/download.mdx
+++ b/docs/vocs/docs/pages/cli/reth/download.mdx
@@ -192,6 +192,13 @@ Storage:
 
           Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
+      --storage.use-hashed-state
+          Use hashed state tables (`HashedAccounts`/`HashedStorages`) as canonical state representation instead of plain state tables.
+
+          When enabled, execution writes directly to hashed tables, eliminating the need for separate hashing stages. This should only be enabled for new databases.
+
+          WARNING: Changing this setting on an existing database requires a full resync.
+
   -u, --url <URL>
           Specify a snapshot URL or let the command propose a default one.
 

--- a/docs/vocs/docs/pages/cli/reth/export-era.mdx
+++ b/docs/vocs/docs/pages/cli/reth/export-era.mdx
@@ -192,6 +192,13 @@ Storage:
 
           Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
+      --storage.use-hashed-state
+          Use hashed state tables (`HashedAccounts`/`HashedStorages`) as canonical state representation instead of plain state tables.
+
+          When enabled, execution writes directly to hashed tables, eliminating the need for separate hashing stages. This should only be enabled for new databases.
+
+          WARNING: Changing this setting on an existing database requires a full resync.
+
       --first-block-number <first-block-number>
           Optional first block number to export from the db.
           It is by default 0.

--- a/docs/vocs/docs/pages/cli/reth/import-era.mdx
+++ b/docs/vocs/docs/pages/cli/reth/import-era.mdx
@@ -192,6 +192,13 @@ Storage:
 
           Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
+      --storage.use-hashed-state
+          Use hashed state tables (`HashedAccounts`/`HashedStorages`) as canonical state representation instead of plain state tables.
+
+          When enabled, execution writes directly to hashed tables, eliminating the need for separate hashing stages. This should only be enabled for new databases.
+
+          WARNING: Changing this setting on an existing database requires a full resync.
+
       --path <IMPORT_ERA_PATH>
           The path to a directory for import.
 

--- a/docs/vocs/docs/pages/cli/reth/import.mdx
+++ b/docs/vocs/docs/pages/cli/reth/import.mdx
@@ -192,6 +192,13 @@ Storage:
 
           Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
+      --storage.use-hashed-state
+          Use hashed state tables (`HashedAccounts`/`HashedStorages`) as canonical state representation instead of plain state tables.
+
+          When enabled, execution writes directly to hashed tables, eliminating the need for separate hashing stages. This should only be enabled for new databases.
+
+          WARNING: Changing this setting on an existing database requires a full resync.
+
       --no-state
           Disables stages that require state.
 

--- a/docs/vocs/docs/pages/cli/reth/init-state.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init-state.mdx
@@ -192,6 +192,13 @@ Storage:
 
           Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
+      --storage.use-hashed-state
+          Use hashed state tables (`HashedAccounts`/`HashedStorages`) as canonical state representation instead of plain state tables.
+
+          When enabled, execution writes directly to hashed tables, eliminating the need for separate hashing stages. This should only be enabled for new databases.
+
+          WARNING: Changing this setting on an existing database requires a full resync.
+
       --without-evm
           Specifies whether to initialize the state without relying on EVM historical data.
 

--- a/docs/vocs/docs/pages/cli/reth/init.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init.mdx
@@ -192,6 +192,13 @@ Storage:
 
           Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
+      --storage.use-hashed-state
+          Use hashed state tables (`HashedAccounts`/`HashedStorages`) as canonical state representation instead of plain state tables.
+
+          When enabled, execution writes directly to hashed tables, eliminating the need for separate hashing stages. This should only be enabled for new databases.
+
+          WARNING: Changing this setting on an existing database requires a full resync.
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -1110,6 +1110,13 @@ Storage:
 
           Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
+      --storage.use-hashed-state
+          Use hashed state tables (`HashedAccounts`/`HashedStorages`) as canonical state representation instead of plain state tables.
+
+          When enabled, execution writes directly to hashed tables, eliminating the need for separate hashing stages. This should only be enabled for new databases.
+
+          WARNING: Changing this setting on an existing database requires a full resync.
+
 Ress:
       --ress.enable
           Enable support for `ress` subprotocol

--- a/docs/vocs/docs/pages/cli/reth/prune.mdx
+++ b/docs/vocs/docs/pages/cli/reth/prune.mdx
@@ -192,6 +192,13 @@ Storage:
 
           Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
+      --storage.use-hashed-state
+          Use hashed state tables (`HashedAccounts`/`HashedStorages`) as canonical state representation instead of plain state tables.
+
+          When enabled, execution writes directly to hashed tables, eliminating the need for separate hashing stages. This should only be enabled for new databases.
+
+          WARNING: Changing this setting on an existing database requires a full resync.
+
 Metrics:
       --metrics <PROMETHEUS>
           Enable Prometheus metrics.

--- a/docs/vocs/docs/pages/cli/reth/re-execute.mdx
+++ b/docs/vocs/docs/pages/cli/reth/re-execute.mdx
@@ -192,6 +192,13 @@ Storage:
 
           Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
+      --storage.use-hashed-state
+          Use hashed state tables (`HashedAccounts`/`HashedStorages`) as canonical state representation instead of plain state tables.
+
+          When enabled, execution writes directly to hashed tables, eliminating the need for separate hashing stages. This should only be enabled for new databases.
+
+          WARNING: Changing this setting on an existing database requires a full resync.
+
       --from <FROM>
           The height to start at
 

--- a/docs/vocs/docs/pages/cli/reth/stage/drop.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/drop.mdx
@@ -192,6 +192,13 @@ Storage:
 
           Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
+      --storage.use-hashed-state
+          Use hashed state tables (`HashedAccounts`/`HashedStorages`) as canonical state representation instead of plain state tables.
+
+          When enabled, execution writes directly to hashed tables, eliminating the need for separate hashing stages. This should only be enabled for new databases.
+
+          WARNING: Changing this setting on an existing database requires a full resync.
+
   <STAGE>
           Possible values:
           - headers:         The headers stage within the pipeline

--- a/docs/vocs/docs/pages/cli/reth/stage/dump.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump.mdx
@@ -199,6 +199,13 @@ Storage:
 
           Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
+      --storage.use-hashed-state
+          Use hashed state tables (`HashedAccounts`/`HashedStorages`) as canonical state representation instead of plain state tables.
+
+          When enabled, execution writes directly to hashed tables, eliminating the need for separate hashing stages. This should only be enabled for new databases.
+
+          WARNING: Changing this setting on an existing database requires a full resync.
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/docs/vocs/docs/pages/cli/reth/stage/run.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/run.mdx
@@ -192,6 +192,13 @@ Storage:
 
           Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
+      --storage.use-hashed-state
+          Use hashed state tables (`HashedAccounts`/`HashedStorages`) as canonical state representation instead of plain state tables.
+
+          When enabled, execution writes directly to hashed tables, eliminating the need for separate hashing stages. This should only be enabled for new databases.
+
+          WARNING: Changing this setting on an existing database requires a full resync.
+
       --metrics <SOCKET>
           Enable Prometheus metrics.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/unwind.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/unwind.mdx
@@ -197,6 +197,13 @@ Storage:
 
           Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
+      --storage.use-hashed-state
+          Use hashed state tables (`HashedAccounts`/`HashedStorages`) as canonical state representation instead of plain state tables.
+
+          When enabled, execution writes directly to hashed tables, eliminating the need for separate hashing stages. This should only be enabled for new databases.
+
+          WARNING: Changing this setting on an existing database requires a full resync.
+
       --offline
           If this is enabled, then all stages except headers, bodies, and sender recovery will be unwound
 

--- a/docs/vocs/sidebar-cli-reth.ts
+++ b/docs/vocs/sidebar-cli-reth.ts
@@ -171,6 +171,10 @@ export const rethCliSidebar: SidebarItem = {
                                 {
                                     text: "reth db settings set storage_changesets",
                                     link: "/cli/reth/db/settings/set/storage_changesets"
+                                },
+                                {
+                                    text: "reth db settings set use_hashed_state",
+                                    link: "/cli/reth/db/settings/set/use_hashed_state"
                                 }
                             ]
                         }


### PR DESCRIPTION
Adds the storage setting for hashed state only nodes, does not add any other logic related to hashed state only nodes.