### PR TITLE
refactor(storage): add `with_*_opt` builder methods to `StorageSettings`

### DIFF
--- a/crates/node/core/src/node_config.rs
+++ b/crates/node/core/src/node_config.rs
@@ -375,20 +375,12 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
         let mut s = if self.storage.v2 { StorageSettings::v2() } else { StorageSettings::base() };
 
         // Apply static files overrides (only when explicitly set)
-        if let Some(v) = self.static_files.receipts {
-            s = s.with_receipts_in_static_files(v);
-        }
-        if let Some(v) = self.static_files.transaction_senders {
-            s = s.with_transaction_senders_in_static_files(v);
-        }
-        if let Some(v) = self.static_files.account_changesets {
-            s = s.with_account_changesets_in_static_files(v);
-        }
-        if let Some(v) = self.static_files.storage_changesets {
-            s = s.with_storage_changesets_in_static_files(v);
-        }
+        s = s
+            .with_receipts_in_static_files_opt(self.static_files.receipts)
+            .with_transaction_senders_in_static_files_opt(self.static_files.transaction_senders)
+            .with_account_changesets_in_static_files_opt(self.static_files.account_changesets)
+            .with_storage_changesets_in_static_files_opt(self.static_files.storage_changesets);
 
-        // Apply rocksdb overrides
         // --rocksdb.all sets all rocksdb flags to true
         if self.rocksdb.all {
             s = s
@@ -398,15 +390,10 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
         }
 
         // Individual rocksdb flags override --rocksdb.all when explicitly set
-        if let Some(v) = self.rocksdb.tx_hash {
-            s = s.with_transaction_hash_numbers_in_rocksdb(v);
-        }
-        if let Some(v) = self.rocksdb.storages_history {
-            s = s.with_storages_history_in_rocksdb(v);
-        }
-        if let Some(v) = self.rocksdb.account_history {
-            s = s.with_account_history_in_rocksdb(v);
-        }
+        s = s
+            .with_transaction_hash_numbers_in_rocksdb_opt(self.rocksdb.tx_hash)
+            .with_storages_history_in_rocksdb_opt(self.rocksdb.storages_history)
+            .with_account_history_in_rocksdb_opt(self.rocksdb.account_history);
 
         s = s.with_use_hashed_state(self.storage.use_hashed_state);
 

--- a/crates/node/core/src/node_config.rs
+++ b/crates/node/core/src/node_config.rs
@@ -381,6 +381,7 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
             .with_account_changesets_in_static_files_opt(self.static_files.account_changesets)
             .with_storage_changesets_in_static_files_opt(self.static_files.storage_changesets);
 
+        // Apply rocksdb overrides
         // --rocksdb.all sets all rocksdb flags to true
         if self.rocksdb.all {
             s = s

--- a/crates/storage/db-api/src/models/metadata.rs
+++ b/crates/storage/db-api/src/models/metadata.rs
@@ -135,6 +135,74 @@ impl StorageSettings {
         self
     }
 
+    /// Sets `receipts_in_static_files` if `value` is `Some`.
+    pub const fn with_receipts_in_static_files_opt(mut self, value: Option<bool>) -> Self {
+        if let Some(v) = value {
+            self.receipts_in_static_files = v;
+        }
+        self
+    }
+
+    /// Sets `transaction_senders_in_static_files` if `value` is `Some`.
+    pub const fn with_transaction_senders_in_static_files_opt(
+        mut self,
+        value: Option<bool>,
+    ) -> Self {
+        if let Some(v) = value {
+            self.transaction_senders_in_static_files = v;
+        }
+        self
+    }
+
+    /// Sets `account_changesets_in_static_files` if `value` is `Some`.
+    pub const fn with_account_changesets_in_static_files_opt(
+        mut self,
+        value: Option<bool>,
+    ) -> Self {
+        if let Some(v) = value {
+            self.account_changesets_in_static_files = v;
+        }
+        self
+    }
+
+    /// Sets `storage_changesets_in_static_files` if `value` is `Some`.
+    pub const fn with_storage_changesets_in_static_files_opt(
+        mut self,
+        value: Option<bool>,
+    ) -> Self {
+        if let Some(v) = value {
+            self.storage_changesets_in_static_files = v;
+        }
+        self
+    }
+
+    /// Sets `transaction_hash_numbers_in_rocksdb` if `value` is `Some`.
+    pub const fn with_transaction_hash_numbers_in_rocksdb_opt(
+        mut self,
+        value: Option<bool>,
+    ) -> Self {
+        if let Some(v) = value {
+            self.transaction_hash_numbers_in_rocksdb = v;
+        }
+        self
+    }
+
+    /// Sets `storages_history_in_rocksdb` if `value` is `Some`.
+    pub const fn with_storages_history_in_rocksdb_opt(mut self, value: Option<bool>) -> Self {
+        if let Some(v) = value {
+            self.storages_history_in_rocksdb = v;
+        }
+        self
+    }
+
+    /// Sets `account_history_in_rocksdb` if `value` is `Some`.
+    pub const fn with_account_history_in_rocksdb_opt(mut self, value: Option<bool>) -> Self {
+        if let Some(v) = value {
+            self.account_history_in_rocksdb = v;
+        }
+        self
+    }
+
     /// Returns `true` if any tables are configured to be stored in `RocksDB`.
     pub const fn any_in_rocksdb(&self) -> bool {
         self.transaction_hash_numbers_in_rocksdb ||


### PR DESCRIPTION
## Summary
Add `with_*_opt` builder methods to `StorageSettings` that accept `Option<bool>`, applying the value only when `Some`.

## Motivation
`storage_settings()` in `NodeConfig` had repetitive `if let Some(v)` blocks for each optional override. This follows the existing `with_*_opt` pattern used elsewhere (e.g. `with_storage_worker_count_opt`, `with_max_inbound_opt`).

## Changes
- Added 7 `with_*_opt` methods to `StorageSettings` (`crates/storage/db-api/src/models/metadata.rs`)
- Rewrote `NodeConfig::storage_settings()` to use chained builder calls (`crates/node/core/src/node_config.rs`)

## Testing
`cargo test -p reth-db-api -p reth-node-core` — all pass.

---
Thread: https://tempoxyz.slack.com/archives/C0A87C21805/p1770667568978249