### PR TITLE
fix(rpc): use External origin for raw txs and enforce blockHash in filter changes

### DIFF
--- a/crates/rpc/rpc-eth-types/src/logs_utils.rs
+++ b/crates/rpc/rpc-eth-types/src/logs_utils.rs
@@ -79,6 +79,10 @@ pub fn append_matching_block_logs<P>(
 where
     P: BlockReader<Transaction: SignedTransaction>,
 {
+    if !filter.matches_block(&block_num_hash) {
+        return Ok(());
+    }
+
     // Tracks the index of a log in the entire block.
     let mut log_index: u64 = 0;
 

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -556,10 +556,11 @@ where
     #[inline]
     pub async fn add_pool_transaction(
         &self,
+        origin: reth_transaction_pool::TransactionOrigin,
         transaction: <N::Pool as TransactionPool>::Transaction,
     ) -> Result<AddedTransactionOutcome, EthApiError> {
         let (response_tx, response_rx) = tokio::sync::oneshot::channel();
-        let request = reth_transaction_pool::BatchTxRequest::new(transaction, response_tx);
+        let request = reth_transaction_pool::BatchTxRequest::new(transaction, origin, response_tx);
 
         self.tx_batch_sender()
             .send(request)


### PR DESCRIPTION
## Summary
Two audit fixes for RPC behavior.

## Changes

**1. `eth_sendRawTransaction` treated as local origin**

`BatchTxRequest` hardcoded `TransactionOrigin::Local` for all transactions going through the RPC batch path. This meant `eth_sendRawTransaction` submissions bypassed non-local admission controls (min priority fee filtering, stricter sender slot limits).

Fix: plumb `TransactionOrigin` through `BatchTxRequest` and partition batches by origin. The `send_transaction` RPC path now submits as `External`.

**2. `eth_getFilterChanges` ignores blockHash constraints**

`append_matching_block_logs` didn't call `filter.matches_block()`, unlike `matching_block_logs_with_tx_hashes` which does. When `FilterBlockOption::AtBlockHash` was used in `filter_changes`, logs from multiple blocks could be returned.

Fix: add `filter.matches_block()` early-return guard to `append_matching_block_logs`, matching the existing behavior in `matching_block_logs_with_tx_hashes`.

## Testing
```
cargo test -p reth-transaction-pool --lib batcher  # 4 passed
cargo test -p reth-rpc-eth-types --lib logs_utils  # 9 passed
cargo clippy -p reth-transaction-pool -p reth-rpc -p reth-rpc-eth-types  # clean
```