### PR TITLE
feat(docker): include debug symbols in maxperf images

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -310,6 +310,11 @@ inherits = "release"
 lto = "fat"
 codegen-units = 1
 
+[profile.maxperf-symbols]
+inherits = "maxperf"
+debug = "full"
+strip = "none"
+
 [profile.reproducible]
 inherits = "release"
 panic = "abort"

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -9,7 +9,7 @@ variable "TAG" {
 }
 
 variable "BUILD_PROFILE" {
-  default = "maxperf"
+  default = "maxperf-symbols"
 }
 
 variable "FEATURES" {
@@ -139,4 +139,3 @@ target "kurtosis" {
   tags   = ["ghcr.io/paradigmxyz/reth:kurtosis-ci"]
   output = ["type=docker,dest=${HIVE_OUTPUT_DIR}/reth_image.tar"]
 }
-


### PR DESCRIPTION
## Summary
Include debug symbols in all maxperf Docker images for lldb attachment.

## Changes
- `Cargo.toml`: new `maxperf-symbols` profile (inherits `maxperf`, adds `debug = "full"`, `strip = "none"`). Original `maxperf` is unchanged.
- `docker-bake.hcl`: default `BUILD_PROFILE` changed to `maxperf-symbols`

Binary ships with embedded debug symbols — no stripping, no separate files.

Thread: https://tempoxyz.slack.com/archives/C0A87C21805/p1770671358634349