### PR TITLE
feat(engine): add state root task timeout with sequential fallback

### DIFF
--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -1,7 +1,7 @@
 //! Engine tree configuration.
 
 use alloy_eips::merge::EPOCH_SLOTS;
-use std::time::Duration;
+use core::time::Duration;
 
 /// Triggers persistence when the number of canonical blocks in memory exceeds this threshold.
 pub const DEFAULT_PERSISTENCE_THRESHOLD: u64 = 2;

--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -365,6 +365,8 @@ pub struct BlockValidationMetrics {
     pub state_root_parallel_fallback_total: Counter,
     /// Total number of times the state root task failed but the fallback succeeded.
     pub state_root_task_fallback_success_total: Counter,
+    /// Total number of times the state root task timed out and a sequential fallback was spawned.
+    pub state_root_task_timeout_total: Counter,
     /// Latest state root duration, ie the time spent blocked waiting for the state root.
     pub state_root_duration: Gauge,
     /// Histogram for state root duration ie the time spent blocked waiting for the state root

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -736,17 +736,6 @@ impl<Tx, Err, R: Send + Sync + 'static> PayloadHandle<Tx, Err, R> {
         self.state_root.take().expect("state_root is None")
     }
 
-    /// Cancels the sparse trie and proof worker pipeline by closing the multi-proof channel.
-    ///
-    /// Dropping the sender cascades: the multi-proof / hashing task exits, which closes the
-    /// sparse trie update channel, causing the sparse trie task to finish, which in turn
-    /// releases the proof workers and their database transactions.
-    ///
-    /// Idempotent: safe to call multiple times.
-    pub fn terminate_state_root_task(&mut self) {
-        let _ = self.to_multi_proof.take();
-    }
-
     /// Returns a state hook to be used to send state updates to this task.
     ///
     /// If a multiproof task is spawned the hook will notify it about new states.

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -724,6 +724,18 @@ impl<Tx, Err, R: Send + Sync + 'static> PayloadHandle<Tx, Err, R> {
             .map_err(|_| ParallelStateRootError::Other("sparse trie task dropped".to_string()))?
     }
 
+    /// Takes the state root receiver out of the handle for use with custom waiting logic
+    /// (e.g., timeout-based waiting).
+    ///
+    /// # Panics
+    ///
+    /// If payload processing was started without background tasks.
+    pub const fn take_state_root_rx(
+        &mut self,
+    ) -> mpsc::Receiver<Result<StateRootComputeOutcome, ParallelStateRootError>> {
+        self.state_root.take().expect("state_root is None")
+    }
+
     /// Returns a state hook to be used to send state updates to this task.
     ///
     /// If a multiproof task is spawned the hook will notify it about new states.

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -974,7 +974,6 @@ where
                                 target: "engine::tree::payload_validator",
                                 "State root task dropped, waiting for sequential fallback"
                             );
-                            handle.terminate_state_root_task();
                             let result = seq_rx.recv().map_err(|_| {
                                 ProviderError::other(std::io::Error::other(
                                     "both state root computations failed",
@@ -992,8 +991,6 @@ where
                             source = "sequential",
                             "State root timeout race won"
                         );
-                        handle.terminate_state_root_task();
-                        drop(task_rx);
                         let (state_root, trie_updates) = result?;
                         return Ok(Ok(StateRootComputeOutcome { state_root, trie_updates }));
                     }

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -974,6 +974,7 @@ where
                                 target: "engine::tree::payload_validator",
                                 "State root task dropped, waiting for sequential fallback"
                             );
+                            handle.terminate_state_root_task();
                             let result = seq_rx.recv().map_err(|_| {
                                 ProviderError::other(std::io::Error::other(
                                     "both state root computations failed",
@@ -991,6 +992,8 @@ where
                             source = "sequential",
                             "State root timeout race won"
                         );
+                        handle.terminate_state_root_task();
+                        drop(task_rx);
                         let (state_root, trie_updates) = result?;
                         return Ok(Ok(StateRootComputeOutcome { state_root, trie_updates }));
                     }

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -375,8 +375,10 @@ pub struct EngineArgs {
     /// Configure the timeout for the state root task before spawning a sequential fallback.
     /// If the state root task takes longer than this, a sequential computation starts in
     /// parallel and whichever finishes first is used.
-    /// Parses strings using [`humantime::parse_duration`]
-    /// e.g. --engine.state-root-task-timeout 1s
+    ///
+    /// --engine.state-root-task-timeout 1s
+    /// --engine.state-root-task-timeout 400ms
+    ///
     /// Set to 0s to disable.
     #[arg(
         long = "engine.state-root-task-timeout",

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -1022,6 +1022,15 @@ Engine:
 
           [default: 100]
 
+      --engine.state-root-task-timeout <STATE_ROOT_TASK_TIMEOUT>
+          Configure the timeout for the state root task before spawning a sequential fallback. If the state root task takes longer than this, a sequential computation starts in parallel and whichever finishes first is used.
+
+          --engine.state-root-task-timeout 1s --engine.state-root-task-timeout 400ms
+
+          Set to 0s to disable.
+
+          [default: 1s]
+
 ERA:
       --era.enable
           Enable import from ERA1 files


### PR DESCRIPTION
## Summary

Adds a configurable timeout for the state root task. If it exceeds the threshold (default 1s), a sequential state root computation is spawned in parallel and whichever finishes first wins. This avoids stalls caused by state root task bugs.

## Motivation

The state root task (sparse trie) can occasionally stall due to bugs, blocking payload processing indefinitely. This timeout + fallback ensures the node can still make progress by racing a sequential computation against the stuck task.

## Changes

- `crates/engine/primitives/src/config.rs`: add `state_root_task_timeout: Option<Duration>` to `TreeConfig` (default: 1s)
- `crates/node/core/src/args/engine.rs`: add `--engine.state-root-task-timeout-ms` CLI flag (0 to disable)
- `crates/engine/tree/src/tree/payload_validator.rs`: add `await_state_root_with_timeout` method that uses `recv_timeout` + polling loop to race the task result against a sequential fallback
- `crates/engine/tree/src/tree/payload_processor/mod.rs`: add `take_state_root_rx` to expose the state root receiver
- `crates/engine/tree/src/tree/metrics.rs`: add `state_root_task_timeout_total` counter

## How it works

1. Wait for state root task up to the configured timeout via `recv_timeout`
2. On timeout, spawn sequential state root computation in a separate thread
3. Poll both the task receiver (10ms intervals) and sequential result channel
4. Return whichever completes first
5. The losing computation continues running in the background (its result is dropped)

## Testing

```
cargo check -p reth-engine-tree -p reth-node-core -p reth-engine-primitives
cargo clippy -p reth-engine-tree -p reth-node-core -p reth-engine-primitives -- -D warnings
cargo test -p reth-node-core -- engine_args
```

Thread: https://tempoxyz.slack.com/archives/C0A87C21805/p1770671552571389