### PR TITLE
fix(rocksdb): set max_open_files to prevent fd exhaustion

### DIFF
--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -113,10 +113,10 @@ const DEFAULT_MAX_BACKGROUND_JOBS: i32 = 6;
 
 /// Default max open file descriptors for `RocksDB`.
 ///
-/// Caps the number of SST file handles RocksDB keeps open simultaneously.
+/// Caps the number of SST file handles `RocksDB` keeps open simultaneously.
 /// Set to 512 to stay within the common default OS `ulimit -n` of 1024,
 /// leaving headroom for MDBX, static files, and other I/O.
-/// RocksDB uses an internal table cache and re-opens files on demand,
+/// `RocksDB` uses an internal table cache and re-opens files on demand,
 /// so this has negligible performance impact on read-heavy workloads.
 const DEFAULT_MAX_OPEN_FILES: i32 = 512;
 

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -111,6 +111,15 @@ const DEFAULT_BLOCK_SIZE: usize = 16 * 1024;
 /// Default max background jobs for `RocksDB` compaction and flushing.
 const DEFAULT_MAX_BACKGROUND_JOBS: i32 = 6;
 
+/// Default max open file descriptors for `RocksDB`.
+///
+/// Caps the number of SST file handles RocksDB keeps open simultaneously.
+/// Set to 512 to stay within the common default OS `ulimit -n` of 1024,
+/// leaving headroom for MDBX, static files, and other I/O.
+/// RocksDB uses an internal table cache and re-opens files on demand,
+/// so this has negligible performance impact on read-heavy workloads.
+const DEFAULT_MAX_OPEN_FILES: i32 = 512;
+
 /// Default bytes per sync for `RocksDB` WAL writes (1 MB).
 const DEFAULT_BYTES_PER_SYNC: u64 = 1_048_576;
 
@@ -202,6 +211,8 @@ impl RocksDBBuilder {
         options.set_compaction_pri(CompactionPri::MinOverlappingRatio);
 
         options.set_log_level(log_level);
+
+        options.set_max_open_files(DEFAULT_MAX_OPEN_FILES);
 
         // Delete obsolete WAL files immediately after all column families have flushed.
         // Both set to 0 means "delete ASAP, no archival".


### PR DESCRIPTION
## Summary

Sets `max_open_files=512` on RocksDB to prevent `Too many open files` errors on systems with the default `ulimit -n 1024`.

## Motivation

RocksDB defaults to `max_open_files=-1` (unlimited SST file handles). On systems with the default ulimit of 1024, this causes:
```
IO error: While open a file for random read: .../rocksdb/001487.sst: Too many open files (-1)
```

This is reproducible with CLI commands like `reth db hash-storage-changesets` on a mature database with many SST files.

## Changes

- Added `DEFAULT_MAX_OPEN_FILES = 512` constant
- Applied it in `RocksDBBuilder::default_options()`
- 512 leaves headroom for MDBX, static files, networking, and other I/O within the default 1024 fd limit
- RocksDB's internal table cache re-opens files on demand, so this has negligible read performance impact

## Testing

`cargo check -p reth-provider` — passes clean.

Thread: https://tempoxyz.slack.com/archives/C0A87C21805/p1770672581138199