### PR TITLE
fix(rpc): enforce blockHash constraint in append_matching_block_logs

### DIFF
--- a/crates/rpc/rpc-eth-types/src/logs_utils.rs
+++ b/crates/rpc/rpc-eth-types/src/logs_utils.rs
@@ -79,6 +79,10 @@ pub fn append_matching_block_logs<P>(
 where
     P: BlockReader<Transaction: SignedTransaction>,
 {
+    if !filter.matches_block(&block_num_hash) {
+        return Ok(());
+    }
+
     // Tracks the index of a log in the entire block.
     let mut log_index: u64 = 0;
 


### PR DESCRIPTION
## Summary
Fixes [RETH-392](https://linear.app/tempoxyz/issue/RETH-392): `eth_getFilterChanges` ignores `blockHash` constraints in some paths.

## Problem
`append_matching_block_logs` did not call `filter.matches_block()`, unlike `matching_block_logs_with_tx_hashes` which does. When `FilterBlockOption::AtBlockHash` was used via `eth_getFilterChanges`, logs from multiple blocks could be returned — deviating from the expected single-block filtering semantics.

## Fix
Add `filter.matches_block()` early-return guard to `append_matching_block_logs`, matching the existing behavior in `matching_block_logs_with_tx_hashes`.

## Testing
```
cargo test -p reth-rpc-eth-types --lib logs_utils  # 9/9 pass
```