### PR TITLE
feat(net): add reason label to backed_off_peers metric

### DIFF
--- a/.changelog/dry-ducks-write.md
+++ b/.changelog/dry-ducks-write.md
@@ -1,0 +1,5 @@
+---
+reth-network: minor
+---
+
+Added reason label to backed_off_peers metric. The metric now tracks backed off peers by reason (too_many_peers, graceful_close, connection_error) to improve observability.

--- a/crates/net/network/src/metrics.rs
+++ b/crates/net/network/src/metrics.rs
@@ -110,6 +110,36 @@ impl Default for PendingSessionFailureMetrics {
     }
 }
 
+/// Metrics for backed off peers, split by reason.
+#[derive(Debug)]
+pub struct BackedOffPeersMetrics {
+    /// Peers backed off because they reported too many peers.
+    pub too_many_peers: Gauge,
+    /// Peers backed off after a graceful session close.
+    pub graceful_close: Gauge,
+    /// Peers backed off due to connection or protocol errors.
+    pub connection_error: Gauge,
+}
+
+impl Default for BackedOffPeersMetrics {
+    fn default() -> Self {
+        Self {
+            too_many_peers: metrics::gauge!("network_backed_off_peers", "reason" => "too_many_peers"),
+            graceful_close: metrics::gauge!("network_backed_off_peers", "reason" => "graceful_close"),
+            connection_error: metrics::gauge!("network_backed_off_peers", "reason" => "connection_error"),
+        }
+    }
+}
+
+impl BackedOffPeersMetrics {
+    /// Sets the gauge values from the given counts.
+    pub fn set(&self, counts: &crate::peers::BackoffCounts) {
+        self.too_many_peers.set(counts.too_many_peers as f64);
+        self.graceful_close.set(counts.graceful_close as f64);
+        self.connection_error.set(counts.connection_error as f64);
+    }
+}
+
 /// Metrics for `SessionManager`
 #[derive(Metrics)]
 #[metrics(scope = "network")]

--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -533,12 +533,7 @@ impl PeersManager {
         peer_id: &PeerId,
         err: &PendingSessionHandshakeError,
     ) {
-        self.on_connection_failure(
-            remote_addr,
-            peer_id,
-            err,
-            ReputationChangeKind::FailedToConnect,
-        )
+        self.on_connection_failure(remote_addr, peer_id, err, ReputationChangeKind::FailedToConnect)
     }
 
     /// Gracefully disconnected an active session
@@ -625,12 +620,7 @@ impl PeersManager {
             }
         }
 
-        self.on_connection_failure(
-            remote_addr,
-            peer_id,
-            err,
-            ReputationChangeKind::FailedToConnect,
-        )
+        self.on_connection_failure(remote_addr, peer_id, err, ReputationChangeKind::FailedToConnect)
     }
 
     fn on_connection_failure(


### PR DESCRIPTION
## Summary

Adds a `reason` label to the `backed_off_peers` gauge so operators can distinguish **why** peers are backed off. This addresses the issue where `reth_network_too_many_peers` fires even when the node isn't at peering limits — the metric was conflating remote `TooManyPeers` disconnects with other backoff reasons.

## New metric

```
network_backed_off_peers{reason="too_many_peers"}
network_backed_off_peers{reason="graceful_close"}
network_backed_off_peers{reason="connection_error"}
```

The existing `network_backed_off_peers` total gauge is preserved.

## Changes

- **peers.rs**: Store a `BackoffReason` alongside the backoff expiry in the `backed_off_peers` map. Reason is derived from the concrete `DisconnectReason` at each callsite (`TooManyPeers` vs graceful close vs other errors).
- **metrics.rs**: Add `BackedOffPeersMetrics` struct with labeled gauges.
- **manager.rs**: Report per-reason counts via `update_backed_off_peers_metrics()` helper.