### PR TITLE
refactor(engine): move slow block logging out of persistence and ExecutedBlock

### DIFF
--- a/crates/engine/service/src/service.rs
+++ b/crates/engine/service/src/service.rs
@@ -95,12 +95,8 @@ where
 
         let downloader = BasicBlockDownloader::new(client, consensus.clone());
 
-        let persistence_handle = PersistenceHandle::<N::Primitives>::spawn_service(
-            provider,
-            pruner,
-            sync_metrics_tx,
-            tree_config.slow_block_threshold(),
-        );
+        let persistence_handle =
+            PersistenceHandle::<N::Primitives>::spawn_service(provider, pruner, sync_metrics_tx);
 
         let canonical_in_memory_state = blockchain_db.canonical_in_memory_state();
 

--- a/crates/engine/tree/src/tree/persistence_state.rs
+++ b/crates/engine/tree/src/tree/persistence_state.rs
@@ -20,11 +20,24 @@
 //! The [`PersistenceState`] tracks ongoing persistence operations and coordinates
 //! between the main execution thread and background persistence workers.
 
+use crate::persistence::SaveBlocksResult;
 use alloy_eips::BlockNumHash;
 use alloy_primitives::B256;
 use crossbeam_channel::Receiver as CrossbeamReceiver;
 use std::time::Instant;
 use tracing::trace;
+
+/// Receiver for the result of a persistence operation.
+///
+/// Different persistence actions produce different result types, so the receiver
+/// is an enum that captures both channel types.
+#[derive(Debug)]
+pub(crate) enum PersistenceRx {
+    /// Receiver for the result of a save-blocks operation.
+    SaveBlocks(CrossbeamReceiver<Option<SaveBlocksResult>>),
+    /// Receiver for the result of a remove-blocks operation.
+    RemoveBlocks(CrossbeamReceiver<Option<BlockNumHash>>),
+}
 
 /// The state of the persistence task.
 #[derive(Debug)]
@@ -35,8 +48,7 @@ pub struct PersistenceState {
     pub(crate) last_persisted_block: BlockNumHash,
     /// Receiver end of channel where the result of the persistence task will be
     /// sent when done. A None value means there's no persistence task in progress.
-    pub(crate) rx:
-        Option<(CrossbeamReceiver<Option<BlockNumHash>>, Instant, CurrentPersistenceAction)>,
+    pub(crate) rx: Option<(PersistenceRx, Instant, CurrentPersistenceAction)>,
 }
 
 impl PersistenceState {
@@ -52,17 +64,24 @@ impl PersistenceState {
         new_tip_num: u64,
         rx: CrossbeamReceiver<Option<BlockNumHash>>,
     ) {
-        self.rx =
-            Some((rx, Instant::now(), CurrentPersistenceAction::RemovingBlocks { new_tip_num }));
+        self.rx = Some((
+            PersistenceRx::RemoveBlocks(rx),
+            Instant::now(),
+            CurrentPersistenceAction::RemovingBlocks { new_tip_num },
+        ));
     }
 
     /// Sets the state for a block save operation.
     pub(crate) fn start_save(
         &mut self,
         highest: BlockNumHash,
-        rx: CrossbeamReceiver<Option<BlockNumHash>>,
+        rx: CrossbeamReceiver<Option<SaveBlocksResult>>,
     ) {
-        self.rx = Some((rx, Instant::now(), CurrentPersistenceAction::SavingBlocks { highest }));
+        self.rx = Some((
+            PersistenceRx::SaveBlocks(rx),
+            Instant::now(),
+            CurrentPersistenceAction::SavingBlocks { highest },
+        ));
     }
 
     /// Returns the current persistence action. If there is no persistence task in progress, then

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{
-    persistence::PersistenceAction,
+    persistence::{PersistenceAction, SaveBlocksResult},
     tree::{
         payload_validator::{BasicEngineValidator, TreeCtx, ValidationOutcome},
         persistence_state::CurrentPersistenceAction,
@@ -36,6 +36,7 @@ use std::{
         mpsc::{Receiver, Sender},
         Arc,
     },
+    time::Duration,
 };
 use tokio::sync::oneshot;
 
@@ -411,14 +412,13 @@ impl ValidatorTestHarness {
 
     /// Configure `PersistenceState` for specific persistence scenarios
     fn start_persistence_operation(&mut self, action: CurrentPersistenceAction) {
-        // Create a dummy receiver for testing - it will never receive a value
-        let (_tx, rx) = crossbeam_channel::bounded(1);
-
         match action {
             CurrentPersistenceAction::SavingBlocks { highest } => {
+                let (_tx, rx) = crossbeam_channel::bounded(1);
                 self.harness.tree.persistence_state.start_save(highest, rx);
             }
             CurrentPersistenceAction::RemovingBlocks { new_tip_num } => {
+                let (_tx, rx) = crossbeam_channel::bounded(1);
                 self.harness.tree.persistence_state.start_remove(new_tip_num, rx);
             }
         }
@@ -755,7 +755,12 @@ async fn test_tree_state_on_new_head_reorg() {
     assert_eq!(saved_blocks, vec![blocks[0].clone(), blocks[1].clone()]);
 
     // send the response so we can advance again
-    sender.send(Some(blocks[1].recovered_block().num_hash())).unwrap();
+    sender
+        .send(Some(SaveBlocksResult {
+            last_block: blocks[1].recovered_block().num_hash(),
+            commit_duration: Duration::ZERO,
+        }))
+        .unwrap();
 
     // we should be persisting blocks[1] because we threw out the prev action
     let current_action = test_harness.tree.persistence_state.current_action().cloned();
@@ -2030,7 +2035,12 @@ mod forkchoice_updated_tests {
                 if let Some(last) = saved_blocks.last() {
                     last_persisted_number = last.recovered_block().number;
                 }
-                sender.send(saved_blocks.last().map(|b| b.recovered_block().num_hash())).unwrap();
+                sender
+                    .send(saved_blocks.last().map(|b| SaveBlocksResult {
+                        last_block: b.recovered_block().num_hash(),
+                        commit_duration: Duration::ZERO,
+                    }))
+                    .unwrap();
             }
         }
 

--- a/crates/node/events/src/node.rs
+++ b/crates/node/events/src/node.rs
@@ -1,11 +1,14 @@
 //! Support for handling events emitted by node components.
 
 use crate::cl::ConsensusLayerHealthEvent;
-use alloy_consensus::{constants::GWEI_TO_WEI, BlockHeader};
+use alloy_consensus::{
+    constants::{GWEI_TO_WEI, MGAS_TO_GAS},
+    BlockHeader,
+};
 use alloy_primitives::{BlockNumber, B256};
 use alloy_rpc_types_engine::ForkchoiceState;
 use futures::Stream;
-use reth_engine_primitives::{ConsensusEngineEvent, ForkchoiceStatus};
+use reth_engine_primitives::{ConsensusEngineEvent, ForkchoiceStatus, SlowBlockInfo};
 use reth_network_api::PeersInfo;
 use reth_primitives_traits::{format_gas, format_gas_throughput, BlockBody, NodePrimitives};
 use reth_prune_types::PrunerEvent;
@@ -267,7 +270,61 @@ impl NodeState {
             ConsensusEngineEvent::BlockReceived(num_hash) => {
                 info!(number=num_hash.number, hash=?num_hash.hash, "Received block from consensus engine");
             }
+            ConsensusEngineEvent::SlowBlock(info) => {
+                Self::log_slow_block(&info);
+            }
         }
+    }
+
+    fn log_slow_block(info: &SlowBlockInfo) {
+        fn hit_rate(hits: usize, misses: usize) -> f64 {
+            let total = hits + misses;
+            if total > 0 {
+                (hits as f64 / total as f64) * 100.0
+            } else {
+                0.0
+            }
+        }
+
+        let stats = &info.stats;
+        let mgas_per_sec = (stats.gas_used as f64 / MGAS_TO_GAS as f64) /
+            (stats.execution_duration.as_secs_f64() + stats.state_hash_duration.as_secs_f64());
+
+        warn!(
+            target: "reth::slow_block",
+            message = "Slow block",
+            block.number = stats.block_number,
+            block.hash = ?stats.block_hash,
+            block.gas_used = stats.gas_used,
+            block.tx_count = stats.tx_count,
+            timing.execution_ms = stats.execution_duration.as_millis(),
+            timing.state_read_ms = stats.state_read_duration.as_millis(),
+            timing.state_hash_ms = stats.state_hash_duration.as_millis(),
+            timing.commit_ms = info.commit_duration.as_millis(),
+            timing.total_ms = info.total_duration.as_millis(),
+            throughput.mgas_per_sec = format!("{:.2}", mgas_per_sec),
+            state_reads.accounts = stats.accounts_read,
+            state_reads.storage_slots = stats.storage_read,
+            state_reads.code = stats.code_read,
+            state_reads.code_bytes = stats.code_bytes_read,
+            state_writes.accounts = stats.accounts_changed,
+            state_writes.accounts_deleted = stats.accounts_deleted,
+            state_writes.storage_slots = stats.storage_slots_changed,
+            state_writes.storage_slots_deleted = stats.storage_slots_deleted,
+            state_writes.code = stats.bytecodes_changed,
+            state_writes.code_bytes = stats.code_bytes_written,
+            state_writes.eip7702_delegations_set = stats.eip7702_delegations_set,
+            state_writes.eip7702_delegations_cleared = stats.eip7702_delegations_cleared,
+            cache.account.hits = stats.account_cache_hits,
+            cache.account.misses = stats.account_cache_misses,
+            cache.account.hit_rate = format!("{:.2}", hit_rate(stats.account_cache_hits, stats.account_cache_misses)),
+            cache.storage.hits = stats.storage_cache_hits,
+            cache.storage.misses = stats.storage_cache_misses,
+            cache.storage.hit_rate = format!("{:.2}", hit_rate(stats.storage_cache_hits, stats.storage_cache_misses)),
+            cache.code.hits = stats.code_cache_hits,
+            cache.code.misses = stats.code_cache_misses,
+            cache.code.hit_rate = format!("{:.2}", hit_rate(stats.code_cache_hits, stats.code_cache_misses)),
+        );
     }
 
     fn handle_consensus_layer_health_event(&self, event: ConsensusLayerHealthEvent) {


### PR DESCRIPTION
## Summary
Addresses [mattsse's review](https://github.com/paradigmxyz/reth/pull/21433#pullrequestreview-3775750558) on #21433.

## Motivation
The review asked for three things:
1. Don't track `timing_stats` as part of `ExecutedBlock` — keep observability concerns out of the block type
2. Return metrics from persistence as part of the response, not just `Option<BlockNumHash>`
3. Emit slow block info via `ConsensusEngineEvent` so logging happens on the event task, not blocking persistence

## Changes
- Remove `timing_stats: Option<ExecutionTimingStats>` from `ExecutedBlock`
- Store timing stats internally in `EngineApiTreeHandler` keyed by block hash
- Add `SaveBlocksResult { last_block, commit_duration }` as persistence response
- Add `PersistenceRx` enum to handle different response types for save vs remove
- Add `ConsensusEngineEvent::SlowBlock(SlowBlockInfo)` event variant
- Move slow block logging to node event handler (`crates/node/events`)
- Clean up timing stats on backfill completion, reorg, and block removal paths

## Testing
```
cargo test -p reth-engine-tree --lib -- persistence
```
All 5 persistence + tree tests pass.

Slack thread: https://tempoxyz.slack.com/archives/C0A87C21805/p1770676765464099