### PR TITLE
feat(rpc): add `subscribeFinalizedChainNotifications` endpoint

### DIFF
--- a/.changelog/warm-geese-build.md
+++ b/.changelog/warm-geese-build.md
@@ -1,0 +1,7 @@
+---
+reth-rpc-api: minor
+reth-rpc-builder: patch
+reth-rpc: minor
+---
+
+Added `subscribeFinalizedChainNotifications` RPC endpoint that buffers committed chain notifications and emits them once a new finalized block is received.

--- a/crates/rpc/rpc-api/src/reth.rs
+++ b/crates/rpc/rpc-api/src/reth.rs
@@ -2,7 +2,7 @@ use alloy_eips::BlockId;
 use alloy_primitives::{map::AddressMap, U256};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
-// Required for the subscription attribute below
+// Required for the subscription attributes below
 use reth_chain_state as _;
 
 /// Reth API namespace for reth-specific methods
@@ -33,4 +33,17 @@ pub trait RethApi {
         item = alloy_eips::BlockNumHash
     )]
     async fn reth_subscribe_persisted_block(&self) -> jsonrpsee::core::SubscriptionResult;
+
+    /// Subscribe to finalized chain notifications.
+    ///
+    /// Buffers committed chain notifications and emits them once a new finalized block is received.
+    /// Each notification contains all committed chain segments up to the finalized block.
+    #[subscription(
+        name = "subscribeFinalizedChainNotifications",
+        unsubscribe = "unsubscribeFinalizedChainNotifications",
+        item = Vec<reth_chain_state::CanonStateNotification>
+    )]
+    async fn reth_subscribe_finalized_chain_notifications(
+        &self,
+    ) -> jsonrpsee::core::SubscriptionResult;
 }

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -103,7 +103,9 @@ pub use eth::EthHandlers;
 mod metrics;
 use crate::middleware::RethRpcMiddleware;
 pub use metrics::{MeteredBatchRequestsFuture, MeteredRequestFuture, RpcRequestMetricsService};
-use reth_chain_state::{CanonStateSubscriptions, PersistedBlockSubscriptions};
+use reth_chain_state::{
+    CanonStateSubscriptions, ForkChoiceSubscriptions, PersistedBlockSubscriptions,
+};
 use reth_rpc::eth::sim_bundle::EthSimBundle;
 
 // Rpc rate limiter
@@ -311,6 +313,7 @@ where
     N: NodePrimitives,
     Provider: FullRpcProvider<Block = N::Block, Receipt = N::Receipt, Header = N::BlockHeader>
         + CanonStateSubscriptions<Primitives = N>
+        + ForkChoiceSubscriptions<Header = N::BlockHeader>
         + PersistedBlockSubscriptions
         + AccountReader
         + ChangeSetReader,
@@ -656,7 +659,8 @@ where
             Transaction = N::SignedTx,
         > + AccountReader
         + ChangeSetReader
-        + CanonStateSubscriptions
+        + CanonStateSubscriptions<Primitives = N>
+        + ForkChoiceSubscriptions<Header = N::BlockHeader>
         + PersistedBlockSubscriptions,
     Network: NetworkInfo + Peers + Clone + 'static,
     EthApi: EthApiServer<
@@ -845,6 +849,7 @@ where
     N: NodePrimitives,
     Provider: FullRpcProvider<Block = N::Block>
         + CanonStateSubscriptions<Primitives = N>
+        + ForkChoiceSubscriptions<Header = N::BlockHeader>
         + PersistedBlockSubscriptions
         + AccountReader
         + ChangeSetReader,


### PR DESCRIPTION
## Summary

Adds a new RPC subscription endpoint `reth_subscribeFinalizedChainNotifications` that emits committed chain notifications once a new finalized block is received.

### How it works

- Buffers `Commit` notifications from `canonical_state_stream`
- Clears the buffer on `Reorg`
- When a finalized block arrives via `finalized_block_stream`, drains all buffered commits whose tip is at or below the finalized block number and emits them as `Vec<CanonStateNotification>`

### Changes

- **`rpc-api`**: Added `subscribeFinalizedChainNotifications` / `unsubscribeFinalizedChainNotifications` subscription definition
- **`rpc`**: Added `ForkChoiceSubscriptions` trait bound on the `RethApiServer` impl and implemented the `finalized_chain_notifications` handler
- **`rpc-builder`**: Propagated `ForkChoiceSubscriptions` bound to the relevant impl blocks