### PR TITLE
feat(net): add direction labels to closed_sessions and pending_session_failures metrics

### DIFF
--- a/.changelog/warm-foxes-glow.md
+++ b/.changelog/warm-foxes-glow.md
@@ -1,0 +1,5 @@
+---
+reth-network: minor
+---
+
+Added direction labels to `closed_sessions` and `pending_session_failures` metrics. Operators can now distinguish session closures and failures by direction (`active`, `incoming_pending`, `outgoing_pending` for closed sessions; `inbound`, `outbound` for pending session failures).

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -875,7 +875,6 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
                     self.swarm.state_mut().peers_mut().on_active_session_gracefully_closed(peer_id);
                     None
                 };
-                self.metrics.closed_sessions.increment(1);
                 self.closed_sessions_metrics.active.increment(1);
                 self.update_active_connection_metrics();
 
@@ -901,7 +900,6 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
                         .state_mut()
                         .peers_mut()
                         .on_incoming_pending_session_dropped(remote_addr, err);
-                    self.metrics.pending_session_failures.increment(1);
                     self.pending_session_failure_metrics.inbound.increment(1);
                     if let Some(reason) = err.as_disconnected() {
                         self.disconnect_metrics.increment(reason);
@@ -912,7 +910,6 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
                         .peers_mut()
                         .on_incoming_pending_session_gracefully_closed();
                 }
-                self.metrics.closed_sessions.increment(1);
                 self.closed_sessions_metrics.incoming_pending.increment(1);
                 self.metrics
                     .incoming_connections
@@ -936,7 +933,6 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
                         &peer_id,
                         err,
                     );
-                    self.metrics.pending_session_failures.increment(1);
                     self.pending_session_failure_metrics.outbound.increment(1);
                     if let Some(reason) = err.as_disconnected() {
                         self.disconnect_metrics.increment(reason);
@@ -947,7 +943,6 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
                         .peers_mut()
                         .on_outgoing_pending_session_gracefully_closed(&peer_id);
                 }
-                self.metrics.closed_sessions.increment(1);
                 self.closed_sessions_metrics.outgoing_pending.increment(1);
                 self.update_pending_connection_metrics();
 

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -24,7 +24,10 @@ use crate::{
     import::{BlockImport, BlockImportEvent, BlockImportOutcome, BlockValidation, NewBlockEvent},
     listener::ConnectionListener,
     message::{NewBlockMessage, PeerMessage},
-    metrics::{DisconnectMetrics, NetworkMetrics, NETWORK_POOL_TRANSACTIONS_SCOPE},
+    metrics::{
+        ClosedSessionsMetrics, DisconnectMetrics, NetworkMetrics, PendingSessionFailureMetrics,
+        NETWORK_POOL_TRANSACTIONS_SCOPE,
+    },
     network::{NetworkHandle, NetworkHandleMessage},
     peers::PeersManager,
     poll_nested_stream_with_budget,
@@ -139,6 +142,10 @@ pub struct NetworkManager<N: NetworkPrimitives = EthNetworkPrimitives> {
     metrics: NetworkMetrics,
     /// Disconnect metrics for the Network
     disconnect_metrics: DisconnectMetrics,
+    /// Closed sessions metrics, split by direction.
+    closed_sessions_metrics: ClosedSessionsMetrics,
+    /// Pending session failure metrics, split by direction.
+    pending_session_failure_metrics: PendingSessionFailureMetrics,
 }
 
 impl NetworkManager {
@@ -354,6 +361,8 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
             num_active_peers,
             metrics: Default::default(),
             disconnect_metrics: Default::default(),
+            closed_sessions_metrics: Default::default(),
+            pending_session_failure_metrics: Default::default(),
         })
     }
 
@@ -867,6 +876,7 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
                     None
                 };
                 self.metrics.closed_sessions.increment(1);
+                self.closed_sessions_metrics.active.increment(1);
                 self.update_active_connection_metrics();
 
                 if let Some(reason) = reason {
@@ -892,6 +902,7 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
                         .peers_mut()
                         .on_incoming_pending_session_dropped(remote_addr, err);
                     self.metrics.pending_session_failures.increment(1);
+                    self.pending_session_failure_metrics.inbound.increment(1);
                     if let Some(reason) = err.as_disconnected() {
                         self.disconnect_metrics.increment(reason);
                     }
@@ -902,6 +913,7 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
                         .on_incoming_pending_session_gracefully_closed();
                 }
                 self.metrics.closed_sessions.increment(1);
+                self.closed_sessions_metrics.incoming_pending.increment(1);
                 self.metrics
                     .incoming_connections
                     .set(self.swarm.state().peers().num_inbound_connections() as f64);
@@ -925,6 +937,7 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
                         err,
                     );
                     self.metrics.pending_session_failures.increment(1);
+                    self.pending_session_failure_metrics.outbound.increment(1);
                     if let Some(reason) = err.as_disconnected() {
                         self.disconnect_metrics.increment(reason);
                     }
@@ -935,6 +948,7 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
                         .on_outgoing_pending_session_gracefully_closed(&peer_id);
                 }
                 self.metrics.closed_sessions.increment(1);
+                self.closed_sessions_metrics.outgoing_pending.increment(1);
                 self.update_pending_connection_metrics();
 
                 self.metrics

--- a/crates/net/network/src/metrics.rs
+++ b/crates/net/network/src/metrics.rs
@@ -2,7 +2,7 @@ use metrics::Histogram;
 use reth_eth_wire::DisconnectReason;
 use reth_ethereum_primitives::TxType;
 use reth_metrics::{
-    metrics::{Counter, Gauge},
+    metrics::{self, Counter, Gauge},
     Metrics,
 };
 
@@ -75,6 +75,45 @@ pub struct NetworkMetrics {
     ///
     /// Duration in seconds.
     pub(crate) acc_duration_poll_swarm: Gauge,
+}
+
+/// Metrics for closed sessions, split by direction.
+#[derive(Debug)]
+pub struct ClosedSessionsMetrics {
+    /// Sessions closed from active (established) connections.
+    pub active: Counter,
+    /// Sessions closed from incoming pending connections.
+    pub incoming_pending: Counter,
+    /// Sessions closed from outgoing pending connections.
+    pub outgoing_pending: Counter,
+}
+
+impl Default for ClosedSessionsMetrics {
+    fn default() -> Self {
+        Self {
+            active: metrics::counter!("network_closed_sessions", "direction" => "active"),
+            incoming_pending: metrics::counter!("network_closed_sessions", "direction" => "incoming_pending"),
+            outgoing_pending: metrics::counter!("network_closed_sessions", "direction" => "outgoing_pending"),
+        }
+    }
+}
+
+/// Metrics for pending session failures, split by direction.
+#[derive(Debug)]
+pub struct PendingSessionFailureMetrics {
+    /// Failures on incoming pending sessions.
+    pub inbound: Counter,
+    /// Failures on outgoing pending sessions.
+    pub outbound: Counter,
+}
+
+impl Default for PendingSessionFailureMetrics {
+    fn default() -> Self {
+        Self {
+            inbound: metrics::counter!("network_pending_session_failures", "direction" => "inbound"),
+            outbound: metrics::counter!("network_pending_session_failures", "direction" => "outbound"),
+        }
+    }
 }
 
 /// Metrics for `SessionManager`

--- a/crates/net/network/src/metrics.rs
+++ b/crates/net/network/src/metrics.rs
@@ -22,12 +22,6 @@ pub struct NetworkMetrics {
     /// Number of peers known to the node
     pub(crate) tracked_peers: Gauge,
 
-    /// Cumulative number of failures of pending sessions
-    pub(crate) pending_session_failures: Counter,
-
-    /// Total number of sessions closed
-    pub(crate) closed_sessions: Counter,
-
     /// Number of active incoming connections
     pub(crate) incoming_connections: Gauge,
 


### PR DESCRIPTION
## Summary

Adds `direction` labels to the `closed_sessions` and `pending_session_failures` counters so operators can distinguish **where** sessions are failing. Follows the same pattern as #22009 (backed_off_peers reason labels).

## New metrics

```
network_closed_sessions{direction="active"}
network_closed_sessions{direction="incoming_pending"}
network_closed_sessions{direction="outgoing_pending"}

network_pending_session_failures{direction="inbound"}
network_pending_session_failures{direction="outbound"}
```

The existing aggregate `network_closed_sessions` and `network_pending_session_failures` counters are preserved for backward compatibility.

## Changes

- **metrics.rs**: Add `ClosedSessionsMetrics` and `PendingSessionFailureMetrics` structs with labeled counters.
- **manager.rs**: Increment the labeled counters alongside the existing aggregate counters at each swarm event callsite.