### PR TITLE
feat(reth-bench): add progress field to per-block benchmark logs

### DIFF
--- a/bin/reth-bench/src/bench/gas_limit_ramp.rs
+++ b/bin/reth-bench/src/bench/gas_limit_ramp.rs
@@ -192,6 +192,15 @@ impl Command {
             parent_header = block.header;
             parent_hash = block_hash;
             blocks_processed += 1;
+
+            let progress = match mode {
+                RampMode::Blocks(total) => format!("{blocks_processed}/{total}"),
+                RampMode::TargetGasLimit(target) => {
+                    let pct = (parent_header.gas_limit as f64 / target as f64 * 100.0).min(100.0);
+                    format!("{pct:.1}%")
+                }
+            };
+            info!(target: "reth-bench", progress, block_number = parent_header.number, gas_limit = parent_header.gas_limit, "Block processed");
         }
 
         let final_gas_limit = parent_header.gas_limit;

--- a/bin/reth-bench/src/bench/new_payload_fcu.rs
+++ b/bin/reth-bench/src/bench/new_payload_fcu.rs
@@ -150,6 +150,7 @@ impl Command {
             ..
         } = BenchContext::new(&self.benchmark, self.rpc_url).await?;
 
+        let total_blocks = benchmark_mode.total_blocks();
         let buffer_size = self.rpc_block_buffer_size;
 
         // Use a oneshot channel to propagate errors from the spawned task
@@ -203,6 +204,7 @@ impl Command {
         });
 
         let mut results = Vec::new();
+        let mut blocks_processed = 0u64;
         let total_benchmark_duration = Instant::now();
         let mut total_wait_time = Duration::ZERO;
 
@@ -246,8 +248,13 @@ impl Command {
 
             // Exclude time spent waiting on the block prefetch channel from the benchmark duration.
             // We want to measure engine throughput, not RPC fetch latency.
+            blocks_processed += 1;
             let current_duration = total_benchmark_duration.elapsed() - total_wait_time;
-            info!(target: "reth-bench", %combined_result);
+            let progress = match total_blocks {
+                Some(total) => format!("{blocks_processed}/{total}"),
+                None => format!("{blocks_processed}"),
+            };
+            info!(target: "reth-bench", progress, %combined_result);
 
             if let Some(w) = &mut waiter {
                 w.on_block(block_number).await?;

--- a/bin/reth-bench/src/bench/replay_payloads.rs
+++ b/bin/reth-bench/src/bench/replay_payloads.rs
@@ -338,7 +338,8 @@ impl Command {
             };
 
             let current_duration = total_benchmark_duration.elapsed();
-            info!(target: "reth-bench", %combined_result);
+            let progress = format!("{}/{}", i + 1, payloads.len());
+            info!(target: "reth-bench", progress, %combined_result);
 
             if let Some(w) = &mut waiter {
                 w.on_block(block_number).await?;

--- a/bin/reth-bench/src/bench_mode.rs
+++ b/bin/reth-bench/src/bench_mode.rs
@@ -20,6 +20,19 @@ impl BenchMode {
         }
     }
 
+    /// Returns the total number of blocks in the benchmark, if known.
+    ///
+    /// For [`BenchMode::Range`] this is the length of the range.
+    /// For [`BenchMode::Continuous`] the total is unbounded, so `None` is returned.
+    pub const fn total_blocks(&self) -> Option<u64> {
+        match self {
+            Self::Continuous(_) => None,
+            Self::Range(range) => {
+                Some(range.end().saturating_sub(*range.start()).saturating_add(1))
+            }
+        }
+    }
+
     /// Create a [`BenchMode`] from optional `from` and `to` fields.
     pub fn new(from: Option<u64>, to: Option<u64>, latest_block: u64) -> Result<Self, eyre::Error> {
         // If neither `--from` nor `--to` are provided, we will run the benchmark continuously,


### PR DESCRIPTION
## Summary
Add a `progress` field to per-block log lines so you can see how far along a benchmark is.

## Motivation
When running long benchmarks (e.g. 2000 blocks), there's no way to tell how far along you are from the logs. This adds progress tracking to every per-block log line.

## Changes
- Added `BenchMode::total_blocks()` to expose total block count for range-based benchmarks
- `new-payload-fcu`: logs `progress="5/2000"` (range) or `progress="5"` (continuous)
- `new-payload-only`: same
- `replay-payloads`: logs `progress="5/200"` (total always known from loaded payloads)
- `gas-limit-ramp`: logs `progress="5/100"` (block mode) or `progress="42.5%"` (target gas limit mode)

## Testing
`cargo test -p reth-bench` — all 9 tests pass

Thread: https://tempoxyz.slack.com/archives/C0A87C21805/p1770697278119489