### PR TITLE
rpc: fix eth_simulateV1 revert error code

### DIFF
--- a/.changelog/eth-simulatev1-revert-error-code.md
+++ b/.changelog/eth-simulatev1-revert-error-code.md
@@ -1,0 +1,10 @@
+---
+reth-rpc-eth-types: minor
+reth-rpc-e2e-tests: patch
+---
+
+Aligned `eth_simulateV1` revert error handling with the Execution APIs spec  
+(see https://github.com/ethereum/execution-apis/pull/748).
+
+EVM reverts now return JSON-RPC error code `3` instead of the generic `-32000`, while VM execution errors continue to return `-32015`.  
+Updated the RPC compatibility test harness to propagate actual RPC error codes instead of masking them, enabling correct validation against execution-apis test cases.

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -32,7 +32,7 @@ use revm::{
 /// Error code for execution reverted in `eth_simulateV1`.
 ///
 /// <https://github.com/ethereum/execution-apis>
-pub const SIMULATE_REVERT_CODE: i32 = -32000;
+pub const SIMULATE_REVERT_CODE: i32 = 3;
 
 /// Error code for VM execution errors (e.g., out of gas) in `eth_simulateV1`.
 ///


### PR DESCRIPTION
### What

Align `eth_simulateV1` revert error handling with the Execution APIs specification.

EVM reverts now return JSON-RPC error code `3` instead of the generic `-32000`.
VM execution failures (e.g. OOG, invalid opcode) continue to return `-32015`.

### Why

The Execution APIs spec defines:
- `code = 3` for EVM `REVERT`
- `-32015` for VM execution errors

Returning `-32000` made it impossible for clients and tooling to reliably
distinguish reverts from generic RPC failures.

refrence: https://github.com/ethereum/execution-apis/pull/748