### PR TITLE
chore: remove base.reth.rs public endpoint references

### DIFF
--- a/bin/reth-bench-compare/src/cli.rs
+++ b/bin/reth-bench-compare/src/cli.rs
@@ -277,8 +277,8 @@ impl Args {
     /// Get the default RPC URL for a given chain
     const fn get_default_rpc_url(chain: &Chain) -> &'static str {
         match chain.id() {
-            27082 => "https://rpc.hoodi.ethpandaops.io",    // hoodi
-            _ => "https://ethereum.reth.rs/rpc",            // mainnet and fallback
+            27082 => "https://rpc.hoodi.ethpandaops.io", // hoodi
+            _ => "https://ethereum.reth.rs/rpc",         // mainnet and fallback
         }
     }
 

--- a/bin/reth-bench-compare/src/cli.rs
+++ b/bin/reth-bench-compare/src/cli.rs
@@ -277,7 +277,6 @@ impl Args {
     /// Get the default RPC URL for a given chain
     const fn get_default_rpc_url(chain: &Chain) -> &'static str {
         match chain.id() {
-            84532 => "https://base-sepolia.rpc.ithaca.xyz", // base-sepolia
             27082 => "https://rpc.hoodi.ethpandaops.io",    // hoodi
             _ => "https://ethereum.reth.rs/rpc",            // mainnet and fallback
         }

--- a/bin/reth-bench-compare/src/cli.rs
+++ b/bin/reth-bench-compare/src/cli.rs
@@ -277,7 +277,6 @@ impl Args {
     /// Get the default RPC URL for a given chain
     const fn get_default_rpc_url(chain: &Chain) -> &'static str {
         match chain.id() {
-            8453 => "https://base.reth.rs/rpc",             // base
             84532 => "https://base-sepolia.rpc.ithaca.xyz", // base-sepolia
             27082 => "https://rpc.hoodi.ethpandaops.io",    // hoodi
             _ => "https://ethereum.reth.rs/rpc",            // mainnet and fallback

--- a/docs/vocs/docs/pages/run/overview.mdx
+++ b/docs/vocs/docs/pages/run/overview.mdx
@@ -38,7 +38,6 @@ Find answers to common questions and troubleshooting tips:
 | --------------- | -------- | ------------------------------------ |
 | Ethereum        | 1        | https://ethereum.reth.rs/rpc |
 | Sepolia Testnet | 11155111 | https://sepolia.drpc.org             |
-| Base            | 8453     | https://base.reth.rs/rpc  |
 | Base Sepolia    | 84532    | https://base-sepolia.drpc.org        |
 
 :::tip

--- a/docs/vocs/docs/pages/run/overview.mdx
+++ b/docs/vocs/docs/pages/run/overview.mdx
@@ -38,7 +38,6 @@ Find answers to common questions and troubleshooting tips:
 | --------------- | -------- | ------------------------------------ |
 | Ethereum        | 1        | https://ethereum.reth.rs/rpc |
 | Sepolia Testnet | 11155111 | https://sepolia.drpc.org             |
-| Base Sepolia    | 84532    | https://base-sepolia.drpc.org        |
 
 :::tip
 Want to add more networks to this table? Feel free to [contribute](https://github.com/paradigmxyz/reth/edit/main/docs/vocs/docs/pages/run/overview.mdx) by submitting a PR with additional networks that Reth supports!


### PR DESCRIPTION
## Summary
Remove references to base.reth.rs public RPC endpoint which is being decommissioned.

## Changes
- Removed Base row from supported networks table in docs
- Removed base.reth.rs default RPC URL from reth-bench-compare CLI (falls back to ethereum.reth.rs)

## Testing
N/A - config/docs removal only