### PR TITLE
ci: skip scheduled workflows on forks

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   update:
+    if: github.repository == 'paradigmxyz/reth'
     uses: tempoxyz/ci/.github/workflows/cargo-update-pr.yml@main
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,6 +31,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'paradigmxyz/reth'
     name: Build Docker images
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -64,7 +64,7 @@ jobs:
 
   era-files:
     name: era1 file integration tests once a day
-    if: github.event_name == 'schedule'
+    if: github.event_name == 'schedule' && github.repository == 'paradigmxyz/reth'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/kurtosis.yml
+++ b/.github/workflows/kurtosis.yml
@@ -20,6 +20,7 @@ concurrency:
 
 jobs:
   build-reth:
+    if: github.repository == 'paradigmxyz/reth'
     uses: ./.github/workflows/docker-test.yml
     with:
       hive_target: kurtosis

--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'paradigmxyz/reth'
     name: build reproducible binaries
     runs-on: ${{ matrix.runner }}
     strategy:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   close-issues:
+    if: github.repository == 'paradigmxyz/reth'
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/sync-era.yml
+++ b/.github/workflows/sync-era.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   sync:
+    if: github.repository == 'paradigmxyz/reth'
     name: sync (${{ matrix.chain.bin }})
     runs-on: depot-ubuntu-latest
     env:

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   sync:
+    if: github.repository == 'paradigmxyz/reth'
     name: sync (${{ matrix.chain.bin }})
     runs-on: depot-ubuntu-latest
     env:


### PR DESCRIPTION
My inbox was getting bombed by CI failure emails from fork scheduled runs😧 — sync tests, docker nightly builds, kurtosis.....  On top of that, the cargo update workflow was auto-creating PRs on forks which makes no sense.

Noticed `hive.yml` already had a `github.repository == 'paradigmxyz/reth'` guard, so just applied the same pattern to the remaining 7 scheduled workflows.