### PR TITLE
ci: remove PR title comment steps

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -16,11 +16,8 @@ jobs:
   conventional-title:
     name: Validate PR title is Conventional Commit
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     steps:
       - name: Check title
-        id: lint_pr_title
         uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -37,50 +34,3 @@ jobs:
             ci
             revert
             deps
-        continue-on-error: true
-      - name: Add PR Comment for Invalid Title
-        if: steps.lint_pr_title.outcome == 'failure'
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: pr-title-lint-error
-          message: |
-            Your PR title doesn't follow the Conventional Commit guidelines.
-
-            **Example of valid titles:**
-            - `feat: add new user login`
-            - `fix: correct button size`
-            - `docs: update README`
-
-            **Usage:**
-            - `feat`: Introduces a new feature
-            - `fix`: Patches a bug
-            - `chore`: General maintenance tasks or updates
-            - `test`: Adding new tests or modifying existing tests
-            - `bench`: Adding new benchmarks or modifying existing benchmarks
-            - `perf`: Performance improvements
-            - `refactor`: Changes to improve code structure
-            - `docs`: Documentation updates
-            - `ci`: Changes to CI/CD configurations
-            - `revert`: Reverts a previously merged PR
-            - `deps`: Updates dependencies
-
-            **Breaking Changes**
-
-            Breaking changes are noted by using an exclamation mark. For example:
-            - `feat!: changed the API`
-            - `chore(node)!: Removed unused public function`
-
-            **Help**
-
-            For more information, follow the guidelines here: https://www.conventionalcommits.org/en/v1.0.0/
-
-      - name: Remove Comment for Valid Title
-        if: steps.lint_pr_title.outcome == 'success'
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: pr-title-lint-error
-          delete: true
-
-      - name: Fail workflow if title invalid
-        if: steps.lint_pr_title.outcome == 'failure'
-        run: exit 1


### PR DESCRIPTION
## Summary
Remove the sticky comment steps from the PR title validation workflow.

## Motivation
The comment steps require `pull-requests: write` and use `marocchino/sticky-pull-request-comment` which can fail when GitHub services are degraded, causing spurious CI failures even when the title is valid. The `continue-on-error: true` + outcome check pattern also means any action error (not just validation failure) triggers the comment.

Example: https://github.com/paradigmxyz/reth/actions/runs/21870695919/job/63124666513

## Changes
- Removed `Add PR Comment for Invalid Title` step
- Removed `Remove Comment for Valid Title` step  
- Removed `Fail workflow if title invalid` step (the action itself exits non-zero on invalid titles)
- Dropped `pull-requests: write` permission (no longer needed)
- Removed `continue-on-error: true` (let the action fail the job directly)

The check name "Validate PR title is Conventional Commit" is self-explanatory enough.