### PR TITLE
perf(trie): reduce allocations in sparse trie hot paths

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -947,7 +947,7 @@ where
                 trace!(target: "engine::tree::payload_processor::sparse_trie", ?slot_nibbles, "Updating storage slot");
                 storage_trie.update_leaf(
                     slot_nibbles,
-                    alloy_rlp::encode_fixed_size(&value).to_vec(),
+                    &alloy_rlp::encode_fixed_size(&value),
                     &storage_provider,
                 )?;
             }

--- a/crates/stateless/src/trie.rs
+++ b/crates/stateless/src/trie.rs
@@ -261,7 +261,7 @@ fn calculate_state_root(
             } else {
                 storage_trie.update_leaf(
                     nibbles,
-                    alloy_rlp::encode_fixed_size(&value).to_vec(),
+                    &alloy_rlp::encode_fixed_size(&value),
                     &storage_provider,
                 )?;
             }
@@ -300,7 +300,7 @@ fn calculate_state_root(
         if let Some(account) = account {
             account_rlp_buf.clear();
             account.into_trie_account(storage_root).encode(&mut account_rlp_buf);
-            trie.update_account_leaf(nibbles, account_rlp_buf.clone(), &provider_factory)?;
+            trie.update_account_leaf(nibbles, &account_rlp_buf, &provider_factory)?;
         } else {
             trie.remove_account_leaf(&nibbles, &provider_factory)?;
         }

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -945,7 +945,7 @@ where
     pub fn update_account_leaf(
         &mut self,
         path: Nibbles,
-        value: Vec<u8>,
+        value: &[u8],
         provider_factory: impl TrieNodeProviderFactory,
     ) -> SparseStateTrieResult<()> {
         if !self.revealed_account_paths.contains(&path) {
@@ -962,7 +962,7 @@ where
         &mut self,
         address: B256,
         slot: Nibbles,
-        value: Vec<u8>,
+        value: &[u8],
         provider_factory: impl TrieNodeProviderFactory,
     ) -> SparseStateTrieResult<()> {
         let provider = provider_factory.storage_node_provider(address);
@@ -1012,7 +1012,10 @@ where
         let nibbles = Nibbles::unpack(address);
         self.account_rlp_buf.clear();
         account.into_trie_account(storage_root).encode(&mut self.account_rlp_buf);
-        self.update_account_leaf(nibbles, self.account_rlp_buf.clone(), provider_factory)?;
+        let value = core::mem::take(&mut self.account_rlp_buf);
+        let result = self.update_account_leaf(nibbles, &value, provider_factory);
+        self.account_rlp_buf = value;
+        result?;
 
         Ok(true)
     }
@@ -1065,7 +1068,10 @@ where
         let nibbles = Nibbles::unpack(address);
         self.account_rlp_buf.clear();
         trie_account.encode(&mut self.account_rlp_buf);
-        self.update_account_leaf(nibbles, self.account_rlp_buf.clone(), provider_factory)?;
+        let value = core::mem::take(&mut self.account_rlp_buf);
+        let result = self.update_account_leaf(nibbles, &value, provider_factory);
+        self.account_rlp_buf = value;
+        result?;
 
         Ok(true)
     }
@@ -2090,7 +2096,7 @@ mod tests {
         sparse
             .update_account_leaf(
                 address_path_3,
-                alloy_rlp::encode(trie_account_3),
+                &alloy_rlp::encode(trie_account_3),
                 &provider_factory,
             )
             .unwrap();
@@ -2099,7 +2105,7 @@ mod tests {
             .update_storage_leaf(
                 address_1,
                 slot_path_3,
-                alloy_rlp::encode(value_3),
+                &alloy_rlp::encode(value_3),
                 &provider_factory,
             )
             .unwrap();
@@ -2107,7 +2113,7 @@ mod tests {
         sparse
             .update_account_leaf(
                 address_path_1,
-                alloy_rlp::encode(trie_account_1),
+                &alloy_rlp::encode(trie_account_1),
                 &provider_factory,
             )
             .unwrap();
@@ -2117,7 +2123,7 @@ mod tests {
         sparse
             .update_account_leaf(
                 address_path_2,
-                alloy_rlp::encode(trie_account_2),
+                &alloy_rlp::encode(trie_account_2),
                 &provider_factory,
             )
             .unwrap();

--- a/crates/trie/sparse/src/traits.rs
+++ b/crates/trie/sparse/src/traits.rs
@@ -155,7 +155,7 @@ pub trait SparseTrie: Sized + Debug + Send + Sync {
     fn update_leaf<P: TrieNodeProvider>(
         &mut self,
         full_path: Nibbles,
-        value: Vec<u8>,
+        value: &[u8],
         provider: P,
     ) -> SparseTrieResult<()>;
 

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -2,7 +2,7 @@ use crate::{
     provider::TrieNodeProvider, LeafUpdate, ParallelSparseTrie, SparseTrie as SparseTrieTrait,
     SparseTrieExt, SparseTrieUpdates,
 };
-use alloc::{boxed::Box, vec::Vec};
+use alloc::boxed::Box;
 use alloy_primitives::{map::B256Map, B256};
 use reth_execution_errors::{SparseTrieErrorKind, SparseTrieResult};
 use reth_trie_common::{BranchNodeMasks, Nibbles, RlpNode, TrieMask, TrieNode};
@@ -211,7 +211,7 @@ impl<T: SparseTrieTrait> RevealableSparseTrie<T> {
     pub fn update_leaf(
         &mut self,
         path: Nibbles,
-        value: Vec<u8>,
+        value: &[u8],
         provider: impl TrieNodeProvider,
     ) -> SparseTrieResult<()> {
         let revealed = self.as_revealed_mut().ok_or(SparseTrieErrorKind::Blind)?;

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -172,7 +172,7 @@ where
                 let maybe_leaf_value = storage
                     .and_then(|s| s.storage.get(&hashed_slot))
                     .filter(|v| !v.is_zero())
-                    .map(|v| alloy_rlp::encode_fixed_size(v));
+                    .map(alloy_rlp::encode_fixed_size);
 
                 if let Some(value) = maybe_leaf_value {
                     storage_trie.update_leaf(storage_nibbles, &value, &provider).map_err(

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -172,12 +172,17 @@ where
                 let maybe_leaf_value = storage
                     .and_then(|s| s.storage.get(&hashed_slot))
                     .filter(|v| !v.is_zero())
-                    .map(|v| alloy_rlp::encode_fixed_size(v).to_vec());
+                    .map(|v| alloy_rlp::encode_fixed_size(v));
 
                 if let Some(value) = maybe_leaf_value {
-                    storage_trie.update_leaf(storage_nibbles, value, &provider).map_err(|err| {
-                        SparseStateTrieErrorKind::SparseStorageTrie(hashed_address, err.into_kind())
-                    })?;
+                    storage_trie.update_leaf(storage_nibbles, &value, &provider).map_err(
+                        |err| {
+                            SparseStateTrieErrorKind::SparseStorageTrie(
+                                hashed_address,
+                                err.into_kind(),
+                            )
+                        },
+                    )?;
                 } else {
                     storage_trie.remove_leaf(&storage_nibbles, &provider).map_err(|err| {
                         SparseStateTrieErrorKind::SparseStorageTrie(hashed_address, err.into_kind())


### PR DESCRIPTION
## Summary

Change `update_leaf`, `update_account_leaf`, and `update_storage_leaf` signatures from `Vec<u8>` to `&[u8]`.

Rebased version of #21931 onto current main (after the sparse-parallel crate merge).

## Motivation

The original PR claimed profiling showed allocation bottlenecks — there was no profiling data. The "bottlenecks" were identified by code reading, not measurement. This is an API cleanup, not a proven optimization.

## Honest allocation accounting

The trie stores leaf values as `HashMap<Nibbles, Vec<u8>>`, so every leaf insertion **must** allocate one `Vec<u8>` regardless of the API. This PR does **not** reduce the number of heap allocations — it moves them from callers to callees.

| Call site | Before | After | Net |
|-----------|--------|-------|-----|
| `sparse_trie.rs` (engine) | `encode_fixed_size().to_vec()` → move into map | `&encode_fixed_size()` → `.to_vec()` inside trie | **neutral** (1 alloc + 1 copy both ways) |
| `stateless/trie.rs` (storage) | same as above | same as above | **neutral** |
| `stateless/trie.rs` (account) | `account_rlp_buf.clone()` → move into map | `&account_rlp_buf` → `.to_vec()` inside trie | **neutral** (clone = to_vec) |
| `state.rs` `update_account` (×2) | `account_rlp_buf.clone()` → move into map | `mem::take` + `&value` → `.to_vec()` inside trie | **neutral** |
| `witness.rs` | `encode_fixed_size().to_vec()` → move into map | `encode_fixed_size()` → `&value` → `.to_vec()` inside trie | **neutral** |

### What this actually improves

- **API cleanliness**: callers no longer need `.to_vec()` / `.clone()` boilerplate to satisfy the `Vec<u8>` parameter
- **Borrow flexibility**: callers with stack-allocated values (`FixedBytes`, `ArrayVec`, etc.) can pass a reference directly

### What would actually reduce allocations

To genuinely save the per-leaf allocation, the trie would need to either:
1. Accept `Cow<'_, [u8]>` or have both `update_leaf(&[u8])` and `update_leaf_owned(Vec<u8>)`, so callers with owned data can move instead of copy
2. Use inline storage (`SmallVec<[u8; 64]>`) for small leaf values
3. Use a bump allocator / arena for leaf values within a block

None of these are in scope here.

## Testing

```
cargo test -p reth-trie-sparse --lib  # 100/100 passed
cargo check -p reth-trie-sparse -p reth-engine-tree -p reth-stateless -p reth-trie
```

Thread: https://tempoxyz.slack.com/archives/C0A87C21805/p1770746698863869