### PR TITLE
chore: move jemalloc, asm-keccak, min-debug-logs to default features

### DIFF
--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -38,7 +38,7 @@ jobs:
           cache-on-failure: true
       - name: Build reth
         run: |
-          cargo install --features asm-keccak,jemalloc --path bin/reth
+          cargo install --path bin/reth
       - name: Run headers stage
         run: |
           reth stage run headers --from ${{ env.FROM_BLOCK }} --to ${{ env.TO_BLOCK }} --commit --checkpoints

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -381,7 +381,7 @@ cargo nextest run --workspace
 cargo bench --bench bench_name
 
 # Build optimized binary
-cargo build --release --features "jemalloc asm-keccak"
+cargo build --release
 
 # Check compilation for all features
 cargo check --workspace --all-features

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ FULL_DB_TOOLS_DIR := $(shell pwd)/$(DB_TOOLS_DIR)/
 CARGO_TARGET_DIR ?= target
 
 # List of features to use when building. Can be overridden via the environment.
-# jemalloc, asm-keccak, and min-debug-logs are already default features.
 FEATURES ?=
 
 # Cargo profile for builds. Default is for local builds, CI uses an override.
@@ -242,7 +241,7 @@ maxperf: ## Builds `reth` with the most aggressive optimisations.
 
 .PHONY: maxperf-no-asm
 maxperf-no-asm: ## Builds `reth` with the most aggressive optimisations, minus the "asm-keccak" feature.
-	RUSTFLAGS="-C target-cpu=native" cargo build --profile maxperf --no-default-features --features jemalloc,min-debug-logs,otlp,otlp-logs,reth-revm/portable,js-tracer,keccak-cache-global,rocksdb
+	RUSTFLAGS="-C target-cpu=native" cargo build --profile maxperf
 
 
 fmt:

--- a/Makefile
+++ b/Makefile
@@ -241,8 +241,7 @@ maxperf: ## Builds `reth` with the most aggressive optimisations.
 
 .PHONY: maxperf-no-asm
 maxperf-no-asm: ## Builds `reth` with the most aggressive optimisations, minus the "asm-keccak" feature.
-	RUSTFLAGS="-C target-cpu=native" cargo build --profile maxperf
-
+	RUSTFLAGS="-C target-cpu=native" cargo build --profile maxperf --no-default-features --features jemalloc,min-debug-logs,otlp,otlp-logs,reth-revm/portable,js-tracer,keccak-cache-global,rocksdb
 
 fmt:
 	cargo +nightly fmt

--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,8 @@ FULL_DB_TOOLS_DIR := $(shell pwd)/$(DB_TOOLS_DIR)/
 CARGO_TARGET_DIR ?= target
 
 # List of features to use when building. Can be overridden via the environment.
-# No jemalloc on Windows
-ifeq ($(OS),Windows_NT)
-    FEATURES ?= asm-keccak min-debug-logs
-else
-    FEATURES ?= jemalloc asm-keccak min-debug-logs
-endif
+# jemalloc, asm-keccak, and min-debug-logs are already default features.
+FEATURES ?=
 
 # Cargo profile for builds. Default is for local builds, CI uses an override.
 PROFILE ?= release
@@ -238,15 +234,15 @@ update-book-cli: build-debug ## Update book cli documentation.
 
 .PHONY: profiling
 profiling: ## Builds `reth` with optimisations, but also symbols.
-	RUSTFLAGS="-C target-cpu=native" cargo build --profile profiling --features jemalloc,asm-keccak
+	RUSTFLAGS="-C target-cpu=native" cargo build --profile profiling
 
 .PHONY: maxperf
 maxperf: ## Builds `reth` with the most aggressive optimisations.
-	RUSTFLAGS="-C target-cpu=native" cargo build --profile maxperf --features jemalloc,asm-keccak
+	RUSTFLAGS="-C target-cpu=native" cargo build --profile maxperf
 
 .PHONY: maxperf-no-asm
 maxperf-no-asm: ## Builds `reth` with the most aggressive optimisations, minus the "asm-keccak" feature.
-	RUSTFLAGS="-C target-cpu=native" cargo build --profile maxperf --features jemalloc
+	RUSTFLAGS="-C target-cpu=native" cargo build --profile maxperf --no-default-features --features jemalloc,min-debug-logs,otlp,otlp-logs,reth-revm/portable,js-tracer,keccak-cache-global,rocksdb
 
 
 fmt:

--- a/bin/reth-bench-compare/README.md
+++ b/bin/reth-bench-compare/README.md
@@ -30,7 +30,7 @@ reth-bench-compare \
 | `--draw` | Generate charts (needs Python/uv) | `false` | No |
 | `--profile` | Enable CPU profiling (needs samply) | `false` | No |
 | `-vvvv` | Debug logging | Info | No |
-| `--features <FEATURES>` | Rust features for both builds | `jemalloc,asm-keccak` | No |
+| `--features <FEATURES>` | Extra Rust features for both builds | - | No |
 | `--rustflags <FLAGS>` | RUSTFLAGS for both builds | `-C target-cpu=native` | No |
 | `--baseline-features <FEATURES>` | Features for baseline only | Inherits `--features` | No |
 | `--feature-features <FEATURES>` | Features for feature only | Inherits `--features` | No |

--- a/bin/reth-bench-compare/src/cli.rs
+++ b/bin/reth-bench-compare/src/cli.rs
@@ -191,10 +191,9 @@ pub(crate) struct Args {
     #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     pub reth_args: Vec<String>,
 
-    /// Comma-separated list of features to enable during reth compilation (applied to both builds)
-    ///
-    /// Example: `jemalloc,asm-keccak`
-    #[arg(long, value_name = "FEATURES", default_value = "jemalloc,asm-keccak")]
+    /// Comma-separated list of extra features to enable during reth compilation (applied to both
+    /// builds)
+    #[arg(long, value_name = "FEATURES", default_value = "")]
     pub features: String,
 
     /// Comma-separated list of features to enable only for baseline build (overrides --features)
@@ -205,7 +204,7 @@ pub(crate) struct Args {
 
     /// Comma-separated list of features to enable only for feature build (overrides --features)
     ///
-    /// Example: `--feature-features jemalloc,asm-keccak`
+    /// Example: `--feature-features jemalloc-prof`
     #[arg(long, value_name = "FEATURES")]
     pub feature_features: Option<String>,
 

--- a/bin/reth-bench/README.md
+++ b/bin/reth-bench/README.md
@@ -73,7 +73,7 @@ make profiling
 
 If the purpose of the benchmark is to obtain `jemalloc` memory profiles that can then be analyzed by `jeprof`, it should be compiled with the `profiling` profile and the `jemalloc-prof` feature:
 ```bash
-RUSTFLAGS="-C target-cpu=native" cargo build --profile profiling --features "jemalloc-prof,asm-keccak"
+RUSTFLAGS="-C target-cpu=native" cargo build --profile profiling --features "jemalloc-prof"
 ```
 
 > [!NOTE]
@@ -82,7 +82,7 @@ RUSTFLAGS="-C target-cpu=native" cargo build --profile profiling --features "jem
 Finally, if the purpose of the benchmark is to profile the node when `snmalloc` is configured as the default allocator, it would be built with the following
 command:
 ```bash
-RUSTFLAGS="-C target-cpu=native" cargo build --profile profiling --no-default-features --features "snmalloc-native,asm-keccak"
+RUSTFLAGS="-C target-cpu=native" cargo build --profile profiling --no-default-features --features "snmalloc-native,asm-keccak,min-debug-logs"
 ```
 
 ### Run the Benchmark:

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -89,6 +89,7 @@ default = [
     "js-tracer",
     "keccak-cache-global",
     "asm-keccak",
+    "min-debug-logs",
     "rocksdb",
 ]
 

--- a/bin/reth/src/lib.rs
+++ b/bin/reth/src/lib.rs
@@ -37,6 +37,7 @@
 //! - `min-warn-logs`: Disables all logs below `warn` level.
 //! - `min-info-logs`: Disables all logs below `info` level. This can speed up the node, since fewer
 //!   calls to the logging component are made.
+//! - `min-debug-logs`: Disables all logs below `debug` level.
 //! - `min-trace-logs`: Disables all logs below `trace` level.
 //!
 //! ### Development Features

--- a/bin/reth/src/lib.rs
+++ b/bin/reth/src/lib.rs
@@ -15,6 +15,7 @@
 //! - `asm-keccak`: Replaces the default, pure-Rust implementation of Keccak256 with one implemented
 //!   in assembly; see [the `keccak-asm` crate](https://github.com/DaniPopes/keccak-asm) for more
 //!   details and supported targets.
+//! - `min-debug-logs`: Disables all logs below `debug` level.
 //!
 //! ### Allocator Features
 //!
@@ -36,7 +37,6 @@
 //! - `min-warn-logs`: Disables all logs below `warn` level.
 //! - `min-info-logs`: Disables all logs below `info` level. This can speed up the node, since fewer
 //!   calls to the logging component are made.
-//! - `min-debug-logs`: Disables all logs below `debug` level.
 //! - `min-trace-logs`: Disables all logs below `trace` level.
 //!
 //! ### Development Features

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -13,7 +13,7 @@ variable "BUILD_PROFILE" {
 }
 
 variable "FEATURES" {
-  default = "jemalloc asm-keccak min-debug-logs"
+  default = ""
 }
 
 // Git info for vergen (since .git is excluded from Docker context)
@@ -77,7 +77,7 @@ target "ethereum-profiling" {
     BINARY        = "reth"
     MANIFEST_PATH = "bin/reth"
     BUILD_PROFILE = "profiling"
-    FEATURES      = "jemalloc jemalloc-prof asm-keccak min-debug-logs"
+    FEATURES      = "jemalloc-prof"
   }
   tags = ["${REGISTRY}/reth:nightly-profiling"]
 }
@@ -88,7 +88,7 @@ target "ethereum-edge-profiling" {
     BINARY        = "reth"
     MANIFEST_PATH = "bin/reth"
     BUILD_PROFILE = "profiling"
-    FEATURES      = "jemalloc jemalloc-prof asm-keccak min-debug-logs edge"
+    FEATURES      = "jemalloc-prof edge"
   }
   tags = ["${REGISTRY}/reth:nightly-edge-profiling"]
 }
@@ -111,7 +111,6 @@ target "hive-stable" {
   args = {
     BINARY        = "reth"
     MANIFEST_PATH = "bin/reth"
-    FEATURES      = "asm-keccak"
   }
   tags   = ["reth:local"]
   output = ["type=docker,dest=${HIVE_OUTPUT_DIR}/reth_image.tar"]
@@ -122,7 +121,7 @@ target "hive-edge" {
   args = {
     BINARY        = "reth"
     MANIFEST_PATH = "bin/reth"
-    FEATURES      = "asm-keccak edge"
+    FEATURES      = "edge"
   }
   tags   = ["reth:local"]
   output = ["type=docker,dest=${HIVE_OUTPUT_DIR}/reth_image.tar"]
@@ -134,7 +133,6 @@ target "kurtosis" {
   args = {
     BINARY        = "reth"
     MANIFEST_PATH = "bin/reth"
-    FEATURES      = "asm-keccak"
   }
   tags   = ["ghcr.io/paradigmxyz/reth:kurtosis-ci"]
   output = ["type=docker,dest=${HIVE_OUTPUT_DIR}/reth_image.tar"]

--- a/docs/vocs/docs/pages/installation/source.mdx
+++ b/docs/vocs/docs/pages/installation/source.mdx
@@ -110,18 +110,16 @@ RUSTFLAGS="-C target-cpu=native" cargo build --profile maxperf
 
 **Features**
 
-Finally, some optional features are present that may improve performance, but may not very portable,
-and as such might not compile on your particular system. These are currently:
+The following performance features are enabled by default: `jemalloc` (except on Windows), `asm-keccak`, and `min-debug-logs`.
 
--   `jemalloc`: replaces the default system memory allocator with [`jemalloc`](https://jemalloc.net/); this feature is unstable on Windows
--   `asm-keccak`: replaces the default, pure-Rust implementation of Keccak256 with one implemented in assembly; see [the `keccak-asm` crate](https://github.com/DaniPopes/keccak-asm) for more details and supported targets
--   `min-LEVEL-logs`, where `LEVEL` is one of `error`, `warn`, `info`, `debug`, `trace`: disables compilation of logs of lower level than the given one; this in general isn't that significant, and is not recommended due to the loss of debugging that the logs would provide
+Some additional optional features are available:
 
-You can activate features by passing them to the `--features` or `-F` Cargo flag;
-multiple features can be activated with a space- or comma-separated list to the flag:
+-   `min-LEVEL-logs`, where `LEVEL` is one of `error`, `warn`, `info`, `debug`, `trace`: disables compilation of logs of lower level than the given one; `min-debug-logs` is enabled by default
+
+You can build with maximum performance optimizations using:
 
 ```bash
-RUSTFLAGS="-C target-cpu=native" cargo build --profile maxperf --features jemalloc,asm-keccak
+RUSTFLAGS="-C target-cpu=native" cargo build --profile maxperf
 ```
 
 ## Troubleshooting

--- a/flake.nix
+++ b/flake.nix
@@ -58,7 +58,6 @@
 
         withMaxPerf = prev: {
           cargoBuildCommand = "cargo build --profile=maxperf";
-          cargoExtraArgs = prev.cargoExtraArgs or "" + " --features=jemalloc,asm-keccak";
           RUSTFLAGS = prev.RUSTFLAGS or [] ++ [
             "-Ctarget-cpu=native"
           ];


### PR DESCRIPTION
## Summary
Add `min-debug-logs` to `bin/reth` default features (`jemalloc` and `asm-keccak` were already defaults) and remove redundant explicit `--features` flags everywhere.

## Changes
- `bin/reth/Cargo.toml`: add `min-debug-logs` to `default`
- `Makefile`: remove `jemalloc asm-keccak min-debug-logs` from `FEATURES`, remove redundant `--features` from `profiling`/`maxperf` targets, fix `maxperf-no-asm` to use `--no-default-features`
- `docker-bake.hcl`: clear default `FEATURES`, remove redundant feature lists from targets
- `flake.nix`: remove `--features=jemalloc,asm-keccak` from `withMaxPerf`
- Update docs in `bin/reth/src/lib.rs`, `bin/reth-bench/README.md`, `docs/vocs/`

Thread: https://tempoxyz.slack.com/archives/C0A87C21805/p1770752866702069