### PR TITLE
chore: remove maxperf-no-asm Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,10 +239,6 @@ profiling: ## Builds `reth` with optimisations, but also symbols.
 maxperf: ## Builds `reth` with the most aggressive optimisations.
 	RUSTFLAGS="-C target-cpu=native" cargo build --profile maxperf
 
-.PHONY: maxperf-no-asm
-maxperf-no-asm: ## Builds `reth` with the most aggressive optimisations, minus the "asm-keccak" feature.
-	RUSTFLAGS="-C target-cpu=native" cargo build --profile maxperf
-
 
 fmt:
 	cargo +nightly fmt


### PR DESCRIPTION
Remove `maxperf-no-asm` target — it was already broken since `asm-keccak` is a default feature and can't be excluded without `--no-default-features`.

Stacked on #22034.

Thread: https://tempoxyz.slack.com/archives/C0A87C21805/p1770752866702069