### PR TITLE
fix(reth-bench): increase WS keepalive interval to match persistence timeout

### DIFF
--- a/bin/reth-bench/src/bench/new_payload_fcu.rs
+++ b/bin/reth-bench/src/bench/new_payload_fcu.rs
@@ -117,7 +117,7 @@ impl Command {
                     self.benchmark.ws_rpc_url.as_deref(),
                     &self.benchmark.engine_rpc_url,
                 )?;
-                let sub = setup_persistence_subscription(ws_url).await?;
+                let sub = setup_persistence_subscription(ws_url, self.persistence_timeout).await?;
                 Some(PersistenceWaiter::with_duration_and_subscription(
                     duration,
                     sub,
@@ -131,7 +131,7 @@ impl Command {
                     self.benchmark.ws_rpc_url.as_deref(),
                     &self.benchmark.engine_rpc_url,
                 )?;
-                let sub = setup_persistence_subscription(ws_url).await?;
+                let sub = setup_persistence_subscription(ws_url, self.persistence_timeout).await?;
                 Some(PersistenceWaiter::with_subscription(
                     sub,
                     self.persistence_threshold,

--- a/bin/reth-bench/src/bench/persistence_waiter.rs
+++ b/bin/reth-bench/src/bench/persistence_waiter.rs
@@ -155,7 +155,7 @@ impl PersistenceSubscription {
 
 /// Establishes a websocket connection and subscribes to `reth_subscribePersistedBlock`.
 ///
-/// The `keepalive_interval` is set to match `persistence_timeout` so that the WebSocket
+/// The `keepalive_interval` is set to match `persistence_timeout` so that the `WebSocket`
 /// connection is not dropped during long MDBX commits that block the server from responding
 /// to pings.
 pub(crate) async fn setup_persistence_subscription(

--- a/bin/reth-bench/src/bench/persistence_waiter.rs
+++ b/bin/reth-bench/src/bench/persistence_waiter.rs
@@ -154,12 +154,18 @@ impl PersistenceSubscription {
 }
 
 /// Establishes a websocket connection and subscribes to `reth_subscribePersistedBlock`.
+///
+/// The `keepalive_interval` is set to match `persistence_timeout` so that the WebSocket
+/// connection is not dropped during long MDBX commits that block the server from responding
+/// to pings.
 pub(crate) async fn setup_persistence_subscription(
     ws_url: Url,
+    persistence_timeout: Duration,
 ) -> eyre::Result<PersistenceSubscription> {
     info!(target: "reth-bench", "Connecting to WebSocket at {} for persistence subscription", ws_url);
 
-    let ws_connect = WsConnect::new(ws_url.to_string());
+    let ws_connect =
+        WsConnect::new(ws_url.to_string()).with_keepalive_interval(persistence_timeout);
     let client = RpcClient::connect_pubsub(ws_connect)
         .await
         .wrap_err("Failed to connect to WebSocket RPC endpoint")?;

--- a/bin/reth-bench/src/bench/replay_payloads.rs
+++ b/bin/reth-bench/src/bench/replay_payloads.rs
@@ -166,7 +166,7 @@ impl Command {
         let mut waiter = match (self.wait_time, self.wait_for_persistence) {
             (Some(duration), true) => {
                 let ws_url = derive_ws_rpc_url(self.ws_rpc_url.as_deref(), &self.engine_rpc_url)?;
-                let sub = setup_persistence_subscription(ws_url).await?;
+                let sub = setup_persistence_subscription(ws_url, self.persistence_timeout).await?;
                 Some(PersistenceWaiter::with_duration_and_subscription(
                     duration,
                     sub,
@@ -177,7 +177,7 @@ impl Command {
             (Some(duration), false) => Some(PersistenceWaiter::with_duration(duration)),
             (None, true) => {
                 let ws_url = derive_ws_rpc_url(self.ws_rpc_url.as_deref(), &self.engine_rpc_url)?;
-                let sub = setup_persistence_subscription(ws_url).await?;
+                let sub = setup_persistence_subscription(ws_url, self.persistence_timeout).await?;
                 Some(PersistenceWaiter::with_subscription(
                     sub,
                     self.persistence_threshold,


### PR DESCRIPTION
## Summary
Set WS keepalive interval to match the persistence timeout so the persistence subscription survives long MDBX commits.

## Motivation
reth-bench workflows are failing with `Persistence timeout: target block X not persisted within 120s. Last persisted: 0`. Root cause: MDBX commits take 30-40s, during which the node can't respond to WS pings. The default alloy WS keepalive is 10s, so after ~20s without a pong the transport reconnects, dropping the `reth_subscribePersistedBlock` subscription. The persistence notification fires during reconnection and is lost, causing a timeout.

## Changes
- Pass `persistence_timeout` to `setup_persistence_subscription()`
- Use it as the WS `keepalive_interval` via `WsConnect::with_keepalive_interval()`
- Affects both `new_payload_fcu` and `replay_payloads` commands

## Testing
`cargo test -p reth-bench` — all 9 tests pass.