### PR TITLE
fix(consistent): actually use range in storage range query

### DIFF
--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -1409,6 +1409,10 @@ impl<N: ProviderNodeTypes> StorageChangeSetReader for ConsistentProvider<N> {
 
             let chain = head_block.chain().collect::<Vec<_>>();
             for state in chain {
+                if !range.contains(&state.number()) {
+                    continue;
+                }
+
                 let block_changesets = state
                     .block_ref()
                     .execution_output
@@ -1588,6 +1592,10 @@ impl<N: ProviderNodeTypes> ChangeSetReader for ConsistentProvider<N> {
 
             let chain = head_block.chain().collect::<Vec<_>>();
             for state in chain {
+                if !range.contains(&state.number()) {
+                    continue;
+                }
+
                 // found block in memory, collect its changesets
                 let block_changesets = state
                     .block_ref()


### PR DESCRIPTION
We didn't actually use the range in this fn so it just returns everything, this now skips things not part of the range