### PR TITLE
perf: downgrade on_hashed_state_update and on_prewarm_targets spans to trace

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -590,11 +590,7 @@ where
             return
         };
 
-        while let Ok(IndexedTransaction { index, tx }) = {
-            let _enter = debug_span!(target: "engine::tree::payload_processor::prewarm", "recv tx")
-                .entered();
-            txs.recv()
-        } {
+        while let Ok(IndexedTransaction { index, tx }) = txs.recv() {
             let enter = debug_span!(
                 target: "engine::tree::payload_processor::prewarm",
                 "prewarm tx",

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -486,7 +486,7 @@ where
     }
 
     #[instrument(
-        level = "debug",
+        level = "trace",
         target = "engine::tree::payload_processor::sparse_trie",
         skip_all
     )]
@@ -518,7 +518,7 @@ where
 
     /// Processes a hashed state update and encodes all state changes as trie updates.
     #[instrument(
-        level = "debug",
+        level = "trace",
         target = "engine::tree::payload_processor::sparse_trie",
         skip_all
     )]


### PR DESCRIPTION
## Summary

Downgrades `on_hashed_state_update` and `on_prewarm_targets` tracing spans from `debug` to `trace`.

## Motivation

These spans fire ~1.4M times per block. With opentelemetry overhead (alloc + channel send + span new/enter/exit/drop), they account for significant CPU time — profiling shows tracing spans are ~70% of the cost in hot paths. Since both functions typically complete in <1us, the span overhead dominates.

## Changes

- Downgraded `on_prewarm_targets` span to `trace` in `sparse_trie.rs`
- Downgraded `on_hashed_state_update` span to `trace` in `sparse_trie.rs`

## Testing

reth-bench pending.