### PR TITLE
chore(docker): pass RUSTC_WRAPPER to cargo build in Dockerfile.depot

### DIFF
--- a/Dockerfile.depot
+++ b/Dockerfile.depot
@@ -51,13 +51,14 @@ RUN --mount=type=secret,id=DEPOT_TOKEN,env=SCCACHE_WEBDAV_TOKEN \
     --mount=type=cache,target=/usr/local/cargo/registry,sharing=shared \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=shared \
     --mount=type=cache,target=$SCCACHE_DIR,sharing=shared \
-    SCCACHE_WEBDAV_ENDPOINT=https://cache.depot.dev SCCACHE_DIR=/sccache sccache --start-server && \
+    export RUSTC_WRAPPER=sccache SCCACHE_WEBDAV_ENDPOINT=https://cache.depot.dev SCCACHE_DIR=/sccache && \
+    sccache --start-server && \
     if [ -n "$RUSTFLAGS" ]; then \
         export RUSTFLAGS="$RUSTFLAGS"; \
     elif [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
         export RUSTFLAGS="-C target-cpu=x86-64-v3 -C target-feature=+pclmulqdq"; \
     fi && \
-    RUSTC_WRAPPER=sccache cargo build --profile $BUILD_PROFILE --features "$FEATURES" --locked --bin $BINARY --manifest-path $MANIFEST_PATH/Cargo.toml && \
+    cargo build --profile $BUILD_PROFILE --features "$FEATURES" --locked --bin $BINARY --manifest-path $MANIFEST_PATH/Cargo.toml && \
     sccache --show-stats
 
 # Copy binary to a known location (ARG not resolved in COPY)

--- a/Dockerfile.depot
+++ b/Dockerfile.depot
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y libclang-dev pkg-config
 
 # Install sccache for compilation caching
 RUN cargo install sccache --locked
+ENV RUSTC_WRAPPER=sccache
 ENV SCCACHE_DIR=/sccache
 ENV SCCACHE_WEBDAV_ENDPOINT=https://cache.depot.dev
 

--- a/Dockerfile.depot
+++ b/Dockerfile.depot
@@ -14,7 +14,8 @@ RUN apt-get update && apt-get install -y libclang-dev pkg-config
 
 # Install sccache for compilation caching
 RUN cargo install sccache --locked
-ENV RUSTC_WRAPPER=sccache
+ARG RUSTC_WRAPPER=sccache
+ENV RUSTC_WRAPPER=$RUSTC_WRAPPER
 ENV SCCACHE_DIR=/sccache
 ENV SCCACHE_WEBDAV_ENDPOINT=https://cache.depot.dev
 

--- a/Dockerfile.depot
+++ b/Dockerfile.depot
@@ -14,8 +14,6 @@ RUN apt-get update && apt-get install -y libclang-dev pkg-config
 
 # Install sccache for compilation caching
 RUN cargo install sccache --locked
-ARG RUSTC_WRAPPER=sccache
-ENV RUSTC_WRAPPER=$RUSTC_WRAPPER
 ENV SCCACHE_DIR=/sccache
 ENV SCCACHE_WEBDAV_ENDPOINT=https://cache.depot.dev
 
@@ -58,7 +56,7 @@ RUN --mount=type=secret,id=DEPOT_TOKEN,env=SCCACHE_WEBDAV_TOKEN \
     elif [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
         export RUSTFLAGS="-C target-cpu=x86-64-v3 -C target-feature=+pclmulqdq"; \
     fi && \
-    cargo build --profile $BUILD_PROFILE --features "$FEATURES" --locked --bin $BINARY --manifest-path $MANIFEST_PATH/Cargo.toml && \
+    RUSTC_WRAPPER=sccache cargo build --profile $BUILD_PROFILE --features "$FEATURES" --locked --bin $BINARY --manifest-path $MANIFEST_PATH/Cargo.toml && \
     sccache --show-stats
 
 # Copy binary to a known location (ARG not resolved in COPY)


### PR DESCRIPTION
Passes `RUSTC_WRAPPER=sccache` inline to the `cargo build` command in `Dockerfile.depot`, matching the pattern used for `SCCACHE_WEBDAV_ENDPOINT` and `SCCACHE_DIR`.