### PR TITLE
chore(log): simplify default profiler tracing filter

### DIFF
--- a/crates/node/core/src/args/log.rs
+++ b/crates/node/core/src/args/log.rs
@@ -12,20 +12,7 @@ use tracing::{level_filters::LevelFilter, Level};
 /// Constant to convert megabytes to bytes
 const MB_TO_BYTES: u64 = 1024 * 1024;
 
-const PROFILER_TRACING_FILTER: &str = concat!(
-    "info",
-    ",engine=debug",
-    ",trie=debug",
-    ",providers=debug",
-    ",rpc=debug",
-    ",sync=debug",
-    ",pruner=debug",
-    ",libmdbx=debug",
-    ",jsonrpsee-server=debug",
-    ",jsonrpsee-core=debug",
-    ",jsonrpsee-http=debug",
-    ",jsonrpsee=debug",
-);
+const PROFILER_TRACING_FILTER: &str = "debug";
 
 /// The log configuration.
 #[derive(Debug, Args)]


### PR DESCRIPTION
Simplifies `PROFILER_TRACING_FILTER` from a verbose per-target filter to just `"debug"`.

The old default listed specific targets at debug level on top of a base info filter. Just using `debug` is simpler and captures everything needed when profiling.

Thread: https://tempoxyz.slack.com/archives/C0A87C21805/p1770783768615699