### PR TITLE
fix(trie): remove redundant is_deleted assignment in extend_ref

### DIFF
--- a/crates/trie/common/src/updates.rs
+++ b/crates/trie/common/src/updates.rs
@@ -786,7 +786,6 @@ impl StorageTrieUpdatesSorted {
 
         // Extend storage nodes
         extend_sorted_vec(&mut self.storage_nodes, &other.storage_nodes);
-        self.is_deleted = self.is_deleted || other.is_deleted;
     }
 
     /// Batch-merge sorted storage trie updates. Iterator yields **newest to oldest**.


### PR DESCRIPTION
The line `self.is_deleted = self.is_deleted || other.is_deleted` in `StorageTrieUpdatesSorted::extend_ref()` was unreachable with `other.is_deleted == true` because of the early return above. When reached, `other.is_deleted` is always false, making this a no-op assignment.