### PR TITLE
chore(engine): downgrade failed response delivery logs to warn

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1510,7 +1510,7 @@ where
                                         .engine
                                         .failed_forkchoice_updated_response_deliveries
                                         .increment(1);
-                                    error!(target: "engine::tree", ?state, elapsed=?start.elapsed(), "Failed to send event: {err:?}");
+                                    warn!(target: "engine::tree", ?state, elapsed=?start.elapsed(), "Failed to deliver forkchoiceUpdated response, receiver dropped (request cancelled): {err:?}");
                                 }
                             }
                             BeaconEngineMessage::NewPayload { payload, tx } => {
@@ -1534,7 +1534,7 @@ where
                                         BeaconOnNewPayloadError::Internal(Box::new(e))
                                     }))
                                 {
-                                    error!(target: "engine::tree", payload=?num_hash, elapsed=?start.elapsed(), "Failed to send event: {err:?}");
+                                    warn!(target: "engine::tree", payload=?num_hash, elapsed=?start.elapsed(), "Failed to deliver newPayload response, receiver dropped (request cancelled): {err:?}");
                                     self.metrics
                                         .engine
                                         .failed_new_payload_response_deliveries


### PR DESCRIPTION
## Summary
Downgrades the two "Failed to send event" error logs to `warn` and improves the messages to clarify these occur when the CL drops the HTTP request before the engine finishes processing (receiver dropped / request cancelled). This is expected behavior and not an error condition.

## Changes
- `error!` → `warn!` for forkchoiceUpdated and newPayload response delivery failures
- Improved log messages to indicate the receiver was dropped (request cancelled)

Thread: https://tempoxyz.slack.com/archives/C0A87C21805/p1770812012655349