### PR TITLE
feat(reth-bench): add gas-range measurement filter for small blocks benchmarking

### DIFF
--- a/.changelog/evil-clams-read.md
+++ b/.changelog/evil-clams-read.md
@@ -1,0 +1,6 @@
+---
+reth-bench-compare: minor
+reth-bench: minor
+---
+
+Added gas range filtering for benchmark measurements. Blocks with gas usage outside the specified `--measure-gas-min` and `--measure-gas-max` range are now executed but excluded from timing statistics, allowing more focused performance analysis of blocks within specific gas usage ranges.

--- a/bin/reth-bench-compare/src/benchmark.rs
+++ b/bin/reth-bench-compare/src/benchmark.rs
@@ -21,6 +21,8 @@ pub(crate) struct BenchmarkRunner {
     wait_for_persistence: bool,
     persistence_threshold: Option<u64>,
     warmup_blocks: u64,
+    measure_gas_min: Option<String>,
+    measure_gas_max: Option<String>,
 }
 
 impl BenchmarkRunner {
@@ -33,6 +35,8 @@ impl BenchmarkRunner {
             wait_for_persistence: args.wait_for_persistence,
             persistence_threshold: args.persistence_threshold,
             warmup_blocks: args.get_warmup_blocks(),
+            measure_gas_min: args.measure_gas_min.clone(),
+            measure_gas_max: args.measure_gas_max.clone(),
         }
     }
 
@@ -102,6 +106,13 @@ impl BenchmarkRunner {
             &to_block.to_string(),
             "--wait-time=0ms", // Warmup should avoid persistence waits.
         ]);
+
+        if let Some(ref gas_min) = self.measure_gas_min {
+            cmd.args(["--measure-gas-min", gas_min]);
+        }
+        if let Some(ref gas_max) = self.measure_gas_max {
+            cmd.args(["--measure-gas-max", gas_max]);
+        }
 
         cmd.env("RUST_LOG_STYLE", "never")
             .stdout(std::process::Stdio::piped())
@@ -185,6 +196,13 @@ impl BenchmarkRunner {
             "--output",
             &output_dir.to_string_lossy(),
         ]);
+
+        if let Some(ref gas_min) = self.measure_gas_min {
+            cmd.args(["--measure-gas-min", gas_min]);
+        }
+        if let Some(ref gas_max) = self.measure_gas_max {
+            cmd.args(["--measure-gas-max", gas_max]);
+        }
 
         // Configure wait mode: both can be used together
         // When both are set: wait at least wait_time, and also wait for persistence if needed

--- a/bin/reth-bench-compare/src/cli.rs
+++ b/bin/reth-bench-compare/src/cli.rs
@@ -140,13 +140,13 @@ pub(crate) struct Args {
     #[arg(long, value_name = "PERSISTENCE_THRESHOLD")]
     pub persistence_threshold: Option<u64>,
 
-    /// Minimum gas_used for a block to be included in benchmark measurements.
+    /// Minimum `gas_used` for a block to be included in benchmark measurements.
     /// Blocks below this threshold are still executed but excluded from timing stats.
     /// Accepts short notation: K for thousand, M for million, G for billion.
     #[arg(long, value_name = "GAS")]
     pub measure_gas_min: Option<String>,
 
-    /// Maximum gas_used for a block to be included in benchmark measurements.
+    /// Maximum `gas_used` for a block to be included in benchmark measurements.
     /// Blocks above this threshold are still executed but excluded from timing stats.
     /// Accepts short notation: K for thousand, M for million, G for billion.
     #[arg(long, value_name = "GAS")]

--- a/bin/reth-bench-compare/src/cli.rs
+++ b/bin/reth-bench-compare/src/cli.rs
@@ -140,6 +140,18 @@ pub(crate) struct Args {
     #[arg(long, value_name = "PERSISTENCE_THRESHOLD")]
     pub persistence_threshold: Option<u64>,
 
+    /// Minimum gas_used for a block to be included in benchmark measurements.
+    /// Blocks below this threshold are still executed but excluded from timing stats.
+    /// Accepts short notation: K for thousand, M for million, G for billion.
+    #[arg(long, value_name = "GAS")]
+    pub measure_gas_min: Option<String>,
+
+    /// Maximum gas_used for a block to be included in benchmark measurements.
+    /// Blocks above this threshold are still executed but excluded from timing stats.
+    /// Accepts short notation: K for thousand, M for million, G for billion.
+    #[arg(long, value_name = "GAS")]
+    pub measure_gas_max: Option<String>,
+
     /// Number of blocks to run for cache warmup after clearing caches.
     /// If not specified, defaults to the same as --blocks
     #[arg(long, value_name = "N")]


### PR DESCRIPTION
## Summary

Adds `--measure-gas-min` and `--measure-gas-max` flags to `reth-bench new-payload-fcu` and `reth-bench-compare` for focused benchmarking of specific gas ranges.

## Motivation

We need to benchmark reth's performance specifically on small blocks (0-20M gas) to identify tuning opportunities for typical mainnet block sizes. The existing `new-payload-fcu` benchmark replays all blocks indiscriminately, making it hard to isolate small block performance.

## Usage

```bash
# Benchmark only small blocks (0-20M gas)
reth-bench new-payload-fcu --measure-gas-max 20M ...

# Benchmark medium blocks (10-30M gas)  
reth-bench new-payload-fcu --measure-gas-min 10M --measure-gas-max 30M ...

# Via reth-bench-compare
reth-bench-compare --measure-gas-max 20M --baseline-ref main --feature-ref feat/optimize ...
```