### PR TITLE
fix: don't drop node

### DIFF
--- a/bin/reth/src/main.rs
+++ b/bin/reth/src/main.rs
@@ -10,7 +10,6 @@ static MALLOC_CONF: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
 use clap::Parser;
 use reth::cli::Cli;
 use reth_ethereum_cli::chainspec::EthereumChainSpecParser;
-use reth_node_builder::NodeHandle;
 use reth_node_ethereum::EthereumNode;
 use tracing::info;
 
@@ -24,10 +23,9 @@ fn main() {
 
     if let Err(err) = Cli::<EthereumChainSpecParser>::parse().run(async move |builder, _| {
         info!(target: "reth::cli", "Launching node");
-        let NodeHandle { node_exit_future, .. } =
-            builder.node(EthereumNode::default()).launch_with_debug_capabilities().await?;
+        let handle = builder.node(EthereumNode::default()).launch_with_debug_capabilities().await?;
 
-        node_exit_future.await
+        handle.wait_for_node_exit().await
     }) {
         eprintln!("Error: {err:?}");
         std::process::exit(1);

--- a/crates/tasks/src/runtime.rs
+++ b/crates/tasks/src/runtime.rs
@@ -793,9 +793,7 @@ impl RuntimeBuilder {
     /// The [`TaskManager`] is automatically spawned as a background task that monitors
     /// critical tasks for panics. Use [`Runtime::take_task_manager_handle`] to extract
     /// the join handle if you need to poll for panic errors.
-    #[tracing::instrument(level = "debug", skip_all)]
     pub fn build(self) -> Result<Runtime, RuntimeBuildError> {
-        debug!(?self.config, "Building runtime");
         let config = self.config;
 
         let (owned_runtime, handle) = match &config.tokio {

--- a/crates/tasks/src/runtime.rs
+++ b/crates/tasks/src/runtime.rs
@@ -793,7 +793,9 @@ impl RuntimeBuilder {
     /// The [`TaskManager`] is automatically spawned as a background task that monitors
     /// critical tasks for panics. Use [`Runtime::take_task_manager_handle`] to extract
     /// the join handle if you need to poll for panic errors.
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn build(self) -> Result<Runtime, RuntimeBuildError> {
+        debug!(?self.config, "Building runtime");
         let config = self.config;
 
         let (owned_runtime, handle) = match &config.tokio {


### PR DESCRIPTION
Fixes the RPC server immediately stopping after startup.

In #22057, `main.rs` changed from `let NodeHandle { node, node_exit_future }` to `let NodeHandle { node_exit_future, .. }`, which drops the `node` field immediately after launch. This drops the only `RpcServerHandle`, whose inner `ServerHandle(Arc<watch::Sender<()>>)` closes the jsonrpsee stop channel, causing the server accept loop to exit before any connections can be accepted.

The fix keeps the full `NodeHandle` alive by using `handle.wait_for_node_exit()` instead of destructuring.
