### PR TITLE
perf(engine): add PrewarmMode::Skipped to avoid spawning idle workers

### DIFF
--- a/bin/reth/src/main.rs
+++ b/bin/reth/src/main.rs
@@ -10,6 +10,7 @@ static MALLOC_CONF: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
 use clap::Parser;
 use reth::cli::Cli;
 use reth_ethereum_cli::chainspec::EthereumChainSpecParser;
+use reth_node_builder::NodeHandle;
 use reth_node_ethereum::EthereumNode;
 use tracing::info;
 
@@ -23,9 +24,10 @@ fn main() {
 
     if let Err(err) = Cli::<EthereumChainSpecParser>::parse().run(async move |builder, _| {
         info!(target: "reth::cli", "Launching node");
-        let handle = builder.node(EthereumNode::default()).launch_with_debug_capabilities().await?;
+        let NodeHandle { node_exit_future, .. } =
+            builder.node(EthereumNode::default()).launch_with_debug_capabilities().await?;
 
-        handle.wait_for_node_exit().await
+        node_exit_future.await
     }) {
         eprintln!("Error: {err:?}");
         std::process::exit(1);

--- a/bin/reth/src/main.rs
+++ b/bin/reth/src/main.rs
@@ -10,7 +10,6 @@ static MALLOC_CONF: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
 use clap::Parser;
 use reth::cli::Cli;
 use reth_ethereum_cli::chainspec::EthereumChainSpecParser;
-use reth_node_builder::NodeHandle;
 use reth_node_ethereum::EthereumNode;
 use tracing::info;
 
@@ -24,10 +23,9 @@ fn main() {
 
     if let Err(err) = Cli::<EthereumChainSpecParser>::parse().run(async move |builder, _| {
         info!(target: "reth::cli", "Launching node");
-        let NodeHandle { node_exit_future, .. } =
-            builder.node(EthereumNode::default()).launch_with_debug_capabilities().await?;
+        let handle = builder.node(EthereumNode::default()).launch_with_debug_capabilities().await?;
 
-        node_exit_future.await
+        handle.wait_for_node_exit().await
     }) {
         eprintln!("Error: {err:?}");
         std::process::exit(1);

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -464,6 +464,8 @@ where
                     PrewarmMode::Skipped
                 } else if let Some(bal) = bal {
                     PrewarmMode::BlockAccessList(bal)
+                } else if skip_prewarm {
+                    PrewarmMode::Skipped
                 } else {
                     PrewarmMode::Transactions(transactions)
                 };

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -464,8 +464,6 @@ where
                     PrewarmMode::Skipped
                 } else if let Some(bal) = bal {
                     PrewarmMode::BlockAccessList(bal)
-                } else if skip_prewarm {
-                    PrewarmMode::Skipped
                 } else {
                     PrewarmMode::Transactions(transactions)
                 };

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -422,7 +422,6 @@ where
             PrewarmMode::Skipped => {
                 let _ = actions_tx
                     .send(PrewarmTaskEvent::FinishedTxExecution { executed_transactions: 0 });
-                drop(actions_tx);
             }
         }
 

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -56,8 +56,7 @@ pub enum PrewarmMode<Tx> {
     Transactions(Receiver<Tx>),
     /// Prewarm by prefetching slots from a Block Access List.
     BlockAccessList(Arc<BlockAccessList>),
-    /// Transaction prewarming is skipped (e.g. small blocks where the overhead exceeds the
-    /// benefit). No workers are spawned.
+    /// Transaction prewarming is disabled via config. No workers are spawned.
     Skipped,
 }
 

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -56,7 +56,8 @@ pub enum PrewarmMode<Tx> {
     Transactions(Receiver<Tx>),
     /// Prewarm by prefetching slots from a Block Access List.
     BlockAccessList(Arc<BlockAccessList>),
-    /// Transaction prewarming is disabled via config. No workers are spawned.
+    /// Transaction prewarming is skipped (e.g. small blocks where the overhead exceeds the
+    /// benefit). No workers are spawned.
     Skipped,
 }
 
@@ -421,6 +422,7 @@ where
             PrewarmMode::Skipped => {
                 let _ = actions_tx
                     .send(PrewarmTaskEvent::FinishedTxExecution { executed_transactions: 0 });
+                drop(actions_tx);
             }
         }
 


### PR DESCRIPTION
**Summary**
When prewarming is disabled, workers were still spawned via a dead-channel hack (`mpsc::channel().1`) only to exit immediately. This replaces that with a `PrewarmMode::Skipped` variant that sends `FinishedTxExecution` directly — no workers spawned, cache saving still works.

**Changes**
- Add `PrewarmMode::Skipped` — skips worker spawning, signals completion immediately
- Remove dead-channel hack and `mut` on `transactions` param
- Remove redundant `drop(actions_tx)`