### PR TITLE
feat(engine): add gas bucket label to newPayload metrics

### DIFF
--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -12,6 +12,13 @@ use reth_primitives_traits::constants::gas_units::MEGAGAS;
 use reth_trie::updates::TrieUpdates;
 use std::time::{Duration, Instant};
 
+/// Width of each gas bucket in gas units (10 Mgas).
+const GAS_BUCKET_SIZE: u64 = 10 * MEGAGAS;
+
+/// Number of gas buckets. The last bucket is a catch-all for everything above
+/// `(NUM_GAS_BUCKETS - 1) * GAS_BUCKET_SIZE`.
+const NUM_GAS_BUCKETS: usize = 5;
+
 /// Metrics for the `EngineApi`.
 #[derive(Debug, Default)]
 pub struct EngineApiMetrics {
@@ -235,13 +242,6 @@ impl ForkchoiceUpdatedMetrics {
         }
     }
 }
-
-/// Width of each gas bucket in gas units (10 Mgas).
-const GAS_BUCKET_SIZE: u64 = 10 * MEGAGAS;
-
-/// Number of gas buckets. The last bucket is a catch-all for everything above
-/// `(NUM_GAS_BUCKETS - 1) * GAS_BUCKET_SIZE`.
-const NUM_GAS_BUCKETS: usize = 5;
 
 /// Per-gas-bucket newPayload metrics, initialized once via [`Self::new_with_labels`].
 #[derive(Clone, Metrics)]

--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -248,9 +248,9 @@ impl ForkchoiceUpdatedMetrics {
 #[metrics(scope = "consensus.engine.beacon")]
 pub(crate) struct NewPayloadGasBucketMetrics {
     /// Latency for new payload calls in this gas bucket.
-    pub(crate) new_payload_latency: Histogram,
+    pub(crate) new_payload_gas_bucket_latency: Histogram,
     /// Gas per second for new payload calls in this gas bucket.
-    pub(crate) new_payload_gas_per_second: Histogram,
+    pub(crate) new_payload_gas_bucket_gas_per_second: Histogram,
 }
 
 /// Holds pre-initialized [`NewPayloadGasBucketMetrics`] instances, one per gas bucket.
@@ -273,9 +273,9 @@ impl Default for GasBucketMetrics {
 impl GasBucketMetrics {
     fn record(&self, gas_used: u64, elapsed: Duration) {
         let idx = Self::bucket_index(gas_used);
-        self.buckets[idx].new_payload_latency.record(elapsed);
+        self.buckets[idx].new_payload_gas_bucket_latency.record(elapsed);
         self.buckets[idx]
-            .new_payload_gas_per_second
+            .new_payload_gas_bucket_gas_per_second
             .record(gas_used as f64 / elapsed.as_secs_f64());
     }
 

--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -8,6 +8,7 @@ use reth_metrics::{
     metrics::{Counter, Gauge, Histogram},
     Metrics,
 };
+use reth_primitives_traits::constants::gas_units::MEGAGAS;
 use reth_trie::updates::TrieUpdates;
 use std::time::{Duration, Instant};
 
@@ -234,8 +235,6 @@ impl ForkchoiceUpdatedMetrics {
         }
     }
 }
-
-use reth_primitives_traits::constants::gas_units::MEGAGAS;
 
 /// Width of each gas bucket in gas units (10 Mgas).
 const GAS_BUCKET_SIZE: u64 = 10 * MEGAGAS;

--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -235,8 +235,10 @@ impl ForkchoiceUpdatedMetrics {
     }
 }
 
-/// Width of each gas bucket in gas units (10 million).
-const GAS_BUCKET_SIZE: u64 = 10_000_000;
+use reth_primitives_traits::constants::gas_units::MEGAGAS;
+
+/// Width of each gas bucket in gas units (10 Mgas).
+const GAS_BUCKET_SIZE: u64 = 10 * MEGAGAS;
 
 /// Number of gas buckets. The last bucket is a catch-all for everything above
 /// `(NUM_GAS_BUCKETS - 1) * GAS_BUCKET_SIZE`.


### PR DESCRIPTION
## Summary

Adds gas-bucket-labeled histograms to `newPayload` metrics so operators can break down latency and gas throughput by payload size.

## Changes

- Added `GasBucketMetrics` struct with pre-registered labeled histograms
- Two new metrics:
  - `consensus.engine.beacon.new_payload_latency_by_gas_bucket` — latency histogram per gas bucket
  - `consensus.engine.beacon.new_payload_gas_per_second_by_gas_bucket` — gas/s histogram per gas bucket
- Gas bucket labels: `<10M`, `10-20M`, `20-30M`, `30-40M`, `>40M`

## Testing

```
cargo test -p reth-engine-tree --lib metrics
```