### PR TITLE
test: add CLI integration tests for reth binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7514,6 +7514,7 @@ dependencies = [
  "aquamarine",
  "backon",
  "clap",
+ "reqwest",
  "reth-chainspec",
  "reth-cli-runner",
  "reth-cli-util",
@@ -7542,6 +7543,7 @@ dependencies = [
  "reth-rpc-server-types",
  "reth-tasks",
  "reth-transaction-pool",
+ "serde_json",
  "tempfile",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,7 +295,7 @@ checksum = "d2ccfe6d724ceabd5518350cfb34f17dd3a6c3cc33579eee94d98101d3a511ff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-hardforks",
+ "alloy-hardforks 0.4.7",
  "alloy-op-hardforks",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -322,6 +322,19 @@ dependencies = [
  "borsh",
  "serde",
  "serde_with",
+]
+
+[[package]]
+name = "alloy-hardforks"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165210652f71dfc094b051602bafd691f506c54050a174b1cba18fb5ef706a3"
+dependencies = [
+ "alloy-chains",
+ "alloy-eip2124",
+ "alloy-primitives",
+ "auto_impl",
+ "dyn-clone",
 ]
 
 [[package]]
@@ -405,13 +418,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-node-bindings"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ce6930ce52e43b0768dc99ceeff5cb9e673e8c9f87d926914cd028b2e3f7233"
+dependencies = [
+ "alloy-genesis",
+ "alloy-hardforks 0.2.13",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-signer",
+ "alloy-signer-local",
+ "k256",
+ "libc",
+ "rand 0.8.5",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "alloy-op-hardforks"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6472c610150c4c4c15be9e1b964c9b78068f933bda25fb9cdf09b9ac2bb66f36"
 dependencies = [
  "alloy-chains",
- "alloy-hardforks",
+ "alloy-hardforks 0.4.7",
  "alloy-primitives",
  "auto_impl",
 ]
@@ -7510,11 +7545,12 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 name = "reth"
 version = "1.10.2"
 dependencies = [
+ "alloy-node-bindings",
+ "alloy-provider",
  "alloy-rpc-types",
  "aquamarine",
  "backon",
  "clap",
- "reqwest",
  "reth-chainspec",
  "reth-cli-runner",
  "reth-cli-util",
@@ -7543,8 +7579,8 @@ dependencies = [
  "reth-rpc-server-types",
  "reth-tasks",
  "reth-transaction-pool",
- "serde_json",
  "tempfile",
+ "tokio",
  "tracing",
 ]
 
@@ -8545,7 +8581,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-genesis",
- "alloy-hardforks",
+ "alloy-hardforks 0.4.7",
  "alloy-primitives",
  "alloy-rlp",
  "arbitrary",
@@ -8663,7 +8699,7 @@ name = "reth-ethereum-forks"
 version = "1.10.2"
 dependencies = [
  "alloy-eip2124",
- "alloy-hardforks",
+ "alloy-hardforks 0.4.7",
  "alloy-primitives",
  "arbitrary",
  "auto_impl",

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -69,6 +69,8 @@ clap = { workspace = true, features = ["derive", "env"] }
 
 [dev-dependencies]
 backon.workspace = true
+reqwest = { workspace = true, features = ["blocking", "json"] }
+serde_json.workspace = true
 tempfile.workspace = true
 
 [features]

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -68,10 +68,11 @@ aquamarine.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 
 [dev-dependencies]
+alloy-node-bindings = "1.6.3"
+alloy-provider = { workspace = true, features = ["reqwest"] }
 backon.workspace = true
-reqwest = { workspace = true, features = ["blocking", "json"] }
-serde_json.workspace = true
 tempfile.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [features]
 default = [

--- a/bin/reth/tests/it/main.rs
+++ b/bin/reth/tests/it/main.rs
@@ -1,0 +1,151 @@
+#![allow(missing_docs)]
+
+use std::{
+    net::TcpListener,
+    process::{Command, Stdio},
+    time::Duration,
+};
+
+const RETH: &str = env!("CARGO_BIN_EXE_reth");
+
+fn unused_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0").unwrap().local_addr().unwrap().port()
+}
+
+#[test]
+fn help() {
+    let output = Command::new(RETH).arg("--help").output().unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success());
+    assert!(stdout.contains("Usage"), "stdout: {stdout}");
+    assert!(stdout.contains("node"), "stdout: {stdout}");
+}
+
+#[test]
+fn version() {
+    let output = Command::new(RETH).arg("--version").output().unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success());
+    assert!(stdout.to_lowercase().contains("reth"), "stdout: {stdout}");
+}
+
+#[test]
+fn node_help() {
+    let output = Command::new(RETH).args(["node", "--help"]).output().unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success());
+    assert!(stdout.contains("--dev"), "stdout: {stdout}");
+    assert!(stdout.contains("--http"), "stdout: {stdout}");
+}
+
+#[test]
+fn unknown_subcommand() {
+    let output = Command::new(RETH).arg("definitely-not-a-cmd").output().unwrap();
+    assert!(!output.status.success());
+}
+
+#[test]
+fn unknown_flag() {
+    let output = Command::new(RETH).args(["node", "--no-such-flag"]).output().unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success());
+    assert!(stderr.contains("--no-such-flag"), "stderr: {stderr}");
+}
+
+#[test]
+#[ignore = "heavy test: starts a full dev node and queries RPC"]
+fn dev_node_rpc() {
+    let http_port = unused_port();
+    let authrpc_port = unused_port();
+    let datadir = tempfile::tempdir().unwrap();
+
+    let mut child = Command::new(RETH)
+        .args([
+            "node",
+            "--dev",
+            "--http.port",
+            &http_port.to_string(),
+            "--authrpc.port",
+            &authrpc_port.to_string(),
+            "--port",
+            "0",
+            "--ipcdisable",
+            "--no-persist-peers",
+            "--datadir",
+        ])
+        .arg(datadir.path())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+
+    let url = format!("http://127.0.0.1:{http_port}");
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let client =
+            reqwest::blocking::Client::builder().timeout(Duration::from_secs(5)).build().unwrap();
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(60);
+        let mut ready = false;
+
+        while std::time::Instant::now() < deadline {
+            let req = serde_json::json!({
+                "jsonrpc": "2.0",
+                "method": "web3_clientVersion",
+                "params": [],
+                "id": 1,
+            });
+
+            match client.post(&url).json(&req).send() {
+                Ok(resp) if resp.status().is_success() => {
+                    let body: serde_json::Value = resp.json().unwrap();
+                    let version = body["result"].as_str().unwrap();
+                    assert!(version.contains("reth"), "unexpected client version: {version}");
+                    ready = true;
+                    break;
+                }
+                _ => std::thread::sleep(Duration::from_millis(500)),
+            }
+        }
+        assert!(ready, "node did not become ready within 60s at {url}");
+
+        let resp = client
+            .post(&url)
+            .json(&serde_json::json!({
+                "jsonrpc": "2.0",
+                "method": "eth_chainId",
+                "params": [],
+                "id": 2,
+            }))
+            .send()
+            .unwrap();
+        assert!(resp.status().is_success());
+        let body: serde_json::Value = resp.json().unwrap();
+        let chain_id = body["result"].as_str().unwrap();
+        assert!(chain_id.starts_with("0x"), "unexpected chain id: {chain_id}");
+
+        let resp = client
+            .post(&url)
+            .json(&serde_json::json!({
+                "jsonrpc": "2.0",
+                "method": "eth_blockNumber",
+                "params": [],
+                "id": 3,
+            }))
+            .send()
+            .unwrap();
+        assert!(resp.status().is_success());
+        let body: serde_json::Value = resp.json().unwrap();
+        let block_number = body["result"].as_str().unwrap();
+        assert!(block_number.starts_with("0x"), "unexpected block number: {block_number}");
+    }));
+
+    let _ = child.kill();
+    let _ = child.wait();
+
+    if let Err(panic) = result {
+        std::panic::resume_unwind(panic);
+    }
+}
+
+const fn main() {}

--- a/bin/reth/tests/it/main.rs
+++ b/bin/reth/tests/it/main.rs
@@ -57,6 +57,9 @@ async fn dev_node_eth_syncing() {
 
     let provider = ProviderBuilder::new().connect_http(reth.endpoint().parse().unwrap());
 
+    // give the node a moment to fully initialize
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     // eth_syncing should not fail on a dev node
     let _syncing = provider.syncing().await.expect("eth_syncing failed");
 }


### PR DESCRIPTION
## Summary
Add `tests/it/main.rs` to the reth bin crate with integration tests that invoke the CLI binary directly via `CARGO_BIN_EXE_reth`.

## Motivation
There were no tests exercising the actual `reth` binary as a subprocess. All existing e2e tests use `NodeBuilder` programmatically, which doesn't catch issues with CLI arg parsing, clap wiring, or binary entrypoint setup.

## Changes
- `bin/reth/tests/it/main.rs`: 6 integration tests
  - `help`: `--help` exits 0, shows usage and subcommands
  - `version`: `--version` exits 0, contains "reth"
  - `node_help`: `node --help` shows `--dev` and `--http` flags
  - `unknown_subcommand`: exits non-zero
  - `unknown_flag`: exits non-zero, stderr mentions the bad flag
  - `dev_node_eth_syncing`: uses `alloy-node-bindings` to spawn the reth binary in dev mode (mirroring args from `tempoxyz/helm-charts` reth-bench workflows: `--disable-discovery`, `--max-outbound-peers 0`, `--max-inbound-peers 0`), then calls `eth_syncing` via `alloy-provider`
- `bin/reth/Cargo.toml`: add `alloy-node-bindings`, `alloy-provider`, `tokio` dev-dependencies

## Testing
```
cargo test -p reth --test it --no-default-features
```