### PR TITLE
feat(network): add inbound / outbound scopes for disconnect reasons

### DIFF
--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -25,7 +25,7 @@ use crate::{
     listener::ConnectionListener,
     message::{NewBlockMessage, PeerMessage},
     metrics::{
-        BackedOffPeersMetrics, ClosedSessionsMetrics, DisconnectMetrics, NetworkMetrics,
+        BackedOffPeersMetrics, ClosedSessionsMetrics, DirectionalDisconnectMetrics, NetworkMetrics,
         PendingSessionFailureMetrics, NETWORK_POOL_TRANSACTIONS_SCOPE,
     },
     network::{NetworkHandle, NetworkHandleMessage},
@@ -140,8 +140,8 @@ pub struct NetworkManager<N: NetworkPrimitives = EthNetworkPrimitives> {
     num_active_peers: Arc<AtomicUsize>,
     /// Metrics for the Network
     metrics: NetworkMetrics,
-    /// Disconnect metrics for the Network
-    disconnect_metrics: DisconnectMetrics,
+    /// Disconnect metrics for the Network, split by connection direction.
+    disconnect_metrics: DirectionalDisconnectMetrics,
     /// Closed sessions metrics, split by direction.
     closed_sessions_metrics: ClosedSessionsMetrics,
     /// Pending session failure metrics, split by direction.
@@ -864,6 +864,9 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
                     "Session disconnected"
                 );
 
+                // Capture direction before state is reset to Idle
+                let is_inbound = self.swarm.state().peers().is_inbound_peer(&peer_id);
+
                 let reason = if let Some(ref err) = error {
                     // If the connection was closed due to an error, we report
                     // the peer
@@ -887,7 +890,11 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
                 self.update_active_connection_metrics();
 
                 if let Some(reason) = reason {
-                    self.disconnect_metrics.increment(reason);
+                    if is_inbound {
+                        self.disconnect_metrics.increment_inbound(reason);
+                    } else {
+                        self.disconnect_metrics.increment_outbound(reason);
+                    }
                 }
                 self.metrics
                     .backed_off_peers
@@ -910,7 +917,7 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
                         .on_incoming_pending_session_dropped(remote_addr, err);
                     self.pending_session_failure_metrics.inbound.increment(1);
                     if let Some(reason) = err.as_disconnected() {
-                        self.disconnect_metrics.increment(reason);
+                        self.disconnect_metrics.increment_inbound(reason);
                     }
                 } else {
                     self.swarm
@@ -943,7 +950,7 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
                         BackoffReason::from_disconnect(err.as_disconnected()),
                     );
                     if let Some(reason) = err.as_disconnected() {
-                        self.disconnect_metrics.increment(reason);
+                        self.disconnect_metrics.increment_outbound(reason);
                     }
                 } else {
                     self.swarm

--- a/crates/net/network/src/metrics.rs
+++ b/crates/net/network/src/metrics.rs
@@ -301,6 +301,34 @@ macro_rules! duration_metered_exec {
     }};
 }
 
+/// Direction-aware wrapper for disconnect metrics.
+///
+/// Tracks disconnect reasons for inbound and outbound connections separately, in addition to
+/// the combined (legacy) counters.
+#[derive(Debug, Default)]
+pub(crate) struct DirectionalDisconnectMetrics {
+    /// Combined disconnect metrics (all directions).
+    pub(crate) total: DisconnectMetrics,
+    /// Disconnect metrics for inbound connections only.
+    pub(crate) inbound: InboundDisconnectMetrics,
+    /// Disconnect metrics for outbound connections only.
+    pub(crate) outbound: OutboundDisconnectMetrics,
+}
+
+impl DirectionalDisconnectMetrics {
+    /// Increments disconnect counters for an inbound connection.
+    pub(crate) fn increment_inbound(&self, reason: DisconnectReason) {
+        self.total.increment(reason);
+        self.inbound.increment(reason);
+    }
+
+    /// Increments disconnect counters for an outbound connection.
+    pub(crate) fn increment_outbound(&self, reason: DisconnectReason) {
+        self.total.increment(reason);
+        self.outbound.increment(reason);
+    }
+}
+
 /// Metrics for Disconnection types
 ///
 /// These are just counters, and ideally we would implement these metrics on a peer-by-peer basis,
@@ -350,6 +378,144 @@ pub struct DisconnectMetrics {
 }
 
 impl DisconnectMetrics {
+    /// Increments the proper counter for the given disconnect reason
+    pub(crate) fn increment(&self, reason: DisconnectReason) {
+        match reason {
+            DisconnectReason::DisconnectRequested => self.disconnect_requested.increment(1),
+            DisconnectReason::TcpSubsystemError => self.tcp_subsystem_error.increment(1),
+            DisconnectReason::ProtocolBreach => self.protocol_breach.increment(1),
+            DisconnectReason::UselessPeer => self.useless_peer.increment(1),
+            DisconnectReason::TooManyPeers => self.too_many_peers.increment(1),
+            DisconnectReason::AlreadyConnected => self.already_connected.increment(1),
+            DisconnectReason::IncompatibleP2PProtocolVersion => self.incompatible.increment(1),
+            DisconnectReason::NullNodeIdentity => self.null_node_identity.increment(1),
+            DisconnectReason::ClientQuitting => self.client_quitting.increment(1),
+            DisconnectReason::UnexpectedHandshakeIdentity => self.unexpected_identity.increment(1),
+            DisconnectReason::ConnectedToSelf => self.connected_to_self.increment(1),
+            DisconnectReason::PingTimeout => self.ping_timeout.increment(1),
+            DisconnectReason::SubprotocolSpecific => self.subprotocol_specific.increment(1),
+        }
+    }
+}
+
+/// Disconnect metrics scoped to inbound connections only.
+///
+/// These counters track disconnect reasons exclusively for sessions that were initiated by
+/// remote peers connecting to this node. This helps operators distinguish between being rejected
+/// by remote peers (outbound) vs rejecting incoming peers (inbound).
+#[derive(Metrics)]
+#[metrics(scope = "network.inbound")]
+pub struct InboundDisconnectMetrics {
+    /// Number of inbound peer disconnects due to `DisconnectRequested` (0x00)
+    pub(crate) disconnect_requested: Counter,
+
+    /// Number of inbound peer disconnects due to `TcpSubsystemError` (0x01)
+    pub(crate) tcp_subsystem_error: Counter,
+
+    /// Number of inbound peer disconnects due to `ProtocolBreach` (0x02)
+    pub(crate) protocol_breach: Counter,
+
+    /// Number of inbound peer disconnects due to `UselessPeer` (0x03)
+    pub(crate) useless_peer: Counter,
+
+    /// Number of inbound peer disconnects due to `TooManyPeers` (0x04)
+    pub(crate) too_many_peers: Counter,
+
+    /// Number of inbound peer disconnects due to `AlreadyConnected` (0x05)
+    pub(crate) already_connected: Counter,
+
+    /// Number of inbound peer disconnects due to `IncompatibleP2PProtocolVersion` (0x06)
+    pub(crate) incompatible: Counter,
+
+    /// Number of inbound peer disconnects due to `NullNodeIdentity` (0x07)
+    pub(crate) null_node_identity: Counter,
+
+    /// Number of inbound peer disconnects due to `ClientQuitting` (0x08)
+    pub(crate) client_quitting: Counter,
+
+    /// Number of inbound peer disconnects due to `UnexpectedHandshakeIdentity` (0x09)
+    pub(crate) unexpected_identity: Counter,
+
+    /// Number of inbound peer disconnects due to `ConnectedToSelf` (0x0a)
+    pub(crate) connected_to_self: Counter,
+
+    /// Number of inbound peer disconnects due to `PingTimeout` (0x0b)
+    pub(crate) ping_timeout: Counter,
+
+    /// Number of inbound peer disconnects due to `SubprotocolSpecific` (0x10)
+    pub(crate) subprotocol_specific: Counter,
+}
+
+impl InboundDisconnectMetrics {
+    /// Increments the proper counter for the given disconnect reason
+    pub(crate) fn increment(&self, reason: DisconnectReason) {
+        match reason {
+            DisconnectReason::DisconnectRequested => self.disconnect_requested.increment(1),
+            DisconnectReason::TcpSubsystemError => self.tcp_subsystem_error.increment(1),
+            DisconnectReason::ProtocolBreach => self.protocol_breach.increment(1),
+            DisconnectReason::UselessPeer => self.useless_peer.increment(1),
+            DisconnectReason::TooManyPeers => self.too_many_peers.increment(1),
+            DisconnectReason::AlreadyConnected => self.already_connected.increment(1),
+            DisconnectReason::IncompatibleP2PProtocolVersion => self.incompatible.increment(1),
+            DisconnectReason::NullNodeIdentity => self.null_node_identity.increment(1),
+            DisconnectReason::ClientQuitting => self.client_quitting.increment(1),
+            DisconnectReason::UnexpectedHandshakeIdentity => self.unexpected_identity.increment(1),
+            DisconnectReason::ConnectedToSelf => self.connected_to_self.increment(1),
+            DisconnectReason::PingTimeout => self.ping_timeout.increment(1),
+            DisconnectReason::SubprotocolSpecific => self.subprotocol_specific.increment(1),
+        }
+    }
+}
+
+/// Disconnect metrics scoped to outbound connections only.
+///
+/// These counters track disconnect reasons exclusively for sessions that this node initiated
+/// by dialing out to remote peers. A high `too_many_peers` count here indicates remote peers
+/// are rejecting our connection attempts because they are full.
+#[derive(Metrics)]
+#[metrics(scope = "network.outbound")]
+pub struct OutboundDisconnectMetrics {
+    /// Number of outbound peer disconnects due to `DisconnectRequested` (0x00)
+    pub(crate) disconnect_requested: Counter,
+
+    /// Number of outbound peer disconnects due to `TcpSubsystemError` (0x01)
+    pub(crate) tcp_subsystem_error: Counter,
+
+    /// Number of outbound peer disconnects due to `ProtocolBreach` (0x02)
+    pub(crate) protocol_breach: Counter,
+
+    /// Number of outbound peer disconnects due to `UselessPeer` (0x03)
+    pub(crate) useless_peer: Counter,
+
+    /// Number of outbound peer disconnects due to `TooManyPeers` (0x04)
+    pub(crate) too_many_peers: Counter,
+
+    /// Number of outbound peer disconnects due to `AlreadyConnected` (0x05)
+    pub(crate) already_connected: Counter,
+
+    /// Number of outbound peer disconnects due to `IncompatibleP2PProtocolVersion` (0x06)
+    pub(crate) incompatible: Counter,
+
+    /// Number of outbound peer disconnects due to `NullNodeIdentity` (0x07)
+    pub(crate) null_node_identity: Counter,
+
+    /// Number of outbound peer disconnects due to `ClientQuitting` (0x08)
+    pub(crate) client_quitting: Counter,
+
+    /// Number of outbound peer disconnects due to `UnexpectedHandshakeIdentity` (0x09)
+    pub(crate) unexpected_identity: Counter,
+
+    /// Number of outbound peer disconnects due to `ConnectedToSelf` (0x0a)
+    pub(crate) connected_to_self: Counter,
+
+    /// Number of outbound peer disconnects due to `PingTimeout` (0x0b)
+    pub(crate) ping_timeout: Counter,
+
+    /// Number of outbound peer disconnects due to `SubprotocolSpecific` (0x10)
+    pub(crate) subprotocol_specific: Counter,
+}
+
+impl OutboundDisconnectMetrics {
     /// Increments the proper counter for the given disconnect reason
     pub(crate) fn increment(&self, reason: DisconnectReason) {
         match reason {

--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -218,6 +218,13 @@ impl PeersManager {
         })
     }
 
+    /// Returns `true` if the given peer is connected via an inbound session.
+    pub(crate) fn is_inbound_peer(&self, peer_id: &PeerId) -> bool {
+        self.peers.get(peer_id).is_some_and(|p| {
+            matches!(p.state, PeerConnectionState::In | PeerConnectionState::DisconnectingIn)
+        })
+    }
+
     /// Returns an iterator over all peer ids for peers with the given kind
     pub(crate) fn peers_by_kind(&self, kind: PeerKind) -> impl Iterator<Item = PeerId> + '_ {
         self.peers.iter().filter_map(move |(peer_id, peer)| (peer.kind == kind).then_some(*peer_id))


### PR DESCRIPTION
This lets us determine why we disconnect from peers vs why they disconnect from us. Keeps the old cumulative metrics as well