### PR TITLE
feat: make PayloadAttributesBuilder::build async

### DIFF
--- a/crates/engine/local/src/miner.rs
+++ b/crates/engine/local/src/miner.rs
@@ -196,11 +196,12 @@ where
     /// Generates payload attributes for a new block, passes them to FCU and inserts built payload
     /// through newPayload.
     async fn advance(&mut self) -> eyre::Result<()> {
+        let attributes = self.payload_attributes_builder.build(&self.last_header).await;
         let res = self
             .to_engine
             .fork_choice_updated(
                 self.forkchoice_state(),
-                Some(self.payload_attributes_builder.build(&self.last_header)),
+                Some(attributes),
                 EngineApiMessageVersion::default(),
             )
             .await?;

--- a/crates/engine/local/src/payload.rs
+++ b/crates/engine/local/src/payload.rs
@@ -3,6 +3,7 @@
 
 use alloy_consensus::BlockHeader;
 use alloy_primitives::{Address, B256};
+use core::{future::Future, pin::Pin};
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_ethereum_engine_primitives::EthPayloadAttributes;
 use reth_payload_primitives::PayloadAttributesBuilder;
@@ -37,27 +38,34 @@ impl<ChainSpec> PayloadAttributesBuilder<EthPayloadAttributes, ChainSpec::Header
 where
     ChainSpec: EthChainSpec + EthereumHardforks + 'static,
 {
-    fn build(&self, parent: &SealedHeader<ChainSpec::Header>) -> EthPayloadAttributes {
-        let mut timestamp =
-            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
+    fn build<'a>(
+        &'a self,
+        parent: &'a SealedHeader<ChainSpec::Header>,
+    ) -> Pin<Box<dyn Future<Output = EthPayloadAttributes> + Send + 'a>> {
+        Box::pin(async move {
+            let mut timestamp = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs();
 
-        if self.enforce_increasing_timestamp {
-            timestamp = std::cmp::max(parent.timestamp().saturating_add(1), timestamp);
-        }
+            if self.enforce_increasing_timestamp {
+                timestamp = std::cmp::max(parent.timestamp().saturating_add(1), timestamp);
+            }
 
-        EthPayloadAttributes {
-            timestamp,
-            prev_randao: B256::random(),
-            suggested_fee_recipient: Address::random(),
-            withdrawals: self
-                .chain_spec
-                .is_shanghai_active_at_timestamp(timestamp)
-                .then(Default::default),
-            parent_beacon_block_root: self
-                .chain_spec
-                .is_cancun_active_at_timestamp(timestamp)
-                .then(B256::random),
-        }
+            EthPayloadAttributes {
+                timestamp,
+                prev_randao: B256::random(),
+                suggested_fee_recipient: Address::random(),
+                withdrawals: self
+                    .chain_spec
+                    .is_shanghai_active_at_timestamp(timestamp)
+                    .then(Default::default),
+                parent_beacon_block_root: self
+                    .chain_spec
+                    .is_cancun_active_at_timestamp(timestamp)
+                    .then(B256::random),
+            }
+        })
     }
 }
 
@@ -68,48 +76,53 @@ impl<ChainSpec>
 where
     ChainSpec: EthChainSpec + EthereumHardforks + 'static,
 {
-    fn build(
-        &self,
-        parent: &SealedHeader<ChainSpec::Header>,
-    ) -> op_alloy_rpc_types_engine::OpPayloadAttributes {
-        use alloy_primitives::B64;
-        use reth_chainspec::BaseFeeParams;
-        use std::env;
-        /// Dummy system transaction for dev mode.
-        /// OP Mainnet transaction at index 0 in block 124665056.
-        ///
-        /// <https://optimistic.etherscan.io/tx/0x312e290cf36df704a2217b015d6455396830b0ce678b860ebfcc30f41403d7b1>
-        const TX_SET_L1_BLOCK_OP_MAINNET_BLOCK_124665056: [u8; 251] = alloy_primitives::hex!(
-            "7ef8f8a0683079df94aa5b9cf86687d739a60a9b4f0835e520ec4d664e2e415dca17a6df94deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8a4440a5e200000146b000f79c500000000000000040000000066d052e700000000013ad8a3000000000000000000000000000000000000000000000000000000003ef1278700000000000000000000000000000000000000000000000000000000000000012fdf87b89884a61e74b322bbcf60386f543bfae7827725efaaf0ab1de2294a590000000000000000000000006887246668a3b87f54deb3b94ba47a6f63f32985"
-        );
+    fn build<'a>(
+        &'a self,
+        parent: &'a SealedHeader<ChainSpec::Header>,
+    ) -> Pin<Box<dyn Future<Output = op_alloy_rpc_types_engine::OpPayloadAttributes> + Send + 'a>>
+    {
+        Box::pin(async move {
+            use alloy_primitives::B64;
+            use reth_chainspec::BaseFeeParams;
+            use std::env;
+            /// Dummy system transaction for dev mode.
+            /// OP Mainnet transaction at index 0 in block 124665056.
+            ///
+            /// <https://optimistic.etherscan.io/tx/0x312e290cf36df704a2217b015d6455396830b0ce678b860ebfcc30f41403d7b1>
+            const TX_SET_L1_BLOCK_OP_MAINNET_BLOCK_124665056: [u8; 251] = alloy_primitives::hex!(
+                "7ef8f8a0683079df94aa5b9cf86687d739a60a9b4f0835e520ec4d664e2e415dca17a6df94deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8a4440a5e200000146b000f79c500000000000000040000000066d052e700000000013ad8a3000000000000000000000000000000000000000000000000000000003ef1278700000000000000000000000000000000000000000000000000000000000000012fdf87b89884a61e74b322bbcf60386f543bfae7827725efaaf0ab1de2294a590000000000000000000000006887246668a3b87f54deb3b94ba47a6f63f32985"
+            );
 
-        // Configure EIP-1559 parameters for dev mode. These can be overridden via environment
-        // variables (OP_DEV_EIP1559_DENOMINATOR, OP_DEV_EIP1559_ELASTICITY, OP_DEV_GAS_LIMIT),
-        // otherwise defaults from Optimism's BaseFeeParams are used. The parameters are encoded
-        // as an 8-byte value (denominator + elasticity) required by Optimism's Jovian fork.
-        let default_eip_1559_params = BaseFeeParams::optimism();
-        let denominator = env::var("OP_DEV_EIP1559_DENOMINATOR")
-            .ok()
-            .and_then(|v| v.parse::<u32>().ok())
-            .unwrap_or(default_eip_1559_params.max_change_denominator as u32);
-        let elasticity = env::var("OP_DEV_EIP1559_ELASTICITY")
-            .ok()
-            .and_then(|v| v.parse::<u32>().ok())
-            .unwrap_or(default_eip_1559_params.elasticity_multiplier as u32);
-        let gas_limit = env::var("OP_DEV_GAS_LIMIT").ok().and_then(|v| v.parse::<u64>().ok());
+            let default_eip_1559_params = BaseFeeParams::optimism();
+            let denominator = env::var("OP_DEV_EIP1559_DENOMINATOR")
+                .ok()
+                .and_then(|v| v.parse::<u32>().ok())
+                .unwrap_or(default_eip_1559_params.max_change_denominator as u32);
+            let elasticity = env::var("OP_DEV_EIP1559_ELASTICITY")
+                .ok()
+                .and_then(|v| v.parse::<u32>().ok())
+                .unwrap_or(default_eip_1559_params.elasticity_multiplier as u32);
+            let gas_limit = env::var("OP_DEV_GAS_LIMIT").ok().and_then(|v| v.parse::<u64>().ok());
 
-        let mut eip1559_bytes = [0u8; 8];
-        eip1559_bytes[0..4].copy_from_slice(&denominator.to_be_bytes());
-        eip1559_bytes[4..8].copy_from_slice(&elasticity.to_be_bytes());
-        let eip_1559_params = Some(B64::from(eip1559_bytes));
+            let mut eip1559_bytes = [0u8; 8];
+            eip1559_bytes[0..4].copy_from_slice(&denominator.to_be_bytes());
+            eip1559_bytes[4..8].copy_from_slice(&elasticity.to_be_bytes());
+            let eip_1559_params = Some(B64::from(eip1559_bytes));
 
-        op_alloy_rpc_types_engine::OpPayloadAttributes {
-            payload_attributes: self.build(parent),
-            transactions: Some(vec![TX_SET_L1_BLOCK_OP_MAINNET_BLOCK_124665056.into()]),
-            no_tx_pool: None,
-            gas_limit,
-            eip_1559_params,
-            min_base_fee: Some(0),
-        }
+            let payload_attributes = <Self as PayloadAttributesBuilder<
+                EthPayloadAttributes,
+                ChainSpec::Header,
+            >>::build(self, parent)
+            .await;
+
+            op_alloy_rpc_types_engine::OpPayloadAttributes {
+                payload_attributes,
+                transactions: Some(vec![TX_SET_L1_BLOCK_OP_MAINNET_BLOCK_124665056.into()]),
+                no_tx_pool: None,
+                gas_limit,
+                eip_1559_params,
+                min_base_fee: Some(0),
+            }
+        })
     }
 }


### PR DESCRIPTION
## Summary
Make `PayloadAttributesBuilder::build` return a boxed future (`Pin<Box<dyn Future<Output = Attributes> + Send + 'a>>`) instead of returning attributes synchronously.

## Changes
- `crates/payload/primitives/src/traits.rs`: trait method now returns `Pin<Box<dyn Future + Send + 'a>>`, updated blanket impls for closures, `Either`, and `Box<dyn ...>`
- `crates/engine/local/src/payload.rs`: `LocalPayloadAttributesBuilder` impls wrap body in `Box::pin(async move { ... })`, OP impl uses UFCS to call the Eth build
- `crates/engine/local/src/miner.rs`: `.await` the build call
- `crates/node/builder/src/launch/debug.rs`: mapping closure uses `Arc` for cloneability and returns an async block

## Testing
Targeted crate checks pass: `reth-payload-primitives`, `reth-engine-local --all-features`, `reth-node-builder`, `reth-node-ethereum`.