### PR TITLE
fix(net): correct EthMessageID::max for eth70 and later versions

### DIFF
--- a/crates/net/eth-wire-types/src/message.rs
+++ b/crates/net/eth-wire-types/src/message.rs
@@ -589,7 +589,7 @@ impl EthMessageID {
 
     /// Returns the max value for the given version.
     pub const fn max(version: EthVersion) -> u8 {
-        if version.is_eth69() {
+        if version as u8 >= EthVersion::Eth69 as u8 {
             Self::BlockRangeUpdate.to_u8()
         } else {
             Self::Receipts.to_u8()
@@ -935,6 +935,13 @@ mod tests {
         .unwrap();
 
         assert!(matches!(decoded, StatusMessage::Legacy(s) if s == status));
+    }
+
+    #[test]
+    fn eth_message_id_max_includes_block_range_update() {
+        assert_eq!(EthMessageID::max(EthVersion::Eth69), EthMessageID::BlockRangeUpdate.to_u8(),);
+        assert_eq!(EthMessageID::max(EthVersion::Eth70), EthMessageID::BlockRangeUpdate.to_u8(),);
+        assert_eq!(EthMessageID::max(EthVersion::Eth68), EthMessageID::Receipts.to_u8());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`EthMessageID::max()` used `is_eth69()` which only matched exactly eth69. For eth70 (and any future versions), it fell through to return `Receipts` as the max, causing `BlockRangeUpdate` messages (id `0x11`) to be routed through snap decoding instead of eth decoding in `eth_snap_stream.rs`. This resulted in auto-disconnecting eth70 peers.

## Changes

- Changed `EthMessageID::max()` to use `version as u8 >= EthVersion::Eth69 as u8` instead of `version.is_eth69()`, so eth70+ correctly includes `BlockRangeUpdate` in the eth message range
- Added test covering eth68, eth69, and eth70 max values

## Testing

```
cargo test -p reth-eth-wire-types -- message
# 21 passed; 0 failed
```