### PR TITLE
perf: collect-based fast path for small block tx iterator

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -43,7 +43,6 @@ use reth_trie_sparse::{
     ParallelSparseTrie, ParallelismThresholds, RevealableSparseTrie, SparseStateTrie,
 };
 use std::{
-    
     ops::Not,
     sync::{
         atomic::AtomicBool,
@@ -364,7 +363,7 @@ where
     }
 
     /// Below this threshold, transactions are converted via rayon's order-preserving `collect()`
-    /// in a single task, eliminating the out-of-order channel and BTreeMap reorder task.
+    /// in a single task, eliminating the out-of-order channel and `BTreeMap` reorder task.
     const PARALLEL_REORDER_TX_THRESHOLD: usize = 30;
 
     /// Spawns a task advancing transaction env iterator and streaming updates through a channel.
@@ -421,8 +420,7 @@ where
 
             self.executor.spawn_blocking(move || {
                 let mut next = 0usize;
-                let mut buf: Vec<Option<Result<_, _>>> =
-                    (0..tx_count).map(|_| None).collect();
+                let mut buf: Vec<Option<Result<_, _>>> = (0..tx_count).map(|_| None).collect();
                 while let Ok((idx, tx)) = ooo_rx.recv() {
                     if idx == next {
                         let _ = execute_tx.send(tx);

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -365,7 +365,7 @@ where
 
     /// Below this threshold, transactions are converted via rayon's order-preserving `collect()`
     /// in a single task, eliminating the out-of-order channel and BTreeMap reorder task.
-    const PARALLEL_REORDER_TX_THRESHOLD: usize = 128;
+    const PARALLEL_REORDER_TX_THRESHOLD: usize = 30;
 
     /// Spawns a task advancing transaction env iterator and streaming updates through a channel.
     #[expect(clippy::type_complexity)]


### PR DESCRIPTION
**Summary**
Reth spawns the same heavy parallel tx conversion pipeline regardless of block size: rayon `for_each_with` sends results out-of-order through an intermediate channel, then a second `spawn_blocking` task reorders via `BTreeMap`. For small blocks (<30 txs), this coordination overhead exceeds the benefit. This PR adds a collect-based fast path using `par_iter().map().collect()` which preserves order natively, eliminating the intermediate channel and reorder task. For large blocks, replaces `BTreeMap` with pre-allocated `Vec<Option<_>>` for O(1) reorder.

**Changes**
- Add `PARALLEL_REORDER_TX_THRESHOLD` (30 txs)
- Small blocks: single `rayon::spawn` with `collect()` + sequential channel sends
- Large blocks: `Vec<Option<_>>` reorder buffer instead of `BTreeMap`