### PR TITLE
perf: inline receipt root computation for small blocks

### DIFF
--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -742,7 +742,7 @@ where
 
         let execution_start = Instant::now();
 
-        const INLINE_RECEIPT_ROOT_TX_THRESHOLD: usize = 128;
+        const INLINE_RECEIPT_ROOT_TX_THRESHOLD: usize = 30;
 
         if transaction_count < INLINE_RECEIPT_ROOT_TX_THRESHOLD {
             let (executor, senders) = self.execute_transactions_no_stream(


### PR DESCRIPTION
**Summary**
Every block spawns a `spawn_blocking` task + crossbeam channel + per-receipt clone for receipt root computation, even when the block has few transactions. For small blocks (<30 txs), the pipelining overhead exceeds the benefit. This PR computes the receipt root inline after execution completes — no task spawn, no channel, no per-receipt clone.

**Changes**
- Add `INLINE_RECEIPT_ROOT_TX_THRESHOLD` (30 txs)
- Small blocks: execute without streaming receipts, compute receipt root inline from final receipts vec
- Large blocks: keep existing streaming background task