### PR TITLE
feat(cli): add `reth db compress` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7792,6 +7792,7 @@ dependencies = [
  "reth-evm",
  "reth-exex",
  "reth-fs-util",
+ "reth-libmdbx",
  "reth-net-nat",
  "reth-network",
  "reth-network-p2p",

--- a/crates/cli/commands/Cargo.toml
+++ b/crates/cli/commands/Cargo.toml
@@ -76,7 +76,7 @@ human_bytes.workspace = true
 eyre.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 lz4.workspace = true
-zstd.workspace = true
+zstd = { workspace = true, features = ["zdict_builder"] }
 serde.workspace = true
 serde_json.workspace = true
 parking_lot.workspace = true

--- a/crates/cli/commands/Cargo.toml
+++ b/crates/cli/commands/Cargo.toml
@@ -20,6 +20,7 @@ reth-config = { workspace = true, features = ["serde"] }
 reth-consensus.workspace = true
 reth-db = { workspace = true, features = ["mdbx"] }
 reth-db-api.workspace = true
+reth-libmdbx.workspace = true
 reth-db-common.workspace = true
 reth-downloaders = { workspace = true, features = ["file-client"] }
 reth-ecies.workspace = true

--- a/crates/cli/commands/src/db/compress.rs
+++ b/crates/cli/commands/src/db/compress.rs
@@ -6,24 +6,28 @@ use reth_db_api::{
     Tables,
 };
 use reth_db_common::DbTool;
+use reth_libmdbx::{DatabaseFlags, Environment, Geometry, WriteFlags};
 use reth_node_builder::NodeTypesWithDB;
 use reth_provider::{providers::ProviderNodeTypes, DBProvider};
-use std::{io::Write, path::PathBuf, time::Instant};
+use std::{path::PathBuf, time::Instant};
 use tracing::{info, warn};
 
 const PROGRESS_LOG_INTERVAL: usize = 100_000;
 
-/// LZ4-compresses all values from a table and writes them to a file.
+/// Batch size for MDBX write transactions to avoid unbounded growth.
+const COMMIT_BATCH_SIZE: usize = 50_000;
+
+/// LZ4-compresses all values from a table and writes them to a new MDBX database.
 ///
-/// Iterates every row in the source table, compresses each value with LZ4 block mode,
-/// and writes `[key_len: u32][key][original_len: u32][compressed_len: u32][compressed]` records
-/// to the output file. Reports compression ratio and throughput at the end.
+/// Creates a fresh MDBX environment at `--out`, with a single table named after the source.
+/// Each row is written as `(original_key, lz4_compressed_value)`, preserving key ordering.
+/// This allows apples-to-apples comparison of on-disk size including btree/page overhead.
 #[derive(Parser, Debug)]
 pub struct Command {
     /// The source table to compress.
     table: Tables,
 
-    /// Path to write the compressed table data.
+    /// Path for the output MDBX database directory.
     #[arg(long)]
     out: PathBuf,
 }
@@ -49,29 +53,56 @@ impl<N: ProviderNodeTypes> TableViewer<()> for CompressViewer<'_, N> {
             self.tool.provider_factory.provider()?.disable_long_read_transaction_safety();
         let tx = provider.tx_ref();
 
-        info!("Compressing table `{}` with LZ4 block mode", T::NAME);
+        // Create output MDBX environment
+        std::fs::create_dir_all(&self.out)
+            .map_err(|e| eyre::eyre!("Failed to create output dir {:?}: {e}", self.out))?;
+
+        let out_env = {
+            let mut builder = Environment::builder();
+            builder.set_max_dbs(1);
+            builder.write_map();
+            builder.set_geometry(Geometry {
+                size: Some(0..(1024 * 1024 * 1024 * 1024)), // up to 1 TiB
+                ..Default::default()
+            });
+            builder
+                .open(&self.out)
+                .map_err(|e| eyre::eyre!("Failed to open output MDBX at {:?}: {e}", self.out))?
+        };
+
+        // Create the output table with the same name as the source
+        let out_dbi = {
+            let out_tx = out_env
+                .begin_rw_txn()
+                .map_err(|e| eyre::eyre!("Failed to begin write txn: {e}"))?;
+            let db = out_tx
+                .create_db(Some(T::NAME), DatabaseFlags::empty())
+                .map_err(|e| eyre::eyre!("Failed to create table `{}`: {e}", T::NAME))?;
+            out_tx.commit().map_err(|e| eyre::eyre!("Failed to commit table creation: {e}"))?;
+            db
+        };
+
+        info!("Compressing table `{}` with LZ4 -> {:?}", T::NAME, self.out);
         let start = Instant::now();
 
-        let mut out_file = std::io::BufWriter::new(
-            std::fs::File::create(&self.out)
-                .map_err(|e| eyre::eyre!("Failed to create output file {:?}: {e}", self.out))?,
-        );
         let mut cursor = tx.cursor_read::<RawTable<T>>()?;
         let mut row_count = 0usize;
         let mut original_bytes = 0u64;
         let mut compressed_bytes = 0u64;
         let mut verify_samples: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
 
+        let mut out_tx =
+            out_env.begin_rw_txn().map_err(|e| eyre::eyre!("Failed to begin write txn: {e}"))?;
+
         for entry in cursor.walk(None)? {
             let (k, v): (RawKey<T::Key>, RawValue<T::Value>) = entry?;
 
             let key_bytes = k.raw_key();
             let value_bytes = v.raw_value();
-            let value_len = value_bytes.len();
-            original_bytes += value_len as u64;
+            original_bytes += value_bytes.len() as u64;
 
-            // LZ4 block compress without size prefix (we store original length ourselves)
-            let compressed = block::compress(value_bytes, None, false)
+            // LZ4 block compress with size prefix for self-describing decompression
+            let compressed = block::compress(value_bytes, None, true)
                 .map_err(|e| eyre::eyre!("LZ4 compression failed at row {row_count}: {e}"))?;
             compressed_bytes += compressed.len() as u64;
 
@@ -80,30 +111,27 @@ impl<N: ProviderNodeTypes> TableViewer<()> for CompressViewer<'_, N> {
                 verify_samples.push((value_bytes.to_vec(), compressed.clone()));
             }
 
-            // Record: [key_len: u32][key][original_len: u32][compressed_len: u32][compressed]
-            let key_len: u32 = key_bytes.len().try_into().map_err(|_| {
-                eyre::eyre!("Key too large ({} bytes) at row {row_count}", key_bytes.len())
-            })?;
-            let comp_len: u32 = compressed.len().try_into().map_err(|_| {
-                eyre::eyre!(
-                    "Compressed value too large ({} bytes) at row {row_count}",
-                    compressed.len()
-                )
-            })?;
-
-            out_file.write_all(&key_len.to_le_bytes())?;
-            out_file.write_all(key_bytes)?;
-            out_file.write_all(&(value_len as u32).to_le_bytes())?;
-            out_file.write_all(&comp_len.to_le_bytes())?;
-            out_file.write_all(&compressed)?;
+            out_tx
+                .put(out_dbi.dbi(), key_bytes, &compressed, WriteFlags::APPEND)
+                .map_err(|e| eyre::eyre!("MDBX put failed at row {row_count}: {e}"))?;
 
             row_count += 1;
-            if row_count.is_multiple_of(PROGRESS_LOG_INTERVAL) {
-                info!("Compressed {row_count} rows");
+            if row_count.is_multiple_of(COMMIT_BATCH_SIZE) {
+                out_tx
+                    .commit()
+                    .map_err(|e| eyre::eyre!("Failed to commit batch at row {row_count}: {e}"))?;
+                out_tx = out_env
+                    .begin_rw_txn()
+                    .map_err(|e| eyre::eyre!("Failed to begin write txn: {e}"))?;
+
+                if row_count.is_multiple_of(PROGRESS_LOG_INTERVAL) {
+                    info!("Compressed {row_count} rows");
+                }
             }
         }
 
-        out_file.flush()?;
+        // Final commit
+        out_tx.commit().map_err(|e| eyre::eyre!("Failed to final commit: {e}"))?;
 
         let elapsed = start.elapsed();
         let ratio =
@@ -129,7 +157,7 @@ impl<N: ProviderNodeTypes> TableViewer<()> for CompressViewer<'_, N> {
         // Round-trip verify samples
         info!("Verifying {} samples round-trip...", verify_samples.len());
         for (i, (original, compressed)) in verify_samples.iter().enumerate() {
-            let decompressed = block::decompress(compressed, Some(original.len() as i32))
+            let decompressed = block::decompress(compressed, None)
                 .map_err(|e| eyre::eyre!("Verification decompress failed on sample {i}: {e}"))?;
             eyre::ensure!(
                 decompressed == *original,

--- a/crates/cli/commands/src/db/compress.rs
+++ b/crates/cli/commands/src/db/compress.rs
@@ -1,6 +1,5 @@
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use human_bytes::human_bytes;
-use lz4::block;
 use reth_db_api::{
     cursor::DbCursorRO, table::Table, transaction::DbTx, RawKey, RawTable, RawValue, TableViewer,
     Tables,
@@ -17,10 +16,26 @@ const PROGRESS_LOG_INTERVAL: usize = 100_000;
 /// Batch size for MDBX write transactions to avoid unbounded growth.
 const COMMIT_BATCH_SIZE: usize = 50_000;
 
-/// LZ4-compresses all values from a table and writes them to a new MDBX database.
+/// Default number of samples for zstd dictionary training.
+const DEFAULT_MAX_SAMPLES: usize = 100_000;
+
+/// Default zstd dictionary size (112 KiB, matching reth's existing dictionaries).
+const DEFAULT_DICT_SIZE: usize = 112_640;
+
+/// Compression algorithm to use.
+#[derive(Debug, Clone, Copy, Default, ValueEnum)]
+pub enum CompressionType {
+    /// LZ4 block compression (fast, no dictionary).
+    #[default]
+    Lz4,
+    /// Zstd compression with a trained dictionary (better ratio, two-pass).
+    ZstdDict,
+}
+
+/// Compresses all values from a table and writes them to a new MDBX database.
 ///
 /// Creates a fresh MDBX environment at `--out`, with a single table named after the source.
-/// Each row is written as `(original_key, lz4_compressed_value)`, preserving key ordering.
+/// Each row is written as `(original_key, compressed_value)`, preserving key ordering.
 /// This allows apples-to-apples comparison of on-disk size including btree/page overhead.
 #[derive(Parser, Debug)]
 pub struct Command {
@@ -30,19 +45,200 @@ pub struct Command {
     /// Path for the output MDBX database directory.
     #[arg(long)]
     out: PathBuf,
+
+    /// Compression algorithm.
+    #[arg(long, value_enum, default_value_t = CompressionType::Lz4)]
+    compression: CompressionType,
+
+    /// Path to write the trained zstd dictionary (only used with `--compression zstd-dict`).
+    #[arg(long)]
+    dict_out: Option<PathBuf>,
+
+    /// Maximum number of value samples for dictionary training (only with `zstd-dict`).
+    #[arg(long, default_value_t = DEFAULT_MAX_SAMPLES)]
+    max_samples: usize,
+
+    /// Maximum dictionary size in bytes (only with `zstd-dict`).
+    #[arg(long, default_value_t = DEFAULT_DICT_SIZE)]
+    dict_size: usize,
+
+    /// Zstd compression level. 0 = default (3). Higher = better ratio, slower.
+    #[arg(long, default_value_t = 3)]
+    zstd_level: i32,
 }
 
 impl Command {
     /// Execute `db compress` command
     pub fn execute<N: ProviderNodeTypes>(self, tool: &DbTool<N>) -> eyre::Result<()> {
         warn!("This command should be run without the node running!");
-        self.table.view(&CompressViewer { tool, out: self.out })
+        self.table.view(&CompressViewer {
+            tool,
+            out: self.out,
+            compression: self.compression,
+            dict_out: self.dict_out,
+            max_samples: self.max_samples,
+            dict_size: self.dict_size,
+            zstd_level: self.zstd_level,
+        })
     }
 }
 
 struct CompressViewer<'a, N: NodeTypesWithDB> {
     tool: &'a DbTool<N>,
     out: PathBuf,
+    compression: CompressionType,
+    dict_out: Option<PathBuf>,
+    max_samples: usize,
+    dict_size: usize,
+    zstd_level: i32,
+}
+
+/// Opens a fresh output MDBX environment at `path` and creates a table named `table_name`.
+fn open_output_env(
+    path: &PathBuf,
+    table_name: &str,
+) -> eyre::Result<(Environment, reth_libmdbx::Database)> {
+    std::fs::create_dir_all(path)
+        .map_err(|e| eyre::eyre!("Failed to create output dir {path:?}: {e}"))?;
+
+    let env = {
+        let mut builder = Environment::builder();
+        builder.set_max_dbs(1);
+        builder.write_map();
+        builder.set_geometry(Geometry {
+            size: Some(0..(1024 * 1024 * 1024 * 1024)), // up to 1 TiB
+            ..Default::default()
+        });
+        builder
+            .open(path)
+            .map_err(|e| eyre::eyre!("Failed to open output MDBX at {path:?}: {e}"))?
+    };
+
+    let db = {
+        let tx = env.begin_rw_txn().map_err(|e| eyre::eyre!("Failed to begin write txn: {e}"))?;
+        let db = tx
+            .create_db(Some(table_name), DatabaseFlags::empty())
+            .map_err(|e| eyre::eyre!("Failed to create table `{table_name}`: {e}"))?;
+        tx.commit().map_err(|e| eyre::eyre!("Failed to commit table creation: {e}"))?;
+        db
+    };
+
+    Ok((env, db))
+}
+
+/// Trait abstracting over compression algorithms for the write loop.
+trait Compressor {
+    fn compress(&mut self, data: &[u8]) -> eyre::Result<Vec<u8>>;
+    fn decompress(&self, compressed: &[u8], original_len: usize) -> eyre::Result<Vec<u8>>;
+    fn name(&self) -> &'static str;
+}
+
+struct Lz4Compressor;
+
+impl Compressor for Lz4Compressor {
+    fn compress(&mut self, data: &[u8]) -> eyre::Result<Vec<u8>> {
+        lz4::block::compress(data, None, true)
+            .map_err(|e| eyre::eyre!("LZ4 compression failed: {e}"))
+    }
+
+    fn decompress(&self, compressed: &[u8], _original_len: usize) -> eyre::Result<Vec<u8>> {
+        // Size prefix is embedded (prepend_size=true during compress)
+        lz4::block::decompress(compressed, None)
+            .map_err(|e| eyre::eyre!("LZ4 decompression failed: {e}"))
+    }
+
+    fn name(&self) -> &'static str {
+        "LZ4"
+    }
+}
+
+struct ZstdDictCompressor {
+    compressor: zstd::bulk::Compressor<'static>,
+    dictionary: Vec<u8>,
+}
+
+impl ZstdDictCompressor {
+    fn new(dictionary: Vec<u8>, level: i32) -> eyre::Result<Self> {
+        let compressor = zstd::bulk::Compressor::with_dictionary(level, &dictionary)
+            .map_err(|e| eyre::eyre!("Failed to create zstd compressor: {e}"))?;
+        Ok(Self { compressor, dictionary })
+    }
+}
+
+impl Compressor for ZstdDictCompressor {
+    fn compress(&mut self, data: &[u8]) -> eyre::Result<Vec<u8>> {
+        self.compressor.compress(data).map_err(|e| eyre::eyre!("Zstd compression failed: {e}"))
+    }
+
+    fn decompress(&self, compressed: &[u8], original_len: usize) -> eyre::Result<Vec<u8>> {
+        let mut decompressor = zstd::bulk::Decompressor::with_dictionary(&self.dictionary)
+            .map_err(|e| eyre::eyre!("Failed to create zstd decompressor: {e}"))?;
+        decompressor
+            .decompress(compressed, original_len)
+            .map_err(|e| eyre::eyre!("Zstd decompression failed: {e}"))
+    }
+
+    fn name(&self) -> &'static str {
+        "Zstd+dict"
+    }
+}
+
+/// Stats returned from the compression pass.
+type CompressResult = (usize, u64, u64, Vec<(Vec<u8>, Vec<u8>)>);
+
+/// Writes compressed rows to the output MDBX, returning (row_count, original_bytes,
+/// compressed_bytes, verify_samples).
+fn compress_to_mdbx<T: Table>(
+    tx: &impl DbTx,
+    out_env: &Environment,
+    out_dbi: &reth_libmdbx::Database,
+    compressor: &mut dyn Compressor,
+) -> eyre::Result<CompressResult> {
+    let mut cursor = tx.cursor_read::<RawTable<T>>()?;
+    let mut row_count = 0usize;
+    let mut original_bytes = 0u64;
+    let mut compressed_bytes = 0u64;
+    let mut verify_samples: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+
+    let mut out_tx =
+        out_env.begin_rw_txn().map_err(|e| eyre::eyre!("Failed to begin write txn: {e}"))?;
+
+    for entry in cursor.walk(None)? {
+        let (k, v): (RawKey<T::Key>, RawValue<T::Value>) = entry?;
+
+        let key_bytes = k.raw_key();
+        let value_bytes = v.raw_value();
+        original_bytes += value_bytes.len() as u64;
+
+        let compressed = compressor.compress(value_bytes)?;
+        compressed_bytes += compressed.len() as u64;
+
+        if verify_samples.len() < 10 {
+            verify_samples.push((value_bytes.to_vec(), compressed.clone()));
+        }
+
+        out_tx
+            .put(out_dbi.dbi(), key_bytes, &compressed, WriteFlags::APPEND)
+            .map_err(|e| eyre::eyre!("MDBX put failed at row {row_count}: {e}"))?;
+
+        row_count += 1;
+        if row_count.is_multiple_of(COMMIT_BATCH_SIZE) {
+            out_tx
+                .commit()
+                .map_err(|e| eyre::eyre!("Failed to commit batch at row {row_count}: {e}"))?;
+            out_tx = out_env
+                .begin_rw_txn()
+                .map_err(|e| eyre::eyre!("Failed to begin write txn: {e}"))?;
+
+            if row_count.is_multiple_of(PROGRESS_LOG_INTERVAL) {
+                info!("Compressed {row_count} rows");
+            }
+        }
+    }
+
+    out_tx.commit().map_err(|e| eyre::eyre!("Failed to final commit: {e}"))?;
+
+    Ok((row_count, original_bytes, compressed_bytes, verify_samples))
 }
 
 impl<N: ProviderNodeTypes> TableViewer<()> for CompressViewer<'_, N> {
@@ -53,92 +249,98 @@ impl<N: ProviderNodeTypes> TableViewer<()> for CompressViewer<'_, N> {
             self.tool.provider_factory.provider()?.disable_long_read_transaction_safety();
         let tx = provider.tx_ref();
 
-        // Create output MDBX environment
-        std::fs::create_dir_all(&self.out)
-            .map_err(|e| eyre::eyre!("Failed to create output dir {:?}: {e}", self.out))?;
+        let (out_env, out_dbi) = open_output_env(&self.out, T::NAME)?;
 
-        let out_env = {
-            let mut builder = Environment::builder();
-            builder.set_max_dbs(1);
-            builder.write_map();
-            builder.set_geometry(Geometry {
-                size: Some(0..(1024 * 1024 * 1024 * 1024)), // up to 1 TiB
-                ..Default::default()
-            });
-            builder
-                .open(&self.out)
-                .map_err(|e| eyre::eyre!("Failed to open output MDBX at {:?}: {e}", self.out))?
+        let mut compressor: Box<dyn Compressor> = match self.compression {
+            CompressionType::Lz4 => {
+                info!("Compressing table `{}` with LZ4 -> {:?}", T::NAME, self.out);
+                Box::new(Lz4Compressor)
+            }
+            CompressionType::ZstdDict => {
+                // Pass 1: sample values for dictionary training
+                info!(
+                    "Pass 1: sampling up to {} values from `{}` for zstd dictionary training",
+                    self.max_samples,
+                    T::NAME
+                );
+                let sample_start = Instant::now();
+
+                let mut cursor = tx.cursor_read::<RawTable<T>>()?;
+                let mut samples: Vec<Vec<u8>> = Vec::with_capacity(self.max_samples);
+                let mut total_scanned = 0usize;
+
+                for entry in cursor.walk(None)? {
+                    let (_k, v): (RawKey<T::Key>, RawValue<T::Value>) = entry?;
+                    total_scanned += 1;
+
+                    if samples.len() < self.max_samples {
+                        samples.push(v.raw_value().to_vec());
+                    }
+
+                    if total_scanned.is_multiple_of(PROGRESS_LOG_INTERVAL) {
+                        info!("Scanned {total_scanned} rows, collected {} samples", samples.len());
+                    }
+                }
+
+                info!(
+                    "Scanned {total_scanned} rows, collected {} samples in {:?}",
+                    samples.len(),
+                    sample_start.elapsed()
+                );
+
+                if samples.is_empty() {
+                    eyre::bail!("Table `{}` is empty, nothing to compress", T::NAME);
+                }
+
+                // Train dictionary using zstd's from_continuous API
+                info!(
+                    "Training zstd dictionary (target {} bytes) from {} samples",
+                    self.dict_size,
+                    samples.len()
+                );
+                let train_start = Instant::now();
+
+                let mut sizes = Vec::with_capacity(samples.len());
+                let data: Vec<u8> = samples
+                    .iter()
+                    .flat_map(|s| {
+                        sizes.push(s.len());
+                        s.iter().copied()
+                    })
+                    .collect();
+
+                let dictionary = zstd::dict::from_continuous(&data, &sizes, self.dict_size)
+                    .map_err(|e| eyre::eyre!("Failed to train zstd dictionary: {e}"))?;
+
+                info!(
+                    "Dictionary trained in {:?} ({} bytes)",
+                    train_start.elapsed(),
+                    dictionary.len()
+                );
+
+                // Optionally write dictionary to file
+                if let Some(dict_path) = &self.dict_out {
+                    reth_fs_util::write(dict_path, &dictionary)?;
+                    info!("Dictionary written to {dict_path:?}");
+                }
+
+                info!("Pass 2: compressing table `{}` with Zstd+dict -> {:?}", T::NAME, self.out);
+                Box::new(ZstdDictCompressor::new(dictionary, self.zstd_level)?)
+            }
         };
 
-        // Create the output table with the same name as the source
-        let out_dbi = {
-            let out_tx = out_env
-                .begin_rw_txn()
-                .map_err(|e| eyre::eyre!("Failed to begin write txn: {e}"))?;
-            let db = out_tx
-                .create_db(Some(T::NAME), DatabaseFlags::empty())
-                .map_err(|e| eyre::eyre!("Failed to create table `{}`: {e}", T::NAME))?;
-            out_tx.commit().map_err(|e| eyre::eyre!("Failed to commit table creation: {e}"))?;
-            db
-        };
-
-        info!("Compressing table `{}` with LZ4 -> {:?}", T::NAME, self.out);
         let start = Instant::now();
 
-        let mut cursor = tx.cursor_read::<RawTable<T>>()?;
-        let mut row_count = 0usize;
-        let mut original_bytes = 0u64;
-        let mut compressed_bytes = 0u64;
-        let mut verify_samples: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
-
-        let mut out_tx =
-            out_env.begin_rw_txn().map_err(|e| eyre::eyre!("Failed to begin write txn: {e}"))?;
-
-        for entry in cursor.walk(None)? {
-            let (k, v): (RawKey<T::Key>, RawValue<T::Value>) = entry?;
-
-            let key_bytes = k.raw_key();
-            let value_bytes = v.raw_value();
-            original_bytes += value_bytes.len() as u64;
-
-            // LZ4 block compress with size prefix for self-describing decompression
-            let compressed = block::compress(value_bytes, None, true)
-                .map_err(|e| eyre::eyre!("LZ4 compression failed at row {row_count}: {e}"))?;
-            compressed_bytes += compressed.len() as u64;
-
-            // Keep a few samples for round-trip verification
-            if verify_samples.len() < 10 {
-                verify_samples.push((value_bytes.to_vec(), compressed.clone()));
-            }
-
-            out_tx
-                .put(out_dbi.dbi(), key_bytes, &compressed, WriteFlags::APPEND)
-                .map_err(|e| eyre::eyre!("MDBX put failed at row {row_count}: {e}"))?;
-
-            row_count += 1;
-            if row_count.is_multiple_of(COMMIT_BATCH_SIZE) {
-                out_tx
-                    .commit()
-                    .map_err(|e| eyre::eyre!("Failed to commit batch at row {row_count}: {e}"))?;
-                out_tx = out_env
-                    .begin_rw_txn()
-                    .map_err(|e| eyre::eyre!("Failed to begin write txn: {e}"))?;
-
-                if row_count.is_multiple_of(PROGRESS_LOG_INTERVAL) {
-                    info!("Compressed {row_count} rows");
-                }
-            }
-        }
-
-        // Final commit
-        out_tx.commit().map_err(|e| eyre::eyre!("Failed to final commit: {e}"))?;
+        let (row_count, original_bytes, compressed_bytes, verify_samples) =
+            compress_to_mdbx::<T>(tx, &out_env, &out_dbi, compressor.as_mut())?;
 
         let elapsed = start.elapsed();
         let ratio =
             if original_bytes > 0 { compressed_bytes as f64 / original_bytes as f64 } else { 0.0 };
 
         info!(
-            "Done: {} rows, {} -> {} ({:.1}% of original, ratio {:.3}), elapsed {:?}",
+            "Done ({}): {} rows, {} -> {} ({:.1}% of original, ratio {:.3}), elapsed {:?}",
+            compressor.name(),
             row_count,
             human_bytes(original_bytes as f64),
             human_bytes(compressed_bytes as f64),
@@ -154,11 +356,10 @@ impl<N: ProviderNodeTypes> TableViewer<()> for CompressViewer<'_, N> {
             );
         }
 
-        // Round-trip verify samples
+        // Round-trip verify
         info!("Verifying {} samples round-trip...", verify_samples.len());
         for (i, (original, compressed)) in verify_samples.iter().enumerate() {
-            let decompressed = block::decompress(compressed, None)
-                .map_err(|e| eyre::eyre!("Verification decompress failed on sample {i}: {e}"))?;
+            let decompressed = compressor.decompress(compressed, original.len())?;
             eyre::ensure!(
                 decompressed == *original,
                 "Round-trip verification failed on sample {i}"

--- a/crates/cli/commands/src/db/compress.rs
+++ b/crates/cli/commands/src/db/compress.rs
@@ -1,0 +1,143 @@
+use clap::Parser;
+use human_bytes::human_bytes;
+use lz4::block;
+use reth_db_api::{
+    cursor::DbCursorRO, table::Table, transaction::DbTx, RawKey, RawTable, RawValue, TableViewer,
+    Tables,
+};
+use reth_db_common::DbTool;
+use reth_node_builder::NodeTypesWithDB;
+use reth_provider::{providers::ProviderNodeTypes, DBProvider};
+use std::{io::Write, path::PathBuf, time::Instant};
+use tracing::{info, warn};
+
+const PROGRESS_LOG_INTERVAL: usize = 100_000;
+
+/// LZ4-compresses all values from a table and writes them to a file.
+///
+/// Iterates every row in the source table, compresses each value with LZ4 block mode,
+/// and writes `[key_len: u32][key][original_len: u32][compressed_len: u32][compressed]` records
+/// to the output file. Reports compression ratio and throughput at the end.
+#[derive(Parser, Debug)]
+pub struct Command {
+    /// The source table to compress.
+    table: Tables,
+
+    /// Path to write the compressed table data.
+    #[arg(long)]
+    out: PathBuf,
+}
+
+impl Command {
+    /// Execute `db compress` command
+    pub fn execute<N: ProviderNodeTypes>(self, tool: &DbTool<N>) -> eyre::Result<()> {
+        warn!("This command should be run without the node running!");
+        self.table.view(&CompressViewer { tool, out: self.out })
+    }
+}
+
+struct CompressViewer<'a, N: NodeTypesWithDB> {
+    tool: &'a DbTool<N>,
+    out: PathBuf,
+}
+
+impl<N: ProviderNodeTypes> TableViewer<()> for CompressViewer<'_, N> {
+    type Error = eyre::Report;
+
+    fn view<T: Table>(&self) -> Result<(), Self::Error> {
+        let provider =
+            self.tool.provider_factory.provider()?.disable_long_read_transaction_safety();
+        let tx = provider.tx_ref();
+
+        info!("Compressing table `{}` with LZ4 block mode", T::NAME);
+        let start = Instant::now();
+
+        let mut out_file = std::io::BufWriter::new(
+            std::fs::File::create(&self.out)
+                .map_err(|e| eyre::eyre!("Failed to create output file {:?}: {e}", self.out))?,
+        );
+        let mut cursor = tx.cursor_read::<RawTable<T>>()?;
+        let mut row_count = 0usize;
+        let mut original_bytes = 0u64;
+        let mut compressed_bytes = 0u64;
+        let mut verify_samples: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+
+        for entry in cursor.walk(None)? {
+            let (k, v): (RawKey<T::Key>, RawValue<T::Value>) = entry?;
+
+            let key_bytes = k.raw_key();
+            let value_bytes = v.raw_value();
+            let value_len = value_bytes.len();
+            original_bytes += value_len as u64;
+
+            // LZ4 block compress without size prefix (we store original length ourselves)
+            let compressed = block::compress(value_bytes, None, false)
+                .map_err(|e| eyre::eyre!("LZ4 compression failed at row {row_count}: {e}"))?;
+            compressed_bytes += compressed.len() as u64;
+
+            // Keep a few samples for round-trip verification
+            if verify_samples.len() < 10 {
+                verify_samples.push((value_bytes.to_vec(), compressed.clone()));
+            }
+
+            // Record: [key_len: u32][key][original_len: u32][compressed_len: u32][compressed]
+            let key_len: u32 = key_bytes.len().try_into().map_err(|_| {
+                eyre::eyre!("Key too large ({} bytes) at row {row_count}", key_bytes.len())
+            })?;
+            let comp_len: u32 = compressed.len().try_into().map_err(|_| {
+                eyre::eyre!(
+                    "Compressed value too large ({} bytes) at row {row_count}",
+                    compressed.len()
+                )
+            })?;
+
+            out_file.write_all(&key_len.to_le_bytes())?;
+            out_file.write_all(key_bytes)?;
+            out_file.write_all(&(value_len as u32).to_le_bytes())?;
+            out_file.write_all(&comp_len.to_le_bytes())?;
+            out_file.write_all(&compressed)?;
+
+            row_count += 1;
+            if row_count.is_multiple_of(PROGRESS_LOG_INTERVAL) {
+                info!("Compressed {row_count} rows");
+            }
+        }
+
+        out_file.flush()?;
+
+        let elapsed = start.elapsed();
+        let ratio =
+            if original_bytes > 0 { compressed_bytes as f64 / original_bytes as f64 } else { 0.0 };
+
+        info!(
+            "Done: {} rows, {} -> {} ({:.1}% of original, ratio {:.3}), elapsed {:?}",
+            row_count,
+            human_bytes(original_bytes as f64),
+            human_bytes(compressed_bytes as f64),
+            ratio * 100.0,
+            ratio,
+            elapsed,
+        );
+
+        if ratio > 1.0 {
+            warn!(
+                "Compressed output is larger than original — \
+                 data may already be in a compact/compressed format"
+            );
+        }
+
+        // Round-trip verify samples
+        info!("Verifying {} samples round-trip...", verify_samples.len());
+        for (i, (original, compressed)) in verify_samples.iter().enumerate() {
+            let decompressed = block::decompress(compressed, Some(original.len() as i32))
+                .map_err(|e| eyre::eyre!("Verification decompress failed on sample {i}: {e}"))?;
+            eyre::ensure!(
+                decompressed == *original,
+                "Round-trip verification failed on sample {i}"
+            );
+        }
+        info!("Verification passed.");
+
+        Ok(())
+    }
+}

--- a/crates/cli/commands/src/db/mod.rs
+++ b/crates/cli/commands/src/db/mod.rs
@@ -12,6 +12,7 @@ use std::{
 mod account_storage;
 mod checksum;
 mod clear;
+mod compress;
 mod diff;
 mod get;
 mod list;
@@ -54,6 +55,8 @@ pub enum Subcommands {
     },
     /// Deletes all table entries
     Clear(clear::Command),
+    /// LZ4-compresses all values of a table and writes compressed output to a file
+    Compress(compress::Command),
     /// Verifies trie consistency and outputs any inconsistencies
     RepairTrie(repair_trie::Command),
     /// Reads and displays the static file segment header
@@ -158,6 +161,11 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
             }
             Subcommands::Clear(command) => {
                 db_exec!(self.env, tool, N, AccessRights::RW, {
+                    command.execute(&tool)?;
+                });
+            }
+            Subcommands::Compress(command) => {
+                db_exec!(self.env, tool, N, AccessRights::RO, {
                     command.execute(&tool)?;
                 });
             }

--- a/docs/vocs/docs/pages/cli/SUMMARY.mdx
+++ b/docs/vocs/docs/pages/cli/SUMMARY.mdx
@@ -21,6 +21,7 @@
       - [`reth db clear`](./reth/db/clear.mdx)
         - [`reth db clear mdbx`](./reth/db/clear/mdbx.mdx)
         - [`reth db clear static-file`](./reth/db/clear/static-file.mdx)
+      - [`reth db compress`](./reth/db/compress.mdx)
       - [`reth db repair-trie`](./reth/db/repair-trie.mdx)
       - [`reth db static-file-header`](./reth/db/static-file-header.mdx)
         - [`reth db static-file-header block`](./reth/db/static-file-header/block.mdx)

--- a/docs/vocs/docs/pages/cli/reth/db.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db.mdx
@@ -16,6 +16,7 @@ Commands:
   get                 Gets the content of a table for the given key
   drop                Deletes all database entries
   clear               Deletes all table entries
+  compress            LZ4-compresses all values of a table and writes compressed output to a file
   repair-trie         Verifies trie consistency and outputs any inconsistencies
   static-file-header  Reads and displays the static file segment header
   version             Lists current and local database versions

--- a/docs/vocs/docs/pages/cli/reth/db/compress.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/compress.mdx
@@ -1,0 +1,200 @@
+# reth db compress
+
+LZ4-compresses all values of a table and writes compressed output to a file
+
+```bash
+$ reth db compress --help
+```
+```txt
+Usage: reth db compress [OPTIONS] --out <OUT> <TABLE>
+
+Arguments:
+  <TABLE>
+          The source table to compress
+
+Options:
+      --out <OUT>
+          Path for the output MDBX database directory
+
+      --compression <COMPRESSION>
+          Compression algorithm
+
+          Possible values:
+          - lz4:       LZ4 block compression (fast, no dictionary)
+          - zstd-dict: Zstd compression with a trained dictionary (better ratio, two-pass)
+
+          [default: lz4]
+
+      --dict-out <DICT_OUT>
+          Path to write the trained zstd dictionary (only used with `--compression zstd-dict`)
+
+      --max-samples <MAX_SAMPLES>
+          Maximum number of value samples for dictionary training (only with `zstd-dict`)
+
+          [default: 100000]
+
+      --dict-size <DICT_SIZE>
+          Maximum dictionary size in bytes (only with `zstd-dict`)
+
+          [default: 112640]
+
+      --zstd-level <ZSTD_LEVEL>
+          Zstd compression level. 0 = default (3). Higher = better ratio, slower
+
+          [default: 3]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+Datadir:
+      --chain <CHAIN_OR_PATH>
+          The chain this node is running.
+          Possible values are either a built-in chain or the path to a chain specification file.
+
+          Built-in chains:
+              mainnet, sepolia, holesky, hoodi, dev
+
+          [default: mainnet]
+
+Logging:
+      --log.stdout.format <FORMAT>
+          The format to use for logs written to stdout
+
+          Possible values:
+          - json:     Represents JSON formatting for logs. This format outputs log records as JSON objects, making it suitable for structured logging
+          - log-fmt:  Represents logfmt (key=value) formatting for logs. This format is concise and human-readable, typically used in command-line applications
+          - terminal: Represents terminal-friendly formatting for logs
+
+          [default: terminal]
+
+      --log.stdout.filter <FILTER>
+          The filter to use for logs written to stdout
+
+          [default: ]
+
+      --log.file.format <FORMAT>
+          The format to use for logs written to the log file
+
+          Possible values:
+          - json:     Represents JSON formatting for logs. This format outputs log records as JSON objects, making it suitable for structured logging
+          - log-fmt:  Represents logfmt (key=value) formatting for logs. This format is concise and human-readable, typically used in command-line applications
+          - terminal: Represents terminal-friendly formatting for logs
+
+          [default: terminal]
+
+      --log.file.filter <FILTER>
+          The filter to use for logs written to the log file
+
+          [default: debug]
+
+      --log.file.directory <PATH>
+          The path to put log files in
+
+          [default: <CACHE_DIR>/logs]
+
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
+      --log.file.max-size <SIZE>
+          The maximum size (in MB) of one log file
+
+          [default: 200]
+
+      --log.file.max-files <COUNT>
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled
+
+          [default: 5]
+
+      --log.journald
+          Write logs to journald
+
+      --log.journald.filter <FILTER>
+          The filter to use for logs written to journald
+
+          [default: error]
+
+      --color <COLOR>
+          Sets whether or not the formatter emits ANSI terminal escape codes for colors and other text formatting
+
+          Possible values:
+          - always: Colors on
+          - auto:   Auto-detect
+          - never:  Colors off
+
+          [default: always]
+
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
+Display:
+  -v, --verbosity...
+          Set the minimum log level.
+
+          -v      Errors
+          -vv     Warnings
+          -vvv    Info
+          -vvvv   Debug
+          -vvvvv  Traces (warning: very verbose!)
+
+  -q, --quiet
+          Silence all log output
+
+Tracing:
+      --tracing-otlp[=<URL>]
+          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/traces` - gRPC: `http://localhost:4317`
+
+          Example: --tracing-otlp=http://collector:4318/v1/traces
+
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
+
+      --tracing-otlp-protocol <PROTOCOL>
+          OTLP transport protocol to use for exporting traces and logs.
+
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
+
+          Defaults to HTTP if not specified.
+
+          Possible values:
+          - http: HTTP/Protobuf transport, port 4318, requires `/v1/traces` path
+          - grpc: gRPC transport, port 4317
+
+          [env: OTEL_EXPORTER_OTLP_PROTOCOL=]
+          [default: http]
+
+      --tracing-otlp.filter <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
+
+          Defaults to TRACE if not specified.
+
+          [default: debug]
+
+      --tracing-otlp.sample-ratio <RATIO>
+          Trace sampling ratio to control the percentage of traces to export.
+
+          Valid range: 0.0 to 1.0 - 1.0, default: Sample all traces - 0.01: Sample 1% of traces - 0.0: Disable sampling
+
+          Example: --tracing-otlp.sample-ratio=0.0.
+
+          [env: OTEL_TRACES_SAMPLER_ARG=]
+```

--- a/docs/vocs/sidebar-cli-reth.ts
+++ b/docs/vocs/sidebar-cli-reth.ts
@@ -104,6 +104,10 @@ export const rethCliSidebar: SidebarItem = {
                     ]
                 },
                 {
+                    text: "reth db compress",
+                    link: "/cli/reth/db/compress"
+                },
+                {
                     text: "reth db repair-trie",
                     link: "/cli/reth/db/repair-trie"
                 },


### PR DESCRIPTION
## Summary

Adds `reth db compress` — a CLI tool to LZ4-compress all values from any MDBX table and write compressed output to a file. Useful for measuring compression ratios across tables and experimenting with storage size reduction.

## Changes

- New `crates/cli/commands/src/db/compress.rs` implementing the subcommand
- Wired into `db/mod.rs` as a new `Subcommands::Compress` variant
- Uses `RawTable<T>` for zero-copy raw byte access to table data
- LZ4 block compression per value, output format: `[key_len: u32][key][original_len: u32][compressed_len: u32][compressed]`
- Round-trip verification on first 10 entries

## Usage

```bash
reth db compress Headers --out /tmp/headers_compressed.bin
reth db compress Transactions --out /tmp/txs_compressed.bin
```

## Testing

- Compiled and clippy-clean against `reth-cli-commands`
- No dependency changes (uses existing `lz4` workspace dep)