### PR TITLE
perf(engine): skip transaction prewarming for low-gas blocks

### DIFF
--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -413,6 +413,7 @@ where
             parent_state_root: parent_block.state_root(),
             transaction_count: input.transaction_count(),
             withdrawals: input.withdrawals().map(|w| w.to_vec()),
+            gas_used: input.gas_used(),
         };
 
         // Plan the strategy used for state root computation.
@@ -1571,6 +1572,17 @@ impl<T: PayloadTypes> BlockOrPayload<T> {
         match self {
             Self::Payload(payload) => payload.withdrawals().map(|w| w.as_slice()),
             Self::Block(block) => block.body().withdrawals().map(|w| w.as_slice()),
+        }
+    }
+
+    /// Returns the gas used by the block.
+    pub fn gas_used(&self) -> u64
+    where
+        T::ExecutionData: ExecutionPayload,
+    {
+        match self {
+            Self::Payload(payload) => payload.gas_used(),
+            Self::Block(block) => block.gas_used(),
         }
     }
 }


### PR DESCRIPTION
## Summary
Skip transaction prewarming when a block uses ≤20M gas.

## Motivation
For low-gas blocks, the overhead of spawning parallel prewarming threads outweighs the benefit of cache warming since sequential execution is fast enough. This avoids unnecessary thread/task overhead for blocks that don't benefit from it.

## Changes
- Add `PREWARMING_GAS_THRESHOLD` constant (20M gas) in `payload_processor/mod.rs`
- Add `gas_used` field to `ExecutionEnv` to propagate block gas info to the prewarming decision point
- Add `gas_used()` method to `BlockOrPayload`
- In `spawn_caching_with`, skip transaction prewarming when `gas_used <= PREWARMING_GAS_THRESHOLD`, alongside the existing `disable_transaction_prewarming` check

## Testing
```
cargo check -p reth-engine-tree  # clean
cargo clippy -p reth-engine-tree -- -D warnings  # no warnings
cargo test -p reth-engine-tree --lib  # all tests pass
```

Prompted by: georgios