### PR TITLE
refactor(trie): use JoinHandle instead of channel for parallel storage roots

### DIFF
--- a/crates/trie/parallel/Cargo.toml
+++ b/crates/trie/parallel/Cargo.toml
@@ -35,6 +35,7 @@ derive_more.workspace = true
 rayon.workspace = true
 itertools.workspace = true
 crossbeam-channel.workspace = true
+tokio = { workspace = true, features = ["rt"] }
 
 # `metrics` feature
 reth-metrics = { workspace = true, optional = true }


### PR DESCRIPTION
## Summary
Replace `mpsc::sync_channel` with direct `JoinHandle` return from `spawn_blocking` in `ParallelStateRoot::calculate`.

## Changes
- Remove `mpsc::sync_channel(1)` + `tx.send` pattern
- Have `spawn_blocking` closure return the result directly
- Store `JoinHandle` in the hashmap instead of `Receiver`
- Use `block_in_place` + `block_on` to resolve the handle when the result is needed
- Update test to use `multi_thread` flavor (required by `block_in_place`)

## Testing
`cargo test -p reth-trie-parallel` — all 3 tests pass.

Prompted by: DaniPopes