### PR TITLE
perf(engine): skip spawning PrewarmCacheTask entirely when prewarming disabled

### DIFF
--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -640,6 +640,8 @@ where
             let _ = valid_block_tx.send(());
         }
 
+        handle.commit_cache();
+
         Ok(self.spawn_deferred_trie_task(
             block,
             output,


### PR DESCRIPTION
**Summary**
Follow-up to #22066 addressing DaniPopes' review feedback: "we still spawn workers, can we avoid that entirely?" When transaction prewarming is disabled (via config or small block gas threshold) and no BAL is present, `spawn_caching_with` now returns early without creating `PrewarmContext`, `PrewarmCacheTask`, or spawning any background task.

**Changes**
- Early return in `spawn_caching_with` when `skip_prewarm && bal.is_none()`, avoiding all task creation overhead
- Extended `CacheTaskHandle` with `execution_cache`, `block_hash`, and `pending_outcome` fields for the inline commit path
- Added `CacheTaskHandle::commit_cache()` which performs the same cache update as `PrewarmCacheTask::save_cache` without a background task
- Forwarded `commit_cache()` through `PayloadHandle` and call it in the validator after block validation succeeds
- When `terminate_caching` is called without a prewarm task, the execution outcome is stashed for `commit_cache`

**Expected Impact**
Eliminates unnecessary task spawning overhead for small blocks (~23% of recent mainnet blocks) and when prewarming is explicitly disabled. The execution cache is still correctly updated after valid blocks.