### PR TITLE
perf(engine): lower small block prewarm threshold to 5M gas

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -101,9 +101,9 @@ pub const SPARSE_TRIE_MAX_VALUES_SHRINK_CAPACITY: usize = 1_000_000;
 /// fixed overhead of spawning prewarm workers (building state providers, creating EVM instances,
 /// wrapping precompiles) which exceeds execution time on small blocks.
 ///
-/// 20M gas is used as the threshold because ~23% of recent mainnet blocks fall under this level
-/// where prewarming overhead dominates.
-pub const SMALL_BLOCK_GAS_THRESHOLD: u64 = 20_000_000;
+/// 5M gas is used as a more conservative threshold to only skip prewarming on the smallest blocks
+/// where the overhead most clearly dominates.
+pub const SMALL_BLOCK_GAS_THRESHOLD: u64 = 5_000_000;
 
 /// Type alias for [`PayloadHandle`] returned by payload processor spawn methods.
 type IteratorPayloadHandle<Evm, I, N> = PayloadHandle<


### PR DESCRIPTION
## Summary
Lower the `SMALL_BLOCK_GAS_THRESHOLD` from 20M to 5M gas, only skipping transaction prewarming on the smallest blocks.

## Motivation
Follow-up to #22059. 20M was too aggressive — it skipped prewarming for ~23% of mainnet blocks. 5M is a more conservative threshold that targets only the blocks where prewarm overhead most clearly dominates execution time.

## Changes
- Changed `SMALL_BLOCK_GAS_THRESHOLD` from `20_000_000` to `5_000_000`

## Testing
- `cargo check -p reth-engine-tree` — clean

Prompted by: yk