### PR TITLE
perf(engine): use transaction count threshold for prewarm skip

### DIFF
--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -412,7 +412,6 @@ where
             parent_hash: input.parent_hash(),
             parent_state_root: parent_block.state_root(),
             transaction_count: input.transaction_count(),
-            gas_used: input.gas_used(),
             withdrawals: input.withdrawals().map(|w| w.to_vec()),
         };
 
@@ -1660,17 +1659,6 @@ impl<T: PayloadTypes> BlockOrPayload<T> {
         match self {
             Self::Payload(payload) => payload.transaction_count(),
             Self::Block(block) => block.transaction_count(),
-        }
-    }
-
-    /// Returns the total gas used by all transactions in the payload or block.
-    pub fn gas_used(&self) -> u64
-    where
-        T::ExecutionData: ExecutionPayload,
-    {
-        match self {
-            Self::Payload(payload) => payload.gas_used(),
-            Self::Block(block) => block.header().gas_used(),
         }
     }
 


### PR DESCRIPTION
## Summary
Switch prewarming skip threshold from gas-based (20M gas) to transaction-count-based (30 txns).

## Motivation
Follow-up to #22059. Transaction count is a more direct proxy for prewarm overhead than gas, since the overhead comes from per-worker setup (state providers, EVM instances, precompile wrapping) which scales with transaction count, not gas.

## Changes
- Replace `SMALL_BLOCK_GAS_THRESHOLD` (20M gas) with `SMALL_BLOCK_TX_THRESHOLD` (30 txns)
- Remove `gas_used` field from `ExecutionEnv` (no longer needed)
- Remove `BlockOrPayload::gas_used()` method

## Testing
`cargo check -p reth-engine-tree` passes.

Prompted by: yk