### PR TITLE
revert: skip transaction prewarming for small blocks (#22059)

### DIFF
--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -412,7 +412,6 @@ where
             parent_hash: input.parent_hash(),
             parent_state_root: parent_block.state_root(),
             transaction_count: input.transaction_count(),
-            gas_used: input.gas_used(),
             withdrawals: input.withdrawals().map(|w| w.to_vec()),
         };
 
@@ -1660,17 +1659,6 @@ impl<T: PayloadTypes> BlockOrPayload<T> {
         match self {
             Self::Payload(payload) => payload.transaction_count(),
             Self::Block(block) => block.transaction_count(),
-        }
-    }
-
-    /// Returns the total gas used by all transactions in the payload or block.
-    pub fn gas_used(&self) -> u64
-    where
-        T::ExecutionData: ExecutionPayload,
-    {
-        match self {
-            Self::Payload(payload) => payload.gas_used(),
-            Self::Block(block) => block.header().gas_used(),
         }
     }
 


### PR DESCRIPTION
## Summary
Reverts #22059 — skip transaction prewarming for small blocks (<20M gas).

Prompted by: yk