### PR TITLE
perf: reduce tracing span noise in prewarm and proof workers

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -602,9 +602,6 @@ where
                 target: "engine::tree::payload_processor::prewarm",
                 "prewarm tx",
                 index,
-                tx_hash = %tx.tx().tx_hash(),
-                is_success = tracing::field::Empty,
-                gas_used = tracing::field::Empty,
             )
             .entered();
 
@@ -635,12 +632,6 @@ where
             };
             metrics.execution_duration.record(start.elapsed());
 
-            // record some basic information about the transactions
-            enter.record("gas_used", res.result.gas_used());
-            enter.record("is_success", res.result.is_success());
-
-            drop(enter);
-
             // If the task was cancelled, stop execution, and exit.
             if terminate_execution.load(Ordering::Relaxed) {
                 break
@@ -649,17 +640,15 @@ where
             // Only send outcome for transactions after the first txn
             // as the main execution will be just as fast
             if index > 0 {
-                let _enter =
-                    debug_span!(target: "engine::tree::payload_processor::prewarm", "prewarm outcome", index, tx_hash=%tx.tx().tx_hash())
-                        .entered();
                 let (targets, storage_targets) =
                     multiproof_targets_from_state(res.state, v2_proofs_enabled);
                 metrics.prefetch_storage_targets.record(storage_targets as f64);
                 if let Some(to_multi_proof) = &to_multi_proof {
                     let _ = to_multi_proof.send(MultiProofMessage::PrefetchProofs(targets));
                 }
-                drop(_enter);
             }
+
+            drop(enter);
 
             metrics.total_runtime.record(start.elapsed());
         }

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -598,7 +598,7 @@ where
         };
 
         while let Ok(IndexedTransaction { index, tx }) = txs.recv() {
-            let enter = debug_span!(
+            let _enter = debug_span!(
                 target: "engine::tree::payload_processor::prewarm",
                 "prewarm tx",
                 index,
@@ -647,8 +647,6 @@ where
                     let _ = to_multi_proof.send(MultiProofMessage::PrefetchProofs(targets));
                 }
             }
-
-            drop(enter);
 
             metrics.total_runtime.record(start.elapsed());
         }

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -844,7 +844,7 @@ where
             trace!(target: "engine::tree", "Executing transaction");
 
             let tx_start = Instant::now();
-            let _gas_used = executor.execute_transaction(tx)?;
+            executor.execute_transaction(tx)?;
             self.metrics.record_transaction_execution(tx_start.elapsed());
 
             let current_len = executor.receipts().len();

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -833,21 +833,18 @@ where
 
             let tx = tx_result.map_err(BlockExecutionError::other)?;
             let tx_signer = *<Tx as alloy_evm::RecoveredTx<InnerTx>>::signer(&tx);
-            let tx_hash = <Tx as alloy_evm::RecoveredTx<InnerTx>>::tx(&tx).tx_hash();
 
             senders.push(tx_signer);
 
-            let span = debug_span!(
+            let _enter = debug_span!(
                 target: "engine::tree",
                 "execute tx",
-                ?tx_hash,
-                gas_used = tracing::field::Empty,
-            );
-            let enter = span.entered();
+            )
+            .entered();
             trace!(target: "engine::tree", "Executing transaction");
 
             let tx_start = Instant::now();
-            let gas_used = executor.execute_transaction(tx)?;
+            let _gas_used = executor.execute_transaction(tx)?;
             self.metrics.record_transaction_execution(tx_start.elapsed());
 
             let current_len = executor.receipts().len();
@@ -859,8 +856,6 @@ where
                     let _ = receipt_tx.send(IndexedReceipt::new(tx_index, receipt.clone()));
                 }
             }
-
-            enter.record("gas_used", gas_used);
         }
         drop(exec_span);
 

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -190,7 +190,7 @@ impl ProofWorkerHandle {
                 .entered();
             // Spawn storage workers
             for worker_id in 0..storage_worker_count {
-                let span = debug_span!(target: "trie::proof_task", "storage worker");
+                let span = debug_span!(target: "trie::proof_task", "storage worker", ?worker_id);
                 let task_ctx_clone = task_ctx_for_storage.clone();
                 let work_rx_clone = storage_work_rx.clone();
                 let storage_available_workers_clone = storage_available_workers.clone();
@@ -234,7 +234,7 @@ impl ProofWorkerHandle {
                 .entered();
             // Spawn account workers
             for worker_id in 0..account_worker_count {
-                let span = debug_span!(target: "trie::proof_task", "account worker");
+                let span = debug_span!(target: "trie::proof_task", "account worker", ?worker_id);
                 let task_ctx_clone = task_ctx.clone();
                 let work_rx_clone = account_work_rx.clone();
                 let storage_work_tx_clone = storage_work_tx.clone();

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -190,7 +190,7 @@ impl ProofWorkerHandle {
                 .entered();
             // Spawn storage workers
             for worker_id in 0..storage_worker_count {
-                let span = debug_span!(target: "trie::proof_task", "storage worker", ?worker_id);
+                let span = debug_span!(target: "trie::proof_task", "storage worker");
                 let task_ctx_clone = task_ctx_for_storage.clone();
                 let work_rx_clone = storage_work_rx.clone();
                 let storage_available_workers_clone = storage_available_workers.clone();
@@ -234,7 +234,7 @@ impl ProofWorkerHandle {
                 .entered();
             // Spawn account workers
             for worker_id in 0..account_worker_count {
-                let span = debug_span!(target: "trie::proof_task", "account worker", ?worker_id);
+                let span = debug_span!(target: "trie::proof_task", "account worker");
                 let task_ctx_clone = task_ctx.clone();
                 let work_rx_clone = account_work_rx.clone();
                 let storage_work_tx_clone = storage_work_tx.clone();
@@ -482,9 +482,7 @@ where
         let span = debug_span!(
             target: "trie::proof_task",
             "Storage proof calculation",
-            ?hashed_address,
             target_slots = ?target_slots.len(),
-            worker_id = self.id,
         );
         let _span_guard = span.enter();
 
@@ -532,9 +530,7 @@ where
         let span = debug_span!(
             target: "trie::proof_task",
             "V2 Storage proof calculation",
-            ?hashed_address,
             targets = ?targets.len(),
-            worker_id = self.id,
         );
         let _span_guard = span.enter();
 
@@ -1316,7 +1312,6 @@ where
             "Account multiproof calculation",
             targets = targets.len(),
             num_slots = targets.values().map(|slots| slots.len()).sum::<usize>(),
-            worker_id=self.worker_id,
         );
         let _span_guard = span.enter();
 
@@ -1382,7 +1377,6 @@ where
             "Account V2 multiproof calculation",
             account_targets = account_targets.len(),
             storage_targets = storage_targets.values().map(|t| t.len()).sum::<usize>(),
-            worker_id = self.worker_id,
         );
         let _span_guard = span.enter();
 
@@ -1531,7 +1525,6 @@ where
             target: "trie::proof_task",
             "Blinded account node calculation",
             ?path,
-            worker_id,
         );
         let _span_guard = span.enter();
 
@@ -1639,7 +1632,6 @@ where
                         let _guard = debug_span!(
                             target: "trie::proof_task",
                             "Waiting for storage proof",
-                            ?hashed_address,
                         );
                         // Block on this specific storage proof receiver - enables interleaved
                         // parallelism

--- a/crates/trie/trie/src/hashed_cursor/metrics.rs
+++ b/crates/trie/trie/src/hashed_cursor/metrics.rs
@@ -2,7 +2,7 @@ use super::{HashedCursor, HashedStorageCursor};
 use alloy_primitives::B256;
 use reth_storage_errors::db::DatabaseError;
 use std::time::{Duration, Instant};
-use tracing::debug_span;
+use tracing::trace_span;
 
 #[cfg(feature = "metrics")]
 use crate::TrieType;
@@ -112,7 +112,7 @@ impl HashedCursorMetricsCache {
 
     /// Record the span for metrics.
     pub fn record_span(&self, name: &'static str) {
-        let _span = debug_span!(
+        let _span = trace_span!(
             target: "trie::trie_cursor",
             "Hashed cursor metrics",
             name,

--- a/crates/trie/trie/src/trie_cursor/metrics.rs
+++ b/crates/trie/trie/src/trie_cursor/metrics.rs
@@ -3,7 +3,7 @@ use crate::{BranchNodeCompact, Nibbles};
 use alloy_primitives::B256;
 use reth_storage_errors::db::DatabaseError;
 use std::time::{Duration, Instant};
-use tracing::debug_span;
+use tracing::trace_span;
 
 #[cfg(feature = "metrics")]
 use crate::TrieType;
@@ -108,7 +108,7 @@ impl TrieCursorMetricsCache {
 
     /// Record the span for metrics.
     pub fn record_span(&self, name: &'static str) {
-        let _span = debug_span!(
+        let _span = trace_span!(
             target: "trie::trie_cursor",
             "Trie cursor metrics",
             name,


### PR DESCRIPTION
Reduces profiler trace overhead by cutting redundant/noisy tracing spans that contribute to massive trace file sizes (~286MB string overhead from B256 formatting, ~10.5M zones from trie machinery alone).

**Metric spans to trace level**: Trie cursor and hashed cursor metric spans (`Trie cursor metrics`, `Hashed cursor metrics`) are pure noise at debug level — they dump counter data into the timeline after every proof calculation (~304k zones). Moved to trace.

**Prewarm span cleanup**: The `prewarm tx` → `execute` → `prewarm outcome` span triple is redundant per transaction (~1.65M zones each). Removed the `prewarm outcome` span entirely and dropped `tx_hash`, `is_success`, and `gas_used` fields from `prewarm tx`. Similarly dropped `tx_hash` and `gas_used` from `execute tx` in the payload validator.

**Proof span field removal**: Removed `worker_id` from all proof worker spans (storage/account worker, storage/account/V2 multiproof calculation, blinded node). Removed `hashed_address` from storage proof calculation and waiting-for-storage-proof spans. These B256 Debug-format fields are the primary driver of the 6.2M strings in traces.