### PR TITLE
feat(evm): impl ExecutableTxTuple for Either via EitherTxIterator

### DIFF
--- a/crates/engine/primitives/src/lib.rs
+++ b/crates/engine/primitives/src/lib.rs
@@ -23,7 +23,7 @@ use serde::{de::DeserializeOwned, Serialize};
 
 // Re-export [`ExecutionPayload`] moved to `reth_payload_primitives`
 #[cfg(feature = "std")]
-pub use reth_evm::{ConfigureEngineEvm, ExecutableTxIterator, ExecutableTxTuple};
+pub use reth_evm::{ConfigureEngineEvm, ConvertTx, ExecutableTxIterator, ExecutableTxTuple};
 pub use reth_payload_primitives::ExecutionPayload;
 
 mod error;

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -23,8 +23,8 @@ use rayon::prelude::*;
 use reth_evm::{
     block::ExecutableTxParts,
     execute::{ExecutableTxFor, WithTxEnv},
-    ConfigureEvm, EvmEnvFor, ExecutableTxIterator, ExecutableTxTuple, OnStateHook, SpecFor,
-    TxEnvFor,
+    ConfigureEvm, ConvertTx, EvmEnvFor, ExecutableTxIterator, ExecutableTxTuple, OnStateHook,
+    SpecFor, TxEnvFor,
 };
 use reth_metrics::Metrics;
 use reth_primitives_traits::NodePrimitives;
@@ -370,9 +370,9 @@ where
 
         // Spawn a task that `convert`s all transactions in parallel and sends them out-of-order.
         rayon::spawn(move || {
-            let (transactions, convert) = transactions.into();
+            let (transactions, convert) = transactions.into_parts();
             transactions.into_par_iter().enumerate().for_each_with(ooo_tx, |ooo_tx, (idx, tx)| {
-                let tx = convert(tx);
+                let tx = convert.convert(tx);
                 let tx = tx.map(|tx| {
                     let (tx_env, tx) = tx.into_parts();
                     WithTxEnv { tx_env, tx: Arc::new(tx) }

--- a/crates/evm/evm/src/lib.rs
+++ b/crates/evm/evm/src/lib.rs
@@ -47,7 +47,7 @@ pub use aliases::*;
 #[cfg(feature = "std")]
 mod engine;
 #[cfg(feature = "std")]
-pub use engine::{ConfigureEngineEvm, ExecutableTxIterator, ExecutableTxTuple};
+pub use engine::{ConfigureEngineEvm, ConvertTx, ExecutableTxIterator, ExecutableTxTuple};
 
 #[cfg(feature = "metrics")]
 pub mod metrics;


### PR DESCRIPTION
## Summary

Adds `EitherTxIterator<A, B>` wrapper that implements `ExecutableTxTuple` for `Either<A, B>`, lifting `RawTx`/`Tx`/`Error` types into `Either` variants. The blanket `ExecutableTxIterator` impl applies automatically.

## Changes

- Added `EitherTxIterator` in `crates/evm/evm/src/engine.rs` with `ExecutableTxTuple` and `From` impls
- Simplified `BasicEngineValidator::tx_iterator_for` from ~30 lines of manual `Either` wrapping + `Box<dyn Fn>` to ~10 lines using `EitherTxIterator`
- Re-exported `EitherTxIterator` from `reth-evm` and `reth-engine-primitives`

## Testing

```
cargo +nightly fmt --all
cargo +nightly clippy -p reth-evm -p reth-engine-tree -- -D warnings
cargo check -p reth-evm -p reth-engine-tree
```

Prompted by: DaniPopes