### PR TITLE
fix(primitives): move feature-referenced deps from dev-dependencies to optional dependencies

### DIFF
--- a/.changelog/nice-waves-bow.md
+++ b/.changelog/nice-waves-bow.md
@@ -1,0 +1,5 @@
+---
+reth-primitives: patch
+---
+
+Moved feature-referenced dependencies from dev-dependencies to optional dependencies to ensure they are available when their corresponding features are enabled.

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -20,27 +20,28 @@ reth-static-file-types.workspace = true
 
 # ethereum
 alloy-consensus.workspace = true
+alloy-primitives = { workspace = true, optional = true }
+alloy-rlp = { workspace = true, optional = true }
+alloy-eips = { workspace = true, optional = true }
+alloy-genesis = { workspace = true, optional = true }
 
 # for eip-4844
 c-kzg = { workspace = true, features = ["serde"], optional = true }
 
 # misc
 once_cell.workspace = true
+reth-codecs = { workspace = true, optional = true }
 
 [dev-dependencies]
 # eth
 reth-primitives-traits = { workspace = true, features = ["arbitrary", "test-utils"] }
 
-alloy-primitives.workspace = true
-alloy-rlp.workspace = true
 alloy-eips = { workspace = true, features = ["arbitrary"] }
-alloy-genesis.workspace = true
 
 arbitrary = { workspace = true, features = ["derive"] }
 
 proptest-arbitrary-interop.workspace = true
 proptest.workspace = true
-reth-codecs.workspace = true
 
 criterion.workspace = true
 

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -18,6 +18,18 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
+// These are used as optional dependencies solely for feature forwarding.
+#[cfg(feature = "alloy-eips")]
+use alloy_eips as _;
+#[cfg(feature = "alloy-genesis")]
+use alloy_genesis as _;
+#[cfg(feature = "alloy-primitives")]
+use alloy_primitives as _;
+#[cfg(feature = "alloy-rlp")]
+use alloy_rlp as _;
+#[cfg(feature = "reth-codecs")]
+use reth_codecs as _;
+
 mod block;
 mod receipt;
 pub use reth_static_file_types as static_file;


### PR DESCRIPTION
## Problem

`cargo install --path bin/reth` fails with:

```
package 'reth v1.10.2' does not have a dependency named 'alloy-primitives'
```

## Root Cause

In `crates/primitives/Cargo.toml`, `alloy-primitives`, `alloy-rlp`, `alloy-eips`, `alloy-genesis`, and `reth-codecs` were in `[dev-dependencies]` but referenced in `[features]` (e.g. `asm-keccak = ["alloy-primitives/asm-keccak"]`).

This worked with `cargo build` because the workspace resolver handles this case, but `cargo install` resolves dependencies independently and doesn't include dev-deps from transitive dependencies.

The bug surfaced after #22034 added `asm-keccak` to default features, which triggered the `alloy-primitives/asm-keccak` feature path during `cargo install`.

## Fix

Moved the 5 crates from `[dev-dependencies]` to `[dependencies]` as **optional**, so they're only pulled in when features that reference them are activated (e.g. `std`, `asm-keccak`, `arbitrary`).