### PR TITLE
fix: move alloy-primitives to regular dependency in bin/reth

### DIFF
--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -58,6 +58,7 @@ reth-node-metrics.workspace = true
 reth-consensus.workspace = true
 
 # alloy
+alloy-primitives.workspace = true
 alloy-rpc-types = { workspace = true, features = ["engine"] }
 
 # tracing
@@ -69,7 +70,6 @@ clap = { workspace = true, features = ["derive", "env"] }
 
 [dev-dependencies]
 alloy-node-bindings = "1.6.3"
-alloy-primitives.workspace = true
 alloy-provider = { workspace = true, features = ["reqwest"] }
 alloy-rpc-types-eth.workspace = true
 backon.workspace = true

--- a/bin/reth/src/lib.rs
+++ b/bin/reth/src/lib.rs
@@ -51,6 +51,9 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+// Used in feature flags only (`asm-keccak`, `keccak-cache-global`)
+use alloy_primitives as _;
+
 pub mod cli;
 
 /// Re-exported utils.


### PR DESCRIPTION
## Problem

The `stage-run-test` CI job fails on `cargo install --path bin/reth` with:

```
package `reth v1.10.2` does not have a dependency named `alloy-primitives`
```

## Root Cause

`alloy-primitives` was listed only as a `[dev-dependencies]` but referenced in feature flags (`asm-keccak`, `keccak-cache-global`). `cargo install` does not resolve dev-dependencies, causing the build to fail.

## Fix

- Move `alloy-primitives` from `[dev-dependencies]` to `[dependencies]`
- Add `use alloy_primitives as _;` to suppress the `unused_crate_dependencies` lint (since it's only used transitively via feature flags)