### PR TITLE
refactor(engine): remove unnecessary turbofish on CachedStateProvider, add new_prewarm

### DIFF
--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -96,10 +96,21 @@ pub struct CachedStateProvider<S, const PREWARM: bool = false> {
     metrics: CachedStateMetrics,
 }
 
-impl<S, const PREWARM: bool> CachedStateProvider<S, PREWARM> {
+impl<S> CachedStateProvider<S> {
     /// Creates a new [`CachedStateProvider`] from an [`ExecutionCache`], state provider, and
     /// [`CachedStateMetrics`].
     pub const fn new(
+        state_provider: S,
+        caches: ExecutionCache,
+        metrics: CachedStateMetrics,
+    ) -> Self {
+        Self { state_provider, caches, metrics }
+    }
+}
+
+impl<S> CachedStateProvider<S, true> {
+    /// Creates a new [`CachedStateProvider`] with prewarming enabled.
+    pub const fn new_prewarm(
         state_provider: S,
         caches: ExecutionCache,
         metrics: CachedStateMetrics,
@@ -858,7 +869,7 @@ mod tests {
 
         let caches = ExecutionCache::new(1000);
         let state_provider =
-            CachedStateProvider::<_, false>::new(provider, caches, CachedStateMetrics::zeroed());
+            CachedStateProvider::new(provider, caches, CachedStateMetrics::zeroed());
 
         let res = state_provider.storage(address, storage_key);
         assert!(res.is_ok());
@@ -878,7 +889,7 @@ mod tests {
 
         let caches = ExecutionCache::new(1000);
         let state_provider =
-            CachedStateProvider::<_, false>::new(provider, caches, CachedStateMetrics::zeroed());
+            CachedStateProvider::new(provider, caches, CachedStateMetrics::zeroed());
 
         let res = state_provider.storage(address, storage_key);
         assert!(res.is_ok());

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -297,7 +297,7 @@ where
                 let provider = provider_builder.build().expect("failed to build provider");
                 let provider = if let Some(saved_cache) = saved_cache {
                     let (cache, metrics, _disable_metrics) = saved_cache.split();
-                    Box::new(CachedStateProvider::<_, false>::new(provider, cache, metrics))
+                    Box::new(CachedStateProvider::new(provider, cache, metrics))
                         as Box<dyn StateProvider>
                 } else {
                     Box::new(provider)

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -535,11 +535,8 @@ where
         if let Some(saved_cache) = saved_cache {
             let caches = saved_cache.cache().clone();
             let cache_metrics = saved_cache.metrics().clone();
-            state_provider = Box::new(CachedStateProvider::<_, true>::new(
-                state_provider,
-                caches,
-                cache_metrics,
-            ));
+            state_provider =
+                Box::new(CachedStateProvider::new_prewarm(state_provider, caches, cache_metrics));
         }
 
         let state_provider = StateProviderDatabase::new(state_provider);
@@ -749,8 +746,7 @@ where
         let saved_cache = saved_cache.expect("BAL prewarm should only run with cache");
         let caches = saved_cache.cache().clone();
         let cache_metrics = saved_cache.metrics().clone();
-        let state_provider =
-            CachedStateProvider::<_, false>::new(state_provider, caches, cache_metrics);
+        let state_provider = CachedStateProvider::new(state_provider, caches, cache_metrics);
 
         let start = Instant::now();
 

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -443,11 +443,8 @@ where
         // Use cached state provider before executing, used in execution after prewarming threads
         // complete
         if let Some((caches, cache_metrics)) = handle.caches().zip(handle.cache_metrics()) {
-            state_provider = Box::new(CachedStateProvider::<_, false>::new(
-                state_provider,
-                caches,
-                cache_metrics,
-            ));
+            state_provider =
+                Box::new(CachedStateProvider::new(state_provider, caches, cache_metrics));
         };
 
         if self.config.state_provider_metrics() {


### PR DESCRIPTION
Follow-up to #22106. Moves `new()` to `impl<S> CachedStateProvider<S>` so the `PREWARM = false` default is used and `<_, false>` turbofish is unnecessary. Adds `new_prewarm()` on `impl<S> CachedStateProvider<S, true>` for the prewarm path.

Prompted by: DaniPopes