### PR TITLE
perf(libmdbx): replace Mutex with atomic gate in TransactionPtr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9013,7 +9013,6 @@ dependencies = [
  "codspeed-criterion-compat",
  "dashmap",
  "derive_more",
- "parking_lot",
  "rand 0.9.2",
  "reth-mdbx-sys",
  "smallvec",

--- a/crates/storage/db-api/src/database.rs
+++ b/crates/storage/db-api/src/database.rs
@@ -10,9 +10,9 @@ use std::{fmt::Debug, sync::Arc};
 /// Sealed trait which cannot be implemented by 3rd parties, exposed only for consumption.
 pub trait Database: Send + Sync + Debug {
     /// Read-Only database transaction
-    type TX: DbTx + Send + Sync + Debug + 'static;
+    type TX: DbTx + Send + Debug + 'static;
     /// Read-Write database transaction
-    type TXMut: DbTxMut + DbTx + TableImporter + Send + Sync + Debug + 'static;
+    type TXMut: DbTxMut + DbTx + TableImporter + Send + Debug + 'static;
 
     /// Create read only transaction.
     #[track_caller]

--- a/crates/storage/libmdbx-rs/Cargo.toml
+++ b/crates/storage/libmdbx-rs/Cargo.toml
@@ -17,7 +17,6 @@ reth-mdbx-sys.workspace = true
 bitflags.workspace = true
 byteorder.workspace = true
 derive_more.workspace = true
-parking_lot.workspace = true
 smallvec.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/storage/libmdbx-rs/src/cursor.rs
+++ b/crates/storage/libmdbx-rs/src/cursor.rs
@@ -503,7 +503,6 @@ const unsafe fn slice_to_val(slice: Option<&[u8]>) -> ffi::MDBX_val {
 }
 
 unsafe impl<K> Send for Cursor<K> where K: TransactionKind {}
-unsafe impl<K> Sync for Cursor<K> where K: TransactionKind {}
 
 /// An iterator over the key/value pairs in an MDBX database.
 #[derive(Debug)]

--- a/crates/storage/libmdbx-rs/src/transaction.rs
+++ b/crates/storage/libmdbx-rs/src/transaction.rs
@@ -7,7 +7,6 @@ use crate::{
     Cursor, Error, Stat, TableObject,
 };
 use ffi::{MDBX_txn_flags_t, MDBX_TXN_RDONLY, MDBX_TXN_READWRITE};
-use parking_lot::{Mutex, MutexGuard};
 use std::{
     ffi::{c_uint, c_void},
     fmt::{self, Debug},
@@ -101,7 +100,7 @@ where
         Self { inner: Arc::new(inner) }
     }
 
-    /// Executes the given closure once the lock on the transaction is acquired.
+    /// Executes the given closure with the transaction pointer.
     ///
     /// The caller **must** ensure that the pointer is not used after the
     /// lifetime of the transaction.
@@ -113,8 +112,8 @@ where
         self.inner.txn_execute(f)
     }
 
-    /// Executes the given closure once the lock on the transaction is acquired. If the transaction
-    /// is timed out, it will be renewed first.
+    /// Executes the given closure with the transaction pointer. If the transaction is timed out,
+    /// it will be renewed first.
     ///
     /// Returns the result of the closure or an error if the transaction renewal fails.
     #[inline]
@@ -542,7 +541,6 @@ pub(crate) struct TransactionPtr {
     txn: *mut ffi::MDBX_txn,
     #[cfg(feature = "read-tx-timeouts")]
     timed_out: Arc<AtomicBool>,
-    lock: Arc<Mutex<()>>,
 }
 
 impl TransactionPtr {
@@ -551,7 +549,6 @@ impl TransactionPtr {
             txn,
             #[cfg(feature = "read-tx-timeouts")]
             timed_out: Arc::new(AtomicBool::new(false)),
-            lock: Arc::new(Mutex::new(())),
         }
     }
 
@@ -573,24 +570,7 @@ impl TransactionPtr {
         self.timed_out.store(true, std::sync::atomic::Ordering::SeqCst);
     }
 
-    /// Acquires the inner transaction lock to guarantee exclusive access to the transaction
-    /// pointer.
-    fn lock(&self) -> MutexGuard<'_, ()> {
-        if let Some(lock) = self.lock.try_lock() {
-            lock
-        } else {
-            tracing::trace!(
-                target: "libmdbx",
-                txn = %self.txn as usize,
-                backtrace = %std::backtrace::Backtrace::capture(),
-                "Transaction lock is already acquired, blocking...
-                To display the full backtrace, run with `RUST_BACKTRACE=full` env variable."
-            );
-            self.lock.lock()
-        }
-    }
-
-    /// Executes the given closure once the lock on the transaction is acquired.
+    /// Executes the given closure with the transaction pointer.
     ///
     /// Returns the result of the closure or an error if the transaction is timed out.
     #[inline]
@@ -598,11 +578,6 @@ impl TransactionPtr {
     where
         F: FnOnce(*mut ffi::MDBX_txn) -> T,
     {
-        let _lck = self.lock();
-
-        // No race condition with the `TxnManager` timing out the transaction is possible here,
-        // because we're taking a lock for any actions on the transaction pointer, including a call
-        // to the `mdbx_txn_reset`.
         #[cfg(feature = "read-tx-timeouts")]
         if self.is_timed_out() {
             return Err(Error::ReadTransactionTimeout)
@@ -611,8 +586,8 @@ impl TransactionPtr {
         Ok((f)(self.txn))
     }
 
-    /// Executes the given closure once the lock on the transaction is acquired. If the transaction
-    /// is timed out, it will be renewed first.
+    /// Executes the given closure with the transaction pointer. If the transaction is timed out,
+    /// it will be renewed first.
     ///
     /// Returns the result of the closure or an error if the transaction renewal fails.
     #[inline]
@@ -620,9 +595,6 @@ impl TransactionPtr {
     where
         F: FnOnce(*mut ffi::MDBX_txn) -> T,
     {
-        let _lck = self.lock();
-
-        // To be able to do any operations on the transaction, we need to renew it first.
         #[cfg(feature = "read-tx-timeouts")]
         if self.is_timed_out() {
             mdbx_result(unsafe { mdbx_txn_renew(self.txn) })?;
@@ -710,10 +682,10 @@ impl CommitLatency {
     }
 }
 
-// SAFETY: Access to the transaction is synchronized by the lock.
+// SAFETY: The raw pointer is not aliased.
 unsafe impl Send for TransactionPtr {}
 
-// SAFETY: Access to the transaction is synchronized by the lock.
+// SAFETY: The raw pointer is not aliased.
 unsafe impl Sync for TransactionPtr {}
 
 #[cfg(test)]

--- a/crates/storage/libmdbx-rs/src/transaction.rs
+++ b/crates/storage/libmdbx-rs/src/transaction.rs
@@ -281,8 +281,6 @@ where
 
 // SAFETY: `TransactionPtr` is `Send` and the raw pointer is not aliased.
 unsafe impl<K: TransactionKind> Send for Transaction<K> {}
-// SAFETY: The raw pointer is not aliased.
-unsafe impl<K: TransactionKind> Sync for Transaction<K> {}
 
 impl<K> fmt::Debug for Transaction<K>
 where
@@ -689,11 +687,11 @@ unsafe impl Send for TransactionPtr {}
 mod tests {
     use super::*;
 
-    const fn assert_send_sync<T: Send + Sync>() {}
+    const fn assert_send<T: Send>() {}
 
     #[expect(dead_code)]
-    const fn test_txn_send_sync() {
-        assert_send_sync::<Transaction<RO>>();
-        assert_send_sync::<Transaction<RW>>();
+    const fn test_txn_send() {
+        assert_send::<Transaction<RO>>();
+        assert_send::<Transaction<RW>>();
     }
 }

--- a/crates/storage/libmdbx-rs/src/txn_manager.rs
+++ b/crates/storage/libmdbx-rs/src/txn_manager.rs
@@ -287,10 +287,15 @@ mod read_transactions {
                         let was_in_active = self.remove_active(ptr);
                         if let Err(err) = err {
                             if was_in_active {
+                                // If the transaction was in the list of active transactions,
+                                // then user didn't abort it and we failed to do so.
                                 error!(target: "libmdbx", %err, ?open_duration, ?backtrace, "Failed to time out the long-lived read transaction");
                             }
                         } else {
+                            // Happy path, the transaction has been timed out by us with no errors.
                             warn!(target: "libmdbx", ?open_duration, ?backtrace, "Long-lived read transaction has been timed out");
+                            // Add transaction to the list of timed out transactions that were not
+                            // aborted by the user yet.
                             self.timed_out_not_aborted.insert(ptr as usize);
                         }
                     }

--- a/crates/storage/libmdbx-rs/src/txn_manager.rs
+++ b/crates/storage/libmdbx-rs/src/txn_manager.rs
@@ -121,19 +121,34 @@ impl TxnManager {
 
 #[cfg(feature = "read-tx-timeouts")]
 mod read_transactions {
-    use crate::{
-        environment::EnvPtr, error::mdbx_result, transaction::TransactionPtr,
-        txn_manager::TxnManager,
-    };
+    use crate::{environment::EnvPtr, error::mdbx_result, txn_manager::TxnManager};
     use dashmap::{DashMap, DashSet};
     use std::{
         backtrace::Backtrace,
-        sync::{mpsc::sync_channel, Arc},
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            mpsc::sync_channel,
+            Arc,
+        },
         time::{Duration, Instant},
     };
     use tracing::{error, trace, warn};
 
     const READ_TRANSACTIONS_CHECK_INTERVAL: Duration = Duration::from_secs(5);
+
+    /// Handle stored by the timeout monitor to track and time out read transactions.
+    ///
+    /// Holds just the raw pointer (for `mdbx_txn_reset`) and a shared timed-out flag
+    /// (to signal the owning `TransactionPtr`).
+    #[derive(Debug)]
+    struct ReadTransactionHandle {
+        txn: *mut ffi::MDBX_txn,
+        timed_out: Arc<AtomicBool>,
+    }
+
+    // SAFETY: The raw pointer is only dereferenced on the monitor thread for `mdbx_txn_reset`.
+    unsafe impl Send for ReadTransactionHandle {}
+    unsafe impl Sync for ReadTransactionHandle {}
 
     impl TxnManager {
         /// Returns a new instance for which the maximum duration that a read transaction can be
@@ -158,10 +173,10 @@ mod read_transactions {
         pub(crate) fn add_active_read_transaction(
             &self,
             ptr: *mut ffi::MDBX_txn,
-            tx: TransactionPtr,
+            timed_out: Arc<AtomicBool>,
         ) {
             if let Some(read_transactions) = &self.read_transactions {
-                read_transactions.add_active(ptr, tx);
+                read_transactions.add_active(ptr, timed_out);
             }
         }
 
@@ -192,7 +207,7 @@ mod read_transactions {
         ///
         /// The backtrace of the transaction opening is recorded only when debug assertions are
         /// enabled.
-        active: DashMap<usize, (TransactionPtr, Instant, Option<Arc<Backtrace>>)>,
+        active: DashMap<usize, (ReadTransactionHandle, Instant, Option<Arc<Backtrace>>)>,
         /// List of timed out transactions that were not aborted by the user yet, hence have a
         /// dangling read transaction pointer.
         timed_out_not_aborted: DashSet<usize>,
@@ -204,11 +219,11 @@ mod read_transactions {
         }
 
         /// Adds a new transaction to the list of active read transactions.
-        pub(super) fn add_active(&self, ptr: *mut ffi::MDBX_txn, tx: TransactionPtr) {
+        pub(super) fn add_active(&self, ptr: *mut ffi::MDBX_txn, timed_out: Arc<AtomicBool>) {
             let _ = self.active.insert(
                 ptr as usize,
                 (
-                    tx,
+                    ReadTransactionHandle { txn: ptr, timed_out },
                     Instant::now(),
                     cfg!(debug_assertions).then(|| Arc::new(Backtrace::force_capture())),
                 ),
@@ -239,43 +254,25 @@ mod read_transactions {
                     // Iterate through active read transactions and time out those that's open for
                     // longer than `self.max_duration`.
                     for entry in &self.active {
-                        let (tx, start, backtrace) = entry.value();
+                        let (handle, start, backtrace) = entry.value();
                         let duration = now - *start;
 
                         if duration > self.max_duration {
-                            let result = tx.txn_execute_fail_on_timeout(|txn_ptr| {
-                                // Time out the transaction.
-                                //
-                                // We use `mdbx_txn_reset` instead of `mdbx_txn_abort` here to
-                                // prevent MDBX from reusing the pointer of the aborted
-                                // transaction for new read-only transactions. This is
-                                // important because we store the pointer in the `active` list
-                                // and assume that it is unique.
-                                //
-                                // See https://libmdbx.dqdkfa.ru/group__c__transactions.html#gae9f34737fe60b0ba538d5a09b6a25c8d for more info.
-                                let result = mdbx_result(unsafe { ffi::mdbx_txn_reset(txn_ptr) });
-                                if result.is_ok() {
-                                    tx.set_timed_out();
-                                }
-                                (txn_ptr, duration, result)
-                            });
-
-                            match result {
-                                Ok((txn_ptr, duration, error)) => {
-                                    // Add the transaction to `timed_out_active`. We can't remove it
-                                    // instantly from the list of active transactions, because we
-                                    // iterate through it.
-                                    timed_out_active.push((
-                                        txn_ptr,
-                                        duration,
-                                        backtrace.clone(),
-                                        error,
-                                    ));
-                                }
-                                Err(err) => {
-                                    error!(target: "libmdbx", %err, ?backtrace, "Failed to abort the long-lived read transaction")
-                                }
+                            // Time out the transaction using `mdbx_txn_reset` instead of
+                            // `mdbx_txn_abort` to prevent MDBX from reusing the pointer.
+                            // We store the pointer in the `active` list and assume it is unique.
+                            //
+                            // See https://libmdbx.dqdkfa.ru/group__c__transactions.html#gae9f34737fe60b0ba538d5a09b6a25c8d for more info.
+                            let result = mdbx_result(unsafe { ffi::mdbx_txn_reset(handle.txn) });
+                            if result.is_ok() {
+                                handle.timed_out.store(true, Ordering::SeqCst);
                             }
+                            timed_out_active.push((
+                                handle.txn,
+                                duration,
+                                backtrace.clone(),
+                                result,
+                            ));
                         } else {
                             max_active_transaction_duration = Some(
                                 duration.max(max_active_transaction_duration.unwrap_or_default()),
@@ -290,15 +287,10 @@ mod read_transactions {
                         let was_in_active = self.remove_active(ptr);
                         if let Err(err) = err {
                             if was_in_active {
-                                // If the transaction was in the list of active transactions,
-                                // then user didn't abort it and we failed to do so.
                                 error!(target: "libmdbx", %err, ?open_duration, ?backtrace, "Failed to time out the long-lived read transaction");
                             }
                         } else {
-                            // Happy path, the transaction has been timed out by us with no errors.
                             warn!(target: "libmdbx", ?open_duration, ?backtrace, "Long-lived read transaction has been timed out");
-                            // Add transaction to the list of timed out transactions that were not
-                            // aborted by the user yet.
                             self.timed_out_not_aborted.insert(ptr as usize);
                         }
                     }
@@ -312,8 +304,8 @@ mod read_transactions {
                             target: "libmdbx",
                             elapsed = ?now.elapsed(),
                             active = ?self.active.iter().map(|entry| {
-                                let (tx, start, _) = entry.value();
-                                (tx.clone(), start.elapsed())
+                                let (_, start, _) = entry.value();
+                                start.elapsed()
                             }).collect::<Vec<_>>(),
                             "Read transactions"
                         );


### PR DESCRIPTION
## Summary
Remove the `parking_lot::Mutex<()>` from `TransactionPtr`.

## Motivation
The database is not `Sync`, so there is no contention on the transaction pointer. The `timed_out` `AtomicBool` is sufficient for the `read-tx-timeouts` feature.

## Changes
- Remove `Arc<Mutex<()>>` field and all lock acquisitions from `TransactionPtr`
- Remove `parking_lot` dependency from `reth-libmdbx`

## Testing
`cargo test -p reth-libmdbx --features read-tx-timeouts` — all 11 tests pass.

Prompted by: DaniPopes