### PR TITLE
fix(cli): replace AccessRights with --read-only flag, auto-detect running node

### DIFF
--- a/crates/cli/commands/src/common.rs
+++ b/crates/cli/commands/src/common.rs
@@ -8,7 +8,7 @@ use reth_chainspec::EthChainSpec;
 use reth_cli::chainspec::ChainSpecParser;
 use reth_config::{config::EtlConfig, Config};
 use reth_consensus::noop::NoopConsensus;
-use reth_db::{init_db, open_db_read_only, DatabaseEnv};
+use reth_db::{init_db, DatabaseEnv};
 use reth_db_common::init::init_genesis_with_settings;
 use reth_downloaders::{bodies::noop::NoopBodiesDownloader, headers::noop::NoopHeaderDownloader};
 use reth_eth_wire::NetPrimitivesFor;
@@ -125,12 +125,11 @@ impl<C: ChainSpecParser> EnvironmentArgs<C> {
         s
     }
 
-    /// Initializes environment according to [`AccessRights`] and returns an instance of
-    /// [`Environment`].
+    /// Initializes environment and returns an instance of [`Environment`].
     ///
     /// Internally builds a [`reth_tasks::Runtime`] attached to the current tokio handle for
     /// parallel storage I/O.
-    pub fn init<N: CliNodeTypes>(&self, access: AccessRights) -> eyre::Result<Environment<N>>
+    pub fn init<N: CliNodeTypes>(&self) -> eyre::Result<Environment<N>>
     where
         C: ChainSpecParser<ChainSpec = N::ChainSpec>,
     {
@@ -140,11 +139,9 @@ impl<C: ChainSpecParser> EnvironmentArgs<C> {
         let sf_path = data_dir.static_files();
         let rocksdb_path = data_dir.rocksdb();
 
-        if access.is_read_write() {
-            reth_fs_util::create_dir_all(&db_path)?;
-            reth_fs_util::create_dir_all(&sf_path)?;
-            reth_fs_util::create_dir_all(&rocksdb_path)?;
-        }
+        reth_fs_util::create_dir_all(&db_path)?;
+        reth_fs_util::create_dir_all(&sf_path)?;
+        reth_fs_util::create_dir_all(&rocksdb_path)?;
 
         let config_path = self.config.clone().unwrap_or_else(|| data_dir.config());
 
@@ -164,53 +161,35 @@ impl<C: ChainSpecParser> EnvironmentArgs<C> {
 
         info!(target: "reth::cli", ?db_path, ?sf_path, "Opening storage");
         let genesis_block_number = self.chain.genesis().number.unwrap_or_default();
-        let (db, sfp) = match access {
-            AccessRights::RW => (
-                init_db(db_path, self.db.database_args())?,
-                StaticFileProviderBuilder::read_write(sf_path)
-                    .with_metrics()
-                    .with_genesis_block_number(genesis_block_number)
-                    .build()?,
-            ),
-            AccessRights::RO | AccessRights::RoInconsistent => {
-                (open_db_read_only(&db_path, self.db.database_args())?, {
-                    let provider = StaticFileProviderBuilder::read_only(sf_path)
-                        .with_metrics()
-                        .with_genesis_block_number(genesis_block_number)
-                        .build()?;
-                    provider.watch_directory();
-                    provider
-                })
-            }
-        };
+        let (db, sfp) = (
+            init_db(db_path, self.db.database_args())?,
+            StaticFileProviderBuilder::read_write(sf_path)
+                .with_metrics()
+                .with_genesis_block_number(genesis_block_number)
+                .build()?,
+        );
         let rocksdb_provider = RocksDBProvider::builder(data_dir.rocksdb())
             .with_default_tables()
             .with_database_log_level(self.db.log_level)
-            .with_read_only(!access.is_read_write())
             .build()?;
 
         let provider_factory =
-            self.create_provider_factory(&config, db, sfp, rocksdb_provider, access, runtime)?;
-        if access.is_read_write() {
-            debug!(target: "reth::cli", chain=%self.chain.chain(), genesis=?self.chain.genesis_hash(), "Initializing genesis");
-            init_genesis_with_settings(&provider_factory, self.storage_settings())?;
-        }
+            self.create_provider_factory(&config, db, sfp, rocksdb_provider, runtime)?;
+        debug!(target: "reth::cli", chain=%self.chain.chain(), genesis=?self.chain.genesis_hash(), "Initializing genesis");
+        init_genesis_with_settings(&provider_factory, self.storage_settings())?;
 
         Ok(Environment { config, provider_factory, data_dir })
     }
 
     /// Returns a [`ProviderFactory`] after executing consistency checks.
     ///
-    /// If it's a read-write environment and an issue is found, it will attempt to heal (including a
-    /// pipeline unwind). Otherwise, it will print out a warning, advising the user to restart the
-    /// node to heal.
+    /// If an issue is found, it will attempt to heal (including a pipeline unwind).
     fn create_provider_factory<N: CliNodeTypes>(
         &self,
         config: &Config,
         db: DatabaseEnv,
         static_file_provider: StaticFileProvider<N::Primitives>,
         rocksdb_provider: RocksDBProvider,
-        access: AccessRights,
         runtime: reth_tasks::Runtime,
     ) -> eyre::Result<ProviderFactory<NodeTypesWithDBAdapter<N, DatabaseEnv>>>
     where
@@ -227,15 +206,9 @@ impl<C: ChainSpecParser> EnvironmentArgs<C> {
         .with_prune_modes(prune_modes.clone());
 
         // Check for consistency between database and static files.
-        if !access.is_read_only_inconsistent() &&
-            let Some(unwind_target) =
-                factory.static_file_provider().check_consistency(&factory.provider()?)?
+        if let Some(unwind_target) =
+            factory.static_file_provider().check_consistency(&factory.provider()?)?
         {
-            if factory.db_ref().is_read_only()? {
-                warn!(target: "reth::cli", ?unwind_target, "Inconsistent storage. Restart node to heal.");
-                return Ok(factory)
-            }
-
             // Highly unlikely to happen, and given its destructive nature, it's better to panic
             // instead.
             assert_ne!(
@@ -281,30 +254,6 @@ pub struct Environment<N: NodeTypes> {
     pub provider_factory: ProviderFactory<NodeTypesWithDBAdapter<N, DatabaseEnv>>,
     /// Datadir path.
     pub data_dir: ChainPath<DataDirPath>,
-}
-
-/// Environment access rights.
-#[derive(Debug, Copy, Clone)]
-pub enum AccessRights {
-    /// Read-write access
-    RW,
-    /// Read-only access
-    RO,
-    /// Read-only access with possibly inconsistent data
-    RoInconsistent,
-}
-
-impl AccessRights {
-    /// Returns `true` if it requires read-write access to the environment.
-    pub const fn is_read_write(&self) -> bool {
-        matches!(self, Self::RW)
-    }
-
-    /// Returns `true` if it requires read-only access to the environment with possibly inconsistent
-    /// data.
-    pub const fn is_read_only_inconsistent(&self) -> bool {
-        matches!(self, Self::RoInconsistent)
-    }
 }
 
 /// Helper alias to satisfy `FullNodeTypes` bound on [`Node`] trait generic.

--- a/crates/cli/commands/src/db/mod.rs
+++ b/crates/cli/commands/src/db/mod.rs
@@ -1,4 +1,4 @@
-use crate::common::{AccessRights, CliNodeTypes, Environment, EnvironmentArgs};
+use crate::common::{CliNodeTypes, Environment, EnvironmentArgs};
 use clap::{Parser, Subcommand};
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_cli::chainspec::ChainSpecParser;
@@ -76,11 +76,10 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
         self,
         ctx: CliContext,
     ) -> eyre::Result<()> {
-        /// Initializes a provider factory with specified access rights, and then executes the
-        /// provided command.
+        /// Initializes a provider factory and then executes the provided command.
         macro_rules! db_exec {
-            ($env:expr, $tool:ident, $N:ident, $access_rights:expr, $command:block) => {
-                let Environment { provider_factory, .. } = $env.init::<$N>($access_rights)?;
+            ($env:expr, $tool:ident, $N:ident, $command:block) => {
+                let Environment { provider_factory, .. } = $env.init::<$N>()?;
 
                 let $tool = DbTool::new(provider_factory)?;
                 $command;
@@ -105,32 +104,27 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
         match self.command {
             // TODO: We'll need to add this on the DB trait.
             Subcommands::Stats(command) => {
-                let access_rights = if command.skip_consistency_checks {
-                    AccessRights::RoInconsistent
-                } else {
-                    AccessRights::RO
-                };
-                db_exec!(self.env, tool, N, access_rights, {
+                db_exec!(self.env, tool, N, {
                     command.execute(data_dir, &tool)?;
                 });
             }
             Subcommands::List(command) => {
-                db_exec!(self.env, tool, N, AccessRights::RO, {
+                db_exec!(self.env, tool, N, {
                     command.execute(&tool)?;
                 });
             }
             Subcommands::Checksum(command) => {
-                db_exec!(self.env, tool, N, AccessRights::RO, {
+                db_exec!(self.env, tool, N, {
                     command.execute(&tool)?;
                 });
             }
             Subcommands::Diff(command) => {
-                db_exec!(self.env, tool, N, AccessRights::RO, {
+                db_exec!(self.env, tool, N, {
                     command.execute(&tool)?;
                 });
             }
             Subcommands::Get(command) => {
-                db_exec!(self.env, tool, N, AccessRights::RO, {
+                db_exec!(self.env, tool, N, {
                     command.execute(&tool)?;
                 });
             }
@@ -152,24 +146,22 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
                     }
                 }
 
-                db_exec!(self.env, tool, N, AccessRights::RW, {
+                db_exec!(self.env, tool, N, {
                     tool.drop(db_path, static_files_path, exex_wal_path)?;
                 });
             }
             Subcommands::Clear(command) => {
-                db_exec!(self.env, tool, N, AccessRights::RW, {
+                db_exec!(self.env, tool, N, {
                     command.execute(&tool)?;
                 });
             }
             Subcommands::RepairTrie(command) => {
-                let access_rights =
-                    if command.dry_run { AccessRights::RO } else { AccessRights::RW };
-                db_exec!(self.env, tool, N, access_rights, {
+                db_exec!(self.env, tool, N, {
                     command.execute(&tool, ctx.task_executor, &data_dir)?;
                 });
             }
             Subcommands::StaticFileHeader(command) => {
-                db_exec!(self.env, tool, N, AccessRights::RoInconsistent, {
+                db_exec!(self.env, tool, N, {
                     command.execute(&tool)?;
                 });
             }
@@ -192,17 +184,17 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
                 println!("{}", db_path.display());
             }
             Subcommands::Settings(command) => {
-                db_exec!(self.env, tool, N, command.access_rights(), {
+                db_exec!(self.env, tool, N, {
                     command.execute(&tool)?;
                 });
             }
             Subcommands::AccountStorage(command) => {
-                db_exec!(self.env, tool, N, AccessRights::RO, {
+                db_exec!(self.env, tool, N, {
                     command.execute(&tool)?;
                 });
             }
             Subcommands::State(command) => {
-                db_exec!(self.env, tool, N, AccessRights::RO, {
+                db_exec!(self.env, tool, N, {
                     command.execute(&tool)?;
                 });
             }

--- a/crates/cli/commands/src/db/settings.rs
+++ b/crates/cli/commands/src/db/settings.rs
@@ -7,23 +7,11 @@ use reth_provider::{
     MetadataWriter, StorageSettings,
 };
 
-use crate::common::AccessRights;
-
 /// `reth db settings` subcommand
 #[derive(Debug, Parser)]
 pub struct Command {
     #[command(subcommand)]
     command: Subcommands,
-}
-
-impl Command {
-    /// Returns database access rights required for the command.
-    pub fn access_rights(&self) -> AccessRights {
-        match self.command {
-            Subcommands::Get => AccessRights::RO,
-            Subcommands::Set(_) => AccessRights::RW,
-        }
-    }
 }
 
 #[derive(Debug, Clone, Copy, Subcommand)]

--- a/crates/cli/commands/src/db/stats.rs
+++ b/crates/cli/commands/src/db/stats.rs
@@ -21,10 +21,6 @@ use std::time::Duration;
 #[derive(Parser, Debug)]
 /// The arguments for the `reth db stats` command
 pub struct Command {
-    /// Skip consistency checks for static files.
-    #[arg(long, default_value_t = false)]
-    pub(crate) skip_consistency_checks: bool,
-
     /// Show only the total size for static files.
     #[arg(long, default_value_t = false)]
     detailed_sizes: bool,

--- a/crates/cli/commands/src/export_era.rs
+++ b/crates/cli/commands/src/export_era.rs
@@ -1,6 +1,6 @@
 //! Command exporting block data to convert them to ERA1 files.
 
-use crate::common::{AccessRights, CliNodeTypes, Environment, EnvironmentArgs};
+use crate::common::{CliNodeTypes, Environment, EnvironmentArgs};
 use clap::{Args, Parser};
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_cli::chainspec::ChainSpecParser;
@@ -48,7 +48,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> ExportEraC
     where
         N: CliNodeTypes<ChainSpec = C::ChainSpec>,
     {
-        let Environment { provider_factory, .. } = self.env.init::<N>(AccessRights::RO)?;
+        let Environment { provider_factory, .. } = self.env.init::<N>()?;
 
         // Either specified path or default to `<data-dir>/<chain>/era1-export/`
         let data_dir = match &self.export.path {

--- a/crates/cli/commands/src/import.rs
+++ b/crates/cli/commands/src/import.rs
@@ -1,6 +1,6 @@
 //! Command that initializes the node by importing a chain from a file.
 use crate::{
-    common::{AccessRights, CliNodeComponents, CliNodeTypes, Environment, EnvironmentArgs},
+    common::{CliNodeComponents, CliNodeTypes, Environment, EnvironmentArgs},
     import_core::{import_blocks_from_file, ImportConfig},
 };
 use clap::Parser;
@@ -54,7 +54,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> ImportComm
     {
         info!(target: "reth::cli", "reth {} starting", version_metadata().short_version);
 
-        let Environment { provider_factory, config, .. } = self.env.init::<N>(AccessRights::RW)?;
+        let Environment { provider_factory, config, .. } = self.env.init::<N>()?;
 
         let components = components(provider_factory.chain_spec());
 

--- a/crates/cli/commands/src/import_era.rs
+++ b/crates/cli/commands/src/import_era.rs
@@ -1,5 +1,5 @@
 //! Command that initializes the node by importing a chain from ERA files.
-use crate::common::{AccessRights, CliNodeTypes, Environment, EnvironmentArgs};
+use crate::common::{CliNodeTypes, Environment, EnvironmentArgs};
 use alloy_chains::{ChainKind, NamedChain};
 use clap::{Args, Parser};
 use eyre::eyre;
@@ -70,7 +70,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> ImportEraC
     {
         info!(target: "reth::cli", "reth {} starting", version_metadata().short_version);
 
-        let Environment { provider_factory, config, .. } = self.env.init::<N>(AccessRights::RW)?;
+        let Environment { provider_factory, config, .. } = self.env.init::<N>()?;
 
         let mut hash_collector = Collector::new(config.stages.etl.file_size, config.stages.etl.dir);
 

--- a/crates/cli/commands/src/init_cmd.rs
+++ b/crates/cli/commands/src/init_cmd.rs
@@ -1,6 +1,6 @@
 //! Command that initializes the node from a genesis file.
 
-use crate::common::{AccessRights, CliNodeTypes, Environment, EnvironmentArgs};
+use crate::common::{CliNodeTypes, Environment, EnvironmentArgs};
 use alloy_consensus::BlockHeader;
 use clap::Parser;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
@@ -21,7 +21,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> InitComman
     pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec>>(self) -> eyre::Result<()> {
         info!(target: "reth::cli", "reth init starting");
 
-        let Environment { provider_factory, .. } = self.env.init::<N>(AccessRights::RW)?;
+        let Environment { provider_factory, .. } = self.env.init::<N>()?;
 
         let genesis_block_number = provider_factory.chain_spec().genesis_header().number();
         let hash = provider_factory

--- a/crates/cli/commands/src/init_state/mod.rs
+++ b/crates/cli/commands/src/init_state/mod.rs
@@ -1,6 +1,6 @@
 //! Command that initializes the node from a genesis file.
 
-use crate::common::{AccessRights, CliNodeTypes, Environment, EnvironmentArgs};
+use crate::common::{CliNodeTypes, Environment, EnvironmentArgs};
 use alloy_consensus::BlockHeader as AlloyBlockHeader;
 use alloy_primitives::{Sealable, B256};
 use clap::Parser;
@@ -74,7 +74,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> InitStateC
     {
         info!(target: "reth::cli", "Reth init-state starting");
 
-        let Environment { config, provider_factory, .. } = self.env.init::<N>(AccessRights::RW)?;
+        let Environment { config, provider_factory, .. } = self.env.init::<N>()?;
 
         let static_file_provider = provider_factory.static_file_provider();
         let provider_rw = provider_factory.database_provider_rw()?;

--- a/crates/cli/commands/src/prune.rs
+++ b/crates/cli/commands/src/prune.rs
@@ -1,5 +1,5 @@
 //! Command that runs pruning.
-use crate::common::{AccessRights, CliNodeTypes, EnvironmentArgs};
+use crate::common::{CliNodeTypes, EnvironmentArgs};
 use clap::Parser;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_cli::chainspec::ChainSpecParser;
@@ -36,7 +36,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> PruneComma
         self,
         ctx: CliContext,
     ) -> eyre::Result<()> {
-        let env = self.env.init::<N>(AccessRights::RW)?;
+        let env = self.env.init::<N>()?;
         let provider_factory = env.provider_factory;
         let config = env.config.prune;
         let data_dir = env.data_dir;

--- a/crates/cli/commands/src/re_execute.rs
+++ b/crates/cli/commands/src/re_execute.rs
@@ -1,8 +1,7 @@
 //! Re-execute blocks from database in parallel.
 
 use crate::common::{
-    AccessRights, CliComponentsBuilder, CliNodeComponents, CliNodeTypes, Environment,
-    EnvironmentArgs,
+    CliComponentsBuilder, CliNodeComponents, CliNodeTypes, Environment, EnvironmentArgs,
 };
 use alloy_consensus::{transaction::TxHashRef, BlockHeader, TxReceipt};
 use clap::Parser;
@@ -64,7 +63,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
     where
         N: CliNodeTypes<ChainSpec = C::ChainSpec>,
     {
-        let Environment { provider_factory, .. } = self.env.init::<N>(AccessRights::RO)?;
+        let Environment { provider_factory, .. } = self.env.init::<N>()?;
 
         let components = components(provider_factory.chain_spec());
 

--- a/crates/cli/commands/src/stage/drop.rs
+++ b/crates/cli/commands/src/stage/drop.rs
@@ -1,5 +1,5 @@
 //! Database debugging tool
-use crate::common::{AccessRights, CliNodeTypes, Environment, EnvironmentArgs};
+use crate::common::{CliNodeTypes, Environment, EnvironmentArgs};
 use clap::Parser;
 use reth_chainspec::EthChainSpec;
 use reth_cli::chainspec::ChainSpecParser;
@@ -41,7 +41,7 @@ impl<C: ChainSpecParser> Command<C> {
     where
         C: ChainSpecParser<ChainSpec = N::ChainSpec>,
     {
-        let Environment { provider_factory, .. } = self.env.init::<N>(AccessRights::RW)?;
+        let Environment { provider_factory, .. } = self.env.init::<N>()?;
 
         let tool = DbTool::new(provider_factory)?;
 

--- a/crates/cli/commands/src/stage/dump/mod.rs
+++ b/crates/cli/commands/src/stage/dump/mod.rs
@@ -1,5 +1,5 @@
 //! Database debugging tool
-use crate::common::{AccessRights, CliNodeComponents, CliNodeTypes, Environment, EnvironmentArgs};
+use crate::common::{CliNodeComponents, CliNodeTypes, Environment, EnvironmentArgs};
 use clap::Parser;
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_cli::chainspec::ChainSpecParser;
@@ -95,7 +95,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
         Comp: CliNodeComponents<N>,
         F: FnOnce(Arc<C::ChainSpec>) -> Comp,
     {
-        let Environment { provider_factory, .. } = self.env.init::<N>(AccessRights::RO)?;
+        let Environment { provider_factory, .. } = self.env.init::<N>()?;
         let tool = DbTool::new(provider_factory)?;
         let components = components(tool.chain());
         let evm_config = components.evm_config().clone();

--- a/crates/cli/commands/src/stage/run.rs
+++ b/crates/cli/commands/src/stage/run.rs
@@ -2,7 +2,7 @@
 //!
 //! Stage debugging tool
 
-use crate::common::{AccessRights, CliNodeComponents, CliNodeTypes, Environment, EnvironmentArgs};
+use crate::common::{CliNodeComponents, CliNodeTypes, Environment, EnvironmentArgs};
 use alloy_eips::BlockHashOrNumber;
 use alloy_primitives::Sealable;
 use clap::Parser;
@@ -119,8 +119,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
         // Does not do anything on windows.
         let _ = fdlimit::raise_fd_limit();
 
-        let Environment { provider_factory, config, data_dir } =
-            self.env.init::<N>(AccessRights::RW)?;
+        let Environment { provider_factory, config, data_dir } = self.env.init::<N>()?;
 
         let mut provider_rw = provider_factory.database_provider_rw()?;
         let components = components(provider_factory.chain_spec());

--- a/crates/cli/commands/src/stage/unwind.rs
+++ b/crates/cli/commands/src/stage/unwind.rs
@@ -1,7 +1,7 @@
 //! Unwinding a certain block range
 
 use crate::{
-    common::{AccessRights, CliNodeTypes, Environment, EnvironmentArgs},
+    common::{CliNodeTypes, Environment, EnvironmentArgs},
     stage::CliNodeComponents,
 };
 use alloy_eips::BlockHashOrNumber;
@@ -51,7 +51,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
         Comp: CliNodeComponents<N>,
         F: FnOnce(Arc<C::ChainSpec>) -> Comp,
     {
-        let Environment { provider_factory, config, .. } = self.env.init::<N>(AccessRights::RW)?;
+        let Environment { provider_factory, config, .. } = self.env.init::<N>()?;
 
         let target = self.command.unwind_target(provider_factory.clone())?;
 

--- a/crates/storage/db/src/lockfile.rs
+++ b/crates/storage/db/src/lockfile.rs
@@ -23,6 +23,15 @@ const LOCKFILE_NAME: &str = "lock";
 pub struct StorageLock(Arc<StorageLockInner>);
 
 impl StorageLock {
+    /// Returns `true` if the storage directory at the given path is locked by another process.
+    pub fn is_locked(path: &Path) -> bool {
+        let file_path = path.join(LOCKFILE_NAME);
+        ProcessUID::parse(&file_path)
+            .ok()
+            .flatten()
+            .is_some_and(|lock| lock.pid != (process::id() as usize) && lock.is_active())
+    }
+
     /// Tries to acquire a write lock on the target directory, returning [`StorageLockError`] if
     /// unsuccessful.
     ///


### PR DESCRIPTION
## Summary
Replaces the internal `AccessRights` enum with a `--read-only` global flag. All CLI subcommands default to read-write mode so storage inconsistencies are always healed automatically. When another process (e.g. the running node) holds the storage lock, automatically falls back to read-only mode with a warning.

## Changes
- Removed `AccessRights` enum and all per-command access rights logic
- All subcommands default to RW with automatic consistency healing
- Added `--read-only` global flag for explicit opt-in to RO mode
- Added `StorageLock::is_locked()` to check lock without acquiring it
- Auto-detect lock held by another process and fall back to RO with a warning
- Removed `skip_consistency_checks` flag from `db stats` (subsumed by `--read-only`)

## Testing
`cargo test -p reth-db -- lockfile` — 2 passed

Prompted by: alexey