### PR TITLE
fix(engine): add await_state_root span to timeout path

### DIFF
--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -907,6 +907,12 @@ where
     /// Returns `ProviderResult<Result<...>>` where the outer `ProviderResult` captures
     /// unrecoverable errors from the sequential fallback (e.g. DB errors), while the inner
     /// `Result` captures parallel state root task errors that can still fall back to serial.
+    #[instrument(
+        level = "debug",
+        target = "engine::tree::payload_validator",
+        name = "await_state_root",
+        skip_all
+    )]
     fn await_state_root_with_timeout<Tx, Err, R: Send + Sync + 'static>(
         &self,
         handle: &mut PayloadHandle<Tx, Err, R>,


### PR DESCRIPTION
## Summary
Adds `await_state_root` tracing span to `await_state_root_with_timeout`.

## Motivation
When timeout is configured (since #22004), the timeout path calls `handle.take_state_root_rx()` + `recv_timeout` directly, bypassing `PayloadHandle::state_root()` which has the `#[instrument(name = "await_state_root")]` span. This means the span was never emitted on the hot path.

## Changes
- Added `#[instrument(name = "await_state_root")]` to `await_state_root_with_timeout`

Prompted by: DaniPopes