### PR TITLE
feat: thread-local ConsistentProvider cache for BlockchainProvider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9694,6 +9694,7 @@ dependencies = [
  "rocksdb",
  "strum",
  "tempfile",
+ "thread_local",
  "tokio",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -700,6 +700,7 @@ sysinfo = { version = "0.38", default-features = false }
 tracing-journald = "0.3"
 tracing-logfmt = "=0.3.5"
 tracing-samply = "0.1"
+thread_local = "1.1"
 tracing-subscriber = { version = "0.3", default-features = false }
 tracing-tracy = "0.11"
 triehash = "0.8"

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -54,6 +54,7 @@ itertools.workspace = true
 notify = { workspace = true, default-features = false, features = ["macos_fsevent"] }
 parking_lot.workspace = true
 strum.workspace = true
+thread_local.workspace = true
 eyre.workspace = true
 
 # test-utils

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -27,7 +27,7 @@ mod consistent_view;
 pub use consistent_view::{ConsistentDbView, ConsistentViewError};
 
 mod blockchain_provider;
-pub use blockchain_provider::BlockchainProvider;
+pub use blockchain_provider::{BlockchainProvider, ConsistentProviderCacheScope};
 
 mod consistent;
 pub use consistent::ConsistentProvider;


### PR DESCRIPTION
Add per-thread caching of ConsistentProvider using the thread_local crate to avoid opening a new database read transaction for every provider trait method call on BlockchainProvider.

The caching is opt-in via a scoped guard API
(consistent_provider_cache_scope) to keep DB transactions short-lived. Inside the scope, a single ConsistentProvider is reused across all trait method calls on the current thread.

Invalidation is handled via:
- A monotonic canonical revision counter bumped on forkchoice updates and canonical head/safe/finalized changes
- A TTL (500ms) to prevent stale read transactions