### PR TITLE
chore: zero-pad thread indices in thread names

### DIFF
--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -232,7 +232,7 @@ impl LaunchContext {
             .map_or(0, |num| num.get().saturating_sub(reserved_cpu_cores).max(1));
         if let Err(err) = ThreadPoolBuilder::new()
             .num_threads(num_threads)
-            .thread_name(|i| format!("rayon-{i}"))
+            .thread_name(|i| format!("rayon-{i:02}"))
             .build_global()
         {
             warn!(%err, "Failed to build global thread pool")

--- a/crates/rpc/rpc/src/eth/builder.rs
+++ b/crates/rpc/rpc/src/eth/builder.rs
@@ -541,7 +541,7 @@ where
             eth_proof_window,
             blocking_task_pool.unwrap_or_else(|| {
                 BlockingTaskPool::builder()
-                    .thread_name(|i| format!("blocking-{i}"))
+                    .thread_name(|i| format!("blocking-{i:02}"))
                     .build()
                     .map(BlockingTaskPool::new)
                     .expect("failed to build blocking task pool")

--- a/crates/tasks/src/runtime.rs
+++ b/crates/tasks/src/runtime.rs
@@ -830,12 +830,12 @@ impl RuntimeBuilder {
 
             let cpu_pool = rayon::ThreadPoolBuilder::new()
                 .num_threads(default_threads)
-                .thread_name(|i| format!("cpu-{i}"))
+                .thread_name(|i| format!("cpu-{i:02}"))
                 .build()?;
 
             let rpc_raw = rayon::ThreadPoolBuilder::new()
                 .num_threads(rpc_threads)
-                .thread_name(|i| format!("rpc-{i}"))
+                .thread_name(|i| format!("rpc-{i:02}"))
                 .build()?;
             let rpc_pool = BlockingTaskPool::new(rpc_raw);
 
@@ -843,7 +843,7 @@ impl RuntimeBuilder {
                 config.rayon.storage_threads.unwrap_or(DEFAULT_STORAGE_POOL_THREADS);
             let storage_pool = rayon::ThreadPoolBuilder::new()
                 .num_threads(storage_threads)
-                .thread_name(|i| format!("storage-{i}"))
+                .thread_name(|i| format!("storage-{i:02}"))
                 .build()?;
 
             let blocking_guard = BlockingTaskGuard::new(config.rayon.max_blocking_tasks);
@@ -852,14 +852,14 @@ impl RuntimeBuilder {
                 config.rayon.proof_storage_worker_threads.unwrap_or(default_threads);
             let proof_storage_worker_pool = rayon::ThreadPoolBuilder::new()
                 .num_threads(proof_storage_worker_threads)
-                .thread_name(|i| format!("proof-strg-{i}"))
+                .thread_name(|i| format!("proof-strg-{i:02}"))
                 .build()?;
 
             let proof_account_worker_threads =
                 config.rayon.proof_account_worker_threads.unwrap_or(default_threads);
             let proof_account_worker_pool = rayon::ThreadPoolBuilder::new()
                 .num_threads(proof_account_worker_threads)
-                .thread_name(|i| format!("proof-acct-{i}"))
+                .thread_name(|i| format!("proof-acct-{i:02}"))
                 .build()?;
 
             debug!(


### PR DESCRIPTION
Uses `:02` formatting for thread name indices so they sort and align nicely (e.g. `cpu-00`, `cpu-01` instead of `cpu-0`, `cpu-1`).

Prompted by: DaniPopes