### PR TITLE
perf(reth-engine-tree): sparse trie bulk move new storage update

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -11,7 +11,7 @@ use alloy_primitives::B256;
 use alloy_rlp::{Decodable, Encodable};
 use crossbeam_channel::{Receiver as CrossbeamReceiver, Sender as CrossbeamSender};
 use rayon::iter::ParallelIterator;
-use reth_primitives_traits::{dashmap::mapref::entry, Account, ParallelBridgeBuffered};
+use reth_primitives_traits::{Account, ParallelBridgeBuffered};
 use reth_tasks::Runtime;
 use reth_trie::{
     proof_v2::Target, updates::TrieUpdates, DecodedMultiProofV2, HashedPostState, Nibbles,

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -11,7 +11,7 @@ use alloy_primitives::B256;
 use alloy_rlp::{Decodable, Encodable};
 use crossbeam_channel::{Receiver as CrossbeamReceiver, Sender as CrossbeamSender};
 use rayon::iter::ParallelIterator;
-use reth_primitives_traits::{Account, ParallelBridgeBuffered};
+use reth_primitives_traits::{dashmap::mapref::entry, Account, ParallelBridgeBuffered};
 use reth_tasks::Runtime;
 use reth_trie::{
     proof_v2::Target, updates::TrieUpdates, DecodedMultiProofV2, HashedPostState, Nibbles,
@@ -582,17 +582,23 @@ where
         self.process_leaf_updates(true)?;
 
         for (address, mut new) in self.new_storage_updates.drain() {
-            let updates = self.storage_updates.entry(address).or_default();
-            for (slot, new) in new.drain() {
-                match updates.entry(slot) {
-                    Entry::Occupied(mut entry) => {
-                        // Only overwrite existing entries with new values
-                        if new.is_changed() {
-                            entry.insert(new);
+            match self.storage_updates.entry(address) {
+                Entry::Vacant(entry) => {
+                    entry.insert(new); // insert the whole map at once, no per-slot loop
+                }
+                Entry::Occupied(mut entry) => {
+                    let updates = entry.get_mut();
+                    for (slot, new) in new.drain() {
+                        match updates.entry(slot) {
+                            Entry::Occupied(mut slot_entry) => {
+                                if new.is_changed() {
+                                    slot_entry.insert(new);
+                                }
+                            }
+                            Entry::Vacant(slot_entry) => {
+                                slot_entry.insert(new);
+                            }
                         }
-                    }
-                    Entry::Vacant(entry) => {
-                        entry.insert(new);
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Optimize `SparseTrieCacheTask::process_new_updates()` by moving the
entire inner storage map in O(1) when the address has no prior entries
in `storage_updates`, instead of draining it slot-by-slot.

On the first call per block, `storage_updates` is empty for all
addresses, so every address takes this fast path — avoiding
thousands of individual HashMap entry lookups.

## Testing

cargo check -p reth-engine-tree passes.
