### PR TITLE
chore(node): update misleading consensus engine log message

### DIFF
--- a/.changelog/lively-foxes-play.md
+++ b/.changelog/lively-foxes-play.md
@@ -1,0 +1,5 @@
+---
+reth-node-events: patch
+---
+
+Updated consensus engine log message to be more accurate about received updates.

--- a/crates/node/events/src/node.rs
+++ b/crates/node/events/src/node.rs
@@ -265,7 +265,7 @@ impl NodeState {
                 warn!(number=block.number(), hash=?block.hash(), "Encountered invalid block");
             }
             ConsensusEngineEvent::BlockReceived(num_hash) => {
-                info!(number=num_hash.number, hash=?num_hash.hash, "Received new update from consensus engine");
+                info!(number=num_hash.number, hash=?num_hash.hash, "Received new payload from consensus engine");
             }
         }
     }

--- a/crates/node/events/src/node.rs
+++ b/crates/node/events/src/node.rs
@@ -265,7 +265,7 @@ impl NodeState {
                 warn!(number=block.number(), hash=?block.hash(), "Encountered invalid block");
             }
             ConsensusEngineEvent::BlockReceived(num_hash) => {
-                info!(number=num_hash.number, hash=?num_hash.hash, "Received block from consensus engine");
+                info!(number=num_hash.number, hash=?num_hash.hash, "Received new update from consensus engine");
             }
         }
     }


### PR DESCRIPTION
## Summary
Update the `BlockReceived` log message from "Received block from consensus engine" to "Received new update from consensus engine".

## Motivation
The old message confused users into thinking their node was fully synced when it was actually just receiving new payloads from the CL via the Engine API.

## Changes
- Updated log message in `crates/node/events/src/node.rs`

Prompted by: zygis