### PR TITLE
feat(reth-bench): add generate-small-block command

### DIFF
--- a/bin/reth-bench/src/bench/generate_big_block.rs
+++ b/bin/reth-bench/src/bench/generate_big_block.rs
@@ -201,25 +201,25 @@ impl<S: TransactionSource> TransactionCollector<S> {
 pub struct Command {
     /// The RPC URL to use for fetching blocks (can be an external archive node).
     #[arg(long, value_name = "RPC_URL")]
-    rpc_url: String,
+    pub(crate) rpc_url: String,
 
     /// The engine RPC URL (with JWT authentication).
     #[arg(long, value_name = "ENGINE_RPC_URL", default_value = "http://localhost:8551")]
-    engine_rpc_url: String,
+    pub(crate) engine_rpc_url: String,
 
     /// The RPC URL for `testing_buildBlockV1` calls (same node as engine, regular RPC port).
     #[arg(long, value_name = "TESTING_RPC_URL", default_value = "http://localhost:8545")]
-    testing_rpc_url: String,
+    pub(crate) testing_rpc_url: String,
 
     /// Path to the JWT secret file for engine API authentication.
     #[arg(long, value_name = "JWT_SECRET")]
-    jwt_secret: std::path::PathBuf,
+    pub(crate) jwt_secret: std::path::PathBuf,
 
     /// Target gas to pack into the block.
     /// Accepts short notation: K for thousand, M for million, G for billion (e.g., 1G = 1
     /// billion).
     #[arg(long, value_name = "TARGET_GAS", default_value = "30000000", value_parser = parse_gas_limit)]
-    target_gas: u64,
+    pub(crate) target_gas: u64,
 
     /// Block number to start fetching transactions from (required).
     ///
@@ -235,27 +235,27 @@ pub struct Command {
     /// Using a block after ramping started will cause transaction collection to fail
     /// because those blocks contain synthetic transactions that cannot be replayed.
     #[arg(long, value_name = "FROM_BLOCK")]
-    from_block: u64,
+    pub(crate) from_block: u64,
 
     /// Execute the payload (call newPayload + forkchoiceUpdated).
     /// If false, only builds the payload and prints it.
     #[arg(long, default_value = "false")]
-    execute: bool,
+    pub(crate) execute: bool,
 
     /// Number of payloads to generate. Each payload uses the previous as parent.
     /// When count == 1, the payload is only generated and saved, not executed.
     /// When count > 1, each payload is executed before building the next.
     #[arg(long, default_value = "1")]
-    count: u64,
+    pub(crate) count: u64,
 
     /// Number of transaction batches to prefetch in background when count > 1.
     /// Higher values reduce latency but use more memory.
     #[arg(long, default_value = "4")]
-    prefetch_buffer: usize,
+    pub(crate) prefetch_buffer: usize,
 
     /// Output directory for generated payloads. Each payload is saved as `payload_block_N.json`.
     #[arg(long, value_name = "OUTPUT_DIR")]
-    output_dir: std::path::PathBuf,
+    pub(crate) output_dir: std::path::PathBuf,
 }
 
 /// A built payload ready for execution.

--- a/bin/reth-bench/src/bench/generate_small_block.rs
+++ b/bin/reth-bench/src/bench/generate_small_block.rs
@@ -1,0 +1,85 @@
+//! Command for generating small blocks (under 20M gas) for benchmarking.
+//!
+//! This is a thin wrapper around `generate-big-block` with a lower default gas target
+//! and no gas limit ramp phase required. Useful for benchmarking small block performance.
+
+use crate::bench::{generate_big_block, helpers::parse_gas_limit};
+use clap::Parser;
+use reth_cli_runner::CliContext;
+
+/// `reth bench generate-small-block` command
+///
+/// Generates a small block by fetching transactions from existing blocks and packing them
+/// into a block with low gas usage (default 15M) using the `testing_buildBlockV1` RPC endpoint.
+///
+/// Unlike `generate-big-block`, this does not require a prior gas limit ramp phase since
+/// the target gas is below the standard 30M block gas limit.
+#[derive(Debug, Parser)]
+pub struct Command {
+    /// The RPC URL to use for fetching blocks (can be an external archive node).
+    #[arg(long, value_name = "RPC_URL")]
+    rpc_url: String,
+
+    /// The engine RPC URL (with JWT authentication).
+    #[arg(long, value_name = "ENGINE_RPC_URL", default_value = "http://localhost:8551")]
+    engine_rpc_url: String,
+
+    /// The RPC URL for `testing_buildBlockV1` calls (same node as engine, regular RPC port).
+    #[arg(long, value_name = "TESTING_RPC_URL", default_value = "http://localhost:8545")]
+    testing_rpc_url: String,
+
+    /// Path to the JWT secret file for engine API authentication.
+    #[arg(long, value_name = "JWT_SECRET")]
+    jwt_secret: std::path::PathBuf,
+
+    /// Target gas to pack into the block (default 15M for small blocks).
+    /// Accepts short notation: K for thousand, M for million, G for billion.
+    #[arg(long, value_name = "TARGET_GAS", default_value = "15000000", value_parser = parse_gas_limit)]
+    target_gas: u64,
+
+    /// Block number to start fetching transactions from (required).
+    ///
+    /// Since small blocks don't require gas limit ramping, this can simply be a recent
+    /// block number with real transaction activity.
+    #[arg(long, value_name = "FROM_BLOCK")]
+    from_block: u64,
+
+    /// Execute the payload (call newPayload + forkchoiceUpdated).
+    /// If false, only builds the payload and prints it.
+    #[arg(long, default_value = "false")]
+    execute: bool,
+
+    /// Number of payloads to generate. Each payload uses the previous as parent.
+    /// When count == 1, the payload is only generated and saved, not executed.
+    /// When count > 1, each payload is executed before building the next.
+    #[arg(long, default_value = "1")]
+    count: u64,
+
+    /// Number of transaction batches to prefetch in background when count > 1.
+    /// Higher values reduce latency but use more memory.
+    #[arg(long, default_value = "4")]
+    prefetch_buffer: usize,
+
+    /// Output directory for generated payloads. Each payload is saved as `payload_block_N.json`.
+    #[arg(long, value_name = "OUTPUT_DIR")]
+    output_dir: std::path::PathBuf,
+}
+
+impl Command {
+    /// Execute the `generate-small-block` command by delegating to `generate-big-block`.
+    pub async fn execute(self, ctx: CliContext) -> eyre::Result<()> {
+        let big_block_cmd = generate_big_block::Command {
+            rpc_url: self.rpc_url,
+            engine_rpc_url: self.engine_rpc_url,
+            testing_rpc_url: self.testing_rpc_url,
+            jwt_secret: self.jwt_secret,
+            target_gas: self.target_gas,
+            from_block: self.from_block,
+            execute: self.execute,
+            count: self.count,
+            prefetch_buffer: self.prefetch_buffer,
+            output_dir: self.output_dir,
+        };
+        big_block_cmd.execute(ctx).await
+    }
+}

--- a/bin/reth-bench/src/bench/mod.rs
+++ b/bin/reth-bench/src/bench/mod.rs
@@ -8,6 +8,7 @@ use reth_tracing::FileWorkerGuard;
 mod context;
 mod gas_limit_ramp;
 mod generate_big_block;
+mod generate_small_block;
 pub(crate) mod helpers;
 pub use generate_big_block::{
     RawTransaction, RpcTransactionSource, TransactionCollector, TransactionSource,
@@ -66,6 +67,18 @@ pub enum Subcommands {
     /// 30000000`
     GenerateBigBlock(generate_big_block::Command),
 
+    /// Generate a small block (under 20M gas) for benchmarking small block performance.
+    ///
+    /// Same as `generate-big-block` but defaults to 15M gas target. Does not require a
+    /// prior gas limit ramp phase since the target is below the standard block gas limit.
+    ///
+    /// Example:
+    ///
+    /// `reth-bench generate-small-block --rpc-url http://localhost:8545 --engine-rpc-url
+    /// http://localhost:8551 --jwt-secret ~/.local/share/reth/mainnet/jwt.hex --from-block
+    /// 21000000`
+    GenerateSmallBlock(generate_small_block::Command),
+
     /// Replay pre-generated payloads from a directory.
     ///
     /// This command reads payload files from a previous `generate-big-block` run and replays
@@ -102,6 +115,7 @@ impl BenchmarkCommand {
             Subcommands::NewPayloadOnly(command) => command.execute(ctx).await,
             Subcommands::SendPayload(command) => command.execute(ctx).await,
             Subcommands::GenerateBigBlock(command) => command.execute(ctx).await,
+            Subcommands::GenerateSmallBlock(command) => command.execute(ctx).await,
             Subcommands::ReplayPayloads(command) => command.execute(ctx).await,
             Subcommands::SendInvalidPayload(command) => (*command).execute(ctx).await,
         }


### PR DESCRIPTION
## Summary
Add `generate-small-block` subcommand for benchmarking small block performance.

## Motivation
Need proper small block benchmarks on our infra to identify bottlenecks (e.g. prewarming regressions for blocks <30 txns). Currently only big block benchmarks exist.

## Changes
- Add `generate_small_block.rs` — thin wrapper over `generate-big-block` with 15M default gas target
- Make `generate_big_block::Command` fields `pub(crate)` for reuse
- Wire up `GenerateSmallBlock` subcommand in CLI enum

No gas limit ramp phase required since 15M is below the standard 30M block gas limit.

## Testing
`cargo check -p reth-bench` — compiles clean.

Prompted by: yk