### PR TITLE
fix(cli): correct --detailed-sizes flag description in db stats

### DIFF
--- a/crates/cli/commands/src/db/stats.rs
+++ b/crates/cli/commands/src/db/stats.rs
@@ -25,7 +25,7 @@ pub struct Command {
     #[arg(long, default_value_t = false)]
     pub(crate) skip_consistency_checks: bool,
 
-    /// Show only the total size for static files.
+    /// Show detailed size breakdown (data, index, offsets, config) for static files.
     #[arg(long, default_value_t = false)]
     detailed_sizes: bool,
 

--- a/docs/vocs/docs/pages/cli/reth/db/stats.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/stats.mdx
@@ -13,7 +13,7 @@ Options:
           Skip consistency checks for static files
 
       --detailed-sizes
-          Show only the total size for static files
+          Show detailed size breakdown (data, index, offsets, config) for static files
 
       --detailed-segments
           Show detailed information per static file segment


### PR DESCRIPTION
The comment said "Show only the total size" but the flag actually enables detailed size breakdown (data, index, offsets, config).