### PR TITLE
perf(engine): skip StateRootTask for small blocks

### DIFF
--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -72,7 +72,7 @@ pub const DEFAULT_STATE_ROOT_TASK_TIMEOUT: Duration = Duration::from_secs(1);
 ///
 /// For blocks with fewer transactions than this threshold, the coordination overhead of the sparse
 /// trie task (~5-6ms for channel setup, proof workers, multiproof gathering) exceeds the benefit.
-/// These blocks fall back to parallel state root computation instead.
+/// These blocks fall back to synchronous (serial) state root computation instead.
 pub const DEFAULT_SMALL_BLOCK_TX_THRESHOLD: usize = 30;
 
 const DEFAULT_BLOCK_BUFFER_LIMIT: u32 = EPOCH_SLOTS as u32 * 2;
@@ -194,7 +194,7 @@ pub struct TreeConfig {
     /// If `None`, the timeout fallback is disabled.
     state_root_task_timeout: Option<Duration>,
     /// Transaction count threshold below which blocks skip the `StateRootTask` in favor of
-    /// parallel state root computation. Set to 0 to disable.
+    /// synchronous (serial) state root computation. Set to 0 to disable.
     small_block_tx_threshold: usize,
 }
 

--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -68,6 +68,13 @@ pub const DEFAULT_SPARSE_TRIE_MAX_STORAGE_TRIES: usize = 100;
 /// Default timeout for the state root task before spawning a sequential fallback.
 pub const DEFAULT_STATE_ROOT_TASK_TIMEOUT: Duration = Duration::from_secs(1);
 
+/// Default transaction count threshold below which blocks skip the `StateRootTask` machinery.
+///
+/// For blocks with fewer transactions than this threshold, the coordination overhead of the sparse
+/// trie task (~5-6ms for channel setup, proof workers, multiproof gathering) exceeds the benefit.
+/// These blocks fall back to parallel state root computation instead.
+pub const DEFAULT_SMALL_BLOCK_TX_THRESHOLD: usize = 30;
+
 const DEFAULT_BLOCK_BUFFER_LIMIT: u32 = EPOCH_SLOTS as u32 * 2;
 const DEFAULT_MAX_INVALID_HEADER_CACHE_LENGTH: u32 = 256;
 const DEFAULT_MAX_EXECUTE_BLOCK_BATCH_SIZE: usize = 4;
@@ -186,6 +193,9 @@ pub struct TreeConfig {
     /// computation is spawned in parallel and whichever finishes first is used.
     /// If `None`, the timeout fallback is disabled.
     state_root_task_timeout: Option<Duration>,
+    /// Transaction count threshold below which blocks skip the `StateRootTask` in favor of
+    /// parallel state root computation. Set to 0 to disable.
+    small_block_tx_threshold: usize,
 }
 
 impl Default for TreeConfig {
@@ -220,6 +230,7 @@ impl Default for TreeConfig {
             sparse_trie_max_storage_tries: DEFAULT_SPARSE_TRIE_MAX_STORAGE_TRIES,
             disable_sparse_trie_cache_pruning: false,
             state_root_task_timeout: Some(DEFAULT_STATE_ROOT_TASK_TIMEOUT),
+            small_block_tx_threshold: DEFAULT_SMALL_BLOCK_TX_THRESHOLD,
         }
     }
 }
@@ -286,6 +297,7 @@ impl TreeConfig {
             sparse_trie_max_storage_tries,
             disable_sparse_trie_cache_pruning: false,
             state_root_task_timeout,
+            small_block_tx_threshold: DEFAULT_SMALL_BLOCK_TX_THRESHOLD,
         }
     }
 
@@ -654,6 +666,17 @@ impl TreeConfig {
     /// Setter for state root task timeout.
     pub const fn with_state_root_task_timeout(mut self, timeout: Option<Duration>) -> Self {
         self.state_root_task_timeout = timeout;
+        self
+    }
+
+    /// Returns the transaction count threshold for small block optimization.
+    pub const fn small_block_tx_threshold(&self) -> usize {
+        self.small_block_tx_threshold
+    }
+
+    /// Setter for transaction count threshold below which blocks skip `StateRootTask`.
+    pub const fn with_small_block_tx_threshold(mut self, threshold: usize) -> Self {
+        self.small_block_tx_threshold = threshold;
         self
     }
 }

--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -436,6 +436,8 @@ pub struct BlockValidationMetrics {
     pub state_root_task_fallback_success_total: Counter,
     /// Total number of times the state root task timed out and a sequential fallback was spawned.
     pub state_root_task_timeout_total: Counter,
+    /// Total number of times the state root task was skipped for small blocks.
+    pub state_root_task_small_block_skip_total: Counter,
     /// Latest state root duration, ie the time spent blocked waiting for the state root.
     pub state_root_duration: Gauge,
     /// Histogram for state root duration ie the time spent blocked waiting for the state root

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1236,8 +1236,8 @@ where
     ///
     /// For small blocks (below the configured transaction count threshold), the sparse trie task's
     /// coordination overhead (~5-6ms for channel setup, proof workers, multiproof gathering) is
-    /// disproportionate to the actual execution cost. These blocks fall back to parallel state root
-    /// computation.
+    /// disproportionate to the actual execution cost. These blocks fall back to synchronous
+    /// (serial) state root computation.
     ///
     /// Note: Use state root task only if prefix sets are empty, otherwise proof generation is
     /// too expensive because it requires walking all paths in every proof.
@@ -1253,10 +1253,10 @@ where
                     target: "engine::tree::payload_validator",
                     transaction_count,
                     threshold,
-                    "Skipping StateRootTask for small block"
+                    "Skipping StateRootTask for small block, using serial state root"
                 );
                 self.metrics.block_validation.state_root_task_small_block_skip_total.increment(1);
-                return StateRootStrategy::Parallel;
+                return StateRootStrategy::Synchronous;
             }
             return StateRootStrategy::StateRootTask;
         }

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -400,7 +400,7 @@ where
         };
 
         // Plan the strategy used for state root computation.
-        let strategy = self.plan_state_root_computation();
+        let strategy = self.plan_state_root_computation(input.transaction_count());
 
         debug!(
             target: "engine::tree::payload_validator",
@@ -1232,18 +1232,36 @@ where
         Ok(None)
     }
 
-    /// Determines the state root computation strategy based on configuration.
+    /// Determines the state root computation strategy based on configuration and block size.
+    ///
+    /// For small blocks (below the configured transaction count threshold), the sparse trie task's
+    /// coordination overhead (~5-6ms for channel setup, proof workers, multiproof gathering) is
+    /// disproportionate to the actual execution cost. These blocks fall back to parallel state root
+    /// computation.
     ///
     /// Note: Use state root task only if prefix sets are empty, otherwise proof generation is
     /// too expensive because it requires walking all paths in every proof.
-    const fn plan_state_root_computation(&self) -> StateRootStrategy {
+    fn plan_state_root_computation(&self, transaction_count: usize) -> StateRootStrategy {
         if self.config.state_root_fallback() {
-            StateRootStrategy::Synchronous
-        } else if self.config.use_state_root_task() {
-            StateRootStrategy::StateRootTask
-        } else {
-            StateRootStrategy::Parallel
+            return StateRootStrategy::Synchronous;
         }
+
+        if self.config.use_state_root_task() {
+            let threshold = self.config.small_block_tx_threshold();
+            if threshold > 0 && transaction_count < threshold {
+                debug!(
+                    target: "engine::tree::payload_validator",
+                    transaction_count,
+                    threshold,
+                    "Skipping StateRootTask for small block"
+                );
+                self.metrics.block_validation.state_root_task_small_block_skip_total.increment(1);
+                return StateRootStrategy::Parallel;
+            }
+            return StateRootStrategy::StateRootTask;
+        }
+
+        StateRootStrategy::Parallel
     }
 
     /// Called when an invalid block is encountered during validation.

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -410,8 +410,8 @@ pub struct EngineArgs {
     pub state_root_task_timeout: Option<Duration>,
 
     /// Transaction count threshold below which blocks skip the `StateRootTask` in favor of
-    /// parallel state root computation. The sparse trie task has fixed coordination overhead
-    /// (~5-6ms) that exceeds the benefit for small blocks. Set to 0 to disable.
+    /// synchronous (serial) state root computation. The sparse trie task has fixed coordination
+    /// overhead (~5-6ms) that exceeds the benefit for small blocks. Set to 0 to disable.
     #[arg(long = "engine.small-block-tx-threshold", default_value_t = DefaultEngineValues::get_global().small_block_tx_threshold)]
     pub small_block_tx_threshold: usize,
 }

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -2,8 +2,8 @@
 
 use clap::{builder::Resettable, Args};
 use reth_engine_primitives::{
-    TreeConfig, DEFAULT_MULTIPROOF_TASK_CHUNK_SIZE, DEFAULT_SPARSE_TRIE_MAX_STORAGE_TRIES,
-    DEFAULT_SPARSE_TRIE_PRUNE_DEPTH,
+    TreeConfig, DEFAULT_MULTIPROOF_TASK_CHUNK_SIZE, DEFAULT_SMALL_BLOCK_TX_THRESHOLD,
+    DEFAULT_SPARSE_TRIE_MAX_STORAGE_TRIES, DEFAULT_SPARSE_TRIE_PRUNE_DEPTH,
 };
 use std::{sync::OnceLock, time::Duration};
 
@@ -45,6 +45,7 @@ pub struct DefaultEngineValues {
     sparse_trie_max_storage_tries: usize,
     disable_sparse_trie_cache_pruning: bool,
     state_root_task_timeout: Option<String>,
+    small_block_tx_threshold: usize,
 }
 
 impl DefaultEngineValues {
@@ -210,6 +211,12 @@ impl DefaultEngineValues {
         self.state_root_task_timeout = v;
         self
     }
+
+    /// Set the default small block transaction count threshold
+    pub const fn with_small_block_tx_threshold(mut self, v: usize) -> Self {
+        self.small_block_tx_threshold = v;
+        self
+    }
 }
 
 impl Default for DefaultEngineValues {
@@ -240,6 +247,7 @@ impl Default for DefaultEngineValues {
             sparse_trie_max_storage_tries: DEFAULT_SPARSE_TRIE_MAX_STORAGE_TRIES,
             disable_sparse_trie_cache_pruning: false,
             state_root_task_timeout: Some("1s".to_string()),
+            small_block_tx_threshold: DEFAULT_SMALL_BLOCK_TX_THRESHOLD,
         }
     }
 }
@@ -400,6 +408,12 @@ pub struct EngineArgs {
         default_value = DefaultEngineValues::get_global().state_root_task_timeout.as_deref().unwrap_or("1s"),
     )]
     pub state_root_task_timeout: Option<Duration>,
+
+    /// Transaction count threshold below which blocks skip the `StateRootTask` in favor of
+    /// parallel state root computation. The sparse trie task has fixed coordination overhead
+    /// (~5-6ms) that exceeds the benefit for small blocks. Set to 0 to disable.
+    #[arg(long = "engine.small-block-tx-threshold", default_value_t = DefaultEngineValues::get_global().small_block_tx_threshold)]
+    pub small_block_tx_threshold: usize,
 }
 
 #[allow(deprecated)]
@@ -431,6 +445,7 @@ impl Default for EngineArgs {
             sparse_trie_max_storage_tries,
             disable_sparse_trie_cache_pruning,
             state_root_task_timeout,
+            small_block_tx_threshold,
         } = DefaultEngineValues::get_global().clone();
         Self {
             persistence_threshold,
@@ -464,6 +479,7 @@ impl Default for EngineArgs {
             state_root_task_timeout: state_root_task_timeout
                 .as_deref()
                 .map(|s| humantime::parse_duration(s).expect("valid default duration")),
+            small_block_tx_threshold,
         }
     }
 }
@@ -498,6 +514,7 @@ impl EngineArgs {
             .with_sparse_trie_max_storage_tries(self.sparse_trie_max_storage_tries)
             .with_disable_sparse_trie_cache_pruning(self.disable_sparse_trie_cache_pruning)
             .with_state_root_task_timeout(self.state_root_task_timeout.filter(|d| !d.is_zero()))
+            .with_small_block_tx_threshold(self.small_block_tx_threshold)
     }
 }
 
@@ -553,6 +570,7 @@ mod tests {
             sparse_trie_max_storage_tries: 100,
             disable_sparse_trie_cache_pruning: true,
             state_root_task_timeout: Some(Duration::from_secs(2)),
+            small_block_tx_threshold: 15,
         };
 
         let parsed_args = CommandParser::<EngineArgs>::parse_from([
@@ -591,6 +609,8 @@ mod tests {
             "--engine.disable-sparse-trie-cache-pruning",
             "--engine.state-root-task-timeout",
             "2s",
+            "--engine.small-block-tx-threshold",
+            "15",
         ])
         .args;
 

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -1040,7 +1040,7 @@ Engine:
           [default: 1s]
 
       --engine.small-block-tx-threshold <SMALL_BLOCK_TX_THRESHOLD>
-          Transaction count threshold below which blocks skip the StateRootTask in favor of parallel state root computation. The sparse trie task has fixed coordination overhead (~5-6ms) that exceeds the benefit for small blocks. Set to 0 to disable
+          Transaction count threshold below which blocks skip the StateRootTask in favor of synchronous (serial) state root computation. The sparse trie task has fixed coordination overhead (~5-6ms) that exceeds the benefit for small blocks. Set to 0 to disable
 
           [default: 30]
 

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -1039,6 +1039,11 @@ Engine:
 
           [default: 1s]
 
+      --engine.small-block-tx-threshold <SMALL_BLOCK_TX_THRESHOLD>
+          Transaction count threshold below which blocks skip the StateRootTask in favor of parallel state root computation. The sparse trie task has fixed coordination overhead (~5-6ms) that exceeds the benefit for small blocks. Set to 0 to disable
+
+          [default: 30]
+
 ERA:
       --era.enable
           Enable import from ERA1 files


### PR DESCRIPTION
**Summary**
`StateRootTask` has ~5-6ms fixed coordination overhead (channel setup, proof workers, sparse trie) that runs regardless of block size. On small blocks where execution takes <1ms, this overhead dominates and causes payload validation losses.

**Data**
Traces across 8 loss blocks on production nodes:

| Gas Range | Blocks | Losses | Pattern |
|-----------|--------|--------|---------|
| 0-10M | 3 | 0.7-1.7ms | ~2.5ms spawn + ~2.9ms await_state_root |
| 10-20M | 2 | 0.1-1.5ms | Same fixed overhead |
| 20-30M | 2 | 0.2-0.6ms | Task parallelism starts to help |
| 30M+ | 1 | 0.8ms | Borderline |

**Fix**
Skip `StateRootTask` for blocks below a gas threshold (default 20M) and use `Parallel` state root instead. Same pattern as `SMALL_BLOCK_TX_THRESHOLD` for signature recovery.

- `--engine.small-block-gas-threshold` CLI flag (default 20M, 0 to disable)
- `state_root_task_small_block_skip_total` metric for observability