### PR TITLE
fix: improve nightly Docker build failure Slack notification

### DIFF
--- a/.changelog/fast-waves-smile.md
+++ b/.changelog/fast-waves-smile.md
@@ -1,0 +1,4 @@
+---
+---
+
+Improved nightly Docker build failure Slack notification with more detailed formatting and context.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -117,6 +117,18 @@ jobs:
       - name: Slack Webhook Action
         uses: rtCamp/action-slack-notify@v2
         env:
-          SLACK_COLOR: ${{ job.status }}
-          SLACK_MESSAGE: "Failed run: https://github.com/paradigmxyz/reth/actions/runs/${{ github.run_id }}"
+          SLACK_COLOR: danger
+          SLACK_ICON_EMOJI: ":rotating_light:"
+          SLACK_USERNAME: "GitHub Actions"
+          SLACK_TITLE: ":rotating_light: Nightly Docker Build Failed"
+          SLACK_MESSAGE: |
+            The scheduled nightly Docker build failed.
+
+            *Commit:* `${{ github.sha }}`
+            *Branch:* `${{ github.ref_name }}`
+            *Run:* <https://github.com/paradigmxyz/reth/actions/runs/${{ github.run_id }}|View logs>
+
+            *Action required:* Re-run the workflow or investigate the build failure.
+          SLACK_FOOTER: "paradigmxyz/reth · docker.yml"
+          MSG_MINIMAL: true
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Problem

The nightly Docker build failure notification was essentially invisible in Slack:

1. **`SLACK_COLOR` was set to `${{ job.status }}`** — this evaluates to `success` (green) because it refers to the *notify* job's status, not the failed *build* job's status. So the failure notification appeared with a green color bar.

2. **Minimal message** — just `"Failed run: <url>"` with no context about what failed.

This caused us to miss a nightly build failure, which cascaded into the nightly regression benchmark also failing due to a stale binary.

## Fix

- Set `SLACK_COLOR: danger` (red) so it's clearly a failure
- Add a descriptive title with 🚨 emoji
- Include commit SHA, branch, and a clickable link to the run logs
- Add "Action required" callout
- Set `MSG_MINIMAL: true` to remove noisy default fields


This was useless:
<img width="695" height="276" alt="Screenshot 2026-02-12 at 12 21 47" src="https://github.com/user-attachments/assets/48dc667f-0b02-40dd-b320-14df6c837bfc" />