### PR TITLE
docs: improve reth.rs/overview page

### DIFF
--- a/.changelog/lively-clouds-bake.md
+++ b/.changelog/lively-clouds-bake.md
@@ -1,0 +1,4 @@
+---
+---
+
+Improved documentation overview page with better structure and clarity.

--- a/docs/vocs/docs/pages/overview.mdx
+++ b/docs/vocs/docs/pages/overview.mdx
@@ -20,6 +20,8 @@ As a full Ethereum node, Reth allows users to connect to the Ethereum network an
 
 ## Goals
 
+Building a successful Ethereum node requires creating a high-quality implementation that is both secure and efficient, as well as being easy to use on consumer hardware. It also requires building a strong community of contributors who can help support and improve the software.
+
 ### Modularity
 
 Every component of Reth is built to be used as a library: well-tested, heavily documented and benchmarked. We envision that developers will import the node's crates, mix and match, and innovate on top of them.

--- a/docs/vocs/docs/pages/overview.mdx
+++ b/docs/vocs/docs/pages/overview.mdx
@@ -10,21 +10,17 @@ Reth is production ready, and suitable for usage in mission-critical environment
 
 ![Reth](https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-prod.png)
 
-## What is this about?
+## What is Reth?
 
-[Reth](https://github.com/paradigmxyz/reth/) is an execution layer (EL) implementation that is compatible with all Ethereum consensus layer (CL) implementations that support the [Engine API](https://github.com/ethereum/execution-apis/tree/59e3a719021f48c1ef5653840e3ea5750e6af693/src/engine).
+[Reth](https://github.com/paradigmxyz/reth/) is an execution layer (EL) implementation that is compatible with all Ethereum consensus layer (CL) implementations that support the [Engine API](https://github.com/ethereum/execution-apis/tree/main/src/engine).
 
 It is originally built and driven forward by [Paradigm](https://paradigm.xyz/), and is licensed under the Apache and MIT licenses.
 
-As a full Ethereum node, Reth allows users to connect to the Ethereum network and interact with the Ethereum blockchain.
+As a full Ethereum node, Reth allows users to connect to the Ethereum network and interact with the Ethereum blockchain. This includes sending and receiving transactions, querying logs and traces, as well as accessing and interacting with smart contracts.
 
-This includes sending and receiving transactions, querying logs and traces, as well as accessing and interacting with smart contracts.
+## Goals
 
-Building a successful Ethereum node requires creating a high-quality implementation that is both secure and efficient, as well as being easy to use on consumer hardware. It also requires building a strong community of contributors who can help support and improve the software.
-
-## What are the goals of Reth?
-
-**1. Modularity**
+### Modularity
 
 Every component of Reth is built to be used as a library: well-tested, heavily documented and benchmarked. We envision that developers will import the node's crates, mix and match, and innovate on top of them.
 
@@ -32,23 +28,23 @@ Examples of such usage include, but are not limited to, spinning up standalone P
 
 To achieve that, we are licensing Reth under the Apache/MIT permissive license.
 
-**2. Performance**
+### Performance
 
 Reth aims to be fast, so we used Rust and the [Erigon staged-sync](https://erigon.substack.com/p/erigon-stage-sync-and-control-flows) node architecture.
 
-We also use our Ethereum libraries (including [Alloy](https://github.com/alloy-rs/alloy/) and [revm](https://github.com/bluealloy/revm/)) which we’ve battle-tested and optimized via [Foundry](https://github.com/foundry-rs/foundry/).
+We also use our Ethereum libraries (including [Alloy](https://github.com/alloy-rs/alloy/) and [revm](https://github.com/bluealloy/revm/)) which we've battle-tested and optimized via [Foundry](https://github.com/foundry-rs/foundry/).
 
-**3. Free for anyone to use any way they want**
+### Free for anyone to use any way they want
 
 Reth is free open-source software, built for the community, by the community.
 
 By licensing the software under the Apache/MIT license, we want developers to use it without being bound by business licenses, or having to think about the implications of GPL-like licenses.
 
-**4. Client Diversity**
+### Client Diversity
 
 The Ethereum protocol becomes more antifragile when no node implementation dominates. This ensures that if there's a software bug, the network does not finalize a bad block. By building a new client, we hope to contribute to Ethereum's antifragility.
 
-**5. Used by a wide demographic**
+### Used by a wide demographic
 
 We want to solve for node operators that care about fast historical queries, but also for hobbyists who cannot operate on large hardware.
 
@@ -60,8 +56,8 @@ We envision that Reth will be configurable enough for the tradeoffs that each te
 
 Reth is a new Ethereum full node that allows users to sync and interact with the entire blockchain, including its historical state if in archive mode.
 
--   Full node: It can be used as a full node, which stores and processes the entire blockchain, validates blocks and transactions, and participates in the consensus process.
--   Archive node: It can also be used as an archive node, which stores the entire history of the blockchain and is useful for applications that need access to historical data.
+-   **Full node**: Stores and processes the entire blockchain, validates blocks and transactions, and participates in the consensus process.
+-   **Archive node**: Stores the entire history of the blockchain and is useful for applications that need access to historical data.
 
 As a data engineer/analyst, or as a data indexer, you'll want to use Archive mode. For all other use cases where historical access is not needed, you can use Full mode.
 
@@ -77,7 +73,7 @@ Reth implements the specification of Ethereum as defined in the [ethereum/execut
 
 We have completed an audit of the [Reth v1.0.0-rc.2](https://github.com/paradigmxyz/reth/releases/tag/v1.0.0-rc.2) with [Sigma Prime](https://sigmaprime.io/), the developers of [Lighthouse](https://github.com/sigp/lighthouse), the Rust Consensus Layer implementation. Find it [here](https://github.com/paradigmxyz/reth/blob/main/audit/sigma_prime_audit_v2.pdf).
 
-[Revm](https://github.com/bluealloy/revm) (the EVM used in Reth) underwent an audit with [Guido Vranken](https://twitter.com/guidovranken) (#1 [Ethereum Bug Bounty](https://ethereum.org/en/bug-bounty)). We will publish the results soon.
+[Revm](https://github.com/bluealloy/revm) (the EVM used in Reth) underwent an audit with [Guido Vranken](https://twitter.com/guidovranken) (#1 [Ethereum Bug Bounty](https://ethereum.org/en/bug-bounty)).
 
 ## Reth Metrics
 
@@ -94,21 +90,18 @@ We operate several public Reth nodes across different networks. You can monitor 
 Want to set up metrics for your own Reth node? Check out our [monitoring guide](/run/monitoring) to learn how to configure Prometheus metrics and build your own dashboards.
 :::
 
-## Sections
+## Get started
 
-Here are some useful sections to jump to:
-
--   Install Reth by following the [guide](/installation/overview).
--   Sync your node on any [official network](/run/overview).
--   View [statistics and metrics](/run/monitoring) about your node.
--   Query the [JSON-RPC](/jsonrpc/intro) using Foundry's `cast` or `curl`.
--   Set up your [development environment and contribute](/introduction/contributing)!
+-   [Install Reth](/installation/overview) and get up and running.
+-   [Run a node](/run/overview) on any official network.
+-   [Monitor your node](/run/monitoring) with statistics and metrics.
+-   [Query the JSON-RPC](/jsonrpc/intro) using Foundry's `cast` or `curl`.
+-   [Explore the SDK](/sdk) to build custom blockchain infrastructure.
+-   [Set up your development environment and contribute](/introduction/contributing)!
 
 :::note
 The documentation is continuously rendered [here](https://reth.rs)!
 You can contribute to the docs on [GitHub][gh-docs].
 :::
 
-[tg-badge]: https://img.shields.io/endpoint?color=neon&logo=telegram&label=chat&url=https%3A%2F%2Ftg.sumanjay.workers.dev%2Fparadigm%5Freth
-[tg-url]: https://t.me/paradigm_reth
 [gh-docs]: https://github.com/paradigmxyz/reth/tree/main/docs


### PR DESCRIPTION
Improves the overview page per #17075.

### Changes

- **Rename 'What is this about?' → 'What is Reth?'** — clearer, less generic heading
- **Goals as proper subheadings** — convert bold numbered items to `###` subheadings (Modularity, Performance, etc.) for better table-of-contents navigation
- **Update Engine API link** — was pinned to an old commit (`59e3a71`), now points to `main` branch
- **Remove stale revm audit text** — "We will publish the results soon" was written years ago; the audit results were never published to this repo
- **Tighten 'Who is this for?' wording** — removed redundant phrasing in bullet points
- **Rename 'Sections' → 'Get started'** — more actionable, added SDK link
- **Cleanup** — removed unused badge link definitions (`tg-badge`, `tg-url`)

Closes #17075