### PR TITLE
perf: release execution cache lock before waiting for state root validation

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -981,16 +981,10 @@ impl PayloadExecutionCache {
     /// Updates the cache with a closure that has exclusive access to the guard.
     /// This ensures that all cache operations happen atomically.
     ///
-    /// ## CRITICAL SAFETY REQUIREMENT
-    ///
-    /// **Before calling this method, you MUST ensure there are no other active cache users.**
-    /// This includes:
-    /// - No running [`PrewarmCacheTask`] instances that could write to the cache
-    /// - No concurrent transactions that might access the cached state
-    /// - All prewarming operations must be completed or cancelled
-    ///
-    /// Violating this requirement can result in cache corruption, incorrect state data,
-    /// and potential consensus failures.
+    /// Callers must not mutate the *underlying* [`ExecutionCache`] data (e.g. via
+    /// [`SavedCache::clear`]) while other tasks may hold clones of the same
+    /// `SavedCache`. Swapping the slot value (`*cached = Some(..)` / `*cached = None`)
+    /// is always safe because existing clones retain their own `Arc` references.
     pub fn update_with_guard<F>(&self, update_fn: F)
     where
         F: FnOnce(&mut Option<SavedCache>),


### PR DESCRIPTION
**Summary**
Traced via Grafana Tempo that `save_cache` is the #1 bottleneck in the `new_payload` pipeline, blocking for ~95-131ms (up to 80% of NP time) while holding the `ExecutionCache` mutex. The root cause is that `valid_block_rx.recv()` (waiting for state root validation) is called *inside* `update_with_guard`, holding the lock for the entire state root duration. This blocks the next block's prewarming from accessing the cache.

Split `save_cache` from a single locked phase into three phases:
1. **Phase 1 (locked, ~1ms):** consume the `SavedCache`, run `insert_state`, and optimistically publish the warmed cache
2. **Phase 2 (unlocked, ~100ms+):** wait for `valid_block_rx` without holding the lock — the next block's prewarming can start immediately
3. **Phase 3 (locked, only if invalid):** re-acquire the lock and clear the cache only if it still belongs to this block (hash guard prevents clearing a newer valid cache from a subsequent block)

**Changes**
- Restructured `save_cache` to release the `ExecutionCache` lock before blocking on `valid_block_rx.recv()`
- Added hash-guarded rollback: on invalid blocks, only clears cache if `executed_block_hash() == hash`

**Expected Impact**
Reduces execution cache lock hold time from ~100ms+ to ~1ms per block, unblocking prewarming for subsequent blocks and improving overall NP throughput.