### PR TITLE
fix(engine): return error on updates channel disconnect in sparse trie task

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -407,7 +407,9 @@ where
                     let update = match message {
                         Ok(m) => m,
                         Err(_) => {
-                            break
+                            return Err(ParallelStateRootError::Other(
+                                "updates channel disconnected before state root calculation".to_string(),
+                            ))
                         }
                     };
 


### PR DESCRIPTION
## Summary

Return an error instead of breaking when the updates channel disconnects in `SparseTrieCacheTask::run()`.

## Motivation

The `select_biased!` loop breaks unconditionally on channel disconnect and falls through to `root_with_updates()`, which iterates all storage tries and panics on any that are still `Blind` (`as_revealed_mut().unwrap()` at `state.rs:916`).

While the channel should not disconnect during normal block processing (multiple senders hold it open), returning an error is the correct defensive behavior — proceeding to compute a state root with potentially incomplete trie state is never valid.

Related: #22118

## Changes

- `crates/engine/tree/src/tree/payload_processor/sparse_trie.rs`: return `Err(ParallelStateRootError)` instead of `break` on `Err(_)` from `self.updates` recv

## Testing

`cargo check -p reth-engine-tree` passes.

Prompted by: yk