### PR TITLE
feat(stages): unify progress log format

### DIFF
--- a/crates/stages/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/stages/src/stages/sender_recovery.rs
@@ -148,7 +148,8 @@ where
 
         let mut writer = EitherWriter::new_senders(provider, *range_output.block_range.start())?;
 
-        info!(target: "sync::stages::sender_recovery", tx_range = ?range_output.tx_range, "Recovering senders");
+        let total_txs = range_output.tx_range.end - range_output.tx_range.start;
+        info!(target: "sync::stages::sender_recovery", total_txs, "Recovering senders");
 
         // Iterate over transactions in batches, recover the senders and append them
         let batch = range_output
@@ -166,6 +167,7 @@ where
         let block_body_indices_elapsed = start.elapsed();
         let mut blocks_with_indices = range_output.block_range.zip(block_body_indices).peekable();
 
+        let total_batches = batch.len();
         for range in batch {
             // Pair each transaction number with its block number
             let start = Instant::now();
@@ -181,7 +183,22 @@ where
             });
             let fold_elapsed = start.elapsed();
             debug!(target: "sync::stages::sender_recovery", ?block_body_indices_elapsed, ?fold_elapsed, len = block_numbers.len(), "Calculated block numbers");
-            recover_range(range, block_numbers, provider, tx_batch_sender.clone(), &mut writer)?;
+            recover_range(
+                range.clone(),
+                block_numbers,
+                provider,
+                tx_batch_sender.clone(),
+                &mut writer,
+            )?;
+
+            let processed = range.end - range_output.tx_range.start;
+            if total_batches > 1 {
+                info!(
+                    target: "sync::stages::sender_recovery",
+                    progress = %format!("{}/{} ({:.2}%)", processed, total_txs, (processed as f64 / total_txs as f64) * 100.0),
+                    "Recovered senders"
+                );
+            }
         }
 
         // Advance the static file header to the end of this range to account for empty blocks.

--- a/crates/stages/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/stages/src/stages/tx_lookup.rs
@@ -176,7 +176,7 @@ where
                             info!(
                                 target: "sync::stages::transaction_lookup",
                                 ?append_only,
-                                progress = %format!("{:.2}%", (index as f64 / total_hashes as f64) * 100.0),
+                                progress = %format!("{}/{} ({:.2}%)", index, total_hashes, (index as f64 / total_hashes as f64) * 100.0),
                                 "Inserting hashes"
                             );
                         }

--- a/crates/stages/stages/src/stages/utils.rs
+++ b/crates/stages/stages/src/stages/utils.rs
@@ -83,7 +83,7 @@ where
         cache.entry(key).or_default().push(block_number);
 
         if idx > 0 && idx.is_multiple_of(interval) && total_changesets > 1000 {
-            info!(target: "sync::stages::index_history", progress = %format!("{:.4}%", (idx as f64 / total_changesets as f64) * 100.0), "Collecting indices");
+            info!(target: "sync::stages::index_history", progress = %format!("{}/{} ({:.2}%)", idx, total_changesets, (idx as f64 / total_changesets as f64) * 100.0), "Collecting indices");
         }
 
         // Make sure we only flush the cache every DEFAULT_CACHE_THRESHOLD blocks.
@@ -156,7 +156,7 @@ where
         cache.entry(address).or_default().push(block_number);
 
         if idx > 0 && idx % interval == 0 && total_changesets > 1000 {
-            info!(target: "sync::stages::index_history", progress = %format!("{:.4}%", (idx as f64 / total_changesets as f64) * 100.0), "Collecting indices");
+            info!(target: "sync::stages::index_history", progress = %format!("{}/{} ({:.2}%)", idx, total_changesets, (idx as f64 / total_changesets as f64) * 100.0), "Collecting indices");
         }
 
         if block_number != current_block_number {
@@ -214,7 +214,7 @@ where
             .push(block_number);
 
         if idx > 0 && idx % interval == 0 && total_changesets > 1000 {
-            info!(target: "sync::stages::index_history", progress = %format!("{:.4}%", (idx as f64 / total_changesets as f64) * 100.0), "Collecting indices");
+            info!(target: "sync::stages::index_history", progress = %format!("{}/{} ({:.2}%)", idx, total_changesets, (idx as f64 / total_changesets as f64) * 100.0), "Collecting indices");
         }
 
         if block_number != current_block_number {
@@ -267,7 +267,7 @@ where
         let new_list = BlockNumberList::decompress_owned(v)?;
 
         if index > 0 && index.is_multiple_of(interval) && total_entries > 10 {
-            info!(target: "sync::stages::index_history", progress = %format!("{:.2}%", (index as f64 / total_entries as f64) * 100.0), "Writing indices");
+            info!(target: "sync::stages::index_history", progress = %format!("{}/{} ({:.2}%)", index, total_entries, (index as f64 / total_entries as f64) * 100.0), "Writing indices");
         }
 
         let address = sharded_key.key;
@@ -475,7 +475,7 @@ where
         let new_list = BlockNumberList::decompress_owned(v)?;
 
         if index > 0 && index.is_multiple_of(interval) && total_entries > 10 {
-            info!(target: "sync::stages::index_history", progress = %format!("{:.2}%", (index as f64 / total_entries as f64) * 100.0), "Writing indices");
+            info!(target: "sync::stages::index_history", progress = %format!("{}/{} ({:.2}%)", index, total_entries, (index as f64 / total_entries as f64) * 100.0), "Writing indices");
         }
 
         let partial_key = (sharded_key.address, sharded_key.sharded_key.key);


### PR DESCRIPTION
Unify progress format to `processed/total (XX.XX%)` and add batch progress to sender recovery.

Originally also modified headers.rs, hashing_account.rs, hashing_storage.rs but reverted:
- headers: bottleneck is network, not writes
- hashing_account/storage: only run on first sync or >500K block jumps, no-op with use_hashed_state

Can add them back if needed.