### PR TITLE
perf(trie): use rayon spawn_broadcast for proof workers

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -238,6 +238,7 @@ where
         F: DatabaseProviderROFactory<Provider: TrieCursorFactory + HashedCursorFactory>
             + Clone
             + Send
+            + Sync
             + 'static,
     {
         // start preparing transactions immediately

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -1567,6 +1567,7 @@ mod tests {
                               + BlockNumReader,
             > + Clone
             + Send
+            + Sync
             + 'static,
     {
         let runtime = get_test_runtime();


### PR DESCRIPTION
## Summary
Replace the `for` loop + `pool.spawn()` pattern with `pool.spawn_broadcast()` for spawning proof workers.

## Changes
- Use `spawn_broadcast` on storage and account proof worker pools in `proof_task.rs`, getting the worker ID from `BroadcastContext::index()`
- Add `Sync` bound to `Factory` generic on `ProofWorkerHandle::new` (required by `spawn_broadcast`)
- Propagate the `Sync` bound to callers in `mod.rs` and `multiproof.rs`

## Motivation
`spawn_broadcast` guarantees exactly one task per pool thread and provides a stable per-thread index via the broadcast context, eliminating the manual loop and per-iteration clones.

Prompted by: DaniPopes