### PR TITLE
feat(static-file): add segment duration metrics to StaticFileProducer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10273,6 +10273,7 @@ version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "assert_matches",
+ "metrics",
  "parking_lot",
  "rayon",
  "reth-codecs",

--- a/crates/static-file/static-file/Cargo.toml
+++ b/crates/static-file/static-file/Cargo.toml
@@ -26,6 +26,7 @@ reth-stages-types.workspace = true
 alloy-primitives.workspace = true
 
 # misc
+metrics.workspace = true
 tracing.workspace = true
 rayon.workspace = true
 parking_lot = { workspace = true, features = ["send_guard", "arc_lock"] }

--- a/crates/static-file/static-file/src/static_file_producer.rs
+++ b/crates/static-file/static-file/src/static_file_producer.rs
@@ -145,7 +145,8 @@ where
             let provider = self.provider.database_provider_ro()?.disable_long_read_transaction_safety();
             segment.copy_to_static_files(provider,  block_range.clone())?;
 
-            let elapsed = start.elapsed(); // TODO(alexey): track in metrics
+            let elapsed = start.elapsed();
+            metrics::histogram!("static_files.producer.segment_duration_seconds", "segment" => segment.segment().as_str()).record(elapsed.as_secs_f64());
             debug!(target: "static_file", segment = %segment.segment(), ?block_range, ?elapsed, "Finished StaticFileProducer segment");
 
             Ok(())
@@ -158,7 +159,9 @@ where
                 .update_index(segment.segment(), Some(*block_range.end()))?;
         }
 
-        let elapsed = start.elapsed(); // TODO(alexey): track in metrics
+        let elapsed = start.elapsed();
+        metrics::histogram!("static_files.producer.all_segments_duration_seconds")
+            .record(elapsed.as_secs_f64());
         debug!(target: "static_file", ?targets, ?elapsed, "StaticFileProducer finished");
 
         self.event_sender


### PR DESCRIPTION
Remove two `TODO(alexey): track in metrics` comments

Resolves the missing observability gap between the low-level `StaticFileProvider` metrics (`static_files.segment.*`, `static_files.jar_provider.*`) and the high-level producer orchestration layer.