### PR TITLE
perf: skip dispatch pipeline when all proof targets already fetched

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -771,6 +771,11 @@ impl MultiProofTask {
     fn on_prefetch_proof(&mut self, mut targets: VersionedMultiProofTargets) -> u64 {
         // Remove already fetched proof targets to avoid redundant work.
         targets.retain_difference(&self.fetched_proof_targets);
+
+        if targets.is_empty() {
+            return 0;
+        }
+
         extend_multiproof_targets(&mut self.fetched_proof_targets, &targets);
 
         // For Legacy multiproofs, make sure all target accounts have an `AddedRemovedKeySet` in the
@@ -887,6 +892,10 @@ impl MultiProofTask {
                 state: fetched_state_update,
             });
             state_updates += 1;
+        }
+
+        if not_fetched_state_update.is_empty() {
+            return state_updates;
         }
 
         // Clone+Arc MultiAddedRemovedKeys for sharing with the dispatched multiproof tasks


### PR DESCRIPTION
## Summary

Skip the multiproof dispatch pipeline when all proof targets are already fetched.

## Changes

- **`on_prefetch_proof`**: early return after `retain_difference` yields empty targets
- **`on_hashed_state_update`**: early return after `EmptyProof` sent, when nothing remains unfetched

## Impact

`dispatch_with_chunking` does not short-circuit on empty input — without these guards, an already-covered update still wakes a proof worker, burns a sequence number, and allocates an `Arc<MultiAddedRemovedKeys>` for a no-op. These guards eliminate that overhead. The better prefetch coverage is, the more this fires. No behavioral or sequencing changes.