### PR TITLE
perf: bypass reorder task for sequential small-block tx path

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -983,7 +983,7 @@ impl PayloadExecutionCache {
     /// This ensures that all cache operations happen atomically.
     ///
     /// Callers must not mutate the *underlying* [`ExecutionCache`] data (e.g. via
-    /// [`SavedCache::clear`]) while other tasks may hold clones of the same
+    /// `SavedCache::clear`) while other tasks may hold clones of the same
     /// `SavedCache`. Swapping the slot value (`*cached = Some(..)` / `*cached = None`)
     /// is always safe because existing clones retain their own `Arc` references.
     pub fn update_with_guard<F>(&self, update_fn: F)

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -425,6 +425,7 @@ where
                             let (tx_env, tx) = tx.into_parts();
                             WithTxEnv { tx_env, tx: Arc::new(tx) }
                         });
+                        // Only send Ok(_) variants to the prewarming task.
                         if let Ok(tx) = &tx {
                             let _ = prewarm_tx.send(tx.clone());
                         }

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -981,16 +981,10 @@ impl PayloadExecutionCache {
     /// Updates the cache with a closure that has exclusive access to the guard.
     /// This ensures that all cache operations happen atomically.
     ///
-    /// ## CRITICAL SAFETY REQUIREMENT
-    ///
-    /// **Before calling this method, you MUST ensure there are no other active cache users.**
-    /// This includes:
-    /// - No running [`PrewarmCacheTask`] instances that could write to the cache
-    /// - No concurrent transactions that might access the cached state
-    /// - All prewarming operations must be completed or cancelled
-    ///
-    /// Violating this requirement can result in cache corruption, incorrect state data,
-    /// and potential consensus failures.
+    /// Callers must not mutate the *underlying* [`ExecutionCache`] data (e.g. via
+    /// [`SavedCache::clear`]) while other tasks may hold clones of the same
+    /// `SavedCache`. Swapping the slot value (`*cached = Some(..)` / `*cached = None`)
+    /// is always safe because existing clones retain their own `Arc` references.
     pub fn update_with_guard<F>(&self, update_fn: F)
     where
         F: FnOnce(&mut Option<SavedCache>),


### PR DESCRIPTION
**Summary**
For blocks below `SMALL_BLOCK_TX_THRESHOLD` (30 txs), the sequential signature recovery path was still routing transactions through the out-of-order channel + BTreeMap reorder task, even though they are already produced in order. This eliminates that unnecessary indirection by sending directly to the execution channel, removing one `spawn_blocking` task, one channel pair, and per-tx BTreeMap bookkeeping for small blocks.

**Changes**
- Sequential path sends directly to `execute_tx` instead of going through `ooo_tx` → reorder task → `execute_tx`
- Scoped `ooo` channel + reorder task inside the parallel branch only
- Removed unused `enumerate()` in sequential loop

**Expected Impact**
Reduced coordination overhead for small blocks (≤29 txs): eliminates one spawned task, one channel hop per tx, and BTreeMap insert/lookup per tx.