### PR TITLE
fix(ci): pass docker tags as separate set entries in bake action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -70,18 +70,27 @@ jobs:
             # Add 'latest' tag for non-RC releases
             if [[ ! "$VERSION" =~ -rc ]]; then
               echo "ethereum_tags=${REGISTRY}/reth:${VERSION},${REGISTRY}/reth:latest" >> "$GITHUB_OUTPUT"
+              {
+                echo "ethereum_set<<EOF"
+                echo "ethereum.tags=${REGISTRY}/reth:${VERSION}"
+                echo "ethereum.tags=${REGISTRY}/reth:latest"
+                echo "EOF"
+              } >> "$GITHUB_OUTPUT"
             else
               echo "ethereum_tags=${REGISTRY}/reth:${VERSION}" >> "$GITHUB_OUTPUT"
+              echo "ethereum_set=ethereum.tags=${REGISTRY}/reth:${VERSION}" >> "$GITHUB_OUTPUT"
             fi
 
           elif [[ "${{ github.event_name }}" == "schedule" ]] || [[ "${{ inputs.build_type }}" == "nightly" ]]; then
             echo "targets=nightly" >> "$GITHUB_OUTPUT"
             echo "ethereum_tags=${REGISTRY}/reth:nightly" >> "$GITHUB_OUTPUT"
+            echo "ethereum_set=ethereum.tags=${REGISTRY}/reth:nightly" >> "$GITHUB_OUTPUT"
 
           else
             # git-sha build
             echo "targets=ethereum" >> "$GITHUB_OUTPUT"
             echo "ethereum_tags=${REGISTRY}/reth:${{ github.sha }}" >> "$GITHUB_OUTPUT"
+            echo "ethereum_set=ethereum.tags=${REGISTRY}/reth:${{ github.sha }}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build and push images
@@ -97,7 +106,7 @@ jobs:
           targets: ${{ steps.params.outputs.targets }}
           push: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
           set: |
-            ethereum.tags=${{ steps.params.outputs.ethereum_tags }}
+            ${{ steps.params.outputs.ethereum_set }}
 
       - name: Verify image architectures
         env:


### PR DESCRIPTION
## Summary
Fixes the v1.11.0 Docker image build failure caused by comma-separated tags being passed as a single value to `depot/bake-action`.

## Motivation
The [v1.11.0 Docker build](https://github.com/paradigmxyz/reth/actions/runs/21965662035/job/63454703301) failed with:
```
Error: invalid tag "ghcr.io/paradigmxyz/reth:v1.11.0,ghcr.io/paradigmxyz/reth:latest": invalid reference format
```

The bake action's `set` field passes each line as a separate `--set` flag. When multiple tags were comma-separated on one line, the whole string was treated as a single (invalid) tag.

## Changes
- Added `ethereum_set` output with each tag on a separate `ethereum.tags=` line using multiline GitHub output syntax
- Use `ethereum_set` in the bake action's `set` field
- Kept `ethereum_tags` (comma-separated) for the verify script which already handles that format

Prompted by: alexey