### PR TITLE
perf(cli): remove clone in trie repair

### DIFF
--- a/crates/cli/commands/src/db/repair_trie.rs
+++ b/crates/cli/commands/src/db/repair_trie.rs
@@ -285,7 +285,6 @@ fn verify_and_repair<N: ProviderNodeTypes>(tool: &DbTool<N>) -> eyre::Result<()>
                 // (We can't just use `upsert` method with a dup cursor, it's not properly
                 // supported)
                 let nibbles = StoredNibblesSubKey(path);
-                let entry = StorageTrieEntry { nibbles: nibbles.clone(), node };
                 if storage_trie_cursor
                     .seek_by_key_subkey(account, nibbles.clone())?
                     .filter(|v| v.nibbles == nibbles)
@@ -293,6 +292,7 @@ fn verify_and_repair<N: ProviderNodeTypes>(tool: &DbTool<N>) -> eyre::Result<()>
                 {
                     storage_trie_cursor.delete_current()?;
                 }
+                let entry = StorageTrieEntry { nibbles, node };
                 storage_trie_cursor.upsert(account, &entry)?;
             }
             Output::Progress(path) => {


### PR DESCRIPTION
When upserting storage trie entries, `nibbles` was cloned twice: once for creating the entry struct and once for seek_by_key_subkey.
By moving entry creation after the seek operation, we can move `nibbles` into the entry instead of cloning it.