### PR TITLE
feat(trie): persist storage trie root nodes to database

### DIFF
--- a/crates/trie/db/src/trie_cursor.rs
+++ b/crates/trie/db/src/trie_cursor.rs
@@ -131,8 +131,7 @@ where
         }
 
         let mut num_entries = 0;
-        for (nibbles, maybe_updated) in updates.storage_nodes.iter().filter(|(n, _)| !n.is_empty())
-        {
+        for (nibbles, maybe_updated) in &updates.storage_nodes {
             num_entries += 1;
             let nibbles = StoredNibblesSubKey(*nibbles);
             // Delete the old entry if it exists.

--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -699,7 +699,7 @@ where
         Span::current().record("storage_root", format!("{root:?}"));
 
         let removed_keys = storage_node_iter.walker.take_removed_keys();
-        trie_updates.finalize(hash_builder, removed_keys);
+        trie_updates.finalize(hash_builder, removed_keys, root);
 
         let stats = tracker.finish();
 


### PR DESCRIPTION
## Summary
Write storage trie root `BranchNodeCompact` (with `root_hash`) to the `StoragesTrie` table. Previously these were filtered out at every level.

## Motivation
The `root_hash` field on `BranchNodeCompact` enables the `TrieWalker` to skip an entire storage trie when none of its keys have changed. The infrastructure to read/use it already exists (`CursorSubNode::hash_flag`, `update_skip_node`), but the root node was never actually written to the database.

## Changes
- `StorageTrieUpdates::finalize` — accepts computed `storage_root` and sets `root_hash` on the root node when the `HashBuilder` produces one
- `StorageTrieUpdates::{extend, extend_ref, new, extend_from_sorted}` — stop filtering empty nibbles
- `write_storage_trie_updates_sorted` — stop skipping empty nibbles
- Account trie filtering is unchanged (`TrieUpdates` still uses `exclude_empty`)

## Testing
- `storage_trie_root_node_persisted`: verifies root node is written with correct `root_hash`, read back, and walker skips it
- `storage_trie_root_node_incremental_update`: verifies incremental root matches reference after modifying a slot with cached root node in DB
- All 15 existing `reth-trie-db` trie tests pass
- All 55 `reth-trie` tests pass
- Walker tests pass

Prompted by: alexey