### PR TITLE
tip1016: revm state-gas integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,7 +290,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.27.2"
-source = "git+https://github.com/alloy-rs/evm?rev=742dc14749ea0279c03ca27b1c26f26ac19fbefb#742dc14749ea0279c03ca27b1c26f26ac19fbefb"
+source = "git+https://github.com/alloy-rs/evm?rev=ab97815eedb5152011c8add8c8d98555338d9990#ab97815eedb5152011c8add8c8d98555338d9990"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6423,7 +6423,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "15.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=33330a285e621b9170c30a21cfea9ab32e2a2169#33330a285e621b9170c30a21cfea9ab32e2a2169"
+source = "git+https://github.com/bluealloy/revm?rev=e3223d5b38f7affb901601ed917fa7cdc466be74#e3223d5b38f7affb901601ed917fa7cdc466be74"
 dependencies = [
  "auto_impl",
  "revm",
@@ -10671,7 +10671,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "34.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=33330a285e621b9170c30a21cfea9ab32e2a2169#33330a285e621b9170c30a21cfea9ab32e2a2169"
+source = "git+https://github.com/bluealloy/revm?rev=e3223d5b38f7affb901601ed917fa7cdc466be74#e3223d5b38f7affb901601ed917fa7cdc466be74"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10689,7 +10689,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "8.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=33330a285e621b9170c30a21cfea9ab32e2a2169#33330a285e621b9170c30a21cfea9ab32e2a2169"
+source = "git+https://github.com/bluealloy/revm?rev=e3223d5b38f7affb901601ed917fa7cdc466be74#e3223d5b38f7affb901601ed917fa7cdc466be74"
 dependencies = [
  "bitvec",
  "phf",
@@ -10700,7 +10700,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "13.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=33330a285e621b9170c30a21cfea9ab32e2a2169#33330a285e621b9170c30a21cfea9ab32e2a2169"
+source = "git+https://github.com/bluealloy/revm?rev=e3223d5b38f7affb901601ed917fa7cdc466be74#e3223d5b38f7affb901601ed917fa7cdc466be74"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10716,7 +10716,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "14.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=33330a285e621b9170c30a21cfea9ab32e2a2169#33330a285e621b9170c30a21cfea9ab32e2a2169"
+source = "git+https://github.com/bluealloy/revm?rev=e3223d5b38f7affb901601ed917fa7cdc466be74#e3223d5b38f7affb901601ed917fa7cdc466be74"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10731,7 +10731,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "10.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=33330a285e621b9170c30a21cfea9ab32e2a2169#33330a285e621b9170c30a21cfea9ab32e2a2169"
+source = "git+https://github.com/bluealloy/revm?rev=e3223d5b38f7affb901601ed917fa7cdc466be74#e3223d5b38f7affb901601ed917fa7cdc466be74"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -10744,7 +10744,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "9.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=33330a285e621b9170c30a21cfea9ab32e2a2169#33330a285e621b9170c30a21cfea9ab32e2a2169"
+source = "git+https://github.com/bluealloy/revm?rev=e3223d5b38f7affb901601ed917fa7cdc466be74#e3223d5b38f7affb901601ed917fa7cdc466be74"
 dependencies = [
  "auto_impl",
  "either",
@@ -10757,10 +10757,9 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "15.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=33330a285e621b9170c30a21cfea9ab32e2a2169#33330a285e621b9170c30a21cfea9ab32e2a2169"
+source = "git+https://github.com/bluealloy/revm?rev=e3223d5b38f7affb901601ed917fa7cdc466be74#e3223d5b38f7affb901601ed917fa7cdc466be74"
 dependencies = [
  "auto_impl",
- "bitflags 2.10.0",
  "derive-where",
  "revm-bytecode",
  "revm-context",
@@ -10776,7 +10775,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "15.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=33330a285e621b9170c30a21cfea9ab32e2a2169#33330a285e621b9170c30a21cfea9ab32e2a2169"
+source = "git+https://github.com/bluealloy/revm?rev=e3223d5b38f7affb901601ed917fa7cdc466be74#e3223d5b38f7affb901601ed917fa7cdc466be74"
 dependencies = [
  "auto_impl",
  "either",
@@ -10793,7 +10792,7 @@ dependencies = [
 [[package]]
 name = "revm-inspectors"
 version = "0.34.2"
-source = "git+https://github.com/paradigmxyz/revm-inspectors?rev=e80e2eab72dfa18011e6a99abd37027290a46e83#e80e2eab72dfa18011e6a99abd37027290a46e83"
+source = "git+https://github.com/paradigmxyz/revm-inspectors?rev=8b26ede9215b5cc7e4aa63b4634d5e9480511a9e#8b26ede9215b5cc7e4aa63b4634d5e9480511a9e"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -10812,7 +10811,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "32.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=33330a285e621b9170c30a21cfea9ab32e2a2169#33330a285e621b9170c30a21cfea9ab32e2a2169"
+source = "git+https://github.com/bluealloy/revm?rev=e3223d5b38f7affb901601ed917fa7cdc466be74#e3223d5b38f7affb901601ed917fa7cdc466be74"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10824,7 +10823,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "32.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=33330a285e621b9170c30a21cfea9ab32e2a2169#33330a285e621b9170c30a21cfea9ab32e2a2169"
+source = "git+https://github.com/bluealloy/revm?rev=e3223d5b38f7affb901601ed917fa7cdc466be74#e3223d5b38f7affb901601ed917fa7cdc466be74"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10847,7 +10846,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "22.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=33330a285e621b9170c30a21cfea9ab32e2a2169#33330a285e621b9170c30a21cfea9ab32e2a2169"
+source = "git+https://github.com/bluealloy/revm?rev=e3223d5b38f7affb901601ed917fa7cdc466be74#e3223d5b38f7affb901601ed917fa7cdc466be74"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -10858,7 +10857,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "9.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=33330a285e621b9170c30a21cfea9ab32e2a2169#33330a285e621b9170c30a21cfea9ab32e2a2169"
+source = "git+https://github.com/bluealloy/revm?rev=e3223d5b38f7affb901601ed917fa7cdc466be74#e3223d5b38f7affb901601ed917fa7cdc466be74"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.10.0",
@@ -13977,4 +13976,4 @@ dependencies = [
 [[patch.unused]]
 name = "alloy-op-evm"
 version = "0.27.2"
-source = "git+https://github.com/alloy-rs/evm?rev=742dc14749ea0279c03ca27b1c26f26ac19fbefb#742dc14749ea0279c03ca27b1c26f26ac19fbefb"
+source = "git+https://github.com/alloy-rs/evm?rev=ab97815eedb5152011c8add8c8d98555338d9990#ab97815eedb5152011c8add8c8d98555338d9990"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -712,26 +712,26 @@ ipnet = "2.11"
 
 [patch.crates-io]
 # revm staging patches
-revm = { git = "https://github.com/bluealloy/revm", rev = "33330a285e621b9170c30a21cfea9ab32e2a2169" }
-op-revm = { git = "https://github.com/bluealloy/revm", rev = "33330a285e621b9170c30a21cfea9ab32e2a2169" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "33330a285e621b9170c30a21cfea9ab32e2a2169" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "33330a285e621b9170c30a21cfea9ab32e2a2169" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "33330a285e621b9170c30a21cfea9ab32e2a2169" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "33330a285e621b9170c30a21cfea9ab32e2a2169" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "33330a285e621b9170c30a21cfea9ab32e2a2169" }
-revm-handler = { git = "https://github.com/bluealloy/revm", rev = "33330a285e621b9170c30a21cfea9ab32e2a2169" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "33330a285e621b9170c30a21cfea9ab32e2a2169" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "33330a285e621b9170c30a21cfea9ab32e2a2169" }
-revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "33330a285e621b9170c30a21cfea9ab32e2a2169" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "33330a285e621b9170c30a21cfea9ab32e2a2169" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "33330a285e621b9170c30a21cfea9ab32e2a2169" }
+revm = { git = "https://github.com/bluealloy/revm", rev = "e3223d5b38f7affb901601ed917fa7cdc466be74" }
+op-revm = { git = "https://github.com/bluealloy/revm", rev = "e3223d5b38f7affb901601ed917fa7cdc466be74" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "e3223d5b38f7affb901601ed917fa7cdc466be74" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "e3223d5b38f7affb901601ed917fa7cdc466be74" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "e3223d5b38f7affb901601ed917fa7cdc466be74" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "e3223d5b38f7affb901601ed917fa7cdc466be74" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "e3223d5b38f7affb901601ed917fa7cdc466be74" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "e3223d5b38f7affb901601ed917fa7cdc466be74" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "e3223d5b38f7affb901601ed917fa7cdc466be74" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "e3223d5b38f7affb901601ed917fa7cdc466be74" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "e3223d5b38f7affb901601ed917fa7cdc466be74" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "e3223d5b38f7affb901601ed917fa7cdc466be74" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "e3223d5b38f7affb901601ed917fa7cdc466be74" }
 
 # revm-inspectors staging patch
-revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "e80e2eab72dfa18011e6a99abd37027290a46e83" }
+revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "8b26ede9215b5cc7e4aa63b4634d5e9480511a9e" }
 
 # alloy-evm staging patches
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "742dc14749ea0279c03ca27b1c26f26ac19fbefb" }
-alloy-op-evm = { git = "https://github.com/alloy-rs/evm", rev = "742dc14749ea0279c03ca27b1c26f26ac19fbefb" }
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "ab97815eedb5152011c8add8c8d98555338d9990" }
+alloy-op-evm = { git = "https://github.com/alloy-rs/evm", rev = "ab97815eedb5152011c8add8c8d98555338d9990" }
 
 # alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
 # alloy-contract = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -1371,7 +1371,7 @@ pub fn ensure_intrinsic_gas<T: EthPoolTransaction>(
     );
 
     let gas_limit = transaction.gas_limit();
-    if gas_limit < gas.initial_gas || gas_limit < gas.floor_gas {
+    if gas_limit < gas.initial_total_gas || gas_limit < gas.floor_gas {
         Err(InvalidPoolTransactionError::IntrinsicGasTooLow)
     } else {
         Ok(())


### PR DESCRIPTION
## Summary
- Update revm sub-crate revs to `e3223d5b38f7affb901601ed917fa7cdc466be74` (rakita/state-gas branch)
- Update revm-inspectors rev to `8b26ede9215b5cc7e4aa63b4634d5e9480511a9e`
- Update alloy-evm/alloy-op-evm rev to `ab97815eedb5152011c8add8c8d98555338d9990`
- Fix `InitialAndFloorGas.initial_gas` → `.initial_total_gas` rename in transaction pool validation

## Test plan
- [x] `cargo check` compiles clean
- [x] `cargo +nightly clippy --workspace --all-targets --all-features` passes
- [x] `cargo nextest run` — passes (pre-existing flaky `reth-discv4` network tests unrelated to this change)