### PR TITLE
fix(exex): drain notification channel during backfill to prevent stall

### DIFF
--- a/crates/exex/exex/src/notifications.rs
+++ b/crates/exex/exex/src/notifications.rs
@@ -471,11 +471,11 @@ where
                     this.pending_notifications.push_back(notification);
                     continue;
                 }
-                if let Some(committed) = notification.committed_chain() {
-                    if committed.tip().number() <= this.initial_local_head.number {
-                        // Covered by backfill range, safe to discard
-                        continue;
-                    }
+                if let Some(committed) = notification.committed_chain() &&
+                    committed.tip().number() <= this.initial_local_head.number
+                {
+                    // Covered by backfill range, safe to discard
+                    continue;
                 }
                 // Beyond the backfill range — buffer for delivery after backfill
                 this.pending_notifications.push_back(notification);


### PR DESCRIPTION
Closes #19665

## Summary

When an ExEx is behind the node head and triggers a backfill, `ExExNotificationsWithHead::poll_next` yields backfill results but never polls the notification channel. Since the channel has a capacity of 1, it fills immediately, which blocks the `ExExManager`'s `PollSender`, which eventually fills the 1024-entry internal buffer and stalls all upstream notification senders.

#21135 fixed a related deadlock where the manager didn't wake up after the buffer cleared, but it didn't address the root cause on the consumer side — the channel simply never gets drained during backfill. @meyer9 [confirmed on Jan 28](https://github.com/paradigmxyz/reth/issues/19665#issuecomment-2619264080) that the stall still reproduces after #21135.

## Changes

Adds a drain loop inside `poll_next` that runs on every poll while a backfill job is active. Notifications covered by the backfill range are discarded (the backfill job re-delivers them from the database), while notifications for blocks beyond the backfill range are buffered in a `VecDeque` and delivered in order once the backfill completes. This keeps the channel empty so the manager never gets blocked, regardless of how long the backfill takes.

The regression test fills the capacity-1 channel before starting a backfill, then asserts that `try_send` succeeds after the first `poll_next` — proving the drain loop emptied the channel during the backfill poll. Without the fix, `try_send` fails because the notification is still sitting in the channel.