### PR TITLE
perf(trie): separate Changed and Touched handling in update_leaves

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -69,7 +69,11 @@ use preserved_sparse_trie::{PreservedSparseTrie, SharedPreservedSparseTrie};
 /// the affects. Below 100 throughput would generally be equal or slightly less, while above 150 it
 /// would deteriorate to the point where PST might as well not be used.
 pub const PARALLEL_SPARSE_TRIE_PARALLELISM_THRESHOLDS: ParallelismThresholds =
-    ParallelismThresholds { min_revealed_nodes: 100, min_updated_nodes: 100 };
+    ParallelismThresholds {
+        min_revealed_nodes: 100,
+        min_updated_nodes: 100,
+        min_touched_leaves: 100,
+    };
 
 /// Default node capacity for shrinking the sparse trie. This is used to limit the number of trie
 /// nodes in allocated sparse tries.


### PR DESCRIPTION
## Summary
Separates `ParallelSparseTrie::update_leaves` into two phases: Changed (sequential) then Touched (parallelizable via rayon).

## Motivation
`Touched` updates only call `find_leaf` which takes `&self` — pure read-only. Processing them in parallel with rayon reduces latency on touched-heavy workloads (e.g., optimistic prewarming).

## Changes
- Partition keys into `changed_keys` and `touched_keys` upfront
- Process `Changed` first sequentially (requires `&mut self` for `update_leaf`/`remove_leaf`)
- Process `Touched` with rayon `par_iter` when above threshold, collecting blinded results and applying sequentially
- Add `min_touched_leaves` field to `ParallelismThresholds` (default 100, matching other thresholds)
- Add `is_touched_parallelism_enabled` helper (same pattern as reveal/update)

## Testing
`cargo test -p reth-trie-sparse` — all 100 tests pass including `test_update_leaves_touched`, `test_update_leaves_touched_blinded`, and the fuzz test.

Prompted by: brian