### PR TITLE
feat(execution-types): add account_state helper to BlockExecutionOutput

### DIFF
--- a/crates/evm/execution-types/src/execute.rs
+++ b/crates/evm/execution-types/src/execute.rs
@@ -1,6 +1,6 @@
 use alloy_primitives::{Address, B256, U256};
 use reth_primitives_traits::{Account, Bytecode};
-use revm::database::BundleState;
+use revm::database::{states::BundleState, BundleAccount};
 
 pub use alloy_evm::block::BlockExecutionResult;
 
@@ -35,6 +35,11 @@ impl<T> BlockExecutionOutput<T> {
     /// Get account if account is known.
     pub fn account(&self, address: &Address) -> Option<Option<Account>> {
         self.state.account(address).map(|a| a.info.as_ref().map(Into::into))
+    }
+
+    /// Returns the state [`BundleAccount`] for the given address.
+    pub fn account_state(&self, address: &Address) -> Option<&BundleAccount> {
+        self.state.account(address)
     }
 
     /// Get storage if value is known.


### PR DESCRIPTION
## Summary
Adds `account_state()` helper to `BlockExecutionOutput`, mirroring the existing method on `ExecutionOutcome`.

## Motivation
`BlockExecutionOutput` has `account()` (returns `Option<Option<Account>>`) and `storage()` (returns a single slot), but lacks a way to get the full `BundleAccount` reference. This forces users to reach into `.state.state.get(&addr)` to access the account's storage map directly.

`ExecutionOutcome` already has `account_state()` for this — this PR adds the same to `BlockExecutionOutput`.

## Changes
- Added `account_state(&self, address: &Address) -> Option<&BundleAccount>` to `BlockExecutionOutput` in `crates/evm/execution-types/src/execute.rs`

Prompted by: matthias