### PR TITLE
fix(storage): add back Arc auto_impl for storage-api traits

### DIFF
--- a/.changelog/proud-wolves-spin.md
+++ b/.changelog/proud-wolves-spin.md
@@ -1,0 +1,5 @@
+---
+reth-storage-api: patch
+---
+
+Added `Arc` to `auto_impl` derive for storage-api traits to support automatic `Arc` wrapper implementations.

--- a/crates/storage/storage-api/src/block_writer.rs
+++ b/crates/storage/storage-api/src/block_writer.rs
@@ -39,7 +39,7 @@ impl<T: BlockExecutionWriter> BlockExecutionWriter for &T {
 }
 
 /// Block Writer
-#[auto_impl::auto_impl(&, Box)]
+#[auto_impl::auto_impl(&, Arc, Box)]
 pub trait BlockWriter {
     /// The body this writer can write.
     type Block: Block;

--- a/crates/storage/storage-api/src/hashing.rs
+++ b/crates/storage/storage-api/src/hashing.rs
@@ -9,7 +9,7 @@ use reth_primitives_traits::{Account, StorageEntry};
 use reth_storage_errors::provider::ProviderResult;
 
 /// Hashing Writer
-#[auto_impl(&, Box)]
+#[auto_impl(&, Arc, Box)]
 pub trait HashingWriter: Send {
     /// Unwind and clear account hashing.
     ///

--- a/crates/storage/storage-api/src/history.rs
+++ b/crates/storage/storage-api/src/history.rs
@@ -7,7 +7,7 @@ use reth_db_models::AccountBeforeTx;
 use reth_storage_errors::provider::ProviderResult;
 
 /// History Writer
-#[auto_impl(&, Box)]
+#[auto_impl(&, Arc, Box)]
 pub trait HistoryWriter: Send {
     /// Unwind and clear account history indices.
     ///

--- a/crates/storage/storage-api/src/metadata.rs
+++ b/crates/storage/storage-api/src/metadata.rs
@@ -11,7 +11,7 @@ pub mod keys {
 }
 
 /// Client trait for reading node metadata from the database.
-#[auto_impl::auto_impl(&)]
+#[auto_impl::auto_impl(&, Arc)]
 pub trait MetadataProvider: Send {
     /// Get a metadata value by key
     fn get_metadata(&self, key: &str) -> ProviderResult<Option<Vec<u8>>>;

--- a/crates/storage/storage-api/src/prune_checkpoint.rs
+++ b/crates/storage/storage-api/src/prune_checkpoint.rs
@@ -3,7 +3,7 @@ use reth_prune_types::{PruneCheckpoint, PruneSegment};
 use reth_storage_errors::provider::ProviderResult;
 
 /// The trait for fetching prune checkpoint related data.
-#[auto_impl::auto_impl(&)]
+#[auto_impl::auto_impl(&, Arc)]
 pub trait PruneCheckpointReader: Send {
     /// Fetch the prune checkpoint for the given segment.
     fn get_prune_checkpoint(
@@ -16,7 +16,7 @@ pub trait PruneCheckpointReader: Send {
 }
 
 /// The trait for updating prune checkpoint related data.
-#[auto_impl::auto_impl(&)]
+#[auto_impl::auto_impl(&, Arc)]
 pub trait PruneCheckpointWriter {
     /// Save prune checkpoint.
     fn save_prune_checkpoint(

--- a/crates/storage/storage-api/src/stage_checkpoint.rs
+++ b/crates/storage/storage-api/src/stage_checkpoint.rs
@@ -4,7 +4,7 @@ use reth_stages_types::{StageCheckpoint, StageId};
 use reth_storage_errors::provider::ProviderResult;
 
 /// The trait for fetching stage checkpoint related data.
-#[auto_impl::auto_impl(&)]
+#[auto_impl::auto_impl(&, Arc)]
 pub trait StageCheckpointReader: Send {
     /// Fetch the checkpoint for the given stage.
     fn get_stage_checkpoint(&self, id: StageId) -> ProviderResult<Option<StageCheckpoint>>;
@@ -18,7 +18,7 @@ pub trait StageCheckpointReader: Send {
 }
 
 /// The trait for updating stage checkpoint related data.
-#[auto_impl::auto_impl(&)]
+#[auto_impl::auto_impl(&, Arc)]
 pub trait StageCheckpointWriter {
     /// Save stage checkpoint.
     fn save_stage_checkpoint(&self, id: StageId, checkpoint: StageCheckpoint)

--- a/crates/storage/storage-api/src/state.rs
+++ b/crates/storage/storage-api/src/state.rs
@@ -14,7 +14,7 @@ use reth_trie_common::HashedPostState;
 use revm_database::BundleState;
 
 /// This just receives state, or [`ExecutionOutcome`], from the provider
-#[auto_impl::auto_impl(&, Box)]
+#[auto_impl::auto_impl(&, Arc, Box)]
 pub trait StateReader: Send {
     /// Receipt type in [`ExecutionOutcome`].
     type Receipt: Send + Sync;
@@ -30,7 +30,7 @@ pub trait StateReader: Send {
 pub type StateProviderBox = Box<dyn StateProvider + Send + 'static>;
 
 /// An abstraction for a type that provides state data.
-#[auto_impl(&, Box)]
+#[auto_impl(&, Arc, Box)]
 pub trait StateProvider:
     BlockHashReader
     + AccountReader
@@ -110,14 +110,14 @@ pub trait AccountInfoReader: AccountReader + BytecodeReader {}
 impl<T: AccountReader + BytecodeReader> AccountInfoReader for T {}
 
 /// Trait that provides the hashed state from various sources.
-#[auto_impl(&, Box)]
+#[auto_impl(&, Arc, Box)]
 pub trait HashedPostStateProvider {
     /// Returns the `HashedPostState` of the provided [`BundleState`].
     fn hashed_post_state(&self, bundle_state: &BundleState) -> HashedPostState;
 }
 
 /// Trait for reading bytecode associated with a given code hash.
-#[auto_impl(&, Box)]
+#[auto_impl(&, Arc, Box)]
 pub trait BytecodeReader {
     /// Get account code by its hash
     fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>>;

--- a/crates/storage/storage-api/src/stats.rs
+++ b/crates/storage/storage-api/src/stats.rs
@@ -1,7 +1,7 @@
 use reth_db_api::table::Table;
 
 /// The trait for fetching provider statistics.
-#[auto_impl::auto_impl(&)]
+#[auto_impl::auto_impl(&, Arc)]
 pub trait StatsReader {
     /// Fetch the number of entries in the corresponding [Table]. Depending on the provider, it may
     /// route to different data sources other than [Table].

--- a/crates/storage/storage-api/src/storage.rs
+++ b/crates/storage/storage-api/src/storage.rs
@@ -35,7 +35,7 @@ impl From<ChangesetEntry> for StorageEntry {
 }
 
 /// Storage reader
-#[auto_impl::auto_impl(&, Box)]
+#[auto_impl::auto_impl(&, Arc, Box)]
 pub trait StorageReader: Send {
     /// Get plainstate storages for addresses and storage keys.
     fn plain_state_storages(
@@ -61,7 +61,7 @@ pub trait StorageReader: Send {
 
 /// Storage `ChangeSet` reader
 #[cfg(feature = "db-api")]
-#[auto_impl::auto_impl(&, Box)]
+#[auto_impl::auto_impl(&, Arc, Box)]
 pub trait StorageChangeSetReader: Send {
     /// Iterate over storage changesets and return the storage state from before this block.
     ///

--- a/crates/storage/storage-api/src/trie.rs
+++ b/crates/storage/storage-api/src/trie.rs
@@ -40,7 +40,7 @@ pub trait StateRootProvider {
 }
 
 /// A type that can compute the storage root for a given account.
-#[auto_impl::auto_impl(&, Box)]
+#[auto_impl::auto_impl(&, Box, Arc)]
 pub trait StorageRootProvider {
     /// Returns the storage root of the `HashedStorage` for target address on top of the current
     /// state.
@@ -66,7 +66,7 @@ pub trait StorageRootProvider {
 }
 
 /// A type that can generate state proof on top of a given post state.
-#[auto_impl::auto_impl(&, Box)]
+#[auto_impl::auto_impl(&, Box, Arc)]
 pub trait StateProofProvider {
     /// Get account and storage proofs of target keys in the `HashedPostState`
     /// on top of the current state.
@@ -90,7 +90,7 @@ pub trait StateProofProvider {
 }
 
 /// Trie Writer
-#[auto_impl::auto_impl(&, Box)]
+#[auto_impl::auto_impl(&, Arc, Box)]
 pub trait TrieWriter: Send {
     /// Writes trie updates to the database.
     ///
@@ -106,7 +106,7 @@ pub trait TrieWriter: Send {
 }
 
 /// Storage Trie Writer
-#[auto_impl::auto_impl(&, Box)]
+#[auto_impl::auto_impl(&, Arc, Box)]
 pub trait StorageTrieWriter: Send {
     /// Writes storage trie updates from the given storage trie map with already sorted updates.
     ///


### PR DESCRIPTION
## Summary
Restores `Arc` in `auto_impl` for all storage-api traits that had it removed in #20516.

## Motivation
Closes #22173 — PR #20516 unintentionally removed `Arc` from `auto_impl` on many storage-api traits when removing `Sync` from `DbTx`. Consumers need `Arc<dyn StateProvider + Send + Sync>` and similar patterns.

## Changes
- Added `Arc` back to `auto_impl` on: `StateReader`, `StateProvider`, `HashedPostStateProvider`, `BytecodeReader`, `StorageRootProvider`, `StateProofProvider`, `TrieWriter`, `StorageTrieWriter`, `StorageReader`, `StorageChangeSetReader`, `HashingWriter`, `HistoryWriter`, `BlockWriter`, `MetadataProvider`, `PruneCheckpointReader`, `PruneCheckpointWriter`, `StageCheckpointReader`, `StageCheckpointWriter`, `StatsReader`

## Testing
`cargo check -p reth-storage-api --all-features` and `cargo check -p reth-provider --all-features` both pass.

Prompted by: mattsse