### PR TITLE
fix(engine-primitives): delegate block_to_payload to T

### DIFF
--- a/crates/ethereum/engine-primitives/src/lib.rs
+++ b/crates/ethereum/engine-primitives/src/lib.rs
@@ -53,9 +53,7 @@ impl<
             <<Self::BuiltPayload as BuiltPayload>::Primitives as NodePrimitives>::Block,
         >,
     ) -> Self::ExecutionData {
-        let (payload, sidecar) =
-            ExecutionPayload::from_block_unchecked(block.hash(), &block.into_block());
-        ExecutionData { payload, sidecar }
+        T::block_to_payload(block)
     }
 }
 


### PR DESCRIPTION
EthEngineTypes<T> forwards all associated types to T but duplicated the block_to_payload body instead of delegating to T::block_to_payload