### PR TITLE
feat(txpool): add PoolTransaction::consensus_ref

### DIFF
--- a/.changelog/fast-seals-play.md
+++ b/.changelog/fast-seals-play.md
@@ -1,0 +1,5 @@
+---
+reth-transaction-pool: minor
+---
+
+Added `consensus_ref` method to `PoolTransaction` trait for borrowing consensus transactions without cloning.

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -34,7 +34,7 @@ use reth_primitives_traits::{
 use alloy_consensus::error::ValueError;
 use alloy_eips::eip4844::env_settings::KzgSettings;
 use rand::distr::weighted::WeightedIndex;
-use std::{ops::Range, sync::Arc, time::Instant, vec::IntoIter};
+use std::{borrow::Cow, ops::Range, sync::Arc, time::Instant, vec::IntoIter};
 
 /// A transaction pool implementation using [`MockOrdering`] for transaction ordering.
 ///
@@ -704,8 +704,10 @@ impl PoolTransaction for MockTransaction {
 
     type Pooled = PooledTransactionVariant;
 
-    fn consensus_ref(&self) -> Recovered<&Self::Consensus> {
-        unimplemented!("mock transaction does not wrap a consensus transaction")
+    fn consensus_ref(&self) -> Recovered<Cow<'_, Self::Consensus>> {
+        let recovered = self.clone().into_consensus();
+        let (tx, signer) = recovered.into_parts();
+        Recovered::new_unchecked(Cow::Owned(tx), signer)
     }
 
     fn into_consensus(self) -> Recovered<Self::Consensus> {

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -34,7 +34,7 @@ use reth_primitives_traits::{
 use alloy_consensus::error::ValueError;
 use alloy_eips::eip4844::env_settings::KzgSettings;
 use rand::distr::weighted::WeightedIndex;
-use std::{borrow::Cow, ops::Range, sync::Arc, time::Instant, vec::IntoIter};
+use std::{ops::Range, sync::Arc, time::Instant, vec::IntoIter};
 
 /// A transaction pool implementation using [`MockOrdering`] for transaction ordering.
 ///
@@ -704,10 +704,8 @@ impl PoolTransaction for MockTransaction {
 
     type Pooled = PooledTransactionVariant;
 
-    fn consensus_ref(&self) -> Recovered<Cow<'_, Self::Consensus>> {
-        let recovered = self.clone().into_consensus();
-        let (tx, signer) = recovered.into_parts();
-        Recovered::new_unchecked(Cow::Owned(tx), signer)
+    fn consensus_ref(&self) -> Recovered<&Self::Consensus> {
+        unimplemented!("mock transaction does not wrap a consensus transaction")
     }
 
     fn into_consensus(self) -> Recovered<Self::Consensus> {

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -704,6 +704,10 @@ impl PoolTransaction for MockTransaction {
 
     type Pooled = PooledTransactionVariant;
 
+    fn consensus_ref(&self) -> Recovered<&Self::Consensus> {
+        unimplemented!("mock transaction does not wrap a consensus transaction")
+    }
+
     fn into_consensus(self) -> Recovered<Self::Consensus> {
         self.into()
     }

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -78,7 +78,6 @@ use reth_execution_types::ChangedAccount;
 use reth_primitives_traits::{Block, InMemorySize, Recovered, SealedBlock, SignedTransaction};
 use serde::{Deserialize, Serialize};
 use std::{
-    borrow::Cow,
     collections::HashMap,
     fmt,
     fmt::Debug,
@@ -1259,7 +1258,7 @@ pub trait PoolTransaction:
     }
 
     /// Returns a reference to the consensus transaction with the recovered sender.
-    fn consensus_ref(&self) -> Recovered<Cow<'_, Self::Consensus>>;
+    fn consensus_ref(&self) -> Recovered<&Self::Consensus>;
 
     /// Define a method to convert from the `Self` type to `Consensus`
     fn into_consensus(self) -> Recovered<Self::Consensus>;
@@ -1451,8 +1450,8 @@ impl PoolTransaction for EthPooledTransaction {
         self.transaction().clone()
     }
 
-    fn consensus_ref(&self) -> Recovered<Cow<'_, Self::Consensus>> {
-        Recovered::new_unchecked(Cow::Borrowed(&*self.transaction), self.transaction.signer())
+    fn consensus_ref(&self) -> Recovered<&Self::Consensus> {
+        Recovered::new_unchecked(&*self.transaction, self.transaction.signer())
     }
 
     fn into_consensus(self) -> Recovered<Self::Consensus> {

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -1257,6 +1257,9 @@ pub trait PoolTransaction:
         self.clone().into_consensus()
     }
 
+    /// Returns a reference to the consensus transaction with the recovered sender.
+    fn consensus_ref(&self) -> Recovered<&Self::Consensus>;
+
     /// Define a method to convert from the `Self` type to `Consensus`
     fn into_consensus(self) -> Recovered<Self::Consensus>;
 
@@ -1445,6 +1448,10 @@ impl PoolTransaction for EthPooledTransaction {
 
     fn clone_into_consensus(&self) -> Recovered<Self::Consensus> {
         self.transaction().clone()
+    }
+
+    fn consensus_ref(&self) -> Recovered<&Self::Consensus> {
+        Recovered::new_unchecked(&*self.transaction, self.transaction.signer())
     }
 
     fn into_consensus(self) -> Recovered<Self::Consensus> {

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -78,6 +78,7 @@ use reth_execution_types::ChangedAccount;
 use reth_primitives_traits::{Block, InMemorySize, Recovered, SealedBlock, SignedTransaction};
 use serde::{Deserialize, Serialize};
 use std::{
+    borrow::Cow,
     collections::HashMap,
     fmt,
     fmt::Debug,
@@ -1258,7 +1259,7 @@ pub trait PoolTransaction:
     }
 
     /// Returns a reference to the consensus transaction with the recovered sender.
-    fn consensus_ref(&self) -> Recovered<&Self::Consensus>;
+    fn consensus_ref(&self) -> Recovered<Cow<'_, Self::Consensus>>;
 
     /// Define a method to convert from the `Self` type to `Consensus`
     fn into_consensus(self) -> Recovered<Self::Consensus>;
@@ -1450,8 +1451,8 @@ impl PoolTransaction for EthPooledTransaction {
         self.transaction().clone()
     }
 
-    fn consensus_ref(&self) -> Recovered<&Self::Consensus> {
-        Recovered::new_unchecked(&*self.transaction, self.transaction.signer())
+    fn consensus_ref(&self) -> Recovered<Cow<'_, Self::Consensus>> {
+        Recovered::new_unchecked(Cow::Borrowed(&*self.transaction), self.transaction.signer())
     }
 
     fn into_consensus(self) -> Recovered<Self::Consensus> {


### PR DESCRIPTION
Add `fn consensus_ref(&self) -> Recovered<&Self::Consensus>` to the `PoolTransaction` trait.

Since `PoolTransaction` wraps the consensus format, we can return a `Recovered<&Self::Consensus>` without cloning — counterpart to the existing `clone_into_consensus` and `into_consensus`.

## Changes
- Added `consensus_ref` method to the `PoolTransaction` trait
- Implemented for `EthPooledTransaction` (zero-copy via stored `Recovered<T>`)
- Added `unimplemented!()` stub for `MockTransaction` (doesn't wrap consensus internally)

Prompted by: matthias