### PR TITLE
feat(txpool): add pool monitor to track mined tx availability

### DIFF
--- a/crates/node/builder/src/components/pool.rs
+++ b/crates/node/builder/src/components/pool.rs
@@ -310,15 +310,19 @@ where
     spawn_local_backup_task(ctx, pool.clone())?;
     spawn_pool_maintenance_task(ctx, pool.clone(), pool_config)?;
 
-    if ctx.config().txpool.monitor {
-        spawn_pool_monitor_task(ctx, pool)?;
+    if ctx.config().txpool.monitor_orderflow {
+        spawn_pool_orderflow_monitor_task(ctx, pool)?;
     }
 
     Ok(())
 }
 
-/// Spawn the pool monitoring task that tracks how many mined transactions were locally available.
-fn spawn_pool_monitor_task<Node, Pool>(ctx: &BuilderContext<Node>, pool: Pool) -> eyre::Result<()>
+/// Spawn the pool orderflow monitoring task that tracks how many mined transactions were locally
+/// available.
+fn spawn_pool_orderflow_monitor_task<Node, Pool>(
+    ctx: &BuilderContext<Node>,
+    pool: Pool,
+) -> eyre::Result<()>
 where
     Node: FullNodeTypes,
     Pool: TransactionPool + Clone + 'static,
@@ -326,8 +330,8 @@ where
     let chain_events = ctx.provider().canonical_state_stream();
 
     ctx.task_executor().spawn_critical_task(
-        "txpool monitor task",
-        reth_transaction_pool::monitor::monitor_pool_transactions_future(
+        "txpool orderflow monitor task",
+        reth_transaction_pool::orderflow::monitor_orderflow_future(
             pool,
             chain_events,
             Default::default(),

--- a/crates/node/core/src/args/txpool.rs
+++ b/crates/node/core/src/args/txpool.rs
@@ -55,7 +55,7 @@ pub struct DefaultTxPoolValues {
     transactions_backup_path: Option<PathBuf>,
     disable_transactions_backup: bool,
     max_batch_size: usize,
-    monitor: bool,
+    monitor_orderflow: bool,
 }
 
 impl DefaultTxPoolValues {
@@ -249,9 +249,9 @@ impl DefaultTxPoolValues {
         self
     }
 
-    /// Set whether pool monitoring is enabled by default
-    pub const fn with_monitor(mut self, v: bool) -> Self {
-        self.monitor = v;
+    /// Set whether pool orderflow monitoring is enabled by default
+    pub const fn with_monitor_orderflow(mut self, v: bool) -> Self {
+        self.monitor_orderflow = v;
         self
     }
 }
@@ -289,7 +289,7 @@ impl Default for DefaultTxPoolValues {
             transactions_backup_path: None,
             disable_transactions_backup: false,
             max_batch_size: 1,
-            monitor: false,
+            monitor_orderflow: false,
         }
     }
 }
@@ -420,10 +420,10 @@ pub struct TxPoolArgs {
     #[arg(long = "txpool.max-batch-size", default_value_t = DefaultTxPoolValues::get_global().max_batch_size)]
     pub max_batch_size: usize,
 
-    /// Enable transaction pool monitoring to track how many mined transactions were available in
-    /// the local pool.
-    #[arg(long = "txpool.monitor", default_value_t = DefaultTxPoolValues::get_global().monitor)]
-    pub monitor: bool,
+    /// Enable orderflow monitoring to track how many mined transactions were available in the
+    /// local pool.
+    #[arg(long = "txpool.monitor-orderflow", default_value_t = DefaultTxPoolValues::get_global().monitor_orderflow)]
+    pub monitor_orderflow: bool,
 }
 
 impl TxPoolArgs {
@@ -477,7 +477,7 @@ impl Default for TxPoolArgs {
             transactions_backup_path,
             disable_transactions_backup,
             max_batch_size,
-            monitor,
+            monitor_orderflow,
         } = DefaultTxPoolValues::get_global().clone();
         Self {
             pending_max_count,
@@ -510,7 +510,7 @@ impl Default for TxPoolArgs {
             transactions_backup_path,
             disable_transactions_backup,
             max_batch_size,
-            monitor,
+            monitor_orderflow,
         }
     }
 }
@@ -640,6 +640,7 @@ mod tests {
             transactions_backup_path: Some(PathBuf::from("/tmp/txpool-backup")),
             disable_transactions_backup: false,
             max_batch_size: 10,
+            monitor_orderflow: false,
         };
 
         let parsed_args = CommandParser::<TxPoolArgs>::parse_from([

--- a/crates/node/core/src/args/txpool.rs
+++ b/crates/node/core/src/args/txpool.rs
@@ -55,6 +55,7 @@ pub struct DefaultTxPoolValues {
     transactions_backup_path: Option<PathBuf>,
     disable_transactions_backup: bool,
     max_batch_size: usize,
+    monitor: bool,
 }
 
 impl DefaultTxPoolValues {
@@ -247,6 +248,12 @@ impl DefaultTxPoolValues {
         self.max_batch_size = v;
         self
     }
+
+    /// Set whether pool monitoring is enabled by default
+    pub const fn with_monitor(mut self, v: bool) -> Self {
+        self.monitor = v;
+        self
+    }
 }
 
 impl Default for DefaultTxPoolValues {
@@ -282,6 +289,7 @@ impl Default for DefaultTxPoolValues {
             transactions_backup_path: None,
             disable_transactions_backup: false,
             max_batch_size: 1,
+            monitor: false,
         }
     }
 }
@@ -411,6 +419,11 @@ pub struct TxPoolArgs {
     /// Max batch size for transaction pool insertions
     #[arg(long = "txpool.max-batch-size", default_value_t = DefaultTxPoolValues::get_global().max_batch_size)]
     pub max_batch_size: usize,
+
+    /// Enable transaction pool monitoring to track how many mined transactions were available in
+    /// the local pool.
+    #[arg(long = "txpool.monitor", default_value_t = DefaultTxPoolValues::get_global().monitor)]
+    pub monitor: bool,
 }
 
 impl TxPoolArgs {
@@ -464,6 +477,7 @@ impl Default for TxPoolArgs {
             transactions_backup_path,
             disable_transactions_backup,
             max_batch_size,
+            monitor,
         } = DefaultTxPoolValues::get_global().clone();
         Self {
             pending_max_count,
@@ -496,6 +510,7 @@ impl Default for TxPoolArgs {
             transactions_backup_path,
             disable_transactions_backup,
             max_batch_size,
+            monitor,
         }
     }
 }

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -322,8 +322,8 @@ use tracing::{instrument, trace};
 pub mod error;
 pub mod maintain;
 pub mod metrics;
-pub mod monitor;
 pub mod noop;
+pub mod orderflow;
 pub mod pool;
 pub mod validate;
 

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -322,6 +322,7 @@ use tracing::{instrument, trace};
 pub mod error;
 pub mod maintain;
 pub mod metrics;
+pub mod monitor;
 pub mod noop;
 pub mod pool;
 pub mod validate;

--- a/crates/transaction-pool/src/monitor.rs
+++ b/crates/transaction-pool/src/monitor.rs
@@ -1,0 +1,241 @@
+//! Transaction pool monitoring.
+//!
+//! Monitors how many transactions in each mined block were available in the local transaction pool.
+//! This is useful for assessing mempool health and understanding how well-connected the node is.
+//!
+//! Two snapshots are taken per slot:
+//! - A mid-slot snapshot taken at a configurable offset (default: 4s) after the last canonical
+//!   block, capturing the pool state during the block building window.
+//! - An on-block snapshot taken when a new canonical block notification is received, capturing the
+//!   pool state at the moment the block is observed.
+
+use crate::traits::TransactionPool;
+use alloy_consensus::BlockHeader;
+use alloy_primitives::{map::HashSet, BlockNumber, TxHash};
+use futures_util::{FutureExt, Stream, StreamExt};
+use reth_chain_state::CanonStateNotification;
+use reth_metrics::{
+    metrics::{Counter, Gauge, Histogram},
+    Metrics,
+};
+use reth_primitives_traits::NodePrimitives;
+use std::time::Duration;
+use tokio::time::Sleep;
+use tracing::{debug, info};
+
+/// Default offset into the slot at which the mid-slot snapshot is taken.
+///
+/// 4 seconds matches the Ethereum block building window even though the slot time is 12s.
+pub const DEFAULT_MONITOR_SLOT_OFFSET: Duration = Duration::from_secs(4);
+
+/// Metrics for the transaction pool monitor.
+#[derive(Metrics)]
+#[metrics(scope = "transaction_pool.monitor")]
+pub struct MonitorMetrics {
+    /// Total number of transactions in the mined block (mid-slot observation).
+    pub mid_slot_mined_transactions: Gauge,
+    /// Number of mined transactions that were present in the local pool at the mid-slot snapshot.
+    pub mid_slot_matched_transactions: Gauge,
+    /// Ratio of matched/mined transactions at mid-slot (0.0 to 1.0 scaled to 0-10000 for gauge
+    /// precision).
+    pub mid_slot_match_ratio_bps: Gauge,
+
+    /// Total number of transactions in the mined block (on-block observation).
+    pub on_block_mined_transactions: Gauge,
+    /// Number of mined transactions that were present in the local pool at the on-block snapshot.
+    pub on_block_matched_transactions: Gauge,
+    /// Ratio of matched/mined transactions at on-block (0.0 to 1.0 scaled to 0-10000 for gauge
+    /// precision).
+    pub on_block_match_ratio_bps: Gauge,
+
+    /// Histogram of mid-slot match ratios.
+    pub mid_slot_match_ratio: Histogram,
+    /// Histogram of on-block match ratios.
+    pub on_block_match_ratio: Histogram,
+
+    /// Counter of total blocks monitored.
+    pub blocks_monitored: Counter,
+}
+
+/// A snapshot of transaction hashes currently in the pool.
+#[derive(Debug)]
+struct PoolSnapshot {
+    /// The block number after which this snapshot was taken (i.e. the last canonical block
+    /// number).
+    after_block: BlockNumber,
+    /// Transaction hashes of all pending (executable) transactions at snapshot time.
+    pending_hashes: HashSet<TxHash>,
+}
+
+/// Configuration for the pool monitor.
+#[derive(Debug, Clone)]
+pub struct MonitorConfig {
+    /// Offset into the slot at which the mid-slot snapshot is taken.
+    pub slot_offset: Duration,
+}
+
+impl Default for MonitorConfig {
+    fn default() -> Self {
+        Self { slot_offset: DEFAULT_MONITOR_SLOT_OFFSET }
+    }
+}
+
+/// Returns a spawnable future that monitors pool availability of mined transactions.
+pub fn monitor_pool_transactions_future<N, P, St>(
+    pool: P,
+    events: St,
+    config: MonitorConfig,
+) -> futures_util::future::BoxFuture<'static, ()>
+where
+    N: NodePrimitives,
+    P: TransactionPool + 'static,
+    St: Stream<Item = CanonStateNotification<N>> + Send + Unpin + 'static,
+{
+    async move {
+        monitor_pool_transactions(pool, events, config).await;
+    }
+    .boxed()
+}
+
+/// Monitors pool availability of mined transactions.
+///
+/// For each canonical block, this compares the block's transactions against snapshots of the
+/// local pool to determine how many mined transactions were locally available.
+async fn monitor_pool_transactions<N, P, St>(pool: P, mut events: St, config: MonitorConfig)
+where
+    N: NodePrimitives,
+    P: TransactionPool + 'static,
+    St: Stream<Item = CanonStateNotification<N>> + Send + Unpin + 'static,
+{
+    let metrics = MonitorMetrics::default();
+
+    // The mid-slot snapshot taken `slot_offset` after the last block.
+    let mut mid_slot_snapshot: Option<PoolSnapshot> = None;
+
+    // Timer that fires `slot_offset` after each new canonical block to trigger the mid-slot
+    // snapshot.
+    let mut snapshot_timer: std::pin::Pin<Box<Sleep>> =
+        Box::pin(tokio::time::sleep(config.slot_offset));
+    let mut timer_armed = false;
+
+    // The block number we expect the mid-slot snapshot to correspond to (last seen block).
+    let mut last_block_number: Option<BlockNumber> = None;
+
+    loop {
+        tokio::select! {
+            // Mid-slot snapshot timer fires
+            _ = &mut snapshot_timer, if timer_armed => {
+                timer_armed = false;
+                if let Some(block_num) = last_block_number {
+                    let pending = pool.pending_transactions();
+                    let pending_hashes: HashSet<TxHash> = pending
+                        .iter()
+                        .map(|tx| *tx.hash())
+                        .collect();
+
+                    debug!(
+                        target: "txpool::monitor",
+                        block = %block_num,
+                        pending_count = %pending_hashes.len(),
+                        "mid-slot pool snapshot taken"
+                    );
+
+                    mid_slot_snapshot = Some(PoolSnapshot {
+                        after_block: block_num,
+                        pending_hashes,
+                    });
+                }
+            }
+
+            ev = events.next() => {
+                let Some(event) = ev else {
+                    break;
+                };
+
+                let new = event.committed();
+                let (blocks, _state) = new.inner();
+                let tip = blocks.tip();
+                let tip_number = tip.number();
+                let mined_hashes: HashSet<TxHash> = blocks.transaction_hashes().collect();
+
+                if mined_hashes.is_empty() {
+                    // empty block, still reset timer
+                    last_block_number = Some(tip_number);
+                    snapshot_timer
+                        .as_mut()
+                        .reset(tokio::time::Instant::now() + config.slot_offset);
+                    timer_armed = true;
+                    continue;
+                }
+
+                // --- Mid-slot comparison ---
+                // Compare the mid-slot snapshot (taken 4s after the previous block) against
+                // this block's transactions.
+                if let Some(ref snapshot) = mid_slot_snapshot {
+                    let matched = mined_hashes
+                        .iter()
+                        .filter(|h| snapshot.pending_hashes.contains(*h))
+                        .count();
+
+                    let ratio = matched as f64 / mined_hashes.len() as f64;
+
+                    metrics.mid_slot_mined_transactions.set(mined_hashes.len() as f64);
+                    metrics.mid_slot_matched_transactions.set(matched as f64);
+                    metrics.mid_slot_match_ratio_bps.set((ratio * 10000.0).round());
+                    metrics.mid_slot_match_ratio.record(ratio);
+
+                    info!(
+                        target: "txpool::monitor",
+                        block = %tip_number,
+                        mined = %mined_hashes.len(),
+                        matched = %matched,
+                        ratio = %format!("{:.2}%", ratio * 100.0),
+                        snapshot_after_block = %snapshot.after_block,
+                        "mid-slot pool coverage"
+                    );
+                }
+
+                // --- On-block comparison ---
+                // Snapshot of the pool right now (before the pool processes this block).
+                let pending = pool.pending_transactions();
+                let on_block_hashes: HashSet<TxHash> = pending
+                    .iter()
+                    .map(|tx| *tx.hash())
+                    .collect();
+
+                let matched = mined_hashes
+                    .iter()
+                    .filter(|h| on_block_hashes.contains(*h))
+                    .count();
+
+                let ratio = matched as f64 / mined_hashes.len() as f64;
+
+                metrics.on_block_mined_transactions.set(mined_hashes.len() as f64);
+                metrics.on_block_matched_transactions.set(matched as f64);
+                metrics.on_block_match_ratio_bps.set((ratio * 10000.0).round());
+                metrics.on_block_match_ratio.record(ratio);
+                metrics.blocks_monitored.increment(1);
+
+                info!(
+                    target: "txpool::monitor",
+                    block = %tip_number,
+                    mined = %mined_hashes.len(),
+                    matched = %matched,
+                    ratio = %format!("{:.2}%", ratio * 100.0),
+                    pool_pending = %on_block_hashes.len(),
+                    "on-block pool coverage"
+                );
+
+                // Clear mid-slot snapshot after use since it was for this block.
+                mid_slot_snapshot = None;
+
+                // Arm the timer for the next mid-slot snapshot.
+                last_block_number = Some(tip_number);
+                snapshot_timer
+                    .as_mut()
+                    .reset(tokio::time::Instant::now() + config.slot_offset);
+                timer_armed = true;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a transaction pool monitoring task that measures how many transactions in each mined block were available in the local pool.

## Motivation

Understanding mempool health — specifically, how many of a block's transactions our node already had in its pool — is valuable for assessing network connectivity and transaction propagation.

## Changes

- `crates/transaction-pool/src/monitor.rs`: New monitoring task that takes two snapshots per slot:
  - **Mid-slot** (4s after last canonical block): captures the pool state during the block building window
  - **On-block**: captures the pool state when the new canonical block notification arrives
  - Compares each snapshot against the mined block's tx hashes and reports coverage metrics
- `crates/node/core/src/args/txpool.rs`: `--txpool.monitor` CLI flag to enable the monitor
- `crates/node/builder/src/components/pool.rs`: Spawns the monitor task when enabled

## Metrics

All under `transaction_pool.monitor`:
- `mid_slot_mined_transactions` / `mid_slot_matched_transactions` / `mid_slot_match_ratio_bps`
- `on_block_mined_transactions` / `on_block_matched_transactions` / `on_block_match_ratio_bps`
- `mid_slot_match_ratio` / `on_block_match_ratio` (histograms)
- `blocks_monitored`

## Testing

```
cargo check -p reth-transaction-pool -p reth-node-builder -p reth-node-core
cargo +nightly fmt --all --check
```

Prompted by: matthias