### PR TITLE
feat(evm): add CachedHeaderValues to BlockAssemblerInput

### DIFF
--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -236,6 +236,26 @@ pub struct PrecomputedHeaderValues {
     pub logs_bloom: Option<Bloom>,
 }
 
+impl PrecomputedHeaderValues {
+    /// Sets the pre-computed transactions root.
+    pub const fn with_transactions_root(mut self, root: B256) -> Self {
+        self.transactions_root = Some(root);
+        self
+    }
+
+    /// Sets the pre-computed receipts root.
+    pub const fn with_receipts_root(mut self, root: B256) -> Self {
+        self.receipts_root = Some(root);
+        self
+    }
+
+    /// Sets the pre-computed logs bloom.
+    pub const fn with_logs_bloom(mut self, bloom: Bloom) -> Self {
+        self.logs_bloom = Some(bloom);
+        self
+    }
+}
+
 impl<'a, 'b, F: BlockExecutorFactory, H> BlockAssemblerInput<'a, 'b, F, H> {
     /// Creates a new [`BlockAssemblerInput`].
     #[expect(clippy::too_many_arguments)]

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -266,7 +266,7 @@ impl<'a, 'b, F: BlockExecutorFactory, H> BlockAssemblerInput<'a, 'b, F, H> {
     }
 
     /// Sets the [`CachedHeaderValues`] on this input.
-    pub fn with_cached_header_values(mut self, cached: CachedHeaderValues) -> Self {
+    pub const fn with_cached_header_values(mut self, cached: CachedHeaderValues) -> Self {
         self.cached_header_values = cached;
         self
     }


### PR DESCRIPTION
## Summary
Adds `CachedHeaderValues` to `BlockAssemblerInput`, allowing callers to pre-compute tx/receipt roots and logs bloom in parallel with the state root.

## Motivation
During block sealing, the state root is the bottleneck. Currently tx root, receipt root, and logs bloom are computed *after* the state root in `assemble_block`, adding unnecessary latency. These values only depend on already-available execution results and can be computed while the state root is in progress.

## Changes
- Added `CachedHeaderValues` struct (`crates/evm/evm/src/execute.rs`) with optional `transactions_root`, `receipts_root`, and `logs_bloom`
- Added `cached_header_values` field to `BlockAssemblerInput` (backwards-compatible via `#[non_exhaustive]` + `Default`)
- Added `BlockAssemblerInput::with_cached_header_values()` builder method
- Updated `EthBlockAssembler` (`crates/ethereum/evm/src/build.rs`) to use cached values via `unwrap_or_else`, falling back to recomputation
- Added `#[cfg(debug_assertions)]` validation that cached values match recomputed ones

## How callers use this
```rust
// Compute roots while state root is in progress
let tx_root = proofs::calculate_transaction_root(&transactions);
let receipt_root = calculate_receipt_root(&receipts_with_bloom);
let bloom = logs_bloom(receipts.iter().flat_map(|r| r.logs()));

// Pass pre-computed values to assembler
let input = BlockAssemblerInput::new(/* ... */)
    .with_cached_header_values(CachedHeaderValues {
        transactions_root: Some(tx_root),
        receipts_root: Some(receipt_root),
        logs_bloom: Some(bloom),
    });
```

## Testing
- `cargo check -p reth-evm -p reth-evm-ethereum -p reth-ethereum-payload-builder -p reth-rpc -p reth-engine-util -p reth-engine-tree` — all pass
- `cargo +nightly clippy -p reth-evm -p reth-evm-ethereum` — no warnings

Prompted by: mattsse