### PR TITLE
feat(rpc): add eth_getStorageValues batch storage slot retrieval

### DIFF
--- a/.changelog/merry-koalas-nod.md
+++ b/.changelog/merry-koalas-nod.md
@@ -1,0 +1,6 @@
+---
+reth-rpc-eth-api: minor
+reth-rpc-server-types: minor
+---
+
+Added `eth_getStorageValues` RPC method for batch storage slot retrieval across multiple addresses.

--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -20,6 +20,7 @@ use reth_primitives_traits::TxTy;
 use reth_rpc_convert::RpcTxReq;
 use reth_rpc_eth_types::FillTransaction;
 use reth_rpc_server_types::{result::internal_rpc_err, ToRpcResult};
+use std::collections::HashMap;
 use tracing::trace;
 
 /// Helper trait, unifies functionality that must be supported to implement all RPC methods for
@@ -200,6 +201,14 @@ pub trait EthApi<
         index: JsonStorageKey,
         block_number: Option<BlockId>,
     ) -> RpcResult<B256>;
+
+    /// Returns values from multiple storage positions across multiple addresses.
+    #[method(name = "getStorageValues")]
+    async fn storage_values(
+        &self,
+        requests: HashMap<Address, Vec<JsonStorageKey>>,
+        block_number: Option<BlockId>,
+    ) -> RpcResult<HashMap<Address, Vec<B256>>>;
 
     /// Returns the number of transactions sent from an address at given block number.
     #[method(name = "getTransactionCount")]
@@ -649,6 +658,16 @@ where
     ) -> RpcResult<B256> {
         trace!(target: "rpc::eth", ?address, ?block_number, "Serving eth_getStorageAt");
         Ok(EthState::storage_at(self, address, index, block_number).await?)
+    }
+
+    /// Handler for: `eth_getStorageValues`
+    async fn storage_values(
+        &self,
+        requests: HashMap<Address, Vec<JsonStorageKey>>,
+        block_number: Option<BlockId>,
+    ) -> RpcResult<HashMap<Address, Vec<B256>>> {
+        trace!(target: "rpc::eth", ?block_number, "Serving eth_getStorageValues");
+        Ok(EthState::storage_values(self, requests, block_number).await?)
     }
 
     /// Handler for: `eth_getTransactionCount`

--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -94,7 +94,7 @@ pub trait EthState: LoadState + SpawnBlocking {
         requests: HashMap<Address, Vec<JsonStorageKey>>,
         block_id: Option<BlockId>,
     ) -> impl Future<Output = Result<HashMap<Address, Vec<B256>>, Self::Error>> + Send {
-        self.spawn_blocking_io_fut(move |this| async move {
+        async move {
             let total_slots: usize = requests.values().map(|slots| slots.len()).sum();
             if total_slots > DEFAULT_MAX_STORAGE_VALUES_SLOTS {
                 return Err(Self::Error::from_eth_err(EthApiError::InvalidParams(
@@ -104,23 +104,26 @@ pub trait EthState: LoadState + SpawnBlocking {
                 )));
             }
 
-            let state = this.state_at_block_id_or_latest(block_id).await?;
+            let state = self.state_at_block_id_or_latest(block_id).await?;
 
-            let mut result = HashMap::with_capacity(requests.len());
-            for (address, slots) in requests {
-                let mut values = Vec::with_capacity(slots.len());
-                for slot in &slots {
-                    let value = state
-                        .storage(address, slot.as_b256())
-                        .map_err(Self::Error::from_eth_err)?
-                        .unwrap_or_default();
-                    values.push(B256::new(value.to_be_bytes()));
+            self.spawn_blocking_io(move |_| {
+                let mut result = HashMap::with_capacity(requests.len());
+                for (address, slots) in requests {
+                    let mut values = Vec::with_capacity(slots.len());
+                    for slot in &slots {
+                        let value = state
+                            .storage(address, slot.as_b256())
+                            .map_err(Self::Error::from_eth_err)?
+                            .unwrap_or_default();
+                        values.push(B256::new(value.to_be_bytes()));
+                    }
+                    result.insert(address, values);
                 }
-                result.insert(address, values);
-            }
 
-            Ok(result)
-        })
+                Ok(result)
+            })
+            .await
+        }
     }
 
     /// Returns values stored of given account, with Merkle-proof, at given blocknumber.

--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -94,31 +94,36 @@ pub trait EthState: LoadState + SpawnBlocking {
         requests: HashMap<Address, Vec<JsonStorageKey>>,
         block_id: Option<BlockId>,
     ) -> impl Future<Output = Result<HashMap<Address, Vec<B256>>, Self::Error>> + Send {
-        self.spawn_blocking_io_fut(move |this| async move {
+        async move {
             let total_slots: usize = requests.values().map(|slots| slots.len()).sum();
             if total_slots > DEFAULT_MAX_STORAGE_VALUES_SLOTS {
-                return Err(Self::Error::from_eth_err(EthApiError::InvalidParams(format!(
-                    "total slot count {total_slots} exceeds limit {DEFAULT_MAX_STORAGE_VALUES_SLOTS}",
-                ))));
+                return Err(Self::Error::from_eth_err(EthApiError::InvalidParams(
+                    format!(
+                        "total slot count {total_slots} exceeds limit {DEFAULT_MAX_STORAGE_VALUES_SLOTS}",
+                    ),
+                )));
             }
 
-            let state = this.state_at_block_id_or_latest(block_id).await?;
+            self.spawn_blocking_io_fut(move |this| async move {
+                let state = this.state_at_block_id_or_latest(block_id).await?;
 
-            let mut result = HashMap::with_capacity(requests.len());
-            for (address, slots) in requests {
-                let mut values = Vec::with_capacity(slots.len());
-                for slot in &slots {
-                    let value = state
-                        .storage(address, slot.as_b256())
-                        .map_err(Self::Error::from_eth_err)?
-                        .unwrap_or_default();
-                    values.push(B256::new(value.to_be_bytes()));
+                let mut result = HashMap::with_capacity(requests.len());
+                for (address, slots) in requests {
+                    let mut values = Vec::with_capacity(slots.len());
+                    for slot in &slots {
+                        let value = state
+                            .storage(address, slot.as_b256())
+                            .map_err(Self::Error::from_eth_err)?
+                            .unwrap_or_default();
+                        values.push(B256::new(value.to_be_bytes()));
+                    }
+                    result.insert(address, values);
                 }
-                result.insert(address, values);
-            }
 
-            Ok(result)
-        })
+                Ok(result)
+            })
+            .await
+        }
     }
 
     /// Returns values stored of given account, with Merkle-proof, at given blocknumber.

--- a/crates/rpc/rpc-server-types/src/constants.rs
+++ b/crates/rpc/rpc-server-types/src/constants.rs
@@ -55,6 +55,9 @@ pub const DEFAULT_ENGINE_API_IPC_ENDPOINT: &str = "/tmp/reth_engine_api.ipc";
 /// The default limit for blocks count in `eth_simulateV1`.
 pub const DEFAULT_MAX_SIMULATE_BLOCKS: u64 = 256;
 
+/// The default maximum number of total storage slots for `eth_getStorageValues`.
+pub const DEFAULT_MAX_STORAGE_VALUES_SLOTS: usize = 1024;
+
 /// The default eth historical proof window.
 pub const DEFAULT_ETH_PROOF_WINDOW: u64 = 0;
 


### PR DESCRIPTION
## Summary
Implements `eth_getStorageValues` per [ethereum/execution-apis#752](https://github.com/ethereum/execution-apis/issues/752).

## Motivation
`eth_getStorageAt` fetches one storage slot per call. Consumers doing heavy local simulations often need hundreds of slots across multiple contracts at the same block. A batch method eliminates repeated state lookups and round-trips.

## Changes
- `crates/rpc/rpc-server-types/src/constants.rs`: add `DEFAULT_MAX_STORAGE_VALUES_SLOTS = 1024`
- `crates/rpc/rpc-eth-api/src/core.rs`: add `getStorageValues` to `EthApi` trait + server impl
- `crates/rpc/rpc-eth-api/src/helpers/state.rs`: add `storage_values` to `EthState` trait with slot cap enforcement

## Testing
Compilation verified. Method follows existing `storage_at` pattern exactly.

Prompted by: mattsse