### PR TITLE
test(reth-bench): add unit tests for InvalidationConfig and parse_gas_limit overflow

### DIFF
--- a/bin/reth-bench/src/bench/helpers.rs
+++ b/bin/reth-bench/src/bench/helpers.rs
@@ -291,6 +291,14 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_gas_limit_overflow() {
+        // u64::MAX * 1G overflows
+        assert!(parse_gas_limit("18446744073709551615G").is_err());
+        // Just above u64::MAX / 1_000_000_000
+        assert!(parse_gas_limit("18446744074G").is_err());
+    }
+
+    #[test]
     fn test_parse_duration_with_unit() {
         assert_eq!(parse_duration("100ms").unwrap(), Duration::from_millis(100));
         assert_eq!(parse_duration("2s").unwrap(), Duration::from_secs(2));


### PR DESCRIPTION
## Summary
- Add 11 unit tests for `InvalidationConfig` in `send_invalid_payload/invalidation.rs`:
  - Default config produces no changes
  - Explicit field override (state_root)
  - Auto-invalidation behaviors: gas_used exceeds limit, timestamp zeroed, invalid RLP prepended
  - V2 withdrawal injection
  - V3 blob gas explicit override and auto-invalidation
  - `should_skip_hash_recalc` for both explicit hash and auto-invalidate triggers
- Add 1 test for `parse_gas_limit` overflow via `checked_mul` in `helpers.rs`