### PR TITLE
fix(primitives-traits): handle KECCAK_EMPTY in From<TrieAccount>

### DIFF
--- a/crates/primitives-traits/src/account.rs
+++ b/crates/primitives-traits/src/account.rs
@@ -91,7 +91,11 @@ impl From<revm_state::Account> for Account {
 
 impl From<TrieAccount> for Account {
     fn from(value: TrieAccount) -> Self {
-        Self { balance: value.balance, nonce: value.nonce, bytecode_hash: Some(value.code_hash) }
+        Self {
+            balance: value.balance,
+            nonce: value.nonce,
+            bytecode_hash: (value.code_hash != KECCAK_EMPTY).then_some(value.code_hash),
+        }
     }
 }
 


### PR DESCRIPTION
`From<TrieAccount>` added in #21943 always sets `bytecode_hash` to `Some(code_hash)`, even for `KECCAK_EMPTY`. This is inconsistent with `From<AccountInfo>` which returns `None` for empty code.
