### PR TITLE
chore: bump MSRV to 1.93

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -124,7 +124,7 @@ jobs:
       - uses: rui314/setup-mold@v1
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.88" # MSRV
+          toolchain: "1.93" # MSRV
       - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: Swatinem/rust-cache@v2
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 version = "1.11.0"
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.93"
 license = "MIT OR Apache-2.0"
 homepage = "https://paradigmxyz.github.io/reth"
 repository = "https://github.com/paradigmxyz/reth"

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ When updating this, also update:
 - .github/workflows/lint.yml
 -->
 
-The Minimum Supported Rust Version (MSRV) of this project is [1.88.0](https://blog.rust-lang.org/2025/06/26/Rust-1.88.0/).
+The Minimum Supported Rust Version (MSRV) of this project is [1.93.0](https://blog.rust-lang.org/2026/01/22/Rust-1.93.0/).
 
 See the docs for detailed instructions on how to [build from source](https://reth.rs/installation/source/).
 


### PR DESCRIPTION
## Summary
Bump MSRV from 1.88 to 1.93.

## Changes
- `Cargo.toml`: `rust-version = "1.93"`
- `.github/workflows/lint.yml`: MSRV CI job toolchain
- `README.md`: MSRV docs link

Prompted by: DaniPopes