### PR TITLE
perf(engine): bound channels in spawn_tx_iterator by transaction count

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -392,9 +392,9 @@ where
         mpsc::Receiver<WithTxEnv<TxEnvFor<Evm>, I::Recovered>>,
         mpsc::Receiver<Result<WithTxEnv<TxEnvFor<Evm>, I::Recovered>, I::Error>>,
     ) {
-        let (ooo_tx, ooo_rx) = mpsc::channel();
-        let (prewarm_tx, prewarm_rx) = mpsc::channel();
-        let (execute_tx, execute_rx) = mpsc::channel();
+        let (ooo_tx, ooo_rx) = mpsc::sync_channel(transaction_count);
+        let (prewarm_tx, prewarm_rx) = mpsc::sync_channel(transaction_count);
+        let (execute_tx, execute_rx) = mpsc::sync_channel(transaction_count);
 
         if transaction_count == 0 {
             // Empty block — nothing to do.


### PR DESCRIPTION
## Summary
Use `sync_channel(transaction_count)` instead of unbounded `channel()` for the out-of-order, prewarm, and execute channels in `spawn_tx_iterator`.

## Changes
- Replace `mpsc::channel()` with `mpsc::sync_channel(transaction_count)` for all 3 channels in `spawn_tx_iterator`

## Motivation
The channels can never hold more than `transaction_count` items, so using bounded channels with that capacity avoids unbounded memory growth and provides natural backpressure.

Prompted by: DaniPopes