### PR TITLE
fix: record bare tracing instrument fields

### DIFF
--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -119,7 +119,7 @@ where
         Ok(())
     }
 
-    #[instrument(level = "debug", target = "engine::persistence", skip_all, fields(new_tip_num))]
+    #[instrument(level = "debug", target = "engine::persistence", skip_all, fields(%new_tip_num))]
     fn on_remove_blocks_above(
         &self,
         new_tip_num: u64,

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2602,7 +2602,7 @@ where
     /// Returns `InsertPayloadOk::Inserted(BlockStatus::Valid)` on successful execution,
     /// `InsertPayloadOk::AlreadySeen` if the block already exists, or
     /// `InsertPayloadOk::Inserted(BlockStatus::Disconnected)` if parent state is missing.
-    #[instrument(level = "debug", target = "engine::tree", skip_all, fields(block_id))]
+    #[instrument(level = "debug", target = "engine::tree", skip_all, fields(?block_id))]
     fn insert_block_or_payload<Input, Err>(
         &mut self,
         block_id: BlockWithParent,

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1142,7 +1142,7 @@ where
         level = "debug",
         target = "engine::tree::payload_validator",
         skip_all,
-        fields(strategy)
+        fields(?strategy)
     )]
     fn spawn_payload_processor<T: ExecutableTxIterator<Evm>>(
         &mut self,

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -908,7 +908,7 @@ pub(crate) async fn start_pending_incoming_session<N: NetworkPrimitives>(
 }
 
 /// Starts the authentication process for a connection initiated by a remote peer.
-#[instrument(level = "trace", target = "net::network", skip_all, fields(%remote_addr, peer_id))]
+#[instrument(level = "trace", target = "net::network", skip_all, fields(%remote_addr, peer_id = ?remote_peer_id))]
 #[expect(clippy::too_many_arguments)]
 async fn start_pending_outbound_session<N: NetworkPrimitives>(
     handshake: Arc<dyn EthRlpxHandshake>,

--- a/crates/storage/provider/src/providers/state/overlay.rs
+++ b/crates/storage/provider/src/providers/state/overlay.rs
@@ -282,7 +282,7 @@ where
         level = "debug",
         target = "providers::state::overlay",
         skip_all,
-        fields(db_tip_block)
+        fields(%db_tip_block)
     )]
     fn calculate_overlay(
         &self,

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -1159,7 +1159,7 @@ where
         name = "SparseStateTrie::prune",
         target = "trie::sparse",
         skip_all,
-        fields(max_depth, max_storage_tries)
+        fields(%max_depth, %max_storage_tries)
     )]
     pub fn prune(&mut self, max_depth: usize, max_storage_tries: usize) {
         // Prune state and storage tries in parallel


### PR DESCRIPTION
## Summary

Several `#[instrument(fields(ident))]` calls used bare identifiers, which creates empty uninitialized tracing fields instead of capturing function argument values. This adds `?` or `%` prefixes so values are actually recorded.

## Changes

- `fields(db_tip_block)` → `fields(%db_tip_block)` in overlay state provider
- `fields(peer_id)` → `fields(peer_id = ?remote_peer_id)` in network session (param name mismatch)
- `fields(new_tip_num)` → `fields(%new_tip_num)` in persistence
- `fields(strategy)` → `fields(?strategy)` in payload validator
- `fields(block_id)` → `fields(?block_id)` in engine tree
- `fields(max_depth, max_storage_tries)` → `fields(%max_depth, %max_storage_tries)` in sparse trie

## Note

`fields(range)` in `crates/trie/db/src/state.rs` is also bare but fixing it requires adding a `Debug` bound to the `DatabaseHashedPostState` trait, so it's left for a separate change.

Prompted by: DaniPopes