### PR TITLE
fix(engine): fix flaky test_prefetch_proofs_batching test

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -2065,7 +2065,7 @@ mod tests {
                 panic!("Expected PrefetchProofs message");
             };
 
-        assert_eq!(proofs_requested, 1);
+        assert!(proofs_requested >= 1);
     }
 
     /// Verifies that different message types arriving mid-batch are not lost and preserve order.


### PR DESCRIPTION
## Summary
Fix flaky `test_prefetch_proofs_batching` test.

## Root Cause
`on_prefetch_proof` returns the chunk count from `dispatch_with_chunking`. Whether chunking kicks in depends on `available_account_workers`/`available_storage_workers` atomics, which are incremented by worker threads as they start. This creates a race:
- Workers not yet started → counters at 0 → `should_chunk = false` → returns **1**
- Workers already started → counters > 1 → `should_chunk = true` → with `chunk_size=1` and 3 targets → returns **3**

The test asserted `== 1` but got `3` when workers won the race.

## Fix
Change `assert_eq!(proofs_requested, 1)` to `assert!(proofs_requested >= 1)`. The test validates message batching, not chunk count.

Prompted by: DaniPopes