### PR TITLE
chore: use --locked for all cargo install invocations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Install cross main
         id: cross_main
         run: |
-          cargo install cross --git https://github.com/cross-rs/cross
+          cargo install cross --locked --git https://github.com/cross-rs/cross
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -38,7 +38,7 @@ jobs:
           cache-on-failure: true
       - name: Build reth
         run: |
-          cargo install --path bin/reth
+          cargo install --locked --path bin/reth
       - name: Run headers stage
         run: |
           reth stage run headers --from ${{ env.FROM_BLOCK }} --to ${{ env.TO_BLOCK }} --commit --checkpoints

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ build-native-%:
 #
 # These commands require that:
 #
-# - `cross` is installed (`cargo install cross`).
+# - `cross` is installed (`cargo install --locked cross`).
 # - Docker is running.
 # - The current user is in the `docker` group.
 #
@@ -261,7 +261,7 @@ lint-typos: ensure-typos
 
 ensure-typos:
 	@if ! command -v typos &> /dev/null; then \
-		echo "typos not found. Please install it by running the command 'cargo install typos-cli' or refer to the following link for more information: https://github.com/crate-ci/typos"; \
+		echo "typos not found. Please install it by running the command 'cargo install --locked typos-cli' or refer to the following link for more information: https://github.com/crate-ci/typos"; \
 		exit 1; \
     fi
 


### PR DESCRIPTION
Add `--locked` to all remaining `cargo install` invocations across the Makefile and CI workflows.

- Makefile: `cross` comment, `typos-cli` help text
- `release.yml`: `cross` install from git
- `stage.yml`: `reth` install from path

Prompted by: danipopes