### PR TITLE
fix(test): activate prague for sparse trie reuse e2e test

### DIFF
--- a/crates/ethereum/node/tests/e2e/eth.rs
+++ b/crates/ethereum/node/tests/e2e/eth.rs
@@ -282,6 +282,7 @@ async fn test_sparse_trie_reuse_across_blocks() -> eyre::Result<()> {
                 .chain(MAINNET.chain)
                 .genesis(serde_json::from_str(include_str!("../assets/genesis.json")).unwrap())
                 .cancun_activated()
+                .prague_activated()
                 .build(),
         ),
         false,


### PR DESCRIPTION
## Summary
Fixes flaky timeout in `test_sparse_trie_reuse_across_blocks`.

## Motivation
`advance_with_random_transactions` generates EIP-7702 (type 4) txs which require Prague. The test only activated Cancun, so these txs get rejected. When the RNG picks mostly type-4 txs, the pool ends up empty, the payload builder produces an empty block, and `wait_for_built_payload` loops forever waiting for a non-empty payload.

The p2p tests that use the same helper correctly activate Prague — this test was missing it.

## Changes
- Added `.prague_activated()` to the chain spec builder in `test_sparse_trie_reuse_across_blocks`

## Testing
`cargo check -p reth-node-ethereum --tests` passes.

Prompted by: DaniPopes