### PR TITLE
test: speed up slow integration tests

### DIFF
--- a/crates/ethereum/node/tests/e2e/blobs.rs
+++ b/crates/ethereum/node/tests/e2e/blobs.rs
@@ -214,7 +214,7 @@ async fn blob_conversion_at_osaka() -> eyre::Result<()> {
     TransactionTestContext::validate_sidecar(envelope);
 
     // build last Prague payload
-    node.payload.timestamp = current_timestamp + 11;
+    node.payload.timestamp = current_timestamp + 1;
     let prague_payload = node.new_payload().await?;
     assert!(matches!(prague_payload.sidecars(), BlobSidecars::Eip4844(_)));
 
@@ -227,7 +227,7 @@ async fn blob_conversion_at_osaka() -> eyre::Result<()> {
     // validate sidecar
     TransactionTestContext::validate_sidecar(envelope);
 
-    tokio::time::sleep(Duration::from_secs(11)).await;
+    tokio::time::sleep(Duration::from_secs(6)).await;
 
     // fetch second blob tx from rpc again
     let envelope = node.rpc.envelope_by_hash(blob_tx_hash).await?;

--- a/crates/ethereum/node/tests/e2e/rpc.rs
+++ b/crates/ethereum/node/tests/e2e/rpc.rs
@@ -90,8 +90,8 @@ async fn test_fee_history() -> eyre::Result<()> {
     assert_eq!(block.header.gas_used, receipt.gas_used,);
     assert_eq!(block.header.base_fee_per_gas.unwrap(), expected_first_base_fee as u64);
 
-    for _ in 0..100 {
-        let _ = GasWaster::deploy_builder(&provider, U256::from(rng.random_range(0..1000)))
+    for _ in 0..20 {
+        let _ = GasWaster::deploy_builder(&provider, U256::from(rng.random_range(0..100)))
             .send()
             .await?;
 
@@ -100,7 +100,7 @@ async fn test_fee_history() -> eyre::Result<()> {
 
     let latest_block = provider.get_block_number().await?;
 
-    for _ in 0..100 {
+    for _ in 0..20 {
         let latest_block = rng.random_range(0..=latest_block);
         let block_count = rng.random_range(1..=(latest_block + 1));
 

--- a/crates/net/network/tests/it/connect.rs
+++ b/crates/net/network/tests/it/connect.rs
@@ -19,7 +19,6 @@ use reth_network_p2p::{
     sync::{NetworkSyncUpdater, SyncState},
 };
 use reth_network_peers::{mainnet_nodes, NodeRecord, TrustedPeer};
-use reth_network_types::peers::config::PeerBackoffDurations;
 use reth_provider::test_utils::MockEthProvider;
 use reth_storage_api::noop::NoopProvider;
 use reth_tracing::init_test_tracing;
@@ -380,10 +379,7 @@ async fn test_trusted_peer_only() {
     let _handle = net.spawn();
 
     let secret_key = SecretKey::new(&mut rand_08::thread_rng());
-    let peers_config = PeersConfig::default()
-        .with_backoff_durations(PeerBackoffDurations::test())
-        .with_ban_duration(Duration::from_millis(200))
-        .with_trusted_nodes_only(true);
+    let peers_config = PeersConfig::test().with_trusted_nodes_only(true);
 
     let config = NetworkConfigBuilder::eth(secret_key)
         .listener_port(0)
@@ -405,8 +401,8 @@ async fn test_trusted_peer_only() {
     // connect to an untrusted peer should fail.
     handle.add_peer(*handle0.peer_id(), handle0.local_addr());
 
-    // wait 1 second, the number of connection is still 0.
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    // wait 500ms, the number of connection is still 0.
+    tokio::time::sleep(Duration::from_millis(500)).await;
     assert_eq!(handle.num_connected_peers(), 0);
 
     // add to trusted peer.
@@ -419,8 +415,8 @@ async fn test_trusted_peer_only() {
     // only receive connections from trusted peers.
     handle1.add_peer(*handle.peer_id(), handle.local_addr());
 
-    // wait 1 second, the number of connections is still 1, because peer1 is untrusted.
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    // wait 500ms, the number of connections is still 1, because peer1 is untrusted.
+    tokio::time::sleep(Duration::from_millis(500)).await;
     assert_eq!(handle.num_connected_peers(), 1);
 
     handle.add_trusted_peer(*handle1.peer_id(), handle1.local_addr());
@@ -429,7 +425,7 @@ async fn test_trusted_peer_only() {
     let outgoing_peer_id1 = event_stream.next_session_established().await.unwrap();
     assert_eq!(outgoing_peer_id1, *handle1.peer_id());
 
-    tokio::time::sleep(Duration::from_secs(2)).await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
     assert_eq!(handle.num_connected_peers(), 2);
 
     // check that handle0 and handle1 both have peers.
@@ -441,8 +437,7 @@ async fn test_trusted_peer_only() {
 async fn test_network_state_change() {
     let net = Testnet::create(1).await;
     let secret_key = SecretKey::new(&mut rand_08::thread_rng());
-    let peers_config =
-        PeersConfig::default().with_refill_slots_interval(Duration::from_millis(500));
+    let peers_config = PeersConfig::test();
 
     let config = NetworkConfigBuilder::eth(secret_key)
         .listener_port(0)
@@ -466,16 +461,16 @@ async fn test_network_state_change() {
 
     handle.add_peer(*handle0.peer_id(), handle0.local_addr());
 
-    // wait 2 seconds, the number of connections is still 0, because network is Hibernate.
-    tokio::time::sleep(Duration::from_secs(2)).await;
+    // wait 500ms, the number of connections is still 0, because network is Hibernate.
+    tokio::time::sleep(Duration::from_millis(500)).await;
     assert_eq!(handle.num_connected_peers(), 0);
 
     // Set network state to Active.
     handle.set_network_active();
 
-    // wait 2 seconds, the number of connections should be 1, because network is Active and outbound
+    // wait 500ms, the number of connections should be 1, because network is Active and outbound
     // slot should be filled.
-    tokio::time::sleep(Duration::from_secs(2)).await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
     assert_eq!(handle.num_connected_peers(), 1);
 }
 
@@ -483,7 +478,7 @@ async fn test_network_state_change() {
 async fn test_exceed_outgoing_connections() {
     let net = Testnet::create(2).await;
     let secret_key = SecretKey::new(&mut rand_08::thread_rng());
-    let peers_config = PeersConfig::default().with_max_outbound(1);
+    let peers_config = PeersConfig::test().with_max_outbound(1);
 
     let config = NetworkConfigBuilder::eth(secret_key)
         .listener_port(0)
@@ -514,9 +509,9 @@ async fn test_exceed_outgoing_connections() {
 
     handle.add_peer(*handle1.peer_id(), handle1.local_addr());
 
-    // wait 2 seconds, the number of connections is still 1, indicating that the max outbound is in
+    // wait 500ms, the number of connections is still 1, indicating that the max outbound is in
     // effect.
-    tokio::time::sleep(Duration::from_secs(2)).await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
     assert_eq!(handle.num_connected_peers(), 1);
 }
 
@@ -524,7 +519,7 @@ async fn test_exceed_outgoing_connections() {
 async fn test_disconnect_incoming_when_exceeded_incoming_connections() {
     let net = Testnet::create(1).await;
     let secret_key = SecretKey::new(&mut rand_08::thread_rng());
-    let peers_config = PeersConfig::default().with_max_inbound(0);
+    let peers_config = PeersConfig::test().with_max_inbound(0);
 
     let config = NetworkConfigBuilder::eth(secret_key)
         .listener_port(0)
@@ -543,7 +538,7 @@ async fn test_disconnect_incoming_when_exceeded_incoming_connections() {
     tokio::task::spawn(network);
     let net_handle = net.spawn();
 
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
 
     assert_eq!(handle.num_connected_peers(), 0);
 
@@ -623,15 +618,15 @@ async fn test_rejected_by_already_connect() {
     // incoming connection from the same peer should be rejected by already connected
     // and num_inbount should still be 1
     other_peer_handle1.add_peer(*handle.peer_id(), handle.local_addr());
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
 
     // incoming connection from other_peer2 should succeed
     other_peer_handle2.add_peer(*handle.peer_id(), handle.local_addr());
     let peer_id = events.next_session_established().await.unwrap();
     assert_eq!(peer_id, *other_peer_handle2.peer_id());
 
-    // wait 2 seconds and check that other_peer2 is not rejected by TooManyPeers
-    tokio::time::sleep(Duration::from_secs(2)).await;
+    // wait 500ms and check that other_peer2 is not rejected by TooManyPeers
+    tokio::time::sleep(Duration::from_millis(500)).await;
     assert_eq!(handle.num_connected_peers(), 2);
 }
 
@@ -641,7 +636,7 @@ async fn new_random_peer(
 ) -> NetworkManager<EthNetworkPrimitives> {
     let secret_key = SecretKey::new(&mut rand_08::thread_rng());
     let peers_config =
-        PeersConfig::default().with_max_inbound(max_in_bound).with_trusted_nodes(trusted_nodes);
+        PeersConfig::test().with_max_inbound(max_in_bound).with_trusted_nodes(trusted_nodes);
 
     let config = NetworkConfigBuilder::new(secret_key)
         .listener_port(0)
@@ -775,7 +770,7 @@ async fn test_reconnect_trusted() {
 
     // Await that handle1 (trusted peer) reconnects automatically
     let reconnect_result =
-        tokio::time::timeout(Duration::from_secs(60), listener0.next_session_established()).await;
+        tokio::time::timeout(Duration::from_secs(10), listener0.next_session_established()).await;
 
     match reconnect_result {
         Ok(Some(peer)) => {


### PR DESCRIPTION
## Summary
Speed up slow integration tests identified from [CI run #22048722296](https://github.com/paradigmxyz/reth/actions/runs/22048722296/job/63702264372).

## Changes

**Network tests** (`crates/net/network/tests/it/connect.rs`):
- Use `PeersConfig::test()` (100ms refill, 200ms backoff) instead of `PeersConfig::default()` (5s refill, 30s backoff) — this explains the ~5.07s cluster of network tests
- Reduce negative-assertion sleeps from 1-2s to 500ms
- Reduce `test_reconnect_trusted` timeout from 60s to 10s
- Affected tests: `test_trusted_peer_only`, `test_network_state_change`, `test_exceed_outgoing_connections`, `test_disconnect_incoming_when_exceeded_incoming_connections`, `test_rejected_by_already_connect`, `new_random_peer` helper

**Blob test** (`crates/ethereum/node/tests/e2e/blobs.rs`):
- Reduce `blob_conversion_at_osaka` sleep from 11s to 6s by setting Prague payload timestamp closer to current time (still satisfies the 2-slot-before-osaka conversion trigger with 4s internal delay + buffer)

**Fee history test** (`crates/ethereum/node/tests/e2e/rpc.rs`):
- Reduce `test_fee_history` contract deployment loop from 100 to 20 iterations
- Reduce gas waster storage writes from `0..1000` to `0..100` per deploy
- Reduce fee history query loop from 100 to 20 iterations

## Expected CI savings
| Test | Before | After (est.) |
|------|--------|-------------|
| Network tests (~5s cluster) | ~5s each | ~0.5s each |
| `test_reconnect_trusted` | 45s | <10s |
| `blob_conversion_at_osaka` | 16s | ~10s |
| `test_fee_history` | 16s | ~3s |

Prompted by: DaniPopes