### PR TITLE
perf: use synchronous state root for small blocks

### DIFF
--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -53,6 +53,10 @@ use std::{
 };
 use tracing::{debug, debug_span, error, info, instrument, trace, warn};
 
+/// Blocks with at most this many transactions compute the state root synchronously to avoid
+/// background task overhead.
+const SMALL_BLOCK_STATE_ROOT_TX_THRESHOLD: usize = 50;
+
 /// Context providing access to tree state during validation.
 ///
 /// This context is provided to the [`EngineValidator`] and includes the state of the tree's
@@ -401,7 +405,7 @@ where
         };
 
         // Plan the strategy used for state root computation.
-        let strategy = self.plan_state_root_computation();
+        let strategy = self.plan_state_root_computation(input.transaction_count());
 
         debug!(
             target: "engine::tree::payload_validator",
@@ -1237,7 +1241,12 @@ where
     ///
     /// Note: Use state root task only if prefix sets are empty, otherwise proof generation is
     /// too expensive because it requires walking all paths in every proof.
-    const fn plan_state_root_computation(&self) -> StateRootStrategy {
+    fn plan_state_root_computation(&self, transaction_count: usize) -> StateRootStrategy {
+        // Small blocks are faster without spawning parallel state root tasks.
+        if transaction_count > 0 && transaction_count <= SMALL_BLOCK_STATE_ROOT_TX_THRESHOLD {
+            return StateRootStrategy::Synchronous;
+        }
+
         if self.config.state_root_fallback() {
             StateRootStrategy::Synchronous
         } else if self.config.use_state_root_task() {


### PR DESCRIPTION
**Summary**
Reduce newPayload latency for small blocks by avoiding parallel state root tasks when transaction counts are low. This targets fixed overhead from sparse trie task setup that dominates sub-50-tx payloads.

**Changes**
- Choose synchronous state root computation for blocks with <=50 transactions
- Leave config-driven state root strategies unchanged for larger blocks

**Expected Impact**
Lower fixed per-block overhead for small payloads by skipping sparse trie task setup and waiting.