### PR TITLE
chore(trie): add level=debug to sparse trie state spans

### DIFF
--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -262,14 +262,7 @@ where
 
     /// Reveal unknown trie paths from decoded multiproof.
     /// NOTE: This method does not extensively validate the proof.
-    #[instrument(
-        target = "trie::sparse",
-        skip_all,
-        fields(
-            account_nodes = multiproof.account_subtree.len(),
-            storages = multiproof.storages.len()
-        )
-    )]
+    #[instrument(level = "debug", target = "trie::sparse", skip_all)]
     pub fn reveal_decoded_multiproof(
         &mut self,
         multiproof: DecodedMultiProof,
@@ -357,13 +350,7 @@ where
     ///
     /// V2 multiproofs use a simpler format where proof nodes are stored as vectors rather than
     /// hashmaps, with masks already included in the `ProofTrieNode` structure.
-    #[instrument(
-        skip_all,
-        fields(
-            account_nodes = multiproof.account_proofs.len(),
-            storages = multiproof.storage_proofs.len()
-        )
-    )]
+    #[instrument(level = "debug", target = "trie::sparse", skip_all)]
     pub fn reveal_decoded_multiproof_v2(
         &mut self,
         multiproof: reth_trie_common::DecodedMultiProofV2,
@@ -832,7 +819,7 @@ where
     /// Calculates the hashes of subtries.
     ///
     /// If the trie has not been revealed, this function does nothing.
-    #[instrument(target = "trie::sparse", skip_all)]
+    #[instrument(level = "debug", target = "trie::sparse", skip_all)]
     pub fn calculate_subtries(&mut self) {
         if let RevealableSparseTrie::Revealed(trie) = &mut self.state {
             trie.update_subtrie_hashes();
@@ -884,7 +871,7 @@ where
     }
 
     /// Returns sparse trie root and trie updates if the trie has been revealed.
-    #[instrument(target = "trie::sparse", skip_all)]
+    #[instrument(level = "debug", target = "trie::sparse", skip_all)]
     pub fn root_with_updates(
         &mut self,
         provider_factory: impl TrieNodeProviderFactory,
@@ -1023,7 +1010,7 @@ where
     ///
     /// Returns false if the new storage root is empty, and the account info was already empty,
     /// indicating the account leaf should be removed.
-    #[instrument(target = "trie::sparse", skip_all)]
+    #[instrument(level = "debug", target = "trie::sparse", skip_all)]
     pub fn update_account_storage_root(
         &mut self,
         address: B256,
@@ -1071,7 +1058,7 @@ where
     }
 
     /// Remove the account leaf node.
-    #[instrument(target = "trie::sparse", skip_all)]
+    #[instrument(level = "debug", target = "trie::sparse", skip_all)]
     pub fn remove_account_leaf(
         &mut self,
         path: &Nibbles,
@@ -1156,6 +1143,7 @@ where
     /// - Clears `revealed_account_paths` and `revealed_paths` for all storage tries
     #[cfg(feature = "std")]
     #[instrument(
+        level = "debug",
         name = "SparseStateTrie::prune",
         target = "trie::sparse",
         skip_all,


### PR DESCRIPTION
Ensures all #[instrument] spans in SparseStateTrie consistently specify an explicit level, preventing them from defaulting to INFO.