### PR TITLE
fix(net): use test backoff durations in Testnet PeerConfig

### DIFF
--- a/crates/net/network/src/test_utils/testnet.rs
+++ b/crates/net/network/src/test_utils/testnet.rs
@@ -10,7 +10,7 @@ use crate::{
         policy::NetworkPolicies,
         TransactionsHandle, TransactionsManager, TransactionsManagerConfig,
     },
-    NetworkConfig, NetworkConfigBuilder, NetworkHandle, NetworkManager,
+    NetworkConfig, NetworkConfigBuilder, NetworkHandle, NetworkManager, PeersConfig,
 };
 use futures::{FutureExt, StreamExt};
 use pin_project::pin_project;
@@ -718,6 +718,7 @@ where
             .discovery_addr(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0)))
             .disable_dns_discovery()
             .disable_discv4_discovery()
+            .peer_config(PeersConfig::test())
     }
 }
 


### PR DESCRIPTION
## Summary
Fix flaky `test_reconnect_trusted` by using `PeersConfig::test()` in `PeerConfig::network_config_builder`.

## Motivation
`Testnet::create` used default `PeersConfig` with a 30s low backoff for trusted peer reconnection, but `test_reconnect_trusted` only waits 10s — a race that fails under CI load.

## Changes
- Add `.peer_config(PeersConfig::test())` to `PeerConfig::network_config_builder`, giving all `Testnet::create` peers 200ms backoff durations instead of 30s

## Testing
`cargo check -p reth-network --tests`

Prompted by: DaniPopes