### PR TITLE
fix(engine): send correct transaction index in prewarm task

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -52,8 +52,8 @@ use tracing::{debug, debug_span, instrument, trace, warn, Span};
 /// Determines the prewarming mode: transaction-based, BAL-based, or skipped.
 #[derive(Debug)]
 pub enum PrewarmMode<Tx> {
-    /// Prewarm by executing transactions from a stream.
-    Transactions(Receiver<Tx>),
+    /// Prewarm by executing transactions from a stream, each paired with its block index.
+    Transactions(Receiver<(usize, Tx)>),
     /// Prewarm by prefetching slots from a Block Access List.
     BlockAccessList(Arc<BlockAccessList>),
     /// Transaction prewarming is skipped (e.g. small blocks where the overhead exceeds the
@@ -136,7 +136,7 @@ where
     /// subsequent transactions in the block.
     fn spawn_all<Tx>(
         &self,
-        pending: mpsc::Receiver<Tx>,
+        pending: mpsc::Receiver<(usize, Tx)>,
         actions_tx: Sender<PrewarmTaskEvent<N::Receipt>>,
         to_multi_proof: Option<CrossbeamSender<MultiProofMessage>>,
     ) where
@@ -164,8 +164,8 @@ where
             let tx_sender = ctx.clone().spawn_workers(workers_needed, &executor,  to_multi_proof.clone(), done_tx.clone());
 
             // Distribute transactions to workers
-            let mut tx_index = 0usize;
-            while let Ok(tx) = pending.recv() {
+            let mut tx_count = 0usize;
+            while let Ok((tx_index, tx)) = pending.recv() {
                 // Stop distributing if termination was requested
                 if ctx.terminate_execution.load(Ordering::Relaxed) {
                     trace!(
@@ -182,7 +182,7 @@ where
                 // exit early when signaled.
                 let _ = tx_sender.send(indexed_tx);
 
-                tx_index += 1;
+                tx_count += 1;
             }
 
             // Send withdrawal prefetch targets after all transactions have been distributed
@@ -201,7 +201,7 @@ where
             while done_rx.recv().is_ok() {}
 
             let _ = actions_tx
-                .send(PrewarmTaskEvent::FinishedTxExecution { executed_transactions: tx_index });
+                .send(PrewarmTaskEvent::FinishedTxExecution { executed_transactions: tx_count });
         });
     }
 


### PR DESCRIPTION
## Summary
Fixes incorrect transaction index in prewarm task (first part of #20431, supersedes #20911).

## Motivation
The parallel path in `spawn_tx_iterator` sends transactions to the prewarm channel out of order via rayon's parallel `.map()`. The prewarm task's `spawn_all` then assigned indices using a local counter based on arrival order — giving wrong indices.

## Changes
- `spawn_tx_iterator`: send `(idx, tx)` tuples through the prewarm channel in both sequential and parallel paths
- `PrewarmMode::Transactions`: updated to `Receiver<(usize, Tx)>`
- `spawn_all`: use received index instead of local counter
- `spawn_caching_with`: updated receiver type

## Testing
`cargo check -p reth-engine-tree` and `cargo clippy -p reth-engine-tree` pass clean.

Prompted by: DaniPopes