### PR TITLE
perf: streamline storage trie prune evictions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10615,6 +10615,7 @@ dependencies = [
  "arbitrary",
  "assert_matches",
  "auto_impl",
+ "codspeed-criterion-compat",
  "itertools 0.14.0",
  "metrics",
  "pretty_assertions",

--- a/crates/trie/sparse/Cargo.toml
+++ b/crates/trie/sparse/Cargo.toml
@@ -40,6 +40,7 @@ reth-trie = { workspace = true, features = ["test-utils"] }
 reth-trie-common = { workspace = true, features = ["test-utils", "arbitrary"] }
 reth-trie-db = { workspace = true, features = ["test-utils"] }
 reth-tracing.workspace = true
+criterion.workspace = true
 
 arbitrary.workspace = true
 assert_matches.workspace = true
@@ -49,6 +50,10 @@ proptest-arbitrary-interop.workspace = true
 proptest.workspace = true
 rand.workspace = true
 rand_08.workspace = true
+
+[[bench]]
+name = "storage_prune"
+harness = false
 
 [features]
 default = ["std", "metrics"]

--- a/crates/trie/sparse/benches/storage_prune.rs
+++ b/crates/trie/sparse/benches/storage_prune.rs
@@ -1,0 +1,68 @@
+#![allow(missing_docs, unreachable_pub)]
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use rand::{rngs::StdRng, Rng, SeedableRng};
+use reth_trie_common::Nibbles;
+use reth_trie_sparse::{
+    provider::DefaultTrieNodeProviderFactory, ParallelSparseTrie, RevealableSparseTrie,
+    SparseStateTrie,
+};
+
+fn storage_prune_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("sparse storage prune");
+
+    for (storage_tries, keep, depth) in
+        [(50usize, 10usize, 2usize), (50usize, 80usize, 2usize), (200, 40, 2), (200, 40, 4)]
+    {
+        let name = format!("tries={storage_tries} keep={keep} depth={depth}");
+        group.bench_function(name, |b| {
+            b.iter_batched(
+                || build_trie_fixture(storage_tries),
+                |mut trie| {
+                    trie.prune(depth, keep);
+                },
+                BatchSize::LargeInput,
+            )
+        });
+    }
+
+    group.finish();
+}
+
+fn build_trie_fixture(
+    storage_tries: usize,
+) -> SparseStateTrie<ParallelSparseTrie, ParallelSparseTrie> {
+    let mut trie = SparseStateTrie::default()
+        .with_default_storage_trie(RevealableSparseTrie::revealed_empty());
+    let provider_factory = DefaultTrieNodeProviderFactory;
+    let mut rng = StdRng::seed_from_u64(0x5eed);
+
+    for _ in 0..storage_tries {
+        let address = random_b256(&mut rng);
+        let storage_trie = RevealableSparseTrie::revealed_empty();
+        trie.insert_storage_trie(address, storage_trie);
+
+        for _ in 0..64 {
+            let slot = random_b256(&mut rng);
+            let value_len = rng.random_range(8..64);
+            let value = vec![0u8; value_len];
+            trie.update_storage_leaf(address, Nibbles::unpack(slot), value, &provider_factory).ok();
+        }
+    }
+
+    // Compute hashes once so pruning does real work.
+    let _ = trie.root(&provider_factory);
+    trie
+}
+
+fn random_b256(rng: &mut StdRng) -> alloy_primitives::B256 {
+    let mut bytes = [0u8; 32];
+    rng.fill(&mut bytes);
+    alloy_primitives::B256::from(bytes)
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets = storage_prune_benchmark
+}
+criterion_main!(benches);


### PR DESCRIPTION
**Summary**
Reduce overhead in sparse storage trie pruning by evicting non-kept tries via `retain`, clearing revealed paths in the same pass, and pruning modification tracking in place. This avoids collecting and removing keys in separate passes while preserving allocation reuse.

**Changes**
- Replace key collection + removal with `retain` for evicting storage tries
- Clear kept revealed paths during retention and reuse cleared path sets
- Trim modification tracking sets to kept tries only

**Expected Impact**
Lower allocation and lookup overhead during storage trie pruning, especially when many tries are evicted.
