### PR TITLE
perf: adaptive multiproof chunk size based on block gas usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10615,6 +10615,7 @@ dependencies = [
  "arbitrary",
  "assert_matches",
  "auto_impl",
+ "codspeed-criterion-compat",
  "itertools 0.14.0",
  "metrics",
  "pretty_assertions",

--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -32,6 +32,18 @@ fn default_account_worker_count() -> usize {
 /// The size of proof targets chunk to spawn in one multiproof calculation.
 pub const DEFAULT_MULTIPROOF_TASK_CHUNK_SIZE: usize = 60;
 
+/// The size of proof targets chunk optimized for small blocks (≤20M gas used).
+///
+/// Benchmarking showed that chunk size 30 yields the best throughput for blocks with ≤20M gas:
+/// - 10M gas: 1.2051 Ggas/s (best)
+/// - 20M gas: 1.4490 Ggas/s (within 0.3% of best)
+///
+/// See: <https://gist.github.com/yongkangc/fda9c24846f0ba891376bcf81b002008>
+pub const SMALL_BLOCK_MULTIPROOF_CHUNK_SIZE: usize = 30;
+
+/// Gas threshold below which the small block chunk size is used.
+pub const SMALL_BLOCK_GAS_THRESHOLD: u64 = 20_000_000;
+
 /// The size of proof targets chunk to spawn in one multiproof calculation when V2 proofs are
 /// enabled. This is 4x the default chunk size to take advantage of more efficient V2 proof
 /// computation.

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -396,6 +396,7 @@ where
             parent_hash: input.parent_hash(),
             parent_state_root: parent_block.state_root(),
             transaction_count: input.transaction_count(),
+            gas_used: input.gas_used(),
             withdrawals: input.withdrawals().map(|w| w.to_vec()),
         };
 
@@ -1659,6 +1660,17 @@ impl<T: PayloadTypes> BlockOrPayload<T> {
         match self {
             Self::Payload(payload) => payload.withdrawals().map(|w| w.as_slice()),
             Self::Block(block) => block.body().withdrawals().map(|w| w.as_slice()),
+        }
+    }
+
+    /// Returns the total gas used by the block.
+    pub fn gas_used(&self) -> u64
+    where
+        T::ExecutionData: ExecutionPayload,
+    {
+        match self {
+            Self::Payload(payload) => payload.gas_used(),
+            Self::Block(block) => block.gas_used(),
         }
     }
 }

--- a/crates/trie/sparse/Cargo.toml
+++ b/crates/trie/sparse/Cargo.toml
@@ -40,6 +40,7 @@ reth-trie = { workspace = true, features = ["test-utils"] }
 reth-trie-common = { workspace = true, features = ["test-utils", "arbitrary"] }
 reth-trie-db = { workspace = true, features = ["test-utils"] }
 reth-tracing.workspace = true
+criterion.workspace = true
 
 arbitrary.workspace = true
 assert_matches.workspace = true
@@ -49,6 +50,10 @@ proptest-arbitrary-interop.workspace = true
 proptest.workspace = true
 rand.workspace = true
 rand_08.workspace = true
+
+[[bench]]
+name = "storage_prune"
+harness = false
 
 [features]
 default = ["std", "metrics"]

--- a/crates/trie/sparse/benches/storage_prune.rs
+++ b/crates/trie/sparse/benches/storage_prune.rs
@@ -1,0 +1,68 @@
+#![allow(missing_docs, unreachable_pub)]
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use rand::{rngs::StdRng, Rng, SeedableRng};
+use reth_trie_common::Nibbles;
+use reth_trie_sparse::{
+    provider::DefaultTrieNodeProviderFactory, ParallelSparseTrie, RevealableSparseTrie,
+    SparseStateTrie,
+};
+
+fn storage_prune_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("sparse storage prune");
+
+    for (storage_tries, keep, depth) in
+        [(50usize, 10usize, 2usize), (50usize, 80usize, 2usize), (200, 40, 2), (200, 40, 4)]
+    {
+        let name = format!("tries={storage_tries} keep={keep} depth={depth}");
+        group.bench_function(name, |b| {
+            b.iter_batched(
+                || build_trie_fixture(storage_tries),
+                |mut trie| {
+                    trie.prune(depth, keep);
+                },
+                BatchSize::LargeInput,
+            )
+        });
+    }
+
+    group.finish();
+}
+
+fn build_trie_fixture(
+    storage_tries: usize,
+) -> SparseStateTrie<ParallelSparseTrie, ParallelSparseTrie> {
+    let mut trie = SparseStateTrie::default()
+        .with_default_storage_trie(RevealableSparseTrie::revealed_empty());
+    let provider_factory = DefaultTrieNodeProviderFactory;
+    let mut rng = StdRng::seed_from_u64(0x5eed);
+
+    for _ in 0..storage_tries {
+        let address = random_b256(&mut rng);
+        let storage_trie = RevealableSparseTrie::revealed_empty();
+        trie.insert_storage_trie(address, storage_trie);
+
+        for _ in 0..64 {
+            let slot = random_b256(&mut rng);
+            let value_len = rng.random_range(8..64);
+            let value = vec![0u8; value_len];
+            trie.update_storage_leaf(address, Nibbles::unpack(slot), value, &provider_factory).ok();
+        }
+    }
+
+    // Compute hashes once so pruning does real work.
+    let _ = trie.root(&provider_factory);
+    trie
+}
+
+fn random_b256(rng: &mut StdRng) -> alloy_primitives::B256 {
+    let mut bytes = [0u8; 32];
+    rng.fill(&mut bytes);
+    alloy_primitives::B256::from(bytes)
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets = storage_prune_benchmark
+}
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

Makes the multiproof chunk size adaptive based on block gas usage:
- **≤20M gas**: uses chunk size **30** (optimal for small blocks)
- **>20M gas**: uses the configured default (60)

## Benchmark Results

Swept 8 chunk sizes (15, 30, 60, 75, 100, 120, 160, 240) across 4 gas levels (10M, 20M, 30M, 40M). Chunk size 30 wins for blocks with ≤20M gas:

| Gas Level | Chunk 30 (Ggas/s) | Default 60 (Ggas/s) | Improvement |
|-----------|-------------------|---------------------|-------------|
| 10M       | 1.2051            | 1.0909              | +10.5%      |
| 20M       | 1.4490            | 1.4538              | ~same       |
| 30M       | 1.4090            | 1.4340              | -1.7%       |
| 40M       | 1.3543            | 1.3814              | -2.0%       |

At higher gas levels, the default 60 performs better, so we keep it there.

Full methodology and scripts: https://gist.github.com/yongkangc/fda9c24846f0ba891376bcf81b002008

## Changes

- Added `SMALL_BLOCK_MULTIPROOF_CHUNK_SIZE` (30) and `SMALL_BLOCK_GAS_THRESHOLD` (20M) constants
- Added `gas_used` field to `ExecutionEnv` (available from the payload before execution)
- Added `adaptive_chunk_size()` helper in `PayloadProcessor` that selects chunk size based on gas usage
- Both `MultiProofTask` and `SparseTrieCacheTask` use the adaptive chunk size