### PR TITLE
chore(engine): simplify cache and persistence wait logic in reth_newPayload

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1556,6 +1556,8 @@ where
                                 self.on_maybe_tree_event(maybe_event)?;
                             }
                             BeaconEngineMessage::RethNewPayload { payload, tx } => {
+                                let cache_wait = self.payload_validator.wait_for_caches();
+
                                 let pending_persistence = self.persistence_state.rx.take();
 
                                 // Wait for pending persistence to complete before processing
@@ -1569,8 +1571,6 @@ where
                                     } else {
                                         None
                                     };
-
-                                let cache_wait = self.payload_validator.wait_for_caches();
 
                                 debug!(
                                     target: "engine::tree",

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -4,11 +4,11 @@ use crate::tree::{
     cached_state::CachedStateProvider,
     error::{InsertBlockError, InsertBlockErrorKind, InsertPayloadError},
     instrumented_state::InstrumentedStateProvider,
-    payload_processor::{CacheWaitDurations, PayloadProcessor},
+    payload_processor::PayloadProcessor,
     precompile_cache::{CachedPrecompile, CachedPrecompileMetrics, PrecompileCacheMap},
     sparse_trie::StateRootComputeOutcome,
-    EngineApiMetrics, EngineApiTreeState, ExecutionEnv, PayloadHandle, StateProviderBuilder,
-    StateProviderDatabase, TreeConfig, WaitForCaches,
+    CacheWaitDurations, EngineApiMetrics, EngineApiTreeState, ExecutionEnv, PayloadHandle,
+    StateProviderBuilder, StateProviderDatabase, TreeConfig, WaitForCaches,
 };
 use alloy_consensus::transaction::{Either, TxHashRef};
 use alloy_eip7928::BlockAccessList;


### PR DESCRIPTION
## Summary

Cleans up overly complex wait logic in the `reth_newPayload` handler and `PayloadProcessor`.

### Changes

- **Fix broken parallel wait**: The previous `spawn_blocking` + `try_recv` pattern would silently lose persistence results if they took longer than cache waits. Replaced with simple sequential blocking — wait for persistence first, then caches.

- **Simplify `wait_for_caches`**: Replaced two `spawn_blocking` tasks with channels with direct sequential calls. The locks release independently, so parallel waiting adds complexity for no benefit.

- **Move types**: Moved `CacheWaitDurations` and `WaitForCaches` from the top of `payload_processor/mod.rs` to the bottom of `tree/mod.rs` — they're not payload-processor-specific types.

- **Regular method**: Made `wait_for_caches` a regular inherent method on `PayloadProcessor` instead of a trait impl. Only `BasicEngineValidator` needs the `WaitForCaches` trait bound.

- **Minor**: Removed unnecessary temp variable, fixed "Peresistence" typo.