### PR TITLE
fix: correct misleading module doc comment in evm/noop.rs

### DIFF
--- a/crates/evm/evm/src/noop.rs
+++ b/crates/evm/evm/src/noop.rs
@@ -1,4 +1,4 @@
-//! Helpers for testing.
+//! A no-op EVM configuration used as a typesystem placeholder to satisfy [`ConfigureEvm`] bounds.
 
 use crate::{ConfigureEvm, EvmEnvFor};
 use reth_primitives_traits::{BlockTy, HeaderTy, SealedBlock, SealedHeader};


### PR DESCRIPTION
The noop module doc comment says "Helpers for testing" but NoopEvmConfig is used in production code (build_pipeline_with_downloaders, CLI commands) as a type-level placeholder to satisfy ConfigureEvm bounds