### PR TITLE
fix: Use `Option::transpose` in `StaticFileCursor` to remove duplicated Option/Result plumbing

### DIFF
--- a/crates/storage/db/src/static_file/cursor.rs
+++ b/crates/storage/db/src/static_file/cursor.rs
@@ -60,10 +60,7 @@ impl<'a> StaticFileCursor<'a> {
     ) -> ColumnResult<M::FIRST> {
         let row = self.get(key_or_num, M::MASK)?;
 
-        match row {
-            Some(row) => Ok(Some(M::FIRST::decompress(row[0])?)),
-            None => Ok(None),
-        }
+        Ok(row.map(|row| M::FIRST::decompress(row[0])).transpose()?)
     }
 
     /// Gets two column values from a row.
@@ -73,10 +70,11 @@ impl<'a> StaticFileCursor<'a> {
     ) -> ColumnResult<(M::FIRST, M::SECOND)> {
         let row = self.get(key_or_num, M::MASK)?;
 
-        match row {
-            Some(row) => Ok(Some((M::FIRST::decompress(row[0])?, M::SECOND::decompress(row[1])?))),
-            None => Ok(None),
-        }
+        Ok(row
+            .map(|row| -> Result<_, reth_db_api::DatabaseError> {
+                Ok((M::FIRST::decompress(row[0])?, M::SECOND::decompress(row[1])?))
+            })
+            .transpose()?)
     }
 
     /// Gets three column values from a row.
@@ -86,14 +84,15 @@ impl<'a> StaticFileCursor<'a> {
     ) -> ColumnResult<(M::FIRST, M::SECOND, M::THIRD)> {
         let row = self.get(key_or_num, M::MASK)?;
 
-        match row {
-            Some(row) => Ok(Some((
-                M::FIRST::decompress(row[0])?,
-                M::SECOND::decompress(row[1])?,
-                M::THIRD::decompress(row[2])?,
-            ))),
-            None => Ok(None),
-        }
+        Ok(row
+            .map(|row| -> Result<_, reth_db_api::DatabaseError> {
+                Ok((
+                    M::FIRST::decompress(row[0])?,
+                    M::SECOND::decompress(row[1])?,
+                    M::THIRD::decompress(row[2])?,
+                ))
+            })
+            .transpose()?)
     }
 }
 
@@ -117,3 +116,4 @@ impl From<u64> for KeyOrNumber<'_> {
         KeyOrNumber::Number(value)
     }
 }
+

--- a/crates/storage/db/src/static_file/cursor.rs
+++ b/crates/storage/db/src/static_file/cursor.rs
@@ -116,4 +116,3 @@ impl From<u64> for KeyOrNumber<'_> {
         KeyOrNumber::Number(value)
     }
 }
-


### PR DESCRIPTION
Refactor `StaticFileCursor::{get_one, get_two, get_three}` to use `Option::map(...).transpose()?` instead of three hand-written `match` blocks converting `Option<Row>` and fallible `Decompress` calls into `ProviderResult<Option<_>>`.

