### PR TITLE
fix(txpool): notify subscribers when set_block_info promotes transaction

### DIFF
--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -204,9 +204,15 @@ where
     pub fn block_info(&self) -> BlockInfo {
         self.get_pool_data().block_info()
     }
-    /// Sets the currently tracked block
+    /// Sets the currently tracked block.
+    ///
+    /// This will also notify subscribers about any transactions that were promoted to the pending
+    /// pool due to fee changes.
     pub fn set_block_info(&self, info: BlockInfo) {
-        self.pool.write().set_block_info(info)
+        let outcome = self.pool.write().set_block_info(info);
+
+        // Notify subscribers about promoted transactions due to fee changes
+        self.notify_on_transaction_updates(outcome.promoted, outcome.discarded);
     }
 
     /// Returns the internal [`SenderId`] for this address

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -351,15 +351,25 @@ impl<T: TransactionOrdering> TxPool<T> {
 
     /// Sets the current block info for the pool.
     ///
-    /// This will also apply updates to the pool based on the new base fee and blob fee
-    pub fn set_block_info(&mut self, info: BlockInfo) {
-        // first update the subpools based on the new values
-        let basefee_ordering = self.update_basefee(info.pending_basefee, |_| {});
+    /// This will also apply updates to the pool based on the new base fee and blob fee.
+    ///
+    /// Returns the outcome containing any transactions that were promoted due to fee changes.
+    pub(crate) fn set_block_info(&mut self, info: BlockInfo) -> UpdateOutcome<T::Transaction> {
+        let mut outcome = UpdateOutcome::default();
+
+        // first update the subpools based on the new values, collecting promoted transactions
+        let basefee_ordering = self.update_basefee(info.pending_basefee, |tx| {
+            outcome.promoted.push(tx.clone());
+        });
         if let Some(blob_fee) = info.pending_blob_fee {
-            self.update_blob_fee(blob_fee, basefee_ordering, |_| {})
+            self.update_blob_fee(blob_fee, basefee_ordering, |tx| {
+                outcome.promoted.push(tx.clone());
+            })
         }
         // then update tracked values
         self.all_transactions.set_block_info(info);
+
+        outcome
     }
 
     /// Returns an iterator that yields transactions that are ready to be included in the block with

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -354,7 +354,7 @@ impl<T: TransactionOrdering> TxPool<T> {
     /// This will also apply updates to the pool based on the new base fee and blob fee.
     ///
     /// Returns the outcome containing any transactions that were promoted due to fee changes.
-    pub(crate) fn set_block_info(&mut self, info: BlockInfo) -> UpdateOutcome<T::Transaction> {
+    pub fn set_block_info(&mut self, info: BlockInfo) -> UpdateOutcome<T::Transaction> {
         let mut outcome = UpdateOutcome::default();
 
         // first update the subpools based on the new values, collecting promoted transactions

--- a/crates/transaction-pool/src/pool/update.rs
+++ b/crates/transaction-pool/src/pool/update.rs
@@ -35,11 +35,11 @@ impl From<SubPool> for Destination {
 
 /// Tracks the result after updating the pool
 #[derive(Debug)]
-pub(crate) struct UpdateOutcome<T: PoolTransaction> {
+pub struct UpdateOutcome<T: PoolTransaction> {
     /// transactions promoted to the pending pool
-    pub(crate) promoted: Vec<Arc<ValidPoolTransaction<T>>>,
+    pub promoted: Vec<Arc<ValidPoolTransaction<T>>>,
     /// transaction that failed and were discarded
-    pub(crate) discarded: Vec<Arc<ValidPoolTransaction<T>>>,
+    pub discarded: Vec<Arc<ValidPoolTransaction<T>>>,
 }
 
 impl<T: PoolTransaction> Default for UpdateOutcome<T> {


### PR DESCRIPTION
`set_block_info` passes empty closures to `update_basefee`/`update_blob_fee`, so transactions promoted due to fee changes are not notified to subscribers. This affects node startup and deep sync skip scenarios.

Now collects promoted transactions and calls `notify_on_transaction_updates`, consistent with `on_canonical_state_change`.