### PR TITLE
fix(rpc): enforce timeout option in debug trace methods

### DIFF
--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -76,7 +76,7 @@ jsonrpsee-types.workspace = true
 
 # async
 async-trait.workspace = true
-tokio = { workspace = true, features = ["sync"] }
+tokio = { workspace = true, features = ["sync", "time"] }
 tokio-stream.workspace = true
 pin-project.workspace = true
 parking_lot.workspace = true
@@ -100,6 +100,7 @@ reth-provider = { workspace = true, features = ["test-utils"] }
 reth-db-api.workspace = true
 
 rand.workspace = true
+tokio = { workspace = true, features = ["macros", "rt"] }
 
 jsonrpsee = { workspace = true, features = ["client"] }
 


### PR DESCRIPTION
## Summary
- `debug_traceCallMany` (and `debug_traceCall`, `debug_traceTransaction`, `debug_traceBlock`) accepted the `timeout` field in `GethDebugTracingOptions` but never enforced it — `DebugInspector::new()` discards it with `..`, and no reth code checked elapsed time or deadline expiration
- Wraps blocking trace futures with `tokio::time::timeout`, returning `EthApiError::ExecutionTimedOut` when the configured timeout elapses (same pattern used by `sim_bundle`)
- Adds a Go-style duration string parser to handle the timeout format (`"5s"`, `"100ms"`, `"5000ms"` as produced by alloy's `with_timeout`)

## Test plan
- [x] 8 unit tests for `parse_go_duration` covering seconds, milliseconds, fractional, compound, nanosecond strings, all units, invalid inputs, whitespace
- [x] Round-trip test verifying parser handles alloy's `GethDebugTracingOptions::with_timeout` output format
- [x] Async test verifying `tokio::time::timeout` aborts a slow future
- [x] `cargo clippy -p reth-rpc` clean
- [x] `cargo test -p reth-rpc --lib debug::tests` — 11/11 passing

Closes #22027