### PR TITLE
fix(cli): respect --skip-invalid-blocks when no gas mismatch is found

### DIFF
--- a/crates/cli/commands/src/re_execute.rs
+++ b/crates/cli/commands/src/re_execute.rs
@@ -203,6 +203,11 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                             }
                         }
 
+                        if skip_invalid_blocks {
+                            executor = evm_config.batch_executor(db_at(block.number()));
+                            let _ = info_tx.send((block, err));
+                            continue 'blocks;
+                        }
                         return Err(err);
                     }
                     let _ = stats_tx.send(block.gas_used());


### PR DESCRIPTION
Fix `re-execute` command ignoring `--skip-invalid-blocks` flag when consensus validation fails but the receipt diagnostic loop doesn't find a specific gas usage mismatch