### PR TITLE
feat(node-core): add `with_dev_block_time` helper to `NodeConfig`

### DIFF
--- a/.changelog/odd-snails-play.md
+++ b/.changelog/odd-snails-play.md
@@ -1,0 +1,5 @@
+---
+reth-node-core: minor
+---
+
+Added `with_dev_block_time` helper method to `NodeConfig` for configuring dev miner block production interval.

--- a/crates/node/core/src/node_config.rs
+++ b/crates/node/core/src/node_config.rs
@@ -343,6 +343,14 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
         self
     }
 
+    /// Set the dev block time for the node.
+    ///
+    /// This sets the interval at which the dev miner produces new blocks.
+    pub const fn with_dev_block_time(mut self, block_time: std::time::Duration) -> Self {
+        self.dev.block_time = Some(block_time);
+        self
+    }
+
     /// Set the pruning args for the node
     pub fn with_pruning(mut self, pruning: PruningArgs) -> Self {
         self.pruning = pruning;


### PR DESCRIPTION
Adds a convenience builder method to set the dev block time directly, replacing the need for:

```rust
.apply(|mut c| {
    c.dev.block_time = Some(Duration::from_millis(500));
    c
})
```

with:

```rust
.with_dev_block_time(Duration::from_millis(500))
```