### PR TITLE
perf: use mutex in for_each_ordered

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10354,6 +10354,7 @@ dependencies = [
  "crossbeam-utils",
  "futures-util",
  "metrics",
+ "parking_lot",
  "pin-project",
  "quanta",
  "rayon",

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -461,7 +461,7 @@ where
         } else {
             // Parallel path — recover signatures in parallel on rayon, stream results
             // to execution in order via `for_each_ordered`.
-            rayon::spawn(move || {
+            self.executor.spawn_blocking(move || {
                 let (transactions, convert) = transactions.into_parts();
                 transactions
                     .into_par_iter()

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -445,6 +445,8 @@ where
                 "using sequential sig recovery for small block"
             );
             self.executor.spawn_blocking(move || {
+                let _enter =
+                    debug_span!(target: "engine::tree::payload_processor", "tx iterator").entered();
                 let (transactions, convert) = transactions.into_parts();
                 for (idx, tx) in transactions.into_iter().enumerate() {
                     let tx = convert.convert(tx);
@@ -462,6 +464,8 @@ where
             // Parallel path — recover signatures in parallel on rayon, stream results
             // to execution in order via `for_each_ordered`.
             self.executor.spawn_blocking(move || {
+                let _enter =
+                    debug_span!(target: "engine::tree::payload_processor", "tx iterator").entered();
                 let (transactions, convert) = transactions.into_parts();
                 transactions
                     .into_par_iter()

--- a/crates/tasks/Cargo.toml
+++ b/crates/tasks/Cargo.toml
@@ -29,11 +29,12 @@ thiserror.workspace = true
 # feature `rayon`
 rayon = { workspace = true, optional = true }
 crossbeam-utils = { workspace = true, optional = true }
+parking_lot = { workspace = true, optional = true }
 pin-project = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["sync", "rt", "rt-multi-thread", "time", "macros"] }
 
 [features]
-rayon = ["dep:rayon", "dep:crossbeam-utils", "pin-project"]
+rayon = ["dep:rayon", "dep:crossbeam-utils", "dep:parking_lot", "pin-project"]
 test-utils = []

--- a/crates/tasks/src/for_each_ordered.rs
+++ b/crates/tasks/src/for_each_ordered.rs
@@ -1,6 +1,6 @@
 use crossbeam_utils::CachePadded;
-use rayon::iter::{IndexedParallelIterator, ParallelIterator};
 use parking_lot::{Condvar, Mutex};
+use rayon::iter::{IndexedParallelIterator, ParallelIterator};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Extension trait for [`IndexedParallelIterator`]
@@ -331,15 +331,12 @@ mod tests {
         let n = 64usize;
         let input: Vec<usize> = (0..n).collect();
         let mut output = Vec::with_capacity(n);
-        input
-            .par_iter()
-            .map(|&i| i)
-            .for_each_ordered(|x| {
-                if x % 8 == 0 {
-                    std::thread::yield_now();
-                }
-                output.push(x);
-            });
+        input.par_iter().map(|&i| i).for_each_ordered(|x| {
+            if x % 8 == 0 {
+                std::thread::yield_now();
+            }
+            output.push(x);
+        });
         assert_eq!(output, input);
     }
 

--- a/crates/tasks/src/for_each_ordered.rs
+++ b/crates/tasks/src/for_each_ordered.rs
@@ -1,6 +1,6 @@
 use crossbeam_utils::CachePadded;
-use rayon::iter::{IndexedParallelIterator, ParallelIterator};
 use parking_lot::{Condvar, Mutex};
+use rayon::iter::{IndexedParallelIterator, ParallelIterator};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Extension trait for [`IndexedParallelIterator`]
@@ -325,15 +325,12 @@ mod tests {
         let n = 64usize;
         let input: Vec<usize> = (0..n).collect();
         let mut output = Vec::with_capacity(n);
-        input
-            .par_iter()
-            .map(|&i| i)
-            .for_each_ordered(|x| {
-                if x % 8 == 0 {
-                    std::thread::yield_now();
-                }
-                output.push(x);
-            });
+        input.par_iter().map(|&i| i).for_each_ordered(|x| {
+            if x % 8 == 0 {
+                std::thread::yield_now();
+            }
+            output.push(x);
+        });
         assert_eq!(output, input);
     }
 


### PR DESCRIPTION
Current implementation calls rayon::yield_now if the slot isn't ready, making it go do work instead of actually waiting for the work to be done, meaning the function is called later than it should be.

Also removes all unsafe.