### PR TITLE
perf(trie): fast path for single-target proof calculation

### DIFF
--- a/crates/trie/trie/src/proof_v2/target.rs
+++ b/crates/trie/trie/src/proof_v2/target.rs
@@ -54,7 +54,7 @@ impl Target {
     // `min_len` of both 0 and 1 will therefore construct the root node, but only those with
     // `min_len` of 0 will retain it.
     #[inline]
-    fn sub_trie_prefix(&self) -> Nibbles {
+    pub(crate) fn sub_trie_prefix(&self) -> Nibbles {
         let mut sub_trie_prefix = self.key;
         sub_trie_prefix.truncate(self.min_len.saturating_sub(1) as usize);
         sub_trie_prefix


### PR DESCRIPTION
## Summary
Skip `iter_sub_trie_targets` overhead when there's exactly 1 proof target.

## Motivation
Tracy profiling shows 82% (2.18M/2.65M) of V2 storage proof calls have exactly 1 target. For these calls we can skip the sorting and chunking in `iter_sub_trie_targets` (two `sort_unstable` calls + `chunk_by_mut`) and directly construct `SubTrieTargets`.

## Changes
- `proof_inner`: added `targets.len() == 1` fast path that constructs `SubTrieTargets` directly
- `Target::sub_trie_prefix`: made `pub(crate)` so `proof_inner` can call it

## Testing
`cargo test -p reth-trie -- proof_v2` — all 9 tests pass (including the proptest).

Prompted by: georgios