### PR TITLE
fix(trie): replace unwrap with map for optional elapsed time in trace logging

### DIFF
--- a/crates/trie/trie/src/proof/trie_node.rs
+++ b/crates/trie/trie/src/proof/trie_node.rs
@@ -85,7 +85,7 @@ where
 
         trace!(
             target: "trie::proof::blinded",
-            elapsed = ?start.unwrap().elapsed(),
+            elapsed = ?start.map(|started| started.elapsed()),
             ?path,
             ?node,
             ?tree_mask,
@@ -139,7 +139,7 @@ where
         trace!(
             target: "trie::proof::blinded",
             account = ?self.account,
-            elapsed = ?start.unwrap().elapsed(),
+            elapsed = ?start.map(|started| started.elapsed()),
             ?path,
             ?node,
             ?tree_mask,


### PR DESCRIPTION
Replaces `.unwrap().elapsed()` with `.map(|started| started.elapsed())` in trace logging to prevent panic when TRACE level is disabled.