### PR TITLE
feat(rpc): add maxUsedGas to eth_simulateV1 response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,8 +122,7 @@ dependencies = [
 [[package]]
 name = "alloy-consensus"
 version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4ff99651d46cef43767b5e8262ea228cd05287409ccb0c947cc25e70a952f9"
+source = "git+https://github.com/alloy-rs/alloy?rev=2f4b609a48c6d117ec1e2b14740ad7362384319c#2f4b609a48c6d117ec1e2b14740ad7362384319c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -150,8 +149,7 @@ dependencies = [
 [[package]]
 name = "alloy-consensus-any"
 version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a0701b0eda8051a2398591113e7862f807ccdd3315d0b441f06c2a0865a379b"
+source = "git+https://github.com/alloy-rs/alloy?rev=2f4b609a48c6d117ec1e2b14740ad7362384319c#2f4b609a48c6d117ec1e2b14740ad7362384319c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -165,8 +163,7 @@ dependencies = [
 [[package]]
 name = "alloy-contract"
 version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c83c7a3c4e1151e8cac383d0a67ddf358f37e5ea51c95a1283d897c9de0a5a"
+source = "git+https://github.com/alloy-rs/alloy?rev=2f4b609a48c6d117ec1e2b14740ad7362384319c#2f4b609a48c6d117ec1e2b14740ad7362384319c"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -263,8 +260,7 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def1626eea28d48c6cc0a6f16f34d4af0001906e4f889df6c660b39c86fd044d"
+source = "git+https://github.com/alloy-rs/alloy?rev=2f4b609a48c6d117ec1e2b14740ad7362384319c#2f4b609a48c6d117ec1e2b14740ad7362384319c"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -312,8 +308,7 @@ dependencies = [
 [[package]]
 name = "alloy-genesis"
 version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55d9d1aba3f914f0e8db9e4616ae37f3d811426d95bdccf44e47d0605ab202f6"
+source = "git+https://github.com/alloy-rs/alloy?rev=2f4b609a48c6d117ec1e2b14740ad7362384319c#2f4b609a48c6d117ec1e2b14740ad7362384319c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -366,8 +361,7 @@ dependencies = [
 [[package]]
 name = "alloy-json-rpc"
 version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57586581f2008933241d16c3e3f633168b3a5d2738c5c42ea5246ec5e0ef17a"
+source = "git+https://github.com/alloy-rs/alloy?rev=2f4b609a48c6d117ec1e2b14740ad7362384319c#2f4b609a48c6d117ec1e2b14740ad7362384319c"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -381,8 +375,7 @@ dependencies = [
 [[package]]
 name = "alloy-network"
 version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b36c2a0ed74e48851f78415ca5b465211bd678891ba11e88fee09eac534bab1"
+source = "git+https://github.com/alloy-rs/alloy?rev=2f4b609a48c6d117ec1e2b14740ad7362384319c#2f4b609a48c6d117ec1e2b14740ad7362384319c"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -407,8 +400,7 @@ dependencies = [
 [[package]]
 name = "alloy-network-primitives"
 version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "636c8051da58802e757b76c3b65af610b95799f72423dc955737dec73de234fd"
+source = "git+https://github.com/alloy-rs/alloy?rev=2f4b609a48c6d117ec1e2b14740ad7362384319c#2f4b609a48c6d117ec1e2b14740ad7362384319c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -485,8 +477,7 @@ dependencies = [
 [[package]]
 name = "alloy-provider"
 version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3dd56e2eafe8b1803e325867ac2c8a4c73c9fb5f341ffd8347f9344458c5922"
+source = "git+https://github.com/alloy-rs/alloy?rev=2f4b609a48c6d117ec1e2b14740ad7362384319c#2f4b609a48c6d117ec1e2b14740ad7362384319c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -530,8 +521,7 @@ dependencies = [
 [[package]]
 name = "alloy-pubsub"
 version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eebf54983d4fccea08053c218ee5c288adf2e660095a243d0532a8070b43955"
+source = "git+https://github.com/alloy-rs/alloy?rev=2f4b609a48c6d117ec1e2b14740ad7362384319c#2f4b609a48c6d117ec1e2b14740ad7362384319c"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -574,8 +564,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-client"
 version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91577235d341a1bdbee30a463655d08504408a4d51e9f72edbfc5a622829f402"
+source = "git+https://github.com/alloy-rs/alloy?rev=2f4b609a48c6d117ec1e2b14740ad7362384319c#2f4b609a48c6d117ec1e2b14740ad7362384319c"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -600,8 +589,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types"
 version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cff039bf01a17d76c0aace3a3a773d5f895eb4c68baaae729ec9da9e86c99c"
+source = "git+https://github.com/alloy-rs/alloy?rev=2f4b609a48c6d117ec1e2b14740ad7362384319c#2f4b609a48c6d117ec1e2b14740ad7362384319c"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -613,8 +601,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-admin"
 version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "564afceae126df73b95f78c81eb46e2ef689a45ace0fcdaf5c9a178693a5ccca"
+source = "git+https://github.com/alloy-rs/alloy?rev=2f4b609a48c6d117ec1e2b14740ad7362384319c#2f4b609a48c6d117ec1e2b14740ad7362384319c"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -625,8 +612,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-anvil"
 version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22250cf438b6a3926de67683c08163bfa1fd1efa47ee9512cbcd631b6b0243c"
+source = "git+https://github.com/alloy-rs/alloy?rev=2f4b609a48c6d117ec1e2b14740ad7362384319c#2f4b609a48c6d117ec1e2b14740ad7362384319c"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -637,8 +623,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-any"
 version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73234a141ecce14e2989748c04fcac23deee67a445e2c4c167cfb42d4dacd1b6"
+source = "git+https://github.com/alloy-rs/alloy?rev=2f4b609a48c6d117ec1e2b14740ad7362384319c#2f4b609a48c6d117ec1e2b14740ad7362384319c"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -648,8 +633,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-beacon"
 version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625af0c3ebd3c31322edb1fb6b8e3e518acc39e164ed07e422eaff05310ff2fa"
+source = "git+https://github.com/alloy-rs/alloy?rev=2f4b609a48c6d117ec1e2b14740ad7362384319c#2f4b609a48c6d117ec1e2b14740ad7362384319c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -668,8 +652,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-debug"
 version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779f70ab16a77e305571881b07a9bc6b0068ae6f962497baf5762825c5b839fb"
+source = "git+https://github.com/alloy-rs/alloy?rev=2f4b609a48c6d117ec1e2b14740ad7362384319c#2f4b609a48c6d117ec1e2b14740ad7362384319c"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -680,8 +663,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-engine"
 version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10620d600cc46538f613c561ac9a923843c6c74c61f054828dcdb8dd18c72ec4"
+source = "git+https://github.com/alloy-rs/alloy?rev=2f4b609a48c6d117ec1e2b14740ad7362384319c#2f4b609a48c6d117ec1e2b14740ad7362384319c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -701,8 +683,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-eth"
 version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "010e101dbebe0c678248907a2545b574a87d078d82c2f6f5d0e8e7c9a6149a10"
+source = "git+https://github.com/alloy-rs/alloy?rev=2f4b609a48c6d117ec1e2b14740ad7362384319c#2f4b609a48c6d117ec1e2b14740ad7362384319c"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -713,7 +694,7 @@ dependencies = [
  "alloy-serde",
  "alloy-sol-types",
  "arbitrary",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -723,8 +704,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-mev"
 version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375e4bf001135fe4f344db6197fafed8c2b61e99fa14d3597f44cd413f79e45b"
+source = "git+https://github.com/alloy-rs/alloy?rev=2f4b609a48c6d117ec1e2b14740ad7362384319c#2f4b609a48c6d117ec1e2b14740ad7362384319c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -738,8 +718,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-trace"
 version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be096f74d85e1f927580b398bf7bc5b4aa62326f149680ec0867e3c040c9aced"
+source = "git+https://github.com/alloy-rs/alloy?rev=2f4b609a48c6d117ec1e2b14740ad7362384319c#2f4b609a48c6d117ec1e2b14740ad7362384319c"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -752,8 +731,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-txpool"
 version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14ab75189fbc29c5dd6f0bc1529bccef7b00773b458763f4d9d81a77ae4a1a2d"
+source = "git+https://github.com/alloy-rs/alloy?rev=2f4b609a48c6d117ec1e2b14740ad7362384319c#2f4b609a48c6d117ec1e2b14740ad7362384319c"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -764,8 +742,7 @@ dependencies = [
 [[package]]
 name = "alloy-serde"
 version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6d631f8b975229361d8af7b2c749af31c73b3cf1352f90e144ddb06227105e"
+source = "git+https://github.com/alloy-rs/alloy?rev=2f4b609a48c6d117ec1e2b14740ad7362384319c#2f4b609a48c6d117ec1e2b14740ad7362384319c"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -776,8 +753,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer"
 version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97f40010b5e8f79b70bf163b38cd15f529b18ca88c4427c0e43441ee54e4ed82"
+source = "git+https://github.com/alloy-rs/alloy?rev=2f4b609a48c6d117ec1e2b14740ad7362384319c#2f4b609a48c6d117ec1e2b14740ad7362384319c"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -791,8 +767,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer-local"
 version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c4ec1cc27473819399a3f0da83bc1cef0ceaac8c1c93997696e46dc74377a58"
+source = "git+https://github.com/alloy-rs/alloy?rev=2f4b609a48c6d117ec1e2b14740ad7362384319c#2f4b609a48c6d117ec1e2b14740ad7362384319c"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -880,8 +855,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport"
 version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a03bb3f02b9a7ab23dacd1822fa7f69aa5c8eefcdcf57fad085e0b8d76fb4334"
+source = "git+https://github.com/alloy-rs/alloy?rev=2f4b609a48c6d117ec1e2b14740ad7362384319c#2f4b609a48c6d117ec1e2b14740ad7362384319c"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -903,12 +877,11 @@ dependencies = [
 [[package]]
 name = "alloy-transport-http"
 version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce599598ef8ebe067f3627509358d9faaa1ef94f77f834a7783cd44209ef55c"
+source = "git+https://github.com/alloy-rs/alloy?rev=2f4b609a48c6d117ec1e2b14740ad7362384319c#2f4b609a48c6d117ec1e2b14740ad7362384319c"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "reqwest",
  "serde_json",
  "tower",
@@ -919,8 +892,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ipc"
 version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49963a2561ebd439549915ea61efb70a7b13b97500ec16ca507721c9d9957d07"
+source = "git+https://github.com/alloy-rs/alloy?rev=2f4b609a48c6d117ec1e2b14740ad7362384319c#2f4b609a48c6d117ec1e2b14740ad7362384319c"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -939,8 +911,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ws"
 version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ed38ea573c6658e0c2745af9d1f1773b1ed83aa59fbd9c286358ad469c3233a"
+source = "git+https://github.com/alloy-rs/alloy?rev=2f4b609a48c6d117ec1e2b14740ad7362384319c#2f4b609a48c6d117ec1e2b14740ad7362384319c"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -977,8 +948,7 @@ dependencies = [
 [[package]]
 name = "alloy-tx-macros"
 version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397406cf04b11ca2a48e6f81804c70af3f40a36abf648e11dc7416043eb0834d"
+source = "git+https://github.com/alloy-rs/alloy?rev=2f4b609a48c6d117ec1e2b14740ad7362384319c#2f4b609a48c6d117ec1e2b14740ad7362384319c"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -711,33 +711,33 @@ vergen-git2 = "9.1.0"
 ipnet = "2.11"
 
 [patch.crates-io]
-# alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-contract = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-genesis = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-admin = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-debug = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-mev = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-txpool = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-signer-local = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "2f4b609a48c6d117ec1e2b14740ad7362384319c" }
+alloy-contract = { git = "https://github.com/alloy-rs/alloy", rev = "2f4b609a48c6d117ec1e2b14740ad7362384319c" }
+alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "2f4b609a48c6d117ec1e2b14740ad7362384319c" }
+alloy-genesis = { git = "https://github.com/alloy-rs/alloy", rev = "2f4b609a48c6d117ec1e2b14740ad7362384319c" }
+alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", rev = "2f4b609a48c6d117ec1e2b14740ad7362384319c" }
+alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "2f4b609a48c6d117ec1e2b14740ad7362384319c" }
+alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "2f4b609a48c6d117ec1e2b14740ad7362384319c" }
+alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "2f4b609a48c6d117ec1e2b14740ad7362384319c" }
+alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", rev = "2f4b609a48c6d117ec1e2b14740ad7362384319c" }
+alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", rev = "2f4b609a48c6d117ec1e2b14740ad7362384319c" }
+alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "2f4b609a48c6d117ec1e2b14740ad7362384319c" }
+alloy-rpc-types-admin = { git = "https://github.com/alloy-rs/alloy", rev = "2f4b609a48c6d117ec1e2b14740ad7362384319c" }
+alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", rev = "2f4b609a48c6d117ec1e2b14740ad7362384319c" }
+alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", rev = "2f4b609a48c6d117ec1e2b14740ad7362384319c" }
+alloy-rpc-types-debug = { git = "https://github.com/alloy-rs/alloy", rev = "2f4b609a48c6d117ec1e2b14740ad7362384319c" }
+alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "2f4b609a48c6d117ec1e2b14740ad7362384319c" }
+alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "2f4b609a48c6d117ec1e2b14740ad7362384319c" }
+alloy-rpc-types-mev = { git = "https://github.com/alloy-rs/alloy", rev = "2f4b609a48c6d117ec1e2b14740ad7362384319c" }
+alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "2f4b609a48c6d117ec1e2b14740ad7362384319c" }
+alloy-rpc-types-txpool = { git = "https://github.com/alloy-rs/alloy", rev = "2f4b609a48c6d117ec1e2b14740ad7362384319c" }
+alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "2f4b609a48c6d117ec1e2b14740ad7362384319c" }
+alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "2f4b609a48c6d117ec1e2b14740ad7362384319c" }
+alloy-signer-local = { git = "https://github.com/alloy-rs/alloy", rev = "2f4b609a48c6d117ec1e2b14740ad7362384319c" }
+alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "2f4b609a48c6d117ec1e2b14740ad7362384319c" }
+alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", rev = "2f4b609a48c6d117ec1e2b14740ad7362384319c" }
+alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", rev = "2f4b609a48c6d117ec1e2b14740ad7362384319c" }
+alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", rev = "2f4b609a48c6d117ec1e2b14740ad7362384319c" }
 
 # op-alloy-consensus = { git = "https://github.com/alloy-rs/op-alloy", rev = "a79d6fc" }
 # op-alloy-network = { git = "https://github.com/alloy-rs/op-alloy", rev = "a79d6fc" }

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -363,6 +363,7 @@ where
                         ..SimulateError::invalid_params()
                     }),
                     gas_used,
+                    max_used_gas: Some(gas_used),
                     logs: Vec::new(),
                     status: false,
                 }
@@ -378,32 +379,36 @@ where
                         ..SimulateError::invalid_params()
                     }),
                     gas_used,
+                    max_used_gas: Some(gas_used),
                     status: false,
                     logs: Vec::new(),
                 }
             }
-            ExecutionResult::Success { output, gas_used, logs, .. } => SimCallResult {
-                return_data: output.into_data(),
-                error: None,
-                gas_used,
-                logs: logs
-                    .into_iter()
-                    .map(|log| {
-                        log_index += 1;
-                        alloy_rpc_types_eth::Log {
-                            inner: log,
-                            log_index: Some(log_index - 1),
-                            transaction_index: Some(index as u64),
-                            transaction_hash: Some(*tx.tx_hash()),
-                            block_hash: Some(block.hash()),
-                            block_number: Some(block.header().number()),
-                            block_timestamp: Some(block.header().timestamp()),
-                            ..Default::default()
-                        }
-                    })
-                    .collect(),
-                status: true,
-            },
+            ExecutionResult::Success { output, gas_used, gas_refunded, logs, .. } => {
+                SimCallResult {
+                    return_data: output.into_data(),
+                    error: None,
+                    gas_used,
+                    max_used_gas: Some(gas_used + gas_refunded),
+                    logs: logs
+                        .into_iter()
+                        .map(|log| {
+                            log_index += 1;
+                            alloy_rpc_types_eth::Log {
+                                inner: log,
+                                log_index: Some(log_index - 1),
+                                transaction_index: Some(index as u64),
+                                transaction_hash: Some(*tx.tx_hash()),
+                                block_hash: Some(block.hash()),
+                                block_number: Some(block.header().number()),
+                                block_timestamp: Some(block.header().timestamp()),
+                                ..Default::default()
+                            }
+                        })
+                        .collect(),
+                    status: true,
+                }
+            }
         };
 
         calls.push(call);


### PR DESCRIPTION
## Summary
Populates the new `maxUsedGas` field in `eth_simulateV1` call results, representing peak gas consumed during execution before refunds.

## Motivation
Implements [ethereum/execution-apis#746](https://github.com/ethereum/execution-apis/pull/746) / [ethereum/go-ethereum#32789](https://github.com/ethereum/go-ethereum/pull/32789).

`maxUsedGas` enables accurate gas limit estimation for complex tx sequences (e.g. approve + swap). The existing `gasUsed` (post-refund) can underestimate the required gas limit, causing tx failures.

## Changes
- `crates/rpc/rpc-eth-types/src/simulate.rs`: Populate `max_used_gas` in all `SimCallResult` construction sites
  - `Success`: `gas_used + gas_refunded` (peak gas before refunds)
  - `Halt`/`Revert`: `gas_used` (no refunds apply)
- `Cargo.toml`: Patch alloy crates to use [alloy-rs/alloy#3707](https://github.com/alloy-rs/alloy/pull/3707) which adds the `max_used_gas` field to `SimCallResult`

## Testing
`cargo test -p reth-rpc-eth-types` — all 18 tests pass.

Prompted by: mattsse