### PR TITLE
fix(rpc): enforce debug trace timeout by halting EVM execution (fixes #22027)

### DIFF
--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -76,7 +76,7 @@ jsonrpsee-types.workspace = true
 
 # async
 async-trait.workspace = true
-tokio = { workspace = true, features = ["sync"] }
+tokio = { workspace = true, features = ["sync", "time"] }
 tokio-stream.workspace = true
 pin-project.workspace = true
 parking_lot.workspace = true
@@ -100,6 +100,7 @@ reth-provider = { workspace = true, features = ["test-utils"] }
 reth-db-api.workspace = true
 
 rand.workspace = true
+tokio = { workspace = true, features = ["macros", "rt"] }
 
 jsonrpsee = { workspace = true, features = ["client"] }
 


### PR DESCRIPTION
## Problem

`debug_traceCallMany` (and related debug trace methods) do not enforce the `timeout` option as a hard execution limit. A previous fix used only `tokio::time::timeout` around the request future. As [reviewed](https://github.com/paradigmxyz/reth/pull/22248#discussion_r0), that approach does not work: it only cancels the request side; the blocking task that runs the EVM keeps running and keeps consuming CPU until the trace finishes.

## Solution

Timeout is enforced in two places:

1. **Cooperative cancellation inside the EVM**  
   A small inspector (`TimeoutInspector`) is composed with `DebugInspector` via revm’s tuple `(TimeoutInspector, DebugInspector)`. On every opcode, `TimeoutInspector::step()` checks a shared `Arc<AtomicBool>` cancellation flag. When the flag is set, it calls `interp.halt_fatal()`, which stops the interpreter loop (same mechanism revm uses for e.g. DB errors). A timer task is spawned that sleeps for the configured duration and then sets the flag. So when the timeout fires, the **next** opcode step in the blocking task sees the flag and halts; the blocking task then exits and the thread is freed.

2. **`tokio::time::timeout` around the request**  
   This is kept so the client gets a timely `ExecutionTimedOut` response even if the blocking task is slow to notice the flag. When the inspector halts first, we detect it (cancel flag set + `Err` from the closure) and still return `ExecutionTimedOut` so the API is consistent.

So the timeout both (a) stops the EVM and frees the blocking worker, and (b) returns the expected error to the client.

## Scope

- `trace_block` (used by `debug_traceBlockByNumber` / `debug_traceBlockByHash`)
- `debug_traceTransaction`
- `debug_traceCall` (including `debug_trace_call_at_tx_index`)
- `debug_traceCallMany`

Go-style duration parsing (`5s`, `300ms`, `1h30m`, etc.) and `ExecutionTimedOut` behavior are unchanged; only enforcement is fixed.

## Testing

- Unit tests for `parse_go_duration` (including roundtrip with `GethDebugTracingOptions::with_timeout`).
- Test that `TimeoutInspector::step()` calls `halt_fatal()` when the flag is set (interpreter ends with `FatalExternalError`).
- Test that the timer sets the flag and that `tokio::time::timeout` fires as expected.

Fixes #22027