### PR TITLE
ci: use normal Docker builds for fork PRs instead of Depot

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -15,7 +15,6 @@ on:
 
 jobs:
   build:
-    if: github.repository == 'paradigmxyz/reth'
     timeout-minutes: 45
     runs-on: ubuntu-latest
     permissions:
@@ -31,10 +30,22 @@ jobs:
           echo "sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
           echo "describe=$(git describe --always --tags)" >> "$GITHUB_OUTPUT"
 
+      - name: Detect fork
+        id: fork
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+            echo "is_fork=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_fork=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Depot build (upstream only)
       - name: Set up Depot CLI
+        if: steps.fork.outputs.is_fork == 'false'
         uses: depot/setup-action@v1
 
-      - name: Build reth image
+      - name: Build reth image (Depot)
+        if: steps.fork.outputs.is_fork == 'false'
         uses: depot/bake-action@v1
         env:
           DEPOT_TOKEN: ${{ secrets.DEPOT_TOKEN }}
@@ -45,6 +56,24 @@ jobs:
           files: docker-bake.hcl
           targets: ${{ inputs.hive_target }}
           push: false
+
+      # Docker build (forks)
+      - name: Set up Docker Buildx
+        if: steps.fork.outputs.is_fork == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build reth image (Docker)
+        if: steps.fork.outputs.is_fork == 'true'
+        uses: docker/bake-action@v6
+        env:
+          VERGEN_GIT_SHA: ${{ steps.git.outputs.sha }}
+          VERGEN_GIT_DESCRIBE: ${{ steps.git.outputs.describe }}
+        with:
+          files: docker-bake.hcl
+          targets: ${{ inputs.hive_target }}
+          push: false
+          set: |
+            *.dockerfile=Dockerfile
 
       - name: Upload reth image
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
## Summary
Fixes failing hive CI on fork PRs like #22259.

## Motivation
`docker-test.yml` guards with `github.repository == 'paradigmxyz/reth'`, but this is `true` for fork PRs targeting upstream. Fork PRs don't have `DEPOT_TOKEN` or `DEPOT_PROJECT_ID`, causing:
```
Error: Project ID is missing for target hive-stable
```

## Changes
- Detect fork PRs via `github.event.pull_request.head.repo.full_name`
- Upstream: still uses `depot/bake-action` with Depot sccache (`Dockerfile.depot`)
- Forks: falls back to `docker/bake-action` with the standard `Dockerfile` (slower but works without secrets)
- Removed the `if: github.repository == 'paradigmxyz/reth'` guard so forks can build Docker images too

Prompted by: alexey