### PR TITLE
docs: fix default jwt.hex path in cli args

### DIFF
--- a/crates/node/core/src/args/benchmark_args.rs
+++ b/crates/node/core/src/args/benchmark_args.rs
@@ -26,7 +26,8 @@ pub struct BenchmarkArgs {
     /// This will perform JWT authentication for all requests to the given engine RPC url.
     ///
     /// If no path is provided, a secret will be generated and stored in the datadir under
-    /// `<DIR>/<CHAIN_ID>/jwt.hex`. For mainnet this would be `~/.local/share/reth/mainnet/jwt.hex` by default.
+    /// `<DIR>/<CHAIN_ID>/jwt.hex`. For mainnet this would be `~/.local/share/reth/mainnet/jwt.hex`
+    /// by default.
     #[arg(
         long = "jwt-secret",
         alias = "jwtsecret",

--- a/crates/node/core/src/args/benchmark_args.rs
+++ b/crates/node/core/src/args/benchmark_args.rs
@@ -26,7 +26,7 @@ pub struct BenchmarkArgs {
     /// This will perform JWT authentication for all requests to the given engine RPC url.
     ///
     /// If no path is provided, a secret will be generated and stored in the datadir under
-    /// `<DIR>/<CHAIN_ID>/jwt.hex`. For mainnet this would be `~/.reth/mainnet/jwt.hex` by default.
+    /// `<DIR>/<CHAIN_ID>/jwt.hex`. For mainnet this would be `~/.local/share/reth/mainnet/jwt.hex` by default.
     #[arg(
         long = "jwt-secret",
         alias = "jwtsecret",

--- a/crates/node/core/src/args/rpc_server.rs
+++ b/crates/node/core/src/args/rpc_server.rs
@@ -483,7 +483,7 @@ pub struct RpcServerArgs {
     /// This will enforce JWT authentication for all requests coming from the consensus layer.
     ///
     /// If no path is provided, a secret will be generated and stored in the datadir under
-    /// `<DIR>/<CHAIN_ID>/jwt.hex`. For mainnet this would be `~/.reth/mainnet/jwt.hex` by default.
+    /// `<DIR>/<CHAIN_ID>/jwt.hex`. For mainnet this would be `~/.local/share/reth/mainnet/jwt.hex` by default.
     #[arg(long = "authrpc.jwtsecret", value_name = "PATH", global = true, required = false, default_value = Resettable::from(DefaultRpcServerArgs::get_global().auth_jwtsecret.as_ref().map(|v| v.to_string_lossy().into())))]
     pub auth_jwtsecret: Option<PathBuf>,
 

--- a/crates/node/core/src/args/rpc_server.rs
+++ b/crates/node/core/src/args/rpc_server.rs
@@ -483,7 +483,8 @@ pub struct RpcServerArgs {
     /// This will enforce JWT authentication for all requests coming from the consensus layer.
     ///
     /// If no path is provided, a secret will be generated and stored in the datadir under
-    /// `<DIR>/<CHAIN_ID>/jwt.hex`. For mainnet this would be `~/.local/share/reth/mainnet/jwt.hex` by default.
+    /// `<DIR>/<CHAIN_ID>/jwt.hex`. For mainnet this would be `~/.local/share/reth/mainnet/jwt.hex`
+    /// by default.
     #[arg(long = "authrpc.jwtsecret", value_name = "PATH", global = true, required = false, default_value = Resettable::from(DefaultRpcServerArgs::get_global().auth_jwtsecret.as_ref().map(|v| v.to_string_lossy().into())))]
     pub auth_jwtsecret: Option<PathBuf>,
 

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -372,7 +372,7 @@ RPC:
 
           This will enforce JWT authentication for all requests coming from the consensus layer.
 
-          If no path is provided, a secret will be generated and stored in the datadir under `<DIR>/<CHAIN_ID>/jwt.hex`. For mainnet this would be `~/.reth/mainnet/jwt.hex` by default.
+          If no path is provided, a secret will be generated and stored in the datadir under `<DIR>/<CHAIN_ID>/jwt.hex`. For mainnet this would be `~/.local/share/reth/mainnet/jwt.hex` by default.
 
       --auth-ipc
           Enable auth engine API over IPC


### PR DESCRIPTION
## Summary
Fix incorrect default `jwt.hex` path in doc comments and CLI reference — `~/.reth/mainnet/jwt.hex` → `~/.local/share/reth/mainnet/jwt.hex`.

## Changes
- `crates/node/core/src/args/rpc_server.rs` — `authrpc.jwtsecret` doc comment
- `crates/node/core/src/args/benchmark_args.rs` — `jwt-secret` doc comment
- `docs/vocs/docs/pages/cli/reth/node.mdx` — CLI reference page

Prompted by: alexey