### PR TITLE
fix(provider): skip sender pruning during reorg when sender_recovery is full

### DIFF
--- a/.changelog/rich-lakes-bark.md
+++ b/.changelog/rich-lakes-bark.md
@@ -1,0 +1,5 @@
+---
+reth-provider: patch
+---
+
+Fixed sender pruning during block reorg to skip when sender_recovery is fully pruned, preventing a fatal crash when no sender data exists in static files.

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -3576,7 +3576,12 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> BlockWriter
             })?;
         }
 
-        EitherWriter::new_senders(self, last_block_number)?.prune_senders(unwind_tx_from, block)?;
+        // Skip sender pruning when sender_recovery is fully pruned, since no sender data
+        // exists in static files or the database.
+        if self.prune_modes.sender_recovery.is_none_or(|m| !m.is_full()) {
+            EitherWriter::new_senders(self, last_block_number)?
+                .prune_senders(unwind_tx_from, block)?;
+        }
 
         self.remove_bodies_above(block)?;
 


### PR DESCRIPTION
## Summary
Fixes a fatal crash in the persistence service when a reorg occurs on a node running with `storage_v2 = true` and `sender_recovery = full`.

## Motivation
With `storage_v2` enabled and `sender_recovery = full`, no sender data is ever written to static files. However, `remove_blocks_above` unconditionally calls `EitherWriter::new_senders().prune_senders()`, which opens a static file writer for the `TransactionSenders` segment.

During a reorg, if the prune drops the max block below the current jar's range, `update_index` tries to load the previous jar (e.g. `transaction-senders_24350000_24399999`) which doesn't exist — crashing the persistence service and killing the node.

```
WARN Failed to load static file jar path="../hashed/node/static_files/static_file_transaction-senders_24350000_24399999" e=No such file or directory
ERROR Persistence service failed err=ProviderError(Other(FileSystem(Open { ... })))
ERROR Fatal error in consensus engine
```

## Changes
- Added a guard in `remove_blocks_above` (`crates/storage/provider/src/providers/database/provider.rs`) to skip sender pruning when `sender_recovery` prune mode is `Full`, matching the existing pattern in:
  - `SenderRecoveryStage::unwind` (line 207)
  - `StaticFileWriteCtx::write_senders` (line 477)

## Testing
Verified the crash is reproducible on a mainnet node at block 24445332 during a 1-block reorg with the above configuration. The fix prevents the code path from being reached.

Prompted by: joshie