### PR TITLE
fix(rpc): update eth_simulateV1 revert error code to 3

### DIFF
--- a/.changelog/fix-simulate-revert-code.md
+++ b/.changelog/fix-simulate-revert-code.md
@@ -1,0 +1,5 @@
+---
+reth-rpc-eth-types: patch
+---
+
+Updated `eth_simulateV1` revert error code from `-32000` to `3` to be consistent with `eth_call`, per [execution-apis#748](https://github.com/ethereum/execution-apis/pull/748).

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -31,8 +31,10 @@ use revm::{
 
 /// Error code for execution reverted in `eth_simulateV1`.
 ///
-/// <https://github.com/ethereum/execution-apis>
-pub const SIMULATE_REVERT_CODE: i32 = -32000;
+/// Consistent with `eth_call` revert error code.
+///
+/// <https://github.com/ethereum/execution-apis/pull/748>
+pub const SIMULATE_REVERT_CODE: i32 = 3;
 
 /// Error code for VM execution errors (e.g., out of gas) in `eth_simulateV1`.
 ///


### PR DESCRIPTION
## Summary
Updates `SIMULATE_REVERT_CODE` from `-32000` to `3` to be consistent with `eth_call`.

## Motivation
The [execution-apis spec](https://github.com/ethereum/execution-apis/pull/748) is updating the revert error code for `eth_simulateV1` to `3`, matching `eth_call`. Already adopted by [go-ethereum](https://github.com/ethereum/go-ethereum) and [erigon](https://github.com/erigontech/erigon/pull/19006).

## Changes
- Updated `SIMULATE_REVERT_CODE` constant in `crates/rpc/rpc-eth-types/src/simulate.rs` from `-32000` to `3`

Prompted by: mattsse