### PR TITLE
fix: avoid redundant allocations when parsing ERA1 filenames

### DIFF
--- a/crates/era-downloader/src/fs.rs
+++ b/crates/era-downloader/src/fs.rs
@@ -22,14 +22,18 @@ pub fn read_dir(
                 if path.extension() == Some("era1".as_ref()) &&
                     let Some(last) = path.components().next_back()
                 {
-                    let str = last.as_os_str().to_string_lossy().to_string();
-                    let parts = str.split('-').collect::<Vec<_>>();
+                    let name = last.as_os_str().to_string_lossy();
+                    let mut parts = name.split('-');
 
-                    if parts.len() == 3 {
-                        let number = usize::from_str(parts[1])?;
-
-                        return Ok(Some((number, path.into_boxed_path())));
+                    let Some(_prefix) = parts.next() else { return Ok(None) };
+                    let Some(number_str) = parts.next() else { return Ok(None) };
+                    let Some(_suffix) = parts.next() else { return Ok(None) };
+                    if parts.next().is_some() {
+                        return Ok(None);
                     }
+
+                    let number = usize::from_str(number_str)?;
+                    return Ok(Some((number, path.into_boxed_path())));
                 }
 
                 if path.file_name() == Some("checksums.txt".as_ref()) {


### PR DESCRIPTION


Avoid redundant `String` and `Vec` allocations when parsing ERA1 filenames in `read_dir`, keeping the existing filename semantics unchanged.

