### PR TITLE
feat(rpc): add query methods to ActiveFilters

### DIFF
--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -759,6 +759,26 @@ impl<T> ActiveFilters<T> {
     pub fn new() -> Self {
         Self { inner: Arc::new(Mutex::new(HashMap::default())) }
     }
+
+    /// Returns `true` if a filter with the given id exists.
+    pub async fn contains(&self, id: &FilterId) -> bool {
+        self.inner.lock().await.contains_key(id)
+    }
+
+    /// Returns the number of currently active filters.
+    pub async fn len(&self) -> usize {
+        self.inner.lock().await.len()
+    }
+
+    /// Returns `true` if there are no active filters.
+    pub async fn is_empty(&self) -> bool {
+        self.inner.lock().await.is_empty()
+    }
+
+    /// Returns all active filter ids.
+    pub async fn ids(&self) -> Vec<FilterId> {
+        self.inner.lock().await.keys().cloned().collect()
+    }
 }
 
 /// An installed filter


### PR DESCRIPTION
Add public API methods to inspect active filters:

- `contains`: check if a filter with a given id exists
- `len`: get the number of active filters
- `is_empty`: check if there are no active filters
- `ids`: get all active filter ids

These were missing from the public API, making it impossible to check if a filter exists or iterate over installed filters.