### PR TITLE
feat(rpc): update testing_buildBlockV1 to match latest spec

### DIFF
--- a/bin/reth-bench/src/bench/generate_big_block.rs
+++ b/bin/reth-bench/src/bench/generate_big_block.rs
@@ -774,7 +774,7 @@ impl Command {
                 withdrawals: Some(vec![]),
                 parent_beacon_block_root: Some(B256::ZERO),
             },
-            transactions: transactions.to_vec(),
+            transactions: Some(transactions.to_vec()),
             extra_data: None,
         };
 
@@ -787,8 +787,18 @@ impl Command {
             parent_hash = %parent_hash,
             "Sending to testing_buildBlockV1"
         );
-        let envelope: ExecutionPayloadEnvelopeV5 =
-            testing_provider.client().request("testing_buildBlockV1", [request]).await?;
+        let envelope: ExecutionPayloadEnvelopeV5 = testing_provider
+            .client()
+            .request(
+                "testing_buildBlockV1",
+                (
+                    request.parent_block_hash,
+                    request.payload_attributes,
+                    request.transactions,
+                    request.extra_data,
+                ),
+            )
+            .await?;
 
         let v4_envelope = envelope.try_into_v4()?;
 

--- a/crates/e2e-test-utils/src/node.rs
+++ b/crates/e2e-test-utils/src/node.rs
@@ -332,8 +332,17 @@ where
         let client =
             self.rpc_client().ok_or_else(|| eyre::eyre!("HTTP RPC client not available"))?;
 
-        let res: ExecutionPayloadEnvelopeV5 =
-            client.request("testing_buildBlockV1", [request]).await?;
+        let res: ExecutionPayloadEnvelopeV5 = client
+            .request(
+                "testing_buildBlockV1",
+                (
+                    request.parent_block_hash,
+                    request.payload_attributes,
+                    request.transactions,
+                    request.extra_data,
+                ),
+            )
+            .await?;
         eyre::Ok(res)
     }
 }

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -310,6 +310,7 @@ where
                 let mut testing_api = TestingApi::new(
                     container.registry.eth_api().clone(),
                     container.registry.evm_config().clone(),
+                    container.registry.pool().clone(),
                 );
                 if testing_skip_invalid_transactions {
                     testing_api = testing_api.with_skip_invalid_transactions();

--- a/crates/ethereum/node/tests/e2e/eth.rs
+++ b/crates/ethereum/node/tests/e2e/eth.rs
@@ -226,7 +226,7 @@ async fn test_testing_build_block_v1_osaka() -> eyre::Result<()> {
     let request = TestingBuildBlockRequestV1 {
         parent_block_hash: genesis_hash,
         payload_attributes,
-        transactions: vec![raw_tx],
+        transactions: Some(vec![raw_tx]),
         extra_data: None,
     };
 

--- a/crates/ethereum/node/tests/it/testing.rs
+++ b/crates/ethereum/node/tests/it/testing.rs
@@ -61,13 +61,23 @@ async fn testing_rpc_build_block_works() -> eyre::Result<()> {
             let request = TestingBuildBlockRequestV1 {
                 parent_block_hash,
                 payload_attributes,
-                transactions: vec![],
+                transactions: Some(vec![]),
                 extra_data: None,
             };
 
             tokio::spawn(async move {
-                let res: eyre::Result<ExecutionPayloadEnvelopeV4> =
-                    client.request("testing_buildBlockV1", [request]).await.map_err(Into::into);
+                let res: eyre::Result<ExecutionPayloadEnvelopeV4> = client
+                    .request(
+                        "testing_buildBlockV1",
+                        (
+                            request.parent_block_hash,
+                            request.payload_attributes,
+                            request.transactions,
+                            request.extra_data,
+                        ),
+                    )
+                    .await
+                    .map_err(Into::into);
                 let _ = tx.send(res);
             });
 

--- a/crates/rpc/rpc-api/src/testing.rs
+++ b/crates/rpc/rpc-api/src/testing.rs
@@ -5,10 +5,34 @@
 //! disabled by default and never be exposed on public-facing RPC without an
 //! explicit operator flag.
 
-use alloy_rpc_types_engine::ExecutionPayloadEnvelopeV5;
+use alloy_primitives::{Bytes, B256};
+use alloy_rpc_types_engine::{ExecutionPayloadEnvelopeV5, PayloadAttributes};
 use jsonrpsee::proc_macros::rpc;
 
-pub use alloy_rpc_types_engine::{TestingBuildBlockRequestV1, TESTING_BUILD_BLOCK_V1};
+pub use alloy_rpc_types_engine::TESTING_BUILD_BLOCK_V1;
+
+/// Request payload for `testing_buildBlockV1`.
+///
+/// This is a reth-local duplicate of the alloy type, updated to match the latest
+/// spec changes where `transactions` can be `null` (to build from mempool).
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TestingBuildBlockRequestV1 {
+    /// Parent block hash of the block to build.
+    pub parent_block_hash: B256,
+    /// Payload attributes (V3: timestamp, prevRandao, suggestedFeeRecipient,
+    /// withdrawals, parentBeaconBlockRoot).
+    pub payload_attributes: PayloadAttributes,
+    /// Raw signed transactions to force-include in order.
+    ///
+    /// - `Some(vec![])`: build an empty block (no transactions)
+    /// - `Some(vec![...])`: include exactly these transactions
+    /// - `None` / JSON `null`: build a block from the local transaction pool (mempool)
+    pub transactions: Option<Vec<Bytes>>,
+    /// Optional extra data for the block header.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extra_data: Option<Bytes>,
+}
 
 /// Testing RPC interface for building a block in a single call.
 ///
@@ -28,10 +52,18 @@ pub use alloy_rpc_types_engine::{TestingBuildBlockRequestV1, TESTING_BUILD_BLOCK
 pub trait TestingApi {
     /// Builds a block using the provided parent, payload attributes, and transactions.
     ///
-    /// See <https://github.com/marcindsobczak/execution-apis/blob/main/src/testing/testing_buildBlockV1.md>
+    /// The `transactions` parameter can be:
+    /// - An array of raw transactions to include
+    /// - An empty array to build an empty block
+    /// - `null` to build a block from the mempool
+    ///
+    /// See <https://github.com/ethereum/execution-apis/pull/747>
     #[method(name = "buildBlockV1")]
     async fn build_block_v1(
         &self,
-        request: TestingBuildBlockRequestV1,
+        parent_block_hash: B256,
+        payload_attributes: PayloadAttributes,
+        transactions: Option<Vec<Bytes>>,
+        extra_data: Option<Bytes>,
     ) -> jsonrpsee::core::RpcResult<ExecutionPayloadEnvelopeV5>;
 }


### PR DESCRIPTION
## Summary
Updates `testing_buildBlockV1` RPC to match the [latest execution-apis spec](https://github.com/ethereum/execution-apis/pull/747).

## Motivation
The spec changed to use positional params and nullable transactions (null = build from mempool). Changing the alloy `TestingBuildBlockRequestV1` type would be a breaking change, so we duplicate it locally in reth.

## Changes
- `crates/rpc/rpc-api/src/testing.rs`: Define local `TestingBuildBlockRequestV1` with `transactions: Option<Vec<Bytes>>` instead of re-exporting from alloy. RPC trait now uses 4 separate positional params.
- `crates/rpc/rpc/src/testing.rs`: Update impl to take separate params. When `transactions=null`, build block from mempool using `pool.best_transactions_with_attributes()` — same tx selection logic as pending block building (gas limit checks, blob gas, EIP-7934 size limits, nonce-too-low handling, private tx filtering).
- `crates/ethereum/node/src/node.rs`: Pass pool to `TestingApi::new()` (`TestingApi` now takes a `Pool` generic).
- All call sites (`e2e-test-utils`, `reth-bench`, integration tests) updated to pass positional params tuple and use `Some(vec![...])` for transactions.

## Testing
`cargo check` passes for all affected crates (`reth-rpc-api`, `reth-rpc`, `reth-node-ethereum --tests`, `reth-e2e-test-utils`, `reth-bench`).

Prompted by: mattsse