### PR TITLE
fix(cli): handle hex-encoded `--builder.extradata` values

### DIFF
--- a/crates/node/core/src/cli/config.rs
+++ b/crates/node/core/src/cli/config.rs
@@ -24,10 +24,8 @@ pub trait PayloadBuilderConfig {
     /// Otherwise, the raw UTF-8 bytes of the string are used.
     fn extra_data_bytes(&self) -> Bytes {
         let data = self.extra_data();
-        if let Some(hex_str) = data.strip_prefix("0x") {
-            if let Ok(decoded) = alloy_primitives::hex::decode(hex_str) {
-                return decoded.into();
-            }
+        if let Some(Ok(decoded)) = data.strip_prefix("0x").map(alloy_primitives::hex::decode) {
+            return decoded.into();
         }
         data.as_bytes().to_vec().into()
     }


### PR DESCRIPTION
## Summary
Fixes `--builder.extradata` rejecting valid 32-byte hex-encoded values.

## Motivation
Closes #22274 — the CLI parser validated string character count instead of decoded byte count, so a 32-byte SHA256 hash (`0x` + 64 hex chars) was rejected despite being exactly at the limit.

## Changes
- `ExtraDataValueParser::parse_ref()` in `crates/node/core/src/args/payload_builder.rs`: detect `0x` prefix, validate even length, pre-check decoded byte count before allocating, then hex-decode and validate
- `extra_data_bytes()` in `crates/node/core/src/cli/config.rs`: hex-decode `0x`-prefixed input instead of treating it as raw UTF-8 bytes
- Added tests for valid hex, oversized hex, invalid hex, and odd-length hex

## Testing
```
cargo test -p reth-node-core
# 100 passed; 0 failed
```

Prompted by: matthias