### PR TITLE
fix(trie): propagate parent span to proof workers

### DIFF
--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -166,11 +166,12 @@ impl ProofWorkerHandle {
         let storage_task_ctx = task_ctx.clone();
         let storage_avail = storage_available_workers.clone();
         let storage_roots = cached_storage_roots.clone();
+        let storage_parent_span = tracing::Span::current();
         runtime.spawn_blocking(move || {
             let worker_id = AtomicUsize::new(0);
             storage_rt.proof_storage_worker_pool().broadcast(storage_worker_count, |_| {
                 let worker_id = worker_id.fetch_add(1, Ordering::Relaxed);
-                let span = debug_span!(target: "trie::proof_task", "storage worker", ?worker_id);
+                let span = debug_span!(target: "trie::proof_task", parent: storage_parent_span.clone(), "storage worker", ?worker_id);
                 let _guard = span.enter();
 
                 #[cfg(feature = "metrics")]
@@ -203,11 +204,12 @@ impl ProofWorkerHandle {
         let account_rt = runtime.clone();
         let account_tx = storage_work_tx.clone();
         let account_avail = account_available_workers.clone();
+        let account_parent_span = tracing::Span::current();
         runtime.spawn_blocking(move || {
             let worker_id = AtomicUsize::new(0);
             account_rt.proof_account_worker_pool().broadcast(account_worker_count, |_| {
                 let worker_id = worker_id.fetch_add(1, Ordering::Relaxed);
-                let span = debug_span!(target: "trie::proof_task", "account worker", ?worker_id);
+                let span = debug_span!(target: "trie::proof_task", parent: account_parent_span.clone(), "account worker", ?worker_id);
                 let _guard = span.enter();
 
                 #[cfg(feature = "metrics")]


### PR DESCRIPTION
## Summary
Proof worker spans (`storage worker`, `account worker`) were orphaned from the trace tree because `spawn_blocking` didn't propagate the parent span.

## Motivation
When viewing execution traces via Tempo/blockscope, proof worker activity is invisible in the `on_new_payload` trace hierarchy. This makes it impossible to attribute time spent in proof computation back to the block being processed.

The same pattern is already used in `sparse_trie.rs` and `prewarm.rs` — this just brings `proof_task.rs` in line.

## Changes
- Capture `Span::current()` before each `spawn_blocking` call in `ProofWorkerHandle::new()`
- Set it as `parent:` on the storage and account worker debug spans

## Testing
Compile-checked. Tracing change only — no behavioral impact.

Prompted by: joshie