### PR TITLE
chore: reduce storage root span field size

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -577,7 +577,7 @@ where
             })
             .par_bridge_buffered()
             .for_each(|(address, trie)| {
-                let _enter = debug_span!(target: "engine::tree::payload_processor::sparse_trie", parent: &span, "storage root", ?address).entered();
+                let _enter = debug_span!(target: "engine::tree::payload_processor::sparse_trie", parent: &span, "storage root", a=%address).entered();
                 trie.root().expect("updates are drained, trie should be revealed by now");
             });
         drop(span);


### PR DESCRIPTION
Use short field name with Display formatting (`a=%address`) instead of Debug formatting (`?address`) for the `"storage root"` span in `compute_storage_roots`

This may be forgotten in #22253, which applied the same change to the `"storage trie leaf updates"` span but not to the `"storage root"` span in the same file.

