### PR TITLE
fix(rpc): resolve `AtBlockHash` to single block in `eth_getFilterChanges`

### DIFF
--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -271,11 +271,15 @@ where
                             .flatten();
                         logs_utils::get_filter_block_range(from, to, start_block, info)?
                     }
-                    FilterBlockOption::AtBlockHash(_) => {
+                    FilterBlockOption::AtBlockHash(block_hash) => {
                         // blockHash is equivalent to fromBlock = toBlock = the block number with
                         // hash blockHash
                         // get_logs_in_block_range is inclusive
-                        (start_block, best_number)
+                        let block_number = self
+                            .provider()
+                            .block_number(block_hash)?
+                            .ok_or(ProviderError::HeaderNotFound(block_hash.into()))?;
+                        (block_number, block_number)
                     }
                 };
                 let logs = self


### PR DESCRIPTION
When a log filter uses `blockHash`, `filter_changes` should only query that one block.
But it was returning `(start_block, best_number)` — scanning the entire range instead.

The comment right above even says "blockHash is equivalent to fromBlock = toBlock = the block
number with hash blockHash", the code just... didn't do that.

The fix resolves the hash to its block number and uses `(block_number, block_number)`,
matching how `logs_for_filter` already handles `AtBlockHash`.
