### PR TITLE
fix(rpc): simplify error wrapping in AtBlockHash filter path

### DIFF
--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -271,11 +271,15 @@ where
                             .flatten();
                         logs_utils::get_filter_block_range(from, to, start_block, info)?
                     }
-                    FilterBlockOption::AtBlockHash(_) => {
+                    FilterBlockOption::AtBlockHash(block_hash) => {
                         // blockHash is equivalent to fromBlock = toBlock = the block number with
                         // hash blockHash
                         // get_logs_in_block_range is inclusive
-                        (start_block, best_number)
+                        let block_number = self
+                            .provider()
+                            .block_number(block_hash)?
+                            .ok_or(ProviderError::HeaderNotFound(block_hash.into()))?;
+                        (block_number, block_number)
                     }
                 };
                 let logs = self


### PR DESCRIPTION
Followup to #22283 — removes the unnecessary explicit `EthFilterError::from()` wrapper around `ProviderError::HeaderNotFound` in the `AtBlockHash` arm of `filter_changes`. The `?` operator handles the `ProviderError -> EthFilterError` conversion automatically, matching the pattern used in `logs_for_filter`.