### PR TITLE
refactor(trie): drop V2 suffix from trie proof types

### DIFF
--- a/.changelog/drop-v2-suffix.md
+++ b/.changelog/drop-v2-suffix.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Drop V2 suffix from trie types now that legacy proof code paths have been removed.

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -8,7 +8,7 @@ use metrics::{Gauge, Histogram};
 use reth_metrics::Metrics;
 use reth_revm::state::EvmState;
 use reth_trie::{HashedPostState, HashedStorage};
-use reth_trie_parallel::targets_v2::MultiProofTargetsV2;
+use reth_trie_parallel::targets::MultiProofTargets;
 use std::sync::Arc;
 use tracing::trace;
 
@@ -44,7 +44,7 @@ pub(crate) const DEFAULT_MAX_TARGETS_FOR_CHUNKING: usize = 300;
 #[derive(Debug)]
 pub enum MultiProofMessage {
     /// Prefetch proof targets
-    PrefetchProofs(MultiProofTargetsV2),
+    PrefetchProofs(MultiProofTargets),
     /// New state update from transaction execution with its source
     StateUpdate(Source, EvmState),
     /// State update that can be applied to the sparse trie without any new proofs.

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -33,7 +33,7 @@ use reth_provider::{
 };
 use reth_revm::{database::StateProviderDatabase, state::EvmState};
 use reth_tasks::{pool::WorkerPool, Runtime};
-use reth_trie_parallel::targets_v2::MultiProofTargetsV2;
+use reth_trie_parallel::targets::MultiProofTargets;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     mpsc::{self, channel, Receiver, Sender},
@@ -617,12 +617,12 @@ where
     }
 }
 
-/// Returns a set of [`MultiProofTargetsV2`] and the total amount of storage targets, based on the
+/// Returns a set of [`MultiProofTargets`] and the total amount of storage targets, based on the
 /// given state.
-fn multiproof_targets_from_state(state: EvmState) -> (MultiProofTargetsV2, usize) {
+fn multiproof_targets_from_state(state: EvmState) -> (MultiProofTargets, usize) {
     use reth_trie::proof_v2;
 
-    let mut targets = MultiProofTargetsV2::default();
+    let mut targets = MultiProofTargets::default();
     let mut storage_target_count = 0;
     for (addr, account) in state {
         // if the account was not touched, or if the account was selfdestructed, do not
@@ -659,12 +659,12 @@ fn multiproof_targets_from_state(state: EvmState) -> (MultiProofTargetsV2, usize
     (targets, storage_target_count)
 }
 
-/// Returns [`MultiProofTargetsV2`] for withdrawal addresses.
+/// Returns [`MultiProofTargets`] for withdrawal addresses.
 ///
 /// Withdrawals only modify account balances (no storage), so the targets contain
 /// only account-level entries with empty storage sets.
-fn multiproof_targets_from_withdrawals(withdrawals: &[Withdrawal]) -> MultiProofTargetsV2 {
-    MultiProofTargetsV2 {
+fn multiproof_targets_from_withdrawals(withdrawals: &[Withdrawal]) -> MultiProofTargets {
+    MultiProofTargets {
         account_targets: withdrawals.iter().map(|w| keccak256(w.address).into()).collect(),
         ..Default::default()
     }

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -16,7 +16,7 @@ use rayon::iter::ParallelIterator;
 use reth_primitives_traits::{Account, FastInstant as Instant, ParallelBridgeBuffered};
 use reth_tasks::Runtime;
 use reth_trie::{
-    proof_v2::Target, updates::TrieUpdates, DecodedMultiProofV2, HashedPostState, TrieAccount,
+    proof_v2::Target, updates::TrieUpdates, DecodedMultiProof, HashedPostState, TrieAccount,
     EMPTY_ROOT_HASH, TRIE_ACCOUNT_RLP_MAX_SIZE,
 };
 use reth_trie_parallel::{
@@ -24,7 +24,7 @@ use reth_trie_parallel::{
         AccountMultiproofInput, ProofResultContext, ProofResultMessage, ProofWorkerHandle,
     },
     root::ParallelStateRootError,
-    targets_v2::MultiProofTargetsV2,
+    targets::MultiProofTargets,
 };
 #[cfg(feature = "trie-debug")]
 use reth_trie_sparse::debug_recorder::TrieDebugRecorder;
@@ -356,7 +356,7 @@ where
         target = "engine::tree::payload_processor::sparse_trie",
         skip_all
     )]
-    fn on_prewarm_targets(&mut self, targets: MultiProofTargetsV2) {
+    fn on_prewarm_targets(&mut self, targets: MultiProofTargets) {
         for target in targets.account_targets {
             // Only touch accounts that are not yet present in the updates set.
             self.new_account_updates.entry(target.key()).or_insert(LeafUpdate::Touched);
@@ -423,11 +423,8 @@ where
         }
     }
 
-    fn on_proof_result(
-        &mut self,
-        result: DecodedMultiProofV2,
-    ) -> Result<(), ParallelStateRootError> {
-        self.trie.reveal_decoded_multiproof_v2(result).map_err(|e| {
+    fn on_proof_result(&mut self, result: DecodedMultiProof) -> Result<(), ParallelStateRootError> {
+        self.trie.reveal_decoded_multiproof(result).map_err(|e| {
             ParallelStateRootError::Other(format!("could not reveal multiproof: {e:?}"))
         })
     }
@@ -674,7 +671,7 @@ where
             self.max_targets_for_chunking,
             self.proof_worker_handle.available_account_workers(),
             self.proof_worker_handle.available_storage_workers(),
-            MultiProofTargetsV2::chunks,
+            MultiProofTargets::chunks,
             |proof_targets| {
                 if let Err(e) =
                     self.proof_worker_handle.dispatch_account_multiproof(AccountMultiproofInput {
@@ -712,7 +709,7 @@ fn encode_account_leaf_value(
 #[derive(Default)]
 struct PendingTargets {
     /// The proof targets.
-    targets: MultiProofTargetsV2,
+    targets: MultiProofTargets,
     /// Number of account + storage proof targets currently queued.
     len: usize,
 }
@@ -729,7 +726,7 @@ impl PendingTargets {
     }
 
     /// Takes the pending targets, replacing with empty defaults.
-    fn take(&mut self) -> (MultiProofTargetsV2, usize) {
+    fn take(&mut self) -> (MultiProofTargets, usize) {
         (std::mem::take(&mut self.targets), std::mem::take(&mut self.len))
     }
 
@@ -751,7 +748,7 @@ enum SparseTrieTaskMessage {
     /// A hashed state update ready to be processed.
     HashedState(HashedPostState),
     /// Prefetch proof targets (passed through directly).
-    PrefetchProofs(MultiProofTargetsV2),
+    PrefetchProofs(MultiProofTargets),
     /// Signals that all state updates have been received.
     FinishedStateUpdates,
 }

--- a/crates/trie/common/src/lib.rs
+++ b/crates/trie/common/src/lib.rs
@@ -49,7 +49,7 @@ mod subnode;
 pub use subnode::StoredSubNode;
 
 mod trie;
-pub use trie::{BranchNodeMasks, BranchNodeMasksMap, ProofTrieNode};
+pub use trie::{BranchNodeMasks, BranchNodeMasksMap, LegacyProofTrieNode};
 
 mod trie_node_v2;
 pub use trie_node_v2::*;

--- a/crates/trie/common/src/trie.rs
+++ b/crates/trie/common/src/trie.rs
@@ -36,8 +36,8 @@ pub type BranchNodeMasksMap = HashMap<Nibbles, BranchNodeMasks>;
 
 /// Carries all information needed by a sparse trie to reveal a particular node.
 ///
-/// This is the legacy version that wraps alloy's [`TrieNode`]. Prefer [`ProofTrieNode`] (from
-/// `trie_node_v2` module) which merges extension nodes into branch nodes.
+/// This is the legacy version that wraps alloy's [`TrieNode`]. Prefer
+/// [`crate::ProofTrieNode`] which merges extension nodes into branch nodes.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LegacyProofTrieNode {
     /// Path of the node.

--- a/crates/trie/common/src/trie.rs
+++ b/crates/trie/common/src/trie.rs
@@ -35,8 +35,11 @@ impl BranchNodeMasks {
 pub type BranchNodeMasksMap = HashMap<Nibbles, BranchNodeMasks>;
 
 /// Carries all information needed by a sparse trie to reveal a particular node.
+///
+/// This is the legacy version that wraps alloy's [`TrieNode`]. Prefer [`ProofTrieNode`] (from
+/// `trie_node_v2` module) which merges extension nodes into branch nodes.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ProofTrieNode {
+pub struct LegacyProofTrieNode {
     /// Path of the node.
     pub path: Nibbles,
     /// The node itself.

--- a/crates/trie/common/src/trie_node_v2.rs
+++ b/crates/trie/common/src/trie_node_v2.rs
@@ -1,4 +1,4 @@
-//! Version 2 types related to representing nodes in an MPT.
+//! Types related to representing nodes in an MPT with merged extension and branch nodes.
 
 use crate::BranchNodeMasks;
 use alloc::vec::Vec;
@@ -12,7 +12,7 @@ use core::fmt;
 
 /// Carries all information needed by a sparse trie to reveal a particular node.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ProofTrieNodeV2 {
+pub struct ProofTrieNode {
     /// Path of the node.
     pub path: Nibbles,
     /// The node itself.
@@ -22,8 +22,8 @@ pub struct ProofTrieNodeV2 {
     pub masks: Option<BranchNodeMasks>,
 }
 
-impl ProofTrieNodeV2 {
-    /// Converts an iterator of `(path, TrieNode, masks)` tuples into `Vec<ProofTrieNodeV2>`,
+impl ProofTrieNode {
+    /// Converts an iterator of `(path, TrieNode, masks)` tuples into `Vec<ProofTrieNode>`,
     /// merging extension nodes into their child branch nodes.
     ///
     /// The input **must** be sorted in depth-first order (children before parents) for extension
@@ -91,8 +91,8 @@ impl ProofTrieNodeV2 {
 
 /// Enum representing an MPT trie node.
 ///
-/// This is a V2 representiation, differing from [`TrieNode`] in that branch and extension nodes are
-/// compressed into a single node.
+/// This differs from [`TrieNode`] in that branch and extension nodes are compressed into a single
+/// node.
 #[derive(PartialEq, Eq, Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum TrieNodeV2 {

--- a/crates/trie/parallel/src/lib.rs
+++ b/crates/trie/parallel/src/lib.rs
@@ -20,11 +20,11 @@ pub mod root;
 /// Implementation of parallel proof computation.
 pub mod proof_task;
 
-/// Async value encoder for V2 proofs.
+/// Async value encoder for proofs.
 pub(crate) mod value_encoder;
 
-/// V2 multiproof targets and chunking.
-pub mod targets_v2;
+/// Multiproof targets and chunking.
+pub mod targets;
 
 /// Parallel state root metrics.
 #[cfg(feature = "metrics")]

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -30,7 +30,7 @@
 
 use crate::{
     root::ParallelStateRootError,
-    targets_v2::MultiProofTargetsV2,
+    targets::MultiProofTargets,
     value_encoder::{AsyncAccountValueEncoder, ValueEncoderStats},
 };
 use alloy_primitives::{
@@ -48,7 +48,7 @@ use reth_trie::{
     proof::{ProofBlindedAccountProvider, ProofBlindedStorageProvider},
     proof_v2,
     trie_cursor::TrieCursorFactory,
-    DecodedMultiProofV2, HashedPostState, Nibbles, ProofTrieNodeV2,
+    DecodedMultiProof, HashedPostState, Nibbles, ProofTrieNode,
 };
 use reth_trie_sparse::provider::{RevealedNode, TrieNodeProvider, TrieNodeProviderFactory};
 use std::{
@@ -70,8 +70,8 @@ use crate::proof_task_metrics::{
 
 type TrieNodeProviderResult = Result<Option<RevealedNode>, SparseTrieError>;
 
-/// Type alias for the V2 account proof calculator.
-type V2AccountProofCalculator<'a, Provider> = proof_v2::ProofCalculator<
+/// Type alias for the account proof calculator.
+type AccountProofCalculator<'a, Provider> = proof_v2::ProofCalculator<
     <Provider as TrieCursorFactory>::AccountTrieCursor<'a>,
     <Provider as HashedCursorFactory>::AccountCursor<'a>,
     AsyncAccountValueEncoder<
@@ -80,8 +80,8 @@ type V2AccountProofCalculator<'a, Provider> = proof_v2::ProofCalculator<
     >,
 >;
 
-/// Type alias for the V2 storage proof calculator.
-type V2StorageProofCalculator<'a, Provider> = proof_v2::StorageProofCalculator<
+/// Type alias for the storage proof calculator.
+type StorageProofCalculator<'a, Provider> = proof_v2::StorageProofCalculator<
     <Provider as TrieCursorFactory>::StorageTrieCursor<'a>,
     <Provider as HashedCursorFactory>::StorageCursor<'a>,
 >;
@@ -414,7 +414,7 @@ impl<Provider> ProofTaskTx<Provider>
 where
     Provider: TrieCursorFactory + HashedCursorFactory,
 {
-    fn compute_v2_storage_proof(
+    fn compute_storage_proof(
         &self,
         input: StorageProofInput,
         calculator: &mut proof_v2::StorageProofCalculator<
@@ -426,7 +426,7 @@ where
 
         let span = debug_span!(
             target: "trie::proof_task",
-            "V2 Storage proof calculation",
+            "Storage proof calculation",
             n = %targets.len(),
         );
         let _span_guard = span.enter();
@@ -449,7 +449,7 @@ where
             proof_time_us = proof_start.elapsed().as_micros(),
             ?root,
             worker_id = self.id,
-            "Completed V2 storage proof calculation"
+            "Completed storage proof calculation"
         );
 
         Ok(StorageProofResult { proof, root })
@@ -530,7 +530,7 @@ pub type ProofResultSender = CrossbeamSender<ProofResultMessage>;
 #[derive(Debug)]
 pub struct ProofResultMessage {
     /// The proof calculation result
-    pub result: Result<DecodedMultiProofV2, ParallelStateRootError>,
+    pub result: Result<DecodedMultiProof, ParallelStateRootError>,
     /// Time taken for the entire proof calculation (from dispatch to completion)
     pub elapsed: Duration,
     /// Original state update that triggered this proof
@@ -565,9 +565,9 @@ impl ProofResultContext {
 /// The results of a storage proof calculation.
 #[derive(Debug)]
 pub(crate) struct StorageProofResult {
-    /// The calculated V2 proof nodes
-    pub proof: Vec<ProofTrieNodeV2>,
-    /// The storage root calculated by the V2 proof
+    /// The calculated proof nodes
+    pub proof: Vec<ProofTrieNode>,
+    /// The storage root calculated by the proof
     pub root: Option<B256>,
 }
 
@@ -692,7 +692,7 @@ where
         let mut cursor_metrics_cache = ProofTaskCursorMetricsCache::default();
         let trie_cursor = proof_tx.provider.storage_trie_cursor(B256::ZERO)?;
         let hashed_cursor = proof_tx.provider.hashed_storage_cursor(B256::ZERO)?;
-        let mut v2_calculator =
+        let mut calculator =
             proof_v2::StorageProofCalculator::new_storage(trie_cursor, hashed_cursor);
 
         // Initially mark this worker as available.
@@ -711,7 +711,7 @@ where
                 StorageWorkerJob::StorageProof { input, proof_result_sender } => {
                     self.process_storage_proof(
                         &proof_tx,
-                        &mut v2_calculator,
+                        &mut calculator,
                         input,
                         proof_result_sender,
                         &mut storage_proofs_processed,
@@ -759,7 +759,7 @@ where
     fn process_storage_proof<Provider>(
         &self,
         proof_tx: &ProofTaskTx<Provider>,
-        v2_calculator: &mut proof_v2::StorageProofCalculator<
+        calculator: &mut proof_v2::StorageProofCalculator<
             <Provider as TrieCursorFactory>::StorageTrieCursor<'_>,
             <Provider as HashedCursorFactory>::StorageCursor<'_>,
         >,
@@ -777,10 +777,10 @@ where
             worker_id = self.worker_id,
             hashed_address = ?hashed_address,
             targets_len = input.targets.len(),
-            "Processing V2 storage proof"
+            "Processing storage proof"
         );
 
-        let result = proof_tx.compute_v2_storage_proof(input, v2_calculator);
+        let result = proof_tx.compute_storage_proof(input, calculator);
 
         let proof_elapsed = proof_start.elapsed();
         *storage_proofs_processed += 1;
@@ -945,7 +945,7 @@ where
         let mut account_nodes_processed = 0u64;
         let mut cursor_metrics_cache = ProofTaskCursorMetricsCache::default();
 
-        // Create both account and storage calculators for V2 proofs.
+        // Create both account and storage calculators for proofs.
         // The storage calculator is wrapped in Rc<RefCell<...>> for sharing with value encoders.
         let account_trie_cursor = provider.account_trie_cursor()?;
         let account_hashed_cursor = provider.hashed_account_cursor()?;
@@ -953,7 +953,7 @@ where
         let storage_trie_cursor = provider.storage_trie_cursor(B256::ZERO)?;
         let storage_hashed_cursor = provider.hashed_storage_cursor(B256::ZERO)?;
 
-        let mut v2_account_calculator = proof_v2::ProofCalculator::<
+        let mut account_calculator = proof_v2::ProofCalculator::<
             _,
             _,
             AsyncAccountValueEncoder<
@@ -961,7 +961,7 @@ where
                 <Factory::Provider as HashedCursorFactory>::StorageCursor<'_>,
             >,
         >::new(account_trie_cursor, account_hashed_cursor);
-        let v2_storage_calculator =
+        let storage_calculator =
             Rc::new(RefCell::new(proof_v2::StorageProofCalculator::new_storage(
                 storage_trie_cursor,
                 storage_hashed_cursor,
@@ -983,8 +983,8 @@ where
             match job {
                 AccountWorkerJob::AccountMultiproof { input } => {
                     let value_encoder_stats = self.process_account_multiproof::<Factory::Provider>(
-                        &mut v2_account_calculator,
-                        v2_storage_calculator.clone(),
+                        &mut account_calculator,
+                        storage_calculator.clone(),
                         *input,
                         &mut account_proofs_processed,
                         &mut cursor_metrics_cache,
@@ -1030,42 +1030,41 @@ where
         Ok(())
     }
 
-    fn compute_v2_account_multiproof<'a, Provider>(
+    fn compute_account_multiproof<'a, Provider>(
         &self,
-        v2_account_calculator: &mut V2AccountProofCalculator<'a, Provider>,
-        v2_storage_calculator: Rc<RefCell<V2StorageProofCalculator<'a, Provider>>>,
-        targets: MultiProofTargetsV2,
-    ) -> Result<(DecodedMultiProofV2, ValueEncoderStats), ParallelStateRootError>
+        account_calculator: &mut AccountProofCalculator<'a, Provider>,
+        storage_calculator: Rc<RefCell<StorageProofCalculator<'a, Provider>>>,
+        targets: MultiProofTargets,
+    ) -> Result<(DecodedMultiProof, ValueEncoderStats), ParallelStateRootError>
     where
         Provider: TrieCursorFactory + HashedCursorFactory + 'a,
     {
-        let MultiProofTargetsV2 { mut account_targets, storage_targets } = targets;
+        let MultiProofTargets { mut account_targets, storage_targets } = targets;
 
         let span = debug_span!(
             target: "trie::proof_task",
-            "Account V2 multiproof calculation",
+            "Account multiproof calculation",
             account_targets = account_targets.len(),
             storage_targets = storage_targets.values().map(|t| t.len()).sum::<usize>(),
         );
         let _span_guard = span.enter();
 
-        trace!(target: "trie::proof_task", "Processing V2 account multiproof");
+        trace!(target: "trie::proof_task", "Processing account multiproof");
 
         let storage_proof_receivers =
-            dispatch_v2_storage_proofs(&self.storage_work_tx, &account_targets, storage_targets)?;
+            dispatch_storage_proofs(&self.storage_work_tx, &account_targets, storage_targets)?;
 
         let mut value_encoder = AsyncAccountValueEncoder::new(
             storage_proof_receivers,
             self.cached_storage_roots.clone(),
-            v2_storage_calculator,
+            storage_calculator,
         );
 
-        let account_proofs =
-            v2_account_calculator.proof(&mut value_encoder, &mut account_targets)?;
+        let account_proofs = account_calculator.proof(&mut value_encoder, &mut account_targets)?;
 
         let (storage_proofs, value_encoder_stats) = value_encoder.finalize()?;
 
-        let proof = DecodedMultiProofV2 { account_proofs, storage_proofs };
+        let proof = DecodedMultiProof { account_proofs, storage_proofs };
 
         Ok((proof, value_encoder_stats))
     }
@@ -1075,8 +1074,8 @@ where
     /// Returns stats from the value encoder used during proof computation.
     fn process_account_multiproof<'a, Provider>(
         &self,
-        v2_account_calculator: &mut V2AccountProofCalculator<'a, Provider>,
-        v2_storage_calculator: Rc<RefCell<V2StorageProofCalculator<'a, Provider>>>,
+        account_calculator: &mut AccountProofCalculator<'a, Provider>,
+        storage_calculator: Rc<RefCell<StorageProofCalculator<'a, Provider>>>,
         input: AccountMultiproofInput,
         account_proofs_processed: &mut u64,
         cursor_metrics_cache: &mut ProofTaskCursorMetricsCache,
@@ -1088,9 +1087,9 @@ where
         let proof_start = Instant::now();
 
         let AccountMultiproofInput { targets, proof_result_sender } = input;
-        let (result, value_encoder_stats) = match self.compute_v2_account_multiproof::<Provider>(
-            v2_account_calculator,
-            v2_storage_calculator,
+        let (result, value_encoder_stats) = match self.compute_account_multiproof::<Provider>(
+            account_calculator,
+            storage_calculator,
             targets,
         ) {
             Ok((proof, stats)) => (Ok(proof), stats),
@@ -1187,14 +1186,14 @@ where
     }
 }
 
-/// Queues V2 storage proofs for all accounts in the targets and returns receivers.
+/// Queues storage proofs for all accounts in the targets and returns receivers.
 ///
 /// This function queues all storage proof tasks to the worker pool but returns immediately
 /// with receivers, allowing the account trie walk to proceed in parallel with storage proof
 /// computation. This enables interleaved parallelism for better performance.
 ///
 /// Propagates errors up if queuing fails. Receivers must be consumed by the caller.
-fn dispatch_v2_storage_proofs(
+fn dispatch_storage_proofs(
     storage_work_tx: &CrossbeamSender<StorageWorkerJob>,
     account_targets: &[proof_v2::Target],
     mut storage_targets: B256Map<Vec<proof_v2::Target>>,
@@ -1261,7 +1260,7 @@ impl StorageProofInput {
 #[derive(Debug)]
 pub struct AccountMultiproofInput {
     /// The targets for which to compute the multiproof.
-    pub targets: MultiProofTargetsV2,
+    pub targets: MultiProofTargets,
     /// Context for sending the proof result.
     pub proof_result_sender: ProofResultContext,
 }

--- a/crates/trie/sparse/src/debug_recorder.rs
+++ b/crates/trie/sparse/src/debug_recorder.rs
@@ -89,8 +89,8 @@ pub struct ProofTrieNodeRecord {
 }
 
 impl ProofTrieNodeRecord {
-    /// Creates a record from a [`reth_trie_common::ProofTrieNode`].
-    pub fn from_proof_trie_node(node: &reth_trie_common::ProofTrieNode) -> Self {
+    /// Creates a record from a [`reth_trie_common::LegacyProofTrieNode`].
+    pub fn from_legacy_proof_trie_node(node: &reth_trie_common::LegacyProofTrieNode) -> Self {
         Self {
             path: node.path,
             node: TrieNodeRecord(node.node.clone()),
@@ -98,8 +98,8 @@ impl ProofTrieNodeRecord {
         }
     }
 
-    /// Creates a record from a [`reth_trie_common::ProofTrieNodeV2`].
-    pub fn from_proof_trie_node_v2(node: &reth_trie_common::ProofTrieNodeV2) -> Self {
+    /// Creates a record from a [`reth_trie_common::ProofTrieNode`].
+    pub fn from_proof_trie_node(node: &reth_trie_common::ProofTrieNode) -> Self {
         use reth_trie_common::TrieNodeV2;
         let trie_node = match &node.node {
             TrieNodeV2::EmptyRoot => TrieNode::EmptyRoot,

--- a/crates/trie/sparse/src/parallel.rs
+++ b/crates/trie/sparse/src/parallel.rs
@@ -18,7 +18,7 @@ use reth_primitives_traits::FastInstant as Instant;
 use reth_trie_common::{
     prefix_set::{PrefixSet, PrefixSetMut},
     BranchNodeMasks, BranchNodeMasksMap, BranchNodeRef, ExtensionNodeRef, LeafNodeRef, Nibbles,
-    ProofTrieNodeV2, RlpNode, TrieNodeV2,
+    ProofTrieNode, RlpNode, TrieNodeV2,
 };
 use smallvec::SmallVec;
 use tracing::{instrument, trace};
@@ -169,7 +169,7 @@ impl SparseTrie for ParallelSparseTrie {
     ) -> SparseTrieResult<()> {
         #[cfg(feature = "trie-debug")]
         self.debug_recorder.record(RecordedOp::SetRoot {
-            node: ProofTrieNodeRecord::from_proof_trie_node_v2(&ProofTrieNodeV2 {
+            node: ProofTrieNodeRecord::from_proof_trie_node(&ProofTrieNode {
                 path: Nibbles::default(),
                 node: root.clone(),
                 masks,
@@ -201,20 +201,20 @@ impl SparseTrie for ParallelSparseTrie {
         self.updates = retain_updates.then(Default::default);
     }
 
-    fn reveal_nodes(&mut self, nodes: &mut [ProofTrieNodeV2]) -> SparseTrieResult<()> {
+    fn reveal_nodes(&mut self, nodes: &mut [ProofTrieNode]) -> SparseTrieResult<()> {
         if nodes.is_empty() {
             return Ok(())
         }
 
         #[cfg(feature = "trie-debug")]
         self.debug_recorder.record(RecordedOp::RevealNodes {
-            nodes: nodes.iter().map(ProofTrieNodeRecord::from_proof_trie_node_v2).collect(),
+            nodes: nodes.iter().map(ProofTrieNodeRecord::from_proof_trie_node).collect(),
         });
 
         // Sort nodes first by their subtrie, and secondarily by their path. This allows for
         // grouping nodes by their subtrie using `chunk_by`.
         nodes.sort_unstable_by(
-            |ProofTrieNodeV2 { path: path_a, .. }, ProofTrieNodeV2 { path: path_b, .. }| {
+            |ProofTrieNode { path: path_a, .. }, ProofTrieNode { path: path_b, .. }| {
                 let subtrie_type_a = SparseSubtrieType::from_path(path_a);
                 let subtrie_type_b = SparseSubtrieType::from_path(path_b);
                 subtrie_type_a.cmp(&subtrie_type_b).then_with(|| path_a.cmp(path_b))
@@ -223,7 +223,7 @@ impl SparseTrie for ParallelSparseTrie {
 
         // Update the top-level branch node masks. This is simple and can't be done in parallel.
         self.branch_node_masks.reserve(nodes.len());
-        for ProofTrieNodeV2 { path, masks, node } in nodes.iter() {
+        for ProofTrieNode { path, masks, node } in nodes.iter() {
             if let Some(branch_masks) = masks {
                 // Use proper path for branch nodes by combining path and extension key.
                 let path = if let TrieNodeV2::Branch(branch) = node &&
@@ -3579,7 +3579,7 @@ mod tests {
         proof::{ProofNodes, ProofRetainer},
         updates::TrieUpdates,
         BranchNodeMasks, BranchNodeMasksMap, BranchNodeRef, BranchNodeV2, ExtensionNode,
-        HashBuilder, LeafNode, ProofTrieNodeV2, RlpNode, TrieMask, TrieNode, TrieNodeV2,
+        HashBuilder, LeafNode, ProofTrieNode, RlpNode, TrieMask, TrieNode, TrieNodeV2,
         EMPTY_ROOT_HASH,
     };
     use reth_trie_db::DatabaseTrieCursorFactory;
@@ -4162,7 +4162,7 @@ mod tests {
             let node = create_leaf_node([0x2, 0x3], 42);
             let masks = None;
 
-            trie.reveal_nodes(&mut [ProofTrieNodeV2 { path, node, masks }]).unwrap();
+            trie.reveal_nodes(&mut [ProofTrieNode { path, node, masks }]).unwrap();
 
             assert_matches!(
                 trie.upper_subtrie.nodes.get(&path),
@@ -4186,7 +4186,7 @@ mod tests {
         let branch_at_1 =
             create_branch_node_with_children(&[0x2], [RlpNode::word_rlp(&B256::repeat_byte(0xBB))]);
         let mut trie = ParallelSparseTrie::from_root(root_branch, None, false).unwrap();
-        trie.reveal_nodes(&mut [ProofTrieNodeV2 {
+        trie.reveal_nodes(&mut [ProofTrieNode {
             path: Nibbles::from_nibbles([0x1]),
             node: branch_at_1,
             masks: None,
@@ -4198,7 +4198,7 @@ mod tests {
             let node = create_leaf_node([0x3, 0x4], 42);
             let masks = None;
 
-            trie.reveal_nodes(&mut [ProofTrieNodeV2 { path, node, masks }]).unwrap();
+            trie.reveal_nodes(&mut [ProofTrieNode { path, node, masks }]).unwrap();
 
             // Check that the lower subtrie was created
             let idx = path_subtrie_index_unchecked(&path);
@@ -4222,13 +4222,88 @@ mod tests {
             let node = create_leaf_node([0x4, 0x5], 42);
             let masks = None;
 
-            trie.reveal_nodes(&mut [ProofTrieNodeV2 { path, node, masks }]).unwrap();
+            trie.reveal_nodes(&mut [ProofTrieNode { path, node, masks }]).unwrap();
 
             // Check that the lower subtrie's path hasn't changed
             let idx = path_subtrie_index_unchecked(&path);
             let lower_subtrie = trie.lower_subtries[idx].as_revealed_ref().unwrap();
             assert_eq!(lower_subtrie.path, Nibbles::from_nibbles([0x1, 0x2]));
         }
+    }
+
+    #[test]
+    fn test_reveal_node_extension_all_upper() {
+        let path = Nibbles::new();
+        let child_hash = B256::repeat_byte(0xab);
+        let node = create_extension_node([0x1], child_hash);
+        let masks = None;
+        let trie = ParallelSparseTrie::from_root(node, masks, true).unwrap();
+
+        assert_matches!(
+            trie.upper_subtrie.nodes.get(&path),
+            Some(SparseNode::Extension { key, state: SparseNodeState::Dirty, .. })
+            if key == &Nibbles::from_nibbles([0x1])
+        );
+
+        // Child path should be in upper trie
+        let child_path = Nibbles::from_nibbles([0x1]);
+        assert_eq!(trie.upper_subtrie.nodes.get(&child_path), Some(&SparseNode::Hash(child_hash)));
+    }
+
+    #[test]
+    fn test_reveal_node_extension_cross_level() {
+        let path = Nibbles::new();
+        let child_hash = B256::repeat_byte(0xcd);
+        let node = create_extension_node([0x1, 0x2, 0x3], child_hash);
+        let masks = None;
+        let trie = ParallelSparseTrie::from_root(node, masks, true).unwrap();
+
+        // Extension node should be in upper trie
+        assert_matches!(
+            trie.upper_subtrie.nodes.get(&path),
+            Some(SparseNode::Extension { key, state: SparseNodeState::Dirty, .. })
+            if key == &Nibbles::from_nibbles([0x1, 0x2, 0x3])
+        );
+
+        // Child path (0x1, 0x2, 0x3) should be in lower trie
+        let child_path = Nibbles::from_nibbles([0x1, 0x2, 0x3]);
+        let idx = path_subtrie_index_unchecked(&child_path);
+        assert!(trie.lower_subtries[idx].as_revealed_ref().is_some());
+
+        let lower_subtrie = trie.lower_subtries[idx].as_revealed_ref().unwrap();
+        assert_eq!(lower_subtrie.path, child_path);
+        assert_eq!(lower_subtrie.nodes.get(&child_path), Some(&SparseNode::Hash(child_hash)));
+    }
+
+    #[test]
+    fn test_reveal_node_extension_cross_level_boundary() {
+        // Set up root branch with nibble 0x1 so path [0x1] is reachable.
+        let root_branch =
+            create_branch_node_with_children(&[0x1], [RlpNode::word_rlp(&B256::repeat_byte(0xAA))]);
+        let mut trie = ParallelSparseTrie::from_root(root_branch, None, false).unwrap();
+
+        let path = Nibbles::from_nibbles([0x1]);
+        let child_hash = B256::repeat_byte(0xcd);
+        let node = create_extension_node([0x2], child_hash);
+        let masks = None;
+
+        trie.reveal_nodes(&mut [ProofTrieNode { path, node, masks }]).unwrap();
+
+        // Extension node should be in upper trie, hash is memoized from the previous Hash node
+        assert_matches!(
+            trie.upper_subtrie.nodes.get(&path),
+            Some(SparseNode::Extension { key, state: SparseNodeState::Cached { .. }, .. })
+            if key == &Nibbles::from_nibbles([0x2])
+        );
+
+        // Child path (0x1, 0x2) should be in lower trie
+        let child_path = Nibbles::from_nibbles([0x1, 0x2]);
+        let idx = path_subtrie_index_unchecked(&child_path);
+        assert!(trie.lower_subtries[idx].as_revealed_ref().is_some());
+
+        let lower_subtrie = trie.lower_subtries[idx].as_revealed_ref().unwrap();
+        assert_eq!(lower_subtrie.path, child_path);
+        assert_eq!(lower_subtrie.nodes.get(&child_path), Some(&SparseNode::Hash(child_hash)));
     }
 
     #[test]
@@ -4274,7 +4349,7 @@ mod tests {
         let node = create_branch_node_with_children(&[0x0, 0x7, 0xf], child_hashes.clone());
         let masks = None;
 
-        trie.reveal_nodes(&mut [ProofTrieNodeV2 { path, node, masks }]).unwrap();
+        trie.reveal_nodes(&mut [ProofTrieNode { path, node, masks }]).unwrap();
 
         // Branch node should be in upper trie, hash is memoized from the previous Hash node
         assert_eq!(
@@ -4302,7 +4377,7 @@ mod tests {
 
         let mut children = child_paths
             .iter()
-            .map(|path| ProofTrieNodeV2 {
+            .map(|path| ProofTrieNode {
                 path: *path,
                 node: create_leaf_node([0x0], 1),
                 masks: None,
@@ -4375,9 +4450,9 @@ mod tests {
 
         // Reveal the existing nodes
         trie.reveal_nodes(&mut [
-            ProofTrieNodeV2 { path: branch_path, node: branch_node, masks: None },
-            ProofTrieNodeV2 { path: leaf_1_path, node: leaf_1, masks: None },
-            ProofTrieNodeV2 { path: leaf_2_path, node: leaf_2, masks: None },
+            ProofTrieNode { path: branch_path, node: branch_node, masks: None },
+            ProofTrieNode { path: leaf_1_path, node: leaf_1, masks: None },
+            ProofTrieNode { path: leaf_2_path, node: leaf_2, masks: None },
         ])
         .unwrap();
 
@@ -4881,7 +4956,7 @@ mod tests {
         assert_matches!(err.kind(), SparseTrieErrorKind::BlindedNode(path) if *path == Nibbles::from_nibbles([0x1]));
 
         // Now reveal the leaf and try removing it again
-        trie.reveal_nodes(&mut [ProofTrieNodeV2 {
+        trie.reveal_nodes(&mut [ProofTrieNode {
             path: Nibbles::from_nibbles([0x1]),
             node: revealed_leaf,
             masks: None,
@@ -5099,8 +5174,9 @@ mod tests {
         // Step 2: Reveal nodes in the trie
         let mut trie = ParallelSparseTrie::from_root(branch, None, true).unwrap();
         trie.reveal_nodes(&mut [
-            ProofTrieNodeV2 { path: leaf_1_path, node: leaf_1, masks: None },
-            ProofTrieNodeV2 { path: leaf_2_path, node: leaf_2, masks: None },
+            ProofTrieNode { path: branch_path, node: branch, masks: None },
+            ProofTrieNode { path: leaf_1_path, node: leaf_1, masks: None },
+            ProofTrieNode { path: leaf_2_path, node: leaf_2, masks: None },
         ])
         .unwrap();
 
@@ -5703,7 +5779,7 @@ mod tests {
         // └── 1 -> Leaf (Path = 1)
         sparse
             .reveal_nodes(&mut [
-                ProofTrieNodeV2 {
+                ProofTrieNode {
                     path: Nibbles::default(),
                     node: branch,
                     masks: Some(BranchNodeMasks {
@@ -5711,7 +5787,7 @@ mod tests {
                         tree_mask: TrieMask::new(0b01),
                     }),
                 },
-                ProofTrieNodeV2 {
+                ProofTrieNode {
                     path: Nibbles::from_nibbles([0x1]),
                     node: TrieNodeV2::Leaf(leaf),
                     masks: None,
@@ -5760,7 +5836,7 @@ mod tests {
         // └── 1 -> Leaf (Path = 1)
         sparse
             .reveal_nodes(&mut [
-                ProofTrieNodeV2 {
+                ProofTrieNode {
                     path: Nibbles::default(),
                     node: branch,
                     masks: Some(BranchNodeMasks {
@@ -5768,7 +5844,7 @@ mod tests {
                         tree_mask: TrieMask::new(0b01),
                     }),
                 },
-                ProofTrieNodeV2 {
+                ProofTrieNode {
                     path: Nibbles::from_nibbles([0x1]),
                     node: TrieNodeV2::Leaf(leaf),
                     masks: None,
@@ -6032,14 +6108,14 @@ mod tests {
                 Default::default(),
                 [key1()],
             );
-        let mut revealed_nodes: Vec<ProofTrieNodeV2> = hash_builder_proof_nodes
+        let mut revealed_nodes: Vec<ProofTrieNode> = hash_builder_proof_nodes
             .nodes_sorted()
             .into_iter()
             .map(|(path, node)| {
                 let hash_mask = branch_node_hash_masks.get(&path).copied();
                 let tree_mask = branch_node_tree_masks.get(&path).copied();
                 let masks = BranchNodeMasks::from_optional(hash_mask, tree_mask);
-                ProofTrieNodeV2 { path, node: TrieNodeV2::decode(&mut &node[..]).unwrap(), masks }
+                ProofTrieNode { path, node: TrieNodeV2::decode(&mut &node[..]).unwrap(), masks }
             })
             .collect();
         sparse.reveal_nodes(&mut revealed_nodes).unwrap();
@@ -6067,14 +6143,14 @@ mod tests {
                 Default::default(),
                 [key3()],
             );
-        let mut revealed_nodes: Vec<ProofTrieNodeV2> = hash_builder_proof_nodes
+        let mut revealed_nodes: Vec<ProofTrieNode> = hash_builder_proof_nodes
             .nodes_sorted()
             .into_iter()
             .map(|(path, node)| {
                 let hash_mask = branch_node_hash_masks.get(&path).copied();
                 let tree_mask = branch_node_tree_masks.get(&path).copied();
                 let masks = BranchNodeMasks::from_optional(hash_mask, tree_mask);
-                ProofTrieNodeV2 { path, node: TrieNodeV2::decode(&mut &node[..]).unwrap(), masks }
+                ProofTrieNode { path, node: TrieNodeV2::decode(&mut &node[..]).unwrap(), masks }
             })
             .collect();
         sparse.reveal_nodes(&mut revealed_nodes).unwrap();
@@ -6153,14 +6229,14 @@ mod tests {
                 Default::default(),
                 [key1(), Nibbles::from_nibbles_unchecked([0x01])],
             );
-        let mut revealed_nodes: Vec<ProofTrieNodeV2> = hash_builder_proof_nodes
+        let mut revealed_nodes: Vec<ProofTrieNode> = hash_builder_proof_nodes
             .nodes_sorted()
             .into_iter()
             .map(|(path, node)| {
                 let hash_mask = branch_node_hash_masks.get(&path).copied();
                 let tree_mask = branch_node_tree_masks.get(&path).copied();
                 let masks = BranchNodeMasks::from_optional(hash_mask, tree_mask);
-                ProofTrieNodeV2 { path, node: TrieNodeV2::decode(&mut &node[..]).unwrap(), masks }
+                ProofTrieNode { path, node: TrieNodeV2::decode(&mut &node[..]).unwrap(), masks }
             })
             .collect();
         sparse.reveal_nodes(&mut revealed_nodes).unwrap();
@@ -6188,14 +6264,14 @@ mod tests {
                 Default::default(),
                 [key2()],
             );
-        let mut revealed_nodes: Vec<ProofTrieNodeV2> = hash_builder_proof_nodes
+        let mut revealed_nodes: Vec<ProofTrieNode> = hash_builder_proof_nodes
             .nodes_sorted()
             .into_iter()
             .map(|(path, node)| {
                 let hash_mask = branch_node_hash_masks.get(&path).copied();
                 let tree_mask = branch_node_tree_masks.get(&path).copied();
                 let masks = BranchNodeMasks::from_optional(hash_mask, tree_mask);
-                ProofTrieNodeV2 { path, node: TrieNodeV2::decode(&mut &node[..]).unwrap(), masks }
+                ProofTrieNode { path, node: TrieNodeV2::decode(&mut &node[..]).unwrap(), masks }
             })
             .collect();
         sparse.reveal_nodes(&mut revealed_nodes).unwrap();
@@ -6247,7 +6323,7 @@ mod tests {
 
         nodes.sort_unstable_by(|a, b| reth_trie_common::depth_first_cmp(&a.0, &b.0));
 
-        let nodes = ProofTrieNodeV2::from_sorted_trie_nodes(nodes);
+        let nodes = ProofTrieNode::from_sorted_trie_nodes(nodes);
 
         let provider = DefaultTrieNodeProvider;
         let mut sparse =
@@ -6276,14 +6352,14 @@ mod tests {
                 Default::default(),
                 [key1()],
             );
-        let mut revealed_nodes: Vec<ProofTrieNodeV2> = hash_builder_proof_nodes
+        let mut revealed_nodes: Vec<ProofTrieNode> = hash_builder_proof_nodes
             .nodes_sorted()
             .into_iter()
             .map(|(path, node)| {
                 let hash_mask = branch_node_hash_masks.get(&path).copied();
                 let tree_mask = branch_node_tree_masks.get(&path).copied();
                 let masks = BranchNodeMasks::from_optional(hash_mask, tree_mask);
-                ProofTrieNodeV2 { path, node: TrieNodeV2::decode(&mut &node[..]).unwrap(), masks }
+                ProofTrieNode { path, node: TrieNodeV2::decode(&mut &node[..]).unwrap(), masks }
             })
             .collect();
         sparse.reveal_nodes(&mut revealed_nodes).unwrap();
@@ -7191,16 +7267,12 @@ mod tests {
         let leaf_masks = None;
 
         trie.reveal_nodes(&mut [
-            ProofTrieNodeV2 {
+            ProofTrieNode {
                 path: Nibbles::from_nibbles([0x3]),
                 node: TrieNodeV2::Branch(branch_0x3_node),
                 masks: branch_0x3_masks,
             },
-            ProofTrieNodeV2 {
-                path: leaf_path,
-                node: TrieNodeV2::Leaf(leaf_node),
-                masks: leaf_masks,
-            },
+            ProofTrieNode { path: leaf_path, node: TrieNodeV2::Leaf(leaf_node), masks: leaf_masks },
         ])
         .unwrap();
 
@@ -7489,14 +7561,24 @@ mod tests {
         );
 
         // Reveal the trie structure using ProofTrieNode
-        let mut proof_nodes = vec![ProofTrieNodeV2 {
-            path: Nibbles::from_nibbles([0x3, 0x1]),
-            node: branch_0x31_node,
-            masks: Some(BranchNodeMasks {
-                tree_mask: TrieMask::new(4096),
-                hash_mask: TrieMask::new(4096),
-            }),
-        }];
+        let mut proof_nodes = vec![
+            ProofTrieNode {
+                path: Nibbles::from_nibbles([0x3]),
+                node: branch_0x3_node,
+                masks: Some(BranchNodeMasks {
+                    tree_mask: TrieMask::new(26099),
+                    hash_mask: TrieMask::new(65535),
+                }),
+            },
+            ProofTrieNode {
+                path: Nibbles::from_nibbles([0x3, 0x1]),
+                node: branch_0x31_node,
+                masks: Some(BranchNodeMasks {
+                    tree_mask: TrieMask::new(4096),
+                    hash_mask: TrieMask::new(4096),
+                }),
+            },
+        ];
 
         // Create a sparse trie and reveal nodes
         let mut trie = ParallelSparseTrie::default()
@@ -7521,7 +7603,7 @@ mod tests {
         };
         assert_matches!(err.kind(), SparseTrieErrorKind::BlindedNode(path) if path == &Nibbles::from_nibbles([0x3, 0x1, 0xc]));
 
-        trie.reveal_nodes(&mut [ProofTrieNodeV2 {
+        trie.reveal_nodes(&mut [ProofTrieNode {
             path: Nibbles::from_nibbles([0x3, 0x1, 0xc]),
             node: branch_0x31c_node,
             masks: Some(BranchNodeMasks { tree_mask: 0.into(), hash_mask: 4096.into() }),
@@ -7570,7 +7652,7 @@ mod tests {
         let branch_at_1 =
             create_branch_node_with_children(&[0x2], [RlpNode::word_rlp(&B256::repeat_byte(0xBB))]);
         let mut trie = ParallelSparseTrie::from_root(root_branch, None, false).unwrap();
-        trie.reveal_nodes(&mut [ProofTrieNodeV2 {
+        trie.reveal_nodes(&mut [ProofTrieNode {
             path: Nibbles::from_nibbles([0x1]),
             node: branch_at_1,
             masks: None,
@@ -7583,7 +7665,7 @@ mod tests {
         let leaf_node = create_leaf_node(leaf_key.to_vec(), 42);
 
         // Reveal the leaf node
-        trie.reveal_nodes(&mut [ProofTrieNodeV2 { path: leaf_path, node: leaf_node, masks: None }])
+        trie.reveal_nodes(&mut [ProofTrieNode { path: leaf_path, node: leaf_node, masks: None }])
             .unwrap();
 
         // The full path is leaf_path + leaf_key
@@ -8722,12 +8804,12 @@ mod tests {
         let branch_at_5 =
             create_branch_node_with_children(&[0x6], [RlpNode::word_rlp(&B256::repeat_byte(0xDD))]);
         trie.reveal_nodes(&mut [
-            ProofTrieNodeV2 {
+            ProofTrieNode {
                 path: Nibbles::from_nibbles_unchecked([0x1]),
                 node: branch_at_1,
                 masks: None,
             },
-            ProofTrieNodeV2 {
+            ProofTrieNode {
                 path: Nibbles::from_nibbles_unchecked([0x5]),
                 node: branch_at_5,
                 masks: None,
@@ -8736,7 +8818,7 @@ mod tests {
         .unwrap();
 
         let mut nodes = vec![
-            ProofTrieNodeV2 {
+            ProofTrieNode {
                 path: Nibbles::from_nibbles_unchecked([0x1, 0x2]),
                 node: TrieNodeV2::Leaf(LeafNode {
                     key: Nibbles::from_nibbles_unchecked([0x3, 0x4]),
@@ -8744,7 +8826,7 @@ mod tests {
                 }),
                 masks: None,
             },
-            ProofTrieNodeV2 {
+            ProofTrieNode {
                 path: Nibbles::from_nibbles_unchecked([0x5, 0x6]),
                 node: TrieNodeV2::Leaf(LeafNode {
                     key: Nibbles::from_nibbles_unchecked([0x7, 0x8]),
@@ -8818,7 +8900,7 @@ mod tests {
 
         // Reveal the branch and leaves
         let mut nodes = vec![
-            ProofTrieNodeV2 {
+            ProofTrieNode {
                 path: branch_path,
                 node: TrieNodeV2::Branch(BranchNodeV2::new(
                     Nibbles::new(),
@@ -8828,8 +8910,8 @@ mod tests {
                 )),
                 masks: None,
             },
-            ProofTrieNodeV2 { path: leaf1_path, node: TrieNodeV2::Leaf(leaf1_node), masks: None },
-            ProofTrieNodeV2 { path: leaf2_path, node: TrieNodeV2::Leaf(leaf2_node), masks: None },
+            ProofTrieNode { path: leaf1_path, node: TrieNodeV2::Leaf(leaf1_node), masks: None },
+            ProofTrieNode { path: leaf2_path, node: TrieNodeV2::Leaf(leaf2_node), masks: None },
         ];
         trie.reveal_nodes(&mut nodes).unwrap();
 

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -17,7 +17,7 @@ use reth_primitives_traits::Account;
 use reth_primitives_traits::FastInstant as Instant;
 use reth_trie_common::{
     updates::{StorageTrieUpdates, TrieUpdates},
-    BranchNodeMasks, DecodedMultiProof, MultiProof, Nibbles, ProofTrieNodeV2, TrieAccount,
+    BranchNodeMasks, LegacyDecodedMultiProof, MultiProof, Nibbles, ProofTrieNode, TrieAccount,
     TrieNodeV2, EMPTY_ROOT_HASH, TRIE_ACCOUNT_RLP_MAX_SIZE,
 };
 #[cfg(feature = "std")]
@@ -31,7 +31,7 @@ use tracing::{instrument, trace};
 #[derive(Debug, Default)]
 pub struct DeferredDrops {
     /// Each nodes reveal operation creates a new buffer, uses it, and pushes it here.
-    pub proof_nodes_bufs: Vec<Vec<ProofTrieNodeV2>>,
+    pub proof_nodes_bufs: Vec<Vec<ProofTrieNode>>,
 }
 
 #[derive(Debug)]
@@ -48,7 +48,7 @@ pub struct SparseStateTrie<
     storage: StorageTries<S>,
     /// Flag indicating whether trie updates should be retained.
     retain_updates: bool,
-    /// When true, skip filtering of V2 proof nodes that have already been revealed.
+    /// When true, skip filtering of proof nodes that have already been revealed.
     /// This is useful when the sparse trie is being reused across blocks and already
     /// tracks revealed nodes internally.
     skip_proof_node_filtering: bool,
@@ -125,9 +125,9 @@ impl<A, S> SparseStateTrie<A, S> {
         self
     }
 
-    /// Set whether to skip filtering of V2 proof nodes.
+    /// Set whether to skip filtering of proof nodes.
     ///
-    /// When true, `reveal_*_v2_proof_nodes` methods will pass all nodes directly to the
+    /// When true, `reveal_*_proof_nodes` methods will pass all nodes directly to the
     /// sparse trie without filtering already-revealed paths. This is useful when the
     /// sparse trie is being reused across blocks and handles node deduplication internally.
     pub const fn with_skip_proof_node_filtering(mut self, skip: bool) -> Self {
@@ -278,44 +278,44 @@ where
         let decoded_multiproof = multiproof.try_into()?;
 
         // then reveal the decoded multiproof
-        self.reveal_decoded_multiproof(decoded_multiproof)
+        self.reveal_legacy_decoded_multiproof(decoded_multiproof)
     }
 
-    /// Reveal unknown trie paths from decoded multiproof.
+    /// Reveal unknown trie paths from legacy decoded multiproof.
     /// NOTE: This method does not extensively validate the proof.
+    #[instrument(level = "debug", target = "trie::sparse", skip_all)]
+    pub fn reveal_legacy_decoded_multiproof(
+        &mut self,
+        multiproof: LegacyDecodedMultiProof,
+    ) -> SparseStateTrieResult<()> {
+        self.reveal_decoded_multiproof(multiproof.into())
+    }
+
+    /// Reveals a decoded multiproof.
+    ///
+    /// Decoded multiproofs use a simpler format where proof nodes are stored as vectors rather than
+    /// hashmaps, with masks already included in the `ProofTrieNode` structure.
     #[instrument(level = "debug", target = "trie::sparse", skip_all)]
     pub fn reveal_decoded_multiproof(
         &mut self,
-        multiproof: DecodedMultiProof,
-    ) -> SparseStateTrieResult<()> {
-        self.reveal_decoded_multiproof_v2(multiproof.into())
-    }
-
-    /// Reveals a V2 decoded multiproof.
-    ///
-    /// V2 multiproofs use a simpler format where proof nodes are stored as vectors rather than
-    /// hashmaps, with masks already included in the `ProofTrieNode` structure.
-    #[instrument(level = "debug", target = "trie::sparse", skip_all)]
-    pub fn reveal_decoded_multiproof_v2(
-        &mut self,
-        multiproof: reth_trie_common::DecodedMultiProofV2,
+        multiproof: reth_trie_common::DecodedMultiProof,
     ) -> SparseStateTrieResult<()> {
         // Reveal the account proof nodes.
         //
         // Skip revealing account nodes if this result only contains storage proofs.
-        // `reveal_account_v2_proof_nodes` will return an error if empty `nodes` are passed into it
+        // `reveal_account_proof_nodes` will return an error if empty `nodes` are passed into it
         // before the accounts trie root was revealed. This might happen in cases when first account
         // trie proof arrives later than first storage trie proof even though the account trie proof
         // was requested first.
         if !multiproof.account_proofs.is_empty() {
-            self.reveal_account_v2_proof_nodes(multiproof.account_proofs)?;
+            self.reveal_account_proof_nodes(multiproof.account_proofs)?;
         }
 
         #[cfg(not(feature = "std"))]
         // If nostd then serially reveal storage proof nodes for each storage trie
         {
             for (account, storage_proofs) in multiproof.storage_proofs {
-                self.reveal_storage_v2_proof_nodes(account, storage_proofs)?;
+                self.reveal_storage_proof_nodes(account, storage_proofs)?;
                 // Mark this storage trie as hot (accessed this tick)
                 self.storage.modifications.mark_accessed(account);
             }
@@ -346,7 +346,7 @@ where
                 .par_bridge_buffered()
                 .map(|(account, storage_proofs, mut revealed_nodes, mut trie)| {
                     let mut bufs = Vec::new();
-                    let result = Self::reveal_storage_v2_proof_nodes_inner(
+                    let result = Self::reveal_storage_proof_nodes_inner(
                         account,
                         storage_proofs,
                         &mut revealed_nodes,
@@ -385,23 +385,23 @@ where
         }
     }
 
-    /// Reveals account proof nodes from a V2 proof.
+    /// Reveals account proof nodes.
     ///
-    /// V2 proofs already include the masks in the `ProofTrieNode` structure,
+    /// Proofs already include the masks in the `ProofTrieNode` structure,
     /// so no separate masks map is needed.
-    pub fn reveal_account_v2_proof_nodes(
+    pub fn reveal_account_proof_nodes(
         &mut self,
-        mut nodes: Vec<ProofTrieNodeV2>,
+        mut nodes: Vec<ProofTrieNode>,
     ) -> SparseStateTrieResult<()> {
         if self.skip_proof_node_filtering {
-            let capacity = estimate_v2_proof_capacity(&nodes);
+            let capacity = estimate_proof_capacity(&nodes);
 
             #[cfg(feature = "metrics")]
             self.metrics.increment_total_account_nodes(nodes.len() as u64);
 
             let root_node = nodes.iter().find(|n| n.path.is_empty());
             let trie = if let Some(root_node) = root_node {
-                trace!(target: "trie::sparse", ?root_node, "Revealing root account node from V2 proof");
+                trace!(target: "trie::sparse", ?root_node, "Revealing root account node from proof");
                 self.state.reveal_root(
                     root_node.node.clone(),
                     root_node.masks,
@@ -411,15 +411,15 @@ where
                 self.state.as_revealed_mut().ok_or(SparseTrieErrorKind::Blind)?
             };
             trie.reserve_nodes(capacity);
-            trace!(target: "trie::sparse", total_nodes = ?nodes.len(), "Revealing account nodes from V2 proof (unfiltered)");
+            trace!(target: "trie::sparse", total_nodes = ?nodes.len(), "Revealing account nodes from proof (unfiltered)");
             trie.reveal_nodes(&mut nodes)?;
 
             self.deferred_drops.proof_nodes_bufs.push(nodes);
             return Ok(())
         }
 
-        let FilteredV2ProofNodes { root_node, mut nodes, new_nodes, metric_values: _metric_values } =
-            filter_revealed_v2_proof_nodes(nodes, &mut self.revealed_account_paths)?;
+        let FilteredProofNodes { root_node, mut nodes, new_nodes, metric_values: _metric_values } =
+            filter_revealed_proof_nodes(nodes, &mut self.revealed_account_paths)?;
 
         #[cfg(feature = "metrics")]
         {
@@ -428,7 +428,7 @@ where
         }
 
         let trie = if let Some(root_node) = root_node {
-            trace!(target: "trie::sparse", ?root_node, "Revealing root account node from V2 proof");
+            trace!(target: "trie::sparse", ?root_node, "Revealing root account node from proof");
             self.state.reveal_root(root_node.node, root_node.masks, self.retain_updates)?
         } else {
             self.state.as_revealed_mut().ok_or(SparseTrieErrorKind::Blind)?
@@ -436,7 +436,7 @@ where
 
         trie.reserve_nodes(new_nodes);
 
-        trace!(target: "trie::sparse", total_nodes = ?nodes.len(), "Revealing account nodes from V2 proof");
+        trace!(target: "trie::sparse", total_nodes = ?nodes.len(), "Revealing account nodes from proof");
         trie.reveal_nodes(&mut nodes)?;
 
         // Keep buffer for deferred dropping
@@ -445,17 +445,17 @@ where
         Ok(())
     }
 
-    /// Reveals storage proof nodes from a V2 proof for the given address.
+    /// Reveals storage proof nodes for the given address.
     ///
-    /// V2 proofs already include the masks in the `ProofTrieNode` structure,
+    /// Proofs already include the masks in the `ProofTrieNode` structure,
     /// so no separate masks map is needed.
-    pub fn reveal_storage_v2_proof_nodes(
+    pub fn reveal_storage_proof_nodes(
         &mut self,
         account: B256,
-        nodes: Vec<ProofTrieNodeV2>,
+        nodes: Vec<ProofTrieNode>,
     ) -> SparseStateTrieResult<()> {
         let (trie, revealed_paths) = self.storage.get_trie_and_revealed_paths_mut(account);
-        let _metric_values = Self::reveal_storage_v2_proof_nodes_inner(
+        let _metric_values = Self::reveal_storage_proof_nodes_inner(
             account,
             nodes,
             revealed_paths,
@@ -474,42 +474,42 @@ where
         Ok(())
     }
 
-    /// Reveals storage V2 proof nodes for the given address. This is an internal static function
+    /// Reveals storage proof nodes for the given address. This is an internal static function
     /// designed to handle a variety of associated public functions.
-    fn reveal_storage_v2_proof_nodes_inner(
+    fn reveal_storage_proof_nodes_inner(
         account: B256,
-        mut nodes: Vec<ProofTrieNodeV2>,
+        mut nodes: Vec<ProofTrieNode>,
         revealed_nodes: &mut HashSet<Nibbles>,
         trie: &mut RevealableSparseTrie<S>,
-        bufs: &mut Vec<Vec<ProofTrieNodeV2>>,
+        bufs: &mut Vec<Vec<ProofTrieNode>>,
         retain_updates: bool,
         skip_filtering: bool,
     ) -> SparseStateTrieResult<ProofNodesMetricValues> {
         if skip_filtering {
-            let capacity = estimate_v2_proof_capacity(&nodes);
+            let capacity = estimate_proof_capacity(&nodes);
             let metric_values =
                 ProofNodesMetricValues { total_nodes: nodes.len(), skipped_nodes: 0 };
 
             let root_node = nodes.iter().find(|n| n.path.is_empty());
             let trie = if let Some(root_node) = root_node {
-                trace!(target: "trie::sparse", ?account, ?root_node, "Revealing root storage node from V2 proof");
+                trace!(target: "trie::sparse", ?account, ?root_node, "Revealing root storage node from proof");
                 trie.reveal_root(root_node.node.clone(), root_node.masks, retain_updates)?
             } else {
                 trie.as_revealed_mut().ok_or(SparseTrieErrorKind::Blind)?
             };
             trie.reserve_nodes(capacity);
-            trace!(target: "trie::sparse", ?account, total_nodes = ?nodes.len(), "Revealing storage nodes from V2 proof (unfiltered)");
+            trace!(target: "trie::sparse", ?account, total_nodes = ?nodes.len(), "Revealing storage nodes from proof (unfiltered)");
             trie.reveal_nodes(&mut nodes)?;
 
             bufs.push(nodes);
             return Ok(metric_values)
         }
 
-        let FilteredV2ProofNodes { root_node, mut nodes, new_nodes, metric_values } =
-            filter_revealed_v2_proof_nodes(nodes, revealed_nodes)?;
+        let FilteredProofNodes { root_node, mut nodes, new_nodes, metric_values } =
+            filter_revealed_proof_nodes(nodes, revealed_nodes)?;
 
         let trie = if let Some(root_node) = root_node {
-            trace!(target: "trie::sparse", ?account, ?root_node, "Revealing root storage node from V2 proof");
+            trace!(target: "trie::sparse", ?account, ?root_node, "Revealing root storage node from proof");
             trie.reveal_root(root_node.node, root_node.masks, retain_updates)?
         } else {
             trie.as_revealed_mut().ok_or(SparseTrieErrorKind::Blind)?
@@ -517,7 +517,7 @@ where
 
         trie.reserve_nodes(new_nodes);
 
-        trace!(target: "trie::sparse", ?account, total_nodes = ?nodes.len(), "Revealing storage nodes from V2 proof");
+        trace!(target: "trie::sparse", ?account, total_nodes = ?nodes.len(), "Revealing storage nodes from proof");
         trie.reveal_nodes(&mut nodes)?;
 
         // Keep buffer for deferred dropping
@@ -1221,13 +1221,13 @@ struct ProofNodesMetricValues {
     skipped_nodes: usize,
 }
 
-/// Result of [`filter_revealed_v2_proof_nodes`].
+/// Result of [`filter_revealed_proof_nodes`].
 #[derive(Debug, PartialEq, Eq)]
-struct FilteredV2ProofNodes {
+struct FilteredProofNodes {
     /// Root node which was pulled out of the original node set to be handled specially.
-    root_node: Option<ProofTrieNodeV2>,
+    root_node: Option<ProofTrieNode>,
     /// Filtered proof nodes. Root node is removed.
-    nodes: Vec<ProofTrieNodeV2>,
+    nodes: Vec<ProofTrieNode>,
     /// Number of new nodes that will be revealed. This includes all children of branch nodes, even
     /// if they are not in the proof.
     new_nodes: usize,
@@ -1235,12 +1235,12 @@ struct FilteredV2ProofNodes {
     metric_values: ProofNodesMetricValues,
 }
 
-/// Calculates capacity estimation for V2 proof nodes without filtering.
+/// Calculates capacity estimation for proof nodes without filtering.
 ///
 /// This counts nodes and their children (for branch and extension nodes) to provide
 /// proper capacity hints for `reserve_nodes`. Used when `skip_proof_node_filtering` is
 /// enabled and no filtering is performed.
-fn estimate_v2_proof_capacity(nodes: &[ProofTrieNodeV2]) -> usize {
+fn estimate_proof_capacity(nodes: &[ProofTrieNode]) -> usize {
     let mut capacity = nodes.len();
 
     for node in nodes {
@@ -1252,16 +1252,16 @@ fn estimate_v2_proof_capacity(nodes: &[ProofTrieNodeV2]) -> usize {
     capacity
 }
 
-/// Filters V2 proof nodes that are already revealed, separates the root node if present, and
+/// Filters proof nodes that are already revealed, separates the root node if present, and
 /// returns additional information about the number of total, skipped, and new nodes.
 ///
-/// V2 proof nodes already have masks included in the `ProofTrieNode` structure, so no separate
+/// Proof nodes already have masks included in the `ProofTrieNode` structure, so no separate
 /// masks map is needed.
-fn filter_revealed_v2_proof_nodes(
-    proof_nodes: Vec<ProofTrieNodeV2>,
+fn filter_revealed_proof_nodes(
+    proof_nodes: Vec<ProofTrieNode>,
     revealed_nodes: &mut HashSet<Nibbles>,
-) -> SparseStateTrieResult<FilteredV2ProofNodes> {
-    let mut result = FilteredV2ProofNodes {
+) -> SparseStateTrieResult<FilteredProofNodes> {
+    let mut result = FilteredProofNodes {
         root_node: None,
         nodes: Vec::with_capacity(proof_nodes.len()),
         new_nodes: 0,
@@ -1383,7 +1383,7 @@ mod tests {
         };
 
         // Reveal multiproof and check that the state trie contains the leaf node and value
-        sparse.reveal_decoded_multiproof(multiproof.clone().try_into().unwrap()).unwrap();
+        sparse.reveal_legacy_decoded_multiproof(multiproof.clone().try_into().unwrap()).unwrap();
         assert!(matches!(
             sparse.state_trie_ref().unwrap().find_leaf(&full_path_0, None),
             Ok(LeafLookup::Exists)
@@ -1404,7 +1404,7 @@ mod tests {
 
         // Reveal multiproof again and check that the state trie still does not contain the leaf
         // node and value, because they were already revealed before
-        sparse.reveal_decoded_multiproof(multiproof.try_into().unwrap()).unwrap();
+        sparse.reveal_legacy_decoded_multiproof(multiproof.try_into().unwrap()).unwrap();
         assert!(matches!(
             sparse.state_trie_ref().unwrap().find_leaf(&full_path_0, None),
             Ok(LeafLookup::NonExistent)
@@ -1456,7 +1456,7 @@ mod tests {
         };
 
         // Reveal multiproof and check that the storage trie contains the leaf node and value
-        sparse.reveal_decoded_multiproof(multiproof.clone().try_into().unwrap()).unwrap();
+        sparse.reveal_legacy_decoded_multiproof(multiproof.clone().try_into().unwrap()).unwrap();
         assert!(matches!(
             sparse.storage_trie_ref(&B256::ZERO).unwrap().find_leaf(&full_path_0, None),
             Ok(LeafLookup::Exists)
@@ -1481,7 +1481,7 @@ mod tests {
 
         // Reveal multiproof again and check that the storage trie still does not contain the leaf
         // node and value, because they were already revealed before
-        sparse.reveal_decoded_multiproof(multiproof.try_into().unwrap()).unwrap();
+        sparse.reveal_legacy_decoded_multiproof(multiproof.try_into().unwrap()).unwrap();
         assert!(matches!(
             sparse.storage_trie_ref(&B256::ZERO).unwrap().find_leaf(&full_path_0, None),
             Ok(LeafLookup::NonExistent)
@@ -1494,7 +1494,7 @@ mod tests {
     }
 
     #[test]
-    fn reveal_v2_proof_nodes() {
+    fn reveal_proof_nodes() {
         let provider_factory = DefaultTrieNodeProviderFactory;
         let mut sparse = SparseStateTrie::<ParallelSparseTrie>::default();
 
@@ -1515,9 +1515,9 @@ mod tests {
             branch_rlp_node: None,
         });
 
-        // Create V2 proof nodes with masks already included
-        let v2_proof_nodes = vec![
-            ProofTrieNodeV2 {
+        // Create proof nodes with masks already included
+        let proof_nodes = vec![
+            ProofTrieNode {
                 path: Nibbles::default(),
                 node: branch_node,
                 masks: Some(BranchNodeMasks {
@@ -1525,12 +1525,12 @@ mod tests {
                     tree_mask: TrieMask::default(),
                 }),
             },
-            ProofTrieNodeV2 { path: Nibbles::from_nibbles([0x0]), node: leaf_1_node, masks: None },
-            ProofTrieNodeV2 { path: Nibbles::from_nibbles([0x1]), node: leaf_2_node, masks: None },
+            ProofTrieNode { path: Nibbles::from_nibbles([0x0]), node: leaf_1_node, masks: None },
+            ProofTrieNode { path: Nibbles::from_nibbles([0x1]), node: leaf_2_node, masks: None },
         ];
 
-        // Reveal V2 proof nodes
-        sparse.reveal_account_v2_proof_nodes(v2_proof_nodes.clone()).unwrap();
+        // Reveal proof nodes
+        sparse.reveal_account_proof_nodes(proof_nodes.clone()).unwrap();
 
         // Check that the state trie contains the leaf node and value
         assert!(matches!(
@@ -1547,12 +1547,12 @@ mod tests {
         assert!(sparse.state_trie_ref().unwrap().get_leaf_value(&full_path_0).is_none());
 
         // Reveal again - should skip already revealed paths
-        sparse.reveal_account_v2_proof_nodes(v2_proof_nodes).unwrap();
+        sparse.reveal_account_proof_nodes(proof_nodes).unwrap();
         assert!(sparse.state_trie_ref().unwrap().get_leaf_value(&full_path_0).is_none());
     }
 
     #[test]
-    fn reveal_storage_v2_proof_nodes() {
+    fn reveal_storage_proof_nodes_test() {
         let provider_factory = DefaultTrieNodeProviderFactory;
         let mut sparse = SparseStateTrie::<ParallelSparseTrie>::default();
 
@@ -1573,14 +1573,14 @@ mod tests {
             branch_rlp_node: None,
         });
 
-        let v2_proof_nodes = vec![
-            ProofTrieNodeV2 { path: Nibbles::default(), node: branch_node, masks: None },
-            ProofTrieNodeV2 { path: Nibbles::from_nibbles([0x0]), node: leaf_1_node, masks: None },
-            ProofTrieNodeV2 { path: Nibbles::from_nibbles([0x1]), node: leaf_2_node, masks: None },
+        let proof_nodes = vec![
+            ProofTrieNode { path: Nibbles::default(), node: branch_node, masks: None },
+            ProofTrieNode { path: Nibbles::from_nibbles([0x0]), node: leaf_1_node, masks: None },
+            ProofTrieNode { path: Nibbles::from_nibbles([0x1]), node: leaf_2_node, masks: None },
         ];
 
-        // Reveal V2 storage proof nodes for account
-        sparse.reveal_storage_v2_proof_nodes(B256::ZERO, v2_proof_nodes.clone()).unwrap();
+        // Reveal storage proof nodes for account
+        sparse.reveal_storage_proof_nodes(B256::ZERO, proof_nodes.clone()).unwrap();
 
         // Check that the storage trie contains the leaf node and value
         assert!(matches!(
@@ -1601,7 +1601,7 @@ mod tests {
             .is_none());
 
         // Reveal again - should skip already revealed paths
-        sparse.reveal_storage_v2_proof_nodes(B256::ZERO, v2_proof_nodes).unwrap();
+        sparse.reveal_storage_proof_nodes(B256::ZERO, proof_nodes).unwrap();
         assert!(sparse
             .storage_trie_ref(&B256::ZERO)
             .unwrap()
@@ -1667,7 +1667,7 @@ mod tests {
         let provider_factory = DefaultTrieNodeProviderFactory;
         let mut sparse = SparseStateTrie::<ParallelSparseTrie>::default().with_updates(true);
         sparse
-            .reveal_decoded_multiproof(
+            .reveal_legacy_decoded_multiproof(
                 MultiProof {
                     account_subtree: proof_nodes,
                     branch_node_masks: BranchNodeMasksMap::from_iter([(

--- a/crates/trie/sparse/src/traits.rs
+++ b/crates/trie/sparse/src/traits.rs
@@ -9,7 +9,7 @@ use alloy_primitives::{
 };
 use alloy_trie::BranchNodeCompact;
 use reth_execution_errors::SparseTrieResult;
-use reth_trie_common::{BranchNodeMasks, Nibbles, ProofTrieNodeV2, TrieNodeV2};
+use reth_trie_common::{BranchNodeMasks, Nibbles, ProofTrieNode, TrieNodeV2};
 
 #[cfg(feature = "trie-debug")]
 use crate::debug_recorder::TrieDebugRecorder;
@@ -116,7 +116,7 @@ pub trait SparseTrie: Sized + Debug + Send + Sync {
         node: TrieNodeV2,
         masks: Option<BranchNodeMasks>,
     ) -> SparseTrieResult<()> {
-        self.reveal_nodes(&mut [ProofTrieNodeV2 { path, node, masks }])
+        self.reveal_nodes(&mut [ProofTrieNode { path, node, masks }])
     }
 
     /// Reveals one or more trie nodes if they have not been revealed before.
@@ -138,7 +138,7 @@ pub trait SparseTrie: Sized + Debug + Send + Sync {
     ///
     /// The implementation may modify the input nodes. A common thing to do is [`std::mem::replace`]
     /// each node with [`TrieNodeV2::EmptyRoot`] to avoid cloning.
-    fn reveal_nodes(&mut self, nodes: &mut [ProofTrieNodeV2]) -> SparseTrieResult<()>;
+    fn reveal_nodes(&mut self, nodes: &mut [ProofTrieNode]) -> SparseTrieResult<()>;
 
     /// Updates the value of a leaf node at the specified path.
     ///

--- a/crates/trie/trie/src/lib.rs
+++ b/crates/trie/trie/src/lib.rs
@@ -32,7 +32,7 @@ pub mod node_iter;
 /// Merkle proof generation.
 pub mod proof;
 
-/// Merkle proof generation v2 (leaf-only implementation).
+/// Merkle proof generation (leaf-only implementation).
 pub mod proof_v2;
 
 /// Trie witness generation.

--- a/crates/trie/trie/src/proof_v2/node.rs
+++ b/crates/trie/trie/src/proof_v2/node.rs
@@ -2,7 +2,7 @@ use crate::proof_v2::DeferredValueEncoder;
 use alloy_rlp::Encodable;
 use reth_execution_errors::trie::StateProofError;
 use reth_trie_common::{
-    BranchNodeMasks, BranchNodeV2, LeafNode, LeafNodeRef, Nibbles, ProofTrieNodeV2, RlpNode,
+    BranchNodeMasks, BranchNodeV2, LeafNode, LeafNodeRef, Nibbles, ProofTrieNode, RlpNode,
     TrieMask, TrieNodeV2,
 };
 
@@ -67,7 +67,7 @@ impl<RF: DeferredValueEncoder> ProofTrieBranchChild<RF> {
         }
     }
 
-    /// Converts this child into a [`ProofTrieNodeV2`] having the given path.
+    /// Converts this child into a [`ProofTrieNode`] having the given path.
     ///
     /// # Panics
     ///
@@ -76,7 +76,7 @@ impl<RF: DeferredValueEncoder> ProofTrieBranchChild<RF> {
         self,
         path: Nibbles,
         buf: &mut Vec<u8>,
-    ) -> Result<ProofTrieNodeV2, StateProofError> {
+    ) -> Result<ProofTrieNode, StateProofError> {
         let (node, masks) = match self {
             Self::Leaf { short_key, value } => {
                 value.encode(buf)?;
@@ -94,7 +94,7 @@ impl<RF: DeferredValueEncoder> ProofTrieBranchChild<RF> {
             Self::RlpNode(_) => panic!("Cannot call `into_proof_trie_node` on RlpNode"),
         };
 
-        Ok(ProofTrieNodeV2 { node, path, masks })
+        Ok(ProofTrieNode { node, path, masks })
     }
 
     /// Returns the short key of the child, if it is a leaf or branch, or empty if its a


### PR DESCRIPTION
## Summary
Drop V2 suffix from trie proof types now that #22270 removed legacy proof code paths.

## Changes
- `ProofTrieNodeV2` → `ProofTrieNode`
- `DecodedMultiProofV2` → `DecodedMultiProof`
- `MultiProofTargetsV2` → `MultiProofTargets`
- `ChunkedMultiProofTargetsV2` → `ChunkedMultiProofTargets`
- `targets_v2` module → `targets`
- Various `_v2` function/method suffixes dropped
- Old conflicting types renamed with `Legacy` prefix (`LegacyDecodedMultiProof`, `LegacyProofTrieNode`)
- `TrieNodeV2`/`BranchNodeV2` kept as-is to avoid conflict with alloy re-exports

## Testing
`cargo check --workspace` and `cargo test -p reth-trie-common -p reth-trie-sparse -p reth-trie -p reth-trie-parallel --lib` — all 153 tests pass.

Prompted by: mattsse