### PR TITLE
feat(stateless): make witness generation conform to the draft specs

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -1169,6 +1169,7 @@ mod tests {
             &self,
             _input: TrieInput,
             _target: HashedPostState,
+            _mode: reth_trie::ExecutionWitnessMode,
         ) -> ProviderResult<Vec<Bytes>> {
             Ok(Vec::default())
         }

--- a/crates/chain-state/src/memory_overlay.rs
+++ b/crates/chain-state/src/memory_overlay.rs
@@ -197,9 +197,14 @@ impl<N: NodePrimitives> StateProofProvider for MemoryOverlayStateProviderRef<'_,
         self.historical.multiproof(input, targets)
     }
 
-    fn witness(&self, mut input: TrieInput, target: HashedPostState) -> ProviderResult<Vec<Bytes>> {
+    fn witness(
+        &self,
+        mut input: TrieInput,
+        target: HashedPostState,
+        mode: reth_trie::ExecutionWitnessMode,
+    ) -> ProviderResult<Vec<Bytes>> {
         input.prepend_self(self.trie_input().clone());
-        self.historical.witness(input, target)
+        self.historical.witness(input, target, mode)
     }
 }
 

--- a/crates/engine/execution-cache/src/cached_state.rs
+++ b/crates/engine/execution-cache/src/cached_state.rs
@@ -566,8 +566,9 @@ impl<S: StateProofProvider, const PREWARM: bool> StateProofProvider
         &self,
         input: TrieInput,
         target: HashedPostState,
+        mode: reth_trie::ExecutionWitnessMode,
     ) -> ProviderResult<Vec<alloy_primitives::Bytes>> {
-        self.state_provider.witness(input, target)
+        self.state_provider.witness(input, target, mode)
     }
 }
 

--- a/crates/engine/invalid-block-hooks/src/witness.rs
+++ b/crates/engine/invalid-block-hooks/src/witness.rs
@@ -160,7 +160,11 @@ fn generate(
     hashed_state: reth_trie::HashedPostState,
     state_provider: Box<dyn StateProvider>,
 ) -> eyre::Result<ExecutionWitness> {
-    let state = state_provider.witness(Default::default(), hashed_state)?;
+    let state = state_provider.witness(
+        Default::default(),
+        hashed_state,
+        reth_trie::ExecutionWitnessMode::Legacy,
+    )?;
     Ok(ExecutionWitness {
         state,
         codes: codes.into_values().collect(),

--- a/crates/engine/invalid-block-hooks/src/witness.rs
+++ b/crates/engine/invalid-block-hooks/src/witness.rs
@@ -239,6 +239,7 @@ where
                 DebugApiClient::<()>::debug_execution_witness(
                     healthy_node_client,
                     block_number.into(),
+                    None,
                 )
                 .await
             })?;

--- a/crates/engine/tree/src/tree/instrumented_state.rs
+++ b/crates/engine/tree/src/tree/instrumented_state.rs
@@ -237,8 +237,9 @@ impl<S: StateProofProvider> StateProofProvider for InstrumentedStateProvider<S> 
         &self,
         input: TrieInput,
         target: HashedPostState,
+        mode: reth_trie::ExecutionWitnessMode,
     ) -> ProviderResult<Vec<alloy_primitives::Bytes>> {
-        self.state_provider.witness(input, target)
+        self.state_provider.witness(input, target, mode)
     }
 }
 

--- a/crates/revm/src/test_utils.rs
+++ b/crates/revm/src/test_utils.rs
@@ -141,7 +141,12 @@ impl StateProofProvider for StateProviderTest {
         unimplemented!("proof generation is not supported")
     }
 
-    fn witness(&self, _input: TrieInput, _target: HashedPostState) -> ProviderResult<Vec<Bytes>> {
+    fn witness(
+        &self,
+        _input: TrieInput,
+        _target: HashedPostState,
+        _mode: reth_trie::ExecutionWitnessMode,
+    ) -> ProviderResult<Vec<Bytes>> {
         unimplemented!("witness generation is not supported")
     }
 }

--- a/crates/revm/src/witness.rs
+++ b/crates/revm/src/witness.rs
@@ -1,5 +1,5 @@
 use alloc::vec::Vec;
-use alloy_primitives::{keccak256, map::B256Map, Bytes, B256};
+use alloy_primitives::{keccak256, Bytes, B256};
 use reth_trie::{ExecutionWitnessMode, HashedPostState, HashedStorage};
 use revm::database::State;
 

--- a/crates/revm/src/witness.rs
+++ b/crates/revm/src/witness.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
-use alloy_primitives::{keccak256, Bytes, B256};
-use reth_trie::{HashedPostState, HashedStorage};
+use alloy_primitives::{keccak256, map::B256Map, Bytes, B256};
+use reth_trie::{ExecutionWitnessMode, HashedPostState, HashedStorage};
 use revm::database::State;
 
 /// Tracks state changes during execution.
@@ -30,21 +30,36 @@ pub struct ExecutionWitnessRecord {
 }
 
 impl ExecutionWitnessRecord {
-    /// Records the state after execution.
-    pub fn record_executed_state<DB>(&mut self, statedb: &State<DB>) {
-        self.codes = statedb
-            .cache
-            .contracts
-            .values()
-            .map(|code| code.original_bytes())
-            .chain(
-                // cache state does not have all the contracts, especially when
-                // a contract is created within the block
-                // the contract only exists in bundle state, therefore we need
-                // to include them as well
-                statedb.bundle_state.contracts.values().map(|code| code.original_bytes()),
-            )
-            .collect();
+    /// Records the state after execution using the given witness generation mode.
+    pub fn record_executed_state<DB>(&mut self, statedb: &State<DB>, mode: ExecutionWitnessMode) {
+        self.codes = match mode {
+            ExecutionWitnessMode::Legacy => statedb
+                .cache
+                .contracts
+                .values()
+                .map(|code| code.original_bytes())
+                .chain(
+                    // cache state does not have all the contracts, especially when
+                    // a contract is created within the block
+                    // the contract only exists in bundle state, therefore we need
+                    // to include them as well
+                    statedb.bundle_state.contracts.values().map(|code| code.original_bytes()),
+                )
+                .collect(),
+            ExecutionWitnessMode::Canonical => {
+                let mut accessed_codes = B256Map::default();
+                for code in statedb.cache.contracts.values() {
+                    let code = code.original_bytes();
+                    if code.is_empty() {
+                        continue;
+                    }
+                    accessed_codes.entry(keccak256(&code)).or_insert(code);
+                }
+                let mut codes: Vec<_> = accessed_codes.into_values().collect();
+                codes.sort_unstable();
+                codes
+            }
+        };
 
         for (address, account) in &statedb.cache.accounts {
             let hashed_address = keccak256(address);
@@ -75,9 +90,9 @@ impl ExecutionWitnessRecord {
     }
 
     /// Creates the record from the state after execution.
-    pub fn from_executed_state<DB>(state: &State<DB>) -> Self {
+    pub fn from_executed_state<DB>(state: &State<DB>, mode: ExecutionWitnessMode) -> Self {
         let mut record = Self::default();
-        record.record_executed_state(state);
+        record.record_executed_state(state, mode);
         record
     }
 
@@ -93,6 +108,7 @@ impl ExecutionWitnessRecord {
         state_provider: &SP,
         headers_provider: &HP,
         block_number: u64,
+        mode: ExecutionWitnessMode,
     ) -> reth_storage_errors::provider::ProviderResult<alloy_rpc_types_debug::ExecutionWitness>
     where
         SP: reth_storage_api::StateProofProvider + ?Sized,
@@ -101,7 +117,7 @@ impl ExecutionWitnessRecord {
     {
         let Self { hashed_state, codes, keys, lowest_block_number } = self;
 
-        let state = state_provider.witness(Default::default(), hashed_state)?;
+        let state = state_provider.witness(Default::default(), hashed_state, mode)?;
         let mut exec_witness =
             alloy_rpc_types_debug::ExecutionWitness { state, codes, keys, ..Default::default() };
 

--- a/crates/revm/src/witness.rs
+++ b/crates/revm/src/witness.rs
@@ -47,15 +47,13 @@ impl ExecutionWitnessRecord {
                 )
                 .collect(),
             ExecutionWitnessMode::Canonical => {
-                let mut accessed_codes = B256Map::default();
-                for code in statedb.cache.contracts.values() {
-                    let code = code.original_bytes();
-                    if code.is_empty() {
-                        continue;
-                    }
-                    accessed_codes.entry(keccak256(&code)).or_insert(code);
-                }
-                let mut codes: Vec<_> = accessed_codes.into_values().collect();
+                let mut codes: Vec<_> = statedb
+                    .cache
+                    .contracts
+                    .values()
+                    .map(|c| c.original_bytes())
+                    .filter(|code| !code.is_empty())
+                    .collect();
                 codes.sort_unstable();
                 codes
             }

--- a/crates/rpc/rpc-api/Cargo.toml
+++ b/crates/rpc/rpc-api/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 reth-rpc-eth-api.workspace = true
 reth-engine-primitives.workspace = true
 reth-network-peers.workspace = true
-reth-trie-common.workspace = true
+reth-trie-common = { workspace = true, features = ["serde"] }
 reth-chain-state.workspace = true
 
 # ethereum

--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -9,7 +9,7 @@ use alloy_rpc_types_trace::geth::{
     BlockTraceResult, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
 };
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-use reth_trie_common::{updates::TrieUpdates, HashedPostState};
+use reth_trie_common::{updates::TrieUpdates, ExecutionWitnessMode, HashedPostState};
 
 /// Debug rpc interface.
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "debug"))]
@@ -140,21 +140,27 @@ pub trait DebugApi<TxReq: RpcObject> {
     /// to their preimages that were required during the execution of the block, including during
     /// state root recomputation.
     ///
-    /// The first argument is the block number or tag.
+    /// The first argument is the block number or tag. The optional second argument selects the
+    /// witness generation mode and defaults to `legacy`.
     #[method(name = "executionWitness")]
-    async fn debug_execution_witness(&self, block: BlockNumberOrTag)
-        -> RpcResult<ExecutionWitness>;
+    async fn debug_execution_witness(
+        &self,
+        block: BlockNumberOrTag,
+        mode: Option<ExecutionWitnessMode>,
+    ) -> RpcResult<ExecutionWitness>;
 
     /// The `debug_executionWitnessByBlockHash` method allows for re-execution of a block with the
     /// purpose of generating an execution witness. The witness comprises of a map of all hashed
     /// trie nodes to their preimages that were required during the execution of the block,
     /// including during state root recomputation.
     ///
-    /// The first argument is the block hash.
+    /// The first argument is the block hash. The optional second argument selects the witness
+    /// generation mode and defaults to `legacy`.
     #[method(name = "executionWitnessByBlockHash")]
     async fn debug_execution_witness_by_block_hash(
         &self,
         hash: B256,
+        mode: Option<ExecutionWitnessMode>,
     ) -> RpcResult<ExecutionWitness>;
 
     /// Re-executes a block and returns the Block Access List (BAL) as defined in EIP-7928.

--- a/crates/rpc/rpc-eth-types/src/cache/db.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/db.rs
@@ -101,8 +101,9 @@ impl reth_storage_api::StateProofProvider for StateProviderTraitObjWrapper {
         &self,
         input: reth_trie::TrieInput,
         target: reth_trie::HashedPostState,
+        mode: reth_trie::ExecutionWitnessMode,
     ) -> reth_errors::ProviderResult<Vec<alloy_primitives::Bytes>> {
-        self.0.witness(input, target)
+        self.0.witness(input, target, mode)
     }
 }
 

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -33,11 +33,10 @@ use reth_rpc_eth_types::EthApiError;
 use reth_rpc_server_types::{result::internal_rpc_err, ToRpcResult};
 use reth_storage_api::{
     BlockIdReader, BlockReaderIdExt, HashedPostStateProvider, HeaderProvider, ProviderBlock,
-    ReceiptProviderIdExt, StateProofProvider, StateProviderFactory, StateRootProvider,
-    TransactionVariant,
+    ReceiptProviderIdExt, StateProviderFactory, StateRootProvider, TransactionVariant,
 };
 use reth_tasks::{pool::BlockingTaskGuard, Runtime};
-use reth_trie_common::{updates::TrieUpdates, HashedPostState};
+use reth_trie_common::{updates::TrieUpdates, ExecutionWitnessMode, HashedPostState};
 use revm::{database::states::bundle_state::BundleRetention, DatabaseCommit};
 use revm_inspectors::tracing::{DebugInspector, TransactionContext};
 use serde::{Deserialize, Serialize};
@@ -498,6 +497,7 @@ where
     pub async fn debug_execution_witness_by_block_hash(
         &self,
         hash: B256,
+        mode: Option<ExecutionWitnessMode>,
     ) -> Result<ExecutionWitness, Eth::Error> {
         let this = self.clone();
         let block = this
@@ -506,7 +506,7 @@ where
             .await?
             .ok_or(EthApiError::HeaderNotFound(hash.into()))?;
 
-        self.debug_execution_witness_for_block(block).await
+        self.debug_execution_witness_for_block(block, mode.unwrap_or_default()).await
     }
 
     /// The `debug_executionWitness` method allows for re-execution of a block with the purpose of
@@ -516,6 +516,7 @@ where
     pub async fn debug_execution_witness(
         &self,
         block_id: BlockNumberOrTag,
+        mode: Option<ExecutionWitnessMode>,
     ) -> Result<ExecutionWitness, Eth::Error> {
         let this = self.clone();
         let block = this
@@ -524,18 +525,17 @@ where
             .await?
             .ok_or(EthApiError::HeaderNotFound(block_id.into()))?;
 
-        self.debug_execution_witness_for_block(block).await
+        self.debug_execution_witness_for_block(block, mode.unwrap_or_default()).await
     }
 
     /// Generates an execution witness, using the given recovered block.
     pub async fn debug_execution_witness_for_block(
         &self,
         block: Arc<RecoveredBlock<ProviderBlock<Eth::Provider>>>,
+        mode: ExecutionWitnessMode,
     ) -> Result<ExecutionWitness, Eth::Error> {
         let block_number = block.header().number();
-
-        let (mut exec_witness, lowest_block_number) = self
-            .eth_api()
+        self.eth_api()
             .spawn_with_state_at_block(block.parent_hash(), move |eth_api, mut db| {
                 let block_executor = eth_api.evm_config().executor(&mut db);
 
@@ -543,48 +543,15 @@ where
 
                 let _ = block_executor
                     .execute_with_state_closure(&block, |statedb: &State<_>| {
-                        witness_record.record_executed_state(statedb);
+                        witness_record.record_executed_state(statedb, mode);
                     })
                     .map_err(|err| EthApiError::Internal(err.into()))?;
 
-                let ExecutionWitnessRecord { hashed_state, codes, keys, lowest_block_number } =
-                    witness_record;
-
-                let state = db
-                    .database
-                    .0
-                    .witness(Default::default(), hashed_state)
-                    .map_err(EthApiError::from)?;
-                Ok((
-                    ExecutionWitness { state, codes, keys, ..Default::default() },
-                    lowest_block_number,
-                ))
+                Ok(witness_record
+                    .into_execution_witness(&db.database.0, eth_api.provider(), block_number, mode)
+                    .map_err(EthApiError::from)?)
             })
-            .await?;
-
-        let smallest = match lowest_block_number {
-            Some(smallest) => smallest,
-            None => {
-                // Return only the parent header, if there were no calls to the
-                // BLOCKHASH opcode.
-                block_number.saturating_sub(1)
-            }
-        };
-
-        let range = smallest..block_number;
-        exec_witness.headers = self
-            .provider()
-            .headers_range(range)
-            .map_err(EthApiError::from)?
-            .into_iter()
-            .map(|header| {
-                let mut serialized_header = Vec::new();
-                header.encode(&mut serialized_header);
-                serialized_header.into()
-            })
-            .collect();
-
-        Ok(exec_witness)
+            .await
     }
 
     /// Returns the code associated with a given hash at the specified block ID. If no code is
@@ -846,18 +813,20 @@ where
     async fn debug_execution_witness(
         &self,
         block: BlockNumberOrTag,
+        mode: Option<ExecutionWitnessMode>,
     ) -> RpcResult<ExecutionWitness> {
         let _permit = self.acquire_trace_permit().await;
-        Self::debug_execution_witness(self, block).await.map_err(Into::into)
+        Self::debug_execution_witness(self, block, mode).await.map_err(Into::into)
     }
 
     /// Handler for `debug_executionWitnessByBlockHash`
     async fn debug_execution_witness_by_block_hash(
         &self,
         hash: B256,
+        mode: Option<ExecutionWitnessMode>,
     ) -> RpcResult<ExecutionWitness> {
         let _permit = self.acquire_trace_permit().await;
-        Self::debug_execution_witness_by_block_hash(self, hash).await.map_err(Into::into)
+        Self::debug_execution_witness_by_block_hash(self, hash, mode).await.map_err(Into::into)
     }
 
     async fn debug_get_block_access_list(&self, _block_id: BlockId) -> RpcResult<BlockAccessList> {

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -23,9 +23,9 @@ use reth_trie::{
     trie_cursor::InMemoryTrieCursorFactory,
     updates::TrieUpdates,
     witness::TrieWitness,
-    AccountProof, HashedPostState, HashedPostStateSorted, HashedStorage, KeccakKeyHasher,
-    MultiProof, MultiProofTargets, StateRoot, StorageMultiProof, StorageRoot, TrieInput,
-    TrieInputSorted,
+    AccountProof, ExecutionWitnessMode, HashedPostState, HashedPostStateSorted, HashedStorage,
+    KeccakKeyHasher, MultiProof, MultiProofTargets, StateRoot, StorageMultiProof, StorageRoot,
+    TrieInput, TrieInputSorted,
 };
 use reth_trie_db::{
     hashed_storage_from_reverts_with_provider, DatabaseProof, DatabaseStateRoot,
@@ -524,13 +524,18 @@ impl<
         })
     }
 
-    fn witness(&self, input: TrieInput, target: HashedPostState) -> ProviderResult<Vec<Bytes>> {
+    fn witness(
+        &self,
+        input: TrieInput,
+        target: HashedPostState,
+        mode: ExecutionWitnessMode,
+    ) -> ProviderResult<Vec<Bytes>> {
         reth_trie_db::with_adapter!(self.provider, |A| {
             let mut input = input;
             input.prepend(self.revert_state()?.into());
             let nodes_sorted = input.nodes.into_sorted();
             let state_sorted = input.state.into_sorted();
-            TrieWitness::new(
+            let witness = TrieWitness::new(
                 InMemoryTrieCursorFactory::new(
                     reth_trie_db::DatabaseTrieCursorFactory::<_, A>::new(self.tx()),
                     &nodes_sorted,
@@ -541,10 +546,16 @@ impl<
                 ),
             )
             .with_prefix_sets_mut(input.prefix_sets)
-            .always_include_root_node()
-            .compute(target)
-            .map_err(ProviderError::from)
-            .map(|hm| hm.into_values().collect())
+            .with_execution_witness_mode(mode);
+            let witness =
+                if mode.is_canonical() { witness } else { witness.always_include_root_node() };
+            witness.compute(target).map_err(ProviderError::from).map(|hm| {
+                let mut values: Vec<_> = hm.into_values().collect();
+                if mode.is_canonical() {
+                    values.sort_unstable();
+                }
+                values
+            })
         })
     }
 }

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -14,8 +14,9 @@ use reth_trie::{
     trie_cursor::InMemoryTrieCursorFactory,
     updates::TrieUpdates,
     witness::TrieWitness,
-    AccountProof, HashedPostState, HashedStorage, KeccakKeyHasher, MultiProof, MultiProofTargets,
-    StateRoot, StorageMultiProof, StorageRoot, TrieInput, TrieInputSorted,
+    AccountProof, ExecutionWitnessMode, HashedPostState, HashedStorage, KeccakKeyHasher,
+    MultiProof, MultiProofTargets, StateRoot, StorageMultiProof, StorageRoot, TrieInput,
+    TrieInputSorted,
 };
 use reth_trie_db::{DatabaseProof, DatabaseStateRoot, DatabaseStorageProof, DatabaseStorageRoot};
 
@@ -218,11 +219,16 @@ impl<Provider: DBProvider + StorageSettingsCache> StateProofProvider
         })
     }
 
-    fn witness(&self, input: TrieInput, target: HashedPostState) -> ProviderResult<Vec<Bytes>> {
+    fn witness(
+        &self,
+        input: TrieInput,
+        target: HashedPostState,
+        mode: ExecutionWitnessMode,
+    ) -> ProviderResult<Vec<Bytes>> {
         reth_trie_db::with_adapter!(self.0, |A| {
             let nodes_sorted = input.nodes.into_sorted();
             let state_sorted = input.state.into_sorted();
-            Ok(TrieWitness::new(
+            let witness = TrieWitness::new(
                 InMemoryTrieCursorFactory::new(
                     reth_trie_db::DatabaseTrieCursorFactory::<_, A>::new(self.tx()),
                     &nodes_sorted,
@@ -233,10 +239,14 @@ impl<Provider: DBProvider + StorageSettingsCache> StateProofProvider
                 ),
             )
             .with_prefix_sets_mut(input.prefix_sets)
-            .always_include_root_node()
-            .compute(target)?
-            .into_values()
-            .collect())
+            .with_execution_witness_mode(mode);
+            let witness =
+                if mode.is_canonical() { witness } else { witness.always_include_root_node() };
+            let mut values: Vec<_> = witness.compute(target)?.into_values().collect();
+            if mode.is_canonical() {
+                values.sort_unstable();
+            }
+            Ok(values)
         })
     }
 }

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -857,7 +857,12 @@ where
         Ok(MultiProof::default())
     }
 
-    fn witness(&self, _input: TrieInput, _target: HashedPostState) -> ProviderResult<Vec<Bytes>> {
+    fn witness(
+        &self,
+        _input: TrieInput,
+        _target: HashedPostState,
+        _mode: reth_trie::ExecutionWitnessMode,
+    ) -> ProviderResult<Vec<Bytes>> {
         Ok(Vec::default())
     }
 }

--- a/crates/storage/rpc-provider/src/lib.rs
+++ b/crates/storage/rpc-provider/src/lib.rs
@@ -1303,6 +1303,7 @@ where
         &self,
         _input: TrieInput,
         _target: HashedPostState,
+        _mode: reth_trie::ExecutionWitnessMode,
     ) -> Result<Vec<alloy_primitives::Bytes>, ProviderError> {
         Err(ProviderError::UnsupportedProvider)
     }

--- a/crates/storage/storage-api/src/macros.rs
+++ b/crates/storage/storage-api/src/macros.rs
@@ -59,7 +59,7 @@ macro_rules! delegate_provider_impls {
             StateProofProvider $(where [$($generics)*])? {
                 fn proof(&self, input: reth_trie::TrieInput, address: alloy_primitives::Address, slots: &[alloy_primitives::B256]) -> reth_storage_api::errors::provider::ProviderResult<reth_trie::AccountProof>;
                 fn multiproof(&self, input: reth_trie::TrieInput, targets: reth_trie::MultiProofTargets) -> reth_storage_api::errors::provider::ProviderResult<reth_trie::MultiProof>;
-                fn witness(&self, input: reth_trie::TrieInput, target: reth_trie::HashedPostState) -> reth_storage_api::errors::provider::ProviderResult<Vec<alloy_primitives::Bytes>>;
+                fn witness(&self, input: reth_trie::TrieInput, target: reth_trie::HashedPostState, mode: reth_trie::ExecutionWitnessMode) -> reth_storage_api::errors::provider::ProviderResult<Vec<alloy_primitives::Bytes>>;
             }
             HashedPostStateProvider $(where [$($generics)*])? {
                 fn hashed_post_state(&self, bundle_state: &revm_database::BundleState) -> reth_trie::HashedPostState;

--- a/crates/storage/storage-api/src/noop.rs
+++ b/crates/storage/storage-api/src/noop.rs
@@ -35,8 +35,8 @@ use reth_prune_types::{PruneCheckpoint, PruneSegment};
 use reth_stages_types::{StageCheckpoint, StageId};
 use reth_storage_errors::provider::{ProviderError, ProviderResult};
 use reth_trie_common::{
-    updates::TrieUpdates, AccountProof, HashedPostState, HashedStorage, MultiProof,
-    MultiProofTargets, StorageMultiProof, StorageProof, TrieInput,
+    updates::TrieUpdates, AccountProof, ExecutionWitnessMode, HashedPostState, HashedStorage,
+    MultiProof, MultiProofTargets, StorageMultiProof, StorageProof, TrieInput,
 };
 
 /// Supports various api interfaces for testing purposes.
@@ -504,7 +504,12 @@ impl<C: Send + Sync, N: NodePrimitives> StateProofProvider for NoopProvider<C, N
         Ok(MultiProof::default())
     }
 
-    fn witness(&self, _input: TrieInput, _target: HashedPostState) -> ProviderResult<Vec<Bytes>> {
+    fn witness(
+        &self,
+        _input: TrieInput,
+        _target: HashedPostState,
+        _mode: ExecutionWitnessMode,
+    ) -> ProviderResult<Vec<Bytes>> {
         Ok(Vec::default())
     }
 }

--- a/crates/storage/storage-api/src/trie.rs
+++ b/crates/storage/storage-api/src/trie.rs
@@ -3,8 +3,8 @@ use alloy_primitives::{Address, Bytes, B256};
 use reth_storage_errors::provider::ProviderResult;
 use reth_trie_common::{
     updates::{StorageTrieUpdatesSorted, TrieUpdates, TrieUpdatesSorted},
-    AccountProof, HashedPostState, HashedStorage, MultiProof, MultiProofTargets, StorageMultiProof,
-    StorageProof, TrieInput,
+    AccountProof, ExecutionWitnessMode, HashedPostState, HashedStorage, MultiProof,
+    MultiProofTargets, StorageMultiProof, StorageProof, TrieInput,
 };
 
 /// A type that can compute the state root of a given post state.
@@ -85,8 +85,13 @@ pub trait StateProofProvider {
         targets: MultiProofTargets,
     ) -> ProviderResult<MultiProof>;
 
-    /// Get trie witness for provided state.
-    fn witness(&self, input: TrieInput, target: HashedPostState) -> ProviderResult<Vec<Bytes>>;
+    /// Get trie witness for provided state using the given witness generation mode.
+    fn witness(
+        &self,
+        input: TrieInput,
+        target: HashedPostState,
+        mode: ExecutionWitnessMode,
+    ) -> ProviderResult<Vec<Bytes>>;
 }
 
 /// Trie Writer

--- a/crates/trie/common/src/execution_witness.rs
+++ b/crates/trie/common/src/execution_witness.rs
@@ -1,0 +1,18 @@
+/// Controls how execution witnesses are generated.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
+pub enum ExecutionWitnessMode {
+    /// Preserve the current witness shape for compatibility with existing consumers.
+    #[default]
+    Legacy,
+    /// Produce the minimized, draft-spec witness form.
+    Canonical,
+}
+
+impl ExecutionWitnessMode {
+    /// Returns `true` if the mode is [`Self::Canonical`].
+    pub const fn is_canonical(self) -> bool {
+        matches!(self, Self::Canonical)
+    }
+}

--- a/crates/trie/common/src/execution_witness.rs
+++ b/crates/trie/common/src/execution_witness.rs
@@ -3,10 +3,26 @@
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 pub enum ExecutionWitnessMode {
-    /// Preserve the current witness shape for compatibility with existing consumers.
+    /// Produces the legacy execution witness format.
     #[default]
     Legacy,
-    /// Produce the minimized, draft-spec witness form.
+    /// Produces the canonical spec currently implemented in
+    /// ethereum/execution-specs@projects/zkevm. The main differences with the
+    /// legacy format are:
+    /// - For the `bytecode` field:
+    ///     - It contains only bytecodes required for execution, compared to Legacy which also
+    ///       contains created bytecode.
+    ///     - Compared to Legacy, it does not include empty bytecodes (i.e. 0x80).
+    ///     - Values are sorted lexicographically ascending.
+    /// - For the `state` field:
+    ///     - Avoids including empty nodes (i.e. 0x80).
+    ///     - Compared to legacy, it does not include storage trie root nodes if no storae is
+    ///       accessed.
+    ///     - It contains the minimum amount of sibilings for post-state root calculation, since it
+    ///       does updates/insertions first and then deletions. Compared to legacy which does the
+    ///       post-state calculation with removals and then insertions/updates, which results in
+    ///       more siblings.
+    ///     - Values are sorted lexicographically ascending.
     Canonical,
 }
 

--- a/crates/trie/common/src/execution_witness.rs
+++ b/crates/trie/common/src/execution_witness.rs
@@ -18,7 +18,7 @@ pub enum ExecutionWitnessMode {
     ///     - Avoids including empty nodes (i.e. 0x80).
     ///     - Compared to legacy, it does not include storage trie root nodes if no storae is
     ///       accessed.
-    ///     - It contains the minimum amount of sibilings for post-state root calculation, since it
+    ///     - It contains the minimum amount of siblings for post-state root calculation, since it
     ///       does updates/insertions first and then deletions. Compared to legacy which does the
     ///       post-state calculation with removals and then insertions/updates, which results in
     ///       more siblings.

--- a/crates/trie/common/src/execution_witness.rs
+++ b/crates/trie/common/src/execution_witness.rs
@@ -16,7 +16,7 @@ pub enum ExecutionWitnessMode {
     ///     - Values are sorted lexicographically ascending.
     /// - For the `state` field:
     ///     - Avoids including empty nodes (i.e. 0x80).
-    ///     - Compared to legacy, it does not include storage trie root nodes if no storae is
+    ///     - Compared to legacy, it does not include storage trie root nodes if no storage is
     ///       accessed.
     ///     - It contains the minimum amount of siblings for post-state root calculation, since it
     ///       does updates/insertions first and then deletions. Compared to legacy which does the

--- a/crates/trie/common/src/lib.rs
+++ b/crates/trie/common/src/lib.rs
@@ -11,6 +11,9 @@
 
 extern crate alloc;
 
+mod execution_witness;
+pub use execution_witness::ExecutionWitnessMode;
+
 /// Lazy initialization wrapper for trie data.
 mod lazy;
 pub use lazy::{LazyTrieData, SortedTrieData};

--- a/crates/trie/db/tests/witness.rs
+++ b/crates/trie/db/tests/witness.rs
@@ -13,15 +13,18 @@ use reth_primitives_traits::{Account, StorageEntry};
 use reth_provider::{test_utils::create_test_provider_factory, HashingWriter};
 use reth_storage_api::StorageSettingsCache;
 use reth_trie::{
-    proof::Proof, witness::TrieWitness, HashedPostState, HashedStorage, MultiProofTargets,
-    StateRoot,
+    proof::Proof, witness::TrieWitness, ExecutionWitnessMode, HashedPostState, HashedStorage,
+    LeafNode, MultiProofTargets, Nibbles, StateRoot, StorageRoot, TrieNodeV2,
 };
 use reth_trie_db::{
-    DatabaseHashedCursorFactory, DatabaseProof, DatabaseStateRoot, DatabaseTrieCursorFactory,
+    DatabaseHashedCursorFactory, DatabaseProof, DatabaseStateRoot, DatabaseStorageRoot,
+    DatabaseTrieCursorFactory,
 };
 
 type DbStateRoot<'a, TX, A> =
     StateRoot<DatabaseTrieCursorFactory<&'a TX, A>, DatabaseHashedCursorFactory<&'a TX>>;
+type DbStorageRoot<'a, TX, A> =
+    StorageRoot<DatabaseTrieCursorFactory<&'a TX, A>, DatabaseHashedCursorFactory<&'a TX>>;
 type DbProof<'a, TX, A> =
     Proof<DatabaseTrieCursorFactory<&'a TX, A>, DatabaseHashedCursorFactory<&'a TX>>;
 #[test]
@@ -34,19 +37,32 @@ fn includes_empty_node_preimage() {
     let hashed_slot = B256::random();
 
     reth_trie_db::with_adapter!(provider, |A| {
-        // witness includes empty state trie root node
+        let legacy_empty_witness = TrieWitness::new(
+            DatabaseTrieCursorFactory::<_, A>::new(provider.tx_ref()),
+            DatabaseHashedCursorFactory::new(provider.tx_ref()),
+        )
+        .with_execution_witness_mode(ExecutionWitnessMode::Legacy)
+        .compute(HashedPostState {
+            accounts: HashMap::from_iter([(hashed_address, Some(Account::default()))]),
+            storages: HashMap::default(),
+        })
+        .unwrap();
         assert_eq!(
-            TrieWitness::new(
-                DatabaseTrieCursorFactory::<_, A>::new(provider.tx_ref()),
-                DatabaseHashedCursorFactory::new(provider.tx_ref()),
-            )
-            .compute(HashedPostState {
-                accounts: HashMap::from_iter([(hashed_address, Some(Account::default()))]),
-                storages: HashMap::default(),
-            })
-            .unwrap(),
+            legacy_empty_witness,
             HashMap::from_iter([(EMPTY_ROOT_HASH, Bytes::from([EMPTY_STRING_CODE]))])
         );
+
+        let canonical_empty_witness = TrieWitness::new(
+            DatabaseTrieCursorFactory::<_, A>::new(provider.tx_ref()),
+            DatabaseHashedCursorFactory::new(provider.tx_ref()),
+        )
+        .with_execution_witness_mode(ExecutionWitnessMode::Canonical)
+        .compute(HashedPostState {
+            accounts: HashMap::from_iter([(hashed_address, Some(Account::default()))]),
+            storages: HashMap::default(),
+        })
+        .unwrap();
+        assert!(canonical_empty_witness.is_empty());
 
         // Insert account into database
         provider.insert_account_for_hashing([(address, Some(Account::default()))]).unwrap();
@@ -60,10 +76,11 @@ fn includes_empty_node_preimage() {
             )]))
             .unwrap();
 
-        let witness = TrieWitness::new(
+        let legacy_witness = TrieWitness::new(
             DatabaseTrieCursorFactory::<_, A>::new(provider.tx_ref()),
             DatabaseHashedCursorFactory::new(provider.tx_ref()),
         )
+        .with_execution_witness_mode(ExecutionWitnessMode::Legacy)
         .compute(HashedPostState {
             accounts: HashMap::from_iter([(hashed_address, Some(Account::default()))]),
             storages: HashMap::from_iter([(
@@ -72,12 +89,30 @@ fn includes_empty_node_preimage() {
             )]),
         })
         .unwrap();
-        assert!(witness.contains_key(&state_root));
+        assert!(legacy_witness.contains_key(&state_root));
         for node in multiproof.account_subtree.values() {
-            assert_eq!(witness.get(&keccak256(node)), Some(node));
+            assert_eq!(legacy_witness.get(&keccak256(node)), Some(node));
         }
-        // witness includes empty state trie root node
-        assert_eq!(witness.get(&EMPTY_ROOT_HASH), Some(&Bytes::from([EMPTY_STRING_CODE])));
+        assert_eq!(legacy_witness.get(&EMPTY_ROOT_HASH), Some(&Bytes::from([EMPTY_STRING_CODE])));
+
+        let canonical_witness = TrieWitness::new(
+            DatabaseTrieCursorFactory::<_, A>::new(provider.tx_ref()),
+            DatabaseHashedCursorFactory::new(provider.tx_ref()),
+        )
+        .with_execution_witness_mode(ExecutionWitnessMode::Canonical)
+        .compute(HashedPostState {
+            accounts: HashMap::from_iter([(hashed_address, Some(Account::default()))]),
+            storages: HashMap::from_iter([(
+                hashed_address,
+                HashedStorage::from_iter(false, [(hashed_slot, U256::from(1))]),
+            )]),
+        })
+        .unwrap();
+        assert!(canonical_witness.contains_key(&state_root));
+        for node in multiproof.account_subtree.values() {
+            assert_eq!(canonical_witness.get(&keccak256(node)), Some(node));
+        }
+        assert!(!canonical_witness.contains_key(&EMPTY_ROOT_HASH));
     });
 }
 
@@ -183,5 +218,165 @@ fn correctly_decodes_branch_node_values() {
         for node in multiproof.storages.values().flat_map(|storage| storage.subtree.values()) {
             assert_eq!(witness.get(&keccak256(node)), Some(node));
         }
+    });
+}
+
+#[test]
+fn skips_storage_root_node_for_account_only_changes_in_canonical_mode() {
+    let factory = create_test_provider_factory();
+    let provider = factory.provider_rw().unwrap();
+
+    let address = Address::random();
+    let hashed_address = keccak256(address);
+    let slot = B256::random();
+
+    provider
+        .insert_account_for_hashing([(
+            address,
+            Some(Account { balance: U256::from(1), ..Default::default() }),
+        )])
+        .unwrap();
+    provider
+        .insert_storage_for_hashing([(address, [StorageEntry { key: slot, value: U256::from(7) }])])
+        .unwrap();
+
+    reth_trie_db::with_adapter!(provider, |A| {
+        let state_root = DbStateRoot::<_, A>::from_tx(provider.tx_ref()).root().unwrap();
+        let storage_root =
+            DbStorageRoot::<_, A>::from_tx(provider.tx_ref(), address).root().unwrap();
+        let proof = <DbProof<'_, _, A> as DatabaseProof>::from_tx(provider.tx_ref());
+        let multiproof = proof
+            .multiproof(MultiProofTargets::from_iter([(hashed_address, HashSet::default())]))
+            .unwrap();
+
+        let target_state = HashedPostState {
+            accounts: HashMap::from_iter([(
+                hashed_address,
+                Some(Account { balance: U256::from(2), ..Default::default() }),
+            )]),
+            storages: HashMap::default(),
+        };
+
+        let legacy_witness = TrieWitness::new(
+            DatabaseTrieCursorFactory::<_, A>::new(provider.tx_ref()),
+            DatabaseHashedCursorFactory::new(provider.tx_ref()),
+        )
+        .with_execution_witness_mode(ExecutionWitnessMode::Legacy)
+        .compute(target_state.clone())
+        .unwrap();
+        assert!(legacy_witness.contains_key(&state_root));
+        for node in multiproof.account_subtree.values() {
+            assert_eq!(legacy_witness.get(&keccak256(node)), Some(node));
+        }
+        assert!(legacy_witness.contains_key(&storage_root));
+
+        let canonical_witness = TrieWitness::new(
+            DatabaseTrieCursorFactory::<_, A>::new(provider.tx_ref()),
+            DatabaseHashedCursorFactory::new(provider.tx_ref()),
+        )
+        .with_execution_witness_mode(ExecutionWitnessMode::Canonical)
+        .compute(target_state)
+        .unwrap();
+        assert!(canonical_witness.contains_key(&state_root));
+        for node in multiproof.account_subtree.values() {
+            assert_eq!(canonical_witness.get(&keccak256(node)), Some(node));
+        }
+        assert!(!canonical_witness.contains_key(&storage_root));
+    });
+}
+
+#[test]
+fn canonical_mode_handles_mixed_storage_inserts_and_removals() {
+    let factory = create_test_provider_factory();
+    let provider = factory.provider_rw().unwrap();
+
+    let address = Address::random();
+    let hashed_address = keccak256(address);
+
+    // Pre-state storage root is a branch with two children at nibbles 1 and 2.
+    let removed_slot = {
+        let mut bytes = [0u8; 32];
+        bytes[0] = 0x10;
+        B256::from(bytes)
+    };
+    let retained_slot = {
+        let mut bytes = [0u8; 32];
+        bytes[0] = 0x20;
+        B256::from(bytes)
+    };
+    let inserted_slot = {
+        let mut bytes = [0u8; 32];
+        bytes[0] = 0x30;
+        B256::from(bytes)
+    };
+    let retained_leaf = Bytes::from(alloy_rlp::encode(TrieNodeV2::Leaf(LeafNode::new(
+        Nibbles::unpack(retained_slot).slice(1..),
+        alloy_rlp::encode_fixed_size(&U256::from(2)).to_vec(),
+    ))));
+    let retained_leaf_hash = keccak256(&retained_leaf);
+
+    // The initial proof targets only the removed slot and the missing inserted slot, so the
+    // surviving sibling starts out blinded.
+    provider.insert_account_for_hashing([(address, Some(Account::default()))]).unwrap();
+    let mut hashed_storage_cursor =
+        provider.tx_ref().cursor_dup_write::<tables::HashedStorages>().unwrap();
+    hashed_storage_cursor
+        .upsert(hashed_address, &StorageEntry { key: removed_slot, value: U256::from(1) })
+        .unwrap();
+    hashed_storage_cursor
+        .upsert(hashed_address, &StorageEntry { key: retained_slot, value: U256::from(2) })
+        .unwrap();
+
+    reth_trie_db::with_adapter!(provider, |A| {
+        let state_root = DbStateRoot::<_, A>::from_tx(provider.tx_ref()).root().unwrap();
+        let proof = <DbProof<'_, _, A> as DatabaseProof>::from_tx(provider.tx_ref());
+        let initial_multiproof = proof
+            .multiproof(MultiProofTargets::from_iter([(
+                hashed_address,
+                HashSet::from_iter([removed_slot, inserted_slot]),
+            )]))
+            .unwrap();
+        assert!(initial_multiproof
+            .storages
+            .values()
+            .flat_map(|storage| storage.subtree.values())
+            .all(|node| node != &retained_leaf));
+
+        // Apply one removal and one insertion in the same storage trie subtree.
+        let state_diff = HashedPostState {
+            accounts: HashMap::from_iter([(hashed_address, Some(Account::default()))]),
+            storages: HashMap::from_iter([(
+                hashed_address,
+                HashedStorage::from_iter(
+                    false,
+                    [(removed_slot, U256::ZERO), (inserted_slot, U256::from(3))],
+                ),
+            )]),
+        };
+
+        // Legacy removes first, so the two-child branch collapses onto the surviving sibling
+        // before the new child exists. That forces an extra proof fetch for the sibling leaf.
+        let legacy_witness = TrieWitness::new(
+            DatabaseTrieCursorFactory::<_, A>::new(provider.tx_ref()),
+            DatabaseHashedCursorFactory::new(provider.tx_ref()),
+        )
+        .with_execution_witness_mode(ExecutionWitnessMode::Legacy)
+        .compute(state_diff.clone())
+        .unwrap();
+        assert!(legacy_witness.contains_key(&state_root));
+        assert_eq!(legacy_witness.get(&retained_leaf_hash), Some(&retained_leaf));
+
+        // Canonical inserts first, so the branch never compresses to a single blinded child and
+        // the surviving sibling leaf is not needed in the witness.
+        let canonical_witness = TrieWitness::new(
+            DatabaseTrieCursorFactory::<_, A>::new(provider.tx_ref()),
+            DatabaseHashedCursorFactory::new(provider.tx_ref()),
+        )
+        .with_execution_witness_mode(ExecutionWitnessMode::Canonical)
+        .compute(state_diff)
+        .unwrap();
+        assert!(canonical_witness.contains_key(&state_root));
+        assert!(!canonical_witness.contains_key(&retained_leaf_hash));
+        assert!(canonical_witness.iter().all(|(_, node)| node.as_ref() != [EMPTY_STRING_CODE]));
     });
 }

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -15,7 +15,8 @@ use alloy_rlp::{Encodable, EMPTY_STRING_CODE};
 use alloy_trie::{nodes::BranchNodeRef, EMPTY_ROOT_HASH};
 use reth_execution_errors::{SparseStateTrieErrorKind, StateProofError, TrieWitnessError};
 use reth_trie_common::{
-    DecodedMultiProofV2, HashedPostState, MultiProofTargetsV2, ProofV2Target, TrieNodeV2,
+    DecodedMultiProofV2, ExecutionWitnessMode, HashedPostState, MultiProofTargetsV2, ProofV2Target,
+    TrieNodeV2,
 };
 use reth_trie_sparse::{LeafUpdate, SparseStateTrie, SparseTrie as _};
 
@@ -33,6 +34,8 @@ pub struct TrieWitness<T, H> {
     /// parent state root.
     /// Set to `false` by default.
     always_include_root_node: bool,
+    /// Controls how the witness is generated.
+    mode: ExecutionWitnessMode,
     /// Recorded witness.
     witness: B256Map<Bytes>,
 }
@@ -45,6 +48,7 @@ impl<T, H> TrieWitness<T, H> {
             hashed_cursor_factory,
             prefix_sets: TriePrefixSetsMut::default(),
             always_include_root_node: false,
+            mode: ExecutionWitnessMode::Legacy,
             witness: HashMap::default(),
         }
     }
@@ -56,6 +60,7 @@ impl<T, H> TrieWitness<T, H> {
             hashed_cursor_factory: self.hashed_cursor_factory,
             prefix_sets: self.prefix_sets,
             always_include_root_node: self.always_include_root_node,
+            mode: self.mode,
             witness: self.witness,
         }
     }
@@ -67,6 +72,7 @@ impl<T, H> TrieWitness<T, H> {
             hashed_cursor_factory,
             prefix_sets: self.prefix_sets,
             always_include_root_node: self.always_include_root_node,
+            mode: self.mode,
             witness: self.witness,
         }
     }
@@ -82,6 +88,12 @@ impl<T, H> TrieWitness<T, H> {
     /// parent state root.
     pub const fn always_include_root_node(mut self) -> Self {
         self.always_include_root_node = true;
+        self
+    }
+
+    /// Set the execution witness generation mode.
+    pub const fn with_execution_witness_mode(mut self, mode: ExecutionWitnessMode) -> Self {
+        self.mode = mode;
         self
     }
 }
@@ -146,11 +158,11 @@ where
         sparse_trie.reveal_decoded_multiproof_v2(multiproof)?;
 
         // Build storage leaf updates for all accounts with storage changes, split into
-        // removals and upserts. Removals must be applied first so that branch collapse
-        // detection fires correctly: if a removal and an insertion target siblings under
-        // the same branch, processing the removal first may reduce the branch to a single
-        // blinded child, triggering a proof fetch for the sibling. Processing the insertion
-        // first would add a new child that keeps the count above one, masking the need.
+        // removals and upserts. Legacy mode applies removals first to preserve the
+        // historical witness shape expected by existing consumers: a removal can collapse
+        // a branch and force proof fetches that some consumers still rely on. Canonical
+        // mode applies upserts first to avoid those compatibility-only nodes and emit
+        // the minimized draft-spec witness.
         let mut storage_removals: B256Map<B256Map<LeafUpdate>> = B256Map::default();
         let mut storage_upserts: B256Map<B256Map<LeafUpdate>> = B256Map::default();
         for (hashed_address, storage) in &state.storages {
@@ -169,8 +181,14 @@ where
             }
         }
 
-        // Apply storage removals first, then upserts, fetching additional proofs as needed.
-        for storage_updates in [&mut storage_removals, &mut storage_upserts] {
+        let storage_update_sets = if self.mode.is_canonical() {
+            [&mut storage_upserts, &mut storage_removals]
+        } else {
+            [&mut storage_removals, &mut storage_upserts]
+        };
+
+        // Apply storage updates in mode-specific order, fetching additional proofs as needed.
+        for storage_updates in storage_update_sets {
             loop {
                 let mut targets = MultiProofTargetsV2::default();
 
@@ -212,8 +230,10 @@ where
             }
         }
 
-        // Build account leaf updates, split into removals and upserts (same reasoning
-        // as for storage updates above).
+        // Build account leaf updates, split into removals and upserts. Legacy mode keeps
+        // removals-first for the same compatibility reason as storage updates, while
+        // canonical mode uses upserts-first so account updates follow the minimized
+        // draft-spec witness order.
         let mut account_removals: B256Map<LeafUpdate> = B256Map::default();
         let mut account_upserts: B256Map<LeafUpdate> = B256Map::default();
         for &hashed_address in state.accounts.keys().chain(state.storages.keys()) {
@@ -233,7 +253,12 @@ where
                 if let Some(storage_trie) = sparse_trie.storage_trie_mut(&hashed_address) {
                     storage_trie.root()
                 } else {
-                    self.account_storage_root(hashed_address)?
+                    let record_root_node = !self.mode.is_canonical() ||
+                        state
+                            .storages
+                            .get(&hashed_address)
+                            .is_some_and(|storage| !storage.storage.is_empty());
+                    self.account_storage_root(hashed_address, record_root_node)?
                 };
 
             if account.is_empty() && storage_root == EMPTY_ROOT_HASH {
@@ -245,8 +270,14 @@ where
             }
         }
 
-        // Apply account removals first, then upserts, fetching additional proofs as needed.
-        for account_updates in [&mut account_removals, &mut account_upserts] {
+        let account_update_sets = if self.mode.is_canonical() {
+            [&mut account_upserts, &mut account_removals]
+        } else {
+            [&mut account_removals, &mut account_upserts]
+        };
+
+        // Apply account updates in mode-specific order, fetching additional proofs as needed.
+        for account_updates in account_update_sets {
             loop {
                 let mut targets = MultiProofTargetsV2::default();
 
@@ -270,6 +301,12 @@ where
                 self.record_multiproof_nodes(&multiproof);
                 sparse_trie.reveal_decoded_multiproof_v2(multiproof)?;
             }
+        }
+
+        if self.mode.is_canonical() {
+            // Empty trie nodes carry no useful witness information and are trivially
+            // reconstructible from the empty root hash.
+            self.witness.retain(|_, value| value.as_ref() != [EMPTY_STRING_CODE]);
         }
 
         Ok(self.witness)
@@ -306,8 +343,12 @@ where
     }
 
     /// Compute the storage root for an account by walking the storage trie using the cursor
-    /// factories and trie input prefix sets. Records the root node in the witness.
-    fn account_storage_root(&mut self, hashed_address: B256) -> Result<B256, TrieWitnessError> {
+    /// factories and trie input prefix sets. Records the root node in the witness when requested.
+    fn account_storage_root(
+        &mut self,
+        hashed_address: B256,
+        record_root_node: bool,
+    ) -> Result<B256, TrieWitnessError> {
         let storage_trie_cursor = self
             .trie_cursor_factory
             .storage_trie_cursor(hashed_address)
@@ -328,8 +369,10 @@ where
             .compute_root_hash(core::slice::from_ref(&root_node))?
             .unwrap_or(EMPTY_ROOT_HASH);
         drop(calculator);
-        let mut encoded = Vec::new();
-        self.record_witness_node(&root_node.node, &mut encoded);
+        if record_root_node {
+            let mut encoded = Vec::new();
+            self.record_witness_node(&root_node.node, &mut encoded);
+        }
         Ok(root_hash)
     }
 


### PR DESCRIPTION
This PR contains changes to Reth to conform to the witness generations specs draft. These specs are still in flux ([PR 1](https://github.com/jsign/execution-specs/pull/1) and [PR 3](https://github.com/jsign/execution-specs/pull/3)). We are working with the EF STEEL team to officialize them.

I'm leaving this PR in draft for a bit to get some feedback about the changes, mostly reg the last paragraph of this PR description.

You don't need to understand the specs fully to review this PR, since all changes must make sense on their own, which I'll help to explain in this PR description and comments.

Note that other required fixes aren't in this repo but in the newly created [paradigmxyz/stateless](https://github.com/paradigmxyz/stateless) (PR there to be created soon).

Below, I’ll summarise the changes, but I’ll also create PR comments extending the explanation a bit more for each case:
- Avoid including empty bytecode case in the witness (i.e. rlp encoded `0x80` ).
- Avoid including empty MPT node references (i.e. rlp encoded `0x80`).
- Avoid including bytecodes generated during execution (i.e., only pre-state bytecodes are needed by a stateless validator).
- Avoid including storage tries root node if the accessed account never accessed any storage slots.
- Change both ParallelTrie and StatelessTrie (but this now lies in `stateless` repo thus in other PR) post-root calculation to apply insertions/updates first and deletions after to minimise MPT nodes included in the witness — this is related to minimising cases of sibling branch compression inclusions.
- Conform to the ordering of `nodes`, `bytecodes` and `ancestors` in `ExecutionWitness` as defined in the spec (basically, lexicographic order for the first two, and `blockNum asc` for the latter).

There is only one change that makes this new execution witness version a breaking change: the new post-state root update ordering (5th bullet point above). If someone uses an execution witness generated by Reth done with this PR, with an older stateless trie implementation, it might find that the post-state root can’t be calculated because the older version of the trie might ask for more MPT nodes than strictly needed. 

We could fix this by adding more code to still support both witness generation styles for a while until people update their code (prob also involves modifying RPC `debug_executionWitness` to have an extra optional param to ask for “canonical form” or the current/mainnet style, or create a new one). If we also want to keep the behavior for other fields (i.e. still keep the bytecodes bloating and other cases, it can become a bit messy since basically all code fixes in this PR should be guarded in some kind of `if canonical_witness` or similar. I guess doable but can get tricky.

Note that the reverse is okay — the new stateless trie (that now lives in paradigmxyz/stateless) can support older-style execution witnesses, since these extra MPT nodes are totally okay to be there (they won’t be used). I want to gauge a bit what the Reth team prefers to do on this front. 

