### PR TITLE
fix: correct message ID in NodeData version error

### DIFF
--- a/crates/net/eth-wire-types/src/message.rs
+++ b/crates/net/eth-wire-types/src/message.rs
@@ -133,7 +133,7 @@ impl<N: NetworkPrimitives> ProtocolMessage<N> {
             }
             EthMessageID::NodeData => {
                 if version >= EthVersion::Eth67 {
-                    return Err(MessageError::Invalid(version, EthMessageID::GetNodeData))
+                    return Err(MessageError::Invalid(version, EthMessageID::NodeData))
                 }
                 EthMessage::NodeData(RequestPair::decode(buf)?)
             }


### PR DESCRIPTION
What was wrong: When rejecting NodeData message for eth/67+, the error incorrectly reported GetNodeData as the invalid message ID instead of NodeData.
Changes: Fixed the error to use correct EthMessageID::NodeData in the error message, matching the actual message type being rejected.