### PR TITLE
perf(storage): skip plain state conversion in write_state for storage v2

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -845,10 +845,6 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
     }
 
     /// Writes bytecodes to MDBX.
-    ///
-    /// Also used as a fast path in [`StateWriter::write_state`] for storage v2 where plain state
-    /// and changesets are written to static files, making the full
-    /// [`BundleState::to_plain_state_and_reverts`] conversion unnecessary.
     fn write_bytecodes(
         &self,
         bytecodes: impl IntoIterator<Item = (B256, Bytecode)>,

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -28,7 +28,7 @@ use alloy_eips::BlockHashOrNumber;
 use alloy_primitives::{
     keccak256,
     map::{hash_map, AddressSet, B256Map, HashMap},
-    Address, BlockHash, BlockNumber, TxHash, TxNumber, B256, KECCAK256_EMPTY,
+    Address, BlockHash, BlockNumber, TxHash, TxNumber, B256,
 };
 use itertools::Itertools;
 use parking_lot::RwLock;
@@ -70,9 +70,8 @@ use reth_trie::{
     HashedPostStateSorted, StoredNibbles,
 };
 use reth_trie_db::{ChangesetCache, DatabaseStorageTrieCursor};
-use revm_database::{
-    states::{PlainStateReverts, PlainStorageChangeset, PlainStorageRevert, StateChangeset},
-    BundleState,
+use revm_database::states::{
+    PlainStateReverts, PlainStorageChangeset, PlainStorageRevert, StateChangeset,
 };
 use std::{
     cmp::Ordering,
@@ -2354,26 +2353,6 @@ impl<TX: DbTx + 'static, N: NodeTypes> StorageReader for DatabaseProvider<TX, N>
     }
 }
 
-impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> DatabaseProvider<TX, N> {
-    /// Writes only bytecodes from the bundle state, skipping plain state and changeset conversion.
-    ///
-    /// Used in storage v2 where plain state and changesets are written to static files, making
-    /// the full [`BundleState::to_plain_state_and_reverts`] conversion unnecessary.
-    fn write_bytecodes(&self, state: &BundleState) -> ProviderResult<()> {
-        if state.contracts.is_empty() {
-            return Ok(());
-        }
-
-        let mut bytecodes_cursor = self.tx_ref().cursor_write::<tables::Bytecodes>()?;
-        for (hash, bytecode) in &state.contracts {
-            if *hash != KECCAK256_EMPTY {
-                bytecodes_cursor.upsert(*hash, &Bytecode(bytecode.clone()))?;
-            }
-        }
-        Ok(())
-    }
-}
-
 impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
     for DatabaseProvider<TX, N>
 {
@@ -2393,10 +2372,9 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
             !config.write_account_changesets &&
             !config.write_storage_changesets
         {
-            // In storage v2 with all outputs directed to static files, plain state and changesets
-            // are written elsewhere. Only bytecodes need MDBX writes, so skip the expensive
+            // In storage v2 with all outputs directed to static files, plain state, changesets,
+            // and bytecodes are all written elsewhere. Skip the expensive
             // to_plain_state_and_reverts conversion that iterates all accounts and storage.
-            self.write_bytecodes(execution_outcome.state())?;
             return Ok(());
         }
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -28,7 +28,7 @@ use alloy_eips::BlockHashOrNumber;
 use alloy_primitives::{
     keccak256,
     map::{hash_map, AddressSet, B256Map, HashMap},
-    Address, BlockHash, BlockNumber, TxHash, TxNumber, B256,
+    Address, BlockHash, BlockNumber, TxHash, TxNumber, B256, KECCAK256_EMPTY,
 };
 use itertools::Itertools;
 use parking_lot::RwLock;
@@ -70,8 +70,9 @@ use reth_trie::{
     HashedPostStateSorted, StoredNibbles,
 };
 use reth_trie_db::{ChangesetCache, DatabaseStorageTrieCursor};
-use revm_database::states::{
-    PlainStateReverts, PlainStorageChangeset, PlainStorageRevert, StateChangeset,
+use revm_database::{
+    states::{PlainStateReverts, PlainStorageChangeset, PlainStorageRevert, StateChangeset},
+    BundleState,
 };
 use std::{
     cmp::Ordering,
@@ -2353,6 +2354,26 @@ impl<TX: DbTx + 'static, N: NodeTypes> StorageReader for DatabaseProvider<TX, N>
     }
 }
 
+impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> DatabaseProvider<TX, N> {
+    /// Writes only bytecodes from the bundle state, skipping plain state and changeset conversion.
+    ///
+    /// Used in storage v2 where plain state and changesets are written to static files, making
+    /// the full [`BundleState::to_plain_state_and_reverts`] conversion unnecessary.
+    fn write_bytecodes(&self, state: &BundleState) -> ProviderResult<()> {
+        if state.contracts.is_empty() {
+            return Ok(());
+        }
+
+        let mut bytecodes_cursor = self.tx_ref().cursor_write::<tables::Bytecodes>()?;
+        for (hash, bytecode) in &state.contracts {
+            if *hash != KECCAK256_EMPTY {
+                bytecodes_cursor.upsert(*hash, &Bytecode(bytecode.clone()))?;
+            }
+        }
+        Ok(())
+    }
+}
+
 impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
     for DatabaseProvider<TX, N>
 {
@@ -2366,8 +2387,20 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
         config: StateWriteConfig,
     ) -> ProviderResult<()> {
         let execution_outcome = execution_outcome.into();
-        let first_block = execution_outcome.first_block();
 
+        if self.cached_storage_settings().use_hashed_state() &&
+            !config.write_receipts &&
+            !config.write_account_changesets &&
+            !config.write_storage_changesets
+        {
+            // In storage v2 with all outputs directed to static files, plain state and changesets
+            // are written elsewhere. Only bytecodes need MDBX writes, so skip the expensive
+            // to_plain_state_and_reverts conversion that iterates all accounts and storage.
+            self.write_bytecodes(execution_outcome.state())?;
+            return Ok(());
+        }
+
+        let first_block = execution_outcome.first_block();
         let (plain_state, reverts) =
             execution_outcome.state().to_plain_state_and_reverts(is_value_known);
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -2599,6 +2599,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
         // and take smaller memory footprint.
         changes.accounts.par_sort_by_key(|a| a.0);
         changes.storage.par_sort_by_key(|a| a.address);
+        changes.contracts.par_sort_by_key(|a| a.0);
 
         // When use_hashed_state is enabled, skip plain state writes for accounts and storage.
         // The hashed state is already written by the separate `write_hashed_state()` call.


### PR DESCRIPTION
## Summary
Skip the expensive `BundleState::to_plain_state_and_reverts` conversion in `write_state` when running with `--storage.v2`.

## Motivation
In storage v2, plain state and changesets are written to static files — not MDBX. When `save_blocks` calls `write_state` with all config flags disabled (`write_receipts=false`, `write_account_changesets=false`, `write_storage_changesets=false`), the only useful work is writing bytecodes. But `to_plain_state_and_reverts` still iterates every changed account and storage slot to build `StateChangeset` and `PlainStateReverts` structs that are immediately discarded. This shows up as non-trivial time on the `save_blocks_write_state` metric.

## Changes
- Added early return in `write_state` when `use_hashed_state()` is true and all config outputs are disabled
- Added `write_bytecodes` helper that extracts contracts directly from `BundleState.contracts`, skipping the full plain state conversion
- The optimization only triggers when called from `save_blocks` (config flags all false); other callers passing `StateWriteConfig::default()` are unaffected

## Testing
`cargo test -p reth-provider` — 110 passed, 0 failed

Prompted by: joshie