### PR TITLE
docs: clarify StateWriteConfig is about database (MDBX) writes vs static files

### DIFF
--- a/crates/storage/storage-api/src/state_writer.rs
+++ b/crates/storage/storage-api/src/state_writer.rs
@@ -127,16 +127,25 @@ pub trait StateWriter {
     ) -> ProviderResult<ExecutionOutcome<Self::Receipt>>;
 }
 
-/// Configuration for what to write when calling [`StateWriter::write_state`].
+/// Configuration for what to write to the database (MDBX) when calling
+/// [`StateWriter::write_state`].
 ///
-/// Used to skip writing certain data types, when they are being written separately.
+/// During pipeline execution, some data types (receipts, changesets) may be written directly to
+/// static files instead of the database. This config allows skipping those data types in the
+/// database write to avoid duplication.
 #[derive(Debug, Clone, Copy)]
 pub struct StateWriteConfig {
-    /// Whether to write receipts.
+    /// Whether to write receipts to the database.
+    ///
+    /// Set to `false` when receipts are being written to static files instead.
     pub write_receipts: bool,
-    /// Whether to write account changesets.
+    /// Whether to write account changesets to the database.
+    ///
+    /// Set to `false` when account changesets are being written to static files instead.
     pub write_account_changesets: bool,
-    /// Whether to write storage changesets.
+    /// Whether to write storage changesets to the database.
+    ///
+    /// Set to `false` when storage changesets are being written to static files instead.
     pub write_storage_changesets: bool,
 }
 

--- a/crates/storage/storage-api/src/state_writer.rs
+++ b/crates/storage/storage-api/src/state_writer.rs
@@ -130,9 +130,9 @@ pub trait StateWriter {
 /// Configuration for what to write to the database (MDBX) when calling
 /// [`StateWriter::write_state`].
 ///
-/// During pipeline execution, some data types (receipts, changesets) may be written directly to
-/// static files instead of the database. This config allows skipping those data types in the
-/// database write to avoid duplication.
+/// Some types (receipts, changesets) may be written directly to
+/// static files instead of the database depending on the storage settings. This config allows
+/// skipping those types in the database write to avoid duplication.
 #[derive(Debug, Clone, Copy)]
 pub struct StateWriteConfig {
     /// Whether to write receipts to the database.


### PR DESCRIPTION
## Summary
Clarifies `StateWriteConfig` doc comments to make it obvious this struct controls what gets written to the **database (MDBX)**, not to static files.

## Motivation
The existing docs just said "skip writing certain data types" without explaining the DB vs static file distinction. During pipeline execution, receipts and changesets can be written to static files instead of MDBX, and this config is how the caller signals that — the docs should reflect that.

## Changes
- Updated struct-level doc to mention MDBX and the static file relationship
- Updated each field's doc to explain when `false` is used (static file path)

Prompted by: Dan Cline