### PR TITLE
refactor(download): remove rocksdb indexes and checksum fields

### DIFF
--- a/crates/cli/commands/src/download/mod.rs
+++ b/crates/cli/commands/src/download/mod.rs
@@ -674,7 +674,11 @@ fn extract_archive<R: Read>(
 }
 
 /// Extracts a compressed tar archive without progress tracking.
-fn extract_archive_raw<R: Read>(reader: R, format: CompressionFormat, target_dir: &Path) -> Result<()> {
+fn extract_archive_raw<R: Read>(
+    reader: R,
+    format: CompressionFormat,
+    target_dir: &Path,
+) -> Result<()> {
     match format {
         CompressionFormat::Lz4 => {
             Archive::new(Decoder::new(reader)?).unpack(target_dir)?;

--- a/crates/cli/commands/src/download/tui.rs
+++ b/crates/cli/commands/src/download/tui.rs
@@ -100,8 +100,6 @@ fn build_groups(manifest: &SnapshotManifest) -> Vec<DisplayGroup> {
         groups.push(DisplayGroup { name: "State History", types, required: false });
     }
 
-    // Indexes (rocksdb) intentionally excluded from TUI
-
     groups
 }
 


### PR DESCRIPTION
## Summary
Removes the `Indexes` (rocksdb) snapshot component variant and the `checksum` field from `SingleArchive`.

## Changes
- Removed `SnapshotComponentType::Indexes` variant and all match arms
- Removed `checksum: Option<String>` from `SingleArchive`
- Removed indexes archive scanning from `generate_manifest()`
- Cleaned up rocksdb/indexes references in comments and test names
- Updated `ALL` array from 7 to 6 variants
- Simplified `is_chunked()` to only exclude `State`

## Testing
```
cargo test -p reth-cli-commands --lib download  # 31 passed
cargo check -p reth-ethereum-cli                # compiles
cargo +nightly fmt --all --check                # clean
```

Prompted by: dcline