### PR TITLE
feat(engine): add debug log in tx iterator for_each_ordered

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -443,8 +443,18 @@ where
                             tx
                         })
                     })
-                    .for_each_ordered(|tx| {
-                        let _ = execute_tx.send(tx);
+                    .for_each_ordered({
+                        let mut idx = 0usize;
+                        move |tx| {
+                            debug!(
+                                target: "engine::tree::payload_processor",
+                                idx,
+                                ok = tx.is_ok(),
+                                "yielding tx to execution"
+                            );
+                            let _ = execute_tx.send(tx);
+                            idx += 1;
+                        }
                     });
             });
         }


### PR DESCRIPTION
## Summary
Adds a debug log in the parallel tx iterator's `for_each_ordered` callback to trace when transactions are yielded to execution.

## Changes
- Added `debug!` log in `for_each_ordered` in `PayloadProcessor::spawn_transactions` that logs the tx index and whether conversion succeeded

## Testing
`cargo check -p reth-engine-tree` — passes clean.

Prompted by: danipopes