### PR TITLE
chore(tracing): use underscores instead of spaces in span names

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -409,7 +409,7 @@ where
             );
             self.executor.spawn_blocking(move || {
                 let _enter =
-                    debug_span!(target: "engine::tree::payload_processor", "tx iterator").entered();
+                    debug_span!(target: "engine::tree::payload_processor", "tx_iterator").entered();
                 let (transactions, convert) = transactions.into_parts();
                 for (idx, tx) in transactions.into_iter().enumerate() {
                     let tx = convert.convert(tx);
@@ -428,7 +428,7 @@ where
             // to execution in order via `for_each_ordered`.
             self.executor.spawn_blocking(move || {
                 let _enter =
-                    debug_span!(target: "engine::tree::payload_processor", "tx iterator").entered();
+                    debug_span!(target: "engine::tree::payload_processor", "tx_iterator").entered();
                 let (transactions, convert) = transactions.into_parts();
                 transactions
                     .into_par_iter()

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -624,7 +624,7 @@ where
             let to_multi_proof = to_multi_proof.clone();
             let done_tx = done_tx.clone();
             let rx = tx_receiver.clone();
-            let span = debug_span!(target: "engine::tree::payload_processor::prewarm", parent: &span, "prewarm worker", idx);
+            let span = debug_span!(target: "engine::tree::payload_processor::prewarm", parent: &span, "prewarm_worker", idx);
             task_executor.prewarming_pool().spawn(move || {
                 let _enter = span.entered();
                 ctx.transact_batch(rx, to_multi_proof, done_tx);

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -158,7 +158,7 @@ where
                     SparseTrieTaskMessage::PrefetchProofs(targets)
                 }
                 MultiProofMessage::StateUpdate(_, state) => {
-                    let _span = debug_span!(target: "engine::tree::payload_processor::sparse_trie", "hashing state update", n = state.len()).entered();
+                    let _span = debug_span!(target: "engine::tree::payload_processor::sparse_trie", "hashing_state_update", n = state.len()).entered();
                     let hashed = evm_state_to_hashed_post_state(state);
                     SparseTrieTaskMessage::HashedState(hashed)
                 }
@@ -478,7 +478,7 @@ where
             })
             .par_bridge_buffered()
             .map(|(address, updates, mut fetched, mut trie)| {
-                let _enter = debug_span!(target: "engine::tree::payload_processor::sparse_trie", parent: &span, "storage trie leaf updates", a=%address).entered();
+                let _enter = debug_span!(target: "engine::tree::payload_processor::sparse_trie", parent: &span, "storage_trie_leaf_updates", a=%address).entered();
                 let mut targets = Vec::new();
 
                 trie.update_leaves(updates, |path, min_len| match fetched.entry(path) {
@@ -577,7 +577,7 @@ where
             })
             .par_bridge_buffered()
             .for_each(|(address, trie)| {
-                let _enter = debug_span!(target: "engine::tree::payload_processor::sparse_trie", parent: &span, "storage root", ?address).entered();
+                let _enter = debug_span!(target: "engine::tree::payload_processor::sparse_trie", parent: &span, "storage_root", ?address).entered();
                 trie.root().expect("updates are drained, trie should be revealed by now");
             });
         drop(span);

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -395,7 +395,7 @@ where
 
         trace!(target: "engine::tree::payload_validator", "Fetching block state provider");
         let _enter =
-            debug_span!(target: "engine::tree::payload_validator", "state provider").entered();
+            debug_span!(target: "engine::tree::payload_validator", "state_provider").entered();
         let Some(provider_builder) =
             ensure_ok!(self.state_provider_builder(parent_hash, ctx.state()))
         else {
@@ -420,7 +420,7 @@ where
             .into())
         };
 
-        let evm_env = debug_span!(target: "engine::tree::payload_validator", "evm env")
+        let evm_env = debug_span!(target: "engine::tree::payload_validator", "evm_env")
             .in_scope(|| self.evm_env_for(&input))
             .map_err(NewPayloadError::other)?;
 
@@ -821,7 +821,7 @@ where
         self.metrics.record_post_execution(post_exec_start.elapsed());
 
         // Merge transitions into bundle state
-        debug_span!(target: "engine::tree", "merge transitions")
+        debug_span!(target: "engine::tree", "merge_transitions")
             .in_scope(|| db.merge_transitions(BundleRetention::Reverts));
 
         let output = BlockExecutionOutput { result, state: db.take_bundle() };
@@ -860,7 +860,7 @@ where
 
         // Apply pre-execution changes (e.g., beacon root update)
         let pre_exec_start = Instant::now();
-        debug_span!(target: "engine::tree", "pre execution")
+        debug_span!(target: "engine::tree", "pre_execution")
             .in_scope(|| executor.apply_pre_execution_changes())?;
         self.metrics.record_pre_execution(pre_exec_start.elapsed());
 

--- a/crates/storage/provider/src/providers/state/overlay.rs
+++ b/crates/storage/provider/src/providers/state/overlay.rs
@@ -315,7 +315,7 @@ where
             // Collect trie reverts using changeset cache
             let mut trie_reverts = {
                 let _guard =
-                    debug_span!(target: "providers::state::overlay", "Retrieving trie reverts")
+                    debug_span!(target: "providers::state::overlay", "retrieving_trie_reverts")
                         .entered();
 
                 let start = Instant::now();
@@ -332,7 +332,7 @@ where
 
             // Collect state reverts
             let mut hashed_state_reverts = {
-                let _guard = debug_span!(target: "providers::state::overlay", "Retrieving hashed state reverts").entered();
+                let _guard = debug_span!(target: "providers::state::overlay", "retrieving_hashed_state_reverts").entered();
 
                 let start = Instant::now();
                 let res = reth_trie_db::from_reverts_auto(provider, from_block + 1..)?;

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -1486,7 +1486,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         info!(target: "reth::cli", "Healing static file inconsistencies.");
 
         for segment in self.segments_to_check(provider) {
-            let _guard = info_span!("Healing static file segment", ?segment).entered();
+            let _guard = info_span!("healing_static_file_segment", ?segment).entered();
             let _ = self.maybe_heal_segment(segment)?;
         }
 

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -171,7 +171,7 @@ impl ProofWorkerHandle {
             let worker_id = AtomicUsize::new(0);
             storage_rt.proof_storage_worker_pool().broadcast(storage_worker_count, |_| {
                 let worker_id = worker_id.fetch_add(1, Ordering::Relaxed);
-                let span = debug_span!(target: "trie::proof_task", parent: storage_parent_span.clone(), "storage worker", ?worker_id);
+                let span = debug_span!(target: "trie::proof_task", parent: storage_parent_span.clone(), "storage_worker", ?worker_id);
                 let _guard = span.enter();
 
                 #[cfg(feature = "metrics")]
@@ -209,7 +209,7 @@ impl ProofWorkerHandle {
             let worker_id = AtomicUsize::new(0);
             account_rt.proof_account_worker_pool().broadcast(account_worker_count, |_| {
                 let worker_id = worker_id.fetch_add(1, Ordering::Relaxed);
-                let span = debug_span!(target: "trie::proof_task", parent: account_parent_span.clone(), "account worker", ?worker_id);
+                let span = debug_span!(target: "trie::proof_task", parent: account_parent_span.clone(), "account_worker", ?worker_id);
                 let _guard = span.enter();
 
                 #[cfg(feature = "metrics")]

--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -611,7 +611,7 @@ where
     ///
     /// The storage root, number of walked entries and trie updates
     /// for a given address if requested.
-    #[instrument(skip_all, target = "trie::storage_root", name = "Storage trie", fields(hashed_address = ?self.hashed_address, storage_root = tracing::field::Empty))]
+    #[instrument(skip_all, target = "trie::storage_root", name = "storage_trie", fields(hashed_address = ?self.hashed_address, storage_root = tracing::field::Empty))]
     pub fn calculate(self, retain_updates: bool) -> Result<StorageRootProgress, StorageRootError> {
         trace!(target: "trie::storage_root", "calculating storage root");
 


### PR DESCRIPTION
## Summary
Replace spaces with underscores in all tracing span names for consistency.

## Changes
- `instrument(name = "Storage trie")` → `"storage_trie"`
- `info_span!("Healing static file segment")` → `"healing_static_file_segment"`
- `debug_span!("Retrieving trie reverts")` → `"retrieving_trie_reverts"`
- `debug_span!("Retrieving hashed state reverts")` → `"retrieving_hashed_state_reverts"`
- `debug_span!("state provider")` → `"state_provider"`
- `debug_span!("evm env")` → `"evm_env"`
- `debug_span!("merge transitions")` → `"merge_transitions"`
- `debug_span!("pre execution")` → `"pre_execution"`
- `debug_span!("hashing state update")` → `"hashing_state_update"`
- `debug_span!("storage trie leaf updates")` → `"storage_trie_leaf_updates"`
- `debug_span!("storage root")` → `"storage_root"`
- `debug_span!("prewarm worker")` → `"prewarm_worker"`
- `debug_span!("tx iterator")` → `"tx_iterator"`
- `debug_span!("storage worker")` → `"storage_worker"`
- `debug_span!("account worker")` → `"account_worker"`

Prompted by: DaniPopes