### PR TITLE
fix(txpool): ensure transactions are added to pending subpool in nonce order

### DIFF
--- a/.changelog/warm-pandas-cook.md
+++ b/.changelog/warm-pandas-cook.md
@@ -1,0 +1,5 @@
+---
+reth-transaction-pool: patch
+---
+
+Fixed a bug where transactions from the same sender were added to the pending subpool out of nonce order. Ensured `process_updates` runs before `add_new_transaction` so that lower-nonce promotions are enqueued before the newly inserted higher-nonce transaction, preserving correct ordering for live `BestTransactions` iterators.


### PR DESCRIPTION
## Summary

Fixes nonce-disordered iteration in live `BestTransactions` iterators when a newly added transaction triggers promotion of same-sender lower-nonce transactions.

## Motivation

When `TxPool::add_transaction` inserts a tx that also causes a lower-nonce same-sender tx to be promoted (via `updates`), the new tx was added to the pending subpool *before* the promoted tx. Live `BestTransactions` iterators then received nonce 2 before nonce 1, violating the partial nonce ordering contract and causing nonce gaps during block building.

Supersedes #17702.

## Changes

- Partition `updates` in `add_transaction`: same-sender lower-nonce promotions are processed *before* adding the new tx; everything else is processed after.
- Added `best_transactions_nonce_order_on_promotion` test that reproduces the exact scenario from #17701.

## Testing

```
cargo test -p reth-transaction-pool --lib  # 222 passed
```

Prompted by: mattsse