### PR TITLE
fix(net): stop penalizing peers for empty block body responses

### DIFF
--- a/crates/net/p2p/src/error.rs
+++ b/crates/net/p2p/src/error.rs
@@ -197,6 +197,23 @@ pub enum DownloadError {
     Provider(ProviderError),
 }
 
+impl DownloadError {
+    /// Returns `true` if this error indicates a clearly malicious or invalid peer response.
+    ///
+    /// Empty responses are NOT considered malicious because they can legitimately occur when a
+    /// block body exceeds the peer's soft response size limit (e.g. 2MB). Only responses that
+    /// violate protocol rules (too many bodies, validation failures) are treated as malicious.
+    pub const fn is_malicious_response(&self) -> bool {
+        matches!(
+            self,
+            Self::TooManyBodies(_)
+                | Self::BodyValidation { .. }
+                | Self::HeaderValidation { .. }
+                | Self::InvalidTip(_)
+        )
+    }
+}
+
 impl From<DatabaseError> for DownloadError {
     fn from(error: DatabaseError) -> Self {
         Self::Provider(ProviderError::Database(error))


### PR DESCRIPTION
## Summary
Stop penalizing peers for returning empty block body responses, which can be legitimate when a block body exceeds the peer's soft response size limit (~2MB).

## Motivation
With increasing gas limits, block bodies can grow large enough that they exceed the ~2MB soft response limit applied by peers. In this case, a peer legitimately returns an empty response because it can't fit even a single body. Previously, `BodiesRequestFuture` treated all errors (including `EmptyResponse`) as bad messages and penalized the peer via `report_bad_message`. This is too aggressive — the peer did nothing wrong.

The `StateFetcher` already handles this somewhat correctly by marking peers as `last_response_likely_bad` (de-ranking, not penalizing), but the downloader layer was additionally calling `report_bad_message` which applies reputation damage.

## Changes
- `crates/net/p2p/src/error.rs`: Add `DownloadError::is_malicious_response()` which returns `true` only for clearly invalid/malicious responses (`TooManyBodies`, `BodyValidation`, `HeaderValidation`, `InvalidTip`)
- `crates/net/downloaders/src/bodies/request.rs`:
  - Only call `report_bad_message` when `error.is_malicious_response()` is true
  - Track consecutive empty response retries with `empty_response_retries` counter
  - Emit a warning after exceeding `MAX_EMPTY_RESPONSE_RETRIES` (5) to surface blocks that are too large for any peer to serve
  - Reset retry counter on successful (non-empty) response

## Testing
- `cargo test -p reth-downloaders --lib bodies` — 12/12 tests pass
- `cargo test -p reth-network-p2p` — 7/7 tests pass

Prompted by: mattsse