### PR TITLE
fix(prune): correct deleted entries count when skip_filter is used

### DIFF
--- a/crates/prune/prune/src/db_ext.rs
+++ b/crates/prune/prune/src/db_ext.rs
@@ -10,7 +10,7 @@ use tracing::debug;
 
 /// Result of a single prune step in [`DbTxPruneExt::prune_table_with_range_step`].
 #[derive(Debug, Clone, Copy)]
-struct PruneStepResult {
+pub(crate) struct PruneStepResult {
     /// `true` if the walker is finished, `false` if it may have more data to prune.
     done: bool,
     /// `true` if the current entry was deleted, `false` if it was skipped.


### PR DESCRIPTION
`prune_table_with_range` incremented `deleted_entries` on every iteration, even when the entry was skipped and not deleted. This caused inflated pruning stats in `ReceiptsByLogs` where skip_filter preserves certain receipts.