### PR TITLE
perf: use stack-allocated [u8; 65] for StoredNibblesSubKey encoding

### DIFF
--- a/.changelog/proud-crabs-bark.md
+++ b/.changelog/proud-crabs-bark.md
@@ -1,0 +1,5 @@
+---
+reth-db-api: patch
+---
+
+Changed `StoredNibblesSubKey` encoding to use a stack-allocated `[u8; 65]` array instead of a heap-allocated `Vec<u8>`, avoiding unnecessary heap allocation.

--- a/crates/storage/db-api/src/models/mod.rs
+++ b/crates/storage/db-api/src/models/mod.rs
@@ -141,9 +141,7 @@ impl Encode for StoredNibblesSubKey {
     type Encoded = [u8; 65];
 
     fn encode(self) -> Self::Encoded {
-        let mut buf = [0u8; 65];
-        self.to_compact(&mut buf.as_mut());
-        buf
+        self.to_compact_array()
     }
 }
 

--- a/crates/storage/db-api/src/models/mod.rs
+++ b/crates/storage/db-api/src/models/mod.rs
@@ -127,14 +127,7 @@ impl Encode for StoredNibbles {
     type Encoded = arrayvec::ArrayVec<u8, 64>;
 
     fn encode(self) -> Self::Encoded {
-        let mut buf = arrayvec::ArrayVec::new();
-        let len = self.0.len();
-        // SAFETY: len is at most 64, which is within ArrayVec capacity.
-        unsafe { buf.set_len(len) };
-        for (i, nibble) in self.0.iter().enumerate() {
-            buf[i] = nibble;
-        }
-        buf
+        self.0.iter().collect()
     }
 }
 
@@ -149,11 +142,7 @@ impl Encode for StoredNibblesSubKey {
 
     fn encode(self) -> Self::Encoded {
         let mut buf = [0u8; 65];
-        let len = self.0.len();
-        for (i, nibble) in self.0.iter().enumerate() {
-            buf[i] = nibble;
-        }
-        buf[64] = len as u8;
+        self.to_compact(&mut buf.as_mut());
         buf
     }
 }

--- a/crates/storage/db-api/src/models/mod.rs
+++ b/crates/storage/db-api/src/models/mod.rs
@@ -127,7 +127,14 @@ impl Encode for StoredNibbles {
     type Encoded = arrayvec::ArrayVec<u8, 64>;
 
     fn encode(self) -> Self::Encoded {
-        self.0.iter().collect()
+        let mut buf = arrayvec::ArrayVec::new();
+        let len = self.0.len();
+        // SAFETY: len is at most 64, which is within ArrayVec capacity.
+        unsafe { buf.set_len(len) };
+        for (i, nibble) in self.0.iter().enumerate() {
+            buf[i] = nibble;
+        }
+        buf
     }
 }
 
@@ -142,7 +149,11 @@ impl Encode for StoredNibblesSubKey {
 
     fn encode(self) -> Self::Encoded {
         let mut buf = [0u8; 65];
-        self.to_compact(&mut buf.as_mut());
+        let len = self.0.len();
+        for (i, nibble) in self.0.iter().enumerate() {
+            buf[i] = nibble;
+        }
+        buf[64] = len as u8;
         buf
     }
 }

--- a/crates/storage/db-api/src/models/mod.rs
+++ b/crates/storage/db-api/src/models/mod.rs
@@ -138,12 +138,11 @@ impl Decode for StoredNibbles {
 }
 
 impl Encode for StoredNibblesSubKey {
-    type Encoded = Vec<u8>;
+    type Encoded = [u8; 65];
 
-    // Delegate to the Compact implementation
     fn encode(self) -> Self::Encoded {
-        let mut buf = Vec::with_capacity(65);
-        self.to_compact(&mut buf);
+        let mut buf = [0u8; 65];
+        self.to_compact(&mut buf.as_mut());
         buf
     }
 }


### PR DESCRIPTION
StoredNibblesSubKey::encode() always produces exactly 65 bytes (64 padded nibbles + 1 length byte), but was using Vec<u8> as the Encoded type, causing a heap allocation on every StoragesTrie cursor seek.

Switch to [u8; 65] to keep the encoding entirely on the stack.