### PR TITLE
perf: add StoredNibblesSubKey::to_compact_array for direct encoding

### DIFF
--- a/crates/storage/db-api/src/models/mod.rs
+++ b/crates/storage/db-api/src/models/mod.rs
@@ -141,9 +141,7 @@ impl Encode for StoredNibblesSubKey {
     type Encoded = [u8; 65];
 
     fn encode(self) -> Self::Encoded {
-        let mut buf = [0u8; 65];
-        self.to_compact(&mut buf.as_mut());
-        buf
+        self.to_compact_array()
     }
 }
 


### PR DESCRIPTION
Follow-up to #22314: adds a specialized `to_compact_array()` method that writes nibbles directly into a `[u8; 65]` via indexed writes, avoiding the `ArrayVec` collect and `BufMut` overhead used by the generic `to_compact()` path.

`Encode::encode()` now calls `to_compact_array()` directly.

Includes tests for empty, full (64 nibbles), roundtrip, equivalence with `to_compact()`, and zero-padding.