### PR TITLE
ci(bench): use ABBA run order to reduce variance

### DIFF
--- a/.github/scripts/bench-reth-charts.py
+++ b/.github/scripts/bench-reth-charts.py
@@ -188,30 +188,56 @@ def plot_gas_vs_latency(
     plt.close(fig)
 
 
+def merge_csvs(paths: list[str]) -> list[dict]:
+    """Parse and merge multiple CSVs, averaging values for duplicate blocks."""
+    by_block: dict[int, list[dict]] = {}
+    for path in paths:
+        for row in parse_combined_csv(path):
+            by_block.setdefault(row["block_number"], []).append(row)
+
+    merged = []
+    for bn in sorted(by_block):
+        rows = by_block[bn]
+        if len(rows) == 1:
+            merged.append(rows[0])
+        else:
+            avg = {"block_number": bn}
+            for key in ("gas_used", "new_payload_latency_us"):
+                avg[key] = int(sum(r[key] for r in rows) / len(rows))
+            for key in ("persistence_wait_us", "execution_cache_wait_us", "sparse_trie_wait_us"):
+                vals = [r[key] for r in rows if r[key] is not None]
+                avg[key] = int(sum(vals) / len(vals)) if vals else None
+            merged.append(avg)
+    return merged
+
+
 def main():
     parser = argparse.ArgumentParser(description="Generate benchmark charts")
-    parser.add_argument("combined_csv", help="Path to combined_latency.csv (feature)")
+    parser.add_argument(
+        "--feature", nargs="+", required=True,
+        help="Path(s) to feature combined_latency.csv",
+    )
     parser.add_argument(
         "--output-dir", required=True, help="Output directory for PNG charts"
     )
     parser.add_argument(
-        "--baseline", help="Path to baseline combined_latency.csv"
+        "--baseline", nargs="+", help="Path(s) to baseline combined_latency.csv"
     )
     parser.add_argument("--baseline-name", default="baseline", help="Label for baseline")
     parser.add_argument("--feature-name", "--branch-name", default="feature", help="Label for feature")
     args = parser.parse_args()
 
-    feature = parse_combined_csv(args.combined_csv)
+    feature = merge_csvs(args.feature)
     if not feature:
-        print("No results found in combined CSV", file=sys.stderr)
+        print("No results found in feature CSV(s)", file=sys.stderr)
         sys.exit(1)
 
     baseline = None
     if args.baseline:
-        baseline = parse_combined_csv(args.baseline)
+        baseline = merge_csvs(args.baseline)
         if not baseline:
             print(
-                "Warning: no results in baseline CSV, skipping comparison",
+                "Warning: no results in baseline CSV(s), skipping comparison",
                 file=sys.stderr,
             )
             baseline = None

--- a/.github/scripts/bench-reth-summary.py
+++ b/.github/scripts/bench-reth-summary.py
@@ -183,11 +183,13 @@ def compute_paired_stats(
     all_pairs = []
     all_lat_diffs = []
     all_mgas_diffs = []
+    blocks_per_pair = []
     for baseline, feature in zip(baseline_runs, feature_runs):
         pairs, lat_diffs, mgas_diffs = _paired_data(baseline, feature)
         all_pairs.extend(pairs)
         all_lat_diffs.extend(lat_diffs)
         all_mgas_diffs.extend(mgas_diffs)
+        blocks_per_pair.append(len(pairs))
 
     if not all_lat_diffs:
         return {}
@@ -237,6 +239,7 @@ def compute_paired_stats(
         "p99_ci_ms": (p99_boot[hi] - p99_boot[lo]) / 2,
         "mean_mgas_diff": mean_mgas_diff,
         "mgas_ci": mgas_ci,
+        "blocks": max(blocks_per_pair),
     }
 
 
@@ -298,7 +301,7 @@ def generate_comparison_table(
     feature_sha: str,
 ) -> str:
     """Generate a markdown comparison table between baseline and feature."""
-    n = paired["n"]
+    n = paired["blocks"]
 
     def pct(base: float, feat: float) -> float:
         return (feat - base) / base * 100.0 if base > 0 else 0.0

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -551,7 +551,7 @@ jobs:
       # ABBA run order: baseline1, feature1, feature2, baseline2
       # This cancels out systematic drift (thermal, memory, etc.)
 
-      - name: Update status (running baseline #1)
+      - name: "Update status (running baseline #1)"
         if: success() && env.BENCH_COMMENT_ID
         uses: actions/github-script@v7
         with:
@@ -563,7 +563,7 @@ jobs:
         id: run-baseline-1
         run: taskset -c 0 .github/scripts/bench-reth-run.sh baseline-1 ../reth-baseline/target/profiling/reth /tmp/bench-results-baseline-1
 
-      - name: Update status (running feature #1)
+      - name: "Update status (running feature #1)"
         if: success() && env.BENCH_COMMENT_ID
         uses: actions/github-script@v7
         with:
@@ -575,7 +575,7 @@ jobs:
         id: run-feature-1
         run: taskset -c 0 .github/scripts/bench-reth-run.sh feature-1 ../reth-feature/target/profiling/reth /tmp/bench-results-feature-1
 
-      - name: Update status (running feature #2)
+      - name: "Update status (running feature #2)"
         if: success() && env.BENCH_COMMENT_ID
         uses: actions/github-script@v7
         with:
@@ -587,7 +587,7 @@ jobs:
         id: run-feature-2
         run: taskset -c 0 .github/scripts/bench-reth-run.sh feature-2 ../reth-feature/target/profiling/reth /tmp/bench-results-feature-2
 
-      - name: Update status (running baseline #2)
+      - name: "Update status (running baseline #2)"
         if: success() && env.BENCH_COMMENT_ID
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -612,8 +612,9 @@ jobs:
           BASELINE_NAME: ${{ steps.refs.outputs.baseline-name }}
           FEATURE_NAME: ${{ steps.refs.outputs.feature-name }}
         run: |
-          CHART_ARGS="/tmp/bench-results-feature/combined_latency.csv --output-dir /tmp/bench-charts"
-          CHART_ARGS="$CHART_ARGS --baseline /tmp/bench-results-baseline/combined_latency.csv"
+          CHART_ARGS="--output-dir /tmp/bench-charts"
+          CHART_ARGS="$CHART_ARGS --feature /tmp/bench-results-feature-1/combined_latency.csv /tmp/bench-results-feature-2/combined_latency.csv"
+          CHART_ARGS="$CHART_ARGS --baseline /tmp/bench-results-baseline-1/combined_latency.csv /tmp/bench-results-baseline-2/combined_latency.csv"
           CHART_ARGS="$CHART_ARGS --baseline-name ${BASELINE_NAME}"
           CHART_ARGS="$CHART_ARGS --feature-name ${FEATURE_NAME}"
           # shellcheck disable=SC2086

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -476,12 +476,13 @@ jobs:
 
       - name: Prepare source dirs
         run: |
+          BASELINE_REF="${{ steps.refs.outputs.baseline-ref }}"
           if [ -d ../reth-baseline ]; then
-            git -C ../reth-baseline fetch origin
+            git -C ../reth-baseline fetch origin "$BASELINE_REF"
           else
             git clone . ../reth-baseline
           fi
-          git -C ../reth-baseline checkout "${{ steps.refs.outputs.baseline-ref }}"
+          git -C ../reth-baseline checkout "$BASELINE_REF"
           ln -sfn "$(pwd)" ../reth-feature
 
       - name: Build baseline and feature binaries in parallel
@@ -713,12 +714,12 @@ jobs:
               ['running feature benchmark', '${{ steps.run-feature.outcome }}'],
             ];
             const failed = steps_status.find(([, o]) => o === 'failure');
-            const detail = failed ? ` while ${failed[0]}` : '';
+            const failedStep = failed ? failed[0] : 'unknown step';
 
             await github.rest.issues.updateComment({
               owner: context.repo.owner, repo: context.repo.repo,
               comment_id: parseInt(process.env.BENCH_COMMENT_ID),
-              body: `cc @${process.env.BENCH_ACTOR}\n\n❌ Benchmark failed${detail}. [View logs](${process.env.BENCH_JOB_URL})`,
+              body: `cc @${process.env.BENCH_ACTOR}\n\n❌ Benchmark failed while ${failedStep}. [View logs](${process.env.BENCH_JOB_URL})`,
             });
 
       - name: Upload node log

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -548,29 +548,56 @@ jobs:
           pkill -9 reth || true
           mountpoint -q "$SCHELK_MOUNT" && sudo schelk recover -y || true
 
-      - name: Update status (running baseline benchmark)
+      # ABBA run order: baseline1, feature1, feature2, baseline2
+      # This cancels out systematic drift (thermal, memory, etc.)
+
+      - name: Update status (running baseline #1)
         if: success() && env.BENCH_COMMENT_ID
         uses: actions/github-script@v7
         with:
           script: |
             const s = require('./.github/scripts/bench-update-status.js');
-            await s({github, context, status: 'Running baseline benchmark...'});
+            await s({github, context, status: 'Running baseline benchmark (1/2)...'});
 
-      - name: "Run benchmark: baseline"
-        id: run-baseline
-        run: taskset -c 0 .github/scripts/bench-reth-run.sh baseline ../reth-baseline/target/profiling/reth /tmp/bench-results-baseline
+      - name: "Run benchmark: baseline #1"
+        id: run-baseline-1
+        run: taskset -c 0 .github/scripts/bench-reth-run.sh baseline-1 ../reth-baseline/target/profiling/reth /tmp/bench-results-baseline-1
 
-      - name: Update status (running feature benchmark)
+      - name: Update status (running feature #1)
         if: success() && env.BENCH_COMMENT_ID
         uses: actions/github-script@v7
         with:
           script: |
             const s = require('./.github/scripts/bench-update-status.js');
-            await s({github, context, status: 'Running feature benchmark...'});
+            await s({github, context, status: 'Running feature benchmark (1/2)...'});
 
-      - name: "Run benchmark: feature"
-        id: run-feature
-        run: taskset -c 0 .github/scripts/bench-reth-run.sh feature ../reth-feature/target/profiling/reth /tmp/bench-results-feature
+      - name: "Run benchmark: feature #1"
+        id: run-feature-1
+        run: taskset -c 0 .github/scripts/bench-reth-run.sh feature-1 ../reth-feature/target/profiling/reth /tmp/bench-results-feature-1
+
+      - name: Update status (running feature #2)
+        if: success() && env.BENCH_COMMENT_ID
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const s = require('./.github/scripts/bench-update-status.js');
+            await s({github, context, status: 'Running feature benchmark (2/2)...'});
+
+      - name: "Run benchmark: feature #2"
+        id: run-feature-2
+        run: taskset -c 0 .github/scripts/bench-reth-run.sh feature-2 ../reth-feature/target/profiling/reth /tmp/bench-results-feature-2
+
+      - name: Update status (running baseline #2)
+        if: success() && env.BENCH_COMMENT_ID
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const s = require('./.github/scripts/bench-update-status.js');
+            await s({github, context, status: 'Running baseline benchmark (2/2)...'});
+
+      - name: "Run benchmark: baseline #2"
+        id: run-baseline-2
+        run: taskset -c 0 .github/scripts/bench-reth-run.sh baseline-2 ../reth-baseline/target/profiling/reth /tmp/bench-results-baseline-2
 
       # Results & charts
       - name: Parse results
@@ -596,9 +623,9 @@ jobs:
           SUMMARY_ARGS="$SUMMARY_ARGS --baseline-name ${BASELINE_NAME}"
           SUMMARY_ARGS="$SUMMARY_ARGS --feature-name ${FEATURE_NAME}"
           SUMMARY_ARGS="$SUMMARY_ARGS --feature-ref ${FEATURE_REF}"
-          SUMMARY_ARGS="$SUMMARY_ARGS --baseline-csv /tmp/bench-results-baseline/combined_latency.csv"
-          SUMMARY_ARGS="$SUMMARY_ARGS --feature-csv /tmp/bench-results-feature/combined_latency.csv"
-          SUMMARY_ARGS="$SUMMARY_ARGS --gas-csv /tmp/bench-results-feature/total_gas.csv"
+          SUMMARY_ARGS="$SUMMARY_ARGS --baseline-csv /tmp/bench-results-baseline-1/combined_latency.csv /tmp/bench-results-baseline-2/combined_latency.csv"
+          SUMMARY_ARGS="$SUMMARY_ARGS --feature-csv /tmp/bench-results-feature-1/combined_latency.csv /tmp/bench-results-feature-2/combined_latency.csv"
+          SUMMARY_ARGS="$SUMMARY_ARGS --gas-csv /tmp/bench-results-feature-1/total_gas.csv"
           if [ "$BEHIND_BASELINE" -gt 0 ]; then
             SUMMARY_ARGS="$SUMMARY_ARGS --behind-baseline $BEHIND_BASELINE"
           fi
@@ -611,8 +638,9 @@ jobs:
           BASELINE_NAME: ${{ steps.refs.outputs.baseline-name }}
           FEATURE_NAME: ${{ steps.refs.outputs.feature-name }}
         run: |
-          CHART_ARGS="/tmp/bench-results-feature/combined_latency.csv --output-dir /tmp/bench-charts"
-          CHART_ARGS="$CHART_ARGS --baseline /tmp/bench-results-baseline/combined_latency.csv"
+          CHART_ARGS="--feature /tmp/bench-results-feature-1/combined_latency.csv /tmp/bench-results-feature-2/combined_latency.csv"
+          CHART_ARGS="$CHART_ARGS --output-dir /tmp/bench-charts"
+          CHART_ARGS="$CHART_ARGS --baseline /tmp/bench-results-baseline-1/combined_latency.csv /tmp/bench-results-baseline-2/combined_latency.csv"
           CHART_ARGS="$CHART_ARGS --baseline-name ${BASELINE_NAME}"
           CHART_ARGS="$CHART_ARGS --feature-name ${FEATURE_NAME}"
           # shellcheck disable=SC2086
@@ -624,8 +652,10 @@ jobs:
         with:
           name: bench-reth-results
           path: |
-            /tmp/bench-results-baseline/
-            /tmp/bench-results-feature/
+            /tmp/bench-results-baseline-1/
+            /tmp/bench-results-baseline-2/
+            /tmp/bench-results-feature-1/
+            /tmp/bench-results-feature-2/
             /tmp/bench-summary.json
             /tmp/bench-charts/
 
@@ -709,8 +739,10 @@ jobs:
           script: |
             const steps_status = [
               ['building binaries', '${{ steps.build.outcome }}'],
-              ['running baseline benchmark', '${{ steps.run-baseline.outcome }}'],
-              ['running feature benchmark', '${{ steps.run-feature.outcome }}'],
+              ['running baseline benchmark (1/2)', '${{ steps.run-baseline-1.outcome }}'],
+              ['running feature benchmark (1/2)', '${{ steps.run-feature-1.outcome }}'],
+              ['running feature benchmark (2/2)', '${{ steps.run-feature-2.outcome }}'],
+              ['running baseline benchmark (2/2)', '${{ steps.run-baseline-2.outcome }}'],
             ];
             const failed = steps_status.find(([, o]) => o === 'failure');
             const failedStep = failed ? failed[0] : 'unknown step';
@@ -727,8 +759,10 @@ jobs:
         with:
           name: reth-node-log
           path: |
-            /tmp/reth-bench-node-baseline.log
-            /tmp/reth-bench-node-feature.log
+            /tmp/reth-bench-node-baseline-1.log
+            /tmp/reth-bench-node-baseline-2.log
+            /tmp/reth-bench-node-feature-1.log
+            /tmp/reth-bench-node-feature-2.log
 
       - name: Restore system settings
         if: always()

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -548,56 +548,29 @@ jobs:
           pkill -9 reth || true
           mountpoint -q "$SCHELK_MOUNT" && sudo schelk recover -y || true
 
-      # ABBA run order: baseline1, feature1, feature2, baseline2
-      # This cancels out systematic drift (thermal, memory, etc.)
-
-      - name: "Update status (running baseline #1)"
+      - name: Update status (running baseline benchmark)
         if: success() && env.BENCH_COMMENT_ID
         uses: actions/github-script@v7
         with:
           script: |
             const s = require('./.github/scripts/bench-update-status.js');
-            await s({github, context, status: 'Running baseline benchmark (1/2)...'});
+            await s({github, context, status: 'Running baseline benchmark...'});
 
-      - name: "Run benchmark: baseline #1"
-        id: run-baseline-1
-        run: taskset -c 0 .github/scripts/bench-reth-run.sh baseline-1 ../reth-baseline/target/profiling/reth /tmp/bench-results-baseline-1
+      - name: "Run benchmark: baseline"
+        id: run-baseline
+        run: taskset -c 0 .github/scripts/bench-reth-run.sh baseline ../reth-baseline/target/profiling/reth /tmp/bench-results-baseline
 
-      - name: "Update status (running feature #1)"
+      - name: Update status (running feature benchmark)
         if: success() && env.BENCH_COMMENT_ID
         uses: actions/github-script@v7
         with:
           script: |
             const s = require('./.github/scripts/bench-update-status.js');
-            await s({github, context, status: 'Running feature benchmark (1/2)...'});
+            await s({github, context, status: 'Running feature benchmark...'});
 
-      - name: "Run benchmark: feature #1"
-        id: run-feature-1
-        run: taskset -c 0 .github/scripts/bench-reth-run.sh feature-1 ../reth-feature/target/profiling/reth /tmp/bench-results-feature-1
-
-      - name: "Update status (running feature #2)"
-        if: success() && env.BENCH_COMMENT_ID
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const s = require('./.github/scripts/bench-update-status.js');
-            await s({github, context, status: 'Running feature benchmark (2/2)...'});
-
-      - name: "Run benchmark: feature #2"
-        id: run-feature-2
-        run: taskset -c 0 .github/scripts/bench-reth-run.sh feature-2 ../reth-feature/target/profiling/reth /tmp/bench-results-feature-2
-
-      - name: "Update status (running baseline #2)"
-        if: success() && env.BENCH_COMMENT_ID
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const s = require('./.github/scripts/bench-update-status.js');
-            await s({github, context, status: 'Running baseline benchmark (2/2)...'});
-
-      - name: "Run benchmark: baseline #2"
-        id: run-baseline-2
-        run: taskset -c 0 .github/scripts/bench-reth-run.sh baseline-2 ../reth-baseline/target/profiling/reth /tmp/bench-results-baseline-2
+      - name: "Run benchmark: feature"
+        id: run-feature
+        run: taskset -c 0 .github/scripts/bench-reth-run.sh feature ../reth-feature/target/profiling/reth /tmp/bench-results-feature
 
       # Results & charts
       - name: Parse results
@@ -623,9 +596,9 @@ jobs:
           SUMMARY_ARGS="$SUMMARY_ARGS --baseline-name ${BASELINE_NAME}"
           SUMMARY_ARGS="$SUMMARY_ARGS --feature-name ${FEATURE_NAME}"
           SUMMARY_ARGS="$SUMMARY_ARGS --feature-ref ${FEATURE_REF}"
-          SUMMARY_ARGS="$SUMMARY_ARGS --baseline-csv /tmp/bench-results-baseline-1/combined_latency.csv /tmp/bench-results-baseline-2/combined_latency.csv"
-          SUMMARY_ARGS="$SUMMARY_ARGS --feature-csv /tmp/bench-results-feature-1/combined_latency.csv /tmp/bench-results-feature-2/combined_latency.csv"
-          SUMMARY_ARGS="$SUMMARY_ARGS --gas-csv /tmp/bench-results-feature-1/total_gas.csv"
+          SUMMARY_ARGS="$SUMMARY_ARGS --baseline-csv /tmp/bench-results-baseline/combined_latency.csv"
+          SUMMARY_ARGS="$SUMMARY_ARGS --feature-csv /tmp/bench-results-feature/combined_latency.csv"
+          SUMMARY_ARGS="$SUMMARY_ARGS --gas-csv /tmp/bench-results-feature/total_gas.csv"
           if [ "$BEHIND_BASELINE" -gt 0 ]; then
             SUMMARY_ARGS="$SUMMARY_ARGS --behind-baseline $BEHIND_BASELINE"
           fi
@@ -638,9 +611,8 @@ jobs:
           BASELINE_NAME: ${{ steps.refs.outputs.baseline-name }}
           FEATURE_NAME: ${{ steps.refs.outputs.feature-name }}
         run: |
-          CHART_ARGS="--feature /tmp/bench-results-feature-1/combined_latency.csv /tmp/bench-results-feature-2/combined_latency.csv"
-          CHART_ARGS="$CHART_ARGS --output-dir /tmp/bench-charts"
-          CHART_ARGS="$CHART_ARGS --baseline /tmp/bench-results-baseline-1/combined_latency.csv /tmp/bench-results-baseline-2/combined_latency.csv"
+          CHART_ARGS="/tmp/bench-results-feature/combined_latency.csv --output-dir /tmp/bench-charts"
+          CHART_ARGS="$CHART_ARGS --baseline /tmp/bench-results-baseline/combined_latency.csv"
           CHART_ARGS="$CHART_ARGS --baseline-name ${BASELINE_NAME}"
           CHART_ARGS="$CHART_ARGS --feature-name ${FEATURE_NAME}"
           # shellcheck disable=SC2086
@@ -652,10 +624,8 @@ jobs:
         with:
           name: bench-reth-results
           path: |
-            /tmp/bench-results-baseline-1/
-            /tmp/bench-results-baseline-2/
-            /tmp/bench-results-feature-1/
-            /tmp/bench-results-feature-2/
+            /tmp/bench-results-baseline/
+            /tmp/bench-results-feature/
             /tmp/bench-summary.json
             /tmp/bench-charts/
 
@@ -739,18 +709,16 @@ jobs:
           script: |
             const steps_status = [
               ['building binaries', '${{ steps.build.outcome }}'],
-              ['running baseline benchmark (1/2)', '${{ steps.run-baseline-1.outcome }}'],
-              ['running feature benchmark (1/2)', '${{ steps.run-feature-1.outcome }}'],
-              ['running feature benchmark (2/2)', '${{ steps.run-feature-2.outcome }}'],
-              ['running baseline benchmark (2/2)', '${{ steps.run-baseline-2.outcome }}'],
+              ['running baseline benchmark', '${{ steps.run-baseline.outcome }}'],
+              ['running feature benchmark', '${{ steps.run-feature.outcome }}'],
             ];
             const failed = steps_status.find(([, o]) => o === 'failure');
-            const failedStep = failed ? failed[0] : 'unknown step';
+            const detail = failed ? ` while ${failed[0]}` : '';
 
             await github.rest.issues.updateComment({
               owner: context.repo.owner, repo: context.repo.repo,
               comment_id: parseInt(process.env.BENCH_COMMENT_ID),
-              body: `cc @${process.env.BENCH_ACTOR}\n\n❌ Benchmark failed while ${failedStep}. [View logs](${process.env.BENCH_JOB_URL})`,
+              body: `cc @${process.env.BENCH_ACTOR}\n\n❌ Benchmark failed${detail}. [View logs](${process.env.BENCH_JOB_URL})`,
             });
 
       - name: Upload node log
@@ -759,10 +727,8 @@ jobs:
         with:
           name: reth-node-log
           path: |
-            /tmp/reth-bench-node-baseline-1.log
-            /tmp/reth-bench-node-baseline-2.log
-            /tmp/reth-bench-node-feature-1.log
-            /tmp/reth-bench-node-feature-2.log
+            /tmp/reth-bench-node-baseline.log
+            /tmp/reth-bench-node-feature.log
 
       - name: Restore system settings
         if: always()


### PR DESCRIPTION
Run benchmarks as baseline→feature→feature→baseline instead of baseline→feature. Temporally adjacent pairs cancel out thermal, cache, and other monotonic drift when diffs are pooled.

Update charts script to accept multiple CSVs via --feature/--baseline flags and average per-block values across runs.