### PR TITLE
ci(bench): build baseline and feature binaries in parallel

### DIFF
--- a/.github/scripts/bench-reth-build.sh
+++ b/.github/scripts/bench-reth-build.sh
@@ -2,55 +2,56 @@
 #
 # Builds (or fetches from cache) reth binaries for benchmarking.
 #
-# Usage: bench-reth-build.sh <baseline|feature> <commit> [branch-sha]
+# Usage: bench-reth-build.sh <baseline|feature> <source-dir> <commit> [branch-sha]
 #
 #   baseline — build/fetch the baseline binary at <commit> (merge-base)
+#              source-dir must be checked out at <commit>
 #   feature  — build/fetch the candidate binary + reth-bench at <commit>
+#              source-dir must be checked out at <commit>
 #              optional branch-sha is the PR head commit for cache key
 #
 # Outputs:
-#   baseline: target/profiling-baseline/reth
-#   feature:  target/profiling/reth, reth-bench installed to cargo bin
+#   baseline: <source-dir>/target/profiling/reth
+#   feature:  <source-dir>/target/profiling/reth, reth-bench installed to cargo bin
 #
 # Required: mc (MinIO client) configured at /home/ubuntu/.mc
 set -euo pipefail
 
 MC="mc --config-dir /home/ubuntu/.mc"
 MODE="$1"
-COMMIT="$2"
+SOURCE_DIR="$2"
+COMMIT="$3"
 
 case "$MODE" in
   baseline|main)
     BUCKET="minio/reth-binaries/${COMMIT}"
-    mkdir -p target/profiling-baseline
+    mkdir -p "${SOURCE_DIR}/target/profiling"
 
     if $MC stat "${BUCKET}/reth" &>/dev/null; then
       echo "Cache hit for baseline (${COMMIT}), downloading binary..."
-      $MC cp "${BUCKET}/reth" target/profiling-baseline/reth
-      chmod +x target/profiling-baseline/reth
+      $MC cp "${BUCKET}/reth" "${SOURCE_DIR}/target/profiling/reth"
+      chmod +x "${SOURCE_DIR}/target/profiling/reth"
     else
       echo "Cache miss for baseline (${COMMIT}), building from source..."
-      CURRENT_REF=$(git rev-parse HEAD)
-      git checkout "${COMMIT}"
+      cd "${SOURCE_DIR}"
       cargo build --profile profiling --bin reth
-      cp target/profiling/reth target/profiling-baseline/reth
-      $MC cp target/profiling-baseline/reth "${BUCKET}/reth"
-      git checkout "${CURRENT_REF}"
+      $MC cp target/profiling/reth "${BUCKET}/reth"
     fi
     ;;
 
   feature|branch)
-    BRANCH_SHA="${3:-$COMMIT}"
+    BRANCH_SHA="${4:-$COMMIT}"
     BUCKET="minio/reth-binaries/${BRANCH_SHA}"
 
     if $MC stat "${BUCKET}/reth" &>/dev/null && $MC stat "${BUCKET}/reth-bench" &>/dev/null; then
       echo "Cache hit for ${BRANCH_SHA}, downloading binaries..."
-      mkdir -p target/profiling
-      $MC cp "${BUCKET}/reth" target/profiling/reth
+      mkdir -p "${SOURCE_DIR}/target/profiling"
+      $MC cp "${BUCKET}/reth" "${SOURCE_DIR}/target/profiling/reth"
       $MC cp "${BUCKET}/reth-bench" /home/ubuntu/.cargo/bin/reth-bench
-      chmod +x target/profiling/reth /home/ubuntu/.cargo/bin/reth-bench
+      chmod +x "${SOURCE_DIR}/target/profiling/reth" /home/ubuntu/.cargo/bin/reth-bench
     else
       echo "Cache miss for ${BRANCH_SHA}, building from source..."
+      cd "${SOURCE_DIR}"
       rustup show active-toolchain || rustup default stable
       make profiling
       make install-reth-bench
@@ -60,7 +61,7 @@ case "$MODE" in
     ;;
 
   *)
-    echo "Usage: $0 <baseline|feature> <commit> [branch-sha]"
+    echo "Usage: $0 <baseline|feature> <source-dir> <commit> [branch-sha]"
     exit 1
     ;;
 esac

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -403,7 +403,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               comment_id: parseInt(process.env.BENCH_COMMENT_ID),
-              body: buildBody('Building baseline binary...'),
+              body: buildBody('Building binaries...'),
             });
 
       - uses: dtolnay/rust-toolchain@stable
@@ -474,21 +474,28 @@ jobs:
           echo "feature-ref=$FEATURE_REF" >> "$GITHUB_OUTPUT"
           echo "feature-name=$FEATURE_NAME" >> "$GITHUB_OUTPUT"
 
-      - name: Fetch or build baseline binaries
-        id: build-baseline
-        run: .github/scripts/bench-reth-build.sh baseline "${{ steps.refs.outputs.baseline-ref }}"
+      - name: Prepare baseline source dir
+        run: |
+          git clone . ../reth-baseline
+          git -C ../reth-baseline checkout "${{ steps.refs.outputs.baseline-ref }}"
 
-      - name: Update status (baseline built)
-        if: success() && env.BENCH_COMMENT_ID
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const s = require('./.github/scripts/bench-update-status.js');
-            await s({github, context, status: 'Building feature binary...'});
+      - name: Build baseline and feature binaries in parallel
+        run: |
+          BASELINE_DIR="$(cd ../reth-baseline && pwd)"
+          FEATURE_DIR="$(pwd)"
 
-      - name: Fetch or build feature binaries
-        id: build-feature
-        run: .github/scripts/bench-reth-build.sh feature "${{ steps.refs.outputs.feature-ref }}"
+          .github/scripts/bench-reth-build.sh baseline "${BASELINE_DIR}" "${{ steps.refs.outputs.baseline-ref }}" &
+          PID_BASELINE=$!
+          .github/scripts/bench-reth-build.sh feature "${FEATURE_DIR}" "${{ steps.refs.outputs.feature-ref }}" &
+          PID_FEATURE=$!
+
+          FAIL=0
+          wait $PID_BASELINE || FAIL=1
+          wait $PID_FEATURE || FAIL=1
+          if [ $FAIL -ne 0 ]; then
+            echo "::error::One or both builds failed"
+            exit 1
+          fi
 
       # System tuning for reproducible benchmarks
       - name: System setup
@@ -545,7 +552,7 @@ jobs:
 
       - name: "Run benchmark: baseline"
         id: run-baseline
-        run: taskset -c 0 .github/scripts/bench-reth-run.sh baseline target/profiling-baseline/reth /tmp/bench-results-baseline
+        run: taskset -c 0 .github/scripts/bench-reth-run.sh baseline ../reth-baseline/target/profiling/reth /tmp/bench-results-baseline
 
       - name: Update status (running feature benchmark)
         if: success() && env.BENCH_COMMENT_ID

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -480,6 +480,7 @@ jobs:
           git -C ../reth-baseline checkout "${{ steps.refs.outputs.baseline-ref }}"
 
       - name: Build baseline and feature binaries in parallel
+        id: build
         run: |
           BASELINE_DIR="$(cd ../reth-baseline && pwd)"
           FEATURE_DIR="$(pwd)"
@@ -702,8 +703,7 @@ jobs:
         with:
           script: |
             const steps_status = [
-              ['building baseline binary', '${{ steps.build-baseline.outcome }}'],
-              ['building feature binary', '${{ steps.build-feature.outcome }}'],
+              ['building binaries', '${{ steps.build.outcome }}'],
               ['running baseline benchmark', '${{ steps.run-baseline.outcome }}'],
               ['running feature benchmark', '${{ steps.run-feature.outcome }}'],
             ];

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -474,16 +474,17 @@ jobs:
           echo "feature-ref=$FEATURE_REF" >> "$GITHUB_OUTPUT"
           echo "feature-name=$FEATURE_NAME" >> "$GITHUB_OUTPUT"
 
-      - name: Prepare baseline source dir
+      - name: Prepare source dirs
         run: |
           git clone . ../reth-baseline
           git -C ../reth-baseline checkout "${{ steps.refs.outputs.baseline-ref }}"
+          ln -s "$(pwd)" ../reth-feature
 
       - name: Build baseline and feature binaries in parallel
         id: build
         run: |
           BASELINE_DIR="$(cd ../reth-baseline && pwd)"
-          FEATURE_DIR="$(pwd)"
+          FEATURE_DIR="$(cd ../reth-feature && pwd)"
 
           .github/scripts/bench-reth-build.sh baseline "${BASELINE_DIR}" "${{ steps.refs.outputs.baseline-ref }}" &
           PID_BASELINE=$!
@@ -565,7 +566,7 @@ jobs:
 
       - name: "Run benchmark: feature"
         id: run-feature
-        run: taskset -c 0 .github/scripts/bench-reth-run.sh feature target/profiling/reth /tmp/bench-results-feature
+        run: taskset -c 0 .github/scripts/bench-reth-run.sh feature ../reth-feature/target/profiling/reth /tmp/bench-results-feature
 
       # Results & charts
       - name: Parse results

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -476,9 +476,13 @@ jobs:
 
       - name: Prepare source dirs
         run: |
-          git clone . ../reth-baseline
+          if [ -d ../reth-baseline ]; then
+            git -C ../reth-baseline fetch origin
+          else
+            git clone . ../reth-baseline
+          fi
           git -C ../reth-baseline checkout "${{ steps.refs.outputs.baseline-ref }}"
-          ln -s "$(pwd)" ../reth-feature
+          ln -sfn "$(pwd)" ../reth-feature
 
       - name: Build baseline and feature binaries in parallel
         id: build


### PR DESCRIPTION
Use two separate repo directories (local git clone for baseline) so both builds can run concurrently. The build script now takes a source-dir argument instead of doing git checkout internally.