### PR TITLE
feat(trie-debug): record SetRoot op in ParallelSparseTrie::set_root

### DIFF
--- a/.changelog/dull-koalas-play.md
+++ b/.changelog/dull-koalas-play.md
@@ -1,0 +1,5 @@
+---
+reth-trie-sparse: patch
+---
+
+Added recording of `SetRoot` operation in `ParallelSparseTrie::set_root` when the `trie-debug` feature is enabled.

--- a/crates/trie/sparse/src/debug_recorder.rs
+++ b/crates/trie/sparse/src/debug_recorder.rs
@@ -70,6 +70,11 @@ pub enum RecordedOp {
     UpdateSubtrieHashes,
     /// Records a `root()` call.
     Root,
+    /// Records a `set_root` call with the root node that was set.
+    SetRoot {
+        /// The root trie node that was set.
+        node: ProofTrieNodeRecord,
+    },
 }
 
 /// A serializable record of a proof trie node.

--- a/crates/trie/sparse/src/parallel.rs
+++ b/crates/trie/sparse/src/parallel.rs
@@ -169,6 +169,15 @@ impl SparseTrie for ParallelSparseTrie {
         masks: Option<BranchNodeMasks>,
         retain_updates: bool,
     ) -> SparseTrieResult<()> {
+        #[cfg(feature = "trie-debug")]
+        self.debug_recorder.record(RecordedOp::SetRoot {
+            node: ProofTrieNodeRecord::from_proof_trie_node_v2(&ProofTrieNodeV2 {
+                path: Nibbles::default(),
+                node: root.clone(),
+                masks,
+            }),
+        });
+
         // A fresh/cleared `ParallelSparseTrie` has a `SparseNode::Empty` at its root in the upper
         // subtrie. Delete that so we can reveal the new root node.
         let path = Nibbles::default();


### PR DESCRIPTION
Forgot to do this in the original PR