### PR TITLE
fix(storage): prevent double-hashing of storage keys in v2/hashed-state mode

### DIFF
--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -29,6 +29,7 @@ use reth_stages_types::{StageCheckpoint, StageId};
 use reth_static_file_types::StaticFileSegment;
 use reth_storage_api::{
     BlockBodyIndicesProvider, ChangesetEntry, NodePrimitivesProvider, StorageChangeSetReader,
+    StorageSettingsCache,
 };
 use reth_storage_errors::provider::ProviderResult;
 use reth_trie::{HashedPostState, KeccakKeyHasher};
@@ -621,7 +622,15 @@ impl<N: ProviderNodeTypes> StateProviderFactory for BlockchainProvider<N> {
 
 impl<N: NodeTypesWithDB> HashedPostStateProvider for BlockchainProvider<N> {
     fn hashed_post_state(&self, bundle_state: &BundleState) -> HashedPostState {
-        HashedPostState::from_bundle_state::<KeccakKeyHasher>(bundle_state.state())
+        if self.database.cached_storage_settings().use_hashed_state() {
+            // In v2 / hashed-state mode the BundleState already contains keccak256-hashed
+            // storage keys. Skip hashing them again to avoid double-hashing.
+            HashedPostState::from_bundle_state_hashed_storage::<KeccakKeyHasher>(
+                bundle_state.state(),
+            )
+        } else {
+            HashedPostState::from_bundle_state::<KeccakKeyHasher>(bundle_state.state())
+        }
     }
 }
 

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -719,7 +719,13 @@ impl<N: ProviderNodeTypes> PruneCheckpointReader for ProviderFactory<N> {
 
 impl<N: ProviderNodeTypes> HashedPostStateProvider for ProviderFactory<N> {
     fn hashed_post_state(&self, bundle_state: &BundleState) -> HashedPostState {
-        HashedPostState::from_bundle_state::<KeccakKeyHasher>(bundle_state.state())
+        if self.cached_storage_settings().use_hashed_state() {
+            HashedPostState::from_bundle_state_hashed_storage::<KeccakKeyHasher>(
+                bundle_state.state(),
+            )
+        } else {
+            HashedPostState::from_bundle_state::<KeccakKeyHasher>(bundle_state.state())
+        }
     }
 }
 

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -489,9 +489,17 @@ impl<
     }
 }
 
-impl<Provider> HashedPostStateProvider for HistoricalStateProviderRef<'_, Provider> {
+impl<Provider: StorageSettingsCache> HashedPostStateProvider
+    for HistoricalStateProviderRef<'_, Provider>
+{
     fn hashed_post_state(&self, bundle_state: &revm_database::BundleState) -> HashedPostState {
-        HashedPostState::from_bundle_state::<KeccakKeyHasher>(bundle_state.state())
+        if self.provider.cached_storage_settings().use_hashed_state() {
+            HashedPostState::from_bundle_state_hashed_storage::<KeccakKeyHasher>(
+                bundle_state.state(),
+            )
+        } else {
+            HashedPostState::from_bundle_state::<KeccakKeyHasher>(bundle_state.state())
+        }
     }
 }
 

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -165,9 +165,17 @@ impl<Provider: DBProvider> StateProofProvider for LatestStateProviderRef<'_, Pro
     }
 }
 
-impl<Provider: DBProvider> HashedPostStateProvider for LatestStateProviderRef<'_, Provider> {
+impl<Provider: DBProvider + StorageSettingsCache> HashedPostStateProvider
+    for LatestStateProviderRef<'_, Provider>
+{
     fn hashed_post_state(&self, bundle_state: &revm_database::BundleState) -> HashedPostState {
-        HashedPostState::from_bundle_state::<KeccakKeyHasher>(bundle_state.state())
+        if self.0.cached_storage_settings().use_hashed_state() {
+            HashedPostState::from_bundle_state_hashed_storage::<KeccakKeyHasher>(
+                bundle_state.state(),
+            )
+        } else {
+            HashedPostState::from_bundle_state::<KeccakKeyHasher>(bundle_state.state())
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes storage key double-hashing that causes invalid payload rejections on `--storage.v2` nodes.

## Motivation

Both edge snapshotter lighthouses (`reth-minimal-edge` and `reth-edge` in `ethereum-mainnet-snapshotter`) hit `Invalid execution payload` → `InvalidJustifiedCheckpointExecutionStatus` on nightly. Root cause identified by @pepyakin: `ConsistentProvider::get_state` reconstructs a `BundleState` where storage keys are already keccak256-hashed (v2 mode), but `hashed_post_state()` → `from_bundle_state()` → `from_plain_storage()` hashes them again, producing wrong trie keys and a bad state root.

## Changes

- `HashedStorage::from_hashed_storage()` — like `from_plain_storage()` but skips keccak256 for already-hashed keys
- `HashedPostState::from_bundle_state_hashed_storage()` — uses the above for v2-mode bundles
- `BlockchainProvider` and `ProviderFactory` `hashed_post_state()` impls now check `use_hashed_state()` and pick the correct path

## Testing

All existing hashed-state tests pass (12 tests):
```
cargo test -p reth-provider -- hashed
cargo test -p reth-trie-common -- hashed_storage
```

Prompted by: joshie