### PR TITLE
perf(trie): remove redundant HashMap lookup in sparse trie account state query

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -613,13 +613,13 @@ where
                 }
 
                 // Get the current account state either from the trie or from latest account update.
-                let trie_account = if let Some(LeafUpdate::Changed(encoded)) = self.account_updates.get(addr) {
-                    Some(encoded).filter(|encoded| !encoded.is_empty())
-                } else if !self.account_updates.contains_key(addr) {
-                    self.trie.get_account_value(addr)
-                } else {
+                let trie_account = match self.account_updates.get(addr) {
+                    Some(LeafUpdate::Changed(encoded)) => {
+                        Some(encoded).filter(|encoded| !encoded.is_empty())
+                    }
+                    None => self.trie.get_account_value(addr),
                     // Needs to be revealed first
-                    return true;
+                    Some(LeafUpdate::Touched) => return true,
                 };
 
                 let trie_account = trie_account.map(|value| TrieAccount::decode(&mut &value[..]).expect("invalid account RLP"));

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -617,9 +617,9 @@ where
                     Some(LeafUpdate::Changed(encoded)) => {
                         Some(encoded).filter(|encoded| !encoded.is_empty())
                     }
-                    None => self.trie.get_account_value(addr),
                     // Needs to be revealed first
                     Some(LeafUpdate::Touched) => return true,
+                    None => self.trie.get_account_value(addr),
                 };
 
                 let trie_account = trie_account.map(|value| TrieAccount::decode(&mut &value[..]).expect("invalid account RLP"));


### PR DESCRIPTION
In `sparse_trie.rs`, the account state lookup first calls `get(addr)` on `account_updates`, and if the pattern doesn't match `LeafUpdate::Changed`, it falls through to call `contains_key(addr)` on the same map with the same key. This is unnecessary since `get` already tells us whether the key exists.

Replaced the `if let` / `else if contains_key` chain with a single `match` on `get()`, which covers all three cases (`Changed`, `None`, `Touched`) in one lookup.