### PR TITLE
refactor: separate hashed storage from BundleState via TakenState enum

### DIFF
--- a/crates/chain-state/src/test_utils.rs
+++ b/crates/chain-state/src/test_utils.rs
@@ -213,7 +213,7 @@ impl<N: NodePrimitives> TestBlockBuilder<N> {
                     gas_used: 0,
                     blob_gas_used: 0,
                 },
-                state: BundleState::default(),
+                state: Default::default(),
             }),
             trie_data,
         )

--- a/crates/engine/invalid-block-hooks/src/witness.rs
+++ b/crates/engine/invalid-block-hooks/src/witness.rs
@@ -351,7 +351,9 @@ where
         let block_prefix = format!("{}_{}", block.number(), block.hash());
         self.handle_witness_operations(&witness, &block_prefix, block.number())?;
 
-        self.validate_bundle_state(&bundle_state, &output.state, &block_prefix)?;
+        if let Some(original_state) = output.state.as_plain() {
+            self.validate_bundle_state(&bundle_state, original_state, &block_prefix)?;
+        }
 
         self.validate_state_root_and_trie(
             parent_header,
@@ -834,7 +836,7 @@ mod tests {
 
         // Create mock BlockExecutionOutput
         let output = BlockExecutionOutput {
-            state: bundle_state,
+            state: bundle_state.into(),
             result: reth_provider::BlockExecutionResult {
                 receipts: vec![],
                 requests: Requests::default(),

--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -61,14 +61,16 @@ impl EngineApiMetrics {
         self.executor.execution_duration.set(execution_secs);
 
         // Update the metrics for the number of accounts, storage slots and bytecodes
-        let accounts = output.state.state.len();
-        let storage_slots =
-            output.state.state.values().map(|account| account.storage.len()).sum::<usize>();
-        let bytecodes = output.state.contracts.len();
+        if let Some(plain_state) = output.state.as_plain() {
+            let accounts = plain_state.state.len();
+            let storage_slots =
+                plain_state.state.values().map(|account| account.storage.len()).sum::<usize>();
+            let bytecodes = plain_state.contracts.len();
 
-        self.executor.accounts_updated_histogram.record(accounts as f64);
-        self.executor.storage_slots_updated_histogram.record(storage_slots as f64);
-        self.executor.bytecodes_updated_histogram.record(bytecodes as f64);
+            self.executor.accounts_updated_histogram.record(accounts as f64);
+            self.executor.storage_slots_updated_histogram.record(storage_slots as f64);
+            self.executor.bytecodes_updated_histogram.record(bytecodes as f64);
+        }
     }
 
     /// Returns a reference to the executor metrics for use in state hooks.

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -233,7 +233,11 @@ where
 
                 // Insert state into cache while holding the lock
                 // Access the BundleState through the shared ExecutionOutcome
-                if new_cache.cache().insert_state(&execution_outcome.state).is_err() {
+                let Some(plain_state) = execution_outcome.state.as_plain() else {
+                    *cached = Some(new_cache);
+                    return;
+                };
+                if new_cache.cache().insert_state(plain_state).is_err() {
                     // Clear the cache on error to prevent having a polluted cache
                     *cached = None;
                     debug!(target: "engine::caching", "cleared execution cache on update error");

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -64,7 +64,7 @@ pub trait Executor<DB: Database>: Sized {
     {
         let result = self.execute_one(block)?;
         let mut state = self.into_state();
-        Ok(BlockExecutionOutput { state: state.take_bundle(), result })
+        Ok(BlockExecutionOutput { state: state.take_bundle().into(), result })
     }
 
     /// Executes multiple inputs in the batch, and returns an aggregated [`ExecutionOutcome`].
@@ -106,7 +106,7 @@ pub trait Executor<DB: Database>: Sized {
         let result = self.execute_one(block)?;
         let mut state = self.into_state();
         f(&state);
-        Ok(BlockExecutionOutput { state: state.take_bundle(), result })
+        Ok(BlockExecutionOutput { state: state.take_bundle().into(), result })
     }
 
     /// Executes the EVM with the given input and accepts a state closure that is always invoked
@@ -123,7 +123,7 @@ pub trait Executor<DB: Database>: Sized {
         let mut state = self.into_state();
         f(&state);
 
-        Ok(BlockExecutionOutput { state: state.take_bundle(), result: result? })
+        Ok(BlockExecutionOutput { state: state.take_bundle().into(), result: result? })
     }
 
     /// Executes the EVM with the given input and accepts a state hook closure that is invoked with
@@ -138,7 +138,7 @@ pub trait Executor<DB: Database>: Sized {
     {
         let result = self.execute_one_with_state_hook(block, state_hook)?;
         let mut state = self.into_state();
-        Ok(BlockExecutionOutput { state: state.take_bundle(), result })
+        Ok(BlockExecutionOutput { state: state.take_bundle().into(), result })
     }
 
     /// Consumes the executor and returns the [`State`] containing all state changes.

--- a/crates/evm/execution-types/src/execute.rs
+++ b/crates/evm/execution-types/src/execute.rs
@@ -1,8 +1,89 @@
+use crate::HashedStorageBundleState;
 use alloy_primitives::{Address, B256, U256};
 use reth_primitives_traits::{Account, Bytecode};
 use revm::database::{states::BundleState, BundleAccount};
 
 pub use alloy_evm::block::BlockExecutionResult;
+
+/// The kind of state stored in a [`BlockExecutionOutput`].
+///
+/// After execution, the state always uses plain `U256` storage keys ([`BundleState`]).
+/// When state is reconstructed from hashed database tables, storage keys are keccak256 hashes
+/// (`B256`) and are stored in a [`HashedStorageBundleState`] to prevent mixing key formats.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BundleKind {
+    /// Plain storage keys (`U256`), produced by EVM execution or plain DB reconstruction.
+    Plain(BundleState),
+    /// Hashed storage keys (`B256`), produced by hashed DB reconstruction.
+    Hashed(HashedStorageBundleState),
+}
+
+impl BundleKind {
+    /// Returns a reference to the plain [`BundleState`], or `None` if hashed.
+    pub const fn as_plain(&self) -> Option<&BundleState> {
+        match self {
+            Self::Plain(state) => Some(state),
+            Self::Hashed(_) => None,
+        }
+    }
+
+    /// Returns the plain [`BundleState`], or `None` if hashed.
+    pub fn into_plain(self) -> Option<BundleState> {
+        match self {
+            Self::Plain(state) => Some(state),
+            Self::Hashed(_) => None,
+        }
+    }
+
+    /// Returns a reference to the [`HashedStorageBundleState`], or `None` if plain.
+    pub const fn as_hashed(&self) -> Option<&HashedStorageBundleState> {
+        match self {
+            Self::Plain(_) => None,
+            Self::Hashed(state) => Some(state),
+        }
+    }
+
+    /// Returns `true` if this is a plain bundle state.
+    pub const fn is_plain(&self) -> bool {
+        matches!(self, Self::Plain(_))
+    }
+
+    /// Returns `true` if this is a hashed bundle state.
+    pub const fn is_hashed(&self) -> bool {
+        matches!(self, Self::Hashed(_))
+    }
+
+    /// Iterates over all contracts `(code_hash, bytecode)` regardless of variant.
+    ///
+    /// Both plain and hashed states track contracts identically (keyed by code hash).
+    /// The `reth_primitives_traits::Bytecode` wrapper is unwrapped to the inner revm bytecode.
+    pub fn contracts_iter(
+        &self,
+    ) -> Box<dyn Iterator<Item = (&B256, &revm::bytecode::Bytecode)> + '_> {
+        match self {
+            Self::Plain(state) => Box::new(state.contracts.iter()),
+            Self::Hashed(state) => Box::new(state.contracts.iter().map(|(k, v)| (k, &v.0))),
+        }
+    }
+}
+
+impl Default for BundleKind {
+    fn default() -> Self {
+        Self::Plain(BundleState::default())
+    }
+}
+
+impl From<BundleState> for BundleKind {
+    fn from(state: BundleState) -> Self {
+        Self::Plain(state)
+    }
+}
+
+impl From<HashedStorageBundleState> for BundleKind {
+    fn from(state: HashedStorageBundleState) -> Self {
+        Self::Hashed(state)
+    }
+}
 
 /// [`BlockExecutionResult`] combined with state.
 #[derive(
@@ -23,30 +104,51 @@ pub struct BlockExecutionOutput<T> {
     #[deref_mut]
     pub result: BlockExecutionResult<T>,
     /// The changed state of the block after execution.
-    pub state: BundleState,
+    pub state: BundleKind,
 }
 
 impl<T> BlockExecutionOutput<T> {
     /// Return bytecode if known.
     pub fn bytecode(&self, code_hash: &B256) -> Option<Bytecode> {
-        self.state.bytecode(code_hash).map(Bytecode)
+        match &self.state {
+            BundleKind::Plain(state) => state.bytecode(code_hash).map(Bytecode),
+            BundleKind::Hashed(state) => state.contracts.get(code_hash).cloned(),
+        }
     }
 
     /// Get account if account is known.
     pub fn account(&self, address: &Address) -> Option<Option<Account>> {
-        self.state.account(address).map(|a| a.info.as_ref().map(Into::into))
+        match &self.state {
+            BundleKind::Plain(state) => {
+                state.account(address).map(|a| a.info.as_ref().map(Into::into))
+            }
+            BundleKind::Hashed(state) => {
+                state.state.get(address).map(|a| a.info.as_ref().map(Into::into))
+            }
+        }
     }
 
     /// Returns the state [`BundleAccount`] for the given address.
+    ///
+    /// Returns `None` if the state is hashed (different account type).
     pub fn account_state(&self, address: &Address) -> Option<&BundleAccount> {
-        self.state.account(address)
+        match &self.state {
+            BundleKind::Plain(state) => state.account(address),
+            BundleKind::Hashed(_) => None,
+        }
     }
 
     /// Get storage if value is known.
     ///
     /// This means that depending on status we can potentially return `U256::ZERO`.
+    /// Returns `None` if the state is hashed (storage keys are hashed `B256`, not plain `U256`).
     pub fn storage(&self, address: &Address, storage_key: U256) -> Option<U256> {
-        self.state.account(address).and_then(|a| a.storage_slot(storage_key))
+        match &self.state {
+            BundleKind::Plain(state) => {
+                state.account(address).and_then(|a| a.storage_slot(storage_key))
+            }
+            BundleKind::Hashed(_) => None,
+        }
     }
 }
 

--- a/crates/evm/execution-types/src/execution_outcome.rs
+++ b/crates/evm/execution-types/src/execution_outcome.rs
@@ -132,9 +132,13 @@ impl<T> ExecutionOutcome<T> {
     }
 
     /// Creates a new `ExecutionOutcome` from a single block execution result.
+    ///
+    /// If the state is [`BundleKind::Hashed`], the bundle is set to an empty [`BundleState`]
+    /// since hashed storage keys cannot be represented in a plain `BundleState`.
     pub fn single(block_number: u64, output: BlockExecutionOutput<T>) -> Self {
+        let bundle = output.state.into_plain().unwrap_or_default();
         Self {
-            bundle: output.state,
+            bundle,
             receipts: vec![output.result.receipts],
             first_block: block_number,
             requests: vec![output.result.requests],

--- a/crates/exex/exex/src/backfill/job.rs
+++ b/crates/exex/exex/src/backfill/job.rs
@@ -254,6 +254,7 @@ mod tests {
     use reth_primitives_traits::crypto::secp256k1::public_key_to_address;
     use reth_provider::{
         providers::BlockchainProvider, test_utils::create_test_provider_factory_with_chain_spec,
+        BundleKind,
     };
     use reth_testing_utils::generators;
 
@@ -325,7 +326,9 @@ mod tests {
         // block
         for (i, res) in blocks_and_outcomes.into_iter().enumerate() {
             let (block, mut execution_output) = res?;
-            execution_output.state.reverts.sort();
+            if let BundleKind::Plain(ref mut state) = execution_output.state {
+                state.reverts.sort();
+            }
 
             let expected_block = blocks_and_execution_outcomes[i].0.clone();
             let expected_output = &blocks_and_execution_outcomes[i].1;

--- a/crates/exex/exex/src/backfill/stream.rs
+++ b/crates/exex/exex/src/backfill/stream.rs
@@ -261,7 +261,7 @@ mod tests {
     use reth_provider::{
         providers::{BlockchainProvider, ProviderNodeTypes},
         test_utils::create_test_provider_factory_with_chain_spec,
-        ProviderFactory,
+        BundleKind, ProviderFactory,
     };
     use reth_stages_api::ExecutionStageThresholds;
     use reth_testing_utils::{generators, generators::sign_tx_with_key_pair};
@@ -293,7 +293,9 @@ mod tests {
 
         // execute first block
         let (block, mut execution_output) = backfill_stream.next().await.unwrap().unwrap();
-        execution_output.state.reverts.sort();
+        if let BundleKind::Plain(ref mut state) = execution_output.state {
+            state.reverts.sort();
+        }
         let expected_block = blocks_and_execution_outcomes[0].0.clone();
         let expected_output = &blocks_and_execution_outcomes[0].1;
         assert_eq!(block, expected_block);

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -364,7 +364,7 @@ pub trait LoadPendingBlock:
             builder.finish(NoopProvider::default()).map_err(Self::Error::from_eth_err)?;
 
         let execution_outcome =
-            BlockExecutionOutput { state: db.take_bundle(), result: execution_result };
+            BlockExecutionOutput { state: db.take_bundle().into(), result: execution_result };
 
         Ok(ExecutedBlock::new(
             block.into(),

--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -206,8 +206,9 @@ where
 
         self.ensure_payment(&block, &output, &message)?;
 
-        let state_root =
-            state_provider.state_root(state_provider.hashed_post_state(&output.state))?;
+        let state_root = state_provider.state_root(state_provider.hashed_post_state(
+            output.state.as_plain().expect("execution output must have plain state"),
+        ))?;
 
         if state_root != block.header().state_root() {
             return Err(ConsensusError::BodyStateRootDiff(
@@ -289,7 +290,7 @@ where
         message: &BidTrace,
     ) -> Result<(), ValidationApiError> {
         let (mut balance_before, balance_after) = if let Some(acc) =
-            output.state.state.get(&message.proposer_fee_recipient)
+            output.state.as_plain().and_then(|s| s.state.get(&message.proposer_fee_recipient))
         {
             let balance_before = acc.original_info.as_ref().map(|i| i.balance).unwrap_or_default();
             let balance_after = acc.info.as_ref().map(|i| i.balance).unwrap_or_default();

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -21,7 +21,7 @@ use reth_chain_state::{
 };
 use reth_chainspec::ChainInfo;
 use reth_db_api::models::{AccountBeforeTx, BlockNumberAddress, StoredBlockBodyIndices};
-use reth_execution_types::{ExecutionOutcome, TakenState};
+use reth_execution_types::TakenState;
 use reth_node_types::{BlockTy, HeaderTy, NodeTypesWithDB, ReceiptTy, TxTy};
 use reth_primitives_traits::{Account, RecoveredBlock, SealedHeader};
 use reth_prune_types::{PruneCheckpoint, PruneSegment};
@@ -136,7 +136,7 @@ impl<N: ProviderNodeTypes> BlockchainProvider<N> {
         Ok(state.state_provider(latest_historical))
     }
 
-    /// Return the last N blocks of state, recreating the [`ExecutionOutcome`].
+    /// Return the last N blocks of state, recreating the [`TakenState`].
     ///
     /// If the range is empty, or there are no blocks for the given range, then this returns `None`.
     pub fn get_state(
@@ -778,7 +778,7 @@ impl<N: ProviderNodeTypes> AccountReader for BlockchainProvider<N> {
 impl<N: ProviderNodeTypes> StateReader for BlockchainProvider<N> {
     type Receipt = ReceiptTy<N>;
 
-    /// Re-constructs the [`ExecutionOutcome`] from in-memory and database state, if necessary.
+    /// Re-constructs the [`TakenState`] from in-memory and database state, if necessary.
     ///
     /// If data for the block does not exist, this will return [`None`].
     ///
@@ -787,10 +787,7 @@ impl<N: ProviderNodeTypes> StateReader for BlockchainProvider<N> {
     /// inconsistent. Currently this can safely be called within the blockchain tree thread,
     /// because the tree thread is responsible for modifying the [`CanonicalInMemoryState`] in the
     /// first place.
-    fn get_state(
-        &self,
-        block: BlockNumber,
-    ) -> ProviderResult<Option<ExecutionOutcome<Self::Receipt>>> {
+    fn get_state(&self, block: BlockNumber) -> ProviderResult<Option<TakenState<Self::Receipt>>> {
         StateReader::get_state(&self.consistent_provider()?, block)
     }
 }

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -942,7 +942,7 @@ mod tests {
                             gas_used: 0,
                             blob_gas_used: 0,
                         },
-                        state: BundleState::default(),
+                        state: Default::default(),
                     };
 
                     ExecutedBlock {
@@ -1737,7 +1737,8 @@ mod tests {
                                     (*address, Some(Some((*account).into())), Vec::new())
                                 })],
                                 [],
-                            ),
+                            )
+                            .into(),
                             result: BlockExecutionResult {
                                 receipts: Default::default(),
                                 requests: Default::default(),

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -21,7 +21,7 @@ use reth_chain_state::{
 };
 use reth_chainspec::ChainInfo;
 use reth_db_api::models::{AccountBeforeTx, BlockNumberAddress, StoredBlockBodyIndices};
-use reth_execution_types::ExecutionOutcome;
+use reth_execution_types::{ExecutionOutcome, TakenState};
 use reth_node_types::{BlockTy, HeaderTy, NodeTypesWithDB, ReceiptTy, TxTy};
 use reth_primitives_traits::{Account, RecoveredBlock, SealedHeader};
 use reth_prune_types::{PruneCheckpoint, PruneSegment};
@@ -142,7 +142,7 @@ impl<N: ProviderNodeTypes> BlockchainProvider<N> {
     pub fn get_state(
         &self,
         range: RangeInclusive<BlockNumber>,
-    ) -> ProviderResult<Option<ExecutionOutcome<ReceiptTy<N>>>> {
+    ) -> ProviderResult<Option<TakenState<ReceiptTy<N>>>> {
         self.consistent_provider()?.get_state(range)
     }
 }

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -1715,15 +1715,12 @@ impl<N: ProviderNodeTypes> StateReader for ConsistentProvider<N> {
     /// inconsistent. Currently this can safely be called within the blockchain tree thread,
     /// because the tree thread is responsible for modifying the [`CanonicalInMemoryState`] in the
     /// first place.
-    fn get_state(
-        &self,
-        block: BlockNumber,
-    ) -> ProviderResult<Option<ExecutionOutcome<Self::Receipt>>> {
+    fn get_state(&self, block: BlockNumber) -> ProviderResult<Option<TakenState<Self::Receipt>>> {
         if let Some(state) = self.head_block.as_ref().and_then(|b| b.block_on_chain(block.into())) {
             let state = state.block_ref().execution_outcome().clone();
-            Ok(Some(ExecutionOutcome::from((state, block))))
+            Ok(Some(TakenState::Plain(ExecutionOutcome::from((state, block)))))
         } else {
-            Ok(Self::get_state(self, block..=block)?.and_then(|s| s.into_plain()))
+            Self::get_state(self, block..=block)
         }
     }
 }

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -1296,7 +1296,10 @@ impl RocksDBProvider {
 
         for (block_idx, block) in blocks.iter().enumerate() {
             let block_number = ctx.first_block_number + block_idx as u64;
-            let reverts = block.execution_outcome().state.reverts.to_plain_state_reverts();
+            let Some(plain_state) = block.execution_outcome().state.as_plain() else {
+                continue;
+            };
+            let reverts = plain_state.reverts.to_plain_state_reverts();
 
             // Iterate through account reverts - these are exactly the accounts that have
             // changesets written, ensuring history indices match changeset entries.
@@ -1329,7 +1332,10 @@ impl RocksDBProvider {
 
         for (block_idx, block) in blocks.iter().enumerate() {
             let block_number = ctx.first_block_number + block_idx as u64;
-            let reverts = block.execution_outcome().state.reverts.to_plain_state_reverts();
+            let Some(plain_state) = block.execution_outcome().state.as_plain() else {
+                continue;
+            };
+            let reverts = plain_state.reverts.to_plain_state_reverts();
 
             // Iterate through storage reverts - these are exactly the slots that have
             // changesets written, ensuring history indices match changeset entries.

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -612,7 +612,10 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
     ) -> ProviderResult<()> {
         for block in blocks {
             let block_number = block.recovered_block().number();
-            let reverts = block.execution_outcome().state.reverts.to_plain_state_reverts();
+            let Some(plain_state) = block.execution_outcome().state.as_plain() else {
+                continue;
+            };
+            let reverts = plain_state.reverts.to_plain_state_reverts();
 
             let changeset: Vec<_> = reverts
                 .accounts
@@ -633,7 +636,10 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
     ) -> ProviderResult<()> {
         for block in blocks {
             let block_number = block.recovered_block().number();
-            let reverts = block.execution_outcome().state.reverts.to_plain_state_reverts();
+            let Some(plain_state) = block.execution_outcome().state.as_plain() else {
+                continue;
+            };
+            let reverts = plain_state.reverts.to_plain_state_reverts();
 
             let changeset: Vec<_> = reverts
                 .storage

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -25,7 +25,7 @@ use reth_db_api::{
     models::{AccountBeforeTx, StorageSettings, StoredBlockBodyIndices},
 };
 use reth_ethereum_primitives::EthPrimitives;
-use reth_execution_types::ExecutionOutcome;
+use reth_execution_types::TakenState;
 use reth_primitives_traits::{
     Account, Block, BlockBody, Bytecode, GotExpected, NodePrimitives, RecoveredBlock, SealedHeader,
     SignerRecoverable,
@@ -1057,10 +1057,7 @@ impl<T: NodePrimitives, ChainSpec: Send + Sync> StorageChangeSetReader
 impl<T: NodePrimitives, ChainSpec: Send + Sync> StateReader for MockEthProvider<T, ChainSpec> {
     type Receipt = T::Receipt;
 
-    fn get_state(
-        &self,
-        _block: BlockNumber,
-    ) -> ProviderResult<Option<ExecutionOutcome<Self::Receipt>>> {
+    fn get_state(&self, _block: BlockNumber) -> ProviderResult<Option<TakenState<Self::Receipt>>> {
         Ok(None)
     }
 }

--- a/crates/storage/rpc-provider/src/lib.rs
+++ b/crates/storage/rpc-provider/src/lib.rs
@@ -1338,7 +1338,7 @@ where
     fn get_state(
         &self,
         _block: BlockNumber,
-    ) -> Result<Option<reth_execution_types::ExecutionOutcome<Self::Receipt>>, ProviderError> {
+    ) -> Result<Option<reth_execution_types::TakenState<Self::Receipt>>, ProviderError> {
         // RPC doesn't provide execution outcomes
         Err(ProviderError::UnsupportedProvider)
     }

--- a/crates/storage/storage-api/src/noop.rs
+++ b/crates/storage/storage-api/src/noop.rs
@@ -27,7 +27,7 @@ use reth_chainspec::{ChainInfo, ChainSpecProvider, EthChainSpec, MAINNET};
 use reth_db_api::mock::{DatabaseMock, TxMock};
 use reth_db_models::{AccountBeforeTx, StoredBlockBodyIndices};
 use reth_ethereum_primitives::EthPrimitives;
-use reth_execution_types::ExecutionOutcome;
+use reth_execution_types::TakenState;
 use reth_primitives_traits::{Account, Bytecode, NodePrimitives, RecoveredBlock, SealedHeader};
 #[cfg(feature = "db-api")]
 use reth_prune_types::PruneModes;
@@ -522,10 +522,7 @@ impl<C: Send + Sync, N: NodePrimitives> HashedPostStateProvider for NoopProvider
 impl<C: Send + Sync, N: NodePrimitives> StateReader for NoopProvider<C, N> {
     type Receipt = N::Receipt;
 
-    fn get_state(
-        &self,
-        _block: BlockNumber,
-    ) -> ProviderResult<Option<ExecutionOutcome<Self::Receipt>>> {
+    fn get_state(&self, _block: BlockNumber) -> ProviderResult<Option<TakenState<Self::Receipt>>> {
         Ok(None)
     }
 }

--- a/crates/storage/storage-api/src/state.rs
+++ b/crates/storage/storage-api/src/state.rs
@@ -7,23 +7,20 @@ use alloy_consensus::constants::KECCAK_EMPTY;
 use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_primitives::{Address, BlockHash, BlockNumber, StorageKey, StorageValue, B256, U256};
 use auto_impl::auto_impl;
-use reth_execution_types::ExecutionOutcome;
+use reth_execution_types::TakenState;
 use reth_primitives_traits::Bytecode;
 use reth_storage_errors::provider::ProviderResult;
 use reth_trie_common::HashedPostState;
 use revm_database::BundleState;
 
-/// This just receives state, or [`ExecutionOutcome`], from the provider
+/// This just receives state, or [`TakenState`], from the provider
 #[auto_impl::auto_impl(&, Arc, Box)]
 pub trait StateReader: Send {
-    /// Receipt type in [`ExecutionOutcome`].
+    /// Receipt type in [`TakenState`].
     type Receipt: Send + Sync;
 
-    /// Get the [`ExecutionOutcome`] for the given block
-    fn get_state(
-        &self,
-        block: BlockNumber,
-    ) -> ProviderResult<Option<ExecutionOutcome<Self::Receipt>>>;
+    /// Get the [`TakenState`] for the given block
+    fn get_state(&self, block: BlockNumber) -> ProviderResult<Option<TakenState<Self::Receipt>>>;
 }
 
 /// Type alias of boxed [`StateProvider`].

--- a/crates/storage/storage-api/src/state_writer.rs
+++ b/crates/storage/storage-api/src/state_writer.rs
@@ -1,7 +1,7 @@
 use alloc::vec::Vec;
 use alloy_consensus::transaction::Either;
 use alloy_primitives::BlockNumber;
-use reth_execution_types::{BlockExecutionOutput, ExecutionOutcome};
+use reth_execution_types::{BlockExecutionOutput, ExecutionOutcome, TakenState};
 use reth_storage_errors::provider::ProviderResult;
 use reth_trie_common::HashedPostStateSorted;
 use revm_database::{
@@ -119,12 +119,12 @@ pub trait StateWriter {
     /// removed.
     fn remove_state_above(&self, block: BlockNumber) -> ProviderResult<()>;
 
-    /// Take the block range of state, recreating the [`ExecutionOutcome`]. The state of the passed
-    /// block is not removed.
-    fn take_state_above(
-        &self,
-        block: BlockNumber,
-    ) -> ProviderResult<ExecutionOutcome<Self::Receipt>>;
+    /// Take the block range of state, recreating the execution outcome.
+    ///
+    /// Returns [`TakenState::Plain`] with a standard [`ExecutionOutcome`] when using plain storage
+    /// keys, or [`TakenState::Hashed`] when the database uses hashed storage keys.
+    /// The state of the passed block is not removed.
+    fn take_state_above(&self, block: BlockNumber) -> ProviderResult<TakenState<Self::Receipt>>;
 }
 
 /// Configuration for what to write to the database (MDBX) when calling

--- a/crates/storage/storage-api/src/state_writer.rs
+++ b/crates/storage/storage-api/src/state_writer.rs
@@ -57,11 +57,14 @@ impl<'a, R> WriteStateInput<'a, R> {
         }
     }
 
-    /// Returns a reference to the [`BundleState`].
-    pub const fn state(&self) -> &BundleState {
+    /// Returns a reference to the plain [`BundleState`].
+    ///
+    /// For [`WriteStateInput::Multiple`], the bundle is always plain.
+    /// For [`WriteStateInput::Single`], returns `None` if the state is hashed.
+    pub fn plain_state(&self) -> Option<&BundleState> {
         match self {
-            Self::Single { outcome, .. } => &outcome.state,
-            Self::Multiple(outcome) => &outcome.bundle,
+            Self::Single { outcome, .. } => outcome.state.as_plain(),
+            Self::Multiple(outcome) => Some(&outcome.bundle),
         }
     }
 

--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -256,8 +256,13 @@ fn run_case(case: &BlockchainTest) -> Result<(), Error> {
             .map_err(|err| Error::block_failed(block_number, err))?;
 
         // Compute and check the post state root
-        let hashed_state =
-            HashedPostState::from_bundle_state::<KeccakKeyHasher>(output.state.state());
+        let hashed_state = HashedPostState::from_bundle_state::<KeccakKeyHasher>(
+            output
+                .state
+                .as_plain()
+                .expect("ef-test execution output must have plain state")
+                .state(),
+        );
         let (computed_state_root, _) = StateRoot::overlay_root_with_updates(
             provider.tx_ref(),
             &hashed_state.clone_into_sorted(),


### PR DESCRIPTION
## Summary

Prevents hashed storage keys from being stuffed into a plain `BundleState` by introducing separate types for hashed state and routing them through a `TakenState` enum.

## Motivation

When `use_hashed_state()` is enabled, `populate_bundle_state_hashed` reconstructs state from hashed DB tables where storage keys are `keccak256(slot)`. Previously, these hashed `B256` keys were silently converted to `U256` and packed into `BundleState::new()`, mixing hashed and plain storage slots in the same struct. This makes it impossible to distinguish key formats downstream.

## Changes

- `HashedStorageBundleAccount`, `HashedStorageBundleState` — mirrors of revm's `BundleAccount`/`BundleState` with `B256` storage keys
- `HashedBundleStateInit`, `HashedRevertsInit` — type aliases for hashed state initialization
- `HashedExecutionOutcome<T>` — like `ExecutionOutcome` but wraps `HashedStorageBundleState`
- `TakenState<T>` enum (`Plain(ExecutionOutcome)` | `Hashed(HashedExecutionOutcome)`)
- `StateWriter::take_state_above` now returns `TakenState` instead of `ExecutionOutcome`
- `DatabaseProvider::take_state_above`: hashed path produces `HashedExecutionOutcome`, plain path produces `ExecutionOutcome`
- Updated `take_block_and_execution_above` and execution stage unwind to match on `TakenState`

## Testing

- `cargo check -p reth-provider -p reth-stages -p reth-execution-types -p reth-storage-api` — passes
- `cargo check -p reth-provider --tests` — passes
- `cargo +nightly fmt --all --check` — passes

## Notes

For `TakenState::Hashed` at the `Chain`/ExEx boundary, we currently create an `ExecutionOutcome` with an empty `BundleState` (receipts/requests preserved). This is documented. A follow-up could extend `Chain` to carry `TakenState` directly so ExExes can access hashed state changes.

Prompted by: joshie