### PR TITLE
fix(storage): clarify storage settings mismatch warning

### DIFF
--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -176,7 +176,7 @@ where
                         target: "reth::storage",
                         ?stored,
                         requested = ?genesis_storage_settings,
-                        "Storage settings mismatch detected"
+                        "Storage settings mismatch detected. Using the stored settings from the existing database."
                     );
                 }
 


### PR DESCRIPTION
## Summary
Clarifies the storage settings mismatch warning to explicitly state the node uses stored settings, not the requested ones.

## Motivation
The current warning `Storage settings mismatch detected` doesn't tell users which settings win. For example when `stored=StorageSettings { storage_v2: true }` and `requested=StorageSettings { storage_v2: false }`, users can't tell whether the node uses v1 or v2.

Similar to the pruning config mismatch warning which says `Using config from file`, this makes the behavior explicit.

## Changes
- Updated warning message in `crates/storage/db-common/src/init.rs` to say: *"Storage settings mismatch detected. Using the stored settings from the existing database."*

Prompted by: alexey