### PR TITLE
fix: propagate trie update diff result to trigger debug recorder writes

### DIFF
--- a/.changelog/odd-donkeys-chirp.md
+++ b/.changelog/odd-donkeys-chirp.md
@@ -1,0 +1,5 @@
+---
+reth-engine-tree: patch
+---
+
+Fixed `compare_trie_updates` to return `bool` indicating whether differences were found, and updated the caller to properly use the return value instead of treating all successful comparisons as having no differences.

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1097,17 +1097,20 @@ where
                 // Get a database provider to use as trie cursor factory
                 match overlay_factory.database_provider_ro() {
                     Ok(provider) => {
-                        if let Err(err) = super::trie_updates::compare_trie_updates(
+                        match super::trie_updates::compare_trie_updates(
                             &provider,
                             task_trie_updates,
                             serial_trie_updates,
                         ) {
-                            warn!(
-                                target: "engine::tree::payload_validator",
-                                %err,
-                                "Error comparing trie updates"
-                            );
-                            return true;
+                            Ok(has_diff) => return has_diff,
+                            Err(err) => {
+                                warn!(
+                                    target: "engine::tree::payload_validator",
+                                    %err,
+                                    "Error comparing trie updates"
+                                );
+                                return true;
+                            }
                         }
                     }
                     Err(err) => {

--- a/crates/engine/tree/src/tree/trie_updates.rs
+++ b/crates/engine/tree/src/tree/trie_updates.rs
@@ -101,11 +101,13 @@ impl StorageTrieUpdatesDiff {
 
 /// Compares the trie updates from state root task, regular state root calculation and database,
 /// and logs the differences if there's any.
+///
+/// Returns `true` if there are differences.
 pub(crate) fn compare_trie_updates(
     trie_cursor_factory: impl TrieCursorFactory,
     task: TrieUpdates,
     regular: TrieUpdates,
-) -> Result<(), DatabaseError> {
+) -> Result<bool, DatabaseError> {
     let mut task = adjust_trie_updates(task);
     let mut regular = adjust_trie_updates(regular);
 
@@ -179,9 +181,10 @@ pub(crate) fn compare_trie_updates(
     }
 
     // log differences
+    let has_differences = diff.has_differences();
     diff.log_differences();
 
-    Ok(())
+    Ok(has_differences)
 }
 
 fn compare_storage_trie_updates<C: TrieCursor>(


### PR DESCRIPTION
compare_trie_updates returned Result<()> so the caller never knew differences existed. compare_trie_updates_with_serial always returned false, preventing write_trie_debug_recorders from firing.

Changed compare_trie_updates to return Result<bool> indicating whether differences were found, and propagated the result in compare_trie_updates_with_serial.