### PR TITLE
fix(trie): handle deleted nodes in `seek_exact`

### DIFF
--- a/crates/trie/trie/src/trie_cursor/in_memory.rs
+++ b/crates/trie/trie/src/trie_cursor/in_memory.rs
@@ -215,9 +215,8 @@ impl<C: TrieCursor> TrieCursor for InMemoryTrieCursor<'_, C> {
         self.seeked = true;
 
         let entry = match (mem_entry, &self.cursor_entry) {
-            (Some((mem_key, entry_inner)), _) if *mem_key == key => {
-                entry_inner.clone().map(|node| (key, node))
-            }
+            (Some((mem_key, Some(node))), _) if *mem_key == key => Some((key, node.clone())),
+            (Some((mem_key, None)), _) if *mem_key == key => None,
             (_, Some((db_key, node))) if db_key == &key => Some((key, node.clone())),
             _ => None,
         };


### PR DESCRIPTION
`seek_exact` in `InMemoryTrieCursor` didn't check if a node was deleted (`None`) in the in-memory overlay. It would return the DB value instead of `None` when a key existed in in-memory but was marked as deleted.
Added explicit check for deleted nodes (`None`) in the match arm - now returns `None` when in-memory has exact match with deleted node, consistent with seek behavior.