### PR TITLE
fix(net): use continue instead of return in buffer_hashes loop

### DIFF
--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -381,7 +381,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
             let Some(TxFetchMetadata { retries, fallback_peers, .. }) =
                 self.hashes_fetch_inflight_and_pending_fetch.get(&hash)
             else {
-                return
+                continue
             };
 
             if let Some(peer_id) = fallback_peer {


### PR DESCRIPTION
In `buffer_hashes`, if `get(&hash)` returned `None` for any hash in the loop, the function would return early instead of continuing to process remaining hashes. This could cause unprocessed hashes to be lost.
Changed return to continue on line 384 so the loop processes all hashes in the input iterator.