### PR TITLE
fix(events): handle `PipelineEvent::Unwound` to clean up `current_stage`

### DIFF
--- a/crates/node/events/src/node.rs
+++ b/crates/node/events/src/node.rs
@@ -206,6 +206,10 @@ impl NodeState {
 
                 self.current_stage = Some(current_stage);
             }
+            PipelineEvent::Unwound { stage_id, result } => {
+                info!(stage = %stage_id, checkpoint = %result.checkpoint.block_number, "Unwound stage");
+                self.current_stage = None;
+            }
             _ => (),
         }
     }


### PR DESCRIPTION
The code handled `PipelineEvent::Unwind` (before unwind starts) but not `PipelineEvent::Unwound` (after unwind completes). This left the stage stuck in `current_stage` with stale data, causing incorrect status logs and ETA calculations.
Added handler for `PipelineEvent::Unwound` that logs the completion and clears `current_stage`, matching the behavior of `PipelineEvent::Ran` with `done = true`