### PR TITLE
docs: fix remote ExEx image path

### DIFF
--- a/docs/vocs/docs/pages/exex/remote.mdx
+++ b/docs/vocs/docs/pages/exex/remote.mdx
@@ -168,4 +168,4 @@ And in the other, we will run our consumer:
 cargo run --bin consumer --release
 ```
 
-![remote_exex](/remote_exex.png)
+![remote_exex](../../public/remote_exex.png)


### PR DESCRIPTION
Fix broken image path in remote ExEx documentation