### PR TITLE
perf(storage): batch MDBX cursor writes in save_blocks

### DIFF
--- a/crates/storage/provider/src/providers/database/metrics.rs
+++ b/crates/storage/provider/src/providers/database/metrics.rs
@@ -38,10 +38,8 @@ pub(crate) enum Action {
     InsertHashes,
     InsertHistoryIndices,
     UpdatePipelineStages,
-    InsertHeaderNumbers,
     InsertBlockBodyIndices,
     InsertTransactionBlocks,
-    InsertTransactionSenders,
     InsertTransactionHashNumbers,
 }
 
@@ -59,14 +57,10 @@ pub(crate) struct DatabaseProviderMetrics {
     insert_history_indices: Histogram,
     /// Duration of update pipeline stages
     update_pipeline_stages: Histogram,
-    /// Duration of insert header numbers
-    insert_header_numbers: Histogram,
     /// Duration of insert block body indices
     insert_block_body_indices: Histogram,
     /// Duration of insert transaction blocks
     insert_tx_blocks: Histogram,
-    /// Duration of insert transaction senders
-    insert_transaction_senders: Histogram,
     /// Duration of insert transaction hash numbers
     insert_transaction_hash_numbers: Histogram,
     /// Duration of `save_blocks`
@@ -160,10 +154,8 @@ impl DatabaseProviderMetrics {
             Action::InsertHashes => self.insert_hashes.record(duration),
             Action::InsertHistoryIndices => self.insert_history_indices.record(duration),
             Action::UpdatePipelineStages => self.update_pipeline_stages.record(duration),
-            Action::InsertHeaderNumbers => self.insert_header_numbers.record(duration),
             Action::InsertBlockBodyIndices => self.insert_block_body_indices.record(duration),
             Action::InsertTransactionBlocks => self.insert_tx_blocks.record(duration),
-            Action::InsertTransactionSenders => self.insert_transaction_senders.record(duration),
             Action::InsertTransactionHashNumbers => {
                 self.insert_transaction_hash_numbers.record(duration)
             }

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -5275,8 +5275,10 @@ mod tests {
 
             let first_tx_num = tx_num;
             let tx_count_u64 = tx_count as u64;
-            expected_body_indices
-                .push((block_number, StoredBlockBodyIndices { first_tx_num, tx_count: tx_count_u64 }));
+            expected_body_indices.push((
+                block_number,
+                StoredBlockBodyIndices { first_tx_num, tx_count: tx_count_u64 },
+            ));
             expected_header_numbers.push((recovered.hash(), block_number));
 
             if tx_count_u64 > 0 {
@@ -5339,7 +5341,8 @@ mod tests {
             .unwrap();
         assert_eq!(got_senders, expected_senders);
 
-        let mut header_numbers_cursor = provider.tx_ref().cursor_read::<tables::HeaderNumbers>().unwrap();
+        let mut header_numbers_cursor =
+            provider.tx_ref().cursor_read::<tables::HeaderNumbers>().unwrap();
         for (hash, number) in expected_header_numbers {
             let entry = header_numbers_cursor.seek_exact(hash).unwrap();
             assert_eq!(entry.map(|(_, value)| value), Some(number));


### PR DESCRIPTION
## Summary
Batch MDBX cursor writes in `save_blocks` to avoid opening/closing cursors per block.

## Motivation
`save_blocks` previously called `insert_block_mdbx_only()` and `write_state()` in a per-block loop. Each call opened fresh MDBX cursors (`BlockBodyIndices`, `TransactionBlocks`, `TransactionSenders`, `BlockOmmers`, `BlockWithdrawals`, `Bytecodes`) — for a 3-block batch that's ~18 cursor open/close cycles that can be reduced to ~6.

## Changes
- Replaced per-block `insert_block_mdbx_only()` loop with `insert_blocks_mdbx_batch()` that opens each cursor once
- `write_block_bodies()` now receives all blocks at once (opens `BlockOmmers`/`BlockWithdrawals` cursors once)
- In storage v2 mode, bytecodes are batched across all blocks in a single `Bytecodes` cursor session instead of per-block `write_state` calls
- Removed now-unused `insert_block_mdbx_only`, `write_block_body_indices`, and their per-block metric variants

## Testing
`cargo test -p reth-provider` — 110 tests pass, 0 failures.

Prompted by: yk