### PR TITLE
fix(cli): store extradata as Bytes, decode hex in parser

### DIFF
--- a/crates/ethereum/node/src/payload.rs
+++ b/crates/ethereum/node/src/payload.rs
@@ -55,7 +55,7 @@ where
             EthereumBuilderConfig::new()
                 .with_gas_limit(gas_limit)
                 .with_max_blobs_per_block(conf.max_blobs_per_block())
-                .with_extra_data(conf.extra_data_bytes()),
+                .with_extra_data(conf.extra_data()),
         ))
     }
 }

--- a/crates/node/core/src/args/payload_builder.rs
+++ b/crates/node/core/src/args/payload_builder.rs
@@ -145,7 +145,7 @@ impl Default for PayloadBuilderArgs {
 }
 
 impl PayloadBuilderConfig for PayloadBuilderArgs {
-    fn extra_data_bytes(&self) -> Bytes {
+    fn extra_data(&self) -> Bytes {
         self.extra_data.clone()
     }
 

--- a/crates/node/core/src/cli/config.rs
+++ b/crates/node/core/src/cli/config.rs
@@ -16,7 +16,7 @@ const ETHEREUM_BLOCK_GAS_LIMIT_60M: u64 = 60_000_000;
 /// [`PayloadBuilderArgs`](crate::args::PayloadBuilderArgs) type.
 pub trait PayloadBuilderConfig {
     /// Returns the extra data as bytes.
-    fn extra_data_bytes(&self) -> Bytes;
+    fn extra_data(&self) -> Bytes;
 
     /// The interval at which the job should build a new payload after the last.
     fn interval(&self) -> Duration;

--- a/crates/node/core/src/cli/config.rs
+++ b/crates/node/core/src/cli/config.rs
@@ -5,7 +5,7 @@ use alloy_primitives::Bytes;
 use reth_chainspec::{Chain, ChainKind, NamedChain};
 use reth_network::{protocol::IntoRlpxSubProtocol, NetworkPrimitives};
 use reth_transaction_pool::PoolConfig;
-use std::{borrow::Cow, time::Duration};
+use std::time::Duration;
 
 /// 60M gas limit
 const ETHEREUM_BLOCK_GAS_LIMIT_60M: u64 = 60_000_000;
@@ -15,13 +15,8 @@ const ETHEREUM_BLOCK_GAS_LIMIT_60M: u64 = 60_000_000;
 /// This provides all basic payload builder settings and is implemented by the
 /// [`PayloadBuilderArgs`](crate::args::PayloadBuilderArgs) type.
 pub trait PayloadBuilderConfig {
-    /// Block extra data set by the payload builder.
-    fn extra_data(&self) -> Cow<'_, str>;
-
     /// Returns the extra data as bytes.
-    fn extra_data_bytes(&self) -> Bytes {
-        self.extra_data().as_bytes().to_vec().into()
-    }
+    fn extra_data_bytes(&self) -> Bytes;
 
     /// The interval at which the job should build a new payload after the last.
     fn interval(&self) -> Duration;

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -685,7 +685,9 @@ TxPool:
 
 Builder:
       --builder.extradata <EXTRA_DATA>
-          Block extra data set by the payload builder
+          Block extra data set by the payload builder.
+
+          If the value is a `0x`-prefixed hex string, it is decoded into raw bytes. Otherwise, the raw UTF-8 bytes of the string are used.
 
           [default: reth/<VERSION>/<OS>]
 

--- a/examples/custom-engine-types/src/main.rs
+++ b/examples/custom-engine-types/src/main.rs
@@ -339,7 +339,7 @@ where
                 pool,
                 evm_config,
                 EthereumBuilderConfig::new()
-                    .with_extra_data(ctx.payload_builder_config().extra_data_bytes()),
+                    .with_extra_data(ctx.payload_builder_config().extra_data()),
             ),
         };
         Ok(payload_builder)

--- a/examples/custom-payload-builder/src/main.rs
+++ b/examples/custom-payload-builder/src/main.rs
@@ -62,8 +62,7 @@ where
             ctx.provider().clone(),
             pool,
             evm_config,
-            EthereumBuilderConfig::new()
-                .with_extra_data(ctx.payload_builder_config().extra_data()),
+            EthereumBuilderConfig::new().with_extra_data(ctx.payload_builder_config().extra_data()),
         );
 
         let conf = ctx.payload_builder_config();

--- a/examples/custom-payload-builder/src/main.rs
+++ b/examples/custom-payload-builder/src/main.rs
@@ -63,7 +63,7 @@ where
             pool,
             evm_config,
             EthereumBuilderConfig::new()
-                .with_extra_data(ctx.payload_builder_config().extra_data_bytes()),
+                .with_extra_data(ctx.payload_builder_config().extra_data()),
         );
 
         let conf = ctx.payload_builder_config();


### PR DESCRIPTION
## Summary
Fixes `--builder.extradata` rejecting valid 32-byte hex-encoded values. Rewrites #22277 to store parsed bytes directly instead of deferring hex decoding to `extra_data_bytes()`.

## Motivation
Closes #22274 — the CLI parser validated string character count instead of decoded byte count, so a 32-byte SHA256 hash (`0x` + 64 hex chars) was rejected.

## Changes
- `PayloadBuilderArgs::extra_data` is now `Bytes` instead of `String`
- `ExtraDataValueParser` decodes at parse time: `0x`-prefixed → `hex::decode`, otherwise → `to_vec()`
- `PayloadBuilderConfig::extra_data() -> Cow<str>` removed, `extra_data_bytes() -> Bytes` is now the required method (just returns a clone)
- Added tests for valid hex, oversized hex, invalid hex, and odd-length hex

## Testing
```
cargo test -p reth-node-core
# 98 passed; 0 failed
```

Prompted by: danipopes