### PR TITLE
perf(engine): release preserved trie lock during expensive prepare-for-reuse work

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/preserved_sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/preserved_sparse_trie.rs
@@ -1,7 +1,7 @@
 //! Preserved sparse trie for reuse across payload validations.
 
 use alloy_primitives::B256;
-use parking_lot::Mutex;
+use parking_lot::{Condvar, Mutex};
 use reth_trie_sparse::SparseStateTrie;
 use std::{sync::Arc, time::Instant};
 use tracing::debug;
@@ -9,36 +9,68 @@ use tracing::debug;
 /// Type alias for the sparse trie type used in preservation.
 pub(super) type SparseTrie = SparseStateTrie;
 
+/// Inner state protected by the mutex.
+#[derive(Debug, Default)]
+struct PreservedTrieInner {
+    /// Whether the trie is currently being prepared (expensive work in progress).
+    /// When true, `take()` and `wait_for_availability()` will block on the condvar.
+    preparing: bool,
+    /// The preserved trie slot.
+    slot: Option<PreservedSparseTrie>,
+}
+
 /// Shared handle to a preserved sparse trie that can be reused across payload validations.
 ///
 /// This is stored in [`PayloadProcessor`](super::PayloadProcessor) and cloned to pass to
 /// [`SparseTrieCacheTask`](super::sparse_trie::SparseTrieCacheTask) for trie reuse.
-#[derive(Debug, Default, Clone)]
-pub(super) struct SharedPreservedSparseTrie(Arc<Mutex<Option<PreservedSparseTrie>>>);
+///
+/// Uses a condvar-backed "preparing" flag to allow expensive trie preparation work
+/// (prune + shrink) to happen outside the mutex while still blocking consumers.
+#[derive(Debug, Clone)]
+pub(super) struct SharedPreservedSparseTrie(Arc<(Mutex<PreservedTrieInner>, Condvar)>);
+
+impl Default for SharedPreservedSparseTrie {
+    fn default() -> Self {
+        Self(Arc::new((Mutex::new(PreservedTrieInner::default()), Condvar::new())))
+    }
+}
 
 impl SharedPreservedSparseTrie {
     /// Takes the preserved trie if present, leaving `None` in its place.
+    ///
+    /// Blocks while the trie is being prepared (preparing flag is set).
     pub(super) fn take(&self) -> Option<PreservedSparseTrie> {
-        self.0.lock().take()
+        let (lock, cvar) = &*self.0;
+        let mut inner = lock.lock();
+        while inner.preparing {
+            cvar.wait(&mut inner);
+        }
+        inner.slot.take()
     }
 
     /// Acquires a guard that blocks `take()` until dropped.
     /// Use this before sending the state root result to ensure the next block
     /// waits for the trie to be stored.
     pub(super) fn lock(&self) -> PreservedTrieGuard<'_> {
-        PreservedTrieGuard(self.0.lock())
+        let (lock, cvar) = &*self.0;
+        PreservedTrieGuard { inner: lock.lock(), cvar }
     }
 
-    /// Waits until the sparse trie lock becomes available.
+    /// Waits until the sparse trie becomes available (not locked and not preparing).
     ///
-    /// This acquires and immediately releases the lock, ensuring that any
-    /// ongoing operations complete before returning. Useful for synchronization
-    /// before starting payload processing.
+    /// This acquires the lock and waits for the preparing flag to clear, ensuring
+    /// that any ongoing operations complete before returning. Useful for
+    /// synchronization before starting payload processing.
     ///
-    /// Returns the time spent waiting for the lock.
+    /// Returns the time spent waiting.
     pub(super) fn wait_for_availability(&self) -> std::time::Duration {
         let start = Instant::now();
-        let _guard = self.0.lock();
+        let (lock, cvar) = &*self.0;
+        let mut inner = lock.lock();
+        while inner.preparing {
+            cvar.wait(&mut inner);
+        }
+        drop(inner);
         let elapsed = start.elapsed();
         if elapsed.as_millis() > 5 {
             debug!(
@@ -49,16 +81,81 @@ impl SharedPreservedSparseTrie {
         }
         elapsed
     }
+
+    /// Creates a [`PreparingGuard`] after the preparing flag has already been set.
+    ///
+    /// The returned RAII guard will clear the preparing flag and notify waiters
+    /// if dropped without calling [`PreparingGuard::store`] (panic/early-return safety).
+    const fn preparing_guard(&self) -> PreparingGuard<'_> {
+        PreparingGuard { shared: self, committed: false }
+    }
 }
 
 /// Guard that holds the lock on the preserved trie.
-/// While held, `take()` will block. Call `store()` to save the trie before dropping.
-pub(super) struct PreservedTrieGuard<'a>(parking_lot::MutexGuard<'a, Option<PreservedSparseTrie>>);
+/// While held, `take()` will block. Call `store()` to save the trie before dropping,
+/// or call `mark_preparing_and_release()` to set the preparing flag and release the lock
+/// for expensive work.
+pub(super) struct PreservedTrieGuard<'a> {
+    inner: parking_lot::MutexGuard<'a, PreservedTrieInner>,
+    cvar: &'a Condvar,
+}
 
-impl PreservedTrieGuard<'_> {
+impl<'a> PreservedTrieGuard<'a> {
     /// Stores a preserved trie for later reuse.
     pub(super) fn store(&mut self, trie: PreservedSparseTrie) {
-        self.0.replace(trie);
+        self.inner.slot = Some(trie);
+        self.inner.preparing = false;
+        self.cvar.notify_all();
+    }
+
+    /// Sets the preparing flag and releases the mutex lock, returning a [`PreparingGuard`].
+    ///
+    /// After this call the mutex is unlocked but `take()` / `wait_for_availability()` will
+    /// still block on the condvar until [`PreparingGuard::store`] is called (or the guard
+    /// is dropped, which clears the flag for safety).
+    ///
+    /// `shared` must be the same [`SharedPreservedSparseTrie`] this guard was obtained from.
+    pub(super) fn mark_preparing_and_release(
+        mut self,
+        shared: &'a SharedPreservedSparseTrie,
+    ) -> PreparingGuard<'a> {
+        self.inner.preparing = true;
+        drop(self); // releases the mutex
+        shared.preparing_guard()
+    }
+}
+
+/// RAII guard that clears the `preparing` flag on drop unless committed via [`store`](Self::store).
+///
+/// This ensures that if the task panics or returns early after marking `preparing`,
+/// the flag is always cleared and waiters are notified.
+pub(super) struct PreparingGuard<'a> {
+    shared: &'a SharedPreservedSparseTrie,
+    committed: bool,
+}
+
+impl Drop for PreparingGuard<'_> {
+    fn drop(&mut self) {
+        if !self.committed {
+            let (lock, cvar) = &*self.shared.0;
+            let mut inner = lock.lock();
+            inner.preparing = false;
+            cvar.notify_all();
+        }
+    }
+}
+
+impl PreparingGuard<'_> {
+    /// Stores the prepared trie, clears the preparing flag, and notifies waiters.
+    ///
+    /// Consumes the guard so the Drop impl does not fire.
+    pub(super) fn store(mut self, trie: PreservedSparseTrie) {
+        let (lock, cvar) = &*self.shared.0;
+        let mut inner = lock.lock();
+        inner.slot = Some(trie);
+        inner.preparing = false;
+        self.committed = true;
+        cvar.notify_all();
     }
 }
 
@@ -133,5 +230,151 @@ impl PreservedSparseTrie {
                 trie
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc as StdArc,
+        },
+        thread,
+        time::Duration,
+    };
+
+    #[test]
+    fn take_blocks_while_preparing_then_unblocks_after_store() {
+        let shared = SharedPreservedSparseTrie::default();
+        let took = StdArc::new(AtomicBool::new(false));
+
+        // Mark preparing via the guard flow
+        {
+            let mut guard = shared.lock();
+            guard.inner.preparing = true;
+        }
+
+        let preparing_guard = shared.preparing_guard();
+
+        // Spawn a thread that tries to take – it should block
+        let shared_clone = shared.clone();
+        let took_clone = took.clone();
+        let handle = thread::spawn(move || {
+            let result = shared_clone.take();
+            took_clone.store(true, Ordering::SeqCst);
+            result
+        });
+
+        // Give the thread time to block
+        thread::sleep(Duration::from_millis(50));
+        assert!(!took.load(Ordering::SeqCst), "take() should be blocked while preparing");
+
+        // Store a cleared trie to unblock
+        let trie = SparseStateTrie::new();
+        preparing_guard.store(PreservedSparseTrie::cleared(trie));
+
+        let result = handle.join().unwrap();
+        assert!(took.load(Ordering::SeqCst), "take() should have completed");
+        assert!(result.is_some(), "take() should return the stored trie");
+    }
+
+    #[test]
+    fn wait_for_availability_blocks_while_preparing() {
+        let shared = SharedPreservedSparseTrie::default();
+        let available = StdArc::new(AtomicBool::new(false));
+
+        // Set preparing
+        {
+            let mut guard = shared.lock();
+            guard.inner.preparing = true;
+        }
+
+        let shared_clone = shared.clone();
+        let available_clone = available.clone();
+        let handle = thread::spawn(move || {
+            shared_clone.wait_for_availability();
+            available_clone.store(true, Ordering::SeqCst);
+        });
+
+        thread::sleep(Duration::from_millis(50));
+        assert!(
+            !available.load(Ordering::SeqCst),
+            "wait_for_availability should block while preparing"
+        );
+
+        // Clear preparing
+        {
+            let (lock, cvar) = &*shared.0;
+            let mut inner = lock.lock();
+            inner.preparing = false;
+            cvar.notify_all();
+        }
+
+        handle.join().unwrap();
+        assert!(available.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn preparing_guard_drop_clears_flag_on_panic_path() {
+        let shared = SharedPreservedSparseTrie::default();
+        let unblocked = StdArc::new(AtomicBool::new(false));
+
+        // Set preparing
+        {
+            let mut guard = shared.lock();
+            guard.inner.preparing = true;
+        }
+
+        let preparing_guard = shared.preparing_guard();
+
+        // Spawn a thread that waits on take
+        let shared_clone = shared.clone();
+        let unblocked_clone = unblocked.clone();
+        let handle = thread::spawn(move || {
+            let _ = shared_clone.take();
+            unblocked_clone.store(true, Ordering::SeqCst);
+        });
+
+        thread::sleep(Duration::from_millis(50));
+        assert!(!unblocked.load(Ordering::SeqCst), "take() should be blocked");
+
+        // Drop the guard without committing (simulates panic/early-return)
+        drop(preparing_guard);
+
+        handle.join().unwrap();
+        assert!(
+            unblocked.load(Ordering::SeqCst),
+            "take() should unblock after PreparingGuard drop"
+        );
+
+        // Verify preparing is cleared
+        let (lock, _) = &*shared.0;
+        let inner = lock.lock();
+        assert!(!inner.preparing, "preparing flag should be cleared after guard drop");
+    }
+
+    #[test]
+    fn mark_preparing_and_release_returns_preparing_guard() {
+        let shared = SharedPreservedSparseTrie::default();
+
+        let guard = shared.lock();
+        let preparing_guard = guard.mark_preparing_and_release(&shared);
+
+        // Verify preparing is set
+        {
+            let (lock, _) = &*shared.0;
+            let inner = lock.lock();
+            assert!(inner.preparing);
+        }
+
+        // Store clears it
+        preparing_guard.store(PreservedSparseTrie::cleared(SparseStateTrie::new()));
+
+        let (lock, _) = &*shared.0;
+        let inner = lock.lock();
+        assert!(!inner.preparing);
+        assert!(inner.slot.is_some());
     }
 }

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -27,8 +27,8 @@ use reth_trie_parallel::{
 #[cfg(feature = "trie-debug")]
 use reth_trie_sparse::debug_recorder::TrieDebugRecorder;
 use reth_trie_sparse::{
-    errors::SparseTrieResult, DeferredDrops, LeafUpdate, LeafValue, ParallelSparseTrie, SparseStateTrie,
-    SparseTrie,
+    errors::SparseTrieResult, DeferredDrops, LeafUpdate, LeafValue, ParallelSparseTrie,
+    SparseStateTrie, SparseTrie,
 };
 use revm_primitives::{hash_map::Entry, B256Map};
 use tracing::{debug, debug_span, error, instrument};

--- a/crates/trie/sparse/src/debug_recorder.rs
+++ b/crates/trie/sparse/src/debug_recorder.rs
@@ -171,7 +171,7 @@ pub enum LeafUpdateRecord {
 impl From<&crate::LeafUpdate> for LeafUpdateRecord {
     fn from(update: &crate::LeafUpdate) -> Self {
         match update {
-            crate::LeafUpdate::Changed(value) => Self::Changed(value.clone().into()),
+            crate::LeafUpdate::Changed(value) => Self::Changed(value.to_vec().into()),
             crate::LeafUpdate::Touched => Self::Touched,
         }
     }

--- a/crates/trie/sparse/src/parallel.rs
+++ b/crates/trie/sparse/src/parallel.rs
@@ -5379,7 +5379,7 @@ mod tests {
             );
 
         let mut sparse = ParallelSparseTrie::default().with_updates(true);
-        ctx.update_leaves(&mut sparse, [(key, value_encoded().into())]);
+        ctx.update_leaves(&mut sparse, [(key, value_encoded())]);
         ctx.assert_with_hash_builder(
             &mut sparse,
             hash_builder_root,
@@ -5443,7 +5443,7 @@ mod tests {
         let provider = DefaultTrieNodeProvider;
         let mut sparse = ParallelSparseTrie::default().with_updates(true);
         for path in &paths {
-            sparse.update_leaf(*path, value_encoded().into(), &provider).unwrap();
+            sparse.update_leaf(*path, value_encoded(), &provider).unwrap();
         }
         let sparse_root = sparse.root();
         let sparse_updates = sparse.take_updates();
@@ -6238,7 +6238,7 @@ mod tests {
         );
 
         // Insert the leaf for the second key
-        sparse.update_leaf(key2(), value_encoded().into(), &provider).unwrap();
+        sparse.update_leaf(key2(), value_encoded(), &provider).unwrap();
 
         // Check that the branch node was updated and another nibble was set
         assert_eq!(
@@ -6451,7 +6451,7 @@ mod tests {
         );
 
         // Insert the leaf with a different prefix
-        sparse.update_leaf(key3(), value_encoded().into(), &provider).unwrap();
+        sparse.update_leaf(key3(), value_encoded(), &provider).unwrap();
 
         // Check that the extension node was turned into a branch node
         assert_matches!(
@@ -7456,7 +7456,7 @@ mod tests {
         let result = sparse.find_leaf(&path, Some(&wrong_value));
         assert_matches!(
             result,
-            Err(LeafLookupError::ValueMismatch { path: p, expected, actual: _a }) if p == path && *expected == Some(wrong_value.clone())
+            Err(LeafLookupError::ValueMismatch { path: p, expected, actual: _a }) if p == path && *expected == Some(wrong_value)
         );
     }
 

--- a/crates/trie/sparse/src/parallel.rs
+++ b/crates/trie/sparse/src/parallel.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "trie-debug")]
 use crate::debug_recorder::{LeafUpdateRecord, ProofTrieNodeRecord, RecordedOp, TrieDebugRecorder};
 use crate::{
+    LeafValue,
     lower::LowerSparseSubtrie,
     provider::{RevealedNode, TrieNodeProvider},
     LeafLookup, LeafLookupError, RlpNodeStackItem, SparseNode, SparseNodeState, SparseNodeType,
@@ -398,7 +399,7 @@ impl SparseTrie for ParallelSparseTrie {
     fn update_leaf<P: TrieNodeProvider>(
         &mut self,
         full_path: Nibbles,
-        value: Vec<u8>,
+        value: LeafValue,
         _provider: P,
     ) -> SparseTrieResult<()> {
         debug_assert_eq!(
@@ -938,7 +939,7 @@ impl SparseTrie for ParallelSparseTrie {
         }
     }
 
-    fn get_leaf_value(&self, full_path: &Nibbles) -> Option<&Vec<u8>> {
+    fn get_leaf_value(&self, full_path: &Nibbles) -> Option<&LeafValue> {
         // `subtrie_for_path` is intended for a node path, but here we are using a full key path. So
         // we need to check if the subtrie that the key might belong to has any nodes; if not then
         // the key's portion of the trie doesn't have enough depth to reach into the subtrie, and
@@ -1012,7 +1013,7 @@ impl SparseTrie for ParallelSparseTrie {
     fn find_leaf(
         &self,
         full_path: &Nibbles,
-        expected_value: Option<&Vec<u8>>,
+        expected_value: Option<&LeafValue>,
     ) -> Result<LeafLookup, LeafLookupError> {
         // Inclusion proof
         //
@@ -2487,7 +2488,7 @@ impl SparseSubtrie {
     ///
     /// This method is atomic: if an error occurs during structural changes, all modifications
     /// are rolled back and the trie state is unchanged.
-    pub fn update_leaf(&mut self, full_path: Nibbles, value: Vec<u8>) -> SparseTrieResult<()> {
+    pub fn update_leaf(&mut self, full_path: Nibbles, value: LeafValue) -> SparseTrieResult<()> {
         debug_assert!(full_path.starts_with(&self.path));
 
         // Check if value already exists - if so, just update it (no structural changes needed)
@@ -2915,7 +2916,7 @@ impl SparseSubtrie {
                         return Ok(false)
                     }
                     Entry::Vacant(entry) => {
-                        entry.insert(leaf.value.clone());
+                        entry.insert(LeafValue::from_slice(&leaf.value));
                     }
                 }
 
@@ -3081,7 +3082,7 @@ impl SparseSubtrie {
         for (path, value) in &self.inner.values {
             size += core::mem::size_of::<Nibbles>();
             size += path.len(); // Nibbles heap allocation
-            size += core::mem::size_of::<Vec<u8>>() + value.capacity();
+            size += core::mem::size_of::<LeafValue>() + value.capacity();
         }
 
         // Buffers
@@ -3097,7 +3098,7 @@ impl SparseSubtrie {
 struct SparseSubtrieInner {
     /// Map from leaf key paths to their values.
     /// All values are stored here instead of directly in leaf nodes.
-    values: HashMap<Nibbles, Vec<u8>>,
+    values: HashMap<Nibbles, LeafValue>,
     /// Reusable buffers for [`SparseSubtrie::update_hashes`].
     buffers: SparseSubtrieBuffers,
 }
@@ -3686,7 +3687,7 @@ mod tests {
         parallel::ChangedSubtrie,
         provider::{DefaultTrieNodeProvider, RevealedNode, TrieNodeProvider},
         trie::SparseNodeState,
-        LeafLookup, LeafLookupError, SparseNode, SparseTrie, SparseTrieUpdates,
+        LeafLookup, LeafLookupError, LeafValue, SparseNode, SparseTrie, SparseTrieUpdates,
     };
     use alloy_primitives::{
         b256, hex,
@@ -3769,7 +3770,7 @@ mod tests {
         Account { nonce, ..Default::default() }
     }
 
-    fn large_account_value() -> Vec<u8> {
+    fn large_account_value() -> LeafValue {
         let account = Account {
             nonce: 0x123456789abcdef,
             balance: U256::from(0x123456789abcdef0123456789abcdef_u128),
@@ -3777,15 +3778,15 @@ mod tests {
         };
         let mut buf = Vec::new();
         account.into_trie_account(EMPTY_ROOT_HASH).encode(&mut buf);
-        buf
+        LeafValue::from_vec(buf)
     }
 
-    fn encode_account_value(nonce: u64) -> Vec<u8> {
+    fn encode_account_value(nonce: u64) -> LeafValue {
         let account = Account { nonce, ..Default::default() };
         let trie_account = account.into_trie_account(EMPTY_ROOT_HASH);
         let mut buf = Vec::new();
         trie_account.encode(&mut buf);
-        buf
+        LeafValue::from_slice(&buf)
     }
 
     /// Test context that provides helper methods for trie testing
@@ -3837,7 +3838,7 @@ mod tests {
         }
 
         /// Create test leaves with consecutive account values
-        fn create_test_leaves(&self, paths: &[&[u8]]) -> Vec<(Nibbles, Vec<u8>)> {
+        fn create_test_leaves(&self, paths: &[&[u8]]) -> Vec<(Nibbles, LeafValue)> {
             paths
                 .iter()
                 .enumerate()
@@ -3851,7 +3852,7 @@ mod tests {
         }
 
         /// Create a single test leaf with the given path and value nonce
-        fn create_test_leaf(&self, path: impl AsRef<[u8]>, value_nonce: u64) -> (Nibbles, Vec<u8>) {
+        fn create_test_leaf(&self, path: impl AsRef<[u8]>, value_nonce: u64) -> (Nibbles, LeafValue) {
             (pad_nibbles_right(Nibbles::from_nibbles(path)), encode_account_value(value_nonce))
         }
 
@@ -3859,7 +3860,7 @@ mod tests {
         fn update_leaves(
             &self,
             trie: &mut ParallelSparseTrie,
-            leaves: impl IntoIterator<Item = (Nibbles, Vec<u8>)>,
+            leaves: impl IntoIterator<Item = (Nibbles, LeafValue)>,
         ) {
             for (path, value) in leaves {
                 trie.update_leaf(path, value, DefaultTrieNodeProvider).unwrap();
@@ -3970,7 +3971,7 @@ mod tests {
     fn create_leaf_node(key: impl AsRef<[u8]>, value_nonce: u64) -> TrieNodeV2 {
         TrieNodeV2::Leaf(LeafNode::new(
             Nibbles::from_nibbles(key),
-            encode_account_value(value_nonce),
+            encode_account_value(value_nonce).to_vec(),
         ))
     }
 
@@ -4082,7 +4083,7 @@ mod tests {
             if let SparseNode::Leaf { key, .. } = &node {
                 let mut full_key = path;
                 full_key.extend(key);
-                subtrie.inner.values.insert(full_key, "LEAF VALUE".into());
+                subtrie.inner.values.insert(full_key, LeafValue::from_slice(b"LEAF VALUE"));
             }
             subtrie.nodes.insert(path, node);
         }
@@ -4324,9 +4325,10 @@ mod tests {
             );
 
             let full_path = Nibbles::from_nibbles([0x1, 0x2, 0x3]);
+            let expected_value = encode_account_value(42);
             assert_eq!(
                 trie.upper_subtrie.inner.values.get(&full_path),
-                Some(&encode_account_value(42))
+                Some(&expected_value)
             );
         }
 
@@ -5365,7 +5367,7 @@ mod tests {
         let value_encoded = || {
             let mut account_rlp = Vec::new();
             value().into_trie_account(EMPTY_ROOT_HASH).encode(&mut account_rlp);
-            account_rlp
+            LeafValue::from_vec(account_rlp)
         };
 
         let (hash_builder_root, hash_builder_updates, hash_builder_proof_nodes, _, _) =
@@ -5377,7 +5379,7 @@ mod tests {
             );
 
         let mut sparse = ParallelSparseTrie::default().with_updates(true);
-        ctx.update_leaves(&mut sparse, [(key, value_encoded())]);
+        ctx.update_leaves(&mut sparse, [(key, value_encoded().into())]);
         ctx.assert_with_hash_builder(
             &mut sparse,
             hash_builder_root,
@@ -5395,7 +5397,7 @@ mod tests {
         let value_encoded = || {
             let mut account_rlp = Vec::new();
             value().into_trie_account(EMPTY_ROOT_HASH).encode(&mut account_rlp);
-            account_rlp
+            LeafValue::from_vec(account_rlp)
         };
 
         let (hash_builder_root, hash_builder_updates, hash_builder_proof_nodes, _, _) =
@@ -5427,7 +5429,7 @@ mod tests {
         let value_encoded = || {
             let mut account_rlp = Vec::new();
             value().into_trie_account(EMPTY_ROOT_HASH).encode(&mut account_rlp);
-            account_rlp
+            LeafValue::from_vec(account_rlp)
         };
 
         let (hash_builder_root, hash_builder_updates, hash_builder_proof_nodes, _, _) =
@@ -5441,7 +5443,7 @@ mod tests {
         let provider = DefaultTrieNodeProvider;
         let mut sparse = ParallelSparseTrie::default().with_updates(true);
         for path in &paths {
-            sparse.update_leaf(*path, value_encoded(), &provider).unwrap();
+            sparse.update_leaf(*path, value_encoded().into(), &provider).unwrap();
         }
         let sparse_root = sparse.root();
         let sparse_updates = sparse.take_updates();
@@ -5468,7 +5470,7 @@ mod tests {
         let value_encoded = || {
             let mut account_rlp = Vec::new();
             value().into_trie_account(EMPTY_ROOT_HASH).encode(&mut account_rlp);
-            account_rlp
+            LeafValue::from_vec(account_rlp)
         };
 
         let (hash_builder_root, hash_builder_updates, hash_builder_proof_nodes, _, _) =
@@ -5501,13 +5503,13 @@ mod tests {
         let old_value_encoded = {
             let mut account_rlp = Vec::new();
             old_value.into_trie_account(EMPTY_ROOT_HASH).encode(&mut account_rlp);
-            account_rlp
+            LeafValue::from_vec(account_rlp)
         };
         let new_value = Account { nonce: 2, ..Default::default() };
         let new_value_encoded = {
             let mut account_rlp = Vec::new();
             new_value.into_trie_account(EMPTY_ROOT_HASH).encode(&mut account_rlp);
-            account_rlp
+            LeafValue::from_vec(account_rlp)
         };
 
         let (hash_builder_root, hash_builder_updates, hash_builder_proof_nodes, _, _) =
@@ -5556,7 +5558,7 @@ mod tests {
         let provider = DefaultTrieNodeProvider;
         let mut sparse = ParallelSparseTrie::default();
 
-        let value = alloy_rlp::encode_fixed_size(&U256::ZERO).to_vec();
+        let value = LeafValue::from_slice(&alloy_rlp::encode_fixed_size(&U256::ZERO));
 
         ctx.update_leaves(
             &mut sparse,
@@ -5990,7 +5992,7 @@ mod tests {
                         let account = account.into_trie_account(EMPTY_ROOT_HASH);
                         let mut account_rlp = Vec::new();
                         account.encode(&mut account_rlp);
-                        sparse.update_leaf(key, account_rlp, &default_provider).unwrap();
+                        sparse.update_leaf(key, LeafValue::from_slice(&account_rlp), &default_provider).unwrap();
                     }
                     // We need to clone the sparse trie, so that all updated branch nodes are
                     // preserved, and not only those that were changed after the last call to
@@ -6137,11 +6139,11 @@ mod tests {
         account.encode(&mut account_rlp);
 
         // Add a leaf and calculate the root.
-        trie.update_leaf(key_50, account_rlp.clone(), &provider).unwrap();
+        trie.update_leaf(key_50, LeafValue::from_slice(&account_rlp), &provider).unwrap();
         trie.root();
 
         // Add a second leaf and assert that the root is the expected value.
-        trie.update_leaf(key_51, account_rlp.clone(), &provider).unwrap();
+        trie.update_leaf(key_51, LeafValue::from_slice(&account_rlp), &provider).unwrap();
 
         let expected_root =
             hex!("0xdaf0ef9f91a2f179bb74501209effdb5301db1697bcab041eca2234b126e25de");
@@ -6170,7 +6172,7 @@ mod tests {
         let value_encoded = || {
             let mut account_rlp = Vec::new();
             value().into_trie_account(EMPTY_ROOT_HASH).encode(&mut account_rlp);
-            account_rlp
+            LeafValue::from_vec(account_rlp)
         };
 
         // Generate the proof for the root node and initialize the sparse trie with it
@@ -6230,7 +6232,7 @@ mod tests {
         );
 
         // Insert the leaf for the second key
-        sparse.update_leaf(key2(), value_encoded(), &provider).unwrap();
+        sparse.update_leaf(key2(), value_encoded().into(), &provider).unwrap();
 
         // Check that the branch node was updated and another nibble was set
         assert_eq!(
@@ -6403,7 +6405,7 @@ mod tests {
         let value_encoded = || {
             let mut account_rlp = Vec::new();
             value().into_trie_account(EMPTY_ROOT_HASH).encode(&mut account_rlp);
-            account_rlp
+            LeafValue::from_vec(account_rlp)
         };
 
         // Generate the proof for the root node and initialize the sparse trie with it
@@ -6443,7 +6445,7 @@ mod tests {
         );
 
         // Insert the leaf with a different prefix
-        sparse.update_leaf(key3(), value_encoded(), &provider).unwrap();
+        sparse.update_leaf(key3(), value_encoded().into(), &provider).unwrap();
 
         // Check that the extension node was turned into a branch node
         assert_matches!(
@@ -7368,9 +7370,9 @@ mod tests {
         let leaf_key = Nibbles::unpack(
             &hex!("d65eaa92c6bc4c13a5ec45527f0c18ea8932588728769ec7aecfe6d9f32e42")[..],
         );
-        let leaf_value = hex!("f8440180a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0f57acd40259872606d76197ef052f3d35588dadf919ee1f0e3cb9b62d3f4b02c").to_vec();
+        let leaf_value = LeafValue::from_slice(&hex!("f8440180a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0f57acd40259872606d76197ef052f3d35588dadf919ee1f0e3cb9b62d3f4b02c"));
 
-        let leaf_node = LeafNode::new(leaf_key, leaf_value);
+        let leaf_node = LeafNode::new(leaf_key, leaf_value.to_vec());
         let leaf_masks = None;
 
         trie.reveal_nodes(&mut [
@@ -7391,12 +7393,12 @@ mod tests {
         let mut leaf_full_path = leaf_path;
         leaf_full_path.extend(&leaf_key);
 
-        let leaf_new_value = vec![
+        let leaf_new_value: LeafValue = vec![
             248, 68, 1, 128, 160, 224, 163, 152, 169, 122, 160, 155, 102, 53, 41, 0, 47, 28, 205,
             190, 199, 5, 215, 108, 202, 22, 138, 70, 196, 178, 193, 208, 18, 96, 95, 63, 238, 160,
             245, 122, 205, 64, 37, 152, 114, 96, 109, 118, 25, 126, 240, 82, 243, 211, 85, 136,
             218, 223, 145, 158, 225, 240, 227, 203, 155, 98, 211, 244, 176, 44,
-        ];
+        ].into();
 
         trie.update_leaf(leaf_full_path, leaf_new_value.clone(), DefaultTrieNodeProvider).unwrap();
 
@@ -7419,7 +7421,7 @@ mod tests {
         let provider = DefaultTrieNodeProvider;
         let mut sparse = ParallelSparseTrie::default();
         let path = pad_nibbles_right(Nibbles::from_nibbles([0x1, 0x2, 0x3]));
-        let value = b"test_value".to_vec();
+        let value: LeafValue = LeafValue::from_slice(b"test_value");
 
         sparse.update_leaf(path, value.clone(), &provider).unwrap();
 
@@ -7438,8 +7440,8 @@ mod tests {
         let provider = DefaultTrieNodeProvider;
         let mut sparse = ParallelSparseTrie::default();
         let path = pad_nibbles_right(Nibbles::from_nibbles([0x1, 0x2, 0x3]));
-        let value = b"test_value".to_vec();
-        let wrong_value = b"wrong_value".to_vec();
+        let value: LeafValue = LeafValue::from_slice(b"test_value");
+        let wrong_value: LeafValue = LeafValue::from_slice(b"wrong_value");
 
         sparse.update_leaf(path, value, &provider).unwrap();
 
@@ -7660,7 +7662,7 @@ mod tests {
         // Reveal leaf at 0x31b0b645a6c4a0a1bb3d2f0c1d31c39f4aba2e3b015928a8eef7161e28388b81
         let leaf_path = hex!("31b0b645a6c4a0a1bb3d2f0c1d31c39f4aba2e3b015928a8eef7161e28388b81");
         let leaf_nibbles = Nibbles::unpack(leaf_path.as_slice());
-        let leaf_value = hex!("0009ae8ce8245bff").to_vec();
+        let leaf_value = LeafValue::from_slice(&hex!("0009ae8ce8245bff"));
 
         // Reveal branch at 0x31c
         let branch_0x31c_hashes = vec![
@@ -7876,7 +7878,7 @@ mod tests {
 
         // Single storage slot - leaf will be at root (depth 0)
         let slot_path = pad_nibbles_right(Nibbles::from_nibbles([0x2, 0x9]));
-        let slot_value = alloy_rlp::encode(U256::from(12345));
+        let slot_value: LeafValue = alloy_rlp::encode(U256::from(12345)).into();
         trie.update_leaf(slot_path, slot_value.clone(), &provider).unwrap();
 
         // Value should be retrievable
@@ -7911,7 +7913,7 @@ mod tests {
             parallel
                 .update_leaf(
                     pad_nibbles_right(Nibbles::from_nibbles([i, 0x1, 0x2, 0x3, 0x4, 0x5])),
-                    value.clone(),
+                    LeafValue::from_slice(&value),
                     &provider,
                 )
                 .unwrap();
@@ -8127,7 +8129,7 @@ mod tests {
         let mut trie = ParallelSparseTrie::default();
 
         let large_value = large_account_value();
-        let small_value = vec![0x80];
+        let small_value: LeafValue = vec![0x80].into();
 
         for i in 0..8u8 {
             let value = if i < 4 { large_value.clone() } else { small_value.clone() };
@@ -8427,7 +8429,7 @@ mod tests {
 
         // Create an update to remove key1 (empty value = removal)
         let mut updates: B256Map<LeafUpdate> = B256Map::default();
-        updates.insert(b256_key1, LeafUpdate::Changed(vec![])); // empty = removal
+        updates.insert(b256_key1, LeafUpdate::Changed(vec![].into())); // empty = removal
 
         let proof_targets = RefCell::new(Vec::new());
         trie.update_leaves(&mut updates, |path, min_len| {
@@ -8492,7 +8494,7 @@ mod tests {
         trie.upper_subtrie.inner.values.insert(full_path, old_value.clone());
 
         let mut updates: B256Map<LeafUpdate> = B256Map::default();
-        updates.insert(b256_key, LeafUpdate::Changed(vec![])); // empty = removal
+        updates.insert(b256_key, LeafUpdate::Changed(vec![].into())); // empty = removal
 
         let proof_targets = RefCell::new(Vec::new());
         let prefix_set_len_before = trie.prefix_set.len();
@@ -8585,7 +8587,7 @@ mod tests {
                 .sum::<usize>();
 
         let mut updates: B256Map<LeafUpdate> = B256Map::default();
-        updates.insert(b256_key, LeafUpdate::Changed(vec![])); // removal
+        updates.insert(b256_key, LeafUpdate::Changed(vec![].into())); // removal
 
         let proof_targets = RefCell::new(Vec::new());
         trie.update_leaves(&mut updates, |path, min_len| {
@@ -9057,8 +9059,8 @@ mod tests {
 
         // Create an empty trie and update with two leaves
         let mut trie = ParallelSparseTrie::default();
-        trie.update_leaf(leaf1_path, vec![0x1], DefaultTrieNodeProvider).unwrap();
-        trie.update_leaf(leaf2_path, vec![0x2], DefaultTrieNodeProvider).unwrap();
+        trie.update_leaf(leaf1_path, vec![0x1].into(), DefaultTrieNodeProvider).unwrap();
+        trie.update_leaf(leaf2_path, vec![0x2].into(), DefaultTrieNodeProvider).unwrap();
 
         // Call root() to compute the trie root hash
         let _root = trie.root();

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -1,10 +1,9 @@
 #[cfg(feature = "trie-debug")]
 use crate::debug_recorder::TrieDebugRecorder;
 use crate::{
-    LeafValue,
     provider::{TrieNodeProvider, TrieNodeProviderFactory},
     traits::SparseTrie as SparseTrieTrait,
-    ParallelSparseTrie, RevealableSparseTrie,
+    LeafValue, ParallelSparseTrie, RevealableSparseTrie,
 };
 use alloc::vec::Vec;
 use alloy_primitives::{
@@ -718,7 +717,11 @@ where
         let nibbles = Nibbles::unpack(address);
         self.account_rlp_buf.clear();
         account.into_trie_account(storage_root).encode(&mut self.account_rlp_buf);
-        self.update_account_leaf(nibbles, LeafValue::from_slice(&self.account_rlp_buf), provider_factory)?;
+        self.update_account_leaf(
+            nibbles,
+            LeafValue::from_slice(&self.account_rlp_buf),
+            provider_factory,
+        )?;
 
         Ok(true)
     }
@@ -771,7 +774,11 @@ where
         let nibbles = Nibbles::unpack(address);
         self.account_rlp_buf.clear();
         trie_account.encode(&mut self.account_rlp_buf);
-        self.update_account_leaf(nibbles, LeafValue::from_slice(&self.account_rlp_buf), provider_factory)?;
+        self.update_account_leaf(
+            nibbles,
+            LeafValue::from_slice(&self.account_rlp_buf),
+            provider_factory,
+        )?;
 
         Ok(true)
     }
@@ -1546,7 +1553,8 @@ mod tests {
         // Full 64-nibble path
         let full_path_0 = leaf_key([0x0], 64);
 
-        let storage_value: LeafValue = LeafValue::from_slice(&alloy_rlp::encode_fixed_size(&U256::from(42)));
+        let storage_value: LeafValue =
+            LeafValue::from_slice(&alloy_rlp::encode_fixed_size(&U256::from(42)));
         let leaf_1_node = TrieNodeV2::Leaf(LeafNode::new(leaf_key([], 63), storage_value.to_vec()));
         let leaf_2_node = TrieNodeV2::Leaf(LeafNode::new(leaf_key([], 63), storage_value.to_vec()));
 

--- a/crates/trie/sparse/src/traits.rs
+++ b/crates/trie/sparse/src/traits.rs
@@ -2,8 +2,7 @@
 
 use core::fmt::Debug;
 
-use alloc::borrow::Cow;
-use smallvec::SmallVec;
+use alloc::{borrow::Cow, boxed::Box};
 use alloy_primitives::{
     map::{B256Map, HashMap, HashSet},
     B256,
@@ -11,6 +10,7 @@ use alloy_primitives::{
 use alloy_trie::BranchNodeCompact;
 use reth_execution_errors::SparseTrieResult;
 use reth_trie_common::{BranchNodeMasks, Nibbles, ProofTrieNodeV2, TrieNodeV2};
+use smallvec::SmallVec;
 
 #[cfg(feature = "trie-debug")]
 use crate::debug_recorder::TrieDebugRecorder;
@@ -389,9 +389,9 @@ pub enum LeafLookupError {
         /// Path to the leaf.
         path: Nibbles,
         /// Expected value.
-        expected: Option<LeafValue>,
+        expected: Box<Option<LeafValue>>,
         /// Actual value found.
-        actual: LeafValue,
+        actual: Box<LeafValue>,
     },
 }
 

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -1,8 +1,8 @@
 use crate::{
-    provider::TrieNodeProvider, LeafUpdate, ParallelSparseTrie, SparseTrie as SparseTrieTrait,
-    SparseTrieUpdates,
+    provider::TrieNodeProvider, LeafUpdate, LeafValue, ParallelSparseTrie,
+    SparseTrie as SparseTrieTrait, SparseTrieUpdates,
 };
-use alloc::{borrow::Cow, boxed::Box, vec::Vec};
+use alloc::{borrow::Cow, boxed::Box};
 use alloy_primitives::{map::B256Map, B256};
 use reth_execution_errors::{SparseTrieErrorKind, SparseTrieResult};
 use reth_trie_common::{BranchNodeMasks, Nibbles, RlpNode, TrieMask, TrieNode, TrieNodeV2};
@@ -211,7 +211,7 @@ impl<T: SparseTrieTrait> RevealableSparseTrie<T> {
     pub fn update_leaf(
         &mut self,
         path: Nibbles,
-        value: Vec<u8>,
+        value: LeafValue,
         provider: impl TrieNodeProvider,
     ) -> SparseTrieResult<()> {
         let revealed = self.as_revealed_mut().ok_or(SparseTrieErrorKind::Blind)?;

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -172,7 +172,9 @@ where
                 let maybe_leaf_value = storage
                     .and_then(|s| s.storage.get(&hashed_slot))
                     .filter(|v| !v.is_zero())
-                    .map(|v| reth_trie_sparse::LeafValue::from_slice(&alloy_rlp::encode_fixed_size(v)));
+                    .map(|v| {
+                        reth_trie_sparse::LeafValue::from_slice(&alloy_rlp::encode_fixed_size(v))
+                    });
 
                 if let Some(value) = maybe_leaf_value {
                     storage_trie.update_leaf(storage_nibbles, value, &provider).map_err(|err| {

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -172,7 +172,7 @@ where
                 let maybe_leaf_value = storage
                     .and_then(|s| s.storage.get(&hashed_slot))
                     .filter(|v| !v.is_zero())
-                    .map(|v| alloy_rlp::encode_fixed_size(v).to_vec());
+                    .map(|v| reth_trie_sparse::LeafValue::from_slice(&alloy_rlp::encode_fixed_size(v)));
 
                 if let Some(value) = maybe_leaf_value {
                     storage_trie.update_leaf(storage_nibbles, value, &provider).map_err(|err| {


### PR DESCRIPTION
## Problem

The preserved sparse trie mutex is held during expensive `into_trie_for_reuse()` work (prune + shrink), serializing the next payload on trie cleanup. This means the next block's `take()` blocks on the mutex for the entire duration of trie preparation, preventing any overlap between payload processing and trie cleanup.

## Solution

Replace the mutex-held pattern with a 2-phase Condvar-backed protocol:

1. **Lock phase** (brief): Acquire mutex → `send()` result → set `preparing` flag → release mutex
2. **Prepare phase** (expensive, unlocked): Run `into_trie_for_reuse()` (prune + shrink) outside the lock → `store()` result and clear flag via `PreparingGuard`

The next payload's `take()` and `wait_for_availability()` now block on the Condvar while `preparing` is true, rather than contending on the mutex itself.

### Key design decisions

- **`PreparingGuard` RAII safety**: If the task panics or returns early after marking `preparing`, the Drop impl clears the flag and notifies waiters, preventing deadlock.
- **`mark_preparing_and_release()`**: Single method on `PreservedTrieGuard` that atomically sets the flag and drops the mutex guard, returning a `PreparingGuard`.
- **`PreservedTrieInner`**: New struct wrapping `preparing: bool` + `slot: Option<PreservedSparseTrie>` behind `Arc<(Mutex<_>, Condvar)>`.

### Changes

- `preserved_sparse_trie.rs`: New `PreservedTrieInner`, `PreparingGuard`, Condvar-based blocking in `take()`/`wait_for_availability()`, `mark_preparing_and_release()` on guard, plus unit tests
- `mod.rs`: Restructured lock usage to release before expensive work

### Tests

4 new unit tests covering:
- `take()` blocks while preparing, unblocks after `store()`
- `wait_for_availability()` blocks while preparing
- `PreparingGuard` drop (without commit) clears flag
- `mark_preparing_and_release()` round-trip
