### PR TITLE
perf(trie): cache pending sparse trie target count

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -90,10 +90,8 @@ pub(super) struct SparseTrieCacheTask<A = ParallelSparseTrie, S = ParallelSparse
     account_rlp_buf: Vec<u8>,
     /// Whether the last state update has been received.
     finished_state_updates: bool,
-    /// Pending targets to be dispatched to the proof workers.
-    pending_targets: MultiProofTargetsV2,
-    /// Cached number of account + storage proof targets currently queued in `pending_targets`.
-    pending_targets_len: usize,
+    /// Pending proof targets queued for dispatch to proof workers.
+    pending_targets: PendingTargets,
     /// Number of pending execution/prewarming updates received but not yet passed to
     /// `update_leaves`.
     pending_updates: usize,
@@ -143,7 +141,6 @@ where
             account_rlp_buf: Vec::with_capacity(TRIE_ACCOUNT_RLP_MAX_SIZE),
             finished_state_updates: Default::default(),
             pending_targets: Default::default(),
-            pending_targets_len: Default::default(),
             pending_updates: Default::default(),
             metrics,
         }
@@ -286,7 +283,7 @@ where
                 // them to the trie,
                 self.process_new_updates()?;
                 self.dispatch_pending_targets();
-            } else if self.pending_targets_len > self.chunk_size.unwrap_or_default() {
+            } else if self.pending_targets.len() > self.chunk_size.unwrap_or_default() {
                 // Make sure to dispatch targets if we've accumulated a lot of them.
                 self.dispatch_pending_targets();
             }
@@ -508,8 +505,7 @@ where
             self.trie.insert_storage_trie(*address, trie);
 
             if !targets.is_empty() {
-                self.pending_targets_len += targets.len();
-                self.pending_targets.storage_targets.entry(*address).or_default().extend(targets);
+                self.pending_targets.extend_storage_targets(address, targets);
             }
         }
 
@@ -539,17 +535,13 @@ where
                     if min_len < *entry.get() {
                         entry.insert(min_len);
                         self.pending_targets
-                            .account_targets
-                            .push(Target::new(target).with_min_len(min_len));
-                        self.pending_targets_len += 1;
+                            .push_account_target(Target::new(target).with_min_len(min_len));
                     }
                 }
                 Entry::Vacant(entry) => {
                     entry.insert(min_len);
                     self.pending_targets
-                        .account_targets
-                        .push(Target::new(target).with_min_len(min_len));
-                    self.pending_targets_len += 1;
+                        .push_account_target(Target::new(target).with_min_len(min_len));
                 }
             }
         })?;
@@ -658,13 +650,10 @@ where
         skip_all
     )]
     fn dispatch_pending_targets(&mut self) {
-        // Guard against cached-length drift if future enqueue paths miss counter updates.
-        debug_assert_eq!(self.pending_targets_len, self.pending_targets.chunking_length());
-        if self.pending_targets_len > 0 {
-            let chunking_length = self.pending_targets_len;
-            self.pending_targets_len = 0;
+        if !self.pending_targets.is_empty() {
+            let (targets, chunking_length) = self.pending_targets.take();
             dispatch_with_chunking(
-                std::mem::take(&mut self.pending_targets),
+                targets,
                 chunking_length,
                 self.chunk_size,
                 self.max_targets_for_chunking,
@@ -704,6 +693,44 @@ fn encode_account_leaf_value(
     account_rlp_buf.clear();
     account.unwrap_or_default().into_trie_account(storage_root).encode(account_rlp_buf);
     account_rlp_buf.clone()
+}
+
+/// Pending proof targets queued for dispatch to proof workers, along with their count.
+#[derive(Default)]
+struct PendingTargets {
+    /// The proof targets.
+    targets: MultiProofTargetsV2,
+    /// Number of account + storage proof targets currently queued.
+    len: usize,
+}
+
+impl PendingTargets {
+    /// Returns the number of pending targets.
+    const fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns `true` if there are no pending targets.
+    const fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Takes the pending targets, replacing with empty defaults.
+    fn take(&mut self) -> (MultiProofTargetsV2, usize) {
+        (std::mem::take(&mut self.targets), std::mem::take(&mut self.len))
+    }
+
+    /// Adds a target to the account targets.
+    fn push_account_target(&mut self, target: Target) {
+        self.targets.account_targets.push(target);
+        self.len += 1;
+    }
+
+    /// Extends storage targets for the given address.
+    fn extend_storage_targets(&mut self, address: &B256, targets: Vec<Target>) {
+        self.len += targets.len();
+        self.targets.storage_targets.entry(*address).or_default().extend(targets);
+    }
 }
 
 /// Message type for the sparse trie task.

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -658,6 +658,8 @@ where
         skip_all
     )]
     fn dispatch_pending_targets(&mut self) {
+        // Guard against cached-length drift if future enqueue paths miss counter updates.
+        debug_assert_eq!(self.pending_targets_len, self.pending_targets.chunking_length());
         if self.pending_targets_len > 0 {
             let chunking_length = self.pending_targets_len;
             self.pending_targets_len = 0;

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -92,6 +92,8 @@ pub(super) struct SparseTrieCacheTask<A = ParallelSparseTrie, S = ParallelSparse
     finished_state_updates: bool,
     /// Pending targets to be dispatched to the proof workers.
     pending_targets: MultiProofTargetsV2,
+    /// Cached number of account + storage proof targets currently queued in `pending_targets`.
+    pending_targets_len: usize,
     /// Number of pending execution/prewarming updates received but not yet passed to
     /// `update_leaves`.
     pending_updates: usize,
@@ -141,6 +143,7 @@ where
             account_rlp_buf: Vec::with_capacity(TRIE_ACCOUNT_RLP_MAX_SIZE),
             finished_state_updates: Default::default(),
             pending_targets: Default::default(),
+            pending_targets_len: Default::default(),
             pending_updates: Default::default(),
             metrics,
         }
@@ -283,7 +286,7 @@ where
                 // them to the trie,
                 self.process_new_updates()?;
                 self.dispatch_pending_targets();
-            } else if self.pending_targets.chunking_length() > self.chunk_size.unwrap_or_default() {
+            } else if self.pending_targets_len > self.chunk_size.unwrap_or_default() {
                 // Make sure to dispatch targets if we've accumulated a lot of them.
                 self.dispatch_pending_targets();
             }
@@ -505,6 +508,7 @@ where
             self.trie.insert_storage_trie(*address, trie);
 
             if !targets.is_empty() {
+                self.pending_targets_len += targets.len();
                 self.pending_targets.storage_targets.entry(*address).or_default().extend(targets);
             }
         }
@@ -537,6 +541,7 @@ where
                         self.pending_targets
                             .account_targets
                             .push(Target::new(target).with_min_len(min_len));
+                        self.pending_targets_len += 1;
                     }
                 }
                 Entry::Vacant(entry) => {
@@ -544,6 +549,7 @@ where
                     self.pending_targets
                         .account_targets
                         .push(Target::new(target).with_min_len(min_len));
+                    self.pending_targets_len += 1;
                 }
             }
         })?;
@@ -652,8 +658,9 @@ where
         skip_all
     )]
     fn dispatch_pending_targets(&mut self) {
-        if !self.pending_targets.is_empty() {
-            let chunking_length = self.pending_targets.chunking_length();
+        if self.pending_targets_len > 0 {
+            let chunking_length = self.pending_targets_len;
+            self.pending_targets_len = 0;
             dispatch_with_chunking(
                 std::mem::take(&mut self.pending_targets),
                 chunking_length,


### PR DESCRIPTION
Removes repeated O(n) rescans of pending_targets in a hot loop and replaces them with O(1) counter reads.


**Summary**
Sparse trie processing repeatedly computed `pending_targets.chunking_length()` in the run loop and dispatch path, rescanning queued storage targets each time. This change keeps an incremental `pending_targets_len` counter updated as targets are enqueued and uses the cached value for threshold checks and dispatch sizing.
