### PR TITLE
chore(engine): rename finish span to BlockExecutor::finish

### DIFF
--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -829,7 +829,7 @@ where
 
         // Finish execution and get the result
         let post_exec_start = Instant::now();
-        let (_evm, result) = debug_span!(target: "engine::tree", "finish")
+        let (_evm, result) = debug_span!(target: "engine::tree", "BlockExecutor::finish")
             .in_scope(|| executor.finish())
             .map(|(evm, result)| (evm.into_db(), result))?;
         self.metrics.record_post_execution(post_exec_start.elapsed());


### PR DESCRIPTION
Rename the `finish` tracing span to `BlockExecutor::finish` in the payload validator for clarity in profiles/traces.

Prompted by: DaniPopes