### PR TITLE
perf(storage): use sort_unstable_by_key in iter_static_files

### DIFF
--- a/crates/storage/db/src/static_file/mod.rs
+++ b/crates/storage/db/src/static_file/mod.rs
@@ -48,7 +48,7 @@ pub fn iter_static_files(path: &Path) -> Result<SortedStaticFiles, NippyJarError
 
     // Sort by block end range.
     for range_list in static_files.values_mut() {
-        range_list.sort_by_key(|(block_range, _)| block_range.end());
+        range_list.sort_unstable_by_key(|(block_range, _)| block_range.end());
     }
 
     Ok(static_files)


### PR DESCRIPTION
Replace sort_by_key with sort_unstable_by_key when sorting static file ranges by block end