### PR TITLE
feat(trie): expose storage_wait_time as dedicated Prometheus metric

### DIFF
--- a/crates/trie/parallel/src/proof_task_metrics.rs
+++ b/crates/trie/parallel/src/proof_task_metrics.rs
@@ -28,6 +28,10 @@ pub struct ProofTaskTrieMetrics {
     deferred_encoder_sync: Histogram,
     /// Histogram for dispatched storage proofs that fell back to sync due to missing root.
     deferred_encoder_dispatched_missing_root: Histogram,
+    /// Histogram for time account workers spent blocked waiting for storage proof results
+    /// (seconds). This is the portion of account worker idle time attributable to storage
+    /// worker latency rather than queue wait.
+    account_worker_storage_wait_seconds: Histogram,
 }
 
 impl ProofTaskTrieMetrics {
@@ -51,13 +55,14 @@ impl ProofTaskTrieMetrics {
         self.account_worker_idle_time_seconds.record(duration.as_secs_f64());
     }
 
-    /// Record value encoder stats (deferred encoder variant counts).
+    /// Record value encoder stats (deferred encoder variant counts and storage wait time).
     pub(crate) fn record_value_encoder_stats(&self, stats: &ValueEncoderStats) {
         self.deferred_encoder_dispatched.record(stats.dispatched_count as f64);
         self.deferred_encoder_from_cache.record(stats.from_cache_count as f64);
         self.deferred_encoder_sync.record(stats.sync_count as f64);
         self.deferred_encoder_dispatched_missing_root
             .record(stats.dispatched_missing_root_count as f64);
+        self.account_worker_storage_wait_seconds.record(stats.storage_wait_time.as_secs_f64());
     }
 }
 


### PR DESCRIPTION
TLDR: 

We have storage_wait_time in the encoder stats, but we dont expose it. This could be useful to measure the actual stall and determine whether decoupling storage dispatch from account workers is worthwhile.