### PR TITLE
fix(db-api): preserve Excluded bound type in CursorMock::walk_range

### DIFF
--- a/crates/storage/db-api/src/mock.rs
+++ b/crates/storage/db-api/src/mock.rs
@@ -263,7 +263,8 @@ impl<T: Table> DbCursorRO<T> for CursorMock {
         };
 
         let end_key = match range.end_bound() {
-            Bound::Included(key) | Bound::Excluded(key) => Bound::Included((*key).clone()),
+            Bound::Included(key) => Bound::Included((*key).clone()),
+            Bound::Excluded(key) => Bound::Excluded((*key).clone()),
             Bound::Unbounded => Bound::Unbounded,
         };
 


### PR DESCRIPTION
`Bound::Excluded` was being converted to `Bound::Included` due to merged match arms. This caused exclusive ranges like `0..5` to incorrectly include the end key. Now matches the real MDBX cursor behavior.