### PR TITLE
feat(metric): add finished_height metrics for ExExs

### DIFF
--- a/crates/exex/exex/src/manager.rs
+++ b/crates/exex/exex/src/manager.rs
@@ -160,15 +160,11 @@ impl<N: NodePrimitives> ExExHandle<N> {
                         return Poll::Ready(Ok(()))
                     }
                 }
-                // Always send reorg/revert notifications, and reset finished_height because the
-                // ExEx will revert its state to an earlier block. Without resetting, subsequent
-                // ChainCommitted notifications could be incorrectly skipped if the new chain's tip
-                // is at or below the stale finished_height from the old chain.
-                ExExNotification::ChainReorged { old: chain, .. } |
-                ExExNotification::ChainReverted { old: chain } => {
-                    let safe_height = chain.fork_block();
-                    self.set_finished_height(safe_height);
-                }
+                // Do not handle [ExExNotification::ChainReorged] and
+                // [ExExNotification::ChainReverted] cases and always send the
+                // notification, because the ExEx should be aware of the reorgs and reverts lower
+                // than its finished height
+                ExExNotification::ChainReorged { .. } | ExExNotification::ChainReverted { .. } => {}
             }
         }
 

--- a/crates/exex/exex/src/manager.rs
+++ b/crates/exex/exex/src/manager.rs
@@ -67,7 +67,7 @@ struct ExExMetrics {
     notifications_sent_total: Counter,
     /// The total number of events an `ExEx` has sent to the manager.
     events_sent_total: Counter,
-    /// Current finished height of this ExEx (block number, or -1 if None).
+    /// Current finished height of this ExEx (block number).
     finished_height: Gauge,
 }
 

--- a/etc/grafana/dashboards/overview.json
+++ b/etc/grafana/dashboards/overview.json
@@ -12037,6 +12037,103 @@
           ],
           "title": "Number of ExExes",
           "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Current finished height (processed block number) for each ExEx",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 386
+          },
+          "id": 245,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.4.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "reth_exex_finished_height{$instance_label=\"$instance\"}",
+              "hide": false,
+              "legendFormat": "{{exex}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "ExEx Finished Heights",
+          "type": "timeseries"
         }
       ],
       "title": "Execution Extensions",


### PR DESCRIPTION
## Summary

Adds `reth_exex_finished_height` gauge metric to track the current processed block height for each Execution Extension (ExEx). This enables monitoring ExEx progress and detecting when ExExs fall behind or stall.

## Motivation

Currently, there is no direct metric to monitor which block each ExEx has processed up to. Operators need visibility into:
- Whether ExExs are keeping up with chain tip
- How far behind each ExEx is
- If an ExEx has stalled or stopped processing

This metric addresses these observability gaps by exposing each ExEx's finished height.

<img width="653" height="201" alt="Screenshot 2026-02-19 at 2 50 17 PM" src="https://github.com/user-attachments/assets/bab59bb3-0edd-40b7-bd97-0eccc1381c49" />
