### PR TITLE
feat(engine): add sub-phase timing histograms for sparse trie event loop

### DIFF
--- a/.changelog/keen-geese-bake.md
+++ b/.changelog/keen-geese-bake.md
@@ -1,0 +1,5 @@
+---
+reth-engine-tree: patch
+---
+
+Added sub-phase timing histograms to the sparse trie event loop, tracking channel wait, proof coalescing, multiproof reveal, and trie update durations separately.

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -162,6 +162,14 @@ pub(crate) struct MultiProofTaskMetrics {
 
     /// Histogram of sparse trie update durations.
     pub sparse_trie_update_duration_histogram: Histogram,
+    /// Time spent revealing multiproof results into the sparse trie.
+    pub sparse_trie_reveal_multiproof_duration_histogram: Histogram,
+    /// Time spent coalescing multiple proof results from the channel.
+    pub sparse_trie_proof_coalesce_duration_histogram: Histogram,
+    /// Time the event loop spent blocked waiting on channels (idle time).
+    pub sparse_trie_channel_wait_duration_histogram: Histogram,
+    /// Time spent in `process_new_updates` + `promote_pending_account_updates` (trie mutations).
+    pub sparse_trie_process_updates_duration_histogram: Histogram,
     /// Histogram of sparse trie final update durations.
     pub sparse_trie_final_update_duration_histogram: Histogram,
     /// Histogram of sparse trie total durations.

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -162,13 +162,13 @@ pub(crate) struct MultiProofTaskMetrics {
 
     /// Histogram of sparse trie update durations.
     pub sparse_trie_update_duration_histogram: Histogram,
-    /// Time spent revealing multiproof results into the sparse trie.
+    /// Histogram of durations spent revealing multiproof results into the sparse trie.
     pub sparse_trie_reveal_multiproof_duration_histogram: Histogram,
-    /// Time spent coalescing multiple proof results from the channel.
+    /// Histogram of durations spent coalescing multiple proof results from the channel.
     pub sparse_trie_proof_coalesce_duration_histogram: Histogram,
-    /// Time the event loop spent blocked waiting on channels (idle time).
+    /// Histogram of durations the event loop spent blocked waiting on channels.
     pub sparse_trie_channel_wait_duration_histogram: Histogram,
-    /// Time spent in `process_new_updates` + `promote_pending_account_updates` (trie mutations).
+    /// Histogram of durations spent processing trie updates and promoting pending accounts.
     pub sparse_trie_process_updates_duration_histogram: Histogram,
     /// Histogram of sparse trie final update durations.
     pub sparse_trie_final_update_duration_histogram: Histogram,

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -290,9 +290,7 @@ where
                 t = Instant::now();
                 self.process_new_updates()?;
                 self.promote_pending_account_updates()?;
-                self.metrics
-                    .sparse_trie_process_updates_duration_histogram
-                    .record(t.elapsed());
+                self.metrics.sparse_trie_process_updates_duration_histogram.record(t.elapsed());
 
                 if self.finished_state_updates &&
                     self.account_updates.is_empty() &&
@@ -307,9 +305,7 @@ where
                 // them to the trie,
                 t = Instant::now();
                 self.process_new_updates()?;
-                self.metrics
-                    .sparse_trie_process_updates_duration_histogram
-                    .record(t.elapsed());
+                self.metrics.sparse_trie_process_updates_duration_histogram.record(t.elapsed());
                 self.dispatch_pending_targets();
             } else if self.pending_targets.chunking_length() > self.chunk_size.unwrap_or_default() {
                 // Make sure to dispatch targets if we've accumulated a lot of them.

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -234,12 +234,12 @@ where
         let now = Instant::now();
 
         loop {
-            let wait_start = Instant::now();
+            let mut t = Instant::now();
             crossbeam_channel::select_biased! {
                 recv(self.updates) -> message => {
                     self.metrics
                         .sparse_trie_channel_wait_duration_histogram
-                        .record(wait_start.elapsed());
+                        .record(t.elapsed());
 
                     let update = match message {
                         Ok(m) => m,
@@ -254,29 +254,32 @@ where
                     self.pending_updates += 1;
                 }
                 recv(self.proof_result_rx) -> message => {
+                    let phase_end = Instant::now();
                     self.metrics
                         .sparse_trie_channel_wait_duration_histogram
-                        .record(wait_start.elapsed());
+                        .record(phase_end.duration_since(t));
+                    t = phase_end;
 
                     let Ok(result) = message else {
                         unreachable!("we own the sender half")
                     };
 
-                    let coalesce_start = Instant::now();
                     let mut result = result.result?;
                     while let Ok(next) = self.proof_result_rx.try_recv() {
                         let res = next.result?;
                         result.extend(res);
                     }
+
+                    let phase_end = Instant::now();
                     self.metrics
                         .sparse_trie_proof_coalesce_duration_histogram
-                        .record(coalesce_start.elapsed());
+                        .record(phase_end.duration_since(t));
+                    t = phase_end;
 
-                    let reveal_start = Instant::now();
                     self.on_proof_result(result)?;
                     self.metrics
                         .sparse_trie_reveal_multiproof_duration_histogram
-                        .record(reveal_start.elapsed());
+                        .record(t.elapsed());
                 },
             }
 
@@ -284,12 +287,12 @@ where
                 // If we don't have any pending messages, we can spend some time on computing
                 // storage roots and promoting account updates.
                 self.dispatch_pending_targets();
-                let updates_start = Instant::now();
+                t = Instant::now();
                 self.process_new_updates()?;
                 self.promote_pending_account_updates()?;
                 self.metrics
                     .sparse_trie_process_updates_duration_histogram
-                    .record(updates_start.elapsed());
+                    .record(t.elapsed());
 
                 if self.finished_state_updates &&
                     self.account_updates.is_empty() &&
@@ -302,11 +305,11 @@ where
             } else if self.updates.is_empty() || self.pending_updates > MAX_PENDING_UPDATES {
                 // If we don't have any pending updates OR we've accumulated a lot already, apply
                 // them to the trie,
-                let updates_start = Instant::now();
+                t = Instant::now();
                 self.process_new_updates()?;
                 self.metrics
                     .sparse_trie_process_updates_duration_histogram
-                    .record(updates_start.elapsed());
+                    .record(t.elapsed());
                 self.dispatch_pending_targets();
             } else if self.pending_targets.chunking_length() > self.chunk_size.unwrap_or_default() {
                 // Make sure to dispatch targets if we've accumulated a lot of them.

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -234,8 +234,13 @@ where
         let now = Instant::now();
 
         loop {
+            let wait_start = Instant::now();
             crossbeam_channel::select_biased! {
                 recv(self.updates) -> message => {
+                    self.metrics
+                        .sparse_trie_channel_wait_duration_histogram
+                        .record(wait_start.elapsed());
+
                     let update = match message {
                         Ok(m) => m,
                         Err(_) => {
@@ -249,17 +254,29 @@ where
                     self.pending_updates += 1;
                 }
                 recv(self.proof_result_rx) -> message => {
+                    self.metrics
+                        .sparse_trie_channel_wait_duration_histogram
+                        .record(wait_start.elapsed());
+
                     let Ok(result) = message else {
                         unreachable!("we own the sender half")
                     };
-                    let mut result = result.result?;
 
+                    let coalesce_start = Instant::now();
+                    let mut result = result.result?;
                     while let Ok(next) = self.proof_result_rx.try_recv() {
                         let res = next.result?;
                         result.extend(res);
                     }
+                    self.metrics
+                        .sparse_trie_proof_coalesce_duration_histogram
+                        .record(coalesce_start.elapsed());
 
+                    let reveal_start = Instant::now();
                     self.on_proof_result(result)?;
+                    self.metrics
+                        .sparse_trie_reveal_multiproof_duration_histogram
+                        .record(reveal_start.elapsed());
                 },
             }
 
@@ -267,8 +284,12 @@ where
                 // If we don't have any pending messages, we can spend some time on computing
                 // storage roots and promoting account updates.
                 self.dispatch_pending_targets();
+                let updates_start = Instant::now();
                 self.process_new_updates()?;
                 self.promote_pending_account_updates()?;
+                self.metrics
+                    .sparse_trie_process_updates_duration_histogram
+                    .record(updates_start.elapsed());
 
                 if self.finished_state_updates &&
                     self.account_updates.is_empty() &&
@@ -281,7 +302,11 @@ where
             } else if self.updates.is_empty() || self.pending_updates > MAX_PENDING_UPDATES {
                 // If we don't have any pending updates OR we've accumulated a lot already, apply
                 // them to the trie,
+                let updates_start = Instant::now();
                 self.process_new_updates()?;
+                self.metrics
+                    .sparse_trie_process_updates_duration_histogram
+                    .record(updates_start.elapsed());
                 self.dispatch_pending_targets();
             } else if self.pending_targets.chunking_length() > self.chunk_size.unwrap_or_default() {
                 // Make sure to dispatch targets if we've accumulated a lot of them.


### PR DESCRIPTION
**Summary**
Adds 4 sub-phase histograms to break down `sparse_trie_total_duration` and identify the bottleneck in the single-threaded event loop.

<img width="606" height="461" alt="image" src="https://github.com/user-attachments/assets/07b4f102-7567-4740-8787-e151aab3fc62" />


RETH-409