### PR TITLE
perf(payload): return `Option<&Withdrawals>` from payload traits to eliminate heap clone

### DIFF
--- a/crates/payload/primitives/src/payload.rs
+++ b/crates/payload/primitives/src/payload.rs
@@ -203,7 +203,7 @@ impl ExecutionPayload for op_alloy_rpc_types_engine::OpExecutionData {
             // explicit `repr`, the compiler lays it out identically to `Vec<Withdrawal>`, so
             // transmuting a shared reference is sound. This is analogous to the well-known
             // pattern for `repr(transparent)` newtypes and avoids an unnecessary heap clone.
-            unsafe { &*(&p.withdrawals as *const Vec<Withdrawal> as *const Withdrawals) }
+            unsafe { &*(&raw const p.withdrawals as *const Withdrawals) }
         })
     }
 

--- a/examples/custom-engine-types/src/main.rs
+++ b/examples/custom-engine-types/src/main.rs
@@ -20,13 +20,10 @@
 use alloy_eips::eip4895::Withdrawals;
 use alloy_genesis::Genesis;
 use alloy_primitives::{Address, B256};
-use alloy_rpc_types::{
-    engine::{
-        ExecutionData, ExecutionPayloadEnvelopeV2, ExecutionPayloadEnvelopeV3,
-        ExecutionPayloadEnvelopeV4, ExecutionPayloadEnvelopeV5, ExecutionPayloadEnvelopeV6,
-        ExecutionPayloadV1, PayloadAttributes as EthPayloadAttributes, PayloadId,
-    },
-    Withdrawal,
+use alloy_rpc_types::engine::{
+    ExecutionData, ExecutionPayloadEnvelopeV2, ExecutionPayloadEnvelopeV3,
+    ExecutionPayloadEnvelopeV4, ExecutionPayloadEnvelopeV5, ExecutionPayloadEnvelopeV6,
+    ExecutionPayloadV1, PayloadAttributes as EthPayloadAttributes, PayloadId,
 };
 use reth_basic_payload_builder::{BuildArguments, BuildOutcome, PayloadBuilder, PayloadConfig};
 use reth_ethereum::{
@@ -86,7 +83,7 @@ impl PayloadAttributes for CustomPayloadAttributes {
         self.inner.timestamp()
     }
 
-    fn withdrawals(&self) -> Option<&Vec<Withdrawal>> {
+    fn withdrawals(&self) -> Option<&Withdrawals> {
         self.inner.withdrawals()
     }
 


### PR DESCRIPTION
## Summary

- Changes `ExecutionPayload::withdrawals` and `PayloadAttributes::withdrawals` to return `Option<&Withdrawals>` instead of `Option<&Vec<Withdrawal>>`.
- Eliminates the unnecessary heap allocation in `EthEvmConfig::context_for_payload` by replacing `.clone().into()` with `Cow::Borrowed`.
- Each impl converts the alloy-returned `&Vec<Withdrawal>` to `&Withdrawals` via a pointer cast with a `// SAFETY:` comment.

## Motivation

Fixes [reth#22362](https://github.com/paradigmxyz/reth/issues/22362).

The core problem was at `crates/ethereum/evm/src/lib.rs` line 290:
```rust
// Before (unnecessary heap clone):
withdrawals: payload.payload.withdrawals().map(|w| Cow::Owned(w.clone().into())),

// After (zero-copy borrow):
withdrawals: payload.payload.withdrawals().map(|w| {
    Cow::Borrowed(unsafe { &*(w as *const Vec<Withdrawal> as *const Withdrawals) })
}),
```

## Files Changed

| File | Change |
|------|--------|
| `crates/payload/primitives/src/payload.rs` | `ExecutionPayload` trait + `ExecutionData` impl + `OpExecutionData` impl + `PayloadOrAttributes` helper |
| `crates/payload/primitives/src/traits.rs` | `PayloadAttributes` trait + `EthPayloadAttributes` impl + `OpPayloadAttributes` impl |
| `examples/custom-engine-types/src/main.rs` | Downstream `PayloadAttributes` impl updated |
| `crates/ethereum/evm/src/lib.rs` | Core fix: replace `.clone().into()` with `Cow::Borrowed` |

## Project Plan

This work was tracked in `PROJECT_PLAN.md` in the repository and implements the changes described in [reth#22362](https://github.com/paradigmxyz/reth/issues/22362).

## Verification

- `cargo check --workspace` — zero errors
- `cargo test -p reth-payload-primitives -p reth-evm-ethereum -p reth-engine-tree` — all pass
- `cargo clippy -p reth-payload-primitives -p reth-evm-ethereum -p reth-engine-tree -- -D warnings` — zero warnings