### PR TITLE
fix(bench): handle stale mount cleanup after cancelled jobs

### DIFF
--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -23,8 +23,13 @@ cleanup() {
       sleep 1
     done
     sudo kill -9 "$RETH_PID" 2>/dev/null || true
+    sleep 1
   fi
-  mountpoint -q "$SCHELK_MOUNT" && sudo schelk recover -y || true
+  if ! sudo schelk recover -y 2>/dev/null; then
+    # recover can fail with "target is busy" after cancellation, force-cleanup
+    sudo umount "$SCHELK_MOUNT" 2>/dev/null || sudo umount -l "$SCHELK_MOUNT" 2>/dev/null || true
+    sudo dmsetup remove bench_era 2>/dev/null || true
+  fi
 }
 TAIL_PID=
 trap cleanup EXIT

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -571,11 +571,18 @@ jobs:
           cat /sys/kernel/mm/transparent_hugepage/enabled 2>/dev/null || cat /sys/kernel/mm/transparent_hugepages/enabled 2>/dev/null || echo "THP: unknown"
           free -h
 
-      # Clean up any leftover state
+      # Clean up any leftover state from a previous cancelled/crashed job.
+      # schelk recover can fail with "target is busy" if reth is still running,
+      # so we force-kill, wait, then force-unmount before recovering.
       - name: Pre-flight cleanup
         run: |
           pkill -9 reth || true
-          mountpoint -q "$SCHELK_MOUNT" && sudo schelk recover -y || true
+          sleep 2
+          if mountpoint -q "$SCHELK_MOUNT" 2>/dev/null; then
+            sudo umount "$SCHELK_MOUNT" 2>/dev/null || sudo umount -l "$SCHELK_MOUNT" 2>/dev/null || true
+          fi
+          sudo dmsetup remove bench_era 2>/dev/null || true
+          sudo schelk recover -y 2>/dev/null || true
 
       - name: Update status (running baseline benchmark)
         if: success() && env.BENCH_COMMENT_ID


### PR DESCRIPTION
## Summary
When a bench job is cancelled while reth holds the mount, `schelk recover` fails with "target is busy". Next run then hits "Volume is already mounted".

## Changes
- **`bench.yml` pre-flight cleanup**: Kill reth, wait 2s, force-unmount (with `umount -l` fallback), remove dm-era device, then try schelk recover
- **`bench-reth-run.sh` cleanup trap**: Try `schelk recover` first; if it fails, fall back to force-unmount + dm-era removal

## Testing
Triggered by cancelled CI bench jobs leaving stale mounts.

Prompted by: alexey