### PR TITLE
ci(bench): fix cleanup to use sudo pkill and lazy unmount

### DIFF
--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -23,8 +23,12 @@ cleanup() {
       sleep 1
     done
     sudo kill -9 "$RETH_PID" 2>/dev/null || true
+    sleep 1
   fi
-  mountpoint -q "$SCHELK_MOUNT" && sudo schelk recover -y || true
+  if mountpoint -q "$SCHELK_MOUNT"; then
+    sudo umount -l "$SCHELK_MOUNT" || true
+    sudo schelk recover -y || true
+  fi
 }
 TAIL_PID=
 trap cleanup EXIT

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -574,8 +574,12 @@ jobs:
       # Clean up any leftover state
       - name: Pre-flight cleanup
         run: |
-          pkill -9 reth || true
-          mountpoint -q "$SCHELK_MOUNT" && sudo schelk recover -y || true
+          sudo pkill -9 reth || true
+          sleep 1
+          if mountpoint -q "$SCHELK_MOUNT"; then
+            sudo umount -l "$SCHELK_MOUNT" || true
+            sudo schelk recover -y || true
+          fi
 
       - name: Update status (running baseline benchmark)
         if: success() && env.BENCH_COMMENT_ID


### PR DESCRIPTION
Use sudo for pkill (reth runs as root) and lazy unmount before schelk recover to prevent stuck volumes when a workflow is cancelled.