### PR TITLE
ci(hive): fix eels runner OOM crashes

### DIFF
--- a/.github/scripts/hive/run_simulator.sh
+++ b/.github/scripts/hive/run_simulator.sh
@@ -6,8 +6,14 @@ cd hivetests/
 sim="${1}"
 limit="${2}"
 
+# Use lower parallelism for eels tests to avoid OOM-killing the runner
+parallelism=16
+if [[ "${sim}" == *"eels"* ]]; then
+    parallelism=4
+fi
+
 run_hive() {
-    hive --sim "${sim}" --sim.limit "${limit}" --sim.parallelism 16 --client reth 2>&1 | tee /tmp/log || true
+    hive --sim "${sim}" --sim.limit "${limit}" --sim.parallelism "${parallelism}" --client reth 2>&1 | tee /tmp/log || true
 }
 
 check_log() {

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -188,7 +188,8 @@ jobs:
       - build-reth-edge
       - prepare-hive
     name: ${{ matrix.storage }} / ${{ matrix.scenario.sim }}${{ matrix.scenario.limit && format(' - {0}', matrix.scenario.limit) }}
-    runs-on: ${{ github.repository == 'paradigmxyz/reth' && 'depot-ubuntu-latest-4' || 'ubuntu-latest' }}
+    # Use larger runners for eels tests to avoid OOM runner crashes
+    runs-on: ${{ github.repository == 'paradigmxyz/reth' && (contains(matrix.scenario.sim, 'eels') && 'depot-ubuntu-latest-8' || 'depot-ubuntu-latest-4') || 'ubuntu-latest' }}
     permissions:
       issues: write
     steps:


### PR DESCRIPTION
## Problem

All ~30 `eels/consume-engine` and `eels/consume-rlp` hive jobs consistently crash with:

> The self-hosted runner lost communication with the server.

This is caused by OOM when running 16 Docker containers in parallel on `depot-ubuntu-latest-4` runners (4 vCPU / ~8GB RAM). This makes the entire hive CI run red and obscures real test failures.

Example run: https://github.com/paradigmxyz/reth/actions/runs/22163290014

## Fix

Two changes to reduce memory pressure on eels jobs:

1. **`run_simulator.sh`**: Reduce `--sim.parallelism` from 16 → 4 for eels tests
2. **`hive.yml`**: Bump eels jobs to `depot-ubuntu-latest-8` runners (8 vCPU / ~16GB RAM), while keeping all other hive jobs on `-4`

## Impact

- ~30 fewer spurious CI failures per nightly hive run
- Real test failures become visible instead of being buried in infra noise