### PR TITLE
ci(hive): ignore flaky reorg and sync timeout tests

### DIFF
--- a/.github/scripts/hive/ignored_tests.yaml
+++ b/.github/scripts/hive/ignored_tests.yaml
@@ -16,12 +16,16 @@ engine-withdrawals:
   - Withdrawals Fork on Block 1 - 8 Block Re-Org NewPayload (Paris) (reth)
   - Withdrawals Fork on Block 8 - 10 Block Re-Org NewPayload (Paris) (reth)
   - Withdrawals Fork on Canonical Block 8 / Side Block 7 - 10 Block Re-Org (Paris) (reth)
+  - Sync after 2 blocks - Withdrawals on Block 2 - Multiple Withdrawal Accounts (Paris) (reth)
+  - Sync after 2 blocks - Withdrawals on Block 2 - Multiple Withdrawal Accounts - No Transactions (Paris) (reth)
   - Sync after 128 blocks - Withdrawals on Block 2 - Multiple Withdrawal Accounts (Paris) (reth)
 engine-cancun:
   - Transaction Re-Org, New Payload on Revert Back (Cancun) (reth)
   - Transaction Re-Org, Re-Org to Different Block (Cancun) (reth)
   - Transaction Re-Org, Re-Org Out (Cancun) (reth)
   - Invalid Missing Ancestor ReOrg, StateRoot, EmptyTxs=False, Invalid P9 (Cancun) (reth)
+  - Invalid Missing Ancestor Syncing ReOrg, Timestamp, EmptyTxs=False, CanonicalReOrg=False, Invalid P8 (Cancun) (reth)
+  - Invalid Missing Ancestor Syncing ReOrg, Timestamp, EmptyTxs=False, CanonicalReOrg=True, Invalid P8 (Cancun) (reth)
   - Multiple New Payloads Extending Canonical Chain, Wait for Canonical Payload (Cancun) (reth)
 engine-api:
   - Transaction Re-Org, Re-Org Out (Paris) (reth)


### PR DESCRIPTION
### engine-cancun
- `Invalid Missing Ancestor Syncing ReOrg, Timestamp, EmptyTxs=False, CanonicalReOrg=False, Invalid P8 (Cancun)`
- `Invalid Missing Ancestor Syncing ReOrg, Timestamp, EmptyTxs=False, CanonicalReOrg=True, Invalid P8 (Cancun)`

These fail with `missing trie node` errors during deep reorg scenarios. The P9 variant is already ignored.

**Root cause**: Known hive test infrastructure bug. The modified geth sidecar that hive uses to construct invalid blocks switched to `PathScheme` for state storage, which has strict trie integrity requirements incompatible with inserting blocks with intentionally invalid headers. Affects **all clients**, not just reth. Tracked upstream: https://github.com/ethereum/hive/issues/1382

--------

### engine-withdrawals
- `Sync after 2 blocks - Withdrawals on Block 2 - Multiple Withdrawal Accounts (Paris)`
- `Sync after 2 blocks - Withdrawals on Block 2 - Multiple Withdrawal Accounts - No Transactions (Paris)`

These fail with `Timeout while waiting for secondary client to sync`. The 128-block variant is already ignored.

**Root cause**: P2P sync timing issue in the hive Docker environment. The test spins up two reth containers — a primary with 2 blocks and a secondary that receives block 3 via `engine_newPayloadV2`. The secondary returns `SYNCING` (missing parent blocks 1 & 2) and is expected to fetch them via P2P from the primary. With `--sim.parallelism 16` tests sharing resources on the same runner, P2P peer discovery/connection sometimes doesn't complete within the hive timeout. Not a correctness bug — purely a CI timing issue.