### PR TITLE
ci(bench): drop root privileges for reth-bench

### DIFF
--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -79,8 +79,12 @@ for i in $(seq 1 60); do
   sleep 1
 done
 
+# Run reth-bench with high priority but as the current user so output
+# files are not root-owned (avoids EACCES on next checkout).
+BENCH_NICE="sudo nice -n -20 sudo -u $(id -un)"
+
 # Warmup
-sudo nice -n -20 "$RETH_BENCH" new-payload-fcu \
+$BENCH_NICE "$RETH_BENCH" new-payload-fcu \
   --rpc-url "$BENCH_RPC_URL" \
   --engine-rpc-url http://127.0.0.1:8551 \
   --jwt-secret "$DATADIR/jwt.hex" \
@@ -88,7 +92,7 @@ sudo nice -n -20 "$RETH_BENCH" new-payload-fcu \
   --reth-new-payload 2>&1 | sed -u "s/^/[bench] /"
 
 # Benchmark
-sudo nice -n -20 "$RETH_BENCH" new-payload-fcu \
+$BENCH_NICE "$RETH_BENCH" new-payload-fcu \
   --rpc-url "$BENCH_RPC_URL" \
   --engine-rpc-url http://127.0.0.1:8551 \
   --jwt-secret "$DATADIR/jwt.hex" \


### PR DESCRIPTION
reth-bench was run via 'sudo nice -n -20' for scheduling priority, which caused output CSVs in bench-work/ to be root-owned. On subsequent CI runs, actions/checkout could not delete these files (EACCES).

Fix by re-dropping to the runner user after elevating for nice: 'sudo nice -n -20 sudo -u $(id -un)'. This keeps the -20 niceness while writing output files as the non-root runner user.