### PR TITLE
docs(hive): add comments explaining why flaky tests are ignored

### DIFF
--- a/.github/scripts/hive/ignored_tests.yaml
+++ b/.github/scripts/hive/ignored_tests.yaml
@@ -16,6 +16,9 @@ engine-withdrawals:
   - Withdrawals Fork on Block 1 - 8 Block Re-Org NewPayload (Paris) (reth)
   - Withdrawals Fork on Block 8 - 10 Block Re-Org NewPayload (Paris) (reth)
   - Withdrawals Fork on Canonical Block 8 / Side Block 7 - 10 Block Re-Org (Paris) (reth)
+  # P2P sync timing issue in hive Docker environment: secondary client returns SYNCING but
+  # peer discovery/connection doesn't complete within the timeout when running with
+  # --sim.parallelism 16. Not a correctness bug, purely a CI timing issue.
   - Sync after 2 blocks - Withdrawals on Block 2 - Multiple Withdrawal Accounts (Paris) (reth)
   - Sync after 2 blocks - Withdrawals on Block 2 - Multiple Withdrawal Accounts - No Transactions (Paris) (reth)
   - Sync after 128 blocks - Withdrawals on Block 2 - Multiple Withdrawal Accounts (Paris) (reth)
@@ -24,6 +27,9 @@ engine-cancun:
   - Transaction Re-Org, Re-Org to Different Block (Cancun) (reth)
   - Transaction Re-Org, Re-Org Out (Cancun) (reth)
   - Invalid Missing Ancestor ReOrg, StateRoot, EmptyTxs=False, Invalid P9 (Cancun) (reth)
+  # Hive test infra bug: geth sidecar switched to PathScheme for state storage, which has
+  # strict trie integrity requirements incompatible with inserting intentionally invalid blocks.
+  # Affects all clients, not just reth. Tracked: https://github.com/ethereum/hive/issues/1382
   - Invalid Missing Ancestor Syncing ReOrg, Timestamp, EmptyTxs=False, CanonicalReOrg=False, Invalid P8 (Cancun) (reth)
   - Invalid Missing Ancestor Syncing ReOrg, Timestamp, EmptyTxs=False, CanonicalReOrg=True, Invalid P8 (Cancun) (reth)
   - Multiple New Payloads Extending Canonical Chain, Wait for Canonical Payload (Cancun) (reth)


### PR DESCRIPTION
Adds inline comments to the ignored hive tests added in #22376, so the reasoning is explicit and shareable with the EF.

### engine-cancun (P8 reorg tests)
Hive test infra bug: geth sidecar switched to `PathScheme` for state storage, which has strict trie integrity requirements incompatible with inserting intentionally invalid blocks. Affects **all clients**, not just reth. Tracked upstream: [ethereum/hive#1382](https://github.com/ethereum/hive/issues/1382)

### engine-withdrawals (sync timeout tests)
P2P sync timing issue in the hive Docker environment. Secondary client returns `SYNCING` but peer discovery/connection doesn't complete within the timeout when running with `--sim.parallelism 16`. Not a correctness bug — purely a CI timing issue.