### PR TITLE
feat(payload): add build duration and composition metrics to BasicPayloadJob

### DIFF
--- a/crates/payload/basic/src/metrics.rs
+++ b/crates/payload/basic/src/metrics.rs
@@ -1,9 +1,12 @@
 //! Metrics for the payload builder impl
 
-use reth_metrics::{metrics::Counter, Metrics};
+use reth_metrics::{
+    metrics::{Counter, Gauge, Histogram},
+    Metrics,
+};
 
 /// Payload builder metrics
-#[derive(Metrics)]
+#[derive(Metrics, Clone)]
 #[metrics(scope = "payloads")]
 pub(crate) struct PayloadBuilderMetrics {
     /// Total number of times an empty payload was returned because a built one was not ready.
@@ -12,6 +15,16 @@ pub(crate) struct PayloadBuilderMetrics {
     pub(crate) initiated_payload_builds: Counter,
     /// Total number of failed payload build attempts.
     pub(crate) failed_payload_builds: Counter,
+    /// Total time it took to build the payload in seconds.
+    pub(crate) payload_build_duration_seconds: Histogram,
+    /// Number of transactions included in the built payload.
+    pub(crate) built_payload_transactions: Histogram,
+    /// Gas used by the built payload.
+    pub(crate) built_payload_gas_used: Gauge,
+    /// RLP-encoded size of the built payload in bytes.
+    pub(crate) built_payload_rlp_size: Histogram,
+    /// Gas throughput measured as `gas_used` / `build_duration`.
+    pub(crate) built_payload_gas_per_second: Gauge,
 }
 
 impl PayloadBuilderMetrics {


### PR DESCRIPTION
## Summary
Adds observability metrics to the basic payload builder so operators can monitor build performance and payload composition.

## Motivation
The payload builder currently only exposes counters (initiated/failed/empty builds) and revenue gauges at the service level. There are no timing or composition metrics, making it hard to understand builder performance or diagnose regressions.

## Changes
Adds the following metrics under the `payloads.*` scope in `reth-basic-payload-builder`:

| Metric | Type | Description |
|--------|------|-------------|
| `payload_build_duration_seconds` | Histogram | Total time for `try_build` |
| `built_payload_transactions` | Histogram | Transaction count per payload |
| `built_payload_gas_used` | Gauge | Gas consumed by the payload |
| `built_payload_rlp_size` | Histogram | RLP-encoded block size in bytes |
| `built_payload_gas_per_second` | Gauge | Gas throughput (`gas_used / duration`) |

- Build duration and gas/s are recorded in the spawned build task where both timing and payload data are available
- Composition metrics (tx count, gas, rlp size) are recorded when `Better` or `Freeze` outcomes are received in poll

## Testing
```
cargo +nightly fmt --all --check
cargo +nightly clippy -p reth-basic-payload-builder  # 0 warnings
cargo check -p reth-basic-payload-builder
```

Prompted by: alexey