### PR TITLE
fix: align static-file changeset checksum with MDBX semantics

### DIFF
--- a/crates/cli/commands/src/db/checksum/mod.rs
+++ b/crates/cli/commands/src/db/checksum/mod.rs
@@ -202,6 +202,8 @@ fn checksum_static_file<N: CliNodeTypes<ChainSpec: EthereumHardforks>>(
 
     let start_block = start_block.unwrap_or(0);
     let end_block = end_block.unwrap_or(u64::MAX);
+    let is_change_based = segment.is_change_based();
+    let is_storage = segment.is_storage_change_sets();
 
     info!(
         "Computing checksum for {} static files, start_block={}, end_block={}, limit={:?}",
@@ -230,7 +232,7 @@ fn checksum_static_file<N: CliNodeTypes<ChainSpec: EthereumHardforks>>(
 
         let mut cursor = jar_provider.cursor()?;
 
-        if segment.is_change_based() {
+        if is_change_based {
             let offsets = jar_provider.read_changeset_offsets()?.ok_or_else(|| {
                 eyre::eyre!(
                     "Missing changeset offsets sidecar for segment {} at range {}",
@@ -238,8 +240,6 @@ fn checksum_static_file<N: CliNodeTypes<ChainSpec: EthereumHardforks>>(
                     block_range
                 )
             })?;
-
-            let is_storage = segment.is_storage_change_sets();
 
             for (offset_index, offset) in offsets.iter().enumerate() {
                 let block_number = block_range.start() + offset_index as u64;

--- a/crates/cli/commands/src/db/checksum/mod.rs
+++ b/crates/cli/commands/src/db/checksum/mod.rs
@@ -239,7 +239,7 @@ fn checksum_static_file<N: CliNodeTypes<ChainSpec: EthereumHardforks>>(
                 )
             })?;
 
-            let is_storage = segment == StaticFileSegment::StorageChangeSets;
+            let is_storage = segment.is_storage_change_sets();
 
             for (offset_index, offset) in offsets.iter().enumerate() {
                 let block_number = block_range.start() + offset_index as u64;


### PR DESCRIPTION
## Summary
- Aligns `reth db checksum static-file` behavior for change-based segments with MDBX by hashing block key bytes together with row value bytes.
- Uses changeset offset sidecar metadata to map each static-file row to its block number during checksum calculation.
- Improves the checksum loop flow so limit handling is clearer and static-file provider cache cleanup remains deterministic.
- Adds consistency guards that error when changeset offsets are missing or do not fully cover stored rows.

## Validation
- `cargo test -p reth-cli-commands checksum --no-run`
