### PR TITLE
fix(bench): checkout feature source to correct ref instead of symlinking

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -523,7 +523,14 @@ jobs:
             git clone . ../reth-baseline
           fi
           git -C ../reth-baseline checkout "$BASELINE_REF"
-          ln -sfn "$(pwd)" ../reth-feature
+
+          FEATURE_REF="${{ steps.refs.outputs.feature-ref }}"
+          if [ -d ../reth-feature ]; then
+            git -C ../reth-feature fetch origin "$FEATURE_REF"
+          else
+            git clone . ../reth-feature
+          fi
+          git -C ../reth-feature checkout "$FEATURE_REF"
 
       - name: Build binaries and download snapshot in parallel
         id: build


### PR DESCRIPTION
## Summary

The `Prepare source dirs` step symlinked `../reth-feature` to the checkout directory (`ln -sfn $(pwd) ../reth-feature`), which is always at `refs/heads/main` for `workflow_dispatch` runs. When `FEATURE_REF` differs from the checked-out commit, the feature build on cache miss compiles baseline code and caches it under the feature ref — both runs end up using the same baseline binary.

## Changes

- Replace the symlink with a proper `git clone` + `checkout` to `FEATURE_REF`, matching how `../reth-baseline` is already handled.

Prompted by: alexey