### PR TITLE
ci(bench): use schelk promote instead of recover when updating snapshot

### DIFF
--- a/.github/scripts/bench-reth-snapshot.sh
+++ b/.github/scripts/bench-reth-snapshot.sh
@@ -116,10 +116,12 @@ wait $PROGRESS_PID 2>/dev/null || true
 update_comment "100"
 echo "Snapshot download complete"
 
-# Sync the new snapshot as the schelk baseline
+# Promote the new snapshot to become the schelk baseline (virgin volume).
+# This copies changed blocks from scratch → virgin so that future
+# `schelk recover` calls restore to this new state.
 sync
-sudo schelk recover -y
+sudo schelk promote -y
 
 # Save ETag marker
 echo "$REMOTE_ETAG" > "$ETAG_FILE"
-echo "Snapshot synced to schelk (ETag: ${REMOTE_ETAG})"
+echo "Snapshot promoted to schelk baseline (ETag: ${REMOTE_ETAG})"


### PR DESCRIPTION
## Summary

The snapshot download script was incorrectly reverting newly downloaded snapshots instead of promoting them to the baseline. The script called `schelk recover` after download, which copied changed blocks from virgin → scratch, undoing all the new data. Now it calls `schelk promote` to copy changed blocks from scratch → virgin, making the newly downloaded snapshot the persistent baseline. This ensures benchmark runs use current snapshot data instead of stale cached versions.

## Changes

- Replace `schelk recover` with `schelk promote` after snapshot download
- Update comment and log message to reflect the new behavior

## Test plan

- Verify benchmark runs pick up updated snapshots on next execution
- Confirm snapshots with new block numbers are properly reflected in benchmark runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)