### PR TITLE
fix: handle missing rocksdb gracefully in read-only db commands

### DIFF
--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -691,6 +691,14 @@ impl RocksDBProvider {
         RocksDBBuilder::new(path)
     }
 
+    /// Returns `true` if a `RocksDB` database exists at the given path.
+    ///
+    /// Checks for the presence of the `CURRENT` file, which `RocksDB` creates
+    /// when initializing a database.
+    pub fn exists(path: impl AsRef<Path>) -> bool {
+        path.as_ref().join("CURRENT").exists()
+    }
+
     /// Returns `true` if this provider is in read-only mode.
     pub fn is_read_only(&self) -> bool {
         matches!(self.0.as_ref(), RocksDBProviderInner::ReadOnly { .. })

--- a/crates/storage/provider/src/providers/rocksdb_stub.rs
+++ b/crates/storage/provider/src/providers/rocksdb_stub.rs
@@ -74,6 +74,13 @@ impl RocksDBProvider {
         RocksDBBuilder::new(path)
     }
 
+    /// Returns `true` if a `RocksDB` database exists at the given path (stub implementation).
+    ///
+    /// Always returns `false` since `RocksDB` is not available.
+    pub fn exists(_path: impl AsRef<Path>) -> bool {
+        false
+    }
+
     /// Check consistency of `RocksDB` tables (stub implementation).
     ///
     /// Returns `None` since there is no `RocksDB` data to check when the feature is disabled.


### PR DESCRIPTION
## Summary

When running `reth db stats` or other read-only db subcommands on a datadir that has MDBX and static files but no RocksDB directory, the command would panic with "IO error: No such file or directory" when trying to open the rocksdb database in read-only mode.

Now we check if RocksDB exists before attempting to open it in read-only mode. If it doesn't exist, we initialize an empty database instead. This allows read-only commands to work on any valid datadir without panicking.