### PR TITLE
perf(engine): cap prewarm workers for small blocks

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -50,7 +50,7 @@ use tracing::{debug, debug_span, instrument, trace, warn, Span};
 /// wastes CPU on context setup and creates contention with the sparse trie's critical path.
 /// Capping to fewer workers still emits `PrefetchProofs` targets (keeping the sparse trie fed)
 /// while avoiding the overhead.
-const SMALL_BLOCK_PREWARM_WORKER_THRESHOLD: usize = 16;
+const SMALL_BLOCK_PREWARM_WORKER_THRESHOLD: usize = 50;
 
 /// Maximum number of prewarm workers for blocks at or below
 /// [`SMALL_BLOCK_PREWARM_WORKER_THRESHOLD`] transactions.

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -42,6 +42,20 @@ use std::sync::{
 };
 use tracing::{debug, debug_span, instrument, trace, warn, Span};
 
+/// Transaction count threshold below which prewarm workers are capped to
+/// [`SMALL_BLOCK_MAX_PREWARM_WORKERS`].
+///
+/// For small blocks, each prewarm worker pays ~400µs for EVM context setup (`evm_for_ctx`),
+/// but actual per-transaction execution is only ~30µs. Spawning N workers for N transactions
+/// wastes CPU on context setup and creates contention with the sparse trie's critical path.
+/// Capping to fewer workers still emits `PrefetchProofs` targets (keeping the sparse trie fed)
+/// while avoiding the overhead.
+const SMALL_BLOCK_PREWARM_WORKER_THRESHOLD: usize = 16;
+
+/// Maximum number of prewarm workers for blocks at or below
+/// [`SMALL_BLOCK_PREWARM_WORKER_THRESHOLD`] transactions.
+const SMALL_BLOCK_MAX_PREWARM_WORKERS: usize = 1;
+
 /// Determines the prewarming mode: transaction-based, BAL-based, or skipped.
 #[derive(Debug)]
 pub enum PrewarmMode<Tx> {
@@ -145,11 +159,19 @@ where
             let pool_threads = executor.prewarming_pool().current_num_threads();
             // Don't spawn more workers than transactions. When transaction_count is 0
             // (unknown), use all pool threads.
-            let workers_needed = if ctx.env.transaction_count > 0 {
+            let mut workers_needed = if ctx.env.transaction_count > 0 {
                 ctx.env.transaction_count.min(pool_threads)
             } else {
                 pool_threads
             };
+
+            // For small blocks, cap workers to reduce EVM context setup overhead while
+            // still emitting PrefetchProofs targets to keep the sparse trie fed.
+            if ctx.env.transaction_count > 0
+                && ctx.env.transaction_count <= SMALL_BLOCK_PREWARM_WORKER_THRESHOLD
+            {
+                workers_needed = workers_needed.min(SMALL_BLOCK_MAX_PREWARM_WORKERS);
+            }
 
             let (done_tx, done_rx) = mpsc::sync_channel(workers_needed);
 


### PR DESCRIPTION
## Summary

Caps prewarm workers to 1 for blocks with ≤16 transactions to reduce EVM context setup overhead while still feeding the sparse trie with proof prefetch targets.

## Motivation

Reth loses disproportionately on small blocks (<10M gas) in ethpandaops benchmarks:
- 0-5M gas: 20.8% win rate (losing 66.2%)
- 5-10M gas: 34.8% win rate (losing 55.1%)

Jaeger traces of ~5M gas blocks show prewarm is a major CPU consumer: each worker pays ~400µs for `evm_for_ctx` setup, but actual per-tx execution is only ~30µs. For a 6-tx block, 6 workers = ~2.4ms of CPU overhead for ~180µs of useful EVM work. This CPU contention competes with the sparse trie's critical path.

Simply skipping prewarm regresses because workers emit `PrefetchProofs` targets that keep the sparse trie fed with early proof hints. Without them, the sparse trie sits idle (23.5% channel_wait).

## Changes

- Added `SMALL_BLOCK_PREWARM_WORKER_THRESHOLD` (16) and `SMALL_BLOCK_MAX_PREWARM_WORKERS` (1) constants in `prewarm.rs`
- Cap `workers_needed` to 1 when `transaction_count <= 16` in `spawn_all()`
- Single worker still executes all txs and emits `PrefetchProofs` — no regression from lost prefetch targets

## Testing

```
cargo test -p reth-engine-tree --lib
cargo clippy -p reth-engine-tree --lib
```

Prompted by: yk