### PR TITLE
perf(engine): drain sparse trie updates in bounded batches

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -4,7 +4,7 @@ use alloy_evm::block::StateChangeSource;
 use alloy_primitives::{keccak256, B256};
 use crossbeam_channel::Sender as CrossbeamSender;
 use derive_more::derive::Deref;
-use metrics::{Gauge, Histogram};
+use metrics::{Counter, Gauge, Histogram};
 use reth_metrics::Metrics;
 use reth_revm::state::EvmState;
 use reth_trie::{HashedPostState, HashedStorage};
@@ -189,6 +189,12 @@ pub(crate) struct MultiProofTaskMetrics {
     pub into_trie_for_reuse_duration_histogram: Histogram,
     /// Time spent waiting for preserved sparse trie cache to become available.
     pub sparse_trie_cache_wait_duration_histogram: Histogram,
+    /// Number of additional updates drained from the updates channel in a single wakeup.
+    pub sparse_trie_update_drain_count_histogram: Histogram,
+    /// Time spent draining additional updates from the updates channel.
+    pub sparse_trie_update_drain_duration_histogram: Histogram,
+    /// Number of times update draining hits the configured per-tick cap.
+    pub sparse_trie_update_drain_cap_hit_counter: Counter,
 }
 
 /// Dispatches work items as a single unit or in chunks based on target size and worker

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -445,7 +445,7 @@ where
                     self.pending_updates += 1;
                     drained += 1;
                 }
-                Err(TryRecvError::Empty) | Err(TryRecvError::Disconnected) => break,
+                Err(TryRecvError::Empty | TryRecvError::Disconnected) => break,
             }
         }
 


### PR DESCRIPTION
## Summary
- Batch-drain additional sparse-trie update messages after each update receive in `SparseTrieCacheTask::run`.
- Cap draining per loop tick (`MAX_UPDATE_DRAIN_PER_TICK = 64`) to avoid starving proof-result handling.
- Add metrics to measure fast-path impact:
  - `sparse_trie_update_drain_count_histogram`
  - `sparse_trie_update_drain_duration_histogram`
  - `sparse_trie_update_drain_cap_hit_counter`

## Motivation
Small-block traces show sparse-trie latency dominated by proof round-trip waiting. Draining ready updates in bounded batches reduces dispatch/wait ping-pong and should lower channel wait time.

## Validation
- `cargo +nightly fmt --all`
- `cargo +nightly check -p reth-engine-tree`
- `cargo +nightly clippy --workspace --lib --examples --tests --benches --all-features --locked`
- `cargo +nightly clippy --workspace --bin reth --all-features --locked`
