### PR TITLE
perf(engine): release cache lock before waiting for state root validation

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -198,15 +198,15 @@ where
         });
     }
 
-    /// This method calls `ExecutionCache::update_with_guard` which requires exclusive access.
-    /// It should only be called after ensuring that:
-    /// 1. All prewarming tasks have completed execution
-    /// 2. No other concurrent operations are accessing the cache
-    ///
     /// Saves the warmed caches back into the shared slot after prewarming completes.
     ///
-    /// This consumes the `SavedCache` held by the task, which releases its usage guard and allows
-    /// the new, warmed cache to be inserted.
+    /// Waits for block validation without any lock held, then only on success inserts
+    /// state and publishes under a brief write lock. This avoids the ~100ms+ lock hold
+    /// that previously blocked concurrent readers during `valid_block_rx.recv()`.
+    ///
+    /// The ordering is critical: `insert_state()` mutates the shared fixed-caches
+    /// in-place while the usage guard is still held (keeping `is_available() == false`),
+    /// then `split()` releases the guard and publishes the new cache atomically.
     ///
     /// This method is called from `run()` only after all execution tasks are complete.
     #[instrument(level = "debug", target = "engine::tree::payload_processor::prewarm", skip_all)]
@@ -223,36 +223,36 @@ where
 
         if let Some(saved_cache) = saved_cache {
             debug!(target: "engine::caching", parent_hash=?hash, "Updating execution cache");
-            // Perform all cache operations atomically under the lock
-            execution_cache.update_with_guard(|cached| {
-                // consumes the `SavedCache` held by the prewarming task, which releases its usage
-                // guard
-                let (caches, cache_metrics, disable_cache_metrics) = saved_cache.split();
-                let new_cache = SavedCache::new(hash, caches, cache_metrics)
-                    .with_disable_cache_metrics(disable_cache_metrics);
 
-                // Insert state into cache while holding the lock
-                // Access the BundleState through the shared ExecutionOutcome
-                if new_cache.cache().insert_state(&execution_outcome.state).is_err() {
-                    // Clear the cache on error to prevent having a polluted cache
+            // Wait for state root validation WITHOUT holding the cache lock.
+            // This is the key optimization: the original code held the lock across this
+            // blocking recv(), which blocked the next block's prewarming from accessing
+            // the cache for ~100ms+.
+            if valid_block_rx.recv().is_err() {
+                debug!(target: "engine::caching", parent_hash=?hash, "skipped cache publish on invalid block");
+                return;
+            }
+
+            // Block is valid — mutate caches while the usage guard is still held
+            // (keeping is_available() == false) so no concurrent reader can observe
+            // the cache mid-mutation via get_cache_for().
+            if saved_cache.cache().insert_state(&execution_outcome.state).is_err() {
+                execution_cache.update_with_guard(|cached| {
                     *cached = None;
-                    debug!(target: "engine::caching", "cleared execution cache on update error");
-                    return;
-                }
+                });
+                debug!(target: "engine::caching", "cleared execution cache on update error");
+            } else {
+                saved_cache.update_metrics();
 
-                new_cache.update_metrics();
-
-                if valid_block_rx.recv().is_ok() {
-                    // Replace the shared cache with the new one; the previous cache (if any) is
-                    // dropped.
+                // Now consume the SavedCache (releasing the usage guard) and publish
+                // the new cache under a brief lock.
+                execution_cache.update_with_guard(|cached| {
+                    let (caches, cache_metrics, disable_cache_metrics) = saved_cache.split();
+                    let new_cache = SavedCache::new(hash, caches, cache_metrics)
+                        .with_disable_cache_metrics(disable_cache_metrics);
                     *cached = Some(new_cache);
-                } else {
-                    // Block was invalid; caches were already mutated by insert_state above,
-                    // so we must clear to prevent using polluted state
-                    *cached = None;
-                    debug!(target: "engine::caching", "cleared execution cache on invalid block");
-                }
-            });
+                });
+            }
 
             let elapsed = start.elapsed();
             debug!(target: "engine::caching", parent_hash=?hash, elapsed=?elapsed, "Updated execution cache");


### PR DESCRIPTION
## Summary
`save_cache()` currently holds the execution-cache write lock while blocking on `valid_block_rx.recv()`. This can stall cache readers (`get_cache_for`) for ~100ms+ during state-root validation.

This PR moves the blocking wait out of the write-lock critical section.

## What Changed
- Wait for block validation without holding the cache write lock.
- If valid: update cache state while the usage guard is still held.
- Publish the updated cache under a short write lock.
- Update `update_with_guard` docs to match the lock/guard contract.

## Why This Is Safe
- While prewarming holds `SavedCache`, `is_available()` is false, so `get_cache_for()` does not expose it.
- Cache mutation happens before guard release.
- Guard release + cache publication happen atomically under write lock.

## Expected Impact
- Reduces lock contention in `save_cache()`.
- Allows next-block prewarming to access cache sooner.

## Validation
- `cargo nextest run -p reth-engine-tree --lib`
- `cargo clippy -p reth-engine-tree --lib --all-features`
