### PR TITLE
feat(trie): add thread names to proof worker spawns

### DIFF
--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -167,7 +167,7 @@ impl ProofWorkerHandle {
         let storage_avail = storage_available_workers.clone();
         let storage_roots = cached_storage_roots.clone();
         let storage_parent_span = tracing::Span::current();
-        runtime.spawn_blocking(move || {
+        runtime.spawn_blocking_named("proof-storage-workers", move || {
             let worker_id = AtomicUsize::new(0);
             storage_rt.proof_storage_worker_pool().broadcast(storage_worker_count, |_| {
                 let worker_id = worker_id.fetch_add(1, Ordering::Relaxed);
@@ -205,7 +205,7 @@ impl ProofWorkerHandle {
         let account_tx = storage_work_tx.clone();
         let account_avail = account_available_workers.clone();
         let account_parent_span = tracing::Span::current();
-        runtime.spawn_blocking(move || {
+        runtime.spawn_blocking_named("proof-account-workers", move || {
             let worker_id = AtomicUsize::new(0);
             account_rt.proof_account_worker_pool().broadcast(account_worker_count, |_| {
                 let worker_id = worker_id.fetch_add(1, Ordering::Relaxed);


### PR DESCRIPTION
## Motivation
This improves observability when profiling with tools like Samply, making it easier to identify these worker threads in profiles.

## Notes
This approach is different from the reverted PR #18670 which created custom tokio runtimes. This PR only uses `spawn_blocking_named()` which is already widely used in the codebase (e.g., in `prewarm.rs`) and does not introduce the process-exporter cardinality issues mentioned in #18670.

Attempts to deal with low hanging fruit #20430