### PR TITLE
fix(net): log transaction count instead of bool in broadcast debug log

### DIFF
--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -1932,7 +1932,6 @@ impl PooledTransactionsHashesBuilder {
         }
     }
 
-
     /// Appends all hashes
     fn extend<T: SignedTransaction>(
         &mut self,

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -1927,8 +1927,8 @@ impl PooledTransactionsHashesBuilder {
     /// Returns the number of transactions in the builder.
     fn len(&self) -> usize {
         match self {
-            Self::Eth66(hashes) => hashes.0.len(),
-            Self::Eth68(hashes) => hashes.hashes.len(),
+            Self::Eth66(hashes) => hashes.len(),
+            Self::Eth68(hashes) => hashes.len(),
         }
     }
 

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -1236,7 +1236,7 @@ where
             msg_builder.push_pooled(pooled_tx);
         }
 
-        debug!(target: "net::tx", ?peer_id, tx_count = msg_builder.is_empty(), "Broadcasting transaction hashes");
+        debug!(target: "net::tx", ?peer_id, tx_count = msg_builder.len(), "Broadcasting transaction hashes");
         let msg = msg_builder.build();
         self.network.send_transactions_hashes(peer_id, msg);
     }
@@ -1923,6 +1923,15 @@ impl PooledTransactionsHashesBuilder {
             Self::Eth68(hashes) => hashes.is_empty(),
         }
     }
+
+    /// Returns the number of transactions in the builder.
+    fn len(&self) -> usize {
+        match self {
+            Self::Eth66(hashes) => hashes.0.len(),
+            Self::Eth68(hashes) => hashes.hashes.len(),
+        }
+    }
+
 
     /// Appends all hashes
     fn extend<T: SignedTransaction>(


### PR DESCRIPTION
PooledTransactionsHashesBuilder::is_empty() was used as the value for tx_count in a debug log, resulting in tx_count=false instead of the actual number of transactions being broadcast