### PR TITLE
feat(trie): add per-account cached storage trie node metrics

### DIFF
--- a/crates/trie/sparse/src/metrics.rs
+++ b/crates/trie/sparse/src/metrics.rs
@@ -72,6 +72,10 @@ pub(crate) struct SparseStateTrieInnerMetrics {
     pub(crate) multiproof_skipped_storage_nodes: Histogram,
     /// Histogram of total storage nodes, including those that were skipped.
     pub(crate) multiproof_total_storage_nodes: Histogram,
+    /// Histogram of the number of nodes in the in-memory cached sparse trie for a storage
+    /// account at the time a new proof is revealed. 0 means the account had no cached sparse
+    /// trie (it was either absent or blind).
+    pub(crate) storage_trie_cached_nodes: Histogram,
 }
 
 /// Metrics for the parallel sparse trie


### PR DESCRIPTION
## Summary

Add a histogram to measure the distribution of in-memory cached sparse trie node counts per modified storage trie.

## Motivation

We want to evaluate whether a `FlatSparseTrie` (sorted vec + `HashBuilder`) would be faster than a full sparse trie for small storage tries. The key question: for each modified storage trie in a block, how many nodes does the in-memory cached sparse trie (retained between blocks) already have?

If most modified storage tries have 0 cached nodes (no sparse trie carried over from the previous block), then building a full `ParallelSparseTrie` for them may be unnecessary overhead — a simpler flat approach could work.

## Changes

- Added `storage_trie_cached_nodes` histogram to `SparseStateTrieInnerMetrics`
- In `reveal_storage_v2_proof_nodes()`, records the node count of the existing cached sparse trie for the account **before** revealing new proof nodes
  - 0 = account had no cached sparse trie (absent or `Blind`)
  - N = account had a `Revealed` sparse trie with N nodes from previous blocks
- Gated behind `#[cfg(feature = "metrics")]`, zero overhead when disabled

## Testing

- `cargo check -p reth-trie-sparse --features metrics` ✅
- `cargo check -p reth-trie-sparse` (no metrics) ✅
- `cargo check -p reth-trie-parallel --features metrics` ✅
- `cargo test -p reth-trie-sparse --lib -- state` — 5/5 pass ✅
- `cargo +nightly fmt --all --check` ✅

Prompted by: yk