### PR TITLE
feat(trie): add storage trie diagnostics metrics for cached node distribution

### DIFF
--- a/crates/trie/parallel/src/proof_task_metrics.rs
+++ b/crates/trie/parallel/src/proof_task_metrics.rs
@@ -32,6 +32,12 @@ pub struct ProofTaskTrieMetrics {
     /// (seconds). This is the portion of account worker idle time attributable to storage
     /// worker latency rather than queue wait.
     account_worker_storage_wait_seconds: Histogram,
+    /// Histogram for the number of cached trie nodes in `StoragesTrie` per modified storage trie.
+    /// Used to identify small storage tries that could benefit from a flat trie optimization.
+    storage_trie_cached_nodes: Histogram,
+    /// Histogram for the number of modified storage slots for accounts with zero cached trie
+    /// nodes. Used to determine the size distribution of small storage tries.
+    modified_slots_when_no_cached_nodes: Histogram,
 }
 
 impl ProofTaskTrieMetrics {
@@ -63,6 +69,16 @@ impl ProofTaskTrieMetrics {
         self.deferred_encoder_dispatched_missing_root
             .record(stats.dispatched_missing_root_count as f64);
         self.account_worker_storage_wait_seconds.record(stats.storage_wait_time.as_secs_f64());
+    }
+
+    /// Record the number of cached storage trie nodes for a modified account.
+    pub fn record_storage_trie_cached_nodes(&self, count: usize) {
+        self.storage_trie_cached_nodes.record(count as f64);
+    }
+
+    /// Record the number of modified storage slots for an account with no cached trie nodes.
+    pub fn record_modified_slots_when_uncached(&self, slots: usize) {
+        self.modified_slots_when_no_cached_nodes.record(slots as f64);
     }
 }
 


### PR DESCRIPTION
## Summary

Add diagnostic metrics to measure the distribution of cached trie nodes per modified storage trie per block.

## Motivation

For small storage tries with no cached trie nodes in `StoragesTrie`, we could skip full sparse trie construction and use a simpler `FlatSparseTrie` that just feeds sorted key/values through `HashBuilder`. Before building that optimization, we need data on how many modified storage tries are actually "small" (0 cached nodes).

## Changes

Two new histogram metrics under `trie.proof_task`:

- **`storage_trie_cached_nodes`** — for each modified storage trie in a block, how many cached trie nodes exist in the `StoragesTrie` DB table. Distribution shows how many tries are "small" (0 nodes) vs "large".
- **`modified_slots_when_no_cached_nodes`** — for accounts with 0 cached trie nodes, how many storage slots were modified. Shows the size distribution of small tries.

Implementation:
- Accumulate modified slot counts per account in `SparseTrieCacheTask::on_hashed_state_update`
- After all state updates are processed (before `root_with_updates`), dispatch lightweight diagnostics jobs to storage proof workers
- Each diagnostics job iterates the storage trie cursor for the account (capped at 4096 to bound overhead) and records metrics
- Uses separate cursor from proof computation, no interference with active proof work

## Testing

Compiled and clippy-clean:
```
cargo check -p reth-trie-parallel -p reth-engine-tree
cargo clippy -p reth-trie-parallel -p reth-engine-tree -- -D warnings
```

Prompted by: yk