### PR TITLE
fix(net): update peer block info for fully validated blocks

### DIFF
--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -594,6 +594,11 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
                             self.swarm.state_mut().announce_new_block(block);
                         }
                         BlockValidation::ValidBlock { block } => {
+                            self.swarm.state_mut().update_peer_block(
+                                &peer,
+                                block.hash,
+                                block.number(),
+                            );
                             self.swarm.state_mut().announce_new_block_hash(block);
                         }
                     },


### PR DESCRIPTION
Add missing update_peer_block call in the ValidBlock arm of BlockImportEvent::Outcome