### PR TITLE
refactor(cli): deduplicate storage trie entry deletion logic

### DIFF
--- a/crates/cli/commands/src/db/repair_trie.rs
+++ b/crates/cli/commands/src/db/repair_trie.rs
@@ -301,7 +301,11 @@ fn verify_and_repair<N: ProviderNodeTypes>(tool: &DbTool<N>) -> eyre::Result<()>
                 // (We can't just use `upsert` method with a dup cursor, it's not properly
                 // supported)
                 let nibbles = StoredNibblesSubKey(path);
-                delete_storage_trie_entry_if_exists(&mut storage_trie_cursor, account, nibbles.clone())?;
+                delete_storage_trie_entry_if_exists(
+                    &mut storage_trie_cursor,
+                    account,
+                    nibbles.clone(),
+                )?;
                 let entry = StorageTrieEntry { nibbles, node };
                 storage_trie_cursor.upsert(account, &entry)?;
             }

--- a/crates/cli/commands/src/db/repair_trie.rs
+++ b/crates/cli/commands/src/db/repair_trie.rs
@@ -5,8 +5,8 @@ use reth_cli_util::parse_socket_address;
 use reth_db_api::{
     cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO},
     database::Database,
-    tables,
     table::DupSort,
+    tables,
     transaction::{DbTx, DbTxMut},
 };
 use reth_db_common::DbTool;


### PR DESCRIPTION


Removes code duplication in `verify_and_repair` function by extracting the repeated "seek + delete if exists" logic for storage trie entries into a reusable closure.

