### PR TITLE
perf: bump MAX_PENDING_UPDATES to 200

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -208,7 +208,7 @@ where
 }
 
 /// Maximum number of pending/prewarm updates that we accumulate in memory before actually applying.
-const MAX_PENDING_UPDATES: usize = 100;
+const MAX_PENDING_UPDATES: usize = 200;
 
 /// Sparse trie task implementation that uses in-memory sparse trie data to schedule proof fetching.
 pub(super) struct SparseTrieCacheTask<A = ParallelSparseTrie, S = ParallelSparseTrie> {


### PR DESCRIPTION
## Summary
Bumps `MAX_PENDING_UPDATES` in sparse trie cache from 100 to 200 to test if accumulating more updates before applying improves state root computation throughput.

## Changes
- `crates/engine/tree/src/tree/payload_processor/sparse_trie.rs`: `MAX_PENDING_UPDATES` 100 → 200

## Testing
Submitting to reth-bench for comparison against main.

Prompted by: yk