### PR TITLE
perf: reduce MAX_PENDING_UPDATES to 10

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -208,7 +208,7 @@ where
 }
 
 /// Maximum number of pending/prewarm updates that we accumulate in memory before actually applying.
-const MAX_PENDING_UPDATES: usize = 100;
+const MAX_PENDING_UPDATES: usize = 10;
 
 /// Sparse trie task implementation that uses in-memory sparse trie data to schedule proof fetching.
 pub(super) struct SparseTrieCacheTask<A = ParallelSparseTrie, S = ParallelSparseTrie> {


### PR DESCRIPTION
## Summary
Reduces `MAX_PENDING_UPDATES` in sparse trie cache from 100 to 10 to test if flushing more frequently improves state root computation.

## Changes
- `crates/engine/tree/src/tree/payload_processor/sparse_trie.rs`: `MAX_PENDING_UPDATES` 100 → 10

## Testing
Submitting to reth-bench for comparison against main.

Prompted by: yk