### PR TITLE
fix(tracing): handle file_writer in LogFmt format

### DIFF
--- a/crates/tracing/src/formatter.rs
+++ b/crates/tracing/src/formatter.rs
@@ -67,7 +67,14 @@ impl LogFormat {
                     layer.with_filter(filter).boxed()
                 }
             }
-            Self::LogFmt => tracing_logfmt::layer().with_filter(filter).boxed(),
+            Self::LogFmt => {
+                let layer = tracing_logfmt::builder().layer();
+                if let Some(writer) = file_writer {
+                    layer.with_writer(writer).with_filter(filter).boxed()
+                } else {
+                    layer.with_filter(filter).boxed()
+                }
+            }
             Self::Terminal => {
                 let layer = tracing_subscriber::fmt::layer().with_ansi(ansi).with_target(target);
 


### PR DESCRIPTION
The LogFmt branch in LogFormat::apply was dropping the file_writer on the floor, so file logging with logfmt format just never worked — the writer and guard get allocated but logs still go to stdout.

Switched from tracing_logfmt::layer() (returns opaque impl Layer) to tracing_logfmt::builder().layer() (returns concrete fmt::Layer with with_writer support), matching what Json and Terminal already do.

e.g. reth node --log.file.format logfmt would produce an empty log file before this fix.
