### PR TITLE
fix: update PR comment when bench workflow is cancelled

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -790,6 +790,18 @@ jobs:
               body: `cc @${process.env.BENCH_ACTOR}\n\n❌ Benchmark failed while ${failedStep}. [View logs](${process.env.BENCH_JOB_URL})`,
             });
 
+      - name: Update status (cancelled)
+        if: cancelled() && env.BENCH_COMMENT_ID
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const jobUrl = process.env.BENCH_JOB_URL || `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner, repo: context.repo.repo,
+              comment_id: parseInt(process.env.BENCH_COMMENT_ID),
+              body: `cc @${process.env.BENCH_ACTOR}\n\n⚠️ Benchmark cancelled. [View logs](${jobUrl})`,
+            });
+
       - name: Upload node log
         if: failure()
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
When a `reth-bench` workflow is cancelled (e.g., by user action or superseded by a newer run), the PR comment is now updated with a clear indication instead of showing stale status like "⏳ **Status:** Running benchmarks...".

Adds a new "Update status (cancelled)" step to the `reth-bench` job that runs on `cancelled() && env.BENCH_COMMENT_ID`, matching the pattern of the existing "Update status (failed)" step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)