### PR TITLE
perf(engine): consolidate receipt-root into shared post-exec worker

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -115,10 +115,10 @@ pub struct PayloadProcessor<Evm>
 where
     Evm: ConfigureEvm,
 {
-    /// The executor used by to spawn tasks.
-    executor: Runtime,
     /// Shared worker that computes incremental post-execution roots.
     post_exec_coordinator: PostExecCoordinatorFor<Evm>,
+    /// The executor used by to spawn tasks.
+    executor: Runtime,
     /// The most recent cache used for execution.
     execution_cache: PayloadExecutionCache,
     /// Metrics for trie operations
@@ -166,10 +166,10 @@ where
         config: &TreeConfig,
         precompile_cache_map: PrecompileCacheMap<SpecFor<Evm>>,
     ) -> Self {
-        let post_exec_coordinator = post_exec::PostExecCoordinator::new(&executor);
+        let post_exec_coordinator = post_exec::PostExecCoordinator::new();
         Self {
-            executor,
             post_exec_coordinator,
+            executor,
             execution_cache: Default::default(),
             trie_metrics: Default::default(),
             cross_block_cache_size: config.cross_block_cache_size(),

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -55,6 +55,7 @@ use tracing::{debug, debug_span, instrument, warn, Span};
 
 pub mod bal;
 pub mod multiproof;
+pub mod post_exec;
 mod preserved_sparse_trie;
 pub mod prewarm;
 pub mod receipt_root_task;
@@ -104,6 +105,10 @@ type IteratorPayloadHandle<Evm, I, N> = PayloadHandle<
     <N as NodePrimitives>::Receipt,
 >;
 
+/// Type alias for the shared post-execution coordinator.
+type PostExecCoordinatorFor<Evm> =
+    post_exec::PostExecCoordinator<<<Evm as ConfigureEvm>::Primitives as NodePrimitives>::Receipt>;
+
 /// Entrypoint for executing the payload.
 #[derive(Debug)]
 pub struct PayloadProcessor<Evm>
@@ -112,6 +117,8 @@ where
 {
     /// The executor used by to spawn tasks.
     executor: Runtime,
+    /// Shared worker that computes incremental post-execution roots.
+    post_exec_coordinator: PostExecCoordinatorFor<Evm>,
     /// The most recent cache used for execution.
     execution_cache: PayloadExecutionCache,
     /// Metrics for trie operations
@@ -159,8 +166,10 @@ where
         config: &TreeConfig,
         precompile_cache_map: PrecompileCacheMap<SpecFor<Evm>>,
     ) -> Self {
+        let post_exec_coordinator = post_exec::PostExecCoordinator::new(&executor);
         Self {
             executor,
+            post_exec_coordinator,
             execution_cache: Default::default(),
             trie_metrics: Default::default(),
             cross_block_cache_size: config.cross_block_cache_size(),
@@ -175,6 +184,14 @@ where
             disable_sparse_trie_cache_pruning: config.disable_sparse_trie_cache_pruning(),
             disable_cache_metrics: config.disable_cache_metrics(),
         }
+    }
+
+    /// Starts a new post-execution receipt-root stream for a block.
+    pub fn begin_post_exec_block(
+        &self,
+        receipts_len: usize,
+    ) -> post_exec::PostExecBlockHandle<N::Receipt> {
+        self.post_exec_coordinator.begin_block(receipts_len)
     }
 }
 

--- a/crates/engine/tree/src/tree/payload_processor/post_exec.rs
+++ b/crates/engine/tree/src/tree/payload_processor/post_exec.rs
@@ -26,6 +26,12 @@ impl<R> core::fmt::Debug for PostExecCoordinator<R> {
     }
 }
 
+impl<R: Receipt + Send + 'static> Default for PostExecCoordinator<R> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<R: Receipt + Send + 'static> PostExecCoordinator<R> {
     /// Create a new coordinator and its worker thread.
     pub fn new() -> Self {

--- a/crates/engine/tree/src/tree/payload_processor/post_exec.rs
+++ b/crates/engine/tree/src/tree/payload_processor/post_exec.rs
@@ -1,0 +1,391 @@
+//! Long-lived post-execution worker for incremental receipt-root computation.
+//!
+//! The worker receives per-block events from execution and maintains block-local
+//! accumulators keyed by block id. This avoids per-block task spawning overhead.
+
+use super::receipt_root_task::IndexedReceipt;
+use alloy_eips::Encodable2718;
+use alloy_primitives::{Bloom, B256};
+use reth_primitives_traits::Receipt;
+use reth_tasks::{LazyHandle, Runtime};
+use reth_trie_common::ordered_root::OrderedTrieRootEncodedBuilder;
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        mpsc::{self, Receiver, Sender},
+    },
+};
+use tokio::sync::oneshot;
+use tracing::{debug, error, warn};
+
+/// Handle to the long-lived post-execution worker.
+pub struct PostExecCoordinator<R> {
+    events_tx: Sender<PostExecEvent<R>>,
+    next_block_id: AtomicU64,
+    _worker_handle: LazyHandle<()>,
+}
+
+impl<R> core::fmt::Debug for PostExecCoordinator<R> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PostExecCoordinator")
+            .field("next_block_id", &self.next_block_id.load(Ordering::Relaxed))
+            .finish()
+    }
+}
+
+impl<R: Receipt + Send + 'static> PostExecCoordinator<R> {
+    /// Create a new worker bound to the given runtime.
+    pub fn new(runtime: &Runtime) -> Self {
+        let (events_tx, events_rx) = mpsc::channel();
+        let worker_handle =
+            runtime.spawn_blocking_named("post-exec", move || PostExecWorker::run(events_rx));
+
+        Self { events_tx, next_block_id: AtomicU64::new(1), _worker_handle: worker_handle }
+    }
+
+    /// Begin receipt-root streaming for a new block.
+    pub fn begin_block(&self, receipts_len: usize) -> PostExecBlockHandle<R> {
+        let block_id = self.next_block_id.fetch_add(1, Ordering::Relaxed);
+        if self.events_tx.send(PostExecEvent::BeginBlock { block_id, receipts_len }).is_err() {
+            error!(
+                target: "engine::tree::payload_processor",
+                block_id,
+                "post-exec worker dropped before BeginBlock event",
+            );
+        }
+
+        PostExecBlockHandle { block_id, events_tx: self.events_tx.clone(), completed: false }
+    }
+}
+
+/// Block-scoped stream handle used by execution to send receipts and finalize.
+pub struct PostExecBlockHandle<R> {
+    block_id: u64,
+    events_tx: Sender<PostExecEvent<R>>,
+    completed: bool,
+}
+
+impl<R> core::fmt::Debug for PostExecBlockHandle<R> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PostExecBlockHandle")
+            .field("block_id", &self.block_id)
+            .field("completed", &self.completed)
+            .finish()
+    }
+}
+
+impl<R: Receipt + Send + 'static> PostExecBlockHandle<R> {
+    /// Stream one receipt to the background worker.
+    pub fn push_receipt(&self, index: usize, receipt: R) {
+        if self
+            .events_tx
+            .send(PostExecEvent::Receipt {
+                block_id: self.block_id,
+                receipt: IndexedReceipt::new(index, receipt),
+            })
+            .is_err()
+        {
+            error!(
+                target: "engine::tree::payload_processor",
+                block_id = self.block_id,
+                index,
+                "post-exec worker dropped before Receipt event",
+            );
+        }
+    }
+
+    /// Finalize this block and return a receiver for the computed root+bloom.
+    pub fn finalize(mut self) -> oneshot::Receiver<(B256, Bloom)> {
+        self.completed = true;
+        let (result_tx, result_rx) = oneshot::channel();
+        if self
+            .events_tx
+            .send(PostExecEvent::FinalizeBlock { block_id: self.block_id, result_tx })
+            .is_err()
+        {
+            error!(
+                target: "engine::tree::payload_processor",
+                block_id = self.block_id,
+                "post-exec worker dropped before FinalizeBlock event",
+            );
+        }
+        result_rx
+    }
+}
+
+impl<R> Drop for PostExecBlockHandle<R> {
+    fn drop(&mut self) {
+        if self.completed {
+            return;
+        }
+
+        let _ = self.events_tx.send(PostExecEvent::AbortBlock { block_id: self.block_id });
+    }
+}
+
+enum PostExecEvent<R> {
+    BeginBlock { block_id: u64, receipts_len: usize },
+    Receipt { block_id: u64, receipt: IndexedReceipt<R> },
+    FinalizeBlock { block_id: u64, result_tx: oneshot::Sender<(B256, Bloom)> },
+    AbortBlock { block_id: u64 },
+}
+
+#[derive(Debug)]
+struct ReceiptAccumulator {
+    builder: OrderedTrieRootEncodedBuilder,
+    aggregated_bloom: Bloom,
+    expected_count: usize,
+    received_count: usize,
+    encode_buf: Vec<u8>,
+}
+
+impl ReceiptAccumulator {
+    fn new(receipts_len: usize) -> Self {
+        Self {
+            builder: OrderedTrieRootEncodedBuilder::new(receipts_len),
+            aggregated_bloom: Bloom::ZERO,
+            expected_count: receipts_len,
+            received_count: 0,
+            encode_buf: Vec::new(),
+        }
+    }
+
+    fn push<R: Receipt>(&mut self, receipt: IndexedReceipt<R>) {
+        let receipt_with_bloom = receipt.receipt.with_bloom_ref();
+        self.encode_buf.clear();
+        receipt_with_bloom.encode_2718(&mut self.encode_buf);
+        self.aggregated_bloom |= *receipt_with_bloom.bloom_ref();
+
+        match self.builder.push(receipt.index, &self.encode_buf) {
+            Ok(()) => {
+                self.received_count += 1;
+            }
+            Err(err) => {
+                error!(
+                    target: "engine::tree::payload_processor",
+                    index = receipt.index,
+                    ?err,
+                    "post-exec worker received invalid receipt index",
+                );
+            }
+        }
+    }
+
+    fn finalize(self) -> Option<(B256, Bloom)> {
+        let Ok(root) = self.builder.finalize() else {
+            error!(
+                target: "engine::tree::payload_processor",
+                expected = self.expected_count,
+                received = self.received_count,
+                "post-exec worker received incomplete receipts",
+            );
+            return None;
+        };
+
+        Some((root, self.aggregated_bloom))
+    }
+}
+
+struct PostExecWorker {
+    inflight: HashMap<u64, ReceiptAccumulator>,
+}
+
+impl PostExecWorker {
+    fn run<R: Receipt>(events_rx: Receiver<PostExecEvent<R>>) {
+        let mut worker = Self { inflight: HashMap::new() };
+        while let Ok(event) = events_rx.recv() {
+            worker.handle_event(event);
+        }
+
+        if !worker.inflight.is_empty() {
+            debug!(
+                target: "engine::tree::payload_processor",
+                inflight = worker.inflight.len(),
+                "post-exec worker shutting down with unfinished blocks",
+            );
+        }
+    }
+
+    fn handle_event<R: Receipt>(&mut self, event: PostExecEvent<R>) {
+        match event {
+            PostExecEvent::BeginBlock { block_id, receipts_len } => {
+                let previous =
+                    self.inflight.insert(block_id, ReceiptAccumulator::new(receipts_len));
+                if previous.is_some() {
+                    warn!(
+                        target: "engine::tree::payload_processor",
+                        block_id,
+                        "post-exec worker replaced existing inflight block state",
+                    );
+                }
+            }
+            PostExecEvent::Receipt { block_id, receipt } => {
+                let Some(accumulator) = self.inflight.get_mut(&block_id) else {
+                    warn!(
+                        target: "engine::tree::payload_processor",
+                        block_id,
+                        "post-exec worker received receipt for unknown block",
+                    );
+                    return;
+                };
+                accumulator.push(receipt);
+            }
+            PostExecEvent::FinalizeBlock { block_id, result_tx } => {
+                let Some(accumulator) = self.inflight.remove(&block_id) else {
+                    warn!(
+                        target: "engine::tree::payload_processor",
+                        block_id,
+                        "post-exec worker finalized unknown block",
+                    );
+                    return;
+                };
+
+                if let Some(result) = accumulator.finalize() {
+                    let _ = result_tx.send(result);
+                }
+            }
+            PostExecEvent::AbortBlock { block_id } => {
+                self.inflight.remove(&block_id);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::{proofs::calculate_receipt_root, TxReceipt};
+    use alloy_primitives::{Address, Bytes, Log, B256};
+    use reth_ethereum_primitives::{Receipt, TxType};
+    use reth_tasks::Runtime;
+
+    fn sample_receipts() -> Vec<Receipt> {
+        vec![
+            Receipt {
+                tx_type: TxType::Legacy,
+                cumulative_gas_used: 21_000,
+                success: true,
+                logs: vec![],
+            },
+            Receipt {
+                tx_type: TxType::Eip1559,
+                cumulative_gas_used: 42_000,
+                success: true,
+                logs: vec![Log {
+                    address: Address::ZERO,
+                    data: alloy_primitives::LogData::new_unchecked(vec![B256::ZERO], Bytes::new()),
+                }],
+            },
+            Receipt {
+                tx_type: TxType::Eip2930,
+                cumulative_gas_used: 63_000,
+                success: false,
+                logs: vec![],
+            },
+        ]
+    }
+
+    fn expected_root_bloom(receipts: &[Receipt]) -> (B256, Bloom) {
+        let receipts_with_bloom: Vec<_> = receipts.iter().map(|r| r.with_bloom_ref()).collect();
+        let root = calculate_receipt_root(&receipts_with_bloom);
+        let bloom =
+            receipts_with_bloom.iter().fold(Bloom::ZERO, |acc, receipt| acc | *receipt.bloom_ref());
+        (root, bloom)
+    }
+
+    #[tokio::test]
+    async fn post_exec_worker_computes_receipt_root_and_bloom() {
+        let runtime = Runtime::test();
+        let coordinator = PostExecCoordinator::<Receipt>::new(&runtime);
+
+        let receipts = sample_receipts();
+        let (expected_root, expected_bloom) = expected_root_bloom(&receipts);
+
+        let handle = coordinator.begin_block(receipts.len());
+        for (index, receipt) in receipts.into_iter().enumerate() {
+            handle.push_receipt(index, receipt);
+        }
+
+        let (root, bloom) = handle.finalize().await.unwrap();
+        assert_eq!(root, expected_root);
+        assert_eq!(bloom, expected_bloom);
+    }
+
+    #[tokio::test]
+    async fn post_exec_worker_handles_out_of_order_receipts() {
+        let runtime = Runtime::test();
+        let coordinator = PostExecCoordinator::<Receipt>::new(&runtime);
+
+        let receipts = sample_receipts();
+        let (expected_root, expected_bloom) = expected_root_bloom(&receipts);
+
+        let handle = coordinator.begin_block(receipts.len());
+        for (index, receipt) in receipts.into_iter().enumerate().rev() {
+            handle.push_receipt(index, receipt);
+        }
+
+        let (root, bloom) = handle.finalize().await.unwrap();
+        assert_eq!(root, expected_root);
+        assert_eq!(bloom, expected_bloom);
+    }
+
+    #[tokio::test]
+    async fn post_exec_worker_drops_duplicate_index_blocks() {
+        let runtime = Runtime::test();
+        let coordinator = PostExecCoordinator::<Receipt>::new(&runtime);
+
+        let mut receipts = sample_receipts();
+        let first = receipts.remove(0);
+        let second = receipts.remove(0);
+
+        let handle = coordinator.begin_block(2);
+        handle.push_receipt(0, first.clone());
+        handle.push_receipt(0, second);
+
+        assert!(handle.finalize().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn post_exec_worker_supports_multiple_inflight_blocks() {
+        let runtime = Runtime::test();
+        let coordinator = PostExecCoordinator::<Receipt>::new(&runtime);
+
+        let receipts_a = sample_receipts();
+        let (expected_root_a, expected_bloom_a) = expected_root_bloom(&receipts_a);
+
+        let receipts_b = vec![Receipt::default(); 2];
+        let (expected_root_b, expected_bloom_b) = expected_root_bloom(&receipts_b);
+
+        let handle_a = coordinator.begin_block(receipts_a.len());
+        let handle_b = coordinator.begin_block(receipts_b.len());
+
+        handle_a.push_receipt(0, receipts_a[0].clone());
+        handle_b.push_receipt(0, receipts_b[0].clone());
+        handle_a.push_receipt(1, receipts_a[1].clone());
+        handle_b.push_receipt(1, receipts_b[1].clone());
+        handle_a.push_receipt(2, receipts_a[2].clone());
+
+        let (root_b, bloom_b) = handle_b.finalize().await.unwrap();
+        let (root_a, bloom_a) = handle_a.finalize().await.unwrap();
+
+        assert_eq!(root_a, expected_root_a);
+        assert_eq!(bloom_a, expected_bloom_a);
+        assert_eq!(root_b, expected_root_b);
+        assert_eq!(bloom_b, expected_bloom_b);
+    }
+
+    #[tokio::test]
+    async fn post_exec_worker_aborts_incomplete_blocks() {
+        let runtime = Runtime::test();
+        let coordinator = PostExecCoordinator::<Receipt>::new(&runtime);
+
+        let handle = coordinator.begin_block(2);
+        handle.push_receipt(0, Receipt::default());
+        drop(handle);
+
+        let second = coordinator.begin_block(1);
+        second.push_receipt(0, Receipt::default());
+        assert!(second.finalize().await.is_ok());
+    }
+}

--- a/crates/engine/tree/src/tree/payload_processor/post_exec.rs
+++ b/crates/engine/tree/src/tree/payload_processor/post_exec.rs
@@ -7,17 +7,17 @@ use super::receipt_root_task::{IndexedReceipt, ReceiptRootTaskHandle};
 use alloy_primitives::{Bloom, B256};
 use crossbeam_channel::{self, Receiver as CrossbeamReceiver, Sender as CrossbeamSender};
 use reth_primitives_traits::Receipt;
-use std::{
-    sync::mpsc::{self, Receiver, Sender},
-    thread::JoinHandle,
-};
+use std::sync::mpsc::{self, Receiver, Sender};
 use tokio::sync::oneshot;
 use tracing::error;
 
 /// Handle to the long-lived post-execution worker.
+///
+/// Dropping the coordinator disconnects the command channel, causing the worker thread to exit
+/// after finishing any in-progress block. The thread is detached on drop rather than joined to
+/// avoid blocking if the worker is waiting on an open receipt stream.
 pub struct PostExecCoordinator<R> {
     commands_tx: Sender<WorkerCommand<R>>,
-    worker: Option<JoinHandle<()>>,
 }
 
 impl<R> core::fmt::Debug for PostExecCoordinator<R> {
@@ -26,22 +26,24 @@ impl<R> core::fmt::Debug for PostExecCoordinator<R> {
     }
 }
 
-impl<R: Receipt + Send + 'static> Default for PostExecCoordinator<R> {
+impl<R: Receipt + 'static> Default for PostExecCoordinator<R> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<R: Receipt + Send + 'static> PostExecCoordinator<R> {
-    /// Create a new coordinator and its worker thread.
+impl<R: Receipt + 'static> PostExecCoordinator<R> {
+    /// Create a new coordinator and spawn its worker thread.
     pub fn new() -> Self {
         let (commands_tx, commands_rx) = mpsc::channel();
-        let worker = std::thread::Builder::new()
+        // Worker thread is detached: it exits when `commands_tx` is dropped (coordinator drop)
+        // and any in-progress block finishes.
+        std::thread::Builder::new()
             .name("post-exec".to_string())
             .spawn(move || PostExecWorker::run(commands_rx))
             .expect("failed to spawn post-exec worker");
 
-        Self { commands_tx, worker: Some(worker) }
+        Self { commands_tx }
     }
 
     /// Begin receipt-root streaming for a new block.
@@ -63,16 +65,10 @@ impl<R: Receipt + Send + 'static> PostExecCoordinator<R> {
     }
 }
 
-impl<R> Drop for PostExecCoordinator<R> {
-    fn drop(&mut self) {
-        let _ = self.commands_tx.send(WorkerCommand::Shutdown);
-        if let Some(worker) = self.worker.take() {
-            let _ = worker.join();
-        }
-    }
-}
-
 /// Block-scoped stream handle used by execution to send receipts and finalize.
+///
+/// The caller **must** either call [`finalize`](Self::finalize) or drop this handle to close
+/// the receipt stream and unblock the worker for the next block.
 pub struct PostExecBlockHandle<R> {
     receipt_tx: Option<CrossbeamSender<IndexedReceipt<R>>>,
     result_rx: Option<oneshot::Receiver<(B256, Bloom)>>,
@@ -84,7 +80,7 @@ impl<R> core::fmt::Debug for PostExecBlockHandle<R> {
     }
 }
 
-impl<R: Receipt + Send + 'static> PostExecBlockHandle<R> {
+impl<R: Receipt + 'static> PostExecBlockHandle<R> {
     /// Stream one receipt to the background worker.
     pub fn push_receipt(&self, index: usize, receipt: R) {
         if self
@@ -114,20 +110,16 @@ enum WorkerCommand<R> {
         receipt_rx: CrossbeamReceiver<IndexedReceipt<R>>,
         result_tx: oneshot::Sender<(B256, Bloom)>,
     },
-    Shutdown,
 }
 
 struct PostExecWorker;
 
 impl PostExecWorker {
     fn run<R: Receipt>(commands_rx: Receiver<WorkerCommand<R>>) {
-        while let Ok(command) = commands_rx.recv() {
-            match command {
-                WorkerCommand::RunBlock { receipts_len, receipt_rx, result_tx } => {
-                    ReceiptRootTaskHandle::new(receipt_rx, result_tx).run(receipts_len);
-                }
-                WorkerCommand::Shutdown => break,
-            }
+        while let Ok(WorkerCommand::RunBlock { receipts_len, receipt_rx, result_tx }) =
+            commands_rx.recv()
+        {
+            ReceiptRootTaskHandle::new(receipt_rx, result_tx).run(receipts_len);
         }
     }
 }
@@ -216,7 +208,7 @@ mod tests {
         let second = receipts.remove(0);
 
         let handle = coordinator.begin_block(2);
-        handle.push_receipt(0, first.clone());
+        handle.push_receipt(0, first);
         handle.push_receipt(0, second);
 
         assert!(handle.finalize().await.is_err());


### PR DESCRIPTION
**Summary**
Payload validation currently spawns a dedicated receipt-root background task per block. This change keeps a single long-lived post-exec worker per payload processor and feeds each block's receipt stream into that worker, so we avoid per-block task lifecycle overhead while preserving the same incremental root+bloom computation semantics.

**Changes**
- Add a minimal `post_exec` coordinator that runs one worker thread and reuses `ReceiptRootTaskHandle` for each queued block.
- Wire `PayloadProcessor` to own this coordinator and expose `begin_post_exec_block`.
- Replace per-block `receipt-root` task spawn in `payload_validator::execute_block` with coordinator begin/push/finalize.
- Keep trie-input and sparse-trie state-root paths unchanged.
- Add focused unit tests for root+bloom correctness, out-of-order receipts, duplicate index failure, queued blocks, incomplete-block abort, and shutdown behavior.

**Expected Impact**
Reduces receipt-root task lifecycle churn while keeping validation behavior equivalent (including fallback when receipt root is unavailable).

**Notes**
Validated with:
- `cargo check -p reth-engine-tree`
- `cargo test -p reth-engine-tree post_exec_worker -- --nocapture`
