### PR TITLE
ci(bench): add samply profiling support

### DIFF
--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -62,8 +62,9 @@ RETH_ARGS=(
 )
 
 if [ "${BENCH_SAMPLY:-false}" = "true" ]; then
+  SAMPLY="$(which samply)"
   sudo taskset -c "$RETH_CPUS" nice -n -20 \
-    samply record --save-only --presymbolicate \
+    "$SAMPLY" record --save-only --presymbolicate \
     --output "$OUTPUT_DIR/samply-profile.json.gz" \
     -- "$BINARY" "${RETH_ARGS[@]}" \
     > "$LOG" 2>&1 &

--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -19,20 +19,21 @@ cleanup() {
   kill "$TAIL_PID" 2>/dev/null || true
   if [ -n "${RETH_PID:-}" ] && sudo kill -0 "$RETH_PID" 2>/dev/null; then
     if [ "${BENCH_SAMPLY:-false}" = "true" ]; then
-      # Send SIGINT to the inner reth process (not samply) so samply can
-      # capture the exit and save the profile
-      sudo pkill -INT -f "reth.*node" 2>/dev/null || true
+      # Send SIGINT to the inner reth process by exact name (not -f which
+      # would also match samply's cmdline containing "reth"). Samply will
+      # capture reth's exit and save the profile.
+      sudo pkill -INT -x reth 2>/dev/null || true
       # Wait for samply to finish writing the profile and exit
       for i in $(seq 1 120); do
-        sudo pgrep -f samply > /dev/null 2>&1 || break
+        sudo pgrep -x samply > /dev/null 2>&1 || break
         if [ $((i % 10)) -eq 0 ]; then
           echo "Waiting for samply to finish writing profile... (${i}s)"
         fi
         sleep 1
       done
-      if sudo pgrep -f samply > /dev/null 2>&1; then
+      if sudo pgrep -x samply > /dev/null 2>&1; then
         echo "Samply still running after 120s, sending SIGTERM..."
-        sudo pkill -f samply 2>/dev/null || true
+        sudo pkill -x samply 2>/dev/null || true
       fi
     else
       sudo kill "$RETH_PID"

--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -19,15 +19,6 @@ cleanup() {
   kill "$TAIL_PID" 2>/dev/null || true
   if [ -n "${RETH_PID:-}" ] && sudo kill -0 "$RETH_PID" 2>/dev/null; then
     if [ "${BENCH_SAMPLY:-false}" = "true" ]; then
-      # Debug: show the process tree so we can see what's running
-      echo "=== Process tree before cleanup ==="
-      ps auxf | grep -E "samply|reth|taskset|nice" | grep -v grep || true
-      echo "=== pgrep results ==="
-      echo "pgrep -x reth: $(sudo pgrep -x reth 2>&1 || echo 'no match')"
-      echo "pgrep -x samply: $(sudo pgrep -x samply 2>&1 || echo 'no match')"
-      echo "pgrep -f samply: $(sudo pgrep -f samply 2>&1 || echo 'no match')"
-      echo "RETH_PID=$RETH_PID"
-      echo "==="
       # Send SIGINT to the inner reth process by exact name (not -f which
       # would also match samply's cmdline containing "reth"). Samply will
       # capture reth's exit and save the profile.
@@ -37,7 +28,6 @@ cleanup() {
         sudo pgrep -x samply > /dev/null 2>&1 || break
         if [ $((i % 10)) -eq 0 ]; then
           echo "Waiting for samply to finish writing profile... (${i}s)"
-          ps auxf | grep -E "samply|reth" | grep -v grep || true
         fi
         sleep 1
       done

--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -19,6 +19,15 @@ cleanup() {
   kill "$TAIL_PID" 2>/dev/null || true
   if [ -n "${RETH_PID:-}" ] && sudo kill -0 "$RETH_PID" 2>/dev/null; then
     if [ "${BENCH_SAMPLY:-false}" = "true" ]; then
+      # Debug: show the process tree so we can see what's running
+      echo "=== Process tree before cleanup ==="
+      ps auxf | grep -E "samply|reth|taskset|nice" | grep -v grep || true
+      echo "=== pgrep results ==="
+      echo "pgrep -x reth: $(sudo pgrep -x reth 2>&1 || echo 'no match')"
+      echo "pgrep -x samply: $(sudo pgrep -x samply 2>&1 || echo 'no match')"
+      echo "pgrep -f samply: $(sudo pgrep -f samply 2>&1 || echo 'no match')"
+      echo "RETH_PID=$RETH_PID"
+      echo "==="
       # Send SIGINT to the inner reth process by exact name (not -f which
       # would also match samply's cmdline containing "reth"). Samply will
       # capture reth's exit and save the profile.
@@ -28,6 +37,7 @@ cleanup() {
         sudo pgrep -x samply > /dev/null 2>&1 || break
         if [ $((i % 10)) -eq 0 ]; then
           echo "Waiting for samply to finish writing profile... (${i}s)"
+          ps auxf | grep -E "samply|reth" | grep -v grep || true
         fi
         sleep 1
       done

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -196,12 +196,6 @@ jobs:
                   } else {
                     defaults[key] = value;
                   }
-                } else if (boolArgs.has(key)) {
-                  if (value !== 'true' && value !== 'false') {
-                    invalid.push(`\`${key}=${value}\` (must be \`true\` or \`false\`)`);
-                  } else {
-                    defaults[key] = value;
-                  }
                 } else {
                   unknown.push(key);
                 }

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -677,38 +677,46 @@ jobs:
 
       - name: Upload samply profiles
         if: success() && env.BENCH_SAMPLY == 'true'
-        env:
-          BASELINE_REF: ${{ steps.refs.outputs.baseline-ref }}
-          FEATURE_REF: ${{ steps.refs.outputs.feature-ref }}
         run: |
-          MC="mc --config-dir /home/ubuntu/.mc"
-          TIMESTAMP=$(date +%Y%m%d-%H%M%S)
-          BASELINE_SHORT=$(echo "$BASELINE_REF" | cut -c1-8)
-          FEATURE_SHORT=$(echo "$FEATURE_REF" | cut -c1-8)
+          PROFILER_API="https://api.profiler.firefox.com"
+          PROFILER_ACCEPT="Accept: application/vnd.firefox-profiler+json;version=1.0"
 
           for run_dir in baseline-1 baseline-2 feature-1 feature-2; do
             PROFILE="$BENCH_WORK_DIR/$run_dir/samply-profile.json.gz"
             if [ ! -f "$PROFILE" ]; then continue; fi
 
-            case "$run_dir" in
-              baseline-*) SHORT="$BASELINE_SHORT" ;;
-              feature-*)  SHORT="$FEATURE_SHORT" ;;
-            esac
-
-            FILENAME="${run_dir}-${SHORT}-${TIMESTAMP}.json.gz"
-            MINIO_PATH="minio/samply-profiles/$FILENAME"
             PROFILE_SIZE=$(du -h "$PROFILE" | cut -f1)
-            echo "Uploading $run_dir samply profile (${PROFILE_SIZE})..."
-            $MC cp "$PROFILE" "$MINIO_PATH"
+            echo "Uploading $run_dir samply profile (${PROFILE_SIZE}) to Firefox Profiler..."
 
-            SHARE_OUTPUT=$($MC share download --expire 168h "$MINIO_PATH" 2>&1 || true)
-            URL=$(echo "$SHARE_OUTPUT" | grep '^Share:' | sed 's/^Share: //' | tr -d '[:space:]')
-            if [ -n "$URL" ]; then
-              echo "$URL" > "$BENCH_WORK_DIR/$run_dir/samply-profile-url.txt"
-              echo "Presigned URL for $run_dir (expires in 7 days): $URL"
-            else
-              echo "::warning::Failed to generate presigned URL for $run_dir"
-            fi
+            # Upload compressed profile and get JWT back
+            JWT=$(curl -sf -X POST \
+              -H "Content-Type: application/octet-stream" \
+              -H "$PROFILER_ACCEPT" \
+              --data-binary "@$PROFILE" \
+              "$PROFILER_API/compressed-store") || {
+              echo "::warning::Failed to upload $run_dir profile to Firefox Profiler"
+              continue
+            }
+
+            # Extract profileToken from JWT payload (header.payload.signature)
+            PAYLOAD=$(echo "$JWT" | cut -d. -f2)
+            # Fix base64 padding
+            case $(( ${#PAYLOAD} % 4 )) in
+              2) PAYLOAD="${PAYLOAD}==" ;;
+              3) PAYLOAD="${PAYLOAD}=" ;;
+            esac
+            PROFILE_TOKEN=$(echo "$PAYLOAD" | base64 -d 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin)['profileToken'])")
+            PROFILE_URL="https://profiler.firefox.com/public/${PROFILE_TOKEN}"
+            echo "Profile uploaded: $PROFILE_URL"
+
+            # Shorten the URL
+            SHORT_URL=$(curl -sf -X POST \
+              -H "Content-Type: application/json" \
+              -H "$PROFILER_ACCEPT" \
+              -d "{\"longUrl\":\"$PROFILE_URL\"}" \
+              "$PROFILER_API/shorten" | python3 -c "import sys,json; print(json.load(sys.stdin)['shortUrl'])" 2>/dev/null) || SHORT_URL="$PROFILE_URL"
+            echo "$SHORT_URL" > "$BENCH_WORK_DIR/$run_dir/samply-profile-url.txt"
+            echo "Short profile URL for $run_dir: $SHORT_URL"
           done
 
       # Results & charts
@@ -826,17 +834,15 @@ jobs:
               comment += chartMarkdown;
             }
 
-            // Samply profile links
+            // Samply profile links (URLs point directly to Firefox Profiler)
             if (process.env.BENCH_SAMPLY === 'true') {
-              const profilerBase = 'https://profiler.firefox.com/from-url/';
               const runs = ['baseline-1', 'feature-1', 'feature-2', 'baseline-2'];
               const links = [];
               for (const run of runs) {
                 try {
                   const url = fs.readFileSync(`${process.env.BENCH_WORK_DIR}/${run}/samply-profile-url.txt`, 'utf8').trim();
                   if (url) {
-                    const profilerUrl = profilerBase + encodeURIComponent(url);
-                    links.push(`- **${run}**: [Firefox Profiler](${profilerUrl}) · [Download](${url})`);
+                    links.push(`- **${run}**: [Firefox Profiler](${url})`);
                   }
                 } catch (e) {}
               }

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -35,6 +35,11 @@ on:
         required: false
         default: ""
         type: string
+      samply:
+        description: "Enable samply profiling"
+        required: false
+        default: "false"
+        type: boolean
 
 env:
   CARGO_TERM_COLOR: always
@@ -104,6 +109,7 @@ jobs:
       feature: ${{ steps.args.outputs.feature }}
       baseline-name: ${{ steps.args.outputs.baseline-name }}
       feature-name: ${{ steps.args.outputs.feature-name }}
+      samply: ${{ steps.args.outputs.samply }}
       comment-id: ${{ steps.ack.outputs.comment-id }}
     steps:
       - name: Check org membership
@@ -131,7 +137,7 @@ jobs:
         with:
           github-token: ${{ secrets.DEREK_PAT }}
           script: |
-            let pr, actor, blocks, warmup, baseline, feature;
+            let pr, actor, blocks, warmup, baseline, feature, samply;
 
             if (context.eventName === 'workflow_dispatch') {
               actor = '${{ github.actor }}';
@@ -139,6 +145,7 @@ jobs:
               warmup = '${{ github.event.inputs.warmup }}' || '100';
               baseline = '${{ github.event.inputs.baseline }}';
               feature = '${{ github.event.inputs.feature }}';
+              samply = '${{ github.event.inputs.samply }}' === 'true' ? 'true' : 'false';
 
               // Find PR for the selected branch
               const branch = '${{ github.ref_name }}';
@@ -160,7 +167,8 @@ jobs:
               const body = context.payload.comment.body.trim();
               const intArgs = new Set(['blocks', 'warmup']);
               const refArgs = new Set(['baseline', 'feature']);
-              const defaults = { blocks: '500', warmup: '100', baseline: '', feature: '' };
+              const boolArgs = new Set(['samply']);
+              const defaults = { blocks: '500', warmup: '100', baseline: '', feature: '', samply: 'false' };
               const unknown = [];
               const invalid = [];
               const args = body.replace(/^(?:@decofe|derek) bench\s*/, '');
@@ -184,6 +192,12 @@ jobs:
                   } else {
                     defaults[key] = value;
                   }
+                } else if (boolArgs.has(key)) {
+                  if (value !== 'true' && value !== 'false') {
+                    invalid.push(`\`${key}=${value}\` (must be \`true\` or \`false\`)`);
+                  } else {
+                    defaults[key] = value;
+                  }
                 } else {
                   unknown.push(key);
                 }
@@ -192,7 +206,7 @@ jobs:
               if (unknown.length) errors.push(`Unknown argument(s): \`${unknown.join('`, `')}\``);
               if (invalid.length) errors.push(`Invalid value(s): ${invalid.join(', ')}`);
               if (errors.length) {
-                const msg = `❌ **Invalid bench command**\n\n${errors.join('\n')}\n\n**Usage:** \`@decofe bench [blocks=N] [warmup=N] [baseline=REF] [feature=REF]\``;
+                const msg = `❌ **Invalid bench command**\n\n${errors.join('\n')}\n\n**Usage:** \`@decofe bench [blocks=N] [warmup=N] [baseline=REF] [feature=REF] [samply]\``;
                 await github.rest.issues.createComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
@@ -206,6 +220,7 @@ jobs:
               warmup = defaults.warmup;
               baseline = defaults.baseline;
               feature = defaults.feature;
+              samply = defaults.samply;
             }
 
             // Resolve display names for baseline/feature
@@ -232,6 +247,7 @@ jobs:
             core.setOutput('feature', feature);
             core.setOutput('baseline-name', baselineName);
             core.setOutput('feature-name', featureName);
+            core.setOutput('samply', samply);
 
       - name: Acknowledge request
         id: ack
@@ -287,7 +303,9 @@ jobs:
             const warmup = '${{ steps.args.outputs.warmup }}';
             const baseline = '${{ steps.args.outputs.baseline-name }}';
             const feature = '${{ steps.args.outputs.feature-name }}';
-            const config = `**Config:** ${blocks} blocks, ${warmup} warmup blocks, baseline: \`${baseline}\`, feature: \`${feature}\``;
+            const samply = '${{ steps.args.outputs.samply }}' === 'true';
+            const samplyNote = samply ? ', samply: `enabled`' : '';
+            const config = `**Config:** ${blocks} blocks, ${warmup} warmup blocks, baseline: \`${baseline}\`, feature: \`${feature}\`${samplyNote}`;
 
             const { data: comment } = await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -311,7 +329,9 @@ jobs:
             const warmup = '${{ steps.args.outputs.warmup }}';
             const baseline = '${{ steps.args.outputs.baseline-name }}';
             const feature = '${{ steps.args.outputs.feature-name }}';
-            const config = `**Config:** ${blocks} blocks, ${warmup} warmup blocks, baseline: \`${baseline}\`, feature: \`${feature}\``;
+            const samply = '${{ steps.args.outputs.samply }}' === 'true';
+            const samplyNote = samply ? ', samply: `enabled`' : '';
+            const config = `**Config:** ${blocks} blocks, ${warmup} warmup blocks, baseline: \`${baseline}\`, feature: \`${feature}\`${samplyNote}`;
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
             async function getQueuePosition() {
@@ -374,6 +394,7 @@ jobs:
       BENCH_ACTOR: ${{ needs.reth-bench-ack.outputs.actor }}
       BENCH_BLOCKS: ${{ needs.reth-bench-ack.outputs.blocks }}
       BENCH_WARMUP_BLOCKS: ${{ needs.reth-bench-ack.outputs.warmup }}
+      BENCH_SAMPLY: ${{ needs.reth-bench-ack.outputs.samply }}
       BENCH_COMMENT_ID: ${{ needs.reth-bench-ack.outputs.comment-id }}
     steps:
       - name: Resolve checkout ref
@@ -423,7 +444,9 @@ jobs:
             const warmup = process.env.BENCH_WARMUP_BLOCKS;
             const baseline = '${{ needs.reth-bench-ack.outputs.baseline-name }}';
             const feature = '${{ needs.reth-bench-ack.outputs.feature-name }}';
-            core.exportVariable('BENCH_CONFIG', `**Config:** ${blocks} blocks, ${warmup} warmup blocks, baseline: \`${baseline}\`, feature: \`${feature}\``);
+            const samply = process.env.BENCH_SAMPLY === 'true';
+            const samplyNote = samply ? ', samply: `enabled`' : '';
+            core.exportVariable('BENCH_CONFIG', `**Config:** ${blocks} blocks, ${warmup} warmup blocks, baseline: \`${baseline}\`, feature: \`${feature}\`${samplyNote}`);
 
             const { buildBody } = require('./.github/scripts/bench-update-status.js');
             await github.rest.issues.updateComment({
@@ -452,6 +475,13 @@ jobs:
             exit 1
           fi
           echo "All dependencies found"
+
+      - name: Install samply
+        if: env.BENCH_SAMPLY == 'true'
+        run: |
+          if ! command -v samply &>/dev/null; then
+            cargo install samply --git https://github.com/DaniPopes/samply --branch edge --locked
+          fi
 
       # Build binaries
       - name: Resolve PR head branch

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -675,6 +675,42 @@ jobs:
         id: run-baseline-2
         run: taskset -c 0 .github/scripts/bench-reth-run.sh baseline ../reth-baseline/target/profiling/reth "$BENCH_WORK_DIR/baseline-2"
 
+      - name: Upload samply profiles
+        if: success() && env.BENCH_SAMPLY == 'true'
+        env:
+          BASELINE_REF: ${{ steps.refs.outputs.baseline-ref }}
+          FEATURE_REF: ${{ steps.refs.outputs.feature-ref }}
+        run: |
+          MC="mc --config-dir /home/ubuntu/.mc"
+          TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+          BASELINE_SHORT=$(echo "$BASELINE_REF" | cut -c1-8)
+          FEATURE_SHORT=$(echo "$FEATURE_REF" | cut -c1-8)
+
+          for run_dir in baseline-1 baseline-2 feature-1 feature-2; do
+            PROFILE="$BENCH_WORK_DIR/$run_dir/samply-profile.json.gz"
+            if [ ! -f "$PROFILE" ]; then continue; fi
+
+            case "$run_dir" in
+              baseline-*) SHORT="$BASELINE_SHORT" ;;
+              feature-*)  SHORT="$FEATURE_SHORT" ;;
+            esac
+
+            FILENAME="${run_dir}-${SHORT}-${TIMESTAMP}.json.gz"
+            MINIO_PATH="minio/samply-profiles/$FILENAME"
+            PROFILE_SIZE=$(du -h "$PROFILE" | cut -f1)
+            echo "Uploading $run_dir samply profile (${PROFILE_SIZE})..."
+            $MC cp "$PROFILE" "$MINIO_PATH"
+
+            SHARE_OUTPUT=$($MC share download --expire 168h "$MINIO_PATH" 2>&1 || true)
+            URL=$(echo "$SHARE_OUTPUT" | grep '^Share:' | sed 's/^Share: //' | tr -d '[:space:]')
+            if [ -n "$URL" ]; then
+              echo "$URL" > "$BENCH_WORK_DIR/$run_dir/samply-profile-url.txt"
+              echo "Presigned URL for $run_dir (expires in 7 days): $URL"
+            else
+              echo "::warning::Failed to generate presigned URL for $run_dir"
+            fi
+          done
+
       # Results & charts
       - name: Parse results
         id: results
@@ -788,6 +824,25 @@ jobs:
                 chartMarkdown += `</details>\n\n`;
               }
               comment += chartMarkdown;
+            }
+
+            // Samply profile links
+            if (process.env.BENCH_SAMPLY === 'true') {
+              const profilerBase = 'https://profiler.firefox.com/from-url/';
+              const runs = ['baseline-1', 'feature-1', 'feature-2', 'baseline-2'];
+              const links = [];
+              for (const run of runs) {
+                try {
+                  const url = fs.readFileSync(`${process.env.BENCH_WORK_DIR}/${run}/samply-profile-url.txt`, 'utf8').trim();
+                  if (url) {
+                    const profilerUrl = profilerBase + encodeURIComponent(url);
+                    links.push(`- **${run}**: [Firefox Profiler](${profilerUrl}) · [Download](${url})`);
+                  }
+                } catch (e) {}
+              }
+              if (links.length > 0) {
+                comment += `\n\n### Samply Profiles\n\n${links.join('\n')}\n`;
+              }
             }
 
             const jobUrl = process.env.BENCH_JOB_URL || `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -175,7 +175,11 @@ jobs:
               for (const part of args.split(/\s+/).filter(Boolean)) {
                 const eq = part.indexOf('=');
                 if (eq === -1) {
-                  unknown.push(part);
+                  if (boolArgs.has(part)) {
+                    defaults[part] = 'true';
+                  } else {
+                    unknown.push(part);
+                  }
                   continue;
                 }
                 const key = part.slice(0, eq);


### PR DESCRIPTION
## Summary

Add opt-in samply CPU profiling to the reth-bench workflow. Developers can enable profiling via `derek bench samply=true` comment or workflow_dispatch input to capture CPU profiles during benchmark runs.

## Changes

- Extract reth node arguments into array to support conditional wrapping with samply
- Add `samply` boolean parameter to workflow_dispatch and derek bench comment parser
- Conditionally install samply from `DaniPopes/samply` edge branch when profiling is enabled
- Wrap reth launch with `samply record --save-only --presymbolicate` when `BENCH_SAMPLY=true`
- Update PR comments to display samply status in the config line
- Profiles saved as compressed JSON files alongside benchmark results

All four ABBA benchmark runs are individually profiled for comprehensive data collection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)