### PR TITLE
fix(transaction-pool): clean up closed blob sidecar listeners on add

### DIFF
--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -290,7 +290,9 @@ where
     pub fn add_blob_sidecar_listener(&self) -> mpsc::Receiver<NewBlobSidecar> {
         let (sender, rx) = mpsc::channel(BLOB_SIDECAR_LISTENER_BUFFER_SIZE);
         let listener = BlobTransactionSidecarListener { sender };
-        self.blob_transaction_sidecar_listener.lock().push(listener);
+        let mut listeners = self.blob_transaction_sidecar_listener.lock();
+        listeners.retain(|l| !l.sender.is_closed());
+        listeners.push(listener);
         rx
     }
 


### PR DESCRIPTION
Previously, `add_blob_sidecar_listener` did not clean up closed channel senders before adding new listeners, unlike `add_pending_listener` and `add_new_transaction_listener`. This caused closed blob listeners to accumulate in memory indefinitely if no new blob transactions were added after a receiver was dropped.

Added `listeners.retain(|l| !l.sender.is_closed())` before pushing new blob sidecar listeners, matching the existing pattern for other listener types.