### PR TITLE
feat(net/tx): deterministic peer selection for full tx broadcasts

### DIFF
--- a/crates/net/network/src/transactions/config.rs
+++ b/crates/net/network/src/transactions/config.rs
@@ -52,20 +52,10 @@ pub enum TransactionPropagationMode {
     Sqrt,
     /// Always send transactions in full.
     All,
-    /// Send full transactions to a maximum number of peers
+    /// Send full transactions to a maximum number of peers.
     Max(usize),
 }
 
-impl TransactionPropagationMode {
-    /// Returns the number of peers full transactions should be propagated to.
-    pub(crate) fn full_peer_count(&self, peer_count: usize) -> usize {
-        match self {
-            Self::Sqrt => (peer_count as f64).sqrt().round() as usize,
-            Self::All => peer_count,
-            Self::Max(max) => peer_count.min(*max),
-        }
-    }
-}
 impl FromStr for TransactionPropagationMode {
     type Err = String;
 

--- a/crates/net/network/src/transactions/config.rs
+++ b/crates/net/network/src/transactions/config.rs
@@ -56,6 +56,17 @@ pub enum TransactionPropagationMode {
     Max(usize),
 }
 
+impl TransactionPropagationMode {
+    /// Returns the number of peers full transactions should be propagated to.
+    pub(crate) fn full_peer_count(&self, peer_count: usize) -> usize {
+        match self {
+            Self::Sqrt => (peer_count as f64).sqrt().ceil() as usize,
+            Self::All => peer_count,
+            Self::Max(max) => peer_count.min(*max),
+        }
+    }
+}
+
 impl FromStr for TransactionPropagationMode {
     type Err = String;
 

--- a/crates/net/network/src/transactions/constants.rs
+++ b/crates/net/network/src/transactions/constants.rs
@@ -14,6 +14,11 @@ pub const SOFT_LIMIT_COUNT_HASHES_IN_NEW_POOLED_TRANSACTIONS_BROADCAST_MESSAGE: 
 /// Default is 128 KiB.
 pub const DEFAULT_SOFT_LIMIT_BYTE_SIZE_TRANSACTIONS_BROADCAST_MESSAGE: usize = 128 * 1024;
 
+/// Maximum size of a single transaction that will be broadcast in full.
+/// Transactions larger than this are only announced as hashes and must be
+/// fetched by interested peers.
+pub const DEFAULT_MAX_FULL_BROADCAST_TX_SIZE: usize = 4096;
+
 /* ================ REQUEST-RESPONSE ================ */
 
 /// Recommended soft limit for the number of hashes in a


### PR DESCRIPTION
Replaces the random-index-based peer selection for full transaction broadcasts with SipHash-scored deterministic selection via `BroadcastChoice`. Also introduces `TxPeerTracking` for originator-only penalization on bad imports.

Split out from #22247 to keep the fetcher rewrite and propagation improvements reviewable independently.

## BroadcastChoice

Previously, the first `sqrt(N)` peers in iteration order received full transactions and the rest received hashes (via `TransactionPropagationMode::full_peer_count`). This was non-deterministic across poll cycles.

Now, for each transaction sender, `ceil(sqrt(N))` peers are chosen by hashing `(local_id, peer_id, tx_sender)` using SipHash:

- **Per-sender determinism:** All transactions from the same sender are routed to the same peer subset, reducing network-wide duplicate full-body sends and avoiding nonce gaps at receiving peers.
- **Per-node variation:** Different nodes select different subsets due to the `local_id` and random key in the hash.
- **Per-peer routing:** Each peer independently receives full or hash for each transaction based on the sender→peer mapping, rather than a global index cutoff.

## TxPeerTracking

`transactions_by_peers` now uses `TxPeerTracking` instead of `HashSet<PeerId>`, separating the originator (first peer to send us a transaction) from subsequent peers. On bad import, only the originator is penalized — not all peers who relayed the hash.

Peer disconnect cleanup also improved: entries are removed when the originator disconnects, and disconnected peers are pruned from the `others` set.

## Other Changes

- **`DEFAULT_MAX_FULL_BROADCAST_TX_SIZE`** (4 KiB): Transactions larger than this are only announced as hashes, reducing bandwidth for large transactions.
- **`PropagateTransactionsBuilder` removed:** Replaced by direct use of `FullTransactionsBuilder` + `PooledTransactionsHashesBuilder` in `propagate_transactions`, since each peer now independently gets full vs hash per-sender.
- **`TransactionPropagationMode::full_peer_count` removed:** Logic moved into `BroadcastChoice::choose_full_peers`.
- **`PropagateTransaction.sender` field:** Carries the sender address for deterministic routing.
- **26 tests** covering BroadcastChoice scoring, mode variants, propagation routing, forced bypass, disconnect cleanup, and TxPeerTracking operations.