### PR TITLE
chore(payload): use Transaction::blob_versioned_hashes() directly

### DIFF
--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -253,8 +253,8 @@ where
         // There's only limited amount of blob space available per block, so we need to check if
         // the EIP-4844 can still fit in the block
         let mut blob_tx_sidecar = None;
-        if let Some(blob_tx) = tx.as_eip4844() {
-            let tx_blob_count = blob_tx.tx().blob_versioned_hashes.len() as u64;
+        if let Some(blob_hashes) = tx.blob_versioned_hashes() {
+            let tx_blob_count = blob_hashes.len() as u64;
 
             if block_blob_count + tx_blob_count > max_blob_count {
                 // we can't fit this _blob_ transaction into the block, so we mark it as
@@ -329,8 +329,8 @@ where
         };
 
         // add to the total blob gas used if the transaction successfully executed
-        if let Some(blob_tx) = tx.as_eip4844() {
-            block_blob_count += blob_tx.tx().blob_versioned_hashes.len() as u64;
+        if let Some(blob_hashes) = tx.blob_versioned_hashes() {
+            block_blob_count += blob_hashes.len() as u64;
 
             // if we've reached the max blob count, we can skip blob txs entirely
             if block_blob_count == max_blob_count {


### PR DESCRIPTION
## Summary

Replace the 3-level method chain `tx.as_eip4844().tx().blob_versioned_hashes.len()` with `tx.blob_versioned_hashes().map(|h| h.len())` in the Ethereum payload builder.

## Details

Both occurrences in `try_best_fill_payload` were downcasting to the EIP-4844 variant (`as_eip4844()`) solely to access the blob versioned hashes count. The `blob_versioned_hashes()` method is already available on the `Transaction` trait (from `alloy_consensus`), so we can use it directly — avoiding the unnecessary envelope → EIP-4844 variant → inner tx → field access chain.

This also removes the last usage of `as_eip4844()` in this file.