### PR TITLE
feat(bench): add Slack notifications with Block Kit

### DIFF
--- a/.github/scripts/bench-slack-notify.js
+++ b/.github/scripts/bench-slack-notify.js
@@ -70,7 +70,9 @@ function buildSuccessBlocks({ summary, prNumber, actor, actorSlackId, jobUrl, re
   function fmtMgas(v) { return v.toFixed(2); }
   function fmtChange(ch) {
     if (!ch.pct && !ch.ci_pct) return ' ';
-    return `${ch.pct >= 0 ? '+' : ''}${ch.pct.toFixed(2)}% ${sigEmoji[ch.sig]}`;
+    const pctStr = `${ch.pct >= 0 ? '+' : ''}${ch.pct.toFixed(2)}%`;
+    const ciStr = ch.ci_pct ? ` (\u00b1${ch.ci_pct.toFixed(2)}%)` : '';
+    return `${pctStr}${ciStr} ${sigEmoji[ch.sig]}`;
   }
 
   // Overall result for header

--- a/.github/scripts/bench-slack-notify.js
+++ b/.github/scripts/bench-slack-notify.js
@@ -1,0 +1,238 @@
+// Sends Slack notifications for reth-bench results.
+//
+// Reads from environment:
+//   SLACK_BENCH_BOT_TOKEN  – Slack Bot User OAuth Token (xoxb-...)
+//   SLACK_BENCH_CHANNEL    – Public channel ID for significant improvements
+//   BENCH_WORK_DIR         – Directory containing summary.json
+//   BENCH_PR               – PR number (may be empty)
+//   BENCH_ACTOR            – GitHub user who triggered the bench
+//   BENCH_JOB_URL          – URL to the Actions job page
+//
+// Usage from actions/github-script:
+//   const notify = require('./.github/scripts/bench-slack-notify.js');
+//   await notify.success({ core, context });
+//   await notify.failure({ core, context, failedStep: '...' });
+
+const fs = require('fs');
+const path = require('path');
+
+const SLACK_API = 'https://slack.com/api/chat.postMessage';
+
+function loadSlackUsers(repoRoot) {
+  try {
+    const raw = fs.readFileSync(path.join(repoRoot, '.github', 'scripts', 'bench-slack-users.json'), 'utf8');
+    const data = JSON.parse(raw);
+    // Filter out non-user-ID entries (like _comment)
+    const users = {};
+    for (const [k, v] of Object.entries(data)) {
+      if (!k.startsWith('_') && typeof v === 'string' && v.startsWith('U')) {
+        users[k] = v;
+      }
+    }
+    return users;
+  } catch {
+    return {};
+  }
+}
+
+async function postToSlack(token, channel, blocks, core) {
+  const resp = await fetch(SLACK_API, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ channel, blocks, unfurl_links: false }),
+  });
+  const data = await resp.json();
+  if (!data.ok) {
+    core.warning(`Slack API error (channel ${channel}): ${data.error}`);
+  }
+  return data;
+}
+
+function buildSuccessBlocks({ summary, prNumber, actor, jobUrl, repo }) {
+  const b = summary.baseline.stats;
+  const f = summary.feature.stats;
+  const c = summary.changes;
+
+  const sigEmoji = { good: ':white_check_mark:', bad: ':x:', neutral: ':white_circle:' };
+
+  function fmtChange(ch) {
+    const e = sigEmoji[ch.sig];
+    return `${ch.pct >= 0 ? '+' : ''}${ch.pct.toFixed(2)}% ${e}`;
+  }
+
+  const prUrl = prNumber ? `https://github.com/${repo}/pull/${prNumber}` : '';
+  const meta = prNumber
+    ? `*<${prUrl}|PR #${prNumber}>* by @${actor} | <${jobUrl}|View job> | ${summary.blocks} blocks`
+    : `Triggered by @${actor} | <${jobUrl}|View job> | ${summary.blocks} blocks`;
+
+  const blocks = [
+    {
+      type: 'header',
+      text: { type: 'plain_text', text: `Bench: ${summary.baseline.name} vs ${summary.feature.name}`, emoji: true },
+    },
+    {
+      type: 'section',
+      text: { type: 'mrkdwn', text: meta },
+    },
+    { type: 'divider' },
+    {
+      type: 'section',
+      text: { type: 'mrkdwn', text: '*Latency (newPayload)*' },
+      fields: [
+        { type: 'mrkdwn', text: '*Metric*' },
+        { type: 'mrkdwn', text: '*Change*' },
+        { type: 'mrkdwn', text: `Mean: ${b.mean_ms.toFixed(2)} \u2192 ${f.mean_ms.toFixed(2)} ms` },
+        { type: 'mrkdwn', text: fmtChange(c.mean) },
+        { type: 'mrkdwn', text: `P50: ${b.p50_ms.toFixed(2)} \u2192 ${f.p50_ms.toFixed(2)} ms` },
+        { type: 'mrkdwn', text: fmtChange(c.p50) },
+        { type: 'mrkdwn', text: `P90: ${b.p90_ms.toFixed(2)} \u2192 ${f.p90_ms.toFixed(2)} ms` },
+        { type: 'mrkdwn', text: fmtChange(c.p90) },
+        { type: 'mrkdwn', text: `P99: ${b.p99_ms.toFixed(2)} \u2192 ${f.p99_ms.toFixed(2)} ms` },
+        { type: 'mrkdwn', text: fmtChange(c.p99) },
+      ],
+    },
+    { type: 'divider' },
+    {
+      type: 'section',
+      fields: [
+        { type: 'mrkdwn', text: '*Throughput*' },
+        { type: 'mrkdwn', text: '*Change*' },
+        { type: 'mrkdwn', text: `Mgas/s: ${b.mean_mgas_s.toFixed(2)} \u2192 ${f.mean_mgas_s.toFixed(2)}` },
+        { type: 'mrkdwn', text: fmtChange(c.mgas_s) },
+      ],
+    },
+  ];
+
+  // Wait times
+  const waitTimes = summary.wait_times || {};
+  const waitKeys = Object.keys(waitTimes);
+  if (waitKeys.length > 0) {
+    const waitFields = [
+      { type: 'mrkdwn', text: '*Wait Time*' },
+      { type: 'mrkdwn', text: '*Base \u2192 Feature (mean)*' },
+    ];
+    for (const key of waitKeys) {
+      const wt = waitTimes[key];
+      waitFields.push({ type: 'mrkdwn', text: wt.title });
+      waitFields.push({
+        type: 'mrkdwn',
+        text: `${wt.baseline.mean_ms.toFixed(2)} \u2192 ${wt.feature.mean_ms.toFixed(2)} ms`,
+      });
+    }
+    blocks.push({ type: 'divider' });
+    blocks.push({ type: 'section', fields: waitFields });
+  }
+
+  // Footer
+  blocks.push({
+    type: 'context',
+    elements: [{
+      type: 'mrkdwn',
+      text: `${repo} | ${summary.baseline.name} (\`${summary.baseline.ref.slice(0, 8)}\`) vs ${summary.feature.name} (\`${summary.feature.ref.slice(0, 8)}\`)`,
+    }],
+  });
+
+  return blocks;
+}
+
+function buildFailureBlocks({ prNumber, actor, jobUrl, repo, failedStep }) {
+  const prUrl = prNumber ? `https://github.com/${repo}/pull/${prNumber}` : '';
+  const parts = [
+    prNumber ? `*<${prUrl}|PR #${prNumber}>*` : '',
+    `Triggered by @${actor}`,
+    `Failed while *${failedStep}*`,
+    `<${jobUrl}|View logs>`,
+  ].filter(Boolean);
+
+  return [
+    {
+      type: 'header',
+      text: { type: 'plain_text', text: ':rotating_light: Bench Failed', emoji: true },
+    },
+    {
+      type: 'section',
+      text: { type: 'mrkdwn', text: parts.join(' | ') },
+    },
+  ];
+}
+
+async function success({ core, context }) {
+  const token = process.env.SLACK_BENCH_BOT_TOKEN;
+  if (!token) {
+    core.info('SLACK_BENCH_BOT_TOKEN not set, skipping Slack notification');
+    return;
+  }
+
+  let summary;
+  try {
+    summary = JSON.parse(fs.readFileSync(process.env.BENCH_WORK_DIR + '/summary.json', 'utf8'));
+  } catch (e) {
+    core.warning('Could not read summary.json for Slack notification');
+    return;
+  }
+
+  const repo = `${context.repo.owner}/${context.repo.repo}`;
+  const prNumber = process.env.BENCH_PR;
+  const actor = process.env.BENCH_ACTOR;
+  const jobUrl = process.env.BENCH_JOB_URL ||
+    `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+  const blocks = buildSuccessBlocks({ summary, prNumber, actor, jobUrl, repo });
+  const slackUsers = loadSlackUsers(process.env.GITHUB_WORKSPACE || '.');
+
+  // Always DM the actor
+  const actorSlackId = slackUsers[actor];
+  if (actorSlackId) {
+    await postToSlack(token, actorSlackId, blocks, core);
+  } else {
+    core.info(`No Slack user mapping for GitHub user '${actor}', skipping DM`);
+  }
+
+  // Post to public channel if any metric shows significant improvement
+  const channel = process.env.SLACK_BENCH_CHANNEL;
+  if (channel) {
+    const changes = summary.changes || {};
+    const hasImprovement = Object.values(changes).some(c => c.sig === 'good');
+    if (hasImprovement) {
+      await postToSlack(token, channel, blocks, core);
+    } else {
+      core.info('No significant improvement, skipping public channel notification');
+    }
+  }
+}
+
+async function failure({ core, context, failedStep }) {
+  const token = process.env.SLACK_BENCH_BOT_TOKEN;
+  if (!token) {
+    core.info('SLACK_BENCH_BOT_TOKEN not set, skipping Slack notification');
+    return;
+  }
+
+  const repo = `${context.repo.owner}/${context.repo.repo}`;
+  const prNumber = process.env.BENCH_PR;
+  const actor = process.env.BENCH_ACTOR;
+  const jobUrl = process.env.BENCH_JOB_URL ||
+    `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+  const blocks = buildFailureBlocks({ prNumber, actor, jobUrl, repo, failedStep });
+  const slackUsers = loadSlackUsers(process.env.GITHUB_WORKSPACE || '.');
+
+  // Always DM the actor
+  const actorSlackId = slackUsers[actor];
+  if (actorSlackId) {
+    await postToSlack(token, actorSlackId, blocks, core);
+  } else {
+    core.info(`No Slack user mapping for GitHub user '${actor}', skipping DM`);
+  }
+
+  // Always post failures to public channel
+  const channel = process.env.SLACK_BENCH_CHANNEL;
+  if (channel) {
+    await postToSlack(token, channel, blocks, core);
+  }
+}
+
+module.exports = { success, failure };

--- a/.github/scripts/bench-slack-notify.js
+++ b/.github/scripts/bench-slack-notify.js
@@ -322,11 +322,7 @@ async function failure({ core, context, failedStep }) {
     core.info(`No Slack user mapping for GitHub user '${actor}', skipping DM`);
   }
 
-  // Always post failures to public channel
-  const channel = process.env.SLACK_BENCH_CHANNEL;
-  if (channel) {
-    await postToSlack(token, channel, blocks, text, core);
-  }
+  // Only DM for failures, don't post to public channel
 }
 
 module.exports = { success, failure };

--- a/.github/scripts/bench-slack-users.json
+++ b/.github/scripts/bench-slack-users.json
@@ -1,0 +1,13 @@
+{
+  "_comment": "Maps GitHub usernames to Slack user IDs. Find yours: Slack profile > ··· > Copy member ID.",
+  "shekhirin": "U09FAL2UMLJ",
+  "mattsse": "U09FQNPMRT3",
+  "klkvr": "U09FAK95FC2",
+  "joshieDo": "U09LHN6GYAU",
+  "mediocregopher": "U09FF75KMQU",
+  "yongkangc": "U09FB0ECTD4",
+  "gakonst": "U092SEPDM40",
+  "Rjected": "U09F6SCKRGT",
+  "DaniPopes": "U09FAT8EK2A",
+  "emmajam": "U0A34UN92HW"
+}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -906,6 +906,17 @@ jobs:
               await core.summary.addRaw(body).write();
             }
 
+      - name: Send Slack notification (success)
+        if: success()
+        uses: actions/github-script@v8
+        env:
+          SLACK_BENCH_BOT_TOKEN: ${{ secrets.SLACK_BENCH_BOT_TOKEN }}
+          SLACK_BENCH_CHANNEL: ${{ secrets.SLACK_BENCH_CHANNEL }}
+        with:
+          script: |
+            const notify = require('./.github/scripts/bench-slack-notify.js');
+            await notify.success({ core, context });
+
       - name: Update status (failed)
         if: failure() && env.BENCH_COMMENT_ID
         uses: actions/github-script@v8
@@ -927,6 +938,26 @@ jobs:
               comment_id: parseInt(process.env.BENCH_COMMENT_ID),
               body: `cc @${process.env.BENCH_ACTOR}\n\n❌ Benchmark failed while ${failedStep}. [View logs](${process.env.BENCH_JOB_URL})`,
             });
+
+      - name: Send Slack notification (failure)
+        if: failure()
+        uses: actions/github-script@v8
+        env:
+          SLACK_BENCH_BOT_TOKEN: ${{ secrets.SLACK_BENCH_BOT_TOKEN }}
+          SLACK_BENCH_CHANNEL: ${{ secrets.SLACK_BENCH_CHANNEL }}
+        with:
+          script: |
+            const steps_status = [
+              ['building binaries${{ steps.snapshot-check.outputs.needed == 'true' && ' & downloading snapshot' || '' }}', '${{ steps.build.outcome }}'],
+              ['running baseline benchmark (1/2)', '${{ steps.run-baseline-1.outcome }}'],
+              ['running feature benchmark (1/2)', '${{ steps.run-feature-1.outcome }}'],
+              ['running feature benchmark (2/2)', '${{ steps.run-feature-2.outcome }}'],
+              ['running baseline benchmark (2/2)', '${{ steps.run-baseline-2.outcome }}'],
+            ];
+            const failed = steps_status.find(([, o]) => o === 'failure');
+            const failedStep = failed ? failed[0] : 'unknown step';
+            const notify = require('./.github/scripts/bench-slack-notify.js');
+            await notify.failure({ core, context, failedStep });
 
       - name: Update status (cancelled)
         if: cancelled() && env.BENCH_COMMENT_ID

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -543,32 +543,51 @@ jobs:
 
       - name: Resolve refs
         id: refs
-        run: |
-          BASELINE_ARG="${{ needs.reth-bench-ack.outputs.baseline }}"
-          FEATURE_ARG="${{ needs.reth-bench-ack.outputs.feature }}"
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { execSync } = require('child_process');
+            const run = (cmd) => execSync(cmd, { encoding: 'utf8' }).trim();
 
-          if [ -n "$BASELINE_ARG" ]; then
-            git fetch origin "$BASELINE_ARG" --quiet 2>/dev/null || true
-            BASELINE_REF=$(git rev-parse "$BASELINE_ARG" 2>/dev/null || git rev-parse "origin/$BASELINE_ARG" 2>/dev/null)
-            BASELINE_NAME="$BASELINE_ARG"
-          else
-            BASELINE_REF=$(git merge-base HEAD origin/main 2>/dev/null || echo "${{ github.sha }}")
-            BASELINE_NAME="main"
-          fi
+            const baselineArg = '${{ needs.reth-bench-ack.outputs.baseline }}';
+            const featureArg = '${{ needs.reth-bench-ack.outputs.feature }}';
 
-          if [ -n "$FEATURE_ARG" ]; then
-            git fetch origin "$FEATURE_ARG" --quiet 2>/dev/null || true
-            FEATURE_REF=$(git rev-parse "$FEATURE_ARG" 2>/dev/null || git rev-parse "origin/$FEATURE_ARG" 2>/dev/null)
-            FEATURE_NAME="$FEATURE_ARG"
-          else
-            FEATURE_REF="${{ steps.pr-info.outputs.head-sha }}"
-            FEATURE_NAME="${{ steps.pr-info.outputs.head-ref }}"
-          fi
+            let baselineRef, baselineName, featureRef, featureName;
 
-          echo "baseline-ref=$BASELINE_REF" >> "$GITHUB_OUTPUT"
-          echo "baseline-name=$BASELINE_NAME" >> "$GITHUB_OUTPUT"
-          echo "feature-ref=$FEATURE_REF" >> "$GITHUB_OUTPUT"
-          echo "feature-name=$FEATURE_NAME" >> "$GITHUB_OUTPUT"
+            if (baselineArg) {
+              try { run(`git fetch origin "${baselineArg}" --quiet`); } catch {}
+              try {
+                baselineRef = run(`git rev-parse "${baselineArg}"`);
+              } catch {
+                baselineRef = run(`git rev-parse "origin/${baselineArg}"`);
+              }
+              baselineName = baselineArg;
+            } else {
+              try {
+                baselineRef = run('git merge-base HEAD origin/main');
+              } catch {
+                baselineRef = '${{ github.sha }}';
+              }
+              baselineName = 'main';
+            }
+
+            if (featureArg) {
+              try { run(`git fetch origin "${featureArg}" --quiet`); } catch {}
+              try {
+                featureRef = run(`git rev-parse "${featureArg}"`);
+              } catch {
+                featureRef = run(`git rev-parse "origin/${featureArg}"`);
+              }
+              featureName = featureArg;
+            } else {
+              featureRef = '${{ steps.pr-info.outputs.head-sha }}';
+              featureName = '${{ steps.pr-info.outputs.head-ref }}';
+            }
+
+            core.setOutput('baseline-ref', baselineRef);
+            core.setOutput('baseline-name', baselineName);
+            core.setOutput('feature-ref', featureRef);
+            core.setOutput('feature-name', featureName);
 
       - name: Check if snapshot needs update
         id: snapshot-check


### PR DESCRIPTION
## Summary

- Extend `summary.json` to persist all computed benchmark stats, pre-computed changes with significance, and wait time breakdowns
- Add `bench-slack-notify.js` helper module to build and post Block Kit formatted notifications via Slack Bot Token
- Always DM the benchmark actor; post to public channel only when any metric shows significant improvement
- Add `bench-slack-users.json` for GitHub→Slack user ID mapping (team members add their IDs)

## Setup

Add repository secrets:
- `SLACK_BENCH_BOT_TOKEN`: Slack Bot OAuth Token (`xoxb-...`) with `chat:write` scope
- `SLACK_BENCH_CHANNEL`: Public channel ID (e.g., `C0123456789`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)