### PR TITLE
perf(trie): inline single-target storage proofs in account worker

### DIFF
--- a/crates/trie/parallel/src/proof_task_metrics.rs
+++ b/crates/trie/parallel/src/proof_task_metrics.rs
@@ -28,6 +28,9 @@ pub struct ProofTaskTrieMetrics {
     deferred_encoder_sync: Histogram,
     /// Histogram for dispatched storage proofs that fell back to sync due to missing root.
     deferred_encoder_dispatched_missing_root: Histogram,
+    /// Histogram for `InlineSingle` deferred encoder variant count (single-target storage proofs
+    /// computed inline in the account worker).
+    deferred_encoder_inline_single: Histogram,
     /// Histogram for time account workers spent blocked waiting for storage proof results
     /// (seconds). This is the portion of account worker idle time attributable to storage
     /// worker latency rather than queue wait.
@@ -62,6 +65,7 @@ impl ProofTaskTrieMetrics {
         self.deferred_encoder_sync.record(stats.sync_count as f64);
         self.deferred_encoder_dispatched_missing_root
             .record(stats.dispatched_missing_root_count as f64);
+        self.deferred_encoder_inline_single.record(stats.inline_single_count as f64);
         self.account_worker_storage_wait_seconds.record(stats.storage_wait_time.as_secs_f64());
     }
 }

--- a/crates/trie/parallel/src/value_encoder.rs
+++ b/crates/trie/parallel/src/value_encoder.rs
@@ -8,7 +8,7 @@ use reth_primitives_traits::{dashmap::DashMap, Account};
 use reth_storage_errors::db::DatabaseError;
 use reth_trie::{
     hashed_cursor::HashedStorageCursor,
-    proof_v2::{self, DeferredValueEncoder, LeafValueEncoder, StorageProofCalculator},
+    proof_v2::{DeferredValueEncoder, LeafValueEncoder, StorageProofCalculator},
     trie_cursor::TrieStorageCursor,
     ProofTrieNodeV2,
 };
@@ -80,20 +80,6 @@ pub(crate) enum AsyncAccountDeferredValueEncoder<TC, HC> {
         storage_calculator: Rc<RefCell<StorageProofCalculator<TC, HC>>>,
         hashed_address: B256,
         account: Account,
-        /// Cache to store computed storage roots for future reuse.
-        cached_storage_roots: Arc<DashMap<B256, B256>>,
-    },
-    /// Single-target storage proof computed inline in the account worker to avoid
-    /// dispatch/channel overhead for trivially small proof requests.
-    InlineSingle {
-        /// Shared storage proof calculator for computing the storage proof.
-        storage_calculator: Rc<RefCell<StorageProofCalculator<TC, HC>>>,
-        hashed_address: B256,
-        account: Account,
-        /// The single-target proof targets to compute inline.
-        targets: Vec<proof_v2::Target>,
-        /// Shared storage proof results.
-        storage_proof_results: Rc<RefCell<B256Map<Vec<ProofTrieNodeV2>>>>,
         /// Cache to store computed storage roots for future reuse.
         cached_storage_roots: Arc<DashMap<B256, B256>>,
     },
@@ -212,37 +198,6 @@ where
                 cached_storage_roots.insert(hashed_address, storage_root);
                 (account, storage_root)
             }
-            Self::InlineSingle {
-                storage_calculator,
-                hashed_address,
-                account,
-                targets,
-                storage_proof_results,
-                cached_storage_roots,
-            } => {
-                let hashed_address = *hashed_address;
-                let account = *account;
-                let mut calculator = storage_calculator.borrow_mut();
-                let proof = calculator.storage_proof(hashed_address, targets)?;
-                let root = calculator.compute_root_hash(&proof)?;
-
-                storage_proof_results.borrow_mut().insert(hashed_address, proof);
-
-                if let Some(root) = root {
-                    cached_storage_roots.insert(hashed_address, root);
-                }
-
-                let storage_root = root.unwrap_or_else(|| {
-                    let root_node =
-                        calculator.storage_root_node(hashed_address).expect("root node");
-                    calculator
-                        .compute_root_hash(&[root_node])
-                        .expect("root hash")
-                        .expect("storage_root_node returns a node at empty path")
-                });
-
-                (account, storage_root)
-            }
         };
 
         let account = account.into_trie_account(root);
@@ -259,14 +214,9 @@ where
 /// For accounts without pre-dispatched proofs or cached roots, uses a shared
 /// [`StorageProofCalculator`] to compute storage roots synchronously, reusing cursors across
 /// multiple accounts.
-///
-/// Single-target storage proofs are computed inline via the `InlineSingle` variant to avoid
-/// dispatch/channel overhead for trivially small proof requests.
 pub(crate) struct AsyncAccountValueEncoder<TC, HC> {
     /// Storage proof jobs which were dispatched ahead of time.
     dispatched: B256Map<CrossbeamReceiver<StorageProofResultMessage>>,
-    /// Single-target storage proofs to compute inline in the account worker.
-    inline_single: B256Map<Vec<proof_v2::Target>>,
     /// Storage roots which have already been computed. This can be used only if a storage proof
     /// wasn't dispatched for an account, otherwise we must consume the proof result.
     cached_storage_roots: Arc<DashMap<B256, B256>>,
@@ -286,18 +236,15 @@ impl<TC, HC> AsyncAccountValueEncoder<TC, HC> {
     ///
     /// # Parameters
     /// - `dispatched`: Pre-dispatched storage proof receivers for target accounts
-    /// - `inline_single`: Single-target storage proofs to compute inline in the account worker
     /// - `cached_storage_roots`: Shared cache of already-computed storage roots
     /// - `storage_calculator`: Shared storage proof calculator for synchronous computation
     pub(crate) fn new(
         dispatched: B256Map<CrossbeamReceiver<StorageProofResultMessage>>,
-        inline_single: B256Map<Vec<proof_v2::Target>>,
         cached_storage_roots: Arc<DashMap<B256, B256>>,
         storage_calculator: Rc<RefCell<StorageProofCalculator<TC, HC>>>,
     ) -> Self {
         Self {
             dispatched,
-            inline_single,
             cached_storage_roots,
             storage_proof_results: Default::default(),
             storage_calculator,
@@ -317,20 +264,12 @@ impl<TC, HC> AsyncAccountValueEncoder<TC, HC> {
     /// been dropped.
     pub(crate) fn finalize(
         self,
-    ) -> Result<(B256Map<Vec<ProofTrieNodeV2>>, ValueEncoderStats), StateProofError>
-    where
-        TC: TrieStorageCursor,
-        HC: HashedStorageCursor<Value = alloy_primitives::U256>,
-    {
+    ) -> Result<(B256Map<Vec<ProofTrieNodeV2>>, ValueEncoderStats), StateProofError> {
         let mut storage_proof_results = Rc::into_inner(self.storage_proof_results)
             .expect("no deferred encoders are still allocated")
             .into_inner();
 
         let mut stats = Rc::into_inner(self.stats)
-            .expect("no deferred encoders are still allocated")
-            .into_inner();
-
-        let storage_calculator = Rc::into_inner(self.storage_calculator)
             .expect("no deferred encoders are still allocated")
             .into_inner();
 
@@ -349,22 +288,6 @@ impl<TC, HC> AsyncAccountValueEncoder<TC, HC> {
             stats.storage_wait_time += wait_start.elapsed();
 
             storage_proof_results.insert(*hashed_address, result.proof);
-        }
-
-        // Any remaining inline single proofs need to be computed synchronously.
-        // These are proofs that were not consumed during proof calculation.
-        let mut calculator = storage_calculator;
-        for (hashed_address, mut targets) in self.inline_single {
-            let proof = calculator.storage_proof(hashed_address, &mut targets)?;
-            let root = calculator.compute_root_hash(&proof)?;
-
-            storage_proof_results.insert(hashed_address, proof);
-
-            if let Some(root) = root {
-                self.cached_storage_roots.insert(hashed_address, root);
-            }
-
-            stats.inline_single_count += 1;
         }
 
         Ok((storage_proof_results, stats))
@@ -395,19 +318,6 @@ where
                 storage_proof_results: self.storage_proof_results.clone(),
                 stats: self.stats.clone(),
                 storage_calculator: self.storage_calculator.clone(),
-                cached_storage_roots: self.cached_storage_roots.clone(),
-            }
-        }
-
-        // Check if this address has a single-target proof to compute inline.
-        if let Some(targets) = self.inline_single.remove(&hashed_address) {
-            self.stats.borrow_mut().inline_single_count += 1;
-            return AsyncAccountDeferredValueEncoder::InlineSingle {
-                storage_calculator: self.storage_calculator.clone(),
-                hashed_address,
-                account,
-                targets,
-                storage_proof_results: self.storage_proof_results.clone(),
                 cached_storage_roots: self.cached_storage_roots.clone(),
             }
         }


### PR DESCRIPTION
## Summary
Inline storage proofs with `targets.len() <= 1` into the account proof worker instead of dispatching to the storage worker pool.

## Motivation
Single-target storage proofs (and root-only requests) incur channel allocation, cross-thread dispatch, and synchronization overhead that dominates the actual trie work. By computing these inline in the account worker, we eliminate this overhead for the most common case.

Related: [RETH-418](https://linear.app/tempoxyz/issue/RETH-418)

## Changes
- `dispatch_v2_storage_proofs` (`proof_task.rs`): separates single-target proofs into an `inline_single` map instead of dispatching them to storage workers
- `AsyncAccountDeferredValueEncoder` (`value_encoder.rs`): new `InlineSingle` variant that computes the storage proof synchronously using the account worker's existing `StorageProofCalculator`
- `AsyncAccountValueEncoder::deferred_encoder`: checks `inline_single` map before falling through to `Sync`/`FromCache` paths
- `AsyncAccountValueEncoder::finalize`: handles remaining unconsumed inline proofs
- `ProofTaskTrieMetrics` (`proof_task_metrics.rs`): new `deferred_encoder_inline_single` histogram

## Testing
```
cargo test -p reth-trie-parallel  # 2 passed
cargo +nightly clippy -p reth-trie-parallel --all-features  # clean
```

Needs reth-bench A/B comparison (baseline=main, feature=this branch) to measure throughput impact.

Prompted by: yk