### PR TITLE
chore: remove unused Default impl for ExecutionEnv

### DIFF
--- a/crates/engine/tree/benches/state_root_task.rs
+++ b/crates/engine/tree/benches/state_root_task.rs
@@ -12,7 +12,8 @@ use rand::Rng;
 use reth_chainspec::ChainSpec;
 use reth_db_common::init::init_genesis;
 use reth_engine_tree::tree::{
-    precompile_cache::PrecompileCacheMap, PayloadProcessor, StateProviderBuilder, TreeConfig,
+    precompile_cache::PrecompileCacheMap, ExecutionEnv, PayloadProcessor, StateProviderBuilder,
+    TreeConfig,
 };
 use reth_ethereum_primitives::TransactionSigned;
 use reth_evm::OnStateHook;
@@ -230,7 +231,7 @@ fn bench_state_root(c: &mut Criterion) {
                     |(genesis_hash, mut payload_processor, provider, state_updates)| {
                         black_box({
                             let mut handle = payload_processor.spawn(
-                                Default::default(),
+                                ExecutionEnv::test_default(),
                                 (
                                     Vec::<
                                         Result<

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -1074,23 +1074,6 @@ pub struct ExecutionEnv<Evm: ConfigureEvm> {
     pub withdrawals: Option<Vec<Withdrawal>>,
 }
 
-impl<Evm: ConfigureEvm> Default for ExecutionEnv<Evm>
-where
-    EvmEnvFor<Evm>: Default,
-{
-    fn default() -> Self {
-        Self {
-            evm_env: Default::default(),
-            hash: Default::default(),
-            parent_hash: Default::default(),
-            parent_state_root: Default::default(),
-            transaction_count: 0,
-            gas_used: 0,
-            withdrawals: None,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::PayloadExecutionCache;

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -1079,7 +1079,7 @@ where
     EvmEnvFor<Evm>: Default,
 {
     /// Creates a new [`ExecutionEnv`] with default values for testing.
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-utils"))]
     fn test_default() -> Self {
         Self {
             evm_env: Default::default(),

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -1080,7 +1080,7 @@ where
 {
     /// Creates a new [`ExecutionEnv`] with default values for testing.
     #[cfg(any(test, feature = "test-utils"))]
-    fn test_default() -> Self {
+    pub fn test_default() -> Self {
         Self {
             evm_env: Default::default(),
             hash: Default::default(),

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -1074,12 +1074,31 @@ pub struct ExecutionEnv<Evm: ConfigureEvm> {
     pub withdrawals: Option<Vec<Withdrawal>>,
 }
 
+impl<Evm: ConfigureEvm> ExecutionEnv<Evm>
+where
+    EvmEnvFor<Evm>: Default,
+{
+    /// Creates a new [`ExecutionEnv`] with default values for testing.
+    #[cfg(test)]
+    fn test_default() -> Self {
+        Self {
+            evm_env: Default::default(),
+            hash: Default::default(),
+            parent_hash: Default::default(),
+            parent_state_root: Default::default(),
+            transaction_count: 0,
+            gas_used: 0,
+            withdrawals: None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::PayloadExecutionCache;
     use crate::tree::{
         cached_state::{CachedStateMetrics, ExecutionCache, SavedCache},
-        payload_processor::{evm_state_to_hashed_post_state, PayloadProcessor},
+        payload_processor::{evm_state_to_hashed_post_state, ExecutionEnv, PayloadProcessor},
         precompile_cache::PrecompileCacheMap,
         StateProviderBuilder, TreeConfig,
     };
@@ -1354,7 +1373,7 @@ mod tests {
         let provider_factory = BlockchainProvider::new(factory).unwrap();
 
         let mut handle = payload_processor.spawn(
-            Default::default(),
+            ExecutionEnv::test_default(),
             (
                 Vec::<Result<Recovered<TransactionSigned>, core::convert::Infallible>>::new(),
                 std::convert::identity,


### PR DESCRIPTION
## Summary
Remove the `Default` impl for `ExecutionEnv` — it's unused anywhere in the codebase.

## Changes
- Removed `impl<Evm: ConfigureEvm> Default for ExecutionEnv<Evm>` from `crates/engine/tree/src/tree/payload_processor/mod.rs`

Prompted by: matthias