### PR TITLE
fix(txpool): prevent underflow in blobstore versioned hash lookup

### DIFF
--- a/crates/transaction-pool/src/blobstore/disk.rs
+++ b/crates/transaction-pool/src/blobstore/disk.rs
@@ -82,10 +82,11 @@ impl DiskFileBlobStore {
                 for (hash_idx, match_result) in
                     blob_sidecar.match_versioned_hashes(versioned_hashes)
                 {
-                    if result[hash_idx].is_none() {
+                    let slot = &mut result[hash_idx];
+                    if slot.is_none() {
                         missing_count -= 1;
                     }
-                    result[hash_idx] = Some(match_result);
+                    *slot = Some(match_result);
                 }
             }
 

--- a/crates/transaction-pool/src/blobstore/disk.rs
+++ b/crates/transaction-pool/src/blobstore/disk.rs
@@ -82,8 +82,10 @@ impl DiskFileBlobStore {
                 for (hash_idx, match_result) in
                     blob_sidecar.match_versioned_hashes(versioned_hashes)
                 {
+                    if result[hash_idx].is_none() {
+                        missing_count -= 1;
+                    }
                     result[hash_idx] = Some(match_result);
-                    missing_count -= 1;
                 }
             }
 

--- a/crates/transaction-pool/src/blobstore/mem.rs
+++ b/crates/transaction-pool/src/blobstore/mem.rs
@@ -30,8 +30,10 @@ impl InMemoryBlobStore {
                 for (hash_idx, match_result) in
                     blob_sidecar.match_versioned_hashes(versioned_hashes)
                 {
+                    if result[hash_idx].is_none() {
+                        missing_count -= 1;
+                    }
                     result[hash_idx] = Some(match_result);
-                    missing_count -= 1;
                 }
             }
 

--- a/crates/transaction-pool/src/blobstore/mem.rs
+++ b/crates/transaction-pool/src/blobstore/mem.rs
@@ -30,10 +30,11 @@ impl InMemoryBlobStore {
                 for (hash_idx, match_result) in
                     blob_sidecar.match_versioned_hashes(versioned_hashes)
                 {
-                    if result[hash_idx].is_none() {
+                    let slot = &mut result[hash_idx];
+                    if slot.is_none() {
                         missing_count -= 1;
                     }
-                    result[hash_idx] = Some(match_result);
+                    *slot = Some(match_result);
                 }
             }
 


### PR DESCRIPTION
`missing_count` was decremented on every hash match, but if `versioned_hashes` has duplicates the same index gets written multiple times, causing underflow. Only decrement when the slot was actually empty.