### PR TITLE
fix(net): correct high-priority request queue insertion order

### DIFF
--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -210,7 +210,7 @@ impl<N: NetworkPrimitives> StateFetcher<N> {
                                 .queued_requests
                                 .iter()
                                 .position(|req| req.is_normal_priority())
-                                .unwrap_or(0);
+                                .unwrap_or(self.queued_requests.len());
                             self.queued_requests.insert(pos, request);
                         }
                         Priority::Normal => {


### PR DESCRIPTION
Fix FIFO violation for high-priority download requests when the queue has no normal-priority items. `position(is_normal)` returns None and unwrap_or(0) inserts at the front instead of the back, reversing the order of high-priority requests.