### PR TITLE
chore(ci): enhance benchmark artifact collection

### DIFF
--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -45,6 +45,8 @@ cleanup() {
     sudo kill -9 "$RETH_PID" 2>/dev/null || true
     sleep 1
   fi
+  # Fix ownership of reth-created files (reth runs as root)
+  sudo chown -R "$(id -un):$(id -gn)" "$OUTPUT_DIR" 2>/dev/null || true
   if mountpoint -q "$SCHELK_MOUNT"; then
     sudo umount -l "$SCHELK_MOUNT" || true
     sudo schelk recover -y || true
@@ -70,6 +72,7 @@ RETH_CPUS="1-$(( ONLINE - 1 ))"
 RETH_ARGS=(
   node
   --datadir "$DATADIR"
+  --log.file.directory "$OUTPUT_DIR/reth-logs"
   --engine.accept-execution-requests-hash
   --http
   --http.port 8545

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -825,7 +825,7 @@ jobs:
           uv run --with matplotlib python3 .github/scripts/bench-reth-charts.py $CHART_ARGS
 
       - name: Upload results
-        if: success()
+        if: "!cancelled()"
         uses: actions/upload-artifact@v6
         with:
           name: bench-reth-results
@@ -990,14 +990,6 @@ jobs:
               comment_id: parseInt(process.env.BENCH_COMMENT_ID),
               body: `cc @${process.env.BENCH_ACTOR}\n\n⚠️ Benchmark cancelled. [View logs](${jobUrl})`,
             });
-
-      - name: Upload node log
-        if: failure()
-        uses: actions/upload-artifact@v6
-        with:
-          name: reth-node-log
-          path: |
-            ${{ env.BENCH_WORK_DIR }}/*/node.log
 
       - name: Restore system settings
         if: always()


### PR DESCRIPTION
## Summary

Improves benchmark workflow artifact collection by capturing debug logs and ensuring artifacts are preserved even on failure:
- Direct reth's file logging to each run's output directory instead of shared cache
- Upload artifacts on both success and failure (previously only on success)
- Remove redundant node log upload step (now included in main artifact)

## Changes

- `--log.file.directory "$OUTPUT_DIR/reth-logs"` routes reth's internal debug logs into each run's directory
- Fix file ownership in cleanup function so root-created artifacts can be uploaded
- Change Upload results step to `if: !cancelled()` to capture partial data on failure
- Remove separate Upload node log step since node.log is now always collected

This ensures complete benchmark data (CSV results, samply profiles, debug logs) is available even when the benchmark fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)