### PR TITLE
feat(bench): scrape all Prometheus metrics in CI

### DIFF
--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -73,6 +73,7 @@ RETH_ARGS=(
   node
   --datadir "$DATADIR"
   --log.file.directory "$OUTPUT_DIR/reth-logs"
+  --metrics 127.0.0.1:9001
   --engine.accept-execution-requests-hash
   --http
   --http.port 8545
@@ -134,6 +135,7 @@ $BENCH_NICE "$RETH_BENCH" new-payload-fcu \
   --jwt-secret "$DATADIR/jwt.hex" \
   --advance "$BENCH_BLOCKS" \
   --reth-new-payload \
+  --metrics-url http://127.0.0.1:9001/metrics \
   --output "$OUTPUT_DIR" 2>&1 | sed -u "s/^/[bench] /"
 
 # cleanup runs via trap

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7641,6 +7641,7 @@ dependencies = [
  "reth-tracing",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tower",

--- a/bin/reth-bench/Cargo.toml
+++ b/bin/reth-bench/Cargo.toml
@@ -76,6 +76,7 @@ humantime.workspace = true
 csv.workspace = true
 
 [dev-dependencies]
+tempfile.workspace = true
 
 [features]
 default = ["jemalloc"]

--- a/bin/reth-bench/src/bench/metrics_scraper.rs
+++ b/bin/reth-bench/src/bench/metrics_scraper.rs
@@ -1,39 +1,38 @@
 //! Prometheus metrics scraper for reth-bench.
 //!
 //! Scrapes a node's Prometheus metrics endpoint after each block to record
-//! execution and state root durations with block-level granularity.
+//! all metric values with block-level granularity.
 
-use csv::Writer;
 use eyre::Context;
 use reqwest::Client;
-use serde::Serialize;
-use std::{path::Path, time::Duration};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    io::Write,
+    path::Path,
+    time::Duration,
+};
 use tracing::info;
 
 /// Suffix for the metrics CSV output file.
 pub(crate) const METRICS_OUTPUT_SUFFIX: &str = "metrics.csv";
 
-/// A single row of scraped prometheus metrics for one block.
-#[derive(Debug, Clone, Serialize)]
-pub(crate) struct MetricsRow {
-    /// The block number.
-    pub(crate) block_number: u64,
-    /// EVM execution duration in seconds (from `sync_execution_execution_duration` gauge).
-    pub(crate) execution_duration_secs: Option<f64>,
-    /// State root computation duration in seconds (from
-    /// `sync_block_validation_state_root_duration` gauge).
-    pub(crate) state_root_duration_secs: Option<f64>,
-}
-
 /// Scrapes a Prometheus metrics endpoint after each block to collect
-/// execution and state root durations.
+/// all metric values.
 pub(crate) struct MetricsScraper {
     /// The full URL of the Prometheus metrics endpoint.
     url: String,
     /// Reusable HTTP client.
     client: Client,
-    /// Collected metrics rows, one per block.
-    rows: Vec<MetricsRow>,
+    /// Collected metrics snapshots, one per block.
+    rows: Vec<MetricsSnapshot>,
+}
+
+/// A single snapshot of all scraped prometheus metrics for one block.
+struct MetricsSnapshot {
+    /// The block number.
+    block_number: u64,
+    /// All metric name→value pairs from this scrape.
+    values: BTreeMap<String, f64>,
 }
 
 impl MetricsScraper {
@@ -49,7 +48,7 @@ impl MetricsScraper {
         })
     }
 
-    /// Scrapes the metrics endpoint and records values for the given block.
+    /// Scrapes the metrics endpoint and records all values for the given block.
     pub(crate) async fn scrape_after_block(&mut self, block_number: u64) -> eyre::Result<()> {
         let text = self
             .client
@@ -63,60 +62,87 @@ impl MetricsScraper {
             .await
             .wrap_err("failed to read metrics response body")?;
 
-        let execution = parse_gauge(&text, "sync_execution_execution_duration");
-        let state_root = parse_gauge(&text, "sync_block_validation_state_root_duration");
-
-        self.rows.push(MetricsRow {
-            block_number,
-            execution_duration_secs: execution,
-            state_root_duration_secs: state_root,
-        });
+        let values = parse_all_metrics(&text);
+        self.rows.push(MetricsSnapshot { block_number, values });
         Ok(())
     }
 
     /// Writes collected metrics to a CSV file in the output directory.
+    ///
+    /// The CSV has a dynamic set of columns derived from the union of all metric
+    /// names seen across all scraped blocks. Missing values are left empty.
     pub(crate) fn write_csv(&self, output_dir: &Path) -> eyre::Result<()> {
         let path = output_dir.join(METRICS_OUTPUT_SUFFIX);
         info!(target: "reth-bench", "Writing scraped metrics to file: {:?}", path);
-        let mut writer = Writer::from_path(&path)?;
-        for row in &self.rows {
-            writer.serialize(row)?;
+
+        // Collect the union of all metric names across all snapshots.
+        let all_names: BTreeSet<&str> =
+            self.rows.iter().flat_map(|s| s.values.keys().map(|k| k.as_str())).collect();
+        let columns: Vec<&str> = all_names.into_iter().collect();
+
+        let mut writer = std::io::BufWriter::new(std::fs::File::create(&path)?);
+
+        // Write header.
+        write!(writer, "block_number")?;
+        for col in &columns {
+            write!(writer, ",{col}")?;
         }
+        writeln!(writer)?;
+
+        // Write rows.
+        for snapshot in &self.rows {
+            write!(writer, "{}", snapshot.block_number)?;
+            for col in &columns {
+                if let Some(val) = snapshot.values.get(*col) {
+                    write!(writer, ",{val}")?;
+                } else {
+                    write!(writer, ",")?;
+                }
+            }
+            writeln!(writer)?;
+        }
+
         writer.flush()?;
         Ok(())
     }
 }
 
-/// Parses a Prometheus gauge value from exposition-format text.
+/// Parses all metric values from Prometheus exposition-format text.
 ///
-/// Searches for lines starting with `name` followed by either a space or `{`
-/// (for labeled metrics), then parses the numeric value. Returns the last
-/// matching sample to handle metrics emitted with multiple label sets.
-fn parse_gauge(text: &str, name: &str) -> Option<f64> {
-    let mut result = None;
+/// For metrics with labels (e.g. `metric{label="value"} 1.0`), the label set is
+/// appended to the name so each unique label combination gets its own column in
+/// the output CSV.
+///
+/// When multiple samples share the same fully-qualified name (name + labels),
+/// the last value wins.
+fn parse_all_metrics(text: &str) -> BTreeMap<String, f64> {
+    let mut result = BTreeMap::new();
     for line in text.lines() {
         let line = line.trim();
         if line.is_empty() || line.starts_with('#') {
             continue;
         }
 
-        if !line.starts_with(name) {
+        // Prometheus exposition format: `name{labels} value [timestamp]`
+        // or: `name value [timestamp]`
+        let (name_and_labels, rest) = if let Some(brace_start) = line.find('{') {
+            if let Some(brace_end) = line[brace_start..].find('}') {
+                let end = brace_start + brace_end + 1;
+                (&line[..end], line[end..].trim())
+            } else {
+                continue;
+            }
+        } else if let Some(space) = line.find(' ') {
+            (&line[..space], line[space..].trim())
+        } else {
             continue;
-        }
+        };
 
-        // Ensure we match the full metric name, not a prefix of another metric.
-        let rest = &line[name.len()..];
-        if !rest.starts_with(' ') && !rest.starts_with('{') {
-            continue;
-        }
-
-        // Format: `metric_name{labels} value [timestamp]` or `metric_name value [timestamp]`
-        // Value is always the second whitespace-separated token.
-        let mut parts = line.split_whitespace();
-        if let Some(value_str) = parts.nth(1) &&
-            let Ok(v) = value_str.parse::<f64>()
-        {
-            result = Some(v);
+        // The value is the first whitespace-separated token in the rest.
+        if let Some(value_str) = rest.split_whitespace().next() {
+            if let Ok(v) = value_str.parse::<f64>() {
+                result.insert(name_and_labels.to_string(), v);
+            }
         }
     }
     result
@@ -127,30 +153,86 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_parse_gauge_simple() {
+    fn test_parse_all_metrics_simple() {
         let text = r#"# HELP sync_execution_execution_duration Duration of execution
 # TYPE sync_execution_execution_duration gauge
 sync_execution_execution_duration 0.123456
+some_counter 42
 "#;
-        assert_eq!(parse_gauge(text, "sync_execution_execution_duration"), Some(0.123456));
+        let metrics = parse_all_metrics(text);
+        assert_eq!(metrics.get("sync_execution_execution_duration"), Some(&0.123456));
+        assert_eq!(metrics.get("some_counter"), Some(&42.0));
+        assert_eq!(metrics.len(), 2);
     }
 
     #[test]
-    fn test_parse_gauge_missing() {
-        let text = "some_other_metric 1.0\n";
-        assert_eq!(parse_gauge(text, "sync_execution_execution_duration"), None);
+    fn test_parse_all_metrics_with_labels() {
+        let text = r#"http_requests_total{method="GET",status="200"} 100
+http_requests_total{method="POST",status="200"} 50
+"#;
+        let metrics = parse_all_metrics(text);
+        assert_eq!(metrics.get(r#"http_requests_total{method="GET",status="200"}"#), Some(&100.0));
+        assert_eq!(metrics.get(r#"http_requests_total{method="POST",status="200"}"#), Some(&50.0));
+        assert_eq!(metrics.len(), 2);
     }
 
     #[test]
-    fn test_parse_gauge_with_labels() {
-        let text = "sync_block_validation_state_root_duration{instance=\"node1\"} 0.5\n";
-        assert_eq!(parse_gauge(text, "sync_block_validation_state_root_duration"), Some(0.5));
+    fn test_parse_all_metrics_skips_comments_and_empty() {
+        let text = r#"
+# HELP my_metric A metric
+# TYPE my_metric gauge
+
+my_metric 1.5
+"#;
+        let metrics = parse_all_metrics(text);
+        assert_eq!(metrics.len(), 1);
+        assert_eq!(metrics.get("my_metric"), Some(&1.5));
     }
 
     #[test]
-    fn test_parse_gauge_prefix_no_false_match() {
-        let text =
-            "sync_execution_execution_duration_total 99.0\nsync_execution_execution_duration 0.5\n";
-        assert_eq!(parse_gauge(text, "sync_execution_execution_duration"), Some(0.5));
+    fn test_parse_all_metrics_with_timestamp() {
+        let text = "my_metric 1.5 1234567890\n";
+        let metrics = parse_all_metrics(text);
+        assert_eq!(metrics.get("my_metric"), Some(&1.5));
+    }
+
+    #[test]
+    fn test_parse_all_metrics_last_value_wins() {
+        let text = "my_metric 1.0\nmy_metric 2.0\n";
+        let metrics = parse_all_metrics(text);
+        assert_eq!(metrics.get("my_metric"), Some(&2.0));
+    }
+
+    #[test]
+    fn test_write_csv_dynamic_columns() {
+        let scraper = MetricsScraper {
+            url: String::new(),
+            client: Client::new(),
+            rows: vec![
+                MetricsSnapshot {
+                    block_number: 1,
+                    values: BTreeMap::from([
+                        ("metric_a".to_string(), 1.0),
+                        ("metric_b".to_string(), 2.0),
+                    ]),
+                },
+                MetricsSnapshot {
+                    block_number: 2,
+                    values: BTreeMap::from([
+                        ("metric_a".to_string(), 3.0),
+                        ("metric_c".to_string(), 4.0),
+                    ]),
+                },
+            ],
+        };
+
+        let dir = tempfile::tempdir().unwrap();
+        scraper.write_csv(dir.path()).unwrap();
+
+        let csv = std::fs::read_to_string(dir.path().join("metrics.csv")).unwrap();
+        let lines: Vec<&str> = csv.lines().collect();
+        assert_eq!(lines[0], "block_number,metric_a,metric_b,metric_c");
+        assert_eq!(lines[1], "1,1,2,");
+        assert_eq!(lines[2], "2,3,,4");
     }
 }

--- a/bin/reth-bench/src/bench/metrics_scraper.rs
+++ b/bin/reth-bench/src/bench/metrics_scraper.rs
@@ -139,10 +139,10 @@ fn parse_all_metrics(text: &str) -> BTreeMap<String, f64> {
         };
 
         // The value is the first whitespace-separated token in the rest.
-        if let Some(value_str) = rest.split_whitespace().next() {
-            if let Ok(v) = value_str.parse::<f64>() {
-                result.insert(name_and_labels.to_string(), v);
-            }
+        if let Some(value_str) = rest.split_whitespace().next()
+            && let Ok(v) = value_str.parse::<f64>()
+        {
+            result.insert(name_and_labels.to_string(), v);
         }
     }
     result

--- a/bin/reth-bench/src/bench/metrics_scraper.rs
+++ b/bin/reth-bench/src/bench/metrics_scraper.rs
@@ -139,8 +139,8 @@ fn parse_all_metrics(text: &str) -> BTreeMap<String, f64> {
         };
 
         // The value is the first whitespace-separated token in the rest.
-        if let Some(value_str) = rest.split_whitespace().next()
-            && let Ok(v) = value_str.parse::<f64>()
+        if let Some(value_str) = rest.split_whitespace().next() &&
+            let Ok(v) = value_str.parse::<f64>()
         {
             result.insert(name_and_labels.to_string(), v);
         }


### PR DESCRIPTION
## Summary

Enable Prometheus metrics collection in benchmark workflow by adding `--metrics` to reth startup and `--metrics-url` to reth-bench. Rewrite metrics scraper to collect **all** metrics instead of just 2 hardcoded gauges.

The CSV schema is now dynamic: columns derive from the union of all metric names seen across blocks. This enables complete observability of engine performance across all reth metrics during benchmarks.

## Changes

- Enable metrics endpoint in reth: `--metrics 127.0.0.1:9001`
- Enable metrics scraping in reth-bench: `--metrics-url http://127.0.0.1:9001/metrics`
- Parse entire Prometheus exposition format (including labeled metrics like `metric{label="value"}`)
- Generate dynamic CSV columns with missing values left empty
- Add tempfile dev-dependency for tests

All 18 tests pass including new metrics scraper tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)