### PR TITLE
[autoopt] Remove unnecessary shrink_to_fit in PrefixSetMut::freeze

### DIFF
--- a/crates/trie/common/src/prefix_set.rs
+++ b/crates/trie/common/src/prefix_set.rs
@@ -167,8 +167,6 @@ impl PrefixSetMut {
         } else {
             self.keys.sort_unstable();
             self.keys.dedup();
-            // Shrink after deduplication to release unused capacity.
-            self.keys.shrink_to_fit();
             PrefixSet { index: 0, all: false, keys: Arc::new(self.keys) }
         }
     }
@@ -289,27 +287,6 @@ mod tests {
         assert!(prefix_set.contains(&Nibbles::from_nibbles_unchecked([4, 5])));
         assert!(!prefix_set.contains(&Nibbles::from_nibbles_unchecked([7, 8])));
         assert_eq!(prefix_set.keys.len(), 3); // Length should be 3 (excluding duplicate)
-        assert_eq!(prefix_set.keys.capacity(), 3); // Capacity should be 3 after shrinking
-    }
-
-    #[test]
-    fn test_freeze_shrinks_existing_capacity() {
-        // do the above test but with preallocated capacity
-        let mut prefix_set_mut = PrefixSetMut::with_capacity(101);
-        prefix_set_mut.insert(Nibbles::from_nibbles([1, 2, 3]));
-        prefix_set_mut.insert(Nibbles::from_nibbles([1, 2, 4]));
-        prefix_set_mut.insert(Nibbles::from_nibbles([4, 5, 6]));
-        prefix_set_mut.insert(Nibbles::from_nibbles([1, 2, 3])); // Duplicate
-
-        assert_eq!(prefix_set_mut.keys.len(), 4); // Length is 4 (before deduplication)
-        assert_eq!(prefix_set_mut.keys.capacity(), 101); // Capacity is 101 (before deduplication)
-
-        let mut prefix_set = prefix_set_mut.freeze();
-        assert!(prefix_set.contains(&Nibbles::from_nibbles_unchecked([1, 2])));
-        assert!(prefix_set.contains(&Nibbles::from_nibbles_unchecked([4, 5])));
-        assert!(!prefix_set.contains(&Nibbles::from_nibbles_unchecked([7, 8])));
-        assert_eq!(prefix_set.keys.len(), 3); // Length should be 3 (excluding duplicate)
-        assert_eq!(prefix_set.keys.capacity(), 3); // Capacity should be 3 after shrinking
     }
 
     #[test]


### PR DESCRIPTION
Auto-generated optimization hypothesis. Branch: `auto-opt/20260221-prefixset-skip-shrink`