### PR TITLE
perf(storage): add bloom filter to skip MDBX seeks for empty slots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9236,6 +9236,7 @@ dependencies = [
  "reth-rpc-layer",
  "reth-stages",
  "reth-static-file",
+ "reth-storage-bloom",
  "reth-tasks",
  "reth-tokio-util",
  "reth-tracing",
@@ -9600,6 +9601,7 @@ dependencies = [
  "reth-stages-types",
  "reth-static-file-types",
  "reth-storage-api",
+ "reth-storage-bloom",
  "reth-storage-errors",
  "reth-tasks",
  "reth-testing-utils",
@@ -10249,6 +10251,14 @@ dependencies = [
  "reth-trie-common",
  "revm-database",
  "serde_json",
+]
+
+[[package]]
+name = "reth-storage-bloom"
+version = "1.11.0"
+dependencies = [
+ "alloy-primitives",
+ "codspeed-criterion-compat",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,9 +186,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "1.5.6"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ab1b2f1b48a7e6b3597cb2afae04f93879fb69d71e39736b5663d7366b23f2"
+checksum = "cc2db5c583aaef0255aa63a4fe827f826090142528bba48d1bf4119b62780cad"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -249,9 +249,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3231de68d5d6e75332b7489cfcc7f4dfabeba94d990a10e4b923af0e6623540"
+checksum = "f8222b1d88f9a6d03be84b0f5e76bb60cd83991b43ad8ab6477f0e4a7809b98d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -354,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.5.6"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e414aa37b335ad2acb78a95814c59d137d53139b412f87aed1e10e2d862cd49"
+checksum = "e9dbe713da0c737d9e5e387b0ba790eb98b14dd207fe53eef50e19a5a8ec3dac"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -420,9 +420,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-node-bindings"
-version = "1.6.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ce6930ce52e43b0768dc99ceeff5cb9e673e8c9f87d926914cd028b2e3f7233"
+checksum = "091dc8117d84de3a9ac7ec97f2c4d83987e24d485b478d26aa1ec455d7d52f7d"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks 0.2.13",
@@ -454,9 +454,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.5.6"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b1483f8c2562bf35f0270b697d5b5fe8170464e935bd855a4c5eaf6f89b354"
+checksum = "de3b431b4e72cd8bd0ec7a50b4be18e73dab74de0dba180eef171055e5d5926e"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -466,7 +466,7 @@ dependencies = [
  "derive_more",
  "fixed-cache",
  "foldhash 0.2.0",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "hashbrown 0.16.1",
  "indexmap 2.13.0",
  "itoa",
@@ -569,7 +569,7 @@ checksum = "ce8849c74c9ca0f5a03da1c865e3eb6f768df816e67dd3721a398a8a7e398011"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -810,23 +810,23 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.5.6"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4b64c8146291f750c3f391dff2dd40cf896f7e2b253417a31e342aa7265baa"
+checksum = "ab81bab693da9bb79f7a95b64b394718259fdd7e41dceeced4cad57cb71c4f6a"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.5.6"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9df903674682f9bae8d43fdea535ab48df2d6a8cb5104ca29c58ada22ef67b3"
+checksum = "489f1620bb7e2483fb5819ed01ab6edc1d2f93939dce35a5695085a1afd1d699"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
@@ -836,15 +836,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha3",
- "syn 2.0.115",
+ "syn 2.0.117",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.5.6"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "737b8a959f527a86e07c44656db237024a32ae9b97d449f788262a547e8aa136"
+checksum = "56cef806ad22d4392c5fc83cf8f2089f988eb99c7067b4e0c6f1971fc1cca318"
 dependencies = [
  "const-hex",
  "dunce",
@@ -852,15 +852,15 @@ dependencies = [
  "macro-string",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.5.6"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b28e6e86c6d2db52654b65a5a76b4f57eae5a32a7f0aa2222d1dbdb74e2cb8e0"
+checksum = "a6df77fea9d6a2a75c0ef8d2acbdfd92286cc599983d3175ccdc170d3433d249"
 dependencies = [
  "serde",
  "winnow",
@@ -868,9 +868,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.5.6"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdf7effe4ab0a4f52c865959f790036e61a7983f68b13b75d7fbcedf20b753ce"
+checksum = "64612d29379782a5dde6f4b6570d9c756d734d760c0c94c254d361e678a6591f"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -984,7 +984,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1054,9 +1054,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "approx"
@@ -1078,7 +1078,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1220,7 +1220,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1258,7 +1258,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1347,7 +1347,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1397,9 +1397,9 @@ dependencies = [
 
 [[package]]
 name = "asn1_der"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "155a5a185e42c6b77ac7b88a15143d930a9e9727a5b7b77eed417404ab15c247"
+checksum = "4858a9d740c5007a9069007c3b4e91152d0506f13c1b31dd49051fd537656156"
 
 [[package]]
 name = "assert_matches"
@@ -1420,9 +1420,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.39"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68650b7df54f0293fd061972a0fb05aaf4fc0879d3b3d21a638a182c5c543b9f"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -1463,7 +1463,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1474,7 +1474,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1486,6 +1486,15 @@ dependencies = [
  "futures",
  "pharos",
  "rustc_version 0.4.1",
+]
+
+[[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
 ]
 
 [[package]]
@@ -1512,7 +1521,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1614,32 +1623,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "bincode"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
-dependencies = [
- "bincode_derive",
- "serde",
- "unty",
-]
-
-[[package]]
-name = "bincode_derive"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
-dependencies = [
- "virtue",
-]
-
-[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -1648,7 +1637,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1690,9 +1679,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "arbitrary",
  "serde_core",
@@ -1756,7 +1745,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc119a5ad34c3f459062a96907f53358989b173d104258891bb74f95d93747e8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "boa_interner",
  "boa_macros",
  "boa_string",
@@ -1773,7 +1762,7 @@ checksum = "e637ec52ea66d76b0ca86180c259d6c7bb6e6a6e14b2f36b85099306d8b00cc3"
 dependencies = [
  "aligned-vec",
  "arrayvec",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "boa_ast",
  "boa_gc",
  "boa_interner",
@@ -1855,7 +1844,7 @@ dependencies = [
  "cow-utils",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -1865,7 +1854,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02f99bf5b684f0de946378fcfe5f38c3a0fbd51cbf83a0f39ff773a0e218541f"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "boa_ast",
  "boa_interner",
  "boa_macros",
@@ -1911,7 +1900,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1967,9 +1956,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "byte-slice-cast"
@@ -1994,7 +1983,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2111,9 +2100,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.55"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2150,9 +2139,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -2212,9 +2201,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.58"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63be97961acde393029492ce0be7a1af7e323e6bae9511ebfac33751be5e6806"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2222,9 +2211,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.58"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f13174bda5dfd69d7e947827e5af4b0f2f94a4a3ee92912fba07a66150f21e2"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2241,7 +2230,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2257,6 +2246,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2448,9 +2446,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.36"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00828ba6fd27b45a448e57dbfe84f1029d4c9f26b368157e9a448a5f49a2ec2a"
+checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
 dependencies = [
  "brotli",
  "compression-core",
@@ -2498,9 +2496,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.17.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bb320cac8a0750d7f25280aa97b09c26edfe161164238ecbbb31092b079e735"
+checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2678,7 +2676,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -2765,7 +2763,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
- "nix 0.31.1",
+ "nix 0.31.2",
  "windows-sys 0.61.2",
 ]
 
@@ -2793,7 +2791,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2850,7 +2848,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2865,7 +2863,7 @@ dependencies = [
  "quote",
  "serde",
  "strsim",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2878,7 +2876,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2889,7 +2887,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2900,7 +2898,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2911,7 +2909,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2953,7 +2951,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2985,9 +2983,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
@@ -3012,7 +3010,7 @@ checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3023,7 +3021,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3044,7 +3042,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3054,7 +3052,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3076,7 +3074,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.115",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -3163,11 +3161,11 @@ dependencies = [
 
 [[package]]
 name = "dispatch2"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block2",
  "libc",
  "objc2",
@@ -3181,7 +3179,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3228,7 +3226,7 @@ checksum = "1ec431cd708430d5029356535259c5d645d60edd3d39c54e5eea9782d46caa7d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3280,7 +3278,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3353,6 +3351,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3387,7 +3397,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3407,7 +3417,7 @@ checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3427,7 +3437,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3509,7 +3519,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3521,7 +3531,7 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4030,7 +4040,7 @@ checksum = "6dc7a9cb3326bafb80642c5ce99b39a2c0702d4bfa8ee8a3e773791a6cbe2407"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4103,9 +4113,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -4118,9 +4128,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -4141,15 +4151,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -4158,9 +4168,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-lite"
@@ -4192,26 +4202,26 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
@@ -4225,9 +4235,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -4237,7 +4247,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -4306,20 +4315,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -4346,7 +4355,7 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "libc",
  "libgit2-sys",
  "log",
@@ -4453,6 +4462,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d23bd4e7b5eda0d0f3a307e8b381fdc8ba9000f26fbe912250c0a4cc3956364a"
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4514,6 +4532,20 @@ checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
 dependencies = [
  "byteorder",
  "num-traits",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version 0.4.1",
+ "serde",
+ "spin",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -4953,7 +4985,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5026,7 +5058,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "inotify-sys",
  "libc",
 ]
@@ -5072,7 +5104,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5086,9 +5118,9 @@ dependencies = [
 
 [[package]]
 name = "interprocess"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53bf2b0e0785c5394a7392f66d7c4fb9c653633c29b27a932280da3cb344c66a"
+checksum = "6be5e5c847dbdb44564bd85294740d031f4f8aeb3464e5375ef7141f7538db69"
 dependencies = [
  "doctest-file",
  "futures-core",
@@ -5122,9 +5154,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
@@ -5237,9 +5269,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -5349,7 +5381,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5460,9 +5492,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures",
 ]
@@ -5511,9 +5543,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libgit2-sys"
@@ -5575,13 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "libc",
- "redox_syscall 0.7.1",
+ "plain",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -5602,9 +5635,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.23"
+version = "1.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
+checksum = "4735e9cbde5aac84a5ce588f6b23a90b9b0b528f6c5a8db8a4aff300463a0839"
 dependencies = [
  "cc",
  "libc",
@@ -5618,7 +5651,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -5639,9 +5672,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -5756,7 +5789,7 @@ checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5780,7 +5813,7 @@ checksum = "757aee279b8bdbb9f9e676796fd459e4207a1f986e87886700abf589f5abf771"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5800,9 +5833,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
 ]
@@ -5834,7 +5867,7 @@ checksum = "161ab904c2c62e7bda0f7562bf22f96440ca35ff79e66c800cbac298f2f4f5ec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5967,14 +6000,14 @@ checksum = "59b43b4fd69e3437618106f7754f34021b831a514f9e1a98ae863cabcd8d8dad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "moka"
-version = "0.12.13"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac832c50ced444ef6be0767a008b02c106a909ba79d1d830501e94b96f6b7e"
+checksum = "85f8024e1c8e71c778968af91d43700ce1d11b219d127d79fb2934153b82b42b"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -6040,7 +6073,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -6048,11 +6081,11 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225e7cfe711e0ba79a68baeddb2982723e4235247aefce1482f2f16c27865b66"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -6074,7 +6107,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -6092,7 +6125,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -6223,7 +6256,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6252,9 +6285,9 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
  "objc2-encode",
 ]
@@ -6265,7 +6298,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -6546,9 +6579,9 @@ dependencies = [
 
 [[package]]
 name = "owo-colors"
-version = "4.2.3"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "p256"
@@ -6599,7 +6632,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6714,7 +6747,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6728,29 +6761,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -6773,6 +6806,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plain_hasher"
@@ -6830,6 +6869,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6884,7 +6936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6909,9 +6961,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
 ]
@@ -6935,7 +6987,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6953,7 +7005,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25485360a54d6861439d60facef26de713b1e126bf015ec8f98239467a2b82f7"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "chrono",
  "flate2",
  "procfs-core",
@@ -6966,7 +7018,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6401bf7b6af22f78b563665d15a22e9aef27775b79b149a66ca022468a4e405"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "chrono",
  "hex",
 ]
@@ -6979,7 +7031,7 @@ checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
@@ -7008,7 +7060,7 @@ checksum = "fb6dc647500e84a25a85b100e76c85b8ace114c209432dc174f20aac11d4ed6c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7031,7 +7083,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7121,9 +7173,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -7133,6 +7185,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -7263,9 +7321,9 @@ dependencies = [
 
 [[package]]
 name = "rapidhash"
-version = "4.3.0"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84816e4c99c467e92cf984ee6328caa976dfecd33a673544489d79ca2caaefe5"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
 dependencies = [
  "rand 0.9.2",
  "rustversion",
@@ -7289,7 +7347,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "compact_str",
  "hashbrown 0.16.1",
  "indoc",
@@ -7321,7 +7379,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "hashbrown 0.16.1",
  "indoc",
  "instability",
@@ -7340,7 +7398,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -7375,16 +7433,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35985aa610addc02e24fc232012c86fd11f14111180f902b67e2d5331f8ebf2b"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -7415,7 +7473,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7443,9 +7501,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "regress"
@@ -7644,7 +7702,7 @@ dependencies = [
  "csv",
  "ctrlc",
  "eyre",
- "nix 0.31.1",
+ "nix 0.31.2",
  "reth-chainspec",
  "reth-cli-runner",
  "reth-cli-util",
@@ -7869,7 +7927,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "similar-asserts",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8774,7 +8832,7 @@ dependencies = [
  "alloy-evm",
  "alloy-primitives",
  "arbitrary",
- "bincode 1.3.3",
+ "bincode",
  "derive_more",
  "rand 0.9.2",
  "reth-ethereum-primitives",
@@ -8868,7 +8926,7 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "arbitrary",
- "bincode 1.3.3",
+ "bincode",
  "rand 0.9.2",
  "reth-chain-state",
  "reth-ethereum-primitives",
@@ -8946,7 +9004,7 @@ dependencies = [
 name = "reth-libmdbx"
 version = "1.11.1"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "byteorder",
  "crossbeam-queue",
  "dashmap",
@@ -9142,7 +9200,7 @@ name = "reth-nippy-jar"
 version = "1.11.1"
 dependencies = [
  "anyhow",
- "bincode 1.3.3",
+ "bincode",
  "derive_more",
  "lz4_flex",
  "memmap2",
@@ -9541,7 +9599,7 @@ dependencies = [
  "alloy-trie",
  "arbitrary",
  "auto_impl",
- "bincode 1.3.3",
+ "bincode",
  "byteorder",
  "bytes",
  "dashmap",
@@ -10087,7 +10145,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "assert_matches",
- "bincode 1.3.3",
+ "bincode",
  "eyre",
  "futures-util",
  "itertools 0.14.0",
@@ -10255,7 +10313,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-bloom"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "codspeed-criterion-compat",
@@ -10397,7 +10455,7 @@ dependencies = [
  "aquamarine",
  "assert_matches",
  "auto_impl",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "futures",
  "futures-util",
  "metrics",
@@ -10482,7 +10540,7 @@ dependencies = [
  "alloy-trie",
  "arbitrary",
  "arrayvec",
- "bincode 1.3.3",
+ "bincode",
  "bytes",
  "derive_more",
  "hash-db",
@@ -10805,7 +10863,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29404707763da607e5d6e4771cb203998c28159279c2f64cc32de08d2814651"
 dependencies = [
  "alloy-eip7928",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "revm-bytecode",
  "revm-primitives",
  "serde",
@@ -10948,7 +11006,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version 0.4.1",
- "syn 2.0.115",
+ "syn 2.0.117",
  "unicode-ident",
 ]
 
@@ -11037,11 +11095,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -11050,9 +11108,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "log",
  "once_cell",
@@ -11276,11 +11334,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.5.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -11289,9 +11347,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -11388,7 +11446,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -11439,9 +11497,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.16.1"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
+checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -11458,14 +11516,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.1"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -11605,9 +11663,9 @@ dependencies = [
 
 [[package]]
 name = "simple_asn1"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -11623,9 +11681,9 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "sketches-ddsketch"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
 
 [[package]]
 name = "slab"
@@ -11714,6 +11772,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11769,7 +11836,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -11791,9 +11858,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.115"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e614ed320ac28113fa64972c4262d5dbc89deacdfd00c34a3e4cea073243c12"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11802,14 +11869,14 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.5.6"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8658017776544996edc21c8c7cc8bb4f13db60955382f4bac25dc6303b38438"
+checksum = "53f425ae0b12e2f5ae65542e00898d500d4d318b4baf09f40fd0d410454e9947"
 dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -11829,14 +11896,14 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "sysinfo"
-version = "0.38.1"
+version = "0.38.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5792d209c2eac902426c0c4a166c9f72147db453af548cf9bf3242644c4d4fe3"
+checksum = "d03c61d2a49c649a15c407338afe7accafde9dac869995dccb73e5f7ef7d9034"
 dependencies = [
  "libc",
  "memchr",
@@ -11877,12 +11944,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand 2.3.0",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -11906,7 +11973,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -11917,15 +11984,15 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
  "test-case-core",
 ]
 
 [[package]]
 name = "test-fuzz"
-version = "7.2.5"
+version = "7.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11e5c77910b1d5b469a342be541cf44933f0ad2c4b8d5acb32ee46697fd60546"
+checksum = "bdcc9e8244ec7140f52b55bb67ff77fe5e10f1e7651a9d7ca1187555344a212d"
 dependencies = [
  "serde",
  "serde_combinators",
@@ -11936,35 +12003,35 @@ dependencies = [
 
 [[package]]
 name = "test-fuzz-internal"
-version = "7.2.5"
+version = "7.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d25f2f0ee315b130411a98570dd128dfe344bfaa0a28bf33d38f4a1fe85f39b"
+checksum = "b36ec8e4151160eb1b1d42d4691c24b5a6f3891c75d41afb343346801ab60ce5"
 dependencies = [
- "bincode 2.0.1",
  "cargo_metadata 0.19.2",
+ "postcard",
  "serde",
 ]
 
 [[package]]
 name = "test-fuzz-macro"
-version = "7.2.5"
+version = "7.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c03ba0a9e3e4032f94d71c85e149af147843c6f212e4ca4383542d606b04a6"
+checksum = "bd45ef045619b976f1efa036aee72b6a80dc359d800e11f9d636332ebf6655f9"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "heck",
  "itertools 0.14.0",
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "test-fuzz-runtime"
-version = "7.2.5"
+version = "7.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a4ac481aa983d386e857a7be0006c2f0ef26e0c5326bbc7262f73c2891b91d"
+checksum = "91e243f304ded602493cfd77bee2f627f376bec4ea185cf8e9674b6150ea3837"
 dependencies = [
  "hex",
  "num-traits",
@@ -12005,7 +12072,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -12016,7 +12083,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -12025,7 +12092,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2210811179577da3d54eb69ab0b50490ee40491a25d95b8c6011ba40771cb721"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cfg-if",
  "libc",
  "log",
@@ -12154,9 +12221,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -12171,13 +12238,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -12254,7 +12321,7 @@ dependencies = [
  "indexmap 2.13.0",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow",
@@ -12270,22 +12337,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+name = "toml_datetime"
+version = "1.0.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0a07913e63758bc95142d9863a5a45173b71515e68b690cad70cf99c3255ce1"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime",
+ "toml_datetime 1.0.0+spec-1.1.0",
  "toml_parser",
  "winnow",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.7+spec-1.1.0"
+version = "1.0.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "247eaa3197818b831697600aadf81514e577e0cba5eab10f7e064e78ae154df1"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
@@ -12298,9 +12374,9 @@ checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tonic"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a286e33f82f8a1ee2df63f4fa35c0becf4a85a0cb03091a15fd7bf0b402dc94a"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -12324,9 +12400,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c55a2d6a14174563de34409c9f92ff981d006f56da9c6ecd40d9d4a31500b0"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
 dependencies = [
  "bytes",
  "prost",
@@ -12361,7 +12437,7 @@ checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "async-compression",
  "base64 0.22.1",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -12428,7 +12504,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -12622,7 +12698,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -12733,9 +12809,9 @@ checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
@@ -12789,12 +12865,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "unty"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12833,11 +12903,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.20.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
+checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -12902,12 +12972,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
-name = "virtue"
-version = "0.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
-
-[[package]]
 name = "visibility"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12915,7 +12979,7 @@ checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -12984,9 +13048,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -12997,9 +13061,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -13011,9 +13075,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -13021,22 +13085,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
@@ -13082,7 +13146,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap 2.13.0",
  "semver 1.0.27",
@@ -13104,9 +13168,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -13294,7 +13358,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -13305,7 +13369,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -13740,7 +13804,7 @@ dependencies = [
  "heck",
  "indexmap 2.13.0",
  "prettyplease",
- "syn 2.0.115",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -13756,7 +13820,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -13768,7 +13832,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "indexmap 2.13.0",
  "log",
  "serde",
@@ -13879,28 +13943,28 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -13920,7 +13984,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -13941,7 +14005,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -13975,7 +14039,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ members = [
     "crates/storage/db-common",
     "crates/storage/db-models/",
     "crates/storage/db/",
+    "crates/storage/bloom/",
     "crates/storage/errors/",
     "crates/storage/libmdbx-rs/",
     "crates/storage/libmdbx-rs/mdbx-sys/",
@@ -422,6 +423,7 @@ reth-stages-types = { path = "crates/stages/types", default-features = false }
 reth-static-file = { path = "crates/static-file/static-file" }
 reth-static-file-types = { path = "crates/static-file/types", default-features = false }
 reth-storage-api = { path = "crates/storage/storage-api", default-features = false }
+reth-storage-bloom = { path = "crates/storage/bloom", default-features = false }
 reth-storage-errors = { path = "crates/storage/errors", default-features = false }
 reth-tasks = { path = "crates/tasks" }
 reth-testing-utils = { path = "testing/testing-utils" }

--- a/crates/node/builder/Cargo.toml
+++ b/crates/node/builder/Cargo.toml
@@ -49,6 +49,7 @@ reth-rpc-eth-types.workspace = true
 reth-rpc-layer.workspace = true
 reth-stages.workspace = true
 reth-static-file.workspace = true
+reth-storage-bloom = { workspace = true, features = ["std"] }
 reth-tasks = { workspace = true, features = ["rayon"] }
 reth-tokio-util.workspace = true
 reth-tracing.workspace = true

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -78,6 +78,7 @@ use reth_stages::{
     StageId,
 };
 use reth_static_file::StaticFileProducer;
+use reth_storage_bloom::StorageBloomFilter;
 use reth_tasks::TaskExecutor;
 use reth_tracing::{
     throttle,
@@ -496,7 +497,7 @@ where
             .with_statistics()
             .build()?;
 
-        let factory = ProviderFactory::new(
+        let mut factory = ProviderFactory::new(
             self.right().clone(),
             self.chain_spec(),
             static_file_provider,
@@ -564,6 +565,66 @@ where
             rx.await?.inspect_err(|err| {
                 error!(target: "reth::cli", %unwind_target, %inconsistency_source, %err, "failed to run unwind")
             })?;
+        }
+
+        // Optionally initialize the storage bloom filter for short-circuiting empty slot reads.
+        if self.node_config().storage.bloom_filter {
+            let size_mb = self.node_config().storage.bloom_filter_size_mb;
+            let size_bytes = (size_mb as usize) * 1024 * 1024;
+            let bloom_path = self.data_dir().data_dir().join("storage_bloom.bin");
+
+            // Snapshot the tip before bloom init so the saved block number
+            // matches what the bloom actually contains.
+            let tip = factory.provider()?.best_block_number()?;
+            let start = std::time::Instant::now();
+
+            // Try loading a persisted bloom filter first; fall back to full scan.
+            // IO errors (permission denied, corruption) are non-fatal — log and rebuild.
+            let persisted = match StorageBloomFilter::load_from_file(&bloom_path, size_bytes) {
+                Ok(result) => result,
+                Err(err) => {
+                    warn!(
+                        target: "reth::cli",
+                        %err,
+                        "Failed to load bloom filter file, rebuilding from scratch"
+                    );
+                    None
+                }
+            };
+
+            let bloom = if let Some((loaded, saved_block)) = persisted {
+                let catchup =
+                    factory.provider()?.catchup_storage_bloom(&loaded, saved_block)?;
+                let elapsed = start.elapsed();
+                info!(
+                    target: "reth::cli",
+                    size_mb,
+                    saved_block,
+                    catchup_entries = catchup,
+                    elapsed_secs = elapsed.as_secs_f64(),
+                    "Loaded storage bloom filter from disk"
+                );
+                Arc::new(loaded)
+            } else {
+                let fresh = Arc::new(StorageBloomFilter::with_size_mb(size_mb));
+                let entries = factory.provider()?.populate_storage_bloom(&fresh)?;
+                let elapsed = start.elapsed();
+                info!(
+                    target: "reth::cli",
+                    entries,
+                    size_mb,
+                    elapsed_secs = elapsed.as_secs_f64(),
+                    "Populated storage bloom filter from scratch"
+                );
+                fresh
+            };
+
+            // Persist the bloom so the next restart can do an incremental catchup.
+            if let Err(err) = bloom.save_to_file(&bloom_path, tip) {
+                warn!(target: "reth::cli", %err, "Failed to persist storage bloom filter");
+            }
+
+            factory = factory.with_storage_bloom(bloom);
         }
 
         Ok(factory)

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -593,8 +593,7 @@ where
             };
 
             let bloom = if let Some((loaded, saved_block)) = persisted {
-                let catchup =
-                    factory.provider()?.catchup_storage_bloom(&loaded, saved_block)?;
+                let catchup = factory.provider()?.catchup_storage_bloom(&loaded, saved_block)?;
                 let elapsed = start.elapsed();
                 info!(
                     target: "reth::cli",

--- a/crates/node/core/src/args/storage.rs
+++ b/crates/node/core/src/args/storage.rs
@@ -8,7 +8,7 @@ use clap::{ArgAction, Args};
 /// optimizations) or v1/legacy storage defaults.
 ///
 /// Individual storage settings can be overridden with `--static-files.*` and `--rocksdb.*` flags.
-#[derive(Debug, Args, PartialEq, Eq, Clone, Copy, Default)]
+#[derive(Debug, Args, PartialEq, Eq, Clone, Copy)]
 #[command(next_help_heading = "Storage")]
 pub struct StorageArgs {
     /// Enable v2 storage defaults (static files + `RocksDB` routing).
@@ -25,6 +25,33 @@ pub struct StorageArgs {
     /// flags.
     #[arg(long = "storage.v2", action = ArgAction::SetTrue)]
     pub v2: bool,
+
+    /// Enable in-memory bloom filter for short-circuiting empty storage slot reads.
+    ///
+    /// When enabled, the node builds a bloom filter over all `(address, slot)` pairs on startup
+    /// and checks it before every MDBX storage seek. If the filter says a slot was never
+    /// written, the seek is skipped entirely. This benefits the 30-40% of SLOAD operations
+    /// that target empty slots.
+    #[arg(long = "storage.bloom-filter", action = ArgAction::SetTrue)]
+    pub bloom_filter: bool,
+
+    /// Bloom filter size in megabytes (default: 1024, minimum: 1).
+    ///
+    /// Larger filters have fewer false positives but use more RAM.
+    /// With K=3 hash functions, a 1024 MB filter supports ~700M entries at <1% FP rate,
+    /// covering mainnet's ~500M non-zero storage slots with room to grow.
+    #[arg(
+        long = "storage.bloom-filter-size-mb",
+        default_value_t = 1024,
+        value_parser = clap::value_parser!(u64).range(1..),
+    )]
+    pub bloom_filter_size_mb: u64,
+}
+
+impl Default for StorageArgs {
+    fn default() -> Self {
+        Self { v2: false, bloom_filter: false, bloom_filter_size_mb: 1024 }
+    }
 }
 
 #[cfg(test)]
@@ -45,11 +72,37 @@ mod tests {
         let args = CommandParser::<StorageArgs>::parse_from(["reth"]).args;
         assert_eq!(args, default_args);
         assert!(!args.v2);
+        assert!(!args.bloom_filter);
+        assert_eq!(args.bloom_filter_size_mb, 1024);
     }
 
     #[test]
     fn test_parse_v2_flag() {
         let args = CommandParser::<StorageArgs>::parse_from(["reth", "--storage.v2"]).args;
         assert!(args.v2);
+    }
+
+    #[test]
+    fn test_parse_bloom_filter_flags() {
+        let args = CommandParser::<StorageArgs>::parse_from([
+            "reth",
+            "--storage.bloom-filter",
+            "--storage.bloom-filter-size-mb",
+            "128",
+        ])
+        .args;
+        assert!(args.bloom_filter);
+        assert_eq!(args.bloom_filter_size_mb, 128);
+    }
+
+    #[test]
+    fn test_bloom_filter_size_zero_rejected() {
+        let result = CommandParser::<StorageArgs>::try_parse_from([
+            "reth",
+            "--storage.bloom-filter",
+            "--storage.bloom-filter-size-mb",
+            "0",
+        ]);
+        assert!(result.is_err(), "size 0 should be rejected by value_parser");
     }
 }

--- a/crates/storage/bloom/Cargo.toml
+++ b/crates/storage/bloom/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "reth-storage-bloom"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "In-memory bloom filter for short-circuiting empty storage slot reads"
+
+[lints]
+workspace = true
+
+[dependencies]
+# ethereum
+alloy-primitives.workspace = true
+
+[dev-dependencies]
+criterion.workspace = true
+
+[[bench]]
+name = "bloom_filter"
+harness = false
+
+[features]
+default = ["std"]
+std = [
+    "alloy-primitives/std",
+]

--- a/crates/storage/bloom/benches/bloom_filter.rs
+++ b/crates/storage/bloom/benches/bloom_filter.rs
@@ -1,0 +1,157 @@
+//! Benchmarks for `StorageBloomFilter`.
+//!
+//! Measures insert and lookup throughput to validate that the bloom filter
+//! adds negligible overhead compared to MDBX seeks (~1-10us).
+
+use alloy_primitives::{address, Address, B256, U256};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use reth_storage_bloom::StorageBloomFilter;
+
+/// Generate deterministic (address, slot) pairs for benchmarking.
+fn generate_pairs(n: u64) -> Vec<(Address, B256)> {
+    let addr = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
+    (0..n).map(|i| (addr, B256::from(U256::from(i)))).collect()
+}
+
+/// Generate absent pairs (different address, so guaranteed not in bloom after inserting
+/// pairs from `generate_pairs`).
+fn generate_absent_pairs(n: u64) -> Vec<(Address, B256)> {
+    let addr = address!("1111111111111111111111111111111111111111");
+    (0..n).map(|i| (addr, B256::from(U256::from(i)))).collect()
+}
+
+fn bench_insert(c: &mut Criterion) {
+    let mut group = c.benchmark_group("bloom_insert");
+
+    for size_mb in [16, 128, 256] {
+        let bloom = StorageBloomFilter::with_size_mb(size_mb);
+        let pairs = generate_pairs(10_000);
+
+        group.bench_with_input(
+            BenchmarkId::new("insert", format!("{size_mb}MB")),
+            &pairs,
+            |b, pairs| {
+                b.iter(|| {
+                    for (addr, slot) in pairs {
+                        bloom.insert(addr, slot);
+                    }
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_might_contain_true_negative(c: &mut Criterion) {
+    let mut group = c.benchmark_group("bloom_true_negative");
+
+    for size_mb in [16, 128, 256] {
+        let bloom = StorageBloomFilter::with_size_mb(size_mb);
+        let pairs = generate_pairs(100_000);
+        for (addr, slot) in &pairs {
+            bloom.insert(addr, slot);
+        }
+
+        let absent = generate_absent_pairs(10_000);
+
+        group.bench_with_input(
+            BenchmarkId::new("might_contain_miss", format!("{size_mb}MB")),
+            &absent,
+            |b, absent| {
+                b.iter(|| {
+                    for (addr, slot) in absent {
+                        std::hint::black_box(bloom.might_contain(addr, slot));
+                    }
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_might_contain_true_positive(c: &mut Criterion) {
+    let mut group = c.benchmark_group("bloom_true_positive");
+
+    for size_mb in [16, 128, 256] {
+        let bloom = StorageBloomFilter::with_size_mb(size_mb);
+        let pairs = generate_pairs(100_000);
+        for (addr, slot) in &pairs {
+            bloom.insert(addr, slot);
+        }
+
+        // Query the same pairs we inserted — all should be true positives
+        let query: Vec<_> = pairs.iter().take(10_000).copied().collect();
+
+        group.bench_with_input(
+            BenchmarkId::new("might_contain_hit", format!("{size_mb}MB")),
+            &query,
+            |b, query| {
+                b.iter(|| {
+                    for (addr, slot) in query {
+                        std::hint::black_box(bloom.might_contain(addr, slot));
+                    }
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_mixed_workload(c: &mut Criterion) {
+    let mut group = c.benchmark_group("bloom_mixed_workload");
+
+    // Simulate realistic workload: 35% misses, 65% hits (based on Nethermind data)
+    let bloom = StorageBloomFilter::with_size_mb(256);
+    let hit_pairs = generate_pairs(65_000);
+    for (addr, slot) in &hit_pairs {
+        bloom.insert(addr, slot);
+    }
+
+    let miss_pairs = generate_absent_pairs(35_000);
+
+    // Interleave hits and misses
+    let mut mixed: Vec<(Address, B256, bool)> = Vec::with_capacity(10_000);
+    let mut hit_idx = 0;
+    let mut miss_idx = 0;
+    for i in 0..10_000u64 {
+        if i % 100 < 35 {
+            // 35% miss
+            mixed.push((miss_pairs[miss_idx].0, miss_pairs[miss_idx].1, false));
+            miss_idx += 1;
+        } else {
+            // 65% hit
+            mixed.push((hit_pairs[hit_idx].0, hit_pairs[hit_idx].1, true));
+            hit_idx += 1;
+        }
+    }
+
+    group.bench_function("35pct_miss_65pct_hit", |b| {
+        b.iter(|| {
+            let mut short_circuited = 0u64;
+            for (addr, slot, _expected) in &mixed {
+                if !bloom.might_contain(addr, slot) {
+                    short_circuited += 1;
+                    continue;
+                }
+                // In production this would be an MDBX seek.
+                // Here we just simulate the bloom check overhead.
+                std::hint::black_box(());
+            }
+            std::hint::black_box(short_circuited);
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_insert,
+    bench_might_contain_true_negative,
+    bench_might_contain_true_positive,
+    bench_mixed_workload,
+);
+criterion_main!(benches);

--- a/crates/storage/bloom/benches/bloom_filter.rs
+++ b/crates/storage/bloom/benches/bloom_filter.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 //! Benchmarks for `StorageBloomFilter`.
 //!
 //! Measures insert and lookup throughput to validate that the bloom filter

--- a/crates/storage/bloom/src/lib.rs
+++ b/crates/storage/bloom/src/lib.rs
@@ -1,0 +1,467 @@
+//! In-memory bloom filter for short-circuiting empty storage slot reads.
+//!
+//! When the EVM executes `SLOAD`, 30-40% of reads target storage slots that have
+//! never been written (Nethermind data). Each of these still requires a full MDBX
+//! B-tree seek. This bloom filter returns a definitive "not present" answer in <400ns,
+//! eliminating the seek entirely for those cases.
+//!
+//! # Design
+//!
+//! - **Lock-free**: Bit array uses [`AtomicU64`] with relaxed ordering — no contention
+//!   between reader threads, no locks on the hot path.
+//! - **Zero false negatives**: If `might_contain` returns `false`, the slot is
+//!   guaranteed absent. A `true` result may be a false positive.
+//! - **Insert-only**: Bits are never cleared. Deleted storage slots become false
+//!   positives, causing a harmless fallback to MDBX. Rebuild on restart resets the
+//!   filter.
+//! - **Double hashing**: We extract two 64-bit values from `keccak256(address || slot)`
+//!   and derive K probe positions via `h1 + i·h2 mod m`. This avoids multiple
+//!   independent hash function calls.
+
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
+    html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",
+    issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
+)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+use alloc::boxed::Box;
+use alloy_primitives::{keccak256, Address, B256};
+use core::sync::atomic::{AtomicU64, Ordering};
+
+/// Default number of hash functions.
+const DEFAULT_NUM_HASHES: u8 = 3;
+
+/// Magic bytes identifying a bloom filter file: "RETHBLOM"
+#[cfg(feature = "std")]
+const BLOOM_FILE_MAGIC: &[u8; 8] = b"RETHBLOM";
+
+/// File format version. Bump this if the format changes.
+#[cfg(feature = "std")]
+const BLOOM_FILE_VERSION: u8 = 1;
+
+/// A concurrent, insert-only bloom filter for `(Address, StorageSlot)` pairs.
+///
+/// Designed to sit in front of MDBX storage reads and short-circuit lookups
+/// for slots that have never been written.
+pub struct StorageBloomFilter {
+    /// Bit array stored as atomic 64-bit words for lock-free access.
+    bits: Box<[AtomicU64]>,
+    /// Total number of usable bits (`bits.len() * 64`).
+    num_bits: u64,
+    /// Number of hash probe positions per key (K).
+    num_hashes: u8,
+}
+
+impl StorageBloomFilter {
+    /// Creates a new bloom filter with the given size in bytes and hash count.
+    ///
+    /// # Arguments
+    /// - `size_bytes`: Total memory for the bit array. Must be >= 8 (one u64).
+    /// - `num_hashes`: Number of probe positions per key (K). Typical: 3.
+    ///
+    /// # Panics
+    /// Panics if `size_bytes < 8`.
+    pub fn new(size_bytes: usize, num_hashes: u8) -> Self {
+        assert!(size_bytes >= 8, "bloom filter must be at least 8 bytes");
+        let num_words = size_bytes / 8;
+        let bits: Box<[AtomicU64]> = (0..num_words)
+            .map(|_| AtomicU64::new(0))
+            .collect::<alloc::vec::Vec<_>>()
+            .into_boxed_slice();
+        let num_bits = (num_words as u64) * 64;
+        Self { bits, num_bits, num_hashes }
+    }
+
+    /// Creates a bloom filter with the given size in megabytes and default hash count.
+    pub fn with_size_mb(size_mb: u64) -> Self {
+        let size_bytes = (size_mb as usize) * 1024 * 1024;
+        Self::new(size_bytes, DEFAULT_NUM_HASHES)
+    }
+
+    /// Hashes `address || slot` with keccak256 and returns `(h1, h2)` for double hashing.
+    #[inline]
+    fn hash_pair(address: &Address, slot: &B256) -> (u64, u64) {
+        let mut buf = [0u8; 52];
+        buf[..20].copy_from_slice(address.as_ref());
+        buf[20..].copy_from_slice(slot.as_ref());
+        let hash = keccak256(buf);
+        let h1 = u64::from_le_bytes(hash[0..8].try_into().unwrap());
+        let h2 = u64::from_le_bytes(hash[8..16].try_into().unwrap());
+        (h1, h2)
+    }
+
+    /// Inserts an `(address, slot)` pair into the bloom filter.
+    ///
+    /// After this call, `might_contain(address, slot)` is guaranteed to return `true`.
+    /// This operation is lock-free (atomic OR).
+    #[inline]
+    pub fn insert(&self, address: &Address, slot: &B256) {
+        let (h1, h2) = Self::hash_pair(address, slot);
+        for i in 0..self.num_hashes as u64 {
+            let pos = h1.wrapping_add(i.wrapping_mul(h2)) % self.num_bits;
+            let word_idx = (pos / 64) as usize;
+            let bit_idx = pos % 64;
+            self.bits[word_idx].fetch_or(1u64 << bit_idx, Ordering::Relaxed);
+        }
+    }
+
+    /// Checks whether an `(address, slot)` pair *might* be in the filter.
+    ///
+    /// - Returns `false` → the slot is **guaranteed absent** (true negative).
+    /// - Returns `true`  → the slot is **probably present** (may be a false positive).
+    #[inline]
+    pub fn might_contain(&self, address: &Address, slot: &B256) -> bool {
+        let (h1, h2) = Self::hash_pair(address, slot);
+        for i in 0..self.num_hashes as u64 {
+            let pos = h1.wrapping_add(i.wrapping_mul(h2)) % self.num_bits;
+            let word_idx = (pos / 64) as usize;
+            let bit_idx = pos % 64;
+            if self.bits[word_idx].load(Ordering::Relaxed) & (1u64 << bit_idx) == 0 {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Returns the memory usage in bytes.
+    pub fn memory_usage_bytes(&self) -> usize {
+        self.bits.len() * 8
+    }
+
+    /// Returns the total number of bits set to 1.
+    pub fn count_set_bits(&self) -> u64 {
+        self.bits.iter().map(|w| w.load(Ordering::Relaxed).count_ones() as u64).sum()
+    }
+
+    /// Saves the bloom filter to a file.
+    ///
+    /// File format: `[magic: 8B][version: 1B][num_hashes: 1B][block_number: 8B][num_words: 8B][raw bits...]`
+    ///
+    /// The `block_number` is stored so that on restart we can incrementally catch up
+    /// from changesets instead of re-scanning the entire `PlainStorageState` table.
+    #[cfg(feature = "std")]
+    pub fn save_to_file(
+        &self,
+        path: &std::path::Path,
+        block_number: u64,
+    ) -> std::io::Result<()> {
+        use std::io::Write;
+
+        let tmp = path.with_extension("tmp");
+        let mut file = std::fs::File::create(&tmp)?;
+
+        // Header
+        file.write_all(BLOOM_FILE_MAGIC)?;
+        file.write_all(&[BLOOM_FILE_VERSION])?;
+        file.write_all(&[self.num_hashes])?;
+        file.write_all(&block_number.to_le_bytes())?;
+        let num_words = self.bits.len() as u64;
+        file.write_all(&num_words.to_le_bytes())?;
+
+        // Bit array — read each atomic word and write as LE bytes
+        for word in self.bits.iter() {
+            file.write_all(&word.load(Ordering::Relaxed).to_le_bytes())?;
+        }
+
+        file.flush()?;
+        drop(file);
+
+        // Atomic rename to avoid partial reads on crash
+        std::fs::rename(&tmp, path)?;
+        Ok(())
+    }
+
+    /// Loads a bloom filter from a file previously written by [`save_to_file`](Self::save_to_file).
+    ///
+    /// Returns `(bloom, block_number)` where `block_number` is the tip at which the filter
+    /// was saved. The caller should catch up from `block_number + 1` to the current tip
+    /// using storage changesets.
+    ///
+    /// Returns `Ok(None)` if the file does not exist or has an incompatible format/size.
+    #[cfg(feature = "std")]
+    pub fn load_from_file(
+        path: &std::path::Path,
+        expected_size_bytes: usize,
+    ) -> std::io::Result<Option<(Self, u64)>> {
+        use std::io::Read;
+
+        if !path.exists() {
+            return Ok(None);
+        }
+
+        let mut file = std::fs::File::open(path)?;
+
+        // Read header
+        let mut magic = [0u8; 8];
+        if file.read_exact(&mut magic).is_err() {
+            return Ok(None);
+        }
+        if magic != *BLOOM_FILE_MAGIC {
+            return Ok(None);
+        }
+
+        let mut version = [0u8; 1];
+        file.read_exact(&mut version)?;
+        if version[0] != BLOOM_FILE_VERSION {
+            return Ok(None);
+        }
+
+        let mut num_hashes_buf = [0u8; 1];
+        file.read_exact(&mut num_hashes_buf)?;
+        let num_hashes = num_hashes_buf[0];
+
+        let mut block_buf = [0u8; 8];
+        file.read_exact(&mut block_buf)?;
+        let block_number = u64::from_le_bytes(block_buf);
+
+        let mut words_buf = [0u8; 8];
+        file.read_exact(&mut words_buf)?;
+        let num_words = u64::from_le_bytes(words_buf) as usize;
+
+        // Validate size matches what we expect
+        let expected_words = expected_size_bytes / 8;
+        if num_words != expected_words {
+            return Ok(None);
+        }
+
+        // Read bit array
+        let mut bits: Box<[AtomicU64]> = (0..num_words)
+            .map(|_| AtomicU64::new(0))
+            .collect::<alloc::vec::Vec<_>>()
+            .into_boxed_slice();
+
+        let mut word_bytes = [0u8; 8];
+        for word in bits.iter_mut() {
+            file.read_exact(&mut word_bytes)?;
+            *word = AtomicU64::new(u64::from_le_bytes(word_bytes));
+        }
+
+        let num_bits = (num_words as u64) * 64;
+        let bloom = Self { bits, num_bits, num_hashes };
+        Ok(Some((bloom, block_number)))
+    }
+
+    /// Returns the approximate false positive rate based on saturation.
+    ///
+    /// Formula: `(set_bits / total_bits) ^ num_hashes`
+    #[cfg(feature = "std")]
+    pub fn estimated_false_positive_rate(&self) -> f64 {
+        let set_bits = self.count_set_bits();
+        let saturation = set_bits as f64 / self.num_bits as f64;
+        saturation.powi(self.num_hashes as i32)
+    }
+
+    /// Returns the total number of items that can be tracked before exceeding
+    /// a given target false positive rate.
+    ///
+    /// Useful for deciding filter size.
+    #[cfg(feature = "std")]
+    pub fn capacity_at_fp_rate(&self, target_fp: f64) -> u64 {
+        // n = -m * ln(1 - (fp^(1/k))) / k
+        // where m = num_bits, k = num_hashes, fp = target false positive rate
+        let k = self.num_hashes as f64;
+        let m = self.num_bits as f64;
+        let inner = 1.0 - target_fp.powf(1.0 / k);
+        if inner <= 0.0 {
+            return 0;
+        }
+        ((-m * inner.ln()) / k) as u64
+    }
+}
+
+impl core::fmt::Debug for StorageBloomFilter {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut s = f.debug_struct("StorageBloomFilter");
+        s.field("size_mb", &(self.memory_usage_bytes() / (1024 * 1024)))
+            .field("num_bits", &self.num_bits)
+            .field("num_hashes", &self.num_hashes)
+            .field("set_bits", &self.count_set_bits());
+        #[cfg(feature = "std")]
+        s.field("est_fp_rate", &self.estimated_false_positive_rate());
+        s.finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{address, b256};
+
+    #[test]
+    fn insert_and_query() {
+        let bloom = StorageBloomFilter::new(1024, 3); // 1KB
+        let addr = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
+        let slot = b256!("0000000000000000000000000000000000000000000000000000000000000001");
+
+        assert!(!bloom.might_contain(&addr, &slot));
+        bloom.insert(&addr, &slot);
+        assert!(bloom.might_contain(&addr, &slot));
+    }
+
+    #[test]
+    fn absent_key_returns_false() {
+        let bloom = StorageBloomFilter::new(1024 * 1024, 3); // 1MB - low FP rate
+        let addr = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
+        let slot = b256!("0000000000000000000000000000000000000000000000000000000000000001");
+        let absent = b256!("0000000000000000000000000000000000000000000000000000000000000002");
+
+        bloom.insert(&addr, &slot);
+        // With 1MB filter and 1 inserted key, the absent key should almost certainly be false
+        assert!(!bloom.might_contain(&addr, &absent));
+    }
+
+    #[test]
+    fn empty_bloom_returns_false() {
+        let bloom = StorageBloomFilter::new(64, 3); // minimum size
+        let addr = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
+        let slot = b256!("0000000000000000000000000000000000000000000000000000000000000001");
+
+        assert!(!bloom.might_contain(&addr, &slot));
+        assert_eq!(bloom.count_set_bits(), 0);
+    }
+
+    #[test]
+    fn false_positive_rate_stays_low() {
+        // Insert 10K keys into a 1MB filter, expect FP rate < 1%
+        let bloom = StorageBloomFilter::new(1024 * 1024, 3);
+        let base_addr = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
+
+        // Insert 10K distinct slots
+        for i in 0u64..10_000 {
+            let slot = B256::from(alloy_primitives::U256::from(i));
+            bloom.insert(&base_addr, &slot);
+        }
+
+        // Check 10K absent slots (different address)
+        let other_addr = address!("1111111111111111111111111111111111111111");
+        let mut false_positives = 0u64;
+        for i in 0u64..10_000 {
+            let slot = B256::from(alloy_primitives::U256::from(i));
+            if bloom.might_contain(&other_addr, &slot) {
+                false_positives += 1;
+            }
+        }
+
+        let fp_rate = false_positives as f64 / 10_000.0;
+        assert!(
+            fp_rate < 0.01,
+            "false positive rate too high: {fp_rate:.4} ({false_positives}/10000)"
+        );
+    }
+
+    #[test]
+    fn no_false_negatives() {
+        // Every inserted key must be found
+        let bloom = StorageBloomFilter::new(1024 * 1024, 3);
+        let addr = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
+
+        let slots: Vec<B256> =
+            (0u64..1000).map(|i| B256::from(alloy_primitives::U256::from(i))).collect();
+
+        for slot in &slots {
+            bloom.insert(&addr, slot);
+        }
+
+        for slot in &slots {
+            assert!(bloom.might_contain(&addr, slot), "false negative for slot {slot}");
+        }
+    }
+
+    #[test]
+    fn thread_safety() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let bloom = Arc::new(StorageBloomFilter::new(1024 * 1024, 3));
+        let addr = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
+
+        // Spawn 4 writer threads
+        let mut handles = vec![];
+        for t in 0..4u64 {
+            let bloom = Arc::clone(&bloom);
+            handles.push(thread::spawn(move || {
+                for i in 0..1000u64 {
+                    let slot = B256::from(alloy_primitives::U256::from(t * 1000 + i));
+                    bloom.insert(&addr, &slot);
+                }
+            }));
+        }
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        // All 4000 keys must be present
+        for t in 0..4u64 {
+            for i in 0..1000u64 {
+                let slot = B256::from(alloy_primitives::U256::from(t * 1000 + i));
+                assert!(bloom.might_contain(&addr, &slot));
+            }
+        }
+    }
+
+    #[test]
+    fn memory_usage_matches() {
+        let bloom = StorageBloomFilter::with_size_mb(1);
+        assert_eq!(bloom.memory_usage_bytes(), 1024 * 1024);
+    }
+
+    #[test]
+    fn debug_format() {
+        let bloom = StorageBloomFilter::new(1024, 3);
+        let debug = format!("{bloom:?}");
+        assert!(debug.contains("StorageBloomFilter"));
+        assert!(debug.contains("num_hashes: 3"));
+    }
+
+    #[test]
+    fn save_and_load_roundtrip() {
+        let dir = std::env::temp_dir().join("reth_bloom_test_roundtrip");
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("bloom.bin");
+
+        let bloom = StorageBloomFilter::new(1024, 3); // 1KB
+        let addr = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
+        let slot = b256!("0000000000000000000000000000000000000000000000000000000000000001");
+        bloom.insert(&addr, &slot);
+
+        bloom.save_to_file(&path, 42).unwrap();
+
+        let (loaded, block) = StorageBloomFilter::load_from_file(&path, 1024).unwrap().unwrap();
+        assert_eq!(block, 42);
+        assert!(loaded.might_contain(&addr, &slot));
+        assert_eq!(loaded.memory_usage_bytes(), bloom.memory_usage_bytes());
+        assert_eq!(loaded.count_set_bits(), bloom.count_set_bits());
+
+        // Cleanup
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn load_missing_file_returns_none() {
+        let path = std::path::Path::new("/tmp/reth_bloom_nonexistent.bin");
+        let result = StorageBloomFilter::load_from_file(path, 1024).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn load_wrong_size_returns_none() {
+        let dir = std::env::temp_dir().join("reth_bloom_test_wrong_size");
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("bloom.bin");
+
+        let bloom = StorageBloomFilter::new(1024, 3); // 1KB = 128 words
+        bloom.save_to_file(&path, 0).unwrap();
+
+        // Try to load with a different expected size
+        let result = StorageBloomFilter::load_from_file(&path, 2048).unwrap();
+        assert!(result.is_none(), "should reject mismatched size");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/storage/bloom/src/lib.rs
+++ b/crates/storage/bloom/src/lib.rs
@@ -139,7 +139,8 @@ impl StorageBloomFilter {
 
     /// Saves the bloom filter to a file.
     ///
-    /// File format: `[magic: 8B][version: 1B][num_hashes: 1B][block_number: 8B][num_words: 8B][raw bits...]`
+    /// File format: `[magic: 8B][version: 1B][num_hashes: 1B][block_number: 8B][num_words: 8B][raw
+    /// bits...]`
     ///
     /// The `block_number` is stored so that on restart we can incrementally catch up
     /// from changesets instead of re-scanning the entire `PlainStorageState` table.
@@ -465,7 +466,8 @@ mod tests {
     #[test]
     fn false_positive_rate_vs_num_hashes() {
         // Sweep K=1..8 to show how FP rate changes with num_hashes.
-        // Run with: cargo test -p reth-storage-bloom false_positive_rate_vs_num_hashes -- --nocapture
+        // Run with: cargo test -p reth-storage-bloom false_positive_rate_vs_num_hashes --
+        // --nocapture
         let size_bytes = 1024 * 1024; // 1MB filter
         let n_insert = 100_000u64;
         let n_query = 100_000u64;

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -18,6 +18,7 @@ reth-execution-types.workspace = true
 reth-ethereum-primitives = { workspace = true, features = ["reth-codec"] }
 reth-primitives-traits = { workspace = true, features = ["reth-codec", "secp256k1", "dashmap"] }
 reth-errors.workspace = true
+reth-storage-bloom.workspace = true
 reth-storage-errors.workspace = true
 reth-storage-api = { workspace = true, features = ["std", "db-api"] }
 reth-db = { workspace = true, features = ["mdbx"] }

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -790,7 +790,12 @@ where
             .field("rocksdb_provider", &rocksdb_provider)
             .field("changeset_cache", &changeset_cache)
             .field("runtime", &runtime)
-            .field("storage_bloom", &storage_bloom.as_ref().map(|b| format!("{}MB", b.memory_usage_bytes() / (1024 * 1024))))
+            .field(
+                "storage_bloom",
+                &storage_bloom
+                    .as_ref()
+                    .map(|b| format!("{}MB", b.memory_usage_bytes() / (1024 * 1024))),
+            )
             .finish()
     }
 }

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     providers::{
-        state::latest::LatestStateProvider, NodeTypesForProvider, RocksDBProvider,
-        StaticFileProvider, StaticFileProviderRWRefMut,
+        state::{bloom::BloomStateProvider, latest::LatestStateProvider},
+        NodeTypesForProvider, RocksDBProvider, StaticFileProvider, StaticFileProviderRWRefMut,
     },
     to_range,
     traits::{BlockSource, ReceiptProvider},
@@ -31,6 +31,7 @@ use reth_storage_api::{
     BlockBodyIndicesProvider, NodePrimitivesProvider, StorageSettings, StorageSettingsCache,
     TryIntoHistoricalStateProvider,
 };
+use reth_storage_bloom::StorageBloomFilter;
 use reth_storage_errors::provider::ProviderResult;
 use reth_trie::HashedPostState;
 use reth_trie_db::ChangesetCache;
@@ -80,6 +81,8 @@ pub struct ProviderFactory<N: NodeTypesWithDB> {
     changeset_cache: ChangesetCache,
     /// Task runtime for spawning parallel I/O work.
     runtime: reth_tasks::Runtime,
+    /// Optional bloom filter for short-circuiting empty storage slot reads.
+    storage_bloom: Option<Arc<StorageBloomFilter>>,
 }
 
 impl<N: NodeTypesForProvider> ProviderFactory<NodeTypesWithDBAdapter<N, DatabaseEnv>> {
@@ -134,6 +137,7 @@ impl<N: ProviderNodeTypes> ProviderFactory<N> {
             rocksdb_provider,
             changeset_cache: ChangesetCache::new(),
             runtime,
+            storage_bloom: None,
         })
     }
 
@@ -166,6 +170,26 @@ impl<N: NodeTypesWithDB> ProviderFactory<N> {
     pub fn with_changeset_cache(mut self, changeset_cache: ChangesetCache) -> Self {
         self.changeset_cache = changeset_cache;
         self
+    }
+
+    /// Sets the storage bloom filter for short-circuiting empty slot reads.
+    pub fn with_storage_bloom(mut self, bloom: Arc<StorageBloomFilter>) -> Self {
+        self.storage_bloom = Some(bloom);
+        self
+    }
+
+    /// Returns a reference to the storage bloom filter, if configured.
+    pub fn storage_bloom(&self) -> Option<&Arc<StorageBloomFilter>> {
+        self.storage_bloom.as_ref()
+    }
+
+    /// Wraps a boxed state provider with a bloom filter check, if configured.
+    fn maybe_wrap_bloom(&self, provider: StateProviderBox) -> StateProviderBox {
+        if let Some(bloom) = &self.storage_bloom {
+            Box::new(BloomStateProvider::new(provider, Arc::clone(bloom)))
+        } else {
+            provider
+        }
     }
 
     /// Returns reference to the underlying database.
@@ -257,7 +281,7 @@ impl<N: ProviderNodeTypes> ProviderFactory<N> {
     /// open.
     #[track_caller]
     pub fn provider_rw(&self) -> ProviderResult<DatabaseProviderRW<N::DB, N>> {
-        Ok(DatabaseProviderRW(DatabaseProvider::new_rw(
+        let mut provider = DatabaseProvider::new_rw(
             self.db.tx_mut()?,
             self.chain_spec.clone(),
             self.static_file_provider.clone(),
@@ -268,7 +292,11 @@ impl<N: ProviderNodeTypes> ProviderFactory<N> {
             self.changeset_cache.clone(),
             self.runtime.clone(),
             self.db.path(),
-        )))
+        );
+        if let Some(bloom) = &self.storage_bloom {
+            provider = provider.with_storage_bloom(Arc::clone(bloom));
+        }
+        Ok(DatabaseProviderRW(provider))
     }
 
     /// Returns a provider with a created `DbTxMut` inside, configured for unwind operations.
@@ -296,7 +324,9 @@ impl<N: ProviderNodeTypes> ProviderFactory<N> {
     #[track_caller]
     pub fn latest(&self) -> ProviderResult<StateProviderBox> {
         trace!(target: "providers::db", "Returning latest state provider");
-        Ok(Box::new(LatestStateProvider::new(self.database_provider_ro()?)))
+        let provider: StateProviderBox =
+            Box::new(LatestStateProvider::new(self.database_provider_ro()?));
+        Ok(self.maybe_wrap_bloom(provider))
     }
 
     /// Storage provider for state at that given block
@@ -306,7 +336,7 @@ impl<N: ProviderNodeTypes> ProviderFactory<N> {
     ) -> ProviderResult<StateProviderBox> {
         let state_provider = self.provider()?.try_into_history_at_block(block_number)?;
         trace!(target: "providers::db", ?block_number, "Returning historical state provider for block number");
-        Ok(state_provider)
+        Ok(self.maybe_wrap_bloom(state_provider))
     }
 
     /// Storage provider for state at that given block hash
@@ -319,7 +349,7 @@ impl<N: ProviderNodeTypes> ProviderFactory<N> {
 
         let state_provider = provider.try_into_history_at_block(block_number)?;
         trace!(target: "providers::db", ?block_number, %block_hash, "Returning historical state provider for block hash");
-        Ok(state_provider)
+        Ok(self.maybe_wrap_bloom(state_provider))
     }
 
     /// Asserts that the static files and database are consistent. If not,
@@ -748,6 +778,7 @@ where
             rocksdb_provider,
             changeset_cache,
             runtime,
+            storage_bloom,
         } = self;
         f.debug_struct("ProviderFactory")
             .field("db", &db)
@@ -759,6 +790,7 @@ where
             .field("rocksdb_provider", &rocksdb_provider)
             .field("changeset_cache", &changeset_cache)
             .field("runtime", &runtime)
+            .field("storage_bloom", &storage_bloom.as_ref().map(|b| format!("{}MB", b.memory_usage_bytes() / (1024 * 1024))))
             .finish()
     }
 }
@@ -775,6 +807,7 @@ impl<N: NodeTypesWithDB> Clone for ProviderFactory<N> {
             rocksdb_provider: self.rocksdb_provider.clone(),
             changeset_cache: self.changeset_cache.clone(),
             runtime: self.runtime.clone(),
+            storage_bloom: self.storage_bloom.clone(),
         }
     }
 }

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -179,7 +179,7 @@ impl<N: NodeTypesWithDB> ProviderFactory<N> {
     }
 
     /// Returns a reference to the storage bloom filter, if configured.
-    pub fn storage_bloom(&self) -> Option<&Arc<StorageBloomFilter>> {
+    pub const fn storage_bloom(&self) -> Option<&Arc<StorageBloomFilter>> {
         self.storage_bloom.as_ref()
     }
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -213,6 +213,8 @@ pub struct DatabaseProvider<TX, N: NodeTypes> {
     minimum_pruning_distance: u64,
     /// Database provider metrics
     metrics: metrics::DatabaseProviderMetrics,
+    /// Optional bloom filter for inserting new storage entries on write.
+    storage_bloom: Option<Arc<reth_storage_bloom::StorageBloomFilter>>,
 }
 
 impl<TX: Debug, N: NodeTypes> Debug for DatabaseProvider<TX, N> {
@@ -230,6 +232,13 @@ impl<TX: Debug, N: NodeTypes> Debug for DatabaseProvider<TX, N> {
             .field("pending_rocksdb_batches", &"<pending batches>")
             .field("commit_order", &self.commit_order)
             .field("minimum_pruning_distance", &self.minimum_pruning_distance)
+            .field(
+                "storage_bloom",
+                &self
+                    .storage_bloom
+                    .as_ref()
+                    .map(|b| format!("{}MB", b.memory_usage_bytes() / (1024 * 1024))),
+            )
             .finish()
     }
 }
@@ -239,9 +248,67 @@ impl<TX, N: NodeTypes> DatabaseProvider<TX, N> {
     pub const fn prune_modes_ref(&self) -> &PruneModes {
         &self.prune_modes
     }
+
+    /// Sets the storage bloom filter for inserting new entries on write.
+    pub fn with_storage_bloom(
+        mut self,
+        bloom: Arc<reth_storage_bloom::StorageBloomFilter>,
+    ) -> Self {
+        self.storage_bloom = Some(bloom);
+        self
+    }
 }
 
 impl<TX: DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
+    /// Populates a [`StorageBloomFilter`] by walking the `PlainStorageState` table.
+    ///
+    /// Inserts every non-zero `(address, slot)` pair into the bloom filter.
+    /// Returns the number of entries inserted.
+    pub fn populate_storage_bloom(
+        &self,
+        bloom: &reth_storage_bloom::StorageBloomFilter,
+    ) -> ProviderResult<u64> {
+        let mut cursor = self.tx.cursor_dup_read::<tables::PlainStorageState>()?;
+        let mut count = 0u64;
+        let mut walker = cursor.walk(None)?;
+        while let Some(result) = walker.next() {
+            let (address, entry) = result?;
+            if !entry.value.is_zero() {
+                bloom.insert(&address, &entry.key);
+                count += 1;
+            }
+        }
+        Ok(count)
+    }
+
+    /// Catches up the bloom filter by walking `StorageChangeSets` from
+    /// `from_block + 1` to the current tip.
+    ///
+    /// This is used after loading a persisted bloom to insert any storage slots
+    /// that were written since the bloom was last saved. Since the bloom is
+    /// insert-only (bits are never cleared), inserting every changed slot key is
+    /// sufficient: non-zero slots need to be present, and zeroed slots become
+    /// harmless false positives.
+    ///
+    /// Returns the number of changeset entries processed.
+    pub fn catchup_storage_bloom(
+        &self,
+        bloom: &reth_storage_bloom::StorageBloomFilter,
+        from_block: u64,
+    ) -> ProviderResult<u64> {
+        let start = BlockNumberAddress((from_block + 1, alloy_primitives::Address::ZERO));
+        let mut cursor = self.tx.cursor_dup_read::<tables::StorageChangeSets>()?;
+        let mut walker = cursor.walk(Some(start))?;
+        let mut count = 0u64;
+        while let Some(result) = walker.next() {
+            let (block_address, entry) = result?;
+            let BlockNumberAddress((_, address)) = block_address;
+            bloom.insert(&address, &entry.key);
+            count += 1;
+        }
+        Ok(count)
+    }
+
     /// State provider for latest state
     pub fn latest<'a>(&'a self) -> Box<dyn StateProvider + 'a> {
         trace!(target: "providers::db", "Returning latest state provider");
@@ -379,6 +446,7 @@ impl<TX: DbTxMut, N: NodeTypes> DatabaseProvider<TX, N> {
             commit_order,
             minimum_pruning_distance: MINIMUM_UNWIND_SAFE_DISTANCE,
             metrics: metrics::DatabaseProviderMetrics::default(),
+            storage_bloom: None,
         }
     }
 
@@ -1015,6 +1083,7 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> DatabaseProvider<TX, N> {
             commit_order: CommitOrder::Normal,
             minimum_pruning_distance: MINIMUM_UNWIND_SAFE_DISTANCE,
             metrics: metrics::DatabaseProviderMetrics::default(),
+            storage_bloom: None,
         }
     }
 
@@ -2618,6 +2687,11 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
 
                     if !entry.value.is_zero() {
                         storages_cursor.upsert(address, &entry)?;
+                        // Keep bloom filter in sync so subsequent reads don't
+                        // false-negative on newly written slots.
+                        if let Some(bloom) = &self.storage_bloom {
+                            bloom.insert(&address, &entry.key);
+                        }
                     }
                 }
             }

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -271,8 +271,8 @@ impl<TX: DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
     ) -> ProviderResult<u64> {
         let mut cursor = self.tx.cursor_dup_read::<tables::PlainStorageState>()?;
         let mut count = 0u64;
-        let mut walker = cursor.walk(None)?;
-        while let Some(result) = walker.next() {
+        let walker = cursor.walk(None)?;
+        for result in walker {
             let (address, entry) = result?;
             if !entry.value.is_zero() {
                 bloom.insert(&address, &entry.key);
@@ -299,9 +299,9 @@ impl<TX: DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
     ) -> ProviderResult<u64> {
         let start = BlockNumberAddress((from_block + 1, alloy_primitives::Address::ZERO));
         let mut cursor = self.tx.cursor_dup_read::<tables::StorageChangeSets>()?;
-        let mut walker = cursor.walk(Some(start))?;
+        let walker = cursor.walk(Some(start))?;
         let mut count = 0u64;
-        while let Some(result) = walker.next() {
+        for result in walker {
             let (block_address, entry) = result?;
             let BlockNumberAddress((_, address)) = block_address;
             bloom.insert(&address, &entry.key);

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -260,7 +260,8 @@ impl<TX, N: NodeTypes> DatabaseProvider<TX, N> {
 }
 
 impl<TX: DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
-    /// Populates a [`StorageBloomFilter`] by walking the `PlainStorageState` table.
+    /// Populates a [`StorageBloomFilter`](reth_storage_bloom::StorageBloomFilter) by walking the
+    /// `PlainStorageState` table.
     ///
     /// Inserts every non-zero `(address, slot)` pair into the bloom filter.
     /// Returns the number of entries inserted.

--- a/crates/storage/provider/src/providers/state/bloom.rs
+++ b/crates/storage/provider/src/providers/state/bloom.rs
@@ -1,0 +1,167 @@
+use crate::{
+    AccountReader, BlockHashReader, HashedPostStateProvider, StateProvider, StateRootProvider,
+};
+use alloy_primitives::{Address, BlockNumber, Bytes, StorageKey, StorageValue, B256};
+use reth_primitives_traits::{Account, Bytecode};
+use reth_storage_api::{BytecodeReader, StateProofProvider, StorageRootProvider};
+use reth_storage_bloom::StorageBloomFilter;
+use reth_storage_errors::provider::ProviderResult;
+use reth_trie::{
+    updates::TrieUpdates, AccountProof, HashedPostState, HashedStorage, MultiProof,
+    MultiProofTargets, StorageMultiProof, StorageProof, TrieInput,
+};
+use std::sync::Arc;
+
+/// A [`StateProvider`] wrapper that short-circuits storage reads using a bloom filter.
+///
+/// If the bloom filter reports that an `(address, slot)` pair is absent, the read
+/// returns `Ok(None)` immediately without hitting the database. Otherwise it falls
+/// through to the inner provider.
+///
+/// This follows the same wrapper pattern as `InstrumentedStateProvider` in
+/// `crates/engine/tree/src/tree/instrumented_state.rs`.
+#[derive(Debug)]
+pub(crate) struct BloomStateProvider<S> {
+    /// The wrapped state provider
+    inner: S,
+    /// Shared bloom filter for storage slot presence checks
+    bloom: Arc<StorageBloomFilter>,
+}
+
+impl<S> BloomStateProvider<S> {
+    /// Creates a new [`BloomStateProvider`] wrapping the given provider with a bloom filter.
+    pub(crate) fn new(inner: S, bloom: Arc<StorageBloomFilter>) -> Self {
+        Self { inner, bloom }
+    }
+}
+
+impl<S: AccountReader> AccountReader for BloomStateProvider<S> {
+    fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
+        self.inner.basic_account(address)
+    }
+}
+
+impl<S: StateProvider> StateProvider for BloomStateProvider<S> {
+    fn storage(
+        &self,
+        account: Address,
+        storage_key: StorageKey,
+    ) -> ProviderResult<Option<StorageValue>> {
+        // Bloom filter check: if the filter says "not present", the slot is
+        // guaranteed absent — skip the MDBX seek entirely.
+        if !self.bloom.might_contain(&account, &storage_key) {
+            return Ok(None);
+        }
+        self.inner.storage(account, storage_key)
+    }
+
+    fn storage_by_hashed_key(
+        &self,
+        address: Address,
+        hashed_storage_key: StorageKey,
+    ) -> ProviderResult<Option<StorageValue>> {
+        // Cannot bloom-check pre-hashed keys — bloom stores unhashed (address, slot) pairs.
+        self.inner.storage_by_hashed_key(address, hashed_storage_key)
+    }
+}
+
+impl<S: BytecodeReader> BytecodeReader for BloomStateProvider<S> {
+    fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>> {
+        self.inner.bytecode_by_hash(code_hash)
+    }
+}
+
+impl<S: StateRootProvider> StateRootProvider for BloomStateProvider<S> {
+    fn state_root(&self, hashed_state: HashedPostState) -> ProviderResult<B256> {
+        self.inner.state_root(hashed_state)
+    }
+
+    fn state_root_from_nodes(&self, input: TrieInput) -> ProviderResult<B256> {
+        self.inner.state_root_from_nodes(input)
+    }
+
+    fn state_root_with_updates(
+        &self,
+        hashed_state: HashedPostState,
+    ) -> ProviderResult<(B256, TrieUpdates)> {
+        self.inner.state_root_with_updates(hashed_state)
+    }
+
+    fn state_root_from_nodes_with_updates(
+        &self,
+        input: TrieInput,
+    ) -> ProviderResult<(B256, TrieUpdates)> {
+        self.inner.state_root_from_nodes_with_updates(input)
+    }
+}
+
+impl<S: StorageRootProvider> StorageRootProvider for BloomStateProvider<S> {
+    fn storage_root(
+        &self,
+        address: Address,
+        hashed_storage: HashedStorage,
+    ) -> ProviderResult<B256> {
+        self.inner.storage_root(address, hashed_storage)
+    }
+
+    fn storage_proof(
+        &self,
+        address: Address,
+        slot: B256,
+        hashed_storage: HashedStorage,
+    ) -> ProviderResult<StorageProof> {
+        self.inner.storage_proof(address, slot, hashed_storage)
+    }
+
+    fn storage_multiproof(
+        &self,
+        address: Address,
+        slots: &[B256],
+        hashed_storage: HashedStorage,
+    ) -> ProviderResult<StorageMultiProof> {
+        self.inner.storage_multiproof(address, slots, hashed_storage)
+    }
+}
+
+impl<S: StateProofProvider> StateProofProvider for BloomStateProvider<S> {
+    fn proof(
+        &self,
+        input: TrieInput,
+        address: Address,
+        slots: &[B256],
+    ) -> ProviderResult<AccountProof> {
+        self.inner.proof(input, address, slots)
+    }
+
+    fn multiproof(
+        &self,
+        input: TrieInput,
+        targets: MultiProofTargets,
+    ) -> ProviderResult<MultiProof> {
+        self.inner.multiproof(input, targets)
+    }
+
+    fn witness(&self, input: TrieInput, target: HashedPostState) -> ProviderResult<Vec<Bytes>> {
+        self.inner.witness(input, target)
+    }
+}
+
+impl<S: BlockHashReader> BlockHashReader for BloomStateProvider<S> {
+    fn block_hash(&self, number: BlockNumber) -> ProviderResult<Option<B256>> {
+        self.inner.block_hash(number)
+    }
+
+    fn canonical_hashes_range(
+        &self,
+        start: BlockNumber,
+        end: BlockNumber,
+    ) -> ProviderResult<Vec<B256>> {
+        self.inner.canonical_hashes_range(start, end)
+    }
+}
+
+impl<S: HashedPostStateProvider> HashedPostStateProvider for BloomStateProvider<S> {
+    fn hashed_post_state(&self, bundle_state: &revm_database::BundleState) -> HashedPostState {
+        self.inner.hashed_post_state(bundle_state)
+    }
+}

--- a/crates/storage/provider/src/providers/state/bloom.rs
+++ b/crates/storage/provider/src/providers/state/bloom.rs
@@ -30,7 +30,7 @@ pub(crate) struct BloomStateProvider<S> {
 
 impl<S> BloomStateProvider<S> {
     /// Creates a new [`BloomStateProvider`] wrapping the given provider with a bloom filter.
-    pub(crate) fn new(inner: S, bloom: Arc<StorageBloomFilter>) -> Self {
+    pub(crate) const fn new(inner: S, bloom: Arc<StorageBloomFilter>) -> Self {
         Self { inner, bloom }
     }
 }

--- a/crates/storage/provider/src/providers/state/bloom.rs
+++ b/crates/storage/provider/src/providers/state/bloom.rs
@@ -55,15 +55,6 @@ impl<S: StateProvider> StateProvider for BloomStateProvider<S> {
         self.inner.storage(account, storage_key)
     }
 
-    fn storage_by_hashed_key(
-        &self,
-        address: Address,
-        hashed_storage_key: StorageKey,
-    ) -> ProviderResult<Option<StorageValue>> {
-        // Cannot bloom-check pre-hashed keys — bloom stores unhashed (address, slot) pairs.
-        self.inner.storage_by_hashed_key(address, hashed_storage_key)
-    }
-}
 
 impl<S: BytecodeReader> BytecodeReader for BloomStateProvider<S> {
     fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>> {

--- a/crates/storage/provider/src/providers/state/mod.rs
+++ b/crates/storage/provider/src/providers/state/mod.rs
@@ -1,4 +1,5 @@
 //! [`StateProvider`](crate::StateProvider) implementations
+pub(crate) mod bloom;
 pub(crate) mod historical;
 pub(crate) mod latest;
 pub(crate) mod overlay;

--- a/docs/vocs/docs/pages/cli/reth/db.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db.mdx
@@ -141,6 +141,18 @@ Storage:
 
           Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
+      --storage.bloom-filter
+          Enable in-memory bloom filter for short-circuiting empty storage slot reads.
+
+          When enabled, the node builds a bloom filter over all `(address, slot)` pairs on startup and checks it before every MDBX storage seek. If the filter says a slot was never written, the seek is skipped entirely. This benefits the 30-40% of SLOAD operations that target empty slots.
+
+      --storage.bloom-filter-size-mb <BLOOM_FILTER_SIZE_MB>
+          Bloom filter size in megabytes (default: 1024, minimum: 1).
+
+          Larger filters have fewer false positives but use more RAM. With K=3 hash functions, a 1024 MB filter supports ~700M entries at <1% FP rate, covering mainnet's ~500M non-zero storage slots with room to grow.
+
+          [default: 1024]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/docs/vocs/docs/pages/cli/reth/download.mdx
+++ b/docs/vocs/docs/pages/cli/reth/download.mdx
@@ -121,6 +121,18 @@ Storage:
 
           Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
+      --storage.bloom-filter
+          Enable in-memory bloom filter for short-circuiting empty storage slot reads.
+
+          When enabled, the node builds a bloom filter over all `(address, slot)` pairs on startup and checks it before every MDBX storage seek. If the filter says a slot was never written, the seek is skipped entirely. This benefits the 30-40% of SLOAD operations that target empty slots.
+
+      --storage.bloom-filter-size-mb <BLOOM_FILTER_SIZE_MB>
+          Bloom filter size in megabytes (default: 1024, minimum: 1).
+
+          Larger filters have fewer false positives but use more RAM. With K=3 hash functions, a 1024 MB filter supports ~700M entries at <1% FP rate, covering mainnet's ~500M non-zero storage slots with room to grow.
+
+          [default: 1024]
+
   -u, --url <URL>
           Specify a snapshot URL or let the command propose a default one.
 

--- a/docs/vocs/docs/pages/cli/reth/export-era.mdx
+++ b/docs/vocs/docs/pages/cli/reth/export-era.mdx
@@ -121,6 +121,18 @@ Storage:
 
           Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
+      --storage.bloom-filter
+          Enable in-memory bloom filter for short-circuiting empty storage slot reads.
+
+          When enabled, the node builds a bloom filter over all `(address, slot)` pairs on startup and checks it before every MDBX storage seek. If the filter says a slot was never written, the seek is skipped entirely. This benefits the 30-40% of SLOAD operations that target empty slots.
+
+      --storage.bloom-filter-size-mb <BLOOM_FILTER_SIZE_MB>
+          Bloom filter size in megabytes (default: 1024, minimum: 1).
+
+          Larger filters have fewer false positives but use more RAM. With K=3 hash functions, a 1024 MB filter supports ~700M entries at <1% FP rate, covering mainnet's ~500M non-zero storage slots with room to grow.
+
+          [default: 1024]
+
       --first-block-number <first-block-number>
           Optional first block number to export from the db.
           It is by default 0.

--- a/docs/vocs/docs/pages/cli/reth/import-era.mdx
+++ b/docs/vocs/docs/pages/cli/reth/import-era.mdx
@@ -121,6 +121,18 @@ Storage:
 
           Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
+      --storage.bloom-filter
+          Enable in-memory bloom filter for short-circuiting empty storage slot reads.
+
+          When enabled, the node builds a bloom filter over all `(address, slot)` pairs on startup and checks it before every MDBX storage seek. If the filter says a slot was never written, the seek is skipped entirely. This benefits the 30-40% of SLOAD operations that target empty slots.
+
+      --storage.bloom-filter-size-mb <BLOOM_FILTER_SIZE_MB>
+          Bloom filter size in megabytes (default: 1024, minimum: 1).
+
+          Larger filters have fewer false positives but use more RAM. With K=3 hash functions, a 1024 MB filter supports ~700M entries at <1% FP rate, covering mainnet's ~500M non-zero storage slots with room to grow.
+
+          [default: 1024]
+
       --path <IMPORT_ERA_PATH>
           The path to a directory for import.
 

--- a/docs/vocs/docs/pages/cli/reth/import.mdx
+++ b/docs/vocs/docs/pages/cli/reth/import.mdx
@@ -121,6 +121,18 @@ Storage:
 
           Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
+      --storage.bloom-filter
+          Enable in-memory bloom filter for short-circuiting empty storage slot reads.
+
+          When enabled, the node builds a bloom filter over all `(address, slot)` pairs on startup and checks it before every MDBX storage seek. If the filter says a slot was never written, the seek is skipped entirely. This benefits the 30-40% of SLOAD operations that target empty slots.
+
+      --storage.bloom-filter-size-mb <BLOOM_FILTER_SIZE_MB>
+          Bloom filter size in megabytes (default: 1024, minimum: 1).
+
+          Larger filters have fewer false positives but use more RAM. With K=3 hash functions, a 1024 MB filter supports ~700M entries at <1% FP rate, covering mainnet's ~500M non-zero storage slots with room to grow.
+
+          [default: 1024]
+
       --no-state
           Disables stages that require state.
 

--- a/docs/vocs/docs/pages/cli/reth/init-state.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init-state.mdx
@@ -121,6 +121,18 @@ Storage:
 
           Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
+      --storage.bloom-filter
+          Enable in-memory bloom filter for short-circuiting empty storage slot reads.
+
+          When enabled, the node builds a bloom filter over all `(address, slot)` pairs on startup and checks it before every MDBX storage seek. If the filter says a slot was never written, the seek is skipped entirely. This benefits the 30-40% of SLOAD operations that target empty slots.
+
+      --storage.bloom-filter-size-mb <BLOOM_FILTER_SIZE_MB>
+          Bloom filter size in megabytes (default: 1024, minimum: 1).
+
+          Larger filters have fewer false positives but use more RAM. With K=3 hash functions, a 1024 MB filter supports ~700M entries at <1% FP rate, covering mainnet's ~500M non-zero storage slots with room to grow.
+
+          [default: 1024]
+
       --without-evm
           Specifies whether to initialize the state without relying on EVM historical data.
 

--- a/docs/vocs/docs/pages/cli/reth/init.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init.mdx
@@ -121,6 +121,18 @@ Storage:
 
           Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
+      --storage.bloom-filter
+          Enable in-memory bloom filter for short-circuiting empty storage slot reads.
+
+          When enabled, the node builds a bloom filter over all `(address, slot)` pairs on startup and checks it before every MDBX storage seek. If the filter says a slot was never written, the seek is skipped entirely. This benefits the 30-40% of SLOAD operations that target empty slots.
+
+      --storage.bloom-filter-size-mb <BLOOM_FILTER_SIZE_MB>
+          Bloom filter size in megabytes (default: 1024, minimum: 1).
+
+          Larger filters have fewer false positives but use more RAM. With K=3 hash functions, a 1024 MB filter supports ~700M entries at <1% FP rate, covering mainnet's ~500M non-zero storage slots with room to grow.
+
+          [default: 1024]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -1052,6 +1052,18 @@ Storage:
 
           Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
+      --storage.bloom-filter
+          Enable in-memory bloom filter for short-circuiting empty storage slot reads.
+
+          When enabled, the node builds a bloom filter over all `(address, slot)` pairs on startup and checks it before every MDBX storage seek. If the filter says a slot was never written, the seek is skipped entirely. This benefits the 30-40% of SLOAD operations that target empty slots.
+
+      --storage.bloom-filter-size-mb <BLOOM_FILTER_SIZE_MB>
+          Bloom filter size in megabytes (default: 1024, minimum: 1).
+
+          Larger filters have fewer false positives but use more RAM. With K=3 hash functions, a 1024 MB filter supports ~700M entries at <1% FP rate, covering mainnet's ~500M non-zero storage slots with room to grow.
+
+          [default: 1024]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/docs/vocs/docs/pages/cli/reth/prune.mdx
+++ b/docs/vocs/docs/pages/cli/reth/prune.mdx
@@ -121,6 +121,18 @@ Storage:
 
           Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
+      --storage.bloom-filter
+          Enable in-memory bloom filter for short-circuiting empty storage slot reads.
+
+          When enabled, the node builds a bloom filter over all `(address, slot)` pairs on startup and checks it before every MDBX storage seek. If the filter says a slot was never written, the seek is skipped entirely. This benefits the 30-40% of SLOAD operations that target empty slots.
+
+      --storage.bloom-filter-size-mb <BLOOM_FILTER_SIZE_MB>
+          Bloom filter size in megabytes (default: 1024, minimum: 1).
+
+          Larger filters have fewer false positives but use more RAM. With K=3 hash functions, a 1024 MB filter supports ~700M entries at <1% FP rate, covering mainnet's ~500M non-zero storage slots with room to grow.
+
+          [default: 1024]
+
 Metrics:
       --metrics <PROMETHEUS>
           Enable Prometheus metrics.

--- a/docs/vocs/docs/pages/cli/reth/re-execute.mdx
+++ b/docs/vocs/docs/pages/cli/reth/re-execute.mdx
@@ -121,6 +121,18 @@ Storage:
 
           Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
+      --storage.bloom-filter
+          Enable in-memory bloom filter for short-circuiting empty storage slot reads.
+
+          When enabled, the node builds a bloom filter over all `(address, slot)` pairs on startup and checks it before every MDBX storage seek. If the filter says a slot was never written, the seek is skipped entirely. This benefits the 30-40% of SLOAD operations that target empty slots.
+
+      --storage.bloom-filter-size-mb <BLOOM_FILTER_SIZE_MB>
+          Bloom filter size in megabytes (default: 1024, minimum: 1).
+
+          Larger filters have fewer false positives but use more RAM. With K=3 hash functions, a 1024 MB filter supports ~700M entries at <1% FP rate, covering mainnet's ~500M non-zero storage slots with room to grow.
+
+          [default: 1024]
+
       --from <FROM>
           The height to start at
 

--- a/docs/vocs/docs/pages/cli/reth/stage/drop.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/drop.mdx
@@ -121,6 +121,18 @@ Storage:
 
           Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
+      --storage.bloom-filter
+          Enable in-memory bloom filter for short-circuiting empty storage slot reads.
+
+          When enabled, the node builds a bloom filter over all `(address, slot)` pairs on startup and checks it before every MDBX storage seek. If the filter says a slot was never written, the seek is skipped entirely. This benefits the 30-40% of SLOAD operations that target empty slots.
+
+      --storage.bloom-filter-size-mb <BLOOM_FILTER_SIZE_MB>
+          Bloom filter size in megabytes (default: 1024, minimum: 1).
+
+          Larger filters have fewer false positives but use more RAM. With K=3 hash functions, a 1024 MB filter supports ~700M entries at <1% FP rate, covering mainnet's ~500M non-zero storage slots with room to grow.
+
+          [default: 1024]
+
   <STAGE>
           Possible values:
           - headers:         The headers stage within the pipeline

--- a/docs/vocs/docs/pages/cli/reth/stage/dump.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump.mdx
@@ -128,6 +128,18 @@ Storage:
 
           Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
+      --storage.bloom-filter
+          Enable in-memory bloom filter for short-circuiting empty storage slot reads.
+
+          When enabled, the node builds a bloom filter over all `(address, slot)` pairs on startup and checks it before every MDBX storage seek. If the filter says a slot was never written, the seek is skipped entirely. This benefits the 30-40% of SLOAD operations that target empty slots.
+
+      --storage.bloom-filter-size-mb <BLOOM_FILTER_SIZE_MB>
+          Bloom filter size in megabytes (default: 1024, minimum: 1).
+
+          Larger filters have fewer false positives but use more RAM. With K=3 hash functions, a 1024 MB filter supports ~700M entries at <1% FP rate, covering mainnet's ~500M non-zero storage slots with room to grow.
+
+          [default: 1024]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/docs/vocs/docs/pages/cli/reth/stage/run.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/run.mdx
@@ -121,6 +121,18 @@ Storage:
 
           Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
+      --storage.bloom-filter
+          Enable in-memory bloom filter for short-circuiting empty storage slot reads.
+
+          When enabled, the node builds a bloom filter over all `(address, slot)` pairs on startup and checks it before every MDBX storage seek. If the filter says a slot was never written, the seek is skipped entirely. This benefits the 30-40% of SLOAD operations that target empty slots.
+
+      --storage.bloom-filter-size-mb <BLOOM_FILTER_SIZE_MB>
+          Bloom filter size in megabytes (default: 1024, minimum: 1).
+
+          Larger filters have fewer false positives but use more RAM. With K=3 hash functions, a 1024 MB filter supports ~700M entries at <1% FP rate, covering mainnet's ~500M non-zero storage slots with room to grow.
+
+          [default: 1024]
+
       --metrics <SOCKET>
           Enable Prometheus metrics.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/unwind.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/unwind.mdx
@@ -126,6 +126,18 @@ Storage:
 
           Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
+      --storage.bloom-filter
+          Enable in-memory bloom filter for short-circuiting empty storage slot reads.
+
+          When enabled, the node builds a bloom filter over all `(address, slot)` pairs on startup and checks it before every MDBX storage seek. If the filter says a slot was never written, the seek is skipped entirely. This benefits the 30-40% of SLOAD operations that target empty slots.
+
+      --storage.bloom-filter-size-mb <BLOOM_FILTER_SIZE_MB>
+          Bloom filter size in megabytes (default: 1024, minimum: 1).
+
+          Larger filters have fewer false positives but use more RAM. With K=3 hash functions, a 1024 MB filter supports ~700M entries at <1% FP rate, covering mainnet's ~500M non-zero storage slots with room to grow.
+
+          [default: 1024]
+
       --offline
           If this is enabled, then all stages except headers, bodies, and sender recovery will be unwound
 


### PR DESCRIPTION
## Summary

Opt-in bloom filter that skips MDBX seeks for storage slots that were never written. ~30-40% of `SLOAD` ops hit empty slots ([Nethermind data](https://github.com/NethermindEth/nethermind/issues/9854)) — each one currently walks the B-tree for nothing. The bloom answers "definitely not present" in <400ns and avoids the seek entirely.

Closes #21184

```
SLOAD(address, slot)
  → bloom.might_contain(address, slot)?
    false → Ok(None)                       ← <400ns, no MDBX touch
    true  → PlainStorageState seek          ← same path as before
```

## Design

Lock-free `AtomicU64` bit array, Kirsch-Mitzenmacher double hashing from a single `keccak256(address || slot)`, K=3 probes. Insert-only — deleted slots just become false positives (harmless, falls back to MDBX). Persisted to `<datadir>/storage_bloom.bin` with block number so restarts only need an incremental catchup via `StorageChangeSets` instead of a full table scan.

Default size is 1024 MB (~700M capacity at <1% FP, mainnet has ~500M non-zero slots today).

## Changes

**New crate `reth-storage-bloom`** — the filter itself, `no_std` compatible, with persistence (`save_to_file`/`load_from_file`, atomic rename, format versioning). Includes criterion benchmarks and 11 unit tests.

**Provider integration** — `BloomStateProvider<S>` wraps any `StateProvider` and intercepts `storage()` with a bloom check (same pattern as `InstrumentedStateProvider`). `ProviderFactory` wraps `latest()` / `history_by_block_*()` providers. `DatabaseProvider` inserts into the bloom on every non-zero storage write so new slots are immediately visible.

**Startup** — first run does a full `PlainStorageState` walk, subsequent runs load from disk and catch up from `StorageChangeSets`. Graceful fallback if the file is missing or corrupted.

## Benchmarks

256 MB filter, K=3, x86-64:

| Operation | Latency | |
|---|---|---|
| insert | ~359ns | keccak + 3 atomic ORs |
| true negative | ~391ns | early exit on first 0 bit |
| true positive | ~413ns | all 3 bits checked |
| mixed 35/65 | ~437ns | realistic empty/occupied ratio |

vs MDBX seek 1-10µs → 2.5-25x speedup on the empty-slot fraction.
