### PR TITLE
fix(rpc): stop IPC handle in AuthServerHandle::stop()

### DIFF
--- a/crates/rpc/rpc-builder/src/auth.rs
+++ b/crates/rpc/rpc-builder/src/auth.rs
@@ -337,8 +337,15 @@ impl AuthServerHandle {
 
     /// Tell the server to stop without waiting for the server to stop.
     pub fn stop(self) -> Result<(), AlreadyStoppedError> {
-        let Some(handle) = self.handle else { return Ok(()) };
-        handle.stop()
+        if let Some(handle) = self.handle {
+            handle.stop()?;
+        }
+
+        if let Some(ipc_handle) = self.ipc_handle {
+            ipc_handle.stop()?;
+        }
+
+        Ok(())
     }
 
     /// Returns the url to the http server


### PR DESCRIPTION
The stop() method only stopped the HTTP server handle but ignored the IPC handle, leaving the IPC server running after calling stop(). This broke the documented contract that "the server will be stopped" and inconsistently with RpcServerHandle::stop() which correctly stops all handles.
 
Now stop() gracefully shuts down both HTTP and IPC servers.