### PR TITLE
refactor(rpc): deduplicate debug_trace_transaction using shared tracing

### DIFF
--- a/crates/rpc/rpc/src/otterscan.rs
+++ b/crates/rpc/rpc/src/otterscan.rs
@@ -103,8 +103,8 @@ where
             .eth
             .spawn_trace_transaction_in_block_with_inspector(
                 tx_hash,
-                TransferInspector::new(false),
-                |_tx_info, inspector, _, _| Ok(inspector.into_transfers()),
+                || Ok(TransferInspector::new(false)),
+                |_tx_info, inspector, _, _, _, _| Ok(inspector.into_transfers()),
             )
             .await
             .map_err(Into::into)?

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -260,8 +260,8 @@ where
         self.eth_api()
             .spawn_trace_transaction_in_block_with_inspector(
                 tx_hash,
-                OpcodeGasInspector::default(),
-                move |_tx_info, inspector, _res, _| {
+                move || Ok(OpcodeGasInspector::default()),
+                move |_tx_info, inspector, _res, _, _, _| {
                     let trace = TransactionOpcodeGas {
                         transaction_hash: tx_hash,
                         opcode_gas: inspector.opcode_gas_iter().collect(),


### PR DESCRIPTION
`debug_trace_transaction` had its own hand-rolled block replay implementation duplicating the logic already in `spawn_trace_transaction_in_block_with_inspector`. This was necessary because the shared helper required `Insp: Send`, which`DebugInspector` can't satisfy when the `js-tracer` feature is enabled (boa's `Context` holds `Rc` fields).

This PR changes the helper to accept an inspector factory closure instead of a pre-built inspector, so the inspector is created inside the blocking task and never needs to be `Send`. With that constraint lifted, `debug_trace_transaction`can use the shared helper directly, removing the duplicated code and one redundant DB round-trip.