### PR TITLE
perf(trie): inline len=1 storage proofs on account worker

### DIFF
--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -1071,6 +1071,7 @@ where
         let mut dispatched_storage_targets =
             B256Map::with_capacity_and_hasher(storage_targets.len(), Default::default());
 
+        let inline_start = Instant::now();
         for (hashed_address, mut targets) in storage_targets {
             if targets.len() == 1 && account_target_addresses.contains(&hashed_address) {
                 // Apply min_len(0) so the root node is included for storage root computation.
@@ -1090,6 +1091,7 @@ where
                 dispatched_storage_targets.insert(hashed_address, targets);
             }
         }
+        let inlined_duration = inline_start.elapsed();
 
         let inlined_count = inlined_accounts.len() as u64;
 
@@ -1114,6 +1116,7 @@ where
         // Merge inlined proof results into the final output.
         storage_proofs.extend(inlined_storage_proofs);
         value_encoder_stats.inlined_count += inlined_count;
+        value_encoder_stats.inlined_duration += inlined_duration;
 
         let proof = DecodedMultiProofV2 { account_proofs, storage_proofs };
 

--- a/crates/trie/parallel/src/proof_task_metrics.rs
+++ b/crates/trie/parallel/src/proof_task_metrics.rs
@@ -30,6 +30,8 @@ pub struct ProofTaskTrieMetrics {
     deferred_encoder_dispatched_missing_root: Histogram,
     /// Histogram for storage proofs inlined on the account worker (len=1 targets).
     deferred_encoder_inlined: Histogram,
+    /// Histogram for time spent computing inlined storage proofs on the account worker (seconds).
+    deferred_encoder_inlined_seconds: Histogram,
     /// Histogram for time account workers spent blocked waiting for storage proof results
     /// (seconds). This is the portion of account worker idle time attributable to storage
     /// worker latency rather than queue wait.
@@ -65,6 +67,7 @@ impl ProofTaskTrieMetrics {
         self.deferred_encoder_dispatched_missing_root
             .record(stats.dispatched_missing_root_count as f64);
         self.deferred_encoder_inlined.record(stats.inlined_count as f64);
+        self.deferred_encoder_inlined_seconds.record(stats.inlined_duration.as_secs_f64());
         self.account_worker_storage_wait_seconds.record(stats.storage_wait_time.as_secs_f64());
     }
 }

--- a/crates/trie/parallel/src/proof_task_metrics.rs
+++ b/crates/trie/parallel/src/proof_task_metrics.rs
@@ -28,6 +28,8 @@ pub struct ProofTaskTrieMetrics {
     deferred_encoder_sync: Histogram,
     /// Histogram for dispatched storage proofs that fell back to sync due to missing root.
     deferred_encoder_dispatched_missing_root: Histogram,
+    /// Histogram for storage proofs inlined on the account worker (len=1 targets).
+    deferred_encoder_inlined: Histogram,
     /// Histogram for time account workers spent blocked waiting for storage proof results
     /// (seconds). This is the portion of account worker idle time attributable to storage
     /// worker latency rather than queue wait.
@@ -62,6 +64,7 @@ impl ProofTaskTrieMetrics {
         self.deferred_encoder_sync.record(stats.sync_count as f64);
         self.deferred_encoder_dispatched_missing_root
             .record(stats.dispatched_missing_root_count as f64);
+        self.deferred_encoder_inlined.record(stats.inlined_count as f64);
         self.account_worker_storage_wait_seconds.record(stats.storage_wait_time.as_secs_f64());
     }
 }

--- a/crates/trie/parallel/src/value_encoder.rs
+++ b/crates/trie/parallel/src/value_encoder.rs
@@ -36,6 +36,8 @@ pub(crate) struct ValueEncoderStats {
     pub(crate) dispatched_missing_root_count: u64,
     /// Number of storage proofs inlined on the account worker (len=1 targets).
     pub(crate) inlined_count: u64,
+    /// Time spent computing inlined storage proofs on the account worker.
+    pub(crate) inlined_duration: Duration,
 }
 
 impl ValueEncoderStats {
@@ -47,6 +49,7 @@ impl ValueEncoderStats {
         self.sync_count += other.sync_count;
         self.dispatched_missing_root_count += other.dispatched_missing_root_count;
         self.inlined_count += other.inlined_count;
+        self.inlined_duration += other.inlined_duration;
     }
 }
 

--- a/crates/trie/parallel/src/value_encoder.rs
+++ b/crates/trie/parallel/src/value_encoder.rs
@@ -34,6 +34,8 @@ pub(crate) struct ValueEncoderStats {
     /// Number of times a dispatched storage proof had no root node and fell back to sync
     /// computation.
     pub(crate) dispatched_missing_root_count: u64,
+    /// Number of storage proofs inlined on the account worker (len=1 targets).
+    pub(crate) inlined_count: u64,
 }
 
 impl ValueEncoderStats {
@@ -44,6 +46,7 @@ impl ValueEncoderStats {
         self.from_cache_count += other.from_cache_count;
         self.sync_count += other.sync_count;
         self.dispatched_missing_root_count += other.dispatched_missing_root_count;
+        self.inlined_count += other.inlined_count;
     }
 }
 


### PR DESCRIPTION
## Summary
Inline single-target storage proofs on the account worker instead of dispatching them to the storage worker pool, avoiding channel send/recv and worker scheduling overhead for the majority of storage proof calls.

## Motivation
Tracy profiling shows ~82% of storage proof calls (2.18M out of 2.65M) have `targets.len() == 1`. Each of these currently goes through the full dispatch path: crossbeam channel send → storage worker recv → compute → channel send result → account worker recv. For a single-target proof, the dispatch overhead dominates the actual computation.

## Changes
- In `compute_v2_account_multiproof`, partition storage targets: inline len=1 proofs for accounts that are also in `account_targets`, dispatch the rest
- Compute inlined proofs using the account worker's existing `v2_storage_calculator`, cache the storage root immediately
- Pass `inlined_accounts` set to `dispatch_v2_storage_proofs` to skip synthetic root-only dispatches for already-covered accounts
- Add `inlined_count` metric to `ValueEncoderStats` and `ProofTaskTrieMetrics` for observability

## Design decisions
- **Inline only when address is in `account_targets`**: these are the proofs that gate account-leaf encoding (storage root needed). Non-overlapping storage proofs stay dispatched to preserve concurrency.
- **Conservative scope**: only targets len=1, not a broader threshold, to avoid turning the account worker into a bottleneck for heavier storage proofs.

## Testing
- `cargo test -p reth-trie-parallel` — all pass
- `cargo test -p reth-trie --lib proof_v2` — all pass
- Compiles with and without `metrics` feature

Prompted by: yk