### PR TITLE
refactor(chainspec): use existing paris difficulty getter

### DIFF
--- a/crates/chainspec/src/api.rs
+++ b/crates/chainspec/src/api.rs
@@ -132,6 +132,6 @@ impl<H: BlockHeader> EthChainSpec for ChainSpec<H> {
     }
 
     fn final_paris_total_difficulty(&self) -> Option<U256> {
-        self.paris_block_and_final_difficulty.map(|(_, final_difficulty)| final_difficulty)
+        self.get_final_paris_total_difficulty()
     }
 }


### PR DESCRIPTION
EthChainSpec::final_paris_total_difficulty duplicated the map logic that already exists in ChainSpec::get_final_paris_total_difficulty. Now it just calls the existing method.