### PR TITLE
fix(engine): record missing multiproof task histogram metrics

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -233,6 +233,11 @@ where
     pub(super) fn run(&mut self) -> Result<StateRootComputeOutcome, ParallelStateRootError> {
         let now = Instant::now();
 
+        let mut total_state_updates: u64 = 0;
+        let mut total_proofs_processed: u64 = 0;
+        let mut first_update_wait_time = None;
+        let mut last_proof_wait_time = std::time::Duration::ZERO;
+
         loop {
             let mut t = Instant::now();
             crossbeam_channel::select_biased! {
@@ -240,6 +245,10 @@ where
                     self.metrics
                         .sparse_trie_channel_wait_duration_histogram
                         .record(t.elapsed());
+
+                    if first_update_wait_time.is_none() {
+                        first_update_wait_time = Some(now.elapsed());
+                    }
 
                     let update = match message {
                         Ok(m) => m,
@@ -250,15 +259,26 @@ where
                         }
                     };
 
+                    if matches!(&update, SparseTrieTaskMessage::HashedState(_)) {
+                        total_state_updates += 1;
+                    }
+
                     self.on_message(update);
                     self.pending_updates += 1;
                 }
                 recv(self.proof_result_rx) -> message => {
                     let phase_end = Instant::now();
+                    let wait_duration = phase_end.duration_since(t);
                     self.metrics
                         .sparse_trie_channel_wait_duration_histogram
-                        .record(phase_end.duration_since(t));
+                        .record(wait_duration);
                     t = phase_end;
+
+                    if first_update_wait_time.is_none() {
+                        first_update_wait_time = Some(now.elapsed());
+                    }
+                    last_proof_wait_time = wait_duration;
+                    total_proofs_processed += 1;
 
                     let Ok(result) = message else {
                         unreachable!("we own the sender half")
@@ -268,6 +288,7 @@ where
                     while let Ok(next) = self.proof_result_rx.try_recv() {
                         let res = next.result?;
                         result.extend(res);
+                        total_proofs_processed += 1;
                     }
 
                     let phase_end = Instant::now();
@@ -327,6 +348,14 @@ where
         let end = Instant::now();
         self.metrics.sparse_trie_final_update_duration_histogram.record(end.duration_since(start));
         self.metrics.sparse_trie_total_duration_histogram.record(end.duration_since(now));
+
+        self.metrics.state_updates_received_histogram.record(total_state_updates as f64);
+        self.metrics.proofs_processed_histogram.record(total_proofs_processed as f64);
+        self.metrics.multiproof_task_total_duration_histogram.record(end.duration_since(now));
+        if let Some(first_wait) = first_update_wait_time {
+            self.metrics.first_update_wait_time_histogram.record(first_wait);
+        }
+        self.metrics.last_proof_wait_time_histogram.record(last_proof_wait_time);
 
         Ok(StateRootComputeOutcome {
             state_root,


### PR DESCRIPTION
5 histograms in MultiProofTaskMetrics were defined with pub visibility and doc comments but never .record()'d anywhere. Two of them (proofs_processed_histogram and multiproof_task_total_duration_histogram) are already referenced in the Grafana dashboard (overview.json:3680, :4663), so those panels have been showing empty data.

The other histograms in the same struct (channel_wait, proof_coalesce, reveal_multiproof, process_updates, final_update, total) are all recorded correctly in SparseTrieCacheTask::run() — these 5 were just missed.

Added tracking in the event loop and record calls at the end of run(), matching the existing pattern.