### PR TITLE
fix(rpc): use actual configured limit in trace_filter

### DIFF
--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -367,9 +367,10 @@ where
         // ensure that the range is not too large, since we need to fetch all blocks in the range
         let distance = end.saturating_sub(start);
         if distance > self.inner.eth_config.max_trace_filter_blocks {
-            return Err(EthApiError::InvalidParams(
-                format!("Block range too large; currently limited to {} blocks", self.inner.eth_config.max_trace_filter_blocks),
-            )
+            return Err(EthApiError::InvalidParams(format!(
+                "Block range too large; currently limited to {} blocks",
+                self.inner.eth_config.max_trace_filter_blocks
+            ))
             .into())
         }
 

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -368,7 +368,7 @@ where
         let distance = end.saturating_sub(start);
         if distance > self.inner.eth_config.max_trace_filter_blocks {
             return Err(EthApiError::InvalidParams(
-                "Block range too large; currently limited to 100 blocks".to_string(),
+                format!("Block range too large; currently limited to {} blocks", self.inner.eth_config.max_trace_filter_blocks),
             )
             .into())
         }


### PR DESCRIPTION
The trace_filter error message was hardcoded to "currently limited to 100 blocks" but the actual limit comes from `max_trace_filter_blocks` which is configurable via `--rpc.max-trace-filter-blocks`. If an operator changes this value, the error would show 100 instead of the real limit, confusing RPC callers trying to adjust their requests.