### PR TITLE
refactor(engine): consolidate post-exec tasks into OnceLock worker

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -55,6 +55,7 @@ use tracing::{debug, debug_span, instrument, warn, Span};
 
 pub mod bal;
 pub mod multiproof;
+pub mod post_exec;
 mod preserved_sparse_trie;
 pub mod prewarm;
 pub mod receipt_root_task;

--- a/crates/engine/tree/src/tree/payload_processor/post_exec.rs
+++ b/crates/engine/tree/src/tree/payload_processor/post_exec.rs
@@ -1,0 +1,446 @@
+//! Per-block post-execution handle for background receipt-root and hashed-post-state computation.
+//!
+//! This module provides [`PostExecHandle`], a block-scoped facade that spawns a single
+//! event-driven background worker via [`Runtime::spawn_blocking_named`]. Receipts are
+//! streamed incrementally during execution; after execution completes, a `Done` event
+//! triggers both receipt-root finalization and hashed-post-state computation.
+//!
+//! Results are stored in shared [`OnceLock`] fields and accessed via [`OnceLock::wait`],
+//! which blocks until the value is available.
+
+use super::receipt_root_task::IndexedReceipt;
+use alloy_eips::Encodable2718;
+use alloy_primitives::{Bloom, B256};
+use crossbeam_channel::Sender as CrossbeamSender;
+use reth_primitives_traits::Receipt;
+use reth_tasks::Runtime;
+use reth_trie::HashedPostState;
+use reth_trie_common::ordered_root::OrderedTrieRootEncodedBuilder;
+use std::sync::{Arc, OnceLock};
+use tracing::error;
+
+/// Block-scoped handle for post-execution background tasks.
+///
+/// Created once per block via [`PostExecHandle::new`], which immediately spawns a single
+/// background worker. During transaction execution, receipts are streamed via
+/// [`push_receipt`](Self::push_receipt). After execution completes, call
+/// [`finish`](Self::finish) to send the hashed-post-state closure and close the channel.
+///
+/// Results are stored in shared [`OnceLock`] fields and resolved lazily via
+/// [`OnceLock::wait`].
+pub struct PostExecHandle<R> {
+    tx: Option<CrossbeamSender<PostExecEvent<R>>>,
+    results: Arc<PostExecResults>,
+}
+
+impl<R> core::fmt::Debug for PostExecHandle<R> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PostExecHandle").finish()
+    }
+}
+
+impl<R: Receipt + 'static> PostExecHandle<R> {
+    /// Creates a new handle and immediately spawns the post-exec background worker.
+    ///
+    /// The worker begins waiting for events via the crossbeam channel and builds the
+    /// receipt trie incrementally as receipts arrive.
+    pub fn new(executor: &Runtime, receipts_len: usize) -> Self {
+        let (tx, rx) = crossbeam_channel::unbounded();
+        let results = Arc::new(PostExecResults::default());
+        let results_clone = results.clone();
+
+        executor.spawn_blocking_named("post-exec", move || {
+            run_post_exec_worker(rx, results_clone, receipts_len);
+        });
+
+        Self { tx: Some(tx), results }
+    }
+
+    /// Streams one receipt to the background worker.
+    #[inline]
+    pub fn push_receipt(&self, index: usize, receipt: R) {
+        if self.tx.as_ref().is_some_and(|tx| {
+            tx.send(PostExecEvent::Receipt(IndexedReceipt::new(index, receipt))).is_err()
+        }) {
+            error!(
+                target: "engine::tree::payload_processor",
+                index,
+                "post-exec worker dropped before receipt event",
+            );
+        }
+    }
+
+    /// Sends the `Done` event with the hashed-post-state closure and closes the channel.
+    ///
+    /// The background worker will finalize the receipt root, then invoke `f` to compute
+    /// the hashed post state. Must be called after all receipts have been pushed.
+    pub fn finish(&mut self, f: impl FnOnce() -> HashedPostState + Send + 'static) {
+        if let Some(tx) = self.tx.take() {
+            let _ = tx.send(PostExecEvent::Done(Box::new(f)));
+        }
+    }
+
+    /// Returns the computed receipt root and aggregated logs bloom.
+    ///
+    /// Blocks until the background worker completes receipt-root computation. Returns
+    /// `None` if the receipt stream was incomplete (e.g., execution was aborted).
+    pub fn receipt_root_bloom(&self) -> Option<(B256, Bloom)> {
+        *self.results.receipt_root_bloom.wait()
+    }
+
+    /// Returns a reference to the computed hashed post state.
+    ///
+    /// Blocks until the background worker completes.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the post-exec worker was aborted before computing the hashed post state.
+    pub fn hashed_post_state(&self) -> &HashedPostState {
+        self.results
+            .hashed_post_state
+            .wait()
+            .as_ref()
+            .expect("post-exec worker aborted before computing hashed post state")
+    }
+
+    /// Extracts a [`LazyHashedPostState`] wrapper from this handle.
+    pub fn into_lazy_hashed_state(self) -> LazyHashedPostState {
+        LazyHashedPostState { results: self.results }
+    }
+}
+
+/// Shared results written by the post-exec background worker.
+#[derive(Debug, Default)]
+struct PostExecResults {
+    receipt_root_bloom: OnceLock<Option<(B256, Bloom)>>,
+    hashed_post_state: OnceLock<Option<HashedPostState>>,
+}
+
+/// Event sent from the main execution thread to the post-exec background worker.
+enum PostExecEvent<R> {
+    /// A receipt produced during transaction execution.
+    Receipt(IndexedReceipt<R>),
+    /// Execution is complete; the closure computes the hashed post state.
+    Done(Box<dyn FnOnce() -> HashedPostState + Send>),
+}
+
+/// Handle to a [`HashedPostState`] computed on a background thread.
+///
+/// Wraps `Arc<PostExecResults>` and provides a `LazyHandle`-compatible API so downstream
+/// code that calls `.get()`, `.clone()`, and `.try_into_inner()` continues to work.
+#[derive(Clone)]
+pub struct LazyHashedPostState {
+    results: Arc<PostExecResults>,
+}
+
+impl core::fmt::Debug for LazyHashedPostState {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut s = f.debug_struct("LazyHashedPostState");
+        if let Some(value) = self.results.hashed_post_state.get() {
+            s.field("value", &value.is_some());
+        } else {
+            s.field("value", &"<pending>");
+        }
+        s.finish()
+    }
+}
+
+impl LazyHashedPostState {
+    /// Blocks until the background worker completes and returns a reference to the result.
+    pub fn get(&self) -> &HashedPostState {
+        self.results
+            .hashed_post_state
+            .wait()
+            .as_ref()
+            .expect("post-exec worker aborted before computing hashed post state")
+    }
+
+    /// Consumes the handle and returns the inner value if this is the only reference.
+    ///
+    /// Returns `Err(self)` if other clones exist.
+    /// Blocks if the background worker hasn't completed yet.
+    pub fn try_into_inner(self) -> Result<HashedPostState, Self> {
+        self.get();
+        match Arc::try_unwrap(self.results) {
+            Ok(inner) => Ok(inner
+                .hashed_post_state
+                .into_inner()
+                .expect("value was just set by get()")
+                .expect("post-exec worker aborted")),
+            Err(arc) => Err(Self { results: arc }),
+        }
+    }
+}
+
+/// Runs the single post-exec background worker.
+///
+/// Receives events from the main execution thread: [`PostExecEvent::Receipt`] during
+/// execution, then [`PostExecEvent::Done`] after execution completes. Incrementally builds
+/// the receipt trie, finalizes it, then computes the hashed post state.
+///
+/// An RAII guard ensures all [`OnceLock`] fields are set on every exit path (including
+/// panics), so [`OnceLock::wait`] never hangs.
+fn run_post_exec_worker<R: Receipt>(
+    rx: crossbeam_channel::Receiver<PostExecEvent<R>>,
+    results: Arc<PostExecResults>,
+    receipts_len: usize,
+) {
+    // RAII guard: sets any unset OnceLocks on drop (abort safety).
+    // OnceLock::set is first-writer-wins, so successful sets are not overwritten.
+    struct AbortGuard<'a> {
+        results: &'a PostExecResults,
+    }
+    impl Drop for AbortGuard<'_> {
+        fn drop(&mut self) {
+            let _ = self.results.receipt_root_bloom.set(None);
+            let _ = self.results.hashed_post_state.set(None);
+        }
+    }
+
+    let guard = AbortGuard { results: &results };
+
+    let mut builder = OrderedTrieRootEncodedBuilder::new(receipts_len);
+    let mut aggregated_bloom = Bloom::ZERO;
+    let mut encode_buf = Vec::new();
+    let mut received_count = 0usize;
+
+    // Process events until Done or channel close.
+    let done_f = loop {
+        match rx.recv() {
+            Ok(PostExecEvent::Receipt(indexed_receipt)) => {
+                let receipt_with_bloom = indexed_receipt.receipt.with_bloom_ref();
+
+                encode_buf.clear();
+                receipt_with_bloom.encode_2718(&mut encode_buf);
+
+                aggregated_bloom |= *receipt_with_bloom.bloom_ref();
+                match builder.push(indexed_receipt.index, &encode_buf) {
+                    Ok(()) => {
+                        received_count += 1;
+                    }
+                    Err(err) => {
+                        error!(
+                            target: "engine::tree::payload_processor",
+                            index = indexed_receipt.index,
+                            ?err,
+                            "Post-exec worker received invalid receipt index, skipping"
+                        );
+                    }
+                }
+            }
+            Ok(PostExecEvent::Done(f)) => break f,
+            Err(_) => {
+                // Channel closed before Done — execution was aborted.
+                // Guard will set all OnceLocks to None.
+                return;
+            }
+        }
+    };
+
+    // Finalize receipt root.
+    match builder.finalize() {
+        Ok(root) => {
+            let _ = results.receipt_root_bloom.set(Some((root, aggregated_bloom)));
+        }
+        Err(_) => {
+            error!(
+                target: "engine::tree::payload_processor",
+                expected = receipts_len,
+                received = received_count,
+                "Post-exec worker received incomplete receipts, execution likely aborted"
+            );
+            let _ = results.receipt_root_bloom.set(None);
+        }
+    }
+
+    // Compute hashed post state.
+    let hashed = done_f();
+    let _ = results.hashed_post_state.set(Some(hashed));
+
+    // All OnceLocks set successfully — prevent guard from overwriting.
+    core::mem::forget(guard);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::{proofs::calculate_receipt_root, TxReceipt};
+    use alloy_primitives::{Address, Bytes, Log, B256};
+    use reth_ethereum_primitives::{Receipt, TxType};
+
+    fn test_runtime() -> Runtime {
+        Runtime::test()
+    }
+
+    fn sample_receipts() -> Vec<Receipt> {
+        vec![
+            Receipt {
+                tx_type: TxType::Legacy,
+                cumulative_gas_used: 21_000,
+                success: true,
+                logs: vec![],
+            },
+            Receipt {
+                tx_type: TxType::Eip1559,
+                cumulative_gas_used: 42_000,
+                success: true,
+                logs: vec![Log {
+                    address: Address::ZERO,
+                    data: alloy_primitives::LogData::new_unchecked(vec![B256::ZERO], Bytes::new()),
+                }],
+            },
+            Receipt {
+                tx_type: TxType::Eip2930,
+                cumulative_gas_used: 63_000,
+                success: false,
+                logs: vec![],
+            },
+        ]
+    }
+
+    fn expected_root_bloom(receipts: &[Receipt]) -> (B256, Bloom) {
+        let receipts_with_bloom: Vec<_> = receipts.iter().map(|r| r.with_bloom_ref()).collect();
+        let root = calculate_receipt_root(&receipts_with_bloom);
+        let bloom =
+            receipts_with_bloom.iter().fold(Bloom::ZERO, |acc, receipt| acc | *receipt.bloom_ref());
+        (root, bloom)
+    }
+
+    #[test]
+    fn post_exec_handle_computes_receipt_root_and_bloom() {
+        let rt = test_runtime();
+
+        let receipts = sample_receipts();
+        let (expected_root, expected_bloom) = expected_root_bloom(&receipts);
+
+        let mut handle = PostExecHandle::<Receipt>::new(&rt, receipts.len());
+        for (index, receipt) in receipts.into_iter().enumerate() {
+            handle.push_receipt(index, receipt);
+        }
+        handle.finish(|| HashedPostState::default());
+
+        let (root, bloom) = handle.receipt_root_bloom().unwrap();
+        assert_eq!(root, expected_root);
+        assert_eq!(bloom, expected_bloom);
+    }
+
+    #[test]
+    fn post_exec_handle_handles_out_of_order_receipts() {
+        let rt = test_runtime();
+
+        let receipts = sample_receipts();
+        let (expected_root, expected_bloom) = expected_root_bloom(&receipts);
+
+        let mut handle = PostExecHandle::<Receipt>::new(&rt, receipts.len());
+        for (index, receipt) in receipts.into_iter().enumerate().rev() {
+            handle.push_receipt(index, receipt);
+        }
+        handle.finish(|| HashedPostState::default());
+
+        let (root, bloom) = handle.receipt_root_bloom().unwrap();
+        assert_eq!(root, expected_root);
+        assert_eq!(bloom, expected_bloom);
+    }
+
+    #[test]
+    fn post_exec_handle_returns_none_for_incomplete_stream() {
+        let rt = test_runtime();
+
+        let mut handle = PostExecHandle::<Receipt>::new(&rt, 2);
+        handle.push_receipt(0, Receipt::default());
+        // Finish with only 1 of 2 receipts — root should be None.
+        handle.finish(|| HashedPostState::default());
+
+        assert!(handle.receipt_root_bloom().is_none());
+    }
+
+    #[test]
+    fn post_exec_handle_with_hashed_post_state() {
+        let rt = test_runtime();
+
+        let mut handle = PostExecHandle::<Receipt>::new(&rt, 0);
+        let expected = HashedPostState::default();
+        handle.finish(|| HashedPostState::default());
+
+        assert_eq!(handle.hashed_post_state(), &expected);
+    }
+
+    #[test]
+    fn post_exec_handle_parallel_blocks() {
+        let rt = test_runtime();
+
+        let receipts_a = sample_receipts();
+        let (expected_root_a, expected_bloom_a) = expected_root_bloom(&receipts_a);
+
+        let receipts_b = vec![Receipt::default(); 2];
+        let (expected_root_b, expected_bloom_b) = expected_root_bloom(&receipts_b);
+
+        let mut handle_a = PostExecHandle::<Receipt>::new(&rt, receipts_a.len());
+        let mut handle_b = PostExecHandle::<Receipt>::new(&rt, receipts_b.len());
+
+        for (index, receipt) in receipts_a.into_iter().enumerate() {
+            handle_a.push_receipt(index, receipt);
+        }
+        for (index, receipt) in receipts_b.into_iter().enumerate() {
+            handle_b.push_receipt(index, receipt);
+        }
+
+        handle_a.finish(|| HashedPostState::default());
+        handle_b.finish(|| HashedPostState::default());
+
+        let (root_a, bloom_a) = handle_a.receipt_root_bloom().unwrap();
+        let (root_b, bloom_b) = handle_b.receipt_root_bloom().unwrap();
+
+        assert_eq!(root_a, expected_root_a);
+        assert_eq!(bloom_a, expected_bloom_a);
+        assert_eq!(root_b, expected_root_b);
+        assert_eq!(bloom_b, expected_bloom_b);
+    }
+
+    #[test]
+    fn post_exec_handle_aborted_block_then_next_succeeds() {
+        let rt = test_runtime();
+
+        // First block: aborted (dropped without finishing)
+        let handle = PostExecHandle::<Receipt>::new(&rt, 2);
+        handle.push_receipt(0, Receipt::default());
+        drop(handle);
+
+        // Second block: succeeds
+        let mut handle = PostExecHandle::<Receipt>::new(&rt, 1);
+        handle.push_receipt(0, Receipt::default());
+        handle.finish(|| HashedPostState::default());
+        assert!(handle.receipt_root_bloom().is_some());
+    }
+
+    #[test]
+    fn lazy_hashed_post_state_get_and_try_into_inner() {
+        let rt = test_runtime();
+
+        let mut handle = PostExecHandle::<Receipt>::new(&rt, 0);
+        handle.finish(|| HashedPostState::default());
+
+        let lazy = handle.into_lazy_hashed_state();
+        assert_eq!(lazy.get(), &HashedPostState::default());
+
+        // try_into_inner succeeds because into_lazy_hashed_state consumed the handle,
+        // leaving only one Arc reference.
+        let inner = lazy.try_into_inner().unwrap();
+        assert_eq!(inner, HashedPostState::default());
+    }
+
+    #[test]
+    fn lazy_hashed_post_state_clone_prevents_try_into_inner() {
+        let rt = test_runtime();
+
+        let mut handle = PostExecHandle::<Receipt>::new(&rt, 0);
+        handle.finish(|| HashedPostState::default());
+
+        let lazy = handle.into_lazy_hashed_state();
+        let _clone = lazy.clone();
+
+        // try_into_inner fails because there are multiple Arc references.
+        let lazy = lazy.try_into_inner().unwrap_err();
+        assert_eq!(lazy.get(), &HashedPostState::default());
+    }
+}

--- a/crates/engine/tree/src/tree/payload_processor/receipt_root_task.rs
+++ b/crates/engine/tree/src/tree/payload_processor/receipt_root_task.rs
@@ -11,7 +11,6 @@ use alloy_primitives::{Bloom, B256};
 use crossbeam_channel::Receiver;
 use reth_primitives_traits::Receipt;
 use reth_trie_common::ordered_root::OrderedTrieRootEncodedBuilder;
-use tokio::sync::oneshot;
 
 /// Receipt with index, ready to be sent to the background task for encoding and trie building.
 #[derive(Debug, Clone)]
@@ -32,30 +31,25 @@ impl<R> IndexedReceipt<R> {
 
 /// Handle for running the receipt root computation in a background task.
 ///
-/// This struct holds the channels needed to receive receipts and send the result.
+/// This struct holds the channel needed to receive receipts.
 /// Use [`Self::run`] to execute the computation (typically in a spawned blocking task).
 #[derive(Debug)]
 pub struct ReceiptRootTaskHandle<R> {
     /// Receiver for indexed receipts.
     receipt_rx: Receiver<IndexedReceipt<R>>,
-    /// Sender for the computed result.
-    result_tx: oneshot::Sender<(B256, Bloom)>,
 }
 
 impl<R: Receipt> ReceiptRootTaskHandle<R> {
-    /// Creates a new handle from the receipt receiver and result sender channels.
-    pub const fn new(
-        receipt_rx: Receiver<IndexedReceipt<R>>,
-        result_tx: oneshot::Sender<(B256, Bloom)>,
-    ) -> Self {
-        Self { receipt_rx, result_tx }
+    /// Creates a new handle from the receipt receiver channel.
+    pub const fn new(receipt_rx: Receiver<IndexedReceipt<R>>) -> Self {
+        Self { receipt_rx }
     }
 
     /// Runs the receipt root computation, consuming the handle.
     ///
     /// This method receives indexed receipts from the channel, encodes them,
     /// and builds the trie incrementally. When all receipts have been received
-    /// (channel closed), it sends the result through the oneshot channel.
+    /// (channel closed), it returns the computed root and aggregated bloom.
     ///
     /// This is designed to be called inside a blocking task (e.g., via
     /// `executor.spawn_blocking(move || handle.run(receipts_len))`).
@@ -64,7 +58,7 @@ impl<R: Receipt> ReceiptRootTaskHandle<R> {
     ///
     /// * `receipts_len` - The total number of receipts expected. This is needed to correctly order
     ///   the trie keys according to RLP encoding rules.
-    pub fn run(self, receipts_len: usize) {
+    pub fn run(self, receipts_len: usize) -> Option<(B256, Bloom)> {
         let mut builder = OrderedTrieRootEncodedBuilder::new(receipts_len);
         let mut aggregated_bloom = Bloom::ZERO;
         let mut encode_buf = Vec::new();
@@ -98,16 +92,16 @@ impl<R: Receipt> ReceiptRootTaskHandle<R> {
         let Ok(root) = builder.finalize() else {
             // Finalize fails if we didn't receive exactly `receipts_len` receipts. This can
             // happen if execution was aborted early (e.g., invalid transaction encountered).
-            // We return without sending a result, allowing the caller to handle the abort.
+            // We return `None`, allowing the caller to handle the abort.
             tracing::error!(
                 target: "engine::tree::payload_processor",
                 expected = receipts_len,
                 received = received_count,
                 "Receipt root task received incomplete receipts, execution likely aborted"
             );
-            return;
+            return None;
         };
-        let _ = self.result_tx.send((root, aggregated_bloom));
+        Some((root, aggregated_bloom))
     }
 }
 
@@ -122,13 +116,11 @@ mod tests {
     #[tokio::test]
     async fn test_receipt_root_task_empty() {
         let (_tx, rx) = bounded::<IndexedReceipt<Receipt>>(1);
-        let (result_tx, result_rx) = oneshot::channel();
         drop(_tx);
 
-        let handle = ReceiptRootTaskHandle::new(rx, result_tx);
-        tokio::task::spawn_blocking(move || handle.run(0)).await.unwrap();
-
-        let (root, bloom) = result_rx.await.unwrap();
+        let handle = ReceiptRootTaskHandle::new(rx);
+        let (root, bloom) =
+            tokio::task::spawn_blocking(move || handle.run(0)).await.unwrap().unwrap();
 
         // Empty trie root
         assert_eq!(root, reth_trie_common::EMPTY_ROOT_HASH);
@@ -140,10 +132,9 @@ mod tests {
         let receipts: Vec<Receipt> = vec![Receipt::default()];
 
         let (tx, rx) = bounded(1);
-        let (result_tx, result_rx) = oneshot::channel();
         let receipts_len = receipts.len();
 
-        let handle = ReceiptRootTaskHandle::new(rx, result_tx);
+        let handle = ReceiptRootTaskHandle::new(rx);
         let join_handle = tokio::task::spawn_blocking(move || handle.run(receipts_len));
 
         for (i, receipt) in receipts.clone().into_iter().enumerate() {
@@ -151,8 +142,7 @@ mod tests {
         }
         drop(tx);
 
-        join_handle.await.unwrap();
-        let (root, _bloom) = result_rx.await.unwrap();
+        let (root, _bloom) = join_handle.await.unwrap().unwrap();
 
         // Verify against the standard calculation
         let receipts_with_bloom: Vec<_> = receipts.iter().map(|r| r.with_bloom_ref()).collect();
@@ -166,10 +156,9 @@ mod tests {
         let receipts: Vec<Receipt> = vec![Receipt::default(); 5];
 
         let (tx, rx) = bounded(4);
-        let (result_tx, result_rx) = oneshot::channel();
         let receipts_len = receipts.len();
 
-        let handle = ReceiptRootTaskHandle::new(rx, result_tx);
+        let handle = ReceiptRootTaskHandle::new(rx);
         let join_handle = tokio::task::spawn_blocking(move || handle.run(receipts_len));
 
         for (i, receipt) in receipts.into_iter().enumerate() {
@@ -177,8 +166,7 @@ mod tests {
         }
         drop(tx);
 
-        join_handle.await.unwrap();
-        let (root, bloom) = result_rx.await.unwrap();
+        let (root, bloom) = join_handle.await.unwrap().unwrap();
 
         // Verify against expected values from existing test
         assert_eq!(
@@ -226,10 +214,9 @@ mod tests {
 
         // Calculate using the task
         let (tx, rx) = bounded(4);
-        let (result_tx, result_rx) = oneshot::channel();
         let receipts_len = receipts.len();
 
-        let handle = ReceiptRootTaskHandle::new(rx, result_tx);
+        let handle = ReceiptRootTaskHandle::new(rx);
         let join_handle = tokio::task::spawn_blocking(move || handle.run(receipts_len));
 
         for (i, receipt) in receipts.into_iter().enumerate() {
@@ -237,8 +224,7 @@ mod tests {
         }
         drop(tx);
 
-        join_handle.await.unwrap();
-        let (task_root, task_bloom) = result_rx.await.unwrap();
+        let (task_root, task_bloom) = join_handle.await.unwrap().unwrap();
 
         assert_eq!(task_root, expected_root);
         assert_eq!(task_bloom, expected_bloom);
@@ -253,10 +239,9 @@ mod tests {
         let expected_root = calculate_receipt_root(&receipts_with_bloom);
 
         let (tx, rx) = bounded(4);
-        let (result_tx, result_rx) = oneshot::channel();
         let receipts_len = receipts.len();
 
-        let handle = ReceiptRootTaskHandle::new(rx, result_tx);
+        let handle = ReceiptRootTaskHandle::new(rx);
         let join_handle = tokio::task::spawn_blocking(move || handle.run(receipts_len));
 
         // Send in reverse order to test out-of-order handling
@@ -265,8 +250,7 @@ mod tests {
         }
         drop(tx);
 
-        join_handle.await.unwrap();
-        let (root, _bloom) = result_rx.await.unwrap();
+        let (root, _bloom) = join_handle.await.unwrap().unwrap();
 
         assert_eq!(root, expected_root);
     }

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -18,7 +18,7 @@ use alloy_primitives::B256;
 #[cfg(feature = "trie-debug")]
 use reth_trie_sparse::debug_recorder::TrieDebugRecorder;
 
-use crate::tree::payload_processor::receipt_root_task::{IndexedReceipt, ReceiptRootTaskHandle};
+use crate::tree::payload_processor::post_exec::{LazyHashedPostState, PostExecHandle};
 use reth_chain_state::{CanonicalInMemoryState, DeferredTrieData, ExecutedBlock, LazyOverlay};
 use reth_consensus::{ConsensusError, FullConsensus, ReceiptRootBloom};
 use reth_engine_primitives::{
@@ -43,7 +43,7 @@ use reth_provider::{
     StateProviderFactory, StateReader, StorageChangeSetReader, StorageSettingsCache,
 };
 use reth_revm::db::{states::bundle_state::BundleRetention, State};
-use reth_trie::{updates::TrieUpdates, HashedPostState, StateRoot};
+use reth_trie::{updates::TrieUpdates, StateRoot};
 use reth_trie_db::ChangesetCache;
 use reth_trie_parallel::root::{ParallelStateRoot, ParallelStateRootError};
 use revm_primitives::Address;
@@ -53,9 +53,6 @@ use std::{
     sync::{mpsc::RecvTimeoutError, Arc},
 };
 use tracing::{debug, debug_span, error, info, instrument, trace, warn};
-
-/// Handle to a [`HashedPostState`] computed on a background thread.
-type LazyHashedPostState = reth_tasks::LazyHandle<HashedPostState>;
 
 /// Context providing access to tree state during validation.
 ///
@@ -494,7 +491,7 @@ where
         // Execute the block and handle any execution errors.
         // The receipt root task is spawned before execution and receives receipts incrementally
         // as transactions complete, allowing parallel computation during execution.
-        let (output, senders, receipt_root_rx) =
+        let (output, senders, mut post_exec) =
             match self.execute_block(state_provider, env, &input, &mut handle) {
                 Ok(output) => output,
                 Err(err) => return self.handle_execution_error(input, err, &parent_block),
@@ -512,33 +509,23 @@ where
         // needed. This frees up resources while state root computation continues.
         let valid_block_tx = handle.terminate_caching(Some(output.clone()));
 
-        // Spawn hashed post state computation in background so it runs concurrently with
-        // block conversion and receipt root computation. This is a pure CPU-bound task
-        // (keccak256 hashing of all changed addresses and storage slots).
+        // Send Done event to the post-exec worker, which will finalize receipt root
+        // and compute hashed post state in the same background thread.
         let hashed_state_output = output.clone();
         let hashed_state_provider = self.provider.clone();
-        let hashed_state: LazyHashedPostState =
-            self.payload_processor.executor().spawn_blocking_named("hash-post-state", move || {
-                let _span = debug_span!(
-                    target: "engine::tree::payload_validator",
-                    "hashed_post_state",
-                )
-                .entered();
-                hashed_state_provider.hashed_post_state(&hashed_state_output.state)
-            });
+        post_exec.finish(move || {
+            let _span = debug_span!(
+                target: "engine::tree::payload_validator",
+                "hashed_post_state",
+            )
+            .entered();
+            hashed_state_provider.hashed_post_state(&hashed_state_output.state)
+        });
 
         let block = convert_to_block(input)?.with_senders(senders);
 
-        // Wait for the receipt root computation to complete.
-        let receipt_root_bloom = receipt_root_rx
-            .blocking_recv()
-            .inspect_err(|_| {
-                tracing::error!(
-                    target: "engine::tree::payload_validator",
-                    "Receipt root task dropped sender without result, receipt root calculation likely aborted"
-                );
-            })
-            .ok();
+        let receipt_root_bloom = post_exec.receipt_root_bloom();
+        let hashed_state = post_exec.into_lazy_hashed_state();
 
         let hashed_state = ensure_ok_post_block!(
             self.validate_post_execution(
@@ -767,11 +754,7 @@ where
         input: &BlockOrPayload<T>,
         handle: &mut PayloadHandle<impl ExecutableTxFor<Evm>, Err, N::Receipt>,
     ) -> Result<
-        (
-            BlockExecutionOutput<N::Receipt>,
-            Vec<Address>,
-            tokio::sync::oneshot::Receiver<(B256, alloy_primitives::Bloom)>,
-        ),
+        (BlockExecutionOutput<N::Receipt>, Vec<Address>, PostExecHandle<N::Receipt>),
         InsertBlockErrorKind,
     >
     where
@@ -820,14 +803,8 @@ where
         }
 
         // Spawn background task to compute receipt root and logs bloom incrementally.
-        // Unbounded channel is used since tx count bounds capacity anyway (max ~30k txs per block).
         let receipts_len = input.transaction_count();
-        let (receipt_tx, receipt_rx) = crossbeam_channel::unbounded();
-        let (result_tx, result_rx) = tokio::sync::oneshot::channel();
-        let task_handle = ReceiptRootTaskHandle::new(receipt_rx, result_tx);
-        self.payload_processor
-            .executor()
-            .spawn_blocking_named("receipt-root", move || task_handle.run(receipts_len));
+        let post_exec = PostExecHandle::new(self.payload_processor.executor(), receipts_len);
 
         let transaction_count = input.transaction_count();
         let executor = executor.with_state_hook(Some(Box::new(handle.state_hook())));
@@ -839,9 +816,8 @@ where
             executor,
             transaction_count,
             handle.iter_transactions(),
-            &receipt_tx,
+            &post_exec,
         )?;
-        drop(receipt_tx);
 
         // Finish execution and get the result
         let post_exec_start = Instant::now();
@@ -861,7 +837,7 @@ where
         self.metrics.record_block_execution_gas_bucket(output.result.gas_used, execution_duration);
 
         debug!(target: "engine::tree::payload_validator", elapsed = ?execution_duration, "Executed block");
-        Ok((output, senders, result_rx))
+        Ok((output, senders, post_exec))
     }
 
     /// Executes transactions and collects senders, streaming receipts to a background task.
@@ -878,7 +854,7 @@ where
         mut executor: E,
         transaction_count: usize,
         transactions: impl Iterator<Item = Result<Tx, Err>>,
-        receipt_tx: &crossbeam_channel::Sender<IndexedReceipt<N::Receipt>>,
+        post_exec: &PostExecHandle<N::Receipt>,
     ) -> Result<(E, Vec<Address>), BlockExecutionError>
     where
         E: BlockExecutor<Receipt = N::Receipt>,
@@ -931,7 +907,7 @@ where
                 // Send the latest receipt to the background task for incremental root computation.
                 if let Some(receipt) = executor.receipts().last() {
                     let tx_index = current_len - 1;
-                    let _ = receipt_tx.send(IndexedReceipt::new(tx_index, receipt.clone()));
+                    post_exec.push_receipt(tx_index, receipt.clone());
                 }
             }
         }


### PR DESCRIPTION
## Summary
- consolidate post-execution background work into a single event-driven `post-exec` worker
- replace dual-task orchestration (receipt root + hashed post state) with a single channel carrying `PostExecEvent::{Receipt, Done}`
- store worker outputs in `OnceLock`-backed shared results and expose hashed post-state through a `LazyHandle`-compatible wrapper

## What Changed
- added `post_exec.rs` with:
  - `PostExecHandle<R>` for block-scoped event streaming and finalization
  - `PostExecEvent<R>` (`Receipt`, `Done`) for single-worker signaling
  - `PostExecResults` with `OnceLock<Option<(B256, Bloom)>>` and `OnceLock<Option<HashedPostState>>`
  - `LazyHashedPostState` wrapper with `.get()`, `.clone()`, `.try_into_inner()` compatibility
  - RAII abort guard to ensure all `OnceLock`s are always set (prevents `wait()` hangs on abort)
- updated `payload_validator.rs` to:
  - use `PostExecHandle` instead of separate receipt-root channel + hashed-state task
  - stream receipts through `post_exec.push_receipt(...)`
  - send final `Done` closure via `post_exec.finish(...)`
  - consume results via `post_exec.receipt_root_bloom()` and `post_exec.into_lazy_hashed_state()`
- simplified `receipt_root_task.rs` API by removing oneshot sender dependency and returning `Option<(B256, Bloom)>` directly from `run`
- exported `pub mod post_exec` from payload processor module

## Architecture
### Before
```mermaid
flowchart LR
    A[execute_block / tx loop] -->|stream receipts| B[receipt-root task<br/>spawn_blocking named: receipt-root]
    A -->|after execution| C[hashed-post-state task<br/>spawn_blocking named: hash-post-state]

    B --> D[oneshot receiver<br/>receipt_root_bloom]
    C --> E[LazyHandle HashedPostState]

    D --> F[validate_post_execution]
    E --> F
```

### After
```mermaid
flowchart LR
    A[execute_block / tx loop] -->|post exec receipt event| B[single post-exec worker<br/>spawn_blocking named: post-exec]
    A -->|post exec done event| B

    B --> G[receipt_root_bloom<br/>OnceLock option B256 Bloom]
    B --> H[hashed_post_state<br/>OnceLock option HashedPostState]

    G --> I[validate_post_execution]
    H --> J[LazyHashedPostState<br/>get clone try_into_inner]
    J --> I
```

## Motivation
- reduces task orchestration complexity by centralizing post-exec work in one worker
- removes oneshot handoff plumbing between producer and receipt-root task
- preserves downstream lazy hashed-state access semantics while adopting `OnceLock::wait()` synchronization
- improves abort behavior by guaranteeing result slots are always resolved to `Some`/`None`

## Testing
- `cargo +nightly fmt --all --check`
- `cargo test -p reth-engine-tree post_exec::tests:: -- --nocapture`
- `cargo test -p reth-engine-tree receipt_root_task::tests:: -- --nocapture`
