### PR TITLE
feat(engine): consolidate post-execution tasks into single block-scoped worker

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -55,6 +55,7 @@ use tracing::{debug, debug_span, instrument, warn, Span};
 
 pub mod bal;
 pub mod multiproof;
+pub mod post_exec;
 mod preserved_sparse_trie;
 pub mod prewarm;
 pub mod receipt_root_task;
@@ -175,6 +176,15 @@ where
             disable_sparse_trie_cache_pruning: config.disable_sparse_trie_cache_pruning(),
             disable_cache_metrics: config.disable_cache_metrics(),
         }
+    }
+
+    /// Creates a new block-scoped post-execution handle.
+    pub fn post_exec_handle(
+        &self,
+        receipts_len: usize,
+        withdrawals: Option<Vec<Withdrawal>>,
+    ) -> post_exec::PostExecHandle<N::Receipt> {
+        post_exec::PostExecHandle::new(&self.executor, receipts_len, withdrawals)
     }
 }
 

--- a/crates/engine/tree/src/tree/payload_processor/post_exec.rs
+++ b/crates/engine/tree/src/tree/payload_processor/post_exec.rs
@@ -1,0 +1,344 @@
+//! Block-scoped post-execution handle for receipt-root, withdrawals-root and hashed-post-state.
+//!
+//! This module introduces [`PostExecOutput`], a per-block output container backed by
+//! [`OnceLock`](reth_primitives_traits::sync::OnceLock). Each artifact can be awaited
+//! independently via `wait`-backed getters.
+
+use super::receipt_root_task::{IndexedReceipt, ReceiptRootTaskHandle};
+use alloy_eips::eip4895::Withdrawal;
+use alloy_primitives::{Bloom, B256};
+use crossbeam_channel::{self, Sender as CrossbeamSender};
+use reth_primitives_traits::{proofs::calculate_withdrawals_root, sync::OnceLock, Receipt};
+use reth_tasks::Runtime;
+use reth_trie::HashedPostState;
+use std::{
+    panic::{self, AssertUnwindSafe},
+    sync::{mpsc, Arc},
+};
+use tracing::error;
+
+type HashedPostStateJob = Box<dyn FnOnce() -> HashedPostState + Send + 'static>;
+
+/// Block-scoped post-execution outputs.
+///
+/// Each field is resolved exactly once by the background post-exec task. Callers can wait on
+/// individual artifacts as needed.
+#[derive(Debug, Default)]
+pub struct PostExecOutput {
+    receipt_root_bloom: OnceLock<Option<(B256, Bloom)>>,
+    withdrawals_root: OnceLock<Option<B256>>,
+    hashed_post_state: OnceLock<Option<Arc<HashedPostState>>>,
+}
+
+impl PostExecOutput {
+    #[inline]
+    fn set_receipt_root_bloom(&self, value: Option<(B256, Bloom)>) {
+        let _ = self.receipt_root_bloom.set(value);
+    }
+
+    #[inline]
+    fn set_withdrawals_root(&self, value: Option<B256>) {
+        let _ = self.withdrawals_root.set(value);
+    }
+
+    #[inline]
+    fn set_hashed_post_state(&self, value: Option<Arc<HashedPostState>>) {
+        let _ = self.hashed_post_state.set(value);
+    }
+
+    /// Waits for the receipt root + logs bloom output.
+    pub fn receipt_root_bloom(&self) -> Option<(B256, Bloom)> {
+        self.receipt_root_bloom.wait().clone()
+    }
+
+    /// Waits for the withdrawals root output.
+    pub fn withdrawals_root(&self) -> Option<B256> {
+        self.withdrawals_root.wait().clone()
+    }
+
+    /// Waits for the hashed post state output.
+    pub fn hashed_post_state(&self) -> Option<Arc<HashedPostState>> {
+        self.hashed_post_state.wait().clone()
+    }
+}
+
+/// Block-scoped handle for post-execution background work.
+///
+/// The handle streams receipts while execution is running, then schedules hashed post-state
+/// computation and exposes all outputs through [`PostExecOutput`].
+pub struct PostExecHandle<R> {
+    receipt_tx: Option<CrossbeamSender<IndexedReceipt<R>>>,
+    hashed_post_state_tx: Option<mpsc::Sender<HashedPostStateJob>>,
+    output: Arc<PostExecOutput>,
+}
+
+impl<R> core::fmt::Debug for PostExecHandle<R> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PostExecHandle").finish()
+    }
+}
+
+impl<R: Receipt + 'static> PostExecHandle<R> {
+    /// Creates a new block-scoped post-exec handle and spawns the background task.
+    pub fn new(
+        executor: &Runtime,
+        receipts_len: usize,
+        withdrawals: Option<Vec<Withdrawal>>,
+    ) -> Self {
+        let (receipt_tx, receipt_rx) = crossbeam_channel::unbounded();
+        let (hashed_post_state_tx, hashed_post_state_rx) = mpsc::channel::<HashedPostStateJob>();
+        let output = Arc::new(PostExecOutput::default());
+        let output_for_task = Arc::clone(&output);
+
+        executor.spawn_blocking_named("post-exec", move || {
+            let run = || {
+                output_for_task
+                    .set_withdrawals_root(withdrawals.as_deref().map(calculate_withdrawals_root));
+
+                let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+                ReceiptRootTaskHandle::new(receipt_rx, result_tx).run(receipts_len);
+                output_for_task.set_receipt_root_bloom(result_rx.blocking_recv().ok());
+
+                let hashed_post_state = hashed_post_state_rx
+                    .recv()
+                    .ok()
+                    .and_then(|job| panic::catch_unwind(AssertUnwindSafe(job)).ok().map(Arc::new));
+                output_for_task.set_hashed_post_state(hashed_post_state);
+            };
+
+            if panic::catch_unwind(AssertUnwindSafe(run)).is_err() {
+                error!(
+                    target: "engine::tree::payload_processor",
+                    "post-exec task panicked, returning empty outputs"
+                );
+            }
+
+            if output_for_task.withdrawals_root.get().is_none() {
+                output_for_task.set_withdrawals_root(None);
+            }
+            if output_for_task.receipt_root_bloom.get().is_none() {
+                output_for_task.set_receipt_root_bloom(None);
+            }
+            if output_for_task.hashed_post_state.get().is_none() {
+                output_for_task.set_hashed_post_state(None);
+            }
+        });
+
+        Self {
+            receipt_tx: Some(receipt_tx),
+            hashed_post_state_tx: Some(hashed_post_state_tx),
+            output,
+        }
+    }
+
+    /// Streams one receipt to the background receipt-root task.
+    pub fn push_receipt(&self, index: usize, receipt: R) {
+        if self
+            .receipt_tx
+            .as_ref()
+            .is_some_and(|tx| tx.send(IndexedReceipt::new(index, receipt)).is_err())
+        {
+            error!(
+                target: "engine::tree::payload_processor",
+                index,
+                "post-exec task dropped before receipt event",
+            );
+        }
+    }
+
+    /// Finalizes the receipt stream for this block.
+    #[inline]
+    pub fn finish_receipts(&mut self) {
+        self.receipt_tx.take();
+    }
+
+    /// Queues hashed post-state computation for this block.
+    ///
+    /// This should be called exactly once per block after execution output is available.
+    pub fn spawn_hashed_post_state(
+        &mut self,
+        f: impl FnOnce() -> HashedPostState + Send + 'static,
+    ) {
+        let Some(tx) = self.hashed_post_state_tx.take() else {
+            error!(
+                target: "engine::tree::payload_processor",
+                "hashed-post-state job already queued or handle dropped"
+            );
+            return;
+        };
+
+        if tx.send(Box::new(f)).is_err() {
+            error!(
+                target: "engine::tree::payload_processor",
+                "post-exec task dropped before hashed-post-state job was queued",
+            );
+        }
+    }
+
+    /// Waits for and returns the computed receipt root + logs bloom.
+    pub fn receipt_root_bloom(&self) -> Option<(B256, Bloom)> {
+        self.output.receipt_root_bloom()
+    }
+
+    /// Waits for and returns the computed withdrawals root.
+    pub fn withdrawals_root(&self) -> Option<B256> {
+        self.output.withdrawals_root()
+    }
+
+    /// Waits for and returns the computed hashed post state.
+    pub fn hashed_post_state(&self) -> Option<Arc<HashedPostState>> {
+        self.output.hashed_post_state()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::{proofs::calculate_receipt_root, TxReceipt};
+    use alloy_primitives::{Address, Bytes, Log, B256};
+    use reth_ethereum_primitives::{Receipt, TxType};
+
+    fn test_runtime() -> Runtime {
+        Runtime::test()
+    }
+
+    fn sample_receipts() -> Vec<Receipt> {
+        vec![
+            Receipt {
+                tx_type: TxType::Legacy,
+                cumulative_gas_used: 21_000,
+                success: true,
+                logs: vec![],
+            },
+            Receipt {
+                tx_type: TxType::Eip1559,
+                cumulative_gas_used: 42_000,
+                success: true,
+                logs: vec![Log {
+                    address: Address::ZERO,
+                    data: alloy_primitives::LogData::new_unchecked(vec![B256::ZERO], Bytes::new()),
+                }],
+            },
+            Receipt {
+                tx_type: TxType::Eip2930,
+                cumulative_gas_used: 63_000,
+                success: false,
+                logs: vec![],
+            },
+        ]
+    }
+
+    fn sample_withdrawals() -> Vec<Withdrawal> {
+        vec![Withdrawal { index: 1, validator_index: 2, address: Address::ZERO, amount: 3 }]
+    }
+
+    fn expected_root_bloom(receipts: &[Receipt]) -> (B256, Bloom) {
+        let receipts_with_bloom: Vec<_> = receipts.iter().map(|r| r.with_bloom_ref()).collect();
+        let root = calculate_receipt_root(&receipts_with_bloom);
+        let bloom =
+            receipts_with_bloom.iter().fold(Bloom::ZERO, |acc, receipt| acc | *receipt.bloom_ref());
+        (root, bloom)
+    }
+
+    #[test]
+    fn post_exec_handle_computes_receipt_root_and_bloom() {
+        let rt = test_runtime();
+
+        let receipts = sample_receipts();
+        let (expected_root, expected_bloom) = expected_root_bloom(&receipts);
+
+        let mut handle = PostExecHandle::<Receipt>::new(&rt, receipts.len(), None);
+        for (index, receipt) in receipts.into_iter().enumerate() {
+            handle.push_receipt(index, receipt);
+        }
+        handle.finish_receipts();
+        handle.spawn_hashed_post_state(HashedPostState::default);
+
+        let (root, bloom) = handle.receipt_root_bloom().unwrap();
+        assert_eq!(root, expected_root);
+        assert_eq!(bloom, expected_bloom);
+    }
+
+    #[test]
+    fn post_exec_handle_handles_out_of_order_receipts() {
+        let rt = test_runtime();
+
+        let receipts = sample_receipts();
+        let (expected_root, expected_bloom) = expected_root_bloom(&receipts);
+
+        let mut handle = PostExecHandle::<Receipt>::new(&rt, receipts.len(), None);
+        for (index, receipt) in receipts.into_iter().enumerate().rev() {
+            handle.push_receipt(index, receipt);
+        }
+        handle.finish_receipts();
+        handle.spawn_hashed_post_state(HashedPostState::default);
+
+        let (root, bloom) = handle.receipt_root_bloom().unwrap();
+        assert_eq!(root, expected_root);
+        assert_eq!(bloom, expected_bloom);
+    }
+
+    #[test]
+    fn post_exec_handle_returns_none_for_incomplete_stream() {
+        let rt = test_runtime();
+
+        let mut handle = PostExecHandle::<Receipt>::new(&rt, 2, None);
+        handle.push_receipt(0, Receipt::default());
+        handle.finish_receipts();
+        handle.spawn_hashed_post_state(HashedPostState::default);
+
+        assert!(handle.receipt_root_bloom().is_none());
+    }
+
+    #[test]
+    fn post_exec_handle_waits_for_hashed_state() {
+        let rt = test_runtime();
+
+        let mut handle = PostExecHandle::<Receipt>::new(&rt, 0, None);
+        handle.finish_receipts();
+        handle.spawn_hashed_post_state(HashedPostState::default);
+
+        assert!(handle.hashed_post_state().is_some());
+    }
+
+    #[test]
+    fn post_exec_handle_computes_withdrawals_root() {
+        let rt = test_runtime();
+
+        let withdrawals = sample_withdrawals();
+        let expected = Some(calculate_withdrawals_root(&withdrawals));
+
+        let mut handle = PostExecHandle::<Receipt>::new(&rt, 0, Some(withdrawals));
+        handle.finish_receipts();
+        handle.spawn_hashed_post_state(HashedPostState::default);
+
+        assert_eq!(handle.withdrawals_root(), expected);
+    }
+
+    #[test]
+    fn post_exec_handle_withdrawals_root_none_without_withdrawals() {
+        let rt = test_runtime();
+
+        let mut handle = PostExecHandle::<Receipt>::new(&rt, 0, None);
+        handle.finish_receipts();
+        handle.spawn_hashed_post_state(HashedPostState::default);
+
+        assert_eq!(handle.withdrawals_root(), None);
+    }
+
+    #[test]
+    fn post_exec_handle_aborted_block_then_next_succeeds() {
+        let rt = test_runtime();
+
+        let handle = PostExecHandle::<Receipt>::new(&rt, 2, None);
+        handle.push_receipt(0, Receipt::default());
+        drop(handle);
+
+        let mut handle = PostExecHandle::<Receipt>::new(&rt, 1, None);
+        handle.push_receipt(0, Receipt::default());
+        handle.finish_receipts();
+        handle.spawn_hashed_post_state(HashedPostState::default);
+
+        assert!(handle.receipt_root_bloom().is_some());
+    }
+}

--- a/crates/engine/tree/src/tree/payload_processor/post_exec.rs
+++ b/crates/engine/tree/src/tree/payload_processor/post_exec.rs
@@ -4,7 +4,7 @@
 //! [`OnceLock`](reth_primitives_traits::sync::OnceLock). Each artifact can be awaited
 //! independently via `wait`-backed getters.
 
-use super::receipt_root_task::{IndexedReceipt, ReceiptRootTaskHandle};
+use super::receipt_root_task::{compute_receipt_root_bloom, IndexedReceipt};
 use alloy_eips::eip4895::Withdrawal;
 use alloy_primitives::{Bloom, B256};
 use crossbeam_channel::{self, Sender as CrossbeamSender};
@@ -95,9 +95,8 @@ impl<R: Receipt + 'static> PostExecHandle<R> {
                 output_for_task
                     .set_withdrawals_root(withdrawals.as_deref().map(calculate_withdrawals_root));
 
-                let (result_tx, result_rx) = tokio::sync::oneshot::channel();
-                ReceiptRootTaskHandle::new(receipt_rx, result_tx).run(receipts_len);
-                output_for_task.set_receipt_root_bloom(result_rx.blocking_recv().ok());
+                output_for_task
+                    .set_receipt_root_bloom(compute_receipt_root_bloom(receipt_rx, receipts_len));
 
                 let hashed_post_state = hashed_post_state_rx
                     .recv()
@@ -299,6 +298,17 @@ mod tests {
         handle.spawn_hashed_post_state(HashedPostState::default);
 
         assert!(handle.hashed_post_state().is_some());
+    }
+
+    #[test]
+    fn post_exec_handle_returns_none_when_hashed_state_panics() {
+        let rt = test_runtime();
+
+        let mut handle = PostExecHandle::<Receipt>::new(&rt, 0, None);
+        handle.finish_receipts();
+        handle.spawn_hashed_post_state(|| panic!("hashed-state panic"));
+
+        assert!(handle.hashed_post_state().is_none());
     }
 
     #[test]

--- a/crates/engine/tree/src/tree/payload_processor/receipt_root_task.rs
+++ b/crates/engine/tree/src/tree/payload_processor/receipt_root_task.rs
@@ -65,50 +65,62 @@ impl<R: Receipt> ReceiptRootTaskHandle<R> {
     /// * `receipts_len` - The total number of receipts expected. This is needed to correctly order
     ///   the trie keys according to RLP encoding rules.
     pub fn run(self, receipts_len: usize) {
-        let mut builder = OrderedTrieRootEncodedBuilder::new(receipts_len);
-        let mut aggregated_bloom = Bloom::ZERO;
-        let mut encode_buf = Vec::new();
-        let mut received_count = 0usize;
+        if let Some((root, aggregated_bloom)) =
+            compute_receipt_root_bloom(self.receipt_rx, receipts_len)
+        {
+            let _ = self.result_tx.send((root, aggregated_bloom));
+        }
+    }
+}
 
-        for indexed_receipt in self.receipt_rx {
-            let receipt_with_bloom = indexed_receipt.receipt.with_bloom_ref();
+/// Computes receipt root + aggregated bloom from a stream of indexed receipts.
+pub(crate) fn compute_receipt_root_bloom<R: Receipt>(
+    receipt_rx: Receiver<IndexedReceipt<R>>,
+    receipts_len: usize,
+) -> Option<(B256, Bloom)> {
+    let mut builder = OrderedTrieRootEncodedBuilder::new(receipts_len);
+    let mut aggregated_bloom = Bloom::ZERO;
+    let mut encode_buf = Vec::new();
+    let mut received_count = 0usize;
 
-            encode_buf.clear();
-            receipt_with_bloom.encode_2718(&mut encode_buf);
+    for indexed_receipt in receipt_rx {
+        let receipt_with_bloom = indexed_receipt.receipt.with_bloom_ref();
 
-            aggregated_bloom |= *receipt_with_bloom.bloom_ref();
-            match builder.push(indexed_receipt.index, &encode_buf) {
-                Ok(()) => {
-                    received_count += 1;
-                }
-                Err(err) => {
-                    // If a duplicate or out-of-bounds index is streamed, skip it and
-                    // fall back to computing the receipt root from the full receipts
-                    // vector later.
-                    tracing::error!(
-                        target: "engine::tree::payload_processor",
-                        index = indexed_receipt.index,
-                        ?err,
-                        "Receipt root task received invalid receipt index, skipping"
-                    );
-                }
+        encode_buf.clear();
+        receipt_with_bloom.encode_2718(&mut encode_buf);
+
+        aggregated_bloom |= *receipt_with_bloom.bloom_ref();
+        match builder.push(indexed_receipt.index, &encode_buf) {
+            Ok(()) => {
+                received_count += 1;
+            }
+            Err(err) => {
+                // If a duplicate or out-of-bounds index is streamed, skip it and
+                // fall back to computing the receipt root from the full receipts
+                // vector later.
+                tracing::error!(
+                    target: "engine::tree::payload_processor",
+                    index = indexed_receipt.index,
+                    ?err,
+                    "Receipt root task received invalid receipt index, skipping"
+                );
             }
         }
-
-        let Ok(root) = builder.finalize() else {
-            // Finalize fails if we didn't receive exactly `receipts_len` receipts. This can
-            // happen if execution was aborted early (e.g., invalid transaction encountered).
-            // We return without sending a result, allowing the caller to handle the abort.
-            tracing::error!(
-                target: "engine::tree::payload_processor",
-                expected = receipts_len,
-                received = received_count,
-                "Receipt root task received incomplete receipts, execution likely aborted"
-            );
-            return;
-        };
-        let _ = self.result_tx.send((root, aggregated_bloom));
     }
+
+    let Ok(root) = builder.finalize() else {
+        // Finalize fails if we didn't receive exactly `receipts_len` receipts. This can
+        // happen if execution was aborted early (e.g., invalid transaction encountered).
+        // We return `None`, allowing the caller to handle the abort/fallback.
+        tracing::error!(
+            target: "engine::tree::payload_processor",
+            expected = receipts_len,
+            received = received_count,
+            "Receipt root task received incomplete receipts, execution likely aborted"
+        );
+        return None;
+    };
+    Some((root, aggregated_bloom))
 }
 
 #[cfg(test)]

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -524,6 +524,8 @@ where
 
         let block = convert_to_block(input)?.with_senders(senders);
 
+        // If the stream is incomplete (e.g. execution abort), this returns `None` and consensus
+        // falls back to computing receipt-root + logs-bloom from `output.receipts`.
         let receipt_root_bloom = post_exec.receipt_root_bloom();
         let withdrawals_root = post_exec.withdrawals_root();
         let Some(hashed_state) = post_exec.hashed_post_state() else {
@@ -752,7 +754,7 @@ where
     ///
     /// This method orchestrates block execution:
     /// 1. Sets up the EVM with state database and precompile caching
-    /// 2. Spawns a background task for incremental receipt root computation
+    /// 2. Spawns a block-scoped post-execution task
     /// 3. Executes transactions with metrics collection via state hooks
     /// 4. Merges state transitions and records execution metrics
     #[instrument(level = "debug", target = "engine::tree::payload_validator", skip_all)]
@@ -760,7 +762,7 @@ where
     fn execute_block<S, Err, T>(
         &mut self,
         state_provider: S,
-        env: ExecutionEnv<Evm>,
+        mut env: ExecutionEnv<Evm>,
         input: &BlockOrPayload<T>,
         handle: &mut PayloadHandle<impl ExecutableTxFor<Evm>, Err, N::Receipt>,
     ) -> Result<
@@ -775,6 +777,7 @@ where
         Evm: ConfigureEngineEvm<T::ExecutionData, Primitives = N>,
     {
         debug!(target: "engine::tree::payload_validator", "Executing block");
+        let withdrawals = env.withdrawals.take();
 
         let mut db = debug_span!(target: "engine::tree", "build_state_db").in_scope(|| {
             State::builder()
@@ -813,7 +816,6 @@ where
         }
 
         let receipts_len = input.transaction_count();
-        let withdrawals = input.withdrawals().map(|w| w.to_vec());
         let mut post_exec = self.payload_processor.post_exec_handle(receipts_len, withdrawals);
 
         let transaction_count = input.transaction_count();
@@ -1239,11 +1241,17 @@ where
         }
         drop(_enter);
 
-        debug_assert_eq!(
-            withdrawals_root,
-            block.withdrawals_root(),
-            "post-exec withdrawals root does not match block header"
-        );
+        if let (Some(withdrawals_root), Some(header_withdrawals_root)) =
+            (withdrawals_root, block.withdrawals_root())
+        {
+            if withdrawals_root != header_withdrawals_root {
+                self.on_invalid_block(parent_block, block, output, None, ctx.state_mut());
+                return Err(ConsensusError::BodyWithdrawalsRootDiff(
+                    GotExpected { got: withdrawals_root, expected: header_withdrawals_root }.into(),
+                )
+                .into())
+            }
+        }
 
         let _enter = debug_span!(target: "engine::tree::payload_validator", "validate_block_post_execution_with_hashed_state").entered();
         if let Err(err) = self

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -528,15 +528,6 @@ where
         // falls back to computing receipt-root + logs-bloom from `output.receipts`.
         let receipt_root_bloom = post_exec.receipt_root_bloom();
         let withdrawals_root = post_exec.withdrawals_root();
-        let Some(hashed_state) = post_exec.hashed_post_state() else {
-            return Err(InsertBlockError::new(
-                block.into_sealed_block(),
-                InsertBlockErrorKind::Other(Box::new(std::io::Error::other(
-                    "post-exec worker did not produce hashed post state",
-                ))),
-            )
-            .into())
-        };
 
         let hashed_state = ensure_ok_post_block!(
             self.validate_post_execution(
@@ -546,7 +537,7 @@ where
                 &mut ctx,
                 receipt_root_bloom,
                 withdrawals_root,
-                hashed_state,
+                &post_exec,
             ),
             block
         );
@@ -1205,7 +1196,7 @@ where
         ctx: &mut TreeCtx<'_, N>,
         receipt_root_bloom: Option<ReceiptRootBloom>,
         withdrawals_root: Option<B256>,
-        hashed_state: LazyHashedPostState,
+        post_exec: &PostExecHandle<N::Receipt>,
     ) -> Result<LazyHashedPostState, InsertBlockErrorKind>
     where
         V: PayloadValidator<T, Block = N::Block>,
@@ -1252,6 +1243,12 @@ where
                 .into())
             }
         }
+
+        let Some(hashed_state) = post_exec.hashed_post_state() else {
+            return Err(InsertBlockErrorKind::Other(Box::new(std::io::Error::other(
+                "post-exec worker did not produce hashed post state",
+            ))))
+        };
 
         let _enter = debug_span!(target: "engine::tree::payload_validator", "validate_block_post_execution_with_hashed_state").entered();
         if let Err(err) = self
@@ -1737,6 +1734,97 @@ where
 {
     fn wait_for_caches(&self) -> CacheWaitDurations {
         self.payload_processor.wait_for_caches()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tree::{payload_processor::post_exec::PostExecHandle, EngineApiKind};
+    use alloy_primitives::{Address, B256};
+    use alloy_rpc_types_engine::ExecutionData;
+    use reth_chain_state::{test_utils::TestBlockBuilder, CanonicalInMemoryState};
+    use reth_chainspec::MAINNET;
+    use reth_engine_primitives::NoopInvalidBlockHook;
+    use reth_ethereum_consensus::EthBeaconConsensus;
+    use reth_ethereum_engine_primitives::EthEngineTypes;
+    use reth_ethereum_primitives::{Block, EthPrimitives, Receipt};
+    use reth_evm_ethereum::MockEvmConfig;
+    use reth_payload_primitives::NewPayloadError;
+    use reth_primitives_traits::SealedHeader;
+    use reth_provider::test_utils::MockEthProvider;
+    use reth_tasks::Runtime;
+    use reth_trie_db::ChangesetCache;
+    use std::{sync::Arc, time::Duration};
+
+    #[derive(Clone, Debug)]
+    struct MockPayloadValidator;
+
+    impl reth_engine_primitives::PayloadValidator<EthEngineTypes> for MockPayloadValidator {
+        type Block = Block;
+
+        fn convert_payload_to_block(
+            &self,
+            _payload: ExecutionData,
+        ) -> Result<reth_primitives_traits::SealedBlock<Self::Block>, NewPayloadError> {
+            unreachable!("not needed for this regression test")
+        }
+    }
+
+    #[test]
+    fn validate_post_execution_fails_fast_without_waiting_for_hashed_state() {
+        let (tx, rx) = std::sync::mpsc::channel();
+
+        std::thread::spawn(move || {
+            let chain_spec = MAINNET.clone();
+            let provider = MockEthProvider::<EthPrimitives>::default();
+            let consensus = Arc::new(EthBeaconConsensus::new(chain_spec.clone()));
+            let validator = BasicEngineValidator::new(
+                provider,
+                consensus,
+                MockEvmConfig::default(),
+                MockPayloadValidator,
+                TreeConfig::default(),
+                Box::new(NoopInvalidBlockHook::default()),
+                ChangesetCache::new(),
+                Runtime::test(),
+            );
+
+            let mut builder = TestBlockBuilder::eth().with_chain_spec((*chain_spec).clone());
+            // Deliberately mismatch parent hash so validation fails before hashed-state use.
+            let sealed_block = builder.generate_random_block(1, B256::random());
+            let senders = vec![Address::ZERO; sealed_block.body().transactions.len()];
+            let block = reth_primitives_traits::RecoveredBlock::new_sealed(sealed_block, senders);
+
+            let parent = SealedHeader::seal_slow(chain_spec.genesis_header().clone());
+            let mut tree_state =
+                EngineApiTreeState::new(8, 8, parent.num_hash(), EngineApiKind::Ethereum);
+            let canonical = CanonicalInMemoryState::with_head(parent.clone(), None, None);
+            let mut ctx = TreeCtx::new(&mut tree_state, &canonical);
+
+            // Keep receipts/hash-state channels open and never queue hashed-state work.
+            // If hashed state is awaited eagerly, this call would block indefinitely.
+            let runtime = Runtime::test();
+            let post_exec = PostExecHandle::<Receipt>::new(&runtime, 0, None);
+
+            let result = validator.validate_post_execution::<EthEngineTypes>(
+                &block,
+                &parent,
+                &BlockExecutionOutput::default(),
+                &mut ctx,
+                None,
+                None,
+                &post_exec,
+            );
+
+            let _ = tx.send(result.is_err());
+        });
+
+        assert_eq!(
+            rx.recv_timeout(Duration::from_secs(2)),
+            Ok(true),
+            "expected fast validation failure before waiting for hashed post state",
+        );
     }
 }
 

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -18,7 +18,7 @@ use alloy_primitives::B256;
 #[cfg(feature = "trie-debug")]
 use reth_trie_sparse::debug_recorder::TrieDebugRecorder;
 
-use crate::tree::payload_processor::receipt_root_task::{IndexedReceipt, ReceiptRootTaskHandle};
+use crate::tree::payload_processor::post_exec::PostExecHandle;
 use reth_chain_state::{CanonicalInMemoryState, DeferredTrieData, ExecutedBlock, LazyOverlay};
 use reth_consensus::{ConsensusError, FullConsensus, ReceiptRootBloom};
 use reth_engine_primitives::{
@@ -54,8 +54,8 @@ use std::{
 };
 use tracing::{debug, debug_span, error, info, instrument, trace, warn};
 
-/// Handle to a [`HashedPostState`] computed on a background thread.
-type LazyHashedPostState = reth_tasks::LazyHandle<HashedPostState>;
+/// Shared handle to a computed [`HashedPostState`].
+type LazyHashedPostState = Arc<HashedPostState>;
 
 /// Context providing access to tree state during validation.
 ///
@@ -494,7 +494,7 @@ where
         // Execute the block and handle any execution errors.
         // The receipt root task is spawned before execution and receives receipts incrementally
         // as transactions complete, allowing parallel computation during execution.
-        let (output, senders, receipt_root_rx) =
+        let (output, senders, mut post_exec) =
             match self.execute_block(state_provider, env, &input, &mut handle) {
                 Ok(output) => output,
                 Err(err) => return self.handle_execution_error(input, err, &parent_block),
@@ -512,33 +512,29 @@ where
         // needed. This frees up resources while state root computation continues.
         let valid_block_tx = handle.terminate_caching(Some(output.clone()));
 
-        // Spawn hashed post state computation in background so it runs concurrently with
-        // block conversion and receipt root computation. This is a pure CPU-bound task
-        // (keccak256 hashing of all changed addresses and storage slots).
+        // Queue hashed post state computation so it runs after receipt-root resolution inside the
+        // post-exec worker.
         let hashed_state_output = output.clone();
         let hashed_state_provider = self.provider.clone();
-        let hashed_state: LazyHashedPostState =
-            self.payload_processor.executor().spawn_blocking_named("hash-post-state", move || {
-                let _span = debug_span!(
-                    target: "engine::tree::payload_validator",
-                    "hashed_post_state",
-                )
+        post_exec.spawn_hashed_post_state(move || {
+            let _span = debug_span!(target: "engine::tree::payload_validator", "hashed_post_state")
                 .entered();
-                hashed_state_provider.hashed_post_state(&hashed_state_output.state)
-            });
+            hashed_state_provider.hashed_post_state(&hashed_state_output.state)
+        });
 
         let block = convert_to_block(input)?.with_senders(senders);
 
-        // Wait for the receipt root computation to complete.
-        let receipt_root_bloom = receipt_root_rx
-            .blocking_recv()
-            .inspect_err(|_| {
-                tracing::error!(
-                    target: "engine::tree::payload_validator",
-                    "Receipt root task dropped sender without result, receipt root calculation likely aborted"
-                );
-            })
-            .ok();
+        let receipt_root_bloom = post_exec.receipt_root_bloom();
+        let withdrawals_root = post_exec.withdrawals_root();
+        let Some(hashed_state) = post_exec.hashed_post_state() else {
+            return Err(InsertBlockError::new(
+                block.into_sealed_block(),
+                InsertBlockErrorKind::Other(Box::new(std::io::Error::other(
+                    "post-exec worker did not produce hashed post state",
+                ))),
+            )
+            .into())
+        };
 
         let hashed_state = ensure_ok_post_block!(
             self.validate_post_execution(
@@ -547,6 +543,7 @@ where
                 &output,
                 &mut ctx,
                 receipt_root_bloom,
+                withdrawals_root,
                 hashed_state,
             ),
             block
@@ -767,11 +764,7 @@ where
         input: &BlockOrPayload<T>,
         handle: &mut PayloadHandle<impl ExecutableTxFor<Evm>, Err, N::Receipt>,
     ) -> Result<
-        (
-            BlockExecutionOutput<N::Receipt>,
-            Vec<Address>,
-            tokio::sync::oneshot::Receiver<(B256, alloy_primitives::Bloom)>,
-        ),
+        (BlockExecutionOutput<N::Receipt>, Vec<Address>, PostExecHandle<N::Receipt>),
         InsertBlockErrorKind,
     >
     where
@@ -819,15 +812,9 @@ where
             });
         }
 
-        // Spawn background task to compute receipt root and logs bloom incrementally.
-        // Unbounded channel is used since tx count bounds capacity anyway (max ~30k txs per block).
         let receipts_len = input.transaction_count();
-        let (receipt_tx, receipt_rx) = crossbeam_channel::unbounded();
-        let (result_tx, result_rx) = tokio::sync::oneshot::channel();
-        let task_handle = ReceiptRootTaskHandle::new(receipt_rx, result_tx);
-        self.payload_processor
-            .executor()
-            .spawn_blocking_named("receipt-root", move || task_handle.run(receipts_len));
+        let withdrawals = input.withdrawals().map(|w| w.to_vec());
+        let mut post_exec = self.payload_processor.post_exec_handle(receipts_len, withdrawals);
 
         let transaction_count = input.transaction_count();
         let executor = executor.with_state_hook(Some(Box::new(handle.state_hook())));
@@ -839,9 +826,9 @@ where
             executor,
             transaction_count,
             handle.iter_transactions(),
-            &receipt_tx,
+            &post_exec,
         )?;
-        drop(receipt_tx);
+        post_exec.finish_receipts();
 
         // Finish execution and get the result
         let post_exec_start = Instant::now();
@@ -861,10 +848,10 @@ where
         self.metrics.record_block_execution_gas_bucket(output.result.gas_used, execution_duration);
 
         debug!(target: "engine::tree::payload_validator", elapsed = ?execution_duration, "Executed block");
-        Ok((output, senders, result_rx))
+        Ok((output, senders, post_exec))
     }
 
-    /// Executes transactions and collects senders, streaming receipts to a background task.
+    /// Executes transactions and collects senders, streaming receipts to the post-exec task.
     ///
     /// This method handles:
     /// - Applying pre-execution changes (e.g., beacon root updates)
@@ -878,7 +865,7 @@ where
         mut executor: E,
         transaction_count: usize,
         transactions: impl Iterator<Item = Result<Tx, Err>>,
-        receipt_tx: &crossbeam_channel::Sender<IndexedReceipt<N::Receipt>>,
+        post_exec: &PostExecHandle<N::Receipt>,
     ) -> Result<(E, Vec<Address>), BlockExecutionError>
     where
         E: BlockExecutor<Receipt = N::Receipt>,
@@ -931,7 +918,7 @@ where
                 // Send the latest receipt to the background task for incremental root computation.
                 if let Some(receipt) = executor.receipts().last() {
                     let tx_index = current_len - 1;
-                    let _ = receipt_tx.send(IndexedReceipt::new(tx_index, receipt.clone()));
+                    post_exec.push_receipt(tx_index, receipt.clone());
                 }
             }
         }
@@ -956,7 +943,7 @@ where
         overlay_factory: OverlayStateProviderFactory<P>,
         hashed_state: &LazyHashedPostState,
     ) -> Result<(B256, TrieUpdates), ParallelStateRootError> {
-        let hashed_state = hashed_state.get();
+        let hashed_state = hashed_state.as_ref();
         // The `hashed_state` argument will be taken into account as part of the overlay, but we
         // need to use the prefix sets which were generated from it to indicate to the
         // ParallelStateRoot which parts of the trie need to be recomputed.
@@ -976,7 +963,7 @@ where
         overlay_factory: OverlayStateProviderFactory<P>,
         hashed_state: &LazyHashedPostState,
     ) -> ProviderResult<(B256, TrieUpdates)> {
-        let hashed_state = hashed_state.get();
+        let hashed_state = hashed_state.as_ref();
         // The `hashed_state` argument will be taken into account as part of the overlay, but we
         // need to use the prefix sets which were generated from it to indicate to the
         // StateRoot which parts of the trie need to be recomputed.
@@ -1215,6 +1202,7 @@ where
         output: &BlockExecutionOutput<N::Receipt>,
         ctx: &mut TreeCtx<'_, N>,
         receipt_root_bloom: Option<ReceiptRootBloom>,
+        withdrawals_root: Option<B256>,
         hashed_state: LazyHashedPostState,
     ) -> Result<LazyHashedPostState, InsertBlockErrorKind>
     where
@@ -1251,10 +1239,16 @@ where
         }
         drop(_enter);
 
+        debug_assert_eq!(
+            withdrawals_root,
+            block.withdrawals_root(),
+            "post-exec withdrawals root does not match block header"
+        );
+
         let _enter = debug_span!(target: "engine::tree::payload_validator", "validate_block_post_execution_with_hashed_state").entered();
         if let Err(err) = self
             .validator
-            .validate_block_post_execution_with_hashed_state(hashed_state.get(), block)
+            .validate_block_post_execution_with_hashed_state(hashed_state.as_ref(), block)
         {
             // call post-block hook
             self.on_invalid_block(parent_block, block, output, None, ctx.state_mut());
@@ -1495,12 +1489,7 @@ where
             overlay_blocks.iter().rev().map(|b| b.trie_data_handle()).collect();
 
         // Create deferred handle with fallback inputs in case the background task hasn't completed.
-        // Resolve the lazy handle into Arc<HashedPostState>. By this point the hashed state has
-        // already been computed and used for state root verification, so .get() returns instantly.
-        let hashed_state = match hashed_state.try_into_inner() {
-            Ok(state) => Arc::new(state),
-            Err(handle) => Arc::new(handle.get().clone()),
-        };
+        // The hashed post state is already computed and shared as an `Arc`.
         let deferred_trie_data =
             DeferredTrieData::pending(hashed_state, Arc::new(trie_output), anchor_hash, ancestors);
         let deferred_handle_task = deferred_trie_data.clone();


### PR DESCRIPTION
**Summary**

Currently each block spawns three independent `spawn_blocking` tasks (`receipt-root`, `hash-post-state`, `trie-input`) for post-execution artifact computation. This consolidates them into a single `spawn_blocking_named("post-exec")` task per block, reducing thread scheduling overhead while preserving per-artifact readiness through `OnceLock`-backed getters. Supersedes #22431.

**Changes**

- Add `PostExecOutput` struct holding `OnceLock<Option<T>>` for receipt-root+bloom, withdrawals-root, and hashed-post-state
- Add `PostExecHandle` as the block-scoped facade that streams receipts, queues hashed-state work, and exposes `wait`-backed getters
- Wire `PostExecHandle` into `PayloadProcessor` and `PayloadValidator`, replacing the three separate task spawns
- Simplify `LazyHashedPostState` from `reth_tasks::LazyHandle<HashedPostState>` to `Arc<HashedPostState>`
- Add unit tests for receipt-root correctness, out-of-order receipts, withdrawals-root, incomplete streams, and abort-then-retry

**Design**

```mermaid
flowchart TD
    subgraph "execute_block (main thread)"
        A["Create PostExecHandle::new(...)"] --> B["spawn_blocking_named('post-exec')"]
        A --> C["Execute transactions"]
        C -->|"push_receipt(i, r)"| D["crossbeam channel"]
        C --> E["finish_receipts()"]
        E --> F["spawn_hashed_post_state(job)"]
    end

    subgraph "post-exec worker (single blocking thread)"
        B --> G["calculate_withdrawals_root"]
        G -->|"set OnceLock"| H["withdrawals_root ✓"]
        D --> I["ReceiptRootTaskHandle::run()"]
        I -->|"set OnceLock"| J["receipt_root_bloom ✓"]
        J --> K["recv hashed-post-state job"]
        K --> L["run job → HashedPostState"]
        L -->|"set OnceLock"| M["hashed_post_state ✓"]
    end

    subgraph "validation (main thread, after execute)"
        N["post_exec.receipt_root_bloom()"] -->|"OnceLock::wait()"| J
        O["post_exec.withdrawals_root()"] -->|"OnceLock::wait()"| H
        P["post_exec.hashed_post_state()"] -->|"OnceLock::wait()"| M
    end
```

Before (3 tasks per block):
```
execute_block ──┬── spawn_blocking("receipt-root")
                ├── spawn_blocking("hash-post-state")
                └── spawn_blocking("trie-input")
```

After (1 task per block):
```
execute_block ──── spawn_blocking_named("post-exec")
                     ├── withdrawals_root   → OnceLock
                     ├── receipt_root_bloom  → OnceLock
                     └── hashed_post_state   → OnceLock
```

**Expected Impact**

Reduces per-block thread scheduling overhead from 3 spawns to 1 while keeping per-artifact readiness semantics. Named thread reuse via `spawn_blocking_named` means the OS thread is recycled across blocks.

**Notes**

- Follow-up: investigate persisting worker state (encode buffers, bloom accumulator) across blocks to avoid re-allocation
- The `trie-input` spawn is unchanged by this PR as it serves a different lifecycle (deferred trie data)

