### PR TITLE
fix: replace unmaintained `shellexpand` with our own path expansion

### DIFF
--- a/.changelog/fix-shellexpand-nightly.md
+++ b/.changelog/fix-shellexpand-nightly.md
@@ -1,0 +1,7 @@
+---
+reth-node-core: patch
+reth-cli: patch
+reth-bench-compare: patch
+---
+
+Replaced unmaintained `shellexpand` dependency with inline tilde (`~`) and environment variable (`$VAR`/`${VAR}`) expansion. The `shellexpand` crate fails to compile on nightly Rust due to a method resolution conflict from the stabilization of `OsStr::as_str()`.

--- a/.changelog/fix-shellexpand-nightly.md
+++ b/.changelog/fix-shellexpand-nightly.md
@@ -1,4 +1,5 @@
 ---
+reth-cli-util: patch
 reth-node-core: patch
 reth-cli: patch
 reth-bench-compare: patch

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7696,9 +7696,9 @@ version = "1.11.0"
 dependencies = [
  "alloy-genesis",
  "clap",
- "dirs-next",
  "eyre",
  "reth-cli-runner",
+ "reth-cli-util",
  "reth-db",
  "serde_json",
 ]
@@ -7806,6 +7806,7 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "cfg-if",
+ "dirs-next",
  "eyre",
  "libc",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3102,15 +3102,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3121,25 +3112,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users 0.5.2",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "dirs-sys-next"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
- "redox_users 0.4.6",
+ "redox_users",
  "winapi",
 ]
 
@@ -6537,12 +6516,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
 name = "ordered-float"
 version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7406,17 +7379,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7670,7 +7632,6 @@ dependencies = [
  "reth-tracing",
  "serde",
  "serde_json",
- "shellexpand",
  "shlex",
  "tokio",
  "tracing",
@@ -7735,11 +7696,11 @@ version = "1.11.0"
 dependencies = [
  "alloy-genesis",
  "clap",
+ "dirs-next",
  "eyre",
  "reth-cli-runner",
  "reth-db",
  "serde_json",
- "shellexpand",
 ]
 
 [[package]]
@@ -9322,7 +9283,6 @@ dependencies = [
  "reth-transaction-pool",
  "secp256k1 0.30.0",
  "serde",
- "shellexpand",
  "strum",
  "thiserror 2.0.18",
  "tokio",
@@ -11546,15 +11506,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
-]
-
-[[package]]
-name = "shellexpand"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
-dependencies = [
- "dirs",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -538,7 +538,6 @@ serde = { version = "1.0", default-features = false }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 serde_with = { version = "3", default-features = false, features = ["macros"] }
 sha2 = { version = "0.10", default-features = false }
-shellexpand = "3.0.0"
 shlex = "1.3"
 smallvec = "1"
 strum = { version = "0.27", default-features = false }

--- a/bin/reth-bench-compare/Cargo.toml
+++ b/bin/reth-bench-compare/Cargo.toml
@@ -45,9 +45,6 @@ serde_json.workspace = true
 # Time handling
 chrono = { workspace = true, features = ["serde"] }
 
-# Path manipulation
-shellexpand.workspace = true
-
 # CSV handling
 csv.workspace = true
 

--- a/bin/reth-bench-compare/src/cli.rs
+++ b/bin/reth-bench-compare/src/cli.rs
@@ -291,8 +291,8 @@ impl Args {
         match &self.jwt_secret {
             Some(path) => {
                 let jwt_secret_str = path.to_string_lossy();
-                let expanded = shellexpand::tilde(&jwt_secret_str);
-                PathBuf::from(expanded.as_ref())
+                reth_node_core::utils::parse_path(&jwt_secret_str)
+                    .unwrap_or_else(|_| PathBuf::from(path))
             }
             None => {
                 // Use the same logic as reth: <datadir>/<chain>/jwt.hex
@@ -310,8 +310,8 @@ impl Args {
 
     /// Get the expanded output directory path
     pub(crate) fn output_dir_path(&self) -> PathBuf {
-        let expanded = shellexpand::tilde(&self.output_dir);
-        PathBuf::from(expanded.as_ref())
+        reth_node_core::utils::parse_path(&self.output_dir)
+            .unwrap_or_else(|_| PathBuf::from(&self.output_dir))
     }
 
     /// Get the effective warmup blocks value - either specified or defaults to blocks

--- a/bin/reth-bench-compare/src/cli.rs
+++ b/bin/reth-bench-compare/src/cli.rs
@@ -291,8 +291,10 @@ impl Args {
         match &self.jwt_secret {
             Some(path) => {
                 let jwt_secret_str = path.to_string_lossy();
-                reth_node_core::utils::parse_path(&jwt_secret_str)
-                    .unwrap_or_else(|_| PathBuf::from(path))
+                reth_node_core::utils::parse_path(&jwt_secret_str).unwrap_or_else(|err| {
+                    warn!(target: "reth::cli", %err, path = %jwt_secret_str, "failed to expand JWT secret path, using as-is");
+                    PathBuf::from(path)
+                })
             }
             None => {
                 // Use the same logic as reth: <datadir>/<chain>/jwt.hex
@@ -310,8 +312,10 @@ impl Args {
 
     /// Get the expanded output directory path
     pub(crate) fn output_dir_path(&self) -> PathBuf {
-        reth_node_core::utils::parse_path(&self.output_dir)
-            .unwrap_or_else(|_| PathBuf::from(&self.output_dir))
+        reth_node_core::utils::parse_path(&self.output_dir).unwrap_or_else(|err| {
+            warn!(target: "reth::cli", %err, path = %self.output_dir, "failed to expand output dir path, using as-is");
+            PathBuf::from(&self.output_dir)
+        })
     }
 
     /// Get the effective warmup blocks value - either specified or defaults to blocks

--- a/crates/cli/cli/Cargo.toml
+++ b/crates/cli/cli/Cargo.toml
@@ -18,6 +18,6 @@ alloy-genesis.workspace = true
 
 # misc
 clap.workspace = true
-shellexpand.workspace = true
+dirs-next.workspace = true
 eyre.workspace = true
 serde_json.workspace = true

--- a/crates/cli/cli/Cargo.toml
+++ b/crates/cli/cli/Cargo.toml
@@ -17,7 +17,7 @@ reth-db.workspace = true
 alloy-genesis.workspace = true
 
 # misc
+reth-cli-util.workspace = true
 clap.workspace = true
-dirs-next.workspace = true
 eyre.workspace = true
 serde_json.workspace = true

--- a/crates/cli/cli/src/chainspec.rs
+++ b/crates/cli/cli/src/chainspec.rs
@@ -1,4 +1,4 @@
-use std::{fs, path::PathBuf, sync::Arc};
+use std::{fs, sync::Arc};
 
 use clap::builder::TypedValueParser;
 
@@ -73,7 +73,7 @@ pub trait ChainSpecParser: Clone + Send + Sync + 'static {
 /// A helper to parse a [`Genesis`](alloy_genesis::Genesis) as argument or from disk.
 pub fn parse_genesis(s: &str) -> eyre::Result<alloy_genesis::Genesis> {
     // try to read json from path first
-    let expanded = expand_path(s)?;
+    let expanded = reth_cli_util::expand_path(s).map_err(|e| eyre::eyre!("{e}"))?;
     let raw = match fs::read_to_string(&expanded) {
         Ok(raw) => raw,
         Err(io_err) => {
@@ -87,55 +87,4 @@ pub fn parse_genesis(s: &str) -> eyre::Result<alloy_genesis::Genesis> {
     };
 
     Ok(serde_json::from_str(&raw)?)
-}
-
-fn expand_path(input: &str) -> eyre::Result<PathBuf> {
-    let s = if input == "~" || input.starts_with("~/") || input.starts_with("~\\") {
-        let home = dirs_next::home_dir()
-            .ok_or_else(|| eyre::eyre!("could not determine home directory"))?;
-        let mut out = home.to_string_lossy().into_owned();
-        if input.len() > 1 {
-            out.push_str(&input[1..]);
-        }
-        out
-    } else {
-        input.to_string()
-    };
-
-    let mut result = String::with_capacity(s.len());
-    let mut chars = s.chars().peekable();
-    while let Some(c) = chars.next() {
-        if c != '$' {
-            result.push(c);
-            continue;
-        }
-        let braced = chars.peek() == Some(&'{');
-        if braced {
-            chars.next();
-        }
-        let mut name = String::new();
-        while let Some(&c) = chars.peek() {
-            if braced {
-                if c == '}' {
-                    chars.next();
-                    break;
-                }
-            } else if !c.is_ascii_alphanumeric() && c != '_' {
-                break;
-            }
-            name.push(c);
-            chars.next();
-        }
-        if name.is_empty() {
-            result.push('$');
-            if braced {
-                result.push('{');
-            }
-        } else {
-            let value =
-                std::env::var(&name).map_err(|e| eyre::eyre!("env var `{name}` not found: {e}"))?;
-            result.push_str(&value);
-        }
-    }
-    Ok(PathBuf::from(result))
 }

--- a/crates/cli/cli/src/chainspec.rs
+++ b/crates/cli/cli/src/chainspec.rs
@@ -73,7 +73,8 @@ pub trait ChainSpecParser: Clone + Send + Sync + 'static {
 /// A helper to parse a [`Genesis`](alloy_genesis::Genesis) as argument or from disk.
 pub fn parse_genesis(s: &str) -> eyre::Result<alloy_genesis::Genesis> {
     // try to read json from path first
-    let raw = match fs::read_to_string(PathBuf::from(shellexpand::full(s)?.into_owned())) {
+    let expanded = expand_path(s)?;
+    let raw = match fs::read_to_string(&expanded) {
         Ok(raw) => raw,
         Err(io_err) => {
             // valid json may start with "\n", but must contain "{"
@@ -86,4 +87,55 @@ pub fn parse_genesis(s: &str) -> eyre::Result<alloy_genesis::Genesis> {
     };
 
     Ok(serde_json::from_str(&raw)?)
+}
+
+fn expand_path(input: &str) -> eyre::Result<PathBuf> {
+    let s = if input == "~" || input.starts_with("~/") || input.starts_with("~\\") {
+        let home = dirs_next::home_dir()
+            .ok_or_else(|| eyre::eyre!("could not determine home directory"))?;
+        let mut out = home.to_string_lossy().into_owned();
+        if input.len() > 1 {
+            out.push_str(&input[1..]);
+        }
+        out
+    } else {
+        input.to_string()
+    };
+
+    let mut result = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '$' {
+            result.push(c);
+            continue;
+        }
+        let braced = chars.peek() == Some(&'{');
+        if braced {
+            chars.next();
+        }
+        let mut name = String::new();
+        while let Some(&c) = chars.peek() {
+            if braced {
+                if c == '}' {
+                    chars.next();
+                    break;
+                }
+            } else if !c.is_ascii_alphanumeric() && c != '_' {
+                break;
+            }
+            name.push(c);
+            chars.next();
+        }
+        if name.is_empty() {
+            result.push('$');
+            if braced {
+                result.push('{');
+            }
+        } else {
+            let value =
+                std::env::var(&name).map_err(|e| eyre::eyre!("env var `{name}` not found: {e}"))?;
+            result.push_str(&value);
+        }
+    }
+    Ok(PathBuf::from(result))
 }

--- a/crates/cli/util/Cargo.toml
+++ b/crates/cli/util/Cargo.toml
@@ -25,6 +25,7 @@ secp256k1 = { workspace = true, features = ["rand"] }
 rand_08.workspace = true
 thiserror.workspace = true
 serde.workspace = true
+dirs-next.workspace = true
 
 tracy-client = { workspace = true, optional = true }
 reth-tracing = { workspace = true, optional = true }

--- a/crates/cli/util/src/expand_path.rs
+++ b/crates/cli/util/src/expand_path.rs
@@ -1,0 +1,170 @@
+//! Shell-like path expansion utilities.
+//!
+//! Supports expanding leading `~` to the user's home directory and
+//! `$VAR`/`${VAR}` to environment variable values. This is *not* a full
+//! shell parser.
+
+use std::path::PathBuf;
+
+/// An error that can occur when expanding a path.
+#[derive(Debug, thiserror::Error)]
+pub enum ExpandPathError {
+    /// Home directory could not be determined.
+    #[error("could not determine home directory")]
+    NoHomeDir,
+    /// Environment variable lookup failed.
+    #[error("environment variable `{var_name}` not found: {source}")]
+    Var {
+        /// The variable name that was looked up.
+        var_name: String,
+        /// The underlying error.
+        source: std::env::VarError,
+    },
+}
+
+/// Expands a user-specified path, replacing leading `~` with the home directory
+/// and `$VAR`/`${VAR}` with environment variable values.
+pub fn expand_path(input: &str) -> Result<PathBuf, ExpandPathError> {
+    let tilde_expanded = expand_tilde(input)?;
+    let expanded = expand_env_vars(&tilde_expanded)?;
+    Ok(PathBuf::from(expanded))
+}
+
+fn expand_tilde(input: &str) -> Result<String, ExpandPathError> {
+    if input == "~" || input.starts_with("~/") || input.starts_with("~\\") {
+        let home = dirs_next::home_dir().ok_or(ExpandPathError::NoHomeDir)?;
+        let mut out = home.to_string_lossy().into_owned();
+        if input.len() > 1 {
+            out.push_str(&input[1..]);
+        }
+        Ok(out)
+    } else {
+        Ok(input.to_string())
+    }
+}
+
+fn expand_env_vars(input: &str) -> Result<String, ExpandPathError> {
+    let mut result = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        if c != '$' {
+            result.push(c);
+            continue;
+        }
+
+        let braced = chars.peek() == Some(&'{');
+        if braced {
+            chars.next();
+        }
+
+        let mut name = String::new();
+        while let Some(&c) = chars.peek() {
+            if braced {
+                if c == '}' {
+                    chars.next();
+                    break;
+                }
+            } else if !c.is_ascii_alphanumeric() && c != '_' {
+                break;
+            }
+            name.push(c);
+            chars.next();
+        }
+
+        if name.is_empty() {
+            result.push('$');
+            if braced {
+                result.push('{');
+            }
+        } else {
+            let value = std::env::var(&name)
+                .map_err(|e| ExpandPathError::Var { var_name: name, source: e })?;
+            result.push_str(&value);
+        }
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_expand_tilde_home() {
+        let home = dirs_next::home_dir().unwrap();
+        assert_eq!(expand_path("~").unwrap(), home);
+    }
+
+    #[test]
+    fn test_expand_tilde_subpath() {
+        let home = dirs_next::home_dir().unwrap();
+        assert_eq!(expand_path("~/foo/bar").unwrap(), home.join("foo/bar"));
+    }
+
+    #[test]
+    fn test_tilde_not_at_start() {
+        // tilde mid-path should NOT expand
+        assert_eq!(expand_path("foo/~/bar").unwrap(), PathBuf::from("foo/~/bar"));
+    }
+
+    #[test]
+    fn test_expand_env_var_bare() {
+        unsafe { std::env::set_var("RETH_TEST_VAR", "hello") };
+        assert_eq!(expand_path("$RETH_TEST_VAR/data").unwrap(), PathBuf::from("hello/data"));
+        unsafe { std::env::remove_var("RETH_TEST_VAR") };
+    }
+
+    #[test]
+    fn test_expand_env_var_braced() {
+        unsafe { std::env::set_var("RETH_TEST_VAR2", "world") };
+        assert_eq!(expand_path("${RETH_TEST_VAR2}/data").unwrap(), PathBuf::from("world/data"));
+        unsafe { std::env::remove_var("RETH_TEST_VAR2") };
+    }
+
+    #[test]
+    fn test_expand_unset_var_errors() {
+        let result = expand_path("$RETH_NONEXISTENT_VAR_12345/data");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_trailing_dollar() {
+        // trailing $ should be kept as-is
+        assert_eq!(expand_path("foo$").unwrap(), PathBuf::from("foo$"));
+    }
+
+    #[test]
+    fn test_dollar_non_ident() {
+        // $ followed by non-identifier char should be kept as-is
+        assert_eq!(expand_path("foo$/bar").unwrap(), PathBuf::from("foo$/bar"));
+    }
+
+    #[test]
+    fn test_unclosed_brace() {
+        // unclosed ${ treats the rest as a variable name, which errors if unset
+        let result = expand_path("${UNCLOSED");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_empty_braces() {
+        // empty ${} keeps ${ literally (} is consumed as the closing brace)
+        assert_eq!(expand_path("${}foo").unwrap(), PathBuf::from("${foo"));
+    }
+
+    #[test]
+    fn test_no_expansion_needed() {
+        assert_eq!(expand_path("/absolute/path").unwrap(), PathBuf::from("/absolute/path"));
+        assert_eq!(expand_path("relative/path").unwrap(), PathBuf::from("relative/path"));
+    }
+
+    #[test]
+    fn test_tilde_and_env_var() {
+        unsafe { std::env::set_var("RETH_TEST_DIR", "mydir") };
+        let home = dirs_next::home_dir().unwrap();
+        assert_eq!(expand_path("~/$RETH_TEST_DIR/data").unwrap(), home.join("mydir/data"));
+        unsafe { std::env::remove_var("RETH_TEST_DIR") };
+    }
+}

--- a/crates/cli/util/src/expand_path.rs
+++ b/crates/cli/util/src/expand_path.rs
@@ -53,34 +53,51 @@ fn expand_env_vars(input: &str) -> Result<String, ExpandPathError> {
             continue;
         }
 
-        let braced = chars.peek() == Some(&'{');
-        if braced {
+        if chars.peek() == Some(&'{') {
+            // Braced: ${VAR}
             chars.next();
-        }
-
-        let mut name = String::new();
-        while let Some(&c) = chars.peek() {
-            if braced {
+            let mut name = String::new();
+            let mut closed = false;
+            while let Some(&c) = chars.peek() {
                 if c == '}' {
                     chars.next();
+                    closed = true;
                     break;
                 }
-            } else if !c.is_ascii_alphanumeric() && c != '_' {
-                break;
+                name.push(c);
+                chars.next();
             }
-            name.push(c);
-            chars.next();
-        }
 
-        if name.is_empty() {
-            result.push('$');
-            if braced {
-                result.push('{');
+            if !closed || name.is_empty() {
+                // Unterminated `${...` or empty `${}` — keep literal
+                result.push_str("${");
+                result.push_str(&name);
+                if closed {
+                    result.push('}');
+                }
+            } else {
+                let value = std::env::var(&name)
+                    .map_err(|e| ExpandPathError::Var { var_name: name, source: e })?;
+                result.push_str(&value);
             }
         } else {
-            let value = std::env::var(&name)
-                .map_err(|e| ExpandPathError::Var { var_name: name, source: e })?;
-            result.push_str(&value);
+            // Bare: $VAR
+            let mut name = String::new();
+            while let Some(&c) = chars.peek() {
+                if !c.is_ascii_alphanumeric() && c != '_' {
+                    break;
+                }
+                name.push(c);
+                chars.next();
+            }
+
+            if name.is_empty() {
+                result.push('$');
+            } else {
+                let value = std::env::var(&name)
+                    .map_err(|e| ExpandPathError::Var { var_name: name, source: e })?;
+                result.push_str(&value);
+            }
         }
     }
 
@@ -142,16 +159,15 @@ mod tests {
     }
 
     #[test]
-    fn test_unclosed_brace() {
-        // unclosed ${ treats the rest as a variable name, which errors if unset
-        let result = expand_path("${UNCLOSED");
-        assert!(result.is_err());
+    fn test_unclosed_brace_is_literal() {
+        // unterminated `${...` is kept literally
+        assert_eq!(expand_path("${UNCLOSED").unwrap(), PathBuf::from("${UNCLOSED"));
     }
 
     #[test]
-    fn test_empty_braces() {
-        // empty ${} keeps ${ literally (} is consumed as the closing brace)
-        assert_eq!(expand_path("${}foo").unwrap(), PathBuf::from("${foo"));
+    fn test_empty_braces_literal() {
+        // empty `${}` is kept literally
+        assert_eq!(expand_path("${}foo").unwrap(), PathBuf::from("${}foo"));
     }
 
     #[test]

--- a/crates/cli/util/src/expand_path.rs
+++ b/crates/cli/util/src/expand_path.rs
@@ -167,4 +167,126 @@ mod tests {
         assert_eq!(expand_path("~/$RETH_TEST_DIR/data").unwrap(), home.join("mydir/data"));
         unsafe { std::env::remove_var("RETH_TEST_DIR") };
     }
+
+    #[test]
+    fn test_multiple_env_vars() {
+        unsafe { std::env::set_var("RETH_TEST_CHAIN", "mainnet") };
+        unsafe { std::env::set_var("RETH_TEST_NET", "prod") };
+        assert_eq!(
+            expand_path("/data/$RETH_TEST_CHAIN/$RETH_TEST_NET/db").unwrap(),
+            PathBuf::from("/data/mainnet/prod/db")
+        );
+        unsafe { std::env::remove_var("RETH_TEST_CHAIN") };
+        unsafe { std::env::remove_var("RETH_TEST_NET") };
+    }
+
+    #[test]
+    fn test_multiple_braced_env_vars() {
+        unsafe { std::env::set_var("RETH_TEST_A", "alpha") };
+        unsafe { std::env::set_var("RETH_TEST_B", "beta") };
+        assert_eq!(
+            expand_path("${RETH_TEST_A}/${RETH_TEST_B}").unwrap(),
+            PathBuf::from("alpha/beta")
+        );
+        unsafe { std::env::remove_var("RETH_TEST_A") };
+        unsafe { std::env::remove_var("RETH_TEST_B") };
+    }
+
+    #[test]
+    fn test_repeated_same_var() {
+        unsafe { std::env::set_var("RETH_TEST_REP", "val") };
+        assert_eq!(
+            expand_path("$RETH_TEST_REP/$RETH_TEST_REP/db").unwrap(),
+            PathBuf::from("val/val/db")
+        );
+        unsafe { std::env::remove_var("RETH_TEST_REP") };
+    }
+
+    #[test]
+    fn test_env_var_with_suffix() {
+        // bare $VAR stops at non-ident char, so "-db" is literal suffix
+        unsafe { std::env::set_var("RETH_TEST_CHAIN2", "mainnet") };
+        assert_eq!(expand_path("$RETH_TEST_CHAIN2-db").unwrap(), PathBuf::from("mainnet-db"));
+        unsafe { std::env::remove_var("RETH_TEST_CHAIN2") };
+    }
+
+    #[test]
+    fn test_braced_env_var_with_suffix() {
+        // braced ${VAR} allows immediate suffix
+        unsafe { std::env::set_var("RETH_TEST_CHAIN3", "mainnet") };
+        assert_eq!(expand_path("${RETH_TEST_CHAIN3}db").unwrap(), PathBuf::from("mainnetdb"));
+        unsafe { std::env::remove_var("RETH_TEST_CHAIN3") };
+    }
+
+    #[test]
+    fn test_env_var_preceded_by_prefix() {
+        unsafe { std::env::set_var("RETH_TEST_CHAIN4", "mainnet") };
+        assert_eq!(
+            expand_path("prefix_$RETH_TEST_CHAIN4/suffix").unwrap(),
+            PathBuf::from("prefix_mainnet/suffix")
+        );
+        unsafe { std::env::remove_var("RETH_TEST_CHAIN4") };
+    }
+
+    #[test]
+    fn test_env_var_empty_value() {
+        // env var set to empty string should expand to empty, not error
+        unsafe { std::env::set_var("RETH_TEST_EMPTY", "") };
+        assert_eq!(expand_path("/data/$RETH_TEST_EMPTY/db").unwrap(), PathBuf::from("/data//db"));
+        unsafe { std::env::remove_var("RETH_TEST_EMPTY") };
+    }
+
+    #[test]
+    fn test_tilde_user_does_not_expand() {
+        // ~username should NOT expand (we only support bare ~)
+        assert_eq!(expand_path("~user/foo").unwrap(), PathBuf::from("~user/foo"));
+    }
+
+    #[test]
+    fn test_tilde_trailing_slash_only() {
+        let home = dirs_next::home_dir().unwrap();
+        let expected = PathBuf::from(format!("{}/", home.display()));
+        assert_eq!(expand_path("~/").unwrap(), expected);
+    }
+
+    #[test]
+    fn test_tilde_backslash() {
+        // Windows-style ~\ should also trigger tilde expansion
+        let home = dirs_next::home_dir().unwrap();
+        let result = expand_path("~\\foo\\bar").unwrap();
+        let result_str = result.to_string_lossy();
+        let home_str = home.to_string_lossy();
+        assert!(
+            result_str.starts_with(home_str.as_ref()),
+            "expected result '{result_str}' to start with home '{home_str}'"
+        );
+        assert!(result_str.ends_with("\\foo\\bar"));
+    }
+
+    #[test]
+    fn test_env_var_with_underscores_and_digits() {
+        unsafe { std::env::set_var("RETH_V2_TEST_99", "ok") };
+        assert_eq!(expand_path("$RETH_V2_TEST_99").unwrap(), PathBuf::from("ok"));
+        unsafe { std::env::remove_var("RETH_V2_TEST_99") };
+    }
+
+    #[test]
+    fn test_realistic_datadir_path() {
+        // mimics real --datadir usage: ~/.reth/mainnet
+        let home = dirs_next::home_dir().unwrap();
+        assert_eq!(expand_path("~/.reth/mainnet").unwrap(), home.join(".reth/mainnet"));
+    }
+
+    #[test]
+    fn test_realistic_env_datadir_path() {
+        // mimics $HOME/.reth pattern
+        let home = dirs_next::home_dir().unwrap();
+        let home_str = home.to_string_lossy();
+        unsafe { std::env::set_var("RETH_TEST_HOME", home_str.as_ref()) };
+        assert_eq!(
+            expand_path("$RETH_TEST_HOME/.reth/mainnet").unwrap(),
+            home.join(".reth/mainnet")
+        );
+        unsafe { std::env::remove_var("RETH_TEST_HOME") };
+    }
 }

--- a/crates/cli/util/src/expand_path.rs
+++ b/crates/cli/util/src/expand_path.rs
@@ -30,6 +30,8 @@ pub fn expand_path(input: &str) -> Result<PathBuf, ExpandPathError> {
     Ok(PathBuf::from(expanded))
 }
 
+/// Expands a leading `~` or `~/` (or `~\` on Windows) to the user's home
+/// directory. A `~` appearing anywhere else in the path is left unchanged.
 fn expand_tilde(input: &str) -> Result<String, ExpandPathError> {
     if input == "~" || input.starts_with("~/") || input.starts_with("~\\") {
         let home = dirs_next::home_dir().ok_or(ExpandPathError::NoHomeDir)?;
@@ -43,6 +45,23 @@ fn expand_tilde(input: &str) -> Result<String, ExpandPathError> {
     }
 }
 
+/// Replaces `$VAR` and `${VAR}` references in `input` with their environment
+/// variable values.
+///
+/// # Syntax
+///
+/// | Pattern  | Behavior                                              |
+/// |----------|-------------------------------------------------------|
+/// | `$VAR`   | Expands a bare variable (name = `[A-Za-z0-9_]+`)     |
+/// | `${VAR}` | Expands a braced variable                             |
+/// | `$`      | A trailing or isolated `$` is kept literally          |
+/// | `${}`    | Empty braces are kept literally                       |
+/// | `${X`    | Unterminated braces are kept literally                |
+///
+/// # Errors
+///
+/// Returns [`ExpandPathError::Var`] if a well-formed variable name references
+/// an unset environment variable.
 fn expand_env_vars(input: &str) -> Result<String, ExpandPathError> {
     let mut result = String::with_capacity(input.len());
     let mut chars = input.chars().peekable();
@@ -53,55 +72,73 @@ fn expand_env_vars(input: &str) -> Result<String, ExpandPathError> {
             continue;
         }
 
-        if chars.peek() == Some(&'{') {
-            // Braced: ${VAR}
-            chars.next();
-            let mut name = String::new();
-            let mut closed = false;
-            while let Some(&c) = chars.peek() {
-                if c == '}' {
-                    chars.next();
-                    closed = true;
-                    break;
-                }
-                name.push(c);
-                chars.next();
+        match chars.peek() {
+            Some(&'{') => expand_braced_var(&mut chars, &mut result)?,
+            Some(&c) if c.is_ascii_alphanumeric() || c == '_' => {
+                expand_bare_var(&mut chars, &mut result)?;
             }
-
-            if !closed || name.is_empty() {
-                // Unterminated `${...` or empty `${}` — keep literal
-                result.push_str("${");
-                result.push_str(&name);
-                if closed {
-                    result.push('}');
-                }
-            } else {
-                let value = std::env::var(&name)
-                    .map_err(|e| ExpandPathError::Var { var_name: name, source: e })?;
-                result.push_str(&value);
-            }
-        } else {
-            // Bare: $VAR
-            let mut name = String::new();
-            while let Some(&c) = chars.peek() {
-                if !c.is_ascii_alphanumeric() && c != '_' {
-                    break;
-                }
-                name.push(c);
-                chars.next();
-            }
-
-            if name.is_empty() {
-                result.push('$');
-            } else {
-                let value = std::env::var(&name)
-                    .map_err(|e| ExpandPathError::Var { var_name: name, source: e })?;
-                result.push_str(&value);
-            }
+            _ => result.push('$'), // trailing or isolated `$`
         }
     }
 
     Ok(result)
+}
+
+/// Parses and expands `${VAR}`. Assumes the leading `$` has already been
+/// consumed and `chars` is pointing at `{`.
+fn expand_braced_var(
+    chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
+    result: &mut String,
+) -> Result<(), ExpandPathError> {
+    chars.next(); // consume '{'
+
+    let mut name = String::new();
+    let mut closed = false;
+    for c in chars.by_ref() {
+        if c == '}' {
+            closed = true;
+            break;
+        }
+        name.push(c);
+    }
+
+    if !closed || name.is_empty() {
+        // Malformed — keep as literal text
+        result.push_str("${");
+        result.push_str(&name);
+        if closed {
+            result.push('}');
+        }
+        return Ok(());
+    }
+
+    result.push_str(&lookup_var(&name)?);
+    Ok(())
+}
+
+/// Parses and expands `$VAR`. Assumes the leading `$` has already been consumed
+/// and `chars` is pointing at the first character of the variable name.
+fn expand_bare_var(
+    chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
+    result: &mut String,
+) -> Result<(), ExpandPathError> {
+    let mut name = String::new();
+    while let Some(&c) = chars.peek() {
+        if !c.is_ascii_alphanumeric() && c != '_' {
+            break;
+        }
+        name.push(c);
+        chars.next();
+    }
+
+    result.push_str(&lookup_var(&name)?);
+    Ok(())
+}
+
+/// Looks up an environment variable by name, returning an [`ExpandPathError`]
+/// on failure.
+fn lookup_var(name: &str) -> Result<String, ExpandPathError> {
+    std::env::var(name).map_err(|e| ExpandPathError::Var { var_name: name.to_owned(), source: e })
 }
 
 #[cfg(test)]

--- a/crates/cli/util/src/lib.rs
+++ b/crates/cli/util/src/lib.rs
@@ -25,6 +25,10 @@ pub use parsers::{
     parse_ether_value, parse_socket_address,
 };
 
+/// Shell-like path expansion utilities.
+pub mod expand_path;
+pub use expand_path::{expand_path, ExpandPathError};
+
 #[cfg(all(unix, any(target_env = "gnu", target_os = "macos")))]
 pub mod sigsegv_handler;
 

--- a/crates/node/core/Cargo.toml
+++ b/crates/node/core/Cargo.toml
@@ -59,7 +59,6 @@ url.workspace = true
 ipnet.workspace = true
 # io
 dirs-next.workspace = true
-shellexpand.workspace = true
 
 # obs
 tracing.workspace = true

--- a/crates/node/core/src/dirs.rs
+++ b/crates/node/core/src/dirs.rs
@@ -3,7 +3,6 @@
 use crate::{args::DatadirArgs, utils::parse_path};
 use reth_chainspec::Chain;
 use std::{
-    env::VarError,
     fmt::{Debug, Display, Formatter},
     path::{Path, PathBuf},
     str::FromStr,
@@ -127,7 +126,7 @@ impl<D: XdgPath> Default for PlatformPath<D> {
 }
 
 impl<D> FromStr for PlatformPath<D> {
-    type Err = shellexpand::LookupError<VarError>;
+    type Err = crate::utils::ExpandPathError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(Self(parse_path(s)?, std::marker::PhantomData))
@@ -235,7 +234,7 @@ impl<D> Default for MaybePlatformPath<D> {
 }
 
 impl<D> FromStr for MaybePlatformPath<D> {
-    type Err = shellexpand::LookupError<VarError>;
+    type Err = crate::utils::ExpandPathError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let p = match s {

--- a/crates/node/core/src/utils.rs
+++ b/crates/node/core/src/utils.rs
@@ -13,90 +13,12 @@ use reth_primitives_traits::{Block, SealedBlock, SealedHeader};
 use std::path::{Path, PathBuf};
 use tracing::{debug, info};
 
+pub use reth_cli_util::ExpandPathError;
+
 /// Parses a user-specified path with support for environment variables and common shorthands (e.g.
 /// ~ for the user's home directory).
 pub fn parse_path(value: &str) -> Result<PathBuf, ExpandPathError> {
-    let expanded = expand_path(value)?;
-    Ok(PathBuf::from(expanded))
-}
-
-/// Expands `~` to the user's home directory and `$VAR`/`${VAR}` to environment variable values.
-fn expand_path(input: &str) -> Result<String, ExpandPathError> {
-    let tilde_expanded = expand_tilde(input)?;
-    expand_env_vars(&tilde_expanded)
-}
-
-fn expand_tilde(input: &str) -> Result<String, ExpandPathError> {
-    if input == "~" || input.starts_with("~/") || input.starts_with("~\\") {
-        let home = dirs_next::home_dir().ok_or(ExpandPathError::NoHomeDir)?;
-        let mut out = home.to_string_lossy().into_owned();
-        if input.len() > 1 {
-            out.push_str(&input[1..]);
-        }
-        Ok(out)
-    } else {
-        Ok(input.to_string())
-    }
-}
-
-fn expand_env_vars(input: &str) -> Result<String, ExpandPathError> {
-    let mut result = String::with_capacity(input.len());
-    let mut chars = input.chars().peekable();
-
-    while let Some(c) = chars.next() {
-        if c != '$' {
-            result.push(c);
-            continue;
-        }
-
-        let braced = chars.peek() == Some(&'{');
-        if braced {
-            chars.next();
-        }
-
-        let mut name = String::new();
-        while let Some(&c) = chars.peek() {
-            if braced {
-                if c == '}' {
-                    chars.next();
-                    break;
-                }
-            } else if !c.is_ascii_alphanumeric() && c != '_' {
-                break;
-            }
-            name.push(c);
-            chars.next();
-        }
-
-        if name.is_empty() {
-            result.push('$');
-            if braced {
-                result.push('{');
-            }
-        } else {
-            let value = std::env::var(&name)
-                .map_err(|e| ExpandPathError::Var { var_name: name, source: e })?;
-            result.push_str(&value);
-        }
-    }
-
-    Ok(result)
-}
-
-/// An error that can occur when expanding a path.
-#[derive(Debug, thiserror::Error)]
-pub enum ExpandPathError {
-    /// Home directory could not be determined.
-    #[error("could not determine home directory")]
-    NoHomeDir,
-    /// Environment variable lookup failed.
-    #[error("environment variable `{var_name}` not found: {source}")]
-    Var {
-        /// The variable name that was looked up.
-        var_name: String,
-        /// The underlying error.
-        source: std::env::VarError,
-    },
+    reth_cli_util::expand_path(value)
 }
 
 /// Attempts to retrieve or create a JWT secret from the specified path.

--- a/crates/node/core/src/utils.rs
+++ b/crates/node/core/src/utils.rs
@@ -10,16 +10,93 @@ use reth_network_p2p::{
     bodies::client::BodiesClient, headers::client::HeadersClient, priority::Priority,
 };
 use reth_primitives_traits::{Block, SealedBlock, SealedHeader};
-use std::{
-    env::VarError,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 use tracing::{debug, info};
 
 /// Parses a user-specified path with support for environment variables and common shorthands (e.g.
 /// ~ for the user's home directory).
-pub fn parse_path(value: &str) -> Result<PathBuf, shellexpand::LookupError<VarError>> {
-    shellexpand::full(value).map(|path| PathBuf::from(path.into_owned()))
+pub fn parse_path(value: &str) -> Result<PathBuf, ExpandPathError> {
+    let expanded = expand_path(value)?;
+    Ok(PathBuf::from(expanded))
+}
+
+/// Expands `~` to the user's home directory and `$VAR`/`${VAR}` to environment variable values.
+fn expand_path(input: &str) -> Result<String, ExpandPathError> {
+    let tilde_expanded = expand_tilde(input)?;
+    expand_env_vars(&tilde_expanded)
+}
+
+fn expand_tilde(input: &str) -> Result<String, ExpandPathError> {
+    if input == "~" || input.starts_with("~/") || input.starts_with("~\\") {
+        let home = dirs_next::home_dir().ok_or(ExpandPathError::NoHomeDir)?;
+        let mut out = home.to_string_lossy().into_owned();
+        if input.len() > 1 {
+            out.push_str(&input[1..]);
+        }
+        Ok(out)
+    } else {
+        Ok(input.to_string())
+    }
+}
+
+fn expand_env_vars(input: &str) -> Result<String, ExpandPathError> {
+    let mut result = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        if c != '$' {
+            result.push(c);
+            continue;
+        }
+
+        let braced = chars.peek() == Some(&'{');
+        if braced {
+            chars.next();
+        }
+
+        let mut name = String::new();
+        while let Some(&c) = chars.peek() {
+            if braced {
+                if c == '}' {
+                    chars.next();
+                    break;
+                }
+            } else if !c.is_ascii_alphanumeric() && c != '_' {
+                break;
+            }
+            name.push(c);
+            chars.next();
+        }
+
+        if name.is_empty() {
+            result.push('$');
+            if braced {
+                result.push('{');
+            }
+        } else {
+            let value = std::env::var(&name)
+                .map_err(|e| ExpandPathError::Var { var_name: name, source: e })?;
+            result.push_str(&value);
+        }
+    }
+
+    Ok(result)
+}
+
+/// An error that can occur when expanding a path.
+#[derive(Debug, thiserror::Error)]
+pub enum ExpandPathError {
+    /// Home directory could not be determined.
+    #[error("could not determine home directory")]
+    NoHomeDir,
+    /// Environment variable lookup failed.
+    #[error("environment variable `{var_name}` not found: {source}")]
+    Var {
+        /// The variable name that was looked up.
+        var_name: String,
+        /// The underlying error.
+        source: std::env::VarError,
+    },
 }
 
 /// Attempts to retrieve or create a JWT secret from the specified path.


### PR DESCRIPTION
## Summary
`shellexpand` 3.1.1 fails to compile on nightly Rust — the stabilization of `OsStr::as_str()` changed method resolution in its source, producing `E0308` errors. The crate is unmaintained (no fix available).

This replaces all `shellexpand` usage with inline tilde (`~`) and environment variable (`\$VAR`/`\${VAR}`) expansion, removing the dependency entirely.

## Changes
- `crates/node/core/src/utils.rs`: inline `expand_tilde` + `expand_env_vars` helpers, new `ExpandPathError` type
- `crates/node/core/src/dirs.rs`: use `ExpandPathError` instead of `shellexpand::LookupError`
- `crates/cli/cli/src/chainspec.rs`: inline `expand_path` using `dirs-next` + `eyre`
- `bin/reth-bench-compare/src/cli.rs`: use `reth_node_core::utils::parse_path` (already a dep)
- Removed `shellexpand` from all Cargo.toml files and workspace root

## Testing
- `cargo check -p reth-node-core -p reth-cli -p reth-bench-compare` passes
- `cargo +nightly fmt --all`, `zepter`, `dprint fmt` all pass

Prompted by: yk