### PR TITLE
feat(engine): add debug span for receipt root task

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/receipt_root_task.rs
+++ b/crates/engine/tree/src/tree/payload_processor/receipt_root_task.rs
@@ -12,6 +12,7 @@ use crossbeam_channel::Receiver;
 use reth_primitives_traits::Receipt;
 use reth_trie_common::ordered_root::OrderedTrieRootEncodedBuilder;
 use tokio::sync::oneshot;
+use tracing::debug_span;
 
 /// Receipt with index, ready to be sent to the background task for encoding and trie building.
 #[derive(Debug, Clone)]
@@ -65,6 +66,13 @@ impl<R: Receipt> ReceiptRootTaskHandle<R> {
     /// * `receipts_len` - The total number of receipts expected. This is needed to correctly order
     ///   the trie keys according to RLP encoding rules.
     pub fn run(self, receipts_len: usize) {
+        let _span = debug_span!(
+            target: "engine::tree::payload_processor",
+            "receipt_root",
+            receipts_len,
+        )
+        .entered();
+
         let mut builder = OrderedTrieRootEncodedBuilder::new(receipts_len);
         let mut aggregated_bloom = Bloom::ZERO;
         let mut encode_buf = Vec::new();


### PR DESCRIPTION
## Summary
Adds a `debug_span` to the background receipt root computation task, matching the pattern used by `hashed_post_state` and other spawned blocking tasks.

## Changes
- Added `receipt_root` debug span with `receipts_len` field in `ReceiptRootTaskHandle::run()`

## Testing
- All 5 receipt root task unit tests pass

Prompted by: yk