### PR TITLE
perf(engine): add tracing spans for post-execution validation wait times

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/receipt_root_task.rs
+++ b/crates/engine/tree/src/tree/payload_processor/receipt_root_task.rs
@@ -12,6 +12,7 @@ use crossbeam_channel::Receiver;
 use reth_primitives_traits::Receipt;
 use reth_trie_common::ordered_root::OrderedTrieRootEncodedBuilder;
 use tokio::sync::oneshot;
+use tracing::debug_span;
 
 /// Receipt with index, ready to be sent to the background task for encoding and trie building.
 #[derive(Debug, Clone)]
@@ -65,6 +66,13 @@ impl<R: Receipt> ReceiptRootTaskHandle<R> {
     /// * `receipts_len` - The total number of receipts expected. This is needed to correctly order
     ///   the trie keys according to RLP encoding rules.
     pub fn run(self, receipts_len: usize) {
+        let _span = debug_span!(
+            target: "engine::tree::payload_processor",
+            "receipt_root",
+            receipts_len,
+        )
+        .entered();
+
         let mut builder = OrderedTrieRootEncodedBuilder::new(receipts_len);
         let mut aggregated_bloom = Bloom::ZERO;
         let mut encode_buf = Vec::new();


### PR DESCRIPTION
## Summary

Adds `debug_span!` instrumentation for two blind spots in payload validation where wall-time can disappear in Tracy profiles.

## Motivation

When profiling block validation with Tracy, the existing spans cover execution, state root, and the overall `validate_post_execution` duration — but two key **wait points** are invisible:

1. **`receipt_root_rx.blocking_recv()`** — main thread blocks waiting for the background receipt root + bloom task
2. **`hashed_state.get()`** — main thread blocks waiting for the background keccak256 hashing task

Without spans on these waits, you can't tell whether post-execution validation time is spent on actual validation work or just waiting for background tasks to finish.

## Changes

- `wait_receipt_root` span around the `blocking_recv()` call for the receipt root task result
- `wait_hashed_post_state` span around the `LazyHandle::get()` call that blocks until keccak256 hashing completes
- Separated `hashed_state.get()` from the `validate_block_post_execution_with_hashed_state` span so wait vs validation are distinguishable

## Testing

`cargo check -p reth-engine-tree` passes. No logic changes — spans only.

Prompted by: yk