### PR TITLE
fix: correct braced expansion edge cases and log fallback errors

### DIFF
--- a/.changelog/fix-shellexpand-nightly.md
+++ b/.changelog/fix-shellexpand-nightly.md
@@ -1,4 +1,5 @@
 ---
+reth-cli-util: patch
 reth-node-core: patch
 reth-cli: patch
 reth-bench-compare: patch

--- a/bin/reth-bench-compare/src/cli.rs
+++ b/bin/reth-bench-compare/src/cli.rs
@@ -291,8 +291,10 @@ impl Args {
         match &self.jwt_secret {
             Some(path) => {
                 let jwt_secret_str = path.to_string_lossy();
-                reth_node_core::utils::parse_path(&jwt_secret_str)
-                    .unwrap_or_else(|_| PathBuf::from(path))
+                reth_node_core::utils::parse_path(&jwt_secret_str).unwrap_or_else(|err| {
+                    warn!(target: "reth::cli", %err, path = %jwt_secret_str, "failed to expand JWT secret path, using as-is");
+                    PathBuf::from(path)
+                })
             }
             None => {
                 // Use the same logic as reth: <datadir>/<chain>/jwt.hex
@@ -310,8 +312,10 @@ impl Args {
 
     /// Get the expanded output directory path
     pub(crate) fn output_dir_path(&self) -> PathBuf {
-        reth_node_core::utils::parse_path(&self.output_dir)
-            .unwrap_or_else(|_| PathBuf::from(&self.output_dir))
+        reth_node_core::utils::parse_path(&self.output_dir).unwrap_or_else(|err| {
+            warn!(target: "reth::cli", %err, path = %self.output_dir, "failed to expand output dir path, using as-is");
+            PathBuf::from(&self.output_dir)
+        })
     }
 
     /// Get the effective warmup blocks value - either specified or defaults to blocks

--- a/crates/cli/util/src/expand_path.rs
+++ b/crates/cli/util/src/expand_path.rs
@@ -53,34 +53,51 @@ fn expand_env_vars(input: &str) -> Result<String, ExpandPathError> {
             continue;
         }
 
-        let braced = chars.peek() == Some(&'{');
-        if braced {
+        if chars.peek() == Some(&'{') {
+            // Braced: ${VAR}
             chars.next();
-        }
-
-        let mut name = String::new();
-        while let Some(&c) = chars.peek() {
-            if braced {
+            let mut name = String::new();
+            let mut closed = false;
+            while let Some(&c) = chars.peek() {
                 if c == '}' {
                     chars.next();
+                    closed = true;
                     break;
                 }
-            } else if !c.is_ascii_alphanumeric() && c != '_' {
-                break;
+                name.push(c);
+                chars.next();
             }
-            name.push(c);
-            chars.next();
-        }
 
-        if name.is_empty() {
-            result.push('$');
-            if braced {
-                result.push('{');
+            if !closed || name.is_empty() {
+                // Unterminated `${...` or empty `${}` — keep literal
+                result.push_str("${");
+                result.push_str(&name);
+                if closed {
+                    result.push('}');
+                }
+            } else {
+                let value = std::env::var(&name)
+                    .map_err(|e| ExpandPathError::Var { var_name: name, source: e })?;
+                result.push_str(&value);
             }
         } else {
-            let value = std::env::var(&name)
-                .map_err(|e| ExpandPathError::Var { var_name: name, source: e })?;
-            result.push_str(&value);
+            // Bare: $VAR
+            let mut name = String::new();
+            while let Some(&c) = chars.peek() {
+                if !c.is_ascii_alphanumeric() && c != '_' {
+                    break;
+                }
+                name.push(c);
+                chars.next();
+            }
+
+            if name.is_empty() {
+                result.push('$');
+            } else {
+                let value = std::env::var(&name)
+                    .map_err(|e| ExpandPathError::Var { var_name: name, source: e })?;
+                result.push_str(&value);
+            }
         }
     }
 
@@ -142,16 +159,15 @@ mod tests {
     }
 
     #[test]
-    fn test_unclosed_brace() {
-        // unclosed ${ treats the rest as a variable name, which errors if unset
-        let result = expand_path("${UNCLOSED");
-        assert!(result.is_err());
+    fn test_unclosed_brace_is_literal() {
+        // unterminated `${...` is kept literally
+        assert_eq!(expand_path("${UNCLOSED").unwrap(), PathBuf::from("${UNCLOSED"));
     }
 
     #[test]
-    fn test_empty_braces() {
-        // empty ${} keeps ${ literally (} is consumed as the closing brace)
-        assert_eq!(expand_path("${}foo").unwrap(), PathBuf::from("${foo"));
+    fn test_empty_braces_literal() {
+        // empty `${}` is kept literally
+        assert_eq!(expand_path("${}foo").unwrap(), PathBuf::from("${}foo"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Fix nits from review of #22481.

## Changes
- **Fix `${}` edge case**: `${}foo` was producing `${foo` (mangled output). Now kept literally as `${}foo`.
- **Fix unterminated `${...`**: Was erroring on unset var. Now kept literally (`${UNCLOSED` → `${UNCLOSED`), matching shellexpand behavior.
- **Log fallback errors in reth-bench-compare**: `jwt_secret_path()` and `output_dir_path()` were silently swallowing expansion errors. Now logs a warning before falling back.
- **Changelog**: Added `reth-cli-util` to changelog since it's the crate that received the new `expand_path` module.

## Testing
```
cargo test -p reth-cli-util -- expand_path  # 12/12 pass
cargo check -p reth-bench-compare           # compiles clean
cargo +nightly fmt --all -- --check         # clean
```

Prompted by: yk