### PR TITLE
ci: pin nightly to 2026-02-21

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Install Rust nightly
         uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly-2026-02-21
 
       - uses: mozilla-actions/sccache-action@v0.0.9
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,6 +49,9 @@ jobs:
       - uses: rui314/setup-mold@v1
       - uses: dtolnay/rust-toolchain@nightly
         with:
+          # Pin nightly to avoid breakage from str::as_str() stabilization
+          # which breaks shellexpand 3.1.1 method resolution.
+          toolchain: nightly-2026-02-21
           components: clippy
       - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: Swatinem/rust-cache@v2
@@ -141,6 +144,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: rui314/setup-mold@v1
       - uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly-2026-02-21
       - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: Swatinem/rust-cache@v2
         with:
@@ -160,6 +165,7 @@ jobs:
       - uses: rui314/setup-mold@v1
       - uses: dtolnay/rust-toolchain@nightly
         with:
+          toolchain: nightly-2026-02-21
           components: rustfmt
       - uses: mozilla-actions/sccache-action@v0.0.9
       - name: Run fmt
@@ -173,6 +179,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: rui314/setup-mold@v1
       - uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly-2026-02-21
       - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: Swatinem/rust-cache@v2
         with:
@@ -188,6 +196,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: rui314/setup-mold@v1
       - uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly-2026-02-21
       - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,9 @@ jobs:
       - uses: rui314/setup-mold@v1
       - uses: dtolnay/rust-toolchain@clippy
         with:
+          # Pin nightly to avoid breakage from str::as_str() stabilization
+          # which breaks shellexpand 3.1.1 method resolution.
+          toolchain: nightly-2026-02-21
           components: clippy
       - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
Pin nightly toolchain to avoid breakage from `str::as_str()` stabilization which breaks `shellexpand 3.1.1` method resolution.

Same fix as https://github.com/tempoxyz/tempo/pull/2808.