### PR TITLE
perf(trie): skip buffer allocation for in-order receipt root items

### DIFF
--- a/crates/trie/common/src/ordered_root.rs
+++ b/crates/trie/common/src/ordered_root.rs
@@ -138,6 +138,8 @@ pub struct OrderedTrieRootEncodedBuilder {
     next_insert_i: usize,
     /// Buffer for pending items, indexed by execution index.
     pending: Vec<Option<Vec<u8>>>,
+    /// Tracks which indices have been pushed (for duplicate detection).
+    pushed: Vec<bool>,
     /// The underlying hash builder.
     hb: HashBuilder,
 }
@@ -150,6 +152,7 @@ impl OrderedTrieRootEncodedBuilder {
             received: 0,
             next_insert_i: 0,
             pending: alloc::vec![None; len],
+            pushed: alloc::vec![false; len],
             hb: HashBuilder::default(),
         }
     }
@@ -170,7 +173,7 @@ impl OrderedTrieRootEncodedBuilder {
             return Err(OrderedRootError::IndexOutOfBounds { index, len: self.len });
         }
 
-        if self.pending[index].is_some() {
+        if self.pushed[index] {
             return Err(OrderedRootError::DuplicateIndex { index });
         }
 
@@ -190,11 +193,26 @@ impl OrderedTrieRootEncodedBuilder {
     #[inline]
     pub fn push_unchecked(&mut self, index: usize, bytes: &[u8]) {
         debug_assert!(index < self.len, "index {index} out of bounds for length {}", self.len);
-        debug_assert!(self.pending[index].is_none(), "duplicate item at index {index}");
+        debug_assert!(!self.pushed[index], "duplicate item at index {index}");
 
-        self.pending[index] = Some(bytes.to_vec());
         self.received += 1;
+        self.pushed[index] = true;
 
+        // Fast path: if this item is next in trie insertion order, feed it directly
+        // to the hash builder without copying into the pending buffer.
+        if self.next_insert_i < self.len &&
+            adjust_index_for_rlp(self.next_insert_i, self.len) == index
+        {
+            let index_buffer = alloy_rlp::encode_fixed_size(&index);
+            self.hb.add_leaf(Nibbles::unpack(&index_buffer), bytes);
+            self.next_insert_i += 1;
+            // Drain any previously buffered items that are now ready.
+            self.flush();
+            return;
+        }
+
+        // Slow path: buffer for later flushing.
+        self.pending[index] = Some(bytes.to_vec());
         self.flush();
     }
 
@@ -333,6 +351,30 @@ mod tests {
     }
 
     #[test]
+    fn test_ordered_builder_fast_path_coverage() {
+        for len in [1, 2, 10, 128, 129, 200, 400] {
+            let items: Vec<Vec<u8>> =
+                (0..len).map(|i| format!("item_{i}_data").into_bytes()).collect();
+
+            let expected = ordered_trie_root_encoded(&items);
+
+            // Push in execution order (0, 1, 2, ..., N-1).
+            // All items except index 0 should hit the fast path since they arrive
+            // in trie insertion order after the first item is buffered.
+            let mut builder = OrderedTrieRootEncodedBuilder::new(len);
+            for (i, item) in items.iter().enumerate() {
+                builder.push_unchecked(i, item);
+            }
+
+            let actual = builder.finalize().unwrap();
+            assert_eq!(
+                expected, actual,
+                "fast path mismatch for len={len}: expected {expected:?}, got {actual:?}"
+            );
+        }
+    }
+
+    #[test]
     fn test_ordered_builder_index_errors() {
         let mut builder = OrderedTrieRootEncodedBuilder::new(2);
 
@@ -350,5 +392,17 @@ mod tests {
 
         builder.push(1, b"item_1").unwrap();
         assert!(builder.is_complete());
+    }
+
+    #[test]
+    fn test_ordered_builder_fast_path_duplicate_detection() {
+        // For len=3, trie order is [1, 2, 0]. Pushing index 1 first hits the fast path.
+        // Pushing index 1 again must be detected as a duplicate via the sentinel.
+        let mut builder = OrderedTrieRootEncodedBuilder::new(3);
+        builder.push(1, b"item_1").unwrap(); // fast path
+        assert_eq!(
+            builder.push(1, b"item_1_dup"),
+            Err(OrderedRootError::DuplicateIndex { index: 1 })
+        );
     }
 }

--- a/crates/trie/common/src/ordered_root.rs
+++ b/crates/trie/common/src/ordered_root.rs
@@ -351,30 +351,6 @@ mod tests {
     }
 
     #[test]
-    fn test_ordered_builder_fast_path_coverage() {
-        for len in [1, 2, 10, 128, 129, 200, 400] {
-            let items: Vec<Vec<u8>> =
-                (0..len).map(|i| format!("item_{i}_data").into_bytes()).collect();
-
-            let expected = ordered_trie_root_encoded(&items);
-
-            // Push in execution order (0, 1, 2, ..., N-1).
-            // All items except index 0 should hit the fast path since they arrive
-            // in trie insertion order after the first item is buffered.
-            let mut builder = OrderedTrieRootEncodedBuilder::new(len);
-            for (i, item) in items.iter().enumerate() {
-                builder.push_unchecked(i, item);
-            }
-
-            let actual = builder.finalize().unwrap();
-            assert_eq!(
-                expected, actual,
-                "fast path mismatch for len={len}: expected {expected:?}, got {actual:?}"
-            );
-        }
-    }
-
-    #[test]
     fn test_ordered_builder_index_errors() {
         let mut builder = OrderedTrieRootEncodedBuilder::new(2);
 
@@ -395,15 +371,53 @@ mod tests {
     }
 
     #[test]
-    fn test_ordered_builder_fast_path_duplicate_detection() {
-        // For len=3, trie order is [1, 2, 0]. Pushing index 1 first hits the fast path.
-        // Pushing index 1 again must be detected as a duplicate via the sentinel.
-        let mut builder = OrderedTrieRootEncodedBuilder::new(3);
-        builder.push(1, b"item_1").unwrap(); // fast path
-        assert_eq!(
-            builder.push(1, b"item_1_dup"),
-            Err(OrderedRootError::DuplicateIndex { index: 1 })
-        );
+    fn test_ordered_builder_all_fast_path() {
+        // Push in trie insertion order so every item hits the fast path (including index 0).
+        for len in [1, 2, 3, 10, 128, 129, 200] {
+            let items: Vec<Vec<u8>> =
+                (0..len).map(|i| format!("item_{i}_data").into_bytes()).collect();
+            let expected = ordered_trie_root_encoded(&items);
+
+            let mut builder = OrderedTrieRootEncodedBuilder::new(len);
+            for i in 0..len {
+                let index = adjust_index_for_rlp(i, len);
+                builder.push_unchecked(index, &items[index]);
+            }
+            let actual = builder.finalize().unwrap();
+            assert_eq!(expected, actual, "all-fast-path mismatch for len={len}");
+        }
+    }
+
+    #[test]
+    fn test_ordered_builder_random_permutation() {
+        // Deterministic Fisher-Yates shuffle using a simple LCG PRNG.
+        fn shuffle(slice: &mut [usize], seed: u64) {
+            let mut state = seed;
+            for i in (1..slice.len()).rev() {
+                state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+                let j = (state >> 33) as usize % (i + 1);
+                slice.swap(i, j);
+            }
+        }
+
+        for len in [2, 3, 10, 50, 128, 129, 200] {
+            let items: Vec<Vec<u8>> =
+                (0..len).map(|i| format!("item_{i}_data").into_bytes()).collect();
+            let expected = ordered_trie_root_encoded(&items);
+
+            // Run multiple random permutations per length.
+            for seed in 0..5u64 {
+                let mut order: Vec<usize> = (0..len).collect();
+                shuffle(&mut order, seed.wrapping_add(len as u64));
+
+                let mut builder = OrderedTrieRootEncodedBuilder::new(len);
+                for &i in &order {
+                    builder.push(i, &items[i]).unwrap();
+                }
+                let actual = builder.finalize().unwrap();
+                assert_eq!(expected, actual, "random permutation mismatch for len={len}, seed={seed}");
+            }
+        }
     }
 
     #[test]

--- a/crates/trie/common/src/ordered_root.rs
+++ b/crates/trie/common/src/ordered_root.rs
@@ -405,4 +405,30 @@ mod tests {
             Err(OrderedRootError::DuplicateIndex { index: 1 })
         );
     }
+
+    #[test]
+    fn test_ordered_builder_duplicate_after_flush() {
+        // For len=3, trie order is [1, 2, 0].
+        // Fast-path case: items flushed directly should still reject duplicates.
+        let mut builder = OrderedTrieRootEncodedBuilder::new(3);
+        builder.push(1, b"item_1").unwrap(); // fast path, flushed immediately
+        builder.push(2, b"item_2").unwrap(); // fast path, flushed immediately
+        assert_eq!(
+            builder.push(1, b"item_1_dup"),
+            Err(OrderedRootError::DuplicateIndex { index: 1 })
+        );
+
+        // Slow-path case: item buffered then flushed by a subsequent push.
+        // push(0) buffers in pending[0]. push(1) is fast path (adjust(0,3)=1).
+        // push(2) is fast path (adjust(1,3)=2), flush drains pending[0] (adjust(2,3)=0).
+        // Now pending[0] is None (taken by flush), but pushed[0] must still be set.
+        let mut builder = OrderedTrieRootEncodedBuilder::new(3);
+        builder.push(0, b"item_0").unwrap(); // buffered in pending[0]
+        builder.push(1, b"item_1").unwrap(); // fast path, flush finds pending[2]=None, stops
+        builder.push(2, b"item_2").unwrap(); // fast path, flush finds pending[0]=Some, flushes it
+        assert_eq!(
+            builder.push(0, b"item_0_dup"),
+            Err(OrderedRootError::DuplicateIndex { index: 0 })
+        );
+    }
 }

--- a/crates/trie/common/src/ordered_root.rs
+++ b/crates/trie/common/src/ordered_root.rs
@@ -415,7 +415,10 @@ mod tests {
                     builder.push(i, &items[i]).unwrap();
                 }
                 let actual = builder.finalize().unwrap();
-                assert_eq!(expected, actual, "random permutation mismatch for len={len}, seed={seed}");
+                assert_eq!(
+                    expected, actual,
+                    "random permutation mismatch for len={len}, seed={seed}"
+                );
             }
         }
     }


### PR DESCRIPTION
Skips a heap alloc+copy+free per receipt by feeding bytes directly to the hash builder when receipts arrive in order. Skips ~N-1 allocs per block


**Summary:**

- When the pushed item is next in trie order, feed bytes directly to `HashBuilder::add_leaf` — skipping the `to_vec()` + buffer + flush cycle
- 199/200 receipts hit this fast path; only index 0 needs buffering
- A `pushed: Vec<bool>` bitmap handles duplicate detection since fast-path items bypass `pending`

**Per-receipt savings (fast path hit)**:

| Operation | Saved |
|---|---|
| `bytes.to_vec()` | 1 heap alloc + memcpy (~200 bytes) |
| `pending[index] = Some(...)` | 1 pointer-sized write |
| `flush() → .take()` | 1 read + reset |
| `flush() → add_leaf(&value)` | 1 extra memcpy (~200 bytes) |
| `drop(Vec<u8>)` | 1 heap dealloc |

Branch cost: ~2-3 cycles of inlined comparisons per push, predicted correctly 199/200 times.

**Bonus bug fix**: The bitmap fixes a latent bug where `flush()` calling `.take()` reset pending slots to `None`, allowing silent duplicate acceptance after flush.

### Notes

RLP encodes `0` as `0x80` but `1`-`127` as raw bytes, so the trie inserts index 0 *after* 1-127:

```
Execution order:  0   1   2  ...  127   128  ...  199
Trie order:       1   2   3  ...  127   0    128  ...  199
```

Receipts arrive sequentially (0, 1, 2, ...) but the trie expects 1 first:

```
Push 0:   trie wants 1   → buffer          ← only slow path
Push 1:   trie wants 1   → fast path ✓
Push 2:   trie wants 2   → fast path ✓
  ...
Push 127: trie wants 127 → fast path ✓     → flushes buffered 0
Push 128: trie wants 128 → fast path ✓
  ...
Push 199: trie wants 199 → fast path ✓     → 199/200 skip the buffer
```