### PR TITLE
perf(engine): precompute tx root during payload validation

### DIFF
--- a/crates/consensus/common/Cargo.toml
+++ b/crates/consensus/common/Cargo.toml
@@ -19,6 +19,7 @@ reth-consensus.workspace = true
 reth-primitives-traits.workspace = true
 alloy-consensus.workspace = true
 alloy-eips.workspace = true
+alloy-primitives.workspace = true
 
 [dev-dependencies]
 alloy-primitives = { workspace = true, features = ["rand"] }

--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -2,6 +2,7 @@
 
 use alloy_consensus::{BlockHeader as _, EMPTY_OMMER_ROOT_HASH};
 use alloy_eips::{eip4844::DATA_GAS_PER_BLOB, eip7840::BlobParams};
+use alloy_primitives::B256;
 use reth_chainspec::{EthChainSpec, EthereumHardfork, EthereumHardforks};
 use reth_consensus::ConsensusError;
 use reth_primitives_traits::{
@@ -145,11 +146,33 @@ where
     B: Block,
     ChainSpec: EthChainSpec + EthereumHardforks,
 {
+    validate_block_pre_execution_with_tx_root(block, chain_spec, None)
+}
+
+/// Validate a block without regard for state using an optional pre-computed transaction root.
+///
+/// - Compares the ommer hash in the block header to the block body
+/// - Compares the transactions root in the block header to the block body
+/// - Pre-execution transaction validation
+pub fn validate_block_pre_execution_with_tx_root<B, ChainSpec>(
+    block: &SealedBlock<B>,
+    chain_spec: &ChainSpec,
+    transaction_root: Option<B256>,
+) -> Result<(), ConsensusError>
+where
+    B: Block,
+    ChainSpec: EthChainSpec + EthereumHardforks,
+{
     post_merge_hardfork_fields(block, chain_spec)?;
 
-    // Check transaction root
-    if let Err(error) = block.ensure_transaction_root_valid() {
-        return Err(ConsensusError::BodyTransactionRootDiff(error.into()))
+    let expected_transaction_root = block.header().transactions_root();
+    let calculated_transaction_root =
+        transaction_root.unwrap_or_else(|| block.body().calculate_tx_root());
+    if calculated_transaction_root != expected_transaction_root {
+        return Err(ConsensusError::BodyTransactionRootDiff(
+            GotExpected { got: calculated_transaction_root, expected: expected_transaction_root }
+                .into(),
+        ))
     }
 
     Ok(())

--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -154,6 +154,10 @@ where
 /// - Compares the ommer hash in the block header to the block body
 /// - Compares the transactions root in the block header to the block body
 /// - Pre-execution transaction validation
+///
+/// If `transaction_root` is provided, it is used instead of recomputing the transaction trie
+/// root from the block body. The caller must ensure this value was derived from
+/// `block.body().calculate_tx_root()`.
 pub fn validate_block_pre_execution_with_tx_root<B, ChainSpec>(
     block: &SealedBlock<B>,
     chain_spec: &ChainSpec,
@@ -165,6 +169,7 @@ where
 {
     post_merge_hardfork_fields(block, chain_spec)?;
 
+    // Check transaction root
     let expected_transaction_root = block.header().transactions_root();
     let calculated_transaction_root =
         transaction_root.unwrap_or_else(|| block.body().calculate_tx_root());
@@ -449,7 +454,7 @@ pub fn validate_against_parent_4844<H: BlockHeader>(
 mod tests {
     use super::*;
     use alloy_consensus::{BlockBody, Header, TxEip4844};
-    use alloy_eips::eip4895::Withdrawals;
+    use alloy_eips::{eip4844::DATA_GAS_PER_BLOB, eip4895::Withdrawals};
     use alloy_primitives::{Address, Bytes, Signature, U256};
     use rand::Rng;
     use reth_chainspec::ChainSpecBuilder;
@@ -529,5 +534,67 @@ mod tests {
 
         // Test with custom larger limit - should pass
         assert!(validate_header_extra_data(&header_33, 64).is_ok());
+    }
+
+    #[test]
+    fn precomputed_tx_root_correct_passes() {
+        let chain_spec = ChainSpecBuilder::mainnet().cancun_activated().build();
+
+        let transaction = mock_blob_tx(1, 1);
+        let tx_root = proofs::calculate_transaction_root(std::slice::from_ref(&transaction));
+
+        let header = Header {
+            base_fee_per_gas: Some(1337),
+            withdrawals_root: Some(proofs::calculate_withdrawals_root(&[])),
+            transactions_root: tx_root,
+            blob_gas_used: Some(DATA_GAS_PER_BLOB),
+            excess_blob_gas: Some(0),
+            ..Default::default()
+        };
+        let body = BlockBody {
+            transactions: vec![transaction],
+            ommers: vec![],
+            withdrawals: Some(Withdrawals::default()),
+        };
+
+        let block = SealedBlock::seal_slow(alloy_consensus::Block { header, body });
+
+        // Some(correct_root) should pass just like None
+        assert!(
+            validate_block_pre_execution_with_tx_root(&block, &chain_spec, Some(tx_root)).is_ok()
+        );
+        assert!(validate_block_pre_execution_with_tx_root(&block, &chain_spec, None).is_ok());
+    }
+
+    #[test]
+    fn precomputed_tx_root_wrong_fails() {
+        let chain_spec = ChainSpecBuilder::mainnet().cancun_activated().build();
+
+        let transaction = mock_blob_tx(1, 1);
+        let tx_root = proofs::calculate_transaction_root(std::slice::from_ref(&transaction));
+
+        let header = Header {
+            base_fee_per_gas: Some(1337),
+            withdrawals_root: Some(proofs::calculate_withdrawals_root(&[])),
+            transactions_root: tx_root,
+            blob_gas_used: Some(DATA_GAS_PER_BLOB),
+            excess_blob_gas: Some(0),
+            ..Default::default()
+        };
+        let body = BlockBody {
+            transactions: vec![transaction],
+            ommers: vec![],
+            withdrawals: Some(Withdrawals::default()),
+        };
+
+        let block = SealedBlock::seal_slow(alloy_consensus::Block { header, body });
+
+        let wrong_root = B256::repeat_byte(0xff);
+        assert!(matches!(
+            validate_block_pre_execution_with_tx_root(&block, &chain_spec, Some(wrong_root))
+                .unwrap_err(),
+            ConsensusError::BodyTransactionRootDiff(diff)
+                if diff.0.got == wrong_root && diff.0.expected == tx_root
+        ));
     }
 }

--- a/crates/consensus/consensus/src/lib.rs
+++ b/crates/consensus/consensus/src/lib.rs
@@ -21,6 +21,12 @@ use core::error::Error;
 /// When provided to [`FullConsensus::validate_block_post_execution`], this allows skipping
 /// the receipt root computation and using the pre-computed values instead.
 pub type ReceiptRootBloom = (B256, Bloom);
+
+/// Pre-computed transaction root.
+///
+/// When provided to [`Consensus::validate_block_pre_execution_with_tx_root`], this allows
+/// skipping transaction trie reconstruction from the block body.
+pub type TransactionRoot = B256;
 use reth_execution_types::BlockExecutionResult;
 use reth_primitives_traits::{
     constants::{GAS_LIMIT_BOUND_DIVISOR, MAXIMUM_GAS_LIMIT_BLOCK, MINIMUM_GAS_LIMIT},
@@ -78,6 +84,19 @@ pub trait Consensus<B: Block>: HeaderValidator<B::Header> {
     ///
     /// Note: validating blocks does not include other validations of the Consensus
     fn validate_block_pre_execution(&self, block: &SealedBlock<B>) -> Result<(), ConsensusError>;
+
+    /// Validate a block disregarding world state using an optional pre-computed transaction root.
+    ///
+    /// Implementations may use `transaction_root` to avoid recomputing the transaction trie root
+    /// from the block body. By default this falls back to [`Self::validate_block_pre_execution`].
+    fn validate_block_pre_execution_with_tx_root(
+        &self,
+        block: &SealedBlock<B>,
+        transaction_root: Option<TransactionRoot>,
+    ) -> Result<(), ConsensusError> {
+        let _ = transaction_root;
+        self.validate_block_pre_execution(block)
+    }
 }
 
 /// `HeaderValidator` is a protocol that validates headers and their relationships.

--- a/crates/consensus/consensus/src/lib.rs
+++ b/crates/consensus/consensus/src/lib.rs
@@ -87,8 +87,11 @@ pub trait Consensus<B: Block>: HeaderValidator<B::Header> {
 
     /// Validate a block disregarding world state using an optional pre-computed transaction root.
     ///
-    /// Implementations may use `transaction_root` to avoid recomputing the transaction trie root
-    /// from the block body. By default this falls back to [`Self::validate_block_pre_execution`].
+    /// If `transaction_root` is provided, the implementation should use the pre-computed
+    /// transaction root instead of recomputing it from the block body. The value must have been
+    /// derived from `block.body().calculate_tx_root()`.
+    ///
+    /// By default this falls back to [`Self::validate_block_pre_execution`].
     fn validate_block_pre_execution_with_tx_root(
         &self,
         block: &SealedBlock<B>,

--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -524,6 +524,10 @@ pub struct BlockValidationMetrics {
     pub spawn_payload_processor: Histogram,
     /// Post-execution validation duration
     pub post_execution_validation_duration: Histogram,
+    /// Time spent computing transactions root on the background task.
+    pub tx_root_task_duration: Histogram,
+    /// Time spent waiting for the transactions root task result.
+    pub tx_root_wait_duration: Histogram,
     /// Total duration of the new payload call
     pub total_duration: Histogram,
     /// Size of `HashedPostStateSorted` (`total_len`)

--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -524,10 +524,6 @@ pub struct BlockValidationMetrics {
     pub spawn_payload_processor: Histogram,
     /// Post-execution validation duration
     pub post_execution_validation_duration: Histogram,
-    /// Time spent computing transactions root on the background task.
-    pub tx_root_task_duration: Histogram,
-    /// Time spent waiting for the transactions root task result.
-    pub tx_root_wait_duration: Histogram,
     /// Total duration of the new payload call
     pub total_duration: Histogram,
     /// Size of `HashedPostStateSorted` (`total_len`)

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -292,7 +292,7 @@ where
         let block = self.convert_to_block(input)?;
 
         // Validate block consensus rules which includes header validation
-        if let Err(consensus_err) = self.validate_block_inner(&block) {
+        if let Err(consensus_err) = self.validate_block_inner(&block, None) {
             // Header validation error takes precedence over execution error
             return Err(InsertBlockError::new(block, consensus_err.into()).into())
         }
@@ -334,9 +334,10 @@ where
         V: PayloadValidator<T, Block = N::Block> + Clone,
         Evm: ConfigureEngineEvm<T::ExecutionData, Primitives = N>,
     {
-        // Spawn block conversion on a background thread so it runs concurrently with the
+        // Spawn payload conversion on a background thread so it runs concurrently with the
         // rest of the function (setup + execution). For payloads this overlaps the cost of
-        // RLP decoding + header hashing; for already-converted blocks this is a no-op.
+        // RLP decoding + header hashing and pre-computes the transaction root that is validated
+        // later in post-execution checks.
         let convert_to_block = match &input {
             BlockOrPayload::Payload(_) => {
                 let payload_clone = input.clone();
@@ -347,7 +348,9 @@ where
                         let BlockOrPayload::Payload(payload) = payload_clone else {
                             unreachable!()
                         };
-                        validator.convert_payload_to_block(payload)
+                        let block = validator.convert_payload_to_block(payload)?;
+                        let transaction_root = block.body().calculate_tx_root();
+                        Ok((block, Some(transaction_root)))
                     },
                 );
                 Either::Left(handle)
@@ -357,16 +360,18 @@ where
 
         // Returns the sealed block, either by awaiting the background conversion task (for
         // payloads) or by extracting the already-converted block directly.
-        let convert_to_block =
-            move |input: BlockOrPayload<T>| -> Result<SealedBlock<N::Block>, NewPayloadError> {
-                match convert_to_block {
-                    Either::Left(handle) => handle.try_into_inner().expect("sole handle"),
-                    Either::Right(()) => {
-                        let BlockOrPayload::Block(block) = input else { unreachable!() };
-                        Ok(block)
-                    }
+        let convert_to_block = move |input: BlockOrPayload<T>| -> Result<
+            (SealedBlock<N::Block>, Option<B256>),
+            NewPayloadError,
+        > {
+            match convert_to_block {
+                Either::Left(handle) => handle.try_into_inner().expect("sole handle"),
+                Either::Right(()) => {
+                    let BlockOrPayload::Block(block) = input else { unreachable!() };
+                    Ok((block, None))
                 }
-            };
+            }
+        };
 
         /// A helper macro that returns the block in case there was an error
         /// This macro is used for early returns before block conversion
@@ -375,7 +380,7 @@ where
                 match $expr {
                     Ok(val) => val,
                     Err(e) => {
-                        let block = convert_to_block(input)?;
+                        let (block, _) = convert_to_block(input)?;
                         return Err(InsertBlockError::new(block, e.into()).into())
                     }
                 }
@@ -406,7 +411,7 @@ where
         else {
             // this is pre-validated in the tree
             return Err(InsertBlockError::new(
-                convert_to_block(input)?,
+                convert_to_block(input)?.0,
                 ProviderError::HeaderNotFound(parent_hash.into()).into(),
             )
             .into())
@@ -419,7 +424,7 @@ where
         let Some(parent_block) = ensure_ok!(self.sealed_header_by_hash(parent_hash, ctx.state()))
         else {
             return Err(InsertBlockError::new(
-                convert_to_block(input)?,
+                convert_to_block(input)?.0,
                 ProviderError::HeaderNotFound(parent_hash.into()).into(),
             )
             .into())
@@ -527,7 +532,8 @@ where
                 hashed_state_provider.hashed_post_state(&hashed_state_output.state)
             });
 
-        let block = convert_to_block(input)?.with_senders(senders);
+        let (block, transaction_root) = convert_to_block(input)?;
+        let block = block.with_senders(senders);
 
         // Wait for the receipt root computation to complete.
         let receipt_root_bloom = receipt_root_rx
@@ -546,6 +552,7 @@ where
                 &parent_block,
                 &output,
                 &mut ctx,
+                transaction_root,
                 receipt_root_bloom,
                 hashed_state,
             ),
@@ -737,13 +744,19 @@ where
     /// Validate if block is correct and satisfies all the consensus rules that concern the header
     /// and block body itself.
     #[instrument(level = "debug", target = "engine::tree::payload_validator", skip_all)]
-    fn validate_block_inner(&self, block: &SealedBlock<N::Block>) -> Result<(), ConsensusError> {
+    fn validate_block_inner(
+        &self,
+        block: &SealedBlock<N::Block>,
+        transaction_root: Option<B256>,
+    ) -> Result<(), ConsensusError> {
         if let Err(e) = self.consensus.validate_header(block.sealed_header()) {
             error!(target: "engine::tree::payload_validator", ?block, "Failed to validate header {}: {e}", block.hash());
             return Err(e)
         }
 
-        if let Err(e) = self.consensus.validate_block_pre_execution(block) {
+        if let Err(e) =
+            self.consensus.validate_block_pre_execution_with_tx_root(block, transaction_root)
+        {
             error!(target: "engine::tree::payload_validator", ?block, "Failed to validate block {}: {e}", block.hash());
             return Err(e)
         }
@@ -1208,12 +1221,14 @@ where
     ///
     /// The `hashed_state` handle wraps the background hashed post state computation.
     #[instrument(level = "debug", target = "engine::tree::payload_validator", skip_all)]
+    #[expect(clippy::too_many_arguments)]
     fn validate_post_execution<T: PayloadTypes<BuiltPayload: BuiltPayload<Primitives = N>>>(
         &self,
         block: &RecoveredBlock<N::Block>,
         parent_block: &SealedHeader<N::BlockHeader>,
         output: &BlockExecutionOutput<N::Receipt>,
         ctx: &mut TreeCtx<'_, N>,
+        transaction_root: Option<B256>,
         receipt_root_bloom: Option<ReceiptRootBloom>,
         hashed_state: LazyHashedPostState,
     ) -> Result<LazyHashedPostState, InsertBlockErrorKind>
@@ -1224,7 +1239,7 @@ where
 
         trace!(target: "engine::tree::payload_validator", block=?block.num_hash(), "Validating block consensus");
         // validate block consensus rules
-        if let Err(e) = self.validate_block_inner(block) {
+        if let Err(e) = self.validate_block_inner(block, transaction_root) {
             return Err(e.into())
         }
 

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -52,7 +52,7 @@ use std::{
     panic::{self, AssertUnwindSafe},
     sync::{mpsc::RecvTimeoutError, Arc},
 };
-use tracing::{debug, debug_span, error, info, instrument, trace, warn};
+use tracing::{debug, debug_span, error, info, instrument, trace, warn, Span};
 
 /// Handle to a [`HashedPostState`] computed on a background thread.
 type LazyHashedPostState = reth_tasks::LazyHandle<HashedPostState>;
@@ -531,9 +531,11 @@ where
         let block = convert_to_block(input)?;
         let transaction_root = is_payload.then(|| {
             let block = block.clone();
+            let parent_span = Span::current();
+            let num_hash = block.num_hash();
             self.payload_processor.executor().spawn_blocking_named("payload-tx-root", move || {
                 let _span =
-                    debug_span!(target: "engine::tree::payload_validator", "payload_tx_root")
+                    debug_span!(target: "engine::tree::payload_validator", parent: parent_span, "payload_tx_root", block = ?num_hash)
                         .entered();
                 block.body().calculate_tx_root()
             })
@@ -541,8 +543,6 @@ where
         let block = block.with_senders(senders);
 
         // Wait for the receipt root computation to complete.
-        let _receipt_root_wait_span =
-            debug_span!(target: "engine::tree::payload_validator", "wait_receipt_root").entered();
         let receipt_root_bloom = receipt_root_rx
             .blocking_recv()
             .inspect_err(|_| {
@@ -851,11 +851,9 @@ where
         let (receipt_tx, receipt_rx) = crossbeam_channel::unbounded();
         let (result_tx, result_rx) = tokio::sync::oneshot::channel();
         let task_handle = ReceiptRootTaskHandle::new(receipt_rx, result_tx);
-        self.payload_processor.executor().spawn_blocking_named("receipt-root", move || {
-            let _span = debug_span!(target: "engine::tree::payload_validator", "receipt_root_task")
-                .entered();
-            task_handle.run(receipts_len)
-        });
+        self.payload_processor
+            .executor()
+            .spawn_blocking_named("receipt-root", move || task_handle.run(receipts_len));
 
         let transaction_count = input.transaction_count();
         let executor = executor.with_state_hook(Some(Box::new(handle.state_hook())));

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -336,8 +336,8 @@ where
     {
         // Spawn payload conversion on a background thread so it runs concurrently with the
         // rest of the function (setup + execution). For payloads this overlaps the cost of
-        // RLP decoding + header hashing and pre-computes the transaction root that is validated
-        // later in post-execution checks.
+        // RLP decoding + header hashing.
+        let is_payload = matches!(&input, BlockOrPayload::Payload(_));
         let convert_to_block = match &input {
             BlockOrPayload::Payload(_) => {
                 let payload_clone = input.clone();
@@ -348,9 +348,7 @@ where
                         let BlockOrPayload::Payload(payload) = payload_clone else {
                             unreachable!()
                         };
-                        let block = validator.convert_payload_to_block(payload)?;
-                        let transaction_root = block.body().calculate_tx_root();
-                        Ok((block, Some(transaction_root)))
+                        validator.convert_payload_to_block(payload)
                     },
                 );
                 Either::Left(handle)
@@ -360,18 +358,16 @@ where
 
         // Returns the sealed block, either by awaiting the background conversion task (for
         // payloads) or by extracting the already-converted block directly.
-        let convert_to_block = move |input: BlockOrPayload<T>| -> Result<
-            (SealedBlock<N::Block>, Option<B256>),
-            NewPayloadError,
-        > {
-            match convert_to_block {
-                Either::Left(handle) => handle.try_into_inner().expect("sole handle"),
-                Either::Right(()) => {
-                    let BlockOrPayload::Block(block) = input else { unreachable!() };
-                    Ok((block, None))
+        let convert_to_block =
+            move |input: BlockOrPayload<T>| -> Result<SealedBlock<N::Block>, NewPayloadError> {
+                match convert_to_block {
+                    Either::Left(handle) => handle.try_into_inner().expect("sole handle"),
+                    Either::Right(()) => {
+                        let BlockOrPayload::Block(block) = input else { unreachable!() };
+                        Ok(block)
+                    }
                 }
-            }
-        };
+            };
 
         /// A helper macro that returns the block in case there was an error
         /// This macro is used for early returns before block conversion
@@ -380,7 +376,7 @@ where
                 match $expr {
                     Ok(val) => val,
                     Err(e) => {
-                        let (block, _) = convert_to_block(input)?;
+                        let block = convert_to_block(input)?;
                         return Err(InsertBlockError::new(block, e.into()).into())
                     }
                 }
@@ -411,7 +407,7 @@ where
         else {
             // this is pre-validated in the tree
             return Err(InsertBlockError::new(
-                convert_to_block(input)?.0,
+                convert_to_block(input)?,
                 ProviderError::HeaderNotFound(parent_hash.into()).into(),
             )
             .into())
@@ -424,7 +420,7 @@ where
         let Some(parent_block) = ensure_ok!(self.sealed_header_by_hash(parent_hash, ctx.state()))
         else {
             return Err(InsertBlockError::new(
-                convert_to_block(input)?.0,
+                convert_to_block(input)?,
                 ProviderError::HeaderNotFound(parent_hash.into()).into(),
             )
             .into())
@@ -532,7 +528,13 @@ where
                 hashed_state_provider.hashed_post_state(&hashed_state_output.state)
             });
 
-        let (block, transaction_root) = convert_to_block(input)?;
+        let block = convert_to_block(input)?;
+        let transaction_root = is_payload.then(|| {
+            let block = block.clone();
+            self.payload_processor
+                .executor()
+                .spawn_blocking_named("payload-tx-root", move || block.body().calculate_tx_root())
+        });
         let block = block.with_senders(senders);
 
         // Wait for the receipt root computation to complete.
@@ -545,6 +547,8 @@ where
                 );
             })
             .ok();
+        let transaction_root =
+            transaction_root.map(|handle| handle.try_into_inner().expect("sole handle"));
 
         let hashed_state = ensure_ok_post_block!(
             self.validate_post_execution(

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -530,10 +530,19 @@ where
 
         let block = convert_to_block(input)?;
         let transaction_root = is_payload.then(|| {
+            let block_validation_metrics = self.metrics.block_validation.clone();
             let block = block.clone();
-            self.payload_processor
-                .executor()
-                .spawn_blocking_named("payload-tx-root", move || block.body().calculate_tx_root())
+            self.payload_processor.executor().spawn_blocking_named("payload-tx-root", move || {
+                let _span =
+                    debug_span!(target: "engine::tree::payload_validator", "payload_tx_root")
+                        .entered();
+                let start = Instant::now();
+                let tx_root = block.body().calculate_tx_root();
+                block_validation_metrics
+                    .tx_root_task_duration
+                    .record(start.elapsed().as_secs_f64());
+                tx_root
+            })
         });
         let block = block.with_senders(senders);
 
@@ -547,8 +556,18 @@ where
                 );
             })
             .ok();
-        let transaction_root =
-            transaction_root.map(|handle| handle.try_into_inner().expect("sole handle"));
+        let transaction_root = transaction_root.map(|handle| {
+            let _span =
+                debug_span!(target: "engine::tree::payload_validator", "wait_payload_tx_root")
+                    .entered();
+            let start = Instant::now();
+            let tx_root = handle.try_into_inner().expect("sole handle");
+            self.metrics
+                .block_validation
+                .tx_root_wait_duration
+                .record(start.elapsed().as_secs_f64());
+            tx_root
+        });
 
         let hashed_state = ensure_ok_post_block!(
             self.validate_post_execution(

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -530,23 +530,19 @@ where
 
         let block = convert_to_block(input)?;
         let transaction_root = is_payload.then(|| {
-            let block_validation_metrics = self.metrics.block_validation.clone();
             let block = block.clone();
             self.payload_processor.executor().spawn_blocking_named("payload-tx-root", move || {
                 let _span =
                     debug_span!(target: "engine::tree::payload_validator", "payload_tx_root")
                         .entered();
-                let start = Instant::now();
-                let tx_root = block.body().calculate_tx_root();
-                block_validation_metrics
-                    .tx_root_task_duration
-                    .record(start.elapsed().as_secs_f64());
-                tx_root
+                block.body().calculate_tx_root()
             })
         });
         let block = block.with_senders(senders);
 
         // Wait for the receipt root computation to complete.
+        let _receipt_root_wait_span =
+            debug_span!(target: "engine::tree::payload_validator", "wait_receipt_root").entered();
         let receipt_root_bloom = receipt_root_rx
             .blocking_recv()
             .inspect_err(|_| {
@@ -560,13 +556,7 @@ where
             let _span =
                 debug_span!(target: "engine::tree::payload_validator", "wait_payload_tx_root")
                     .entered();
-            let start = Instant::now();
-            let tx_root = handle.try_into_inner().expect("sole handle");
-            self.metrics
-                .block_validation
-                .tx_root_wait_duration
-                .record(start.elapsed().as_secs_f64());
-            tx_root
+            handle.try_into_inner().expect("sole handle")
         });
 
         let hashed_state = ensure_ok_post_block!(
@@ -861,9 +851,11 @@ where
         let (receipt_tx, receipt_rx) = crossbeam_channel::unbounded();
         let (result_tx, result_rx) = tokio::sync::oneshot::channel();
         let task_handle = ReceiptRootTaskHandle::new(receipt_rx, result_tx);
-        self.payload_processor
-            .executor()
-            .spawn_blocking_named("receipt-root", move || task_handle.run(receipts_len));
+        self.payload_processor.executor().spawn_blocking_named("receipt-root", move || {
+            let _span = debug_span!(target: "engine::tree::payload_validator", "receipt_root_task")
+                .entered();
+            task_handle.run(receipts_len)
+        });
 
         let transaction_count = input.transaction_count();
         let executor = executor.with_state_hook(Some(Box::new(handle.state_hook())));

--- a/crates/ethereum/consensus/src/lib.rs
+++ b/crates/ethereum/consensus/src/lib.rs
@@ -15,13 +15,16 @@ use alloc::{fmt::Debug, sync::Arc};
 use alloy_consensus::{constants::MAXIMUM_EXTRA_DATA_SIZE, EMPTY_OMMER_ROOT_HASH};
 use alloy_eips::eip7840::BlobParams;
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
-use reth_consensus::{Consensus, ConsensusError, FullConsensus, HeaderValidator, ReceiptRootBloom};
+use reth_consensus::{
+    Consensus, ConsensusError, FullConsensus, HeaderValidator, ReceiptRootBloom, TransactionRoot,
+};
 use reth_consensus_common::validation::{
     validate_4844_header_standalone, validate_against_parent_4844,
     validate_against_parent_eip1559_base_fee, validate_against_parent_gas_limit,
     validate_against_parent_hash_number, validate_against_parent_timestamp,
-    validate_block_pre_execution, validate_body_against_header, validate_header_base_fee,
-    validate_header_extra_data, validate_header_gas,
+    validate_block_pre_execution, validate_block_pre_execution_with_tx_root,
+    validate_body_against_header, validate_header_base_fee, validate_header_extra_data,
+    validate_header_gas,
 };
 use reth_execution_types::BlockExecutionResult;
 use reth_primitives_traits::{
@@ -101,6 +104,14 @@ where
 
     fn validate_block_pre_execution(&self, block: &SealedBlock<B>) -> Result<(), ConsensusError> {
         validate_block_pre_execution(block, &self.chain_spec)
+    }
+
+    fn validate_block_pre_execution_with_tx_root(
+        &self,
+        block: &SealedBlock<B>,
+        transaction_root: Option<TransactionRoot>,
+    ) -> Result<(), ConsensusError> {
+        validate_block_pre_execution_with_tx_root(block, &self.chain_spec, transaction_root)
     }
 }
 


### PR DESCRIPTION
**Summary**

Precompute `transactions_root` off the engine thread so tx-root trie construction overlaps other work instead of blocking `validate_post_execution`.

**Motivation**

Traces on a 200-block bench (blocks 24485390→24485589, 6B gas) show `calculate_tx_root` takes ~0.45ms median inside `validate_block_inner` on the engine thread. Since tx-root is a pure function of the transaction list (no state dependency), it can be computed off-thread during payload conversion and reused in post-execution validation.

**Changes**

- Add `validate_block_pre_execution_with_tx_root` to `Consensus` trait + `reth-consensus-common` + `EthBeaconConsensus` — accepts an optional precomputed tx-root to skip recomputation
- In `payload_validator`: spawn tx-root computation off-thread after payload viability checks pass, pass result into post-execution validation
- Default path unchanged — `Block` input without precomputed root still recomputes

**Testing**

```
cargo test -p reth-consensus-common -p reth-engine-tree --lib
```

<details>
<summary><b>Appendix: Trace Data</b></summary>

**newPayload latency** (200 blocks, 0.77 Ggas/s):

| Percentile | Latency |
|---|---|
| min | 12.1ms |
| p50 | 34.0ms |
| p90 | 57.5ms |
| p95 | 71.1ms |
| max | 156.1ms |

**Post-execution spans on engine thread** (50-block sample):

| Span | Median | Mean | P95 | Max |
|---|---|---|---|---|
| `validate_post_execution` | 0.71ms | 0.91ms | — | — |
| `validate_block_inner` | 0.45ms | 0.61ms | — | — |
| `calculate_tx_root` | ~0.45ms | — | — | — |
| `merge_transitions` | 0.35ms | 0.37ms | 0.71ms | 0.85ms |
| `receipt_root` (background) | 23.6ms | 27.2ms | 51.0ms | 131.8ms |
| `hashed_post_state` (background) | 0.25ms | 0.30ms | 0.52ms | 4.0ms |

</details>
