### PR TITLE
fix: handle EIP-7778 gas accounting mismatch in payload builder

### DIFF
--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -331,6 +331,25 @@ where
                 }
                 continue
             }
+            // EIP-7778: the executor tracks gas_before_refund while the payload builder's
+            // pre-check uses gas_after_refund. Near-full blocks can pass the pre-check but
+            // fail the executor's check. Skip the tx and continue building.
+            Err(BlockExecutionError::Validation(
+                BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas {
+                    transaction_gas_limit,
+                    block_available_gas,
+                },
+            )) => {
+                trace!(target: "payload_builder", %transaction_gas_limit, %block_available_gas, ?tx, "skipping transaction exceeding block gas limit");
+                best_txs.mark_invalid(
+                    &pool_tx,
+                    &InvalidPoolTransactionError::ExceedsGasLimit(
+                        transaction_gas_limit,
+                        block_available_gas,
+                    ),
+                );
+                continue
+            }
             // this is an error that we should treat as fatal for this attempt
             Err(err) => return Err(PayloadBuilderError::evm(err)),
         };


### PR DESCRIPTION
## Problem

Under EIP-7778 (Amsterdam), two independent gas counters diverge in the payload builder:

| Counter | Location | Tracks | Used For |
|---------|----------|--------|----------|
| `cumulative_gas_used` | payload builder pre-check (lib.rs:225) | gas_after_refund | filtering txs before execution |
| `self.gas_used` | EthBlockExecutor (alloy-evm block.rs) | gas_before_refund (EIP-7778) | executor validation |

On near-full blocks (~79M/80M gas), the accumulated refund gap (~35K-57K gas) causes a transaction to pass the payload builder's pre-check but fail the executor's gas limit check, returning `TransactionGasLimitMoreThanAvailableBlockGas`. This was previously treated as a **fatal error**, aborting the entire payload build and discarding all ~287 already-executed transactions — causing missed slots.

## Observed Impact

- **bal-devnet-2 slots 87073 and 87074 missed** — both reth nodes failed to produce blocks
- Block 76574 was a near-full block (79.16M / 80M gas, 287 txs)
- Both reth nodes tried to build block 76575 with the same pool txs
- After re-executing ~287 txs, the next tx caused the fatal mismatch
- Another node eventually produced an empty block for slot 87075

## Fix

Catches `TransactionGasLimitMoreThanAvailableBlockGas` as a **soft error**: marks the tx as invalid (removing it and dependents from the pool iterator), skips it, and continues building the block with already-executed transactions.

The existing pre-check at line 225 still works as an optimization for the common case — the edge-case mismatch near block gas limits is now safely handled by the executor's authoritative check.

## Reproduction

The bug triggers reliably with the spamoor `storagerefundtx` scenario at epoch 1+ on bal-devnet-2.