### PR TITLE
feat(rpc): accept optional timeout parameter in eth_sendRawTransactionSync per EIP-7966

### DIFF
--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -374,7 +374,7 @@ pub trait EthApi<
     async fn send_raw_transaction_sync(
         &self,
         bytes: Bytes,
-        timeout_ms: Option<u64>,
+        timeout_ms: Option<U64>,
     ) -> RpcResult<R>;
 
     /// Returns an Ethereum specific signature with: sign(keccak256("\x19Ethereum Signed Message:\n"
@@ -878,7 +878,7 @@ where
     async fn send_raw_transaction_sync(
         &self,
         tx: Bytes,
-        timeout_ms: Option<u64>,
+        timeout_ms: Option<U64>,
     ) -> RpcResult<RpcReceipt<T::NetworkTypes>> {
         trace!(target: "rpc::eth", ?tx, ?timeout_ms, "Serving eth_sendRawTransactionSync");
         Ok(EthTransactions::send_raw_transaction_sync(self, tx, timeout_ms).await?)

--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -367,8 +367,15 @@ pub trait EthApi<
     /// Sends a signed transaction and awaits the transaction receipt.
     ///
     /// This will return a timeout error if the transaction isn't included within some time period.
+    ///
+    /// An optional `timeout_ms` parameter (in milliseconds) allows the client to specify a
+    /// per-request timeout, which is capped by the server-configured maximum.
     #[method(name = "sendRawTransactionSync")]
-    async fn send_raw_transaction_sync(&self, bytes: Bytes) -> RpcResult<R>;
+    async fn send_raw_transaction_sync(
+        &self,
+        bytes: Bytes,
+        timeout_ms: Option<u64>,
+    ) -> RpcResult<R>;
 
     /// Returns an Ethereum specific signature with: sign(keccak256("\x19Ethereum Signed Message:\n"
     /// + len(message) + message))).
@@ -868,9 +875,13 @@ where
     }
 
     /// Handler for: `eth_sendRawTransactionSync`
-    async fn send_raw_transaction_sync(&self, tx: Bytes) -> RpcResult<RpcReceipt<T::NetworkTypes>> {
-        trace!(target: "rpc::eth", ?tx, "Serving eth_sendRawTransactionSync");
-        Ok(EthTransactions::send_raw_transaction_sync(self, tx).await?)
+    async fn send_raw_transaction_sync(
+        &self,
+        tx: Bytes,
+        timeout_ms: Option<u64>,
+    ) -> RpcResult<RpcReceipt<T::NetworkTypes>> {
+        trace!(target: "rpc::eth", ?tx, ?timeout_ms, "Serving eth_sendRawTransactionSync");
+        Ok(EthTransactions::send_raw_transaction_sync(self, tx, timeout_ms).await?)
     }
 
     /// Handler for: `eth_sign`

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -14,7 +14,7 @@ use alloy_consensus::{
 use alloy_dyn_abi::TypedData;
 use alloy_eips::{eip2718::Encodable2718, BlockId};
 use alloy_network::{TransactionBuilder, TransactionBuilder4844};
-use alloy_primitives::{Address, Bytes, TxHash, B256, U256};
+use alloy_primitives::{Address, Bytes, TxHash, B256, U256, U64};
 use alloy_rpc_types_eth::{BlockNumberOrTag, TransactionInfo};
 use futures::{Future, StreamExt};
 use reth_chain_state::CanonStateSubscriptions;
@@ -102,7 +102,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
     fn send_raw_transaction_sync(
         &self,
         tx: Bytes,
-        timeout_ms: Option<u64>,
+        timeout_ms: Option<U64>,
     ) -> impl Future<Output = Result<RpcReceipt<Self::NetworkTypes>, Self::Error>> + Send
     where
         Self: LoadReceipt + 'static,
@@ -110,7 +110,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
         let this = self.clone();
         let server_max = self.send_raw_transaction_sync_timeout();
         let timeout_duration = match timeout_ms {
-            Some(ms) => server_max.min(Duration::from_millis(ms)),
+            Some(ms) => server_max.min(Duration::from_millis(ms.to::<u64>())),
             None => server_max,
         };
         async move {

--- a/crates/rpc/rpc-eth-types/src/builder/config.rs
+++ b/crates/rpc/rpc-eth-types/src/builder/config.rs
@@ -103,7 +103,8 @@ pub struct EthConfig {
     pub pending_block_kind: PendingBlockKind,
     /// The raw transaction forwarder.
     pub raw_tx_forwarder: ForwardConfig,
-    /// Timeout duration for `send_raw_transaction_sync` RPC method.
+    /// Max timeout duration for `send_raw_transaction_sync` RPC method.
+    /// Client-requested timeouts are capped to this value.
     pub send_raw_transaction_sync_timeout: Duration,
     /// Maximum memory the EVM can allocate per RPC request.
     pub rpc_evm_memory_limit: u64,

--- a/crates/rpc/rpc-server-types/src/constants.rs
+++ b/crates/rpc/rpc-server-types/src/constants.rs
@@ -68,7 +68,10 @@ pub const DEFAULT_TX_FEE_CAP_WEI: u128 = 1_000_000_000_000_000_000u128;
 /// second block time, and a month on a 2 second block time.
 pub const MAX_ETH_PROOF_WINDOW: u64 = 28 * 24 * 60 * 60 / 2;
 
-/// Default timeout for send raw transaction sync in seconds.
+/// Default max timeout for send raw transaction sync in seconds.
+///
+/// This serves as an upper bound; clients may request a shorter timeout via the optional
+/// `timeout_ms` parameter per EIP-7966.
 pub const RPC_DEFAULT_SEND_RAW_TX_SYNC_TIMEOUT_SECS: Duration = Duration::from_secs(30);
 
 /// GPO specific constants


### PR DESCRIPTION
The current eth_sendRawTransactionSync signature only accepts the raw tx bytes. Clients following EIP-7966 that send a second timeout_ms parameter (e.g. params: ["0xf86c...", 5000]) get an invalid params error from jsonrpsee because the arity doesn't match.

This adds the optional timeout_ms parameter and caps it against the server-configured max:


effective_timeout = min(client_timeout_ms, server_max_timeout)
When omitted, behavior is unchanged — the server default (30s) applies. When provided, the client can request a shorter wait but never exceed the server cap.

Note: EIP-7966 is still in Draft status, but since we already ships eth_sendRawTransactionSync, we should match the spec's actual interface to avoid breaking compliant callers.