### PR TITLE
chore: release 1.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3300,7 +3300,7 @@ dependencies = [
 
 [[package]]
 name = "ef-test-runner"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "clap",
  "ef-tests",
@@ -3308,7 +3308,7 @@ dependencies = [
 
 [[package]]
 name = "ef-tests"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3749,7 +3749,7 @@ dependencies = [
 
 [[package]]
 name = "example-full-contract-state"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -3894,7 +3894,7 @@ dependencies = [
 
 [[package]]
 name = "exex-subscription"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -7545,7 +7545,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-node-bindings",
  "alloy-primitives",
@@ -7593,7 +7593,7 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7616,7 +7616,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bench"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7663,7 +7663,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bench-compare"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -7691,7 +7691,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7724,7 +7724,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7744,7 +7744,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7757,7 +7757,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7844,7 +7844,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7853,7 +7853,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7874,7 +7874,7 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7898,7 +7898,7 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7908,7 +7908,7 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -7926,7 +7926,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7938,7 +7938,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7952,7 +7952,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7977,7 +7977,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8013,7 +8013,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8044,7 +8044,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8075,7 +8075,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8091,7 +8091,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8117,7 +8117,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8142,7 +8142,7 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8170,7 +8170,7 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8208,7 +8208,7 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8264,7 +8264,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8291,7 +8291,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8314,7 +8314,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8338,7 +8338,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8410,7 +8410,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8437,7 +8437,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8459,7 +8459,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8477,7 +8477,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8503,7 +8503,7 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8513,7 +8513,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8551,7 +8551,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8576,7 +8576,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8616,7 +8616,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "clap",
  "eyre",
@@ -8639,7 +8639,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8655,7 +8655,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8673,7 +8673,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks 0.4.7",
@@ -8686,7 +8686,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8714,7 +8714,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8735,7 +8735,7 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "rayon",
@@ -8745,7 +8745,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8769,7 +8769,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8793,7 +8793,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8805,7 +8805,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8825,7 +8825,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8870,7 +8870,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-test-utils"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-eips",
  "eyre",
@@ -8901,7 +8901,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8918,7 +8918,7 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -8927,7 +8927,7 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8960,7 +8960,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "bytes",
  "futures",
@@ -8982,7 +8982,7 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -9000,7 +9000,7 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "bindgen",
  "cc",
@@ -9008,7 +9008,7 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "futures",
  "metrics",
@@ -9019,7 +9019,7 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9027,7 +9027,7 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9041,7 +9041,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9103,7 +9103,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9127,7 +9127,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9149,7 +9149,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9166,7 +9166,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9179,7 +9179,7 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -9197,7 +9197,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9220,7 +9220,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9291,7 +9291,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9348,7 +9348,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -9408,7 +9408,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9431,7 +9431,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9454,7 +9454,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "bytes",
  "eyre",
@@ -9483,7 +9483,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9494,7 +9494,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9514,7 +9514,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9525,7 +9525,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9548,7 +9548,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-util"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9557,7 +9557,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9566,11 +9566,11 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives"
-version = "1.11.0"
+version = "1.11.1"
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9609,7 +9609,7 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9659,7 +9659,7 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9692,11 +9692,11 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-db"
-version = "1.11.0"
+version = "1.11.1"
 
 [[package]]
 name = "reth-prune-types"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9716,7 +9716,7 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9730,7 +9730,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9810,7 +9810,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -9841,7 +9841,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api-testing-util"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9860,7 +9860,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -9916,7 +9916,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9938,7 +9938,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-e2e-tests"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-genesis",
  "alloy-rpc-types-engine",
@@ -9958,7 +9958,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9994,7 +9994,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10037,7 +10037,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10085,7 +10085,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -10102,7 +10102,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10117,7 +10117,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10179,7 +10179,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10212,7 +10212,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10228,7 +10228,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "assert_matches",
@@ -10251,7 +10251,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10269,7 +10269,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10292,7 +10292,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10308,7 +10308,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-rpc-provider"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10337,7 +10337,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10356,7 +10356,7 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10372,7 +10372,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10381,7 +10381,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "clap",
  "eyre",
@@ -10399,7 +10399,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "clap",
  "eyre",
@@ -10416,7 +10416,7 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10467,7 +10467,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10501,7 +10501,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -10534,7 +10534,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10565,7 +10565,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10594,7 +10594,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10627,7 +10627,7 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.11.0"
+version = "1.11.1"
 edition = "2024"
 rust-version = "1.93"
 license = "MIT OR Apache-2.0"

--- a/docs/vocs/vocs.config.ts
+++ b/docs/vocs/vocs.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
     },
     { text: 'GitHub', link: 'https://github.com/paradigmxyz/reth' },
     {
-      text: 'v1.11.0',
+      text: 'v1.11.1',
       items: [
         {
           text: 'Releases',


### PR DESCRIPTION
Preparing the release candidate and tag for version 1.11.1.

## Changes
- Bump workspace version to `1.11.1`
- Update docs version in `vocs.config.ts`
- Update `Cargo.lock`