### PR TITLE
chore(storage): propagate span context across rayon thread boundaries

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -566,9 +566,13 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
 
         // Write to all backends in parallel.
         let runtime = &self.runtime;
+        // Propagate tracing context into rayon-spawned threads so that static file
+        // and RocksDB write spans appear as children of save_blocks in traces.
+        let span = tracing::Span::current();
         runtime.storage_pool().in_place_scope(|s| {
             // SF writes
             s.spawn(|_| {
+                let _guard = span.enter();
                 let start = Instant::now();
                 sf_result = Some(
                     sf_provider
@@ -581,6 +585,7 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
             #[cfg(all(unix, feature = "rocksdb"))]
             if rocksdb_enabled {
                 s.spawn(|_| {
+                    let _guard = span.enter();
                     let start = Instant::now();
                     rocksdb_result = Some(
                         rocksdb_provider

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -1224,21 +1224,27 @@ impl RocksDBProvider {
         let write_account_history = ctx.storage_settings.storage_v2;
         let write_storage_history = ctx.storage_settings.storage_v2;
 
+        // Propagate tracing context into rayon-spawned threads so that RocksDB
+        // write spans appear as children of write_blocks_data in traces.
+        let span = tracing::Span::current();
         runtime.storage_pool().in_place_scope(|s| {
             if write_tx_hash {
                 s.spawn(|_| {
+                    let _guard = span.enter();
                     r_tx_hash = Some(self.write_tx_hash_numbers(blocks, tx_nums, &ctx));
                 });
             }
 
             if write_account_history {
                 s.spawn(|_| {
+                    let _guard = span.enter();
                     r_account_history = Some(self.write_account_history(blocks, &ctx));
                 });
             }
 
             if write_storage_history {
                 s.spawn(|_| {
+                    let _guard = span.enter();
                     r_storage_history = Some(self.write_storage_history(blocks, &ctx));
                 });
             }


### PR DESCRIPTION
## Summary
Rayon-spawned threads in storage write operations were losing tracing context, causing static file and RocksDB write spans to appear as disconnected root traces in Tempo instead of as children of `on_save_blocks`. This fix captures the current span before entering `in_place_scope` and re-enters it in each spawned closure to preserve the trace hierarchy.

## Changes
- Propagate span context in `save_blocks()` for static file and RocksDB writes
- Propagate span context in RocksDB's `write_blocks_data()` for history writes
- Propagate span context in static file's `write_blocks_data()` for all segment writes
- Add `#[instrument]` to `write_segment()` with segment field for improved observability

🤖 Generated with [Claude Code](https://claude.com/claude-code)