### PR TITLE
chore(release-builds): remove the riscv builds from release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,10 +85,6 @@ jobs:
             os: macos-14
             profile: maxperf
             allow_fail: false
-          - target: riscv64gc-unknown-linux-gnu
-            os: ubuntu-24.04
-            profile: maxperf
-            allow_fail: true
         build:
           - command: build
             binary: reth


### PR DESCRIPTION
chore(release-builds): remove the riscv builds from release pipeline