### PR TITLE
fix(net): terminate discv4 background task when discv5 initialization fails

### DIFF
--- a/crates/net/network/src/discovery.rs
+++ b/crates/net/network/src/discovery.rs
@@ -84,7 +84,9 @@ impl Discovery {
             NodeRecord::from_secret_key(discovery_v4_addr, &sk).with_tcp_port(tcp_addr.port());
 
         let discv4_future = async {
-            let Some(disc_config) = discv4_config else { return Ok((None, None, None)) };
+            let Some(disc_config) = discv4_config else {
+                return Ok::<_, NetworkError>((None, None, None));
+            };
             let (discv4, mut discv4_service) =
                 Discv4::bind(discovery_v4_addr, local_enr, sk, disc_config).await.map_err(
                     |err| {

--- a/crates/net/network/src/discovery.rs
+++ b/crates/net/network/src/discovery.rs
@@ -107,8 +107,18 @@ impl Discovery {
             Ok((Some(discv5), Some(discv5_updates.into())))
         };
 
-        let ((discv4, discv4_updates, _discv4_service), (discv5, discv5_updates)) =
-            tokio::try_join!(discv4_future, discv5_future)?;
+        let (discv4_result, discv5_result) = tokio::join!(discv4_future, discv5_future);
+
+        // If one succeeds but the other fails, we must clean up the successful one's resources
+        // before returning the error — otherwise spawned background tasks and bound sockets leak.
+        if discv5_result.is_err() {
+            if let Ok((Some(discv4), _, _)) = &discv4_result {
+                discv4.terminate();
+            }
+        }
+
+        let (discv4, discv4_updates, _discv4_service) = discv4_result?;
+        let (discv5, discv5_updates) = discv5_result?;
 
         // setup DNS discovery
         let (_dns_discovery, dns_discovery_updates, _dns_disc_service) =


### PR DESCRIPTION
- Fix resource leak where discv4 background tasks and UDP socket persist indefinitely when discv5 initialization fails
- Replace tokio::try_join! with tokio::join! in Discovery::new so we can inspect individual results and clean up on partial failure
- Explicitly call discv4.terminate() before returning the error, which sends Discv4Command::Terminated to gracefully shut down the spawned service