### PR TITLE
fix: don't produce both updates and removals for trie nodes

### DIFF
--- a/.changelog/tidy-stars-cry.md
+++ b/.changelog/tidy-stars-cry.md
@@ -1,0 +1,5 @@
+---
+reth-trie-sparse: patch
+---
+
+Fixed a bug where trie nodes could appear in both `updated_nodes` and `removed_nodes` simultaneously by removing entries from `removed_nodes` when a node is inserted as updated.

--- a/crates/trie/sparse/src/parallel.rs
+++ b/crates/trie/sparse/src/parallel.rs
@@ -1875,6 +1875,7 @@ impl ParallelSparseTrie {
                     }
                     SparseTrieUpdatesAction::InsertUpdated(path, branch_node) => {
                         updates.updated_nodes.insert(path, branch_node);
+                        updates.removed_nodes.remove(&path);
                     }
                 }
             }


### PR DESCRIPTION
if a node is getting removed during one of the root computations but then gets recreated and is recorded as an update, we will end up recording both its update and removal. this will result in it being removed from `branch_node_masks` even though it should be kept for it to stay consistent