### PR TITLE
fix(net): defer deserialization of P2P responses until request_id validation

### DIFF
--- a/crates/net/eth-wire-types/src/lib.rs
+++ b/crates/net/eth-wire-types/src/lib.rs
@@ -18,7 +18,10 @@ pub mod version;
 pub use version::{EthVersion, ProtocolVersion};
 
 pub mod message;
-pub use message::{EthMessage, EthMessageID, ProtocolMessage};
+pub use message::{
+    DeferredResponseData, EthMessage, EthMessageID, ProtocolMessage,
+    extract_response_request_id,
+};
 
 pub mod header;
 pub use header::*;

--- a/crates/net/eth-wire-types/src/lib.rs
+++ b/crates/net/eth-wire-types/src/lib.rs
@@ -19,8 +19,7 @@ pub use version::{EthVersion, ProtocolVersion};
 
 pub mod message;
 pub use message::{
-    DeferredResponseData, EthMessage, EthMessageID, ProtocolMessage,
-    extract_response_request_id,
+    extract_response_request_id, DeferredResponseData, EthMessage, EthMessageID, ProtocolMessage,
 };
 
 pub mod header;

--- a/crates/net/eth-wire-types/src/message.rs
+++ b/crates/net/eth-wire-types/src/message.rs
@@ -17,10 +17,7 @@ use crate::{
     RawCapabilityMessage, Receipts69, Receipts70, SharedTransactions,
 };
 use alloc::{boxed::Box, string::String, sync::Arc};
-use alloy_primitives::{
-    bytes::{Buf, BufMut},
-    Bytes,
-};
+use alloy_primitives::bytes::{Buf, BufMut, Bytes};
 use alloy_rlp::{length_of_length, Decodable, Encodable, Header};
 use core::fmt::Debug;
 
@@ -43,6 +40,39 @@ pub enum MessageError {
     /// Other message error with custom message
     #[error("{0}")]
     Other(String),
+}
+
+/// Holds pre-extracted metadata and raw bytes for a response message whose full deserialization
+/// has been deferred.
+///
+/// When a peer sends a response (e.g. `BlockBodies`, `PooledTransactions`), we first extract only
+/// the lightweight envelope — the message ID and `request_id` — without decoding the potentially
+/// large payload. The session layer then validates the `request_id` against pending inflight
+/// requests *before* committing to the expensive full RLP decode. This prevents a `DoS` vector where
+/// an attacker sends large responses with bogus `request_id` values, forcing the node to allocate
+/// and immediately discard up to ~40 MB of heap per message.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DeferredResponseData {
+    /// The response message type ID.
+    pub message_id: EthMessageID,
+    /// The pre-extracted `request_id` from the [`RequestPair`] wrapper.
+    pub request_id: u64,
+    /// The protocol version needed for correct decoding.
+    pub version: EthVersion,
+    /// The complete raw message bytes (including the leading message-ID byte).
+    pub raw_bytes: Bytes,
+}
+
+impl DeferredResponseData {
+    /// Fully decodes the deferred response message.
+    ///
+    /// This should only be called after the `request_id` has been validated against pending
+    /// inflight requests.
+    pub fn decode_full<N: NetworkPrimitives>(self) -> Result<EthMessage<N>, MessageError> {
+        let mut buf: &[u8] = &self.raw_bytes;
+        let msg = ProtocolMessage::<N>::decode_message_full(self.version, &mut buf)?;
+        Ok(msg.message)
+    }
 }
 
 /// An `eth` protocol message, containing a message ID and payload.
@@ -83,10 +113,49 @@ impl<N: NetworkPrimitives> ProtocolMessage<N> {
         Ok(status)
     }
 
-    /// Create a new `ProtocolMessage` from a message type and message rlp bytes.
+    /// Create a new `ProtocolMessage` from a message type and message RLP bytes.
     ///
-    /// This will enforce decoding according to the given [`EthVersion`] of the connection.
+    /// For response messages (those carrying a `request_id` in a [`RequestPair`] wrapper),
+    /// this performs only a lightweight extraction of the message ID and `request_id` — at most
+    /// 19 bytes of RLP parsing — and returns a [`EthMessage::DeferredResponse`]. The caller
+    /// (typically the session layer) should validate the `request_id` against pending inflight
+    /// requests before calling [`DeferredResponseData::decode_full`] to complete the expensive
+    /// deserialization.
+    ///
+    /// Non-response messages (status, broadcasts, requests) are fully decoded immediately.
     pub fn decode_message(version: EthVersion, buf: &mut &[u8]) -> Result<Self, MessageError> {
+        let original_buf = *buf;
+
+        // For response messages, defer full deserialization: extract only the message ID
+        // and request_id so the session layer can validate before paying the decode cost.
+        match extract_response_request_id(version, original_buf) {
+            Ok(Some((message_id, request_id))) => {
+                // Advance the caller's buffer past the entire message
+                *buf = &[];
+                return Ok(Self {
+                    message_type: message_id,
+                    message: EthMessage::DeferredResponse(DeferredResponseData {
+                        message_id,
+                        request_id,
+                        version,
+                        raw_bytes: Bytes::copy_from_slice(original_buf),
+                    }),
+                });
+            }
+            Ok(None) => {
+                // Not a response — fall through to full decode below
+            }
+            Err(e) => return Err(e),
+        }
+
+        Self::decode_message_full(version, buf)
+    }
+
+    /// Fully decodes a protocol message without deferred-response optimisation.
+    ///
+    /// Used internally to complete the decode of a [`DeferredResponseData`] after its
+    /// `request_id` has been validated, and as the regular decode path for non-response messages.
+    pub fn decode_message_full(version: EthVersion, buf: &mut &[u8]) -> Result<Self, MessageError> {
         let message_type = EthMessageID::decode(buf)?;
 
         // For EIP-7642 (https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7642.md):
@@ -191,6 +260,48 @@ impl<N: NetworkPrimitives> ProtocolMessage<N> {
         };
         Ok(Self { message_type, message })
     }
+}
+
+/// Extracts the `request_id` from a response message's raw bytes without full deserialization.
+///
+/// Returns `Ok(Some((message_id, request_id)))` for response messages, `Ok(None)` for
+/// non-response messages (broadcasts, requests, status). The bytes should start with the
+/// 1-byte [`EthMessageID`], followed by the RLP-encoded [`RequestPair`]:
+/// `[list_header][u64 request_id][payload]`.
+///
+/// Total parsing cost: at most 19 bytes (1 msg ID + 9 list header + 9 u64), regardless of
+/// message size.
+pub fn extract_response_request_id(
+    version: EthVersion,
+    bytes: &[u8],
+) -> Result<Option<(EthMessageID, u64)>, MessageError> {
+    if bytes.is_empty() {
+        return Err(MessageError::RlpError(alloy_rlp::Error::InputTooShort));
+    }
+
+    let mut buf = bytes;
+    let message_id = EthMessageID::decode(&mut buf)?;
+
+    if !message_id.is_response() {
+        return Ok(None);
+    }
+
+    // Version-gating: reject message IDs that are invalid for this protocol version
+    match message_id {
+        EthMessageID::NodeData if version >= EthVersion::Eth67 => {
+            return Err(MessageError::Invalid(version, message_id));
+        }
+        EthMessageID::BlockAccessLists if version < EthVersion::Eth71 => {
+            return Err(MessageError::Invalid(version, message_id));
+        }
+        _ => {}
+    }
+
+    // Decode only the RLP list header and the u64 request_id from the RequestPair envelope
+    let _header = Header::decode(&mut buf)?;
+    let request_id = u64::decode(&mut buf)?;
+
+    Ok(Some((message_id, request_id)))
 }
 
 impl<N: NetworkPrimitives> Encodable for ProtocolMessage<N> {
@@ -356,6 +467,10 @@ pub enum EthMessage<N: NetworkPrimitives = EthNetworkPrimitives> {
         serde(bound = "N::BroadcastedTransaction: serde::Serialize + serde::de::DeserializeOwned")
     )]
     BlockRangeUpdate(BlockRangeUpdate),
+    /// A response message where only the `request_id` has been extracted; full deserialization is
+    /// deferred until the session layer validates the `request_id` against inflight requests.
+    #[cfg_attr(feature = "serde", serde(skip))]
+    DeferredResponse(DeferredResponseData),
     /// Represents an encoded message that doesn't match any other variant
     Other(RawCapabilityMessage),
 }
@@ -384,6 +499,7 @@ impl<N: NetworkPrimitives> EthMessage<N> {
             Self::BlockRangeUpdate(_) => EthMessageID::BlockRangeUpdate,
             Self::GetBlockAccessLists(_) => EthMessageID::GetBlockAccessLists,
             Self::BlockAccessLists(_) => EthMessageID::BlockAccessLists,
+            Self::DeferredResponse(data) => data.message_id,
             Self::Other(msg) => EthMessageID::Other(msg.id as u8),
         }
     }
@@ -413,7 +529,8 @@ impl<N: NetworkPrimitives> EthMessage<N> {
                 Self::BlockAccessLists(_) |
                 Self::BlockHeaders(_) |
                 Self::BlockBodies(_) |
-                Self::NodeData(_)
+                Self::NodeData(_) |
+                Self::DeferredResponse(_)
         )
     }
 
@@ -471,6 +588,11 @@ impl<N: NetworkPrimitives> Encodable for EthMessage<N> {
             Self::Receipts70(receipt70) => receipt70.encode(out),
             Self::BlockAccessLists(block_access_lists) => block_access_lists.encode(out),
             Self::BlockRangeUpdate(block_range_update) => block_range_update.encode(out),
+            Self::DeferredResponse(data) => {
+                // Write the raw payload bytes (everything after the message-ID byte which
+                // is prepended by ProtocolMessage::encode).
+                out.put_slice(&data.raw_bytes[1..]);
+            }
             Self::Other(unknown) => out.put_slice(&unknown.payload),
         }
     }
@@ -498,6 +620,8 @@ impl<N: NetworkPrimitives> Encodable for EthMessage<N> {
             Self::Receipts70(receipt70) => receipt70.length(),
             Self::BlockAccessLists(block_access_lists) => block_access_lists.length(),
             Self::BlockRangeUpdate(block_range_update) => block_range_update.length(),
+            // raw_bytes includes the 1-byte message ID; ProtocolMessage adds that separately
+            Self::DeferredResponse(data) => data.raw_bytes.len() - 1,
             Self::Other(unknown) => unknown.length(),
         }
     }
@@ -642,6 +766,20 @@ impl EthMessageID {
     pub const fn message_count(version: EthVersion) -> u8 {
         Self::max(version) + 1
     }
+
+    /// Returns `true` if this message ID corresponds to a response message
+    /// that carries a `request_id` in a [`RequestPair`] wrapper.
+    pub const fn is_response(&self) -> bool {
+        matches!(
+            self,
+            Self::BlockHeaders |
+                Self::BlockBodies |
+                Self::PooledTransactions |
+                Self::NodeData |
+                Self::Receipts |
+                Self::BlockAccessLists
+        )
+    }
 }
 
 impl Encodable for EthMessageID {
@@ -782,11 +920,11 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::MessageError;
+    use super::{extract_response_request_id, MessageError};
     use crate::{
-        message::RequestPair, BlockAccessLists, EthMessage, EthMessageID, EthNetworkPrimitives,
-        EthVersion, GetBlockAccessLists, GetNodeData, NodeData, ProtocolMessage,
-        RawCapabilityMessage,
+        message::RequestPair, BlockAccessLists, BlockHeaders, EthMessage, EthMessageID,
+        EthNetworkPrimitives, EthVersion, GetBlockAccessLists, GetBlockBodies, GetNodeData,
+        NodeData, PooledTransactions, ProtocolMessage, RawCapabilityMessage,
     };
     use alloy_primitives::hex;
     use alloy_rlp::{Decodable, Encodable, Error};
@@ -926,21 +1064,35 @@ mod tests {
 
     #[test]
     fn empty_block_bodies_protocol() {
-        let empty_block_bodies =
+        let original =
             ProtocolMessage::from(EthMessage::<EthNetworkPrimitives>::BlockBodies(RequestPair {
                 request_id: 0,
                 message: Default::default(),
             }));
         let mut buf = Vec::new();
-        empty_block_bodies.encode(&mut buf);
-        let decoded =
-            ProtocolMessage::decode_message(EthVersion::Eth68, &mut buf.as_slice()).unwrap();
-        assert_eq!(empty_block_bodies, decoded);
+        original.encode(&mut buf);
+
+        // decode_message returns DeferredResponse for response messages
+        let decoded = ProtocolMessage::<EthNetworkPrimitives>::decode_message(
+            EthVersion::Eth68,
+            &mut buf.as_slice(),
+        )
+        .unwrap();
+        let deferred = match decoded.message {
+            EthMessage::DeferredResponse(d) => d,
+            other => panic!("expected DeferredResponse, got {other:?}"),
+        };
+        assert_eq!(deferred.message_id, EthMessageID::BlockBodies);
+        assert_eq!(deferred.request_id, 0);
+
+        // Full decode produces the original message
+        let fully_decoded = deferred.decode_full::<EthNetworkPrimitives>().unwrap();
+        assert_eq!(original.message, fully_decoded);
     }
 
     #[test]
     fn empty_block_body_protocol() {
-        let empty_block_bodies =
+        let original =
             ProtocolMessage::from(EthMessage::<EthNetworkPrimitives>::BlockBodies(RequestPair {
                 request_id: 0,
                 message: vec![BlockBody {
@@ -951,21 +1103,50 @@ mod tests {
                 .into(),
             }));
         let mut buf = Vec::new();
-        empty_block_bodies.encode(&mut buf);
-        let decoded =
-            ProtocolMessage::decode_message(EthVersion::Eth68, &mut buf.as_slice()).unwrap();
-        assert_eq!(empty_block_bodies, decoded);
+        original.encode(&mut buf);
+
+        // decode_message returns DeferredResponse for response messages
+        let decoded = ProtocolMessage::<EthNetworkPrimitives>::decode_message(
+            EthVersion::Eth68,
+            &mut buf.as_slice(),
+        )
+        .unwrap();
+        let deferred = match decoded.message {
+            EthMessage::DeferredResponse(d) => d,
+            other => panic!("expected DeferredResponse, got {other:?}"),
+        };
+        assert_eq!(deferred.message_id, EthMessageID::BlockBodies);
+        assert_eq!(deferred.request_id, 0);
+
+        // Full decode produces the original message
+        let fully_decoded = deferred.decode_full::<EthNetworkPrimitives>().unwrap();
+        assert_eq!(original.message, fully_decoded);
     }
 
     #[test]
     fn decode_block_bodies_message() {
+        // 06: BlockBodies message ID
+        // c4: RLP list header (len 4)
+        // 81 99: request_id = 0x99 (153)
+        // c1 c0: payload (too short for valid BlockBodies)
         let buf = hex!("06c48199c1c0");
-        let msg = ProtocolMessage::<EthNetworkPrimitives>::decode_message(
+
+        // extract_response_request_id succeeds (only reads the envelope)
+        let decoded = ProtocolMessage::<EthNetworkPrimitives>::decode_message(
             EthVersion::Eth68,
             &mut &buf[..],
         )
-        .unwrap_err();
-        assert!(matches!(msg, MessageError::RlpError(alloy_rlp::Error::InputTooShort)));
+        .unwrap();
+        let deferred = match decoded.message {
+            EthMessage::DeferredResponse(d) => d,
+            other => panic!("expected DeferredResponse, got {other:?}"),
+        };
+        assert_eq!(deferred.message_id, EthMessageID::BlockBodies);
+        assert_eq!(deferred.request_id, 0x99);
+
+        // Full decode fails because the payload is malformed
+        let err = deferred.decode_full::<EthNetworkPrimitives>().unwrap_err();
+        assert!(matches!(err, MessageError::RlpError(alloy_rlp::Error::InputTooShort)));
     }
 
     #[test]
@@ -1060,5 +1241,190 @@ mod tests {
             result,
             Err(MessageError::ExpectedStatusMessage(EthMessageID::GetBlockBodies))
         ));
+    }
+
+    // --- Deferred response tests ---
+
+    #[test]
+    fn extract_request_id_from_block_headers_response() {
+        let msg =
+            ProtocolMessage::from(EthMessage::<EthNetworkPrimitives>::BlockHeaders(RequestPair {
+                request_id: 42,
+                message: BlockHeaders(vec![]),
+            }));
+        let buf = encode(msg);
+
+        let result = extract_response_request_id(EthVersion::Eth68, &buf).unwrap();
+        assert_eq!(result, Some((EthMessageID::BlockHeaders, 42)));
+    }
+
+    #[test]
+    fn extract_request_id_from_pooled_transactions_response() {
+        let msg = ProtocolMessage::from(EthMessage::<EthNetworkPrimitives>::PooledTransactions(
+            RequestPair { request_id: 1337, message: PooledTransactions(vec![]) },
+        ));
+        let buf = encode(msg);
+
+        let result = extract_response_request_id(EthVersion::Eth68, &buf).unwrap();
+        assert_eq!(result, Some((EthMessageID::PooledTransactions, 1337)));
+    }
+
+    #[test]
+    fn extract_request_id_returns_none_for_requests() {
+        let msg = ProtocolMessage::from(EthMessage::<EthNetworkPrimitives>::GetBlockBodies(
+            RequestPair { request_id: 1, message: GetBlockBodies::default() },
+        ));
+        let buf = encode(msg);
+
+        let result = extract_response_request_id(EthVersion::Eth68, &buf).unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn extract_request_id_returns_none_for_broadcasts() {
+        let msg = ProtocolMessage::from(EthMessage::<EthNetworkPrimitives>::NewBlockHashes(
+            crate::NewBlockHashes(vec![]),
+        ));
+        let buf = encode(msg);
+
+        let result = extract_response_request_id(EthVersion::Eth68, &buf).unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn extract_request_id_version_gates_node_data() {
+        let msg =
+            ProtocolMessage::from(EthMessage::<EthNetworkPrimitives>::NodeData(RequestPair {
+                request_id: 1,
+                message: NodeData(vec![]),
+            }));
+        let buf = encode(msg);
+
+        // NodeData is invalid for eth/67+
+        let err = extract_response_request_id(EthVersion::Eth67, &buf).unwrap_err();
+        assert!(matches!(err, MessageError::Invalid(EthVersion::Eth67, EthMessageID::NodeData)));
+
+        // NodeData is valid for eth/66
+        let result = extract_response_request_id(EthVersion::Eth66, &buf).unwrap();
+        assert_eq!(result, Some((EthMessageID::NodeData, 1)));
+    }
+
+    #[test]
+    fn extract_request_id_version_gates_block_access_lists() {
+        let msg = ProtocolMessage::from(EthMessage::<EthNetworkPrimitives>::BlockAccessLists(
+            RequestPair { request_id: 1, message: BlockAccessLists(vec![]) },
+        ));
+        let buf = encode(msg);
+
+        // BlockAccessLists is invalid for eth/70 (< eth/71)
+        let err = extract_response_request_id(EthVersion::Eth70, &buf).unwrap_err();
+        assert!(matches!(
+            err,
+            MessageError::Invalid(EthVersion::Eth70, EthMessageID::BlockAccessLists)
+        ));
+
+        // BlockAccessLists is valid for eth/71
+        let result = extract_response_request_id(EthVersion::Eth71, &buf).unwrap();
+        assert_eq!(result, Some((EthMessageID::BlockAccessLists, 1)));
+    }
+
+    #[test]
+    fn deferred_response_decode_full_roundtrip() {
+        let original_msg = EthMessage::<EthNetworkPrimitives>::BlockHeaders(RequestPair {
+            request_id: 999,
+            message: BlockHeaders(vec![]),
+        });
+        let protocol_msg = ProtocolMessage::from(original_msg.clone());
+        let buf = encode(protocol_msg);
+
+        // Go through decode_message → DeferredResponse → decode_full
+        let decoded = ProtocolMessage::<EthNetworkPrimitives>::decode_message(
+            EthVersion::Eth68,
+            &mut &buf[..],
+        )
+        .unwrap();
+
+        let deferred = match decoded.message {
+            EthMessage::DeferredResponse(d) => d,
+            other => panic!("expected DeferredResponse, got {other:?}"),
+        };
+        assert_eq!(deferred.request_id, 999);
+        assert_eq!(deferred.message_id, EthMessageID::BlockHeaders);
+
+        let fully_decoded = deferred.decode_full::<EthNetworkPrimitives>().unwrap();
+        assert_eq!(fully_decoded, original_msg);
+    }
+
+    #[test]
+    fn deferred_response_preserves_raw_bytes_for_re_encoding() {
+        let msg =
+            ProtocolMessage::from(EthMessage::<EthNetworkPrimitives>::BlockBodies(RequestPair {
+                request_id: 7,
+                message: Default::default(),
+            }));
+        let original_encoded = encode(msg);
+
+        let decoded = ProtocolMessage::<EthNetworkPrimitives>::decode_message(
+            EthVersion::Eth68,
+            &mut &original_encoded[..],
+        )
+        .unwrap();
+
+        // Re-encoding the DeferredResponse should produce the same bytes
+        let re_encoded = encode(decoded);
+        assert_eq!(original_encoded, re_encoded);
+    }
+
+    #[test]
+    fn requests_are_not_deferred() {
+        // GetBlockHeaders is a request, not a response — should be fully decoded immediately
+        let msg = ProtocolMessage::from(EthMessage::<EthNetworkPrimitives>::GetBlockHeaders(
+            RequestPair {
+                request_id: 5,
+                message: crate::GetBlockHeaders {
+                    start_block: alloy_primitives::B256::ZERO.into(),
+                    limit: 10,
+                    skip: 0,
+                    direction: crate::HeadersDirection::Falling,
+                },
+            },
+        ));
+        let buf = encode(msg);
+
+        let decoded = ProtocolMessage::<EthNetworkPrimitives>::decode_message(
+            EthVersion::Eth68,
+            &mut &buf[..],
+        )
+        .unwrap();
+        assert!(
+            !matches!(decoded.message, EthMessage::DeferredResponse(_)),
+            "request messages should not be deferred"
+        );
+        assert_eq!(decoded.message_type, EthMessageID::GetBlockHeaders);
+    }
+
+    #[test]
+    fn decode_message_full_bypasses_deferral() {
+        let original =
+            ProtocolMessage::from(EthMessage::<EthNetworkPrimitives>::BlockBodies(RequestPair {
+                request_id: 0,
+                message: Default::default(),
+            }));
+        let mut buf = Vec::new();
+        original.encode(&mut buf);
+
+        // decode_message_full should return the fully decoded message directly
+        let decoded = ProtocolMessage::<EthNetworkPrimitives>::decode_message_full(
+            EthVersion::Eth68,
+            &mut buf.as_slice(),
+        )
+        .unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn extract_request_id_empty_input() {
+        let result = extract_response_request_id(EthVersion::Eth68, &[]);
+        assert!(matches!(result, Err(MessageError::RlpError(alloy_rlp::Error::InputTooShort))));
     }
 }

--- a/crates/net/eth-wire-types/src/message.rs
+++ b/crates/net/eth-wire-types/src/message.rs
@@ -44,13 +44,6 @@ pub enum MessageError {
 
 /// Holds pre-extracted metadata and raw bytes for a response message whose full deserialization
 /// has been deferred.
-///
-/// When a peer sends a response (e.g. `BlockBodies`, `PooledTransactions`), we first extract only
-/// the lightweight envelope — the message ID and `request_id` — without decoding the potentially
-/// large payload. The session layer then validates the `request_id` against pending inflight
-/// requests *before* committing to the expensive full RLP decode. This prevents a `DoS` vector where
-/// an attacker sends large responses with bogus `request_id` values, forcing the node to allocate
-/// and immediately discard up to ~40 MB of heap per message.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DeferredResponseData {
     /// The response message type ID.
@@ -70,7 +63,7 @@ impl DeferredResponseData {
     /// inflight requests.
     pub fn decode_full<N: NetworkPrimitives>(self) -> Result<EthMessage<N>, MessageError> {
         let mut buf: &[u8] = &self.raw_bytes;
-        let msg = ProtocolMessage::<N>::decode_message_full(self.version, &mut buf)?;
+        let msg = ProtocolMessage::<N>::decode_message(self.version, &mut buf)?;
         Ok(msg.message)
     }
 }
@@ -113,49 +106,10 @@ impl<N: NetworkPrimitives> ProtocolMessage<N> {
         Ok(status)
     }
 
-    /// Create a new `ProtocolMessage` from a message type and message RLP bytes.
+    /// Create a new `ProtocolMessage` from a message type and message rlp bytes.
     ///
-    /// For response messages (those carrying a `request_id` in a [`RequestPair`] wrapper),
-    /// this performs only a lightweight extraction of the message ID and `request_id` — at most
-    /// 19 bytes of RLP parsing — and returns a [`EthMessage::DeferredResponse`]. The caller
-    /// (typically the session layer) should validate the `request_id` against pending inflight
-    /// requests before calling [`DeferredResponseData::decode_full`] to complete the expensive
-    /// deserialization.
-    ///
-    /// Non-response messages (status, broadcasts, requests) are fully decoded immediately.
+    /// This will enforce decoding according to the given [`EthVersion`] of the connection.
     pub fn decode_message(version: EthVersion, buf: &mut &[u8]) -> Result<Self, MessageError> {
-        let original_buf = *buf;
-
-        // For response messages, defer full deserialization: extract only the message ID
-        // and request_id so the session layer can validate before paying the decode cost.
-        match extract_response_request_id(version, original_buf) {
-            Ok(Some((message_id, request_id))) => {
-                // Advance the caller's buffer past the entire message
-                *buf = &[];
-                return Ok(Self {
-                    message_type: message_id,
-                    message: EthMessage::DeferredResponse(DeferredResponseData {
-                        message_id,
-                        request_id,
-                        version,
-                        raw_bytes: Bytes::copy_from_slice(original_buf),
-                    }),
-                });
-            }
-            Ok(None) => {
-                // Not a response — fall through to full decode below
-            }
-            Err(e) => return Err(e),
-        }
-
-        Self::decode_message_full(version, buf)
-    }
-
-    /// Fully decodes a protocol message without deferred-response optimisation.
-    ///
-    /// Used internally to complete the decode of a [`DeferredResponseData`] after its
-    /// `request_id` has been validated, and as the regular decode path for non-response messages.
-    pub fn decode_message_full(version: EthVersion, buf: &mut &[u8]) -> Result<Self, MessageError> {
         let message_type = EthMessageID::decode(buf)?;
 
         // For EIP-7642 (https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7642.md):
@@ -254,7 +208,7 @@ impl<N: NetworkPrimitives> ProtocolMessage<N> {
                 buf.advance(raw_payload.len());
                 EthMessage::Other(RawCapabilityMessage::new(
                     message_type.to_u8() as usize,
-                    raw_payload.into(),
+                    raw_payload,
                 ))
             }
         };
@@ -263,14 +217,6 @@ impl<N: NetworkPrimitives> ProtocolMessage<N> {
 }
 
 /// Extracts the `request_id` from a response message's raw bytes without full deserialization.
-///
-/// Returns `Ok(Some((message_id, request_id)))` for response messages, `Ok(None)` for
-/// non-response messages (broadcasts, requests, status). The bytes should start with the
-/// 1-byte [`EthMessageID`], followed by the RLP-encoded [`RequestPair`]:
-/// `[list_header][u64 request_id][payload]`.
-///
-/// Total parsing cost: at most 19 bytes (1 msg ID + 9 list header + 9 u64), regardless of
-/// message size.
 pub fn extract_response_request_id(
     version: EthVersion,
     bytes: &[u8],
@@ -298,7 +244,7 @@ pub fn extract_response_request_id(
     }
 
     // Decode only the RLP list header and the u64 request_id from the RequestPair envelope
-    let _header = Header::decode(&mut buf)?;
+    Header::decode(&mut buf)?;
     let request_id = u64::decode(&mut buf)?;
 
     Ok(Some((message_id, request_id)))
@@ -920,13 +866,13 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{extract_response_request_id, MessageError};
+    use super::{extract_response_request_id, DeferredResponseData, MessageError};
     use crate::{
         message::RequestPair, BlockAccessLists, BlockHeaders, EthMessage, EthMessageID,
         EthNetworkPrimitives, EthVersion, GetBlockAccessLists, GetBlockBodies, GetNodeData,
         NodeData, PooledTransactions, ProtocolMessage, RawCapabilityMessage,
     };
-    use alloy_primitives::hex;
+    use alloy_primitives::{bytes::Bytes, hex};
     use alloy_rlp::{Decodable, Encodable, Error};
     use reth_ethereum_primitives::BlockBody;
 
@@ -1072,22 +1018,12 @@ mod tests {
         let mut buf = Vec::new();
         original.encode(&mut buf);
 
-        // decode_message returns DeferredResponse for response messages
         let decoded = ProtocolMessage::<EthNetworkPrimitives>::decode_message(
             EthVersion::Eth68,
             &mut buf.as_slice(),
         )
         .unwrap();
-        let deferred = match decoded.message {
-            EthMessage::DeferredResponse(d) => d,
-            other => panic!("expected DeferredResponse, got {other:?}"),
-        };
-        assert_eq!(deferred.message_id, EthMessageID::BlockBodies);
-        assert_eq!(deferred.request_id, 0);
-
-        // Full decode produces the original message
-        let fully_decoded = deferred.decode_full::<EthNetworkPrimitives>().unwrap();
-        assert_eq!(original.message, fully_decoded);
+        assert_eq!(original, decoded);
     }
 
     #[test]
@@ -1105,22 +1041,12 @@ mod tests {
         let mut buf = Vec::new();
         original.encode(&mut buf);
 
-        // decode_message returns DeferredResponse for response messages
         let decoded = ProtocolMessage::<EthNetworkPrimitives>::decode_message(
             EthVersion::Eth68,
             &mut buf.as_slice(),
         )
         .unwrap();
-        let deferred = match decoded.message {
-            EthMessage::DeferredResponse(d) => d,
-            other => panic!("expected DeferredResponse, got {other:?}"),
-        };
-        assert_eq!(deferred.message_id, EthMessageID::BlockBodies);
-        assert_eq!(deferred.request_id, 0);
-
-        // Full decode produces the original message
-        let fully_decoded = deferred.decode_full::<EthNetworkPrimitives>().unwrap();
-        assert_eq!(original.message, fully_decoded);
+        assert_eq!(original, decoded);
     }
 
     #[test]
@@ -1130,22 +1056,11 @@ mod tests {
         // 81 99: request_id = 0x99 (153)
         // c1 c0: payload (too short for valid BlockBodies)
         let buf = hex!("06c48199c1c0");
-
-        // extract_response_request_id succeeds (only reads the envelope)
-        let decoded = ProtocolMessage::<EthNetworkPrimitives>::decode_message(
+        let err = ProtocolMessage::<EthNetworkPrimitives>::decode_message(
             EthVersion::Eth68,
             &mut &buf[..],
         )
-        .unwrap();
-        let deferred = match decoded.message {
-            EthMessage::DeferredResponse(d) => d,
-            other => panic!("expected DeferredResponse, got {other:?}"),
-        };
-        assert_eq!(deferred.message_id, EthMessageID::BlockBodies);
-        assert_eq!(deferred.request_id, 0x99);
-
-        // Full decode fails because the payload is malformed
-        let err = deferred.decode_full::<EthNetworkPrimitives>().unwrap_err();
+        .unwrap_err();
         assert!(matches!(err, MessageError::RlpError(alloy_rlp::Error::InputTooShort)));
     }
 
@@ -1330,26 +1245,24 @@ mod tests {
 
     #[test]
     fn deferred_response_decode_full_roundtrip() {
+        // Construct a DeferredResponseData manually (as the stream layers do)
         let original_msg = EthMessage::<EthNetworkPrimitives>::BlockHeaders(RequestPair {
             request_id: 999,
             message: BlockHeaders(vec![]),
         });
         let protocol_msg = ProtocolMessage::from(original_msg.clone());
-        let buf = encode(protocol_msg);
+        let raw = encode(protocol_msg);
 
-        // Go through decode_message → DeferredResponse → decode_full
-        let decoded = ProtocolMessage::<EthNetworkPrimitives>::decode_message(
-            EthVersion::Eth68,
-            &mut &buf[..],
-        )
-        .unwrap();
+        let (_, request_id) =
+            extract_response_request_id(EthVersion::Eth68, &raw).unwrap().unwrap();
+        assert_eq!(request_id, 999);
 
-        let deferred = match decoded.message {
-            EthMessage::DeferredResponse(d) => d,
-            other => panic!("expected DeferredResponse, got {other:?}"),
+        let deferred = DeferredResponseData {
+            message_id: EthMessageID::BlockHeaders,
+            request_id,
+            version: EthVersion::Eth68,
+            raw_bytes: Bytes::from(raw),
         };
-        assert_eq!(deferred.request_id, 999);
-        assert_eq!(deferred.message_id, EthMessageID::BlockHeaders);
 
         let fully_decoded = deferred.decode_full::<EthNetworkPrimitives>().unwrap();
         assert_eq!(fully_decoded, original_msg);
@@ -1364,62 +1277,20 @@ mod tests {
             }));
         let original_encoded = encode(msg);
 
-        let decoded = ProtocolMessage::<EthNetworkPrimitives>::decode_message(
-            EthVersion::Eth68,
-            &mut &original_encoded[..],
-        )
-        .unwrap();
+        let deferred = DeferredResponseData {
+            message_id: EthMessageID::BlockBodies,
+            request_id: 7,
+            version: EthVersion::Eth68,
+            raw_bytes: Bytes::from(original_encoded.clone()),
+        };
 
-        // Re-encoding the DeferredResponse should produce the same bytes
-        let re_encoded = encode(decoded);
+        // Re-encoding via the DeferredResponse variant should produce the same bytes
+        let protocol_msg = ProtocolMessage::<EthNetworkPrimitives> {
+            message_type: EthMessageID::BlockBodies,
+            message: EthMessage::DeferredResponse(deferred),
+        };
+        let re_encoded = encode(protocol_msg);
         assert_eq!(original_encoded, re_encoded);
-    }
-
-    #[test]
-    fn requests_are_not_deferred() {
-        // GetBlockHeaders is a request, not a response — should be fully decoded immediately
-        let msg = ProtocolMessage::from(EthMessage::<EthNetworkPrimitives>::GetBlockHeaders(
-            RequestPair {
-                request_id: 5,
-                message: crate::GetBlockHeaders {
-                    start_block: alloy_primitives::B256::ZERO.into(),
-                    limit: 10,
-                    skip: 0,
-                    direction: crate::HeadersDirection::Falling,
-                },
-            },
-        ));
-        let buf = encode(msg);
-
-        let decoded = ProtocolMessage::<EthNetworkPrimitives>::decode_message(
-            EthVersion::Eth68,
-            &mut &buf[..],
-        )
-        .unwrap();
-        assert!(
-            !matches!(decoded.message, EthMessage::DeferredResponse(_)),
-            "request messages should not be deferred"
-        );
-        assert_eq!(decoded.message_type, EthMessageID::GetBlockHeaders);
-    }
-
-    #[test]
-    fn decode_message_full_bypasses_deferral() {
-        let original =
-            ProtocolMessage::from(EthMessage::<EthNetworkPrimitives>::BlockBodies(RequestPair {
-                request_id: 0,
-                message: Default::default(),
-            }));
-        let mut buf = Vec::new();
-        original.encode(&mut buf);
-
-        // decode_message_full should return the fully decoded message directly
-        let decoded = ProtocolMessage::<EthNetworkPrimitives>::decode_message_full(
-            EthVersion::Eth68,
-            &mut buf.as_slice(),
-        )
-        .unwrap();
-        assert_eq!(original, decoded);
     }
 
     #[test]

--- a/crates/net/eth-wire/src/eth_snap_stream.rs
+++ b/crates/net/eth-wire/src/eth_snap_stream.rs
@@ -5,9 +5,9 @@
 
 use super::message::MAX_MESSAGE_SIZE;
 use crate::{
-    message::{EthBroadcastMessage, ProtocolBroadcastMessage},
-    EthMessage, EthMessageID, EthNetworkPrimitives, EthVersion, NetworkPrimitives, ProtocolMessage,
-    RawCapabilityMessage, SnapMessageId, SnapProtocolMessage,
+    message::{EthBroadcastMessage, ProtocolBroadcastMessage, extract_response_request_id},
+    DeferredResponseData, EthMessage, EthMessageID, EthNetworkPrimitives, EthVersion,
+    NetworkPrimitives, ProtocolMessage, RawCapabilityMessage, SnapMessageId, SnapProtocolMessage,
 };
 use alloy_rlp::{Bytes, BytesMut, Encodable};
 use core::fmt::Debug;
@@ -224,8 +224,29 @@ where
         // snap message IDs are > [`EthMessageID::max()`].
         // See also <https://github.com/paradigmxyz/reth/blob/main/crates/net/eth-wire/src/capability.rs#L272-L283>.
         if message_id <= EthMessageID::max(self.eth_version) {
+            // For response messages, defer full deserialization via zero-copy freeze().
+            match extract_response_request_id(self.eth_version, &bytes) {
+                Ok(Some((msg_id, request_id))) => {
+                    return Ok(EthSnapMessage::Eth(EthMessage::DeferredResponse(
+                        DeferredResponseData {
+                            message_id: msg_id,
+                            request_id,
+                            version: self.eth_version,
+                            raw_bytes: bytes.freeze(),
+                        },
+                    )));
+                }
+                Ok(None) => {}
+                Err(err) => {
+                    return Err(EthSnapStreamError::InvalidMessage(
+                        self.eth_version,
+                        err.to_string(),
+                    ));
+                }
+            }
+
             let mut buf = bytes.as_ref();
-            match ProtocolMessage::decode_message(self.eth_version, &mut buf) {
+            match ProtocolMessage::decode_message_full(self.eth_version, &mut buf) {
                 Ok(protocol_msg) => {
                     if matches!(protocol_msg.message, EthMessage::Status(_)) {
                         return Err(EthSnapStreamError::StatusNotInHandshake);

--- a/crates/net/eth-wire/src/eth_snap_stream.rs
+++ b/crates/net/eth-wire/src/eth_snap_stream.rs
@@ -5,7 +5,7 @@
 
 use super::message::MAX_MESSAGE_SIZE;
 use crate::{
-    message::{EthBroadcastMessage, ProtocolBroadcastMessage, extract_response_request_id},
+    message::{extract_response_request_id, EthBroadcastMessage, ProtocolBroadcastMessage},
     DeferredResponseData, EthMessage, EthMessageID, EthNetworkPrimitives, EthVersion,
     NetworkPrimitives, ProtocolMessage, RawCapabilityMessage, SnapMessageId, SnapProtocolMessage,
 };
@@ -246,7 +246,7 @@ where
             }
 
             let mut buf = bytes.as_ref();
-            match ProtocolMessage::decode_message_full(self.eth_version, &mut buf) {
+            match ProtocolMessage::decode_message(self.eth_version, &mut buf) {
                 Ok(protocol_msg) => {
                     if matches!(protocol_msg.message, EthMessage::Status(_)) {
                         return Err(EthSnapStreamError::StatusNotInHandshake);

--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -7,17 +7,16 @@
 use crate::{
     errors::{EthHandshakeError, EthStreamError},
     handshake::EthereumEthHandshake,
-    message::{EthBroadcastMessage, ProtocolBroadcastMessage},
+    message::{extract_response_request_id, EthBroadcastMessage, ProtocolBroadcastMessage},
     p2pstream::HANDSHAKE_TIMEOUT,
-    CanDisconnect, DisconnectReason, EthMessage, EthNetworkPrimitives, EthVersion, ProtocolMessage,
-    UnifiedStatus,
+    CanDisconnect, DeferredResponseData, DisconnectReason, EthMessage, EthNetworkPrimitives,
+    EthVersion, ProtocolMessage, UnifiedStatus,
 };
 use alloy_primitives::bytes::{Bytes, BytesMut};
 use alloy_rlp::Encodable;
 use futures::{ready, Sink, SinkExt};
 use pin_project::pin_project;
 use reth_eth_wire_types::{NetworkPrimitives, RawCapabilityMessage};
-use crate::{DeferredResponseData, message::extract_response_request_id};
 use reth_ethereum_forks::ForkFilter;
 use std::{
     future::Future,
@@ -158,27 +157,22 @@ where
             }
         }
 
-        let msg =
-            match ProtocolMessage::decode_message_full(self.version, &mut bytes.as_ref()) {
-                Ok(m) => m,
-                Err(err) => {
-                    let msg = if bytes.len() > 50 {
-                        format!(
-                            "{:02x?}...{:x?}",
-                            &bytes[..10],
-                            &bytes[bytes.len() - 10..]
-                        )
-                    } else {
-                        format!("{bytes:02x?}")
-                    };
-                    debug!(
-                        version=?self.version,
-                        %msg,
-                        "failed to decode protocol message"
-                    );
-                    return Err(EthStreamError::InvalidMessage(err));
-                }
-            };
+        let msg = match ProtocolMessage::decode_message(self.version, &mut bytes.as_ref()) {
+            Ok(m) => m,
+            Err(err) => {
+                let msg = if bytes.len() > 50 {
+                    format!("{:02x?}...{:x?}", &bytes[..10], &bytes[bytes.len() - 10..])
+                } else {
+                    format!("{bytes:02x?}")
+                };
+                debug!(
+                    version=?self.version,
+                    %msg,
+                    "failed to decode protocol message"
+                );
+                return Err(EthStreamError::InvalidMessage(err));
+            }
+        };
 
         if matches!(msg.message, EthMessage::Status(_)) {
             return Err(EthStreamError::EthHandshakeError(EthHandshakeError::StatusNotInHandshake));

--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -17,6 +17,7 @@ use alloy_rlp::Encodable;
 use futures::{ready, Sink, SinkExt};
 use pin_project::pin_project;
 use reth_eth_wire_types::{NetworkPrimitives, RawCapabilityMessage};
+use crate::{DeferredResponseData, message::extract_response_request_id};
 use reth_ethereum_forks::ForkFilter;
 use std::{
     future::Future,
@@ -129,27 +130,55 @@ where
     }
 
     /// Decodes incoming bytes into an [`EthMessage`].
+    ///
+    /// For response messages, only the lightweight envelope (message ID + `request_id`) is
+    /// extracted and the raw bytes are retained via zero-copy [`BytesMut::freeze`]. The session
+    /// layer validates the `request_id` before committing to a full RLP decode.
     pub fn decode_message(&self, bytes: BytesMut) -> Result<EthMessage<N>, EthStreamError> {
         if bytes.len() > MAX_MESSAGE_SIZE {
             return Err(EthStreamError::MessageTooBig(bytes.len()));
         }
 
-        let msg = match ProtocolMessage::decode_message(self.version, &mut bytes.as_ref()) {
-            Ok(m) => m,
+        // For response messages, defer full deserialization: extract only the message ID
+        // and request_id (~19 bytes parsed) and keep the buffer via zero-copy freeze().
+        match extract_response_request_id(self.version, &bytes) {
+            Ok(Some((message_id, request_id))) => {
+                return Ok(EthMessage::DeferredResponse(DeferredResponseData {
+                    message_id,
+                    request_id,
+                    version: self.version,
+                    raw_bytes: bytes.freeze(),
+                }));
+            }
+            Ok(None) => {
+                // Not a response — fall through to full decode
+            }
             Err(err) => {
-                let msg = if bytes.len() > 50 {
-                    format!("{:02x?}...{:x?}", &bytes[..10], &bytes[bytes.len() - 10..])
-                } else {
-                    format!("{bytes:02x?}")
-                };
-                debug!(
-                    version=?self.version,
-                    %msg,
-                    "failed to decode protocol message"
-                );
                 return Err(EthStreamError::InvalidMessage(err));
             }
-        };
+        }
+
+        let msg =
+            match ProtocolMessage::decode_message_full(self.version, &mut bytes.as_ref()) {
+                Ok(m) => m,
+                Err(err) => {
+                    let msg = if bytes.len() > 50 {
+                        format!(
+                            "{:02x?}...{:x?}",
+                            &bytes[..10],
+                            &bytes[bytes.len() - 10..]
+                        )
+                    } else {
+                        format!("{bytes:02x?}")
+                    };
+                    debug!(
+                        version=?self.version,
+                        %msg,
+                        "failed to decode protocol message"
+                    );
+                    return Err(EthStreamError::InvalidMessage(err));
+                }
+            };
 
         if matches!(msg.message, EthMessage::Status(_)) {
             return Err(EthStreamError::EthHandshakeError(EthHandshakeError::StatusNotInHandshake));

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -316,6 +316,33 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
 
                 OnIncomingMessageOutcome::Ok
             }
+            EthMessage::DeferredResponse(deferred) => {
+                // Validate the pre-extracted request_id before paying the cost of full
+                // RLP deserialization — prevents a DoS vector where an attacker sends
+                // large response messages with bogus request_ids.
+                if !self.inflight_requests.contains_key(&deferred.request_id) {
+                    trace!(
+                        peer_id=?self.remote_peer_id,
+                        request_id=?deferred.request_id,
+                        msg_id=?deferred.message_id,
+                        "received response with unknown request_id, skipping full decode"
+                    );
+                    self.on_bad_message();
+                    return OnIncomingMessageOutcome::Ok;
+                }
+
+                // request_id matches an inflight request — perform full decode now
+                match deferred.decode_full::<N>() {
+                    Ok(fully_decoded) => self.on_incoming_message(fully_decoded),
+                    Err(err) => OnIncomingMessageOutcome::BadMessage {
+                        error: EthStreamError::InvalidMessage(err),
+                        message: EthMessage::Other(RawCapabilityMessage::new(
+                            0,
+                            Default::default(),
+                        )),
+                    },
+                }
+            }
             EthMessage::Other(bytes) => self.try_emit_broadcast(PeerMessage::Other(bytes)).into(),
         }
     }


### PR DESCRIPTION
Mitigates a DoS vector where a malicious peer sends large ETH response messages (BlockHeaders, BlockBodies, PooledTransactions, Receipts, NodeData, BlockAccessLists) with fabricated `request_id` values. Before this fix, the node fully deserializes the entire RLP payload — allocating heap via `Bytes::to_vec()` for every calldata field, before discovering the `request_id` doesn't match any inflight request and discarding everything.

### The fix
For response messages, `ProtocolMessage::decode_message()` now extracts only the message ID and `request_id` (~19 bytes of RLP parsing) and returns a `DeferredResponse` variant. The session layer validates the `request_id` against `inflight_requests` before calling `decode_full()`. Fake `request_id`s are rejected with a single HashMap lookup — zero RLP decode of the payload.

Non-response messages (Status, broadcasts, requests) are unaffected and continue to be fully decoded immediately.

### Measured impact
Tested on an isolated reth v1.11.0 mainnet node (0 peers, iptables-restricted) with a PoC sending 270 MB of crafted BlockBodies via 10 parallel connections:

Results

| | Unfixed | Fixed |
|---|---|---|
| **Baseline RSS** | 238 MB | 242 MB |
| **Peak RSS** | 371 MB | 259 MB |
| **RSS spike** | **+133 MB** | **+16 MB** |
| **Wire data sent** | 270 MB | 270 MB |
| **Messages decoded** | 30 (full RLP) | 0 (deferred, rejected) |