### PR TITLE
fix: narrow mutex scope in DeferredTrieData::wait_cloned

### DIFF
--- a/crates/chain-state/src/deferred_trie.rs
+++ b/crates/chain-state/src/deferred_trie.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::B256;
-use parking_lot::{Condvar, Mutex};
+use parking_lot::Mutex;
 use reth_metrics::{metrics::Counter, Metrics};
 use reth_trie::{
     updates::{TrieUpdates, TrieUpdatesSorted},
@@ -19,7 +19,7 @@ use tracing::instrument;
 #[derive(Clone)]
 pub struct DeferredTrieData {
     /// Shared deferred state holding either raw inputs (pending) or computed result (ready).
-    state: Arc<(Mutex<DeferredState>, Condvar)>,
+    state: Arc<Mutex<DeferredState>>,
 }
 
 /// Sorted trie data computed for an executed block.
@@ -69,8 +69,7 @@ static DEFERRED_TRIE_METRICS: LazyLock<DeferredTrieMetrics> =
 /// Internal state for deferred trie data.
 enum DeferredState {
     /// Data is not yet available; raw inputs stored for fallback computation.
-    /// Wrapped in `Option` to allow taking ownership during computation.
-    Pending(Option<PendingInputs>),
+    Pending(PendingInputs),
     /// Data has been computed and is ready.
     Ready(ComputedTrieData),
 }
@@ -90,7 +89,7 @@ struct PendingInputs {
 
 impl fmt::Debug for DeferredTrieData {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let state = self.state.0.lock();
+        let state = self.state.lock();
         match &*state {
             DeferredState::Pending(_) => {
                 f.debug_struct("DeferredTrieData").field("state", &"pending").finish()
@@ -120,15 +119,12 @@ impl DeferredTrieData {
         ancestors: Vec<Self>,
     ) -> Self {
         Self {
-            state: Arc::new((
-                Mutex::new(DeferredState::Pending(Some(PendingInputs {
-                    hashed_state,
-                    trie_updates,
-                    anchor_hash,
-                    ancestors,
-                }))),
-                Condvar::new(),
-            )),
+            state: Arc::new(Mutex::new(DeferredState::Pending(PendingInputs {
+                hashed_state,
+                trie_updates,
+                anchor_hash,
+                ancestors,
+            }))),
         }
     }
 
@@ -137,7 +133,7 @@ impl DeferredTrieData {
     /// Useful when trie data is available immediately.
     /// [`Self::wait_cloned`] will return without any computation.
     pub fn ready(bundle: ComputedTrieData) -> Self {
-        Self { state: Arc::new((Mutex::new(DeferredState::Ready(bundle)), Condvar::new())) }
+        Self { state: Arc::new(Mutex::new(DeferredState::Ready(bundle))) }
     }
 
     /// Sort block execution outputs and build a [`TrieInputSorted`] overlay.
@@ -312,10 +308,6 @@ impl DeferredTrieData {
     /// prevents deadlocks when callers participate in the rayon pool while holding external
     /// locks that other rayon tasks may contend on.
     ///
-    /// If a second caller arrives while the first is computing (inputs already taken),
-    /// it spins briefly until the result is published. This avoids both duplicate
-    /// computation and holding the mutex across rayon work.
-    ///
     /// Deadlock is avoided as long as the provided ancestors form a true ancestor chain (a DAG):
     /// - Each block only waits on its ancestors (blocks on the path to the persisted root)
     /// - Sibling blocks (forks) are never in each other's ancestor lists
@@ -324,50 +316,22 @@ impl DeferredTrieData {
     /// Given that invariant, circular wait dependencies are impossible.
     #[instrument(level = "debug", target = "engine::tree::deferred_trie", skip_all)]
     pub fn wait_cloned(&self) -> ComputedTrieData {
-        let (lock, cv) = &*self.state;
-
-        // Take pending inputs while holding the lock briefly. Using `take()` ensures
-        // Arc::try_unwrap can succeed in sort_and_build_trie_input (avoiding expensive clones).
-        let inputs = loop {
-            let mut state = lock.lock();
-            match &mut *state {
+        // Clone pending inputs while holding the lock briefly.
+        let inputs = {
+            let state = self.state.lock();
+            match &*state {
                 DeferredState::Ready(bundle) => {
                     DEFERRED_TRIE_METRICS.deferred_trie_async_ready.increment(1);
                     return bundle.clone();
                 }
-                DeferredState::Pending(maybe_inputs) => {
-                    if let Some(inputs) = maybe_inputs.take() {
-                        DEFERRED_TRIE_METRICS.deferred_trie_sync_fallback.increment(1);
-                        break inputs;
-                    }
-                    // Another caller has taken the inputs and is computing.
-                    // Park until they publish the result or restore inputs on panic.
-                    cv.wait(&mut state);
+                DeferredState::Pending(inputs) => {
+                    DEFERRED_TRIE_METRICS.deferred_trie_sync_fallback.increment(1);
+                    inputs.clone()
                 }
             }
         };
 
-        // Guard restores inputs if computation panics, so waiters don't block forever.
-        struct RestoreOnPanic<'a> {
-            inputs: Option<PendingInputs>,
-            state: &'a (Mutex<DeferredState>, Condvar),
-        }
-        impl Drop for RestoreOnPanic<'_> {
-            fn drop(&mut self) {
-                if let Some(inputs) = self.inputs.take() {
-                    let (lock, cv) = self.state;
-                    let mut state = lock.lock();
-                    if matches!(&*state, DeferredState::Pending(None)) {
-                        *state = DeferredState::Pending(Some(inputs));
-                    }
-                    cv.notify_all();
-                }
-            }
-        }
-        let mut guard = RestoreOnPanic { inputs: Some(inputs), state: &self.state };
-
         // Expensive work (rayon::join inside) runs without holding the mutex.
-        let inputs = guard.inputs.take().unwrap();
         let computed = Self::sort_and_build_trie_input(
             inputs.hashed_state,
             inputs.trie_updates,
@@ -375,18 +339,11 @@ impl DeferredTrieData {
             &inputs.ancestors,
         );
 
-        // Disarm the panic guard — computation succeeded.
-        std::mem::forget(guard);
-
-        // Publish the result. Replace the old state outside the lock to avoid dropping
-        // potentially large PendingInputs (and their ancestor Arcs) while holding it.
-        let old_state = {
-            let mut state = lock.lock();
-            let old = std::mem::replace(&mut *state, DeferredState::Ready(computed.clone()));
-            cv.notify_all();
-            old
-        };
-        drop(old_state);
+        // Publish the result if no other caller beat us.
+        let mut state = self.state.lock();
+        if matches!(&*state, DeferredState::Pending(_)) {
+            *state = DeferredState::Ready(computed.clone());
+        }
 
         computed
     }
@@ -512,12 +469,9 @@ mod tests {
         assert_eq!(first.anchor_hash(), second.anchor_hash());
     }
 
-    /// Verifies that concurrent `wait_cloned` calls all receive the same cached result.
-    ///
-    /// Only one caller takes the pending inputs and computes; others spin until the
-    /// result is published, then return the cached `Ready` value.
+    /// Verifies that concurrent `wait_cloned` calls all receive logically equivalent results.
     #[test]
-    fn concurrent_wait_cloned_shares_result() {
+    fn concurrent_wait_cloned_returns_equivalent_results() {
         let deferred = empty_pending();
 
         // Spawn multiple threads that all call wait_cloned concurrently
@@ -528,14 +482,13 @@ mod tests {
             })
             .collect();
 
-        // Collect all results
         let results: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
 
-        // All results should share the same Arc pointers (same computed result)
+        // All results should be logically equivalent
         let first = &results[0];
         for result in &results[1..] {
-            assert!(Arc::ptr_eq(&first.hashed_state, &result.hashed_state));
-            assert!(Arc::ptr_eq(&first.trie_updates, &result.trie_updates));
+            assert_eq!(first.hashed_state.is_empty(), result.hashed_state.is_empty());
+            assert_eq!(first.anchor_hash(), result.anchor_hash());
         }
     }
 

--- a/crates/chain-state/src/deferred_trie.rs
+++ b/crates/chain-state/src/deferred_trie.rs
@@ -309,9 +309,9 @@ impl DeferredTrieData {
     /// prevents deadlocks when callers participate in the rayon pool while holding external
     /// locks that other rayon tasks may contend on.
     ///
-    /// If two callers race on `Pending`, both may compute independently; the first to
-    /// re-acquire the lock publishes, the second sees `Ready` and discards its duplicate.
-    /// This is safe because the computation is deterministic.
+    /// If a second caller arrives while the first is computing (inputs already taken),
+    /// it spins briefly until the result is published. This avoids both duplicate
+    /// computation and holding the mutex across rayon work.
     ///
     /// Deadlock is avoided as long as the provided ancestors form a true ancestor chain (a DAG):
     /// - Each block only waits on its ancestors (blocks on the path to the persisted root)
@@ -321,17 +321,24 @@ impl DeferredTrieData {
     /// Given that invariant, circular wait dependencies are impossible.
     #[instrument(level = "debug", target = "engine::tree::deferred_trie", skip_all)]
     pub fn wait_cloned(&self) -> ComputedTrieData {
-        // Clone pending inputs (if any) while holding the lock briefly.
-        let inputs = {
-            let state = self.state.lock();
-            match &*state {
+        // Take pending inputs while holding the lock briefly. Using `take()` ensures
+        // Arc::try_unwrap can succeed in sort_and_build_trie_input (avoiding expensive clones).
+        let inputs = loop {
+            let mut state = self.state.lock();
+            match &mut *state {
                 DeferredState::Ready(bundle) => {
                     DEFERRED_TRIE_METRICS.deferred_trie_async_ready.increment(1);
                     return bundle.clone();
                 }
                 DeferredState::Pending(maybe_inputs) => {
-                    DEFERRED_TRIE_METRICS.deferred_trie_sync_fallback.increment(1);
-                    maybe_inputs.as_ref().expect("inputs must be present in Pending state").clone()
+                    if let Some(inputs) = maybe_inputs.take() {
+                        DEFERRED_TRIE_METRICS.deferred_trie_sync_fallback.increment(1);
+                        break inputs;
+                    }
+                    // Another caller has taken the inputs and is computing. Drop the lock
+                    // and yield so we can re-check once the result is published.
+                    drop(state);
+                    std::thread::yield_now();
                 }
             }
         };
@@ -344,11 +351,13 @@ impl DeferredTrieData {
             &inputs.ancestors,
         );
 
-        // Publish the result if no other caller has done so yet.
-        let mut state = self.state.lock();
-        if matches!(&*state, DeferredState::Pending(_)) {
-            *state = DeferredState::Ready(computed.clone());
-        }
+        // Publish the result. Replace the old state outside the lock to avoid dropping
+        // potentially large PendingInputs (and their ancestor Arcs) while holding it.
+        let old_state = {
+            let mut state = self.state.lock();
+            std::mem::replace(&mut *state, DeferredState::Ready(computed.clone()))
+        };
+        drop(old_state);
 
         computed
     }
@@ -474,13 +483,12 @@ mod tests {
         assert_eq!(first.anchor_hash(), second.anchor_hash());
     }
 
-    /// Verifies that concurrent `wait_cloned` calls all produce equivalent results.
+    /// Verifies that concurrent `wait_cloned` calls all receive the same cached result.
     ///
-    /// Because the mutex is not held across the expensive computation, concurrent callers
-    /// may compute independently. The first to re-acquire the lock publishes its result;
-    /// subsequent callers either see `Ready` or compute an equivalent duplicate.
+    /// Only one caller takes the pending inputs and computes; others spin until the
+    /// result is published, then return the cached `Ready` value.
     #[test]
-    fn concurrent_wait_cloned_produces_equivalent_results() {
+    fn concurrent_wait_cloned_shares_result() {
         let deferred = empty_pending();
 
         // Spawn multiple threads that all call wait_cloned concurrently
@@ -494,12 +502,11 @@ mod tests {
         // Collect all results
         let results: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
 
-        // All results should be logically equivalent
+        // All results should share the same Arc pointers (same computed result)
         let first = &results[0];
         for result in &results[1..] {
-            assert_eq!(first.hashed_state.total_len(), result.hashed_state.total_len());
-            assert_eq!(first.trie_updates.total_len(), result.trie_updates.total_len());
-            assert_eq!(first.anchor_hash(), result.anchor_hash());
+            assert!(Arc::ptr_eq(&first.hashed_state, &result.hashed_state));
+            assert!(Arc::ptr_eq(&first.trie_updates, &result.trie_updates));
         }
     }
 

--- a/crates/chain-state/src/deferred_trie.rs
+++ b/crates/chain-state/src/deferred_trie.rs
@@ -304,6 +304,15 @@ impl DeferredTrieData {
     /// - If the async task has completed (`Ready`), returns the cached result.
     /// - If pending, computes synchronously from stored inputs.
     ///
+    /// The mutex is only held for state inspection and result publishing, never across
+    /// the expensive `sort_and_build_trie_input` call (which uses `rayon::join`). This
+    /// prevents deadlocks when callers participate in the rayon pool while holding external
+    /// locks that other rayon tasks may contend on.
+    ///
+    /// If two callers race on `Pending`, both may compute independently; the first to
+    /// re-acquire the lock publishes, the second sees `Ready` and discards its duplicate.
+    /// This is safe because the computation is deterministic.
+    ///
     /// Deadlock is avoided as long as the provided ancestors form a true ancestor chain (a DAG):
     /// - Each block only waits on its ancestors (blocks on the path to the persisted root)
     /// - Sibling blocks (forks) are never in each other's ancestor lists
@@ -312,35 +321,36 @@ impl DeferredTrieData {
     /// Given that invariant, circular wait dependencies are impossible.
     #[instrument(level = "debug", target = "engine::tree::deferred_trie", skip_all)]
     pub fn wait_cloned(&self) -> ComputedTrieData {
+        // Clone pending inputs (if any) while holding the lock briefly.
+        let inputs = {
+            let state = self.state.lock();
+            match &*state {
+                DeferredState::Ready(bundle) => {
+                    DEFERRED_TRIE_METRICS.deferred_trie_async_ready.increment(1);
+                    return bundle.clone();
+                }
+                DeferredState::Pending(maybe_inputs) => {
+                    DEFERRED_TRIE_METRICS.deferred_trie_sync_fallback.increment(1);
+                    maybe_inputs.as_ref().expect("inputs must be present in Pending state").clone()
+                }
+            }
+        };
+
+        // Expensive work (rayon::join inside) runs without holding the mutex.
+        let computed = Self::sort_and_build_trie_input(
+            inputs.hashed_state,
+            inputs.trie_updates,
+            inputs.anchor_hash,
+            &inputs.ancestors,
+        );
+
+        // Publish the result if no other caller has done so yet.
         let mut state = self.state.lock();
-        match &mut *state {
-            // If the deferred trie data is ready, return the cached result.
-            DeferredState::Ready(bundle) => {
-                DEFERRED_TRIE_METRICS.deferred_trie_async_ready.increment(1);
-                bundle.clone()
-            }
-            // If the deferred trie data is pending, compute the trie data synchronously and return
-            // the result. This is the fallback path if the async task hasn't completed.
-            DeferredState::Pending(maybe_inputs) => {
-                DEFERRED_TRIE_METRICS.deferred_trie_sync_fallback.increment(1);
-
-                let inputs = maybe_inputs.take().expect("inputs must be present in Pending state");
-
-                let computed = Self::sort_and_build_trie_input(
-                    inputs.hashed_state,
-                    inputs.trie_updates,
-                    inputs.anchor_hash,
-                    &inputs.ancestors,
-                );
-                *state = DeferredState::Ready(computed.clone());
-
-                // Release lock before inputs (and its ancestors) drop to avoid holding it
-                // while their potential last Arc refs drop (which could trigger recursive locking)
-                drop(state);
-
-                computed
-            }
+        if matches!(&*state, DeferredState::Pending(_)) {
+            *state = DeferredState::Ready(computed.clone());
         }
+
+        computed
     }
 }
 
@@ -464,10 +474,13 @@ mod tests {
         assert_eq!(first.anchor_hash(), second.anchor_hash());
     }
 
-    /// Verifies that concurrent `wait_cloned` calls result in only one computation,
-    /// with all callers receiving the same cached result.
+    /// Verifies that concurrent `wait_cloned` calls all produce equivalent results.
+    ///
+    /// Because the mutex is not held across the expensive computation, concurrent callers
+    /// may compute independently. The first to re-acquire the lock publishes its result;
+    /// subsequent callers either see `Ready` or compute an equivalent duplicate.
     #[test]
-    fn concurrent_wait_cloned_computes_once() {
+    fn concurrent_wait_cloned_produces_equivalent_results() {
         let deferred = empty_pending();
 
         // Spawn multiple threads that all call wait_cloned concurrently
@@ -481,11 +494,12 @@ mod tests {
         // Collect all results
         let results: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
 
-        // All results should share the same Arc pointers (same computed result)
+        // All results should be logically equivalent
         let first = &results[0];
         for result in &results[1..] {
-            assert!(Arc::ptr_eq(&first.hashed_state, &result.hashed_state));
-            assert!(Arc::ptr_eq(&first.trie_updates, &result.trie_updates));
+            assert_eq!(first.hashed_state.total_len(), result.hashed_state.total_len());
+            assert_eq!(first.trie_updates.total_len(), result.trie_updates.total_len());
+            assert_eq!(first.anchor_hash(), result.anchor_hash());
         }
     }
 

--- a/crates/chain-state/src/deferred_trie.rs
+++ b/crates/chain-state/src/deferred_trie.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::B256;
-use parking_lot::Mutex;
+use parking_lot::{Condvar, Mutex};
 use reth_metrics::{metrics::Counter, Metrics};
 use reth_trie::{
     updates::{TrieUpdates, TrieUpdatesSorted},
@@ -19,7 +19,7 @@ use tracing::instrument;
 #[derive(Clone)]
 pub struct DeferredTrieData {
     /// Shared deferred state holding either raw inputs (pending) or computed result (ready).
-    state: Arc<Mutex<DeferredState>>,
+    state: Arc<(Mutex<DeferredState>, Condvar)>,
 }
 
 /// Sorted trie data computed for an executed block.
@@ -90,7 +90,7 @@ struct PendingInputs {
 
 impl fmt::Debug for DeferredTrieData {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let state = self.state.lock();
+        let state = self.state.0.lock();
         match &*state {
             DeferredState::Pending(_) => {
                 f.debug_struct("DeferredTrieData").field("state", &"pending").finish()
@@ -120,12 +120,15 @@ impl DeferredTrieData {
         ancestors: Vec<Self>,
     ) -> Self {
         Self {
-            state: Arc::new(Mutex::new(DeferredState::Pending(Some(PendingInputs {
-                hashed_state,
-                trie_updates,
-                anchor_hash,
-                ancestors,
-            })))),
+            state: Arc::new((
+                Mutex::new(DeferredState::Pending(Some(PendingInputs {
+                    hashed_state,
+                    trie_updates,
+                    anchor_hash,
+                    ancestors,
+                }))),
+                Condvar::new(),
+            )),
         }
     }
 
@@ -134,7 +137,7 @@ impl DeferredTrieData {
     /// Useful when trie data is available immediately.
     /// [`Self::wait_cloned`] will return without any computation.
     pub fn ready(bundle: ComputedTrieData) -> Self {
-        Self { state: Arc::new(Mutex::new(DeferredState::Ready(bundle))) }
+        Self { state: Arc::new((Mutex::new(DeferredState::Ready(bundle)), Condvar::new())) }
     }
 
     /// Sort block execution outputs and build a [`TrieInputSorted`] overlay.
@@ -321,10 +324,12 @@ impl DeferredTrieData {
     /// Given that invariant, circular wait dependencies are impossible.
     #[instrument(level = "debug", target = "engine::tree::deferred_trie", skip_all)]
     pub fn wait_cloned(&self) -> ComputedTrieData {
+        let (lock, cv) = &*self.state;
+
         // Take pending inputs while holding the lock briefly. Using `take()` ensures
         // Arc::try_unwrap can succeed in sort_and_build_trie_input (avoiding expensive clones).
         let inputs = loop {
-            let mut state = self.state.lock();
+            let mut state = lock.lock();
             match &mut *state {
                 DeferredState::Ready(bundle) => {
                     DEFERRED_TRIE_METRICS.deferred_trie_async_ready.increment(1);
@@ -335,15 +340,34 @@ impl DeferredTrieData {
                         DEFERRED_TRIE_METRICS.deferred_trie_sync_fallback.increment(1);
                         break inputs;
                     }
-                    // Another caller has taken the inputs and is computing. Drop the lock
-                    // and yield so we can re-check once the result is published.
-                    drop(state);
-                    std::thread::yield_now();
+                    // Another caller has taken the inputs and is computing.
+                    // Park until they publish the result or restore inputs on panic.
+                    cv.wait(&mut state);
                 }
             }
         };
 
+        // Guard restores inputs if computation panics, so waiters don't block forever.
+        struct RestoreOnPanic<'a> {
+            inputs: Option<PendingInputs>,
+            state: &'a (Mutex<DeferredState>, Condvar),
+        }
+        impl Drop for RestoreOnPanic<'_> {
+            fn drop(&mut self) {
+                if let Some(inputs) = self.inputs.take() {
+                    let (lock, cv) = self.state;
+                    let mut state = lock.lock();
+                    if matches!(&*state, DeferredState::Pending(None)) {
+                        *state = DeferredState::Pending(Some(inputs));
+                    }
+                    cv.notify_all();
+                }
+            }
+        }
+        let mut guard = RestoreOnPanic { inputs: Some(inputs), state: &self.state };
+
         // Expensive work (rayon::join inside) runs without holding the mutex.
+        let inputs = guard.inputs.take().unwrap();
         let computed = Self::sort_and_build_trie_input(
             inputs.hashed_state,
             inputs.trie_updates,
@@ -351,11 +375,16 @@ impl DeferredTrieData {
             &inputs.ancestors,
         );
 
+        // Disarm the panic guard — computation succeeded.
+        std::mem::forget(guard);
+
         // Publish the result. Replace the old state outside the lock to avoid dropping
         // potentially large PendingInputs (and their ancestor Arcs) while holding it.
         let old_state = {
-            let mut state = self.state.lock();
-            std::mem::replace(&mut *state, DeferredState::Ready(computed.clone()))
+            let mut state = lock.lock();
+            let old = std::mem::replace(&mut *state, DeferredState::Ready(computed.clone()));
+            cv.notify_all();
+            old
         };
         drop(old_state);
 


### PR DESCRIPTION
## Summary
Narrows the mutex scope in `wait_cloned()` so the lock is never held across the expensive `sort_and_build_trie_input()` call (which uses `rayon::join` internally).

## Motivation
The persistence thread holds this mutex while participating in rayon via `in_place_scope`. If an overlay prep task on rayon tries to lock the same mutex, a circular dependency forms: persistence waits on rayon progress, rayon worker waits on the mutex → deadlock.

PR #22492 mitigated this by moving overlay prep from `rayon::spawn` to `tokio::spawn_blocking`. This PR fixes the root cause: the mutex should never be held across rayon work, making the deadlock impossible by construction regardless of which threadpool runs the task.

## Changes
- `wait_cloned()` now clones pending inputs (all `Arc`-wrapped, cheap) and drops the lock before computing
- Re-acquires the lock only to publish the result if no other caller beat us
- If two callers race on `Pending`, both compute independently — safe because the computation is deterministic
- Updated `concurrent_wait_cloned_computes_once` test to assert logical equivalence instead of `Arc::ptr_eq`, reflecting the new concurrent behavior

## Testing
```
cargo test -p reth-chain-state  # 47 passed, 0 failed
cargo +nightly fmt --all --check  # clean
```

Prompted by: yk