### PR TITLE
fix: make `SerdeBincodeCompat` generic for `EthereumTxEnvelope`

### DIFF
--- a/crates/primitives-traits/src/serde_bincode_compat.rs
+++ b/crates/primitives-traits/src/serde_bincode_compat.rs
@@ -145,7 +145,7 @@ impl<T: RlpBincode + 'static> SerdeBincodeCompat for T {
 mod block_bincode {
     use crate::serde_bincode_compat::SerdeBincodeCompat;
     use alloc::{borrow::Cow, vec::Vec};
-    use alloy_consensus::{TxEip4844, TxTy};
+    use alloy_consensus::TxTy;
     use alloy_eips::eip4895::Withdrawals;
     use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize, Serializer};
     use serde_with::{DeserializeAs, SerializeAs};
@@ -319,9 +319,11 @@ mod block_bincode {
         }
     }
 
-    impl super::SerdeBincodeCompat for alloy_consensus::EthereumTxEnvelope<TxEip4844> {
+    impl<T: Clone + Serialize + DeserializeOwned + std::fmt::Debug + 'static> super::SerdeBincodeCompat
+        for alloy_consensus::EthereumTxEnvelope<T>
+    {
         type BincodeRepr<'a> =
-            alloy_consensus::serde_bincode_compat::transaction::EthereumTxEnvelope<'a>;
+            alloy_consensus::serde_bincode_compat::transaction::EthereumTxEnvelope<'a, T>;
 
         fn as_repr(&self) -> Self::BincodeRepr<'_> {
             self.into()

--- a/crates/primitives-traits/src/serde_bincode_compat.rs
+++ b/crates/primitives-traits/src/serde_bincode_compat.rs
@@ -319,8 +319,8 @@ mod block_bincode {
         }
     }
 
-    impl<T: Clone + Serialize + DeserializeOwned + std::fmt::Debug + 'static> super::SerdeBincodeCompat
-        for alloy_consensus::EthereumTxEnvelope<T>
+    impl<T: Clone + Serialize + DeserializeOwned + std::fmt::Debug + 'static>
+        super::SerdeBincodeCompat for alloy_consensus::EthereumTxEnvelope<T>
     {
         type BincodeRepr<'a> =
             alloy_consensus::serde_bincode_compat::transaction::EthereumTxEnvelope<'a, T>;

--- a/crates/primitives-traits/src/serde_bincode_compat.rs
+++ b/crates/primitives-traits/src/serde_bincode_compat.rs
@@ -147,6 +147,7 @@ mod block_bincode {
     use alloc::{borrow::Cow, vec::Vec};
     use alloy_consensus::TxTy;
     use alloy_eips::eip4895::Withdrawals;
+    use core::fmt::Debug;
     use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize, Serializer};
     use serde_with::{DeserializeAs, SerializeAs};
 
@@ -319,8 +320,8 @@ mod block_bincode {
         }
     }
 
-    impl<T: Clone + Serialize + DeserializeOwned + std::fmt::Debug + 'static>
-        super::SerdeBincodeCompat for alloy_consensus::EthereumTxEnvelope<T>
+    impl<T: Clone + Serialize + DeserializeOwned + Debug + 'static> super::SerdeBincodeCompat
+        for alloy_consensus::EthereumTxEnvelope<T>
     {
         type BincodeRepr<'a> =
             alloy_consensus::serde_bincode_compat::transaction::EthereumTxEnvelope<'a, T>;


### PR DESCRIPTION
The impl was hardcoded to `TxEip4844`, preventing use with other variants like `TxEip4844WithSidecar`.