### PR TITLE
fix: avoid duplicate runtime initialization on startup

### DIFF
--- a/crates/ethereum/cli/src/app.rs
+++ b/crates/ethereum/cli/src/app.rs
@@ -97,7 +97,21 @@ where
     {
         let runner = match self.runner.take() {
             Some(runner) => runner,
-            None => CliRunner::try_default_runtime()?,
+            None => {
+                let runtime_config = match &self.cli.command {
+                    Commands::Node(command) => {
+                        reth_tasks::RuntimeConfig::default().with_rayon(RayonConfig {
+                            reserved_cpu_cores: command.engine.reserved_cpu_cores,
+                            proof_storage_worker_threads: command.engine.storage_worker_count,
+                            proof_account_worker_threads: command.engine.account_worker_count,
+                            prewarming_threads: command.engine.prewarming_threads,
+                            ..Default::default()
+                        })
+                    }
+                    _ => reth_tasks::RuntimeConfig::default(),
+                };
+                CliRunner::try_with_runtime_config(runtime_config)?
+            }
         };
 
         // Add network name if available to the logs dir
@@ -160,17 +174,6 @@ where
             if let Some(ws_api) = &command.rpc.ws_api {
                 Rpc::validate_selection(ws_api, "ws.api").map_err(|e| eyre!("{e}"))?;
             }
-
-            let rayon_config = RayonConfig {
-                reserved_cpu_cores: command.engine.reserved_cpu_cores,
-                proof_storage_worker_threads: command.engine.storage_worker_count,
-                proof_account_worker_threads: command.engine.account_worker_count,
-                prewarming_threads: command.engine.prewarming_threads,
-                ..Default::default()
-            };
-            let runner = CliRunner::try_with_runtime_config(
-                reth_tasks::RuntimeConfig::default().with_rayon(rayon_config),
-            )?;
 
             runner.run_command_until_exit(|ctx| {
                 command.execute(ctx, FnLauncher::new::<C, Ext>(launcher))

--- a/crates/ethereum/cli/src/app.rs
+++ b/crates/ethereum/cli/src/app.rs
@@ -137,8 +137,8 @@ where
     ///
     /// See [`Cli::init_tracing`] for more information.
     pub fn init_tracing(&mut self, runner: &CliRunner) -> Result<()> {
-        if self.guard.is_none() {
-            self.guard = self.cli.init_tracing(runner, self.layers.take().unwrap_or_default())?;
+        if let Some(layers) = self.layers.take() {
+            self.guard = self.cli.init_tracing(runner, layers)?;
         }
 
         Ok(())

--- a/crates/ethereum/cli/src/interface.rs
+++ b/crates/ethereum/cli/src/interface.rs
@@ -350,7 +350,7 @@ mod tests {
     use super::*;
     use crate::chainspec::SUPPORTED_CHAINS;
     use clap::CommandFactory;
-    use reth_chainspec::SEPOLIA;
+    use reth_chainspec::{EthChainSpec, SEPOLIA};
     use reth_node_core::args::ColorMode;
 
     #[test]

--- a/crates/ethereum/cli/src/interface.rs
+++ b/crates/ethereum/cli/src/interface.rs
@@ -1,11 +1,8 @@
 //! CLI definition and entrypoint to executable
 
-use crate::{
-    app::{run_commands_with, CliApp},
-    chainspec::EthereumChainSpecParser,
-};
+use crate::{app::CliApp, chainspec::EthereumChainSpecParser};
 use clap::{Parser, Subcommand};
-use reth_chainspec::{ChainSpec, EthChainSpec, Hardforks};
+use reth_chainspec::{ChainSpec, Hardforks};
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_commands::{
     common::{CliComponentsBuilder, CliNodeTypes, HeaderMut},
@@ -22,7 +19,6 @@ use reth_node_core::{
     args::{LogArgs, OtlpInitStatus, OtlpLogsStatus, TraceArgs},
     version::version_metadata,
 };
-use reth_node_metrics::recorder::install_prometheus_recorder;
 use reth_rpc_server_types::{DefaultRpcModuleValidator, RpcModuleValidator};
 use reth_tracing::{FileWorkerGuard, Layers};
 use std::{ffi::OsString, fmt, future::Future, marker::PhantomData, sync::Arc};
@@ -135,7 +131,8 @@ impl<
         Fut: Future<Output = eyre::Result<()>>,
         C: ChainSpecParser<ChainSpec = ChainSpec>,
     {
-        self.with_runner(CliRunner::try_default_runtime()?, launcher)
+        self.configure()
+            .run(FnLauncher::new::<C, Ext>(async move |builder, ext| launcher(builder, ext).await))
     }
 
     /// Execute the configured cli command with the provided [`CliComponentsBuilder`].
@@ -156,7 +153,7 @@ impl<
         N: CliNodeTypes<Primitives: NodePrimitives<BlockHeader: HeaderMut>, ChainSpec: Hardforks>,
         C: ChainSpecParser<ChainSpec = N::ChainSpec>,
     {
-        self.with_runner_and_components(CliRunner::try_default_runtime()?, components, launcher)
+        self.configure().run_with_components(components, launcher)
     }
 
     /// Execute the configured cli command with the provided [`CliRunner`].
@@ -192,7 +189,7 @@ impl<
     /// Execute the configured cli command with the provided [`CliRunner`] and
     /// [`CliComponentsBuilder`].
     pub fn with_runner_and_components<N>(
-        mut self,
+        self,
         runner: CliRunner,
         components: impl CliComponentsBuilder<N>,
         launcher: impl AsyncFnOnce(
@@ -204,24 +201,9 @@ impl<
         N: CliNodeTypes<Primitives: NodePrimitives<BlockHeader: HeaderMut>, ChainSpec: Hardforks>,
         C: ChainSpecParser<ChainSpec = N::ChainSpec>,
     {
-        // Add network name if available to the logs dir
-        if let Some(chain_spec) = self.command.chain_spec() {
-            self.logs.log_file_directory =
-                self.logs.log_file_directory.join(chain_spec.chain().to_string());
-        }
-
-        // Apply node-specific log defaults before initializing tracing
-        if matches!(self.command, Commands::Node(_)) {
-            self.logs.apply_node_defaults();
-        }
-
-        let _guard = self.init_tracing(&runner, Layers::new())?;
-
-        // Install the prometheus recorder to be sure to record all metrics
-        install_prometheus_recorder();
-
-        // Use the shared standalone function to avoid duplication
-        run_commands_with::<C, Ext, Rpc, N, SubCmd>(self, runner, components, launcher)
+        let mut app = self.configure();
+        app.set_runner(runner);
+        app.run_with_components(components, launcher)
     }
 
     /// Initializes tracing with the configured options.


### PR DESCRIPTION
Cli::run() and Cli::run_with_components() created a default CliRunner (with all rayon thread pools + tokio runtime) upfront, then for the Node command, run_commands_with() created a second CliRunner with node-specific rayon config. Both sets of identically-named thread pools (cpu, rpc, storage, proof-strg, proof-acct, prewarm) coexisted for the entire process lifetime.

Fix by routing Cli::run() and run_with_components() through self.configure() so CliApp::run_with_components() is the single place that creates the runtime, extracting the Node command's rayon config before construction. Also consolidate with_runner_and_components() to delegate through CliApp instead of duplicating init logic.