### PR TITLE
perf(trie): replace Box clone with unsafe reborrow in prune

### DIFF
--- a/crates/trie/sparse/src/parallel.rs
+++ b/crates/trie/sparse/src/parallel.rs
@@ -1235,8 +1235,14 @@ impl SparseTrie for ParallelSparseTrie {
                 SparseNode::Branch { state_mask, blinded_mask, blinded_hashes, .. } => {
                     // For branch nodes at max depth, collapse all children onto them,
                     if depth == max_depth {
-                        let mut blinded_mask = *blinded_mask;
-                        let mut blinded_hashes = blinded_hashes.clone();
+                        // SAFETY: The branch node fields and the child nodes accessed in the
+                        // loop live in different subtries (parent at max_depth is in the upper
+                        // subtrie, children at max_depth+1 are in lower subtries), so the
+                        // mutable references do not alias.
+                        let state_mask = unsafe { decouple_lt::<TrieMask>(&*state_mask) };
+                        let blinded_mask = unsafe { decouple_lt_mut::<TrieMask>(blinded_mask) };
+                        let blinded_hashes =
+                            unsafe { decouple_lt_mut::<[B256; 16]>(blinded_hashes) };
                         for nibble in state_mask.iter() {
                             if blinded_mask.is_bit_set(nibble) {
                                 continue;
@@ -1261,22 +1267,6 @@ impl SparseTrie for ParallelSparseTrie {
                             blinded_hashes[nibble as usize] = hash;
                             effective_pruned_roots.push(child);
                         }
-
-                        let SparseNode::Branch {
-                            blinded_mask: old_blinded_mask,
-                            blinded_hashes: old_blinded_hashes,
-                            ..
-                        } = self
-                            .subtrie_for_path_mut_untracked(&path)
-                            .unwrap()
-                            .nodes
-                            .get_mut(&path)
-                            .unwrap()
-                        else {
-                            unreachable!("expected branch node at path {path:?}");
-                        };
-                        *old_blinded_mask = blinded_mask;
-                        *old_blinded_hashes = blinded_hashes;
                     } else {
                         for nibble in state_mask.iter() {
                             if blinded_mask.is_bit_set(nibble) {
@@ -8874,4 +8864,14 @@ mod tests {
         // Call root() to compute the trie root hash
         let _root = trie.root();
     }
+}
+
+/// Changes the lifetime of the given reference.
+unsafe fn decouple_lt<'a, T: ?Sized>(x: &T) -> &'a T {
+    unsafe { core::mem::transmute(x) }
+}
+
+/// Changes the lifetime of the given mutable reference.
+unsafe fn decouple_lt_mut<'a, T: ?Sized>(x: &mut T) -> &'a mut T {
+    unsafe { core::mem::transmute(x) }
 }

--- a/crates/trie/sparse/src/parallel.rs
+++ b/crates/trie/sparse/src/parallel.rs
@@ -3535,6 +3535,16 @@ enum SparseTrieUpdatesAction {
     InsertUpdated(Nibbles, BranchNodeCompact),
 }
 
+/// Changes the lifetime of the given reference.
+unsafe fn decouple_lt<'a, T: ?Sized>(x: &T) -> &'a T {
+    unsafe { core::mem::transmute(x) }
+}
+
+/// Changes the lifetime of the given mutable reference.
+unsafe fn decouple_lt_mut<'a, T: ?Sized>(x: &mut T) -> &'a mut T {
+    unsafe { core::mem::transmute(x) }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -8864,14 +8874,4 @@ mod tests {
         // Call root() to compute the trie root hash
         let _root = trie.root();
     }
-}
-
-/// Changes the lifetime of the given reference.
-unsafe fn decouple_lt<'a, T: ?Sized>(x: &T) -> &'a T {
-    unsafe { core::mem::transmute(x) }
-}
-
-/// Changes the lifetime of the given mutable reference.
-unsafe fn decouple_lt_mut<'a, T: ?Sized>(x: &mut T) -> &'a mut T {
-    unsafe { core::mem::transmute(x) }
 }


### PR DESCRIPTION
## Summary
Eliminates a 512-byte heap allocation (`Box<[B256; 16]>::clone()`) per branch node at `max_depth` during `ParallelSparseTrie::prune` by using unsafe lifetime decoupling to mutate `blinded_mask` and `blinded_hashes` in place.

## Changes
- Replace `blinded_hashes.clone()` + write-back pattern with `decouple_lt_mut` to mutate branch fields in-place
- Remove the second `subtrie_for_path_mut_untracked(&path)` lookup that was only needed to write back the cloned values
- Add `decouple_lt` / `decouple_lt_mut` unsafe helpers for lifetime decoupling

## Safety
The parent branch node at `path` (depth = `max_depth`) lives in the upper subtrie, while child nodes at `child` (depth = `max_depth + 1`) are in lower subtries. `subtrie_for_path_mut_untracked(&child)` returns a different subtrie, so the mutable references do not alias.

## Testing
All 95 tests in `reth-trie-sparse` pass.

Prompted by: danipopes