### PR TITLE
perf(trie): reserve capacity in apply_subtrie_update_actions

### DIFF
--- a/crates/trie/sparse/src/parallel.rs
+++ b/crates/trie/sparse/src/parallel.rs
@@ -999,6 +999,7 @@ impl SparseTrie for ParallelSparseTrie {
                 // Sync branch_node_masks with what's being committed to DB.
                 // This ensures that on subsequent root() calls, the masks reflect the actual
                 // DB state, which is needed for correct removal detection.
+                self.branch_node_masks.reserve(updates.updated_nodes.len());
                 for (path, node) in &updates.updated_nodes {
                     self.branch_node_masks.insert(
                         *path,

--- a/crates/trie/sparse/src/parallel.rs
+++ b/crates/trie/sparse/src/parallel.rs
@@ -1864,6 +1864,9 @@ impl ParallelSparseTrie {
         update_actions: impl Iterator<Item = SparseTrieUpdatesAction>,
     ) {
         if let Some(updates) = self.updates.as_mut() {
+            let additional = update_actions.size_hint().0;
+            updates.updated_nodes.reserve(additional);
+            updates.removed_nodes.reserve(additional);
             for action in update_actions {
                 match action {
                     SparseTrieUpdatesAction::InsertRemoved(path) => {


### PR DESCRIPTION
Pre-reserve capacity in `updated_nodes` and `removed_nodes` before iterating over update actions, avoiding incremental reallocations.

Prompted by: danipopes