### PR TITLE
ci: use native ARM runner for aarch64 linux release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
             profile: maxperf
             allow_fail: false
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-24.04
+            os: ubuntu-24.04-arm
             profile: maxperf
             allow_fail: false
           - target: x86_64-apple-darwin


### PR DESCRIPTION
## Summary

Use `ubuntu-24.04-arm` GHA runner for the `aarch64-unknown-linux-gnu` release build.

## Changes

- Switch `aarch64-unknown-linux-gnu` runner from `ubuntu-24.04` to `ubuntu-24.04-arm`

Prompted by: DaniPopes