### PR TITLE
feat(db): warmup branch pages for key tables on startup

### DIFF
--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -615,6 +615,55 @@ impl DatabaseEnv {
         }
     }
 
+    /// Warms up the branch pages of the specified tables by faulting them into the mmap.
+    pub fn warmup_branch_pages(&self, table_names: &[&str]) {
+        let tx = match self.inner.begin_ro_txn() {
+            Ok(tx) => tx,
+            Err(e) => {
+                reth_tracing::tracing::warn!(
+                    target: "storage::db::mdbx",
+                    %e,
+                    "Failed to begin read transaction for branch page warmup"
+                );
+                return
+            }
+        };
+
+        for table_name in table_names {
+            match tx.open_db(Some(table_name)) {
+                Ok(db) => {
+                    let stat = tx.db_stat(db.dbi()).ok();
+                    if let Err(e) = tx.warmup_branch_pages(db.dbi()) {
+                        reth_tracing::tracing::warn!(
+                            target: "storage::db::mdbx",
+                            table = %table_name,
+                            %e,
+                            "Failed to warmup branch pages"
+                        );
+                    } else if let Some(stat) = stat {
+                        reth_tracing::tracing::info!(
+                            target: "storage::db::mdbx",
+                            table = %table_name,
+                            branch_pages = %stat.branch_pages(),
+                            "Warmed up branch pages"
+                        );
+                    }
+                }
+                Err(reth_libmdbx::Error::NotFound) => {}
+                Err(e) => {
+                    reth_tracing::tracing::warn!(
+                        target: "storage::db::mdbx",
+                        table = %table_name,
+                        %e,
+                        "Failed to open table for branch page warmup"
+                    );
+                }
+            }
+        }
+
+        let _ = tx.commit();
+    }
+
     /// Records version that accesses the database with write privileges.
     pub fn record_client_version(&self, version: ClientVersion) -> Result<(), DatabaseError> {
         if version.is_empty() {

--- a/crates/storage/db/src/mdbx.rs
+++ b/crates/storage/db/src/mdbx.rs
@@ -12,6 +12,17 @@ pub use reth_libmdbx::*;
 /// versions. These will be dropped during database initialization.
 const ORPHAN_TABLES: &[&str] = &["AccountsTrieChangeSets", "StoragesTrieChangeSets"];
 
+/// Tables whose branch pages are warmed up on startup to reduce page fault latency
+/// during block execution and state root computation.
+const WARMUP_TABLES: &[&str] = &[
+    "AccountsTrie",
+    "StoragesTrie",
+    "HashedAccounts",
+    "HashedStorages",
+    "PlainAccountState",
+    "PlainStorageState",
+];
+
 /// Creates a new database at the specified path if it doesn't exist. Does NOT create tables. Check
 /// [`init_db`].
 pub fn create_db<P: AsRef<Path>>(path: P, args: DatabaseArguments) -> eyre::Result<DatabaseEnv> {
@@ -50,6 +61,7 @@ pub fn init_db_for<P: AsRef<Path>, TS: TableSet>(
     db.create_and_track_tables_for::<TS>()?;
     db.record_client_version(client_version)?;
     drop_orphan_tables(&db);
+    db.warmup_branch_pages(WARMUP_TABLES);
     Ok(db)
 }
 

--- a/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx.c
+++ b/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx.c
@@ -7104,6 +7104,46 @@ __cold int mdbx_env_warmup(const MDBX_env *env, const MDBX_txn *txn, MDBX_warmup
   return LOG_IFERR(rc);
 }
 
+static int warmup_walk_branches(const MDBX_cursor *mc, const pgno_t pgno,
+                                const unsigned remaining,
+                                const txnid_t front) {
+  if (remaining == 0)
+    return MDBX_SUCCESS;
+
+  page_t *mp;
+  int rc = page_get(mc, pgno, &mp, front);
+  if (unlikely(rc != MDBX_SUCCESS))
+    return rc;
+
+  cASSERT(mc, is_branch(mp));
+  const size_t nkeys = page_numkeys(mp);
+  for (size_t i = 0; i < nkeys; i++) {
+    const node_t *node = page_node(mp, i);
+    rc = warmup_walk_branches(mc, node_pgno(node), remaining - 1, mp->txnid);
+    if (unlikely(rc != MDBX_SUCCESS))
+      return rc;
+  }
+  return MDBX_SUCCESS;
+}
+
+__cold int mdbx_dbi_warmup(const MDBX_txn *txn, MDBX_dbi dbi) {
+  int rc = check_txn(txn, MDBX_TXN_FINISHED | MDBX_TXN_ERROR);
+  if (unlikely(rc != MDBX_SUCCESS))
+    return LOG_IFERR(rc);
+
+  cursor_couple_t couple;
+  rc = cursor_init(&couple.outer, txn, dbi);
+  if (unlikely(rc != MDBX_SUCCESS))
+    return LOG_IFERR(rc);
+
+  const tree_t *tree = &txn->dbs[dbi];
+  if (tree->root == P_INVALID || tree->height <= 1)
+    return MDBX_SUCCESS;
+
+  return LOG_IFERR(warmup_walk_branches(
+      &couple.outer, tree->root, tree->height - 1, tree->mod_txnid));
+}
+
 /*----------------------------------------------------------------------------*/
 
 __cold int mdbx_env_get_fd(const MDBX_env *env, mdbx_filehandle_t *arg) {

--- a/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx.h
+++ b/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx.h
@@ -3278,6 +3278,20 @@ DEFINE_ENUM_FLAG_OPERATORS(MDBX_warmup_flags)
 LIBMDBX_API int mdbx_env_warmup(const MDBX_env *env, const MDBX_txn *txn, MDBX_warmup_flags_t flags,
                                 unsigned timeout_seconds_16dot16);
 
+/** \brief Warms up the branch (internal) pages of a specific database's
+ * B-tree by walking the tree and touching only non-leaf pages.
+ * \ingroup c_settings
+ *
+ * This is useful for preloading the B-tree navigation structure into the
+ * OS page cache on startup, so that subsequent key lookups avoid page faults
+ * on internal nodes. Leaf pages (which hold the actual data) are not touched.
+ *
+ * \param [in] txn  A transaction handle returned by \ref mdbx_txn_begin().
+ * \param [in] dbi  A database handle returned by \ref mdbx_dbi_open().
+ *
+ * \returns A non-zero error value on failure and 0 on success. */
+LIBMDBX_API int mdbx_dbi_warmup(const MDBX_txn *txn, MDBX_dbi dbi);
+
 /** \brief Set environment flags.
  * \ingroup c_settings
  *

--- a/crates/storage/libmdbx-rs/src/transaction.rs
+++ b/crates/storage/libmdbx-rs/src/transaction.rs
@@ -241,6 +241,13 @@ where
         self.db_stat_with_dbi(dbi)
     }
 
+    /// Warms up the branch (internal) pages of the given database's B-tree by
+    /// walking the tree and faulting only non-leaf pages into the mmap.
+    pub fn warmup_branch_pages(&self, dbi: ffi::MDBX_dbi) -> Result<()> {
+        self.txn_execute(|txn| unsafe { mdbx_result(ffi::mdbx_dbi_warmup(txn, dbi)) })??;
+        Ok(())
+    }
+
     /// Retrieves database statistics by the given dbi.
     pub fn db_stat_with_dbi(&self, dbi: ffi::MDBX_dbi) -> Result<Stat> {
         unsafe {


### PR DESCRIPTION
## Summary

Adds `mdbx_dbi_warmup(txn, dbi)` that walks a table's B-tree touching only branch (internal) pages, then calls it during `init_db` for the hot-path tables.

## Motivation

On cold start, the first block executions and state root computations hit page faults on every B-tree internal node lookup. Branch pages are a tiny fraction of total data (~0.1% for large tables) but sit on every lookup path. Preloading them into the OS page cache eliminates these faults.

## Changes

- `mdbx.h` / `mdbx.c`: new `mdbx_dbi_warmup()` C function. Uses tree height to walk only branch levels (depths 0..height-2), never touches leaf pages. Recursive with max depth bounded by `CURSOR_STACK` (~20 levels).
- `libmdbx-rs/src/transaction.rs`: `Transaction::warmup_branch_pages(dbi)` Rust binding.
- `db/src/implementation/mdbx/mod.rs`: `DatabaseEnv::warmup_branch_pages()` that opens tables, calls warmup, logs branch page count per table.
- `db/src/mdbx.rs`: calls warmup in `init_db_for()` for `AccountsTrie`, `StoragesTrie`, `HashedAccounts`, `HashedStorages`, `PlainAccountState`, `PlainStorageState`.

## Testing

```
cargo test -p reth-libmdbx  # 11 passed
cargo test -p reth-db       # 38 passed
```

Prompted by: alexey