### PR TITLE
feat(rpc): extend reth_newPayload to accept RLP-encoded blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9999,6 +9999,7 @@ dependencies = [
  "reth-testing-utils",
  "reth-transaction-pool",
  "serde",
+ "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/crates/rpc/rpc-api/src/lib.rs
+++ b/crates/rpc/rpc-api/src/lib.rs
@@ -48,7 +48,7 @@ pub mod servers {
         net::NetApiServer,
         otterscan::OtterscanServer,
         reth::RethApiServer,
-        reth_engine::{RethEngineApiServer, RethPayloadStatus},
+        reth_engine::{RethEngineApiServer, RethNewPayloadInput, RethPayloadStatus},
         rpc::RpcApiServer,
         testing::TestingApiServer,
         trace::TraceApiServer,

--- a/crates/rpc/rpc-api/src/reth_engine.rs
+++ b/crates/rpc/rpc-api/src/reth_engine.rs
@@ -1,6 +1,7 @@
 //! Reth-specific engine API extensions.
 
-use alloy_rpc_types_engine::{ExecutionData, PayloadStatus};
+use alloy_primitives::Bytes;
+use alloy_rpc_types_engine::PayloadStatus;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use serde::{Deserialize, Serialize};
 
@@ -24,16 +25,35 @@ pub struct RethPayloadStatus {
 
 /// Reth-specific engine API extensions.
 ///
-/// This trait provides a `reth_newPayload` endpoint that takes `ExecutionData` directly
-/// (payload + sidecar), waiting for persistence and cache locks before processing.
+/// This trait provides a `reth_newPayload` endpoint that accepts either an `ExecutionData` JSON
+/// object or an RLP-encoded primitive block (hex bytes), waiting for persistence and cache locks
+/// before processing.
 ///
 /// Responses include timing breakdowns with server-measured execution latency.
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "reth"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "reth"))]
 pub trait RethEngineApi {
-    /// Reth-specific newPayload that takes `ExecutionData` directly.
+    /// Reth-specific newPayload that takes either `ExecutionData` directly or an RLP-encoded
+    /// primitive block.
     ///
     /// Waits for persistence, execution cache, and sparse trie locks before processing.
     #[method(name = "newPayload")]
-    async fn reth_new_payload(&self, payload: ExecutionData) -> RpcResult<RethPayloadStatus>;
+    async fn reth_new_payload(&self, payload: RethNewPayloadInput) -> RpcResult<RethPayloadStatus>;
+}
+
+/// Input for `reth_newPayload`.
+///
+/// Accepts either an `ExecutionData` JSON object or a hex-encoded RLP primitive block.
+/// Uses `#[serde(untagged)]` to distinguish: a JSON string is decoded as RLP bytes, a JSON object
+/// is forwarded as-is for deserialization into the engine's `ExecutionData` type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum RethNewPayloadInput {
+    /// RLP-encoded primitive block (hex-encoded bytes).
+    ///
+    /// Listed first so serde tries matching a JSON string before falling back to the object
+    /// variant.
+    RlpBlock(Bytes),
+    /// Standard execution data (JSON object).
+    ExecutionData(serde_json::Value),
 }

--- a/crates/rpc/rpc-engine-api/Cargo.toml
+++ b/crates/rpc/rpc-engine-api/Cargo.toml
@@ -28,6 +28,7 @@ reth-network-api.workspace = true
 # ethereum
 alloy-eips.workspace = true
 alloy-primitives.workspace = true
+alloy-rlp.workspace = true
 alloy-rpc-types-engine.workspace = true
 
 # async
@@ -42,6 +43,7 @@ async-trait.workspace = true
 jsonrpsee-core.workspace = true
 jsonrpsee-types.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
@@ -51,7 +53,6 @@ reth-provider = { workspace = true, features = ["test-utils"] }
 reth-ethereum-primitives.workspace = true
 reth-payload-builder = { workspace = true, features = ["test-utils"] }
 reth-testing-utils.workspace = true
-alloy-rlp.workspace = true
 reth-node-ethereum.workspace = true
 reth-tasks = { workspace = true, features = ["test-utils"] }
 

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -25,9 +25,10 @@ use reth_payload_primitives::{
     validate_payload_timestamp, EngineApiMessageVersion, MessageValidationKind,
     PayloadOrAttributes, PayloadTypes,
 };
-use reth_primitives_traits::{Block, BlockBody};
+use reth_primitives_traits::{Block, BlockBody, SealedBlock};
 use reth_rpc_api::{
-    EngineApiServer, IntoEngineApiRpcModule, RethEngineApiServer, RethPayloadStatus,
+    EngineApiServer, IntoEngineApiRpcModule, RethEngineApiServer, RethNewPayloadInput,
+    RethPayloadStatus,
 };
 use reth_storage_api::{BlockReader, HeaderProvider, StateProviderFactory};
 use reth_tasks::Runtime;
@@ -275,6 +276,22 @@ where
             execution_cache_wait_us: timings.execution_cache_wait.as_micros() as u64,
             sparse_trie_wait_us: timings.sparse_trie_wait.as_micros() as u64,
         })
+    }
+
+    /// Decodes an RLP-encoded primitive block and converts it to `ExecutionData` via
+    /// [`PayloadTypes::block_to_payload`].
+    pub fn rlp_to_execution_data(rlp: &[u8]) -> EngineApiResult<PayloadT::ExecutionData> {
+        type BlockFor<T> = <<<T as PayloadTypes>::BuiltPayload as reth_payload_primitives::BuiltPayload>::Primitives as reth_primitives_traits::NodePrimitives>::Block;
+
+        let block: BlockFor<PayloadT> = alloy_rlp::Decodable::decode(&mut &*rlp).map_err(|e| {
+            EngineApiError::other(jsonrpsee_types::ErrorObject::owned(
+                jsonrpsee_types::error::INVALID_PARAMS_CODE,
+                format!("failed to RLP-decode block: {e}"),
+                None::<()>,
+            ))
+        })?;
+
+        Ok(PayloadT::block_to_payload(SealedBlock::seal_slow(block)))
     }
 
     /// Metered version of `reth_new_payload`.
@@ -1316,19 +1333,36 @@ where
 /// Implementation of `RethEngineApiServer` under the `reth_` namespace.
 ///
 /// Waits for execution cache and sparse trie locks before processing.
+///
+/// Accepts either `ExecutionData` (JSON object) or an RLP-encoded primitive block (hex bytes).
 #[async_trait]
 impl<Provider, EngineT, Pool, Validator, ChainSpec> RethEngineApiServer
     for EngineApi<Provider, EngineT, Pool, Validator, ChainSpec>
 where
     Provider: HeaderProvider + BlockReader + StateProviderFactory + 'static,
-    EngineT: EngineTypes<ExecutionData = ExecutionData>,
+    EngineT: EngineTypes,
     Pool: TransactionPool + 'static,
     Validator: EngineApiValidator<EngineT>,
     ChainSpec: EthereumHardforks + Send + Sync + 'static,
 {
-    async fn reth_new_payload(&self, payload: ExecutionData) -> RpcResult<RethPayloadStatus> {
+    async fn reth_new_payload(&self, input: RethNewPayloadInput) -> RpcResult<RethPayloadStatus> {
         trace!(target: "rpc::engine", "Serving reth_newPayload");
-        self.reth_new_payload_metered(payload).await
+        let start = Instant::now();
+        let execution_data = match input {
+            RethNewPayloadInput::RlpBlock(rlp) => Self::rlp_to_execution_data(&rlp)?,
+            RethNewPayloadInput::ExecutionData(value) => {
+                serde_json::from_value::<EngineT::ExecutionData>(value).map_err(|e| {
+                    EngineApiError::other(jsonrpsee_types::ErrorObject::owned(
+                        jsonrpsee_types::error::INVALID_PARAMS_CODE,
+                        format!("failed to deserialize ExecutionData: {e}"),
+                        None::<()>,
+                    ))
+                })?
+            }
+        };
+        let res = Self::reth_new_payload(self, execution_data).await;
+        self.inner.metrics.latency.new_payload_v1.record(start.elapsed());
+        Ok(res?)
     }
 }
 


### PR DESCRIPTION
## Summary

Extends `reth_newPayload` to accept either an `ExecutionData` JSON object (existing behavior) or hex-encoded RLP block bytes via an untagged enum `RethNewPayloadInput`.

## Motivation

Chains with custom `ExecutionData` types need a way to submit blocks without going through the Ethereum-specific serialization format. The RLP path decodes the primitive block, seals it, and converts to `ExecutionData` via `PayloadTypes::block_to_payload`.

## Changes

- `RethNewPayloadInput`: new `#[serde(untagged)]` enum with `RlpBlock(Bytes)` and `ExecutionData(serde_json::Value)` variants
- `RethEngineApi` trait method signature changed from `ExecutionData` to `RethNewPayloadInput`
- `RethEngineApiServer` impl relaxed from `EngineTypes<ExecutionData = ExecutionData>` to `EngineTypes`
- `rlp_to_execution_data` helper on `EngineApi` decodes RLP bytes → sealed block → `block_to_payload`

## Testing

```
cargo check -p reth-rpc-engine-api --all-targets
cargo +nightly clippy -p reth-rpc-engine-api -p reth-rpc-api --all-targets -- -D warnings
cargo +nightly fmt --all --check
zepter
```

Prompted by: arsenii