### PR TITLE
fix(rpc): prevent u64 underflow when re-executing genesis block

### DIFF
--- a/crates/rpc/rpc/src/reth.rs
+++ b/crates/rpc/rpc/src/reth.rs
@@ -156,9 +156,7 @@ where
         };
 
         if start_block == 0 {
-            return Err(EthApiError::InvalidParams(
-                "cannot re-execute genesis block".into(),
-            ));
+            return Ok(Some(ExecutionOutcome::default()))
         }
 
         let state_provider = self.provider().history_by_block_number(start_block - 1)?;

--- a/crates/rpc/rpc/src/reth.rs
+++ b/crates/rpc/rpc/src/reth.rs
@@ -155,6 +155,12 @@ where
             return Ok(None)
         };
 
+        if start_block == 0 {
+            return Err(EthApiError::InvalidParams(
+                "cannot re-execute genesis block".into(),
+            ));
+        }
+
         let state_provider = self.provider().history_by_block_number(start_block - 1)?;
         let db = reth_revm::database::StateProviderDatabase::new(&state_provider);
 


### PR DESCRIPTION
Was running a script locally to pull execution outcomes for a range of blocks on a debug build, and it panicked at block 0 with "attempt to subtract with overflow". And realize it's just `start_block - 1` on line 158 not handling the genesis case.

In release mode it wraps to u64::MAX and you get some confusing provider error that doesn't tell you what actually went wrong. Added an early return with a clear error message for block 0 since there's no prior state to re-execute against anyway.