### PR TITLE
feat(rpc): accept RLP-encoded blocks in reth_newPayload

### DIFF
--- a/crates/rpc/rpc-api/src/lib.rs
+++ b/crates/rpc/rpc-api/src/lib.rs
@@ -48,7 +48,7 @@ pub mod servers {
         net::NetApiServer,
         otterscan::OtterscanServer,
         reth::RethApiServer,
-        reth_engine::{RethEngineApiServer, RethPayloadStatus},
+        reth_engine::{RethEngineApiServer, RethNewPayloadInput, RethPayloadStatus},
         rpc::RpcApiServer,
         testing::TestingApiServer,
         trace::TraceApiServer,

--- a/crates/rpc/rpc-api/src/reth_engine.rs
+++ b/crates/rpc/rpc-api/src/reth_engine.rs
@@ -34,7 +34,7 @@ pub enum RethNewPayloadInput<ExecutionData> {
     /// Standard execution data (payload + sidecar).
     ExecutionData(ExecutionData),
     /// An RLP-encoded block.
-    RlpEncodedBlock(Bytes),
+    BlockRlp(Bytes),
 }
 
 /// Reth-specific engine API extensions.

--- a/crates/rpc/rpc-api/src/reth_engine.rs
+++ b/crates/rpc/rpc-api/src/reth_engine.rs
@@ -25,9 +25,6 @@ pub struct RethPayloadStatus {
 
 /// Input for `reth_newPayload` that accepts either `ExecutionData` directly or an RLP-encoded
 /// block.
-///
-/// When an RLP-encoded block is provided, it will be decoded and converted to `ExecutionData` via
-/// [`PayloadTypes::block_to_payload`](reth_payload_primitives::PayloadTypes::block_to_payload).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum RethNewPayloadInput<ExecutionData> {

--- a/crates/rpc/rpc-api/src/reth_engine.rs
+++ b/crates/rpc/rpc-api/src/reth_engine.rs
@@ -1,5 +1,6 @@
 //! Reth-specific engine API extensions.
 
+use alloy_primitives::Bytes;
 use alloy_rpc_types_engine::PayloadStatus;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use serde::{Deserialize, Serialize};
@@ -22,18 +23,37 @@ pub struct RethPayloadStatus {
     pub sparse_trie_wait_us: u64,
 }
 
+/// Input for `reth_newPayload` that accepts either `ExecutionData` directly or an RLP-encoded
+/// block.
+///
+/// When an RLP-encoded block is provided, it will be decoded and converted to `ExecutionData` via
+/// [`PayloadTypes::block_to_payload`](reth_payload_primitives::PayloadTypes::block_to_payload).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum RethNewPayloadInput<ExecutionData> {
+    /// Standard execution data (payload + sidecar).
+    ExecutionData(ExecutionData),
+    /// An RLP-encoded block.
+    RlpEncodedBlock(Bytes),
+}
+
 /// Reth-specific engine API extensions.
 ///
-/// This trait provides a `reth_newPayload` endpoint that takes `ExecutionData` directly
-/// (payload + sidecar), waiting for persistence and cache locks before processing.
+/// This trait provides a `reth_newPayload` endpoint that accepts either `ExecutionData` directly
+/// (payload + sidecar) or an RLP-encoded block, waiting for persistence and cache locks before
+/// processing.
 ///
 /// Responses include timing breakdowns with server-measured execution latency.
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "reth"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "reth"))]
 pub trait RethEngineApi<ExecutionData> {
-    /// Reth-specific newPayload that takes `ExecutionData` directly.
+    /// Reth-specific newPayload that accepts either `ExecutionData` directly or an RLP-encoded
+    /// block.
     ///
     /// Waits for persistence, execution cache, and sparse trie locks before processing.
     #[method(name = "newPayload")]
-    async fn reth_new_payload(&self, payload: ExecutionData) -> RpcResult<RethPayloadStatus>;
+    async fn reth_new_payload(
+        &self,
+        payload: RethNewPayloadInput<ExecutionData>,
+    ) -> RpcResult<RethPayloadStatus>;
 }

--- a/crates/rpc/rpc-engine-api/Cargo.toml
+++ b/crates/rpc/rpc-engine-api/Cargo.toml
@@ -28,6 +28,7 @@ reth-network-api.workspace = true
 # ethereum
 alloy-eips.workspace = true
 alloy-primitives.workspace = true
+alloy-rlp.workspace = true
 alloy-rpc-types-engine.workspace = true
 
 # async

--- a/crates/rpc/rpc-engine-api/src/reth_engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/reth_engine_api.rs
@@ -3,8 +3,8 @@ use alloy_rlp::Decodable;
 use async_trait::async_trait;
 use jsonrpsee_core::RpcResult;
 use reth_engine_primitives::ConsensusEngineHandle;
-use reth_payload_primitives::{BuiltPayload, PayloadTypes};
-use reth_primitives_traits::{NodePrimitives, SealedBlock};
+use reth_payload_primitives::PayloadTypes;
+use reth_primitives_traits::SealedBlock;
 use reth_rpc_api::{RethEngineApiServer, RethNewPayloadInput, RethPayloadStatus};
 use tracing::trace;
 
@@ -35,9 +35,10 @@ impl<Payload: PayloadTypes> RethEngineApiServer<Payload::ExecutionData> for Reth
 
         let payload = match input {
             RethNewPayloadInput::ExecutionData(data) => data,
-            RethNewPayloadInput::RlpEncodedBlock(rlp) => {
-                let block = Decodable::decode(&mut rlp.as_ref()).map_err(|err| EngineApiError::Internal(Box::new(err)))?;
-                Payload::block_to_payload(SealedBlock::seal_slow(block))
+            RethNewPayloadInput::BlockRlp(rlp) => {
+                let block = Decodable::decode(&mut rlp.as_ref())
+                    .map_err(|err| EngineApiError::Internal(Box::new(err)))?;
+                Payload::block_to_payload(SealedBlock::new_unhashed(block))
             }
         };
 

--- a/crates/rpc/rpc-engine-api/src/reth_engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/reth_engine_api.rs
@@ -36,8 +36,7 @@ impl<Payload: PayloadTypes> RethEngineApiServer<Payload::ExecutionData> for Reth
         let payload = match input {
             RethNewPayloadInput::ExecutionData(data) => data,
             RethNewPayloadInput::RlpEncodedBlock(rlp) => {
-                let block = <<Payload::BuiltPayload as BuiltPayload>::Primitives as NodePrimitives>::Block::decode(&mut rlp.as_ref())
-                    .map_err(|err| EngineApiError::Internal(Box::new(err)))?;
+                let block = Decodable::decode(&mut rlp.as_ref()).map_err(|err| EngineApiError::Internal(Box::new(err)))?;
                 Payload::block_to_payload(SealedBlock::seal_slow(block))
             }
         };

--- a/crates/rpc/rpc-engine-api/src/reth_engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/reth_engine_api.rs
@@ -1,16 +1,18 @@
 use crate::EngineApiError;
+use alloy_rlp::Decodable;
 use async_trait::async_trait;
 use jsonrpsee_core::RpcResult;
 use reth_engine_primitives::ConsensusEngineHandle;
-use reth_payload_primitives::PayloadTypes;
-use reth_rpc_api::{RethEngineApiServer, RethPayloadStatus};
+use reth_payload_primitives::{BuiltPayload, PayloadTypes};
+use reth_primitives_traits::{NodePrimitives, SealedBlock};
+use reth_rpc_api::{RethEngineApiServer, RethNewPayloadInput, RethPayloadStatus};
 use tracing::trace;
 
 /// Standalone implementation of the `reth_` engine API namespace.
 ///
-/// Provides the `reth_newPayload` endpoint that takes `ExecutionData` directly,
-/// waits for persistence, execution cache, and sparse trie locks before processing,
-/// and returns timing breakdowns with server-measured execution latency.
+/// Provides the `reth_newPayload` endpoint that accepts either `ExecutionData` directly or an
+/// RLP-encoded block, waits for persistence, execution cache, and sparse trie locks before
+/// processing, and returns timing breakdowns with server-measured execution latency.
 #[derive(Debug)]
 pub struct RethEngineApi<Payload: PayloadTypes> {
     beacon_engine_handle: ConsensusEngineHandle<Payload>,
@@ -27,9 +29,19 @@ impl<Payload: PayloadTypes> RethEngineApi<Payload> {
 impl<Payload: PayloadTypes> RethEngineApiServer<Payload::ExecutionData> for RethEngineApi<Payload> {
     async fn reth_new_payload(
         &self,
-        payload: Payload::ExecutionData,
+        input: RethNewPayloadInput<Payload::ExecutionData>,
     ) -> RpcResult<RethPayloadStatus> {
         trace!(target: "rpc::engine", "Serving reth_newPayload");
+
+        let payload = match input {
+            RethNewPayloadInput::ExecutionData(data) => data,
+            RethNewPayloadInput::RlpEncodedBlock(rlp) => {
+                let block = <<Payload::BuiltPayload as BuiltPayload>::Primitives as NodePrimitives>::Block::decode(&mut rlp.as_ref())
+                    .map_err(|err| EngineApiError::Internal(Box::new(err)))?;
+                Payload::block_to_payload(SealedBlock::seal_slow(block))
+            }
+        };
+
         let (status, timings) = self
             .beacon_engine_handle
             .reth_new_payload(payload)


### PR DESCRIPTION
## Summary

Accept either `ExecutionData` or an RLP-encoded block in `reth_newPayload`.

## Changes

- Add `RethNewPayloadInput<ExecutionData>` untagged enum with two variants: `ExecutionData` (existing JSON object) and `RlpEncodedBlock` (hex-encoded RLP bytes)
- Update `RethEngineApi` / `RethEngineApiServer` trait to take the new enum
- Decode RLP blocks via `Block::decode` and convert to `ExecutionData` via `PayloadTypes::block_to_payload`
- Fully backward-compatible: existing callers sending `ExecutionData` JSON will match the first untagged variant

Prompted by: arsenii