### PR TITLE
feat(rpc): add reth_forkchoiceUpdated endpoint

### DIFF
--- a/bin/reth-bench/src/bench/gas_limit_ramp.rs
+++ b/bin/reth-bench/src/bench/gas_limit_ramp.rs
@@ -6,7 +6,9 @@ use crate::{
         helpers::{build_payload, parse_gas_limit, prepare_payload_request, rpc_block_to_header},
         output::GasRampPayloadFile,
     },
-    valid_payload::{call_forkchoice_updated, call_new_payload_with_reth, payload_to_new_payload},
+    valid_payload::{
+        call_forkchoice_updated_with_reth, call_new_payload_with_reth, payload_to_new_payload,
+    },
 };
 use alloy_eips::BlockNumberOrTag;
 use alloy_provider::{network::AnyNetwork, Provider, RootProvider};
@@ -147,7 +149,7 @@ impl Command {
             }
         }
         if self.reth_new_payload {
-            info!("Using reth_newPayload endpoint");
+            info!("Using reth_newPayload and reth_forkchoiceUpdated endpoints");
         }
 
         let mut blocks_processed = 0u64;
@@ -203,7 +205,13 @@ impl Command {
                 safe_block_hash: block_hash,
                 finalized_block_hash: block_hash,
             };
-            call_forkchoice_updated(&provider, version, forkchoice_state, None).await?;
+            call_forkchoice_updated_with_reth(
+                &provider,
+                version,
+                forkchoice_state,
+                self.reth_new_payload,
+            )
+            .await?;
 
             parent_header = block.header;
             parent_hash = block_hash;

--- a/bin/reth-bench/src/bench/new_payload_fcu.rs
+++ b/bin/reth-bench/src/bench/new_payload_fcu.rs
@@ -21,7 +21,9 @@ use crate::{
             derive_ws_rpc_url, setup_persistence_subscription, PersistenceWaiter,
         },
     },
-    valid_payload::{block_to_new_payload, call_forkchoice_updated, call_new_payload_with_reth},
+    valid_payload::{
+        block_to_new_payload, call_forkchoice_updated_with_reth, call_new_payload_with_reth,
+    },
 };
 use alloy_provider::Provider;
 use alloy_rpc_types_engine::ForkchoiceState;
@@ -159,7 +161,7 @@ impl Command {
         let mut metrics_scraper = MetricsScraper::maybe_new(self.benchmark.metrics_url.clone());
 
         if use_reth_namespace {
-            info!("Using reth_newPayload endpoint");
+            info!("Using reth_newPayload and reth_forkchoiceUpdated endpoints");
         }
 
         let buffer_size = self.rpc_block_buffer_size;
@@ -261,8 +263,17 @@ impl Command {
             };
 
             let fcu_start = Instant::now();
-            call_forkchoice_updated(&auth_provider, version, forkchoice_state, None).await?;
-            let fcu_latency = fcu_start.elapsed();
+            let fcu_server_timings = call_forkchoice_updated_with_reth(
+                &auth_provider,
+                version,
+                forkchoice_state,
+                use_reth_namespace,
+            )
+            .await?;
+            let fcu_latency = fcu_server_timings
+                .as_ref()
+                .map(|t| t.latency)
+                .unwrap_or_else(|| fcu_start.elapsed());
 
             let total_latency = if server_timings.is_some() {
                 // When using server-side latency for newPayload, derive total from the

--- a/bin/reth-bench/src/bench/new_payload_fcu.rs
+++ b/bin/reth-bench/src/bench/new_payload_fcu.rs
@@ -263,17 +263,14 @@ impl Command {
             };
 
             let fcu_start = Instant::now();
-            let fcu_server_timings = call_forkchoice_updated_with_reth(
+            call_forkchoice_updated_with_reth(
                 &auth_provider,
                 version,
                 forkchoice_state,
                 use_reth_namespace,
             )
             .await?;
-            let fcu_latency = fcu_server_timings
-                .as_ref()
-                .map(|t| t.latency)
-                .unwrap_or_else(|| fcu_start.elapsed());
+            let fcu_latency = fcu_start.elapsed();
 
             let total_latency = if server_timings.is_some() {
                 // When using server-side latency for newPayload, derive total from the

--- a/bin/reth-bench/src/bench/replay_payloads.rs
+++ b/bin/reth-bench/src/bench/replay_payloads.rs
@@ -391,17 +391,14 @@ impl Command {
             };
 
             let fcu_start = Instant::now();
-            let fcu_server_timings = call_forkchoice_updated_with_reth(
+            call_forkchoice_updated_with_reth(
                 &auth_provider,
                 EngineApiMessageVersion::V4,
                 fcu_state,
                 self.reth_new_payload,
             )
             .await?;
-            let fcu_latency = fcu_server_timings
-                .as_ref()
-                .map(|t| t.latency)
-                .unwrap_or_else(|| fcu_start.elapsed());
+            let fcu_latency = fcu_start.elapsed();
 
             let total_latency =
                 if server_timings.is_some() { np_latency + fcu_latency } else { start.elapsed() };

--- a/bin/reth-bench/src/bench/replay_payloads.rs
+++ b/bin/reth-bench/src/bench/replay_payloads.rs
@@ -24,10 +24,10 @@ use crate::{
             derive_ws_rpc_url, setup_persistence_subscription, PersistenceWaiter,
         },
     },
-    valid_payload::{call_forkchoice_updated, call_new_payload_with_reth},
+    valid_payload::{call_forkchoice_updated_with_reth, call_new_payload_with_reth},
 };
 use alloy_primitives::B256;
-use alloy_provider::{ext::EngineApi, network::AnyNetwork, Provider, RootProvider};
+use alloy_provider::{network::AnyNetwork, Provider, RootProvider};
 use alloy_rpc_client::ClientBuilder;
 use alloy_rpc_types_engine::{
     CancunPayloadFields, ExecutionData, ExecutionPayloadEnvelopeV4, ExecutionPayloadSidecar,
@@ -184,7 +184,7 @@ impl Command {
             );
         }
         if self.reth_new_payload {
-            info!("Using reth_newPayload endpoint");
+            info!("Using reth_newPayload and reth_forkchoiceUpdated endpoints");
         }
 
         // Set up waiter based on configured options
@@ -288,7 +288,13 @@ impl Command {
                 safe_block_hash: parent_hash,
                 finalized_block_hash: parent_hash,
             };
-            call_forkchoice_updated(&auth_provider, payload.version, fcu_state, None).await?;
+            call_forkchoice_updated_with_reth(
+                &auth_provider,
+                payload.version,
+                fcu_state,
+                self.reth_new_payload,
+            )
+            .await?;
 
             info!(target: "reth-bench", gas_ramp_payload = i + 1, "Gas ramp payload executed successfully");
 
@@ -384,11 +390,18 @@ impl Command {
                 finalized_block_hash: parent_hash,
             };
 
-            debug!(target: "reth-bench", method = "engine_forkchoiceUpdatedV3", ?fcu_state, "Sending forkchoiceUpdated");
-
             let fcu_start = Instant::now();
-            let fcu_result = auth_provider.fork_choice_updated_v3(fcu_state, None).await?;
-            let fcu_latency = fcu_start.elapsed();
+            let fcu_server_timings = call_forkchoice_updated_with_reth(
+                &auth_provider,
+                EngineApiMessageVersion::V4,
+                fcu_state,
+                self.reth_new_payload,
+            )
+            .await?;
+            let fcu_latency = fcu_server_timings
+                .as_ref()
+                .map(|t| t.latency)
+                .unwrap_or_else(|| fcu_start.elapsed());
 
             let total_latency =
                 if server_timings.is_some() { np_latency + fcu_latency } else { start.elapsed() };
@@ -420,7 +433,6 @@ impl Command {
                 TotalGasRow { block_number, transaction_count, gas_used, time: current_duration };
             results.push((gas_row, combined_result));
 
-            debug!(target: "reth-bench", ?fcu_result, "Payload executed successfully");
             parent_hash = block_hash;
         }
 

--- a/bin/reth-bench/src/valid_payload.rs
+++ b/bin/reth-bench/src/valid_payload.rs
@@ -392,3 +392,53 @@ pub(crate) async fn call_forkchoice_updated<N, P: EngineApiValidWaitExt<N>>(
         }
     }
 }
+
+/// Calls either `reth_forkchoiceUpdated` or the standard `engine_forkchoiceUpdated*` depending
+/// on `use_reth`.
+///
+/// When `use_reth` is true, uses the `reth_forkchoiceUpdated` endpoint which sends a regular FCU
+/// with no payload attributes and returns server-side timing breakdown.
+pub(crate) async fn call_forkchoice_updated_with_reth<
+    N: Network,
+    P: Provider<N> + EngineApiValidWaitExt<N>,
+>(
+    provider: P,
+    message_version: EngineApiMessageVersion,
+    forkchoice_state: ForkchoiceState,
+    use_reth: bool,
+) -> TransportResult<Option<NewPayloadTimingBreakdown>> {
+    if use_reth {
+        let method = "reth_forkchoiceUpdated";
+        let reth_params = serde_json::to_value((forkchoice_state,))
+            .expect("ForkchoiceState serialization cannot fail");
+
+        debug!(target: "reth-bench", method, "Sending forkchoiceUpdated");
+
+        let mut resp: RethPayloadStatus = provider.client().request(method, &reth_params).await?;
+
+        while !resp.status.is_valid() {
+            if resp.status.is_invalid() {
+                error!(target: "reth-bench", status=?resp.status, "Invalid {method}");
+                return Err(alloy_json_rpc::RpcError::LocalUsageError(Box::new(
+                    std::io::Error::other(format!("Invalid {method}: {:?}", resp.status)),
+                )))
+            }
+            if resp.status.is_syncing() {
+                return Err(alloy_json_rpc::RpcError::UnsupportedFeature(
+                    "invalid range: no canonical state found for parent of requested block",
+                ))
+            }
+            resp = provider.client().request(method, &reth_params).await?;
+        }
+
+        Ok(Some(NewPayloadTimingBreakdown {
+            latency: Duration::from_micros(resp.latency_us),
+            persistence_wait: resp.persistence_wait_us.map(Duration::from_micros),
+            execution_cache_wait: Duration::from_micros(resp.execution_cache_wait_us),
+            sparse_trie_wait: Duration::from_micros(resp.sparse_trie_wait_us),
+        }))
+    } else {
+        call_forkchoice_updated(provider, message_version, forkchoice_state, None).await?;
+        Ok(None)
+    }
+}

--- a/bin/reth-bench/src/valid_payload.rs
+++ b/bin/reth-bench/src/valid_payload.rs
@@ -397,7 +397,7 @@ pub(crate) async fn call_forkchoice_updated<N, P: EngineApiValidWaitExt<N>>(
 /// on `use_reth`.
 ///
 /// When `use_reth` is true, uses the `reth_forkchoiceUpdated` endpoint which sends a regular FCU
-/// with no payload attributes and returns server-side timing breakdown.
+/// with no payload attributes.
 pub(crate) async fn call_forkchoice_updated_with_reth<
     N: Network,
     P: Provider<N> + EngineApiValidWaitExt<N>,
@@ -406,7 +406,7 @@ pub(crate) async fn call_forkchoice_updated_with_reth<
     message_version: EngineApiMessageVersion,
     forkchoice_state: ForkchoiceState,
     use_reth: bool,
-) -> TransportResult<Option<NewPayloadTimingBreakdown>> {
+) -> TransportResult<ForkchoiceUpdated> {
     if use_reth {
         let method = "reth_forkchoiceUpdated";
         let reth_params = serde_json::to_value((forkchoice_state,))
@@ -414,16 +414,16 @@ pub(crate) async fn call_forkchoice_updated_with_reth<
 
         debug!(target: "reth-bench", method, "Sending forkchoiceUpdated");
 
-        let mut resp: RethPayloadStatus = provider.client().request(method, &reth_params).await?;
+        let mut resp: ForkchoiceUpdated = provider.client().request(method, &reth_params).await?;
 
-        while !resp.status.is_valid() {
-            if resp.status.is_invalid() {
-                error!(target: "reth-bench", status=?resp.status, "Invalid {method}");
+        while !resp.is_valid() {
+            if resp.is_invalid() {
+                error!(target: "reth-bench", ?resp, "Invalid {method}");
                 return Err(alloy_json_rpc::RpcError::LocalUsageError(Box::new(
-                    std::io::Error::other(format!("Invalid {method}: {:?}", resp.status)),
+                    std::io::Error::other(format!("Invalid {method}: {resp:?}")),
                 )))
             }
-            if resp.status.is_syncing() {
+            if resp.is_syncing() {
                 return Err(alloy_json_rpc::RpcError::UnsupportedFeature(
                     "invalid range: no canonical state found for parent of requested block",
                 ))
@@ -431,14 +431,8 @@ pub(crate) async fn call_forkchoice_updated_with_reth<
             resp = provider.client().request(method, &reth_params).await?;
         }
 
-        Ok(Some(NewPayloadTimingBreakdown {
-            latency: Duration::from_micros(resp.latency_us),
-            persistence_wait: resp.persistence_wait_us.map(Duration::from_micros),
-            execution_cache_wait: Duration::from_micros(resp.execution_cache_wait_us),
-            sparse_trie_wait: Duration::from_micros(resp.sparse_trie_wait_us),
-        }))
+        Ok(resp)
     } else {
-        call_forkchoice_updated(provider, message_version, forkchoice_state, None).await?;
-        Ok(None)
+        call_forkchoice_updated(provider, message_version, forkchoice_state, None).await
     }
 }

--- a/crates/rpc/rpc-api/src/reth_engine.rs
+++ b/crates/rpc/rpc-api/src/reth_engine.rs
@@ -54,10 +54,11 @@ pub trait RethEngineApi<ExecutionData> {
         payload: RethNewPayloadInput<ExecutionData>,
     ) -> RpcResult<RethPayloadStatus>;
 
-    /// Reth-specific forkchoiceUpdated that sends a regular FCU with no payload attributes.
+    /// Reth-specific forkchoiceUpdated that sends a regular forkchoice update with no payload
+    /// attributes.
     #[method(name = "forkchoiceUpdated")]
     async fn reth_forkchoice_updated(
         &self,
-        state: ForkchoiceState,
+        forkchoice_state: ForkchoiceState,
     ) -> RpcResult<ForkchoiceUpdated>;
 }

--- a/crates/rpc/rpc-api/src/reth_engine.rs
+++ b/crates/rpc/rpc-api/src/reth_engine.rs
@@ -1,7 +1,7 @@
 //! Reth-specific engine API extensions.
 
 use alloy_primitives::Bytes;
-use alloy_rpc_types_engine::PayloadStatus;
+use alloy_rpc_types_engine::{ForkchoiceState, ForkchoiceUpdated, PayloadStatus};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use serde::{Deserialize, Serialize};
 
@@ -53,4 +53,11 @@ pub trait RethEngineApi<ExecutionData> {
         &self,
         payload: RethNewPayloadInput<ExecutionData>,
     ) -> RpcResult<RethPayloadStatus>;
+
+    /// Reth-specific forkchoiceUpdated that sends a regular FCU with no payload attributes.
+    #[method(name = "forkchoiceUpdated")]
+    async fn reth_forkchoice_updated(
+        &self,
+        state: ForkchoiceState,
+    ) -> RpcResult<ForkchoiceUpdated>;
 }

--- a/crates/rpc/rpc-engine-api/src/reth_engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/reth_engine_api.rs
@@ -1,9 +1,10 @@
 use crate::EngineApiError;
 use alloy_rlp::Decodable;
+use alloy_rpc_types_engine::{ForkchoiceState, ForkchoiceUpdated};
 use async_trait::async_trait;
 use jsonrpsee_core::RpcResult;
 use reth_engine_primitives::ConsensusEngineHandle;
-use reth_payload_primitives::PayloadTypes;
+use reth_payload_primitives::{EngineApiMessageVersion, PayloadTypes};
 use reth_primitives_traits::SealedBlock;
 use reth_rpc_api::{RethEngineApiServer, RethNewPayloadInput, RethPayloadStatus};
 use tracing::trace;
@@ -54,5 +55,16 @@ impl<Payload: PayloadTypes> RethEngineApiServer<Payload::ExecutionData> for Reth
             execution_cache_wait_us: timings.execution_cache_wait.as_micros() as u64,
             sparse_trie_wait_us: timings.sparse_trie_wait.as_micros() as u64,
         })
+    }
+
+    async fn reth_forkchoice_updated(
+        &self,
+        state: ForkchoiceState,
+    ) -> RpcResult<ForkchoiceUpdated> {
+        trace!(target: "rpc::engine", "Serving reth_forkchoiceUpdated");
+        self.beacon_engine_handle
+            .fork_choice_updated(state, None, EngineApiMessageVersion::V3)
+            .await
+            .map_err(|e| EngineApiError::from(e).into())
     }
 }

--- a/crates/rpc/rpc-engine-api/src/reth_engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/reth_engine_api.rs
@@ -59,11 +59,11 @@ impl<Payload: PayloadTypes> RethEngineApiServer<Payload::ExecutionData> for Reth
 
     async fn reth_forkchoice_updated(
         &self,
-        state: ForkchoiceState,
+        forkchoice_state: ForkchoiceState,
     ) -> RpcResult<ForkchoiceUpdated> {
         trace!(target: "rpc::engine", "Serving reth_forkchoiceUpdated");
         self.beacon_engine_handle
-            .fork_choice_updated(state, None, EngineApiMessageVersion::V3)
+            .fork_choice_updated(forkchoice_state, None, EngineApiMessageVersion::V3)
             .await
             .map_err(|e| EngineApiError::from(e).into())
     }


### PR DESCRIPTION
## Summary
Add `reth_forkchoiceUpdated` RPC method to the reth engine API namespace, and use it in reth-bench when `--reth-new-payload` is passed.

## Changes
- Add `reth_forkchoiceUpdated` to `RethEngineApi` trait (`crates/rpc/rpc-api/src/reth_engine.rs`)
- Implement it in `RethEngineApi` — sends regular FCU with no attributes, measures server-side latency, returns `RethPayloadStatus` (`crates/rpc/rpc-engine-api/src/reth_engine_api.rs`)
- Add `call_forkchoice_updated_with_reth` helper in reth-bench (`bin/reth-bench/src/valid_payload.rs`)
- Update all three bench subcommands (new-payload-fcu, replay-payloads, gas-limit-ramp) to use `reth_forkchoiceUpdated` when `--reth-new-payload` is passed

## Design
No separate `BeaconEngineMessage` variant — `reth_forkchoiceUpdated` reuses the existing FCU path with no payload attributes. The RPC handler measures latency around the regular `fork_choice_updated` call.

Prompted by: klkvr