### PR TITLE
feat(bench): support RLP-encoded blocks via debug_getRawBlock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7625,6 +7625,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-provider",
  "alloy-pubsub",
+ "alloy-rlp",
  "alloy-rpc-client",
  "alloy-rpc-types-engine",
  "alloy-transport",

--- a/bin/reth-bench/Cargo.toml
+++ b/bin/reth-bench/Cargo.toml
@@ -31,6 +31,7 @@ reth-chainspec.workspace = true
 alloy-eips.workspace = true
 alloy-json-rpc.workspace = true
 alloy-consensus.workspace = true
+alloy-rlp.workspace = true
 alloy-network.workspace = true
 alloy-primitives = { workspace = true, features = ["rand"] }
 alloy-provider = { workspace = true, features = ["engine-api", "pubsub", "reqwest-rustls-tls"], default-features = false }

--- a/bin/reth-bench/src/bench/context.rs
+++ b/bin/reth-bench/src/bench/context.rs
@@ -31,6 +31,8 @@ pub(crate) struct BenchContext {
     pub(crate) is_optimism: bool,
     /// Whether to use `reth_newPayload` endpoint instead of `engine_newPayload*`.
     pub(crate) use_reth_namespace: bool,
+    /// Whether to fetch and send RLP-encoded blocks via `debug_getRawBlock`.
+    pub(crate) rlp_blocks: bool,
 }
 
 impl BenchContext {
@@ -142,7 +144,8 @@ impl BenchContext {
         };
 
         let next_block = first_block.header.number + 1;
-        let use_reth_namespace = bench_args.reth_new_payload;
+        let rlp_blocks = bench_args.rlp_blocks;
+        let use_reth_namespace = bench_args.reth_new_payload || rlp_blocks;
         Ok(Self {
             auth_provider,
             block_provider,
@@ -150,6 +153,7 @@ impl BenchContext {
             next_block,
             is_optimism,
             use_reth_namespace,
+            rlp_blocks,
         })
     }
 }

--- a/bin/reth-bench/src/bench/new_payload_fcu.rs
+++ b/bin/reth-bench/src/bench/new_payload_fcu.rs
@@ -23,13 +23,11 @@ use crate::{
     },
     valid_payload::{
         block_to_new_payload, call_forkchoice_updated, call_new_payload_with_reth,
-        call_reth_new_payload_rlp, fetch_raw_block,
+        call_reth_new_payload_rlp, fetch_and_decode_raw_block,
     },
 };
-use alloy_consensus::BlockHeader;
 use alloy_primitives::{Bytes, B256};
 use alloy_provider::{network::AnyRpcBlock, Provider};
-use alloy_rlp::Decodable;
 use alloy_rpc_types_engine::ForkchoiceState;
 use clap::Parser;
 use eyre::{Context, OptionExt};
@@ -37,7 +35,6 @@ use reth_cli_runner::CliContext;
 use reth_engine_primitives::config::DEFAULT_PERSISTENCE_THRESHOLD;
 use reth_node_api::EngineApiMessageVersion;
 use reth_node_core::args::BenchmarkArgs;
-use reth_primitives_traits::Block;
 use std::time::{Duration, Instant};
 use tracing::{debug, info, warn};
 
@@ -220,6 +217,7 @@ impl Command {
                 finalized_block_hash: prefetched.finalized_hash,
             };
 
+            let start = Instant::now();
             let (block_number, transaction_count, gas_used, gas_limit, server_timings, version) =
                 match prefetched.block {
                     PrefetchedPayload::Rlp {
@@ -237,7 +235,8 @@ impl Command {
                             gas_used,
                             gas_limit,
                             Some(timings),
-                            EngineApiMessageVersion::V4,
+                            // V3 is correct: FCU V3 is used for Cancun+ (there is no FCU V4)
+                            EngineApiMessageVersion::V3,
                         )
                     }
                     PrefetchedPayload::Json(block) => {
@@ -250,27 +249,16 @@ impl Command {
 
                         let (version, params, execution_data) =
                             block_to_new_payload(block, is_optimism)?;
-                        let start = Instant::now();
                         let reth_data = use_reth_namespace.then_some(execution_data);
                         let timings =
                             call_new_payload_with_reth(&auth_provider, version, params, reth_data)
                                 .await?;
-                        let client_latency = start.elapsed();
-                        (
-                            block_number,
-                            transaction_count,
-                            gas_used,
-                            gas_limit,
-                            timings.or(Some(crate::valid_payload::NewPayloadTimingBreakdown {
-                                latency: client_latency,
-                                ..Default::default()
-                            })),
-                            version,
-                        )
+                        (block_number, transaction_count, gas_used, gas_limit, timings, version)
                     }
                 };
+            let client_latency = start.elapsed();
 
-            let np_latency = server_timings.as_ref().map(|t| t.latency).unwrap_or_default();
+            let np_latency = server_timings.as_ref().map(|t| t.latency).unwrap_or(client_latency);
             let new_payload_result = NewPayloadResult {
                 gas_used,
                 latency: np_latency,
@@ -404,26 +392,19 @@ async fn fetch_rlp_block_with_fcu_hashes(
     provider: &alloy_provider::RootProvider<alloy_network::AnyNetwork>,
     block_number: u64,
 ) -> eyre::Result<PrefetchedBlockWithFcu> {
-    let rlp = fetch_raw_block(provider, block_number)
-        .await
-        .map_err(|e| eyre::eyre!("Failed to fetch raw block {block_number}: {e}"))?;
+    let decoded = fetch_and_decode_raw_block(provider, block_number).await?;
 
-    let block = reth_ethereum_primitives::Block::decode(&mut rlp.as_ref())
-        .map_err(|e| eyre::eyre!("Failed to decode RLP block {block_number}: {e}"))?;
-
-    let head_hash = block.header().hash_slow();
-    let number = block.header().number();
-    let (safe, finalized) = resolve_fcu_hashes(provider, head_hash, number).await;
+    let (safe, finalized) = resolve_fcu_hashes(provider, decoded.hash, decoded.block_number).await;
 
     Ok(PrefetchedBlockWithFcu {
         block: PrefetchedPayload::Rlp {
-            rlp,
-            block_number: number,
-            transaction_count: block.body().transactions().count() as u64,
-            gas_used: block.header().gas_used(),
-            gas_limit: block.header().gas_limit(),
+            rlp: decoded.rlp,
+            block_number: decoded.block_number,
+            transaction_count: decoded.transaction_count,
+            gas_used: decoded.gas_used,
+            gas_limit: decoded.gas_limit,
         },
-        head_hash,
+        head_hash: decoded.hash,
         safe_hash: safe,
         finalized_hash: finalized,
     })

--- a/bin/reth-bench/src/bench/new_payload_fcu.rs
+++ b/bin/reth-bench/src/bench/new_payload_fcu.rs
@@ -21,15 +21,23 @@ use crate::{
             derive_ws_rpc_url, setup_persistence_subscription, PersistenceWaiter,
         },
     },
-    valid_payload::{block_to_new_payload, call_forkchoice_updated, call_new_payload_with_reth},
+    valid_payload::{
+        block_to_new_payload, call_forkchoice_updated, call_new_payload_with_reth,
+        call_reth_new_payload_rlp, fetch_raw_block,
+    },
 };
-use alloy_provider::Provider;
+use alloy_consensus::BlockHeader;
+use alloy_primitives::{Bytes, B256};
+use alloy_provider::{network::AnyRpcBlock, Provider};
+use alloy_rlp::Decodable;
 use alloy_rpc_types_engine::ForkchoiceState;
 use clap::Parser;
 use eyre::{Context, OptionExt};
 use reth_cli_runner::CliContext;
 use reth_engine_primitives::config::DEFAULT_PERSISTENCE_THRESHOLD;
+use reth_node_api::EngineApiMessageVersion;
 use reth_node_core::args::BenchmarkArgs;
+use reth_primitives_traits::Block;
 use std::time::{Duration, Instant};
 use tracing::{debug, info, warn};
 
@@ -152,13 +160,16 @@ impl Command {
             mut next_block,
             is_optimism,
             use_reth_namespace,
+            rlp_blocks,
         } = BenchContext::new(&self.benchmark, self.rpc_url).await?;
 
         let total_blocks = benchmark_mode.total_blocks();
 
         let mut metrics_scraper = MetricsScraper::maybe_new(self.benchmark.metrics_url.clone());
 
-        if use_reth_namespace {
+        if rlp_blocks {
+            info!("Using RLP blocks via debug_getRawBlock → reth_newPayload");
+        } else if use_reth_namespace {
             info!("Using reth_newPayload endpoint");
         }
 
@@ -170,46 +181,24 @@ impl Command {
 
         tokio::task::spawn(async move {
             while benchmark_mode.contains(next_block) {
-                let block_res = block_provider
-                    .get_block_by_number(next_block.into())
-                    .full()
-                    .await
-                    .wrap_err_with(|| format!("Failed to fetch block by number {next_block}"));
-                let block = match block_res.and_then(|opt| opt.ok_or_eyre("Block not found")) {
-                    Ok(block) => block,
+                let prefetched = if rlp_blocks {
+                    fetch_rlp_block_with_fcu_hashes(&block_provider, next_block).await
+                } else {
+                    fetch_json_block_with_fcu_hashes(&block_provider, next_block).await
+                };
+
+                match prefetched {
+                    Ok(data) => {
+                        next_block += 1;
+                        if sender.send(data).await.is_err() {
+                            break;
+                        }
+                    }
                     Err(e) => {
                         tracing::error!(target: "reth-bench", "Failed to fetch block {next_block}: {e}");
                         let _ = error_sender.send(e);
                         break;
                     }
-                };
-
-                let head_block_hash = block.header.hash;
-                let safe_block_hash = block_provider
-                    .get_block_by_number(block.header.number.saturating_sub(32).into());
-
-                let finalized_block_hash = block_provider
-                    .get_block_by_number(block.header.number.saturating_sub(64).into());
-
-                let (safe, finalized) = tokio::join!(safe_block_hash, finalized_block_hash,);
-
-                let safe_block_hash = match safe {
-                    Ok(Some(block)) => block.header.hash,
-                    Ok(None) | Err(_) => head_block_hash,
-                };
-
-                let finalized_block_hash = match finalized {
-                    Ok(Some(block)) => block.header.hash,
-                    Ok(None) | Err(_) => head_block_hash,
-                };
-
-                next_block += 1;
-                if let Err(e) = sender
-                    .send((block, head_block_hash, safe_block_hash, finalized_block_hash))
-                    .await
-                {
-                    tracing::error!(target: "reth-bench", "Failed to send block data: {e}");
-                    break;
                 }
             }
         });
@@ -219,33 +208,69 @@ impl Command {
         let total_benchmark_duration = Instant::now();
         let mut total_wait_time = Duration::ZERO;
 
-        while let Some((block, head, safe, finalized)) = {
+        while let Some(prefetched) = {
             let wait_start = Instant::now();
             let result = receiver.recv().await;
             total_wait_time += wait_start.elapsed();
             result
         } {
-            let gas_used = block.header.gas_used;
-            let gas_limit = block.header.gas_limit;
-            let block_number = block.header.number;
-            let transaction_count = block.transactions.len() as u64;
-
-            debug!(target: "reth-bench", ?block_number, "Sending payload");
-
             let forkchoice_state = ForkchoiceState {
-                head_block_hash: head,
-                safe_block_hash: safe,
-                finalized_block_hash: finalized,
+                head_block_hash: prefetched.head_hash,
+                safe_block_hash: prefetched.safe_hash,
+                finalized_block_hash: prefetched.finalized_hash,
             };
 
-            let (version, params, execution_data) = block_to_new_payload(block, is_optimism)?;
-            let start = Instant::now();
-            let reth_data = use_reth_namespace.then_some(execution_data);
-            let server_timings =
-                call_new_payload_with_reth(&auth_provider, version, params, reth_data).await?;
+            let (block_number, transaction_count, gas_used, gas_limit, server_timings, version) =
+                match prefetched.block {
+                    PrefetchedPayload::Rlp {
+                        rlp,
+                        block_number,
+                        transaction_count,
+                        gas_used,
+                        gas_limit,
+                    } => {
+                        debug!(target: "reth-bench", ?block_number, rlp_len = rlp.len(), "Sending RLP payload");
+                        let timings = call_reth_new_payload_rlp(&auth_provider, rlp).await?;
+                        (
+                            block_number,
+                            transaction_count,
+                            gas_used,
+                            gas_limit,
+                            Some(timings),
+                            EngineApiMessageVersion::V4,
+                        )
+                    }
+                    PrefetchedPayload::Json(block) => {
+                        let block_number = block.header.number;
+                        let transaction_count = block.transactions.len() as u64;
+                        let gas_used = block.header.gas_used as u64;
+                        let gas_limit = block.header.gas_limit as u64;
 
-            let np_latency =
-                server_timings.as_ref().map(|t| t.latency).unwrap_or_else(|| start.elapsed());
+                        debug!(target: "reth-bench", ?block_number, "Sending payload");
+
+                        let (version, params, execution_data) =
+                            block_to_new_payload(block, is_optimism)?;
+                        let start = Instant::now();
+                        let reth_data = use_reth_namespace.then_some(execution_data);
+                        let timings =
+                            call_new_payload_with_reth(&auth_provider, version, params, reth_data)
+                                .await?;
+                        let client_latency = start.elapsed();
+                        (
+                            block_number,
+                            transaction_count,
+                            gas_used,
+                            gas_limit,
+                            timings.or(Some(crate::valid_payload::NewPayloadTimingBreakdown {
+                                latency: client_latency,
+                                ..Default::default()
+                            })),
+                            version,
+                        )
+                    }
+                };
+
+            let np_latency = server_timings.as_ref().map(|t| t.latency).unwrap_or_default();
             let new_payload_result = NewPayloadResult {
                 gas_used,
                 latency: np_latency,
@@ -264,14 +289,7 @@ impl Command {
             call_forkchoice_updated(&auth_provider, version, forkchoice_state, None).await?;
             let fcu_latency = fcu_start.elapsed();
 
-            let total_latency = if server_timings.is_some() {
-                // When using server-side latency for newPayload, derive total from the
-                // independently measured components to avoid mixing server-side and
-                // client-side (network-inclusive) timings.
-                np_latency + fcu_latency
-            } else {
-                start.elapsed()
-            };
+            let total_latency = np_latency + fcu_latency;
             let combined_result = CombinedResult {
                 block_number,
                 gas_limit,
@@ -342,4 +360,95 @@ impl Command {
 
         Ok(())
     }
+}
+
+/// Payload data for a single block, either JSON or RLP.
+enum PrefetchedPayload {
+    Json(AnyRpcBlock),
+    Rlp { rlp: Bytes, block_number: u64, transaction_count: u64, gas_used: u64, gas_limit: u64 },
+}
+
+/// A prefetched block with forkchoice hashes.
+struct PrefetchedBlockWithFcu {
+    block: PrefetchedPayload,
+    head_hash: B256,
+    safe_hash: B256,
+    finalized_hash: B256,
+}
+
+/// Fetches a JSON block and resolves safe/finalized hashes for FCU.
+async fn fetch_json_block_with_fcu_hashes(
+    provider: &alloy_provider::RootProvider<alloy_network::AnyNetwork>,
+    block_number: u64,
+) -> eyre::Result<PrefetchedBlockWithFcu> {
+    let block = provider
+        .get_block_by_number(block_number.into())
+        .full()
+        .await
+        .wrap_err_with(|| format!("Failed to fetch block by number {block_number}"))?
+        .ok_or_eyre("Block not found")?;
+
+    let head_hash = block.header.hash;
+    let (safe, finalized) = resolve_fcu_hashes(provider, head_hash, block.header.number).await;
+
+    Ok(PrefetchedBlockWithFcu {
+        block: PrefetchedPayload::Json(block),
+        head_hash,
+        safe_hash: safe,
+        finalized_hash: finalized,
+    })
+}
+
+/// Fetches a raw RLP block and resolves safe/finalized hashes for FCU.
+async fn fetch_rlp_block_with_fcu_hashes(
+    provider: &alloy_provider::RootProvider<alloy_network::AnyNetwork>,
+    block_number: u64,
+) -> eyre::Result<PrefetchedBlockWithFcu> {
+    let rlp = fetch_raw_block(provider, block_number)
+        .await
+        .map_err(|e| eyre::eyre!("Failed to fetch raw block {block_number}: {e}"))?;
+
+    let block = reth_ethereum_primitives::Block::decode(&mut rlp.as_ref())
+        .map_err(|e| eyre::eyre!("Failed to decode RLP block {block_number}: {e}"))?;
+
+    let head_hash = block.header().hash_slow();
+    let number = block.header().number();
+    let (safe, finalized) = resolve_fcu_hashes(provider, head_hash, number).await;
+
+    Ok(PrefetchedBlockWithFcu {
+        block: PrefetchedPayload::Rlp {
+            rlp,
+            block_number: number,
+            transaction_count: block.body().transactions().count() as u64,
+            gas_used: block.header().gas_used(),
+            gas_limit: block.header().gas_limit(),
+        },
+        head_hash,
+        safe_hash: safe,
+        finalized_hash: finalized,
+    })
+}
+
+/// Resolves safe and finalized block hashes for forkchoice by looking up blocks at
+/// head-32 and head-64.
+async fn resolve_fcu_hashes(
+    provider: &alloy_provider::RootProvider<alloy_network::AnyNetwork>,
+    head_hash: B256,
+    block_number: u64,
+) -> (B256, B256) {
+    let safe_fut = provider.get_block_by_number(block_number.saturating_sub(32).into());
+    let finalized_fut = provider.get_block_by_number(block_number.saturating_sub(64).into());
+
+    let (safe, finalized) = tokio::join!(safe_fut, finalized_fut);
+
+    let safe_hash = match safe {
+        Ok(Some(block)) => block.header.hash,
+        _ => head_hash,
+    };
+    let finalized_hash = match finalized {
+        Ok(Some(block)) => block.header.hash,
+        _ => head_hash,
+    };
+
+    (safe_hash, finalized_hash)
 }

--- a/bin/reth-bench/src/bench/new_payload_only.rs
+++ b/bin/reth-bench/src/bench/new_payload_only.rs
@@ -9,14 +9,21 @@ use crate::{
             NEW_PAYLOAD_OUTPUT_SUFFIX,
         },
     },
-    valid_payload::{block_to_new_payload, call_new_payload_with_reth},
+    valid_payload::{
+        block_to_new_payload, call_new_payload_with_reth, call_reth_new_payload_rlp,
+        fetch_raw_block, NewPayloadTimingBreakdown,
+    },
 };
-use alloy_provider::Provider;
+use alloy_consensus::BlockHeader;
+use alloy_primitives::Bytes;
+use alloy_provider::{network::AnyRpcBlock, Provider};
+use alloy_rlp::Decodable;
 use clap::Parser;
 use csv::Writer;
 use eyre::{Context, OptionExt};
 use reth_cli_runner::CliContext;
 use reth_node_core::args::BenchmarkArgs;
+use reth_primitives_traits::Block;
 use std::time::{Duration, Instant};
 use tracing::{debug, info};
 
@@ -41,6 +48,12 @@ pub struct Command {
     benchmark: BenchmarkArgs,
 }
 
+/// Prefetched block data: either a full JSON block or RLP bytes with decoded metadata.
+enum PrefetchedBlock {
+    Json(AnyRpcBlock),
+    Rlp { rlp: Bytes, block_number: u64, transaction_count: u64, gas_used: u64 },
+}
+
 impl Command {
     /// Execute `benchmark new-payload-only` command
     pub async fn execute(self, _ctx: CliContext) -> eyre::Result<()> {
@@ -51,13 +64,16 @@ impl Command {
             mut next_block,
             is_optimism,
             use_reth_namespace,
+            rlp_blocks,
         } = BenchContext::new(&self.benchmark, self.rpc_url).await?;
 
         let total_blocks = benchmark_mode.total_blocks();
 
         let mut metrics_scraper = MetricsScraper::maybe_new(self.benchmark.metrics_url.clone());
 
-        if use_reth_namespace {
+        if rlp_blocks {
+            info!("Using RLP blocks via debug_getRawBlock → reth_newPayload");
+        } else if use_reth_namespace {
             info!("Using reth_newPayload endpoint");
         }
 
@@ -69,24 +85,45 @@ impl Command {
 
         tokio::task::spawn(async move {
             while benchmark_mode.contains(next_block) {
-                let block_res = block_provider
-                    .get_block_by_number(next_block.into())
-                    .full()
-                    .await
-                    .wrap_err_with(|| format!("Failed to fetch block by number {next_block}"));
-                let block = match block_res.and_then(|opt| opt.ok_or_eyre("Block not found")) {
-                    Ok(block) => block,
+                let prefetched = if rlp_blocks {
+                    match fetch_raw_block(&block_provider, next_block).await {
+                        Ok(rlp) => {
+                            match reth_ethereum_primitives::Block::decode(&mut rlp.as_ref()) {
+                                Ok(block) => Ok(PrefetchedBlock::Rlp {
+                                    rlp,
+                                    block_number: block.header().number(),
+                                    transaction_count: block.body().transactions().count() as u64,
+                                    gas_used: block.header().gas_used(),
+                                }),
+                                Err(e) => {
+                                    Err(eyre::eyre!("Failed to decode RLP block {next_block}: {e}"))
+                                }
+                            }
+                        }
+                        Err(e) => Err(eyre::eyre!("Failed to fetch raw block {next_block}: {e}")),
+                    }
+                } else {
+                    block_provider
+                        .get_block_by_number(next_block.into())
+                        .full()
+                        .await
+                        .wrap_err_with(|| format!("Failed to fetch block by number {next_block}"))
+                        .and_then(|opt| opt.ok_or_eyre("Block not found"))
+                        .map(PrefetchedBlock::Json)
+                };
+
+                match prefetched {
+                    Ok(block) => {
+                        next_block += 1;
+                        if sender.send(block).await.is_err() {
+                            break;
+                        }
+                    }
                     Err(e) => {
                         tracing::error!(target: "reth-bench", "Failed to fetch block {next_block}: {e}");
                         let _ = error_sender.send(e);
                         break;
                     }
-                };
-
-                next_block += 1;
-                if let Err(e) = sender.send(block).await {
-                    tracing::error!(target: "reth-bench", "Failed to send block data: {e}");
-                    break;
                 }
             }
         });
@@ -96,27 +133,46 @@ impl Command {
         let total_benchmark_duration = Instant::now();
         let mut total_wait_time = Duration::ZERO;
 
-        while let Some(block) = {
+        while let Some(prefetched) = {
             let wait_start = Instant::now();
             let result = receiver.recv().await;
             total_wait_time += wait_start.elapsed();
             result
         } {
-            let block_number = block.header.number;
-            let transaction_count = block.transactions.len() as u64;
-            let gas_used = block.header.gas_used;
+            let (block_number, transaction_count, gas_used, server_timings) = match prefetched {
+                PrefetchedBlock::Rlp { rlp, block_number, transaction_count, gas_used } => {
+                    debug!(target: "reth-bench", ?block_number, rlp_len = rlp.len(), "Sending RLP payload to engine");
+                    let timings = call_reth_new_payload_rlp(&auth_provider, rlp).await?;
+                    (block_number, transaction_count, gas_used, Some(timings))
+                }
+                PrefetchedBlock::Json(block) => {
+                    let block_number = block.header.number;
+                    let transaction_count = block.transactions.len() as u64;
+                    let gas_used = block.header.gas_used as u64;
 
-            debug!(target: "reth-bench", number=?block.header.number, "Sending payload to engine");
+                    debug!(target: "reth-bench", ?block_number, "Sending payload to engine");
 
-            let (version, params, execution_data) = block_to_new_payload(block, is_optimism)?;
+                    let (version, params, execution_data) =
+                        block_to_new_payload(block, is_optimism)?;
+                    let start = Instant::now();
+                    let reth_data = use_reth_namespace.then_some(execution_data);
+                    let timings =
+                        call_new_payload_with_reth(&auth_provider, version, params, reth_data)
+                            .await?;
+                    let client_latency = start.elapsed();
+                    (
+                        block_number,
+                        transaction_count,
+                        gas_used,
+                        timings.or(Some(NewPayloadTimingBreakdown {
+                            latency: client_latency,
+                            ..Default::default()
+                        })),
+                    )
+                }
+            };
 
-            let start = Instant::now();
-            let reth_data = use_reth_namespace.then_some(execution_data);
-            let server_timings =
-                call_new_payload_with_reth(&auth_provider, version, params, reth_data).await?;
-
-            let latency =
-                server_timings.as_ref().map(|t| t.latency).unwrap_or_else(|| start.elapsed());
+            let latency = server_timings.as_ref().map(|t| t.latency).unwrap_or_default();
             let new_payload_result = NewPayloadResult {
                 gas_used,
                 latency,

--- a/bin/reth-bench/src/bench/new_payload_only.rs
+++ b/bin/reth-bench/src/bench/new_payload_only.rs
@@ -11,19 +11,16 @@ use crate::{
     },
     valid_payload::{
         block_to_new_payload, call_new_payload_with_reth, call_reth_new_payload_rlp,
-        fetch_raw_block, NewPayloadTimingBreakdown,
+        fetch_and_decode_raw_block,
     },
 };
-use alloy_consensus::BlockHeader;
 use alloy_primitives::Bytes;
 use alloy_provider::{network::AnyRpcBlock, Provider};
-use alloy_rlp::Decodable;
 use clap::Parser;
 use csv::Writer;
 use eyre::{Context, OptionExt};
 use reth_cli_runner::CliContext;
 use reth_node_core::args::BenchmarkArgs;
-use reth_primitives_traits::Block;
 use std::time::{Duration, Instant};
 use tracing::{debug, info};
 
@@ -86,22 +83,14 @@ impl Command {
         tokio::task::spawn(async move {
             while benchmark_mode.contains(next_block) {
                 let prefetched = if rlp_blocks {
-                    match fetch_raw_block(&block_provider, next_block).await {
-                        Ok(rlp) => {
-                            match reth_ethereum_primitives::Block::decode(&mut rlp.as_ref()) {
-                                Ok(block) => Ok(PrefetchedBlock::Rlp {
-                                    rlp,
-                                    block_number: block.header().number(),
-                                    transaction_count: block.body().transactions().count() as u64,
-                                    gas_used: block.header().gas_used(),
-                                }),
-                                Err(e) => {
-                                    Err(eyre::eyre!("Failed to decode RLP block {next_block}: {e}"))
-                                }
-                            }
+                    fetch_and_decode_raw_block(&block_provider, next_block).await.map(|decoded| {
+                        PrefetchedBlock::Rlp {
+                            rlp: decoded.rlp,
+                            block_number: decoded.block_number,
+                            transaction_count: decoded.transaction_count,
+                            gas_used: decoded.gas_used,
                         }
-                        Err(e) => Err(eyre::eyre!("Failed to fetch raw block {next_block}: {e}")),
-                    }
+                    })
                 } else {
                     block_provider
                         .get_block_by_number(next_block.into())
@@ -139,6 +128,7 @@ impl Command {
             total_wait_time += wait_start.elapsed();
             result
         } {
+            let start = Instant::now();
             let (block_number, transaction_count, gas_used, server_timings) = match prefetched {
                 PrefetchedBlock::Rlp { rlp, block_number, transaction_count, gas_used } => {
                     debug!(target: "reth-bench", ?block_number, rlp_len = rlp.len(), "Sending RLP payload to engine");
@@ -154,25 +144,16 @@ impl Command {
 
                     let (version, params, execution_data) =
                         block_to_new_payload(block, is_optimism)?;
-                    let start = Instant::now();
                     let reth_data = use_reth_namespace.then_some(execution_data);
                     let timings =
                         call_new_payload_with_reth(&auth_provider, version, params, reth_data)
                             .await?;
-                    let client_latency = start.elapsed();
-                    (
-                        block_number,
-                        transaction_count,
-                        gas_used,
-                        timings.or(Some(NewPayloadTimingBreakdown {
-                            latency: client_latency,
-                            ..Default::default()
-                        })),
-                    )
+                    (block_number, transaction_count, gas_used, timings)
                 }
             };
+            let client_latency = start.elapsed();
 
-            let latency = server_timings.as_ref().map(|t| t.latency).unwrap_or_default();
+            let latency = server_timings.as_ref().map(|t| t.latency).unwrap_or(client_latency);
             let new_payload_result = NewPayloadResult {
                 gas_used,
                 latency,

--- a/bin/reth-bench/src/valid_payload.rs
+++ b/bin/reth-bench/src/valid_payload.rs
@@ -417,6 +417,48 @@ pub(crate) async fn fetch_raw_block<N: Network, P: Provider<N>>(
     provider.client().request("debug_getRawBlock", &params).await
 }
 
+/// Decoded metadata from an RLP-encoded block.
+pub(crate) struct DecodedRlpBlock {
+    /// The raw RLP bytes (forwarded to the server as-is).
+    pub(crate) rlp: Bytes,
+    /// Block number.
+    pub(crate) block_number: u64,
+    /// Number of transactions.
+    pub(crate) transaction_count: u64,
+    /// Gas used.
+    pub(crate) gas_used: u64,
+    /// Gas limit.
+    pub(crate) gas_limit: u64,
+    /// Block hash (computed via `hash_slow`).
+    pub(crate) hash: B256,
+}
+
+/// Fetches and decodes an RLP block, extracting header metadata for metrics.
+pub(crate) async fn fetch_and_decode_raw_block<N: Network, P: Provider<N>>(
+    provider: &P,
+    block_number: u64,
+) -> eyre::Result<DecodedRlpBlock> {
+    use alloy_consensus::BlockHeader;
+    use alloy_rlp::Decodable;
+    use reth_primitives_traits::Block;
+
+    let rlp = fetch_raw_block(provider, block_number)
+        .await
+        .map_err(|e| eyre::eyre!("Failed to fetch raw block {block_number}: {e}"))?;
+
+    let block = reth_ethereum_primitives::Block::decode(&mut rlp.as_ref())
+        .map_err(|e| eyre::eyre!("Failed to decode RLP block {block_number}: {e}"))?;
+
+    Ok(DecodedRlpBlock {
+        rlp,
+        block_number: block.header().number(),
+        transaction_count: block.body().transactions().count() as u64,
+        gas_used: block.header().gas_used(),
+        gas_limit: block.header().gas_limit(),
+        hash: block.header().hash_slow(),
+    })
+}
+
 /// Calls the correct `engine_forkchoiceUpdated` method depending on the given
 /// `EngineApiMessageVersion`, using the provided forkchoice state and payload attributes for the
 /// actual engine api message call.

--- a/bin/reth-bench/src/valid_payload.rs
+++ b/bin/reth-bench/src/valid_payload.rs
@@ -3,7 +3,7 @@
 //! before sending additional calls.
 
 use alloy_eips::eip7685::Requests;
-use alloy_primitives::B256;
+use alloy_primitives::{Bytes, B256};
 use alloy_provider::{ext::EngineApi, network::AnyRpcBlock, Network, Provider};
 use alloy_rpc_types_engine::{
     ExecutionData, ExecutionPayload, ExecutionPayloadInputV2, ExecutionPayloadSidecar,
@@ -366,6 +366,55 @@ pub(crate) async fn call_new_payload_with_reth<N: Network, P: Provider<N>>(
         }
         Ok(None)
     }
+}
+
+/// Sends an RLP-encoded block to the `reth_newPayload` endpoint.
+///
+/// The server decodes the RLP and converts it to `ExecutionData` via `block_to_payload`.
+/// Returns server-side timing breakdown.
+pub(crate) async fn call_reth_new_payload_rlp<N: Network, P: Provider<N>>(
+    provider: P,
+    rlp: Bytes,
+) -> TransportResult<NewPayloadTimingBreakdown> {
+    let method = "reth_newPayload";
+    let reth_params =
+        serde_json::to_value((rlp.clone(),)).expect("Bytes serialization cannot fail");
+
+    debug!(target: "reth-bench", method, rlp_len = rlp.len(), "Sending RLP block");
+
+    let mut resp: RethPayloadStatus = provider.client().request(method, &reth_params).await?;
+
+    while !resp.status.is_valid() {
+        if resp.status.is_invalid() {
+            error!(target: "reth-bench", status=?resp.status, "Invalid {method}");
+            return Err(alloy_json_rpc::RpcError::LocalUsageError(Box::new(std::io::Error::other(
+                format!("Invalid {method}: {:?}", resp.status),
+            ))))
+        }
+        if resp.status.is_syncing() {
+            return Err(alloy_json_rpc::RpcError::UnsupportedFeature(
+                "invalid range: no canonical state found for parent of requested block",
+            ))
+        }
+        resp = provider.client().request(method, &reth_params).await?;
+    }
+
+    Ok(NewPayloadTimingBreakdown {
+        latency: Duration::from_micros(resp.latency_us),
+        persistence_wait: resp.persistence_wait_us.map(Duration::from_micros),
+        execution_cache_wait: Duration::from_micros(resp.execution_cache_wait_us),
+        sparse_trie_wait: Duration::from_micros(resp.sparse_trie_wait_us),
+    })
+}
+
+/// Fetches a raw RLP-encoded block via `debug_getRawBlock`.
+pub(crate) async fn fetch_raw_block<N: Network, P: Provider<N>>(
+    provider: &P,
+    block_number: u64,
+) -> TransportResult<Bytes> {
+    let params = serde_json::to_value((format!("0x{block_number:x}",),))
+        .expect("block number serialization cannot fail");
+    provider.client().request("debug_getRawBlock", &params).await
 }
 
 /// Calls the correct `engine_forkchoiceUpdated` method depending on the given

--- a/crates/node/core/src/args/benchmark_args.rs
+++ b/crates/node/core/src/args/benchmark_args.rs
@@ -78,6 +78,17 @@ pub struct BenchmarkArgs {
     /// and returns server-side timing breakdowns (latency, persistence wait, cache wait).
     #[arg(long, default_value = "false", verbatim_doc_comment)]
     pub reth_new_payload: bool,
+
+    /// Fetch blocks via `debug_getRawBlock` and send RLP-encoded bytes directly to
+    /// `reth_newPayload`.
+    ///
+    /// This avoids the intermediate JSON-to-ExecutionData conversion by fetching raw
+    /// RLP-encoded blocks from the source RPC and forwarding them as-is. The server
+    /// decodes the RLP and converts to ExecutionData internally.
+    ///
+    /// Implies `--reth-new-payload`.
+    #[arg(long, default_value = "false", verbatim_doc_comment)]
+    pub rlp_blocks: bool,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Add `--rlp-blocks` flag to reth-bench that fetches blocks via `debug_getRawBlock` and sends the raw RLP bytes directly to `reth_newPayload`.

Depends on #22533 for the server-side `RlpEncodedBlock` variant in `reth_newPayload`.

## Changes

- Add `--rlp-blocks` flag to `BenchmarkArgs` (implies `--reth-new-payload`)
- Add `fetch_raw_block` helper that calls `debug_getRawBlock`
- Add `call_reth_new_payload_rlp` that sends raw RLP bytes via `reth_newPayload`
- Update `new-payload-only` and `new-payload-fcu` commands to support the RLP path
- RLP blocks are decoded locally only to extract header metadata (hash, gas, tx count) for metrics and FCU

Prompted by: arsenii