### PR TITLE
chore(tasks): remove quanta upkeep from runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10348,7 +10348,6 @@ dependencies = [
  "metrics",
  "parking_lot",
  "pin-project",
- "quanta",
  "rayon",
  "reth-metrics",
  "thiserror 2.0.18",

--- a/crates/tasks/Cargo.toml
+++ b/crates/tasks/Cargo.toml
@@ -23,7 +23,6 @@ metrics.workspace = true
 
 # misc
 dashmap.workspace = true
-quanta.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
 

--- a/crates/tasks/src/runtime.rs
+++ b/crates/tasks/src/runtime.rs
@@ -268,10 +268,6 @@ struct RuntimeInner {
     /// The task monitors critical tasks for panics and fires the shutdown signal.
     /// Can be taken via [`Runtime::take_task_manager_handle`] to poll for panic errors.
     task_manager_handle: Mutex<Option<JoinHandle<Result<(), PanickedTaskError>>>>,
-    /// Handle to the quanta upkeep thread that periodically refreshes the cached
-    /// high-resolution timestamp used by [`quanta::Instant::recent()`].
-    /// Dropped when the runtime is dropped, stopping the upkeep thread.
-    _quanta_upkeep: Option<quanta::Handle>,
 }
 
 // ── Runtime ───────────────────────────────────────────────────────────
@@ -858,8 +854,6 @@ impl RuntimeBuilder {
             result
         });
 
-        let quanta_upkeep = quanta::Upkeep::new(Duration::from_millis(1)).start().ok();
-
         let inner = RuntimeInner {
             _tokio_runtime: owned_runtime,
             handle,
@@ -883,7 +877,6 @@ impl RuntimeBuilder {
             prewarming_pool,
             worker_map: WorkerMap::new(),
             task_manager_handle: Mutex::new(Some(task_manager_handle)),
-            _quanta_upkeep: quanta_upkeep,
         };
 
         Ok(Runtime(Arc::new(inner)))


### PR DESCRIPTION
Removes the quanta upkeep thread from `RuntimeInner`. Drops the `quanta` dep from `reth-tasks`.

Prompted by: DaniPopes