### PR TITLE
perf(engine): remove spawn for prewarm pool init

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -202,10 +202,11 @@ where
         Tx: ExecutableTxFor<Evm>,
     {
         WorkerPool::with_worker_mut(|worker| {
-            let (evm, metrics, terminate_execution) = worker
-                .get_or_init::<PrewarmEvmState<Evm>>(|| ctx.evm_for_ctx())
-                .as_mut()
-                .expect("prewarm worker EVM state not initialized");
+            let Some((evm, metrics, terminate_execution)) =
+                worker.get_or_init::<PrewarmEvmState<Evm>>(|| ctx.evm_for_ctx()).as_mut()
+            else {
+                return;
+            };
 
             if terminate_execution.load(Ordering::Relaxed) {
                 return;

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -117,7 +117,7 @@ where
     /// Kicks off EVM init on every pool thread, then uses `in_place_scope` to dispatch
     /// transactions as they arrive and wait for all spawned tasks to complete before
     /// clearing per-thread state. Workers that start via work-stealing lazily initialise
-    /// their EVM state on first access via [`Worker::get_or_init`].
+    /// their EVM state on first access via [`get_or_init`](reth_tasks::pool::Worker::get_or_init).
     fn spawn_txs_prewarm<Tx>(
         &self,
         pending: mpsc::Receiver<(usize, Tx)>,
@@ -191,8 +191,8 @@ where
 
     /// Executes a single prewarm transaction on the current pool thread's EVM.
     ///
-    /// Lazily initialises per-thread [`PrewarmEvmState`] via [`Worker::get_or_init`] on first
-    /// access.
+    /// Lazily initialises per-thread [`PrewarmEvmState`] via
+    /// [`get_or_init`](reth_tasks::pool::Worker::get_or_init) on first access.
     fn transact_worker<Tx>(
         ctx: &PrewarmContext<N, P, Evm>,
         index: usize,

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -143,9 +143,7 @@ where
             let mut tx_count = 0usize;
             let to_multi_proof = to_multi_proof.as_ref();
             pool.in_place_scope(|s| {
-                s.spawn(|_| {
-                    pool.init::<PrewarmEvmState<Evm>>(|_| ctx.evm_for_ctx());
-                });
+                pool.init::<PrewarmEvmState<Evm>>(|_| ctx.evm_for_ctx());
 
                 while let Ok((index, tx)) = pending.recv() {
                     if ctx.terminate_execution.load(Ordering::Relaxed) {

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -114,9 +114,9 @@ where
 
     /// Streams pending transactions and executes them in parallel on the prewarming pool.
     ///
-    /// Kicks off EVM init on every pool thread (non-blocking via `pool.spawn`), then
-    /// uses `in_place_scope` to dispatch transactions as they arrive and wait for all
-    /// spawned tasks to complete before clearing per-thread state.
+    /// Uses `in_place_scope` to dispatch transactions as they arrive and wait for all
+    /// spawned tasks to complete before clearing per-thread state. Per-thread EVM state
+    /// is lazily initialized on first access via [`Worker::get_or_init`].
     fn spawn_txs_prewarm<Tx>(
         &self,
         pending: mpsc::Receiver<(usize, Tx)>,
@@ -143,8 +143,6 @@ where
             let mut tx_count = 0usize;
             let to_multi_proof = to_multi_proof.as_ref();
             pool.in_place_scope(|s| {
-                pool.init::<PrewarmEvmState<Evm>>(|_| ctx.evm_for_ctx());
-
                 while let Ok((index, tx)) = pending.recv() {
                     if ctx.terminate_execution.load(Ordering::Relaxed) {
                         trace!(
@@ -164,7 +162,7 @@ where
                             i = index,
                         )
                         .entered();
-                        Self::transact_worker(index, tx, to_multi_proof);
+                        Self::transact_worker(ctx, index, tx, to_multi_proof);
                     });
                 }
 
@@ -188,9 +186,10 @@ where
 
     /// Executes a single prewarm transaction on the current pool thread's EVM.
     ///
-    /// Expects per-thread [`PrewarmEvmState`] to already be initialised via
-    /// the init spawns in [`spawn_txs_prewarm`](Self::spawn_txs_prewarm).
+    /// Lazily initialises per-thread [`PrewarmEvmState`] via [`Worker::get_or_init`] on first
+    /// access.
     fn transact_worker<Tx>(
+        ctx: &PrewarmContext<N, P, Evm>,
         index: usize,
         tx: Tx,
         to_multi_proof: Option<&CrossbeamSender<MultiProofMessage>>,
@@ -199,7 +198,7 @@ where
     {
         WorkerPool::with_worker_mut(|worker| {
             let (evm, metrics, terminate_execution) = worker
-                .get_mut::<PrewarmEvmState<Evm>>()
+                .get_or_init::<PrewarmEvmState<Evm>>(|| ctx.evm_for_ctx())
                 .as_mut()
                 .expect("prewarm worker EVM state not initialized");
 
@@ -499,7 +498,7 @@ where
 }
 
 /// Per-thread EVM state initialised by [`PrewarmContext::evm_for_ctx`] and stored in
-/// [`WorkerPool`] workers via [`Worker::init`](reth_tasks::pool::Worker::init).
+/// [`WorkerPool`] workers via [`Worker::get_or_init`](reth_tasks::pool::Worker::get_or_init).
 type PrewarmEvmState<Evm> = Option<(
     EvmFor<Evm, StateProviderDatabase<reth_provider::StateProviderBox>>,
     PrewarmMetrics,

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -114,9 +114,10 @@ where
 
     /// Streams pending transactions and executes them in parallel on the prewarming pool.
     ///
-    /// Uses `in_place_scope` to dispatch transactions as they arrive and wait for all
-    /// spawned tasks to complete before clearing per-thread state. Per-thread EVM state
-    /// is lazily initialized on first access via [`Worker::get_or_init`].
+    /// Kicks off EVM init on every pool thread, then uses `in_place_scope` to dispatch
+    /// transactions as they arrive and wait for all spawned tasks to complete before
+    /// clearing per-thread state. Workers that start via work-stealing lazily initialise
+    /// their EVM state on first access via [`Worker::get_or_init`].
     fn spawn_txs_prewarm<Tx>(
         &self,
         pending: mpsc::Receiver<(usize, Tx)>,
@@ -143,6 +144,10 @@ where
             let mut tx_count = 0usize;
             let to_multi_proof = to_multi_proof.as_ref();
             pool.in_place_scope(|s| {
+                s.spawn(|_| {
+                    pool.init::<PrewarmEvmState<Evm>>(|_| ctx.evm_for_ctx());
+                });
+
                 while let Ok((index, tx)) = pending.recv() {
                     if ctx.terminate_execution.load(Ordering::Relaxed) {
                         trace!(

--- a/crates/tasks/src/pool.rs
+++ b/crates/tasks/src/pool.rs
@@ -350,10 +350,10 @@ impl Worker {
     ///
     /// Panics if the state was previously initialized with a different type.
     pub fn get_or_init<T: 'static>(&mut self, f: impl FnOnce() -> T) -> &mut T {
-        if self.state.is_none() {
-            self.state = Some(Box::new(f()));
-        }
-        self.state.as_mut().unwrap().downcast_mut::<T>().expect("worker state type mismatch")
+        self.state
+            .get_or_insert_with(|| Box::new(f()))
+            .downcast_mut::<T>()
+            .expect("worker state type mismatch")
     }
 
     /// Clears the worker state, dropping the contained value.


### PR DESCRIPTION
Keep the upfront `pool.init` spawn to eagerly initialize all worker threads, but also use `Worker::get_or_init` in `transact_worker` as a fallback for threads that start via work-stealing without prior setup.

Also cleans up `Worker::get_or_init` internals using `Option::get_or_insert_with`.

Prompted by: danipopes