### PR TITLE
feat(net): use fork_id as tiebreaker in peer selection

### DIFF
--- a/.changelog/tall-stars-shout.md
+++ b/.changelog/tall-stars-shout.md
@@ -1,0 +1,5 @@
+---
+reth-network: minor
+---
+
+Added `fork_id` as a tiebreaker in peer selection when reputations are equal, preferring peers with a discovered `fork_id` as it indicates fork compatibility. Added a test to verify the tiebreaker behavior.


### PR DESCRIPTION
When selecting the best unconnected peer for outbound connections, use the presence of a discovered `fork_id` to break ties between peers with equal reputation. A peer with a `fork_id` is preferred since it indicates the peer is on a compatible fork.