### PR TITLE
fix: compute hashed post state in RpcBlockchainStateProvider

### DIFF
--- a/crates/storage/rpc-provider/src/lib.rs
+++ b/crates/storage/rpc-provider/src/lib.rs
@@ -57,7 +57,9 @@ use reth_storage_api::{
     BlockBodyIndicesProvider, BlockReaderIdExt, BlockSource, DBProvider, NodePrimitivesProvider,
     ReceiptProviderIdExt, StatsReader,
 };
-use reth_trie::{updates::TrieUpdates, AccountProof, HashedPostState, MultiProof, TrieInput};
+use reth_trie::{
+    updates::TrieUpdates, AccountProof, HashedPostState, KeccakKeyHasher, MultiProof, TrieInput,
+};
 pub use rpc_response::{EthRpcConverter, RpcResponseConverter};
 use std::{
     collections::BTreeMap,
@@ -1313,9 +1315,8 @@ where
     N: Network,
     Node: NodeTypes,
 {
-    fn hashed_post_state(&self, _bundle_state: &revm::database::BundleState) -> HashedPostState {
-        // Return empty hashed post state for RPC provider
-        HashedPostState::default()
+    fn hashed_post_state(&self, bundle_state: &revm::database::BundleState) -> HashedPostState {
+        HashedPostState::from_bundle_state::<KeccakKeyHasher>(bundle_state.state())
     }
 }
 


### PR DESCRIPTION
The RpcBlockchainStateProvider was returning an empty HashedPostState, causing incorrect state roots when used with debug_stateRootWithUpdates.