### PR TITLE
perf(discv4): cache signed FindNode packets during Kademlia lookups

### DIFF
--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -503,6 +503,8 @@ pub struct Discv4Service {
     received_pongs: PongTable,
     /// Interval used to expire additionally tracked nodes
     expire_interval: Interval,
+    /// Cached signed `FindNode` packet to avoid redundant ECDSA signing during lookups.
+    cached_find_node: Option<CachedFindNode>,
 }
 
 impl Discv4Service {
@@ -603,6 +605,7 @@ impl Discv4Service {
             queued_events: Default::default(),
             received_pongs: Default::default(),
             expire_interval: tokio::time::interval(EXPIRE_DURATION),
+            cached_find_node: None,
         }
     }
 
@@ -811,9 +814,12 @@ impl Discv4Service {
     fn find_node(&mut self, node: &NodeRecord, ctx: LookupContext) {
         trace!(target: "discv4", ?node, lookup=?ctx.target(), "Sending FindNode");
         ctx.mark_queried(node.id);
-        let id = ctx.target();
-        let msg = Message::FindNode(FindNode { id, expire: self.find_node_expiration() });
-        self.send_packet(msg, node.udp_addr());
+        let (payload, hash) = self.find_node_packet(ctx.target());
+        let to = node.udp_addr();
+        trace!(target: "discv4", ?to, ?hash, "sending FindNode packet");
+        let _ = self.egress.try_send((payload, to)).map_err(|err| {
+            debug!(target: "discv4", %err, "dropped outgoing packet");
+        });
         self.pending_find_nodes.insert(node.id, FindNodeRequest::new(ctx));
     }
 
@@ -955,10 +961,8 @@ impl Discv4Service {
 
         // Check if ENR was updated
         match (last_enr_seq, old_enr) {
-            (Some(new), Some(old)) => {
-                if new > old {
-                    self.send_enr_request(record);
-                }
+            (Some(new), Some(old)) if new > old => {
+                self.send_enr_request(record);
             }
             (Some(_), None) => {
                 // got an ENR
@@ -1074,6 +1078,19 @@ impl Discv4Service {
             );
         });
         hash
+    }
+
+    /// Returns a signed `FindNode` packet for `target`, reusing a cached payload when possible.
+    fn find_node_packet(&mut self, target: PeerId) -> (Bytes, B256) {
+        let expire = self.find_node_expiration();
+        let cache_ttl = self.config.request_timeout / 4;
+        CachedFindNode::get_or_sign(
+            &mut self.cached_find_node,
+            target,
+            cache_ttl,
+            &self.secret_key,
+            expire,
+        )
     }
 
     /// Message handler for an incoming `Ping`
@@ -1195,10 +1212,8 @@ impl Discv4Service {
         } else {
             // Request ENR if included in the ping
             match (ping.enr_sq, old_enr) {
-                (Some(new), Some(old)) => {
-                    if new > old {
-                        self.send_enr_request(record);
-                    }
+                (Some(new), Some(old)) if new > old => {
+                    self.send_enr_request(record);
                 }
                 (Some(_), None) => {
                     self.send_enr_request(record);
@@ -1355,10 +1370,8 @@ impl Discv4Service {
                     _ => return,
                 };
                 match (fork_id, old_fork_id) {
-                    (Some(new), Some(old)) => {
-                        if new != old {
-                            self.notify(DiscoveryUpdate::EnrForkId(record, new))
-                        }
+                    (Some(new), Some(old)) if new != old => {
+                        self.notify(DiscoveryUpdate::EnrForkId(record, new))
                     }
                     (Some(new), None) => self.notify(DiscoveryUpdate::EnrForkId(record, new)),
                     _ => {}
@@ -2285,6 +2298,41 @@ struct FindNodeRequest {
 impl FindNodeRequest {
     fn new(resp: LookupContext) -> Self {
         Self { sent_at: Instant::now(), response_count: 0, answered: false, lookup_context: resp }
+    }
+}
+
+/// Cached signed `FindNode` packet to avoid redundant ECDSA signing during Kademlia lookups.
+#[derive(Debug)]
+struct CachedFindNode {
+    target: PeerId,
+    payload: Bytes,
+    hash: B256,
+    cached_at: Instant,
+}
+
+impl CachedFindNode {
+    /// Returns the cached `(payload, hash)` if the target matches and the cache is still fresh,
+    /// or signs a new packet, updates the cache, and returns it.
+    fn get_or_sign(
+        cache: &mut Option<Self>,
+        target: PeerId,
+        ttl: Duration,
+        secret_key: &secp256k1::SecretKey,
+        expire: u64,
+    ) -> (Bytes, B256) {
+        if let Some(c) = cache.as_ref() &&
+            c.target == target &&
+            c.cached_at.elapsed() < ttl
+        {
+            return (c.payload.clone(), c.hash);
+        }
+
+        let msg = Message::FindNode(FindNode { id: target, expire });
+        let (payload, hash) = msg.encode(secret_key);
+
+        *cache = Some(Self { target, payload: payload.clone(), hash, cached_at: Instant::now() });
+
+        (payload, hash)
     }
 }
 


### PR DESCRIPTION
## Summary

During a Kademlia lookup, `find_node()` constructs a fresh `FindNode` message for each peer and passes it through `send_packet()` → `Message::encode()`, which performs a full `keccak256` + `secp256k1::sign_ecdsa_recoverable` for every single packet.

With `ALPHA = 3` FindNode messages per round and multiple recursive rounds triggered by `on_neighbours()`, a single lookup cycle produces tens of redundant ECDSA sign operations.

**Key insight:** All FindNode messages within a lookup share the **same target ID**. The `FindNode` struct only contains `(id, expire)` — no per-destination fields. Two packets sent milliseconds apart will have nearly identical expiration values, so there is no need to re-sign.

## Changes

Adds a `CachedFindNode` field to `Discv4Service` that caches the last signed FindNode packet. When `find_node()` is called:

1. Check if a cached packet exists with the same target and has not expired (TTL = `request_timeout / 4`)
2. **Cache hit:** reuse the pre-signed `Bytes` payload directly, skip `encode()`/ECDSA sign entirely
3. **Cache miss:** encode + sign as usual, store the result

The TTL is derived from `request_timeout / 4` (default: 5s with 20s timeout) to ensure the `expire` timestamp embedded in the cached packet always has sufficient remaining validity at the receiver.

## Safety

- `FindNode` has no per-destination fields, so the same signed bytes are valid for any peer
- The packet hash return from `send_packet()` is already discarded in `find_node()`, so caching does not change any observable behavior
- Error handling on `egress.try_send()` matches the existing `send_packet()` pattern (logged with `debug!`)
