### PR TITLE
fix(ci): add fallback for BENCH_JOB_URL in bench failure step

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1001,10 +1001,11 @@ jobs:
               }
             } catch (e) {}
 
+            const jobUrl = process.env.BENCH_JOB_URL || `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             await github.rest.issues.updateComment({
               owner: context.repo.owner, repo: context.repo.repo,
               comment_id: parseInt(process.env.BENCH_COMMENT_ID),
-              body: `cc @${process.env.BENCH_ACTOR}\n\n❌ Benchmark failed while ${failedStep}. [View logs](${process.env.BENCH_JOB_URL})${errorDetails}`,
+              body: `cc @${process.env.BENCH_ACTOR}\n\n❌ Benchmark failed while ${failedStep}. [View logs](${jobUrl})${errorDetails}`,
             });
 
       - name: Send Slack notification (failure)


### PR DESCRIPTION
## Summary

The "Update status (failed)" step in bench.yml used `process.env.BENCH_JOB_URL` directly without a fallback, producing `[View logs](undefined)` when the env var wasn't set (e.g. if the step that resolves the job URL itself failed or was skipped).

The success and cancelled steps already had the same fallback pattern — this aligns the failure step.

## Changes

- Added `const jobUrl = process.env.BENCH_JOB_URL || ...` fallback in the failure comment step, matching the pattern used in success (L952) and cancelled (L1036) steps.

## Testing

Verified the fix matches the existing pattern in the same file. No functional changes beyond the URL fallback.

Prompted by: alexey