### PR TITLE
perf(prewarm): skip prewarming for the first transaction

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -737,7 +737,11 @@ fn convert_serial<RawTx, Tx, TxEnv, InnerTx, Recovered, Err, C>(
             WithTxEnv { tx_env, tx: Arc::new(tx) }
         });
         if let Ok(tx) = &tx {
-            let _ = prewarm_tx.send((idx, tx.clone()));
+            // Skip the first transaction since it's already being executed and prewarming
+            // overhead outweighs the benefit for a single transaction ahead.
+            if idx > 0 {
+                let _ = prewarm_tx.send((idx, tx.clone()));
+            }
         }
         let _ = execute_tx.send(tx);
     }


### PR DESCRIPTION
## Summary

Skip prewarming for the first transaction in a block. The first transaction is already being executed immediately by the main execution thread, so spawning a prewarm worker for it adds overhead without benefit.

Prewarming now starts from the second transaction (index 1) onwards.

## Changes

- `convert_serial`: skip sending index 0 to the prewarm channel
- The parallel conversion path (`rayon`) always starts at index ≥ `PARALLEL_PREFETCH_COUNT` (4), so no change is needed there