### PR TITLE
feat(net): persist richer peer metadata to peers file

### DIFF
--- a/.changelog/safe-waves-read.md
+++ b/.changelog/safe-waves-read.md
@@ -1,0 +1,7 @@
+---
+reth-network-types: minor
+reth-network: minor
+reth-node-core: patch
+---
+
+Added `PersistedPeerInfo` struct to persist richer peer metadata (kind, fork ID, reputation) to disk. Updated `PeersConfig::with_basic_nodes_from_file` to support both the new `PersistedPeerInfo` format and the legacy `Vec<NodeRecord>` format with automatic conversion, and updated `write_peers_to_file` to exclude backed-off and banned peers.

--- a/crates/net/network-types/src/lib.rs
+++ b/crates/net/network-types/src/lib.rs
@@ -30,6 +30,6 @@ pub use peers::{
         DEFAULT_REPUTATION,
     },
     state::PeerConnectionState,
-    ConnectionsConfig, Peer, PeersConfig,
+    ConnectionsConfig, Peer, PeersConfig, PersistedPeerInfo,
 };
 pub use session::{SessionLimits, SessionsConfig};

--- a/crates/net/network-types/src/peers/config.rs
+++ b/crates/net/network-types/src/peers/config.rs
@@ -11,7 +11,7 @@ use reth_net_banlist::{BanList, IpFilter};
 use reth_network_peers::{NodeRecord, TrustedPeer};
 use tracing::info;
 
-use crate::{BackoffKind, ReputationChangeWeights};
+use crate::{peers::PersistedPeerInfo, BackoffKind, ReputationChangeWeights};
 
 /// Maximum number of available slots for outbound sessions.
 pub const DEFAULT_MAX_COUNT_PEERS_OUTBOUND: u32 = 100;
@@ -147,6 +147,9 @@ pub struct PeersConfig {
     /// Basic nodes to connect to.
     #[cfg_attr(feature = "serde", serde(skip))]
     pub basic_nodes: HashSet<NodeRecord>,
+    /// Persisted peers loaded from disk, containing richer metadata than basic nodes.
+    #[cfg_attr(feature = "serde", serde(skip))]
+    pub persisted_peers: Vec<PersistedPeerInfo>,
     /// How long to ban bad peers.
     #[cfg_attr(feature = "serde", serde(with = "humantime_serde"))]
     pub ban_duration: Duration,
@@ -193,6 +196,7 @@ impl Default for PeersConfig {
             trusted_nodes_only: false,
             trusted_nodes_resolution_interval: Duration::from_secs(60 * 60),
             basic_nodes: Default::default(),
+            persisted_peers: Default::default(),
             max_backoff_count: 5,
             incoming_ip_throttle_duration: INBOUND_IP_THROTTLE_DURATION,
             ip_filter: IpFilter::default(),
@@ -298,20 +302,39 @@ impl PeersConfig {
         self.connection_info.max_outbound + self.connection_info.max_inbound
     }
 
-    /// Read from file nodes available at launch. Ignored if None.
+    /// Read persisted peers from file at launch.
+    ///
+    /// Supports both the current [`PersistedPeerInfo`] format and the legacy `Vec<NodeRecord>`
+    /// format. Legacy entries are converted to [`PersistedPeerInfo`] with default metadata.
+    ///
+    /// Ignored if `optional_file` is `None` or the file does not exist.
+    #[cfg(feature = "serde")]
     pub fn with_basic_nodes_from_file(
-        self,
+        mut self,
         optional_file: Option<impl AsRef<Path>>,
     ) -> Result<Self, io::Error> {
         let Some(file_path) = optional_file else { return Ok(self) };
-        let reader = match std::fs::File::open(file_path.as_ref()) {
-            Ok(file) => io::BufReader::new(file),
+        let raw = match std::fs::read_to_string(file_path.as_ref()) {
+            Ok(contents) => contents,
             Err(e) if e.kind() == ErrorKind::NotFound => return Ok(self),
-            Err(e) => Err(e)?,
+            Err(e) => return Err(e),
         };
+
         info!(target: "net::peers", file = %file_path.as_ref().display(), "Loading saved peers");
-        let nodes: HashSet<NodeRecord> = serde_json::from_reader(reader)?;
-        Ok(self.with_basic_nodes(nodes))
+
+        // Try the new format first, fall back to legacy Vec<NodeRecord>
+        let peers: Vec<PersistedPeerInfo> = serde_json::from_str(&raw)
+            .or_else(|_| {
+                let nodes: HashSet<NodeRecord> = serde_json::from_str(&raw)?;
+                Ok::<_, serde_json::Error>(
+                    nodes.into_iter().map(PersistedPeerInfo::from_node_record).collect(),
+                )
+            })
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+        info!(target: "net::peers", count = peers.len(), "Loaded persisted peers");
+        self.persisted_peers = peers;
+        Ok(self)
     }
 
     /// Configure the IP filter for restricting network connections to specific IP ranges.

--- a/crates/net/network-types/src/peers/config.rs
+++ b/crates/net/network-types/src/peers/config.rs
@@ -147,7 +147,7 @@ pub struct PeersConfig {
     /// Basic nodes to connect to.
     #[cfg_attr(feature = "serde", serde(skip))]
     pub basic_nodes: HashSet<NodeRecord>,
-    /// Persisted peers loaded from disk, containing richer metadata than basic nodes.
+    /// Peers restored from a previous run, containing richer metadata than basic nodes.
     #[cfg_attr(feature = "serde", serde(skip))]
     pub persisted_peers: Vec<PersistedPeerInfo>,
     /// How long to ban bad peers.

--- a/crates/net/network-types/src/peers/kind.rs
+++ b/crates/net/network-types/src/peers/kind.rs
@@ -2,6 +2,8 @@
 
 /// Represents the kind of peer
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 pub enum PeerKind {
     /// Basic peer kind.
     #[default]

--- a/crates/net/network-types/src/peers/mod.rs
+++ b/crates/net/network-types/src/peers/mod.rs
@@ -167,7 +167,7 @@ impl PersistedPeerInfo {
     }
 
     /// Converts a legacy [`NodeRecord`] into a [`PersistedPeerInfo`] with default metadata.
-    pub fn from_node_record(record: NodeRecord) -> Self {
+    pub const fn from_node_record(record: NodeRecord) -> Self {
         Self { record, kind: PeerKind::Basic, fork_id: None, reputation: DEFAULT_REPUTATION }
     }
 }

--- a/crates/net/network-types/src/peers/mod.rs
+++ b/crates/net/network-types/src/peers/mod.rs
@@ -8,6 +8,7 @@ pub use config::{ConnectionsConfig, PeersConfig};
 pub use reputation::{Reputation, ReputationChange, ReputationChangeKind, ReputationChangeWeights};
 
 use alloy_eip2124::ForkId;
+use reth_network_peers::{NodeRecord, PeerId};
 use tracing::trace;
 
 use crate::{
@@ -138,5 +139,35 @@ impl Peer {
     #[inline]
     pub const fn is_static(&self) -> bool {
         matches!(self.kind, PeerKind::Static)
+    }
+}
+
+/// Peer info persisted to disk.
+///
+/// Contains richer metadata than a plain [`NodeRecord`], preserving the peer's kind, fork ID,
+/// and reputation across restarts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct PersistedPeerInfo {
+    /// The node record (id, address, ports).
+    pub record: NodeRecord,
+    /// The kind of peer.
+    pub kind: PeerKind,
+    /// The [`ForkId`] that the peer announced via discovery.
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
+    pub fork_id: Option<ForkId>,
+    /// The peer's reputation at the time of persisting.
+    pub reputation: i32,
+}
+
+impl PersistedPeerInfo {
+    /// Returns the peer id.
+    pub const fn peer_id(&self) -> PeerId {
+        self.record.id
+    }
+
+    /// Converts a legacy [`NodeRecord`] into a [`PersistedPeerInfo`] with default metadata.
+    pub fn from_node_record(record: NodeRecord) -> Self {
+        Self { record, kind: PeerKind::Basic, fork_id: None, reputation: DEFAULT_REPUTATION }
     }
 }

--- a/crates/net/network/Cargo.toml
+++ b/crates/net/network/Cargo.toml
@@ -33,7 +33,7 @@ reth-storage-api.workspace = true
 reth-tokio-util.workspace = true
 reth-consensus.workspace = true
 reth-network-peers = { workspace = true, features = ["net"] }
-reth-network-types.workspace = true
+reth-network-types = { workspace = true, features = ["serde"] }
 
 # ethereum
 alloy-consensus.workspace = true
@@ -105,7 +105,6 @@ serde = [
     "dep:serde",
     "secp256k1/serde",
     "enr/serde",
-    "reth-network-types/serde",
     "reth-dns-discovery/serde",
     "reth-eth-wire/serde",
     "reth-eth-wire-types/serde",
@@ -125,6 +124,7 @@ serde = [
     "reth-network-api/serde",
     "rand_08/serde",
     "reth-storage-api/serde",
+    "reth-network-types/serde",
 ]
 test-utils = [
     "reth-transaction-pool/test-utils",

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -448,10 +448,13 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
 
     /// Collect the peers from the [`NetworkManager`] and write them to the given
     /// `persistent_peers_file`.
+    ///
+    /// Only persists peers that are not currently backed off or banned. Includes metadata like
+    /// peer kind, fork ID, and reputation.
     pub fn write_peers_to_file(&self, persistent_peers_file: &Path) -> Result<(), FsPathError> {
-        let known_peers = self.all_peers().collect::<Vec<_>>();
+        let peers = self.swarm.state().peers().persistable_peers().collect::<Vec<_>>();
         persistent_peers_file.parent().map(fs::create_dir_all).transpose()?;
-        reth_fs_util::write_json_file(persistent_peers_file, &known_peers)?;
+        reth_fs_util::write_json_file(persistent_peers_file, &peers)?;
         Ok(())
     }
 

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -1104,9 +1104,9 @@ mod tests {
 
         let net_cfg = builder.build_with_noop_provider(MAINNET.clone());
 
-        // Assert basic_nodes contains our node
+        // Assert persisted_peers contains our node (legacy format is auto-converted)
         let node: NodeRecord = enode.parse().unwrap();
-        assert!(net_cfg.peers_config.basic_nodes.contains(&node));
+        assert!(net_cfg.peers_config.persisted_peers.iter().any(|p| p.record == node));
 
         // Cleanup
         let _ = fs::remove_file(&peers_file);


### PR DESCRIPTION
Introduces `PersistedPeerInfo` which preserves peer kind, fork ID, and reputation when writing peers to disk, instead of only storing bare `NodeRecord` addresses.

- `write_peers_to_file` now filters out backed-off and banned peers
- The reader supports both the new format and the legacy `Vec<NodeRecord>` format for backwards compatibility on first restart after upgrade
- Adds serde derives to `PeerKind` (feature-gated)