### PR TITLE
chore(engine): add debug log in spawned tx iterator after yielding tx index

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -431,8 +431,13 @@ where
                             tx
                         })
                     })
-                    .for_each_ordered(|tx| {
-                        let _ = execute_tx.send(tx);
+                    .for_each_ordered({
+                        let mut idx = prefetch;
+                        move |tx| {
+                            let _ = execute_tx.send(tx);
+                            debug!(target: "engine::tree::payload_processor", idx, "yielded transaction");
+                            idx += 1;
+                        }
                     });
             });
         }
@@ -717,6 +722,7 @@ fn convert_serial<RawTx, Tx, TxEnv, InnerTx, Recovered, Err, C>(
             let _ = prewarm_tx.send((idx, tx.clone()));
         }
         let _ = execute_tx.send(tx);
+        debug!(target: "engine::tree::payload_processor", idx, "yielded transaction");
     }
 }
 

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -424,20 +424,17 @@ where
                     .map(|(i, tx)| {
                         let idx = i + prefetch;
                         let tx = convert.convert(tx);
-                        tx.map(|tx| {
+                        let tx = tx.map(|tx| {
                             let (tx_env, tx) = tx.into_parts();
                             let tx = WithTxEnv { tx_env, tx: Arc::new(tx) };
                             let _ = prewarm_tx.send((idx, tx.clone()));
                             tx
-                        })
+                        });
+                        (idx, tx)
                     })
-                    .for_each_ordered({
-                        let mut idx = prefetch;
-                        move |tx| {
-                            let _ = execute_tx.send(tx);
-                            debug!(target: "engine::tree::payload_processor", idx, "yielded transaction");
-                            idx += 1;
-                        }
+                    .for_each_ordered(|(idx, tx)| {
+                        let _ = execute_tx.send(tx);
+                        debug!(target: "engine::tree::payload_processor", idx, "yielded transaction");
                     });
             });
         }


### PR DESCRIPTION
Adds a `debug!` log in the spawned tx iterator (`convert_serial` + parallel `for_each_ordered` path) that fires after each transaction index is yielded to the execution channel. Useful for tracing tx flow through the payload processor pipeline.

Prompted by: danipopes