### PR TITLE
fix(evm): use timestamp-based blob params for first post-Cancun block

### DIFF
--- a/crates/ethereum/evm/src/build.rs
+++ b/crates/ethereum/evm/src/build.rs
@@ -83,10 +83,11 @@ where
             } else {
                 // for the first post-fork block, both parent.blob_gas_used and
                 // parent.excess_blob_gas are evaluated as 0
-                Some(
-                    alloy_eips::eip7840::BlobParams::cancun()
-                        .next_block_excess_blob_gas_osaka(0, 0, 0),
-                )
+                let blob_params = self
+                    .chain_spec
+                    .blob_params_at_timestamp(timestamp)
+                    .unwrap_or_else(alloy_eips::eip7840::BlobParams::cancun);
+                Some(blob_params.next_block_excess_blob_gas_osaka(0, 0, 0))
             };
         }
 


### PR DESCRIPTION
Use `blob_params_at_timestamp` instead of hardcoded `BlobParams::cancun()` for the first post-Cancun block. Fixes incorrect `excess_blob_gas` when Cancun and Prague/Osaka are activated simultaneously (dev mode, testnets).