### PR TITLE
perf(discv4): remove unnecessary Vec allocation in re_ping_oldest

### DIFF
--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -1632,8 +1632,7 @@ impl Discv4Service {
             .map(|n| n.node.value)
             .collect::<Vec<_>>();
         nodes.sort_by_key(|a| a.last_seen);
-        let to_ping = nodes.into_iter().map(|n| n.record).take(MAX_NODES_PING).collect::<Vec<_>>();
-        for node in to_ping {
+        for node in nodes.into_iter().map(|n| n.record).take(MAX_NODES_PING) {
             self.try_ping(node, PingReason::RePing)
         }
     }


### PR DESCRIPTION
Remove redundant `collect::<Vec<_>>()` in `re_ping_oldest` - the collected Vec was immediately iterated in a `for` loop without any intermediate use, so the iterator can be consumed directly.