### PR TITLE
perf(trie): remove unnecessary value clone in `ParallelSparseTrie::update_leaf`

### DIFF
--- a/crates/trie/sparse/src/parallel.rs
+++ b/crates/trie/sparse/src/parallel.rs
@@ -474,7 +474,7 @@ impl SparseTrie for ParallelSparseTrie {
 
         // Insert value into upper subtrie temporarily. We'll move it to the correct subtrie
         // during traversal, or clean it up if we error.
-        self.upper_subtrie.inner.values.insert(full_path, value.clone());
+        self.upper_subtrie.inner.values.insert(full_path, value);
 
         // Start at the root, traversing until we find either the node to update or a subtrie to
         // update.
@@ -572,7 +572,12 @@ impl SparseTrie for ParallelSparseTrie {
             // At this point we know the value is not in the upper subtrie, and the call to
             // `update_leaf` below will insert it into the lower subtrie. So remove it from the
             // upper subtrie.
-            self.upper_subtrie.inner.values.remove(&full_path);
+            let value = self
+                .upper_subtrie
+                .inner
+                .values
+                .remove(&full_path)
+                .expect("value was inserted into upper subtrie at start of update_leaf");
 
             // Use subtrie_for_path to ensure the subtrie has the correct path.
             //


### PR DESCRIPTION
`ParallelSparseTrie::update_leaf` clones the value at entry to insert it into the upper subtrie, but this clone is never needed. When the leaf ends up in a lower subtrie, the clone is immediately removed and the original value is used instead. When the leaf stays in the upper subtrie, the original is dropped unused. Either way one `Vec<u8>` heap allocation is wasted per new leaf insert. This changes the insert to move the value directly and retrieves it back via `remove()` when delegating to a lower subtrie, matching the zero-clone pattern already used by `SparseSubtrie::update_leaf`.
