### PR TITLE
refactor(trie): drop V2 suffix from all trie types

### DIFF
--- a/.changelog/drop-v2-suffix.md
+++ b/.changelog/drop-v2-suffix.md
@@ -1,0 +1,24 @@
+---
+default: minor
+---
+
+# Drop V2 suffix from trie types
+
+Renames trie proof types to remove the `V2` suffix, now that legacy proof code paths
+have been superseded:
+
+- `TrieNodeV2` → `TrieNode`
+- `BranchNodeV2` → `BranchNode`
+- `ProofTrieNodeV2` → `ProofTrieNode`
+- `DecodedMultiProofV2` → `DecodedMultiProof`
+- `ProofV2Target` → `ProofTarget`
+- `MultiProofTargetsV2` → `MultiProofTargets`
+- `ChunkedMultiProofTargetsV2` → `ChunkedMultiProofTargets`
+- `target_v2` module → `target`
+- `trie_node_v2` module → `trie_node`
+- Various `_v2` function/method suffixes dropped
+
+Old conflicting types renamed with `Legacy` prefix (`LegacyDecodedMultiProof`,
+`LegacyProofTrieNode`, `LegacyMultiProofTargets`). Alloy's `TrieNode` and `BranchNode`
+are no longer re-exported from `reth_trie_common` via the `nodes::*` glob to avoid
+name conflicts.

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -8,7 +8,7 @@ use metrics::{Gauge, Histogram};
 use reth_metrics::Metrics;
 use reth_revm::state::EvmState;
 use reth_trie::{HashedPostState, HashedStorage};
-use reth_trie_common::MultiProofTargetsV2;
+use reth_trie_common::MultiProofTargets;
 use std::sync::Arc;
 use tracing::trace;
 
@@ -44,7 +44,7 @@ pub(crate) const DEFAULT_MAX_TARGETS_FOR_CHUNKING: usize = 300;
 #[derive(Debug)]
 pub enum MultiProofMessage {
     /// Prefetch proof targets
-    PrefetchProofs(MultiProofTargetsV2),
+    PrefetchProofs(MultiProofTargets),
     /// New state update from transaction execution with its source
     StateUpdate(Source, EvmState),
     /// State update that can be applied to the sparse trie without any new proofs.

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -33,7 +33,7 @@ use reth_provider::{
 };
 use reth_revm::{database::StateProviderDatabase, state::EvmState};
 use reth_tasks::{pool::WorkerPool, Runtime};
-use reth_trie_common::{MultiProofTargetsV2, ProofV2Target};
+use reth_trie_common::{MultiProofTargets, ProofTarget};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     mpsc::{self, channel, Receiver, Sender},
@@ -617,10 +617,10 @@ where
     }
 }
 
-/// Returns a set of [`MultiProofTargetsV2`] and the total amount of storage targets, based on the
+/// Returns a set of [`MultiProofTargets`] and the total amount of storage targets, based on the
 /// given state.
-fn multiproof_targets_from_state(state: EvmState) -> (MultiProofTargetsV2, usize) {
-    let mut targets = MultiProofTargetsV2::default();
+fn multiproof_targets_from_state(state: EvmState) -> (MultiProofTargets, usize) {
+    let mut targets = MultiProofTargets::default();
     let mut storage_target_count = 0;
     for (addr, account) in state {
         // if the account was not touched, or if the account was selfdestructed, do not
@@ -645,7 +645,7 @@ fn multiproof_targets_from_state(state: EvmState) -> (MultiProofTargetsV2, usize
             }
 
             let hashed_slot = keccak256(B256::new(key.to_be_bytes()));
-            storage_slots.push(ProofV2Target::from(hashed_slot));
+            storage_slots.push(ProofTarget::from(hashed_slot));
         }
 
         storage_target_count += storage_slots.len();
@@ -657,12 +657,12 @@ fn multiproof_targets_from_state(state: EvmState) -> (MultiProofTargetsV2, usize
     (targets, storage_target_count)
 }
 
-/// Returns [`MultiProofTargetsV2`] for withdrawal addresses.
+/// Returns [`MultiProofTargets`] for withdrawal addresses.
 ///
 /// Withdrawals only modify account balances (no storage), so the targets contain
 /// only account-level entries with empty storage sets.
-fn multiproof_targets_from_withdrawals(withdrawals: &[Withdrawal]) -> MultiProofTargetsV2 {
-    MultiProofTargetsV2 {
+fn multiproof_targets_from_withdrawals(withdrawals: &[Withdrawal]) -> MultiProofTargets {
+    MultiProofTargets {
         account_targets: withdrawals.iter().map(|w| keccak256(w.address).into()).collect(),
         ..Default::default()
     }

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -16,10 +16,10 @@ use rayon::iter::ParallelIterator;
 use reth_primitives_traits::{Account, FastInstant as Instant, ParallelBridgeBuffered};
 use reth_tasks::Runtime;
 use reth_trie::{
-    updates::TrieUpdates, DecodedMultiProofV2, HashedPostState, TrieAccount, EMPTY_ROOT_HASH,
+    updates::TrieUpdates, DecodedMultiProof, HashedPostState, TrieAccount, EMPTY_ROOT_HASH,
     TRIE_ACCOUNT_RLP_MAX_SIZE,
 };
-use reth_trie_common::{MultiProofTargetsV2, ProofV2Target};
+use reth_trie_common::{MultiProofTargets, ProofTarget};
 use reth_trie_parallel::{
     proof_task::{
         AccountMultiproofInput, ProofResultContext, ProofResultMessage, ProofWorkerHandle,
@@ -356,7 +356,7 @@ where
         target = "engine::tree::payload_processor::sparse_trie",
         skip_all
     )]
-    fn on_prewarm_targets(&mut self, targets: MultiProofTargetsV2) {
+    fn on_prewarm_targets(&mut self, targets: MultiProofTargets) {
         for target in targets.account_targets {
             // Only touch accounts that are not yet present in the updates set.
             self.new_account_updates.entry(target.key()).or_insert(LeafUpdate::Touched);
@@ -423,11 +423,8 @@ where
         }
     }
 
-    fn on_proof_result(
-        &mut self,
-        result: DecodedMultiProofV2,
-    ) -> Result<(), ParallelStateRootError> {
-        self.trie.reveal_decoded_multiproof_v2(result).map_err(|e| {
+    fn on_proof_result(&mut self, result: DecodedMultiProof) -> Result<(), ParallelStateRootError> {
+        self.trie.reveal_decoded_multiproof(result).map_err(|e| {
             ParallelStateRootError::Other(format!("could not reveal multiproof: {e:?}"))
         })
     }
@@ -509,12 +506,12 @@ where
                 Entry::Occupied(mut entry) => {
                     if min_len < *entry.get() {
                         entry.insert(min_len);
-                        targets.push(ProofV2Target::new(path).with_min_len(min_len));
+                        targets.push(ProofTarget::new(path).with_min_len(min_len));
                     }
                 }
                 Entry::Vacant(entry) => {
                     entry.insert(min_len);
-                    targets.push(ProofV2Target::new(path).with_min_len(min_len));
+                    targets.push(ProofTarget::new(path).with_min_len(min_len));
                 }
             })?;
 
@@ -551,13 +548,13 @@ where
                     if min_len < *entry.get() {
                         entry.insert(min_len);
                         self.pending_targets
-                            .push_account_target(ProofV2Target::new(target).with_min_len(min_len));
+                            .push_account_target(ProofTarget::new(target).with_min_len(min_len));
                     }
                 }
                 Entry::Vacant(entry) => {
                     entry.insert(min_len);
                     self.pending_targets
-                        .push_account_target(ProofV2Target::new(target).with_min_len(min_len));
+                        .push_account_target(ProofTarget::new(target).with_min_len(min_len));
                 }
             }
         })?;
@@ -674,7 +671,7 @@ where
             self.max_targets_for_chunking,
             self.proof_worker_handle.available_account_workers(),
             self.proof_worker_handle.available_storage_workers(),
-            MultiProofTargetsV2::chunks,
+            MultiProofTargets::chunks,
             |proof_targets| {
                 if let Err(e) =
                     self.proof_worker_handle.dispatch_account_multiproof(AccountMultiproofInput {
@@ -712,7 +709,7 @@ fn encode_account_leaf_value(
 #[derive(Default)]
 struct PendingTargets {
     /// The proof targets.
-    targets: MultiProofTargetsV2,
+    targets: MultiProofTargets,
     /// Number of account + storage proof targets currently queued.
     len: usize,
 }
@@ -729,18 +726,18 @@ impl PendingTargets {
     }
 
     /// Takes the pending targets, replacing with empty defaults.
-    fn take(&mut self) -> (MultiProofTargetsV2, usize) {
+    fn take(&mut self) -> (MultiProofTargets, usize) {
         (std::mem::take(&mut self.targets), std::mem::take(&mut self.len))
     }
 
     /// Adds a target to the account targets.
-    fn push_account_target(&mut self, target: ProofV2Target) {
+    fn push_account_target(&mut self, target: ProofTarget) {
         self.targets.account_targets.push(target);
         self.len += 1;
     }
 
     /// Extends storage targets for the given address.
-    fn extend_storage_targets(&mut self, address: &B256, targets: Vec<ProofV2Target>) {
+    fn extend_storage_targets(&mut self, address: &B256, targets: Vec<ProofTarget>) {
         self.len += targets.len();
         self.targets.storage_targets.entry(*address).or_default().extend(targets);
     }
@@ -751,7 +748,7 @@ enum SparseTrieTaskMessage {
     /// A hashed state update ready to be processed.
     HashedState(HashedPostState),
     /// Prefetch proof targets (passed through directly).
-    PrefetchProofs(MultiProofTargetsV2),
+    PrefetchProofs(MultiProofTargets),
     /// Signals that all state updates have been received.
     FinishedStateUpdates,
 }

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -516,7 +516,8 @@ impl<
             let mut input = input;
             input.prepend(self.revert_state()?.into());
             let proof = <DbProof<'_, _, A> as DatabaseProof>::from_tx(self.tx());
-            proof.overlay_multiproof(input, targets).map_err(ProviderError::from)
+            let legacy_targets = targets.into_legacy();
+            proof.overlay_multiproof(input, legacy_targets).map_err(ProviderError::from)
         })
     }
 

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -220,7 +220,8 @@ impl<Provider: DBProvider + StorageSettingsCache> StateProofProvider
     ) -> ProviderResult<MultiProof> {
         reth_trie_db::with_adapter!(self.0, |A| {
             let proof = <DbProof<'_, _, A> as DatabaseProof>::from_tx(self.tx());
-            proof.overlay_multiproof(input, targets).map_err(ProviderError::from)
+            let legacy_targets = targets.into_legacy();
+            proof.overlay_multiproof(input, legacy_targets).map_err(ProviderError::from)
         })
     }
 

--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -4,7 +4,7 @@ use crate::{
     added_removed_keys::MultiAddedRemovedKeys,
     prefix_set::{PrefixSetMut, TriePrefixSetsMut},
     utils::{extend_sorted_vec, kway_merge_sorted},
-    KeyHasher, MultiProofTargets, Nibbles,
+    KeyHasher, LegacyMultiProofTargets, Nibbles,
 };
 use alloc::{borrow::Cow, vec::Vec};
 use alloy_primitives::{
@@ -153,9 +153,9 @@ impl HashedPostState {
     }
 
     /// Create multiproof targets for this state.
-    pub fn multi_proof_targets(&self) -> MultiProofTargets {
+    pub fn multi_proof_targets(&self) -> LegacyMultiProofTargets {
         // Pre-allocate minimum capacity for the targets.
-        let mut targets = MultiProofTargets::with_capacity(self.accounts.len());
+        let mut targets = LegacyMultiProofTargets::with_capacity(self.accounts.len());
         for hashed_address in self.accounts.keys() {
             targets.insert(*hashed_address, Default::default());
         }
@@ -169,12 +169,13 @@ impl HashedPostState {
     /// i.e., the targets that are in targets create from `self` but not in `excluded`.
     ///
     /// This method is preferred to first calling `Self::multi_proof_targets` and the calling
-    /// `MultiProofTargets::retain_difference`, because it does not over allocate the targets map.
+    /// `LegacyMultiProofTargets::retain_difference`, because it does not over allocate the targets
+    /// map.
     pub fn multi_proof_targets_difference(
         &self,
-        excluded: &MultiProofTargets,
-    ) -> MultiProofTargets {
-        let mut targets = MultiProofTargets::default();
+        excluded: &LegacyMultiProofTargets,
+    ) -> LegacyMultiProofTargets {
+        let mut targets = LegacyMultiProofTargets::default();
         for hashed_address in self.accounts.keys() {
             if !excluded.contains_key(hashed_address) {
                 targets.insert(*hashed_address, Default::default());
@@ -202,7 +203,7 @@ impl HashedPostState {
     /// are done correctly.
     pub fn partition_by_targets(
         mut self,
-        targets: &MultiProofTargets,
+        targets: &LegacyMultiProofTargets,
         added_removed_keys: &MultiAddedRemovedKeys,
     ) -> (Self, Self) {
         let mut state_updates_not_in_targets = Self::default();
@@ -1120,7 +1121,7 @@ mod tests {
     #[test]
     fn test_multi_proof_targets_difference_empty_state() {
         let state = HashedPostState::default();
-        let excluded = MultiProofTargets::default();
+        let excluded = LegacyMultiProofTargets::default();
 
         let targets = state.multi_proof_targets_difference(&excluded);
         assert!(targets.is_empty());
@@ -1129,7 +1130,7 @@ mod tests {
     #[test]
     fn test_multi_proof_targets_difference_new_account_targets() {
         let state = create_state_for_multi_proof_targets();
-        let excluded = MultiProofTargets::default();
+        let excluded = LegacyMultiProofTargets::default();
 
         // should return all accounts as targets since excluded is empty
         let targets = state.multi_proof_targets_difference(&excluded);
@@ -1142,7 +1143,7 @@ mod tests {
     #[test]
     fn test_multi_proof_targets_difference_new_storage_targets() {
         let state = create_state_for_multi_proof_targets();
-        let excluded = MultiProofTargets::default();
+        let excluded = LegacyMultiProofTargets::default();
 
         let targets = state.multi_proof_targets_difference(&excluded);
 
@@ -1160,7 +1161,7 @@ mod tests {
     #[test]
     fn test_multi_proof_targets_difference_filter_excluded_accounts() {
         let state = create_state_for_multi_proof_targets();
-        let mut excluded = MultiProofTargets::default();
+        let mut excluded = LegacyMultiProofTargets::default();
 
         // select an account that has no storage updates
         let excluded_addr = state
@@ -1183,7 +1184,7 @@ mod tests {
     #[test]
     fn test_multi_proof_targets_difference_filter_excluded_storage() {
         let state = create_state_for_multi_proof_targets();
-        let mut excluded = MultiProofTargets::default();
+        let mut excluded = LegacyMultiProofTargets::default();
 
         // mark one storage slot as excluded
         let (addr, storage) = state.storages.iter().next().unwrap();
@@ -1203,7 +1204,7 @@ mod tests {
     #[test]
     fn test_multi_proof_targets_difference_mixed_excluded_state() {
         let mut state = HashedPostState::default();
-        let mut excluded = MultiProofTargets::default();
+        let mut excluded = LegacyMultiProofTargets::default();
 
         let addr1 = B256::random();
         let addr2 = B256::random();
@@ -1232,7 +1233,7 @@ mod tests {
     #[test]
     fn test_multi_proof_targets_difference_unmodified_account_with_storage() {
         let mut state = HashedPostState::default();
-        let excluded = MultiProofTargets::default();
+        let excluded = LegacyMultiProofTargets::default();
 
         let addr = B256::random();
         let slot1 = B256::random();
@@ -1279,7 +1280,7 @@ mod tests {
                 },
             )]),
         };
-        let targets = MultiProofTargets::from_iter([(addr1, HashSet::from_iter([slot1]))]);
+        let targets = LegacyMultiProofTargets::from_iter([(addr1, HashSet::from_iter([slot1]))]);
 
         let (with_targets, without_targets) =
             state.partition_by_targets(&targets, &MultiAddedRemovedKeys::new());

--- a/crates/trie/common/src/lib.rs
+++ b/crates/trie/common/src/lib.rs
@@ -33,9 +33,9 @@ pub use constants::*;
 mod account;
 pub use account::TrieAccount;
 
-/// V2 proof targets and chunking.
-pub mod target_v2;
-pub use target_v2::{ChunkedMultiProofTargetsV2, MultiProofTargetsV2, ProofV2Target};
+/// Proof targets and chunking.
+pub mod target;
+pub use target::{ChunkedMultiProofTargets, MultiProofTargets, ProofTarget};
 
 mod key;
 pub use key::{KeccakKeyHasher, KeyHasher};
@@ -53,10 +53,10 @@ mod subnode;
 pub use subnode::StoredSubNode;
 
 mod trie;
-pub use trie::{BranchNodeMasks, BranchNodeMasksMap, ProofTrieNode};
+pub use trie::{BranchNodeMasks, BranchNodeMasksMap, LegacyProofTrieNode};
 
-mod trie_node_v2;
-pub use trie_node_v2::*;
+mod trie_node;
+pub use trie_node::*;
 
 /// The implementation of a container for storing intermediate changes to a trie.
 /// The container indicates when the trie has been modified.
@@ -96,5 +96,6 @@ pub mod serde_bincode_compat {
 
 /// Re-export
 pub use alloy_trie::{
-    nodes::*, proof, BranchNodeCompact, HashBuilder, TrieMask, TrieMaskIter, EMPTY_ROOT_HASH,
+    nodes::{BranchNodeRef, ExtensionNode, ExtensionNodeRef, LeafNode, LeafNodeRef, RlpNode},
+    proof, BranchNodeCompact, HashBuilder, TrieMask, TrieMaskIter, EMPTY_ROOT_HASH,
 };

--- a/crates/trie/common/src/proofs.rs
+++ b/crates/trie/common/src/proofs.rs
@@ -1,6 +1,6 @@
 //! Merkle trie proofs.
 
-use crate::{BranchNodeMasksMap, Nibbles, ProofTrieNodeV2, TrieAccount};
+use crate::{BranchNodeMasksMap, Nibbles, ProofTrieNode, TrieAccount};
 use alloc::{borrow::Cow, vec::Vec};
 use alloy_consensus::constants::KECCAK_EMPTY;
 use alloy_primitives::{
@@ -10,7 +10,6 @@ use alloy_primitives::{
 };
 use alloy_rlp::{encode_fixed_size, Decodable, EMPTY_STRING_CODE};
 use alloy_trie::{
-    nodes::TrieNode,
     proof::{verify_proof, DecodedProofNodes, ProofNodes, ProofVerificationError},
     EMPTY_ROOT_HASH,
 };
@@ -18,28 +17,28 @@ use derive_more::{Deref, DerefMut, IntoIterator};
 use itertools::Itertools;
 use reth_primitives_traits::Account;
 
-/// Proof targets map.
+/// Legacy proof targets map.
 #[derive(Deref, DerefMut, IntoIterator, Clone, PartialEq, Eq, Default, Debug)]
-pub struct MultiProofTargets(B256Map<B256Set>);
+pub struct LegacyMultiProofTargets(B256Map<B256Set>);
 
-impl FromIterator<(B256, B256Set)> for MultiProofTargets {
+impl FromIterator<(B256, B256Set)> for LegacyMultiProofTargets {
     fn from_iter<T: IntoIterator<Item = (B256, B256Set)>>(iter: T) -> Self {
         Self(B256Map::from_iter(iter))
     }
 }
 
-impl MultiProofTargets {
-    /// Creates an empty `MultiProofTargets` with at least the specified capacity.
+impl LegacyMultiProofTargets {
+    /// Creates an empty `LegacyMultiProofTargets` with at least the specified capacity.
     pub fn with_capacity(capacity: usize) -> Self {
         Self(B256Map::with_capacity_and_hasher(capacity, Default::default()))
     }
 
-    /// Create `MultiProofTargets` with a single account as a target.
+    /// Create `LegacyMultiProofTargets` with a single account as a target.
     pub fn account(hashed_address: B256) -> Self {
         Self::accounts([hashed_address])
     }
 
-    /// Create `MultiProofTargets` with a single account and slots as targets.
+    /// Create `LegacyMultiProofTargets` with a single account and slots as targets.
     pub fn account_with_slots<I: IntoIterator<Item = B256>>(
         hashed_address: B256,
         slots_iter: I,
@@ -47,7 +46,7 @@ impl MultiProofTargets {
         Self(B256Map::from_iter([(hashed_address, slots_iter.into_iter().collect())]))
     }
 
-    /// Create `MultiProofTargets` only from accounts.
+    /// Create `LegacyMultiProofTargets` only from accounts.
     pub fn accounts<I: IntoIterator<Item = B256>>(iter: I) -> Self {
         Self(iter.into_iter().map(|hashed_address| (hashed_address, Default::default())).collect())
     }
@@ -85,9 +84,9 @@ impl MultiProofTargets {
 
     /// Returns an iterator that yields chunks of the specified size.
     ///
-    /// See [`ChunkedMultiProofTargets`] for more information.
-    pub fn chunks(self, size: usize) -> ChunkedMultiProofTargets {
-        ChunkedMultiProofTargets::new(self, size)
+    /// See [`LegacyChunkedMultiProofTargets`] for more information.
+    pub fn chunks(self, size: usize) -> LegacyChunkedMultiProofTargets {
+        LegacyChunkedMultiProofTargets::new(self, size)
     }
 
     /// Returns the number of items that will be considered during chunking in `[Self::chunks]`.
@@ -117,13 +116,13 @@ impl MultiProofTargets {
 /// - If account has associated storage slots, each storage slot is counted towards the chunk size.
 /// - If account has no associated storage slots, the account is counted towards the chunk size.
 #[derive(Debug)]
-pub struct ChunkedMultiProofTargets {
+pub struct LegacyChunkedMultiProofTargets {
     flattened_targets: alloc::vec::IntoIter<(B256, Option<B256>)>,
     size: usize,
 }
 
-impl ChunkedMultiProofTargets {
-    fn new(targets: MultiProofTargets, size: usize) -> Self {
+impl LegacyChunkedMultiProofTargets {
+    fn new(targets: LegacyMultiProofTargets, size: usize) -> Self {
         let flattened_targets = targets
             .into_iter()
             .flat_map(|(address, slots)| {
@@ -143,12 +142,12 @@ impl ChunkedMultiProofTargets {
     }
 }
 
-impl Iterator for ChunkedMultiProofTargets {
-    type Item = MultiProofTargets;
+impl Iterator for LegacyChunkedMultiProofTargets {
+    type Item = LegacyMultiProofTargets;
 
     fn next(&mut self) -> Option<Self::Item> {
         let chunk = self.flattened_targets.by_ref().take(self.size).fold(
-            MultiProofTargets::default(),
+            LegacyMultiProofTargets::default(),
             |mut acc, (address, slot)| {
                 let entry = acc.entry(address).or_default();
                 if let Some(slot) = slot {
@@ -233,7 +232,8 @@ impl MultiProof {
         // then the node contains the encoded trie account.
         let info = 'info: {
             if let Some(last) = proof.last() &&
-                let TrieNode::Leaf(leaf) = TrieNode::decode(&mut &last[..])? &&
+                let alloy_trie::nodes::TrieNode::Leaf(leaf) =
+                    alloy_trie::nodes::TrieNode::decode(&mut &last[..])? &&
                 nibbles.ends_with(&leaf.key)
             {
                 let account = TrieAccount::decode(&mut &leaf.value[..])?;
@@ -298,9 +298,9 @@ impl MultiProof {
 }
 
 /// This is a type of [`MultiProof`] that uses decoded proofs, meaning these proofs are stored as a
-/// collection of [`TrieNode`]s instead of RLP-encoded bytes.
+/// collection of [`TrieNode`](alloy_trie::nodes::TrieNode)s instead of RLP-encoded bytes.
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
-pub struct DecodedMultiProof {
+pub struct LegacyDecodedMultiProof {
     /// State trie multiproof for requested accounts.
     pub account_subtree: DecodedProofNodes,
     /// Consolidated branch node masks (`hash_mask`, `tree_mask`) for each path in the account
@@ -310,7 +310,7 @@ pub struct DecodedMultiProof {
     pub storages: B256Map<DecodedStorageMultiProof>,
 }
 
-impl DecodedMultiProof {
+impl LegacyDecodedMultiProof {
     /// Returns true if the multiproof is empty.
     pub fn is_empty(&self) -> bool {
         self.account_subtree.is_empty() &&
@@ -319,7 +319,10 @@ impl DecodedMultiProof {
     }
 
     /// Return the account proof nodes for the given account path.
-    pub fn account_proof_nodes(&self, path: &Nibbles) -> Vec<(Nibbles, TrieNode)> {
+    pub fn account_proof_nodes(
+        &self,
+        path: &Nibbles,
+    ) -> Vec<(Nibbles, alloy_trie::nodes::TrieNode)> {
         self.account_subtree.matching_nodes_sorted(path)
     }
 
@@ -328,7 +331,7 @@ impl DecodedMultiProof {
         &self,
         hashed_address: B256,
         slots: impl IntoIterator<Item = B256>,
-    ) -> Vec<(B256, Vec<(Nibbles, TrieNode)>)> {
+    ) -> Vec<(B256, Vec<(Nibbles, alloy_trie::nodes::TrieNode)>)> {
         self.storages
             .get(&hashed_address)
             .map(|storage_mp| {
@@ -362,7 +365,7 @@ impl DecodedMultiProof {
         // Inspect the last node in the proof. If it's a leaf node with matching suffix,
         // then the node contains the encoded trie account.
         let info = 'info: {
-            if let Some(TrieNode::Leaf(leaf)) = proof.last() &&
+            if let Some(alloy_trie::nodes::TrieNode::Leaf(leaf)) = proof.last() &&
                 nibbles.ends_with(&leaf.key)
             {
                 let account = TrieAccount::decode(&mut &leaf.value[..])?;
@@ -417,7 +420,7 @@ impl DecodedMultiProof {
         }
     }
 
-    /// Create a [`DecodedMultiProof`] from a [`DecodedStorageMultiProof`].
+    /// Create a [`LegacyDecodedMultiProof`] from a [`DecodedStorageMultiProof`].
     pub fn from_storage_proof(
         hashed_address: B256,
         storage_proof: DecodedStorageMultiProof,
@@ -429,7 +432,7 @@ impl DecodedMultiProof {
     }
 }
 
-impl TryFrom<MultiProof> for DecodedMultiProof {
+impl TryFrom<MultiProof> for LegacyDecodedMultiProof {
     type Error = alloy_rlp::Error;
 
     fn try_from(multi_proof: MultiProof) -> Result<Self, Self::Error> {
@@ -443,17 +446,17 @@ impl TryFrom<MultiProof> for DecodedMultiProof {
     }
 }
 
-/// V2 decoded multiproof which contains the results of both account and storage V2 proof
+/// Decoded multiproof which contains the results of both account and storage proof
 /// calculations.
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
-pub struct DecodedMultiProofV2 {
+pub struct DecodedMultiProof {
     /// Account trie proof nodes
-    pub account_proofs: Vec<ProofTrieNodeV2>,
+    pub account_proofs: Vec<ProofTrieNode>,
     /// Storage trie proof nodes indexed by account
-    pub storage_proofs: B256Map<Vec<ProofTrieNodeV2>>,
+    pub storage_proofs: B256Map<Vec<ProofTrieNode>>,
 }
 
-impl DecodedMultiProofV2 {
+impl DecodedMultiProof {
     /// Returns true if there are no proofs
     pub fn is_empty(&self) -> bool {
         self.account_proofs.is_empty() && self.storage_proofs.is_empty()
@@ -477,30 +480,26 @@ impl DecodedMultiProofV2 {
     }
 }
 
-impl From<DecodedMultiProof> for DecodedMultiProofV2 {
-    fn from(proof: DecodedMultiProof) -> Self {
-        let account_proofs =
-            decoded_proof_nodes_to_v2(proof.account_subtree, &proof.branch_node_masks);
+impl From<LegacyDecodedMultiProof> for DecodedMultiProof {
+    fn from(proof: LegacyDecodedMultiProof) -> Self {
+        let account_proofs = decoded_proof_nodes(proof.account_subtree, &proof.branch_node_masks);
         let storage_proofs = proof
             .storages
             .into_iter()
             .map(|(address, storage)| {
-                (address, decoded_proof_nodes_to_v2(storage.subtree, &storage.branch_node_masks))
+                (address, decoded_proof_nodes(storage.subtree, &storage.branch_node_masks))
             })
             .collect();
         Self { account_proofs, storage_proofs }
     }
 }
 
-/// Converts a [`DecodedProofNodes`] (path → [`TrieNode`] map) into a `Vec<ProofTrieNodeV2>`,
-/// merging extension nodes into their child branch nodes.
-fn decoded_proof_nodes_to_v2(
-    nodes: DecodedProofNodes,
-    masks: &BranchNodeMasksMap,
-) -> Vec<ProofTrieNodeV2> {
+/// Converts a [`DecodedProofNodes`] (path → [`alloy_trie::nodes::TrieNode`] map) into a
+/// `Vec<ProofTrieNode>`, merging extension nodes into their child branch nodes.
+fn decoded_proof_nodes(nodes: DecodedProofNodes, masks: &BranchNodeMasksMap) -> Vec<ProofTrieNode> {
     let mut sorted: Vec<_> = nodes.into_inner().into_iter().collect();
     sorted.sort_unstable_by(|a, b| crate::depth_first_cmp(&a.0, &b.0));
-    ProofTrieNodeV2::from_sorted_trie_nodes(
+    ProofTrieNode::from_sorted_trie_nodes(
         sorted.into_iter().map(|(path, node)| (path, node, masks.get(&path).copied())),
     )
 }
@@ -546,7 +545,8 @@ impl StorageMultiProof {
         // then the node contains the encoded slot value.
         let value = 'value: {
             if let Some(last) = proof.last() &&
-                let TrieNode::Leaf(leaf) = TrieNode::decode(&mut &last[..])? &&
+                let alloy_trie::nodes::TrieNode::Leaf(leaf) =
+                    alloy_trie::nodes::TrieNode::decode(&mut &last[..])? &&
                 nibbles.ends_with(&leaf.key)
             {
                 break 'value U256::decode(&mut &leaf.value[..])?
@@ -575,7 +575,10 @@ impl DecodedStorageMultiProof {
     pub fn empty() -> Self {
         Self {
             root: EMPTY_ROOT_HASH,
-            subtree: DecodedProofNodes::from_iter([(Nibbles::default(), TrieNode::EmptyRoot)]),
+            subtree: DecodedProofNodes::from_iter([(
+                Nibbles::default(),
+                alloy_trie::nodes::TrieNode::EmptyRoot,
+            )]),
             branch_node_masks: BranchNodeMasksMap::default(),
         }
     }
@@ -595,7 +598,7 @@ impl DecodedStorageMultiProof {
         // Inspect the last node in the proof. If it's a leaf node with matching suffix,
         // then the node contains the encoded slot value.
         let value = 'value: {
-            if let Some(TrieNode::Leaf(leaf)) = proof.last() &&
+            if let Some(alloy_trie::nodes::TrieNode::Leaf(leaf)) = proof.last() &&
                 nibbles.ends_with(&leaf.key)
             {
                 break 'value U256::decode(&mut &leaf.value[..])?
@@ -752,7 +755,7 @@ pub struct DecodedAccountProof {
     pub info: Option<Account>,
     /// Array of merkle trie nodes which starting from the root node and following the path of the
     /// hashed address as key.
-    pub proof: Vec<TrieNode>,
+    pub proof: Vec<alloy_trie::nodes::TrieNode>,
     /// The storage trie root.
     pub storage_root: B256,
     /// Array of storage proofs as requested.
@@ -865,7 +868,7 @@ pub struct DecodedStorageProof {
     pub value: U256,
     /// Array of merkle trie nodes which starting from the storage root node and following the path
     /// of the hashed storage slot as key.
-    pub proof: Vec<TrieNode>,
+    pub proof: Vec<alloy_trie::nodes::TrieNode>,
 }
 
 impl DecodedStorageProof {
@@ -886,7 +889,7 @@ impl DecodedStorageProof {
     }
 
     /// Set proof nodes on storage proof.
-    pub fn with_proof(mut self, proof: Vec<TrieNode>) -> Self {
+    pub fn with_proof(mut self, proof: Vec<alloy_trie::nodes::TrieNode>) -> Self {
         self.proof = proof;
         self
     }
@@ -992,23 +995,25 @@ mod tests {
 
     #[test]
     fn test_multi_proof_retain_difference() {
-        let mut empty = MultiProofTargets::default();
+        let mut empty = LegacyMultiProofTargets::default();
         empty.retain_difference(&Default::default());
         assert!(empty.is_empty());
 
-        let targets = MultiProofTargets::accounts((0..10).map(B256::with_last_byte));
+        let targets = LegacyMultiProofTargets::accounts((0..10).map(B256::with_last_byte));
 
         let mut diffed = targets.clone();
-        diffed.retain_difference(&MultiProofTargets::account(B256::with_last_byte(11)));
+        diffed.retain_difference(&LegacyMultiProofTargets::account(B256::with_last_byte(11)));
         assert_eq!(diffed, targets);
 
-        diffed.retain_difference(&MultiProofTargets::accounts((0..5).map(B256::with_last_byte)));
-        assert_eq!(diffed, MultiProofTargets::accounts((5..10).map(B256::with_last_byte)));
+        diffed.retain_difference(&LegacyMultiProofTargets::accounts(
+            (0..5).map(B256::with_last_byte),
+        ));
+        assert_eq!(diffed, LegacyMultiProofTargets::accounts((5..10).map(B256::with_last_byte)));
 
         diffed.retain_difference(&targets);
         assert!(diffed.is_empty());
 
-        let mut targets = MultiProofTargets::default();
+        let mut targets = LegacyMultiProofTargets::default();
         let (account1, account2, account3) =
             (1..=3).map(B256::with_last_byte).collect_tuple().unwrap();
         let account2_slots = (1..5).map(B256::with_last_byte).collect::<B256Set>();
@@ -1017,13 +1022,16 @@ mod tests {
         targets.insert(account3, B256Set::from_iter([B256::with_last_byte(1)]));
 
         let mut diffed = targets.clone();
-        diffed.retain_difference(&MultiProofTargets::accounts((1..=3).map(B256::with_last_byte)));
+        diffed.retain_difference(&LegacyMultiProofTargets::accounts(
+            (1..=3).map(B256::with_last_byte),
+        ));
         assert_eq!(diffed, targets);
 
         // remove last 3 slots for account 2
         let mut account2_slots_expected_len = account2_slots.len();
         for slot in account2_slots.iter().skip(1) {
-            diffed.retain_difference(&MultiProofTargets::account_with_slots(account2, [*slot]));
+            diffed
+                .retain_difference(&LegacyMultiProofTargets::account_with_slots(account2, [*slot]));
             account2_slots_expected_len -= 1;
             assert_eq!(
                 diffed.get(&account2).map(|slots| slots.len()),
@@ -1037,7 +1045,7 @@ mod tests {
 
     #[test]
     fn test_multi_proof_retain_difference_no_overlap() {
-        let mut targets = MultiProofTargets::default();
+        let mut targets = LegacyMultiProofTargets::default();
 
         // populate some targets
         let (addr1, addr2) = (B256::random(), B256::random());
@@ -1050,7 +1058,7 @@ mod tests {
         assert_eq!(retained, targets);
 
         // add a different addr and slot to fetched proof targets
-        let mut other_targets = MultiProofTargets::default();
+        let mut other_targets = LegacyMultiProofTargets::default();
         let addr3 = B256::random();
         let slot3 = B256::random();
         other_targets.insert(addr3, B256Set::from_iter([slot3]));
@@ -1065,14 +1073,14 @@ mod tests {
     #[test]
     fn test_get_prefetch_proof_targets_remove_subset() {
         // populate some targets
-        let mut targets = MultiProofTargets::default();
+        let mut targets = LegacyMultiProofTargets::default();
         let (addr1, addr2) = (B256::random(), B256::random());
         let (slot1, slot2) = (B256::random(), B256::random());
         targets.insert(addr1, B256Set::from_iter([slot1]));
         targets.insert(addr2, B256Set::from_iter([slot2]));
 
         // add a subset of the first target to other proof targets
-        let other_targets = MultiProofTargets::account_with_slots(addr1, [slot1]);
+        let other_targets = LegacyMultiProofTargets::account_with_slots(addr1, [slot1]);
 
         let mut retained = targets.clone();
         retained.retain_difference(&other_targets);
@@ -1127,7 +1135,7 @@ mod tests {
 
     #[test]
     fn test_multiproof_targets_chunking_length() {
-        let mut targets = MultiProofTargets::default();
+        let mut targets = LegacyMultiProofTargets::default();
         targets.insert(B256::with_last_byte(1), B256Set::default());
         targets.insert(
             B256::with_last_byte(2),

--- a/crates/trie/common/src/target.rs
+++ b/crates/trie/common/src/target.rs
@@ -1,4 +1,4 @@
-//! V2 proof targets and chunking.
+//! Proof targets and chunking.
 
 use crate::Nibbles;
 use alloc::vec::Vec;
@@ -7,15 +7,15 @@ use alloy_primitives::{map::B256Map, B256};
 /// Target describes a proof target. For every proof target given, a proof calculator will calculate
 /// and return all nodes whose path is a prefix of the target's `key_nibbles`.
 #[derive(Debug, Copy, Clone)]
-pub struct ProofV2Target {
+pub struct ProofTarget {
     /// The key of the proof target, as nibbles.
     pub key_nibbles: Nibbles,
     /// The minimum length of a node's path for it to be retained.
     pub min_len: u8,
 }
 
-impl ProofV2Target {
-    /// Returns a new [`ProofV2Target`] which matches all trie nodes whose path is a prefix of this
+impl ProofTarget {
+    /// Returns a new [`ProofTarget`] which matches all trie nodes whose path is a prefix of this
     /// key.
     pub fn new(key: B256) -> Self {
         // SAFETY: key is a B256 and so is exactly 32-bytes.
@@ -40,23 +40,23 @@ impl ProofV2Target {
     }
 }
 
-impl From<B256> for ProofV2Target {
+impl From<B256> for ProofTarget {
     fn from(key: B256) -> Self {
         Self::new(key)
     }
 }
 
-/// A set of account and storage V2 proof targets. The account and storage targets do not need to
+/// A set of account and storage proof targets. The account and storage targets do not need to
 /// necessarily overlap.
 #[derive(Debug, Default)]
-pub struct MultiProofTargetsV2 {
+pub struct MultiProofTargets {
     /// The set of account proof targets to generate proofs for.
-    pub account_targets: Vec<ProofV2Target>,
+    pub account_targets: Vec<ProofTarget>,
     /// The sets of storage proof targets to generate proofs for.
-    pub storage_targets: B256Map<Vec<ProofV2Target>>,
+    pub storage_targets: B256Map<Vec<ProofTarget>>,
 }
 
-impl MultiProofTargetsV2 {
+impl MultiProofTargets {
     /// Returns true is there are no account or storage targets.
     pub fn is_empty(&self) -> bool {
         self.account_targets.is_empty() && self.storage_targets.is_empty()
@@ -70,32 +70,46 @@ impl MultiProofTargetsV2 {
 
     /// Returns an iterator that yields chunks of the specified size.
     pub fn chunks(self, chunk_size: usize) -> impl Iterator<Item = Self> {
-        ChunkedMultiProofTargetsV2::new(self, chunk_size)
+        ChunkedMultiProofTargets::new(self, chunk_size)
+    }
+
+    /// Converts into the legacy `LegacyMultiProofTargets` format, discarding `min_len` metadata.
+    pub fn into_legacy(self) -> crate::LegacyMultiProofTargets {
+        use alloy_primitives::map::B256Set;
+        let mut targets = crate::LegacyMultiProofTargets::with_capacity(self.account_targets.len());
+        for target in &self.account_targets {
+            targets.entry(target.key()).or_default();
+        }
+        for (account, slots) in self.storage_targets {
+            let slot_set: B256Set = slots.iter().map(|t| t.key()).collect();
+            targets.entry(account).or_default().extend(slot_set);
+        }
+        targets
     }
 }
 
-/// An iterator that yields chunks of V2 proof targets of at most `size` account and storage
+/// An iterator that yields chunks of proof targets of at most `size` account and storage
 /// targets.
 ///
-/// Unlike legacy chunking, V2 preserves account targets exactly as they were (with their `min_len`
-/// metadata). Account targets must appear in a chunk. Storage targets for those accounts are
-/// chunked together, but if they exceed the chunk size, subsequent chunks contain only the
-/// remaining storage targets without repeating the account target.
+/// Preserves account targets exactly as they were (with their `min_len` metadata). Account targets
+/// must appear in a chunk. Storage targets for those accounts are chunked together, but if they
+/// exceed the chunk size, subsequent chunks contain only the remaining storage targets without
+/// repeating the account target.
 #[derive(Debug)]
-pub struct ChunkedMultiProofTargetsV2 {
+pub struct ChunkedMultiProofTargets {
     /// Remaining account targets to process
-    account_targets: alloc::vec::IntoIter<ProofV2Target>,
+    account_targets: alloc::vec::IntoIter<ProofTarget>,
     /// Storage targets by account address
-    storage_targets: B256Map<Vec<ProofV2Target>>,
+    storage_targets: B256Map<Vec<ProofTarget>>,
     /// Current account being processed (if any storage slots remain)
-    current_account_storage: Option<(B256, alloc::vec::IntoIter<ProofV2Target>)>,
+    current_account_storage: Option<(B256, alloc::vec::IntoIter<ProofTarget>)>,
     /// Chunk size
     size: usize,
 }
 
-impl ChunkedMultiProofTargetsV2 {
+impl ChunkedMultiProofTargets {
     /// Creates a new chunked iterator for the given targets.
-    pub fn new(targets: MultiProofTargetsV2, size: usize) -> Self {
+    pub fn new(targets: MultiProofTargets, size: usize) -> Self {
         Self {
             account_targets: targets.account_targets.into_iter(),
             storage_targets: targets.storage_targets,
@@ -105,11 +119,11 @@ impl ChunkedMultiProofTargetsV2 {
     }
 }
 
-impl Iterator for ChunkedMultiProofTargetsV2 {
-    type Item = MultiProofTargetsV2;
+impl Iterator for ChunkedMultiProofTargets {
+    type Item = MultiProofTargets;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let mut chunk = MultiProofTargetsV2::default();
+        let mut chunk = MultiProofTargets::default();
         let mut count = 0;
 
         // First, finish any remaining storage slots from previous account

--- a/crates/trie/common/src/trie.rs
+++ b/crates/trie/common/src/trie.rs
@@ -36,7 +36,7 @@ pub type BranchNodeMasksMap = HashMap<Nibbles, BranchNodeMasks>;
 
 /// Carries all information needed by a sparse trie to reveal a particular node.
 ///
-/// This is the legacy type that uses alloy's [`TrieNode`](alloy_trie::nodes::TrieNode).
+/// This is the legacy type that uses alloy's [`TrieNode`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LegacyProofTrieNode {
     /// Path of the node.

--- a/crates/trie/common/src/trie.rs
+++ b/crates/trie/common/src/trie.rs
@@ -35,8 +35,10 @@ impl BranchNodeMasks {
 pub type BranchNodeMasksMap = HashMap<Nibbles, BranchNodeMasks>;
 
 /// Carries all information needed by a sparse trie to reveal a particular node.
+///
+/// This is the legacy type that uses alloy's [`TrieNode`](alloy_trie::nodes::TrieNode).
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ProofTrieNode {
+pub struct LegacyProofTrieNode {
     /// Path of the node.
     pub path: Nibbles,
     /// The node itself.

--- a/crates/trie/common/src/trie_node.rs
+++ b/crates/trie/common/src/trie_node.rs
@@ -1,51 +1,51 @@
-//! Version 2 types related to representing nodes in an MPT.
+//! Types related to representing nodes in an MPT.
 
 use crate::BranchNodeMasks;
 use alloc::vec::Vec;
 use alloy_primitives::hex;
 use alloy_rlp::{bytes, Decodable, Encodable, EMPTY_STRING_CODE};
 use alloy_trie::{
-    nodes::{BranchNodeRef, ExtensionNode, ExtensionNodeRef, LeafNode, RlpNode, TrieNode},
+    nodes::{BranchNodeRef, ExtensionNode, ExtensionNodeRef, LeafNode, RlpNode},
     Nibbles, TrieMask,
 };
 use core::fmt;
 
 /// Carries all information needed by a sparse trie to reveal a particular node.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ProofTrieNodeV2 {
+pub struct ProofTrieNode {
     /// Path of the node.
     pub path: Nibbles,
     /// The node itself.
-    pub node: TrieNodeV2,
+    pub node: TrieNode,
     /// Tree and hash masks for the node, if known.
     /// Both masks are always set together (from database branch nodes).
     pub masks: Option<BranchNodeMasks>,
 }
 
-impl ProofTrieNodeV2 {
-    /// Converts an iterator of `(path, TrieNode, masks)` tuples into `Vec<ProofTrieNodeV2>`,
+impl ProofTrieNode {
+    /// Converts an iterator of `(path, alloy TrieNode, masks)` tuples into `Vec<ProofTrieNode>`,
     /// merging extension nodes into their child branch nodes.
     ///
     /// The input **must** be sorted in depth-first order (children before parents) for extension
     /// merging to work correctly.
     pub fn from_sorted_trie_nodes(
-        iter: impl IntoIterator<Item = (Nibbles, TrieNode, Option<BranchNodeMasks>)>,
+        iter: impl IntoIterator<Item = (Nibbles, alloy_trie::nodes::TrieNode, Option<BranchNodeMasks>)>,
     ) -> Vec<Self> {
         let iter = iter.into_iter();
         let mut result = Vec::with_capacity(iter.size_hint().0);
 
         for (path, node, masks) in iter {
             match node {
-                TrieNode::EmptyRoot => {
-                    result.push(Self { path, node: TrieNodeV2::EmptyRoot, masks });
+                alloy_trie::nodes::TrieNode::EmptyRoot => {
+                    result.push(Self { path, node: TrieNode::EmptyRoot, masks });
                 }
-                TrieNode::Leaf(leaf) => {
-                    result.push(Self { path, node: TrieNodeV2::Leaf(leaf), masks });
+                alloy_trie::nodes::TrieNode::Leaf(leaf) => {
+                    result.push(Self { path, node: TrieNode::Leaf(leaf), masks });
                 }
-                TrieNode::Branch(branch) => {
+                alloy_trie::nodes::TrieNode::Branch(branch) => {
                     result.push(Self {
                         path,
-                        node: TrieNodeV2::Branch(BranchNodeV2 {
+                        node: TrieNode::Branch(BranchNode {
                             key: Nibbles::new(),
                             branch_rlp_node: None,
                             stack: branch.stack,
@@ -54,7 +54,7 @@ impl ProofTrieNodeV2 {
                         masks,
                     });
                 }
-                TrieNode::Extension(ext) => {
+                alloy_trie::nodes::TrieNode::Extension(ext) => {
                     // In depth-first order, the child branch comes BEFORE the parent
                     // extension. The child branch should be the last item we added to
                     // result, at path extension.path + extension.key.
@@ -63,24 +63,23 @@ impl ProofTrieNodeV2 {
                     // Check if the last item in result is the child branch
                     if let Some(last) = result.last_mut() &&
                         last.path == expected_branch_path &&
-                        let TrieNodeV2::Branch(branch_v2) = &mut last.node
+                        let TrieNode::Branch(branch) = &mut last.node
                     {
                         debug_assert!(
-                            branch_v2.key.is_empty(),
+                            branch.key.is_empty(),
                             "Branch at {:?} already has extension key {:?}",
                             last.path,
-                            branch_v2.key
+                            branch.key
                         );
-                        branch_v2.key = ext.key;
-                        branch_v2.branch_rlp_node = Some(ext.child);
+                        branch.key = ext.key;
+                        branch.branch_rlp_node = Some(ext.child);
                         last.path = path;
                     }
 
                     // If we reach here, the extension's child is not a branch in the
                     // result. This happens when the child branch is hashed (not revealed
-                    // in the proof). In V2 format, extension nodes are always combined
-                    // with their child branch, so we skip extension nodes whose child
-                    // isn't revealed.
+                    // in the proof). Extension nodes are always combined with their child
+                    // branch, so we skip extension nodes whose child isn't revealed.
                 }
             }
         }
@@ -91,15 +90,14 @@ impl ProofTrieNodeV2 {
 
 /// Enum representing an MPT trie node.
 ///
-/// This is a V2 representiation, differing from [`TrieNode`] in that branch and extension nodes are
-/// compressed into a single node.
+/// Branch and extension nodes are compressed into a single node.
 #[derive(PartialEq, Eq, Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum TrieNodeV2 {
+pub enum TrieNode {
     /// Variant representing empty root node.
     EmptyRoot,
-    /// Variant representing a [`BranchNodeV2`].
-    Branch(BranchNodeV2),
+    /// Variant representing a [`BranchNode`].
+    Branch(BranchNode),
     /// Variant representing a [`LeafNode`].
     Leaf(LeafNode),
     /// Variant representing an [`ExtensionNode`].
@@ -110,7 +108,7 @@ pub enum TrieNodeV2 {
     Extension(ExtensionNode),
 }
 
-impl Encodable for TrieNodeV2 {
+impl Encodable for TrieNode {
     fn encode(&self, out: &mut dyn bytes::BufMut) {
         match self {
             Self::EmptyRoot => {
@@ -127,18 +125,18 @@ impl Encodable for TrieNodeV2 {
     }
 }
 
-impl Decodable for TrieNodeV2 {
+impl Decodable for TrieNode {
     fn decode(buf: &mut &[u8]) -> Result<Self, alloy_rlp::Error> {
-        match TrieNode::decode(buf)? {
-            TrieNode::EmptyRoot => Ok(Self::EmptyRoot),
-            TrieNode::Leaf(leaf) => Ok(Self::Leaf(leaf)),
-            TrieNode::Branch(branch) => Ok(Self::Branch(BranchNodeV2::new(
+        match alloy_trie::nodes::TrieNode::decode(buf)? {
+            alloy_trie::nodes::TrieNode::EmptyRoot => Ok(Self::EmptyRoot),
+            alloy_trie::nodes::TrieNode::Leaf(leaf) => Ok(Self::Leaf(leaf)),
+            alloy_trie::nodes::TrieNode::Branch(branch) => Ok(Self::Branch(BranchNode::new(
                 Default::default(),
                 branch.stack,
                 branch.state_mask,
                 None,
             ))),
-            TrieNode::Extension(ext) => {
+            alloy_trie::nodes::TrieNode::Extension(ext) => {
                 if ext.child.is_hash() {
                     Ok(Self::Extension(ext))
                 } else {
@@ -166,7 +164,7 @@ impl Decodable for TrieNodeV2 {
 /// This node also encompasses the possible parent extension node of a branch via the `key` field.
 #[derive(PartialEq, Eq, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct BranchNodeV2 {
+pub struct BranchNode {
     /// The key for the branch's parent extension. if key is empty then the branch does not have a
     /// parent extension.
     pub key: Nibbles,
@@ -179,7 +177,7 @@ pub struct BranchNodeV2 {
     pub branch_rlp_node: Option<RlpNode>,
 }
 
-impl fmt::Debug for BranchNodeV2 {
+impl fmt::Debug for BranchNode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("BranchNode")
             .field("key", &self.key)
@@ -190,7 +188,7 @@ impl fmt::Debug for BranchNodeV2 {
     }
 }
 
-impl BranchNodeV2 {
+impl BranchNode {
     /// Creates a new branch node with the given short key, stack, and state mask.
     pub const fn new(
         key: Nibbles,
@@ -202,7 +200,7 @@ impl BranchNodeV2 {
     }
 }
 
-impl Encodable for BranchNodeV2 {
+impl Encodable for BranchNode {
     fn encode(&self, out: &mut dyn bytes::BufMut) {
         if self.key.is_empty() {
             BranchNodeRef::new(&self.stack, self.state_mask).encode(out);

--- a/crates/trie/db/src/proof.rs
+++ b/crates/trie/db/src/proof.rs
@@ -6,7 +6,7 @@ use reth_trie::{
     hashed_cursor::HashedPostStateCursorFactory,
     proof::{Proof, StorageProof},
     trie_cursor::InMemoryTrieCursorFactory,
-    AccountProof, HashedPostStateSorted, HashedStorage, MultiProof, MultiProofTargets,
+    AccountProof, HashedPostStateSorted, HashedStorage, LegacyMultiProofTargets, MultiProof,
     StorageMultiProof, TrieInput,
 };
 
@@ -30,7 +30,7 @@ pub trait DatabaseProof<'a> {
     fn overlay_multiproof(
         &self,
         input: TrieInput,
-        targets: MultiProofTargets,
+        targets: LegacyMultiProofTargets,
     ) -> Result<MultiProof, StateProofError>;
 }
 
@@ -61,7 +61,7 @@ impl<'a, TX: DbTx, A: TrieTableAdapter> DatabaseProof<'a>
     fn overlay_multiproof(
         &self,
         input: TrieInput,
-        targets: MultiProofTargets,
+        targets: LegacyMultiProofTargets,
     ) -> Result<MultiProof, StateProofError> {
         let nodes_sorted = input.nodes.into_sorted();
         let state_sorted = input.state.into_sorted();

--- a/crates/trie/db/tests/witness.rs
+++ b/crates/trie/db/tests/witness.rs
@@ -13,7 +13,7 @@ use reth_primitives_traits::{Account, StorageEntry};
 use reth_provider::{test_utils::create_test_provider_factory, HashingWriter};
 use reth_storage_api::StorageSettingsCache;
 use reth_trie::{
-    proof::Proof, witness::TrieWitness, HashedPostState, HashedStorage, MultiProofTargets,
+    proof::Proof, witness::TrieWitness, HashedPostState, HashedStorage, LegacyMultiProofTargets,
     StateRoot,
 };
 use reth_trie_db::{
@@ -55,7 +55,7 @@ fn includes_empty_node_preimage() {
         let state_root = DbStateRoot::<_, A>::from_tx(provider.tx_ref()).root().unwrap();
         let proof = <DbProof<'_, _, A> as DatabaseProof>::from_tx(provider.tx_ref());
         let multiproof = proof
-            .multiproof(MultiProofTargets::from_iter([(
+            .multiproof(LegacyMultiProofTargets::from_iter([(
                 hashed_address,
                 HashSet::from_iter([hashed_slot]),
             )]))
@@ -99,7 +99,7 @@ fn includes_nodes_for_destroyed_storage_nodes() {
         let state_root = DbStateRoot::<_, A>::from_tx(provider.tx_ref()).root().unwrap();
         let proof = <DbProof<'_, _, A> as DatabaseProof>::from_tx(provider.tx_ref());
         let multiproof = proof
-            .multiproof(MultiProofTargets::from_iter([(
+            .multiproof(LegacyMultiProofTargets::from_iter([(
                 hashed_address,
                 HashSet::from_iter([hashed_slot]),
             )]))
@@ -149,7 +149,7 @@ fn correctly_decodes_branch_node_values() {
         let state_root = DbStateRoot::<_, A>::from_tx(provider.tx_ref()).root().unwrap();
         let proof = <DbProof<'_, _, A> as DatabaseProof>::from_tx(provider.tx_ref());
         let multiproof = proof
-            .multiproof(MultiProofTargets::from_iter([(
+            .multiproof(LegacyMultiProofTargets::from_iter([(
                 hashed_address,
                 HashSet::from_iter([hashed_slot1, hashed_slot2]),
             )]))

--- a/crates/trie/parallel/src/lib.rs
+++ b/crates/trie/parallel/src/lib.rs
@@ -20,7 +20,7 @@ pub mod root;
 /// Implementation of parallel proof computation.
 pub mod proof_task;
 
-/// Async value encoder for V2 proofs.
+/// Async value encoder for proofs.
 pub(crate) mod value_encoder;
 
 /// Parallel state root metrics.

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -47,8 +47,7 @@ use reth_trie::{
     proof::{ProofBlindedAccountProvider, ProofBlindedStorageProvider},
     proof_v2,
     trie_cursor::TrieCursorFactory,
-    DecodedMultiProofV2, HashedPostState, MultiProofTargetsV2, Nibbles, ProofTrieNodeV2,
-    ProofV2Target,
+    DecodedMultiProof, HashedPostState, MultiProofTargets, Nibbles, ProofTarget, ProofTrieNode,
 };
 use reth_trie_sparse::provider::{RevealedNode, TrieNodeProvider, TrieNodeProviderFactory};
 use std::{
@@ -70,8 +69,8 @@ use crate::proof_task_metrics::{
 
 type TrieNodeProviderResult = Result<Option<RevealedNode>, SparseTrieError>;
 
-/// Type alias for the V2 account proof calculator.
-type V2AccountProofCalculator<'a, Provider> = proof_v2::ProofCalculator<
+/// Type alias for the account proof calculator.
+type AccountProofCalculator<'a, Provider> = proof_v2::ProofCalculator<
     <Provider as TrieCursorFactory>::AccountTrieCursor<'a>,
     <Provider as HashedCursorFactory>::AccountCursor<'a>,
     AsyncAccountValueEncoder<
@@ -80,8 +79,8 @@ type V2AccountProofCalculator<'a, Provider> = proof_v2::ProofCalculator<
     >,
 >;
 
-/// Type alias for the V2 storage proof calculator.
-type V2StorageProofCalculator<'a, Provider> = proof_v2::StorageProofCalculator<
+/// Type alias for the storage proof calculator.
+type StorageProofCalc<'a, Provider> = proof_v2::StorageProofCalculator<
     <Provider as TrieCursorFactory>::StorageTrieCursor<'a>,
     <Provider as HashedCursorFactory>::StorageCursor<'a>,
 >;
@@ -414,7 +413,7 @@ impl<Provider> ProofTaskTx<Provider>
 where
     Provider: TrieCursorFactory + HashedCursorFactory,
 {
-    fn compute_v2_storage_proof(
+    fn compute_storage_proof(
         &self,
         input: StorageProofInput,
         calculator: &mut proof_v2::StorageProofCalculator<
@@ -426,7 +425,7 @@ where
 
         let span = debug_span!(
             target: "trie::proof_task",
-            "V2 Storage proof calculation",
+            "Storage proof calculation",
             n = %targets.len(),
         );
         let _span_guard = span.enter();
@@ -449,7 +448,7 @@ where
             proof_time_us = proof_start.elapsed().as_micros(),
             ?root,
             worker_id = self.id,
-            "Completed V2 storage proof calculation"
+            "Completed storage proof calculation"
         );
 
         Ok(StorageProofResult { proof, root })
@@ -530,7 +529,7 @@ pub type ProofResultSender = CrossbeamSender<ProofResultMessage>;
 #[derive(Debug)]
 pub struct ProofResultMessage {
     /// The proof calculation result
-    pub result: Result<DecodedMultiProofV2, ParallelStateRootError>,
+    pub result: Result<DecodedMultiProof, ParallelStateRootError>,
     /// Time taken for the entire proof calculation (from dispatch to completion)
     pub elapsed: Duration,
     /// Original state update that triggered this proof
@@ -565,9 +564,9 @@ impl ProofResultContext {
 /// The results of a storage proof calculation.
 #[derive(Debug)]
 pub(crate) struct StorageProofResult {
-    /// The calculated V2 proof nodes
-    pub proof: Vec<ProofTrieNodeV2>,
-    /// The storage root calculated by the V2 proof
+    /// The calculated proof nodes
+    pub proof: Vec<ProofTrieNode>,
+    /// The storage root calculated by the proof
     pub root: Option<B256>,
 }
 
@@ -692,7 +691,7 @@ where
         let mut cursor_metrics_cache = ProofTaskCursorMetricsCache::default();
         let trie_cursor = proof_tx.provider.storage_trie_cursor(B256::ZERO)?;
         let hashed_cursor = proof_tx.provider.hashed_storage_cursor(B256::ZERO)?;
-        let mut v2_calculator =
+        let mut calculator =
             proof_v2::StorageProofCalculator::new_storage(trie_cursor, hashed_cursor);
 
         // Initially mark this worker as available.
@@ -711,7 +710,7 @@ where
                 StorageWorkerJob::StorageProof { input, proof_result_sender } => {
                     self.process_storage_proof(
                         &proof_tx,
-                        &mut v2_calculator,
+                        &mut calculator,
                         input,
                         proof_result_sender,
                         &mut storage_proofs_processed,
@@ -759,7 +758,7 @@ where
     fn process_storage_proof<Provider>(
         &self,
         proof_tx: &ProofTaskTx<Provider>,
-        v2_calculator: &mut proof_v2::StorageProofCalculator<
+        calculator: &mut proof_v2::StorageProofCalculator<
             <Provider as TrieCursorFactory>::StorageTrieCursor<'_>,
             <Provider as HashedCursorFactory>::StorageCursor<'_>,
         >,
@@ -777,10 +776,10 @@ where
             worker_id = self.worker_id,
             hashed_address = ?hashed_address,
             targets_len = input.targets.len(),
-            "Processing V2 storage proof"
+            "Processing storage proof"
         );
 
-        let result = proof_tx.compute_v2_storage_proof(input, v2_calculator);
+        let result = proof_tx.compute_storage_proof(input, calculator);
 
         let proof_elapsed = proof_start.elapsed();
         *storage_proofs_processed += 1;
@@ -945,7 +944,7 @@ where
         let mut account_nodes_processed = 0u64;
         let mut cursor_metrics_cache = ProofTaskCursorMetricsCache::default();
 
-        // Create both account and storage calculators for V2 proofs.
+        // Create both account and storage calculators for proofs.
         // The storage calculator is wrapped in Rc<RefCell<...>> for sharing with value encoders.
         let account_trie_cursor = provider.account_trie_cursor()?;
         let account_hashed_cursor = provider.hashed_account_cursor()?;
@@ -953,7 +952,7 @@ where
         let storage_trie_cursor = provider.storage_trie_cursor(B256::ZERO)?;
         let storage_hashed_cursor = provider.hashed_storage_cursor(B256::ZERO)?;
 
-        let mut v2_account_calculator = proof_v2::ProofCalculator::<
+        let mut account_calculator = proof_v2::ProofCalculator::<
             _,
             _,
             AsyncAccountValueEncoder<
@@ -961,7 +960,7 @@ where
                 <Factory::Provider as HashedCursorFactory>::StorageCursor<'_>,
             >,
         >::new(account_trie_cursor, account_hashed_cursor);
-        let v2_storage_calculator =
+        let storage_calculator =
             Rc::new(RefCell::new(proof_v2::StorageProofCalculator::new_storage(
                 storage_trie_cursor,
                 storage_hashed_cursor,
@@ -983,8 +982,8 @@ where
             match job {
                 AccountWorkerJob::AccountMultiproof { input } => {
                     let value_encoder_stats = self.process_account_multiproof::<Factory::Provider>(
-                        &mut v2_account_calculator,
-                        v2_storage_calculator.clone(),
+                        &mut account_calculator,
+                        storage_calculator.clone(),
                         *input,
                         &mut account_proofs_processed,
                         &mut cursor_metrics_cache,
@@ -1030,42 +1029,41 @@ where
         Ok(())
     }
 
-    fn compute_v2_account_multiproof<'a, Provider>(
+    fn compute_account_multiproof<'a, Provider>(
         &self,
-        v2_account_calculator: &mut V2AccountProofCalculator<'a, Provider>,
-        v2_storage_calculator: Rc<RefCell<V2StorageProofCalculator<'a, Provider>>>,
-        targets: MultiProofTargetsV2,
-    ) -> Result<(DecodedMultiProofV2, ValueEncoderStats), ParallelStateRootError>
+        account_calculator: &mut AccountProofCalculator<'a, Provider>,
+        storage_calculator: Rc<RefCell<StorageProofCalc<'a, Provider>>>,
+        targets: MultiProofTargets,
+    ) -> Result<(DecodedMultiProof, ValueEncoderStats), ParallelStateRootError>
     where
         Provider: TrieCursorFactory + HashedCursorFactory + 'a,
     {
-        let MultiProofTargetsV2 { mut account_targets, storage_targets } = targets;
+        let MultiProofTargets { mut account_targets, storage_targets } = targets;
 
         let span = debug_span!(
             target: "trie::proof_task",
-            "Account V2 multiproof calculation",
+            "Account multiproof calculation",
             account_targets = account_targets.len(),
             storage_targets = storage_targets.values().map(|t| t.len()).sum::<usize>(),
         );
         let _span_guard = span.enter();
 
-        trace!(target: "trie::proof_task", "Processing V2 account multiproof");
+        trace!(target: "trie::proof_task", "Processing account multiproof");
 
         let storage_proof_receivers =
-            dispatch_v2_storage_proofs(&self.storage_work_tx, &account_targets, storage_targets)?;
+            dispatch_storage_proofs(&self.storage_work_tx, &account_targets, storage_targets)?;
 
         let mut value_encoder = AsyncAccountValueEncoder::new(
             storage_proof_receivers,
             self.cached_storage_roots.clone(),
-            v2_storage_calculator,
+            storage_calculator,
         );
 
-        let account_proofs =
-            v2_account_calculator.proof(&mut value_encoder, &mut account_targets)?;
+        let account_proofs = account_calculator.proof(&mut value_encoder, &mut account_targets)?;
 
         let (storage_proofs, value_encoder_stats) = value_encoder.finalize()?;
 
-        let proof = DecodedMultiProofV2 { account_proofs, storage_proofs };
+        let proof = DecodedMultiProof { account_proofs, storage_proofs };
 
         Ok((proof, value_encoder_stats))
     }
@@ -1075,8 +1073,8 @@ where
     /// Returns stats from the value encoder used during proof computation.
     fn process_account_multiproof<'a, Provider>(
         &self,
-        v2_account_calculator: &mut V2AccountProofCalculator<'a, Provider>,
-        v2_storage_calculator: Rc<RefCell<V2StorageProofCalculator<'a, Provider>>>,
+        account_calculator: &mut AccountProofCalculator<'a, Provider>,
+        storage_calculator: Rc<RefCell<StorageProofCalc<'a, Provider>>>,
         input: AccountMultiproofInput,
         account_proofs_processed: &mut u64,
         cursor_metrics_cache: &mut ProofTaskCursorMetricsCache,
@@ -1088,9 +1086,9 @@ where
         let proof_start = Instant::now();
 
         let AccountMultiproofInput { targets, proof_result_sender } = input;
-        let (result, value_encoder_stats) = match self.compute_v2_account_multiproof::<Provider>(
-            v2_account_calculator,
-            v2_storage_calculator,
+        let (result, value_encoder_stats) = match self.compute_account_multiproof::<Provider>(
+            account_calculator,
+            storage_calculator,
             targets,
         ) {
             Ok((proof, stats)) => (Ok(proof), stats),
@@ -1187,17 +1185,17 @@ where
     }
 }
 
-/// Queues V2 storage proofs for all accounts in the targets and returns receivers.
+/// Queues storage proofs for all accounts in the targets and returns receivers.
 ///
 /// This function queues all storage proof tasks to the worker pool but returns immediately
 /// with receivers, allowing the account trie walk to proceed in parallel with storage proof
 /// computation. This enables interleaved parallelism for better performance.
 ///
 /// Propagates errors up if queuing fails. Receivers must be consumed by the caller.
-fn dispatch_v2_storage_proofs(
+fn dispatch_storage_proofs(
     storage_work_tx: &CrossbeamSender<StorageWorkerJob>,
-    account_targets: &[ProofV2Target],
-    mut storage_targets: B256Map<Vec<ProofV2Target>>,
+    account_targets: &[ProofTarget],
+    mut storage_targets: B256Map<Vec<ProofTarget>>,
 ) -> Result<B256Map<CrossbeamReceiver<StorageProofResultMessage>>, ParallelStateRootError> {
     let mut storage_proof_receivers =
         B256Map::with_capacity_and_hasher(account_targets.len(), Default::default());
@@ -1247,12 +1245,12 @@ pub struct StorageProofInput {
     /// The hashed address for which the proof is calculated.
     pub hashed_address: B256,
     /// The set of proof targets
-    pub targets: Vec<ProofV2Target>,
+    pub targets: Vec<ProofTarget>,
 }
 
 impl StorageProofInput {
     /// Creates a new [`StorageProofInput`] with the given hashed address and target slots.
-    pub const fn new(hashed_address: B256, targets: Vec<ProofV2Target>) -> Self {
+    pub const fn new(hashed_address: B256, targets: Vec<ProofTarget>) -> Self {
         Self { hashed_address, targets }
     }
 }
@@ -1261,7 +1259,7 @@ impl StorageProofInput {
 #[derive(Debug)]
 pub struct AccountMultiproofInput {
     /// The targets for which to compute the multiproof.
-    pub targets: MultiProofTargetsV2,
+    pub targets: MultiProofTargets,
     /// Context for sending the proof result.
     pub proof_result_sender: ProofResultContext,
 }

--- a/crates/trie/sparse/src/debug_recorder.rs
+++ b/crates/trie/sparse/src/debug_recorder.rs
@@ -6,7 +6,7 @@
 
 use alloc::{string::String, vec::Vec};
 use alloy_primitives::{hex, Bytes, B256};
-use alloy_trie::nodes::TrieNode;
+use alloy_trie::nodes::TrieNode as AlloyTrieNode;
 use reth_trie_common::Nibbles;
 use serde::Serialize;
 
@@ -89,8 +89,8 @@ pub struct ProofTrieNodeRecord {
 }
 
 impl ProofTrieNodeRecord {
-    /// Creates a record from a [`reth_trie_common::ProofTrieNode`].
-    pub fn from_proof_trie_node(node: &reth_trie_common::ProofTrieNode) -> Self {
+    /// Creates a record from a [`reth_trie_common::LegacyProofTrieNode`].
+    pub fn from_legacy_proof_trie_node(node: &reth_trie_common::LegacyProofTrieNode) -> Self {
         Self {
             path: node.path,
             node: TrieNodeRecord(node.node.clone()),
@@ -98,14 +98,14 @@ impl ProofTrieNodeRecord {
         }
     }
 
-    /// Creates a record from a [`reth_trie_common::ProofTrieNodeV2`].
-    pub fn from_proof_trie_node_v2(node: &reth_trie_common::ProofTrieNodeV2) -> Self {
-        use reth_trie_common::TrieNodeV2;
+    /// Creates a record from a [`reth_trie_common::ProofTrieNode`].
+    pub fn from_proof_trie_node(node: &reth_trie_common::ProofTrieNode) -> Self {
+        use reth_trie_common::TrieNode;
         let trie_node = match &node.node {
-            TrieNodeV2::EmptyRoot => TrieNode::EmptyRoot,
-            TrieNodeV2::Leaf(leaf) => TrieNode::Leaf(leaf.clone()),
-            TrieNodeV2::Extension(ext) => TrieNode::Extension(ext.clone()),
-            TrieNodeV2::Branch(branch) => TrieNode::Branch(alloy_trie::nodes::BranchNode::new(
+            TrieNode::EmptyRoot => AlloyTrieNode::EmptyRoot,
+            TrieNode::Leaf(leaf) => AlloyTrieNode::Leaf(leaf.clone()),
+            TrieNode::Extension(ext) => AlloyTrieNode::Extension(ext.clone()),
+            TrieNode::Branch(branch) => AlloyTrieNode::Branch(alloy_trie::nodes::BranchNode::new(
                 branch.stack.clone(),
                 branch.state_mask,
             )),
@@ -118,14 +118,14 @@ impl ProofTrieNodeRecord {
     }
 }
 
-/// A newtype wrapper around [`TrieNode`] with custom serialization that hex-encodes byte fields
-/// (leaf values, branch stack entries, extension child pointers) instead of serializing them as
-/// raw integer arrays.
+/// A newtype wrapper around [`AlloyTrieNode`] with custom serialization that hex-encodes byte
+/// fields (leaf values, branch stack entries, extension child pointers) instead of serializing
+/// them as raw integer arrays.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TrieNodeRecord(pub TrieNode);
+pub struct TrieNodeRecord(pub AlloyTrieNode);
 
-impl From<TrieNode> for TrieNodeRecord {
-    fn from(node: TrieNode) -> Self {
+impl From<AlloyTrieNode> for TrieNodeRecord {
+    fn from(node: AlloyTrieNode) -> Self {
         Self(node)
     }
 }
@@ -134,8 +134,10 @@ impl Serialize for TrieNodeRecord {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         use serde::ser::SerializeStructVariant;
         match &self.0 {
-            TrieNode::EmptyRoot => serializer.serialize_unit_variant("TrieNode", 0, "EmptyRoot"),
-            TrieNode::Branch(branch) => {
+            AlloyTrieNode::EmptyRoot => {
+                serializer.serialize_unit_variant("TrieNode", 0, "EmptyRoot")
+            }
+            AlloyTrieNode::Branch(branch) => {
                 let stack_hex: Vec<String> =
                     branch.stack.iter().map(|n| hex::encode(n.as_ref())).collect();
                 let mut sv = serializer.serialize_struct_variant("TrieNode", 1, "Branch", 2)?;
@@ -143,13 +145,13 @@ impl Serialize for TrieNodeRecord {
                 sv.serialize_field("state_mask", &branch.state_mask.get())?;
                 sv.end()
             }
-            TrieNode::Extension(ext) => {
+            AlloyTrieNode::Extension(ext) => {
                 let mut sv = serializer.serialize_struct_variant("TrieNode", 2, "Extension", 2)?;
                 sv.serialize_field("key", &ext.key)?;
                 sv.serialize_field("child", &hex::encode(ext.child.as_ref()))?;
                 sv.end()
             }
-            TrieNode::Leaf(leaf) => {
+            AlloyTrieNode::Leaf(leaf) => {
                 let mut sv = serializer.serialize_struct_variant("TrieNode", 3, "Leaf", 2)?;
                 sv.serialize_field("key", &leaf.key)?;
                 sv.serialize_field("value", &hex::encode(&leaf.value))?;

--- a/crates/trie/sparse/src/parallel.rs
+++ b/crates/trie/sparse/src/parallel.rs
@@ -18,7 +18,7 @@ use reth_primitives_traits::FastInstant as Instant;
 use reth_trie_common::{
     prefix_set::{PrefixSet, PrefixSetMut},
     BranchNodeMasks, BranchNodeMasksMap, BranchNodeRef, ExtensionNodeRef, LeafNodeRef, Nibbles,
-    ProofTrieNodeV2, RlpNode, TrieNodeV2,
+    ProofTrieNode, RlpNode, TrieNode,
 };
 use smallvec::SmallVec;
 use tracing::{instrument, trace};
@@ -163,13 +163,13 @@ impl Default for ParallelSparseTrie {
 impl SparseTrie for ParallelSparseTrie {
     fn set_root(
         &mut self,
-        root: TrieNodeV2,
+        root: TrieNode,
         masks: Option<BranchNodeMasks>,
         retain_updates: bool,
     ) -> SparseTrieResult<()> {
         #[cfg(feature = "trie-debug")]
         self.debug_recorder.record(RecordedOp::SetRoot {
-            node: ProofTrieNodeRecord::from_proof_trie_node_v2(&ProofTrieNodeV2 {
+            node: ProofTrieNodeRecord::from_proof_trie_node(&ProofTrieNode {
                 path: Nibbles::default(),
                 node: root.clone(),
                 masks,
@@ -185,11 +185,8 @@ impl SparseTrie for ParallelSparseTrie {
         self.set_updates(retain_updates);
 
         if let Some(masks) = masks {
-            let branch_path = if let TrieNodeV2::Branch(branch) = &root {
-                branch.key
-            } else {
-                Nibbles::default()
-            };
+            let branch_path =
+                if let TrieNode::Branch(branch) = &root { branch.key } else { Nibbles::default() };
 
             self.branch_node_masks.insert(branch_path, masks);
         }
@@ -201,20 +198,20 @@ impl SparseTrie for ParallelSparseTrie {
         self.updates = retain_updates.then(Default::default);
     }
 
-    fn reveal_nodes(&mut self, nodes: &mut [ProofTrieNodeV2]) -> SparseTrieResult<()> {
+    fn reveal_nodes(&mut self, nodes: &mut [ProofTrieNode]) -> SparseTrieResult<()> {
         if nodes.is_empty() {
             return Ok(())
         }
 
         #[cfg(feature = "trie-debug")]
         self.debug_recorder.record(RecordedOp::RevealNodes {
-            nodes: nodes.iter().map(ProofTrieNodeRecord::from_proof_trie_node_v2).collect(),
+            nodes: nodes.iter().map(ProofTrieNodeRecord::from_proof_trie_node).collect(),
         });
 
         // Sort nodes first by their subtrie, and secondarily by their path. This allows for
         // grouping nodes by their subtrie using `chunk_by`.
         nodes.sort_unstable_by(
-            |ProofTrieNodeV2 { path: path_a, .. }, ProofTrieNodeV2 { path: path_b, .. }| {
+            |ProofTrieNode { path: path_a, .. }, ProofTrieNode { path: path_b, .. }| {
                 let subtrie_type_a = SparseSubtrieType::from_path(path_a);
                 let subtrie_type_b = SparseSubtrieType::from_path(path_b);
                 subtrie_type_a.cmp(&subtrie_type_b).then_with(|| path_a.cmp(path_b))
@@ -223,10 +220,10 @@ impl SparseTrie for ParallelSparseTrie {
 
         // Update the top-level branch node masks. This is simple and can't be done in parallel.
         self.branch_node_masks.reserve(nodes.len());
-        for ProofTrieNodeV2 { path, masks, node } in nodes.iter() {
+        for ProofTrieNode { path, masks, node } in nodes.iter() {
             if let Some(branch_masks) = masks {
                 // Use proper path for branch nodes by combining path and extension key.
-                let path = if let TrieNodeV2::Branch(branch) = node &&
+                let path = if let TrieNode::Branch(branch) = node &&
                     !branch.key.is_empty()
                 {
                     let mut path = *path;
@@ -1548,7 +1545,7 @@ impl ParallelSparseTrie {
     ///
     /// Self if successful, or an error if revealing fails.
     pub fn from_root(
-        root: TrieNodeV2,
+        root: TrieNode,
         masks: Option<BranchNodeMasks>,
         retain_updates: bool,
     ) -> SparseTrieResult<Self> {
@@ -2072,7 +2069,7 @@ impl ParallelSparseTrie {
     fn reveal_upper_node(
         &mut self,
         path: Nibbles,
-        node: &TrieNodeV2,
+        node: &TrieNode,
         masks: Option<BranchNodeMasks>,
     ) -> SparseTrieResult<()> {
         // Only reveal nodes that can be reached given the current state of the upper trie. If they
@@ -2083,7 +2080,7 @@ impl ParallelSparseTrie {
 
         // Exit early if the node was already revealed before.
         if !self.upper_subtrie.reveal_node(path, node, masks, None)? {
-            if let TrieNodeV2::Branch(branch) = node {
+            if let TrieNode::Branch(branch) = node {
                 if branch.key.is_empty() {
                     return Ok(());
                 }
@@ -2103,7 +2100,7 @@ impl ParallelSparseTrie {
         // here by manually checking the specific cases where this could happen, and calling
         // reveal_node_or_hash for each.
         match node {
-            TrieNodeV2::Branch(branch) => {
+            TrieNode::Branch(branch) => {
                 let mut branch_path = path;
                 branch_path.extend(&branch.key);
 
@@ -2136,7 +2133,7 @@ impl ParallelSparseTrie {
                                 .expect("child_path must have a lower subtrie")
                                 .reveal_node(
                                     child_path,
-                                    &TrieNodeV2::decode(&mut branch.stack[stack_ptr].as_ref())?,
+                                    &TrieNode::decode(&mut branch.stack[stack_ptr].as_ref())?,
                                     None,
                                     None,
                                 )?;
@@ -2144,19 +2141,19 @@ impl ParallelSparseTrie {
                     }
                 }
             }
-            TrieNodeV2::Extension(ext) => {
+            TrieNode::Extension(ext) => {
                 let mut child_path = path;
                 child_path.extend(&ext.key);
                 if let Some(subtrie) = self.lower_subtrie_for_path_mut(&child_path) {
                     subtrie.reveal_node(
                         child_path,
-                        &TrieNodeV2::decode(&mut ext.child.as_ref())?,
+                        &TrieNode::decode(&mut ext.child.as_ref())?,
                         None,
                         None,
                     )?;
                 }
             }
-            TrieNodeV2::EmptyRoot | TrieNodeV2::Leaf(_) => (),
+            TrieNode::EmptyRoot | TrieNode::Leaf(_) => (),
         }
 
         Ok(())
@@ -2260,11 +2257,11 @@ impl ParallelSparseTrie {
     fn is_boundary_leaf_reachable(
         upper_nodes: &HashMap<Nibbles, SparseNode>,
         path: &Nibbles,
-        node: &TrieNodeV2,
+        node: &TrieNode,
     ) -> bool {
         debug_assert_eq!(path.len(), UPPER_TRIE_MAX_DEPTH);
 
-        if !matches!(node, TrieNodeV2::Leaf(_)) {
+        if !matches!(node, TrieNode::Leaf(_)) {
             return true
         }
 
@@ -2691,12 +2688,7 @@ impl SparseSubtrie {
             if !child.is_hash() && Self::is_child_same_level(&path, &child_path) {
                 // Reveal each child node or hash it has, but only if the child is on
                 // the same level as the parent.
-                self.reveal_node(
-                    child_path,
-                    &TrieNodeV2::decode(&mut child.as_ref())?,
-                    None,
-                    None,
-                )?;
+                self.reveal_node(child_path, &TrieNode::decode(&mut child.as_ref())?, None, None)?;
             }
         }
 
@@ -2710,7 +2702,7 @@ impl SparseSubtrie {
     fn reveal_node(
         &mut self,
         path: Nibbles,
-        node: &TrieNodeV2,
+        node: &TrieNode,
         masks: Option<BranchNodeMasks>,
         hash_from_upper: Option<B256>,
     ) -> SparseTrieResult<bool> {
@@ -2753,13 +2745,13 @@ impl SparseSubtrie {
         );
 
         match node {
-            TrieNodeV2::EmptyRoot => {
+            TrieNode::EmptyRoot => {
                 // For an empty root, ensure that we are at the root path, and at the upper subtrie.
                 debug_assert!(path.is_empty());
                 debug_assert!(self.path.is_empty());
                 self.nodes.insert(path, SparseNode::Empty);
             }
-            TrieNodeV2::Branch(branch) => {
+            TrieNode::Branch(branch) => {
                 if branch.key.is_empty() {
                     self.reveal_branch(
                         path,
@@ -2807,8 +2799,8 @@ impl SparseSubtrie {
                     branch.branch_rlp_node.clone(),
                 )?;
             }
-            TrieNodeV2::Extension(_) => unreachable!(),
-            TrieNodeV2::Leaf(leaf) => {
+            TrieNode::Extension(_) => unreachable!(),
+            TrieNode::Leaf(leaf) => {
                 // Skip the reachability check when path.len() == UPPER_TRIE_MAX_DEPTH because
                 // at that boundary the leaf is in the lower subtrie but its parent branch is in
                 // the upper subtrie. The subtrie cannot check connectivity across the upper/lower
@@ -3578,9 +3570,8 @@ mod tests {
         prefix_set::PrefixSetMut,
         proof::{ProofNodes, ProofRetainer},
         updates::TrieUpdates,
-        BranchNodeMasks, BranchNodeMasksMap, BranchNodeRef, BranchNodeV2, ExtensionNode,
-        HashBuilder, LeafNode, ProofTrieNodeV2, RlpNode, TrieMask, TrieNode, TrieNodeV2,
-        EMPTY_ROOT_HASH,
+        BranchNode, BranchNodeMasks, BranchNodeMasksMap, BranchNodeRef, ExtensionNode, HashBuilder,
+        LeafNode, ProofTrieNode, RlpNode, TrieMask, TrieNode, EMPTY_ROOT_HASH,
     };
     use reth_trie_db::DatabaseTrieCursorFactory;
     use std::collections::{BTreeMap, BTreeSet};
@@ -3805,18 +3796,15 @@ mod tests {
         }
     }
 
-    fn create_leaf_node(key: impl AsRef<[u8]>, value_nonce: u64) -> TrieNodeV2 {
-        TrieNodeV2::Leaf(LeafNode::new(
-            Nibbles::from_nibbles(key),
-            encode_account_value(value_nonce),
-        ))
+    fn create_leaf_node(key: impl AsRef<[u8]>, value_nonce: u64) -> TrieNode {
+        TrieNode::Leaf(LeafNode::new(Nibbles::from_nibbles(key), encode_account_value(value_nonce)))
     }
 
     fn create_branch_node(
         key: Nibbles,
         children_indices: &[u8],
         child_hashes: impl IntoIterator<Item = RlpNode>,
-    ) -> TrieNodeV2 {
+    ) -> TrieNode {
         let mut stack = Vec::new();
         let mut state_mask = TrieMask::default();
 
@@ -3831,13 +3819,13 @@ mod tests {
             Some(RlpNode::from_rlp(&alloy_rlp::encode(BranchNodeRef::new(&stack, state_mask))))
         };
 
-        TrieNodeV2::Branch(BranchNodeV2::new(key, stack, state_mask, branch_rlp_node))
+        TrieNode::Branch(BranchNode::new(key, stack, state_mask, branch_rlp_node))
     }
 
     fn create_branch_node_with_children(
         children_indices: &[u8],
         child_hashes: impl IntoIterator<Item = RlpNode>,
-    ) -> TrieNodeV2 {
+    ) -> TrieNode {
         create_branch_node(Nibbles::default(), children_indices, child_hashes)
     }
 
@@ -3959,7 +3947,7 @@ mod tests {
         let proof_nodes = proof_nodes
             .into_nodes_sorted()
             .into_iter()
-            .map(|(path, node)| (path, TrieNodeV2::decode(&mut node.as_ref()).unwrap()));
+            .map(|(path, node)| (path, TrieNode::decode(&mut node.as_ref()).unwrap()));
 
         let all_sparse_nodes = parallel_sparse_trie_nodes(sparse_trie);
 
@@ -3970,20 +3958,20 @@ mod tests {
 
             let equals = match (&proof_node, &sparse_node) {
                 // Both nodes are empty
-                (TrieNodeV2::EmptyRoot, SparseNode::Empty) => true,
+                (TrieNode::EmptyRoot, SparseNode::Empty) => true,
                 // Both nodes are branches and have the same state mask
                 (
-                    TrieNodeV2::Branch(BranchNodeV2 { state_mask: proof_state_mask, .. }),
+                    TrieNode::Branch(BranchNode { state_mask: proof_state_mask, .. }),
                     SparseNode::Branch { state_mask: sparse_state_mask, .. },
                 ) => proof_state_mask == sparse_state_mask,
                 // Both nodes are extensions and have the same key
                 (
-                    TrieNodeV2::Extension(ExtensionNode { key: proof_key, .. }),
+                    TrieNode::Extension(ExtensionNode { key: proof_key, .. }),
                     SparseNode::Extension { key: sparse_key, .. },
                 ) |
                 // Both nodes are leaves and have the same key
                 (
-                    TrieNodeV2::Leaf(LeafNode { key: proof_key, .. }),
+                    TrieNode::Leaf(LeafNode { key: proof_key, .. }),
                     SparseNode::Leaf { key: sparse_key, .. },
                 ) => proof_key == sparse_key,
                 // Empty and hash nodes are specific to the sparse trie, skip them
@@ -4162,7 +4150,7 @@ mod tests {
             let node = create_leaf_node([0x2, 0x3], 42);
             let masks = None;
 
-            trie.reveal_nodes(&mut [ProofTrieNodeV2 { path, node, masks }]).unwrap();
+            trie.reveal_nodes(&mut [ProofTrieNode { path, node, masks }]).unwrap();
 
             assert_matches!(
                 trie.upper_subtrie.nodes.get(&path),
@@ -4186,7 +4174,7 @@ mod tests {
         let branch_at_1 =
             create_branch_node_with_children(&[0x2], [RlpNode::word_rlp(&B256::repeat_byte(0xBB))]);
         let mut trie = ParallelSparseTrie::from_root(root_branch, None, false).unwrap();
-        trie.reveal_nodes(&mut [ProofTrieNodeV2 {
+        trie.reveal_nodes(&mut [ProofTrieNode {
             path: Nibbles::from_nibbles([0x1]),
             node: branch_at_1,
             masks: None,
@@ -4198,7 +4186,7 @@ mod tests {
             let node = create_leaf_node([0x3, 0x4], 42);
             let masks = None;
 
-            trie.reveal_nodes(&mut [ProofTrieNodeV2 { path, node, masks }]).unwrap();
+            trie.reveal_nodes(&mut [ProofTrieNode { path, node, masks }]).unwrap();
 
             // Check that the lower subtrie was created
             let idx = path_subtrie_index_unchecked(&path);
@@ -4222,7 +4210,7 @@ mod tests {
             let node = create_leaf_node([0x4, 0x5], 42);
             let masks = None;
 
-            trie.reveal_nodes(&mut [ProofTrieNodeV2 { path, node, masks }]).unwrap();
+            trie.reveal_nodes(&mut [ProofTrieNode { path, node, masks }]).unwrap();
 
             // Check that the lower subtrie's path hasn't changed
             let idx = path_subtrie_index_unchecked(&path);
@@ -4274,7 +4262,7 @@ mod tests {
         let node = create_branch_node_with_children(&[0x0, 0x7, 0xf], child_hashes.clone());
         let masks = None;
 
-        trie.reveal_nodes(&mut [ProofTrieNodeV2 { path, node, masks }]).unwrap();
+        trie.reveal_nodes(&mut [ProofTrieNode { path, node, masks }]).unwrap();
 
         // Branch node should be in upper trie, hash is memoized from the previous Hash node
         assert_eq!(
@@ -4302,7 +4290,7 @@ mod tests {
 
         let mut children = child_paths
             .iter()
-            .map(|path| ProofTrieNodeV2 {
+            .map(|path| ProofTrieNode {
                 path: *path,
                 node: create_leaf_node([0x0], 1),
                 masks: None,
@@ -4375,9 +4363,9 @@ mod tests {
 
         // Reveal the existing nodes
         trie.reveal_nodes(&mut [
-            ProofTrieNodeV2 { path: branch_path, node: branch_node, masks: None },
-            ProofTrieNodeV2 { path: leaf_1_path, node: leaf_1, masks: None },
-            ProofTrieNodeV2 { path: leaf_2_path, node: leaf_2, masks: None },
+            ProofTrieNode { path: branch_path, node: branch_node, masks: None },
+            ProofTrieNode { path: leaf_1_path, node: leaf_1, masks: None },
+            ProofTrieNode { path: leaf_2_path, node: leaf_2, masks: None },
         ])
         .unwrap();
 
@@ -4881,7 +4869,7 @@ mod tests {
         assert_matches!(err.kind(), SparseTrieErrorKind::BlindedNode(path) if *path == Nibbles::from_nibbles([0x1]));
 
         // Now reveal the leaf and try removing it again
-        trie.reveal_nodes(&mut [ProofTrieNodeV2 {
+        trie.reveal_nodes(&mut [ProofTrieNode {
             path: Nibbles::from_nibbles([0x1]),
             node: revealed_leaf,
             masks: None,
@@ -5099,8 +5087,8 @@ mod tests {
         // Step 2: Reveal nodes in the trie
         let mut trie = ParallelSparseTrie::from_root(branch, None, true).unwrap();
         trie.reveal_nodes(&mut [
-            ProofTrieNodeV2 { path: leaf_1_path, node: leaf_1, masks: None },
-            ProofTrieNodeV2 { path: leaf_2_path, node: leaf_2, masks: None },
+            ProofTrieNode { path: leaf_1_path, node: leaf_1, masks: None },
+            ProofTrieNode { path: leaf_2_path, node: leaf_2, masks: None },
         ])
         .unwrap();
 
@@ -5675,7 +5663,7 @@ mod tests {
             Nibbles::default(),
             alloy_rlp::encode_fixed_size(&U256::from(1)).to_vec(),
         );
-        let branch = TrieNodeV2::Branch(BranchNodeV2::new(
+        let branch = TrieNode::Branch(BranchNode::new(
             Nibbles::default(),
             vec![
                 RlpNode::word_rlp(&B256::repeat_byte(1)),
@@ -5703,7 +5691,7 @@ mod tests {
         // └── 1 -> Leaf (Path = 1)
         sparse
             .reveal_nodes(&mut [
-                ProofTrieNodeV2 {
+                ProofTrieNode {
                     path: Nibbles::default(),
                     node: branch,
                     masks: Some(BranchNodeMasks {
@@ -5711,9 +5699,9 @@ mod tests {
                         tree_mask: TrieMask::new(0b01),
                     }),
                 },
-                ProofTrieNodeV2 {
+                ProofTrieNode {
                     path: Nibbles::from_nibbles([0x1]),
-                    node: TrieNodeV2::Leaf(leaf),
+                    node: TrieNode::Leaf(leaf),
                     masks: None,
                 },
             ])
@@ -5732,7 +5720,7 @@ mod tests {
             Nibbles::default(),
             alloy_rlp::encode_fixed_size(&U256::from(1)).to_vec(),
         );
-        let branch = TrieNodeV2::Branch(BranchNodeV2::new(
+        let branch = TrieNode::Branch(BranchNode::new(
             Nibbles::default(),
             vec![
                 RlpNode::word_rlp(&B256::repeat_byte(1)),
@@ -5760,7 +5748,7 @@ mod tests {
         // └── 1 -> Leaf (Path = 1)
         sparse
             .reveal_nodes(&mut [
-                ProofTrieNodeV2 {
+                ProofTrieNode {
                     path: Nibbles::default(),
                     node: branch,
                     masks: Some(BranchNodeMasks {
@@ -5768,9 +5756,9 @@ mod tests {
                         tree_mask: TrieMask::new(0b01),
                     }),
                 },
-                ProofTrieNodeV2 {
+                ProofTrieNode {
                     path: Nibbles::from_nibbles([0x1]),
-                    node: TrieNodeV2::Leaf(leaf),
+                    node: TrieNode::Leaf(leaf),
                     masks: None,
                 },
             ])
@@ -6018,7 +6006,7 @@ mod tests {
             (None, None) => None,
         };
         let mut sparse = ParallelSparseTrie::from_root(
-            TrieNodeV2::decode(&mut &hash_builder_proof_nodes.nodes_sorted()[0].1[..]).unwrap(),
+            TrieNode::decode(&mut &hash_builder_proof_nodes.nodes_sorted()[0].1[..]).unwrap(),
             masks,
             false,
         )
@@ -6032,14 +6020,14 @@ mod tests {
                 Default::default(),
                 [key1()],
             );
-        let mut revealed_nodes: Vec<ProofTrieNodeV2> = hash_builder_proof_nodes
+        let mut revealed_nodes: Vec<ProofTrieNode> = hash_builder_proof_nodes
             .nodes_sorted()
             .into_iter()
             .map(|(path, node)| {
                 let hash_mask = branch_node_hash_masks.get(&path).copied();
                 let tree_mask = branch_node_tree_masks.get(&path).copied();
                 let masks = BranchNodeMasks::from_optional(hash_mask, tree_mask);
-                ProofTrieNodeV2 { path, node: TrieNodeV2::decode(&mut &node[..]).unwrap(), masks }
+                ProofTrieNode { path, node: TrieNode::decode(&mut &node[..]).unwrap(), masks }
             })
             .collect();
         sparse.reveal_nodes(&mut revealed_nodes).unwrap();
@@ -6067,14 +6055,14 @@ mod tests {
                 Default::default(),
                 [key3()],
             );
-        let mut revealed_nodes: Vec<ProofTrieNodeV2> = hash_builder_proof_nodes
+        let mut revealed_nodes: Vec<ProofTrieNode> = hash_builder_proof_nodes
             .nodes_sorted()
             .into_iter()
             .map(|(path, node)| {
                 let hash_mask = branch_node_hash_masks.get(&path).copied();
                 let tree_mask = branch_node_tree_masks.get(&path).copied();
                 let masks = BranchNodeMasks::from_optional(hash_mask, tree_mask);
-                ProofTrieNodeV2 { path, node: TrieNodeV2::decode(&mut &node[..]).unwrap(), masks }
+                ProofTrieNode { path, node: TrieNode::decode(&mut &node[..]).unwrap(), masks }
             })
             .collect();
         sparse.reveal_nodes(&mut revealed_nodes).unwrap();
@@ -6138,7 +6126,7 @@ mod tests {
             (None, None) => None,
         };
         let mut sparse = ParallelSparseTrie::from_root(
-            TrieNodeV2::decode(&mut &hash_builder_proof_nodes.nodes_sorted()[0].1[..]).unwrap(),
+            TrieNode::decode(&mut &hash_builder_proof_nodes.nodes_sorted()[0].1[..]).unwrap(),
             masks,
             false,
         )
@@ -6153,14 +6141,14 @@ mod tests {
                 Default::default(),
                 [key1(), Nibbles::from_nibbles_unchecked([0x01])],
             );
-        let mut revealed_nodes: Vec<ProofTrieNodeV2> = hash_builder_proof_nodes
+        let mut revealed_nodes: Vec<ProofTrieNode> = hash_builder_proof_nodes
             .nodes_sorted()
             .into_iter()
             .map(|(path, node)| {
                 let hash_mask = branch_node_hash_masks.get(&path).copied();
                 let tree_mask = branch_node_tree_masks.get(&path).copied();
                 let masks = BranchNodeMasks::from_optional(hash_mask, tree_mask);
-                ProofTrieNodeV2 { path, node: TrieNodeV2::decode(&mut &node[..]).unwrap(), masks }
+                ProofTrieNode { path, node: TrieNode::decode(&mut &node[..]).unwrap(), masks }
             })
             .collect();
         sparse.reveal_nodes(&mut revealed_nodes).unwrap();
@@ -6188,14 +6176,14 @@ mod tests {
                 Default::default(),
                 [key2()],
             );
-        let mut revealed_nodes: Vec<ProofTrieNodeV2> = hash_builder_proof_nodes
+        let mut revealed_nodes: Vec<ProofTrieNode> = hash_builder_proof_nodes
             .nodes_sorted()
             .into_iter()
             .map(|(path, node)| {
                 let hash_mask = branch_node_hash_masks.get(&path).copied();
                 let tree_mask = branch_node_tree_masks.get(&path).copied();
                 let masks = BranchNodeMasks::from_optional(hash_mask, tree_mask);
-                ProofTrieNodeV2 { path, node: TrieNodeV2::decode(&mut &node[..]).unwrap(), masks }
+                ProofTrieNode { path, node: TrieNode::decode(&mut &node[..]).unwrap(), masks }
             })
             .collect();
         sparse.reveal_nodes(&mut revealed_nodes).unwrap();
@@ -6242,12 +6230,12 @@ mod tests {
             let hash_mask = branch_node_hash_masks.get(&path).copied();
             let tree_mask = branch_node_tree_masks.get(&path).copied();
             let masks = BranchNodeMasks::from_optional(hash_mask, tree_mask);
-            nodes.push((path, TrieNode::decode(&mut &node[..]).unwrap(), masks));
+            nodes.push((path, alloy_trie::nodes::TrieNode::decode(&mut &node[..]).unwrap(), masks));
         }
 
         nodes.sort_unstable_by(|a, b| reth_trie_common::depth_first_cmp(&a.0, &b.0));
 
-        let nodes = ProofTrieNodeV2::from_sorted_trie_nodes(nodes);
+        let nodes = ProofTrieNode::from_sorted_trie_nodes(nodes);
 
         let provider = DefaultTrieNodeProvider;
         let mut sparse =
@@ -6276,14 +6264,14 @@ mod tests {
                 Default::default(),
                 [key1()],
             );
-        let mut revealed_nodes: Vec<ProofTrieNodeV2> = hash_builder_proof_nodes
+        let mut revealed_nodes: Vec<ProofTrieNode> = hash_builder_proof_nodes
             .nodes_sorted()
             .into_iter()
             .map(|(path, node)| {
                 let hash_mask = branch_node_hash_masks.get(&path).copied();
                 let tree_mask = branch_node_tree_masks.get(&path).copied();
                 let masks = BranchNodeMasks::from_optional(hash_mask, tree_mask);
-                ProofTrieNodeV2 { path, node: TrieNodeV2::decode(&mut &node[..]).unwrap(), masks }
+                ProofTrieNode { path, node: TrieNode::decode(&mut &node[..]).unwrap(), masks }
             })
             .collect();
         sparse.reveal_nodes(&mut revealed_nodes).unwrap();
@@ -6298,7 +6286,7 @@ mod tests {
     #[test]
     fn test_update_leaf_cross_level() {
         let ctx = ParallelSparseTrieTestContext;
-        let mut trie = ParallelSparseTrie::from_root(TrieNodeV2::EmptyRoot, None, true).unwrap();
+        let mut trie = ParallelSparseTrie::from_root(TrieNode::EmptyRoot, None, true).unwrap();
 
         // Test adding leaves that demonstrate the cross-level behavior
         // Based on the example: leaves 0x1234, 0x1245, 0x1334, 0x1345
@@ -6381,7 +6369,7 @@ mod tests {
     #[test]
     fn test_update_leaf_split_at_level_boundary() {
         let ctx = ParallelSparseTrieTestContext;
-        let mut trie = ParallelSparseTrie::from_root(TrieNodeV2::EmptyRoot, None, true).unwrap();
+        let mut trie = ParallelSparseTrie::from_root(TrieNode::EmptyRoot, None, true).unwrap();
 
         // This test demonstrates what happens when we insert leaves that cause
         // splitting exactly at the upper/lower trie boundary (2 nibbles).
@@ -6431,7 +6419,7 @@ mod tests {
     #[test]
     fn test_update_subtrie_with_multiple_leaves() {
         let ctx = ParallelSparseTrieTestContext;
-        let mut trie = ParallelSparseTrie::from_root(TrieNodeV2::EmptyRoot, None, true).unwrap();
+        let mut trie = ParallelSparseTrie::from_root(TrieNode::EmptyRoot, None, true).unwrap();
 
         // First, add multiple leaves that will create a subtrie structure
         // All leaves share the prefix [0x1, 0x2] to ensure they create a subtrie
@@ -6499,7 +6487,7 @@ mod tests {
     #[test]
     fn test_update_subtrie_extension_node_subtrie() {
         let ctx = ParallelSparseTrieTestContext;
-        let mut trie = ParallelSparseTrie::from_root(TrieNodeV2::EmptyRoot, None, true).unwrap();
+        let mut trie = ParallelSparseTrie::from_root(TrieNode::EmptyRoot, None, true).unwrap();
 
         // All leaves share the prefix [0x1, 0x2] to ensure they create a subtrie
         //
@@ -6528,7 +6516,7 @@ mod tests {
     #[test]
     fn update_subtrie_extension_node_cross_level() {
         let ctx = ParallelSparseTrieTestContext;
-        let mut trie = ParallelSparseTrie::from_root(TrieNodeV2::EmptyRoot, None, true).unwrap();
+        let mut trie = ParallelSparseTrie::from_root(TrieNode::EmptyRoot, None, true).unwrap();
 
         // First, add multiple leaves that will create a subtrie structure
         // All leaves share the prefix [0x1, 0x2] to ensure they create a branch node and subtrie
@@ -6560,7 +6548,7 @@ mod tests {
     #[test]
     fn test_update_single_nibble_paths() {
         let ctx = ParallelSparseTrieTestContext;
-        let mut trie = ParallelSparseTrie::from_root(TrieNodeV2::EmptyRoot, None, true).unwrap();
+        let mut trie = ParallelSparseTrie::from_root(TrieNode::EmptyRoot, None, true).unwrap();
 
         // Test edge case: single nibble paths that create branches in upper trie
         //
@@ -6604,7 +6592,7 @@ mod tests {
     #[test]
     fn test_update_deep_extension_chain() {
         let ctx = ParallelSparseTrieTestContext;
-        let mut trie = ParallelSparseTrie::from_root(TrieNodeV2::EmptyRoot, None, true).unwrap();
+        let mut trie = ParallelSparseTrie::from_root(TrieNode::EmptyRoot, None, true).unwrap();
 
         // Test edge case: deep extension chains that span multiple levels
         //
@@ -6648,7 +6636,7 @@ mod tests {
     #[test]
     fn test_update_branch_with_all_nibbles() {
         let ctx = ParallelSparseTrieTestContext;
-        let mut trie = ParallelSparseTrie::from_root(TrieNodeV2::EmptyRoot, None, true).unwrap();
+        let mut trie = ParallelSparseTrie::from_root(TrieNode::EmptyRoot, None, true).unwrap();
 
         // Test edge case: branch node with all 16 possible nibble children
         //
@@ -6697,7 +6685,7 @@ mod tests {
     #[test]
     fn test_update_creates_multiple_subtries() {
         let ctx = ParallelSparseTrieTestContext;
-        let mut trie = ParallelSparseTrie::from_root(TrieNodeV2::EmptyRoot, None, true).unwrap();
+        let mut trie = ParallelSparseTrie::from_root(TrieNode::EmptyRoot, None, true).unwrap();
 
         // Test edge case: updates that create multiple subtries at once
         //
@@ -6748,7 +6736,7 @@ mod tests {
     #[test]
     fn test_update_extension_to_branch_transformation() {
         let ctx = ParallelSparseTrieTestContext;
-        let mut trie = ParallelSparseTrie::from_root(TrieNodeV2::EmptyRoot, None, true).unwrap();
+        let mut trie = ParallelSparseTrie::from_root(TrieNode::EmptyRoot, None, true).unwrap();
 
         // Test edge case: extension node transforms to branch when split
         //
@@ -6799,7 +6787,7 @@ mod tests {
     #[test]
     fn test_update_long_shared_prefix_at_boundary() {
         let ctx = ParallelSparseTrieTestContext;
-        let mut trie = ParallelSparseTrie::from_root(TrieNodeV2::EmptyRoot, None, true).unwrap();
+        let mut trie = ParallelSparseTrie::from_root(TrieNode::EmptyRoot, None, true).unwrap();
 
         // Test edge case: leaves with long shared prefix that ends exactly at 2-nibble boundary
         //
@@ -6836,7 +6824,7 @@ mod tests {
     #[test]
     fn test_update_branch_to_extension_collapse() {
         let ctx = ParallelSparseTrieTestContext;
-        let mut trie = ParallelSparseTrie::from_root(TrieNodeV2::EmptyRoot, None, true).unwrap();
+        let mut trie = ParallelSparseTrie::from_root(TrieNode::EmptyRoot, None, true).unwrap();
 
         // Test creating a trie with leaves that share a long common prefix
         //
@@ -6881,7 +6869,7 @@ mod tests {
         let (new_leaf3_path, new_value3) = ctx.create_test_leaf([0x1, 0x2, 0x3, 0x6], 12);
 
         // Clear and add new leaves
-        let mut trie = ParallelSparseTrie::from_root(TrieNodeV2::EmptyRoot, None, true).unwrap();
+        let mut trie = ParallelSparseTrie::from_root(TrieNode::EmptyRoot, None, true).unwrap();
         trie.update_leaf(new_leaf1_path, new_value1.clone(), DefaultTrieNodeProvider).unwrap();
         trie.update_leaf(new_leaf2_path, new_value2.clone(), DefaultTrieNodeProvider).unwrap();
         trie.update_leaf(new_leaf3_path, new_value3.clone(), DefaultTrieNodeProvider).unwrap();
@@ -6907,7 +6895,7 @@ mod tests {
     #[test]
     fn test_update_shared_prefix_patterns() {
         let ctx = ParallelSparseTrieTestContext;
-        let mut trie = ParallelSparseTrie::from_root(TrieNodeV2::EmptyRoot, None, true).unwrap();
+        let mut trie = ParallelSparseTrie::from_root(TrieNode::EmptyRoot, None, true).unwrap();
 
         // Test edge case: different patterns of shared prefixes
         //
@@ -6950,7 +6938,7 @@ mod tests {
     #[test]
     fn test_progressive_branch_creation() {
         let ctx = ParallelSparseTrieTestContext;
-        let mut trie = ParallelSparseTrie::from_root(TrieNodeV2::EmptyRoot, None, true).unwrap();
+        let mut trie = ParallelSparseTrie::from_root(TrieNode::EmptyRoot, None, true).unwrap();
 
         // Test starting with a single leaf and progressively adding leaves
         // that create branch nodes at shorter and shorter paths
@@ -7061,7 +7049,7 @@ mod tests {
     #[test]
     fn test_update_max_depth_paths() {
         let ctx = ParallelSparseTrieTestContext;
-        let mut trie = ParallelSparseTrie::from_root(TrieNodeV2::EmptyRoot, None, true).unwrap();
+        let mut trie = ParallelSparseTrie::from_root(TrieNode::EmptyRoot, None, true).unwrap();
 
         // Test edge case: very long paths (64 nibbles - max for addresses/storage)
         //
@@ -7124,7 +7112,7 @@ mod tests {
             .map(|hex_str| RlpNode::from_raw_rlp(&hex_str[..]).unwrap())
             .collect();
 
-        let root_branch_node = BranchNodeV2::new(
+        let root_branch_node = BranchNode::new(
             Default::default(),
             root_branch_rlp_stack,
             TrieMask::new(0b1111111111111111), // state_mask: all 16 children present
@@ -7137,7 +7125,7 @@ mod tests {
         });
 
         let mut trie = ParallelSparseTrie::from_root(
-            TrieNodeV2::Branch(root_branch_node),
+            TrieNode::Branch(root_branch_node),
             root_branch_masks,
             true,
         )
@@ -7168,7 +7156,7 @@ mod tests {
             .map(|hex_str| RlpNode::from_raw_rlp(&hex_str[..]).unwrap())
             .collect();
 
-        let branch_0x3_node = BranchNodeV2::new(
+        let branch_0x3_node = BranchNode::new(
             Default::default(),
             branch_0x3_rlp_stack,
             TrieMask::new(0b1111111111111111), // state_mask: all 16 children present
@@ -7191,16 +7179,12 @@ mod tests {
         let leaf_masks = None;
 
         trie.reveal_nodes(&mut [
-            ProofTrieNodeV2 {
+            ProofTrieNode {
                 path: Nibbles::from_nibbles([0x3]),
-                node: TrieNodeV2::Branch(branch_0x3_node),
+                node: TrieNode::Branch(branch_0x3_node),
                 masks: branch_0x3_masks,
             },
-            ProofTrieNodeV2 {
-                path: leaf_path,
-                node: TrieNodeV2::Leaf(leaf_node),
-                masks: leaf_masks,
-            },
+            ProofTrieNode { path: leaf_path, node: TrieNode::Leaf(leaf_node), masks: leaf_masks },
         ])
         .unwrap();
 
@@ -7489,7 +7473,7 @@ mod tests {
         );
 
         // Reveal the trie structure using ProofTrieNode
-        let mut proof_nodes = vec![ProofTrieNodeV2 {
+        let mut proof_nodes = vec![ProofTrieNode {
             path: Nibbles::from_nibbles([0x3, 0x1]),
             node: branch_0x31_node,
             masks: Some(BranchNodeMasks {
@@ -7521,7 +7505,7 @@ mod tests {
         };
         assert_matches!(err.kind(), SparseTrieErrorKind::BlindedNode(path) if path == &Nibbles::from_nibbles([0x3, 0x1, 0xc]));
 
-        trie.reveal_nodes(&mut [ProofTrieNodeV2 {
+        trie.reveal_nodes(&mut [ProofTrieNode {
             path: Nibbles::from_nibbles([0x3, 0x1, 0xc]),
             node: branch_0x31c_node,
             masks: Some(BranchNodeMasks { tree_mask: 0.into(), hash_mask: 4096.into() }),
@@ -7570,7 +7554,7 @@ mod tests {
         let branch_at_1 =
             create_branch_node_with_children(&[0x2], [RlpNode::word_rlp(&B256::repeat_byte(0xBB))]);
         let mut trie = ParallelSparseTrie::from_root(root_branch, None, false).unwrap();
-        trie.reveal_nodes(&mut [ProofTrieNodeV2 {
+        trie.reveal_nodes(&mut [ProofTrieNode {
             path: Nibbles::from_nibbles([0x1]),
             node: branch_at_1,
             masks: None,
@@ -7583,7 +7567,7 @@ mod tests {
         let leaf_node = create_leaf_node(leaf_key.to_vec(), 42);
 
         // Reveal the leaf node
-        trie.reveal_nodes(&mut [ProofTrieNodeV2 { path: leaf_path, node: leaf_node, masks: None }])
+        trie.reveal_nodes(&mut [ProofTrieNode { path: leaf_path, node: leaf_node, masks: None }])
             .unwrap();
 
         // The full path is leaf_path + leaf_key
@@ -7620,7 +7604,7 @@ mod tests {
 
         // Create an empty trie with an empty root
         let mut trie = ParallelSparseTrie::default()
-            .with_root(TrieNodeV2::EmptyRoot, None, false)
+            .with_root(TrieNode::EmptyRoot, None, false)
             .expect("root revealed");
 
         // Create a full 64-nibble path (like a real account hash)
@@ -7651,7 +7635,7 @@ mod tests {
 
         // Create an empty trie
         let mut trie = ParallelSparseTrie::default()
-            .with_root(TrieNodeV2::EmptyRoot, None, false)
+            .with_root(TrieNode::EmptyRoot, None, false)
             .expect("root revealed");
 
         // Insert first leaf - will be at root level (upper subtrie)
@@ -7676,7 +7660,7 @@ mod tests {
 
         // Simulate a storage trie with a single slot
         let mut trie = ParallelSparseTrie::default()
-            .with_root(TrieNodeV2::EmptyRoot, None, false)
+            .with_root(TrieNode::EmptyRoot, None, false)
             .expect("root revealed");
 
         // Single storage slot - leaf will be at root (depth 0)
@@ -8146,7 +8130,7 @@ mod tests {
             Nibbles::default(), // short key for RLP encoding
             small_value,
         );
-        let branch = TrieNodeV2::Branch(BranchNodeV2::new(
+        let branch = TrieNode::Branch(BranchNode::new(
             Nibbles::default(),
             vec![
                 RlpNode::word_rlp(&B256::repeat_byte(1)), // blinded child at 0
@@ -8176,7 +8160,7 @@ mod tests {
             }),
         )
         .unwrap();
-        trie.reveal_node(Nibbles::from_nibbles([0x1]), TrieNodeV2::Leaf(leaf), None).unwrap();
+        trie.reveal_node(Nibbles::from_nibbles([0x1]), TrieNode::Leaf(leaf), None).unwrap();
 
         // The path 0x0... is blinded (Hash node)
         // Create an update targeting the blinded path using a full B256 key
@@ -8257,7 +8241,7 @@ mod tests {
             Nibbles::default(), // short key for RLP encoding
             small_value,
         );
-        let branch = TrieNodeV2::Branch(BranchNodeV2::new(
+        let branch = TrieNode::Branch(BranchNode::new(
             Nibbles::default(),
             vec![
                 RlpNode::word_rlp(&B256::repeat_byte(1)), // blinded child at 0
@@ -8286,7 +8270,7 @@ mod tests {
             }),
         )
         .unwrap();
-        trie.reveal_node(Nibbles::from_nibbles([0x1]), TrieNodeV2::Leaf(leaf), None).unwrap();
+        trie.reveal_node(Nibbles::from_nibbles([0x1]), TrieNode::Leaf(leaf), None).unwrap();
 
         // Simulate having a known value behind the blinded node
         let b256_key = B256::ZERO; // starts with 0x0...
@@ -8341,7 +8325,7 @@ mod tests {
         // - Child at nibble 1: a revealed Leaf node
         let small_value = alloy_rlp::encode_fixed_size(&U256::from(1)).to_vec();
         let leaf = LeafNode::new(Nibbles::default(), small_value);
-        let branch = TrieNodeV2::Branch(BranchNodeV2::new(
+        let branch = TrieNode::Branch(BranchNode::new(
             Nibbles::default(),
             vec![
                 RlpNode::word_rlp(&B256::repeat_byte(1)), // blinded child at nibble 0
@@ -8371,7 +8355,7 @@ mod tests {
             }),
         )
         .unwrap();
-        trie.reveal_node(Nibbles::from_nibbles([0x1]), TrieNodeV2::Leaf(leaf), None).unwrap();
+        trie.reveal_node(Nibbles::from_nibbles([0x1]), TrieNode::Leaf(leaf), None).unwrap();
 
         // Insert the leaf's value into the values map for the revealed leaf
         // Use B256 key that starts with nibble 1 (0x10 has first nibble = 1)
@@ -8540,7 +8524,7 @@ mod tests {
             Nibbles::default(), // short key for RLP encoding
             small_value,
         );
-        let branch = TrieNodeV2::Branch(BranchNodeV2::new(
+        let branch = TrieNode::Branch(BranchNode::new(
             Nibbles::default(),
             vec![
                 RlpNode::word_rlp(&B256::repeat_byte(1)), // blinded child at 0
@@ -8569,7 +8553,7 @@ mod tests {
             }),
         )
         .unwrap();
-        trie.reveal_node(Nibbles::from_nibbles([0x1]), TrieNodeV2::Leaf(leaf), None).unwrap();
+        trie.reveal_node(Nibbles::from_nibbles([0x1]), TrieNode::Leaf(leaf), None).unwrap();
 
         // Create a Touched update targeting the blinded path using full B256 key
         let b256_key = B256::ZERO; // starts with 0x0...
@@ -8611,7 +8595,7 @@ mod tests {
             Nibbles::default(), // short key for RLP encoding
             small_value,
         );
-        let branch = TrieNodeV2::Branch(BranchNodeV2::new(
+        let branch = TrieNode::Branch(BranchNode::new(
             Nibbles::default(),
             vec![
                 RlpNode::word_rlp(&B256::repeat_byte(1)), // blinded child at 0
@@ -8640,7 +8624,7 @@ mod tests {
             }),
         )
         .unwrap();
-        trie.reveal_node(Nibbles::from_nibbles([0x1]), TrieNodeV2::Leaf(leaf), None).unwrap();
+        trie.reveal_node(Nibbles::from_nibbles([0x1]), TrieNode::Leaf(leaf), None).unwrap();
 
         // Create multiple updates that would all hit the same blinded node at path 0x0
         // Use full B256 keys that all start with 0x0
@@ -8722,12 +8706,12 @@ mod tests {
         let branch_at_5 =
             create_branch_node_with_children(&[0x6], [RlpNode::word_rlp(&B256::repeat_byte(0xDD))]);
         trie.reveal_nodes(&mut [
-            ProofTrieNodeV2 {
+            ProofTrieNode {
                 path: Nibbles::from_nibbles_unchecked([0x1]),
                 node: branch_at_1,
                 masks: None,
             },
-            ProofTrieNodeV2 {
+            ProofTrieNode {
                 path: Nibbles::from_nibbles_unchecked([0x5]),
                 node: branch_at_5,
                 masks: None,
@@ -8736,17 +8720,17 @@ mod tests {
         .unwrap();
 
         let mut nodes = vec![
-            ProofTrieNodeV2 {
+            ProofTrieNode {
                 path: Nibbles::from_nibbles_unchecked([0x1, 0x2]),
-                node: TrieNodeV2::Leaf(LeafNode {
+                node: TrieNode::Leaf(LeafNode {
                     key: Nibbles::from_nibbles_unchecked([0x3, 0x4]),
                     value: vec![1, 2, 3],
                 }),
                 masks: None,
             },
-            ProofTrieNodeV2 {
+            ProofTrieNode {
                 path: Nibbles::from_nibbles_unchecked([0x5, 0x6]),
-                node: TrieNodeV2::Leaf(LeafNode {
+                node: TrieNode::Leaf(LeafNode {
                     key: Nibbles::from_nibbles_unchecked([0x7, 0x8]),
                     value: vec![4, 5, 6],
                 }),
@@ -8793,20 +8777,20 @@ mod tests {
         let leaf2_node = LeafNode::new(Nibbles::default(), vec![0x2]);
 
         // RLP encode the leaves to get their RlpNode representations
-        let leaf1_rlp = RlpNode::from_rlp(&alloy_rlp::encode(TrieNodeV2::Leaf(leaf1_node.clone())));
-        let leaf2_rlp = RlpNode::from_rlp(&alloy_rlp::encode(TrieNodeV2::Leaf(leaf2_node.clone())));
+        let leaf1_rlp = RlpNode::from_rlp(&alloy_rlp::encode(TrieNode::Leaf(leaf1_node.clone())));
+        let leaf2_rlp = RlpNode::from_rlp(&alloy_rlp::encode(TrieNode::Leaf(leaf2_node.clone())));
 
         // Create the branch node with children at indices 1 and 2, using the RLP-encoded leaves.
-        // In V2, branch and extension are combined: the key holds the extension prefix.
+        // Branch and extension are combined: the key holds the extension prefix.
         let state_mask = TrieMask::new(0b0000_0110); // bits 1 and 2 set
         let stack = vec![leaf1_rlp, leaf2_rlp];
 
         // First encode the bare branch (empty key) to get its RlpNode
-        let bare_branch = BranchNodeV2::new(Nibbles::new(), stack.clone(), state_mask, None);
+        let bare_branch = BranchNode::new(Nibbles::new(), stack.clone(), state_mask, None);
         let branch_rlp = RlpNode::from_rlp(&alloy_rlp::encode(&bare_branch));
 
         // Create the combined extension+branch node as the root.
-        let root_node = TrieNodeV2::Branch(BranchNodeV2::new(
+        let root_node = TrieNode::Branch(BranchNode::new(
             Nibbles::from_nibbles(ext_key),
             stack.clone(),
             state_mask,
@@ -8818,18 +8802,13 @@ mod tests {
 
         // Reveal the branch and leaves
         let mut nodes = vec![
-            ProofTrieNodeV2 {
+            ProofTrieNode {
                 path: branch_path,
-                node: TrieNodeV2::Branch(BranchNodeV2::new(
-                    Nibbles::new(),
-                    stack,
-                    state_mask,
-                    None,
-                )),
+                node: TrieNode::Branch(BranchNode::new(Nibbles::new(), stack, state_mask, None)),
                 masks: None,
             },
-            ProofTrieNodeV2 { path: leaf1_path, node: TrieNodeV2::Leaf(leaf1_node), masks: None },
-            ProofTrieNodeV2 { path: leaf2_path, node: TrieNodeV2::Leaf(leaf2_node), masks: None },
+            ProofTrieNode { path: leaf1_path, node: TrieNode::Leaf(leaf1_node), masks: None },
+            ProofTrieNode { path: leaf2_path, node: TrieNode::Leaf(leaf2_node), masks: None },
         ];
         trie.reveal_nodes(&mut nodes).unwrap();
 

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -17,8 +17,8 @@ use reth_primitives_traits::Account;
 use reth_primitives_traits::FastInstant as Instant;
 use reth_trie_common::{
     updates::{StorageTrieUpdates, TrieUpdates},
-    BranchNodeMasks, DecodedMultiProof, MultiProof, Nibbles, ProofTrieNodeV2, TrieAccount,
-    TrieNodeV2, EMPTY_ROOT_HASH, TRIE_ACCOUNT_RLP_MAX_SIZE,
+    BranchNodeMasks, DecodedMultiProof, LegacyDecodedMultiProof, MultiProof, Nibbles,
+    ProofTrieNode, TrieAccount, TrieNode, EMPTY_ROOT_HASH, TRIE_ACCOUNT_RLP_MAX_SIZE,
 };
 #[cfg(feature = "std")]
 use tracing::debug;
@@ -31,7 +31,7 @@ use tracing::{instrument, trace};
 #[derive(Debug, Default)]
 pub struct DeferredDrops {
     /// Each nodes reveal operation creates a new buffer, uses it, and pushes it here.
-    pub proof_nodes_bufs: Vec<Vec<ProofTrieNodeV2>>,
+    pub proof_nodes_bufs: Vec<Vec<ProofTrieNode>>,
 }
 
 #[derive(Debug)]
@@ -48,7 +48,7 @@ pub struct SparseStateTrie<
     storage: StorageTries<S>,
     /// Flag indicating whether trie updates should be retained.
     retain_updates: bool,
-    /// When true, skip filtering of V2 proof nodes that have already been revealed.
+    /// When true, skip filtering of proof nodes that have already been revealed.
     /// This is useful when the sparse trie is being reused across blocks and already
     /// tracks revealed nodes internally.
     skip_proof_node_filtering: bool,
@@ -125,9 +125,9 @@ impl<A, S> SparseStateTrie<A, S> {
         self
     }
 
-    /// Set whether to skip filtering of V2 proof nodes.
+    /// Set whether to skip filtering of proof nodes.
     ///
-    /// When true, `reveal_*_v2_proof_nodes` methods will pass all nodes directly to the
+    /// When true, `reveal_*_proof_nodes` methods will pass all nodes directly to the
     /// sparse trie without filtering already-revealed paths. This is useful when the
     /// sparse trie is being reused across blocks and handles node deduplication internally.
     pub const fn with_skip_proof_node_filtering(mut self, skip: bool) -> Self {
@@ -278,44 +278,44 @@ where
         let decoded_multiproof = multiproof.try_into()?;
 
         // then reveal the decoded multiproof
-        self.reveal_decoded_multiproof(decoded_multiproof)
+        self.reveal_legacy_decoded_multiproof(decoded_multiproof)
     }
 
-    /// Reveal unknown trie paths from decoded multiproof.
+    /// Reveal unknown trie paths from legacy decoded multiproof.
     /// NOTE: This method does not extensively validate the proof.
+    #[instrument(level = "debug", target = "trie::sparse", skip_all)]
+    pub fn reveal_legacy_decoded_multiproof(
+        &mut self,
+        multiproof: LegacyDecodedMultiProof,
+    ) -> SparseStateTrieResult<()> {
+        self.reveal_decoded_multiproof(multiproof.into())
+    }
+
+    /// Reveals a decoded multiproof.
+    ///
+    /// Multiproofs use a format where proof nodes are stored as vectors rather than
+    /// hashmaps, with masks already included in the `ProofTrieNode` structure.
     #[instrument(level = "debug", target = "trie::sparse", skip_all)]
     pub fn reveal_decoded_multiproof(
         &mut self,
         multiproof: DecodedMultiProof,
     ) -> SparseStateTrieResult<()> {
-        self.reveal_decoded_multiproof_v2(multiproof.into())
-    }
-
-    /// Reveals a V2 decoded multiproof.
-    ///
-    /// V2 multiproofs use a simpler format where proof nodes are stored as vectors rather than
-    /// hashmaps, with masks already included in the `ProofTrieNode` structure.
-    #[instrument(level = "debug", target = "trie::sparse", skip_all)]
-    pub fn reveal_decoded_multiproof_v2(
-        &mut self,
-        multiproof: reth_trie_common::DecodedMultiProofV2,
-    ) -> SparseStateTrieResult<()> {
         // Reveal the account proof nodes.
         //
         // Skip revealing account nodes if this result only contains storage proofs.
-        // `reveal_account_v2_proof_nodes` will return an error if empty `nodes` are passed into it
+        // `reveal_account_proof_nodes` will return an error if empty `nodes` are passed into it
         // before the accounts trie root was revealed. This might happen in cases when first account
         // trie proof arrives later than first storage trie proof even though the account trie proof
         // was requested first.
         if !multiproof.account_proofs.is_empty() {
-            self.reveal_account_v2_proof_nodes(multiproof.account_proofs)?;
+            self.reveal_account_proof_nodes(multiproof.account_proofs)?;
         }
 
         #[cfg(not(feature = "std"))]
         // If nostd then serially reveal storage proof nodes for each storage trie
         {
             for (account, storage_proofs) in multiproof.storage_proofs {
-                self.reveal_storage_v2_proof_nodes(account, storage_proofs)?;
+                self.reveal_storage_proof_nodes(account, storage_proofs)?;
                 // Mark this storage trie as hot (accessed this tick)
                 self.storage.modifications.mark_accessed(account);
             }
@@ -346,7 +346,7 @@ where
                 .par_bridge_buffered()
                 .map(|(account, storage_proofs, mut revealed_nodes, mut trie)| {
                     let mut bufs = Vec::new();
-                    let result = Self::reveal_storage_v2_proof_nodes_inner(
+                    let result = Self::reveal_storage_proof_nodes_inner(
                         account,
                         storage_proofs,
                         &mut revealed_nodes,
@@ -385,23 +385,23 @@ where
         }
     }
 
-    /// Reveals account proof nodes from a V2 proof.
+    /// Reveals account proof nodes from a proof.
     ///
-    /// V2 proofs already include the masks in the `ProofTrieNode` structure,
+    /// Proofs already include the masks in the `ProofTrieNode` structure,
     /// so no separate masks map is needed.
-    pub fn reveal_account_v2_proof_nodes(
+    pub fn reveal_account_proof_nodes(
         &mut self,
-        mut nodes: Vec<ProofTrieNodeV2>,
+        mut nodes: Vec<ProofTrieNode>,
     ) -> SparseStateTrieResult<()> {
         if self.skip_proof_node_filtering {
-            let capacity = estimate_v2_proof_capacity(&nodes);
+            let capacity = estimate_proof_capacity(&nodes);
 
             #[cfg(feature = "metrics")]
             self.metrics.increment_total_account_nodes(nodes.len() as u64);
 
             let root_node = nodes.iter().find(|n| n.path.is_empty());
             let trie = if let Some(root_node) = root_node {
-                trace!(target: "trie::sparse", ?root_node, "Revealing root account node from V2 proof");
+                trace!(target: "trie::sparse", ?root_node, "Revealing root account node from proof");
                 self.state.reveal_root(
                     root_node.node.clone(),
                     root_node.masks,
@@ -411,15 +411,15 @@ where
                 self.state.as_revealed_mut().ok_or(SparseTrieErrorKind::Blind)?
             };
             trie.reserve_nodes(capacity);
-            trace!(target: "trie::sparse", total_nodes = ?nodes.len(), "Revealing account nodes from V2 proof (unfiltered)");
+            trace!(target: "trie::sparse", total_nodes = ?nodes.len(), "Revealing account nodes from proof (unfiltered)");
             trie.reveal_nodes(&mut nodes)?;
 
             self.deferred_drops.proof_nodes_bufs.push(nodes);
             return Ok(())
         }
 
-        let FilteredV2ProofNodes { root_node, mut nodes, new_nodes, metric_values: _metric_values } =
-            filter_revealed_v2_proof_nodes(nodes, &mut self.revealed_account_paths)?;
+        let FilteredProofNodes { root_node, mut nodes, new_nodes, metric_values: _metric_values } =
+            filter_revealed_proof_nodes(nodes, &mut self.revealed_account_paths)?;
 
         #[cfg(feature = "metrics")]
         {
@@ -428,7 +428,7 @@ where
         }
 
         let trie = if let Some(root_node) = root_node {
-            trace!(target: "trie::sparse", ?root_node, "Revealing root account node from V2 proof");
+            trace!(target: "trie::sparse", ?root_node, "Revealing root account node from proof");
             self.state.reveal_root(root_node.node, root_node.masks, self.retain_updates)?
         } else {
             self.state.as_revealed_mut().ok_or(SparseTrieErrorKind::Blind)?
@@ -436,7 +436,7 @@ where
 
         trie.reserve_nodes(new_nodes);
 
-        trace!(target: "trie::sparse", total_nodes = ?nodes.len(), "Revealing account nodes from V2 proof");
+        trace!(target: "trie::sparse", total_nodes = ?nodes.len(), "Revealing account nodes from proof");
         trie.reveal_nodes(&mut nodes)?;
 
         // Keep buffer for deferred dropping
@@ -445,17 +445,17 @@ where
         Ok(())
     }
 
-    /// Reveals storage proof nodes from a V2 proof for the given address.
+    /// Reveals storage proof nodes from a proof for the given address.
     ///
-    /// V2 proofs already include the masks in the `ProofTrieNode` structure,
+    /// Proofs already include the masks in the `ProofTrieNode` structure,
     /// so no separate masks map is needed.
-    pub fn reveal_storage_v2_proof_nodes(
+    pub fn reveal_storage_proof_nodes(
         &mut self,
         account: B256,
-        nodes: Vec<ProofTrieNodeV2>,
+        nodes: Vec<ProofTrieNode>,
     ) -> SparseStateTrieResult<()> {
         let (trie, revealed_paths) = self.storage.get_trie_and_revealed_paths_mut(account);
-        let _metric_values = Self::reveal_storage_v2_proof_nodes_inner(
+        let _metric_values = Self::reveal_storage_proof_nodes_inner(
             account,
             nodes,
             revealed_paths,
@@ -474,42 +474,42 @@ where
         Ok(())
     }
 
-    /// Reveals storage V2 proof nodes for the given address. This is an internal static function
+    /// Reveals storage proof nodes for the given address. This is an internal static function
     /// designed to handle a variety of associated public functions.
-    fn reveal_storage_v2_proof_nodes_inner(
+    fn reveal_storage_proof_nodes_inner(
         account: B256,
-        mut nodes: Vec<ProofTrieNodeV2>,
+        mut nodes: Vec<ProofTrieNode>,
         revealed_nodes: &mut HashSet<Nibbles>,
         trie: &mut RevealableSparseTrie<S>,
-        bufs: &mut Vec<Vec<ProofTrieNodeV2>>,
+        bufs: &mut Vec<Vec<ProofTrieNode>>,
         retain_updates: bool,
         skip_filtering: bool,
     ) -> SparseStateTrieResult<ProofNodesMetricValues> {
         if skip_filtering {
-            let capacity = estimate_v2_proof_capacity(&nodes);
+            let capacity = estimate_proof_capacity(&nodes);
             let metric_values =
                 ProofNodesMetricValues { total_nodes: nodes.len(), skipped_nodes: 0 };
 
             let root_node = nodes.iter().find(|n| n.path.is_empty());
             let trie = if let Some(root_node) = root_node {
-                trace!(target: "trie::sparse", ?account, ?root_node, "Revealing root storage node from V2 proof");
+                trace!(target: "trie::sparse", ?account, ?root_node, "Revealing root storage node from proof");
                 trie.reveal_root(root_node.node.clone(), root_node.masks, retain_updates)?
             } else {
                 trie.as_revealed_mut().ok_or(SparseTrieErrorKind::Blind)?
             };
             trie.reserve_nodes(capacity);
-            trace!(target: "trie::sparse", ?account, total_nodes = ?nodes.len(), "Revealing storage nodes from V2 proof (unfiltered)");
+            trace!(target: "trie::sparse", ?account, total_nodes = ?nodes.len(), "Revealing storage nodes from proof (unfiltered)");
             trie.reveal_nodes(&mut nodes)?;
 
             bufs.push(nodes);
             return Ok(metric_values)
         }
 
-        let FilteredV2ProofNodes { root_node, mut nodes, new_nodes, metric_values } =
-            filter_revealed_v2_proof_nodes(nodes, revealed_nodes)?;
+        let FilteredProofNodes { root_node, mut nodes, new_nodes, metric_values } =
+            filter_revealed_proof_nodes(nodes, revealed_nodes)?;
 
         let trie = if let Some(root_node) = root_node {
-            trace!(target: "trie::sparse", ?account, ?root_node, "Revealing root storage node from V2 proof");
+            trace!(target: "trie::sparse", ?account, ?root_node, "Revealing root storage node from proof");
             trie.reveal_root(root_node.node, root_node.masks, retain_updates)?
         } else {
             trie.as_revealed_mut().ok_or(SparseTrieErrorKind::Blind)?
@@ -517,7 +517,7 @@ where
 
         trie.reserve_nodes(new_nodes);
 
-        trace!(target: "trie::sparse", ?account, total_nodes = ?nodes.len(), "Revealing storage nodes from V2 proof");
+        trace!(target: "trie::sparse", ?account, total_nodes = ?nodes.len(), "Revealing storage nodes from proof");
         trie.reveal_nodes(&mut nodes)?;
 
         // Keep buffer for deferred dropping
@@ -562,11 +562,11 @@ where
                     .account_node_provider()
                     .trie_node(&Nibbles::default())?
                     .map(|node| {
-                        TrieNodeV2::decode(&mut &node.node[..])
+                        TrieNode::decode(&mut &node.node[..])
                             .map(|decoded| (decoded, node.hash_mask, node.tree_mask))
                     })
                     .transpose()?
-                    .unwrap_or((TrieNodeV2::EmptyRoot, None, None));
+                    .unwrap_or((TrieNode::EmptyRoot, None, None));
                 let masks = BranchNodeMasks::from_optional(hash_mask, tree_mask);
                 self.state.reveal_root(root_node, masks, self.retain_updates).map_err(Into::into)
             }
@@ -1221,13 +1221,13 @@ struct ProofNodesMetricValues {
     skipped_nodes: usize,
 }
 
-/// Result of [`filter_revealed_v2_proof_nodes`].
+/// Result of [`filter_revealed_proof_nodes`].
 #[derive(Debug, PartialEq, Eq)]
-struct FilteredV2ProofNodes {
+struct FilteredProofNodes {
     /// Root node which was pulled out of the original node set to be handled specially.
-    root_node: Option<ProofTrieNodeV2>,
+    root_node: Option<ProofTrieNode>,
     /// Filtered proof nodes. Root node is removed.
-    nodes: Vec<ProofTrieNodeV2>,
+    nodes: Vec<ProofTrieNode>,
     /// Number of new nodes that will be revealed. This includes all children of branch nodes, even
     /// if they are not in the proof.
     new_nodes: usize,
@@ -1235,16 +1235,16 @@ struct FilteredV2ProofNodes {
     metric_values: ProofNodesMetricValues,
 }
 
-/// Calculates capacity estimation for V2 proof nodes without filtering.
+/// Calculates capacity estimation for proof nodes without filtering.
 ///
 /// This counts nodes and their children (for branch and extension nodes) to provide
 /// proper capacity hints for `reserve_nodes`. Used when `skip_proof_node_filtering` is
 /// enabled and no filtering is performed.
-fn estimate_v2_proof_capacity(nodes: &[ProofTrieNodeV2]) -> usize {
+fn estimate_proof_capacity(nodes: &[ProofTrieNode]) -> usize {
     let mut capacity = nodes.len();
 
     for node in nodes {
-        if let TrieNodeV2::Branch(branch) = &node.node {
+        if let TrieNode::Branch(branch) = &node.node {
             capacity += branch.state_mask.count_ones() as usize;
         }
     }
@@ -1252,16 +1252,16 @@ fn estimate_v2_proof_capacity(nodes: &[ProofTrieNodeV2]) -> usize {
     capacity
 }
 
-/// Filters V2 proof nodes that are already revealed, separates the root node if present, and
+/// Filters proof nodes that are already revealed, separates the root node if present, and
 /// returns additional information about the number of total, skipped, and new nodes.
 ///
-/// V2 proof nodes already have masks included in the `ProofTrieNode` structure, so no separate
+/// Proof nodes already have masks included in the `ProofTrieNode` structure, so no separate
 /// masks map is needed.
-fn filter_revealed_v2_proof_nodes(
-    proof_nodes: Vec<ProofTrieNodeV2>,
+fn filter_revealed_proof_nodes(
+    proof_nodes: Vec<ProofTrieNode>,
     revealed_nodes: &mut HashSet<Nibbles>,
-) -> SparseStateTrieResult<FilteredV2ProofNodes> {
-    let mut result = FilteredV2ProofNodes {
+) -> SparseStateTrieResult<FilteredProofNodes> {
+    let mut result = FilteredProofNodes {
         root_node: None,
         nodes: Vec::with_capacity(proof_nodes.len()),
         new_nodes: 0,
@@ -1272,7 +1272,7 @@ fn filter_revealed_v2_proof_nodes(
     // duplicate EmptyRoot nodes may appear (e.g., storage proofs split across chunks for an
     // account with empty storage). We only error if there's an EmptyRoot alongside real nodes.
     let non_empty_root_count =
-        proof_nodes.iter().filter(|n| !matches!(n.node, TrieNodeV2::EmptyRoot)).count();
+        proof_nodes.iter().filter(|n| !matches!(n.node, TrieNode::EmptyRoot)).count();
 
     for node in proof_nodes {
         result.metric_values.total_nodes += 1;
@@ -1289,13 +1289,13 @@ fn filter_revealed_v2_proof_nodes(
         result.new_nodes += 1;
 
         // Count children for capacity estimation
-        if let TrieNodeV2::Branch(branch) = &node.node {
+        if let TrieNode::Branch(branch) = &node.node {
             result.new_nodes += branch.state_mask.count_ones() as usize;
         }
 
         if is_root {
             // Perform sanity check: EmptyRoot is only valid if there are no other real nodes.
-            if matches!(node.node, TrieNodeV2::EmptyRoot) && non_empty_root_count > 0 {
+            if matches!(node.node, TrieNode::EmptyRoot) && non_empty_root_count > 0 {
                 return Err(SparseStateTrieErrorKind::InvalidRootNode {
                     path: node.path,
                     node: {
@@ -1332,7 +1332,7 @@ mod tests {
     use reth_trie::{updates::StorageTrieUpdates, HashBuilder, MultiProof, EMPTY_ROOT_HASH};
     use reth_trie_common::{
         proof::{ProofNodes, ProofRetainer},
-        BranchNodeMasks, BranchNodeMasksMap, BranchNodeV2, LeafNode, RlpNode, StorageMultiProof,
+        BranchNode, BranchNodeMasks, BranchNodeMasksMap, LeafNode, RlpNode, StorageMultiProof,
         TrieMask,
     };
 
@@ -1355,20 +1355,16 @@ mod tests {
 
         let leaf_value = alloy_rlp::encode(TrieAccount::default());
         // Leaf key is 63 nibbles (suffix after 1-nibble node path)
-        let leaf_1 = alloy_rlp::encode(TrieNodeV2::Leaf(LeafNode::new(
-            leaf_key([], 63),
-            leaf_value.clone(),
-        )));
-        let leaf_2 = alloy_rlp::encode(TrieNodeV2::Leaf(LeafNode::new(
-            leaf_key([], 63),
-            leaf_value.clone(),
-        )));
+        let leaf_1 =
+            alloy_rlp::encode(TrieNode::Leaf(LeafNode::new(leaf_key([], 63), leaf_value.clone())));
+        let leaf_2 =
+            alloy_rlp::encode(TrieNode::Leaf(LeafNode::new(leaf_key([], 63), leaf_value.clone())));
 
         let multiproof = MultiProof {
             account_subtree: ProofNodes::from_iter([
                 (
                     Nibbles::default(),
-                    alloy_rlp::encode(TrieNodeV2::Branch(BranchNodeV2 {
+                    alloy_rlp::encode(TrieNode::Branch(BranchNode {
                         key: Nibbles::default(),
                         stack: vec![RlpNode::from_rlp(&leaf_1), RlpNode::from_rlp(&leaf_2)],
                         state_mask: TrieMask::new(0b11),
@@ -1383,7 +1379,7 @@ mod tests {
         };
 
         // Reveal multiproof and check that the state trie contains the leaf node and value
-        sparse.reveal_decoded_multiproof(multiproof.clone().try_into().unwrap()).unwrap();
+        sparse.reveal_legacy_decoded_multiproof(multiproof.clone().try_into().unwrap()).unwrap();
         assert!(matches!(
             sparse.state_trie_ref().unwrap().find_leaf(&full_path_0, None),
             Ok(LeafLookup::Exists)
@@ -1404,7 +1400,7 @@ mod tests {
 
         // Reveal multiproof again and check that the state trie still does not contain the leaf
         // node and value, because they were already revealed before
-        sparse.reveal_decoded_multiproof(multiproof.try_into().unwrap()).unwrap();
+        sparse.reveal_legacy_decoded_multiproof(multiproof.try_into().unwrap()).unwrap();
         assert!(matches!(
             sparse.state_trie_ref().unwrap().find_leaf(&full_path_0, None),
             Ok(LeafLookup::NonExistent)
@@ -1421,14 +1417,10 @@ mod tests {
         let full_path_0 = leaf_key([0x0], 64);
 
         let leaf_value = alloy_rlp::encode(TrieAccount::default());
-        let leaf_1 = alloy_rlp::encode(TrieNodeV2::Leaf(LeafNode::new(
-            leaf_key([], 63),
-            leaf_value.clone(),
-        )));
-        let leaf_2 = alloy_rlp::encode(TrieNodeV2::Leaf(LeafNode::new(
-            leaf_key([], 63),
-            leaf_value.clone(),
-        )));
+        let leaf_1 =
+            alloy_rlp::encode(TrieNode::Leaf(LeafNode::new(leaf_key([], 63), leaf_value.clone())));
+        let leaf_2 =
+            alloy_rlp::encode(TrieNode::Leaf(LeafNode::new(leaf_key([], 63), leaf_value.clone())));
 
         let multiproof = MultiProof {
             storages: HashMap::from_iter([(
@@ -1438,7 +1430,7 @@ mod tests {
                     subtree: ProofNodes::from_iter([
                         (
                             Nibbles::default(),
-                            alloy_rlp::encode(TrieNodeV2::Branch(BranchNodeV2 {
+                            alloy_rlp::encode(TrieNode::Branch(BranchNode {
                                 key: Nibbles::default(),
                                 stack: vec![RlpNode::from_rlp(&leaf_1), RlpNode::from_rlp(&leaf_2)],
                                 state_mask: TrieMask::new(0b11),
@@ -1456,7 +1448,7 @@ mod tests {
         };
 
         // Reveal multiproof and check that the storage trie contains the leaf node and value
-        sparse.reveal_decoded_multiproof(multiproof.clone().try_into().unwrap()).unwrap();
+        sparse.reveal_legacy_decoded_multiproof(multiproof.clone().try_into().unwrap()).unwrap();
         assert!(matches!(
             sparse.storage_trie_ref(&B256::ZERO).unwrap().find_leaf(&full_path_0, None),
             Ok(LeafLookup::Exists)
@@ -1481,7 +1473,7 @@ mod tests {
 
         // Reveal multiproof again and check that the storage trie still does not contain the leaf
         // node and value, because they were already revealed before
-        sparse.reveal_decoded_multiproof(multiproof.try_into().unwrap()).unwrap();
+        sparse.reveal_legacy_decoded_multiproof(multiproof.try_into().unwrap()).unwrap();
         assert!(matches!(
             sparse.storage_trie_ref(&B256::ZERO).unwrap().find_leaf(&full_path_0, None),
             Ok(LeafLookup::NonExistent)
@@ -1494,7 +1486,7 @@ mod tests {
     }
 
     #[test]
-    fn reveal_v2_proof_nodes() {
+    fn reveal_proof_nodes() {
         let provider_factory = DefaultTrieNodeProviderFactory;
         let mut sparse = SparseStateTrie::<ParallelSparseTrie>::default();
 
@@ -1502,10 +1494,10 @@ mod tests {
         let full_path_0 = leaf_key([0x0], 64);
 
         let leaf_value = alloy_rlp::encode(TrieAccount::default());
-        let leaf_1_node = TrieNodeV2::Leaf(LeafNode::new(leaf_key([], 63), leaf_value.clone()));
-        let leaf_2_node = TrieNodeV2::Leaf(LeafNode::new(leaf_key([], 63), leaf_value.clone()));
+        let leaf_1_node = TrieNode::Leaf(LeafNode::new(leaf_key([], 63), leaf_value.clone()));
+        let leaf_2_node = TrieNode::Leaf(LeafNode::new(leaf_key([], 63), leaf_value.clone()));
 
-        let branch_node = TrieNodeV2::Branch(BranchNodeV2 {
+        let branch_node = TrieNode::Branch(BranchNode {
             key: Nibbles::default(),
             stack: vec![
                 RlpNode::from_rlp(&alloy_rlp::encode(&leaf_1_node)),
@@ -1515,9 +1507,9 @@ mod tests {
             branch_rlp_node: None,
         });
 
-        // Create V2 proof nodes with masks already included
-        let v2_proof_nodes = vec![
-            ProofTrieNodeV2 {
+        // Create proof nodes with masks already included
+        let proof_nodes = vec![
+            ProofTrieNode {
                 path: Nibbles::default(),
                 node: branch_node,
                 masks: Some(BranchNodeMasks {
@@ -1525,12 +1517,12 @@ mod tests {
                     tree_mask: TrieMask::default(),
                 }),
             },
-            ProofTrieNodeV2 { path: Nibbles::from_nibbles([0x0]), node: leaf_1_node, masks: None },
-            ProofTrieNodeV2 { path: Nibbles::from_nibbles([0x1]), node: leaf_2_node, masks: None },
+            ProofTrieNode { path: Nibbles::from_nibbles([0x0]), node: leaf_1_node, masks: None },
+            ProofTrieNode { path: Nibbles::from_nibbles([0x1]), node: leaf_2_node, masks: None },
         ];
 
-        // Reveal V2 proof nodes
-        sparse.reveal_account_v2_proof_nodes(v2_proof_nodes.clone()).unwrap();
+        // Reveal proof nodes
+        sparse.reveal_account_proof_nodes(proof_nodes.clone()).unwrap();
 
         // Check that the state trie contains the leaf node and value
         assert!(matches!(
@@ -1547,12 +1539,12 @@ mod tests {
         assert!(sparse.state_trie_ref().unwrap().get_leaf_value(&full_path_0).is_none());
 
         // Reveal again - should skip already revealed paths
-        sparse.reveal_account_v2_proof_nodes(v2_proof_nodes).unwrap();
+        sparse.reveal_account_proof_nodes(proof_nodes).unwrap();
         assert!(sparse.state_trie_ref().unwrap().get_leaf_value(&full_path_0).is_none());
     }
 
     #[test]
-    fn reveal_storage_v2_proof_nodes() {
+    fn reveal_storage_proof_nodes() {
         let provider_factory = DefaultTrieNodeProviderFactory;
         let mut sparse = SparseStateTrie::<ParallelSparseTrie>::default();
 
@@ -1560,10 +1552,10 @@ mod tests {
         let full_path_0 = leaf_key([0x0], 64);
 
         let storage_value: Vec<u8> = alloy_rlp::encode_fixed_size(&U256::from(42)).to_vec();
-        let leaf_1_node = TrieNodeV2::Leaf(LeafNode::new(leaf_key([], 63), storage_value.clone()));
-        let leaf_2_node = TrieNodeV2::Leaf(LeafNode::new(leaf_key([], 63), storage_value.clone()));
+        let leaf_1_node = TrieNode::Leaf(LeafNode::new(leaf_key([], 63), storage_value.clone()));
+        let leaf_2_node = TrieNode::Leaf(LeafNode::new(leaf_key([], 63), storage_value.clone()));
 
-        let branch_node = TrieNodeV2::Branch(BranchNodeV2 {
+        let branch_node = TrieNode::Branch(BranchNode {
             key: Nibbles::default(),
             stack: vec![
                 RlpNode::from_rlp(&alloy_rlp::encode(&leaf_1_node)),
@@ -1573,14 +1565,14 @@ mod tests {
             branch_rlp_node: None,
         });
 
-        let v2_proof_nodes = vec![
-            ProofTrieNodeV2 { path: Nibbles::default(), node: branch_node, masks: None },
-            ProofTrieNodeV2 { path: Nibbles::from_nibbles([0x0]), node: leaf_1_node, masks: None },
-            ProofTrieNodeV2 { path: Nibbles::from_nibbles([0x1]), node: leaf_2_node, masks: None },
+        let proof_nodes = vec![
+            ProofTrieNode { path: Nibbles::default(), node: branch_node, masks: None },
+            ProofTrieNode { path: Nibbles::from_nibbles([0x0]), node: leaf_1_node, masks: None },
+            ProofTrieNode { path: Nibbles::from_nibbles([0x1]), node: leaf_2_node, masks: None },
         ];
 
-        // Reveal V2 storage proof nodes for account
-        sparse.reveal_storage_v2_proof_nodes(B256::ZERO, v2_proof_nodes.clone()).unwrap();
+        // Reveal storage proof nodes for account
+        sparse.reveal_storage_proof_nodes(B256::ZERO, proof_nodes.clone()).unwrap();
 
         // Check that the storage trie contains the leaf node and value
         assert!(matches!(
@@ -1601,7 +1593,7 @@ mod tests {
             .is_none());
 
         // Reveal again - should skip already revealed paths
-        sparse.reveal_storage_v2_proof_nodes(B256::ZERO, v2_proof_nodes).unwrap();
+        sparse.reveal_storage_proof_nodes(B256::ZERO, proof_nodes).unwrap();
         assert!(sparse
             .storage_trie_ref(&B256::ZERO)
             .unwrap()
@@ -1667,7 +1659,7 @@ mod tests {
         let provider_factory = DefaultTrieNodeProviderFactory;
         let mut sparse = SparseStateTrie::<ParallelSparseTrie>::default().with_updates(true);
         sparse
-            .reveal_decoded_multiproof(
+            .reveal_legacy_decoded_multiproof(
                 MultiProof {
                     account_subtree: proof_nodes,
                     branch_node_masks: BranchNodeMasksMap::from_iter([(

--- a/crates/trie/sparse/src/traits.rs
+++ b/crates/trie/sparse/src/traits.rs
@@ -9,7 +9,7 @@ use alloy_primitives::{
 };
 use alloy_trie::BranchNodeCompact;
 use reth_execution_errors::SparseTrieResult;
-use reth_trie_common::{BranchNodeMasks, Nibbles, ProofTrieNodeV2, TrieNodeV2};
+use reth_trie_common::{BranchNodeMasks, Nibbles, ProofTrieNode, TrieNode};
 
 #[cfg(feature = "trie-debug")]
 use crate::debug_recorder::TrieDebugRecorder;
@@ -61,7 +61,7 @@ pub trait SparseTrie: Sized + Debug + Send + Sync {
     /// May panic if the trie is not new/cleared, and has already revealed nodes.
     fn set_root(
         &mut self,
-        root: TrieNodeV2,
+        root: TrieNode,
         masks: Option<BranchNodeMasks>,
         retain_updates: bool,
     ) -> SparseTrieResult<()>;
@@ -71,7 +71,7 @@ pub trait SparseTrie: Sized + Debug + Send + Sync {
     /// See [`Self::set_root`] for more details.
     fn with_root(
         mut self,
-        root: TrieNodeV2,
+        root: TrieNode,
         masks: Option<BranchNodeMasks>,
         retain_updates: bool,
     ) -> SparseTrieResult<Self> {
@@ -113,10 +113,10 @@ pub trait SparseTrie: Sized + Debug + Send + Sync {
     fn reveal_node(
         &mut self,
         path: Nibbles,
-        node: TrieNodeV2,
+        node: TrieNode,
         masks: Option<BranchNodeMasks>,
     ) -> SparseTrieResult<()> {
-        self.reveal_nodes(&mut [ProofTrieNodeV2 { path, node, masks }])
+        self.reveal_nodes(&mut [ProofTrieNode { path, node, masks }])
     }
 
     /// Reveals one or more trie nodes if they have not been revealed before.
@@ -137,8 +137,8 @@ pub trait SparseTrie: Sized + Debug + Send + Sync {
     /// # Note
     ///
     /// The implementation may modify the input nodes. A common thing to do is [`std::mem::replace`]
-    /// each node with [`TrieNodeV2::EmptyRoot`] to avoid cloning.
-    fn reveal_nodes(&mut self, nodes: &mut [ProofTrieNodeV2]) -> SparseTrieResult<()>;
+    /// each node with [`TrieNode::EmptyRoot`] to avoid cloning.
+    fn reveal_nodes(&mut self, nodes: &mut [ProofTrieNode]) -> SparseTrieResult<()>;
 
     /// Updates the value of a leaf node at the specified path.
     ///

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -5,7 +5,7 @@ use crate::{
 use alloc::{borrow::Cow, boxed::Box, vec::Vec};
 use alloy_primitives::{map::B256Map, B256};
 use reth_execution_errors::{SparseTrieErrorKind, SparseTrieResult};
-use reth_trie_common::{BranchNodeMasks, Nibbles, RlpNode, TrieMask, TrieNodeV2};
+use reth_trie_common::{BranchNodeMasks, Nibbles, RlpNode, TrieMask, TrieNode};
 use tracing::instrument;
 
 /// A sparse trie that is either in a "blind" state (no nodes are revealed, root node hash is
@@ -63,7 +63,7 @@ impl<T: SparseTrieTrait + Default> RevealableSparseTrie<T> {
     /// A mutable reference to the underlying [`RevealableSparseTrie`](SparseTrieTrait).
     pub fn reveal_root(
         &mut self,
-        root: TrieNodeV2,
+        root: TrieNode,
         masks: Option<BranchNodeMasks>,
         retain_updates: bool,
     ) -> SparseTrieResult<&mut T> {

--- a/crates/trie/trie/src/lib.rs
+++ b/crates/trie/trie/src/lib.rs
@@ -32,7 +32,7 @@ pub mod node_iter;
 /// Merkle proof generation.
 pub mod proof;
 
-/// Merkle proof generation v2 (leaf-only implementation).
+/// Merkle proof generation (leaf-only implementation).
 pub mod proof_v2;
 
 /// Trie witness generation.

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -323,13 +323,13 @@ mod tests {
         map::{B256Map, HashMap},
     };
     use alloy_trie::{
-        BranchNodeCompact, HashBuilder, Nibbles, TrieAccount, TrieMask, EMPTY_ROOT_HASH,
+        nodes::BranchNode as AlloyBranchNode, BranchNodeCompact, HashBuilder, Nibbles, TrieAccount,
+        TrieMask, EMPTY_ROOT_HASH,
     };
     use itertools::Itertools;
     use reth_primitives_traits::Account;
     use reth_trie_common::{
-        prefix_set::PrefixSetMut, updates::TrieUpdates, BranchNode, HashedPostState, LeafNode,
-        RlpNode,
+        prefix_set::PrefixSetMut, updates::TrieUpdates, HashedPostState, LeafNode, RlpNode,
     };
     use std::collections::BTreeMap;
 
@@ -416,7 +416,7 @@ mod tests {
             (Nibbles::unpack(account_5), empty_account),
         ]);
 
-        let branch_node_1_rlp = RlpNode::from_rlp(&alloy_rlp::encode(BranchNode::new(
+        let branch_node_1_rlp = RlpNode::from_rlp(&alloy_rlp::encode(AlloyBranchNode::new(
             vec![
                 empty_leaf_rlp_for_key(Nibbles::from_nibbles([0])),
                 empty_leaf_rlp_for_key(Nibbles::from_nibbles([0])),
@@ -424,7 +424,7 @@ mod tests {
             TrieMask::new(0b11),
         )));
 
-        let branch_node_3_rlp = RlpNode::from_rlp(&alloy_rlp::encode(BranchNode::new(
+        let branch_node_3_rlp = RlpNode::from_rlp(&alloy_rlp::encode(AlloyBranchNode::new(
             vec![
                 empty_leaf_rlp_for_key(Nibbles::default()),
                 empty_leaf_rlp_for_key(Nibbles::default()),
@@ -442,7 +442,7 @@ mod tests {
                 None,
             ),
         );
-        let branch_node_2_rlp = RlpNode::from_rlp(&alloy_rlp::encode(BranchNode::new(
+        let branch_node_2_rlp = RlpNode::from_rlp(&alloy_rlp::encode(AlloyBranchNode::new(
             vec![branch_node_3_rlp, empty_leaf_rlp_for_key(Nibbles::from_nibbles([0]))],
             TrieMask::new(0b11),
         )));

--- a/crates/trie/trie/src/proof/mod.rs
+++ b/crates/trie/trie/src/proof/mod.rs
@@ -19,8 +19,8 @@ use alloy_rlp::{BufMut, Encodable};
 use alloy_trie::proof::AddedRemovedKeys;
 use reth_execution_errors::trie::StateProofError;
 use reth_trie_common::{
-    proof::ProofRetainer, AccountProof, BranchNodeMasks, BranchNodeMasksMap, DecodedMultiProofV2,
-    MultiProof, MultiProofTargets, MultiProofTargetsV2, StorageMultiProof,
+    proof::ProofRetainer, AccountProof, BranchNodeMasks, BranchNodeMasksMap, DecodedMultiProof,
+    LegacyMultiProofTargets, MultiProof, MultiProofTargets, StorageMultiProof,
 };
 
 mod trie_node;
@@ -132,24 +132,24 @@ where
         slots: &[B256],
     ) -> Result<AccountProof, StateProofError> {
         Ok(self
-            .multiproof(MultiProofTargets::from_iter([(
+            .multiproof(LegacyMultiProofTargets::from_iter([(
                 keccak256(address),
                 slots.iter().map(keccak256).collect(),
             )]))?
             .account_proof(address, slots)?)
     }
 
-    /// Generate a state multiproof using the V2 proof calculator.
+    /// Generate a state multiproof using the `proof_v2` proof calculator.
     ///
     /// This method uses `ProofCalculator` with `SyncAccountValueEncoder` for account proofs
     /// and `StorageProofCalculator` for storage proofs.
-    pub fn multiproof_v2(
+    pub fn multiproof_leaf_only(
         self,
-        targets: MultiProofTargetsV2,
-    ) -> Result<DecodedMultiProofV2, StateProofError> {
-        let MultiProofTargetsV2 { mut account_targets, storage_targets } = targets;
+        targets: MultiProofTargets,
+    ) -> Result<DecodedMultiProof, StateProofError> {
+        let MultiProofTargets { mut account_targets, storage_targets } = targets;
 
-        // Compute account proofs using the V2 proof calculator with sync account encoding.
+        // Compute account proofs using the proof calculator with sync account encoding.
         let account_trie_cursor = self.trie_cursor_factory.account_trie_cursor()?;
         let hashed_account_cursor = self.hashed_cursor_factory.hashed_account_cursor()?;
         let mut account_value_encoder = SyncAccountValueEncoder::new(
@@ -177,13 +177,13 @@ where
             storage_proofs.insert(hashed_address, proofs);
         }
 
-        Ok(DecodedMultiProofV2 { account_proofs, storage_proofs })
+        Ok(DecodedMultiProof { account_proofs, storage_proofs })
     }
 
     /// Generate a state multiproof according to specified targets.
     pub fn multiproof(
         mut self,
-        mut targets: MultiProofTargets,
+        mut targets: LegacyMultiProofTargets,
     ) -> Result<MultiProof, StateProofError> {
         let hashed_account_cursor = self.hashed_cursor_factory.hashed_account_cursor()?;
         let trie_cursor = self.trie_cursor_factory.account_trie_cursor()?;

--- a/crates/trie/trie/src/proof/trie_node.rs
+++ b/crates/trie/trie/src/proof/trie_node.rs
@@ -3,7 +3,7 @@ use crate::{hashed_cursor::HashedCursorFactory, trie_cursor::TrieCursorFactory};
 use alloy_primitives::{map::HashSet, B256};
 use reth_execution_errors::{SparseTrieError, SparseTrieErrorKind};
 use reth_primitives_traits::FastInstant as Instant;
-use reth_trie_common::{MultiProofTargets, Nibbles};
+use reth_trie_common::{LegacyMultiProofTargets, Nibbles};
 use reth_trie_sparse::provider::{
     pad_path_to_key, RevealedNode, TrieNodeProvider, TrieNodeProviderFactory,
 };
@@ -73,7 +73,8 @@ where
     fn trie_node(&self, path: &Nibbles) -> Result<Option<RevealedNode>, SparseTrieError> {
         let start = enabled!(target: "trie::proof::blinded", Level::TRACE).then(Instant::now);
 
-        let targets = MultiProofTargets::from_iter([(pad_path_to_key(path), HashSet::default())]);
+        let targets =
+            LegacyMultiProofTargets::from_iter([(pad_path_to_key(path), HashSet::default())]);
         let mut proof = Proof::new(&self.trie_cursor_factory, &self.hashed_cursor_factory)
             .with_branch_node_masks(true)
             .multiproof(targets)

--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -1,4 +1,4 @@
-//! Proof calculation version 2: Leaf-only implementation.
+//! Proof calculation: Leaf-only implementation.
 //!
 //! This module provides a rewritten proof calculator that:
 //! - Uses only leaf data (HashedAccounts/Storages) to generate proofs
@@ -16,8 +16,8 @@ use alloy_rlp::Encodable;
 use alloy_trie::{BranchNodeCompact, TrieMask};
 use reth_execution_errors::trie::StateProofError;
 use reth_trie_common::{
-    BranchNodeMasks, BranchNodeRef, BranchNodeV2, Nibbles, ProofTrieNodeV2, ProofV2Target, RlpNode,
-    TrieNodeV2,
+    BranchNode, BranchNodeMasks, BranchNodeRef, Nibbles, ProofTarget, ProofTrieNode, RlpNode,
+    TrieNode,
 };
 use std::cmp::Ordering;
 use tracing::{error, instrument, trace};
@@ -89,7 +89,7 @@ pub struct ProofCalculator<TC, HC, VE: LeafValueEncoder> {
     cached_branch_stack: Vec<(Nibbles, BranchNodeCompact)>,
     /// The proofs which will be returned from the calculation. This gets taken at the end of every
     /// proof call.
-    retained_proofs: Vec<ProofTrieNodeV2>,
+    retained_proofs: Vec<ProofTrieNode>,
     /// Free-list of re-usable buffers of [`RlpNode`]s, used for encoding branch nodes to RLP.
     ///
     /// We are generally able to re-use these buffers across different branch nodes for the
@@ -196,7 +196,7 @@ where
 
         trace!(target: TRACE_TARGET, ?path, target = ?lower, "should_retain: called");
         debug_assert!(self.retained_proofs.last().is_none_or(
-                |ProofTrieNodeV2 { path: last_retained_path, .. }| {
+                |ProofTrieNode { path: last_retained_path, .. }| {
                     depth_first::cmp(path, last_retained_path) == Ordering::Greater
                 }
             ),
@@ -273,14 +273,14 @@ where
         if self.should_retain(targets, &child_path, true) {
             trace!(target: TRACE_TARGET, ?child_path, "Retaining child");
 
-            // Convert to `ProofTrieNodeV2`, which will be what is retained.
+            // Convert to `ProofTrieNode`, which will be what is retained.
             //
             // If this node is a branch then its `rlp_nodes_buf` will be taken and not returned to
             // the `rlp_nodes_bufs` free-list.
             self.rlp_encode_buf.clear();
             let proof_node = child.into_proof_trie_node(child_path, &mut self.rlp_encode_buf)?;
 
-            // Use the `ProofTrieNodeV2` to encode the `RlpNode`, and then push it onto retained
+            // Use the `ProofTrieNode` to encode the `RlpNode`, and then push it onto retained
             // nodes before returning.
             self.rlp_encode_buf.clear();
             proof_node.node.encode(&mut self.rlp_encode_buf);
@@ -554,9 +554,9 @@ where
             Some(RlpNode::from_rlp(&self.rlp_encode_buf))
         };
 
-        // Wrap the `BranchNodeV2` so it can be pushed onto the child stack.
+        // Wrap the `BranchNode` so it can be pushed onto the child stack.
         let branch_as_child = ProofTrieBranchChild::Branch {
-            node: BranchNodeV2::new(short_key, rlp_nodes_buf, branch.state_mask, rlp_node),
+            node: BranchNode::new(short_key, rlp_nodes_buf, branch.state_mask, rlp_node),
             masks: branch.masks,
         };
 
@@ -1271,9 +1271,9 @@ where
             (true, None) => {
                 // If `child_stack` is empty it means there was no keys at all, retain an empty
                 // root node.
-                self.retained_proofs.push(ProofTrieNodeV2 {
+                self.retained_proofs.push(ProofTrieNode {
                     path: Nibbles::new(), // root path
-                    node: TrieNodeV2::EmptyRoot,
+                    node: TrieNode::EmptyRoot,
                     masks: None,
                 });
             }
@@ -1294,8 +1294,8 @@ where
     fn proof_inner(
         &mut self,
         value_encoder: &mut VE,
-        targets: &mut [ProofV2Target],
-    ) -> Result<Vec<ProofTrieNodeV2>, StateProofError> {
+        targets: &mut [ProofTarget],
+    ) -> Result<Vec<ProofTrieNode>, StateProofError> {
         // If there are no targets then nothing could be returned, return early.
         if targets.is_empty() {
             trace!(target: TRACE_TARGET, "Empty targets, returning");
@@ -1328,7 +1328,7 @@ where
 
     /// Generate a proof for the given targets.
     ///
-    /// Given a set of [`ProofV2Target`]s, returns nodes whose paths are a prefix of any target. The
+    /// Given a set of [`ProofTarget`]s, returns nodes whose paths are a prefix of any target. The
     /// returned nodes will be sorted depth-first by path.
     ///
     /// # Panics
@@ -1338,8 +1338,8 @@ where
     pub fn proof(
         &mut self,
         value_encoder: &mut VE,
-        targets: &mut [ProofV2Target],
-    ) -> Result<Vec<ProofTrieNodeV2>, StateProofError> {
+        targets: &mut [ProofTarget],
+    ) -> Result<Vec<ProofTrieNode>, StateProofError> {
         self.trie_cursor.reset();
         self.hashed_cursor.reset();
         self.proof_inner(value_encoder, targets)
@@ -1353,7 +1353,7 @@ where
     /// This method reuses the internal RLP encode buffer for efficiency.
     pub fn compute_root_hash(
         &mut self,
-        proof_nodes: &[ProofTrieNodeV2],
+        proof_nodes: &[ProofTrieNode],
     ) -> Result<Option<B256>, StateProofError> {
         // Find the root node (node at empty path)
         let root_node = proof_nodes.iter().find(|node| node.path.is_empty());
@@ -1375,16 +1375,13 @@ where
     /// This method does not accept targets nor retain proofs. Returns the root node which can
     /// be used to compute the root hash via [`Self::compute_root_hash`].
     #[instrument(target = TRACE_TARGET, level = "trace", skip(self, value_encoder))]
-    pub fn root_node(
-        &mut self,
-        value_encoder: &mut VE,
-    ) -> Result<ProofTrieNodeV2, StateProofError> {
+    pub fn root_node(&mut self, value_encoder: &mut VE) -> Result<ProofTrieNode, StateProofError> {
         // Initialize the variables which track the state of the two cursors. Both indicate the
         // cursors are unseeked.
         let mut trie_cursor_state = TrieCursorState::unseeked();
         let mut hashed_cursor_current: Option<(Nibbles, VE::DeferredEncoder)> = None;
 
-        static EMPTY_TARGETS: [ProofV2Target; 0] = [];
+        static EMPTY_TARGETS: [ProofTarget; 0] = [];
         let sub_trie_targets =
             SubTrieTargets { prefix: Nibbles::new(), targets: &EMPTY_TARGETS, retain_root: true };
 
@@ -1433,7 +1430,7 @@ where
 
     /// Generate a proof for a storage trie at the given hashed address.
     ///
-    /// Given a set of [`ProofV2Target`]s, returns nodes whose paths are a prefix of any target. The
+    /// Given a set of [`ProofTarget`]s, returns nodes whose paths are a prefix of any target. The
     /// returned nodes will be sorted depth-first by path.
     ///
     /// # Panics
@@ -1443,16 +1440,16 @@ where
     pub fn storage_proof(
         &mut self,
         hashed_address: B256,
-        targets: &mut [ProofV2Target],
-    ) -> Result<Vec<ProofTrieNodeV2>, StateProofError> {
+        targets: &mut [ProofTarget],
+    ) -> Result<Vec<ProofTrieNode>, StateProofError> {
         self.hashed_cursor.set_hashed_address(hashed_address);
 
         // Shortcut: check if storage is empty
         if self.hashed_cursor.is_storage_empty()? {
             // Return a single EmptyRoot node at the root path
-            return Ok(vec![ProofTrieNodeV2 {
+            return Ok(vec![ProofTrieNode {
                 path: Nibbles::default(),
-                node: TrieNodeV2::EmptyRoot,
+                node: TrieNode::EmptyRoot,
                 masks: None,
             }])
         }
@@ -1474,13 +1471,13 @@ where
     pub fn storage_root_node(
         &mut self,
         hashed_address: B256,
-    ) -> Result<ProofTrieNodeV2, StateProofError> {
+    ) -> Result<ProofTrieNode, StateProofError> {
         self.hashed_cursor.set_hashed_address(hashed_address);
 
         if self.hashed_cursor.is_storage_empty()? {
-            return Ok(ProofTrieNodeV2 {
+            return Ok(ProofTrieNode {
                 path: Nibbles::default(),
-                node: TrieNodeV2::EmptyRoot,
+                node: TrieNode::EmptyRoot,
                 masks: None,
             })
         }
@@ -1495,29 +1492,29 @@ where
     }
 }
 
-/// Helper type wrapping a slice of [`ProofV2Target`]s, primarily used to iterate through targets in
+/// Helper type wrapping a slice of [`ProofTarget`]s, primarily used to iterate through targets in
 /// [`ProofCalculator::should_retain`].
 ///
 /// It is assumed that the underlying slice is never empty, and that the iterator is never
 /// exhausted.
 struct TargetsCursor<'a> {
-    targets: &'a [ProofV2Target],
+    targets: &'a [ProofTarget],
     i: usize,
 }
 
 impl<'a> TargetsCursor<'a> {
-    /// Wraps a slice of [`ProofV2Target`]s with the `TargetsCursor`.
+    /// Wraps a slice of [`ProofTarget`]s with the `TargetsCursor`.
     ///
     /// # Panics
     ///
     /// Will panic in debug mode if called with an empty slice.
-    fn new(targets: &'a [ProofV2Target]) -> Self {
+    fn new(targets: &'a [ProofTarget]) -> Self {
         debug_assert!(!targets.is_empty());
         Self { targets, i: 0 }
     }
 
-    /// Returns the current and next [`ProofV2Target`] that the cursor is pointed at.
-    fn current(&self) -> (&'a ProofV2Target, Option<&'a ProofV2Target>) {
+    /// Returns the current and next [`ProofTarget`] that the cursor is pointed at.
+    fn current(&self) -> (&'a ProofTarget, Option<&'a ProofTarget>) {
         (&self.targets[self.i], self.targets.get(self.i + 1))
     }
 
@@ -1526,20 +1523,20 @@ impl<'a> TargetsCursor<'a> {
     /// # Panics
     ///
     /// Will panic if the cursor is exhausted.
-    fn next(&mut self) -> (&'a ProofV2Target, Option<&'a ProofV2Target>) {
+    fn next(&mut self) -> (&'a ProofTarget, Option<&'a ProofTarget>) {
         self.i += 1;
         debug_assert!(self.i < self.targets.len());
         self.current()
     }
 
-    // Iterate forwards over the slice, starting from the [`ProofV2Target`] after the current.
-    fn skip_iter(&self) -> impl Iterator<Item = &'a ProofV2Target> {
+    // Iterate forwards over the slice, starting from the [`ProofTarget`] after the current.
+    fn skip_iter(&self) -> impl Iterator<Item = &'a ProofTarget> {
         self.targets[self.i + 1..].iter()
     }
 
-    /// Iterated backwards over the slice, starting from the [`ProofV2Target`] previous to the
+    /// Iterated backwards over the slice, starting from the [`ProofTarget`] previous to the
     /// current.
-    fn rev_iter(&self) -> impl Iterator<Item = &'a ProofV2Target> {
+    fn rev_iter(&self) -> impl Iterator<Item = &'a ProofTarget> {
         self.targets[..self.i].iter().rev()
     }
 }
@@ -1658,26 +1655,26 @@ mod tests {
     use reth_primitives_traits::Account;
     use reth_trie_common::{
         updates::{StorageTrieUpdates, TrieUpdates},
-        HashedPostState, MultiProofTargets, ProofTrieNode, TrieNode,
+        HashedPostState, LegacyMultiProofTargets, LegacyProofTrieNode,
     };
 
     /// Target to use with the `tracing` crate.
     static TRACE_TARGET: &str = "trie::proof_v2::tests";
 
-    /// Converts legacy proofs to V2 proofs by combining extension nodes with their child branch
-    /// nodes.
+    /// Converts legacy proofs to merged proofs by combining extension nodes with their child
+    /// branch nodes.
     ///
-    /// In the legacy proof format, extension nodes and branch nodes are separate. In the V2 format,
-    /// they are combined into a single `BranchNodeV2` where the extension's key becomes the
+    /// In the legacy proof format, extension nodes and branch nodes are separate. In the merged
+    /// format, they are combined into a single `BranchNode` where the extension's key becomes the
     /// branch's `key` field.
     ///
-    /// Converts legacy proofs (sorted in depth-first order) to V2 format.
+    /// Converts legacy proofs (sorted in depth-first order) to merged format.
     ///
     /// In depth-first order, children come BEFORE parents. So when we encounter an extension node,
     /// its child branch has already been processed and is in the result. We need to pop it and
     /// combine it with the extension.
-    fn convert_legacy_proofs_to_v2(legacy_proofs: &[ProofTrieNode]) -> Vec<ProofTrieNodeV2> {
-        ProofTrieNodeV2::from_sorted_trie_nodes(
+    fn convert_to_merged_proofs(legacy_proofs: &[LegacyProofTrieNode]) -> Vec<ProofTrieNode> {
+        ProofTrieNode::from_sorted_trie_nodes(
             legacy_proofs.iter().map(|p| (p.path, p.node.clone(), p.masks)),
         )
     }
@@ -1742,17 +1739,17 @@ mod tests {
         /// the results.
         fn assert_proof(
             &self,
-            targets: impl IntoIterator<Item = ProofV2Target>,
+            targets: impl IntoIterator<Item = ProofTarget>,
         ) -> Result<(), StateProofError> {
             let targets_vec = targets.into_iter().collect::<Vec<_>>();
 
-            // Convert ProofV2Target keys to MultiProofTargets for legacy implementation
+            // Convert ProofTarget keys to LegacyMultiProofTargets for legacy implementation
             // For account-only proofs, each account maps to an empty storage set
             // Legacy implementation only uses the keys, not the prefix
             let legacy_targets = targets_vec
                 .iter()
                 .map(|target| (B256::from_slice(&target.key_nibbles.pack()), B256Set::default()))
-                .collect::<MultiProofTargets>();
+                .collect::<LegacyMultiProofTargets>();
 
             // Create ProofCalculator (proof_v2) with account cursors
             let trie_cursor = self.trie_cursor_factory.account_trie_cursor()?;
@@ -1771,12 +1768,12 @@ mod tests {
                 self.hashed_cursor_factory.clone(),
             );
             let mut proof_calculator = ProofCalculator::new(trie_cursor, hashed_cursor);
-            let proof_v2_result =
+            let proof_result =
                 proof_calculator.proof(&mut value_encoder, &mut targets_vec.clone())?;
 
             // Output metrics
-            trace!(target: TRACE_TARGET, ?trie_cursor_metrics, "V2 trie cursor metrics");
-            trace!(target: TRACE_TARGET, ?hashed_cursor_metrics, "V2 hashed cursor metrics");
+            trace!(target: TRACE_TARGET, ?trie_cursor_metrics, "trie cursor metrics");
+            trace!(target: TRACE_TARGET, ?hashed_cursor_metrics, "hashed cursor metrics");
 
             // Call Proof::multiproof (legacy implementation)
             let proof_legacy_result =
@@ -1784,8 +1781,8 @@ mod tests {
                     .with_branch_node_masks(true)
                     .with_added_removed_keys(Some(
                         // This will force the HashBuilder to always retain the child branch of all
-                        // extensions. We need this because in V2 extensions and branches are a
-                        // single node type, so child branches are always included with extensions.
+                        // extensions. We need this because extensions and branches are a single
+                        // node type, so child branches are always included with extensions.
                         AddedRemovedKeys::default().with_assume_added(true),
                     ))
                     .multiproof(legacy_targets)?;
@@ -1806,7 +1803,7 @@ mod tests {
                 .iter()
                 .map(|(path, node_enc)| {
                     let mut buf = node_enc.as_ref();
-                    let node = TrieNode::decode(&mut buf)
+                    let node = alloy_trie::nodes::TrieNode::decode(&mut buf)
                         .expect("legacy implementation should not produce malformed proof nodes");
 
                     // The legacy proof calculator will calculate masks for the root node, even
@@ -1817,23 +1814,24 @@ mod tests {
                         proof_legacy_result.branch_node_masks.get(path).copied()
                     };
 
-                    ProofTrieNode { path: *path, node, masks }
+                    LegacyProofTrieNode { path: *path, node, masks }
                 })
                 .sorted_by(|a, b| depth_first::cmp(&a.path, &b.path))
                 .collect::<Vec<_>>();
 
-            // Convert legacy proofs to V2 proofs by combining extensions with their child branches
-            let proof_legacy_nodes_v2 = convert_legacy_proofs_to_v2(&proof_legacy_nodes);
+            // Convert legacy proofs to merged proofs by combining extensions with their child
+            // branches
+            let proof_legacy_nodes_merged = convert_to_merged_proofs(&proof_legacy_nodes);
 
             // Filter to only keep nodes which match a target. We do this after conversion so we
             // don't keep branches whose extension parents are excluded due to a min_len.
-            let proof_legacy_nodes_v2 = proof_legacy_nodes_v2
+            let proof_legacy_nodes_merged = proof_legacy_nodes_merged
                 .into_iter()
-                .filter(|ProofTrieNodeV2 { path, .. }| node_matches_target(path))
+                .filter(|ProofTrieNode { path, .. }| node_matches_target(path))
                 .collect::<Vec<_>>();
 
             // Basic comparison: both should succeed and produce identical results
-            pretty_assertions::assert_eq!(proof_legacy_nodes_v2, proof_v2_result);
+            pretty_assertions::assert_eq!(proof_legacy_nodes_merged, proof_result);
 
             // Also test root_node - get a fresh calculator and verify it returns the root node
             // that hashes to the expected root
@@ -1894,7 +1892,7 @@ mod tests {
         /// and 20% random keys. Each target has a random `min_len` of 0..16.
         fn proof_targets_strategy(
             account_keys: Vec<B256>,
-        ) -> impl Strategy<Value = Vec<ProofV2Target>> {
+        ) -> impl Strategy<Value = Vec<ProofTarget>> {
             let num_accounts = account_keys.len();
 
             // Generate between 0 and (num_accounts + 5) targets
@@ -1915,7 +1913,7 @@ mod tests {
                         }),
                         0u8..16u8, // Random min_len from 0 to 15
                     )
-                        .prop_map(|(key, min_len)| ProofV2Target::new(key).with_min_len(min_len)),
+                        .prop_map(|(key, min_len)| ProofTarget::new(key).with_min_len(min_len)),
                     count,
                 )
             })
@@ -1983,9 +1981,9 @@ mod tests {
         // Create test harness
         let harness = ProofTestHarness::new(post_state);
 
-        // Assert the proof (convert B256 to ProofV2Target with no min_len for this test)
+        // Assert the proof (convert B256 to ProofTarget with no min_len for this test)
         harness
-            .assert_proof(targets.into_iter().map(ProofV2Target::new))
+            .assert_proof(targets.into_iter().map(ProofTarget::new))
             .expect("Proof generation failed");
     }
 
@@ -2390,15 +2388,15 @@ mod tests {
 
         // Create targets from test case input - these are Nibbles in hex form
         let targets = vec![
-            ProofV2Target::new(b256(
+            ProofTarget::new(b256(
                 "0153000000000000000000000000000000000000000000000000000000000000",
             ))
             .with_min_len(2),
-            ProofV2Target::new(b256(
+            ProofTarget::new(b256(
                 "0000000000000000000000000000000000000000000000000000000000000000",
             ))
             .with_min_len(2),
-            ProofV2Target::new(b256(
+            ProofTarget::new(b256(
                 "2300000000000000000000000000000000000000000000000000000000000000",
             ))
             .with_min_len(2),

--- a/crates/trie/trie/src/proof_v2/node.rs
+++ b/crates/trie/trie/src/proof_v2/node.rs
@@ -2,8 +2,8 @@ use crate::proof_v2::DeferredValueEncoder;
 use alloy_rlp::Encodable;
 use reth_execution_errors::trie::StateProofError;
 use reth_trie_common::{
-    BranchNodeMasks, BranchNodeV2, LeafNode, LeafNodeRef, Nibbles, ProofTrieNodeV2, RlpNode,
-    TrieMask, TrieNodeV2,
+    BranchNode, BranchNodeMasks, LeafNode, LeafNodeRef, Nibbles, ProofTrieNode, RlpNode, TrieMask,
+    TrieNode,
 };
 
 /// A trie node which is the child of a branch in the trie.
@@ -19,7 +19,7 @@ pub(crate) enum ProofTrieBranchChild<RF> {
     /// A branch node whose children have already been flattened into [`RlpNode`]s.
     Branch {
         /// The node itself, for use during RLP encoding.
-        node: BranchNodeV2,
+        node: BranchNode,
         /// Bitmasks carried over from cached `BranchNodeCompact` values, if any.
         masks: Option<BranchNodeMasks>,
     },
@@ -67,7 +67,7 @@ impl<RF: DeferredValueEncoder> ProofTrieBranchChild<RF> {
         }
     }
 
-    /// Converts this child into a [`ProofTrieNodeV2`] having the given path.
+    /// Converts this child into a [`ProofTrieNode`] having the given path.
     ///
     /// # Panics
     ///
@@ -76,7 +76,7 @@ impl<RF: DeferredValueEncoder> ProofTrieBranchChild<RF> {
         self,
         path: Nibbles,
         buf: &mut Vec<u8>,
-    ) -> Result<ProofTrieNodeV2, StateProofError> {
+    ) -> Result<ProofTrieNode, StateProofError> {
         let (node, masks) = match self {
             Self::Leaf { short_key, value } => {
                 value.encode(buf)?;
@@ -88,13 +88,13 @@ impl<RF: DeferredValueEncoder> ProofTrieBranchChild<RF> {
                 // this value, and the passed in buffer can remain with whatever large capacity it
                 // already has.
                 let rlp_val = buf.clone();
-                (TrieNodeV2::Leaf(LeafNode::new(short_key, rlp_val)), None)
+                (TrieNode::Leaf(LeafNode::new(short_key, rlp_val)), None)
             }
-            Self::Branch { node, masks } => (TrieNodeV2::Branch(node), masks),
+            Self::Branch { node, masks } => (TrieNode::Branch(node), masks),
             Self::RlpNode(_) => panic!("Cannot call `into_proof_trie_node` on RlpNode"),
         };
 
-        Ok(ProofTrieNodeV2 { node, path, masks })
+        Ok(ProofTrieNode { node, path, masks })
     }
 
     /// Returns the short key of the child, if it is a leaf or branch, or empty if its a
@@ -102,7 +102,7 @@ impl<RF: DeferredValueEncoder> ProofTrieBranchChild<RF> {
     pub(crate) fn short_key(&self) -> &Nibbles {
         match self {
             Self::Leaf { short_key, .. } |
-            Self::Branch { node: BranchNodeV2 { key: short_key, .. }, .. } => short_key,
+            Self::Branch { node: BranchNode { key: short_key, .. }, .. } => short_key,
             Self::RlpNode(_) => {
                 static EMPTY_NIBBLES: Nibbles = Nibbles::new();
                 &EMPTY_NIBBLES
@@ -125,7 +125,7 @@ impl<RF: DeferredValueEncoder> ProofTrieBranchChild<RF> {
             Self::Leaf { short_key, .. } => {
                 *short_key = trim_nibbles_prefix(short_key, len);
             }
-            Self::Branch { node: BranchNodeV2 { key, branch_rlp_node, .. }, .. } => {
+            Self::Branch { node: BranchNode { key, branch_rlp_node, .. }, .. } => {
                 *key = trim_nibbles_prefix(key, len);
                 if key.is_empty() {
                     *branch_rlp_node = None;

--- a/crates/trie/trie/src/proof_v2/target.rs
+++ b/crates/trie/trie/src/proof_v2/target.rs
@@ -1,5 +1,5 @@
 use crate::proof_v2::increment_and_strip_trailing_zeros;
-use reth_trie_common::{Nibbles, ProofV2Target};
+use reth_trie_common::{Nibbles, ProofTarget};
 
 // A helper function for getting the largest prefix of the sub-trie which contains a particular
 // target, based on its `min_len`.
@@ -20,7 +20,7 @@ use reth_trie_common::{Nibbles, ProofV2Target};
 // `min_len` of both 0 and 1 will therefore construct the root node, but only those with
 // `min_len` of 0 will retain it.
 #[inline]
-pub(crate) fn sub_trie_prefix(target: &ProofV2Target) -> Nibbles {
+pub(crate) fn sub_trie_prefix(target: &ProofTarget) -> Nibbles {
     let mut sub_trie_prefix = target.key_nibbles;
     sub_trie_prefix.truncate(target.min_len.saturating_sub(1) as usize);
     sub_trie_prefix
@@ -40,7 +40,7 @@ pub(crate) struct SubTrieTargets<'a> {
     pub(crate) prefix: Nibbles,
     /// The targets belonging to this sub-trie. These will be sorted by their `key` field,
     /// lexicographically.
-    pub(crate) targets: &'a [ProofV2Target],
+    pub(crate) targets: &'a [ProofTarget],
     /// Will be true if at least one target in the set has a zero `min_len`.
     ///
     /// If this is true then `prefix.is_empty()`, though not necessarily vice-versa.
@@ -55,10 +55,10 @@ impl<'a> SubTrieTargets<'a> {
     }
 }
 
-/// Given a set of [`ProofV2Target`]s, returns an iterator over those same [`ProofV2Target`]s
+/// Given a set of [`ProofTarget`]s, returns an iterator over those same [`ProofTarget`]s
 /// chunked by the sub-tries they apply to within the overall trie.
 pub(crate) fn iter_sub_trie_targets(
-    targets: &mut [ProofV2Target],
+    targets: &mut [ProofTarget],
 ) -> impl Iterator<Item = SubTrieTargets<'_>> {
     // First sort by the sub-trie prefix of each target, falling back to the `min_len` in cases
     // where the sub-trie prefixes are equal (to differentiate targets which match the root node and
@@ -131,7 +131,7 @@ mod tests {
             (vec![], vec![]),
             // Case 2: Single target without min_len
             (
-                vec![ProofV2Target::new(B256::repeat_byte(0x20))],
+                vec![ProofTarget::new(B256::repeat_byte(0x20))],
                 vec![(
                     "",
                     vec!["2020202020202020202020202020202020202020202020202020202020202020"],
@@ -140,8 +140,8 @@ mod tests {
             // Case 3: Multiple targets in same sub-trie (no min_len)
             (
                 vec![
-                    ProofV2Target::new(B256::repeat_byte(0x20)),
-                    ProofV2Target::new(B256::repeat_byte(0x21)),
+                    ProofTarget::new(B256::repeat_byte(0x20)),
+                    ProofTarget::new(B256::repeat_byte(0x21)),
                 ],
                 vec![(
                     "",
@@ -154,8 +154,8 @@ mod tests {
             // Case 4: Multiple targets in different sub-tries
             (
                 vec![
-                    ProofV2Target::new(B256::repeat_byte(0x20)).with_min_len(2),
-                    ProofV2Target::new(B256::repeat_byte(0x40)).with_min_len(2),
+                    ProofTarget::new(B256::repeat_byte(0x20)).with_min_len(2),
+                    ProofTarget::new(B256::repeat_byte(0x40)).with_min_len(2),
                 ],
                 vec![
                     ("2", vec!["2020202020202020202020202020202020202020202020202020202020202020"]),
@@ -165,9 +165,9 @@ mod tests {
             // Case 5: Three targets, two in same sub-trie, one separate
             (
                 vec![
-                    ProofV2Target::new(B256::repeat_byte(0x20)).with_min_len(2),
-                    ProofV2Target::new(B256::repeat_byte(0x2f)).with_min_len(2),
-                    ProofV2Target::new(B256::repeat_byte(0x40)).with_min_len(2),
+                    ProofTarget::new(B256::repeat_byte(0x20)).with_min_len(2),
+                    ProofTarget::new(B256::repeat_byte(0x2f)).with_min_len(2),
+                    ProofTarget::new(B256::repeat_byte(0x40)).with_min_len(2),
                 ],
                 vec![
                     (
@@ -183,8 +183,8 @@ mod tests {
             // Case 6: Targets with different min_len values in same sub-trie
             (
                 vec![
-                    ProofV2Target::new(B256::repeat_byte(0x20)).with_min_len(2),
-                    ProofV2Target::new(B256::repeat_byte(0x2f)).with_min_len(3),
+                    ProofTarget::new(B256::repeat_byte(0x20)).with_min_len(2),
+                    ProofTarget::new(B256::repeat_byte(0x2f)).with_min_len(3),
                 ],
                 vec![(
                     "2",
@@ -197,11 +197,11 @@ mod tests {
             // Case 7: More complex chunking with multiple sub-tries
             (
                 vec![
-                    ProofV2Target::new(B256::repeat_byte(0x20)).with_min_len(2),
-                    ProofV2Target::new(B256::repeat_byte(0x2f)).with_min_len(4),
-                    ProofV2Target::new(B256::repeat_byte(0x4c)).with_min_len(3),
-                    ProofV2Target::new(B256::repeat_byte(0x4c)).with_min_len(4),
-                    ProofV2Target::new(B256::repeat_byte(0x4e)).with_min_len(3),
+                    ProofTarget::new(B256::repeat_byte(0x20)).with_min_len(2),
+                    ProofTarget::new(B256::repeat_byte(0x2f)).with_min_len(4),
+                    ProofTarget::new(B256::repeat_byte(0x4c)).with_min_len(3),
+                    ProofTarget::new(B256::repeat_byte(0x4c)).with_min_len(4),
+                    ProofTarget::new(B256::repeat_byte(0x4e)).with_min_len(3),
                 ],
                 vec![
                     (
@@ -227,8 +227,8 @@ mod tests {
             // Case 8: Min-len 1 should result in zero-length sub-trie prefix
             (
                 vec![
-                    ProofV2Target::new(B256::repeat_byte(0x20)).with_min_len(1),
-                    ProofV2Target::new(B256::repeat_byte(0x40)).with_min_len(1),
+                    ProofTarget::new(B256::repeat_byte(0x20)).with_min_len(1),
+                    ProofTarget::new(B256::repeat_byte(0x40)).with_min_len(1),
                 ],
                 vec![(
                     "",
@@ -241,8 +241,8 @@ mod tests {
             // Case 9: Second target's sub-trie prefix is root
             (
                 vec![
-                    ProofV2Target::new(B256::repeat_byte(0x20)).with_min_len(2),
-                    ProofV2Target::new(B256::repeat_byte(0x40)).with_min_len(1),
+                    ProofTarget::new(B256::repeat_byte(0x20)).with_min_len(2),
+                    ProofTarget::new(B256::repeat_byte(0x40)).with_min_len(1),
                 ],
                 vec![(
                     "",

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -19,7 +19,7 @@ use reth_execution_errors::{
     SparseStateTrieErrorKind, SparseTrieError, SparseTrieErrorKind, StateProofError,
     TrieWitnessError,
 };
-use reth_trie_common::{MultiProofTargets, Nibbles};
+use reth_trie_common::{LegacyMultiProofTargets, Nibbles};
 use reth_trie_sparse::{
     provider::{RevealedNode, TrieNodeProvider, TrieNodeProviderFactory},
     SparseStateTrie,
@@ -111,7 +111,7 @@ where
         }
 
         let proof_targets = if is_state_empty {
-            MultiProofTargets::account(B256::ZERO)
+            LegacyMultiProofTargets::account(B256::ZERO)
         } else {
             self.get_proof_targets(&state)?
         };
@@ -210,8 +210,8 @@ where
     fn get_proof_targets(
         &self,
         state: &HashedPostState,
-    ) -> Result<MultiProofTargets, StateProofError> {
-        let mut proof_targets = MultiProofTargets::default();
+    ) -> Result<LegacyMultiProofTargets, StateProofError> {
+        let mut proof_targets = LegacyMultiProofTargets::default();
         for hashed_address in state.accounts.keys() {
             proof_targets.insert(*hashed_address, B256Set::default());
         }


### PR DESCRIPTION
## Summary
Drop V2 suffix from all trie proof types now that legacy proof code paths have been superseded. Rebased on latest main.

## Changes
- `TrieNodeV2` → `TrieNode`, `BranchNodeV2` → `BranchNode`
- `ProofTrieNodeV2` → `ProofTrieNode`
- `DecodedMultiProofV2` → `DecodedMultiProof`
- `ProofV2Target` → `ProofTarget`
- `MultiProofTargetsV2` → `MultiProofTargets`, `ChunkedMultiProofTargetsV2` → `ChunkedMultiProofTargets`
- `target_v2` module → `target`, `trie_node_v2` module → `trie_node`
- `multiproof_v2` → `multiproof_leaf_only`
- All `_v2` method suffixes dropped (`reveal_decoded_multiproof_v2` → `reveal_decoded_multiproof`, etc.)
- Old conflicting types renamed with `Legacy` prefix (`LegacyDecodedMultiProof`, `LegacyProofTrieNode`, `LegacyMultiProofTargets`)
- Alloy's `TrieNode`/`BranchNode` no longer glob re-exported from `reth_trie_common` to avoid name conflicts — use `alloy_trie::nodes::TrieNode` directly where needed

## Testing
`cargo test -p reth-trie-common -p reth-trie -p reth-trie-sparse -p reth-trie-parallel --lib` — all 150 tests pass.

Prompted by: alexey