### PR TITLE
fix(storage): return early in RocksDB healing when checkpoint is 0

### DIFF
--- a/crates/storage/provider/src/providers/rocksdb/invariants.rs
+++ b/crates/storage/provider/src/providers/rocksdb/invariants.rs
@@ -112,7 +112,7 @@ impl RocksDBProvider {
             .get_highest_static_file_block(StaticFileSegment::Transactions)
             .unwrap_or(0);
 
-        // Fast path: nothing has been indexed yet — clear any stale data and return.
+        // Fast path: clear any stale data and return.
         if checkpoint == 0 {
             tracing::info!(
                 target: "reth::providers::rocksdb",
@@ -264,7 +264,7 @@ impl RocksDBProvider {
             .map(|cp| cp.block_number)
             .unwrap_or(0);
 
-        // Fast path: nothing has been indexed yet — clear any stale data and return.
+        // Fast path: clear any stale data and return.
         if checkpoint == 0 {
             tracing::info!(
                 target: "reth::providers::rocksdb",
@@ -358,7 +358,7 @@ impl RocksDBProvider {
             .map(|cp| cp.block_number)
             .unwrap_or(0);
 
-        // Fast path: nothing has been indexed yet — clear any stale data and return.
+        // Fast path: clear any stale data and return.
         if checkpoint == 0 {
             tracing::info!(
                 target: "reth::providers::rocksdb",

--- a/crates/storage/provider/src/providers/rocksdb/invariants.rs
+++ b/crates/storage/provider/src/providers/rocksdb/invariants.rs
@@ -506,8 +506,8 @@ mod tests {
         assert_eq!(result, None);
     }
 
-    /// Tests that checkpoint=0 with empty RocksDB returns early without attempting
-    /// an expensive healing loop. Previously, when sf_tip > checkpoint=0, the healer
+    /// Tests that `checkpoint=0` with empty `RocksDB` returns early without attempting
+    /// an expensive healing loop. Previously, when `sf_tip` > `checkpoint=0`, the healer
     /// would iterate billions of transactions from static files for no effect, causing
     /// the node to hang on startup with MDBX read transaction timeouts.
     #[test]

--- a/crates/storage/provider/src/providers/rocksdb/invariants.rs
+++ b/crates/storage/provider/src/providers/rocksdb/invariants.rs
@@ -114,6 +114,10 @@ impl RocksDBProvider {
 
         // Fast path: nothing has been indexed yet — clear any stale data and return.
         if checkpoint == 0 {
+            tracing::info!(
+                target: "reth::providers::rocksdb",
+                "TransactionHashNumbers: checkpoint is 0, clearing stale data"
+            );
             self.clear::<tables::TransactionHashNumbers>()?;
             return Ok(None);
         }
@@ -262,6 +266,10 @@ impl RocksDBProvider {
 
         // Fast path: nothing has been indexed yet — clear any stale data and return.
         if checkpoint == 0 {
+            tracing::info!(
+                target: "reth::providers::rocksdb",
+                "StoragesHistory: checkpoint is 0, clearing stale data"
+            );
             self.clear::<tables::StoragesHistory>()?;
             return Ok(None);
         }
@@ -352,6 +360,10 @@ impl RocksDBProvider {
 
         // Fast path: nothing has been indexed yet — clear any stale data and return.
         if checkpoint == 0 {
+            tracing::info!(
+                target: "reth::providers::rocksdb",
+                "AccountsHistory: checkpoint is 0, clearing stale data"
+            );
             self.clear::<tables::AccountsHistory>()?;
             return Ok(None);
         }

--- a/crates/storage/provider/src/providers/rocksdb/invariants.rs
+++ b/crates/storage/provider/src/providers/rocksdb/invariants.rs
@@ -87,7 +87,7 @@ impl RocksDBProvider {
 
     /// Heals the `TransactionHashNumbers` table.
     ///
-    /// - Fast path: if checkpoint == 0 AND `RocksDB` has data, clear everything
+    /// - Fast path: if checkpoint == 0, clear any stale data and return
     /// - If `sf_tip` < checkpoint, return unwind target (static files behind)
     /// - If `sf_tip` == checkpoint, nothing to do
     /// - If `sf_tip` > checkpoint, heal via transaction ranges in batches
@@ -112,12 +112,8 @@ impl RocksDBProvider {
             .get_highest_static_file_block(StaticFileSegment::Transactions)
             .unwrap_or(0);
 
-        // Fast path: if checkpoint is 0 and RocksDB has data, clear everything.
-        if checkpoint == 0 && self.first::<tables::TransactionHashNumbers>()?.is_some() {
-            tracing::info!(
-                target: "reth::providers::rocksdb",
-                "TransactionHashNumbers has data but checkpoint is 0, clearing all"
-            );
+        // Fast path: nothing has been indexed yet — clear any stale data and return.
+        if checkpoint == 0 {
             self.clear::<tables::TransactionHashNumbers>()?;
             return Ok(None);
         }
@@ -264,12 +260,8 @@ impl RocksDBProvider {
             .map(|cp| cp.block_number)
             .unwrap_or(0);
 
-        // Fast path: if checkpoint is 0 and RocksDB has data, clear everything.
-        if checkpoint == 0 && self.first::<tables::StoragesHistory>()?.is_some() {
-            tracing::info!(
-                target: "reth::providers::rocksdb",
-                "StoragesHistory has data but checkpoint is 0, clearing all"
-            );
+        // Fast path: nothing has been indexed yet — clear any stale data and return.
+        if checkpoint == 0 {
             self.clear::<tables::StoragesHistory>()?;
             return Ok(None);
         }
@@ -358,12 +350,8 @@ impl RocksDBProvider {
             .map(|cp| cp.block_number)
             .unwrap_or(0);
 
-        // Fast path: if checkpoint is 0 and RocksDB has data, clear everything.
-        if checkpoint == 0 && self.first::<tables::AccountsHistory>()?.is_some() {
-            tracing::info!(
-                target: "reth::providers::rocksdb",
-                "AccountsHistory has data but checkpoint is 0, clearing all"
-            );
+        // Fast path: nothing has been indexed yet — clear any stale data and return.
+        if checkpoint == 0 {
             self.clear::<tables::AccountsHistory>()?;
             return Ok(None);
         }
@@ -504,6 +492,35 @@ mod tests {
         // Empty RocksDB and no checkpoints - should be consistent (None = no unwind needed)
         let result = rocksdb.check_consistency(&provider).unwrap();
         assert_eq!(result, None);
+    }
+
+    /// Tests that checkpoint=0 with empty RocksDB returns early without attempting
+    /// an expensive healing loop. Previously, when sf_tip > checkpoint=0, the healer
+    /// would iterate billions of transactions from static files for no effect, causing
+    /// the node to hang on startup with MDBX read transaction timeouts.
+    #[test]
+    fn test_check_consistency_checkpoint_zero_empty_rocksdb_returns_early() {
+        let temp_dir = TempDir::new().unwrap();
+        let rocksdb = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(StorageSettings::v2());
+
+        // No checkpoints set — all default to 0 via unwrap_or(0).
+        // RocksDB tables are empty.
+        let provider = factory.database_provider_ro().unwrap();
+
+        let result = rocksdb.heal_transaction_hash_numbers(&provider).unwrap();
+        assert_eq!(result, None, "TransactionHashNumbers should return early at checkpoint 0");
+        assert!(rocksdb.first::<tables::TransactionHashNumbers>().unwrap().is_none());
+
+        let result = rocksdb.heal_storages_history(&provider).unwrap();
+        assert_eq!(result, None, "StoragesHistory should return early at checkpoint 0");
+        assert!(rocksdb.first::<tables::StoragesHistory>().unwrap().is_none());
+
+        let result = rocksdb.heal_accounts_history(&provider).unwrap();
+        assert_eq!(result, None, "AccountsHistory should return early at checkpoint 0");
+        assert!(rocksdb.first::<tables::AccountsHistory>().unwrap().is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix infinite healing loop on startup when RocksDB tables are empty and checkpoint is 0 but static files are ahead.

## Motivation

Reported by ethstaker Discord users after upgrading to v1.11.x. When `checkpoint=0` and the RocksDB `TransactionHashNumbers` table is empty but static files have data (e.g. `sf_tip=24500954`, `sf_tip_end_tx=3279227181`), the healer falls through to an expensive loop that iterates 3.2B transactions in 10k batches, deleting nothing. The MDBX read transaction times out after 5 minutes (`error code -96000`), the node crashes, and the loop restarts indefinitely.

The same pattern exists in `StoragesHistory` and `AccountsHistory` healers.

## Changes

- All three RocksDB healers (`TransactionHashNumbers`, `StoragesHistory`, `AccountsHistory`) now unconditionally return early when `checkpoint == 0`. `clear()` on an empty table is a no-op.
- Added test covering checkpoint=0 with empty RocksDB.

## Testing

```
cargo test -p reth-provider --features rocksdb -- check_consistency
```

All 18 invariant tests pass.

Prompted by: alexey