### PR TITLE
fix(rpc): add missing `apply_pre_execution_changes` in `debug_traceCallMany`

### DIFF
--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -436,6 +436,8 @@ where
                 if replay_block_txs {
                     // only need to replay the transactions in the block if not all transactions are
                     // to be replayed
+                    eth_api.apply_pre_execution_changes(&block, &mut db)?;
+
                     let transactions = block.transactions_recovered().take(num_txs);
 
                     // Execute all transactions until index


### PR DESCRIPTION
`debug_trace_call_many` replays block transactions from parent state when `replay_block_txs` is true, but was missing the `apply_pre_execution_changes` call. The sibling function `debug_trace_call_at_tx_index` in the same file correctly includes this step with a numbered comment "1. apply pre-execution changes", confirming it was an oversight. Without it, EIP-4788 beacon root and EIP-2935 block hash history are not set up, so any traced call that depends on system contract state can produce incorrect results on post-Cancun blocks.
