### PR TITLE
feat(reth-bench): support benchmarking via rlp blocks

### DIFF
--- a/bin/reth-bench/src/bench/context.rs
+++ b/bin/reth-bench/src/bench/context.rs
@@ -31,6 +31,8 @@ pub(crate) struct BenchContext {
     pub(crate) is_optimism: bool,
     /// Whether to use `reth_newPayload` endpoint instead of `engine_newPayload*`.
     pub(crate) use_reth_namespace: bool,
+    /// Whether to fetch and replay RLP-encoded blocks.
+    pub(crate) rlp_blocks: bool,
 }
 
 impl BenchContext {
@@ -142,7 +144,8 @@ impl BenchContext {
         };
 
         let next_block = first_block.header.number + 1;
-        let use_reth_namespace = bench_args.reth_new_payload;
+        let rlp_blocks = bench_args.rlp_blocks;
+        let use_reth_namespace = bench_args.reth_new_payload || rlp_blocks;
         Ok(Self {
             auth_provider,
             block_provider,
@@ -150,6 +153,7 @@ impl BenchContext {
             next_block,
             is_optimism,
             use_reth_namespace,
+            rlp_blocks,
         })
     }
 }

--- a/bin/reth-bench/src/bench/output.rs
+++ b/bin/reth-bench/src/bench/output.rs
@@ -22,14 +22,14 @@ pub(crate) const NEW_PAYLOAD_OUTPUT_SUFFIX: &str = "new_payload_latency.csv";
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct GasRampPayloadFile {
     /// Engine API version (1-5).
-    pub(crate) version: u8,
+    ///
+    /// `None` indicates that `reth_newPayload` should be used.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) version: Option<u8>,
     /// The block hash for FCU.
     pub(crate) block_hash: B256,
     /// The params to pass to newPayload.
     pub(crate) params: serde_json::Value,
-    /// The execution data for `reth_newPayload`.
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub(crate) execution_data: Option<alloy_rpc_types_engine::ExecutionData>,
 }
 
 /// This represents the results of a single `newPayload` call in the benchmark, containing the gas

--- a/crates/node/core/src/args/benchmark_args.rs
+++ b/crates/node/core/src/args/benchmark_args.rs
@@ -78,6 +78,10 @@ pub struct BenchmarkArgs {
     /// and returns server-side timing breakdowns (latency, persistence wait, cache wait).
     #[arg(long, default_value = "false", verbatim_doc_comment)]
     pub reth_new_payload: bool,
+
+    /// Fetch and replay RLP-encoded blocks. Implies `reth_new_payload`.
+    #[arg(long, default_value = "false", verbatim_doc_comment)]
+    pub rlp_blocks: bool,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
adds `--rlp-blocks` flag that configures reth-bench to fetch RLP-encoded blocks via `debug_getRawBlock` and use them as input to `reth_newPayload`