### PR TITLE
fix: default finalized and safe block to genesis on fresh node

### DIFF
--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -90,7 +90,8 @@ impl<N: ProviderNodeTypes> BlockchainProvider<N> {
             .last_finalized_block_number()?
             .map(|num| provider.sealed_header(num))
             .transpose()?
-            .flatten();
+            .flatten()
+            .or(provider.sealed_header(0)?);
         let safe_header = provider
             .last_safe_block_number()?
             .or_else(|| {
@@ -100,7 +101,8 @@ impl<N: ProviderNodeTypes> BlockchainProvider<N> {
             })
             .map(|num| provider.sealed_header(num))
             .transpose()?
-            .flatten();
+            .flatten()
+            .or(provider.sealed_header(0)?);
         Ok(Self {
             database: storage,
             canonical_in_memory_state: CanonicalInMemoryState::with_head(

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -19,7 +19,7 @@ use reth_chain_state::{
     BlockState, CanonicalInMemoryState, ForkChoiceNotifications, ForkChoiceSubscriptions,
     MemoryOverlayStateProvider, PersistedBlockNotifications, PersistedBlockSubscriptions,
 };
-use reth_chainspec::ChainInfo;
+use reth_chainspec::{ChainInfo, EthChainSpec};
 use reth_db_api::models::{AccountBeforeTx, BlockNumberAddress, StoredBlockBodyIndices};
 use reth_execution_types::ExecutionOutcome;
 use reth_node_types::{BlockTy, HeaderTy, NodeTypesWithDB, ReceiptTy, TxTy};
@@ -86,12 +86,13 @@ impl<N: ProviderNodeTypes> BlockchainProvider<N> {
         latest: SealedHeader<HeaderTy<N>>,
     ) -> ProviderResult<Self> {
         let provider = storage.provider()?;
+        let genesis_num = storage.chain_spec().genesis().number.unwrap_or_default();
         let finalized_header = provider
             .last_finalized_block_number()?
+            .or(Some(genesis_num))
             .map(|num| provider.sealed_header(num))
             .transpose()?
-            .flatten()
-            .or(provider.sealed_header(0)?);
+            .flatten();
         let safe_header = provider
             .last_safe_block_number()?
             .or_else(|| {
@@ -99,10 +100,10 @@ impl<N: ProviderNodeTypes> BlockchainProvider<N> {
                 // safe block
                 provider.last_finalized_block_number().ok().flatten()
             })
+            .or(Some(genesis_num))
             .map(|num| provider.sealed_header(num))
             .transpose()?
-            .flatten()
-            .or(provider.sealed_header(0)?);
+            .flatten();
         Ok(Self {
             database: storage,
             canonical_in_memory_state: CanonicalInMemoryState::with_head(


### PR DESCRIPTION
## Summary
On a fresh node, `finalized_block_num_hash()` and `safe_block_num_hash()` return `None` because the `ChainState` table has no entries yet. This defaults both to the genesis header (block 0) when no prior FCU has been received.

## Changes
- Fall back to `sealed_header(0)` for finalized and safe headers in `BlockchainProvider::with_latest` when the DB has no stored value.

## Testing
`cargo test -p reth-provider` — 103 tests pass.

Prompted by: joshie