### PR TITLE
chore(bench): include core count in Slack notification when non-default

### DIFF
--- a/.github/scripts/bench-slack-notify.js
+++ b/.github/scripts/bench-slack-notify.js
@@ -118,9 +118,12 @@ function buildSuccessBlocks({ summary, prNumber, actor, actorSlackId, jobUrl, re
   if (fl2) featureLine += ` | <${fl2}|Samply 2>`;
 
   const warmup = summary.warmup_blocks || process.env.BENCH_WARMUP_BLOCKS || '';
-  const countsLine = warmup
-    ? `*Warmup:* ${warmup} | *Blocks:* ${summary.blocks}`
-    : `*Blocks:* ${summary.blocks}`;
+  const cores = process.env.BENCH_CORES || '0';
+  const countsParts = [];
+  if (warmup) countsParts.push(`*Warmup:* ${warmup}`);
+  countsParts.push(`*Blocks:* ${summary.blocks}`);
+  if (cores !== '0') countsParts.push(`*Cores:* ${cores}`);
+  const countsLine = countsParts.join(' | ');
 
   const sectionText = [metaParts.join(' | '), '', baselineLine, featureLine, countsLine].join('\n');
 


### PR DESCRIPTION
## Summary
Show the number of CPU cores in the bench Slack message when a non-default value is used (i.e. `cores != 0`). This makes it clear when benchmarks were run with restricted cores.

## Changes
- Read `BENCH_CORES` env var in `bench-slack-notify.js`
- Append `*Cores:* N` to the info line when cores is not `0` (all available)

Prompted by: alexey