### PR TITLE
chore(reth): bump revm 35

### DIFF
--- a/.changelog/vain-birds-laugh.md
+++ b/.changelog/vain-birds-laugh.md
@@ -1,0 +1,14 @@
+---
+reth-engine-tree: patch
+reth-evm-ethereum: patch
+reth-evm: patch
+reth-primitives-traits: patch
+reth-revm: patch
+reth-rpc-eth-api: patch
+reth-rpc-eth-types: patch
+reth-provider: patch
+example-custom-evm: patch
+example-precompile-cache: patch
+---
+
+Bumped revm to v35.0.0, revm-inspectors to 0.35.0, and alloy-evm to 0.29.0. Updated call sites throughout the codebase to align with the new APIs, including `ExecutionResult` field changes (`gas_used` → `gas.used()`/`gas.final_refunded()`), removal of `.without_state_clear()`, updated `EthPrecompiles::new(spec)` constructor, and updated `block_hashes.lowest()` access.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13972,8 +13972,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "alloy-op-evm"
-version = "0.27.2"
-source = "git+https://github.com/alloy-rs/evm?rev=417bed0b409f233ca594b4e44deade881da2788e#417bed0b409f233ca594b4e44deade881da2788e"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,8 +289,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.27.2"
-source = "git+https://github.com/alloy-rs/evm?rev=be4208d07e33a4816769dd588821bbd57ad1f40c#be4208d07e33a4816769dd588821bbd57ad1f40c"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c987d1ed9d961097ebf881a86a35a2b8adc5cf4625c3a1286c721e07b585d85"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2023,9 +2024,9 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "2.1.5"
+version = "2.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e00bf4b112b07b505472dbefd19e37e53307e2bfed5a79e0cc161d58ccd0e687"
+checksum = "1a0f582957c24870b7bfd12bf562c40b4734b533cafbaf8ded31d6d85f462c01"
 dependencies = [
  "arbitrary",
  "blst",
@@ -2286,9 +2287,7 @@ dependencies = [
  "codspeed",
  "codspeed-criterion-compat-walltime",
  "colored",
- "futures",
  "regex",
- "tokio",
 ]
 
 [[package]]
@@ -2303,7 +2302,6 @@ dependencies = [
  "clap",
  "codspeed",
  "criterion-plot",
- "futures",
  "is-terminal",
  "itertools 0.10.5",
  "num-traits",
@@ -2316,7 +2314,6 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tinytemplate",
- "tokio",
  "walkdir",
 ]
 
@@ -2656,6 +2653,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -3437,7 +3443,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4252,8 +4258,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -4768,7 +4774,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tokio",
  "tower-service",
  "tracing",
@@ -4786,7 +4792,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5138,7 +5144,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6104,7 +6110,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6311,9 +6317,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "op-alloy"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9b8fee21003dd4f076563de9b9d26f8c97840157ef78593cd7f262c5ca99848"
+checksum = "a95dd0974d5e60ffe9342a70cc0033d299244fab01cb16a958eb7352ddba1fa7"
 dependencies = [
  "op-alloy-consensus",
  "op-alloy-network",
@@ -6324,9 +6330,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736381a95471d23e267263cfcee9e1d96d30b9754a94a2819148f83379de8a86"
+checksum = "fadcb964b0aa645d12e952d470c7585d23286d8bcf1ac41589410b6724216b68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6344,9 +6350,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-network"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4034183dca6bff6632e7c24c92e75ff5f0eabb58144edb4d8241814851334d47"
+checksum = "c8ea44162d493219cc678aaca1253d46c3aa73aa361326dfa9d406f086dfa135"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -6360,9 +6366,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-provider"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6753d90efbaa8ea8bcb89c1737408ca85fa60d7adb875049d3f382c063666f86"
+checksum = "83aa8dc34bdf077c8e6d48ff75beff4ac14b428d982c9722483ccd7473c0e114"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -6375,9 +6381,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd87c6b9e5b6eee8d6b76f41b04368dca0e9f38d83338e5b00e730c282098a4"
+checksum = "be9d16ec9f7810e0623a37edc293d1c05fe9c58a5647f6973fdd93e0b4795015"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6394,9 +6400,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types-engine"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727699310a18cdeed32da3928c709e2704043b6584ed416397d5da65694efc"
+checksum = "2c0ac5c5ddcbffadcd097d278c717d34849bcc629f6e4f8514eb000ec862def8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6416,8 +6422,9 @@ dependencies = [
 
 [[package]]
 name = "op-revm"
-version = "15.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=6ef10066478605c2c5029fbbdea6ec197b20a269#6ef10066478605c2c5029fbbdea6ec197b20a269"
+version = "16.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8929cc941fd6953a6fc3e3c62542f4f554189ea277b4b8207f5d2679a9e3d53"
 dependencies = [
  "auto_impl",
  "revm",
@@ -7070,7 +7077,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7107,9 +7114,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7659,7 +7666,6 @@ dependencies = [
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
- "codspeed-criterion-compat",
  "derive_more",
  "metrics",
  "parking_lot",
@@ -7943,7 +7949,6 @@ dependencies = [
  "alloy-primitives",
  "arbitrary",
  "assert_matches",
- "codspeed-criterion-compat",
  "derive_more",
  "eyre",
  "metrics",
@@ -8308,7 +8313,6 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "assert_matches",
- "codspeed-criterion-compat",
  "crossbeam-channel",
  "derive_more",
  "eyre",
@@ -8737,8 +8741,6 @@ dependencies = [
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rpc-types-engine",
- "derive_more",
- "parking_lot",
  "reth-chainspec",
  "reth-ethereum-forks",
  "reth-ethereum-primitives",
@@ -8946,11 +8948,10 @@ version = "1.11.1"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
- "codspeed-criterion-compat",
+ "crossbeam-queue",
  "dashmap",
  "derive_more",
  "parking_lot",
- "rand 0.9.2",
  "reth-mdbx-sys",
  "smallvec",
  "tempfile",
@@ -9010,7 +9011,6 @@ dependencies = [
  "alloy-rlp",
  "aquamarine",
  "auto_impl",
- "codspeed-criterion-compat",
  "derive_more",
  "discv5",
  "enr",
@@ -10086,7 +10086,6 @@ dependencies = [
  "alloy-rlp",
  "assert_matches",
  "bincode 1.3.3",
- "codspeed-criterion-compat",
  "eyre",
  "futures-util",
  "itertools 0.14.0",
@@ -10304,6 +10303,7 @@ dependencies = [
  "crossbeam-utils",
  "dashmap",
  "futures-util",
+ "libc",
  "metrics",
  "parking_lot",
  "pin-project",
@@ -10388,7 +10388,6 @@ dependencies = [
  "assert_matches",
  "auto_impl",
  "bitflags 2.10.0",
- "codspeed-criterion-compat",
  "futures",
  "futures-util",
  "metrics",
@@ -10446,7 +10445,6 @@ dependencies = [
  "proptest",
  "proptest-arbitrary-interop",
  "rand 0.9.2",
- "reth-ethereum-primitives",
  "reth-execution-errors",
  "reth-metrics",
  "reth-primitives-traits",
@@ -10476,7 +10474,6 @@ dependencies = [
  "arrayvec",
  "bincode 1.3.3",
  "bytes",
- "codspeed-criterion-compat",
  "derive_more",
  "hash-db",
  "itertools 0.14.0",
@@ -10531,7 +10528,6 @@ version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "codspeed-criterion-compat",
  "crossbeam-channel",
  "derive_more",
  "itertools 0.14.0",
@@ -10596,8 +10592,9 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "34.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=6ef10066478605c2c5029fbbdea6ec197b20a269#6ef10066478605c2c5029fbbdea6ec197b20a269"
+version = "35.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c2e61d011af51eed81e8fec74247d8ef3e287d3d4c9f5fd2c67c19d584e25a5"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10614,8 +10611,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "8.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=6ef10066478605c2c5029fbbdea6ec197b20a269#6ef10066478605c2c5029fbbdea6ec197b20a269"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e86e468df3cf5cf59fa7ef71a3e9ccabb76bb336401ea2c0674f563104cf3c5e"
 dependencies = [
  "bitvec",
  "phf",
@@ -10625,8 +10623,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "13.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=6ef10066478605c2c5029fbbdea6ec197b20a269#6ef10066478605c2c5029fbbdea6ec197b20a269"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9e279469c545cc6f8fae08db96b4f0d042754051f6faac840e5d3d89a39ca5"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10641,8 +10640,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "14.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=6ef10066478605c2c5029fbbdea6ec197b20a269#6ef10066478605c2c5029fbbdea6ec197b20a269"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eacf6ee4cf0ee93b245b308a4bcaff8910dad107def9a9ec5a79a558aee7720"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10656,8 +10656,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "10.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=6ef10066478605c2c5029fbbdea6ec197b20a269#6ef10066478605c2c5029fbbdea6ec197b20a269"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8e56f32857c6ccfa90e49f13cfe83b4c767777623364fd39e8fb497dbca529"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -10669,8 +10670,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "9.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=6ef10066478605c2c5029fbbdea6ec197b20a269#6ef10066478605c2c5029fbbdea6ec197b20a269"
+version = "9.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bc1da862c71ba380b0e2ee0b19b186e282f931ba4f479dfbc83903294a5e596"
 dependencies = [
  "auto_impl",
  "either",
@@ -10682,8 +10684,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "15.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=6ef10066478605c2c5029fbbdea6ec197b20a269#6ef10066478605c2c5029fbbdea6ec197b20a269"
+version = "16.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331fe0aa131f34508a87ccd56d9eb64471f83995aaf339e118cada6686655387"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10700,8 +10703,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "15.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=6ef10066478605c2c5029fbbdea6ec197b20a269#6ef10066478605c2c5029fbbdea6ec197b20a269"
+version = "16.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d18917d3ae4ecbc2af75910fb302e4b07a870105f3c1bcca548029b03b7e965"
 dependencies = [
  "auto_impl",
  "either",
@@ -10717,8 +10721,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.34.2"
-source = "git+https://github.com/paradigmxyz/revm-inspectors?rev=7d2f39aa702df10c87e9e1749d2af36934fe57be#7d2f39aa702df10c87e9e1749d2af36934fe57be"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c10dd4936f4f3a20c265415ddf2d56af0b2c99fcbd0b8aa9bfd8919bfab8e3"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -10736,8 +10741,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "32.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=6ef10066478605c2c5029fbbdea6ec197b20a269#6ef10066478605c2c5029fbbdea6ec197b20a269"
+version = "33.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c4cf4fa521d8f40b2bb39e09a809fbde3a9acba60a7586db374730f21fe8c6f"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10748,8 +10754,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "32.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=6ef10066478605c2c5029fbbdea6ec197b20a269#6ef10066478605c2c5029fbbdea6ec197b20a269"
+version = "32.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2ec11f45deec71e4945e1809736bb20d454285f9167ab53c5159dae1deb603f"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10771,8 +10778,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "22.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=6ef10066478605c2c5029fbbdea6ec197b20a269#6ef10066478605c2c5029fbbdea6ec197b20a269"
+version = "22.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfb5ce6cf18b118932bcdb7da05cd9c250f2cb9f64131396b55f3fe3537c35"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -10782,8 +10790,9 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "9.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=6ef10066478605c2c5029fbbdea6ec197b20a269#6ef10066478605c2c5029fbbdea6ec197b20a269"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29404707763da607e5d6e4771cb203998c28159279c2f64cc32de08d2814651"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.10.0",
@@ -11026,7 +11035,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11866,7 +11875,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12578,7 +12587,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f7c95348f20c1c913d72157b3c6dee6ea3e30b3d19502c5a7f6d3f160dacbf"
 dependencies = [
  "cc",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -13167,7 +13176,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.7.3"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c0dc44157867da82c469c13186015b86abef209bf0e41625e4b68bac61d728"
+checksum = "4e4ff99651d46cef43767b5e8262ea228cd05287409ccb0c947cc25e70a952f9"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.7.3"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4cdb42df3871cd6b346d6a938ec2ba69a9a0f49d1f82714bc5c48349268434"
+checksum = "1a0701b0eda8051a2398591113e7862f807ccdd3315d0b441f06c2a0865a379b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -164,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.7.3"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca63b7125a981415898ffe2a2a696c83696c9c6bdb1671c8a912946bbd8e49e7"
+checksum = "f3c83c7a3c4e1151e8cac383d0a67ddf358f37e5ea51c95a1283d897c9de0a5a"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -186,9 +186,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "1.5.7"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2db5c583aaef0255aa63a4fe827f826090142528bba48d1bf4119b62780cad"
+checksum = "e6ab1b2f1b48a7e6b3597cb2afae04f93879fb69d71e39736b5663d7366b23f2"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -262,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.7.3"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f7ef09f21bd1e9cb8a686f168cb4a206646804567f0889eadb8dcc4c9288c8"
+checksum = "def1626eea28d48c6cc0a6f16f34d4af0001906e4f889df6c660b39c86fd044d"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -289,9 +289,8 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d432029684c0239fcf8ddcfd3c61b1887210867548edf5b53a3288772b02478"
+version = "0.27.2"
+source = "git+https://github.com/alloy-rs/evm?rev=417bed0b409f233ca594b4e44deade881da2788e#417bed0b409f233ca594b4e44deade881da2788e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -307,14 +306,13 @@ dependencies = [
  "op-revm",
  "revm",
  "thiserror 2.0.18",
- "tracing",
 ]
 
 [[package]]
 name = "alloy-genesis"
-version = "1.7.3"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9cf3b99f46615fbf7dc1add0c96553abb7bf88fc9ec70dfbe7ad0b47ba7fe8"
+checksum = "55d9d1aba3f914f0e8db9e4616ae37f3d811426d95bdccf44e47d0605ab202f6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -354,9 +352,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.5.7"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9dbe713da0c737d9e5e387b0ba790eb98b14dd207fe53eef50e19a5a8ec3dac"
+checksum = "1e414aa37b335ad2acb78a95814c59d137d53139b412f87aed1e10e2d862cd49"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -366,9 +364,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.7.3"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff42cd777eea61f370c0b10f2648a1c81e0b783066cd7269228aa993afd487f7"
+checksum = "e57586581f2008933241d16c3e3f633168b3a5d2738c5c42ea5246ec5e0ef17a"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -381,9 +379,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.7.3"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cbca04f9b410fdc51aaaf88433cbac761213905a65fe832058bcf6690585762"
+checksum = "3b36c2a0ed74e48851f78415ca5b465211bd678891ba11e88fee09eac534bab1"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -407,9 +405,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.7.3"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d6d15e069a8b11f56bef2eccbad2a873c6dd4d4c81d04dda29710f5ea52f04"
+checksum = "636c8051da58802e757b76c3b65af610b95799f72423dc955737dec73de234fd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -420,9 +418,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-node-bindings"
-version = "1.7.3"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091dc8117d84de3a9ac7ec97f2c4d83987e24d485b478d26aa1ec455d7d52f7d"
+checksum = "3ce6930ce52e43b0768dc99ceeff5cb9e673e8c9f87d926914cd028b2e3f7233"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks 0.2.13",
@@ -454,9 +452,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.5.7"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3b431b4e72cd8bd0ec7a50b4be18e73dab74de0dba180eef171055e5d5926e"
+checksum = "66b1483f8c2562bf35f0270b697d5b5fe8170464e935bd855a4c5eaf6f89b354"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -485,9 +483,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.7.3"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d181c8cc7cf4805d7e589bf4074d56d55064fa1a979f005a45a62b047616d870"
+checksum = "b3dd56e2eafe8b1803e325867ac2c8a4c73c9fb5f341ffd8347f9344458c5922"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -530,9 +528,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.7.3"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8bd82953194dec221aa4cbbbb0b1e2df46066fe9d0333ac25b43a311e122d13"
+checksum = "6eebf54983d4fccea08053c218ee5c288adf2e660095a243d0532a8070b43955"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -569,14 +567,14 @@ checksum = "ce8849c74c9ca0f5a03da1c865e3eb6f768df816e67dd3721a398a8a7e398011"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.7.3"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2792758a93ae32a32e9047c843d536e1448044f78422d71bf7d7c05149e103f"
+checksum = "91577235d341a1bdbee30a463655d08504408a4d51e9f72edbfc5a622829f402"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -600,9 +598,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.7.3"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bdcbf9dfd5eea8bfeb078b1d906da8cd3a39c4d4dbe7a628025648e323611f6"
+checksum = "79cff039bf01a17d76c0aace3a3a773d5f895eb4c68baaae729ec9da9e86c99c"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -613,9 +611,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "1.7.3"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42325c117af3a9e49013f881c1474168db57978e02085fc9853a1c89e0562740"
+checksum = "564afceae126df73b95f78c81eb46e2ef689a45ace0fcdaf5c9a178693a5ccca"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -625,9 +623,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.7.3"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a3100b76987c1b1dc81f3abe592b7edc29e92b1242067a69d65e0030b35cf9"
+checksum = "d22250cf438b6a3926de67683c08163bfa1fd1efa47ee9512cbcd631b6b0243c"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -637,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.7.3"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd720b63f82b457610f2eaaf1f32edf44efffe03ae25d537632e7d23e7929e1a"
+checksum = "73234a141ecce14e2989748c04fcac23deee67a445e2c4c167cfb42d4dacd1b6"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -648,9 +646,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "1.7.3"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a22e13215866f5dfd5d3278f4c41f1fad9410dc68ce39022f58593c873c26f8"
+checksum = "625af0c3ebd3c31322edb1fb6b8e3e518acc39e164ed07e422eaff05310ff2fa"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -668,9 +666,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.7.3"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b21e1ad18ff1b31ff1030e046462ab8168cf8894e6778cd805c8bdfe2bd649"
+checksum = "779f70ab16a77e305571881b07a9bc6b0068ae6f962497baf5762825c5b839fb"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -680,9 +678,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.7.3"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ac61f03f1edabccde1c687b5b25fff28f183afee64eaa2e767def3929e4457"
+checksum = "10620d600cc46538f613c561ac9a923843c6c74c61f054828dcdb8dd18c72ec4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -701,9 +699,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.7.3"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2dc411f13092f237d2bf6918caf80977fc2f51485f9b90cb2a2f956912c8c9"
+checksum = "010e101dbebe0c678248907a2545b574a87d078d82c2f6f5d0e8e7c9a6149a10"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -723,9 +721,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "1.7.3"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe85bf3be739126aa593dca9fb3ab13ca93fa7873e6f2247be64d7f2cb15f34a"
+checksum = "375e4bf001135fe4f344db6197fafed8c2b61e99fa14d3597f44cd413f79e45b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -738,9 +736,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.7.3"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad79f1e27e161943b5a4f99fe5534ef0849876214be411e0032c12f38e94daa"
+checksum = "be096f74d85e1f927580b398bf7bc5b4aa62326f149680ec0867e3c040c9aced"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -752,9 +750,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "1.7.3"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d459f902a2313737bc66d18ed094c25d2aeb268b74d98c26bbbda2aa44182ab0"
+checksum = "14ab75189fbc29c5dd6f0bc1529bccef7b00773b458763f4d9d81a77ae4a1a2d"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -764,9 +762,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.7.3"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2ce1e0dbf7720eee747700e300c99aac01b1a95bb93f493a01e78ee28bb1a37"
+checksum = "9e6d631f8b975229361d8af7b2c749af31c73b3cf1352f90e144ddb06227105e"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -776,9 +774,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.7.3"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2425c6f314522c78e8198979c8cbf6769362be4da381d4152ea8eefce383535d"
+checksum = "97f40010b5e8f79b70bf163b38cd15f529b18ca88c4427c0e43441ee54e4ed82"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -791,9 +789,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.7.3"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ecb71ee53d8d9c3fa7bac17542c8116ebc7a9726c91b1bf333ec3d04f5a789"
+checksum = "9c4ec1cc27473819399a3f0da83bc1cef0ceaac8c1c93997696e46dc74377a58"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -810,23 +808,23 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.5.7"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab81bab693da9bb79f7a95b64b394718259fdd7e41dceeced4cad57cb71c4f6a"
+checksum = "2c4b64c8146291f750c3f391dff2dd40cf896f7e2b253417a31e342aa7265baa"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.5.7"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489f1620bb7e2483fb5819ed01ab6edc1d2f93939dce35a5695085a1afd1d699"
+checksum = "d9df903674682f9bae8d43fdea535ab48df2d6a8cb5104ca29c58ada22ef67b3"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
@@ -836,15 +834,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha3",
- "syn 2.0.117",
+ "syn 2.0.115",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.5.7"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56cef806ad22d4392c5fc83cf8f2089f988eb99c7067b4e0c6f1971fc1cca318"
+checksum = "737b8a959f527a86e07c44656db237024a32ae9b97d449f788262a547e8aa136"
 dependencies = [
  "const-hex",
  "dunce",
@@ -852,15 +850,15 @@ dependencies = [
  "macro-string",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.5.7"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6df77fea9d6a2a75c0ef8d2acbdfd92286cc599983d3175ccdc170d3433d249"
+checksum = "b28e6e86c6d2db52654b65a5a76b4f57eae5a32a7f0aa2222d1dbdb74e2cb8e0"
 dependencies = [
  "serde",
  "winnow",
@@ -868,9 +866,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.5.7"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64612d29379782a5dde6f4b6570d9c756d734d760c0c94c254d361e678a6591f"
+checksum = "fdf7effe4ab0a4f52c865959f790036e61a7983f68b13b75d7fbcedf20b753ce"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -880,9 +878,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.7.3"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa186e560d523d196580c48bf00f1bf62e63041f28ecf276acc22f8b27bb9f53"
+checksum = "a03bb3f02b9a7ab23dacd1822fa7f69aa5c8eefcdcf57fad085e0b8d76fb4334"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -903,9 +901,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.7.3"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa501ad58dd20acddbfebc65b52e60f05ebf97c52fa40d1b35e91f5e2da0ad0e"
+checksum = "5ce599598ef8ebe067f3627509358d9faaa1ef94f77f834a7783cd44209ef55c"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -919,9 +917,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "1.7.3"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ef85688e5ac2da72afc804e0a1f153a1f309f05a864b1998bbbed7804dbaab"
+checksum = "49963a2561ebd439549915ea61efb70a7b13b97500ec16ca507721c9d9957d07"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -939,9 +937,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.7.3"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f00445db69d63298e2b00a0ea1d859f00e6424a3144ffc5eba9c31da995e16"
+checksum = "5ed38ea573c6658e0c2745af9d1f1773b1ed83aa59fbd9c286358ad469c3233a"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -977,14 +975,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.7.3"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fa0c53e8c1e1ef4d01066b01c737fb62fc9397ab52c6e7bb5669f97d281b9bc"
+checksum = "397406cf04b11ca2a48e6f81804c70af3f40a36abf648e11dc7416043eb0834d"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -1054,9 +1052,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "approx"
@@ -1078,7 +1076,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -1220,7 +1218,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -1258,7 +1256,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -1347,7 +1345,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -1397,9 +1395,9 @@ dependencies = [
 
 [[package]]
 name = "asn1_der"
-version = "0.7.7"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4858a9d740c5007a9069007c3b4e91152d0506f13c1b31dd49051fd537656156"
+checksum = "155a5a185e42c6b77ac7b88a15143d930a9e9727a5b7b77eed417404ab15c247"
 
 [[package]]
 name = "assert_matches"
@@ -1420,9 +1418,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.41"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+checksum = "68650b7df54f0293fd061972a0fb05aaf4fc0879d3b3d21a638a182c5c543b9f"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -1463,7 +1461,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -1474,7 +1472,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -1512,7 +1510,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -1543,7 +1541,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -1639,7 +1637,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -1648,7 +1646,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -1690,9 +1688,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 dependencies = [
  "arbitrary",
  "serde_core",
@@ -1756,7 +1754,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc119a5ad34c3f459062a96907f53358989b173d104258891bb74f95d93747e8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "boa_interner",
  "boa_macros",
  "boa_string",
@@ -1773,7 +1771,7 @@ checksum = "e637ec52ea66d76b0ca86180c259d6c7bb6e6a6e14b2f36b85099306d8b00cc3"
 dependencies = [
  "aligned-vec",
  "arrayvec",
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "boa_ast",
  "boa_gc",
  "boa_interner",
@@ -1855,7 +1853,7 @@ dependencies = [
  "cow-utils",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
  "synstructure",
 ]
 
@@ -1865,7 +1863,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02f99bf5b684f0de946378fcfe5f38c3a0fbd51cbf83a0f39ff773a0e218541f"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "boa_ast",
  "boa_interner",
  "boa_macros",
@@ -1911,7 +1909,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -1967,9 +1965,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "byte-slice-cast"
@@ -1994,7 +1992,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -2024,9 +2022,9 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "2.1.6"
+version = "2.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a0f582957c24870b7bfd12bf562c40b4734b533cafbaf8ded31d6d85f462c01"
+checksum = "e00bf4b112b07b505472dbefd19e37e53307e2bfed5a79e0cc161d58ccd0e687"
 dependencies = [
  "arbitrary",
  "blst",
@@ -2111,9 +2109,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2150,16 +2148,16 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2212,9 +2210,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.5.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "63be97961acde393029492ce0be7a1af7e323e6bae9511ebfac33751be5e6806"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2222,9 +2220,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.5.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "7f13174bda5dfd69d7e947827e5af4b0f2f94a4a3ee92912fba07a66150f21e2"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2241,7 +2239,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -2287,7 +2285,9 @@ dependencies = [
  "codspeed",
  "codspeed-criterion-compat-walltime",
  "colored",
+ "futures",
  "regex",
+ "tokio",
 ]
 
 [[package]]
@@ -2302,6 +2302,7 @@ dependencies = [
  "clap",
  "codspeed",
  "criterion-plot",
+ "futures",
  "is-terminal",
  "itertools 0.10.5",
  "num-traits",
@@ -2314,6 +2315,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tinytemplate",
+ "tokio",
  "walkdir",
 ]
 
@@ -2448,9 +2450,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.37"
+version = "0.4.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+checksum = "00828ba6fd27b45a448e57dbfe84f1029d4c9f26b368157e9a448a5f49a2ec2a"
 dependencies = [
  "brotli",
  "compression-core",
@@ -2498,9 +2500,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.18.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af9a108e542ddf1de36743a6126e94d6659dccda38fc8a77e80b915102ac784a"
+checksum = "3bb320cac8a0750d7f25280aa97b09c26edfe161164238ecbbb31092b079e735"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2658,15 +2660,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-queue"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2678,7 +2671,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -2765,7 +2758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
- "nix 0.31.2",
+ "nix 0.31.1",
  "windows-sys 0.61.2",
 ]
 
@@ -2793,7 +2786,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -2850,7 +2843,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -2865,7 +2858,7 @@ dependencies = [
  "quote",
  "serde",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -2878,7 +2871,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -2889,7 +2882,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -2900,7 +2893,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -2911,7 +2904,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -2953,7 +2946,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -2985,9 +2978,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.8"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
 dependencies = [
  "powerfmt",
  "serde_core",
@@ -3012,7 +3005,7 @@ checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -3023,7 +3016,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -3044,7 +3037,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -3054,7 +3047,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -3076,7 +3069,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.117",
+ "syn 2.0.115",
  "unicode-xid",
 ]
 
@@ -3108,6 +3101,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3118,13 +3120,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.5.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "dirs-sys-next"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.4.6",
  "winapi",
 ]
 
@@ -3163,11 +3177,11 @@ dependencies = [
 
 [[package]]
 name = "dispatch2"
-version = "0.3.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "block2",
  "libc",
  "objc2",
@@ -3181,7 +3195,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -3228,7 +3242,7 @@ checksum = "1ec431cd708430d5029356535259c5d645d60edd3d39c54e5eea9782d46caa7d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -3280,12 +3294,12 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
 name = "ef-test-runner"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "clap",
  "ef-tests",
@@ -3293,7 +3307,7 @@ dependencies = [
 
 [[package]]
 name = "ef-tests"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3387,7 +3401,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -3407,7 +3421,7 @@ checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -3427,7 +3441,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -3509,7 +3523,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -3521,7 +3535,7 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -3576,15 +3590,14 @@ dependencies = [
  "reth-eth-wire",
  "reth-eth-wire-types",
  "reth-ethereum-forks",
- "reth-ethereum-primitives",
  "reth-network",
  "reth-network-api",
  "reth-network-peers",
  "reth-node-ethereum",
  "reth-payload-primitives",
+ "reth-primitives",
  "reth-primitives-traits",
  "reth-provider",
- "reth-tasks",
  "reth-tracing",
  "secp256k1 0.30.0",
  "serde",
@@ -3734,7 +3747,7 @@ dependencies = [
 
 [[package]]
 name = "example-full-contract-state"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -3754,19 +3767,6 @@ dependencies = [
  "reth-network-peers",
  "secp256k1 0.30.0",
  "tokio",
-]
-
-[[package]]
-name = "example-migrate-trie-to-packed"
-version = "0.0.0"
-dependencies = [
- "clap",
- "eyre",
- "reth-db",
- "reth-db-api",
- "reth-trie-common",
- "reth-trie-db",
- "serde_json",
 ]
 
 [[package]]
@@ -3879,7 +3879,7 @@ dependencies = [
 
 [[package]]
 name = "exex-subscription"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -4030,7 +4030,7 @@ checksum = "6dc7a9cb3326bafb80642c5ce99b39a2c0702d4bfa8ee8a3e773791a6cbe2407"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -4103,9 +4103,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -4118,9 +4118,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -4141,15 +4141,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -4158,9 +4158,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
@@ -4192,26 +4192,26 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-timer"
@@ -4225,9 +4225,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -4237,6 +4237,7 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
+ "pin-utils",
  "slab",
 ]
 
@@ -4257,8 +4258,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link",
+ "windows-result",
 ]
 
 [[package]]
@@ -4345,7 +4346,7 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "libc",
  "libgit2-sys",
  "log",
@@ -4791,7 +4792,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -4952,7 +4953,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -5025,7 +5026,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "inotify-sys",
  "libc",
 ]
@@ -5071,7 +5072,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -5085,9 +5086,9 @@ dependencies = [
 
 [[package]]
 name = "interprocess"
-version = "2.4.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6be5e5c847dbdb44564bd85294740d031f4f8aeb3464e5375ef7141f7538db69"
+checksum = "53bf2b0e0785c5394a7392f66d7c4fb9c653633c29b27a932280da3cb344c66a"
 dependencies = [
  "doctest-file",
  "futures-core",
@@ -5236,9 +5237,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -5348,7 +5349,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -5459,9 +5460,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.6"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
  "cpufeatures",
 ]
@@ -5510,9 +5511,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libgit2-sys"
@@ -5533,7 +5534,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -5574,14 +5575,13 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "libc",
- "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.1",
 ]
 
 [[package]]
@@ -5602,9 +5602,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.24"
+version = "1.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4735e9cbde5aac84a5ce588f6b23a90b9b0b528f6c5a8db8a4aff300463a0839"
+checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
 dependencies = [
  "cc",
  "libc",
@@ -5618,7 +5618,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -5639,9 +5639,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.12.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -5756,7 +5756,7 @@ checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -5780,7 +5780,7 @@ checksum = "757aee279b8bdbb9f9e676796fd459e4207a1f986e87886700abf589f5abf771"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -5800,9 +5800,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
 dependencies = [
  "libc",
 ]
@@ -5834,7 +5834,7 @@ checksum = "161ab904c2c62e7bda0f7562bf22f96440ca35ff79e66c800cbac298f2f4f5ec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -5864,7 +5864,7 @@ dependencies = [
  "once_cell",
  "procfs",
  "rlimit",
- "windows 0.62.2",
+ "windows",
 ]
 
 [[package]]
@@ -5967,7 +5967,7 @@ checksum = "59b43b4fd69e3437618106f7754f34021b831a514f9e1a98ae863cabcd8d8dad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -6040,7 +6040,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -6048,11 +6048,11 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "225e7cfe711e0ba79a68baeddb2982723e4235247aefce1482f2f16c27865b66"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -6074,7 +6074,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -6092,7 +6092,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -6223,7 +6223,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -6252,9 +6252,9 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.4"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
 dependencies = [
  "objc2-encode",
 ]
@@ -6265,7 +6265,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -6317,9 +6317,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "op-alloy"
-version = "0.24.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a95dd0974d5e60ffe9342a70cc0033d299244fab01cb16a958eb7352ddba1fa7"
+checksum = "e9b8fee21003dd4f076563de9b9d26f8c97840157ef78593cd7f262c5ca99848"
 dependencies = [
  "op-alloy-consensus",
  "op-alloy-network",
@@ -6330,9 +6330,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.24.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fadcb964b0aa645d12e952d470c7585d23286d8bcf1ac41589410b6724216b68"
+checksum = "736381a95471d23e267263cfcee9e1d96d30b9754a94a2819148f83379de8a86"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6350,9 +6350,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-network"
-version = "0.24.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ea44162d493219cc678aaca1253d46c3aa73aa361326dfa9d406f086dfa135"
+checksum = "4034183dca6bff6632e7c24c92e75ff5f0eabb58144edb4d8241814851334d47"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -6366,9 +6366,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-provider"
-version = "0.24.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83aa8dc34bdf077c8e6d48ff75beff4ac14b428d982c9722483ccd7473c0e114"
+checksum = "6753d90efbaa8ea8bcb89c1737408ca85fa60d7adb875049d3f382c063666f86"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -6381,9 +6381,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types"
-version = "0.24.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be9d16ec9f7810e0623a37edc293d1c05fe9c58a5647f6973fdd93e0b4795015"
+checksum = "ddd87c6b9e5b6eee8d6b76f41b04368dca0e9f38d83338e5b00e730c282098a4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6400,9 +6400,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types-engine"
-version = "0.24.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0ac5c5ddcbffadcd097d278c717d34849bcc629f6e4f8514eb000ec862def8"
+checksum = "77727699310a18cdeed32da3928c709e2704043b6584ed416397d5da65694efc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6423,8 +6423,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c92b75162c2ed1661849fa51683b11254a5b661798360a2c24be918edafd40"
+source = "git+https://github.com/bluealloy/revm?rev=6ef10066478605c2c5029fbbdea6ec197b20a269#6ef10066478605c2c5029fbbdea6ec197b20a269"
 dependencies = [
  "auto_impl",
  "revm",
@@ -6536,6 +6535,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "ordered-float"
 version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6546,9 +6551,9 @@ dependencies = [
 
 [[package]]
 name = "owo-colors"
-version = "4.3.0"
+version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
 
 [[package]]
 name = "p256"
@@ -6599,7 +6604,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -6628,7 +6633,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.18",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -6714,7 +6719,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -6728,29 +6733,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.17"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -6773,12 +6778,6 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plain_hasher"
@@ -6890,7 +6889,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -6941,7 +6940,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -6959,7 +6958,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25485360a54d6861439d60facef26de713b1e126bf015ec8f98239467a2b82f7"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "chrono",
  "flate2",
  "procfs-core",
@@ -6972,7 +6971,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6401bf7b6af22f78b563665d15a22e9aef27775b79b149a66ca022468a4e405"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "chrono",
  "hex",
 ]
@@ -6985,7 +6984,7 @@ checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
@@ -7014,7 +7013,7 @@ checksum = "fb6dc647500e84a25a85b100e76c85b8ace114c209432dc174f20aac11d4ed6c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -7037,7 +7036,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -7269,9 +7268,9 @@ dependencies = [
 
 [[package]]
 name = "rapidhash"
-version = "4.4.1"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+checksum = "84816e4c99c467e92cf984ee6328caa976dfecd33a673544489d79ca2caaefe5"
 dependencies = [
  "rand 0.9.2",
  "rustversion",
@@ -7295,7 +7294,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "compact_str",
  "hashbrown 0.16.1",
  "indoc",
@@ -7327,7 +7326,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "hashbrown 0.16.1",
  "indoc",
  "instability",
@@ -7346,7 +7345,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -7381,16 +7380,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "35985aa610addc02e24fc232012c86fd11f14111180f902b67e2d5331f8ebf2b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -7402,6 +7401,17 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7421,7 +7431,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -7449,9 +7459,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "regress"
@@ -7520,7 +7530,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-node-bindings",
  "alloy-primitives",
@@ -7538,7 +7548,6 @@ dependencies = [
  "reth-db",
  "reth-ethereum-cli",
  "reth-ethereum-payload-builder",
- "reth-ethereum-primitives",
  "reth-network",
  "reth-network-api",
  "reth-node-api",
@@ -7548,7 +7557,7 @@ dependencies = [
  "reth-node-metrics",
  "reth-payload-builder",
  "reth-payload-primitives",
- "reth-primitives-traits",
+ "reth-primitives",
  "reth-provider",
  "reth-revm",
  "reth-rpc",
@@ -7568,7 +7577,7 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7591,7 +7600,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bench"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7638,7 +7647,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bench-compare"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -7650,7 +7659,7 @@ dependencies = [
  "csv",
  "ctrlc",
  "eyre",
- "nix 0.31.2",
+ "nix 0.31.1",
  "reth-chainspec",
  "reth-cli-runner",
  "reth-cli-util",
@@ -7658,6 +7667,7 @@ dependencies = [
  "reth-tracing",
  "serde",
  "serde_json",
+ "shellexpand",
  "shlex",
  "tokio",
  "tracing",
@@ -7665,13 +7675,14 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
+ "codspeed-criterion-compat",
  "derive_more",
  "metrics",
  "parking_lot",
@@ -7697,7 +7708,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7717,7 +7728,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7725,11 +7736,12 @@ dependencies = [
  "reth-cli-runner",
  "reth-db",
  "serde_json",
+ "shellexpand",
 ]
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7816,7 +7828,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7825,7 +7837,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7846,7 +7858,7 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7870,17 +7882,17 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "proc-macro2",
  "quote",
  "similar-asserts",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
 name = "reth-config"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -7898,7 +7910,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7910,7 +7922,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7924,7 +7936,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7949,19 +7961,19 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "arbitrary",
  "assert_matches",
+ "codspeed-criterion-compat",
  "derive_more",
  "eyre",
  "metrics",
  "page_size",
  "parking_lot",
  "proptest",
- "quanta",
  "reth-db-api",
  "reth-fs-util",
  "reth-libmdbx",
@@ -7984,7 +7996,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8015,7 +8027,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8046,7 +8058,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8062,7 +8074,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8088,7 +8100,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8113,7 +8125,7 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8141,7 +8153,7 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8179,7 +8191,7 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8214,6 +8226,7 @@ dependencies = [
  "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
+ "reth-primitives",
  "reth-primitives-traits",
  "reth-provider",
  "reth-rpc-api",
@@ -8235,7 +8248,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8262,7 +8275,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8285,7 +8298,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8308,8 +8321,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-engine-service"
+version = "1.10.2"
+dependencies = [
+ "alloy-eips",
+ "futures",
+ "pin-project",
+ "reth-chainspec",
+ "reth-consensus",
+ "reth-engine-primitives",
+ "reth-engine-tree",
+ "reth-ethereum-consensus",
+ "reth-ethereum-engine-primitives",
+ "reth-evm",
+ "reth-evm-ethereum",
+ "reth-exex-types",
+ "reth-network-p2p",
+ "reth-node-ethereum",
+ "reth-node-types",
+ "reth-payload-builder",
+ "reth-primitives-traits",
+ "reth-provider",
+ "reth-prune",
+ "reth-stages-api",
+ "reth-tasks",
+ "reth-trie-db",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "reth-engine-tree"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8319,6 +8362,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "assert_matches",
+ "codspeed-criterion-compat",
  "crossbeam-channel",
  "derive_more",
  "eyre",
@@ -8373,6 +8417,7 @@ dependencies = [
  "revm-state",
  "schnellru",
  "serde_json",
+ "smallvec",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -8380,7 +8425,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8407,7 +8452,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8429,7 +8474,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8447,7 +8492,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8473,7 +8518,7 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8483,7 +8528,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8521,7 +8566,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8546,7 +8591,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8586,7 +8631,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "clap",
  "eyre",
@@ -8609,7 +8654,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8625,7 +8670,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8643,7 +8688,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks 0.4.7",
@@ -8656,7 +8701,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8684,20 +8729,26 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
+ "alloy-serde",
  "arbitrary",
+ "bincode 1.3.3",
+ "derive_more",
+ "modular-bitfield",
  "proptest",
  "proptest-arbitrary-interop",
+ "rand 0.8.5",
  "rand 0.9.2",
  "reth-codecs",
  "reth-primitives-traits",
  "reth-zstd-compressors",
+ "secp256k1 0.30.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -8705,7 +8756,7 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "rayon",
@@ -8715,7 +8766,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8739,7 +8790,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8747,6 +8798,8 @@ dependencies = [
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rpc-types-engine",
+ "derive_more",
+ "parking_lot",
  "reth-chainspec",
  "reth-ethereum-forks",
  "reth-ethereum-primitives",
@@ -8761,7 +8814,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8773,7 +8826,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8793,7 +8846,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8838,7 +8891,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-test-utils"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eips",
  "eyre",
@@ -8869,7 +8922,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8886,7 +8939,7 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -8895,7 +8948,7 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8928,7 +8981,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "bytes",
  "futures",
@@ -8950,14 +9003,15 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "byteorder",
- "crossbeam-queue",
+ "codspeed-criterion-compat",
  "dashmap",
  "derive_more",
  "parking_lot",
+ "rand 0.9.2",
  "reth-mdbx-sys",
  "smallvec",
  "tempfile",
@@ -8967,7 +9021,7 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "bindgen",
  "cc",
@@ -8975,7 +9029,7 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "futures",
  "metrics",
@@ -8986,7 +9040,7 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8994,7 +9048,7 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9008,7 +9062,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9017,6 +9071,7 @@ dependencies = [
  "alloy-rlp",
  "aquamarine",
  "auto_impl",
+ "codspeed-criterion-compat",
  "derive_more",
  "discv5",
  "enr",
@@ -9069,7 +9124,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9093,7 +9148,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9115,7 +9170,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9132,7 +9187,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9145,7 +9200,7 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -9163,7 +9218,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9186,7 +9241,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9213,6 +9268,7 @@ dependencies = [
  "reth-downloaders",
  "reth-engine-local",
  "reth-engine-primitives",
+ "reth-engine-service",
  "reth-engine-tree",
  "reth-engine-util",
  "reth-ethereum-engine-primitives",
@@ -9257,7 +9313,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9295,12 +9351,12 @@ dependencies = [
  "reth-stages-types",
  "reth-storage-api",
  "reth-storage-errors",
- "reth-tasks",
  "reth-tracing",
  "reth-tracing-otlp",
  "reth-transaction-pool",
  "secp256k1 0.30.0",
  "serde",
+ "shellexpand",
  "strum",
  "thiserror 2.0.18",
  "tokio",
@@ -9313,7 +9369,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -9373,7 +9429,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9396,7 +9452,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9419,7 +9475,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "bytes",
  "eyre",
@@ -9448,7 +9504,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9459,7 +9515,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9479,7 +9535,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9490,7 +9546,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9513,7 +9569,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-util"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9522,7 +9578,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9531,11 +9587,29 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives"
-version = "1.11.1"
+version = "1.10.2"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-primitives",
+ "alloy-rlp",
+ "arbitrary",
+ "c-kzg",
+ "codspeed-criterion-compat",
+ "once_cell",
+ "proptest",
+ "proptest-arbitrary-interop",
+ "reth-codecs",
+ "reth-ethereum-forks",
+ "reth-ethereum-primitives",
+ "reth-primitives-traits",
+ "reth-static-file-types",
+]
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9556,7 +9630,6 @@ dependencies = [
  "op-alloy-consensus",
  "proptest",
  "proptest-arbitrary-interop",
- "quanta",
  "rand 0.8.5",
  "rand 0.9.2",
  "rayon",
@@ -9574,7 +9647,7 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9624,7 +9697,7 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9657,11 +9730,11 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-db"
-version = "1.11.1"
+version = "1.10.2"
 
 [[package]]
 name = "reth-prune-types"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9681,7 +9754,7 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9695,7 +9768,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9775,7 +9848,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -9799,14 +9872,13 @@ dependencies = [
  "reth-network-peers",
  "reth-rpc-eth-api",
  "reth-trie-common",
- "serde",
  "serde_json",
  "tokio",
 ]
 
 [[package]]
 name = "reth-rpc-api-testing-util"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9825,7 +9897,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -9855,7 +9927,6 @@ dependencies = [
  "reth-node-core",
  "reth-node-ethereum",
  "reth-payload-builder",
- "reth-payload-primitives",
  "reth-primitives-traits",
  "reth-provider",
  "reth-rpc",
@@ -9882,7 +9953,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9895,7 +9966,9 @@ dependencies = [
  "dyn-clone",
  "jsonrpsee-types",
  "op-alloy-consensus",
+ "op-alloy-network",
  "op-alloy-rpc-types",
+ "reth-ethereum-primitives",
  "reth-evm",
  "reth-primitives-traits",
  "serde_json",
@@ -9904,7 +9977,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-e2e-tests"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-genesis",
  "alloy-rpc-types-engine",
@@ -9924,7 +9997,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9960,7 +10033,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10003,7 +10076,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10051,7 +10124,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -10068,7 +10141,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10083,7 +10156,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10092,11 +10165,11 @@ dependencies = [
  "alloy-rlp",
  "assert_matches",
  "bincode 1.3.3",
+ "codspeed-criterion-compat",
  "eyre",
  "futures-util",
  "itertools 0.14.0",
  "num-traits",
- "page_size",
  "paste",
  "rand 0.9.2",
  "rayon",
@@ -10120,7 +10193,6 @@ dependencies = [
  "reth-execution-types",
  "reth-exex",
  "reth-fs-util",
- "reth-libmdbx",
  "reth-network-p2p",
  "reth-network-peers",
  "reth-primitives-traits",
@@ -10146,7 +10218,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10179,7 +10251,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10195,7 +10267,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "assert_matches",
@@ -10218,7 +10290,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10236,7 +10308,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10259,7 +10331,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10275,7 +10347,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-rpc-provider"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10288,12 +10360,12 @@ dependencies = [
  "reth-chainspec",
  "reth-db-api",
  "reth-errors",
- "reth-ethereum-primitives",
  "reth-execution-types",
  "reth-node-types",
- "reth-primitives-traits",
+ "reth-primitives",
  "reth-provider",
  "reth-prune-types",
+ "reth-rpc-convert",
  "reth-stages-types",
  "reth-storage-api",
  "reth-trie",
@@ -10304,19 +10376,16 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
- "crossbeam-utils",
- "dashmap",
+ "auto_impl",
+ "dyn-clone",
  "futures-util",
- "libc",
  "metrics",
- "parking_lot",
  "pin-project",
  "rayon",
  "reth-metrics",
  "thiserror 2.0.18",
- "thread-priority",
  "tokio",
  "tracing",
  "tracing-futures",
@@ -10324,7 +10393,7 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10340,7 +10409,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10349,7 +10418,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "clap",
  "eyre",
@@ -10367,7 +10436,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "clap",
  "eyre",
@@ -10384,7 +10453,7 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10393,7 +10462,8 @@ dependencies = [
  "aquamarine",
  "assert_matches",
  "auto_impl",
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
+ "codspeed-criterion-compat",
  "futures",
  "futures-util",
  "metrics",
@@ -10434,7 +10504,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10451,6 +10521,7 @@ dependencies = [
  "proptest",
  "proptest-arbitrary-interop",
  "rand 0.9.2",
+ "reth-ethereum-primitives",
  "reth-execution-errors",
  "reth-metrics",
  "reth-primitives-traits",
@@ -10467,7 +10538,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -10480,6 +10551,7 @@ dependencies = [
  "arrayvec",
  "bincode 1.3.3",
  "bytes",
+ "codspeed-criterion-compat",
  "derive_more",
  "hash-db",
  "itertools 0.14.0",
@@ -10499,7 +10571,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10530,10 +10602,11 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "codspeed-criterion-compat",
  "crossbeam-channel",
  "derive_more",
  "itertools 0.14.0",
@@ -10549,6 +10622,7 @@ dependencies = [
  "reth-storage-errors",
  "reth-tasks",
  "reth-trie",
+ "reth-trie-common",
  "reth-trie-db",
  "reth-trie-sparse",
  "thiserror 2.0.18",
@@ -10558,7 +10632,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10583,15 +10657,13 @@ dependencies = [
  "reth-trie",
  "reth-trie-common",
  "reth-trie-db",
- "serde",
- "serde_json",
  "smallvec",
  "tracing",
 ]
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "1.11.1"
+version = "1.10.2"
 dependencies = [
  "zstd",
 ]
@@ -10599,8 +10671,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "34.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2aabdebaa535b3575231a88d72b642897ae8106cf6b0d12eafc6bfdf50abfc7"
+source = "git+https://github.com/bluealloy/revm?rev=6ef10066478605c2c5029fbbdea6ec197b20a269#6ef10066478605c2c5029fbbdea6ec197b20a269"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10618,8 +10689,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d1e5c1eaa44d39d537f668bc5c3409dc01e5c8be954da6c83370bbdf006457"
+source = "git+https://github.com/bluealloy/revm?rev=6ef10066478605c2c5029fbbdea6ec197b20a269#6ef10066478605c2c5029fbbdea6ec197b20a269"
 dependencies = [
  "bitvec",
  "phf",
@@ -10630,8 +10700,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "13.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "892ff3e6a566cf8d72ffb627fdced3becebbd9ba64089c25975b9b028af326a5"
+source = "git+https://github.com/bluealloy/revm?rev=6ef10066478605c2c5029fbbdea6ec197b20a269#6ef10066478605c2c5029fbbdea6ec197b20a269"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10647,8 +10716,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "14.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57f61cc6d23678c4840af895b19f8acfbbd546142ec8028b6526c53cc1c16c98"
+source = "git+https://github.com/bluealloy/revm?rev=6ef10066478605c2c5029fbbdea6ec197b20a269#6ef10066478605c2c5029fbbdea6ec197b20a269"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10663,8 +10731,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "10.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "529528d0b05fe646be86223032c3e77aa8b05caa2a35447d538c55965956a511"
+source = "git+https://github.com/bluealloy/revm?rev=6ef10066478605c2c5029fbbdea6ec197b20a269#6ef10066478605c2c5029fbbdea6ec197b20a269"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -10677,8 +10744,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7bf93ac5b91347c057610c0d96e923db8c62807e03f036762d03e981feddc1d"
+source = "git+https://github.com/bluealloy/revm?rev=6ef10066478605c2c5029fbbdea6ec197b20a269#6ef10066478605c2c5029fbbdea6ec197b20a269"
 dependencies = [
  "auto_impl",
  "either",
@@ -10691,8 +10757,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cd0e43e815a85eded249df886c4badec869195e70cdd808a13cfca2794622d2"
+source = "git+https://github.com/bluealloy/revm?rev=6ef10066478605c2c5029fbbdea6ec197b20a269#6ef10066478605c2c5029fbbdea6ec197b20a269"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10710,8 +10775,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f3ccad59db91ef93696536a0dbaf2f6f17cfe20d4d8843ae118edb7e97947ef"
+source = "git+https://github.com/bluealloy/revm?rev=6ef10066478605c2c5029fbbdea6ec197b20a269#6ef10066478605c2c5029fbbdea6ec197b20a269"
 dependencies = [
  "auto_impl",
  "either",
@@ -10728,8 +10792,7 @@ dependencies = [
 [[package]]
 name = "revm-inspectors"
 version = "0.34.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e435414e9de50a1b930da602067c76365fea2fea11e80ceb50783c94ddd127f"
+source = "git+https://github.com/paradigmxyz/revm-inspectors?rev=0d3bcdacba2494e51786e4bbfe49c4b9521177fd#0d3bcdacba2494e51786e4bbfe49c4b9521177fd"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -10748,8 +10811,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "32.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11406408597bc249392d39295831c4b641b3a6f5c471a7c41104a7a1e3564c07"
+source = "git+https://github.com/bluealloy/revm?rev=6ef10066478605c2c5029fbbdea6ec197b20a269#6ef10066478605c2c5029fbbdea6ec197b20a269"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10761,8 +10823,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "32.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c1285c848d240678bf69cb0f6179ff5a4aee6fc8e921d89708087197a0aff3"
+source = "git+https://github.com/bluealloy/revm?rev=6ef10066478605c2c5029fbbdea6ec197b20a269#6ef10066478605c2c5029fbbdea6ec197b20a269"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10785,8 +10846,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba580c56a8ec824a64f8a1683577876c2e1dbe5247044199e9b881421ad5dcf9"
+source = "git+https://github.com/bluealloy/revm?rev=6ef10066478605c2c5029fbbdea6ec197b20a269#6ef10066478605c2c5029fbbdea6ec197b20a269"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -10797,11 +10857,10 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311720d4f0f239b041375e7ddafdbd20032a33b7bae718562ea188e188ed9fd3"
+source = "git+https://github.com/bluealloy/revm?rev=6ef10066478605c2c5029fbbdea6ec197b20a269#6ef10066478605c2c5029fbbdea6ec197b20a269"
 dependencies = [
  "alloy-eip7928",
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "revm-bytecode",
  "revm-primitives",
  "serde",
@@ -10944,7 +11003,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version 0.4.1",
- "syn 2.0.117",
+ "syn 2.0.115",
  "unicode-ident",
 ]
 
@@ -11033,11 +11092,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.4"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -11046,9 +11105,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "log",
  "once_cell",
@@ -11272,11 +11331,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.7.0"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -11285,9 +11344,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.17.0"
+version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -11384,7 +11443,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -11435,9 +11494,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.17.0"
+version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
+checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -11454,14 +11513,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.17.0"
+version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
+checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -11523,6 +11582,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "shellexpand"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
+dependencies = [
+ "dirs",
 ]
 
 [[package]]
@@ -11601,9 +11669,9 @@ dependencies = [
 
 [[package]]
 name = "simple_asn1"
-version = "0.6.4"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -11765,7 +11833,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -11787,9 +11855,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "6e614ed320ac28113fa64972c4262d5dbc89deacdfd00c34a3e4cea073243c12"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11798,14 +11866,14 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.5.7"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f425ae0b12e2f5ae65542e00898d500d4d318b4baf09f40fd0d410454e9947"
+checksum = "f8658017776544996edc21c8c7cc8bb4f13db60955382f4bac25dc6303b38438"
 dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -11825,21 +11893,21 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
 name = "sysinfo"
-version = "0.38.2"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efc19935b4b66baa6f654ac7924c192f55b175c00a7ab72410fc24284dacda8"
+checksum = "5792d209c2eac902426c0c4a166c9f72147db453af548cf9bf3242644c4d4fe3"
 dependencies = [
  "libc",
  "memchr",
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "windows 0.62.2",
+ "windows",
 ]
 
 [[package]]
@@ -11873,9 +11941,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand 2.3.0",
  "getrandom 0.4.1",
@@ -11902,7 +11970,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -11913,7 +11981,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
  "test-case-core",
 ]
 
@@ -11953,7 +12021,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -12001,7 +12069,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -12012,21 +12080,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "thread-priority"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2210811179577da3d54eb69ab0b50490ee40491a25d95b8c6011ba40771cb721"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "libc",
- "log",
- "rustversion",
- "windows 0.61.3",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -12173,7 +12227,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -12279,9 +12333,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.0.7+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "247eaa3197818b831697600aadf81514e577e0cba5eab10f7e064e78ae154df1"
 dependencies = [
  "winnow",
 ]
@@ -12294,9 +12348,9 @@ checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tonic"
-version = "0.14.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+checksum = "a286e33f82f8a1ee2df63f4fa35c0becf4a85a0cb03091a15fd7bf0b402dc94a"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -12320,9 +12374,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+checksum = "d6c55a2d6a14174563de34409c9f92ff981d006f56da9c6ecd40d9d4a31500b0"
 dependencies = [
  "bytes",
  "prost",
@@ -12357,7 +12411,7 @@ checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "async-compression",
  "base64 0.22.1",
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -12424,7 +12478,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -12618,7 +12672,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -12729,9 +12783,9 @@ checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.24"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
 
 [[package]]
 name = "unicode-segmentation"
@@ -12829,11 +12883,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.21.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
 dependencies = [
- "getrandom 0.4.1",
+ "getrandom 0.3.4",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -12911,7 +12965,7 @@ checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -12980,9 +13034,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -12993,9 +13047,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -13007,9 +13061,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -13017,22 +13071,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
 ]
@@ -13078,7 +13132,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "hashbrown 0.15.5",
  "indexmap 2.13.0",
  "semver 1.0.27",
@@ -13100,9 +13154,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -13193,36 +13247,14 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.61.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
-dependencies = [
- "windows-collections 0.2.0",
- "windows-core 0.61.2",
- "windows-future 0.2.1",
- "windows-link 0.1.3",
- "windows-numerics 0.2.0",
-]
-
-[[package]]
-name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-collections 0.3.2",
- "windows-core 0.62.2",
- "windows-future 0.3.2",
- "windows-numerics 0.3.1",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
-dependencies = [
- "windows-core 0.61.2",
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
 ]
 
 [[package]]
@@ -13231,20 +13263,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.62.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -13255,20 +13274,9 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
- "windows-threading 0.1.0",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -13277,9 +13285,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
- "windows-threading 0.2.1",
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -13290,7 +13298,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -13301,14 +13309,8 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
-
-[[package]]
-name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-link"
@@ -13318,31 +13320,12 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-numerics"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-numerics"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-core",
+ "windows-link",
 ]
 
 [[package]]
@@ -13351,16 +13334,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -13369,7 +13343,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -13423,7 +13397,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -13478,7 +13452,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -13491,20 +13465,11 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-threading"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -13736,7 +13701,7 @@ dependencies = [
  "heck",
  "indexmap 2.13.0",
  "prettyplease",
- "syn 2.0.117",
+ "syn 2.0.115",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -13752,7 +13717,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -13764,7 +13729,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "indexmap 2.13.0",
  "log",
  "serde",
@@ -13875,28 +13840,28 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -13916,7 +13881,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
  "synstructure",
 ]
 
@@ -13937,7 +13902,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -13971,7 +13936,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -14007,3 +13972,8 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "alloy-op-evm"
+version = "0.27.2"
+source = "git+https://github.com/alloy-rs/evm?rev=417bed0b409f233ca594b4e44deade881da2788e#417bed0b409f233ca594b4e44deade881da2788e"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,7 +290,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.27.2"
-source = "git+https://github.com/alloy-rs/evm?rev=e7ee0fc97f1d4eda632287b7af4f2a2798383ccc#e7ee0fc97f1d4eda632287b7af4f2a2798383ccc"
+source = "git+https://github.com/alloy-rs/evm?rev=be4208d07e33a4816769dd588821bbd57ad1f40c#be4208d07e33a4816769dd588821bbd57ad1f40c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3437,7 +3437,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4252,8 +4252,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -4768,7 +4768,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -4786,7 +4786,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5138,7 +5138,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6104,7 +6104,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7070,7 +7070,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7107,9 +7107,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10718,7 +10718,7 @@ dependencies = [
 [[package]]
 name = "revm-inspectors"
 version = "0.34.2"
-source = "git+https://github.com/paradigmxyz/revm-inspectors?rev=0d3bcdacba2494e51786e4bbfe49c4b9521177fd#0d3bcdacba2494e51786e4bbfe49c4b9521177fd"
+source = "git+https://github.com/paradigmxyz/revm-inspectors?rev=7d2f39aa702df10c87e9e1749d2af36934fe57be#7d2f39aa702df10c87e9e1749d2af36934fe57be"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -11026,7 +11026,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11866,7 +11866,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12578,7 +12578,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f7c95348f20c1c913d72157b3c6dee6ea3e30b3d19502c5a7f6d3f160dacbf"
 dependencies = [
  "cc",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -13167,7 +13167,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.6.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4ff99651d46cef43767b5e8262ea228cd05287409ccb0c947cc25e70a952f9"
+checksum = "b0c0dc44157867da82c469c13186015b86abef209bf0e41625e4b68bac61d728"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.6.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a0701b0eda8051a2398591113e7862f807ccdd3315d0b441f06c2a0865a379b"
+checksum = "ba4cdb42df3871cd6b346d6a938ec2ba69a9a0f49d1f82714bc5c48349268434"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -164,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.6.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c83c7a3c4e1151e8cac383d0a67ddf358f37e5ea51c95a1283d897c9de0a5a"
+checksum = "ca63b7125a981415898ffe2a2a696c83696c9c6bdb1671c8a912946bbd8e49e7"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -262,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.6.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def1626eea28d48c6cc0a6f16f34d4af0001906e4f889df6c660b39c86fd044d"
+checksum = "b9f7ef09f21bd1e9cb8a686f168cb4a206646804567f0889eadb8dcc4c9288c8"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -290,7 +290,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.27.2"
-source = "git+https://github.com/alloy-rs/evm?rev=417bed0b409f233ca594b4e44deade881da2788e#417bed0b409f233ca594b4e44deade881da2788e"
+source = "git+https://github.com/alloy-rs/evm?rev=e7ee0fc97f1d4eda632287b7af4f2a2798383ccc#e7ee0fc97f1d4eda632287b7af4f2a2798383ccc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -306,13 +306,14 @@ dependencies = [
  "op-revm",
  "revm",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
 name = "alloy-genesis"
-version = "1.6.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55d9d1aba3f914f0e8db9e4616ae37f3d811426d95bdccf44e47d0605ab202f6"
+checksum = "7c9cf3b99f46615fbf7dc1add0c96553abb7bf88fc9ec70dfbe7ad0b47ba7fe8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -364,9 +365,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.6.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57586581f2008933241d16c3e3f633168b3a5d2738c5c42ea5246ec5e0ef17a"
+checksum = "ff42cd777eea61f370c0b10f2648a1c81e0b783066cd7269228aa993afd487f7"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -379,9 +380,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.6.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b36c2a0ed74e48851f78415ca5b465211bd678891ba11e88fee09eac534bab1"
+checksum = "8cbca04f9b410fdc51aaaf88433cbac761213905a65fe832058bcf6690585762"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -405,9 +406,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.6.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "636c8051da58802e757b76c3b65af610b95799f72423dc955737dec73de234fd"
+checksum = "42d6d15e069a8b11f56bef2eccbad2a873c6dd4d4c81d04dda29710f5ea52f04"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -483,9 +484,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.6.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3dd56e2eafe8b1803e325867ac2c8a4c73c9fb5f341ffd8347f9344458c5922"
+checksum = "d181c8cc7cf4805d7e589bf4074d56d55064fa1a979f005a45a62b047616d870"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -528,9 +529,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.6.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eebf54983d4fccea08053c218ee5c288adf2e660095a243d0532a8070b43955"
+checksum = "e8bd82953194dec221aa4cbbbb0b1e2df46066fe9d0333ac25b43a311e122d13"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -572,9 +573,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.6.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91577235d341a1bdbee30a463655d08504408a4d51e9f72edbfc5a622829f402"
+checksum = "f2792758a93ae32a32e9047c843d536e1448044f78422d71bf7d7c05149e103f"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -598,9 +599,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.6.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cff039bf01a17d76c0aace3a3a773d5f895eb4c68baaae729ec9da9e86c99c"
+checksum = "7bdcbf9dfd5eea8bfeb078b1d906da8cd3a39c4d4dbe7a628025648e323611f6"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -611,9 +612,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "1.6.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "564afceae126df73b95f78c81eb46e2ef689a45ace0fcdaf5c9a178693a5ccca"
+checksum = "42325c117af3a9e49013f881c1474168db57978e02085fc9853a1c89e0562740"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -623,9 +624,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.6.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22250cf438b6a3926de67683c08163bfa1fd1efa47ee9512cbcd631b6b0243c"
+checksum = "e0a3100b76987c1b1dc81f3abe592b7edc29e92b1242067a69d65e0030b35cf9"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -635,9 +636,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.6.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73234a141ecce14e2989748c04fcac23deee67a445e2c4c167cfb42d4dacd1b6"
+checksum = "dd720b63f82b457610f2eaaf1f32edf44efffe03ae25d537632e7d23e7929e1a"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -646,9 +647,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "1.6.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625af0c3ebd3c31322edb1fb6b8e3e518acc39e164ed07e422eaff05310ff2fa"
+checksum = "4a22e13215866f5dfd5d3278f4c41f1fad9410dc68ce39022f58593c873c26f8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -666,9 +667,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.6.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779f70ab16a77e305571881b07a9bc6b0068ae6f962497baf5762825c5b839fb"
+checksum = "e1b21e1ad18ff1b31ff1030e046462ab8168cf8894e6778cd805c8bdfe2bd649"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -678,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.6.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10620d600cc46538f613c561ac9a923843c6c74c61f054828dcdb8dd18c72ec4"
+checksum = "e4ac61f03f1edabccde1c687b5b25fff28f183afee64eaa2e767def3929e4457"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -699,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.6.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "010e101dbebe0c678248907a2545b574a87d078d82c2f6f5d0e8e7c9a6149a10"
+checksum = "9b2dc411f13092f237d2bf6918caf80977fc2f51485f9b90cb2a2f956912c8c9"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -721,9 +722,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "1.6.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375e4bf001135fe4f344db6197fafed8c2b61e99fa14d3597f44cd413f79e45b"
+checksum = "fe85bf3be739126aa593dca9fb3ab13ca93fa7873e6f2247be64d7f2cb15f34a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -736,9 +737,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.6.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be096f74d85e1f927580b398bf7bc5b4aa62326f149680ec0867e3c040c9aced"
+checksum = "1ad79f1e27e161943b5a4f99fe5534ef0849876214be411e0032c12f38e94daa"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -750,9 +751,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "1.6.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14ab75189fbc29c5dd6f0bc1529bccef7b00773b458763f4d9d81a77ae4a1a2d"
+checksum = "d459f902a2313737bc66d18ed094c25d2aeb268b74d98c26bbbda2aa44182ab0"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -762,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.6.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6d631f8b975229361d8af7b2c749af31c73b3cf1352f90e144ddb06227105e"
+checksum = "e2ce1e0dbf7720eee747700e300c99aac01b1a95bb93f493a01e78ee28bb1a37"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -774,9 +775,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.6.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97f40010b5e8f79b70bf163b38cd15f529b18ca88c4427c0e43441ee54e4ed82"
+checksum = "2425c6f314522c78e8198979c8cbf6769362be4da381d4152ea8eefce383535d"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -789,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.6.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c4ec1cc27473819399a3f0da83bc1cef0ceaac8c1c93997696e46dc74377a58"
+checksum = "c3ecb71ee53d8d9c3fa7bac17542c8116ebc7a9726c91b1bf333ec3d04f5a789"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -878,9 +879,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.6.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a03bb3f02b9a7ab23dacd1822fa7f69aa5c8eefcdcf57fad085e0b8d76fb4334"
+checksum = "fa186e560d523d196580c48bf00f1bf62e63041f28ecf276acc22f8b27bb9f53"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -901,9 +902,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.6.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce599598ef8ebe067f3627509358d9faaa1ef94f77f834a7783cd44209ef55c"
+checksum = "aa501ad58dd20acddbfebc65b52e60f05ebf97c52fa40d1b35e91f5e2da0ad0e"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -917,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "1.6.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49963a2561ebd439549915ea61efb70a7b13b97500ec16ca507721c9d9957d07"
+checksum = "c2ef85688e5ac2da72afc804e0a1f153a1f309f05a864b1998bbbed7804dbaab"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -937,9 +938,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.6.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ed38ea573c6658e0c2745af9d1f1773b1ed83aa59fbd9c286358ad469c3233a"
+checksum = "b9f00445db69d63298e2b00a0ea1d859f00e6424a3144ffc5eba9c31da995e16"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -975,9 +976,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.6.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397406cf04b11ca2a48e6f81804c70af3f40a36abf648e11dc7416043eb0834d"
+checksum = "6fa0c53e8c1e1ef4d01066b01c737fb62fc9397ab52c6e7bb5669f97d281b9bc"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
@@ -1541,7 +1542,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2157,7 +2158,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3101,15 +3102,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3120,25 +3112,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users 0.5.2",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "dirs-sys-next"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
- "redox_users 0.4.6",
+ "redox_users",
  "winapi",
 ]
 
@@ -3299,7 +3279,7 @@ dependencies = [
 
 [[package]]
 name = "ef-test-runner"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "clap",
  "ef-tests",
@@ -3307,7 +3287,7 @@ dependencies = [
 
 [[package]]
 name = "ef-tests"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3590,14 +3570,15 @@ dependencies = [
  "reth-eth-wire",
  "reth-eth-wire-types",
  "reth-ethereum-forks",
+ "reth-ethereum-primitives",
  "reth-network",
  "reth-network-api",
  "reth-network-peers",
  "reth-node-ethereum",
  "reth-payload-primitives",
- "reth-primitives",
  "reth-primitives-traits",
  "reth-provider",
+ "reth-tasks",
  "reth-tracing",
  "secp256k1 0.30.0",
  "serde",
@@ -3747,7 +3728,7 @@ dependencies = [
 
 [[package]]
 name = "example-full-contract-state"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -3767,6 +3748,19 @@ dependencies = [
  "reth-network-peers",
  "secp256k1 0.30.0",
  "tokio",
+]
+
+[[package]]
+name = "example-migrate-trie-to-packed"
+version = "0.0.0"
+dependencies = [
+ "clap",
+ "eyre",
+ "reth-db",
+ "reth-db-api",
+ "reth-trie-common",
+ "reth-trie-db",
+ "serde_json",
 ]
 
 [[package]]
@@ -3879,7 +3873,7 @@ dependencies = [
 
 [[package]]
 name = "exex-subscription"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -4258,8 +4252,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link",
- "windows-result",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -4792,7 +4786,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5534,7 +5528,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5864,7 +5858,7 @@ dependencies = [
  "once_cell",
  "procfs",
  "rlimit",
- "windows",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -6535,12 +6529,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
 name = "ordered-float"
 version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6633,7 +6621,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.18",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -7404,17 +7392,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7530,7 +7507,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-node-bindings",
  "alloy-primitives",
@@ -7548,6 +7525,7 @@ dependencies = [
  "reth-db",
  "reth-ethereum-cli",
  "reth-ethereum-payload-builder",
+ "reth-ethereum-primitives",
  "reth-network",
  "reth-network-api",
  "reth-node-api",
@@ -7557,7 +7535,7 @@ dependencies = [
  "reth-node-metrics",
  "reth-payload-builder",
  "reth-payload-primitives",
- "reth-primitives",
+ "reth-primitives-traits",
  "reth-provider",
  "reth-revm",
  "reth-rpc",
@@ -7577,7 +7555,7 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7600,7 +7578,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bench"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7647,7 +7625,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bench-compare"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -7667,7 +7645,6 @@ dependencies = [
  "reth-tracing",
  "serde",
  "serde_json",
- "shellexpand",
  "shlex",
  "tokio",
  "tracing",
@@ -7675,7 +7652,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7708,7 +7685,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7728,7 +7705,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7736,12 +7713,11 @@ dependencies = [
  "reth-cli-runner",
  "reth-db",
  "serde_json",
- "shellexpand",
 ]
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7828,7 +7804,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7837,7 +7813,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7858,7 +7834,7 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7882,7 +7858,7 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7892,7 +7868,7 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -7910,7 +7886,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7922,7 +7898,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7936,7 +7912,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7961,7 +7937,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7974,6 +7950,7 @@ dependencies = [
  "page_size",
  "parking_lot",
  "proptest",
+ "quanta",
  "reth-db-api",
  "reth-fs-util",
  "reth-libmdbx",
@@ -7996,7 +7973,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8027,7 +8004,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8058,7 +8035,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8074,7 +8051,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8100,7 +8077,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8125,7 +8102,7 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8153,7 +8130,7 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8191,7 +8168,7 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8226,7 +8203,6 @@ dependencies = [
  "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
- "reth-primitives",
  "reth-primitives-traits",
  "reth-provider",
  "reth-rpc-api",
@@ -8248,7 +8224,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8275,7 +8251,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8298,7 +8274,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8321,38 +8297,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-engine-service"
-version = "1.10.2"
-dependencies = [
- "alloy-eips",
- "futures",
- "pin-project",
- "reth-chainspec",
- "reth-consensus",
- "reth-engine-primitives",
- "reth-engine-tree",
- "reth-ethereum-consensus",
- "reth-ethereum-engine-primitives",
- "reth-evm",
- "reth-evm-ethereum",
- "reth-exex-types",
- "reth-network-p2p",
- "reth-node-ethereum",
- "reth-node-types",
- "reth-payload-builder",
- "reth-primitives-traits",
- "reth-provider",
- "reth-prune",
- "reth-stages-api",
- "reth-tasks",
- "reth-trie-db",
- "tokio",
- "tokio-stream",
-]
-
-[[package]]
 name = "reth-engine-tree"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8417,7 +8363,6 @@ dependencies = [
  "revm-state",
  "schnellru",
  "serde_json",
- "smallvec",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -8425,7 +8370,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8452,7 +8397,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8474,7 +8419,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8492,7 +8437,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8518,7 +8463,7 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8528,7 +8473,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8566,7 +8511,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8591,7 +8536,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8631,7 +8576,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "clap",
  "eyre",
@@ -8654,7 +8599,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8670,7 +8615,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8688,7 +8633,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks 0.4.7",
@@ -8701,7 +8646,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8729,26 +8674,20 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
- "alloy-serde",
  "arbitrary",
- "bincode 1.3.3",
- "derive_more",
- "modular-bitfield",
  "proptest",
  "proptest-arbitrary-interop",
- "rand 0.8.5",
  "rand 0.9.2",
  "reth-codecs",
  "reth-primitives-traits",
  "reth-zstd-compressors",
- "secp256k1 0.30.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -8756,7 +8695,7 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "rayon",
@@ -8766,7 +8705,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8790,7 +8729,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8814,7 +8753,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8826,7 +8765,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8846,7 +8785,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8891,7 +8830,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-test-utils"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-eips",
  "eyre",
@@ -8922,7 +8861,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8939,7 +8878,7 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -8948,7 +8887,7 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8981,7 +8920,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "bytes",
  "futures",
@@ -9003,7 +8942,7 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -9021,7 +8960,7 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "bindgen",
  "cc",
@@ -9029,7 +8968,7 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "futures",
  "metrics",
@@ -9040,7 +8979,7 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9048,7 +8987,7 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9062,7 +9001,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9124,7 +9063,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9148,7 +9087,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9170,7 +9109,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9187,7 +9126,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9200,7 +9139,7 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -9218,7 +9157,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9241,7 +9180,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9268,7 +9207,6 @@ dependencies = [
  "reth-downloaders",
  "reth-engine-local",
  "reth-engine-primitives",
- "reth-engine-service",
  "reth-engine-tree",
  "reth-engine-util",
  "reth-ethereum-engine-primitives",
@@ -9313,7 +9251,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9351,12 +9289,12 @@ dependencies = [
  "reth-stages-types",
  "reth-storage-api",
  "reth-storage-errors",
+ "reth-tasks",
  "reth-tracing",
  "reth-tracing-otlp",
  "reth-transaction-pool",
  "secp256k1 0.30.0",
  "serde",
- "shellexpand",
  "strum",
  "thiserror 2.0.18",
  "tokio",
@@ -9369,7 +9307,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -9429,7 +9367,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9452,7 +9390,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9475,7 +9413,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "bytes",
  "eyre",
@@ -9504,7 +9442,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9515,7 +9453,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9535,7 +9473,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9546,7 +9484,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9569,7 +9507,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-util"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9578,7 +9516,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9587,29 +9525,11 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives"
-version = "1.10.2"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-rlp",
- "arbitrary",
- "c-kzg",
- "codspeed-criterion-compat",
- "once_cell",
- "proptest",
- "proptest-arbitrary-interop",
- "reth-codecs",
- "reth-ethereum-forks",
- "reth-ethereum-primitives",
- "reth-primitives-traits",
- "reth-static-file-types",
-]
+version = "1.11.1"
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9630,6 +9550,7 @@ dependencies = [
  "op-alloy-consensus",
  "proptest",
  "proptest-arbitrary-interop",
+ "quanta",
  "rand 0.8.5",
  "rand 0.9.2",
  "rayon",
@@ -9647,7 +9568,7 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9697,7 +9618,7 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9730,11 +9651,11 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-db"
-version = "1.10.2"
+version = "1.11.1"
 
 [[package]]
 name = "reth-prune-types"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9754,7 +9675,7 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9768,7 +9689,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9848,7 +9769,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -9872,13 +9793,14 @@ dependencies = [
  "reth-network-peers",
  "reth-rpc-eth-api",
  "reth-trie-common",
+ "serde",
  "serde_json",
  "tokio",
 ]
 
 [[package]]
 name = "reth-rpc-api-testing-util"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9897,7 +9819,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -9927,6 +9849,7 @@ dependencies = [
  "reth-node-core",
  "reth-node-ethereum",
  "reth-payload-builder",
+ "reth-payload-primitives",
  "reth-primitives-traits",
  "reth-provider",
  "reth-rpc",
@@ -9953,7 +9876,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9966,9 +9889,7 @@ dependencies = [
  "dyn-clone",
  "jsonrpsee-types",
  "op-alloy-consensus",
- "op-alloy-network",
  "op-alloy-rpc-types",
- "reth-ethereum-primitives",
  "reth-evm",
  "reth-primitives-traits",
  "serde_json",
@@ -9977,7 +9898,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-e2e-tests"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-genesis",
  "alloy-rpc-types-engine",
@@ -9997,7 +9918,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10033,7 +9954,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10076,7 +9997,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10124,7 +10045,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -10141,7 +10062,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10156,7 +10077,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10170,6 +10091,7 @@ dependencies = [
  "futures-util",
  "itertools 0.14.0",
  "num-traits",
+ "page_size",
  "paste",
  "rand 0.9.2",
  "rayon",
@@ -10193,6 +10115,7 @@ dependencies = [
  "reth-execution-types",
  "reth-exex",
  "reth-fs-util",
+ "reth-libmdbx",
  "reth-network-p2p",
  "reth-network-peers",
  "reth-primitives-traits",
@@ -10218,7 +10141,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10251,7 +10174,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10267,7 +10190,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "assert_matches",
@@ -10290,7 +10213,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10308,7 +10231,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10331,7 +10254,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10347,7 +10270,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-rpc-provider"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10360,12 +10283,12 @@ dependencies = [
  "reth-chainspec",
  "reth-db-api",
  "reth-errors",
+ "reth-ethereum-primitives",
  "reth-execution-types",
  "reth-node-types",
- "reth-primitives",
+ "reth-primitives-traits",
  "reth-provider",
  "reth-prune-types",
- "reth-rpc-convert",
  "reth-stages-types",
  "reth-storage-api",
  "reth-trie",
@@ -10376,16 +10299,18 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
- "auto_impl",
- "dyn-clone",
+ "crossbeam-utils",
+ "dashmap",
  "futures-util",
  "metrics",
+ "parking_lot",
  "pin-project",
  "rayon",
  "reth-metrics",
  "thiserror 2.0.18",
+ "thread-priority",
  "tokio",
  "tracing",
  "tracing-futures",
@@ -10393,7 +10318,7 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10409,7 +10334,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10418,7 +10343,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "clap",
  "eyre",
@@ -10436,7 +10361,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "clap",
  "eyre",
@@ -10453,7 +10378,7 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10504,7 +10429,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10538,7 +10463,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -10571,7 +10496,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10602,7 +10527,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10622,7 +10547,6 @@ dependencies = [
  "reth-storage-errors",
  "reth-tasks",
  "reth-trie",
- "reth-trie-common",
  "reth-trie-db",
  "reth-trie-sparse",
  "thiserror 2.0.18",
@@ -10632,7 +10556,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10657,13 +10581,15 @@ dependencies = [
  "reth-trie",
  "reth-trie-common",
  "reth-trie-db",
+ "serde",
+ "serde_json",
  "smallvec",
  "tracing",
 ]
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "1.10.2"
+version = "1.11.1"
 dependencies = [
  "zstd",
 ]
@@ -11585,15 +11511,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shellexpand"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
-dependencies = [
- "dirs",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11907,7 +11824,7 @@ dependencies = [
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "windows",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -12081,6 +11998,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.115",
+]
+
+[[package]]
+name = "thread-priority"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2210811179577da3d54eb69ab0b50490ee40491a25d95b8c6011ba40771cb721"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -13247,14 +13178,36 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections 0.2.0",
+ "windows-core 0.61.2",
+ "windows-future 0.2.1",
+ "windows-link 0.1.3",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
- "windows-numerics",
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -13263,7 +13216,20 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -13274,9 +13240,20 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading 0.1.0",
 ]
 
 [[package]]
@@ -13285,9 +13262,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core",
- "windows-link",
- "windows-threading",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -13314,9 +13291,25 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-numerics"
@@ -13324,8 +13317,17 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core",
- "windows-link",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -13334,7 +13336,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -13343,7 +13354,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -13397,7 +13408,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -13452,7 +13463,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -13465,11 +13476,20 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -729,7 +729,7 @@ revm-state = { git = "https://github.com/bluealloy/revm", rev = "6ef10066478605c
 revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "0d3bcdacba2494e51786e4bbfe49c4b9521177fd" }
 
 # alloy-evm staging patches
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "001a0f029df929ce9dbe9f84e4f650d15478ec2f" }
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "e7ee0fc97f1d4eda632287b7af4f2a2798383ccc" }
 
 # alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
 # alloy-contract = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -726,10 +726,10 @@ revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "6ef1006647
 revm-state = { git = "https://github.com/bluealloy/revm", rev = "6ef10066478605c2c5029fbbdea6ec197b20a269" }
 
 # revm-inspectors staging patch
-revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "0d3bcdacba2494e51786e4bbfe49c4b9521177fd" }
+revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "7d2f39aa702df10c87e9e1749d2af36934fe57be" }
 
 # alloy-evm staging patches
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "e7ee0fc97f1d4eda632287b7af4f2a2798383ccc" }
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "be4208d07e33a4816769dd588821bbd57ad1f40c" }
 
 # alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
 # alloy-contract = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -755,4 +755,3 @@ ipnet = "2.11"
 # revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "3020ea8" }
 
 # alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "072c248" }
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -710,6 +710,27 @@ vergen-git2 = "9.1.0"
 ipnet = "2.11"
 
 [patch.crates-io]
+# revm staging patches
+revm = { git = "https://github.com/bluealloy/revm", rev = "6ef10066478605c2c5029fbbdea6ec197b20a269" }
+op-revm = { git = "https://github.com/bluealloy/revm", rev = "6ef10066478605c2c5029fbbdea6ec197b20a269" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "6ef10066478605c2c5029fbbdea6ec197b20a269" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "6ef10066478605c2c5029fbbdea6ec197b20a269" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "6ef10066478605c2c5029fbbdea6ec197b20a269" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "6ef10066478605c2c5029fbbdea6ec197b20a269" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "6ef10066478605c2c5029fbbdea6ec197b20a269" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "6ef10066478605c2c5029fbbdea6ec197b20a269" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "6ef10066478605c2c5029fbbdea6ec197b20a269" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "6ef10066478605c2c5029fbbdea6ec197b20a269" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "6ef10066478605c2c5029fbbdea6ec197b20a269" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "6ef10066478605c2c5029fbbdea6ec197b20a269" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "6ef10066478605c2c5029fbbdea6ec197b20a269" }
+
+# revm-inspectors staging patch
+revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "0d3bcdacba2494e51786e4bbfe49c4b9521177fd" }
+
+# alloy-evm staging patches
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "001a0f029df929ce9dbe9f84e4f650d15478ec2f" }
+
 # alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
 # alloy-contract = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
 # alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -445,7 +445,7 @@ revm-primitives = { version = "22.1.0", default-features = false }
 revm-interpreter = { version = "33.0.0", default-features = false }
 revm-database-interface = { version = "9.0.1", default-features = false }
 op-revm = { version = "16.0.0", default-features = false }
-revm-inspectors = "0.34.2"
+revm-inspectors = "0.35.0"
 
 # eth
 alloy-dyn-abi = "1.5.6"
@@ -455,7 +455,7 @@ alloy-sol-types = { version = "1.5.6", default-features = false }
 alloy-chains = { version = "0.2.5", default-features = false }
 alloy-eip2124 = { version = "0.2.0", default-features = false }
 alloy-eip7928 = { version = "0.3.0", default-features = false }
-alloy-evm = { version = "0.28.1", default-features = false }
+alloy-evm = { version = "0.29.0", default-features = false }
 alloy-rlp = { version = "0.3.13", default-features = false, features = ["core-net"] }
 alloy-trie = { version = "0.9.4", default-features = false }
 
@@ -710,9 +710,49 @@ vergen-git2 = "9.1.0"
 ipnet = "2.11"
 
 [patch.crates-io]
-# revm-inspectors: rebased devnet2-revm branch with revm v35.0.0
-revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", branch = "devnet2-revm" }
+# alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
+# alloy-contract = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
+# alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
+# alloy-genesis = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
+# alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
+# alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
+# alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
+# alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
+# alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
+# alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
+# alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
+# alloy-rpc-types-admin = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
+# alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
+# alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
+# alloy-rpc-types-debug = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
+# alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
+# alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
+# alloy-rpc-types-mev = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
+# alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
+# alloy-rpc-types-txpool = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
+# alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
+# alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
+# alloy-signer-local = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
+# alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
+# alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
+# alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
+# alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
 
-# alloy-evm: rebased devnet2-revm branch with revm v35.0.0
-# TODO: update rev once alloy-rs/evm devnet2-revm branch is pushed with revm v35
-alloy-evm = { git = "https://github.com/alloy-rs/evm", branch = "devnet2-revm" }
+# op-alloy-consensus = { git = "https://github.com/alloy-rs/op-alloy", rev = "a79d6fc" }
+# op-alloy-rpc-types = { git = "https://github.com/alloy-rs/op-alloy", rev = "a79d6fc" }
+# op-alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/op-alloy", rev = "a79d6fc" }
+#
+# revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "1207e33" }
+#
+# jsonrpsee = { git = "https://github.com/paradigmxyz/jsonrpsee", branch = "matt/make-rpc-service-pub" }
+# jsonrpsee-core = { git = "https://github.com/paradigmxyz/jsonrpsee", branch = "matt/make-rpc-service-pub" }
+# jsonrpsee-server = { git = "https://github.com/paradigmxyz/jsonrpsee", branch = "matt/make-rpc-service-pub" }
+# jsonrpsee-http-client = { git = "https://github.com/paradigmxyz/jsonrpsee", branch = "matt/make-rpc-service-pub" }
+# jsonrpsee-types = { git = "https://github.com/paradigmxyz/jsonrpsee", branch = "matt/make-rpc-service-pub" }
+
+# alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "df124c0" }
+
+# revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "3020ea8" }
+
+# alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "072c248" }
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -437,14 +437,14 @@ reth-trie-sparse = { path = "crates/trie/sparse", default-features = false }
 reth-zstd-compressors = { path = "crates/storage/zstd-compressors", default-features = false }
 
 # revm
-revm = { version = "34.0.0", default-features = false }
-revm-bytecode = { version = "8.0.0", default-features = false }
-revm-database = { version = "10.0.0", default-features = false }
-revm-state = { version = "9.0.0", default-features = false }
-revm-primitives = { version = "22.0.0", default-features = false }
-revm-interpreter = { version = "32.0.0", default-features = false }
-revm-database-interface = { version = "9.0.0", default-features = false }
-op-revm = { version = "15.0.0", default-features = false }
+revm = { version = "35.0.0", default-features = false }
+revm-bytecode = { version = "9.0.0", default-features = false }
+revm-database = { version = "11.0.0", default-features = false }
+revm-state = { version = "10.0.0", default-features = false }
+revm-primitives = { version = "22.1.0", default-features = false }
+revm-interpreter = { version = "33.0.0", default-features = false }
+revm-database-interface = { version = "9.0.1", default-features = false }
+op-revm = { version = "16.0.0", default-features = false }
 revm-inspectors = "0.34.2"
 
 # eth
@@ -710,69 +710,9 @@ vergen-git2 = "9.1.0"
 ipnet = "2.11"
 
 [patch.crates-io]
-# revm staging patches
-revm = { git = "https://github.com/bluealloy/revm", rev = "6ef10066478605c2c5029fbbdea6ec197b20a269" }
-op-revm = { git = "https://github.com/bluealloy/revm", rev = "6ef10066478605c2c5029fbbdea6ec197b20a269" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "6ef10066478605c2c5029fbbdea6ec197b20a269" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "6ef10066478605c2c5029fbbdea6ec197b20a269" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "6ef10066478605c2c5029fbbdea6ec197b20a269" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "6ef10066478605c2c5029fbbdea6ec197b20a269" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "6ef10066478605c2c5029fbbdea6ec197b20a269" }
-revm-handler = { git = "https://github.com/bluealloy/revm", rev = "6ef10066478605c2c5029fbbdea6ec197b20a269" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "6ef10066478605c2c5029fbbdea6ec197b20a269" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "6ef10066478605c2c5029fbbdea6ec197b20a269" }
-revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "6ef10066478605c2c5029fbbdea6ec197b20a269" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "6ef10066478605c2c5029fbbdea6ec197b20a269" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "6ef10066478605c2c5029fbbdea6ec197b20a269" }
+# revm-inspectors: rebased devnet2-revm branch with revm v35.0.0
+revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", branch = "devnet2-revm" }
 
-# revm-inspectors staging patch
-revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "7d2f39aa702df10c87e9e1749d2af36934fe57be" }
-
-# alloy-evm staging patches
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "be4208d07e33a4816769dd588821bbd57ad1f40c" }
-
-# alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-contract = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-genesis = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-admin = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-debug = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-mev = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-txpool = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-signer-local = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-
-# op-alloy-consensus = { git = "https://github.com/alloy-rs/op-alloy", rev = "a79d6fc" }
-# op-alloy-rpc-types = { git = "https://github.com/alloy-rs/op-alloy", rev = "a79d6fc" }
-# op-alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/op-alloy", rev = "a79d6fc" }
-#
-# revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "1207e33" }
-#
-# jsonrpsee = { git = "https://github.com/paradigmxyz/jsonrpsee", branch = "matt/make-rpc-service-pub" }
-# jsonrpsee-core = { git = "https://github.com/paradigmxyz/jsonrpsee", branch = "matt/make-rpc-service-pub" }
-# jsonrpsee-server = { git = "https://github.com/paradigmxyz/jsonrpsee", branch = "matt/make-rpc-service-pub" }
-# jsonrpsee-http-client = { git = "https://github.com/paradigmxyz/jsonrpsee", branch = "matt/make-rpc-service-pub" }
-# jsonrpsee-types = { git = "https://github.com/paradigmxyz/jsonrpsee", branch = "matt/make-rpc-service-pub" }
-
-# alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "df124c0" }
-
-# revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "3020ea8" }
-
-# alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "072c248" }
+# alloy-evm: rebased devnet2-revm branch with revm v35.0.0
+# TODO: update rev once alloy-rs/evm devnet2-revm branch is pushed with revm v35
+alloy-evm = { git = "https://github.com/alloy-rs/evm", branch = "devnet2-revm" }

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -825,7 +825,6 @@ where
             State::builder()
                 .with_database(StateProviderDatabase::new(state_provider))
                 .with_bundle_update()
-                .without_state_clear()
                 .build()
         });
 

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -273,6 +273,7 @@ where
             gas_limit: payload.payload.gas_limit(),
             basefee: payload.payload.saturated_base_fee_per_gas(),
             blob_excess_gas_and_price,
+            slot_num: 0,
         };
 
         Ok(EvmEnv { cfg_env, block_env })

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -536,7 +536,7 @@ impl<F, DB: Database> BasicBlockExecutor<F, DB> {
     /// Creates a new `BasicBlockExecutor` with the given strategy.
     pub fn new(strategy_factory: F, db: DB) -> Self {
         let db =
-            State::builder().with_database(db).with_bundle_update().without_state_clear().build();
+            State::builder().with_database(db).with_bundle_update().build();
         Self { strategy_factory, db }
     }
 }

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -535,8 +535,7 @@ pub struct BasicBlockExecutor<F, DB> {
 impl<F, DB: Database> BasicBlockExecutor<F, DB> {
     /// Creates a new `BasicBlockExecutor` with the given strategy.
     pub fn new(strategy_factory: F, db: DB) -> Self {
-        let db =
-            State::builder().with_database(db).with_bundle_update().build();
+        let db = State::builder().with_database(db).with_bundle_update().build();
         Self { strategy_factory, db }
     }
 }

--- a/crates/primitives-traits/src/account.rs
+++ b/crates/primitives-traits/src/account.rs
@@ -16,10 +16,10 @@ pub mod compact_ids {
     /// Identifier for removed bytecode variant.
     pub const REMOVED_BYTECODE_ID: u8 = 1;
 
-    /// Identifier for [`LegacyAnalyzed`](revm_bytecode::Bytecode::LegacyAnalyzed).
+    /// Identifier for legacy analyzed bytecode.
     pub const LEGACY_ANALYZED_BYTECODE_ID: u8 = 2;
 
-    /// Identifier for [`Eip7702`](revm_bytecode::Bytecode::Eip7702).
+    /// Identifier for EIP-7702 bytecode.
     pub const EIP7702_BYTECODE_ID: u8 = 4;
 }
 
@@ -141,25 +141,23 @@ impl reth_codecs::Compact for Bytecode {
     {
         use compact_ids::{EIP7702_BYTECODE_ID, LEGACY_ANALYZED_BYTECODE_ID};
 
-        let bytecode = match &self.0 {
-            RevmBytecode::LegacyAnalyzed(analyzed) => analyzed.bytecode(),
-            RevmBytecode::Eip7702(eip7702) => eip7702.raw(),
-        };
+        let bytecode = self.0.bytes_ref();
         buf.put_u32(bytecode.len() as u32);
         buf.put_slice(bytecode.as_ref());
-        let len = match &self.0 {
+        let len = if self.0.is_legacy() {
             // [`REMOVED_BYTECODE_ID`] has been removed.
-            RevmBytecode::LegacyAnalyzed(analyzed) => {
+            if let Some(jump_table) = self.0.legacy_jump_table() {
                 buf.put_u8(LEGACY_ANALYZED_BYTECODE_ID);
-                buf.put_u64(analyzed.original_len() as u64);
-                let map = analyzed.jump_table().as_slice();
+                buf.put_u64(self.0.len() as u64);
+                let map = jump_table.as_slice();
                 buf.put_slice(map);
                 1 + 8 + map.len()
+            } else {
+                unreachable!("legacy bytecode must contain a jump table")
             }
-            RevmBytecode::Eip7702(_) => {
-                buf.put_u8(EIP7702_BYTECODE_ID);
-                1
-            }
+        } else {
+            buf.put_u8(EIP7702_BYTECODE_ID);
+            1
         };
         len + bytecode.len() + 4
     }
@@ -255,12 +253,10 @@ impl From<Account> for AccountInfo {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     use super::*;
     use alloy_primitives::{hex_literal::hex, B256, U256};
     use reth_codecs::Compact;
-    use revm_bytecode::{JumpTable, LegacyAnalyzedBytecode};
+    use revm_bytecode::JumpTable;
 
     #[test]
     fn test_account() {
@@ -317,12 +313,11 @@ mod tests {
         assert_eq!(len, 17);
 
         let mut buf = vec![];
-        let bytecode =
-            Bytecode(RevmBytecode::LegacyAnalyzed(Arc::new(LegacyAnalyzedBytecode::new(
-                Bytes::from(&hex!("ff00")),
-                2,
-                JumpTable::from_slice(&[0], 2),
-            ))));
+        let bytecode = Bytecode(RevmBytecode::new_analyzed(
+            Bytes::from(&hex!("ff00")),
+            2,
+            JumpTable::from_slice(&[0], 2),
+        ));
         let len = bytecode.to_compact(&mut buf);
         assert_eq!(len, 16);
 

--- a/crates/revm/src/witness.rs
+++ b/crates/revm/src/witness.rs
@@ -70,8 +70,8 @@ impl ExecutionWitnessRecord {
                 }
             }
         }
-        // BTreeMap keys are ordered, so the first key is the smallest
-        self.lowest_block_number = statedb.block_hashes.keys().next().copied()
+        self.lowest_block_number =
+            statedb.block_hashes.lowest().map(|(block_number, _)| block_number)
     }
 
     /// Creates the record from the state after execution.

--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -172,7 +172,7 @@ pub trait EstimateCall: Call {
         };
 
         let gas_refund = match res.result {
-            ExecutionResult::Success { gas_refunded, .. } => gas_refunded,
+            ExecutionResult::Success { gas, .. } => gas.final_refunded(),
             ExecutionResult::Halt { reason, .. } => {
                 // here we don't check for invalid opcode because already executed with highest gas
                 // limit

--- a/crates/rpc/rpc-eth-types/src/error/api.rs
+++ b/crates/rpc/rpc-eth-types/src/error/api.rs
@@ -125,8 +125,8 @@ pub trait FromEvmError<Evm: ConfigureEvm>:
         match result {
             ExecutionResult::Success { output, .. } => Ok(output.into_data()),
             ExecutionResult::Revert { output, .. } => Err(Self::from_revert(output)),
-            ExecutionResult::Halt { reason, gas_used } => {
-                Err(Self::from_evm_halt(reason, gas_used))
+            ExecutionResult::Halt { reason, gas, .. } => {
+                Err(Self::from_evm_halt(reason, gas.used()))
             }
         }
     }

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -354,7 +354,7 @@ where
     let mut log_index = 0;
     for (index, (result, tx)) in results.into_iter().zip(block.body().transactions()).enumerate() {
         let call = match result {
-            ExecutionResult::Halt { reason, gas_used } => {
+            ExecutionResult::Halt { reason, gas, .. } => {
                 let error = Err::from_evm_halt(reason, tx.gas_limit());
                 #[allow(clippy::needless_update)]
                 SimCallResult {
@@ -364,13 +364,13 @@ where
                         code: SIMULATE_VM_ERROR_CODE,
                         ..SimulateError::invalid_params()
                     }),
-                    gas_used,
+                    gas_used: gas.used(),
                     logs: Vec::new(),
                     status: false,
                     ..Default::default()
                 }
             }
-            ExecutionResult::Revert { output, gas_used } => {
+            ExecutionResult::Revert { output, gas, .. } => {
                 let error = Err::from_revert(output.clone());
                 #[allow(clippy::needless_update)]
                 SimCallResult {
@@ -380,19 +380,19 @@ where
                         code: SIMULATE_REVERT_CODE,
                         ..SimulateError::invalid_params()
                     }),
-                    gas_used,
+                    gas_used: gas.used(),
                     status: false,
                     logs: Vec::new(),
                     ..Default::default()
                 }
             }
-            ExecutionResult::Success { output, gas_used, logs, .. } =>
+            ExecutionResult::Success { output, gas, logs, .. } =>
             {
                 #[allow(clippy::needless_update)]
                 SimCallResult {
                     return_data: output.into_data(),
                     error: None,
-                    gas_used,
+                    gas_used: gas.used(),
                     logs: logs
                         .into_iter()
                         .map(|log| {

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -4992,15 +4992,15 @@ mod tests {
                     ..Default::default()
                 };
 
-                let storage: HashMap<U256, (U256, U256), FbBuildHasher<32>> = (1..=
-                    slots_per_account as u64)
-                    .map(|s| {
-                        (
-                            U256::from(s + acct_idx as u64 * 100),
-                            (U256::ZERO, U256::from(block_num * 1000 + s)),
-                        )
-                    })
-                    .collect();
+                let storage: HashMap<U256, (U256, U256), FbBuildHasher<32>> =
+                    (1..=slots_per_account as u64)
+                        .map(|s| {
+                            (
+                                U256::from(s + acct_idx as u64 * 100),
+                                (U256::ZERO, U256::from(block_num * 1000 + s)),
+                            )
+                        })
+                        .collect();
 
                 let revert_storage: Vec<(U256, U256)> = (1..=slots_per_account as u64)
                     .map(|s| (U256::from(s + acct_idx as u64 * 100), U256::ZERO))

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -4992,15 +4992,15 @@ mod tests {
                     ..Default::default()
                 };
 
-                let storage: HashMap<U256, (U256, U256), FbBuildHasher<32>> =
-                    (1..=slots_per_account as u64)
-                        .map(|s| {
-                            (
-                                U256::from(s + acct_idx as u64 * 100),
-                                (U256::ZERO, U256::from(block_num * 1000 + s)),
-                            )
-                        })
-                        .collect();
+                let storage: HashMap<U256, (U256, U256), FbBuildHasher<32>> = (1..=
+                    slots_per_account as u64)
+                    .map(|s| {
+                        (
+                            U256::from(s + acct_idx as u64 * 100),
+                            (U256::ZERO, U256::from(block_num * 1000 + s)),
+                        )
+                    })
+                    .collect();
 
                 let revert_storage: Vec<(U256, U256)> = (1..=slots_per_account as u64)
                     .map(|s| (U256::from(s + acct_idx as u64 * 100), U256::ZERO))

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -4940,7 +4940,7 @@ mod tests {
     }
 
     fn run_save_blocks_and_verify(mode: StorageMode) {
-        use alloy_primitives::map::HashMap;
+        use alloy_primitives::map::{FbBuildHasher, HashMap};
 
         let factory = create_test_provider_factory();
 
@@ -4992,7 +4992,8 @@ mod tests {
                     ..Default::default()
                 };
 
-                let storage: HashMap<U256, (U256, U256)> = (1..=slots_per_account as u64)
+                let storage: HashMap<U256, (U256, U256), FbBuildHasher<32>> = (1..=
+                    slots_per_account as u64)
                     .map(|s| {
                         (
                             U256::from(s + acct_idx as u64 * 100),

--- a/docs/vocs/docs/pages/cli/reth.mdx
+++ b/docs/vocs/docs/pages/cli/reth.mdx
@@ -46,7 +46,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/config.mdx
+++ b/docs/vocs/docs/pages/cli/reth/config.mdx
@@ -32,7 +32,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/db.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db.mdx
@@ -155,7 +155,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/db/account-storage.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/account-storage.mdx
@@ -40,7 +40,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/db/checksum.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/checksum.mdx
@@ -42,7 +42,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/db/checksum/mdbx.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/checksum/mdbx.mdx
@@ -49,7 +49,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/db/checksum/rocksdb.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/checksum/rocksdb.mdx
@@ -48,7 +48,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/db/checksum/static-file.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/checksum/static-file.mdx
@@ -57,7 +57,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/db/clear.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/clear.mdx
@@ -41,7 +41,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/db/clear/mdbx.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/clear/mdbx.mdx
@@ -40,7 +40,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/db/clear/static-file.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/clear/static-file.mdx
@@ -46,7 +46,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/db/copy.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/copy.mdx
@@ -49,7 +49,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/db/diff.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/diff.mdx
@@ -92,7 +92,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/db/drop.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/drop.mdx
@@ -39,7 +39,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/db/get.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/get.mdx
@@ -41,7 +41,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/db/get/mdbx.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/get/mdbx.mdx
@@ -55,7 +55,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/db/get/static-file.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/get/static-file.mdx
@@ -55,7 +55,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/db/list.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/list.mdx
@@ -82,7 +82,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/db/path.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/path.mdx
@@ -36,7 +36,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/db/prune-checkpoints.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/prune-checkpoints.mdx
@@ -41,7 +41,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/db/prune-checkpoints/get.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/prune-checkpoints/get.mdx
@@ -41,7 +41,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/db/prune-checkpoints/set.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/prune-checkpoints/set.mdx
@@ -58,7 +58,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/db/repair-trie.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/repair-trie.mdx
@@ -44,7 +44,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/db/settings.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/settings.mdx
@@ -41,7 +41,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/db/settings/get.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/settings/get.mdx
@@ -36,7 +36,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/db/settings/set.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/settings/set.mdx
@@ -40,7 +40,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/db/settings/set/v2.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/settings/set/v2.mdx
@@ -40,7 +40,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/db/stage-checkpoints.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/stage-checkpoints.mdx
@@ -41,7 +41,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/db/stage-checkpoints/get.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/stage-checkpoints/get.mdx
@@ -41,7 +41,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/db/stage-checkpoints/set.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/stage-checkpoints/set.mdx
@@ -47,7 +47,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/db/state.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/state.mdx
@@ -54,7 +54,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/db/static-file-header.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/static-file-header.mdx
@@ -41,7 +41,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/db/static-file-header/block.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/static-file-header/block.mdx
@@ -51,7 +51,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/db/static-file-header/path.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/static-file-header/path.mdx
@@ -40,7 +40,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/db/stats.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/stats.mdx
@@ -52,7 +52,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/db/version.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/version.mdx
@@ -36,7 +36,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/download.mdx
+++ b/docs/vocs/docs/pages/cli/reth/download.mdx
@@ -147,7 +147,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/dump-genesis.mdx
+++ b/docs/vocs/docs/pages/cli/reth/dump-genesis.mdx
@@ -35,7 +35,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/export-era.mdx
+++ b/docs/vocs/docs/pages/cli/reth/export-era.mdx
@@ -151,7 +151,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/import-era.mdx
+++ b/docs/vocs/docs/pages/cli/reth/import-era.mdx
@@ -146,7 +146,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/import.mdx
+++ b/docs/vocs/docs/pages/cli/reth/import.mdx
@@ -154,7 +154,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/init-state.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init-state.mdx
@@ -167,7 +167,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/init.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init.mdx
@@ -135,7 +135,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -1066,7 +1066,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/p2p.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p.mdx
@@ -34,7 +34,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/p2p/body.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/body.mdx
@@ -288,7 +288,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/p2p/bootnode.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/bootnode.mdx
@@ -44,7 +44,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/p2p/enode.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/enode.mdx
@@ -35,7 +35,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/p2p/header.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/header.mdx
@@ -288,7 +288,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/p2p/rlpx.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/rlpx.mdx
@@ -30,7 +30,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/p2p/rlpx/ping.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/rlpx/ping.mdx
@@ -30,7 +30,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/prune.mdx
+++ b/docs/vocs/docs/pages/cli/reth/prune.mdx
@@ -153,7 +153,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/re-execute.mdx
+++ b/docs/vocs/docs/pages/cli/reth/re-execute.mdx
@@ -154,7 +154,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/stage.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage.mdx
@@ -33,7 +33,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/stage/drop.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/drop.mdx
@@ -149,7 +149,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/stage/dump.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump.mdx
@@ -142,7 +142,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/stage/dump/account-hashing.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump/account-hashing.mdx
@@ -48,7 +48,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/stage/dump/execution.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump/execution.mdx
@@ -48,7 +48,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/stage/dump/merkle.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump/merkle.mdx
@@ -48,7 +48,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/stage/dump/storage-hashing.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump/storage-hashing.mdx
@@ -48,7 +48,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/stage/run.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/run.mdx
@@ -401,7 +401,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/stage/unwind.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/unwind.mdx
@@ -143,7 +143,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/stage/unwind/num-blocks.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/unwind/num-blocks.mdx
@@ -40,7 +40,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/docs/vocs/docs/pages/cli/reth/stage/unwind/to-block.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/unwind/to-block.mdx
@@ -40,7 +40,7 @@ Logging:
       --log.stdout.filter <FILTER>
           The filter to use for logs written to stdout
 
-          [default: ""]
+          [default: ]
 
       --log.file.format <FORMAT>
           The format to use for logs written to the log file

--- a/examples/custom-evm/src/main.rs
+++ b/examples/custom-evm/src/main.rs
@@ -64,7 +64,7 @@ impl EvmFactory for MyEvmFactory {
             .with_cfg(input.cfg_env)
             .with_block(input.block_env)
             .build_mainnet_with_inspector(NoOpInspector {})
-            .with_precompiles(PrecompilesMap::from_static(EthPrecompiles::default().precompiles));
+            .with_precompiles(PrecompilesMap::from_static(EthPrecompiles::new(spec).precompiles));
 
         if spec == SpecId::PRAGUE {
             evm = evm.with_precompiles(PrecompilesMap::from_static(prague_custom()));

--- a/examples/precompile-cache/src/main.rs
+++ b/examples/precompile-cache/src/main.rs
@@ -74,13 +74,14 @@ impl EvmFactory for MyEvmFactory {
 
     fn create_evm<DB: Database>(&self, db: DB, input: EvmEnv) -> Self::Evm<DB, NoOpInspector> {
         let new_cache = self.precompile_cache.clone();
+        let spec = input.cfg_env.spec;
 
         let evm = Context::mainnet()
             .with_db(db)
             .with_cfg(input.cfg_env)
             .with_block(input.block_env)
             .build_mainnet_with_inspector(NoOpInspector {})
-            .with_precompiles(PrecompilesMap::from_static(EthPrecompiles::default().precompiles));
+            .with_precompiles(PrecompilesMap::from_static(EthPrecompiles::new(spec).precompiles));
 
         let mut evm = EthEvm::new(evm, false);
 


### PR DESCRIPTION
## Summary
This PR is part of the **revm release procedure** (`devnet2-revm` chain).

It updates `reth` to the selected upstream integration commits:
- `revm*` patch set -> `6ef10066478605c2c5029fbbdea6ec197b20a269`
- `revm-inspectors` -> `0d3bcdacba2494e51786e4bbfe49c4b9521177fd`
- `alloy-evm` -> `e7ee0fc97f1d4eda632287b7af4f2a2798383ccc`

## Changes
- Update patch revisions in `Cargo.toml` / `Cargo.lock`.
- Adapt examples to `EthPrecompiles::new(spec)` after upstream API changes.
- Keep PR mergeable against `main` after rebasing and conflict resolution.

## Validation
- `cargo +nightly clippy --workspace --all-targets --all-features` was previously clean before retargeting.
- After rebasing onto latest `main`, local re-validation is blocked by the workspace MSRV bump in `main` (`rustc 1.93` required in this environment).

## Procedure Context
This PR is the `reth` step in the revm release pipeline and tracks with corresponding `devnet2-revm` PRs in upstream repos.
