### PR TITLE
fix(net): abort discv4 and DNS discovery tasks on Discovery drop

### DIFF
--- a/crates/net/network/src/discovery.rs
+++ b/crates/net/network/src/discovery.rs
@@ -301,6 +301,20 @@ impl Discovery {
     }
 }
 
+impl Drop for Discovery {
+    fn drop(&mut self) {
+        if let Some(discv4) = &self.discv4 {
+            discv4.terminate();
+        }
+        if let Some(handle) = self._discv4_service.take() {
+            handle.abort();
+        }
+        if let Some(handle) = self._dns_disc_service.take() {
+            handle.abort();
+        }
+    }
+}
+
 impl Stream for Discovery {
     type Item = DiscoveryEvent;
 


### PR DESCRIPTION
When dropping an in-process node, net/discv4 and net/dns tasks are only detached and not aborted.

Discovery owns two JoinHandle for the background service tasks:
```rust
_discv4_service: Option<JoinHandle<()>>,
_dns_disc_service: Option<JoinHandle<()>>,
```
When Discovery is dropped both service tasks continue running indefinitely on the runtime as dropping join handles only detaches tasks.

- Discv4Service task never receives Terminated signal. It keeps internal _tasks JoinSet alive, which then keeps send_loop and receive_loop tasks alive.
https://github.com/paradigmxyz/reth/blob/4cec99ed1360b0908ddefa01cd211fe97adb836a/crates/net/discv4/src/lib.rs#L522-L527

- DnsDiscoveryService stream never returns None so it runs forever.
https://github.com/paradigmxyz/reth/blob/4cec99ed1360b0908ddefa01cd211fe97adb836a/crates/net/dns/src/lib.rs#L160
https://github.com/paradigmxyz/reth/blob/4cec99ed1360b0908ddefa01cd211fe97adb836a/crates/net/dns/src/lib.rs#L362

This cause leak of: 1 discv4 service task + 2 udp tasks + 1 dns service task (+ internal hickory dns query task)

A `Drop` impl of Discovery with tasks cleanup should be enough to fix this.

To reproduce:
```rust
loop {
    let node_config = NodeConfig::test()
        .with_unused_ports()
        .with_rpc(RpcServerArgs::default().with_unused_ports().with_http());
    let NodeHandle {
        node,
        node_exit_future: _,
    } = NodeBuilder::new(node_config)
        .testing_node(Runtime::test())
        .node(EthereumNode::default())
        .launch()
        .await?;
    let shutdown_ok = node.task_executor.graceful_shutdown_with_timeout(Duration::from_secs(1));
}
```