### PR TITLE
chore(ci): fix `collapsible_match` clippy lint in chainspec

### DIFF
--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -855,15 +855,9 @@ impl From<Genesis> for ChainSpec {
                             // those networks we use the activation
                             // blocks of those networks
                             match genesis.config.chain_id {
-                                1 => {
-                                    if ttd == MAINNET_PARIS_TTD {
-                                        return Some(MAINNET_PARIS_BLOCK)
-                                    }
-                                }
-                                11155111 => {
-                                    if ttd == SEPOLIA_PARIS_TTD {
-                                        return Some(SEPOLIA_PARIS_BLOCK)
-                                    }
+                                1 if ttd == MAINNET_PARIS_TTD => return Some(MAINNET_PARIS_BLOCK),
+                                11155111 if ttd == SEPOLIA_PARIS_TTD => {
+                                    return Some(SEPOLIA_PARIS_BLOCK)
                                 }
                                 _ => {}
                             };

--- a/crates/cli/commands/src/db/tui.rs
+++ b/crates/cli/commands/src/db/tui.rs
@@ -297,21 +297,18 @@ where
     }
 
     match event {
-        Event::Key(key) => {
-            if key.kind == event::KeyEventKind::Press {
-                match key.code {
-                    KeyCode::Char('q') | KeyCode::Char('Q') => return Ok(true),
-                    KeyCode::Down => app.next(),
-                    KeyCode::Up => app.previous(),
-                    KeyCode::Right => app.next_page(),
-                    KeyCode::Left => app.previous_page(),
-                    KeyCode::Char('G') => {
-                        app.mode = ViewMode::GoToPage;
-                    }
-                    _ => {}
-                }
+        Event::Key(key) if key.kind == event::KeyEventKind::Press => match key.code {
+            KeyCode::Char('q') | KeyCode::Char('Q') => return Ok(true),
+            KeyCode::Down => app.next(),
+            KeyCode::Up => app.previous(),
+            KeyCode::Right => app.next_page(),
+            KeyCode::Left => app.previous_page(),
+            KeyCode::Char('G') => {
+                app.mode = ViewMode::GoToPage;
             }
-        }
+            _ => {}
+        },
+        Event::Key(_) => {}
         Event::Mouse(e) => match e.kind {
             MouseEventKind::ScrollDown => app.next(),
             MouseEventKind::ScrollUp => app.previous(),

--- a/crates/engine/util/src/engine_store.rs
+++ b/crates/engine/util/src/engine_store.rs
@@ -108,7 +108,7 @@ impl EngineMessageStore {
                 tracing::warn!(target: "engine::store", ?filename, "Skipping non json file");
             }
         }
-        Ok(filenames_by_ts.into_iter().flat_map(|(_, paths)| paths))
+        Ok(filenames_by_ts.into_values().flatten())
     }
 }
 

--- a/crates/ethereum/consensus/src/lib.rs
+++ b/crates/ethereum/consensus/src/lib.rs
@@ -242,7 +242,7 @@ mod tests {
     #[test]
     fn test_valid_gas_limit_increase() {
         let parent = header_with_gas_limit(GAS_LIMIT_BOUND_DIVISOR * 10);
-        let child = header_with_gas_limit((parent.gas_limit + 5) as u64);
+        let child = header_with_gas_limit(parent.gas_limit + 5);
 
         assert!(validate_against_parent_gas_limit(
             &child,
@@ -260,7 +260,7 @@ mod tests {
         assert!(matches!(
             validate_against_parent_gas_limit(&child, &parent, &ChainSpec::<Header>::default()).unwrap_err(),
             ConsensusError::GasLimitInvalidMinimum { child_gas_limit }
-                if child_gas_limit == child.gas_limit as u64
+                if child_gas_limit == child.gas_limit
         ));
     }
 

--- a/crates/exex/exex/src/backfill/job.rs
+++ b/crates/exex/exex/src/backfill/job.rs
@@ -376,7 +376,7 @@ mod tests {
         );
 
         for (i, ((pipeline_block, pipeline_output), (backfill_block, mut backfill_output))) in
-            pipeline_results.iter().zip(backfill_results.into_iter()).enumerate()
+            pipeline_results.iter().zip(backfill_results).enumerate()
         {
             backfill_output.state.reverts.sort();
 

--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -955,10 +955,8 @@ impl Discv4Service {
 
         // Check if ENR was updated
         match (last_enr_seq, old_enr) {
-            (Some(new), Some(old)) => {
-                if new > old {
-                    self.send_enr_request(record);
-                }
+            (Some(new), Some(old)) if new > old => {
+                self.send_enr_request(record);
             }
             (Some(_), None) => {
                 // got an ENR
@@ -1195,10 +1193,8 @@ impl Discv4Service {
         } else {
             // Request ENR if included in the ping
             match (ping.enr_sq, old_enr) {
-                (Some(new), Some(old)) => {
-                    if new > old {
-                        self.send_enr_request(record);
-                    }
+                (Some(new), Some(old)) if new > old => {
+                    self.send_enr_request(record);
                 }
                 (Some(_), None) => {
                     self.send_enr_request(record);
@@ -1355,10 +1351,8 @@ impl Discv4Service {
                     _ => return,
                 };
                 match (fork_id, old_fork_id) {
-                    (Some(new), Some(old)) => {
-                        if new != old {
-                            self.notify(DiscoveryUpdate::EnrForkId(record, new))
-                        }
+                    (Some(new), Some(old)) if new != old => {
+                        self.notify(DiscoveryUpdate::EnrForkId(record, new))
                     }
                     (Some(new), None) => self.notify(DiscoveryUpdate::EnrForkId(record, new)),
                     _ => {}

--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -862,7 +862,7 @@ impl PeersManager {
             }
         }
 
-        if kind.filter(|kind| kind.is_trusted()).is_some() {
+        if kind.is_some_and(|kind| kind.is_trusted()) {
             // also track the peer in the peer id set
             self.trusted_peer_ids.insert(peer_id);
         }

--- a/crates/stages/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/stages/src/stages/hashing_storage.rs
@@ -552,8 +552,7 @@ mod tests {
 
                     if storage_cursor
                         .seek_by_key_subkey(bn_address.address(), entry.key)?
-                        .filter(|e| e.key == entry.key)
-                        .is_some()
+                        .is_some_and(|e| e.key == entry.key)
                     {
                         storage_cursor.delete_current()?;
                     }

--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -742,7 +742,7 @@ mod tests {
                     accounts.insert(key, (account, storage));
                 }
 
-                Ok(state_root_prehashed(accounts.into_iter()))
+                Ok(state_root_prehashed(accounts))
             })?;
 
             let static_file_provider = self.db.factory.static_file_provider();

--- a/crates/stages/stages/src/stages/utils.rs
+++ b/crates/stages/stages/src/stages/utils.rs
@@ -64,10 +64,8 @@ where
     let mut collect = |cache: &mut HashMap<P, Vec<u64>>| {
         for (key, indices) in cache.drain() {
             let last = *indices.last().expect("qed");
-            collector.insert(
-                sharded_key_factory(key, last),
-                BlockNumberList::new_pre_sorted(indices.into_iter()),
-            )?;
+            collector
+                .insert(sharded_key_factory(key, last), BlockNumberList::new_pre_sorted(indices))?;
         }
         Ok::<(), StageError>(())
     };
@@ -129,10 +127,8 @@ where
 
     let mut insert_fn = |address: Address, indices: Vec<u64>| {
         let last = indices.last().expect("indices is non-empty");
-        collector.insert(
-            ShardedKey::new(address, *last),
-            BlockNumberList::new_pre_sorted(indices.into_iter()),
-        )?;
+        collector
+            .insert(ShardedKey::new(address, *last), BlockNumberList::new_pre_sorted(indices))?;
         Ok(())
     };
 
@@ -190,7 +186,7 @@ where
         let last = indices.last().expect("qed");
         collector.insert(
             StorageShardedKey::new(key.0 .0, key.0 .1, *last),
-            BlockNumberList::new_pre_sorted(indices.into_iter()),
+            BlockNumberList::new_pre_sorted(indices),
         )?;
         Ok::<(), StageError>(())
     };

--- a/crates/stages/stages/src/test_utils/test_db.rs
+++ b/crates/stages/stages/src/test_utils/test_db.rs
@@ -424,8 +424,7 @@ impl TestStageDB {
                     let mut cursor = tx.cursor_dup_write::<tables::PlainStorageState>()?;
                     if cursor
                         .seek_by_key_subkey(address, entry.key)?
-                        .filter(|e| e.key == entry.key)
-                        .is_some()
+                        .is_some_and(|e| e.key == entry.key)
                     {
                         cursor.delete_current()?;
                     }
@@ -434,8 +433,7 @@ impl TestStageDB {
                     let mut cursor = tx.cursor_dup_write::<tables::HashedStorages>()?;
                     if cursor
                         .seek_by_key_subkey(hashed_address, hashed_entry.key)?
-                        .filter(|e| e.key == hashed_entry.key)
-                        .is_some()
+                        .is_some_and(|e| e.key == hashed_entry.key)
                     {
                         cursor.delete_current()?;
                     }

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -617,10 +617,10 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
                 let mut all_tx_hashes = Vec::with_capacity(total_tx_count);
                 for (i, block) in blocks.iter().enumerate() {
                     let recovered_block = block.recovered_block();
-                    let mut tx_num = tx_nums[i];
-                    for transaction in recovered_block.body().transactions_iter() {
+                    for (tx_num, transaction) in
+                        (tx_nums[i]..).zip(recovered_block.body().transactions_iter())
+                    {
                         all_tx_hashes.push((*transaction.tx_hash(), tx_num));
-                        tx_num += 1;
                     }
                 }
 
@@ -2756,8 +2756,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
                         StorageEntry { key: hashed_storage_key, value: *old_storage_value };
                     if hashed_storage_cursor
                         .seek_by_key_subkey(hashed_address, hashed_storage_key)?
-                        .filter(|s| s.key == hashed_storage_key)
-                        .is_some()
+                        .is_some_and(|s| s.key == hashed_storage_key)
                     {
                         hashed_storage_cursor.delete_current()?
                     }
@@ -2798,8 +2797,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
                         StorageEntry { key: *storage_key, value: *old_storage_value };
                     if plain_storage_cursor
                         .seek_by_key_subkey(*address, *storage_key)?
-                        .filter(|s| s.key == *storage_key)
-                        .is_some()
+                        .is_some_and(|s| s.key == *storage_key)
                     {
                         plain_storage_cursor.delete_current()?
                     }
@@ -2921,8 +2919,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
                         StorageEntry { key: hashed_storage_key, value: *old_storage_value };
                     if hashed_storage_cursor
                         .seek_by_key_subkey(hashed_address, hashed_storage_key)?
-                        .filter(|s| s.key == hashed_storage_key)
-                        .is_some()
+                        .is_some_and(|s| s.key == hashed_storage_key)
                     {
                         hashed_storage_cursor.delete_current()?
                     }
@@ -2965,8 +2962,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
                         StorageEntry { key: *storage_key, value: *old_storage_value };
                     if plain_storage_cursor
                         .seek_by_key_subkey(*address, *storage_key)?
-                        .filter(|s| s.key == *storage_key)
-                        .is_some()
+                        .is_some_and(|s| s.key == *storage_key)
                     {
                         plain_storage_cursor.delete_current()?
                     }
@@ -3200,8 +3196,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> HashingWriter for DatabaseProvi
 
             if hashed_storage
                 .seek_by_key_subkey(hashed_address, key)?
-                .filter(|entry| entry.key == key)
-                .is_some()
+                .is_some_and(|entry| entry.key == key)
             {
                 hashed_storage.delete_current()?;
             }
@@ -3248,8 +3243,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> HashingWriter for DatabaseProvi
             storage.into_iter().try_for_each(|(key, value)| -> ProviderResult<()> {
                 if hashed_storage_cursor
                     .seek_by_key_subkey(hashed_address, key)?
-                    .filter(|entry| entry.key == key)
-                    .is_some()
+                    .is_some_and(|entry| entry.key == key)
                 {
                     hashed_storage_cursor.delete_current()?;
                 }

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -1285,10 +1285,8 @@ impl RocksDBProvider {
         let mut batch = self.batch();
         for (block, &first_tx_num) in blocks.iter().zip(tx_nums) {
             let body = block.recovered_block().body();
-            let mut tx_num = first_tx_num;
-            for transaction in body.transactions_iter() {
+            for (tx_num, transaction) in (first_tx_num..).zip(body.transactions_iter()) {
                 batch.put::<tables::TransactionHashNumbers>(*transaction.tx_hash(), &tx_num)?;
-                tx_num += 1;
             }
         }
         ctx.pending_batches.lock().push(batch.into_inner());

--- a/crates/transaction-pool/benches/canonical_state_change.rs
+++ b/crates/transaction-pool/benches/canonical_state_change.rs
@@ -21,7 +21,7 @@ fn generate_transactions(num_senders: usize, txs_per_sender: usize) -> Vec<MockT
     for sender_idx in 0..num_senders {
         // Create a unique sender address
         let sender_bytes = sender_idx.to_be_bytes();
-        let addr_slice = [0u8; 12].into_iter().chain(sender_bytes.into_iter()).collect::<Vec<_>>();
+        let addr_slice = [0u8; 12].into_iter().chain(sender_bytes).collect::<Vec<_>>();
         let sender = Address::from_slice(&addr_slice);
 
         // Generate transactions for this sender

--- a/crates/transaction-pool/benches/insertion.rs
+++ b/crates/transaction-pool/benches/insertion.rs
@@ -17,7 +17,7 @@ fn generate_transactions(num_senders: usize, txs_per_sender: usize) -> Vec<MockT
     for sender_idx in 0..num_senders {
         // Create a unique sender address
         let sender_bytes = sender_idx.to_be_bytes();
-        let addr_slice = [0u8; 12].into_iter().chain(sender_bytes.into_iter()).collect::<Vec<_>>();
+        let addr_slice = [0u8; 12].into_iter().chain(sender_bytes).collect::<Vec<_>>();
         let sender = Address::from_slice(&addr_slice);
 
         // Generate transactions for this sender

--- a/crates/transaction-pool/benches/truncate.rs
+++ b/crates/transaction-pool/benches/truncate.rs
@@ -77,7 +77,7 @@ fn generate_many_transactions(
         let idx_slice = idx.to_be_bytes();
 
         // pad with 12 bytes of zeros before rest
-        let addr_slice = [0u8; 12].into_iter().chain(idx_slice.into_iter()).collect::<Vec<_>>();
+        let addr_slice = [0u8; 12].into_iter().chain(idx_slice).collect::<Vec<_>>();
 
         let sender = Address::from_slice(&addr_slice);
         txs.extend(create_transactions_for_sender(&mut runner, sender, depth, only_eip4844));

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -213,7 +213,7 @@ pub async fn maintain_transaction_pool<N, Client, P, St>(
                     dirty_addresses.remove(acc);
                 }
                 async move {
-                    let res = load_accounts(c, at, accs_to_reload.into_iter());
+                    let res = load_accounts(c, at, accs_to_reload);
                     let _ = tx.send(res);
                 }
                 .boxed()
@@ -221,7 +221,7 @@ pub async fn maintain_transaction_pool<N, Client, P, St>(
                 // can fetch all dirty accounts at once
                 let accs_to_reload = std::mem::take(&mut dirty_addresses);
                 async move {
-                    let res = load_accounts(c, at, accs_to_reload.into_iter());
+                    let res = load_accounts(c, at, accs_to_reload);
                     let _ = tx.send(res);
                 }
                 .boxed()

--- a/crates/transaction-pool/src/pool/pending.rs
+++ b/crates/transaction-pool/src/pool/pending.rs
@@ -142,9 +142,7 @@ impl<T: TransactionOrdering> PendingPool<T> {
         base_fee_per_blob_gas: u64,
     ) -> BestTransactionsWithFees<T> {
         let mut best = self.best();
-        let mut submission_id = self.submission_id;
-        for tx in unlocked {
-            submission_id += 1;
+        for (submission_id, tx) in (self.submission_id + 1..).zip(unlocked) {
             debug_assert!(!best.all.contains_key(tx.id()), "transaction already included");
             let priority = self.ordering.priority(&tx.transaction, base_fee);
             let tx_id = *tx.id();

--- a/crates/trie/db/src/trie_cursor.rs
+++ b/crates/trie/db/src/trie_cursor.rs
@@ -295,8 +295,8 @@ where
             if self
                 .cursor
                 .seek_by_key_subkey(self.hashed_address, nibbles.clone())?
-                .filter(|e| *e.nibbles() == nibbles)
-                .is_some()
+                .as_ref()
+                .is_some_and(|e| *e.nibbles() == nibbles)
             {
                 self.cursor.delete_current()?;
             }

--- a/crates/trie/db/tests/trie.rs
+++ b/crates/trie/db/tests/trie.rs
@@ -404,8 +404,7 @@ fn account_and_storage_trie() {
         if hashed_storage_cursor
             .seek_by_key_subkey(key3, hashed_slot)
             .unwrap()
-            .filter(|e| e.key == hashed_slot)
-            .is_some()
+            .is_some_and(|e| e.key == hashed_slot)
         {
             hashed_storage_cursor.delete_current().unwrap();
         }

--- a/crates/trie/db/tests/witness.rs
+++ b/crates/trie/db/tests/witness.rs
@@ -118,7 +118,7 @@ fn includes_nodes_for_destroyed_storage_nodes() {
         for node in multiproof.account_subtree.values() {
             assert_eq!(witness.get(&keccak256(node)), Some(node));
         }
-        for node in multiproof.storages.iter().flat_map(|(_, storage)| storage.subtree.values()) {
+        for node in multiproof.storages.values().flat_map(|storage| storage.subtree.values()) {
             assert_eq!(witness.get(&keccak256(node)), Some(node));
         }
     });
@@ -172,7 +172,7 @@ fn correctly_decodes_branch_node_values() {
         for node in multiproof.account_subtree.values() {
             assert_eq!(witness.get(&keccak256(node)), Some(node));
         }
-        for node in multiproof.storages.iter().flat_map(|(_, storage)| storage.subtree.values()) {
+        for node in multiproof.storages.values().flat_map(|storage| storage.subtree.values()) {
             assert_eq!(witness.get(&keccak256(node)), Some(node));
         }
     });

--- a/crates/trie/sparse/src/parallel.rs
+++ b/crates/trie/sparse/src/parallel.rs
@@ -3820,7 +3820,7 @@ mod tests {
         let mut stack = Vec::new();
         let mut state_mask = TrieMask::default();
 
-        for (&idx, hash) in children_indices.iter().zip(child_hashes.into_iter()) {
+        for (&idx, hash) in children_indices.iter().zip(child_hashes) {
             state_mask.set_bit(idx);
             stack.push(hash);
         }

--- a/examples/beacon-api-sidecar-fetcher/src/mined_sidecar.rs
+++ b/examples/beacon-api-sidecar-fetcher/src/mined_sidecar.rs
@@ -116,7 +116,7 @@ where
         match self.pool.get_all_blobs_exact(txs.iter().map(|(tx, _)| *tx.tx_hash()).collect()) {
             Ok(blobs) => {
                 actions_to_queue.reserve_exact(txs.len());
-                for ((tx, _), sidecar) in txs.iter().zip(blobs.into_iter()) {
+                for ((tx, _), sidecar) in txs.iter().zip(blobs) {
                     if let PooledTransactionVariant::Eip4844(transaction) = tx
                         .clone()
                         .try_into_pooled_eip4844(Arc::unwrap_or_clone(sidecar))


### PR DESCRIPTION
Recent nightly clippy started flagging the `if` inside match arms in `spec.rs` as `collapsible_match`. Collapse them into match guards to satisfy the lint.

couples of PR have the same issue
