### PR TITLE
perf(trie): replace global sort with merge sort in ChunkedHashedPostState

### DIFF
--- a/crates/trie/common/benches/hashed_state.rs
+++ b/crates/trie/common/benches/hashed_state.rs
@@ -102,5 +102,151 @@ fn bench_from_parallel_iterator(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_from_parallel_iterator);
+/// V1 global sort approach for chunking (baseline for comparison)
+fn chunks_global_sort(state: HashedPostState, chunk_size: usize) -> Vec<HashedPostState> {
+    use itertools::Itertools;
+
+    #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+    enum Order {
+        StorageWipe,
+        StorageUpdate(B256),
+        Account,
+    }
+
+    enum Item {
+        Account(Option<Account>),
+        StorageWipe,
+        StorageUpdate { slot: B256, value: U256 },
+    }
+
+    impl Item {
+        const fn order(&self) -> Order {
+            match self {
+                Self::StorageWipe => Order::StorageWipe,
+                Self::StorageUpdate { slot, .. } => Order::StorageUpdate(*slot),
+                Self::Account(_) => Order::Account,
+            }
+        }
+    }
+
+    let flattened: Vec<_> = state
+        .storages
+        .into_iter()
+        .flat_map(|(address, storage)| {
+            storage.wiped.then_some((address, Item::StorageWipe)).into_iter().chain(
+                storage
+                    .storage
+                    .into_iter()
+                    .map(move |(slot, value)| (address, Item::StorageUpdate { slot, value })),
+            )
+        })
+        .chain(
+            state.accounts.into_iter().map(|(address, account)| (address, Item::Account(account))),
+        )
+        .sorted_unstable_by_key(|(address, item)| (*address, item.order()))
+        .collect();
+
+    let mut chunks = Vec::new();
+    let mut iter = flattened.into_iter();
+    loop {
+        let mut chunk = HashedPostState::default();
+        let mut count = 0;
+        while count < chunk_size {
+            let Some((address, item)) = iter.next() else {
+                break;
+            };
+            match item {
+                Item::Account(account) => {
+                    chunk.accounts.insert(address, account);
+                }
+                Item::StorageWipe => {
+                    chunk.storages.entry(address).or_default().wiped = true;
+                }
+                Item::StorageUpdate { slot, value } => {
+                    chunk.storages.entry(address).or_default().storage.insert(slot, value);
+                }
+            }
+            count += 1;
+        }
+        if chunk.accounts.is_empty() && chunk.storages.is_empty() {
+            break;
+        }
+        chunks.push(chunk);
+    }
+    chunks
+}
+
+fn generate_chunking_test_data(num_accounts: usize, slots_per_account: usize) -> HashedPostState {
+    let mut state = HashedPostState::default();
+    for i in 0..num_accounts {
+        let hashed_address = B256::from(keccak256_u64(i as u64));
+        state.accounts.insert(
+            hashed_address,
+            if i % 10 == 0 {
+                None
+            } else {
+                Some(Account {
+                    nonce: i as u64,
+                    balance: U256::from(i * 1000),
+                    bytecode_hash: None,
+                })
+            },
+        );
+        if slots_per_account > 0 {
+            let mut storage = HashedStorage::new(i % 20 == 0);
+            for j in 0..slots_per_account {
+                storage
+                    .storage
+                    .insert(B256::from(keccak256_u64((i * 1000 + j) as u64)), U256::from(j));
+            }
+            state.storages.insert(hashed_address, storage);
+        }
+    }
+    state
+}
+
+fn bench_chunking(c: &mut Criterion) {
+    let mut group = c.benchmark_group("ChunkedHashedPostState");
+
+    for (num_accounts, slots_per_account) in [(100, 5), (500, 10), (1000, 5), (200, 50)] {
+        let chunk_size = 50;
+        let label = format!("accounts_{num_accounts}/slots_{slots_per_account}/chunk_{chunk_size}");
+
+        group.throughput(Throughput::Elements(
+            (num_accounts + num_accounts * slots_per_account) as u64,
+        ));
+
+        group.bench_with_input(
+            BenchmarkId::new("v1_global_sort", &label),
+            &(num_accounts, slots_per_account, chunk_size),
+            |b, &(na, spa, cs)| {
+                b.iter_with_setup(
+                    || generate_chunking_test_data(na, spa),
+                    |state| {
+                        let chunks = chunks_global_sort(black_box(state), cs);
+                        black_box(chunks);
+                    },
+                );
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("v2_merge_sort", &label),
+            &(num_accounts, slots_per_account, chunk_size),
+            |b, &(na, spa, cs)| {
+                b.iter_with_setup(
+                    || generate_chunking_test_data(na, spa),
+                    |state| {
+                        let chunks: Vec<_> = black_box(state).chunks(cs).collect();
+                        black_box(chunks);
+                    },
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_from_parallel_iterator, bench_chunking);
 criterion_main!(benches);

--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -12,7 +12,6 @@ use alloy_primitives::{
     map::{hash_map, B256Map, HashMap, HashSet},
     Address, B256, U256,
 };
-use itertools::Itertools;
 #[cfg(feature = "rayon")]
 pub use rayon::*;
 use reth_primitives_traits::Account;
@@ -829,15 +828,6 @@ pub struct ChunkedHashedPostState {
     size: usize,
 }
 
-/// Order discriminant for sorting flattened state items.
-/// Ordering: `StorageWipe` < `StorageUpdate` (by slot) < `Account`
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
-enum FlattenedStateOrder {
-    StorageWipe,
-    StorageUpdate(B256),
-    Account,
-}
-
 #[derive(Debug)]
 enum FlattenedHashedPostStateItem {
     Account(Option<Account>),
@@ -845,40 +835,100 @@ enum FlattenedHashedPostStateItem {
     StorageUpdate { slot: B256, value: U256 },
 }
 
-impl FlattenedHashedPostStateItem {
-    const fn order(&self) -> FlattenedStateOrder {
-        match self {
-            Self::StorageWipe => FlattenedStateOrder::StorageWipe,
-            Self::StorageUpdate { slot, .. } => FlattenedStateOrder::StorageUpdate(*slot),
-            Self::Account(_) => FlattenedStateOrder::Account,
-        }
-    }
-}
-
 impl ChunkedHashedPostState {
     fn new(hashed_post_state: HashedPostState, size: usize) -> Self {
-        let flattened = hashed_post_state
-            .storages
-            .into_iter()
-            .flat_map(|(address, storage)| {
-                storage
-                    .wiped
-                    .then_some((address, FlattenedHashedPostStateItem::StorageWipe))
-                    .into_iter()
-                    .chain(storage.storage.into_iter().map(move |(slot, value)| {
-                        (address, FlattenedHashedPostStateItem::StorageUpdate { slot, value })
-                    }))
-            })
-            .chain(hashed_post_state.accounts.into_iter().map(|(address, account)| {
-                (address, FlattenedHashedPostStateItem::Account(account))
-            }))
-            // Sort by address, then by item order to ensure correct application sequence:
-            // 1. Storage wipes (must come first to clear storage)
-            // 2. Storage updates (sorted by slot for determinism)
-            // 3. Account updates (can be applied last)
-            .sorted_unstable_by_key(|(address, item)| (*address, item.order()));
+        let HashedPostState { accounts, storages } = hashed_post_state;
 
-        Self { flattened, size }
+        // Sort accounts by address: O(a log a)
+        let mut sorted_accounts: Vec<_> = accounts.into_iter().collect();
+        sorted_accounts.sort_unstable_by_key(|(addr, _)| *addr);
+
+        // Sort each storage entry's slots and collect sorted by address:
+        // O(k log k + Σ s_i log s_i)
+        #[allow(clippy::type_complexity)]
+        let mut sorted_storages: Vec<(B256, bool, Vec<(B256, U256)>)> = storages
+            .into_iter()
+            .map(|(addr, storage)| {
+                let mut slots: Vec<_> = storage.storage.into_iter().collect();
+                slots.sort_unstable_by_key(|(slot, _)| *slot);
+                (addr, storage.wiped, slots)
+            })
+            .collect();
+        sorted_storages.sort_unstable_by_key(|(addr, _, _)| *addr);
+
+        // Pre-allocate the flattened vec
+        let total_items = sorted_accounts.len() +
+            sorted_storages
+                .iter()
+                .map(|(_, wiped, slots)| (*wiped as usize) + slots.len())
+                .sum::<usize>();
+        let mut flattened = Vec::with_capacity(total_items);
+
+        // Merge sorted accounts and storages by address.
+        // Within each address, items appear in order:
+        // StorageWipe < StorageUpdates (by slot) < Account
+        let mut accounts_iter = sorted_accounts.into_iter().peekable();
+        let mut storages_iter = sorted_storages.into_iter().peekable();
+
+        loop {
+            let acc_addr = accounts_iter.peek().map(|(a, _)| *a);
+            let stor_addr = storages_iter.peek().map(|(a, _, _)| *a);
+
+            match (acc_addr, stor_addr) {
+                (None, None) => break,
+                (Some(_), None) => {
+                    let (addr, acc) = accounts_iter.next().unwrap();
+                    flattened.push((addr, FlattenedHashedPostStateItem::Account(acc)));
+                }
+                (None, Some(_)) => {
+                    let (addr, wiped, slots) = storages_iter.next().unwrap();
+                    if wiped {
+                        flattened.push((addr, FlattenedHashedPostStateItem::StorageWipe));
+                    }
+                    for (slot, value) in slots {
+                        flattened.push((
+                            addr,
+                            FlattenedHashedPostStateItem::StorageUpdate { slot, value },
+                        ));
+                    }
+                }
+                (Some(aa), Some(sa)) => match aa.cmp(&sa) {
+                    core::cmp::Ordering::Less => {
+                        let (addr, acc) = accounts_iter.next().unwrap();
+                        flattened.push((addr, FlattenedHashedPostStateItem::Account(acc)));
+                    }
+                    core::cmp::Ordering::Greater => {
+                        let (addr, wiped, slots) = storages_iter.next().unwrap();
+                        if wiped {
+                            flattened.push((addr, FlattenedHashedPostStateItem::StorageWipe));
+                        }
+                        for (slot, value) in slots {
+                            flattened.push((
+                                addr,
+                                FlattenedHashedPostStateItem::StorageUpdate { slot, value },
+                            ));
+                        }
+                    }
+                    core::cmp::Ordering::Equal => {
+                        // Same address: storage items first, then account
+                        let (addr, wiped, slots) = storages_iter.next().unwrap();
+                        if wiped {
+                            flattened.push((addr, FlattenedHashedPostStateItem::StorageWipe));
+                        }
+                        for (slot, value) in slots {
+                            flattened.push((
+                                addr,
+                                FlattenedHashedPostStateItem::StorageUpdate { slot, value },
+                            ));
+                        }
+                        let (addr, acc) = accounts_iter.next().unwrap();
+                        flattened.push((addr, FlattenedHashedPostStateItem::Account(acc)));
+                    }
+                },
+            }
+        }
+
+        Self { flattened: flattened.into_iter(), size }
     }
 }
 


### PR DESCRIPTION
## Summary
Replaces the O(n log n) global flatten+sort in `ChunkedHashedPostState` with independent sub-array sorts + O(n) merge.

## Changes
- Sort accounts by address: O(a log a)
- Sort each storage entry's slots independently: O(s_i log s_i)
- Sort storage entries by address: O(k log k)
- Merge in address order with correct item ordering (wipe < slots < account)
- Removed now-unused `FlattenedStateOrder` enum and `order()` method
- Added criterion benchmark comparing v1 (global sort) vs v2 (merge sort)

## Testing
```
cargo test -p reth-trie-common  # all 99 tests pass
cargo bench -p reth-trie-common --features rayon --bench hashed_state -- ChunkedHashedPostState
```

| Workload | V1 (global sort) | V2 (merge sort) | Speedup |
|----------|-----------------|-----------------|---------|
| 100 accounts, 5 slots | 89 µs | 41 µs | **2.2x** |
| 500 accounts, 10 slots | 1.16 ms | 357 µs | **3.2x** |
| 1000 accounts, 5 slots | 1.33 ms | 457 µs | **2.9x** |
| 200 accounts, 50 slots | 2.27 ms | 628 µs | **3.6x** |

Prompted by: arsenii