### PR TITLE
fix(trie): sort targets before chunking in ChunkedMultiProofTargetsV2

### DIFF
--- a/crates/trie/parallel/src/targets_v2.rs
+++ b/crates/trie/parallel/src/targets_v2.rs
@@ -52,7 +52,11 @@ pub struct ChunkedMultiProofTargetsV2 {
 
 impl ChunkedMultiProofTargetsV2 {
     /// Creates a new chunked iterator for the given targets.
-    pub fn new(targets: MultiProofTargetsV2, size: usize) -> Self {
+    pub fn new(mut targets: MultiProofTargetsV2, size: usize) -> Self {
+        targets.account_targets.sort_unstable_by_key(|t| t.key());
+        for slots in targets.storage_targets.values_mut() {
+            slots.sort_unstable_by_key(|t| t.key());
+        }
         Self {
             account_targets: targets.account_targets.into_iter(),
             storage_targets: targets.storage_targets,


### PR DESCRIPTION
## Summary

`ChunkedMultiProofTargets` sorts flattened targets via `.sorted_unstable()` before chunking, but `ChunkedMultiProofTargetsV2` does not. This sorts both `account_targets` and each `storage_targets` vec by key before chunking.

## Changes

- Sort `account_targets` and `storage_targets` by key in `ChunkedMultiProofTargetsV2::new`

## Testing

`cargo test -p reth-trie-parallel` — all pass.

Prompted by: arsenii