### PR TITLE
feat(txpool): implement Geth-compatible 3-level transaction priority ordering

### DIFF
--- a/crates/transaction-pool/src/ordering.rs
+++ b/crates/transaction-pool/src/ordering.rs
@@ -70,18 +70,36 @@ impl<T> TransactionOrdering for CoinbaseTipOrdering<T>
 where
     T: PoolTransaction + 'static,
 {
-    type PriorityValue = u128;
+    /// Priority is a 3-tuple `(effective_tip, fee_cap, tip_cap)` to enable tie-breaking
+    /// when multiple transactions have the same effective tip.
+    ///
+    /// This matches Geth's transaction ordering behavior.
+    type PriorityValue = (u128, u128, u128);
     type Transaction = T;
 
-    /// Source: <https://github.com/ethereum/go-ethereum/blob/7f756dc1185d7f1eeeacb1d12341606b7135f9ea/core/txpool/legacypool/list.go#L469-L482>.
+    /// Returns the priority score for the given transaction.
     ///
-    /// NOTE: The implementation is incomplete for missing base fee.
+    /// Follows the same 3-level comparison as Geth's [`priceHeap.cmp`]:
+    /// 1. Primary: effective tip per gas (miner's actual reward)
+    /// 2. Secondary: max fee per gas (tie-breaker)
+    /// 3. Tertiary: max priority fee per gas (final tie-breaker)
+    ///
+    /// The tuple automatically provides lexicographic ordering, implementing
+    /// the exact same logic as Geth.
+    ///
+    /// [`priceHeap.cmp`]: https://github.com/ethereum/go-ethereum/blob/7f756dc1185d7f1eeeacb1d12341606b7135f9ea/core/txpool/legacypool/list.go#L469-L482
     fn priority(
         &self,
         transaction: &Self::Transaction,
         base_fee: u64,
     ) -> Priority<Self::PriorityValue> {
-        transaction.effective_tip_per_gas(base_fee).into()
+        let effective_tip = transaction.effective_tip_per_gas(base_fee).unwrap_or(0);
+
+        let fee_cap = transaction.max_fee_per_gas();
+
+        let tip_cap = transaction.max_priority_fee_per_gas().unwrap_or(0);
+
+        Priority::Value((effective_tip, fee_cap, tip_cap))
     }
 }
 

--- a/crates/transaction-pool/src/pool/best.rs
+++ b/crates/transaction-pool/src/pool/best.rs
@@ -134,9 +134,9 @@ impl<T: TransactionOrdering> BestTransactions<T> {
                     {
                         // we skip transactions if we already yielded a transaction with lower
                         // priority
-                        return Some(IncomingTransaction::Stash(tx))
+                        return Some(IncomingTransaction::Stash(tx));
                     }
-                    return Some(IncomingTransaction::Process(tx))
+                    return Some(IncomingTransaction::Process(tx));
                 }
                 // note TryRecvError::Lagged can be returned here, which is an error that attempts
                 // to correct itself on consecutive try_recv() attempts
@@ -207,7 +207,7 @@ impl<T: TransactionOrdering> BestTransactions<T> {
                     "[{:?}] skipping invalid transaction",
                     best.transaction.hash()
                 );
-                continue
+                continue;
             }
 
             // Insert transactions that just got unlocked.
@@ -228,7 +228,7 @@ impl<T: TransactionOrdering> BestTransactions<T> {
                 if self.new_transaction_receiver.is_some() {
                     self.last_priority = Some(best.priority.clone())
                 }
-                return Some((best.transaction, best.priority))
+                return Some((best.transaction, best.priority));
             }
         }
     }
@@ -316,7 +316,7 @@ where
         loop {
             let best = self.best.next()?;
             if (self.predicate)(&best) {
-                return Some(best)
+                return Some(best);
             }
             self.best.mark_invalid(
                 &best,
@@ -403,7 +403,7 @@ where
                         self.max_prioritized_gas
                 {
                     self.prioritized_gas += item.transaction.gas_limit();
-                    return Some(item)
+                    return Some(item);
                 }
                 self.buffer.push_back(item);
             }
@@ -716,7 +716,7 @@ mod tests {
         let pending_tx = PendingTransaction {
             submission_id: 10,
             transaction: Arc::new(valid_new_tx.clone()),
-            priority: Priority::Value(1000),
+            priority: Priority::Value((1000, 0, 0)),
         };
         tx_sender.send(pending_tx.clone()).unwrap();
 
@@ -763,7 +763,7 @@ mod tests {
         let pending_tx1 = PendingTransaction {
             submission_id: 10,
             transaction: Arc::new(valid_new_tx1.clone()),
-            priority: Priority::Value(1000),
+            priority: Priority::Value((1000, 0, 0)),
         };
         tx_sender.send(pending_tx1.clone()).unwrap();
 
@@ -786,7 +786,7 @@ mod tests {
         let pending_tx2 = PendingTransaction {
             submission_id: 11, // Different submission ID
             transaction: Arc::new(valid_new_tx2.clone()),
-            priority: Priority::Value(1000),
+            priority: Priority::Value((1000, 0, 0)),
         };
         tx_sender.send(pending_tx2.clone()).unwrap();
 
@@ -1032,7 +1032,7 @@ mod tests {
         let pending_tx = PendingTransaction {
             submission_id: 10,
             transaction: Arc::new(valid_new_higher_fee_tx.clone()),
-            priority: Priority::Value(u128::MAX),
+            priority: Priority::Value((u128::MAX, 0, 0)),
         };
         tx_sender.send(pending_tx).unwrap();
 


### PR DESCRIPTION
## Description
Implements 3-level transaction priority comparison to match Geth's ordering behavior.

## Changes
- Changed `PriorityValue` from `u128` to `(u128, u128, u128)` tuple
- Implements tie-breaking using: effective_tip -> fee_cap -> tip_cap
- Updated test fixtures to use tuple format

## Motivation
The current implementation only compares `effective_tip_per_gas`, lacking deterministic ordering when transactions have equal effective tips. This implements the same 3-level comparison logic as Geth's [`priceHeap.cmp`](https://github.com/ethereum/go-ethereum/blob/7f756dc1185d7f1eeeacb1d12341606b7135f9ea/core/txpool/legacypool/list.go#L469-L482).

Using a tuple leverages Rust's lexicographic ordering to automatically provide the exact same sorting behavior as Geth.