### PR TITLE
refactor(exex): remove redundant update_capacity call

### DIFF
--- a/crates/exex/exex/src/manager.rs
+++ b/crates/exex/exex/src/manager.rs
@@ -505,9 +505,6 @@ where
         }
         let buffer_full = this.buffer.len() >= this.max_capacity;
 
-        // Update capacity
-        this.update_capacity();
-
         // Advance all poll senders
         let mut min_id = usize::MAX;
         for idx in (0..this.exex_handles.len()).rev() {


### PR DESCRIPTION
Remove redundant `update_capacity()` call that runs before `buffer.retain()`. The second call after buffer cleanup already provides the correct capacity value.