### PR TITLE
fix(rpc-provider): state_root delegates to stub that always returns zero

### DIFF
--- a/crates/storage/rpc-provider/src/lib.rs
+++ b/crates/storage/rpc-provider/src/lib.rs
@@ -1166,7 +1166,7 @@ where
     Node: NodeTypes,
 {
     fn state_root(&self, hashed_state: HashedPostState) -> Result<B256, ProviderError> {
-        self.state_root_from_nodes(TrieInput::from_state(hashed_state))
+        self.state_root_with_updates(hashed_state).map(|(root, _)| root)
     }
 
     fn state_root_from_nodes(&self, _input: TrieInput) -> Result<B256, ProviderError> {


### PR DESCRIPTION
`state_root` was forwarding to `state_root_from_nodes` which unconditionally returns `B256::ZERO`, even when `compute_state_root` is enabled. The working implementation lives in `state_root_with_updates` — just delegate there and discard the trie updates.