### PR TITLE
feat: add transaction iterator helpers to Chain

### DIFF
--- a/crates/evm/execution-types/src/chain.rs
+++ b/crates/evm/execution-types/src/chain.rs
@@ -205,15 +205,14 @@ impl<N: NodePrimitives> Chain<N> {
     /// Returns an iterator over all transactions in the chain.
     pub fn transactions_iter(
         &self,
-    ) -> impl Iterator<Item = &<<N::Block as Block>::Body as BlockBody>::Transaction> + '_ {
+    ) -> impl Iterator<Item = &N::SignedTx> + '_ {
         self.blocks_iter().flat_map(|block| block.body().transactions())
     }
 
     /// Returns an iterator over all [`Recovered`] transaction references in the chain.
     pub fn transactions_recovered_iter(
         &self,
-    ) -> impl Iterator<Item = Recovered<&<<N::Block as Block>::Body as BlockBody>::Transaction>> + '_
-    {
+    ) -> impl Iterator<Item = Recovered<&N::SignedTx>> + '_ {
         self.blocks_iter().flat_map(|block| block.transactions_recovered())
     }
 

--- a/crates/evm/execution-types/src/chain.rs
+++ b/crates/evm/execution-types/src/chain.rs
@@ -203,9 +203,7 @@ impl<N: NodePrimitives> Chain<N> {
     }
 
     /// Returns an iterator over all transactions in the chain.
-    pub fn transactions_iter(
-        &self,
-    ) -> impl Iterator<Item = &N::SignedTx> + '_ {
+    pub fn transactions_iter(&self) -> impl Iterator<Item = &N::SignedTx> + '_ {
         self.blocks_iter().flat_map(|block| block.body().transactions())
     }
 

--- a/crates/evm/execution-types/src/chain.rs
+++ b/crates/evm/execution-types/src/chain.rs
@@ -202,6 +202,21 @@ impl<N: NodePrimitives> Chain<N> {
         self.blocks().iter().map(|block| block.1)
     }
 
+    /// Returns an iterator over all transactions in the chain.
+    pub fn transactions_iter(
+        &self,
+    ) -> impl Iterator<Item = &<<N::Block as Block>::Body as BlockBody>::Transaction> + '_ {
+        self.blocks_iter().flat_map(|block| block.body().transactions())
+    }
+
+    /// Returns an iterator over all [`Recovered`] transaction references in the chain.
+    pub fn transactions_recovered_iter(
+        &self,
+    ) -> impl Iterator<Item = Recovered<&<<N::Block as Block>::Body as BlockBody>::Transaction>> + '_
+    {
+        self.blocks_iter().flat_map(|block| block.transactions_recovered())
+    }
+
     /// Returns an iterator over all blocks and their receipts in the chain.
     pub fn blocks_and_receipts(
         &self,


### PR DESCRIPTION
Adds `transactions_iter()` and `transactions_recovered_iter()` to `Chain`, convenience helpers to iterate over all transactions across all blocks without manually flat-mapping.

Prompted by: matthias