### PR TITLE
chore(hive): remove engine-withdrawals from ignored tests

### DIFF
--- a/.github/scripts/hive/ignored_tests.yaml
+++ b/.github/scripts/hive/ignored_tests.yaml
@@ -11,17 +11,6 @@
 #
 # When a test should no longer be ignored, remove it from this list.
 
-# flaky
-engine-withdrawals:
-  - Withdrawals Fork on Block 1 - 8 Block Re-Org NewPayload (Paris) (reth)
-  - Withdrawals Fork on Block 8 - 10 Block Re-Org NewPayload (Paris) (reth)
-  - Withdrawals Fork on Canonical Block 8 / Side Block 7 - 10 Block Re-Org (Paris) (reth)
-  # P2P sync timing issue in hive Docker environment: secondary client returns SYNCING but
-  # peer discovery/connection doesn't complete within the timeout when running with
-  # --sim.parallelism 16. Not a correctness bug, purely a CI timing issue.
-  - Sync after 2 blocks - Withdrawals on Block 2 - Multiple Withdrawal Accounts (Paris) (reth)
-  - Sync after 2 blocks - Withdrawals on Block 2 - Multiple Withdrawal Accounts - No Transactions (Paris) (reth)
-  - Sync after 128 blocks - Withdrawals on Block 2 - Multiple Withdrawal Accounts (Paris) (reth)
 engine-cancun:
   - Transaction Re-Org, New Payload on Revert Back (Cancun) (reth)
   - Transaction Re-Org, Re-Org to Different Block (Cancun) (reth)


### PR DESCRIPTION
The sync bug causing these engine-withdrawals hive tests to flake was fixed in #22613. Removing all 6 tests from the ignored list.

Prompted by: matthias