### PR TITLE
feat(stages): add call trace index for trace_filter optimization

### DIFF
--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -128,6 +128,8 @@ pub struct StageConfig {
     pub index_account_history: IndexHistoryConfig,
     /// Index Storage History stage configuration.
     pub index_storage_history: IndexHistoryConfig,
+    /// Index Transaction History stage configuration.
+    pub index_transaction_history: IndexHistoryConfig,
     /// Common ETL related configuration.
     pub etl: EtlConfig,
 }
@@ -813,6 +815,9 @@ commit_threshold = 100000
 [stages.index_storage_history]
 commit_threshold = 100000
 
+[stages.index_transaction_history]
+commit_threshold = 100000
+
 [peers]
 refill_slots_interval = '1s'
 trusted_nodes = []
@@ -931,6 +936,9 @@ commit_threshold = 100000
 [stages.index_storage_history]
 commit_threshold = 100000
 
+[stages.index_transaction_history]
+commit_threshold = 100000
+
 [peers]
 refill_slots_interval = '5s'
 trusted_nodes = []
@@ -1022,6 +1030,9 @@ commit_threshold = 5000000
 commit_threshold = 100000
 
 [stages.index_storage_history]
+commit_threshold = 100000
+
+[stages.index_transaction_history]
 commit_threshold = 100000
 
 [peers]

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -67,6 +67,7 @@ use std::{
     collections::HashMap,
     fmt::Debug,
     net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+    sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 use tower_http::cors::CorsLayer;
@@ -805,6 +806,7 @@ where
             self.blocking_pool_guard.clone(),
             self.eth_config.clone(),
         )
+        .with_call_trace_index(Arc::new(self.provider.clone()))
     }
 
     /// Instantiates [`EthBundle`] Api
@@ -1006,6 +1008,7 @@ where
                             self.blocking_pool_guard.clone(),
                             self.eth_config.clone(),
                         )
+                        .with_call_trace_index(Arc::new(self.provider.clone()))
                         .into_rpc()
                         .into(),
                         RethRpcModule::Web3 => Web3Api::new(self.network.clone()).into_rpc().into(),

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -27,7 +27,7 @@ use reth_rpc_eth_api::{
     FromEthApiError, RpcNodeCore,
 };
 use reth_rpc_eth_types::{error::EthApiError, utils::recover_raw_transaction, EthConfig};
-use reth_storage_api::{BlockNumReader, BlockReader};
+use reth_storage_api::{BlockNumReader, BlockReader, CallTraceIndexReader, TransactionVariant};
 use reth_tasks::pool::BlockingTaskGuard;
 use reth_transaction_pool::{PoolPooledTx, PoolTransaction, TransactionPool};
 use revm::DatabaseCommit;
@@ -56,7 +56,29 @@ impl<Eth> TraceApi<Eth> {
         blocking_task_guard: BlockingTaskGuard,
         eth_config: EthConfig,
     ) -> Self {
-        let inner = Arc::new(TraceApiInner { eth_api, blocking_task_guard, eth_config });
+        let inner = Arc::new(TraceApiInner {
+            eth_api,
+            blocking_task_guard,
+            eth_config,
+            call_trace_index: None,
+        });
+        Self { inner }
+    }
+
+    /// Enables the call trace index for optimized `trace_filter` queries.
+    ///
+    /// When set, `trace_filter` will use the index to narrow down candidate blocks
+    /// instead of scanning every block in the requested range.
+    pub fn with_call_trace_index(self, index: Arc<dyn CallTraceIndexReader>) -> Self
+    where
+        Eth: Clone,
+    {
+        let inner = Arc::new(TraceApiInner {
+            eth_api: self.inner.eth_api.clone(),
+            blocking_task_guard: self.inner.blocking_task_guard.clone(),
+            eth_config: self.inner.eth_config.clone(),
+            call_trace_index: Some(index),
+        });
         Self { inner }
     }
 
@@ -70,6 +92,90 @@ impl<Eth> TraceApi<Eth> {
     /// Access the underlying `Eth` API.
     pub fn eth_api(&self) -> &Eth {
         &self.inner.eth_api
+    }
+
+    /// Queries the call trace index to find candidate blocks for a `trace_filter` request.
+    ///
+    /// Returns `Some(blocks)` if the index can narrow down the set of blocks to trace,
+    /// or `None` if a full scan is needed (e.g., no address filters specified or no index
+    /// configured).
+    fn candidate_blocks_for_trace_filter(
+        &self,
+        filter: &TraceFilter,
+        start: u64,
+        end: u64,
+    ) -> Result<Option<Vec<u64>>, EthApiError> {
+        let Some(index) = self.inner.call_trace_index.as_ref() else {
+            return Ok(None);
+        };
+
+        let from_addrs = &filter.from_address;
+        let to_addrs = &filter.to_address;
+
+        // If no addresses specified, we can't narrow down — need full scan
+        if from_addrs.is_empty() && to_addrs.is_empty() {
+            return Ok(None)
+        }
+
+        let range = start..=end;
+        let max_blocks = self.inner.eth_config.max_trace_filter_blocks as usize;
+
+        let mut from_blocks = HashSet::<u64>::default();
+        let mut to_blocks = HashSet::<u64>::default();
+
+        for addr in from_addrs {
+            match index.call_trace_from_blocks(*addr, range.clone()) {
+                Ok(blocks) => from_blocks.extend(blocks),
+                Err(err) => {
+                    // Index read failed — fall back to full block scan so results are
+                    // correct rather than silently incomplete.
+                    tracing::warn!(target: "rpc::trace", %err, "Failed to read call trace from-index, falling back to full scan");
+                    return Ok(None);
+                }
+            }
+            if from_blocks.len() > max_blocks {
+                return Err(EthApiError::InvalidParams(format!(
+                    "Too many candidate blocks for trace_filter; currently limited to {max_blocks} blocks",
+                )));
+            }
+        }
+
+        for addr in to_addrs {
+            match index.call_trace_to_blocks(*addr, range.clone()) {
+                Ok(blocks) => to_blocks.extend(blocks),
+                Err(err) => {
+                    tracing::warn!(target: "rpc::trace", %err, "Failed to read call trace to-index, falling back to full scan");
+                    return Ok(None);
+                }
+            }
+            if to_blocks.len() > max_blocks {
+                return Err(EthApiError::InvalidParams(format!(
+                    "Too many candidate blocks for trace_filter; currently limited to {max_blocks} blocks",
+                )));
+            }
+        }
+
+        // Combine based on filter mode
+        let result = match filter.mode {
+            alloy_rpc_types_trace::filter::TraceFilterMode::Union => {
+                let mut combined = from_blocks;
+                combined.extend(to_blocks);
+                combined
+            }
+            alloy_rpc_types_trace::filter::TraceFilterMode::Intersection => {
+                if from_addrs.is_empty() {
+                    to_blocks
+                } else if to_addrs.is_empty() {
+                    from_blocks
+                } else {
+                    from_blocks.intersection(&to_blocks).copied().collect()
+                }
+            }
+        };
+
+        let mut blocks: Vec<u64> = result.into_iter().collect();
+        blocks.sort_unstable();
+        Ok(Some(blocks))
     }
 }
 
@@ -344,15 +450,14 @@ where
     ) -> Result<Vec<LocalizedTransactionTrace>, Eth::Error> {
         // We'll reuse the matcher across multiple blocks that are traced in parallel
         let matcher = Arc::new(filter.matcher());
-        let TraceFilter { from_block, to_block, mut after, count, .. } = filter;
-        let start = from_block.unwrap_or(0);
+        let start = filter.from_block.unwrap_or(0);
 
         let latest_block = self.provider().best_block_number().map_err(Eth::Error::from_eth_err)?;
         if start > latest_block {
             // can't trace that range
             return Err(EthApiError::HeaderNotFound(start.into()).into());
         }
-        let end = to_block.unwrap_or(latest_block);
+        let end = filter.to_block.unwrap_or(latest_block);
         if end > latest_block {
             return Err(EthApiError::HeaderNotFound(end.into()).into());
         }
@@ -364,9 +469,30 @@ where
             .into())
         }
 
-        // ensure that the range is not too large, since we need to fetch all blocks in the range
-        let distance = end.saturating_sub(start);
-        if distance > self.inner.eth_config.max_trace_filter_blocks {
+        // Use the call trace index to narrow down candidate blocks when address
+        // filters are specified. This avoids tracing every block in the range.
+        let candidate_blocks = self.candidate_blocks_for_trace_filter(&filter, start, end)?;
+
+        // Check the range size before allocating the full block list to avoid OOM
+        // on huge ranges (e.g. fromBlock:0, toBlock:latest with no address filter).
+        let is_full_range = candidate_blocks.is_none();
+        if is_full_range {
+            let distance = end.saturating_sub(start);
+            if distance > self.inner.eth_config.max_trace_filter_blocks {
+                return Err(EthApiError::InvalidParams(format!(
+                    "Block range too large; currently limited to {} blocks",
+                    self.inner.eth_config.max_trace_filter_blocks
+                ))
+                .into())
+            }
+        }
+
+        // Build the list of block number ranges to trace. When the index provides
+        // candidate blocks we trace only those; otherwise we fall back to the full range.
+        let block_numbers: Vec<u64> = candidate_blocks.unwrap_or_else(|| (start..=end).collect());
+
+        // ensure that the number of blocks to trace is not too large
+        if block_numbers.len() as u64 > self.inner.eth_config.max_trace_filter_blocks {
             return Err(EthApiError::InvalidParams(format!(
                 "Block range too large; currently limited to {} blocks",
                 self.inner.eth_config.max_trace_filter_blocks
@@ -374,29 +500,48 @@ where
             .into())
         }
 
+        let mut after = filter.after;
+        let count = filter.count;
+
         let mut all_traces = Vec::new();
         let mut block_traces = Vec::with_capacity(self.inner.eth_config.max_tracing_requests);
-        for chunk_start in (start..=end).step_by(self.inner.eth_config.max_tracing_requests) {
-            let chunk_end = std::cmp::min(
-                chunk_start + self.inner.eth_config.max_tracing_requests as u64 - 1,
-                end,
-            );
 
-            // fetch all blocks in that chunk
+        for chunk in block_numbers.chunks(self.inner.eth_config.max_tracing_requests) {
+            let chunk = chunk.to_vec();
+
+            // fetch blocks for this chunk
             let blocks = self
                 .eth_api()
                 .spawn_blocking_io(move |this| {
-                    Ok(this
-                        .provider()
-                        .recovered_block_range(chunk_start..=chunk_end)
-                        .map_err(Eth::Error::from_eth_err)?
-                        .into_iter()
-                        .map(Arc::new)
-                        .collect::<Vec<_>>())
+                    if is_full_range {
+                        // Contiguous range: use the optimized bulk fetch
+                        let chunk_start = chunk[0];
+                        let chunk_end = chunk[chunk.len() - 1];
+                        Ok(this
+                            .provider()
+                            .recovered_block_range(chunk_start..=chunk_end)
+                            .map_err(Eth::Error::from_eth_err)?
+                            .into_iter()
+                            .map(Arc::new)
+                            .collect::<Vec<_>>())
+                    } else {
+                        // Sparse candidate blocks: fetch individually
+                        let mut result = Vec::with_capacity(chunk.len());
+                        for block_num in chunk {
+                            if let Some(block) = this
+                                .provider()
+                                .recovered_block(block_num.into(), TransactionVariant::WithHash)
+                                .map_err(Eth::Error::from_eth_err)?
+                            {
+                                result.push(Arc::new(block));
+                            }
+                        }
+                        Ok(result)
+                    }
                 })
                 .await?;
 
-            // trace all blocks
+            // trace all blocks in the chunk
             for block in &blocks {
                 let matcher = matcher.clone();
                 let traces = self.eth_api().trace_block_until(
@@ -701,8 +846,9 @@ where
     ///
     /// This is similar to `eth_getLogs` but for traces.
     ///
-    /// # Limitations
-    /// This currently requires block filter fields, since reth does not have address indices yet.
+    /// When `fromAddress` or `toAddress` filters are specified, the call trace index
+    /// (`CallTraceFromIndex`/`CallTraceToIndex`) is used to narrow down candidate blocks,
+    /// avoiding full block range scans.
     async fn trace_filter(&self, filter: TraceFilter) -> RpcResult<Vec<LocalizedTransactionTrace>> {
         let _permit = self.inner.blocking_task_guard.clone().acquire_many_owned(2).await;
         Ok(Self::trace_filter(self, filter).await.map_err(Into::into)?)
@@ -764,6 +910,8 @@ struct TraceApiInner<Eth> {
     blocking_task_guard: BlockingTaskGuard,
     // eth config settings
     eth_config: EthConfig,
+    /// Optional call trace index reader for optimizing `trace_filter` queries.
+    call_trace_index: Option<Arc<dyn CallTraceIndexReader>>,
 }
 
 /// Response type for storage tracing that contains all accessed storage slots
@@ -808,5 +956,173 @@ fn reward_trace<H: BlockHeader>(header: &H, reward: RewardAction) -> LocalizedTr
             error: None,
             result: None,
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{address, map::HashMap};
+    use alloy_rpc_types_trace::filter::{TraceFilter, TraceFilterMode};
+    use reth_storage_api::CallTraceIndexReader;
+
+    struct MockCallTraceIndex {
+        from_blocks: HashMap<Address, Vec<u64>>,
+        to_blocks: HashMap<Address, Vec<u64>>,
+    }
+
+    impl CallTraceIndexReader for MockCallTraceIndex {
+        fn call_trace_from_blocks(
+            &self,
+            address: Address,
+            range: std::ops::RangeInclusive<u64>,
+        ) -> reth_storage_api::errors::provider::ProviderResult<Vec<u64>> {
+            Ok(self
+                .from_blocks
+                .get(&address)
+                .cloned()
+                .unwrap_or_default()
+                .into_iter()
+                .filter(|b| range.contains(b))
+                .collect())
+        }
+
+        fn call_trace_to_blocks(
+            &self,
+            address: Address,
+            range: std::ops::RangeInclusive<u64>,
+        ) -> reth_storage_api::errors::provider::ProviderResult<Vec<u64>> {
+            Ok(self
+                .to_blocks
+                .get(&address)
+                .cloned()
+                .unwrap_or_default()
+                .into_iter()
+                .filter(|b| range.contains(b))
+                .collect())
+        }
+    }
+
+    fn make_trace_api(index: Option<MockCallTraceIndex>) -> TraceApi<()> {
+        let inner = Arc::new(TraceApiInner {
+            eth_api: (),
+            blocking_task_guard: BlockingTaskGuard::new(10),
+            eth_config: EthConfig::default(),
+            call_trace_index: index.map(|i| Arc::new(i) as Arc<dyn CallTraceIndexReader>),
+        });
+        TraceApi { inner }
+    }
+
+    fn make_filter(
+        from_address: Vec<Address>,
+        to_address: Vec<Address>,
+        mode: TraceFilterMode,
+    ) -> TraceFilter {
+        TraceFilter {
+            from_block: None,
+            to_block: None,
+            from_address,
+            to_address,
+            mode,
+            after: None,
+            count: None,
+        }
+    }
+
+    #[test]
+    fn test_no_index_returns_none() {
+        let api = make_trace_api(None);
+        let filter = make_filter(
+            vec![address!("0x0000000000000000000000000000000000000001")],
+            vec![],
+            TraceFilterMode::Union,
+        );
+        assert!(api.candidate_blocks_for_trace_filter(&filter, 0, 100).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_no_addresses_returns_none() {
+        let index =
+            MockCallTraceIndex { from_blocks: HashMap::default(), to_blocks: HashMap::default() };
+        let api = make_trace_api(Some(index));
+        let filter = make_filter(vec![], vec![], TraceFilterMode::Union);
+        assert!(api.candidate_blocks_for_trace_filter(&filter, 0, 100).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_union_both_sides() {
+        let addr_a = address!("0x000000000000000000000000000000000000000a");
+        let addr_b = address!("0x000000000000000000000000000000000000000b");
+
+        let index = MockCallTraceIndex {
+            from_blocks: HashMap::from_iter([(addr_a, vec![1, 3, 5])]),
+            to_blocks: HashMap::from_iter([(addr_b, vec![2, 3, 6])]),
+        };
+        let api = make_trace_api(Some(index));
+        let filter = make_filter(vec![addr_a], vec![addr_b], TraceFilterMode::Union);
+
+        let result = api.candidate_blocks_for_trace_filter(&filter, 0, 10).unwrap();
+        assert_eq!(result, Some(vec![1, 2, 3, 5, 6]));
+    }
+
+    #[test]
+    fn test_intersection_both_sides() {
+        let addr_a = address!("0x000000000000000000000000000000000000000a");
+        let addr_b = address!("0x000000000000000000000000000000000000000b");
+
+        let index = MockCallTraceIndex {
+            from_blocks: HashMap::from_iter([(addr_a, vec![1, 3, 5])]),
+            to_blocks: HashMap::from_iter([(addr_b, vec![2, 3, 6])]),
+        };
+        let api = make_trace_api(Some(index));
+        let filter = make_filter(vec![addr_a], vec![addr_b], TraceFilterMode::Intersection);
+
+        let result = api.candidate_blocks_for_trace_filter(&filter, 0, 10).unwrap();
+        assert_eq!(result, Some(vec![3]));
+    }
+
+    #[test]
+    fn test_intersection_from_only() {
+        let addr_a = address!("0x000000000000000000000000000000000000000a");
+
+        let index = MockCallTraceIndex {
+            from_blocks: HashMap::from_iter([(addr_a, vec![1, 3, 5])]),
+            to_blocks: HashMap::default(),
+        };
+        let api = make_trace_api(Some(index));
+        let filter = make_filter(vec![addr_a], vec![], TraceFilterMode::Intersection);
+
+        let result = api.candidate_blocks_for_trace_filter(&filter, 0, 10).unwrap();
+        assert_eq!(result, Some(vec![1, 3, 5]));
+    }
+
+    #[test]
+    fn test_intersection_to_only() {
+        let addr_b = address!("0x000000000000000000000000000000000000000b");
+
+        let index = MockCallTraceIndex {
+            from_blocks: HashMap::default(),
+            to_blocks: HashMap::from_iter([(addr_b, vec![2, 3, 6])]),
+        };
+        let api = make_trace_api(Some(index));
+        let filter = make_filter(vec![], vec![addr_b], TraceFilterMode::Intersection);
+
+        let result = api.candidate_blocks_for_trace_filter(&filter, 0, 10).unwrap();
+        assert_eq!(result, Some(vec![2, 3, 6]));
+    }
+
+    #[test]
+    fn test_range_filtering() {
+        let addr_a = address!("0x000000000000000000000000000000000000000a");
+
+        let index = MockCallTraceIndex {
+            from_blocks: HashMap::from_iter([(addr_a, vec![1, 5, 10, 15, 20])]),
+            to_blocks: HashMap::default(),
+        };
+        let api = make_trace_api(Some(index));
+        let filter = make_filter(vec![addr_a], vec![], TraceFilterMode::Union);
+
+        let result = api.candidate_blocks_for_trace_filter(&filter, 5, 15).unwrap();
+        assert_eq!(result, Some(vec![5, 10, 15]));
     }
 }

--- a/crates/stages/stages/src/sets.rs
+++ b/crates/stages/stages/src/sets.rs
@@ -39,9 +39,9 @@
 use crate::{
     stages::{
         AccountHashingStage, BodyStage, EraImportSource, EraStage, ExecutionStage, FinishStage,
-        HeaderStage, IndexAccountHistoryStage, IndexStorageHistoryStage, MerkleStage,
-        PruneSenderRecoveryStage, PruneStage, SenderRecoveryStage, StorageHashingStage,
-        TransactionLookupStage,
+        HeaderStage, IndexAccountHistoryStage, IndexStorageHistoryStage,
+        IndexTransactionHistoryStage, MerkleStage, PruneSenderRecoveryStage, PruneStage,
+        SenderRecoveryStage, StorageHashingStage, TransactionLookupStage,
     },
     StageSet, StageSetBuilder,
 };
@@ -79,6 +79,7 @@ use tokio::sync::watch;
 /// - [`TransactionLookupStage`]
 /// - [`IndexStorageHistoryStage`]
 /// - [`IndexAccountHistoryStage`]
+/// - [`IndexTransactionHistoryStage`]
 /// - [`PruneStage`] (execute)
 /// - [`FinishStage`]
 #[derive(Debug)]
@@ -457,6 +458,7 @@ where
     TransactionLookupStage: Stage<Provider>,
     IndexStorageHistoryStage: Stage<Provider>,
     IndexAccountHistoryStage: Stage<Provider>,
+    IndexTransactionHistoryStage: Stage<Provider>,
 {
     fn builder(self) -> StageSetBuilder<Provider> {
         StageSetBuilder::default()
@@ -474,6 +476,10 @@ where
                 self.stages_config.index_account_history,
                 self.stages_config.etl.clone(),
                 self.prune_modes.account_history,
+            ))
+            .add_stage(IndexTransactionHistoryStage::new(
+                self.stages_config.index_transaction_history,
+                self.stages_config.etl,
             ))
     }
 }

--- a/crates/stages/stages/src/stages/index_transaction_history.rs
+++ b/crates/stages/stages/src/stages/index_transaction_history.rs
@@ -1,0 +1,750 @@
+use alloy_consensus::Transaction;
+use alloy_primitives::{map::AddressMap, Address, BlockNumber};
+use reth_config::config::{EtlConfig, IndexHistoryConfig};
+use reth_db_api::{
+    cursor::{DbCursorRO, DbCursorRW},
+    models::{sharded_key::NUM_OF_INDICES_IN_SHARD, ShardedKey},
+    table::{Decode, Decompress, Table},
+    tables,
+    transaction::DbTxMut,
+    BlockNumberList,
+};
+use reth_etl::Collector;
+use reth_provider::{
+    BlockReader, DBProvider, StaticFileProviderFactory, StorageSettingsCache, TransactionsProvider,
+};
+use reth_stages_api::{
+    ExecInput, ExecOutput, Stage, StageCheckpoint, StageError, StageId, UnwindInput, UnwindOutput,
+};
+use std::fmt::Debug;
+use tracing::info;
+
+/// Stage that indexes transaction senders and recipients by block number.
+///
+/// Reads from [`tables::TransactionSenders`] and [`tables::Transactions`] to build
+/// [`tables::CallTraceFromIndex`] and [`tables::CallTraceToIndex`], which map addresses
+/// to the block numbers where they appeared as transaction sender or recipient.
+///
+/// This enables `trace_filter` to quickly narrow down candidate blocks for an address
+/// without re-executing every block in the requested range.
+#[derive(Debug)]
+pub struct IndexTransactionHistoryStage {
+    /// Number of blocks after which the control
+    /// flow will be returned to the pipeline for commit.
+    pub commit_threshold: u64,
+    /// ETL configuration
+    pub etl_config: EtlConfig,
+}
+
+impl IndexTransactionHistoryStage {
+    /// Create new instance of [`IndexTransactionHistoryStage`].
+    pub const fn new(config: IndexHistoryConfig, etl_config: EtlConfig) -> Self {
+        Self { commit_threshold: config.commit_threshold, etl_config }
+    }
+}
+
+impl Default for IndexTransactionHistoryStage {
+    fn default() -> Self {
+        Self { commit_threshold: 100_000, etl_config: EtlConfig::default() }
+    }
+}
+
+impl<Provider> Stage<Provider> for IndexTransactionHistoryStage
+where
+    Provider: DBProvider<Tx: DbTxMut>
+        + BlockReader
+        + TransactionsProvider
+        + StaticFileProviderFactory
+        + StorageSettingsCache,
+{
+    fn id(&self) -> StageId {
+        StageId::IndexTransactionHistory
+    }
+
+    fn execute(&mut self, provider: &Provider, input: ExecInput) -> Result<ExecOutput, StageError> {
+        if input.target_reached() {
+            return Ok(ExecOutput::done(input.checkpoint()))
+        }
+
+        let mut range = input.next_block_range();
+        let first_sync = input.checkpoint().block_number == 0;
+
+        // On first sync, clear the tables since it's faster to rebuild from scratch.
+        if first_sync {
+            provider.tx_ref().clear::<tables::CallTraceFromIndex>()?;
+            provider.tx_ref().clear::<tables::CallTraceToIndex>()?;
+            range = 0..=*input.next_block_range().end();
+        }
+
+        info!(target: "sync::stages::index_transaction_history::exec", ?first_sync, ?range, "Collecting transaction history indices");
+
+        let (from_collector, to_collector) =
+            collect_transaction_history_indices(provider, range.clone(), &self.etl_config)?;
+
+        info!(target: "sync::stages::index_transaction_history::exec", "Loading indices into database");
+
+        load_call_trace_index(
+            from_collector,
+            first_sync,
+            &mut provider.tx_ref().cursor_write::<tables::CallTraceFromIndex>()?,
+        )?;
+
+        load_call_trace_index(
+            to_collector,
+            first_sync,
+            &mut provider.tx_ref().cursor_write::<tables::CallTraceToIndex>()?,
+        )?;
+
+        Ok(ExecOutput { checkpoint: StageCheckpoint::new(*range.end()), done: true })
+    }
+
+    fn unwind(
+        &mut self,
+        provider: &Provider,
+        input: UnwindInput,
+    ) -> Result<UnwindOutput, StageError> {
+        let (range, unwind_progress, _) =
+            input.unwind_block_range_with_threshold(self.commit_threshold);
+
+        unwind_transaction_history_indices(provider, range)?;
+
+        Ok(UnwindOutput { checkpoint: StageCheckpoint::new(unwind_progress) })
+    }
+}
+
+/// Collects transaction history indices for both sender and recipient addresses.
+///
+/// A pair of ETL collectors for from/to address call trace indices.
+type CallTraceCollectors = (
+    Collector<ShardedKey<Address>, BlockNumberList>,
+    Collector<ShardedKey<Address>, BlockNumberList>,
+);
+
+/// Iterates over blocks in the given range, reads their transactions and senders,
+/// and groups addresses by block number into two ETL collectors (from/to).
+fn collect_transaction_history_indices<Provider>(
+    provider: &Provider,
+    range: std::ops::RangeInclusive<BlockNumber>,
+    etl_config: &EtlConfig,
+) -> Result<CallTraceCollectors, StageError>
+where
+    Provider: BlockReader + TransactionsProvider,
+{
+    let mut from_collector = Collector::new(etl_config.file_size, etl_config.dir.clone());
+    let mut to_collector = Collector::new(etl_config.file_size, etl_config.dir.clone());
+
+    let mut from_cache: AddressMap<Vec<u64>> = AddressMap::default();
+    let mut to_cache: AddressMap<Vec<u64>> = AddressMap::default();
+
+    let total_blocks = range.end().saturating_sub(*range.start()) + 1;
+    let interval = (total_blocks / 1000).max(1);
+
+    /// Maximum number of address-block entries to buffer before flushing to the ETL collector.
+    /// This bounds memory usage regardless of how many blocks are processed.
+    const MAX_CACHE_ENTRIES: usize = 1_000_000;
+
+    let mut cache_entries = 0usize;
+
+    for (idx, block_number) in range.enumerate() {
+        let body_indices = provider.block_body_indices(block_number)?.ok_or(
+            StageError::MissingStaticFileData {
+                block: Box::new(alloy_eips::eip1898::BlockWithParent {
+                    parent: Default::default(),
+                    block: alloy_eips::eip1898::BlockNumHash::new(block_number, Default::default()),
+                }),
+                segment: reth_static_file_types::StaticFileSegment::Transactions,
+            },
+        )?;
+
+        if body_indices.tx_count == 0 {
+            continue;
+        }
+
+        let tx_range = body_indices.tx_num_range();
+
+        let senders = provider.senders_by_tx_range(tx_range.clone())?;
+        let transactions = provider.transactions_by_tx_range(tx_range)?;
+
+        for (sender, tx) in senders.into_iter().zip(transactions.iter()) {
+            from_cache.entry(sender).or_default().push(block_number);
+            cache_entries += 1;
+
+            if let Some(to_addr) = tx.to() {
+                to_cache.entry(to_addr).or_default().push(block_number);
+                cache_entries += 1;
+            }
+        }
+
+        if idx > 0 && (idx as u64).is_multiple_of(interval) && total_blocks > 1000 {
+            info!(
+                target: "sync::stages::index_transaction_history",
+                progress = %format!("{:.4}%", (idx as f64 / total_blocks as f64) * 100.0),
+                "Collecting indices"
+            );
+        }
+
+        if cache_entries > MAX_CACHE_ENTRIES {
+            flush_cache(&mut from_cache, &mut from_collector)?;
+            flush_cache(&mut to_cache, &mut to_collector)?;
+            cache_entries = 0;
+        }
+    }
+
+    // Flush remaining entries
+    flush_cache(&mut from_cache, &mut from_collector)?;
+    flush_cache(&mut to_cache, &mut to_collector)?;
+
+    Ok((from_collector, to_collector))
+}
+
+/// Flushes the address->block_numbers cache into a collector.
+fn flush_cache(
+    cache: &mut AddressMap<Vec<u64>>,
+    collector: &mut Collector<ShardedKey<Address>, BlockNumberList>,
+) -> Result<(), StageError> {
+    for (address, mut indices) in cache.drain() {
+        indices.dedup();
+        let Some(&last) = indices.last() else { continue };
+        collector
+            .insert(ShardedKey::new(address, last), BlockNumberList::new_pre_sorted(indices))?;
+    }
+    Ok(())
+}
+
+/// Loads collected call trace indices into a database table.
+///
+/// Generic over the table type so it works for both [`tables::CallTraceFromIndex`] and
+/// [`tables::CallTraceToIndex`].
+fn load_call_trace_index<T, C>(
+    mut collector: Collector<ShardedKey<Address>, BlockNumberList>,
+    append_only: bool,
+    cursor: &mut C,
+) -> Result<(), StageError>
+where
+    T: Table<Key = ShardedKey<Address>, Value = BlockNumberList>,
+    C: DbCursorRW<T> + DbCursorRO<T>,
+{
+    let mut current_address: Option<Address> = None;
+    let mut current_list = Vec::<u64>::new();
+
+    let total_entries = collector.len();
+    let interval = (total_entries / 10).max(1);
+
+    for (index, element) in collector.iter()?.enumerate() {
+        let (k, v) = element?;
+        let sharded_key = ShardedKey::<Address>::decode_owned(k)?;
+        let new_list = BlockNumberList::decompress_owned(v)?;
+
+        if index > 0 && index.is_multiple_of(interval) && total_entries > 10 {
+            info!(
+                target: "sync::stages::index_transaction_history",
+                progress = %format!("{:.2}%", (index as f64 / total_entries as f64) * 100.0),
+                "Writing indices"
+            );
+        }
+
+        if current_address != Some(sharded_key.key) {
+            // Flush the previous address's shards
+            if let Some(prev_addr) = current_address {
+                flush_shards::<T, C>(prev_addr, &mut current_list, append_only, cursor)?;
+            }
+
+            current_address = Some(sharded_key.key);
+            current_list.clear();
+
+            // On incremental sync, merge with existing last shard
+            if !append_only &&
+                let Some(existing) =
+                    cursor.seek_exact(ShardedKey::last(sharded_key.key))?.map(|(_, v)| v)
+            {
+                current_list.extend(existing.iter());
+            }
+        }
+
+        current_list.extend(new_list.iter());
+
+        // Flush complete shards, keeping the last partial one buffered
+        if current_list.len() > NUM_OF_INDICES_IN_SHARD {
+            let num_full = current_list.len() / NUM_OF_INDICES_IN_SHARD;
+            let shards_to_flush = if current_list.len().is_multiple_of(NUM_OF_INDICES_IN_SHARD) {
+                num_full - 1
+            } else {
+                num_full
+            };
+
+            if shards_to_flush > 0 {
+                let flush_len = shards_to_flush * NUM_OF_INDICES_IN_SHARD;
+                let remainder = current_list.split_off(flush_len);
+                if let Some(addr) = current_address {
+                    for chunk in current_list.chunks(NUM_OF_INDICES_IN_SHARD) {
+                        let Some(&highest) = chunk.last() else { continue };
+                        let key = ShardedKey::new(addr, highest);
+                        let value = BlockNumberList::new_pre_sorted(chunk.iter().copied());
+                        if append_only {
+                            cursor.append(key, &value)?;
+                        } else {
+                            cursor.upsert(key, &value)?;
+                        }
+                    }
+                }
+                current_list = remainder;
+            }
+        }
+    }
+
+    // Flush the final address's remaining shard
+    if let Some(addr) = current_address {
+        flush_shards::<T, C>(addr, &mut current_list, append_only, cursor)?;
+    }
+
+    Ok(())
+}
+
+/// Flushes all remaining shards for an address, using `u64::MAX` for the last shard.
+fn flush_shards<T, C>(
+    address: Address,
+    list: &mut Vec<u64>,
+    append_only: bool,
+    cursor: &mut C,
+) -> Result<(), StageError>
+where
+    T: Table<Key = ShardedKey<Address>, Value = BlockNumberList>,
+    C: DbCursorRW<T> + DbCursorRO<T>,
+{
+    if list.is_empty() {
+        return Ok(());
+    }
+
+    let num_chunks = list.len().div_ceil(NUM_OF_INDICES_IN_SHARD);
+
+    for (i, chunk) in list.chunks(NUM_OF_INDICES_IN_SHARD).enumerate() {
+        let is_last = i == num_chunks - 1;
+        let highest = if is_last { u64::MAX } else { chunk.last().copied().unwrap_or(u64::MAX) };
+        let key = ShardedKey::new(address, highest);
+        let value = BlockNumberList::new_pre_sorted(chunk.iter().copied());
+
+        if append_only {
+            cursor.append(key, &value)?;
+        } else {
+            cursor.upsert(key, &value)?;
+        }
+    }
+
+    list.clear();
+    Ok(())
+}
+
+/// Unwinds history shards for a given key, removing all block numbers at or above `block_number`.
+///
+/// Returns the remaining block numbers (below the unwind point) from the boundary shard
+/// for reinsertion.
+fn unwind_history_shards<T, C>(
+    cursor: &mut C,
+    start_key: T::Key,
+    block_number: BlockNumber,
+    mut shard_belongs_to_key: impl FnMut(&T::Key) -> bool,
+) -> Result<Vec<u64>, StageError>
+where
+    T: Table<Value = BlockNumberList>,
+    T::Key: AsRef<ShardedKey<Address>>,
+    C: DbCursorRO<T> + DbCursorRW<T>,
+{
+    let mut item = cursor.seek_exact(start_key)?;
+    while let Some((sharded_key, list)) = item {
+        if !shard_belongs_to_key(&sharded_key) {
+            break
+        }
+
+        cursor.delete_current()?;
+
+        let Some(first) = list.iter().next() else {
+            item = cursor.prev()?;
+            continue
+        };
+
+        if first >= block_number {
+            item = cursor.prev()?;
+            continue
+        } else if block_number <= sharded_key.as_ref().highest_block_number {
+            return Ok(list.iter().take_while(|i| *i < block_number).collect::<Vec<_>>())
+        }
+        return Ok(list.iter().collect::<Vec<_>>())
+    }
+
+    Ok(Vec::new())
+}
+
+/// Unwinds transaction history indices by removing block entries above the unwind target.
+fn unwind_transaction_history_indices<Provider>(
+    provider: &Provider,
+    range: std::ops::RangeInclusive<BlockNumber>,
+) -> Result<(), StageError>
+where
+    Provider: DBProvider<Tx: DbTxMut> + BlockReader + TransactionsProvider,
+{
+    // Collect all addresses that need unwinding from the given block range
+    let mut from_addresses: AddressMap<Vec<u64>> = AddressMap::default();
+    let mut to_addresses: AddressMap<Vec<u64>> = AddressMap::default();
+
+    for block_number in range {
+        let body_indices = match provider.block_body_indices(block_number)? {
+            Some(indices) => indices,
+            None => continue,
+        };
+
+        if body_indices.tx_count == 0 {
+            continue;
+        }
+
+        let tx_range = body_indices.tx_num_range();
+        let senders = provider.senders_by_tx_range(tx_range.clone())?;
+        let transactions = provider.transactions_by_tx_range(tx_range)?;
+
+        for (sender, tx) in senders.into_iter().zip(transactions.iter()) {
+            from_addresses.entry(sender).or_default().push(block_number);
+            if let Some(to_addr) = tx.to() {
+                to_addresses.entry(to_addr).or_default().push(block_number);
+            }
+        }
+    }
+
+    // Unwind from_index
+    {
+        let mut cursor = provider.tx_ref().cursor_write::<tables::CallTraceFromIndex>()?;
+        for (address, indices) in &from_addresses {
+            // Indices are sorted in block order; unwinding from the smallest block number
+            // removes all entries >= that block, making subsequent calls redundant.
+            if let Some(&min_block) = indices.first() {
+                let partial_shard = unwind_history_shards::<tables::CallTraceFromIndex, _>(
+                    &mut cursor,
+                    ShardedKey::last(*address),
+                    min_block,
+                    |sharded_key| sharded_key.key == *address,
+                )?;
+
+                if !partial_shard.is_empty() {
+                    cursor.insert(
+                        ShardedKey::last(*address),
+                        &BlockNumberList::new_pre_sorted(partial_shard),
+                    )?;
+                }
+            }
+        }
+    }
+
+    // Unwind to_index
+    {
+        let mut cursor = provider.tx_ref().cursor_write::<tables::CallTraceToIndex>()?;
+        for (address, indices) in &to_addresses {
+            if let Some(&min_block) = indices.first() {
+                let partial_shard = unwind_history_shards::<tables::CallTraceToIndex, _>(
+                    &mut cursor,
+                    ShardedKey::last(*address),
+                    min_block,
+                    |sharded_key| sharded_key.key == *address,
+                )?;
+
+                if !partial_shard.is_empty() {
+                    cursor.insert(
+                        ShardedKey::last(*address),
+                        &BlockNumberList::new_pre_sorted(partial_shard),
+                    )?;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::TestStageDB;
+    use alloy_consensus::{SignableTransaction, TxLegacy};
+    use alloy_primitives::{address, Address, Signature, TxKind};
+    use reth_db_api::{
+        models::{sharded_key::NUM_OF_INDICES_IN_SHARD, StoredBlockBodyIndices},
+        tables,
+        transaction::DbTxMut,
+    };
+    use reth_provider::{providers::StaticFileWriter, DatabaseProviderFactory};
+    use reth_stages_api::{
+        ExecInput, ExecOutput, Stage, StageCheckpoint, UnwindInput, UnwindOutput,
+    };
+    use reth_static_file_types::StaticFileSegment;
+    use std::collections::BTreeMap;
+
+    const SENDER_A: Address = address!("0x000000000000000000000000000000000000000a");
+    const SENDER_B: Address = address!("0x000000000000000000000000000000000000000b");
+    const RECIPIENT_X: Address = address!("0x0000000000000000000000000000000000000011");
+    const RECIPIENT_Y: Address = address!("0x0000000000000000000000000000000000000022");
+
+    type TransactionSigned = reth_ethereum_primitives::TransactionSigned;
+
+    fn make_tx(to: TxKind) -> TransactionSigned {
+        TxLegacy { to, ..Default::default() }.into_signed(Signature::test_signature()).into()
+    }
+
+    fn shard(addr: Address, highest: u64) -> ShardedKey<Address> {
+        ShardedKey { key: addr, highest_block_number: highest }
+    }
+
+    fn cast(
+        table: Vec<(ShardedKey<Address>, BlockNumberList)>,
+    ) -> BTreeMap<ShardedKey<Address>, Vec<u64>> {
+        table.into_iter().map(|(k, v)| (k, v.iter().collect())).collect()
+    }
+
+    /// Write block body indices, transaction senders (MDBX) and transactions (static files).
+    fn setup_test_data(db: &TestStageDB, blocks: &[(u64, Vec<(Address, TxKind)>)]) {
+        // Write transactions to static files first, then drop the writer before MDBX commit.
+        {
+            let provider = db.factory.static_file_provider();
+            let mut txs_writer = provider.latest_writer(StaticFileSegment::Transactions).unwrap();
+
+            let mut tx_num = 0u64;
+            for &(block_number, ref txs) in blocks {
+                // Backfill block gaps for static files (they require no gaps from block 0).
+                let segment_header = txs_writer.user_header();
+                if segment_header.block_end().is_none() &&
+                    segment_header.expected_block_start() == 0
+                {
+                    for b in 0..block_number {
+                        txs_writer.increment_block(b).unwrap();
+                    }
+                }
+
+                for (_sender, to_kind) in txs {
+                    let signed_tx = make_tx(*to_kind);
+                    txs_writer.append_transaction(tx_num, &signed_tx).unwrap();
+                    tx_num += 1;
+                }
+                txs_writer.increment_block(block_number).unwrap();
+            }
+            txs_writer.commit().unwrap();
+        }
+
+        let mut tx_num = 0u64;
+        db.commit(|tx| {
+            for &(block_number, ref txs) in blocks {
+                let first_tx_num = tx_num;
+                let tx_count = txs.len() as u64;
+
+                tx.put::<tables::BlockBodyIndices>(
+                    block_number,
+                    StoredBlockBodyIndices { first_tx_num, tx_count },
+                )?;
+
+                for (sender, _to_kind) in txs {
+                    tx.put::<tables::TransactionSenders>(tx_num, *sender)?;
+                    tx_num += 1;
+                }
+            }
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    fn run(db: &TestStageDB, run_to: u64) {
+        let input = ExecInput { target: Some(run_to), ..Default::default() };
+        let mut stage = IndexTransactionHistoryStage::default();
+        let provider = db.factory.database_provider_rw().unwrap();
+        let out = stage.execute(&provider, input).unwrap();
+        assert_eq!(out, ExecOutput { checkpoint: StageCheckpoint::new(run_to), done: true });
+        provider.commit().unwrap();
+    }
+
+    fn unwind(db: &TestStageDB, unwind_from: u64, unwind_to: u64) {
+        let input = UnwindInput {
+            checkpoint: StageCheckpoint::new(unwind_from),
+            unwind_to,
+            ..Default::default()
+        };
+        let mut stage = IndexTransactionHistoryStage::default();
+        let provider = db.factory.database_provider_rw().unwrap();
+        let out = stage.unwind(&provider, input).unwrap();
+        assert_eq!(out, UnwindOutput { checkpoint: StageCheckpoint::new(unwind_to) });
+        provider.commit().unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_basic_execute() {
+        let db = TestStageDB::default();
+
+        // Block 0: sender_a → recipient_x
+        // Block 1: sender_b → recipient_x
+        // Block 2: sender_a → recipient_y
+        setup_test_data(
+            &db,
+            &[
+                (0, vec![(SENDER_A, TxKind::Call(RECIPIENT_X))]),
+                (1, vec![(SENDER_B, TxKind::Call(RECIPIENT_X))]),
+                (2, vec![(SENDER_A, TxKind::Call(RECIPIENT_Y))]),
+            ],
+        );
+
+        run(&db, 2);
+
+        let from_table = cast(db.table::<tables::CallTraceFromIndex>().unwrap());
+        assert_eq!(
+            from_table,
+            BTreeMap::from([
+                (shard(SENDER_A, u64::MAX), vec![0, 2]),
+                (shard(SENDER_B, u64::MAX), vec![1]),
+            ])
+        );
+
+        let to_table = cast(db.table::<tables::CallTraceToIndex>().unwrap());
+        assert_eq!(
+            to_table,
+            BTreeMap::from([
+                (shard(RECIPIENT_X, u64::MAX), vec![0, 1]),
+                (shard(RECIPIENT_Y, u64::MAX), vec![2]),
+            ])
+        );
+    }
+
+    #[tokio::test]
+    async fn test_unwind() {
+        let db = TestStageDB::default();
+
+        setup_test_data(
+            &db,
+            &[
+                (0, vec![(SENDER_A, TxKind::Call(RECIPIENT_X))]),
+                (1, vec![(SENDER_B, TxKind::Call(RECIPIENT_X))]),
+                (2, vec![(SENDER_A, TxKind::Call(RECIPIENT_Y))]),
+            ],
+        );
+
+        run(&db, 2);
+        unwind(&db, 2, 0);
+
+        let from_table = cast(db.table::<tables::CallTraceFromIndex>().unwrap());
+        assert_eq!(from_table, BTreeMap::from([(shard(SENDER_A, u64::MAX), vec![0])]));
+
+        let to_table = cast(db.table::<tables::CallTraceToIndex>().unwrap());
+        assert_eq!(to_table, BTreeMap::from([(shard(RECIPIENT_X, u64::MAX), vec![0])]));
+    }
+
+    #[tokio::test]
+    async fn test_shard_boundary() {
+        let db = TestStageDB::default();
+
+        let total_blocks = NUM_OF_INDICES_IN_SHARD as u64 + 2;
+        let blocks: Vec<(u64, Vec<(Address, TxKind)>)> =
+            (0..total_blocks).map(|b| (b, vec![(SENDER_A, TxKind::Call(RECIPIENT_X))])).collect();
+
+        setup_test_data(&db, &blocks);
+
+        run(&db, total_blocks - 1);
+
+        let from_table = cast(db.table::<tables::CallTraceFromIndex>().unwrap());
+        let full_shard: Vec<u64> = (0..NUM_OF_INDICES_IN_SHARD as u64).collect();
+        let last_block = NUM_OF_INDICES_IN_SHARD as u64 - 1;
+        let remaining: Vec<u64> = (NUM_OF_INDICES_IN_SHARD as u64..total_blocks).collect();
+
+        assert_eq!(
+            from_table,
+            BTreeMap::from([
+                (shard(SENDER_A, last_block), full_shard),
+                (shard(SENDER_A, u64::MAX), remaining),
+            ])
+        );
+    }
+
+    #[tokio::test]
+    async fn test_contract_creation_no_to_index() {
+        let db = TestStageDB::default();
+
+        // Block 0: sender_a creates a contract (TxKind::Create)
+        // Block 1: empty (target must be > 0 for the stage to execute on first sync)
+        setup_test_data(&db, &[(0, vec![(SENDER_A, TxKind::Create)]), (1, vec![])]);
+
+        run(&db, 1);
+
+        let from_table = cast(db.table::<tables::CallTraceFromIndex>().unwrap());
+        assert_eq!(from_table, BTreeMap::from([(shard(SENDER_A, u64::MAX), vec![0])]));
+
+        let to_table = cast(db.table::<tables::CallTraceToIndex>().unwrap());
+        assert!(to_table.is_empty(), "Create transactions should not produce to-index entries");
+    }
+
+    #[tokio::test]
+    async fn test_empty_blocks() {
+        let db = TestStageDB::default();
+
+        // Three blocks with zero transactions
+        setup_test_data(&db, &[(0, vec![]), (1, vec![]), (2, vec![])]);
+
+        run(&db, 2);
+
+        let from_table = db.table::<tables::CallTraceFromIndex>().unwrap();
+        assert!(from_table.is_empty());
+
+        let to_table = db.table::<tables::CallTraceToIndex>().unwrap();
+        assert!(to_table.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_unwind_across_shard_boundary() {
+        let db = TestStageDB::default();
+
+        let total_blocks = NUM_OF_INDICES_IN_SHARD as u64 + 2;
+        let blocks: Vec<(u64, Vec<(Address, TxKind)>)> =
+            (0..total_blocks).map(|b| (b, vec![(SENDER_A, TxKind::Call(RECIPIENT_X))])).collect();
+
+        setup_test_data(&db, &blocks);
+        run(&db, total_blocks - 1);
+
+        // Verify two shards exist before unwind
+        let from_table = cast(db.table::<tables::CallTraceFromIndex>().unwrap());
+        assert_eq!(from_table.len(), 2);
+
+        // Unwind into the first shard (keep half of the first shard's blocks)
+        let unwind_to = NUM_OF_INDICES_IN_SHARD as u64 / 2;
+        unwind(&db, total_blocks - 1, unwind_to);
+
+        let from_table = cast(db.table::<tables::CallTraceFromIndex>().unwrap());
+        let expected: Vec<u64> = (0..=unwind_to).collect();
+        assert_eq!(from_table, BTreeMap::from([(shard(SENDER_A, u64::MAX), expected)]));
+
+        let to_table = cast(db.table::<tables::CallTraceToIndex>().unwrap());
+        let expected: Vec<u64> = (0..=unwind_to).collect();
+        assert_eq!(to_table, BTreeMap::from([(shard(RECIPIENT_X, u64::MAX), expected)]));
+    }
+
+    #[tokio::test]
+    async fn test_partial_unwind() {
+        let db = TestStageDB::default();
+
+        // Block 0: sender_a → recipient_x
+        // Block 1: sender_b → recipient_x
+        // Block 2: sender_a → recipient_y
+        setup_test_data(
+            &db,
+            &[
+                (0, vec![(SENDER_A, TxKind::Call(RECIPIENT_X))]),
+                (1, vec![(SENDER_B, TxKind::Call(RECIPIENT_X))]),
+                (2, vec![(SENDER_A, TxKind::Call(RECIPIENT_Y))]),
+            ],
+        );
+
+        run(&db, 2);
+        // Unwind to block 1 — block 2 entries should be removed
+        unwind(&db, 2, 1);
+
+        let from_table = cast(db.table::<tables::CallTraceFromIndex>().unwrap());
+        assert_eq!(
+            from_table,
+            BTreeMap::from([
+                (shard(SENDER_A, u64::MAX), vec![0]),
+                (shard(SENDER_B, u64::MAX), vec![1]),
+            ])
+        );
+
+        let to_table = cast(db.table::<tables::CallTraceToIndex>().unwrap());
+        assert_eq!(to_table, BTreeMap::from([(shard(RECIPIENT_X, u64::MAX), vec![0, 1])]));
+    }
+}

--- a/crates/stages/stages/src/stages/mod.rs
+++ b/crates/stages/stages/src/stages/mod.rs
@@ -15,6 +15,8 @@ mod headers;
 mod index_account_history;
 /// Index history of storage changes
 mod index_storage_history;
+/// Index history of transaction senders and recipients
+mod index_transaction_history;
 /// Stage for computing state root.
 mod merkle;
 mod prune;
@@ -32,6 +34,7 @@ pub use hashing_storage::*;
 pub use headers::*;
 pub use index_account_history::*;
 pub use index_storage_history::*;
+pub use index_transaction_history::*;
 pub use merkle::*;
 pub use prune::*;
 pub use sender_recovery::*;

--- a/crates/stages/types/src/id.rs
+++ b/crates/stages/types/src/id.rs
@@ -29,6 +29,7 @@ pub enum StageId {
     TransactionLookup,
     IndexStorageHistory,
     IndexAccountHistory,
+    IndexTransactionHistory,
     Prune,
     Finish,
     /// Other custom stage with a provided string identifier.
@@ -43,7 +44,7 @@ static ENCODED_STAGE_IDS: OnceLock<HashMap<StageId, Vec<u8>>> = OnceLock::new();
 
 impl StageId {
     /// All supported Stages
-    pub const ALL: [Self; 15] = [
+    pub const ALL: [Self; 16] = [
         Self::Era,
         Self::Headers,
         Self::Bodies,
@@ -57,6 +58,7 @@ impl StageId {
         Self::TransactionLookup,
         Self::IndexStorageHistory,
         Self::IndexAccountHistory,
+        Self::IndexTransactionHistory,
         Self::Prune,
         Self::Finish,
     ];
@@ -93,6 +95,7 @@ impl StageId {
             Self::MerkleExecute => "MerkleExecute",
             Self::TransactionLookup => "TransactionLookup",
             Self::IndexAccountHistory => "IndexAccountHistory",
+            Self::IndexTransactionHistory => "IndexTransactionHistory",
             Self::IndexStorageHistory => "IndexStorageHistory",
             Self::Prune => "Prune",
             Self::Finish => "Finish",
@@ -157,6 +160,7 @@ mod tests {
         assert_eq!(StageId::StorageHashing.to_string(), "StorageHashing");
         assert_eq!(StageId::MerkleExecute.to_string(), "MerkleExecute");
         assert_eq!(StageId::IndexAccountHistory.to_string(), "IndexAccountHistory");
+        assert_eq!(StageId::IndexTransactionHistory.to_string(), "IndexTransactionHistory");
         assert_eq!(StageId::IndexStorageHistory.to_string(), "IndexStorageHistory");
         assert_eq!(StageId::TransactionLookup.to_string(), "TransactionLookup");
         assert_eq!(StageId::Finish.to_string(), "Finish");

--- a/crates/storage/db-api/src/tables/mod.rs
+++ b/crates/storage/db-api/src/tables/mod.rs
@@ -501,6 +501,24 @@ tables! {
         type Value = Address;
     }
 
+    /// Stores pointers to block numbers where an address appeared as a transaction sender.
+    ///
+    /// Used by `trace_filter` to quickly find blocks relevant to an address.
+    /// Sharding follows the same pattern as [`AccountsHistory`].
+    table CallTraceFromIndex {
+        type Key = ShardedKey<Address>;
+        type Value = BlockNumberList;
+    }
+
+    /// Stores pointers to block numbers where an address appeared as a transaction recipient.
+    ///
+    /// Used by `trace_filter` to quickly find blocks relevant to an address.
+    /// Sharding follows the same pattern as [`AccountsHistory`].
+    table CallTraceToIndex {
+        type Key = ShardedKey<Address>;
+        type Value = BlockNumberList;
+    }
+
     /// Stores the highest synced block number and stage-specific checkpoint of each stage.
     table StageCheckpoints {
         type Key = StageId;

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -471,6 +471,24 @@ impl<N: ProviderNodeTypes> BlockBodyIndicesProvider for BlockchainProvider<N> {
     }
 }
 
+impl<N: ProviderNodeTypes> reth_storage_api::CallTraceIndexReader for BlockchainProvider<N> {
+    fn call_trace_from_blocks(
+        &self,
+        address: Address,
+        range: std::ops::RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Vec<BlockNumber>> {
+        self.consistent_provider()?.call_trace_from_blocks(address, range)
+    }
+
+    fn call_trace_to_blocks(
+        &self,
+        address: Address,
+        range: std::ops::RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Vec<BlockNumber>> {
+        self.consistent_provider()?.call_trace_to_blocks(address, range)
+    }
+}
+
 impl<N: ProviderNodeTypes> StageCheckpointReader for BlockchainProvider<N> {
     fn get_stage_checkpoint(&self, id: StageId) -> ProviderResult<Option<StageCheckpoint>> {
         self.consistent_provider()?.get_stage_checkpoint(id)

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -1187,6 +1187,24 @@ impl<N: ProviderNodeTypes> BlockBodyIndicesProvider for ConsistentProvider<N> {
     }
 }
 
+impl<N: ProviderNodeTypes> reth_storage_api::CallTraceIndexReader for ConsistentProvider<N> {
+    fn call_trace_from_blocks(
+        &self,
+        address: Address,
+        range: std::ops::RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Vec<BlockNumber>> {
+        self.storage_provider.call_trace_from_blocks(address, range)
+    }
+
+    fn call_trace_to_blocks(
+        &self,
+        address: Address,
+        range: std::ops::RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Vec<BlockNumber>> {
+        self.storage_provider.call_trace_to_blocks(address, range)
+    }
+}
+
 impl<N: ProviderNodeTypes> StageCheckpointReader for ConsistentProvider<N> {
     fn get_stage_checkpoint(&self, id: StageId) -> ProviderResult<Option<StageCheckpoint>> {
         self.storage_provider.get_stage_checkpoint(id)

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -3403,6 +3403,70 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> HistoryWriter for DatabaseProvi
     }
 }
 
+impl<TX: DbTx + Sync + 'static, N: NodeTypes> reth_storage_api::CallTraceIndexReader
+    for DatabaseProvider<TX, N>
+{
+    fn call_trace_from_blocks(
+        &self,
+        address: Address,
+        range: RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Vec<BlockNumber>> {
+        collect_blocks_from_sharded_index::<tables::CallTraceFromIndex>(&self.tx, address, range)
+    }
+
+    fn call_trace_to_blocks(
+        &self,
+        address: Address,
+        range: RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Vec<BlockNumber>> {
+        collect_blocks_from_sharded_index::<tables::CallTraceToIndex>(&self.tx, address, range)
+    }
+}
+
+/// Collects block numbers from a sharded index table for a given address within a range.
+fn collect_blocks_from_sharded_index<T>(
+    tx: &impl DbTx,
+    address: Address,
+    range: RangeInclusive<BlockNumber>,
+) -> ProviderResult<Vec<BlockNumber>>
+where
+    T: Table<Key = ShardedKey<Address>, Value = BlockNumberList>,
+{
+    let mut blocks = Vec::new();
+    let mut cursor = tx.cursor_read::<T>()?;
+
+    // Seek to the first shard that could contain blocks >= range.start()
+    let start_key = ShardedKey::new(address, *range.start());
+    let mut item = cursor.seek(start_key)?;
+
+    while let Some((sharded_key, list)) = item {
+        // Stop if we've moved past this address
+        if sharded_key.as_ref().key != address {
+            break;
+        }
+
+        // Collect block numbers within the requested range
+        for block in list.iter() {
+            if block > *range.end() {
+                // All remaining blocks in subsequent shards will also be > end
+                return Ok(blocks);
+            }
+            if block >= *range.start() {
+                blocks.push(block);
+            }
+        }
+
+        // If this shard's highest block is u64::MAX, this was the last shard
+        if sharded_key.as_ref().highest_block_number == u64::MAX {
+            break;
+        }
+
+        item = cursor.next()?;
+    }
+
+    Ok(blocks)
+}
+
 impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> BlockExecutionWriter
     for DatabaseProvider<TX, N>
 {

--- a/crates/storage/provider/src/traits/full.rs
+++ b/crates/storage/provider/src/traits/full.rs
@@ -1,8 +1,8 @@
 //! Helper provider traits to encapsulate all provider traits for simplicity.
 
 use crate::{
-    AccountReader, BlockReader, BlockReaderIdExt, ChainSpecProvider, ChangeSetReader,
-    DatabaseProviderFactory, HashedPostStateProvider, PruneCheckpointReader,
+    AccountReader, BlockReader, BlockReaderIdExt, CallTraceIndexReader, ChainSpecProvider,
+    ChangeSetReader, DatabaseProviderFactory, HashedPostStateProvider, PruneCheckpointReader,
     RocksDBProviderFactory, StageCheckpointReader, StateProviderFactory, StateReader,
     StaticFileProviderFactory,
 };
@@ -42,6 +42,7 @@ pub trait FullProvider<N: NodeTypesWithDB>:
     + ForkChoiceSubscriptions<Header = HeaderTy<N>>
     + PersistedBlockSubscriptions
     + StageCheckpointReader
+    + CallTraceIndexReader
     + Clone
     + Debug
     + Unpin
@@ -77,6 +78,7 @@ impl<T, N: NodeTypesWithDB> FullProvider<N> for T where
         + ForkChoiceSubscriptions<Header = HeaderTy<N>>
         + PersistedBlockSubscriptions
         + StageCheckpointReader
+        + CallTraceIndexReader
         + Clone
         + Debug
         + Unpin

--- a/crates/storage/storage-api/src/call_trace.rs
+++ b/crates/storage/storage-api/src/call_trace.rs
@@ -1,0 +1,26 @@
+use alloy_primitives::{Address, BlockNumber};
+use auto_impl::auto_impl;
+use reth_storage_errors::provider::ProviderResult;
+
+/// Reader for call trace indices (from/to address → block number bitmaps).
+///
+/// These indices map addresses to block numbers where they appeared as
+/// transaction sender or recipient, enabling efficient `trace_filter` queries.
+#[auto_impl(&, Arc, Box)]
+pub trait CallTraceIndexReader: Send + Sync {
+    /// Returns block numbers where the given address appeared as a transaction sender
+    /// within the specified block range.
+    fn call_trace_from_blocks(
+        &self,
+        address: Address,
+        range: std::ops::RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Vec<BlockNumber>>;
+
+    /// Returns block numbers where the given address appeared as a transaction recipient
+    /// within the specified block range.
+    fn call_trace_to_blocks(
+        &self,
+        address: Address,
+        range: std::ops::RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Vec<BlockNumber>>;
+}

--- a/crates/storage/storage-api/src/call_trace.rs
+++ b/crates/storage/storage-api/src/call_trace.rs
@@ -1,5 +1,7 @@
+use alloc::vec::Vec;
 use alloy_primitives::{Address, BlockNumber};
 use auto_impl::auto_impl;
+use core::ops::RangeInclusive;
 use reth_storage_errors::provider::ProviderResult;
 
 /// Reader for call trace indices (from/to address → block number bitmaps).
@@ -13,7 +15,7 @@ pub trait CallTraceIndexReader: Send + Sync {
     fn call_trace_from_blocks(
         &self,
         address: Address,
-        range: std::ops::RangeInclusive<BlockNumber>,
+        range: RangeInclusive<BlockNumber>,
     ) -> ProviderResult<Vec<BlockNumber>>;
 
     /// Returns block numbers where the given address appeared as a transaction recipient
@@ -21,6 +23,6 @@ pub trait CallTraceIndexReader: Send + Sync {
     fn call_trace_to_blocks(
         &self,
         address: Address,
-        range: std::ops::RangeInclusive<BlockNumber>,
+        range: RangeInclusive<BlockNumber>,
     ) -> ProviderResult<Vec<BlockNumber>>;
 }

--- a/crates/storage/storage-api/src/full.rs
+++ b/crates/storage/storage-api/src/full.rs
@@ -3,8 +3,8 @@
 use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
 
 use crate::{
-    BlockReaderIdExt, HeaderProvider, StageCheckpointReader, StateProviderFactory,
-    TransactionsProvider,
+    BlockReaderIdExt, CallTraceIndexReader, HeaderProvider, StageCheckpointReader,
+    StateProviderFactory, TransactionsProvider,
 };
 
 /// Helper trait to unify all provider traits required to support `eth` RPC server behaviour, for
@@ -16,6 +16,7 @@ pub trait FullRpcProvider:
     + HeaderProvider
     + TransactionsProvider
     + StageCheckpointReader
+    + CallTraceIndexReader
     + Clone
     + Unpin
     + 'static
@@ -29,6 +30,7 @@ impl<T> FullRpcProvider for T where
         + HeaderProvider
         + TransactionsProvider
         + StageCheckpointReader
+        + CallTraceIndexReader
         + Clone
         + Unpin
         + 'static

--- a/crates/storage/storage-api/src/lib.rs
+++ b/crates/storage/storage-api/src/lib.rs
@@ -70,6 +70,11 @@ mod history;
 pub use history::*;
 
 #[cfg(feature = "db-api")]
+mod call_trace;
+#[cfg(feature = "db-api")]
+pub use call_trace::*;
+
+#[cfg(feature = "db-api")]
 mod hashing;
 #[cfg(feature = "db-api")]
 pub use hashing::*;

--- a/crates/storage/storage-api/src/lib.rs
+++ b/crates/storage/storage-api/src/lib.rs
@@ -69,9 +69,7 @@ mod history;
 #[cfg(feature = "db-api")]
 pub use history::*;
 
-#[cfg(feature = "db-api")]
 mod call_trace;
-#[cfg(feature = "db-api")]
 pub use call_trace::*;
 
 #[cfg(feature = "db-api")]

--- a/crates/storage/storage-api/src/noop.rs
+++ b/crates/storage/storage-api/src/noop.rs
@@ -608,6 +608,25 @@ impl<C: Send + Sync + 'static, N: NodePrimitives> StateProviderFactory for NoopP
     }
 }
 
+#[cfg(feature = "db-api")]
+impl<C: Send + Sync, N: Send + Sync> crate::CallTraceIndexReader for NoopProvider<C, N> {
+    fn call_trace_from_blocks(
+        &self,
+        _address: Address,
+        _range: std::ops::RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Vec<BlockNumber>> {
+        Ok(Vec::new())
+    }
+
+    fn call_trace_to_blocks(
+        &self,
+        _address: Address,
+        _range: std::ops::RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Vec<BlockNumber>> {
+        Ok(Vec::new())
+    }
+}
+
 impl<C: Send + Sync, N: NodePrimitives> StageCheckpointReader for NoopProvider<C, N> {
     fn get_stage_checkpoint(&self, _id: StageId) -> ProviderResult<Option<StageCheckpoint>> {
         Ok(None)

--- a/crates/storage/storage-api/src/noop.rs
+++ b/crates/storage/storage-api/src/noop.rs
@@ -608,12 +608,11 @@ impl<C: Send + Sync + 'static, N: NodePrimitives> StateProviderFactory for NoopP
     }
 }
 
-#[cfg(feature = "db-api")]
 impl<C: Send + Sync, N: Send + Sync> crate::CallTraceIndexReader for NoopProvider<C, N> {
     fn call_trace_from_blocks(
         &self,
         _address: Address,
-        _range: std::ops::RangeInclusive<BlockNumber>,
+        _range: core::ops::RangeInclusive<BlockNumber>,
     ) -> ProviderResult<Vec<BlockNumber>> {
         Ok(Vec::new())
     }
@@ -621,7 +620,7 @@ impl<C: Send + Sync, N: Send + Sync> crate::CallTraceIndexReader for NoopProvide
     fn call_trace_to_blocks(
         &self,
         _address: Address,
-        _range: std::ops::RangeInclusive<BlockNumber>,
+        _range: core::ops::RangeInclusive<BlockNumber>,
     ) -> ProviderResult<Vec<BlockNumber>> {
         Ok(Vec::new())
     }


### PR DESCRIPTION
Towards #15394. Adds `CallTraceFromIndex` and `CallTraceToIndex` tables that map addresses to block numbers where they appeared as transaction sender or recipient. `trace_filter` now queries these indexes when `fromAddress/toAddress` filters are specified, executing only the candidate blocks instead of every block in the range. Falls back to the existing full-scan behavior when no address filters are given or the index isn't populated yet.
Limitation until Step 2: `trace_filter` results for contract addresses may be incomplete — blocks where an address is only reached via internal calls will be silently skipped. EOA addresses are unaffected. Step 2 closes this gap.

Next Steps:
Step 2 — Internal call coverage
Instrument the execution stage to emit call frame from/to pairs as a side-effect of the EVM run. Those pairs write into the same `CallTraceFromIndex`/`CallTraceToIndex` tables, making fromAddress/toAddress filters on contracts fully correct. Kept separate because it touches the execution stage.

Step 3 — Token transfer history (eth_getLogs)
Add a log address/topic index built from receipts, same sharded `BlockNumberList` pattern as this PR. Unlocks efficient ERC-20/721/1155 transfer history queries without touching trace infrastructure.

Step 4 — Current token balances
Using Step 3's log index, find every token contract an address has interacted with, then batch `eth_call` for `balanceOf`. Expose as a dedicated RPC method.