### PR TITLE
fix(engine/tree): continue sync-target progression for already-seen downloaded blocks

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2650,8 +2650,10 @@ where
 
         // try to append the block
         match self.insert_block(block) {
-            Ok(InsertPayloadOk::Inserted(BlockStatus::Valid)) |
-            Ok(InsertPayloadOk::AlreadySeen(BlockStatus::Valid)) => {
+            Ok(
+                InsertPayloadOk::Inserted(BlockStatus::Valid) |
+                InsertPayloadOk::AlreadySeen(BlockStatus::Valid),
+            ) => {
                 return self.on_valid_downloaded_block(block_num_hash);
             }
             Ok(InsertPayloadOk::Inserted(BlockStatus::Disconnected { head, missing_ancestor })) => {

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2650,7 +2650,8 @@ where
 
         // try to append the block
         match self.insert_block(block) {
-            Ok(InsertPayloadOk::Inserted(BlockStatus::Valid)) => {
+            Ok(InsertPayloadOk::Inserted(BlockStatus::Valid)) |
+            Ok(InsertPayloadOk::AlreadySeen(BlockStatus::Valid)) => {
                 return self.on_valid_downloaded_block(block_num_hash);
             }
             Ok(InsertPayloadOk::Inserted(BlockStatus::Disconnected { head, missing_ancestor })) => {


### PR DESCRIPTION
another part of #22613

As the stall could still happen in long-gap (e.g. 128-block) flows where downloaded blocks are often duplicates.
When the same block arrived again and `insert_block` returned `AlreadySeen(Valid)`, the handler did nothing, which could stop sync progression toward the FCU head.

ref https://github.com/paradigmxyz/reth/pull/22625#issuecomment-3970617541

