### PR TITLE
chore(libmdbx): fix MDB_ -> MDBX_ typos

### DIFF
--- a/crates/storage/libmdbx-rs/src/environment.rs
+++ b/crates/storage/libmdbx-rs/src/environment.rs
@@ -161,7 +161,7 @@ impl Environment {
             mdbx_result(ffi::mdbx_env_stat_ex(
                 self.env_ptr(),
                 ptr::null(),
-                stat.mdb_stat(),
+                stat.mdbx_stat(),
                 size_of::<Stat>(),
             ))?;
             Ok(stat)
@@ -305,13 +305,13 @@ unsafe impl Sync for EnvPtr {}
 pub struct Stat(ffi::MDBX_stat);
 
 impl Stat {
-    /// Create a new Stat with zero'd inner struct `ffi::MDB_stat`.
+    /// Create a new Stat with zero'd inner struct `ffi::MDBX_stat`.
     pub(crate) const fn new() -> Self {
         unsafe { Self(mem::zeroed()) }
     }
 
-    /// Returns a mut pointer to `ffi::MDB_stat`.
-    pub(crate) const fn mdb_stat(&mut self) -> *mut ffi::MDBX_stat {
+    /// Returns a mut pointer to `ffi::MDBX_stat`.
+    pub(crate) const fn mdbx_stat(&mut self) -> *mut ffi::MDBX_stat {
         &mut self.0
     }
 }

--- a/crates/storage/libmdbx-rs/src/transaction.rs
+++ b/crates/storage/libmdbx-rs/src/transaction.rs
@@ -177,7 +177,7 @@ where
                 self.env().txn_manager().remove_active_read_transaction(txn);
 
                 let mut latency = CommitLatency::new();
-                mdbx_result(unsafe { ffi::mdbx_txn_commit_ex(txn, latency.mdb_commit_latency()) })
+                mdbx_result(unsafe { ffi::mdbx_txn_commit_ex(txn, latency.mdbx_commit_latency()) })
                     .map(|v| (v, latency))
             } else {
                 let (sender, rx) = sync_channel(0);
@@ -246,7 +246,7 @@ where
         unsafe {
             let mut stat = Stat::new();
             self.txn_execute(|txn| {
-                mdbx_result(ffi::mdbx_dbi_stat(txn, dbi, stat.mdb_stat(), size_of::<Stat>()))
+                mdbx_result(ffi::mdbx_dbi_stat(txn, dbi, stat.mdbx_stat(), size_of::<Stat>()))
             })??;
             Ok(stat)
         }
@@ -647,7 +647,7 @@ impl CommitLatency {
     }
 
     /// Returns a mut pointer to `ffi::MDBX_commit_latency`.
-    pub(crate) const fn mdb_commit_latency(&mut self) -> *mut ffi::MDBX_commit_latency {
+    pub(crate) const fn mdbx_commit_latency(&mut self) -> *mut ffi::MDBX_commit_latency {
         &mut self.0
     }
 }

--- a/crates/storage/libmdbx-rs/src/txn_manager.rs
+++ b/crates/storage/libmdbx-rs/src/txn_manager.rs
@@ -100,7 +100,7 @@ impl TxnManager {
                                 .send({
                                     let mut latency = CommitLatency::new();
                                     mdbx_result(unsafe {
-                                        ffi::mdbx_txn_commit_ex(tx.0, latency.mdb_commit_latency())
+                                        ffi::mdbx_txn_commit_ex(tx.0, latency.mdbx_commit_latency())
                                     })
                                     .map(|v| (v, latency))
                                 })


### PR DESCRIPTION
Renames leftover `MDB_`-prefixed function names and doc references to `MDBX_` in the libmdbx-rs wrapper crate.

Prompted by: DaniPopes