### PR TITLE
refactor(trie): align StorageRoot walked count with StateRoot

### DIFF
--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -716,8 +716,7 @@ where
             "calculated storage root"
         );
 
-        let storage_slots_walked = stats.leaves_added() as usize;
-        Ok(StorageRootProgress::Complete(root, storage_slots_walked, trie_updates))
+        Ok(StorageRootProgress::Complete(root, hashed_entries_walked, trie_updates))
     }
 }
 


### PR DESCRIPTION
Replace stats.leaves_added() with hashed_entries_walked in the Complete return path of StorageRoot::calculate. The values are identical, but the Progress path already uses hashed_entries_walked, and StateRoot::calculate follows the same convention.