### PR TITLE
chore(ci): continue on error when codspeed is flakey/cancelled on main

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -62,6 +62,7 @@ permissions:
 jobs:
   codspeed:
     if: github.event_name == 'push'
+    continue-on-error: true
     runs-on: depot-ubuntu-latest
     concurrency:
       group: bench-codspeed-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
currently getting polluted on main branch with failures since codspeed gets cancelled / flakes - we should just continue on error