### PR TITLE
feat(cli): add opcode-level tracing for failed txs in re-execute command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7850,6 +7850,7 @@ dependencies = [
  "reth-trie",
  "reth-trie-common",
  "reth-trie-db",
+ "revm-inspectors",
  "secp256k1 0.30.0",
  "serde",
  "serde_json",

--- a/crates/cli/commands/Cargo.toml
+++ b/crates/cli/commands/Cargo.toml
@@ -45,6 +45,7 @@ reth-provider.workspace = true
 reth-prune.workspace = true
 reth-prune-types.workspace = true
 reth-revm.workspace = true
+revm-inspectors.workspace = true
 reth-stages.workspace = true
 reth-stages-types = { workspace = true, optional = true }
 reth-static-file-types = { workspace = true, features = ["clap"] }

--- a/crates/cli/commands/src/re_execute.rs
+++ b/crates/cli/commands/src/re_execute.rs
@@ -11,14 +11,15 @@ use reth_chainspec::{EthChainSpec, EthereumHardforks, Hardforks};
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_util::cancellation::CancellationToken;
 use reth_consensus::FullConsensus;
-use reth_evm::{execute::Executor, ConfigureEvm};
-use reth_primitives_traits::{format_gas_throughput, BlockBody, GotExpected};
+use reth_evm::{execute::Executor, ConfigureEvm, Evm};
+use reth_primitives_traits::{format_gas_throughput, BlockBody, GotExpected, NodePrimitives};
 use reth_provider::{
     BlockNumReader, BlockReader, ChainSpecProvider, DatabaseProviderFactory, ReceiptProvider,
     StaticFileProviderFactory, TransactionVariant,
 };
-use reth_revm::database::StateProviderDatabase;
+use reth_revm::{database::StateProviderDatabase, State};
 use reth_stages::stages::calculate_gas_used_from_headers;
+use revm_inspectors::tracing::{TracingInspector, TracingInspectorConfig};
 use std::{
     sync::{
         atomic::{AtomicU64, Ordering},
@@ -62,6 +63,139 @@ impl<C: ChainSpecParser> Command<C> {
     /// Returns the underlying chain being used to run this command
     pub fn chain_spec(&self) -> Option<&Arc<C::ChainSpec>> {
         Some(&self.env.chain)
+    }
+}
+
+/// Finds the failing transaction within a block by re-executing transactions individually,
+/// then traces it at the opcode level.
+///
+/// Used when `execute_one` fails for a whole block and we don't know which transaction caused it.
+/// `make_db` is called to build a fresh state provider database at the parent block.
+fn find_and_trace_failing_tx<C, DB>(
+    evm_config: &C,
+    make_db: impl Fn() -> StateProviderDatabase<DB>,
+    block: &reth_primitives_traits::RecoveredBlock<<C::Primitives as NodePrimitives>::Block>,
+) where
+    C: ConfigureEvm,
+    DB: reth_revm::database::EvmStateProvider,
+{
+    let evm_env = match evm_config.evm_env(block.header()) {
+        Ok(env) => env,
+        Err(err) => {
+            error!(%err, "Failed to create EVM env for opcode tracing");
+            return;
+        }
+    };
+
+    // Execute transactions one by one to find which one fails.
+    let mut state = State::builder().with_database(make_db()).with_bundle_update().build();
+    let mut evm = evm_config.evm_with_env(&mut state, evm_env);
+
+    let mut failing_index = None;
+    for (i, tx) in block.transactions_recovered().enumerate() {
+        let tx_env = evm_config.tx_env(tx);
+        if evm.transact_commit(tx_env).is_err() {
+            failing_index = Some(i);
+            break;
+        }
+    }
+    drop(evm);
+    drop(state);
+
+    match failing_index {
+        Some(tx_index) => {
+            trace_failed_transaction(evm_config, make_db(), block, tx_index);
+        }
+        None => {
+            error!(
+                block_number = block.number(),
+                "Could not locate failing transaction within block during tracing"
+            );
+        }
+    }
+}
+
+/// Traces a failed transaction at the given index within a block, producing opcode-level output.
+///
+/// Builds state at the parent block, replays all prior transactions, then re-executes the
+/// failing transaction with a [`TracingInspector`] attached to capture opcode-level detail.
+/// The resulting trace is logged as a JSON-serialized geth-style `DefaultFrame` containing
+/// opcode-level `structLogs`.
+fn trace_failed_transaction<C, DB>(
+    evm_config: &C,
+    db: StateProviderDatabase<DB>,
+    block: &reth_primitives_traits::RecoveredBlock<<C::Primitives as NodePrimitives>::Block>,
+    tx_index: usize,
+) where
+    C: ConfigureEvm,
+    DB: reth_revm::database::EvmStateProvider,
+{
+    let evm_env = match evm_config.evm_env(block.header()) {
+        Ok(env) => env,
+        Err(err) => {
+            error!(%err, "Failed to create EVM env for opcode tracing");
+            return;
+        }
+    };
+
+    let mut state = State::builder().with_database(db).with_bundle_update().build();
+
+    // Replay all transactions before the failing one to build up state.
+    {
+        let mut evm = evm_config.evm_with_env(&mut state, evm_env.clone());
+        for (i, tx) in block.transactions_recovered().enumerate() {
+            if i >= tx_index {
+                break;
+            }
+            let tx_env = evm_config.tx_env(tx);
+            if let Err(err) = evm.transact_commit(tx_env) {
+                error!(index = i, %err, "Failed to replay transaction before failing tx");
+                return;
+            }
+        }
+    }
+
+    // Execute the failing transaction with a tracing inspector.
+    let tx = match block.transactions_recovered().nth(tx_index) {
+        Some(tx) => tx,
+        None => {
+            error!(tx_index, "Transaction index out of bounds for opcode tracing");
+            return;
+        }
+    };
+    let tx_env = evm_config.tx_env(tx);
+    let mut inspector = TracingInspector::new(TracingInspectorConfig::all());
+    let result = {
+        let mut evm =
+            evm_config.evm_with_env_and_inspector(&mut state, evm_env, &mut inspector);
+        evm.transact(tx_env)
+    };
+
+    // Build geth-style trace with opcode-level structLogs.
+    let (gas_used, return_value) = match &result {
+        Ok(r) => (r.result.gas_used(), r.result.output().cloned().unwrap_or_default()),
+        Err(_) => (0, Default::default()),
+    };
+
+    let frame = inspector
+        .into_geth_builder()
+        .geth_traces(gas_used, return_value, Default::default());
+
+    match serde_json::to_string(&frame) {
+        Ok(json) => {
+            error!(
+                block_number = block.number(),
+                block_hash = ?block.hash(),
+                tx_index,
+                tx_hash = ?block.body().transactions()[tx_index].tx_hash(),
+                execution_result = ?result.as_ref().map(|r| &r.result),
+                opcode_trace = %json,
+                "Opcode-level trace for failing transaction"
+            );
+        }
+        Err(err) => {
+            error!(%err, "Failed to serialize opcode trace");
+        }
     }
 }
 
@@ -164,6 +298,14 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                         let result = match executor.execute_one(&block) {
                             Ok(result) => result,
                             Err(err) => {
+                                // Find which tx failed and trace it at the opcode
+                                // level. Re-execute txs one by one to locate the
+                                // failing index, then trace that tx with an inspector.
+                                let parent_num = block.number() - 1;
+                                find_and_trace_failing_tx(
+                                    &evm_config, || db_at(parent_num), &block,
+                                );
+
                                 if skip_invalid_blocks {
                                     executor =
                                         evm_config.batch_executor(db_at(block.number()));
@@ -223,6 +365,15 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                                         };
 
                                         error!(number=?block.number(), ?mismatch, "Gas usage mismatch");
+
+                                        // Trace the mismatched tx at the opcode level.
+                                        trace_failed_transaction(
+                                            &evm_config,
+                                            db_at(block.number() - 1),
+                                            &block,
+                                            i,
+                                        );
+
                                         if skip_invalid_blocks {
                                             executor = evm_config
                                                 .batch_executor(db_at(block.number()));

--- a/crates/cli/commands/src/re_execute.rs
+++ b/crates/cli/commands/src/re_execute.rs
@@ -93,9 +93,7 @@ fn find_and_trace_failing_tx<C, DB, Spec>(
     let mut state = State::builder().with_database(make_db()).with_bundle_update().build();
 
     // EIP-161: set state clear flag based on Spurious Dragon activation.
-    state
-        .cache
-        .set_state_clear_flag(spec.is_spurious_dragon_active_at_block(block.number()));
+    state.cache.set_state_clear_flag(spec.is_spurious_dragon_active_at_block(block.number()));
 
     let mut evm = evm_config.evm_with_env(&mut state, evm_env);
 
@@ -160,9 +158,7 @@ fn trace_failed_transaction<C, DB, Spec>(
     let mut state = State::builder().with_database(db).with_bundle_update().build();
 
     // EIP-161: set state clear flag based on Spurious Dragon activation.
-    state
-        .cache
-        .set_state_clear_flag(spec.is_spurious_dragon_active_at_block(block.number()));
+    state.cache.set_state_clear_flag(spec.is_spurious_dragon_active_at_block(block.number()));
 
     // Apply pre-execution system calls (EIP-4788, EIP-2935) and replay prior txs.
     {
@@ -197,8 +193,7 @@ fn trace_failed_transaction<C, DB, Spec>(
     let tx_env = evm_config.tx_env(tx);
     let mut inspector = TracingInspector::new(TracingInspectorConfig::all());
     let result = {
-        let mut evm =
-            evm_config.evm_with_env_and_inspector(&mut state, evm_env, &mut inspector);
+        let mut evm = evm_config.evm_with_env_and_inspector(&mut state, evm_env, &mut inspector);
         evm.transact(tx_env)
     };
 
@@ -208,9 +203,8 @@ fn trace_failed_transaction<C, DB, Spec>(
         Err(_) => (0, Default::default()),
     };
 
-    let frame = inspector
-        .into_geth_builder()
-        .geth_traces(gas_used, return_value, Default::default());
+    let frame =
+        inspector.into_geth_builder().geth_traces(gas_used, return_value, Default::default());
 
     match serde_json::to_string(&frame) {
         Ok(json) => {

--- a/crates/cli/commands/src/re_execute.rs
+++ b/crates/cli/commands/src/re_execute.rs
@@ -11,7 +11,10 @@ use reth_chainspec::{EthChainSpec, EthereumHardforks, Hardforks};
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_util::cancellation::CancellationToken;
 use reth_consensus::FullConsensus;
-use reth_evm::{execute::Executor, system_calls::SystemCaller, ConfigureEvm, Evm};
+use reth_evm::{
+    execute::{BlockExecutor, Executor},
+    ConfigureEvm, Evm,
+};
 use reth_primitives_traits::{format_gas_throughput, BlockBody, GotExpected, NodePrimitives};
 use reth_provider::{
     BlockNumReader, BlockReader, ChainSpecProvider, DatabaseProviderFactory, ReceiptProvider,
@@ -66,86 +69,22 @@ impl<C: ChainSpecParser> Command<C> {
     }
 }
 
-/// Finds the failing transaction within a block by re-executing transactions individually,
-/// then traces it at the opcode level.
-///
-/// Used when `execute_one` fails for a whole block and we don't know which transaction caused it.
-/// `make_db` is called to build a fresh state provider database at the parent block.
-fn find_and_trace_failing_tx<C, DB, Spec>(
-    evm_config: &C,
-    make_db: impl Fn() -> StateProviderDatabase<DB>,
-    block: &reth_primitives_traits::RecoveredBlock<<C::Primitives as NodePrimitives>::Block>,
-    spec: Spec,
-) where
-    C: ConfigureEvm,
-    DB: reth_revm::database::EvmStateProvider,
-    Spec: EthereumHardforks + Clone,
-{
-    let evm_env = match evm_config.evm_env(block.header()) {
-        Ok(env) => env,
-        Err(err) => {
-            error!(%err, "Failed to create EVM env for opcode tracing");
-            return;
-        }
-    };
-
-    // Execute transactions one by one to find which one fails.
-    let mut state = State::builder().with_database(make_db()).with_bundle_update().build();
-
-    // EIP-161: set state clear flag based on Spurious Dragon activation.
-    state.cache.set_state_clear_flag(spec.is_spurious_dragon_active_at_block(block.number()));
-
-    let mut evm = evm_config.evm_with_env(&mut state, evm_env);
-
-    // Apply pre-execution system calls (EIP-2935, EIP-4788).
-    if let Err(err) =
-        SystemCaller::new(spec.clone()).apply_pre_execution_changes(block.header(), &mut evm)
-    {
-        error!(%err, "Failed to apply pre-execution changes for opcode tracing");
-        return;
-    }
-
-    let mut failing_index = None;
-    for (i, tx) in block.transactions_recovered().enumerate() {
-        let tx_env = evm_config.tx_env(tx);
-        if evm.transact_commit(tx_env).is_err() {
-            failing_index = Some(i);
-            break;
-        }
-    }
-    drop(evm);
-    drop(state);
-
-    match failing_index {
-        Some(tx_index) => {
-            trace_failed_transaction(evm_config, make_db(), block, tx_index, spec);
-        }
-        None => {
-            error!(
-                block_number = block.number(),
-                "Could not locate failing transaction within block during tracing"
-            );
-        }
-    }
-}
-
 /// Traces a failed transaction at the given index within a block, producing opcode-level output.
 ///
-/// Builds state at the parent block, applies pre-execution system calls (EIP-4788, EIP-2935),
-/// replays all prior transactions, then re-executes the failing transaction with a
-/// [`TracingInspector`] attached to capture opcode-level detail.
+/// Uses the [`BlockExecutor`](alloy_evm::block::BlockExecutor) abstraction to apply
+/// pre-execution changes and replay prior transactions in a chain-agnostic way, then
+/// re-executes the failing transaction with a [`TracingInspector`] attached to capture
+/// opcode-level detail.
 /// The resulting trace is logged as a JSON-serialized geth-style `DefaultFrame` containing
 /// opcode-level `structLogs`.
-fn trace_failed_transaction<C, DB, Spec>(
+fn trace_failed_transaction<C, DB>(
     evm_config: &C,
     db: StateProviderDatabase<DB>,
     block: &reth_primitives_traits::RecoveredBlock<<C::Primitives as NodePrimitives>::Block>,
     tx_index: usize,
-    spec: Spec,
 ) where
     C: ConfigureEvm,
     DB: reth_revm::database::EvmStateProvider,
-    Spec: EthereumHardforks,
 {
     let evm_env = match evm_config.evm_env(block.header()) {
         Ok(env) => env,
@@ -157,15 +96,17 @@ fn trace_failed_transaction<C, DB, Spec>(
 
     let mut state = State::builder().with_database(db).with_bundle_update().build();
 
-    // EIP-161: set state clear flag based on Spurious Dragon activation.
-    state.cache.set_state_clear_flag(spec.is_spurious_dragon_active_at_block(block.number()));
-
-    // Apply pre-execution system calls (EIP-4788, EIP-2935) and replay prior txs.
+    // Use BlockExecutor to apply pre-execution changes and replay prior txs.
     {
-        let mut evm = evm_config.evm_with_env(&mut state, evm_env.clone());
-        if let Err(err) =
-            SystemCaller::new(spec).apply_pre_execution_changes(block.header(), &mut evm)
-        {
+        let mut executor = match evm_config.executor_for_block(&mut state, block) {
+            Ok(executor) => executor,
+            Err(err) => {
+                error!(%err, "Failed to create block executor for opcode tracing");
+                return;
+            }
+        };
+
+        if let Err(err) = executor.apply_pre_execution_changes() {
             error!(%err, "Failed to apply pre-execution changes for opcode tracing");
             return;
         }
@@ -174,8 +115,7 @@ fn trace_failed_transaction<C, DB, Spec>(
             if i >= tx_index {
                 break;
             }
-            let tx_env = evm_config.tx_env(tx);
-            if let Err(err) = evm.transact_commit(tx_env) {
+            if let Err(err) = executor.execute_transaction(tx) {
                 error!(index = i, %err, "Failed to replay transaction before failing tx");
                 return;
             }
@@ -323,17 +263,6 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                         let result = match executor.execute_one(&block) {
                             Ok(result) => result,
                             Err(err) => {
-                                // Find which tx failed and trace it at the opcode
-                                // level. Re-execute txs one by one to locate the
-                                // failing index, then trace that tx with an inspector.
-                                let parent_num = block.number() - 1;
-                                find_and_trace_failing_tx(
-                                    &evm_config,
-                                    || db_at(parent_num),
-                                    &block,
-                                    provider_factory.chain_spec(),
-                                );
-
                                 if skip_invalid_blocks {
                                     executor =
                                         evm_config.batch_executor(db_at(block.number()));
@@ -400,7 +329,6 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                                             db_at(block.number() - 1),
                                             &block,
                                             i,
-                                            provider_factory.chain_spec(),
                                         );
 
                                         if skip_invalid_blocks {

--- a/crates/cli/commands/src/re_execute.rs
+++ b/crates/cli/commands/src/re_execute.rs
@@ -91,9 +91,15 @@ fn find_and_trace_failing_tx<C, DB, Spec>(
 
     // Execute transactions one by one to find which one fails.
     let mut state = State::builder().with_database(make_db()).with_bundle_update().build();
+
+    // EIP-161: set state clear flag based on Spurious Dragon activation.
+    state
+        .cache
+        .set_state_clear_flag(spec.is_spurious_dragon_active_at_block(block.number()));
+
     let mut evm = evm_config.evm_with_env(&mut state, evm_env);
 
-    // Apply pre-execution system calls first.
+    // Apply pre-execution system calls (EIP-2935, EIP-4788).
     if let Err(err) =
         SystemCaller::new(spec.clone()).apply_pre_execution_changes(block.header(), &mut evm)
     {
@@ -152,6 +158,11 @@ fn trace_failed_transaction<C, DB, Spec>(
     };
 
     let mut state = State::builder().with_database(db).with_bundle_update().build();
+
+    // EIP-161: set state clear flag based on Spurious Dragon activation.
+    state
+        .cache
+        .set_state_clear_flag(spec.is_spurious_dragon_active_at_block(block.number()));
 
     // Apply pre-execution system calls (EIP-4788, EIP-2935) and replay prior txs.
     {

--- a/crates/cli/commands/src/re_execute.rs
+++ b/crates/cli/commands/src/re_execute.rs
@@ -11,7 +11,7 @@ use reth_chainspec::{EthChainSpec, EthereumHardforks, Hardforks};
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_util::cancellation::CancellationToken;
 use reth_consensus::FullConsensus;
-use reth_evm::{execute::Executor, ConfigureEvm, Evm};
+use reth_evm::{execute::Executor, system_calls::SystemCaller, ConfigureEvm, Evm};
 use reth_primitives_traits::{format_gas_throughput, BlockBody, GotExpected, NodePrimitives};
 use reth_provider::{
     BlockNumReader, BlockReader, ChainSpecProvider, DatabaseProviderFactory, ReceiptProvider,
@@ -71,13 +71,15 @@ impl<C: ChainSpecParser> Command<C> {
 ///
 /// Used when `execute_one` fails for a whole block and we don't know which transaction caused it.
 /// `make_db` is called to build a fresh state provider database at the parent block.
-fn find_and_trace_failing_tx<C, DB>(
+fn find_and_trace_failing_tx<C, DB, Spec>(
     evm_config: &C,
     make_db: impl Fn() -> StateProviderDatabase<DB>,
     block: &reth_primitives_traits::RecoveredBlock<<C::Primitives as NodePrimitives>::Block>,
+    spec: Spec,
 ) where
     C: ConfigureEvm,
     DB: reth_revm::database::EvmStateProvider,
+    Spec: EthereumHardforks + Clone,
 {
     let evm_env = match evm_config.evm_env(block.header()) {
         Ok(env) => env,
@@ -90,6 +92,14 @@ fn find_and_trace_failing_tx<C, DB>(
     // Execute transactions one by one to find which one fails.
     let mut state = State::builder().with_database(make_db()).with_bundle_update().build();
     let mut evm = evm_config.evm_with_env(&mut state, evm_env);
+
+    // Apply pre-execution system calls first.
+    if let Err(err) =
+        SystemCaller::new(spec.clone()).apply_pre_execution_changes(block.header(), &mut evm)
+    {
+        error!(%err, "Failed to apply pre-execution changes for opcode tracing");
+        return;
+    }
 
     let mut failing_index = None;
     for (i, tx) in block.transactions_recovered().enumerate() {
@@ -104,7 +114,7 @@ fn find_and_trace_failing_tx<C, DB>(
 
     match failing_index {
         Some(tx_index) => {
-            trace_failed_transaction(evm_config, make_db(), block, tx_index);
+            trace_failed_transaction(evm_config, make_db(), block, tx_index, spec);
         }
         None => {
             error!(
@@ -117,18 +127,21 @@ fn find_and_trace_failing_tx<C, DB>(
 
 /// Traces a failed transaction at the given index within a block, producing opcode-level output.
 ///
-/// Builds state at the parent block, replays all prior transactions, then re-executes the
-/// failing transaction with a [`TracingInspector`] attached to capture opcode-level detail.
+/// Builds state at the parent block, applies pre-execution system calls (EIP-4788, EIP-2935),
+/// replays all prior transactions, then re-executes the failing transaction with a
+/// [`TracingInspector`] attached to capture opcode-level detail.
 /// The resulting trace is logged as a JSON-serialized geth-style `DefaultFrame` containing
 /// opcode-level `structLogs`.
-fn trace_failed_transaction<C, DB>(
+fn trace_failed_transaction<C, DB, Spec>(
     evm_config: &C,
     db: StateProviderDatabase<DB>,
     block: &reth_primitives_traits::RecoveredBlock<<C::Primitives as NodePrimitives>::Block>,
     tx_index: usize,
+    spec: Spec,
 ) where
     C: ConfigureEvm,
     DB: reth_revm::database::EvmStateProvider,
+    Spec: EthereumHardforks,
 {
     let evm_env = match evm_config.evm_env(block.header()) {
         Ok(env) => env,
@@ -140,9 +153,16 @@ fn trace_failed_transaction<C, DB>(
 
     let mut state = State::builder().with_database(db).with_bundle_update().build();
 
-    // Replay all transactions before the failing one to build up state.
+    // Apply pre-execution system calls (EIP-4788, EIP-2935) and replay prior txs.
     {
         let mut evm = evm_config.evm_with_env(&mut state, evm_env.clone());
+        if let Err(err) =
+            SystemCaller::new(spec).apply_pre_execution_changes(block.header(), &mut evm)
+        {
+            error!(%err, "Failed to apply pre-execution changes for opcode tracing");
+            return;
+        }
+
         for (i, tx) in block.transactions_recovered().enumerate() {
             if i >= tx_index {
                 break;
@@ -303,7 +323,10 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                                 // failing index, then trace that tx with an inspector.
                                 let parent_num = block.number() - 1;
                                 find_and_trace_failing_tx(
-                                    &evm_config, || db_at(parent_num), &block,
+                                    &evm_config,
+                                    || db_at(parent_num),
+                                    &block,
+                                    provider_factory.chain_spec(),
                                 );
 
                                 if skip_invalid_blocks {
@@ -372,6 +395,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                                             db_at(block.number() - 1),
                                             &block,
                                             i,
+                                            provider_factory.chain_spec(),
                                         );
 
                                         if skip_invalid_blocks {

--- a/crates/cli/commands/src/re_execute.rs
+++ b/crates/cli/commands/src/re_execute.rs
@@ -71,10 +71,9 @@ impl<C: ChainSpecParser> Command<C> {
 
 /// Traces a failed transaction at the given index within a block, producing opcode-level output.
 ///
-/// Uses the [`BlockExecutor`](alloy_evm::block::BlockExecutor) abstraction to apply
-/// pre-execution changes and replay prior transactions in a chain-agnostic way, then
-/// re-executes the failing transaction with a [`TracingInspector`] attached to capture
-/// opcode-level detail.
+/// Creates a [`BlockExecutor`](alloy_evm::block::BlockExecutor) with a [`TracingInspector`]
+/// attached but initially disabled. The inspector is enabled only for the target transaction,
+/// keeping pre-execution changes and prior transaction replay uninstrumented.
 /// The resulting trace is logged as a JSON-serialized geth-style `DefaultFrame` containing
 /// opcode-level `structLogs`.
 fn trace_failed_transaction<C, DB>(
@@ -96,33 +95,39 @@ fn trace_failed_transaction<C, DB>(
 
     let mut state = State::builder().with_database(db).with_bundle_update().build();
 
-    // Use BlockExecutor to apply pre-execution changes and replay prior txs.
-    {
-        let mut executor = match evm_config.executor_for_block(&mut state, block) {
-            Ok(executor) => executor,
-            Err(err) => {
-                error!(%err, "Failed to create block executor for opcode tracing");
-                return;
-            }
-        };
-
-        if let Err(err) = executor.apply_pre_execution_changes() {
-            error!(%err, "Failed to apply pre-execution changes for opcode tracing");
+    let ctx = match evm_config.context_for_block(block) {
+        Ok(ctx) => ctx,
+        Err(err) => {
+            error!(%err, "Failed to create execution context for opcode tracing");
             return;
         }
+    };
 
-        for (i, tx) in block.transactions_recovered().enumerate() {
-            if i >= tx_index {
-                break;
-            }
-            if let Err(err) = executor.execute_transaction(tx) {
-                error!(index = i, %err, "Failed to replay transaction before failing tx");
-                return;
-            }
+    let inspector = TracingInspector::new(TracingInspectorConfig::all());
+    let evm = evm_config.evm_with_env_and_inspector(&mut state, evm_env, inspector);
+    let mut executor = evm_config.create_executor(evm, ctx);
+
+    // Disable inspector during pre-execution changes and prior tx replay.
+    executor.evm_mut().disable_inspector();
+
+    if let Err(err) = executor.apply_pre_execution_changes() {
+        error!(%err, "Failed to apply pre-execution changes for opcode tracing");
+        return;
+    }
+
+    for (i, tx) in block.transactions_recovered().enumerate() {
+        if i >= tx_index {
+            break;
+        }
+        if let Err(err) = executor.execute_transaction(tx) {
+            error!(index = i, %err, "Failed to replay transaction before failing tx");
+            return;
         }
     }
 
-    // Execute the failing transaction with a tracing inspector.
+    // Enable inspector for the target transaction.
+    executor.evm_mut().enable_inspector();
+
     let tx = match block.transactions_recovered().nth(tx_index) {
         Some(tx) => tx,
         None => {
@@ -130,21 +135,22 @@ fn trace_failed_transaction<C, DB>(
             return;
         }
     };
-    let tx_env = evm_config.tx_env(tx);
-    let mut inspector = TracingInspector::new(TracingInspectorConfig::all());
-    let result = {
-        let mut evm = evm_config.evm_with_env_and_inspector(&mut state, evm_env, &mut inspector);
-        evm.transact(tx_env)
-    };
+
+    let mut gas_used = 0;
+    let mut return_value = Default::default();
+    let mut execution_result = None;
+    let result = executor.execute_transaction_with_result_closure(tx, |res| {
+        gas_used = res.gas_used();
+        return_value = res.output().cloned().unwrap_or_default();
+        execution_result = Some(format!("{res:?}"));
+    });
 
     // Build geth-style trace with opcode-level structLogs.
-    let (gas_used, return_value) = match &result {
-        Ok(r) => (r.result.gas_used(), r.result.output().cloned().unwrap_or_default()),
-        Err(_) => (0, Default::default()),
-    };
-
-    let frame =
-        inspector.into_geth_builder().geth_traces(gas_used, return_value, Default::default());
+    let frame = executor.evm_mut().inspector_mut().geth_builder().geth_traces(
+        gas_used,
+        return_value,
+        Default::default(),
+    );
 
     match serde_json::to_string(&frame) {
         Ok(json) => {
@@ -153,7 +159,8 @@ fn trace_failed_transaction<C, DB>(
                 block_hash = ?block.hash(),
                 tx_index,
                 tx_hash = ?block.body().transactions()[tx_index].tx_hash(),
-                execution_result = ?result.as_ref().map(|r| &r.result),
+                ?result,
+                execution_result,
                 opcode_trace = %json,
                 "Opcode-level trace for failing transaction"
             );

--- a/crates/cli/commands/src/re_execute.rs
+++ b/crates/cli/commands/src/re_execute.rs
@@ -71,7 +71,7 @@ impl<C: ChainSpecParser> Command<C> {
 
 /// Traces a failed transaction at the given index within a block, producing opcode-level output.
 ///
-/// Creates a [`BlockExecutor`](alloy_evm::block::BlockExecutor) with a [`TracingInspector`]
+/// Creates a [`BlockExecutor`] with a [`TracingInspector`]
 /// attached but initially disabled. The inspector is enabled only for the target transaction,
 /// keeping pre-execution changes and prior transaction replay uninstrumented.
 /// The resulting trace is logged as a JSON-serialized geth-style `DefaultFrame` containing


### PR DESCRIPTION
## Summary
On receipt/gas mismatch during `reth re-execute`, generate opcode-level traces and output them in logs for debugging.

## Motivation
When re-execute hits a gas usage mismatch, the current output only shows the error and receipt diff. To debug execution mismatches you need the full opcode trace — pc, op, gas, stack, memory, storage — which previously required manually setting up `debug_traceTransaction` against a node.

## Changes
- `trace_failed_transaction`: uses the `BlockExecutor` abstraction (`executor_for_block` + `apply_pre_execution_changes` + `execute_transaction`) to replay prior txs in a chain-agnostic way, then re-executes the failing tx with `TracingInspector(TracingInspectorConfig::all())`, logs the geth-style `DefaultFrame` (structLogs) as JSON
- Hooked into receipt gas mismatch path only (where we know the failing tx index)
- Added `revm-inspectors` dep to `reth-cli-commands`

Zero cost on the happy path — tracing only runs on failure.

## Testing
```
cargo check -p reth-cli-commands
cargo clippy -p reth-cli-commands
```

Prompted by: dragan