### PR TITLE
perf(trie): LFU-based sparse trie cache for cross-block storage slot retention

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -199,6 +199,7 @@ where
         let Self { mut trie, .. } = self;
         trie.commit_updates(updates);
         if !disable_pruning {
+            // `max_storage_tries` is treated as global LFU hot-slot capacity by SparseStateTrie.
             trie.prune(prune_depth, max_storage_tries);
             trie.shrink_to(max_nodes_capacity, max_values_capacity);
         }
@@ -500,6 +501,10 @@ where
                 continue;
             }
             let _enter = trace_span!(target: "engine::tree::payload_processor::sparse_trie", parent: &span, "storage_trie_leaf_updates", a=%address).entered();
+
+            for slot in updates.keys().copied() {
+                self.trie.record_hot_storage_slot(*address, slot);
+            }
 
             let trie = self.trie.get_or_create_storage_trie_mut(*address);
             let fetched = self.fetched_storage_targets.entry(*address).or_default();

--- a/crates/trie/sparse/src/parallel.rs
+++ b/crates/trie/sparse/src/parallel.rs
@@ -1268,83 +1268,110 @@ impl SparseTrie for ParallelSparseTrie {
             }
         }
 
-        if effective_pruned_roots.is_empty() {
-            return 0;
+        Self::finalize_pruned_roots(self, effective_pruned_roots)
+    }
+
+    fn prune_by_retained_leaves(&mut self, retained_leaves: &[Nibbles]) -> usize {
+        #[cfg(feature = "trie-debug")]
+        self.debug_recorder.reset();
+
+        if retained_leaves.is_empty() {
+            return self.prune(0)
         }
 
-        let nodes_converted = effective_pruned_roots.len();
+        let mut retained_leaves = retained_leaves.to_vec();
+        retained_leaves.sort_unstable();
+        retained_leaves.dedup();
 
-        // Sort roots by subtrie type (upper first), then by path for efficient partitioning.
-        effective_pruned_roots.sort_unstable_by(|path_a, path_b| {
-            let subtrie_type_a = SparseSubtrieType::from_path(path_a);
-            let subtrie_type_b = SparseSubtrieType::from_path(path_b);
-            subtrie_type_a.cmp(&subtrie_type_b).then(path_a.cmp(path_b))
-        });
+        let mut effective_pruned_roots = Vec::<Nibbles>::new();
+        let mut stack: SmallVec<[Nibbles; 32]> = SmallVec::new();
+        stack.push(Nibbles::default());
 
-        // Split off upper subtrie roots (they come first due to sorting)
-        let num_upper_roots = effective_pruned_roots
-            .iter()
-            .position(|p| !SparseSubtrieType::path_len_is_upper(p.len()))
-            .unwrap_or(effective_pruned_roots.len());
+        while let Some(path) = stack.pop() {
+            let Some(subtrie) = self.subtrie_for_path_mut_untracked(&path) else { continue };
+            let Some(node) = subtrie.nodes.get_mut(&path) else { continue };
 
-        let roots_upper = &effective_pruned_roots[..num_upper_roots];
-        let roots_lower = &effective_pruned_roots[num_upper_roots..];
+            match node {
+                SparseNode::Empty | SparseNode::Leaf { .. } => {}
+                SparseNode::Extension { key, state, .. } => {
+                    let mut child = path;
+                    child.extend(key);
 
-        debug_assert!(
-            {
-                let mut all_roots: Vec<_> = effective_pruned_roots.clone();
-                all_roots.sort_unstable();
-                all_roots.windows(2).all(|w| !w[1].starts_with(&w[0]))
-            },
-            "prune roots must be prefix-free"
-        );
+                    if has_retained_descendant(&retained_leaves, &child) {
+                        stack.push(child);
+                        continue;
+                    }
 
-        // Upper prune roots that are prefixes of lower subtrie root paths cause the entire
-        // subtrie to be cleared (preserving allocations for reuse).
-        if !roots_upper.is_empty() {
-            for subtrie in &mut *self.lower_subtries {
-                let should_clear = subtrie.as_revealed_ref().is_some_and(|s| {
-                    let search_idx = roots_upper.partition_point(|root| root <= &s.path);
-                    search_idx > 0 && s.path.starts_with(&roots_upper[search_idx - 1])
-                });
-                if should_clear {
-                    subtrie.clear();
+                    // Root extension has no parent branch edge to blind; keep it as-is.
+                    if path.is_empty() {
+                        continue;
+                    }
+
+                    let Some(hash) = state.cached_hash() else { continue };
+                    subtrie.nodes.remove(&path);
+
+                    let parent_path = path.slice(0..path.len() - 1);
+                    let SparseNode::Branch { blinded_mask, blinded_hashes, .. } =
+                        subtrie.nodes.get_mut(&parent_path).unwrap()
+                    else {
+                        panic!("expected branch node at path {parent_path:?}");
+                    };
+
+                    let nibble = path.last().unwrap();
+                    blinded_mask.set_bit(nibble);
+                    blinded_hashes[nibble as usize] = hash;
+                    effective_pruned_roots.push(path);
+                }
+                SparseNode::Branch { state_mask, blinded_mask, blinded_hashes, .. } => {
+                    let mut blinded_mask = *blinded_mask;
+                    let mut blinded_hashes = blinded_hashes.clone();
+                    for nibble in state_mask.iter() {
+                        if blinded_mask.is_bit_set(nibble) {
+                            continue;
+                        }
+
+                        let mut child = path;
+                        child.push_unchecked(nibble);
+                        if has_retained_descendant(&retained_leaves, &child) {
+                            stack.push(child);
+                            continue;
+                        }
+
+                        let Entry::Occupied(entry) =
+                            self.subtrie_for_path_mut_untracked(&child).unwrap().nodes.entry(child)
+                        else {
+                            panic!("expected node at path {child:?}");
+                        };
+
+                        let Some(hash) = entry.get().cached_hash() else {
+                            continue;
+                        };
+                        entry.remove();
+                        blinded_mask.set_bit(nibble);
+                        blinded_hashes[nibble as usize] = hash;
+                        effective_pruned_roots.push(child);
+                    }
+
+                    let SparseNode::Branch {
+                        blinded_mask: old_blinded_mask,
+                        blinded_hashes: old_blinded_hashes,
+                        ..
+                    } = self
+                        .subtrie_for_path_mut_untracked(&path)
+                        .unwrap()
+                        .nodes
+                        .get_mut(&path)
+                        .unwrap()
+                    else {
+                        unreachable!("expected branch node at path {path:?}");
+                    };
+                    *old_blinded_mask = blinded_mask;
+                    *old_blinded_hashes = blinded_hashes;
                 }
             }
         }
 
-        // Upper subtrie: prune nodes and values
-        self.upper_subtrie.nodes.retain(|p, _| !is_strict_descendant_in(roots_upper, p));
-        self.upper_subtrie.inner.values.retain(|p, _| {
-            !starts_with_pruned_in(roots_upper, p) && !starts_with_pruned_in(roots_lower, p)
-        });
-
-        // Process lower subtries using chunk_by to group roots by subtrie
-        for roots_group in roots_lower.chunk_by(|path_a, path_b| {
-            SparseSubtrieType::from_path(path_a) == SparseSubtrieType::from_path(path_b)
-        }) {
-            let subtrie_idx = path_subtrie_index_unchecked(&roots_group[0]);
-
-            // Skip unrevealed/blinded subtries - nothing to prune
-            let Some(subtrie) = self.lower_subtries[subtrie_idx].as_revealed_mut() else {
-                continue;
-            };
-
-            // Retain only nodes/values not descended from any pruned root.
-            subtrie.nodes.retain(|p, _| !is_strict_descendant_in(roots_group, p));
-            subtrie.inner.values.retain(|p, _| !starts_with_pruned_in(roots_group, p));
-        }
-
-        // Branch node masks pruning
-        self.branch_node_masks.retain(|p, _| {
-            if SparseSubtrieType::path_len_is_upper(p.len()) {
-                !starts_with_pruned_in(roots_upper, p)
-            } else {
-                !starts_with_pruned_in(roots_lower, p) && !starts_with_pruned_in(roots_upper, p)
-            }
-        });
-
-        nodes_converted
+        Self::finalize_pruned_roots(self, effective_pruned_roots)
     }
 
     fn update_leaves(
@@ -1553,6 +1580,86 @@ impl ParallelSparseTrie {
         retain_updates: bool,
     ) -> SparseTrieResult<Self> {
         Self::default().with_root(root, masks, retain_updates)
+    }
+
+    fn finalize_pruned_roots(&mut self, mut effective_pruned_roots: Vec<Nibbles>) -> usize {
+        if effective_pruned_roots.is_empty() {
+            return 0;
+        }
+
+        let nodes_converted = effective_pruned_roots.len();
+
+        // Sort roots by subtrie type (upper first), then by path for efficient partitioning.
+        effective_pruned_roots.sort_unstable_by(|path_a, path_b| {
+            let subtrie_type_a = SparseSubtrieType::from_path(path_a);
+            let subtrie_type_b = SparseSubtrieType::from_path(path_b);
+            subtrie_type_a.cmp(&subtrie_type_b).then(path_a.cmp(path_b))
+        });
+
+        // Split off upper subtrie roots (they come first due to sorting)
+        let num_upper_roots = effective_pruned_roots
+            .iter()
+            .position(|p| !SparseSubtrieType::path_len_is_upper(p.len()))
+            .unwrap_or(effective_pruned_roots.len());
+
+        let roots_upper = &effective_pruned_roots[..num_upper_roots];
+        let roots_lower = &effective_pruned_roots[num_upper_roots..];
+
+        debug_assert!(
+            {
+                let mut all_roots: Vec<_> = effective_pruned_roots.clone();
+                all_roots.sort_unstable();
+                all_roots.windows(2).all(|w| !w[1].starts_with(&w[0]))
+            },
+            "prune roots must be prefix-free"
+        );
+
+        // Upper prune roots that are prefixes of lower subtrie root paths cause the entire
+        // subtrie to be cleared (preserving allocations for reuse).
+        if !roots_upper.is_empty() {
+            for subtrie in &mut *self.lower_subtries {
+                let should_clear = subtrie.as_revealed_ref().is_some_and(|s| {
+                    let search_idx = roots_upper.partition_point(|root| root <= &s.path);
+                    search_idx > 0 && s.path.starts_with(&roots_upper[search_idx - 1])
+                });
+                if should_clear {
+                    subtrie.clear();
+                }
+            }
+        }
+
+        // Upper subtrie: prune nodes and values
+        self.upper_subtrie.nodes.retain(|p, _| !is_strict_descendant_in(roots_upper, p));
+        self.upper_subtrie.inner.values.retain(|p, _| {
+            !starts_with_pruned_in(roots_upper, p) && !starts_with_pruned_in(roots_lower, p)
+        });
+
+        // Process lower subtries using chunk_by to group roots by subtrie
+        for roots_group in roots_lower.chunk_by(|path_a, path_b| {
+            SparseSubtrieType::from_path(path_a) == SparseSubtrieType::from_path(path_b)
+        }) {
+            let subtrie_idx = path_subtrie_index_unchecked(&roots_group[0]);
+
+            // Skip unrevealed/blinded subtries - nothing to prune
+            let Some(subtrie) = self.lower_subtries[subtrie_idx].as_revealed_mut() else {
+                continue;
+            };
+
+            // Retain only nodes/values not descended from any pruned root.
+            subtrie.nodes.retain(|p, _| !is_strict_descendant_in(roots_group, p));
+            subtrie.inner.values.retain(|p, _| !starts_with_pruned_in(roots_group, p));
+        }
+
+        // Branch node masks pruning
+        self.branch_node_masks.retain(|p, _| {
+            if SparseSubtrieType::path_len_is_upper(p.len()) {
+                !starts_with_pruned_in(roots_upper, p)
+            } else {
+                !starts_with_pruned_in(roots_lower, p) && !starts_with_pruned_in(roots_upper, p)
+            }
+        });
+
+        nodes_converted
     }
 
     /// Returns a reference to the lower `SparseSubtrie` for the given path, or None if the
@@ -3506,6 +3613,18 @@ fn is_strict_descendant_in(roots: &[Nibbles], path: &Nibbles) -> bool {
         }
     }
     false
+}
+
+/// Returns true if any retained leaf path has `prefix` as a prefix.
+///
+/// The `retained` slice must be sorted.
+fn has_retained_descendant(retained: &[Nibbles], prefix: &Nibbles) -> bool {
+    if retained.is_empty() {
+        return false;
+    }
+    debug_assert!(retained.windows(2).all(|w| w[0] <= w[1]), "retained must be sorted by path");
+    let idx = retained.partition_point(|path| path < prefix);
+    idx < retained.len() && retained[idx].starts_with(prefix)
 }
 
 /// Checks if `path` starts with any root in a sorted slice (inclusive).
@@ -7985,6 +8104,31 @@ mod tests {
         for key in &keys {
             assert!(trie.get_leaf_value(key).is_none(), "value should be pruned");
         }
+    }
+
+    #[test]
+    fn test_prune_by_retained_leaves_keeps_only_hot_paths() {
+        let provider = DefaultTrieNodeProvider;
+        let mut trie = ParallelSparseTrie::default();
+
+        let key_keep = pad_nibbles_right(Nibbles::from_nibbles([0x1, 0x2, 0x3, 0x4]));
+        let key_drop_1 = pad_nibbles_right(Nibbles::from_nibbles([0x5, 0x2, 0x3, 0x4]));
+        let key_drop_2 = pad_nibbles_right(Nibbles::from_nibbles([0x9, 0x2, 0x3, 0x4]));
+
+        let value = large_account_value();
+        trie.update_leaf(key_keep, value.clone(), &provider).unwrap();
+        trie.update_leaf(key_drop_1, value.clone(), &provider).unwrap();
+        trie.update_leaf(key_drop_2, value, &provider).unwrap();
+
+        let root_before = trie.root();
+
+        let pruned = trie.prune_by_retained_leaves(&[key_keep]);
+        assert!(pruned > 0, "expected some nodes to be pruned");
+        assert_eq!(root_before, trie.root(), "root hash should be preserved after LFU prune");
+
+        assert!(trie.get_leaf_value(&key_keep).is_some(), "retained key must remain revealed");
+        assert!(trie.get_leaf_value(&key_drop_1).is_none(), "non-retained key should be pruned");
+        assert!(trie.get_leaf_value(&key_drop_2).is_none(), "non-retained key should be pruned");
     }
 
     #[test]

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -5,7 +5,7 @@ use crate::{
     traits::SparseTrie as SparseTrieTrait,
     ParallelSparseTrie, RevealableSparseTrie,
 };
-use alloc::vec::Vec;
+use alloc::{collections::BTreeMap, vec::Vec};
 use alloy_primitives::{
     map::{B256Map, B256Set, HashSet},
     B256,
@@ -56,6 +56,8 @@ pub struct SparseStateTrie<
     account_rlp_buf: Vec<u8>,
     /// Holds data that should be dropped after final state root is calculated.
     deferred_drops: DeferredDrops,
+    /// Global LFU tracker for hot `(address, slot)` storage entries.
+    hot_slots_lfu: HotSlotsLfu,
     /// Metrics for the sparse state trie.
     #[cfg(feature = "metrics")]
     metrics: crate::metrics::SparseStateTrieMetrics,
@@ -75,6 +77,7 @@ where
             skip_proof_node_filtering: false,
             account_rlp_buf: Vec::with_capacity(TRIE_ACCOUNT_RLP_MAX_SIZE),
             deferred_drops: DeferredDrops::default(),
+            hot_slots_lfu: HotSlotsLfu::default(),
             #[cfg(feature = "metrics")]
             metrics: Default::default(),
         }
@@ -214,6 +217,12 @@ where
             .revealed_paths
             .get(&account)
             .is_some_and(|slots| slots.contains(&Nibbles::unpack(slot)))
+    }
+
+    /// Records a storage slot access/update in the global LFU tracker.
+    #[inline]
+    pub fn record_hot_storage_slot(&mut self, account: B256, slot: B256) {
+        self.hot_slots_lfu.touch(account, slot);
     }
 
     /// Returns reference to bytes representing leaf value for the target account.
@@ -846,10 +855,14 @@ where
         self.storage.shrink_to(storage_nodes, storage_values);
     }
 
-    /// Prunes the account trie and selected storage tries to reduce memory usage.
+    /// Prunes account/storage tries according to global LFU hot-slot retention.
     ///
-    /// Storage tries not in the top `max_storage_tries` by revealed node count are cleared
-    /// entirely.
+    /// The `max_storage_tries` argument is interpreted as the LFU hot-slot capacity.
+    ///
+    /// - Top LFU `(address, slot)` entries are retained.
+    /// - Account trie retains only paths needed for retained addresses.
+    /// - Storage tries retain only paths needed for retained slots.
+    /// - All other revealed paths are pruned to hash stubs or fully evicted.
     ///
     /// # Preconditions
     ///
@@ -868,18 +881,26 @@ where
         fields(%max_depth, %max_storage_tries)
     )]
     pub fn prune(&mut self, max_depth: usize, max_storage_tries: usize) {
-        // Prune state and storage tries in parallel
+        let _ = max_depth;
+        self.hot_slots_lfu.set_capacity(max_storage_tries);
+        let retained = self.hot_slots_lfu.retained_slots_by_address();
+        let mut retained_account_paths: Vec<Nibbles> =
+            retained.keys().copied().map(Nibbles::unpack).collect();
+
+        // Prune account and storage tries in parallel using the same LFU-selected set.
         rayon::join(
             || {
                 if let Some(trie) = self.state.as_revealed_mut() {
-                    trie.prune(max_depth);
+                    trie.prune_by_retained_leaves(&retained_account_paths);
                 }
                 self.revealed_account_paths.clear();
             },
             || {
-                self.storage.prune(max_depth, max_storage_tries);
+                self.storage.prune_by_retained_slots(retained);
             },
         );
+
+        retained_account_paths.clear();
     }
 
     /// Commits the [`TrieUpdates`] to the sparse trie.
@@ -922,6 +943,7 @@ impl<S: SparseTrieTrait> StorageTries<S> {
     ///
     /// Keeps the top `max_storage_tries` by a score combining size and heat.
     /// Evicts lower-scored tries entirely, prunes kept tries to `max_depth`.
+    #[allow(dead_code)]
     fn prune(&mut self, max_depth: usize, max_storage_tries: usize) {
         let fn_start = Instant::now();
         let mut stats =
@@ -1025,6 +1047,40 @@ impl<S: SparseTrieTrait> StorageTries<S> {
             ?stats.total_elapsed,
             "StorageTries::prune completed"
         );
+    }
+
+    /// Prunes storage tries using LFU-retained slots.
+    ///
+    /// Tries without retained slots are evicted entirely. Tries with retained slots are pruned to
+    /// those slots.
+    fn prune_by_retained_slots(&mut self, mut retained_slots: B256Map<Vec<Nibbles>>) {
+        let addresses_to_evict: Vec<B256> = self
+            .tries
+            .keys()
+            .filter(|address| !retained_slots.contains_key(*address))
+            .copied()
+            .collect();
+
+        for address in &addresses_to_evict {
+            if let Some(mut trie) = self.tries.remove(address) {
+                trie.clear();
+                self.cleared_tries.push(trie);
+            }
+            if let Some(mut paths) = self.revealed_paths.remove(address) {
+                paths.clear();
+                self.cleared_revealed_paths.push(paths);
+            }
+            self.modifications.remove(address);
+        }
+
+        for (address, slots) in retained_slots.iter_mut() {
+            if let Some(trie) = self.tries.get_mut(address).and_then(|t| t.as_revealed_mut()) {
+                trie.prune_by_retained_leaves(slots);
+            }
+            if let Some(paths) = self.revealed_paths.get_mut(address) {
+                paths.clear();
+            }
+        }
     }
 }
 
@@ -1136,6 +1192,76 @@ struct StorageTriesPruneStats {
     skipped_recently_pruned: usize,
     prune_elapsed: core::time::Duration,
     total_elapsed: core::time::Duration,
+}
+
+/// Key for identifying a storage slot in the global LFU cache.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct HotSlotKey {
+    address: B256,
+    slot: B256,
+}
+
+/// Global LFU tracker for hot storage slots across all storage tries.
+#[derive(Debug, Default)]
+struct HotSlotsLfu {
+    capacity: usize,
+    frequencies: BTreeMap<HotSlotKey, u32>,
+}
+
+impl HotSlotsLfu {
+    /// Sets LFU capacity and trims entries if needed.
+    fn set_capacity(&mut self, capacity: usize) {
+        self.capacity = capacity;
+        while self.frequencies.len() > self.capacity {
+            let Some(evict_key) = self
+                .frequencies
+                .iter()
+                .min_by_key(|(key, frequency)| (**frequency, **key))
+                .map(|(key, _)| *key)
+            else {
+                break;
+            };
+            self.frequencies.remove(&evict_key);
+        }
+    }
+
+    /// Records a storage slot touch.
+    fn touch(&mut self, address: B256, slot: B256) {
+        let key = HotSlotKey { address, slot };
+        if let Some(frequency) = self.frequencies.get_mut(&key) {
+            *frequency = frequency.saturating_add(1);
+            return;
+        }
+
+        if self.capacity != 0 && self.frequencies.len() >= self.capacity {
+            let Some(evict_key) = self
+                .frequencies
+                .iter()
+                .min_by_key(|(existing_key, frequency)| (**frequency, **existing_key))
+                .map(|(existing_key, _)| *existing_key)
+            else {
+                return;
+            };
+            self.frequencies.remove(&evict_key);
+        }
+
+        self.frequencies.insert(key, 1);
+    }
+
+    /// Returns retained slots grouped by address.
+    fn retained_slots_by_address(&self) -> B256Map<Vec<Nibbles>> {
+        let mut grouped = B256Map::<Vec<Nibbles>>::default();
+        for key in self.frequencies.keys() {
+            grouped.entry(key.address).or_default().push(Nibbles::unpack(key.slot));
+        }
+
+        for slots in grouped.values_mut() {
+            slots.sort_unstable();
+            slots.dedup();
+        }
+
+        grouped
+    }
 }
 
 /// Per-trie access tracking and prune state.

--- a/crates/trie/sparse/src/traits.rs
+++ b/crates/trie/sparse/src/traits.rs
@@ -308,6 +308,22 @@ pub trait SparseTrie: Sized + Debug + Send + Sync {
     /// The number of nodes converted to hash stubs.
     fn prune(&mut self, max_depth: usize) -> usize;
 
+    /// Prunes all subtrees that do not contain retained leaves.
+    ///
+    /// Each retained leaf is a full key path (usually 64 nibbles for hashed keys).
+    /// Any revealed subtree that is not a prefix of at least one retained key is collapsed into
+    /// hash stubs when hashes are available.
+    ///
+    /// # Preconditions
+    ///
+    /// Must be called after `root()` to ensure all nodes have computed hashes.
+    /// Calling on a trie without computed hashes will result in limited or no pruning.
+    ///
+    /// # Returns
+    ///
+    /// The number of nodes converted to hash stubs.
+    fn prune_by_retained_leaves(&mut self, retained_leaves: &[Nibbles]) -> usize;
+
     /// Takes the debug recorder out of this trie, replacing it with an empty one.
     ///
     /// Returns the recorder containing all recorded mutations since the last reset.


### PR DESCRIPTION
Replaces the size+heat scoring eviction policy in `SparseStateTrie::prune()` with a global LFU (Least Frequently Used) tracker that retains the hottest `(address, slot)` pairs across blocks.

Instead of keeping the top N storage tries by size and pruning them to a fixed depth, the LFU tracker records every storage slot access/update and retains only the most frequently accessed slots. Account and storage tries are then pruned to keep only the paths needed for retained entries, with everything else converted to hash stubs or evicted.

### Benchmark results (local, schelk replay)

| Workload | Baseline | LFU cache | Change |
|----------|----------|-----------|--------|
| Big blocks (50 blocks) | 1.1724 Ggas/s | 1.1627 Ggas/s | -0.8% (noise) |
| Mainnet payloads (4000 blocks) | 0.4756 Ggas/s | 0.8221 Ggas/s | **+72.8%** |

The mainnet workload benefits heavily because normal blocks have repeated storage access patterns (e.g. DEX routers, token contracts) that the LFU cache serves directly, avoiding expensive re-reveals from the database.