### PR TITLE
feat(rpc): implement debug_storageRangeAt

### DIFF
--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -3,7 +3,7 @@ use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_genesis::ChainConfig;
 use alloy_json_rpc::RpcObject;
 use alloy_primitives::{Address, Bytes, B256, U64};
-use alloy_rpc_types_debug::ExecutionWitness;
+use alloy_rpc_types_debug::{ExecutionWitness, StorageRangeResult};
 use alloy_rpc_types_eth::{Bundle, StateContext};
 use alloy_rpc_types_trace::geth::{
     BlockTraceResult, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
@@ -394,7 +394,7 @@ pub trait DebugApi<TxReq: RpcObject> {
         contract_address: Address,
         key_start: B256,
         max_result: u64,
-    ) -> RpcResult<()>;
+    ) -> RpcResult<StorageRangeResult>;
 
     /// Returns the structured logs created during the execution of EVM against a block pulled
     /// from the pool of bad ones and returns them as a JSON object. For the second parameter see

--- a/crates/rpc/rpc-eth-types/src/cache/db.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/db.rs
@@ -4,6 +4,7 @@
 
 use alloy_primitives::{Address, B256, U256};
 use reth_errors::ProviderResult;
+use reth_primitives_traits::StorageEntry;
 use reth_revm::database::StateProviderDatabase;
 use reth_storage_api::{BytecodeReader, HashedPostStateProvider, StateProvider, StateProviderBox};
 use reth_trie::{HashedStorage, MultiProofTargets};
@@ -152,6 +153,10 @@ impl StateProvider for StateProviderTraitObjWrapper {
         storage_key: alloy_primitives::StorageKey,
     ) -> reth_errors::ProviderResult<Option<alloy_primitives::StorageValue>> {
         self.0.storage(account, storage_key)
+    }
+
+    fn storage_entries(&self, address: Address) -> reth_errors::ProviderResult<Vec<StorageEntry>> {
+        self.0.storage_entries(address)
     }
 
     fn account_code(

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -1,12 +1,12 @@
 use alloy_consensus::{transaction::TxHashRef, BlockHeader};
 use alloy_eip7928::BlockAccessList;
 use alloy_eips::{eip2718::Encodable2718, BlockId, BlockNumberOrTag};
-use alloy_evm::env::BlockEnvironment;
+use alloy_evm::{env::BlockEnvironment, Evm as _};
 use alloy_genesis::ChainConfig;
-use alloy_primitives::{hex::decode, uint, Address, Bytes, B256, U64};
+use alloy_primitives::{hex::decode, keccak256, uint, Address, Bytes, B256, U256, U64};
 use alloy_rlp::{Decodable, Encodable};
 use alloy_rpc_types::BlockTransactionsKind;
-use alloy_rpc_types_debug::ExecutionWitness;
+use alloy_rpc_types_debug::{ExecutionWitness, StorageRangeResult, StorageResult};
 use alloy_rpc_types_eth::{state::EvmOverrides, BlockError, Bundle, StateContext};
 use alloy_rpc_types_trace::geth::{
     BlockTraceResult, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
@@ -27,20 +27,23 @@ use reth_rpc_api::DebugApiServer;
 use reth_rpc_convert::RpcTxReq;
 use reth_rpc_eth_api::{
     helpers::{EthTransactions, TraceExt},
-    FromEthApiError, RpcConvert, RpcNodeCore,
+    FromEthApiError, FromEvmError, RpcConvert, RpcNodeCore,
 };
 use reth_rpc_eth_types::EthApiError;
 use reth_rpc_server_types::{result::internal_rpc_err, ToRpcResult};
 use reth_storage_api::{
     BlockIdReader, BlockReaderIdExt, HeaderProvider, ProviderBlock, ReceiptProviderIdExt,
-    StateProofProvider, StateProviderFactory, StateRootProvider, TransactionVariant,
+    StateProofProvider, StateProvider, StateProviderFactory, StateRootProvider, TransactionVariant,
 };
 use reth_tasks::{pool::BlockingTaskGuard, Runtime};
 use reth_trie_common::{updates::TrieUpdates, HashedPostState};
 use revm::DatabaseCommit;
 use revm_inspectors::tracing::{DebugInspector, TransactionContext};
 use serde::{Deserialize, Serialize};
-use std::{collections::VecDeque, sync::Arc};
+use std::{
+    collections::{BTreeMap, VecDeque},
+    sync::Arc,
+};
 use tokio::sync::{AcquireError, OwnedSemaphorePermit};
 use tokio_stream::StreamExt;
 
@@ -625,6 +628,100 @@ where
             })
             .await
     }
+
+    /// Returns the contract storage for the given address at the block and transaction index.
+    ///
+    /// Replays all transactions up to the given index to build the intermediate state, then
+    /// enumerates storage slots keyed by their keccak hash.
+    pub async fn debug_storage_range_at(
+        &self,
+        block_hash: B256,
+        tx_idx: usize,
+        contract_address: Address,
+        key_start: B256,
+        max_result: u64,
+    ) -> Result<StorageRangeResult, Eth::Error> {
+        let block = self
+            .eth_api()
+            .recovered_block(block_hash.into())
+            .await?
+            .ok_or(EthApiError::HeaderNotFound(block_hash.into()))?;
+
+        if tx_idx > block.transaction_count() {
+            return Err(EthApiError::InvalidParams(format!(
+                "tx index {} out of range for block with {} transactions",
+                tx_idx,
+                block.transaction_count()
+            ))
+            .into())
+        }
+
+        let (evm_env, _) = self.eth_api().evm_env_at(block_hash.into()).await?;
+        let parent_hash = block.parent_hash();
+
+        self.eth_api()
+            .spawn_with_state_at_block(parent_hash, move |eth_api, mut db| {
+                eth_api.apply_pre_execution_changes(&block, &mut db)?;
+
+                // Replay transactions before tx_idx to reach the desired intermediate state
+                let mut evm = eth_api.evm_config().evm_with_env(&mut db, evm_env);
+                for tx in block.transactions_recovered().take(tx_idx) {
+                    let tx_env = eth_api.evm_config().tx_env(tx);
+                    evm.transact_commit(tx_env).map_err(Eth::Error::from_evm_err)?;
+                }
+                drop(evm);
+
+                // Read all base storage entries from the underlying state provider
+                let base_entries = StateProvider::storage_entries(&db.database.0, contract_address)
+                    .map_err(Eth::Error::from_eth_err)?;
+
+                // Build a map keyed by unhashed slot: base values first, overlay on top
+                let mut merged: BTreeMap<B256, U256> = BTreeMap::new();
+                for entry in &base_entries {
+                    if !entry.value.is_zero() {
+                        merged.insert(entry.key, entry.value);
+                    }
+                }
+
+                // Apply overlay from replayed transactions
+                if let Some(account) = db.cache.accounts.get(&contract_address) &&
+                    let Some(plain_account) = &account.account
+                {
+                    for (slot, value) in &plain_account.storage {
+                        let key = B256::from(*slot);
+                        if value.is_zero() {
+                            merged.remove(&key);
+                        } else {
+                            merged.insert(key, *value);
+                        }
+                    }
+                }
+
+                // Hash keys, sort by hash, and paginate
+                let mut hashed: BTreeMap<B256, (B256, U256)> = BTreeMap::new();
+                for (slot, value) in &merged {
+                    hashed.insert(keccak256(slot), (*slot, *value));
+                }
+
+                // Build response starting at key_start
+                let max = max_result as usize;
+                let mut storage = BTreeMap::new();
+                let mut next_key = None;
+                for (hash, (slot, value)) in hashed.range(key_start..) {
+                    if storage.len() >= max {
+                        next_key = Some(*hash);
+                        break;
+                    }
+                    storage.insert(
+                        *hash,
+                        StorageResult { key: *slot, value: B256::from(value.to_be_bytes()) },
+                    );
+                }
+
+                Ok(StorageRangeResult { storage: storage.into(), next_key })
+            })
+            .await
+    }
 }
 
 #[async_trait]
@@ -1059,13 +1156,23 @@ where
 
     async fn debug_storage_range_at(
         &self,
-        _block_hash: B256,
-        _tx_idx: usize,
-        _contract_address: Address,
-        _key_start: B256,
-        _max_result: u64,
-    ) -> RpcResult<()> {
-        Ok(())
+        block_hash: B256,
+        tx_idx: usize,
+        contract_address: Address,
+        key_start: B256,
+        max_result: u64,
+    ) -> RpcResult<StorageRangeResult> {
+        let _permit = self.acquire_trace_permit().await;
+        Self::debug_storage_range_at(
+            self,
+            block_hash,
+            tx_idx,
+            contract_address,
+            key_start,
+            max_result,
+        )
+        .await
+        .map_err(Into::into)
     }
 
     async fn debug_trace_bad_block(

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -11,7 +11,7 @@ use reth_db_api::{
     transaction::DbTx,
     BlockNumberList,
 };
-use reth_primitives_traits::{Account, Bytecode};
+use reth_primitives_traits::{Account, Bytecode, StorageEntry};
 use reth_storage_api::{
     BlockNumReader, BytecodeReader, DBProvider, NodePrimitivesProvider, StateProofProvider,
     StorageChangeSetReader, StorageRootProvider, StorageSettingsCache,
@@ -555,6 +555,48 @@ impl<
         storage_key: StorageKey,
     ) -> ProviderResult<Option<StorageValue>> {
         self.storage_by_lookup_key(address, storage_key)
+    }
+
+    fn storage_entries(&self, address: Address) -> ProviderResult<Vec<StorageEntry>> {
+        use std::collections::BTreeSet;
+
+        // Collect all known storage keys from the current plain state and changesets
+        let mut keys = BTreeSet::new();
+
+        // Walk PlainStorageState for current keys
+        let mut cursor = self.tx().cursor_dup_read::<tables::PlainStorageState>()?;
+        let walker = cursor.walk_dup(Some(address), None)?;
+        for entry in walker {
+            let (_, se) = entry?;
+            keys.insert(se.key);
+        }
+
+        // Walk StorageChangeSets for keys that may have been deleted since this block
+        let mut cs_cursor = self.tx().cursor_dup_read::<tables::StorageChangeSets>()?;
+        let start = reth_db_api::models::BlockNumberAddress((0, address));
+        if let Ok(walker) = cs_cursor.walk(Some(start)) {
+            for entry in walker {
+                let (block_addr, se) = entry?;
+                if block_addr.address() != address {
+                    // Entries are sorted by (block, address), skip once past our address
+                    // range for this block. Other blocks may still have entries.
+                    continue
+                }
+                keys.insert(se.key);
+            }
+        }
+
+        // Query each key at the historical block
+        let mut entries = Vec::new();
+        for key in keys {
+            if let Some(value) = self.storage_by_lookup_key(address, key)? &&
+                !value.is_zero()
+            {
+                entries.push(StorageEntry { key, value });
+            }
+        }
+
+        Ok(entries)
     }
 }
 

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -3,7 +3,7 @@ use crate::{
 };
 use alloy_primitives::{Address, BlockNumber, Bytes, StorageKey, StorageValue, B256};
 use reth_db_api::{cursor::DbDupCursorRO, tables, transaction::DbTx};
-use reth_primitives_traits::{Account, Bytecode};
+use reth_primitives_traits::{Account, Bytecode, StorageEntry};
 use reth_storage_api::{
     BytecodeReader, DBProvider, StateProofProvider, StorageRootProvider, StorageSettingsCache,
 };
@@ -262,6 +262,19 @@ impl<Provider: DBProvider + BlockHashReader + StorageSettingsCache> StateProvide
             }
             Ok(None)
         }
+    }
+
+    fn storage_entries(&self, address: Address) -> ProviderResult<Vec<StorageEntry>> {
+        let mut entries = Vec::new();
+        let mut cursor = self.tx().cursor_dup_read::<tables::PlainStorageState>()?;
+        let walker = cursor.walk_dup(Some(address), None)?;
+        for entry in walker {
+            let (_, storage_entry) = entry?;
+            if !storage_entry.value.is_zero() {
+                entries.push(storage_entry);
+            }
+        }
+        Ok(entries)
     }
 }
 

--- a/crates/storage/storage-api/src/macros.rs
+++ b/crates/storage/storage-api/src/macros.rs
@@ -41,6 +41,7 @@ macro_rules! delegate_provider_impls {
             }
             StateProvider $(where [$($generics)*])? {
                 fn storage(&self, account: alloy_primitives::Address, storage_key: alloy_primitives::StorageKey) -> reth_storage_api::errors::provider::ProviderResult<Option<alloy_primitives::StorageValue>>;
+                fn storage_entries(&self, address: alloy_primitives::Address) -> reth_storage_api::errors::provider::ProviderResult<Vec<reth_primitives_traits::StorageEntry>>;
             }
             BytecodeReader $(where [$($generics)*])? {
                 fn bytecode_by_hash(&self, code_hash: &alloy_primitives::B256) -> reth_storage_api::errors::provider::ProviderResult<Option<reth_primitives_traits::Bytecode>>;

--- a/crates/storage/storage-api/src/state.rs
+++ b/crates/storage/storage-api/src/state.rs
@@ -2,13 +2,13 @@ use super::{
     AccountReader, BlockHashReader, BlockIdReader, StateProofProvider, StateRootProvider,
     StorageRootProvider,
 };
-use alloc::boxed::Box;
+use alloc::{boxed::Box, vec::Vec};
 use alloy_consensus::constants::KECCAK_EMPTY;
 use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_primitives::{Address, BlockHash, BlockNumber, StorageKey, StorageValue, B256, U256};
 use auto_impl::auto_impl;
 use reth_execution_types::ExecutionOutcome;
-use reth_primitives_traits::Bytecode;
+use reth_primitives_traits::{Bytecode, StorageEntry};
 use reth_storage_errors::provider::ProviderResult;
 use reth_trie_common::HashedPostState;
 use revm_database::BundleState;
@@ -87,6 +87,13 @@ pub trait StateProvider:
         // Get basic account information
         // Returns None if acc doesn't exist
         self.basic_account(addr)?.map_or_else(|| Ok(None), |acc| Ok(Some(acc.nonce)))
+    }
+
+    /// Returns all storage entries (non-zero) for the given address.
+    ///
+    /// This can be expensive for contracts with many storage slots.
+    fn storage_entries(&self, _address: Address) -> ProviderResult<Vec<StorageEntry>> {
+        Ok(Vec::new())
     }
 }
 


### PR DESCRIPTION
Closes #17609

Implements `debug_storageRangeAt` which was stubbed out. Replays transactions up to the given index to reconstruct intermediate state, then returns paginated storage entries keyed by keccak hash.

## Changes
- Add `StateProvider::storage_entries()` for enumerating all storage slots for an address
- Implement for `LatestStateProviderRef` (walks `PlainStorageState`) and `HistoricalStateProviderRef` (collects keys from `PlainStorageState` + `StorageChangeSets`, queries each at historical block)
- Implement `debug_storage_range_at` in `DebugApi`: acquires trace permit, replays txs via `spawn_with_state_at_block`, merges base storage with transaction overlay, hashes keys and paginates
- Forward through `StateProviderTraitObjWrapper` and `delegate_provider_impls` macro

## Notes
- Uses trace permit for rate-limiting (expensive operation, especially for large contracts)
- Storage enumeration for historical state walks changesets to find all keys that ever existed, then queries each at the target block
- Follows the same task spawning pattern as `eth_getProof` and `debug_traceCall`

Prompted by: matthias