### PR TITLE
chore: add missing Slack user mappings for bench notifications

### DIFF
--- a/.github/scripts/bench-slack-users.json
+++ b/.github/scripts/bench-slack-users.json
@@ -9,5 +9,16 @@
   "gakonst": "U092SEPDM40",
   "Rjected": "U09F6SCKRGT",
   "DaniPopes": "U09FAT8EK2A",
-  "emmajam": "U0A34UN92HW"
+  "emmajam": "U0A34UN92HW",
+  "onbjerg": "U09FB0UK5AA",
+  "fgimenez": "U09G3GP7CSU",
+  "rakita": "U09FB3Z2M7Y",
+  "jxom": "U09F72MG083",
+  "tmm": "U0AD0U8E88N",
+  "pepyakin": "U0A7HKMGEHJ",
+  "grandizzy": "U09F8DBDDRT",
+  "SuperFluffy": "U095BKHB2Q4",
+  "kamsz": "U0A2563UBRD",
+  "zerosnacks": "U09FARPMN74",
+  "samczsun": "U096R14E4H3"
 }


### PR DESCRIPTION
Adds Slack user IDs for paradigmxyz members and frequent bench users so they get DMs when bench results are ready.

New mappings: onbjerg, fgimenez, rakita, jxom, tmm, pepyakin, grandizzy, SuperFluffy, kamsz, zerosnacks, samczsun.

Prompted by: alexey