### PR TITLE
perf(engine): skip eager hashed_post_state blocking in validate_post_execution

### DIFF
--- a/crates/engine/primitives/src/lib.rs
+++ b/crates/engine/primitives/src/lib.rs
@@ -182,6 +182,13 @@ pub trait PayloadValidator<Types: PayloadTypes>: Send + Sync + Unpin + 'static {
         Ok(())
     }
 
+    /// Whether [`Self::validate_block_post_execution_with_hashed_state`] performs actual
+    /// validation. When `false`, the engine skips eagerly blocking on the background
+    /// hashed-post-state computation, removing ~25ms from the critical path on L1.
+    fn needs_hashed_post_state_validation(&self) -> bool {
+        false
+    }
+
     /// Validates the payload attributes with respect to the header.
     ///
     /// By default, this enforces that the payload attributes timestamp is greater than the

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1291,20 +1291,11 @@ where
         }
         drop(_enter);
 
-        // Wait for the background keccak256 hashing task to complete. This blocks until
-        // all changed addresses and storage slots have been hashed.
-        let hashed_state_ref =
-            debug_span!(target: "engine::tree::payload_validator", "wait_hashed_post_state")
-                .in_scope(|| hashed_state.get());
-
-        let _enter = debug_span!(target: "engine::tree::payload_validator", "validate_block_post_execution_with_hashed_state").entered();
-        if let Err(err) =
-            self.validator.validate_block_post_execution_with_hashed_state(hashed_state_ref, block)
-        {
-            // call post-block hook
-            self.on_invalid_block(parent_block, block, output, None, ctx.state_mut());
-            return Err(err.into())
-        }
+        // Don't block on hashed_post_state here. The background keccak256 hashing task
+        // continues running and will be resolved lazily when actually needed (e.g. state
+        // root fallback or deferred trie input). On L1,
+        // validate_block_post_execution_with_hashed_state is a no-op, so blocking here
+        // just adds ~25ms of unnecessary latency to the critical path.
 
         // record post-execution validation duration
         self.metrics

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1291,11 +1291,23 @@ where
         }
         drop(_enter);
 
-        // Don't block on hashed_post_state here. The background keccak256 hashing task
-        // continues running and will be resolved lazily when actually needed (e.g. state
-        // root fallback or deferred trie input). On L1,
-        // validate_block_post_execution_with_hashed_state is a no-op, so blocking here
-        // just adds ~25ms of unnecessary latency to the critical path.
+        // Only block on hashed_post_state if the validator actually uses it (e.g. OP's
+        // Isthmus withdrawals root verification). On L1 this is a no-op, so skipping the
+        // eager .get() removes ~25ms from the critical path.
+        if self.validator.needs_hashed_post_state_validation() {
+            let hashed_state_ref =
+                debug_span!(target: "engine::tree::payload_validator", "wait_hashed_post_state")
+                    .in_scope(|| hashed_state.get());
+
+            let _enter = debug_span!(target: "engine::tree::payload_validator", "validate_block_post_execution_with_hashed_state").entered();
+            if let Err(err) = self
+                .validator
+                .validate_block_post_execution_with_hashed_state(hashed_state_ref, block)
+            {
+                self.on_invalid_block(parent_block, block, output, None, ctx.state_mut());
+                return Err(err.into())
+            }
+        }
 
         // record post-execution validation duration
         self.metrics


### PR DESCRIPTION
On L1, `validate_block_post_execution_with_hashed_state` is a [no-op](https://github.com/paradigmxyz/reth/blob/main/crates/engine/primitives/src/lib.rs#L176-L183) that returns `Ok(())` immediately, but we block ~25ms on the background keccak256 hashing task before calling it. This removes the eager `.get()` so the `LazyHandle` resolves only when actually needed (timeout fallback, serial fallback, or deferred trie input).

Prompted by: joshie