### PR TITLE
perf(trie): use sequential hashing in BlockchainProvider::hashed_post_state

### DIFF
--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -619,7 +619,7 @@ impl<N: ProviderNodeTypes> StateProviderFactory for BlockchainProvider<N> {
 
 impl<N: NodeTypesWithDB> HashedPostStateProvider for BlockchainProvider<N> {
     fn hashed_post_state(&self, bundle_state: &BundleState) -> HashedPostState {
-        HashedPostState::from_bundle_state::<KeccakKeyHasher>(bundle_state.state())
+        HashedPostState::from_bundle_state_seq::<KeccakKeyHasher>(bundle_state.state())
     }
 }
 

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -619,7 +619,7 @@ impl<N: ProviderNodeTypes> StateProviderFactory for BlockchainProvider<N> {
 
 impl<N: NodeTypesWithDB> HashedPostStateProvider for BlockchainProvider<N> {
     fn hashed_post_state(&self, bundle_state: &BundleState) -> HashedPostState {
-        HashedPostState::from_bundle_state_seq::<KeccakKeyHasher>(bundle_state.state())
+        HashedPostState::from_bundle_state::<KeccakKeyHasher>(bundle_state.state())
     }
 }
 

--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -76,6 +76,16 @@ impl HashedPostState {
     pub fn from_bundle_state<'a, KH: KeyHasher>(
         state: impl IntoIterator<Item = (&'a Address, &'a BundleAccount)>,
     ) -> Self {
+        Self::from_bundle_state_seq::<KH>(state)
+    }
+
+    /// Sequential version of [`Self::from_bundle_state`].
+    ///
+    /// Prefer this over the parallel version when the caller is not running inside a dedicated
+    /// rayon pool, to avoid contending with other work on the global rayon pool.
+    pub fn from_bundle_state_seq<'a, KH: KeyHasher>(
+        state: impl IntoIterator<Item = (&'a Address, &'a BundleAccount)>,
+    ) -> Self {
         state
             .into_iter()
             .map(|(address, account)| {

--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -46,44 +46,7 @@ impl HashedPostState {
     /// Hashes all changed accounts and storage entries that are currently stored in the bundle
     /// state.
     #[inline]
-    #[cfg(feature = "rayon")]
     pub fn from_bundle_state<'a, KH: KeyHasher>(
-        state: impl IntoParallelIterator<Item = (&'a Address, &'a BundleAccount)>,
-    ) -> Self {
-        state
-            .into_par_iter()
-            .map(|(address, account)| {
-                let hashed_address = KH::hash_key(address);
-                let hashed_account = account.info.as_ref().map(Into::into);
-                let hashed_storage = HashedStorage::from_plain_storage(
-                    account.status,
-                    account.storage.iter().map(|(slot, value)| (slot, &value.present_value)),
-                );
-
-                (
-                    hashed_address,
-                    hashed_account,
-                    (!hashed_storage.is_empty()).then_some(hashed_storage),
-                )
-            })
-            .collect()
-    }
-
-    /// Initialize [`HashedPostState`] from bundle state.
-    /// Hashes all changed accounts and storage entries that are currently stored in the bundle
-    /// state.
-    #[cfg(not(feature = "rayon"))]
-    pub fn from_bundle_state<'a, KH: KeyHasher>(
-        state: impl IntoIterator<Item = (&'a Address, &'a BundleAccount)>,
-    ) -> Self {
-        Self::from_bundle_state_seq::<KH>(state)
-    }
-
-    /// Sequential version of [`Self::from_bundle_state`].
-    ///
-    /// Prefer this over the parallel version when the caller is not running inside a dedicated
-    /// rayon pool, to avoid contending with other work on the global rayon pool.
-    pub fn from_bundle_state_seq<'a, KH: KeyHasher>(
         state: impl IntoIterator<Item = (&'a Address, &'a BundleAccount)>,
     ) -> Self {
         state


### PR DESCRIPTION
Adds `HashedPostState::from_bundle_state_seq` and switches `BlockchainProvider::hashed_post_state` to use it.

`from_bundle_state` dispatches to rayon's global pool via `par_iter`. On the engine hot path (`hash-post-state` task), this contends with sparse trie pruning which also uses the global pool via `rayon::join`, causing ~25ms stalls on heavy blocks.

Sequential hashing avoids the contention. The work is lightweight enough that parallelism isn't needed — the stall was from pool contention, not from the hashing itself.

Prompted by: arsenii