### PR TITLE
fix(ci): clean up root-owned bench-work dir before checkout

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -366,6 +366,9 @@ jobs:
       BENCH_CORES: ${{ needs.reth-bench-ack.outputs.cores }}
       BENCH_COMMENT_ID: ${{ needs.reth-bench-ack.outputs.comment-id }}
     steps:
+      - name: Clean up previous bench-work
+        run: sudo rm -rf "$BENCH_WORK_DIR" 2>/dev/null || true
+
       - name: Resolve checkout ref
         id: checkout-ref
         uses: actions/github-script@v8


### PR DESCRIPTION
Reth runs as root via sudo and creates log files in `bench-work/`. The runner can't remove these on next checkout, causing EACCES and a full repo re-clone. Cleans up with sudo at the start of the job.

Prompted by: alexey