### PR TITLE
fix(cli): bail on empty range in re-execute command

### DIFF
--- a/crates/cli/commands/src/re_execute.rs
+++ b/crates/cli/commands/src/re_execute.rs
@@ -96,9 +96,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
         };
 
         if min_block > max_block {
-            eyre::bail!(
-                "--from ({min_block}) is beyond --to ({max_block}), nothing to re-execute"
-            );
+            eyre::bail!("--from ({min_block}) is beyond --to ({max_block}), nothing to re-execute");
         }
 
         let num_tasks = self.num_tasks.unwrap_or_else(|| {

--- a/crates/cli/commands/src/re_execute.rs
+++ b/crates/cli/commands/src/re_execute.rs
@@ -95,6 +95,12 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
             }
         };
 
+        if min_block > max_block {
+            eyre::bail!(
+                "--from ({min_block}) is beyond --to ({max_block}), nothing to re-execute"
+            );
+        }
+
         let num_tasks = self.num_tasks.unwrap_or_else(|| {
             std::thread::available_parallelism().map(|n| n.get() as u64).unwrap_or(10)
         });


### PR DESCRIPTION
`--to` had an out-of-range clamp but `--from` had no validation at all. When `from > to` (or `from` past chain tip), every worker immediately breaks out and the command prints "Re-executed successfully" having done nothing. Add a bail so this is a hard error instead of a silent no-op.