### PR TITLE
fix(codecs): remove hardcoded new_buf variable in Compact derive to a…

### DIFF
--- a/crates/storage/codecs/derive/src/compact/enums.rs
+++ b/crates/storage/codecs/derive/src/compact/enums.rs
@@ -66,8 +66,7 @@ impl<'a> EnumHandler<'a> {
                     // Unnamed type
                     self.enum_lines.push(quote! {
                         #current_variant_index => {
-                            let (inner, new_buf) = #field_type::#from_compact_ident(buf, buf.len());
-                            buf = new_buf;
+                            let (inner, buf) = #field_type::#from_compact_ident(buf, buf.len());
                             #ident::#variant_name(inner)
                         }
                     });

--- a/crates/storage/codecs/derive/src/compact/mod.rs
+++ b/crates/storage/codecs/derive/src/compact/mod.rs
@@ -306,24 +306,15 @@ mod tests {
                 }
                 fn from_compact(mut buf: &[u8], len: usize) -> (Self, &[u8]) {
                     let (flags, mut buf) = TestStructFlags::from(buf);
-                    let (f_u64, new_buf) = u64::from_compact(buf, flags.f_u64_len() as usize);
-                    buf = new_buf;
-                    let (f_u256, new_buf) = U256::from_compact(buf, flags.f_u256_len() as usize);
-                    buf = new_buf;
-                    let (f_bool_t, new_buf) = bool::from_compact(buf, flags.f_bool_t_len() as usize);
-                    buf = new_buf;
-                    let (f_bool_f, new_buf) = bool::from_compact(buf, flags.f_bool_f_len() as usize);
-                    buf = new_buf;
-                    let (f_option_none, new_buf) = Option::from_compact(buf, flags.f_option_none_len() as usize);
-                    buf = new_buf;
-                    let (f_option_some, new_buf) = Option::specialized_from_compact(buf, flags.f_option_some_len() as usize);
-                    buf = new_buf;
-                    let (f_option_some_u64, new_buf) = Option::from_compact(buf, flags.f_option_some_u64_len() as usize);
-                    buf = new_buf;
-                    let (f_vec_empty, new_buf) = Vec::from_compact(buf, buf.len());
-                    buf = new_buf;
-                    let (f_vec_some, new_buf) = Vec::specialized_from_compact(buf, buf.len());
-                    buf = new_buf;
+                    let (f_u64, buf) = u64::from_compact(buf, flags.f_u64_len() as usize);
+                    let (f_u256, buf) = U256::from_compact(buf, flags.f_u256_len() as usize);
+                    let (f_bool_t, buf) = bool::from_compact(buf, flags.f_bool_t_len() as usize);
+                    let (f_bool_f, buf) = bool::from_compact(buf, flags.f_bool_f_len() as usize);
+                    let (f_option_none, buf) = Option::from_compact(buf, flags.f_option_none_len() as usize);
+                    let (f_option_some, buf) = Option::specialized_from_compact(buf, flags.f_option_some_len() as usize);
+                    let (f_option_some_u64, buf) = Option::from_compact(buf, flags.f_option_some_u64_len() as usize);
+                    let (f_vec_empty, buf) = Vec::from_compact(buf, buf.len());
+                    let (f_vec_some, buf) = Vec::specialized_from_compact(buf, buf.len());
                     let obj = TestStruct {
                         f_u64: f_u64,
                         f_u256: f_u256,

--- a/crates/storage/codecs/derive/src/compact/structs.rs
+++ b/crates/storage/codecs/derive/src/compact/structs.rs
@@ -140,26 +140,22 @@ impl<'a> StructHandler<'a> {
 
         if ftype == "Bytes" {
             self.lines.push(quote! {
-                let mut #name = Bytes::new();
-                (#name, buf) = Bytes::from_compact(buf, buf.len() as usize);
+                let (#name, buf) = Bytes::from_compact(buf, buf.len() as usize);
             })
         } else {
             let ident_type = format_ident!("{ftype}");
             if !is_flag_type(ftype) {
                 // It's a type that handles its own length requirements. (B256, Custom, ...)
                 self.lines.push(quote! {
-                    let (#name, new_buf) = #ident_type::#from_compact_ident(buf, buf.len());
+                    let (#name, buf) = #ident_type::#from_compact_ident(buf, buf.len());
                 })
             } else if *is_compact {
                 self.lines.push(quote! {
-                    let (#name, new_buf) = #ident_type::#from_compact_ident(buf, flags.#len() as usize);
+                    let (#name, buf) = #ident_type::#from_compact_ident(buf, flags.#len() as usize);
                 });
             } else {
                 unreachable!("flag-type fields are always compact in Compact derive")
             }
-            self.lines.push(quote! {
-                buf = new_buf;
-            });
         }
     }
 }


### PR DESCRIPTION
The `from_compact` codegen used a hardcoded intermediate variable `new_buf`:

    let (#name, new_buf) = TypeName::from_compact(buf, ...);
    buf = new_buf;

A struct with a field named `new_buf` expands to `let (new_buf, new_buf) = ...`, shadowing the deserialized value with the buffer slice and causing a type error.

Replace with direct buf shadowing `let (#name, buf) = ...` across all branches, consistent with the existing Bytes branch.