### PR TITLE
chore(hive): remove blob transaction ordering from expected failures

### DIFF
--- a/.github/scripts/hive/expected_failures.yaml
+++ b/.github/scripts/hive/expected_failures.yaml
@@ -35,10 +35,6 @@ engine-api: [ ]
 # no fix due to https://github.com/paradigmxyz/reth/issues/8732
 engine-cancun:
   - Invalid PayloadAttributes, Missing BeaconRoot, Syncing=True (Cancun) (reth)
-  # the test fails with older versions of the code for which it passed before, probably related to changes
-  # in hive or its dependencies
-  - Blob Transaction Ordering, Multiple Clients (Cancun) (reth)
-
 sync: [ ]
 
 engine-auth: [ ]


### PR DESCRIPTION
Remove `Blob Transaction Ordering, Multiple Clients (Cancun)` from the `engine-cancun` expected failures in hive tests.

Prompted by: matthias