### PR TITLE
perf(rpc): validate reward percentiles before DB calls in `eth_feeHistory`

### DIFF
--- a/crates/rpc/rpc/src/eth/bundle.rs
+++ b/crates/rpc/rpc/src/eth/bundle.rs
@@ -80,9 +80,7 @@ where
         let transactions = txs
             .into_iter()
             .map(|tx| recover_raw_transaction::<PoolPooledTx<Eth::Pool>>(&tx))
-            .collect::<Result<Vec<_>, _>>()?
-            .into_iter()
-            .collect::<Vec<_>>();
+            .collect::<Result<Vec<_>, _>>()?;
 
         let block_id: alloy_rpc_types_eth::BlockId = state_block_number.into();
         // Note: the block number is considered the `parent` block: <https://github.com/flashbots/mev-geth/blob/fddf97beec5877483f879a77b7dea2e58a58d653/internal/ethapi/api.go#L2104>


### PR DESCRIPTION
Moves the reward percentile range and monotonicity check before the provider DB calls in `fee_history`, so malformed requests are rejected without touching the database.