### PR TITLE
fix(ethstats): handle canonical stream termination correctly

### DIFF
--- a/crates/node/ethstats/src/ethstats.rs
+++ b/crates/node/ethstats/src/ethstats.rs
@@ -648,11 +648,8 @@ where
             let shutdown_tx = shutdown_tx.clone();
 
             tokio::spawn(async move {
-                loop {
-                    let head = canonical_stream.next().await;
-                    if let Some(head) = head &&
-                        head_tx.send(head).await.is_err()
-                    {
+                while let Some(head) = canonical_stream.next().await {
+                    if head_tx.send(head).await.is_err() {
                         break;
                     }
                 }


### PR DESCRIPTION
Replace `loop` + `if let Some` with `while let Some` to properly exit when canonical_state_stream closes. The old code would spin indefinitely on None values instead of terminating the task.