### PR TITLE
fix(rpc-engine-api): enforce FCU SYNCING precedence over V3 payload attr

### DIFF
--- a/.github/scripts/hive/expected_failures.yaml
+++ b/.github/scripts/hive/expected_failures.yaml
@@ -20,9 +20,7 @@ engine-withdrawals: [ ]
 
 engine-api: [ ]
 
-# no fix due to https://github.com/paradigmxyz/reth/issues/8732
-engine-cancun:
-  - Invalid PayloadAttributes, Missing BeaconRoot, Syncing=True (Cancun) (reth)
+engine-cancun: [ ]
 
 sync: [ ]
 

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -1339,7 +1339,9 @@ struct EngineApiInner<Provider, PayloadT: PayloadTypes, Pool, Validator, ChainSp
 mod tests {
     use super::*;
     use alloy_primitives::{Address, B256};
-    use alloy_rpc_types_engine::{ClientCode, ClientVersionV1, PayloadAttributes};
+    use alloy_rpc_types_engine::{
+        ClientCode, ClientVersionV1, PayloadAttributes, PayloadStatusEnum,
+    };
     use assert_matches::assert_matches;
     use reth_chainspec::{ChainSpec, ChainSpecBuilder, MAINNET};
     use reth_engine_primitives::{BeaconEngineMessage, OnForkChoiceUpdated};
@@ -1546,6 +1548,69 @@ mod tests {
             .expect("forkchoiceUpdatedV3 should return a syncing response");
         assert!(response.payload_status.is_syncing());
         assert!(response.payload_id.is_none());
+    }
+
+    #[tokio::test]
+    async fn fcu_v3_valid_forkchoice_missing_beacon_root_returns_invalid_attributes() {
+        let (mut handle, api) = setup_engine_api();
+
+        let state = ForkchoiceState {
+            head_block_hash: B256::from([0x22; 32]),
+            safe_block_hash: B256::ZERO,
+            finalized_block_hash: B256::ZERO,
+        };
+        let payload_attributes = PayloadAttributes {
+            timestamp: 1,
+            prev_randao: B256::ZERO,
+            suggested_fee_recipient: Address::ZERO,
+            withdrawals: Some(vec![]),
+            parent_beacon_block_root: None,
+        };
+
+        let api_task = tokio::spawn(async move {
+            api.fork_choice_updated_v3(state, Some(payload_attributes)).await
+        });
+
+        let request =
+            tokio::time::timeout(std::time::Duration::from_secs(1), handle.from_api.recv())
+                .await
+                .expect("timed out waiting for forkchoiceUpdated request")
+                .expect("expected forkchoiceUpdated request");
+
+        let response_tx = match request {
+            BeaconEngineMessage::ForkchoiceUpdated { payload_attrs, tx, .. } => {
+                assert!(
+                    payload_attrs.is_none(),
+                    "when attrs are invalid, API should first evaluate forkchoice without attrs"
+                );
+                tx
+            }
+            other => panic!("unexpected engine message: {other:?}"),
+        };
+
+        response_tx
+            .send(Ok(OnForkChoiceUpdated::valid(PayloadStatus::from_status(
+                PayloadStatusEnum::Valid,
+            ))))
+            .expect("send valid response");
+
+        let response = api_task.await.expect("api task should not panic");
+        assert_matches!(
+            response,
+            Err(EngineApiError::EngineObjectValidationError(
+                reth_payload_primitives::EngineObjectValidationError::PayloadAttributes(_)
+            ))
+        );
+
+        match tokio::time::timeout(std::time::Duration::from_millis(100), handle.from_api.recv())
+            .await
+        {
+            Err(_) | Ok(None) => {}
+            Ok(Some(BeaconEngineMessage::ForkchoiceUpdated { .. })) => {
+                panic!("no second forkchoiceUpdated call should be sent when attrs are invalid")
+            }
+            Ok(Some(other)) => panic!("unexpected engine message: {other:?}"),
+        }
     }
 
     // tests covering `engine_getPayloadBodiesByRange` and `engine_getPayloadBodiesByHash`

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -13,7 +13,7 @@ use alloy_rpc_types_engine::{
     ExecutionPayloadBodiesV2, ExecutionPayloadBodyV1, ExecutionPayloadBodyV2,
     ExecutionPayloadInputV2, ExecutionPayloadSidecar, ExecutionPayloadV1, ExecutionPayloadV3,
     ExecutionPayloadV4, ForkchoiceState, ForkchoiceUpdated, PayloadId, PayloadStatus,
-    PayloadStatusEnum, PraguePayloadFields,
+    PraguePayloadFields,
 };
 use async_trait::async_trait;
 use jsonrpsee_core::{server::RpcModule, RpcResult};
@@ -747,20 +747,9 @@ where
         state: ForkchoiceState,
         payload_attrs: Option<EngineT::PayloadAttributes>,
     ) -> EngineApiResult<ForkchoiceUpdated> {
-        let payload_attrs = if let Some(attrs) = payload_attrs {
-            // Evaluate forkchoice first. If the node is syncing / accepted / invalid for this
-            // state, return that outcome before validating payload attributes.
-            let fcu_res_without_attrs =
-                self.inner.beacon_consensus.fork_choice_updated(state, None, version).await?;
-            if !matches!(
-                fcu_res_without_attrs.payload_status.status,
-                PayloadStatusEnum::Valid | PayloadStatusEnum::Accepted
-            ) {
-                return Ok(fcu_res_without_attrs)
-            }
-
+        if let Some(ref attrs) = payload_attrs {
             let attr_validation_res =
-                self.inner.validator.ensure_well_formed_attributes(version, &attrs);
+                self.inner.validator.ensure_well_formed_attributes(version, attrs);
 
             // From the engine API spec:
             //
@@ -772,13 +761,14 @@ where
             //
             // NOTE: This also applies to cancun/shanghai-specific payload attributes.
             if let Err(err) = attr_validation_res {
+                let fcu_res =
+                    self.inner.beacon_consensus.fork_choice_updated(state, None, version).await?;
+                if fcu_res.is_invalid() || fcu_res.payload_status.is_syncing() {
+                    return Ok(fcu_res)
+                }
                 return Err(err.into())
             }
-
-            Some(attrs)
-        } else {
-            None
-        };
+        }
 
         Ok(self.inner.beacon_consensus.fork_choice_updated(state, payload_attrs, version).await?)
     }

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -13,7 +13,7 @@ use alloy_rpc_types_engine::{
     ExecutionPayloadBodiesV2, ExecutionPayloadBodyV1, ExecutionPayloadBodyV2,
     ExecutionPayloadInputV2, ExecutionPayloadSidecar, ExecutionPayloadV1, ExecutionPayloadV3,
     ExecutionPayloadV4, ForkchoiceState, ForkchoiceUpdated, PayloadId, PayloadStatus,
-    PraguePayloadFields,
+    PayloadStatusEnum, PraguePayloadFields,
 };
 use async_trait::async_trait;
 use jsonrpsee_core::{server::RpcModule, RpcResult};
@@ -747,9 +747,20 @@ where
         state: ForkchoiceState,
         payload_attrs: Option<EngineT::PayloadAttributes>,
     ) -> EngineApiResult<ForkchoiceUpdated> {
-        if let Some(ref attrs) = payload_attrs {
+        if let Some(attrs) = payload_attrs {
+            // Evaluate forkchoice first. If the node is syncing / accepted / invalid for this
+            // state, return that outcome before validating payload attributes.
+            let fcu_res_without_attrs =
+                self.inner.beacon_consensus.fork_choice_updated(state, None, version).await?;
+            if !matches!(
+                fcu_res_without_attrs.payload_status.status,
+                PayloadStatusEnum::Valid | PayloadStatusEnum::Accepted
+            ) {
+                return Ok(fcu_res_without_attrs)
+            }
+
             let attr_validation_res =
-                self.inner.validator.ensure_well_formed_attributes(version, attrs);
+                self.inner.validator.ensure_well_formed_attributes(version, &attrs);
 
             // From the engine API spec:
             //
@@ -759,24 +770,19 @@ where
             // MUST NOT begin a payload build process. In such an event, the forkchoiceState
             // update MUST NOT be rolled back.
             //
-            // NOTE: This will also apply to the validation result for the cancun or
-            // shanghai-specific fields provided in the payload attributes.
-            //
-            // To do this, we set the payload attrs to `None` if attribute validation failed, but
-            // we still apply the forkchoice update.
+            // NOTE: This also applies to cancun/shanghai-specific payload attributes.
             if let Err(err) = attr_validation_res {
-                let fcu_res =
-                    self.inner.beacon_consensus.fork_choice_updated(state, None, version).await?;
-                // TODO: decide if we want this branch - the FCU INVALID response might be more
-                // useful than the payload attributes INVALID response
-                if fcu_res.is_invalid() {
-                    return Ok(fcu_res)
-                }
                 return Err(err.into())
             }
+
+            return Ok(self
+                .inner
+                .beacon_consensus
+                .fork_choice_updated(state, Some(attrs), version)
+                .await?)
         }
 
-        Ok(self.inner.beacon_consensus.fork_choice_updated(state, payload_attrs, version).await?)
+        Ok(self.inner.beacon_consensus.fork_choice_updated(state, None, version).await?)
     }
 
     /// Returns reference to supported capabilities.

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -1344,10 +1344,11 @@ struct EngineApiInner<Provider, PayloadT: PayloadTypes, Pool, Validator, ChainSp
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_rpc_types_engine::{ClientCode, ClientVersionV1};
+    use alloy_primitives::{Address, B256};
+    use alloy_rpc_types_engine::{ClientCode, ClientVersionV1, PayloadAttributes};
     use assert_matches::assert_matches;
     use reth_chainspec::{ChainSpec, ChainSpecBuilder, MAINNET};
-    use reth_engine_primitives::BeaconEngineMessage;
+    use reth_engine_primitives::{BeaconEngineMessage, OnForkChoiceUpdated};
     use reth_ethereum_engine_primitives::EthEngineTypes;
     use reth_ethereum_primitives::Block;
     use reth_network_api::{
@@ -1503,6 +1504,54 @@ mod tests {
 
         let res = api.get_blobs_v3_metered(vec![B256::ZERO]);
         assert_matches!(res, Ok(None));
+    }
+
+    #[tokio::test]
+    async fn fcu_v3_syncing_precedes_invalid_payload_attributes_validation() {
+        let (mut handle, api) = setup_engine_api();
+
+        let state = ForkchoiceState {
+            head_block_hash: B256::from([0x11; 32]),
+            safe_block_hash: B256::ZERO,
+            finalized_block_hash: B256::ZERO,
+        };
+        let payload_attributes = PayloadAttributes {
+            timestamp: 1,
+            prev_randao: B256::ZERO,
+            suggested_fee_recipient: Address::ZERO,
+            withdrawals: Some(vec![]),
+            // Invalid for V3/Cancun, but should be ignored if forkchoice is SYNCING.
+            parent_beacon_block_root: None,
+        };
+
+        let api_task = tokio::spawn(async move {
+            api.fork_choice_updated_v3(state, Some(payload_attributes)).await
+        });
+
+        let request =
+            tokio::time::timeout(std::time::Duration::from_secs(1), handle.from_api.recv())
+                .await
+                .expect("timed out waiting for forkchoiceUpdated request")
+                .expect("expected forkchoiceUpdated request");
+        let response_tx = match request {
+            BeaconEngineMessage::ForkchoiceUpdated { payload_attrs, tx, .. } => {
+                assert!(
+                    payload_attrs.is_none(),
+                    "FCU for syncing state should be evaluated before payload attributes"
+                );
+                tx
+            }
+            other => panic!("unexpected engine message: {other:?}"),
+        };
+
+        response_tx.send(Ok(OnForkChoiceUpdated::syncing())).expect("send syncing response");
+
+        let response = api_task
+            .await
+            .expect("api task should not panic")
+            .expect("forkchoiceUpdatedV3 should return a syncing response");
+        assert!(response.payload_status.is_syncing());
+        assert!(response.payload_id.is_none());
     }
 
     // tests covering `engine_getPayloadBodiesByRange` and `engine_getPayloadBodiesByHash`

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -747,7 +747,7 @@ where
         state: ForkchoiceState,
         payload_attrs: Option<EngineT::PayloadAttributes>,
     ) -> EngineApiResult<ForkchoiceUpdated> {
-        if let Some(attrs) = payload_attrs {
+        let payload_attrs = if let Some(attrs) = payload_attrs {
             // Evaluate forkchoice first. If the node is syncing / accepted / invalid for this
             // state, return that outcome before validating payload attributes.
             let fcu_res_without_attrs =
@@ -775,14 +775,12 @@ where
                 return Err(err.into())
             }
 
-            return Ok(self
-                .inner
-                .beacon_consensus
-                .fork_choice_updated(state, Some(attrs), version)
-                .await?)
-        }
+            Some(attrs)
+        } else {
+            None
+        };
 
-        Ok(self.inner.beacon_consensus.fork_choice_updated(state, None, version).await?)
+        Ok(self.inner.beacon_consensus.fork_choice_updated(state, payload_attrs, version).await?)
     }
 
     /// Returns reference to supported capabilities.


### PR DESCRIPTION
This PR fixes `engine_forkchoiceUpdatedV3` behavior so forkchoice status is evaluated before Cancun payload-attributes validation in mixed cases (unknown head + invalid attrs).

Fix the hive test `Invalid PayloadAttributes, Missing BeaconRoot, Syncing=True (Cancun)`: ref https://hive.ethpandaops.io/#/test/generic/1769588207-23b235db01bd3d466c3c4b706913cd79?testnumber=184

```
<< (6649d9c4) {"jsonrpc":"2.0","id":24,"error":{"code":-38003,"message":"Invalid payload attributes","data":{"err":"Payload attributes validation error: no parent beacon block root post-cancun"}}}
FAIL (Invalid PayloadAttributes, Missing BeaconRoot, Syncing=True): Unexpected error on EngineForkchoiceUpdatedV3: Invalid payload attributes, expected=<None>
CLMocker: Closing engine client 6649d9c4
CLMocker: Closed engine client 6649d9c4
End test (reth_default): Invalid PayloadAttributes, Missing BeaconRoot, Syncing=True (Cancun)
```

Refer to https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md#specification-1:

> Client software MAY initiate a sync process if forkchoiceState.headBlockHash references an unknown payload or a payload that can't be validated because data that are requisite for the validation is missing. The sync process is specified in the [Sync](https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md#sync) section.

So the client should immediately response with `SYNCING` instead of checking the payload.