### PR TITLE
fix(net): avoid full HashSet clone in bootstrap

### DIFF
--- a/crates/net/dns/src/lib.rs
+++ b/crates/net/dns/src/lib.rs
@@ -165,8 +165,9 @@ impl<R: Resolver> DnsDiscoveryService<R> {
 
     /// Starts discovery with all configured bootstrap links
     pub fn bootstrap(&mut self) {
-        for link in self.bootstrap_dns_networks.clone() {
-            self.sync_tree_with_link(link);
+        let queries = &mut self.queries;
+        for link in self.bootstrap_dns_networks.iter().cloned() {
+            queries.resolve_root(link);
         }
     }
 


### PR DESCRIPTION
`DnsDiscoveryService::bootstrap()` cloned the entire `bootstrap_dns_networks` HashSet before iterating. This introduced unnecessary allocation and extra work, especially with larger bootstrap sets, while only per-item ownership was required.

Updated `bootstrap()` to iterate with `self.bootstrap_dns_networks.iter().cloned()` and enqueue root resolution directly via a scoped mutable borrow of `self.queries`.