### PR TITLE
perf(tasks): deprioritize background tracing/OTel threads on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10309,6 +10309,7 @@ dependencies = [
  "crossbeam-utils",
  "dashmap",
  "futures-util",
+ "libc",
  "metrics",
  "parking_lot",
  "pin-project",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -518,6 +518,7 @@ humantime = "2.1"
 humantime-serde = "1.1"
 itertools = { version = "0.14", default-features = false }
 linked_hash_set = "0.1"
+libc = "0.2"
 lz4 = "1.28.1"
 modular-bitfield = "0.13.1"
 notify = { version = "8.0.0", default-features = false, features = ["macos_fsevent"] }

--- a/crates/ethereum/cli/src/app.rs
+++ b/crates/ethereum/cli/src/app.rs
@@ -128,8 +128,7 @@ where
         self.init_tracing(&runner)?;
 
         // Deprioritize background threads spawned by tracing/OTel libraries.
-        static DEPRIORITIZE: std::sync::Once = std::sync::Once::new();
-        DEPRIORITIZE.call_once(reth_tasks::utils::deprioritize_background_threads);
+        reth_tasks::utils::deprioritize_background_threads();
 
         // Install the prometheus recorder to be sure to record all metrics
         install_prometheus_recorder();

--- a/crates/ethereum/cli/src/app.rs
+++ b/crates/ethereum/cli/src/app.rs
@@ -127,6 +127,10 @@ where
 
         self.init_tracing(&runner)?;
 
+        // Deprioritize background threads spawned by tracing/OTel libraries.
+        static DEPRIORITIZE: std::sync::Once = std::sync::Once::new();
+        DEPRIORITIZE.call_once(reth_tasks::utils::deprioritize_background_threads);
+
         // Install the prometheus recorder to be sure to record all metrics
         install_prometheus_recorder();
 

--- a/crates/tasks/Cargo.toml
+++ b/crates/tasks/Cargo.toml
@@ -33,6 +33,9 @@ crossbeam-utils = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
 pin-project = { workspace = true, optional = true }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+libc.workspace = true
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["sync", "rt", "rt-multi-thread", "time", "macros"] }
 

--- a/crates/tasks/src/utils.rs
+++ b/crates/tasks/src/utils.rs
@@ -43,12 +43,6 @@ const DEPRIORITIZE_THREAD_PREFIXES: &[&str] =
 
 #[cfg(target_os = "linux")]
 fn _deprioritize_background_threads() {
-    use thread_priority::{
-        NormalThreadSchedulePolicy, ThreadPriority, ThreadSchedulePolicy, NICENESS_MIN,
-    };
-
-    let policy = ThreadSchedulePolicy::Normal(NormalThreadSchedulePolicy::Batch);
-
     let pid = std::process::id();
     let task_dir = format!("/proc/{pid}/task");
 
@@ -63,7 +57,7 @@ fn _deprioritize_background_threads() {
     for entry in entries.filter_map(Result::ok) {
         let tid_str = entry.file_name();
         let Some(tid_str) = tid_str.to_str() else { continue };
-        let Ok(tid) = tid_str.parse::<u64>() else { continue };
+        let Ok(tid) = tid_str.parse::<i32>() else { continue };
 
         let comm_path = format!("{task_dir}/{tid_str}/comm");
         let comm = match std::fs::read_to_string(&comm_path) {
@@ -76,12 +70,31 @@ fn _deprioritize_background_threads() {
             continue;
         }
 
-        // set_thread_priority_and_policy only works with pthread_t handles, not kernel TIDs.
-        // We must use sched_setattr directly because these threads are spawned by third-party
-        // libraries and we only have their kernel TIDs from /proc.
-        if let Err(err) = set_thread_priority_and_policy_by_tid(tid, ThreadPriority::Min, policy) {
-            tracing::debug!(tid, comm, ?err, "failed to deprioritize background thread");
-            continue;
+        // SCHED_BATCH signals to the scheduler that this is a CPU-bound non-interactive thread,
+        // allowing the kernel to apply longer timeslices and less aggressive preemption.
+        // SAFETY: sched_setscheduler and setpriority are safe to call with valid TIDs.
+        unsafe {
+            let param = libc::sched_param { sched_priority: 0 };
+            if libc::sched_setscheduler(tid, libc::SCHED_BATCH, std::ptr::from_ref(&param)) != 0 {
+                tracing::debug!(
+                    tid,
+                    comm,
+                    err = std::io::Error::last_os_error().to_string(),
+                    "failed to set SCHED_BATCH"
+                );
+            }
+
+            // PRIO_PROCESS + max niceness to yield CPU to everything else.
+            if libc::setpriority(libc::PRIO_PROCESS, tid as libc::id_t, NICENESS_MIN as libc::c_int) !=
+                0
+            {
+                tracing::debug!(
+                    tid,
+                    comm,
+                    err = std::io::Error::last_os_error().to_string(),
+                    "failed to set niceness"
+                );
+            }
         }
 
         tracing::debug!(
@@ -90,75 +103,5 @@ fn _deprioritize_background_threads() {
             "deprioritized background thread (SCHED_BATCH, nice {})",
             NICENESS_MIN
         );
-    }
-}
-
-/// Sets thread priority and scheduling policy for a thread identified by its kernel TID, using
-/// the `sched_setattr` syscall.
-///
-/// Unlike [`set_thread_priority_and_policy`] which requires a `pthread_t` handle, this works with
-/// raw kernel TIDs (e.g. from `/proc/<pid>/task/<tid>`).
-#[cfg(target_os = "linux")]
-fn set_thread_priority_and_policy_by_tid(
-    tid: u64,
-    priority: thread_priority::ThreadPriority,
-    policy: thread_priority::ThreadSchedulePolicy,
-) -> std::io::Result<()> {
-    use thread_priority::{NormalThreadSchedulePolicy, ThreadSchedulePolicy, NICENESS_MIN};
-
-    let (sched_policy, sched_nice) = match policy {
-        ThreadSchedulePolicy::Normal(NormalThreadSchedulePolicy::Batch) => {
-            (libc::SCHED_BATCH as u32, NICENESS_MIN as i32)
-        }
-        ThreadSchedulePolicy::Normal(NormalThreadSchedulePolicy::Idle) => {
-            (libc::SCHED_IDLE as u32, 0)
-        }
-        ThreadSchedulePolicy::Normal(NormalThreadSchedulePolicy::Other) => {
-            let nice = match priority {
-                ThreadPriority::Min => NICENESS_MIN as i32,
-                _ => 0,
-            };
-            (libc::SCHED_OTHER as u32, nice)
-        }
-        _ => return Err(std::io::Error::from_raw_os_error(libc::EINVAL)),
-    };
-
-    // Mirror of thread_priority::SchedAttr (which has private fields).
-    #[repr(C)]
-    struct SchedAttr {
-        size: u32,
-        sched_policy: u32,
-        sched_flags: u64,
-        sched_nice: i32,
-        sched_priority: u32,
-        sched_runtime: u64,
-        sched_deadline: u64,
-        sched_period: u64,
-        sched_util_min: u32,
-        sched_util_max: u32,
-    }
-
-    let attr = SchedAttr {
-        size: std::mem::size_of::<SchedAttr>() as u32,
-        sched_policy,
-        sched_nice,
-        sched_flags: 0,
-        sched_priority: 0,
-        sched_runtime: 0,
-        sched_deadline: 0,
-        sched_period: 0,
-        sched_util_min: 0,
-        sched_util_max: 0,
-    };
-
-    // SAFETY: sched_setattr is safe to call with a valid TID and a properly initialized attr.
-    let ret = unsafe {
-        libc::syscall(libc::SYS_sched_setattr, tid as libc::pid_t, std::ptr::from_ref(&attr), 0u32)
-    };
-
-    if ret < 0 {
-        Err(std::io::Error::last_os_error())
-    } else {
-        Ok(())
     }
 }

--- a/crates/tasks/src/utils.rs
+++ b/crates/tasks/src/utils.rs
@@ -22,7 +22,7 @@ pub fn increase_thread_priority() {
 
 /// Deprioritizes known background threads spawned by third-party libraries (`OpenTelemetry`,
 /// `tracing-appender`, `reqwest`) by scanning `/proc/<pid>/task/` for matching thread names and
-/// setting `SCHED_BATCH` scheduling policy + maximum niceness on them.
+/// setting `SCHED_IDLE` scheduling policy + maximum niceness on them.
 ///
 /// This is a hack: these threads are spawned by libraries that do not expose a way to hook into
 /// thread initialization or expose the TIDs, so we have to discover them after the fact by
@@ -70,38 +70,21 @@ fn _deprioritize_background_threads() {
             continue;
         }
 
-        // SCHED_BATCH signals to the scheduler that this is a CPU-bound non-interactive thread,
-        // allowing the kernel to apply longer timeslices and less aggressive preemption.
-        // SAFETY: sched_setscheduler and setpriority are safe to call with valid TIDs.
+        // SCHED_IDLE is the lowest-priority scheduling class. The kernel will only schedule these
+        // threads when no other (SCHED_OTHER/SCHED_BATCH/RT) threads need the CPU.
+        // SAFETY: sched_setscheduler is safe to call with a valid TID.
         unsafe {
             let param = libc::sched_param { sched_priority: 0 };
-            if libc::sched_setscheduler(tid, libc::SCHED_BATCH, std::ptr::from_ref(&param)) != 0 {
+            if libc::sched_setscheduler(tid, libc::SCHED_IDLE, std::ptr::from_ref(&param)) != 0 {
                 tracing::debug!(
                     tid,
                     comm,
                     err = std::io::Error::last_os_error().to_string(),
-                    "failed to set SCHED_BATCH"
-                );
-            }
-
-            // PRIO_PROCESS + max niceness to yield CPU to everything else.
-            if libc::setpriority(libc::PRIO_PROCESS, tid as libc::id_t, NICENESS_MIN as libc::c_int) !=
-                0
-            {
-                tracing::debug!(
-                    tid,
-                    comm,
-                    err = std::io::Error::last_os_error().to_string(),
-                    "failed to set niceness"
+                    "failed to set SCHED_IDLE"
                 );
             }
         }
 
-        tracing::debug!(
-            tid,
-            comm,
-            "deprioritized background thread (SCHED_BATCH, nice {})",
-            NICENESS_MIN
-        );
+        tracing::debug!(tid, comm, "deprioritized background thread (SCHED_IDLE)");
     }
 }

--- a/crates/tasks/src/utils.rs
+++ b/crates/tasks/src/utils.rs
@@ -28,7 +28,7 @@ pub fn increase_thread_priority() {
 /// thread initialization or expose the TIDs, so we have to discover them after the fact by
 /// reading `/proc`.
 ///
-/// Intended to be called exactly once via [`std::sync::Once`] after tracing is initialized.
+/// Should be called once after tracing is initialized.
 ///
 /// No-op on non-Linux platforms.
 pub fn deprioritize_background_threads() {

--- a/crates/tasks/src/utils.rs
+++ b/crates/tasks/src/utils.rs
@@ -20,9 +20,9 @@ pub fn increase_thread_priority() {
     }
 }
 
-/// Deprioritizes known background threads spawned by third-party libraries (OpenTelemetry,
-/// tracing-appender) by scanning `/proc/<pid>/task/` for matching thread names and setting
-/// `SCHED_BATCH` scheduling policy + maximum niceness on them.
+/// Deprioritizes known background threads spawned by third-party libraries (`OpenTelemetry`,
+/// `tracing-appender`, `reqwest`) by scanning `/proc/<pid>/task/` for matching thread names and
+/// setting `SCHED_BATCH` scheduling policy + maximum niceness on them.
 ///
 /// This is a hack: these threads are spawned by libraries that do not expose a way to hook into
 /// thread initialization or expose the TIDs, so we have to discover them after the fact by
@@ -38,7 +38,8 @@ pub fn deprioritize_background_threads() {
 
 /// Thread name prefixes to deprioritize.
 #[cfg(target_os = "linux")]
-const DEPRIORITIZE_THREAD_PREFIXES: &[&str] = &["OpenTelemetry.T", "tracing-appende"];
+const DEPRIORITIZE_THREAD_PREFIXES: &[&str] =
+    &["OpenTelemetry.T", "tracing-appende", "reqwest-interna"];
 
 #[cfg(target_os = "linux")]
 fn _deprioritize_background_threads() {
@@ -74,7 +75,7 @@ fn _deprioritize_background_threads() {
         // SAFETY: sched_setscheduler and setpriority are safe to call with valid TIDs.
         unsafe {
             let param = libc::sched_param { sched_priority: 0 };
-            if libc::sched_setscheduler(tid, libc::SCHED_BATCH, &param) != 0 {
+            if libc::sched_setscheduler(tid, libc::SCHED_BATCH, std::ptr::from_ref(&param)) != 0 {
                 tracing::debug!(
                     tid,
                     comm,
@@ -83,8 +84,10 @@ fn _deprioritize_background_threads() {
                 );
             }
 
-            // PRIO_PROCESS + max niceness (19) to yield CPU to everything else.
-            if libc::setpriority(libc::PRIO_PROCESS, tid as libc::id_t, 19) != 0 {
+            // PRIO_PROCESS + max niceness to yield CPU to everything else.
+            if libc::setpriority(libc::PRIO_PROCESS, tid as libc::id_t, NICENESS_MIN as libc::c_int) !=
+                0
+            {
                 tracing::debug!(
                     tid,
                     comm,
@@ -94,6 +97,11 @@ fn _deprioritize_background_threads() {
             }
         }
 
-        tracing::debug!(tid, comm, "deprioritized background thread (SCHED_BATCH, nice 19)");
+        tracing::debug!(
+            tid,
+            comm,
+            "deprioritized background thread (SCHED_BATCH, nice {})",
+            NICENESS_MIN
+        );
     }
 }

--- a/crates/tasks/src/utils.rs
+++ b/crates/tasks/src/utils.rs
@@ -43,6 +43,12 @@ const DEPRIORITIZE_THREAD_PREFIXES: &[&str] =
 
 #[cfg(target_os = "linux")]
 fn _deprioritize_background_threads() {
+    use thread_priority::{
+        NormalThreadSchedulePolicy, ThreadPriority, ThreadSchedulePolicy, NICENESS_MIN,
+    };
+
+    let policy = ThreadSchedulePolicy::Normal(NormalThreadSchedulePolicy::Batch);
+
     let pid = std::process::id();
     let task_dir = format!("/proc/{pid}/task");
 
@@ -57,7 +63,7 @@ fn _deprioritize_background_threads() {
     for entry in entries.filter_map(Result::ok) {
         let tid_str = entry.file_name();
         let Some(tid_str) = tid_str.to_str() else { continue };
-        let Ok(tid) = tid_str.parse::<i32>() else { continue };
+        let Ok(tid) = tid_str.parse::<u64>() else { continue };
 
         let comm_path = format!("{task_dir}/{tid_str}/comm");
         let comm = match std::fs::read_to_string(&comm_path) {
@@ -70,31 +76,12 @@ fn _deprioritize_background_threads() {
             continue;
         }
 
-        // SCHED_BATCH signals to the scheduler that this is a CPU-bound non-interactive thread,
-        // allowing the kernel to apply longer timeslices and less aggressive preemption.
-        // SAFETY: sched_setscheduler and setpriority are safe to call with valid TIDs.
-        unsafe {
-            let param = libc::sched_param { sched_priority: 0 };
-            if libc::sched_setscheduler(tid, libc::SCHED_BATCH, std::ptr::from_ref(&param)) != 0 {
-                tracing::debug!(
-                    tid,
-                    comm,
-                    err = std::io::Error::last_os_error().to_string(),
-                    "failed to set SCHED_BATCH"
-                );
-            }
-
-            // PRIO_PROCESS + max niceness to yield CPU to everything else.
-            if libc::setpriority(libc::PRIO_PROCESS, tid as libc::id_t, NICENESS_MIN as libc::c_int) !=
-                0
-            {
-                tracing::debug!(
-                    tid,
-                    comm,
-                    err = std::io::Error::last_os_error().to_string(),
-                    "failed to set niceness"
-                );
-            }
+        // set_thread_priority_and_policy only works with pthread_t handles, not kernel TIDs.
+        // We must use sched_setattr directly because these threads are spawned by third-party
+        // libraries and we only have their kernel TIDs from /proc.
+        if let Err(err) = set_thread_priority_and_policy_by_tid(tid, ThreadPriority::Min, policy) {
+            tracing::debug!(tid, comm, ?err, "failed to deprioritize background thread");
+            continue;
         }
 
         tracing::debug!(
@@ -103,5 +90,75 @@ fn _deprioritize_background_threads() {
             "deprioritized background thread (SCHED_BATCH, nice {})",
             NICENESS_MIN
         );
+    }
+}
+
+/// Sets thread priority and scheduling policy for a thread identified by its kernel TID, using
+/// the `sched_setattr` syscall.
+///
+/// Unlike [`set_thread_priority_and_policy`] which requires a `pthread_t` handle, this works with
+/// raw kernel TIDs (e.g. from `/proc/<pid>/task/<tid>`).
+#[cfg(target_os = "linux")]
+fn set_thread_priority_and_policy_by_tid(
+    tid: u64,
+    priority: thread_priority::ThreadPriority,
+    policy: thread_priority::ThreadSchedulePolicy,
+) -> std::io::Result<()> {
+    use thread_priority::{NormalThreadSchedulePolicy, ThreadSchedulePolicy, NICENESS_MIN};
+
+    let (sched_policy, sched_nice) = match policy {
+        ThreadSchedulePolicy::Normal(NormalThreadSchedulePolicy::Batch) => {
+            (libc::SCHED_BATCH as u32, NICENESS_MIN as i32)
+        }
+        ThreadSchedulePolicy::Normal(NormalThreadSchedulePolicy::Idle) => {
+            (libc::SCHED_IDLE as u32, 0)
+        }
+        ThreadSchedulePolicy::Normal(NormalThreadSchedulePolicy::Other) => {
+            let nice = match priority {
+                ThreadPriority::Min => NICENESS_MIN as i32,
+                _ => 0,
+            };
+            (libc::SCHED_OTHER as u32, nice)
+        }
+        _ => return Err(std::io::Error::from_raw_os_error(libc::EINVAL)),
+    };
+
+    // Mirror of thread_priority::SchedAttr (which has private fields).
+    #[repr(C)]
+    struct SchedAttr {
+        size: u32,
+        sched_policy: u32,
+        sched_flags: u64,
+        sched_nice: i32,
+        sched_priority: u32,
+        sched_runtime: u64,
+        sched_deadline: u64,
+        sched_period: u64,
+        sched_util_min: u32,
+        sched_util_max: u32,
+    }
+
+    let attr = SchedAttr {
+        size: std::mem::size_of::<SchedAttr>() as u32,
+        sched_policy,
+        sched_nice,
+        sched_flags: 0,
+        sched_priority: 0,
+        sched_runtime: 0,
+        sched_deadline: 0,
+        sched_period: 0,
+        sched_util_min: 0,
+        sched_util_max: 0,
+    };
+
+    // SAFETY: sched_setattr is safe to call with a valid TID and a properly initialized attr.
+    let ret = unsafe {
+        libc::syscall(libc::SYS_sched_setattr, tid as libc::pid_t, std::ptr::from_ref(&attr), 0u32)
+    };
+
+    if ret < 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
     }
 }

--- a/crates/tasks/src/utils.rs
+++ b/crates/tasks/src/utils.rs
@@ -19,3 +19,81 @@ pub fn increase_thread_priority() {
         }
     }
 }
+
+/// Deprioritizes known background threads spawned by third-party libraries (OpenTelemetry,
+/// tracing-appender) by scanning `/proc/<pid>/task/` for matching thread names and setting
+/// `SCHED_BATCH` scheduling policy + maximum niceness on them.
+///
+/// This is a hack: these threads are spawned by libraries that do not expose a way to hook into
+/// thread initialization or expose the TIDs, so we have to discover them after the fact by
+/// reading `/proc`.
+///
+/// Intended to be called exactly once via [`std::sync::Once`] after tracing is initialized.
+///
+/// No-op on non-Linux platforms.
+pub fn deprioritize_background_threads() {
+    #[cfg(target_os = "linux")]
+    _deprioritize_background_threads();
+}
+
+/// Thread name prefixes to deprioritize.
+#[cfg(target_os = "linux")]
+const DEPRIORITIZE_THREAD_PREFIXES: &[&str] = &["OpenTelemetry.T", "tracing-appende"];
+
+#[cfg(target_os = "linux")]
+fn _deprioritize_background_threads() {
+    let pid = std::process::id();
+    let task_dir = format!("/proc/{pid}/task");
+
+    let entries = match std::fs::read_dir(&task_dir) {
+        Ok(entries) => entries,
+        Err(err) => {
+            tracing::debug!(%err, "failed to read /proc task directory");
+            return;
+        }
+    };
+
+    for entry in entries.filter_map(Result::ok) {
+        let tid_str = entry.file_name();
+        let Some(tid_str) = tid_str.to_str() else { continue };
+        let Ok(tid) = tid_str.parse::<i32>() else { continue };
+
+        let comm_path = format!("{task_dir}/{tid_str}/comm");
+        let comm = match std::fs::read_to_string(&comm_path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let comm = comm.trim();
+
+        if !DEPRIORITIZE_THREAD_PREFIXES.iter().any(|prefix| comm.starts_with(prefix)) {
+            continue;
+        }
+
+        // SCHED_BATCH signals to the scheduler that this is a CPU-bound non-interactive thread,
+        // allowing the kernel to apply longer timeslices and less aggressive preemption.
+        // SAFETY: sched_setscheduler and setpriority are safe to call with valid TIDs.
+        unsafe {
+            let param = libc::sched_param { sched_priority: 0 };
+            if libc::sched_setscheduler(tid, libc::SCHED_BATCH, &param) != 0 {
+                tracing::debug!(
+                    tid,
+                    comm,
+                    err = std::io::Error::last_os_error().to_string(),
+                    "failed to set SCHED_BATCH"
+                );
+            }
+
+            // PRIO_PROCESS + max niceness (19) to yield CPU to everything else.
+            if libc::setpriority(libc::PRIO_PROCESS, tid as libc::id_t, 19) != 0 {
+                tracing::debug!(
+                    tid,
+                    comm,
+                    err = std::io::Error::last_os_error().to_string(),
+                    "failed to set niceness"
+                );
+            }
+        }
+
+        tracing::debug!(tid, comm, "deprioritized background thread (SCHED_BATCH, nice 19)");
+    }
+}


### PR DESCRIPTION
Scans `/proc/<pid>/task/<tid>/comm` after tracing init to find threads whose names start with `OpenTelemetry.T` or `tracing-appende`, then sets `SCHED_BATCH` + nice 19 on them so they don't compete with hot-path threads.

Linux-only, no-op on other platforms. Called once via `std::sync::Once` in `CliApp::run_with_components`.

Prompted by: danipopes