### PR TITLE
refactor: remove unnecessary Box::pin from spawn callsites

### DIFF
--- a/crates/ethereum/cli/src/app.rs
+++ b/crates/ethereum/cli/src/app.rs
@@ -73,7 +73,7 @@ where
             (EthEvmConfig::ethereum(spec.clone()), Arc::new(EthBeaconConsensus::new(spec)))
         };
 
-        self.run_with_components::<EthereumNode>(components, |builder, ext| async move {
+        self.run_with_components::<EthereumNode>(components, async move |builder, ext| {
             launcher.entrypoint(builder, ext).await
         })
     }

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -580,7 +580,7 @@ pub fn spawn_populate_kbuckets_bg(
     let metrics = metrics.discovered_peers;
     let mut kbucket_index = MAX_KBUCKET_INDEX;
     let pulse_lookup_interval = Duration::from_secs(bootstrap_lookup_interval);
-    task::spawn(Box::pin(async move {
+    task::spawn(async move {
         // make many fast lookup queries at bootstrap, trying to fill kbuckets at furthest
         // log2distance from local node
         for i in (0..bootstrap_lookup_countdown).rev() {
@@ -622,7 +622,7 @@ pub fn spawn_populate_kbuckets_bg(
 
             tokio::time::sleep(lookup_interval).await;
         }
-    }));
+    });
 }
 
 /// Gets the next lookup target, based on which bucket is currently being targeted.

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -940,7 +940,7 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let local_addr = listener.local_addr().unwrap();
 
-        let handle = tokio::spawn(Box::pin(async move {
+        let handle = tokio::spawn(async move {
             // roughly based off of the design of tokio::net::TcpListener
             let (incoming, _) = listener.accept().await.unwrap();
             let stream = crate::PassthroughCodec::default().framed(incoming);
@@ -960,7 +960,7 @@ mod tests {
                     panic!("expected mismatched protocol version error, got {other_err:?}")
                 }
             }
-        }));
+        });
 
         let outgoing = TcpStream::connect(local_addr).await.unwrap();
         let sink = crate::PassthroughCodec::default().framed(outgoing);

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -1145,7 +1145,7 @@ mod tests {
 
         let expected_disconnect = DisconnectReason::UselessPeer;
 
-        let fut = builder.with_client_stream(local_addr, move |mut client_stream| async move {
+        let fut = builder.with_client_stream(local_addr, async move |mut client_stream| {
             let msg = client_stream.next().await.unwrap().unwrap_err();
             assert_eq!(msg.as_disconnected().unwrap(), expected_disconnect);
         });
@@ -1168,7 +1168,7 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let local_addr = listener.local_addr().unwrap();
 
-        let fut = builder.with_client_stream(local_addr, move |client_stream| async move {
+        let fut = builder.with_client_stream(local_addr, async move |client_stream| {
             drop(client_stream);
             tokio::time::sleep(Duration::from_secs(1)).await
         });
@@ -1198,7 +1198,7 @@ mod tests {
 
         let num_messages = 100;
 
-        let fut = builder.with_client_stream(local_addr, move |mut client_stream| async move {
+        let fut = builder.with_client_stream(local_addr, async move |mut client_stream| {
             for _ in 0..num_messages {
                 client_stream
                     .send(EthMessage::NewPooledTransactionHashes66(Vec::new().into()))
@@ -1234,7 +1234,7 @@ mod tests {
         let request_timeout = Duration::from_millis(100);
         let drop_timeout = Duration::from_millis(1500);
 
-        let fut = builder.with_client_stream(local_addr, move |client_stream| async move {
+        let fut = builder.with_client_stream(local_addr, async move |client_stream| {
             let _client_stream = client_stream;
             tokio::time::sleep(drop_timeout * 60).await;
         });
@@ -1287,7 +1287,7 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let local_addr = listener.local_addr().unwrap();
 
-        let fut = builder.with_client_stream(local_addr, move |mut client_stream| async move {
+        let fut = builder.with_client_stream(local_addr, async move |mut client_stream| {
             let _ = tokio::time::timeout(Duration::from_secs(5), client_stream.next()).await;
             client_stream.into_inner().disconnect(DisconnectReason::UselessPeer).await.unwrap();
         });
@@ -1315,7 +1315,7 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let local_addr = listener.local_addr().unwrap();
 
-        let fut = builder.with_client_stream(local_addr, move |mut client_stream| async move {
+        let fut = builder.with_client_stream(local_addr, async move |mut client_stream| {
             client_stream
                 .send(EthMessage::NewPooledTransactionHashes68(Default::default()))
                 .await

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -903,15 +903,15 @@ impl<Node: FullNodeTypes> BuilderContext<Node> {
             .request_handler(self.provider().clone())
             .split_with_handle();
 
-        self.executor.spawn_critical_blocking_task("p2p txpool", Box::pin(txpool));
-        self.executor.spawn_critical_blocking_task("p2p eth request handler", Box::pin(eth));
+        self.executor.spawn_critical_blocking_task("p2p txpool", txpool);
+        self.executor.spawn_critical_blocking_task("p2p eth request handler", eth);
 
         let default_peers_path = self.config().datadir().known_peers();
         let known_peers_file = self.config().network.persistent_peers_file(default_peers_path);
         self.executor.spawn_critical_with_graceful_shutdown_signal(
             "p2p network task",
             |shutdown| {
-                Box::pin(network.run_until_graceful_shutdown(shutdown, |network| {
+                network.run_until_graceful_shutdown(shutdown, |network| {
                     if let Some(peers_file) = known_peers_file {
                         let num_known_peers = network.num_known_peers();
                         trace!(target: "reth::cli", peers_file=?peers_file, num_peers=%num_known_peers, "Saving current peers");
@@ -924,7 +924,7 @@ impl<Node: FullNodeTypes> BuilderContext<Node> {
                             }
                         }
                     }
-                }))
+                })
             },
         );
 

--- a/crates/node/builder/src/components/payload.rs
+++ b/crates/node/builder/src/components/payload.rs
@@ -107,8 +107,7 @@ where
         let (payload_service, payload_service_handle) =
             PayloadBuilderService::new(payload_generator, ctx.provider().canonical_state_stream());
 
-        ctx.task_executor()
-            .spawn_critical_task("payload builder service", Box::pin(payload_service));
+        ctx.task_executor().spawn_critical_task("payload builder service", payload_service);
 
         Ok(payload_service_handle)
     }

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -256,11 +256,11 @@ impl EngineNodeLauncher {
 
         ctx.task_executor().spawn_critical_task(
             "events task",
-            Box::pin(node::handle_events(
+            node::handle_events(
                 Some(Box::new(ctx.components().network().clone())),
                 Some(ctx.head().number),
                 events,
-            )),
+            ),
         );
 
         let RpcHandle {
@@ -375,7 +375,7 @@ impl EngineNodeLauncher {
 
             let _ = exit.send(res);
         };
-        ctx.task_executor().spawn_critical_task("consensus engine", Box::pin(consensus_engine));
+        ctx.task_executor().spawn_critical_task("consensus engine", consensus_engine);
 
         let engine_events_for_ethstats = engine_events.new_listener();
 

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -993,12 +993,9 @@ where
 
         let new_canonical_blocks = node.provider().canonical_state_stream();
         let c = cache.clone();
-        node.task_executor().spawn_critical_task(
-            "cache canonical blocks task",
-            Box::pin(async move {
-                cache_new_blocks_task(c, new_canonical_blocks).await;
-            }),
-        );
+        node.task_executor().spawn_critical_task("cache canonical blocks task", async move {
+            cache_new_blocks_task(c, new_canonical_blocks).await;
+        });
 
         let eth_config = config.rpc.eth_config().max_batch_size(config.txpool.max_batch_size());
         let ctx = EthApiCtx {

--- a/crates/node/metrics/src/server.rs
+++ b/crates/node/metrics/src/server.rs
@@ -130,40 +130,34 @@ impl MetricServer {
 
         tracing::info!(target: "reth::cli", "Starting metrics endpoint at {}", listener.local_addr().unwrap());
 
-        task_executor.spawn_with_graceful_shutdown_signal(|mut signal| async move {
-            loop {
-                let io = tokio::select! {
-                    _ = &mut signal => break,
-                    io = listener.accept() => {
-                        match io {
-                            Ok((stream, _remote_addr)) => stream,
-                            Err(err) => {
-                                tracing::error!(%err, "failed to accept connection");
-                                continue;
-                            }
+        task_executor.spawn_with_graceful_shutdown_signal(async move |mut signal| loop {
+            let io = tokio::select! {
+                _ = &mut signal => break,
+                io = listener.accept() => {
+                    match io {
+                        Ok((stream, _remote_addr)) => stream,
+                        Err(err) => {
+                            tracing::error!(%err, "failed to accept connection");
+                            continue;
                         }
                     }
-                };
+                }
+            };
 
-                let handle = install_prometheus_recorder();
-                let hook = hook.clone();
-                let pprof_dump_dir = pprof_dump_dir.clone();
-                let service = tower::service_fn(move |req: Request<_>| {
-                    let response =
-                        handle_request(req.uri().path(), &*hook, handle, &pprof_dump_dir);
-                    async move { Ok::<_, Infallible>(response) }
-                });
+            let handle = install_prometheus_recorder();
+            let hook = hook.clone();
+            let pprof_dump_dir = pprof_dump_dir.clone();
+            let service = tower::service_fn(move |req: Request<_>| {
+                let response = handle_request(req.uri().path(), &*hook, handle, &pprof_dump_dir);
+                async move { Ok::<_, Infallible>(response) }
+            });
 
-                let mut shutdown = signal.clone().ignore_guard();
-                tokio::task::spawn(async move {
-                    let _ =
-                        jsonrpsee_server::serve_with_graceful_shutdown(io, service, &mut shutdown)
-                            .await
-                            .inspect_err(
-                                |error| tracing::debug!(%error, "failed to serve request"),
-                            );
-                });
-            }
+            let mut shutdown = signal.clone().ignore_guard();
+            tokio::task::spawn(async move {
+                let _ = jsonrpsee_server::serve_with_graceful_shutdown(io, service, &mut shutdown)
+                    .await
+                    .inspect_err(|error| tracing::debug!(%error, "failed to serve request"));
+            });
         });
 
         Ok(())
@@ -180,7 +174,7 @@ impl MetricServer {
         let client = Client::builder()
             .build()
             .wrap_err("Could not create HTTP client to push metrics to gateway")?;
-        task_executor.spawn_with_graceful_shutdown_signal(move |mut signal| async move {
+        task_executor.spawn_with_graceful_shutdown_signal(async move |mut signal| {
             tracing::info!(url = %url, interval = ?interval, "Starting task to push metrics to gateway");
             let handle = install_prometheus_recorder();
             loop {

--- a/crates/node/metrics/src/server.rs
+++ b/crates/node/metrics/src/server.rs
@@ -130,43 +130,40 @@ impl MetricServer {
 
         tracing::info!(target: "reth::cli", "Starting metrics endpoint at {}", listener.local_addr().unwrap());
 
-        task_executor.spawn_with_graceful_shutdown_signal(|mut signal| {
-            Box::pin(async move {
-                loop {
-                    let io = tokio::select! {
-                        _ = &mut signal => break,
-                        io = listener.accept() => {
-                            match io {
-                                Ok((stream, _remote_addr)) => stream,
-                                Err(err) => {
-                                    tracing::error!(%err, "failed to accept connection");
-                                    continue;
-                                }
+        task_executor.spawn_with_graceful_shutdown_signal(|mut signal| async move {
+            loop {
+                let io = tokio::select! {
+                    _ = &mut signal => break,
+                    io = listener.accept() => {
+                        match io {
+                            Ok((stream, _remote_addr)) => stream,
+                            Err(err) => {
+                                tracing::error!(%err, "failed to accept connection");
+                                continue;
                             }
                         }
-                    };
+                    }
+                };
 
-                    let handle = install_prometheus_recorder();
-                    let hook = hook.clone();
-                    let pprof_dump_dir = pprof_dump_dir.clone();
-                    let service = tower::service_fn(move |req: Request<_>| {
-                        let response =
-                            handle_request(req.uri().path(), &*hook, handle, &pprof_dump_dir);
-                        async move { Ok::<_, Infallible>(response) }
-                    });
+                let handle = install_prometheus_recorder();
+                let hook = hook.clone();
+                let pprof_dump_dir = pprof_dump_dir.clone();
+                let service = tower::service_fn(move |req: Request<_>| {
+                    let response =
+                        handle_request(req.uri().path(), &*hook, handle, &pprof_dump_dir);
+                    async move { Ok::<_, Infallible>(response) }
+                });
 
-                    let mut shutdown = signal.clone().ignore_guard();
-                    tokio::task::spawn(async move {
-                        let _ = jsonrpsee_server::serve_with_graceful_shutdown(
-                            io,
-                            service,
-                            &mut shutdown,
-                        )
-                        .await
-                        .inspect_err(|error| tracing::debug!(%error, "failed to serve request"));
-                    });
-                }
-            })
+                let mut shutdown = signal.clone().ignore_guard();
+                tokio::task::spawn(async move {
+                    let _ =
+                        jsonrpsee_server::serve_with_graceful_shutdown(io, service, &mut shutdown)
+                            .await
+                            .inspect_err(
+                                |error| tracing::debug!(%error, "failed to serve request"),
+                            );
+                });
+            }
         });
 
         Ok(())
@@ -183,36 +180,34 @@ impl MetricServer {
         let client = Client::builder()
             .build()
             .wrap_err("Could not create HTTP client to push metrics to gateway")?;
-        task_executor.spawn_with_graceful_shutdown_signal(move |mut signal| {
-            Box::pin(async move {
-                tracing::info!(url = %url, interval = ?interval, "Starting task to push metrics to gateway");
-                let handle = install_prometheus_recorder();
-                loop {
-                    tokio::select! {
-                        _ = &mut signal => {
-                            tracing::info!("Shutting down task to push metrics to gateway");
-                            break;
-                        }
-                        _ = tokio::time::sleep(interval) => {
-                            hooks.iter().for_each(|hook| hook());
-                            let metrics = handle.handle().render();
-                            match client.put(&url).header("Content-Type", "text/plain").body(metrics).send().await {
-                                Ok(response) => {
-                                    if !response.status().is_success() {
-                                        tracing::warn!(
-                                            status = %response.status(),
-                                            "Failed to push metrics to gateway"
-                                        );
-                                    }
+        task_executor.spawn_with_graceful_shutdown_signal(move |mut signal| async move {
+            tracing::info!(url = %url, interval = ?interval, "Starting task to push metrics to gateway");
+            let handle = install_prometheus_recorder();
+            loop {
+                tokio::select! {
+                    _ = &mut signal => {
+                        tracing::info!("Shutting down task to push metrics to gateway");
+                        break;
+                    }
+                    _ = tokio::time::sleep(interval) => {
+                        hooks.iter().for_each(|hook| hook());
+                        let metrics = handle.handle().render();
+                        match client.put(&url).header("Content-Type", "text/plain").body(metrics).send().await {
+                            Ok(response) => {
+                                if !response.status().is_success() {
+                                    tracing::warn!(
+                                        status = %response.status(),
+                                        "Failed to push metrics to gateway"
+                                    );
                                 }
-                                Err(err) => {
-                                    tracing::warn!(%err, "Failed to push metrics to gateway");
-                                }
+                            }
+                            Err(err) => {
+                                tracing::warn!(%err, "Failed to push metrics to gateway");
                             }
                         }
                     }
                 }
-            })
+            }
         });
         Ok(())
     }

--- a/crates/rpc/rpc-builder/tests/it/middleware.rs
+++ b/crates/rpc/rpc-builder/tests/it/middleware.rs
@@ -50,12 +50,12 @@ where
         tracing::info!("MyMiddleware processed call {}", req.method);
         let count = self.count.clone();
         let service = self.service.clone();
-        Box::pin(async move {
+        async move {
             let rp = service.call(req).await;
             // Modify the state.
             count.fetch_add(1, Ordering::Relaxed);
             rp
-        })
+        }
     }
 
     fn batch<'a>(&self, req: Batch<'a>) -> impl Future<Output = Self::BatchResponse> + Send + 'a {

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -448,7 +448,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
             let block_id = block_number.unwrap_or_default();
             let (evm_env, at) = self.evm_env_at(block_id).await?;
 
-            self.spawn_blocking_io_fut(move |this| async move {
+            self.spawn_blocking_io_fut(async move |this| {
                 this.create_access_list_with(evm_env, at, request, state_override).await
             })
             .await
@@ -467,7 +467,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
     where
         Self: Trace,
     {
-        self.spawn_blocking_io_fut(move |this| async move {
+        self.spawn_blocking_io_fut(async move |this| {
             let state = this.state_at_block_id(at).await?;
             let mut db = State::builder().with_database(StateProviderDatabase::new(state)).build();
 
@@ -564,7 +564,7 @@ pub trait Call:
         R: Send + 'static,
         F: FnOnce(Self, StateProviderBox) -> Result<R, Self::Error> + Send + 'static,
     {
-        self.spawn_blocking_io_fut(move |this| async move {
+        self.spawn_blocking_io_fut(async move |this| {
             let state = this.state_at_block_id(at).await?;
             f(this, state)
         })
@@ -651,7 +651,7 @@ pub trait Call:
         R: Send + 'static,
     {
         let at = at.into();
-        self.spawn_blocking_io_fut(move |this| async move {
+        self.spawn_blocking_io_fut(async move |this| {
             let state = this.state_at_block_id(at).await?;
             let db = State::builder()
                 .with_database(StateProviderDatabase::new(StateProviderTraitObjWrapper(state)))

--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -296,7 +296,7 @@ pub trait EstimateCall: Call {
         async move {
             let (evm_env, at) = self.evm_env_at(at).await?;
 
-            self.spawn_blocking_io_fut(move |this| async move {
+            self.spawn_blocking_io_fut(async move |this| {
                 let state = this.state_at_block_id(at).await?;
                 EstimateCall::estimate_gas_with(&this, evm_env, request, state, state_override)
             })

--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -75,7 +75,7 @@ pub trait EthState: LoadState + SpawnBlocking {
         address: Address,
         block_id: Option<BlockId>,
     ) -> impl Future<Output = Result<U256, Self::Error>> + Send {
-        self.spawn_blocking_io_fut(move |this| async move {
+        self.spawn_blocking_io_fut(async move |this| {
             Ok(this
                 .state_at_block_id_or_latest(block_id)
                 .await?
@@ -92,7 +92,7 @@ pub trait EthState: LoadState + SpawnBlocking {
         index: JsonStorageKey,
         block_id: Option<BlockId>,
     ) -> impl Future<Output = Result<B256, Self::Error>> + Send {
-        self.spawn_blocking_io_fut(move |this| async move {
+        self.spawn_blocking_io_fut(async move |this| {
             Ok(B256::new(
                 this.state_at_block_id_or_latest(block_id)
                     .await?
@@ -123,7 +123,7 @@ pub trait EthState: LoadState + SpawnBlocking {
                 )));
             }
 
-            self.spawn_blocking_io_fut(move |this| async move {
+            self.spawn_blocking_io_fut(async move |this| {
                 let state = this.state_at_block_id_or_latest(block_id).await?;
 
                 let mut result = HashMap::with_capacity(requests.len());
@@ -168,7 +168,7 @@ pub trait EthState: LoadState + SpawnBlocking {
             let block_id = block_id.unwrap_or_default();
             self.ensure_within_proof_window(block_id)?;
 
-            self.spawn_blocking_io_fut(move |this| async move {
+            self.spawn_blocking_io_fut(async move |this| {
                 let state = this.state_at_block_id(block_id).await?;
                 let storage_keys = keys.iter().map(|key| key.as_b256()).collect::<Vec<_>>();
                 let proof = state
@@ -192,7 +192,7 @@ pub trait EthState: LoadState + SpawnBlocking {
         async move {
             self.ensure_within_proof_window(block_id)?;
 
-            self.spawn_blocking_io_fut(move |this| async move {
+            self.spawn_blocking_io_fut(async move |this| {
                 let state = this.state_at_block_id(block_id).await?;
                 let account = state.basic_account(&address).map_err(Self::Error::from_eth_err)?;
                 let Some(account) = account else { return Ok(None) };
@@ -219,7 +219,7 @@ pub trait EthState: LoadState + SpawnBlocking {
         address: Address,
         block_id: BlockId,
     ) -> impl Future<Output = Result<AccountInfo, Self::Error>> + Send {
-        self.spawn_blocking_io_fut(move |this| async move {
+        self.spawn_blocking_io_fut(async move |this| {
             let state = this.state_at_block_id(block_id).await?;
             let account = state
                 .basic_account(&address)
@@ -393,7 +393,7 @@ pub trait LoadState:
     where
         Self: SpawnBlocking,
     {
-        self.spawn_blocking_io_fut(move |this| async move {
+        self.spawn_blocking_io_fut(async move |this| {
             // first fetch the on chain nonce of the account
             let on_chain_account_nonce = this
                 .state_at_block_id_or_latest(block_id)
@@ -439,7 +439,7 @@ pub trait LoadState:
     where
         Self: SpawnBlocking,
     {
-        self.spawn_blocking_io_fut(move |this| async move {
+        self.spawn_blocking_io_fut(async move |this| {
             Ok(this
                 .state_at_block_id_or_latest(block_id)
                 .await?

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -638,11 +638,11 @@ where
 
         let (tx, rx) = oneshot::channel();
         let this = self.clone();
-        self.task_spawner.spawn_blocking_task(Box::pin(async move {
+        self.task_spawner.spawn_blocking_task(async move {
             let res =
                 this.get_logs_in_block_range_inner(&filter, from_block, to_block, limits).await;
             let _ = tx.send(res);
-        }));
+        });
 
         rx.await.map_err(|_| EthFilterError::InternalError)?
     }

--- a/crates/rpc/rpc/src/reth.rs
+++ b/crates/rpc/rpc/src/reth.rs
@@ -80,8 +80,7 @@ where
 
     /// Returns a map of addresses to changed account balanced for a particular block.
     pub async fn balance_changes_in_block(&self, block_id: BlockId) -> EthResult<AddressMap<U256>> {
-        self.on_blocking_task(|this| async move { this.try_balance_changes_in_block(block_id) })
-            .await
+        self.on_blocking_task(async move |this| this.try_balance_changes_in_block(block_id)).await
     }
 
     fn try_balance_changes_in_block(&self, block_id: BlockId) -> EthResult<AddressMap<U256>> {
@@ -139,7 +138,7 @@ where
             .acquire_owned()
             .await
             .map_err(|_| EthApiError::InternalEthError)?;
-        self.on_blocking_task(move |this| async move {
+        self.on_blocking_task(async move |this| {
             let _permit = permit;
             this.try_block_execution_outcome(block_id, block_count)
         })

--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -293,7 +293,7 @@ mod tests {
 
         let val = Arc::new(AtomicBool::new(false));
         let c = val.clone();
-        rt.spawn_critical_with_graceful_shutdown_signal("grace", |shutdown| async move {
+        rt.spawn_critical_with_graceful_shutdown_signal("grace", async move |shutdown| {
             let _guard = shutdown.await;
             tokio::time::sleep(Duration::from_millis(200)).await;
             c.store(true, Ordering::Relaxed);
@@ -311,7 +311,7 @@ mod tests {
         let num = 10;
         for _ in 0..num {
             let c = counter.clone();
-            rt.spawn_critical_with_graceful_shutdown_signal("grace", move |shutdown| async move {
+            rt.spawn_critical_with_graceful_shutdown_signal("grace", async move |shutdown| {
                 let _guard = shutdown.await;
                 tokio::time::sleep(Duration::from_millis(200)).await;
                 c.fetch_add(1, Ordering::SeqCst);
@@ -329,7 +329,7 @@ mod tests {
         let timeout = Duration::from_millis(500);
         let val = Arc::new(AtomicBool::new(false));
         let val2 = val.clone();
-        rt.spawn_critical_with_graceful_shutdown_signal("grace", |shutdown| async move {
+        rt.spawn_critical_with_graceful_shutdown_signal("grace", async move |shutdown| {
             let _guard = shutdown.await;
             tokio::time::sleep(timeout * 3).await;
             val2.store(true, Ordering::Relaxed);
@@ -354,7 +354,7 @@ mod tests {
         let task_did_shutdown_flag = Arc::new(AtomicBool::new(false));
         let flag_clone = task_did_shutdown_flag.clone();
 
-        let spawned_task_handle = rt.spawn_with_signal(|shutdown_signal| async move {
+        let spawned_task_handle = rt.spawn_with_signal(async move |shutdown_signal| {
             shutdown_signal.await;
             flag_clone.store(true, Ordering::SeqCst);
         });

--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -277,10 +277,10 @@ mod tests {
 
         let (signal, shutdown) = signal();
 
-        rt.spawn_task(Box::pin(async move {
+        rt.spawn_task(async move {
             tokio::time::sleep(Duration::from_millis(200)).await;
             drop(signal);
-        }));
+        });
 
         rt.graceful_shutdown();
 

--- a/crates/tasks/src/runtime.rs
+++ b/crates/tasks/src/runtime.rs
@@ -603,7 +603,7 @@ impl Runtime {
     /// ```no_run
     /// # async fn t(executor: reth_tasks::TaskExecutor) {
     ///
-    /// executor.spawn_critical_with_graceful_shutdown_signal("grace", |shutdown| async move {
+    /// executor.spawn_critical_with_graceful_shutdown_signal("grace", async move |shutdown| {
     ///     // await the shutdown signal
     ///     let guard = shutdown.await;
     ///     // do work before exiting the program
@@ -651,7 +651,7 @@ impl Runtime {
     /// ```no_run
     /// # async fn t(executor: reth_tasks::TaskExecutor) {
     ///
-    /// executor.spawn_with_graceful_shutdown_signal(|shutdown| async move {
+    /// executor.spawn_with_graceful_shutdown_signal(async move |shutdown| {
     ///     // await the shutdown signal
     ///     let guard = shutdown.await;
     ///     // do work before exiting the program

--- a/docs/vocs/docs/snippets/sources/exex/remote/src/exex.rs
+++ b/docs/vocs/docs/snippets/sources/exex/remote/src/exex.rs
@@ -63,7 +63,7 @@ async fn remote_exex<Node: FullNodeComponents<Types: NodeTypes<Primitives = EthP
 
 // ANCHOR: snippet
 fn main() -> eyre::Result<()> {
-    reth::cli::Cli::parse_args().run(|builder, _| async move {
+    reth::cli::Cli::parse_args().run(async move |builder, _| {
         let notifications = Arc::new(broadcast::channel(1).0);
 
         let server = Server::builder()
@@ -74,7 +74,7 @@ fn main() -> eyre::Result<()> {
 
         let handle = builder
             .node(EthereumNode::default())
-            .install_exex("remote-exex", |ctx| async move { Ok(remote_exex(ctx, notifications)) })
+            .install_exex("remote-exex", async move |ctx| { Ok(remote_exex(ctx, notifications)) })
             .launch_with_debug_capabilities()
             .await?;
 

--- a/docs/vocs/docs/snippets/sources/exex/remote/src/exex_1.rs
+++ b/docs/vocs/docs/snippets/sources/exex/remote/src/exex_1.rs
@@ -24,7 +24,7 @@ impl RemoteExEx for ExExService {
 }
 
 fn main() -> eyre::Result<()> {
-    reth::cli::Cli::parse_args().run(|builder, _| async move {
+    reth::cli::Cli::parse_args().run(async move |builder, _| {
         let server = Server::builder()
             .add_service(RemoteExExServer::new(ExExService {}))
             .serve("[::1]:10000".parse().unwrap());

--- a/docs/vocs/docs/snippets/sources/exex/remote/src/exex_2.rs
+++ b/docs/vocs/docs/snippets/sources/exex/remote/src/exex_2.rs
@@ -29,7 +29,7 @@ impl RemoteExEx for ExExService {
 }
 
 fn main() -> eyre::Result<()> {
-    reth::cli::Cli::parse_args().run(|builder, _| async move {
+    reth::cli::Cli::parse_args().run(async move |builder, _| {
         let notifications = Arc::new(broadcast::channel(1).0);
 
         let server = Server::builder()

--- a/docs/vocs/docs/snippets/sources/exex/remote/src/exex_3.rs
+++ b/docs/vocs/docs/snippets/sources/exex/remote/src/exex_3.rs
@@ -45,7 +45,7 @@ impl RemoteExEx for ExExService {
 // ANCHOR_END: snippet
 
 fn main() -> eyre::Result<()> {
-    reth::cli::Cli::parse_args().run(|builder, _| async move {
+    reth::cli::Cli::parse_args().run(async move |builder, _| {
         let notifications = Arc::new(broadcast::channel(1).0);
 
         let server = Server::builder()

--- a/docs/vocs/docs/snippets/sources/exex/remote/src/exex_4.rs
+++ b/docs/vocs/docs/snippets/sources/exex/remote/src/exex_4.rs
@@ -65,7 +65,7 @@ async fn remote_exex<Node: FullNodeComponents<Types: NodeTypes<Primitives = EthP
 // ANCHOR_END: snippet
 
 fn main() -> eyre::Result<()> {
-    reth::cli::Cli::parse_args().run(|builder, _| async move {
+    reth::cli::Cli::parse_args().run(async move |builder, _| {
         let notifications = Arc::new(broadcast::channel(1).0);
 
         let server = Server::builder()

--- a/examples/beacon-api-sidecar-fetcher/src/main.rs
+++ b/examples/beacon-api-sidecar-fetcher/src/main.rs
@@ -32,7 +32,7 @@ pub mod mined_sidecar;
 
 fn main() {
     Cli::<EthereumChainSpecParser, BeaconSidecarConfig>::parse()
-        .run(|builder, beacon_config| async move {
+        .run(async move |builder, beacon_config| {
             // launch the node
             let NodeHandle { node, node_exit_future } =
                 builder.node(EthereumNode::default()).launch().await?;

--- a/examples/beacon-api-sse/src/main.rs
+++ b/examples/beacon-api-sse/src/main.rs
@@ -30,7 +30,7 @@ use tracing::{info, warn};
 
 fn main() {
     Cli::<EthereumChainSpecParser, BeaconEventsConfig>::parse()
-        .run(|builder, args| async move {
+        .run(async move |builder, args| {
             let handle = builder.node(EthereumNode::default()).launch().await?;
 
             handle.node.task_executor.spawn_task(args.run());

--- a/examples/beacon-api-sse/src/main.rs
+++ b/examples/beacon-api-sse/src/main.rs
@@ -33,7 +33,7 @@ fn main() {
         .run(|builder, args| async move {
             let handle = builder.node(EthereumNode::default()).launch().await?;
 
-            handle.node.task_executor.spawn_task(Box::pin(args.run()));
+            handle.node.task_executor.spawn_task(args.run());
 
             handle.wait_for_node_exit().await
         })

--- a/examples/bsc-p2p/src/block_import/service.rs
+++ b/examples/bsc-p2p/src/block_import/service.rs
@@ -361,9 +361,9 @@ mod tests {
             handle_engine_msg(from_engine, responses).await;
 
             let (service, handle) = ImportService::new(consensus, engine_handle);
-            tokio::spawn(Box::pin(async move {
+            tokio::spawn(async move {
                 service.await.unwrap();
-            }));
+            });
 
             Self { handle }
         }
@@ -411,7 +411,7 @@ mod tests {
         mut from_engine: mpsc::UnboundedReceiver<BeaconEngineMessage<EthEngineTypes>>,
         responses: EngineResponses,
     ) {
-        tokio::spawn(Box::pin(async move {
+        tokio::spawn(async move {
             while let Some(message) = from_engine.recv().await {
                 match message {
                     BeaconEngineMessage::NewPayload { payload: _, tx } => {
@@ -433,6 +433,6 @@ mod tests {
                     _ => {}
                 }
             }
-        }));
+        });
     }
 }

--- a/examples/custom-beacon-withdrawals/src/main.rs
+++ b/examples/custom-beacon-withdrawals/src/main.rs
@@ -47,7 +47,7 @@ pub const WITHDRAWALS_ADDRESS: Address = address!("0x420000000000000000000000000
 
 fn main() {
     Cli::parse_args()
-        .run(|builder, _| async move {
+        .run(async move |builder, _| {
             let handle = builder
                 // use the default ethereum node types
                 .with_types::<EthereumNode>()

--- a/examples/custom-inspector/src/main.rs
+++ b/examples/custom-inspector/src/main.rs
@@ -50,7 +50,7 @@ fn main() {
             println!("Spawning trace task!");
 
             // Spawn an async block to listen for transactions.
-            node.task_executor.spawn_task(Box::pin(async move {
+            node.task_executor.spawn_task(async move {
                 // Waiting for new transactions
                 while let Some(event) = pending_transactions.next().await {
                     let tx = event.transaction;
@@ -96,7 +96,7 @@ fn main() {
                         }
                     }
                 }
-            }));
+            });
 
             node_exit_future.await
         })

--- a/examples/custom-inspector/src/main.rs
+++ b/examples/custom-inspector/src/main.rs
@@ -34,7 +34,7 @@ use reth_ethereum::{
 
 fn main() {
     Cli::<EthereumChainSpecParser, RethCliTxpoolExt>::parse()
-        .run(|builder, args| async move {
+        .run(async move |builder, args| {
             // launch the node
             let handle = builder.node(EthereumNode::default()).launch().await?;
 

--- a/examples/custom-node-components/src/main.rs
+++ b/examples/custom-node-components/src/main.rs
@@ -23,7 +23,7 @@ use reth_tracing::tracing::{debug, info};
 
 fn main() {
     Cli::parse_args()
-        .run(|builder, _| async move {
+        .run(async move |builder, _| {
             let handle = builder
                 // use the default ethereum node types
                 .with_types::<EthereumNode>()

--- a/examples/custom-payload-builder/src/main.rs
+++ b/examples/custom-payload-builder/src/main.rs
@@ -90,7 +90,7 @@ where
 
 fn main() {
     Cli::parse_args()
-        .run(|builder, _| async move {
+        .run(async move |builder, _| {
             let handle = builder
                 .with_types::<EthereumNode>()
                 // Configure the components of the node

--- a/examples/custom-payload-builder/src/main.rs
+++ b/examples/custom-payload-builder/src/main.rs
@@ -82,8 +82,7 @@ where
         let (payload_service, payload_builder) =
             PayloadBuilderService::new(payload_generator, ctx.provider().canonical_state_stream());
 
-        ctx.task_executor()
-            .spawn_critical_task("custom payload builder service", Box::pin(payload_service));
+        ctx.task_executor().spawn_critical_task("custom payload builder service", payload_service);
 
         Ok(payload_builder)
     }

--- a/examples/custom-rlpx-subprotocol/src/main.rs
+++ b/examples/custom-rlpx-subprotocol/src/main.rs
@@ -35,7 +35,7 @@ use tokio::sync::{mpsc, oneshot};
 use tracing::info;
 
 fn main() -> eyre::Result<()> {
-    reth_ethereum::cli::Cli::parse_args().run(|builder, _args| async move {
+    reth_ethereum::cli::Cli::parse_args().run(async move |builder, _args| {
         // launch the node
         let NodeHandle { node, node_exit_future } =
             builder.node(EthereumNode::default()).launch().await?;

--- a/examples/custom-rpc-middleware/src/main.rs
+++ b/examples/custom-rpc-middleware/src/main.rs
@@ -86,7 +86,7 @@ where
     fn call<'a>(&self, req: Request<'a>) -> impl Future<Output = Self::MethodResponse> + Send + 'a {
         tracing::info!("processed call {:?}", req);
         let service = self.service.clone();
-        Box::pin(async move {
+        async move {
             let resp = service.call(req).await;
 
             //we can modify the response with our own custom error
@@ -101,7 +101,7 @@ where
 
             //otherwise just return the original response
             resp
-        })
+        }
     }
 
     fn batch<'a>(&self, req: Batch<'a>) -> impl Future<Output = Self::BatchResponse> + Send + 'a {

--- a/examples/custom-rpc-middleware/src/main.rs
+++ b/examples/custom-rpc-middleware/src/main.rs
@@ -36,7 +36,7 @@ use tower::Layer;
 
 fn main() {
     Cli::<EthereumChainSpecParser>::parse()
-        .run(|builder, _| async move {
+        .run(async move |builder, _| {
             let handle = builder
                 .with_types::<EthereumNode>()
                 .with_components(EthereumNode::components())

--- a/examples/exex-subscription/src/main.rs
+++ b/examples/exex-subscription/src/main.rs
@@ -161,7 +161,7 @@ async fn my_exex<Node: FullNodeComponents>(
 }
 
 fn main() -> eyre::Result<()> {
-    reth_ethereum::cli::Cli::parse_args().run(|builder, _| async move {
+    reth_ethereum::cli::Cli::parse_args().run(async move |builder, _| {
         let (subscriptions_tx, subscriptions_rx) = mpsc::unbounded_channel::<SubscriptionRequest>();
         let rpc = StorageWatcherRpc::new(subscriptions_tx);
 

--- a/examples/node-builder-api/src/main.rs
+++ b/examples/node-builder-api/src/main.rs
@@ -10,7 +10,7 @@ use reth_ethereum::{
 /// This installs the [`NoopNetworkBuilder`] that does not launch a real network.
 pub fn noop_network() {
     Cli::parse_args()
-        .run(|builder, _| async move {
+        .run(async move |builder, _| {
             let handle = builder
                 // use the default ethereum node types
                 .with_types::<EthereumNode>()

--- a/examples/node-custom-rpc/src/main.rs
+++ b/examples/node-custom-rpc/src/main.rs
@@ -30,7 +30,7 @@ use tokio::time::sleep;
 
 fn main() {
     Cli::<EthereumChainSpecParser, RethCliTxpoolExt>::parse()
-        .run(|builder, args| async move {
+        .run(async move |builder, args| {
             let handle = builder
                 // configure default ethereum node
                 .node(EthereumNode::default())

--- a/examples/node-event-hooks/src/main.rs
+++ b/examples/node-event-hooks/src/main.rs
@@ -17,7 +17,7 @@ use reth_ethereum::{cli::interface::Cli, node::EthereumNode};
 
 fn main() {
     Cli::parse_args()
-        .run(|builder, _| async move {
+        .run(async move |builder, _| {
             let handle = builder
                 .node(EthereumNode::default())
                 .on_node_started(|_ctx| {

--- a/examples/txpool-tracing/src/main.rs
+++ b/examples/txpool-tracing/src/main.rs
@@ -38,7 +38,7 @@ fn main() {
 
             println!("Spawning trace task!");
             // Spawn an async block to listen for transactions.
-            node.task_executor.spawn_task(Box::pin(async move {
+            node.task_executor.spawn_task(async move {
                 // Waiting for new transactions
                 while let Some(event) = pending_transactions.next().await {
                     let tx = event.transaction;
@@ -58,7 +58,7 @@ fn main() {
                         }
                     }
                 }
-            }));
+            });
 
             node_exit_future.await
         })

--- a/examples/txpool-tracing/src/main.rs
+++ b/examples/txpool-tracing/src/main.rs
@@ -25,7 +25,7 @@ mod submit;
 
 fn main() {
     Cli::<EthereumChainSpecParser, RethCliTxpoolExt>::parse()
-        .run(|builder, args| async move {
+        .run(async move |builder, args| {
             // launch the node
             let NodeHandle { node, node_exit_future } =
                 builder.node(EthereumNode::default()).launch().await?;


### PR DESCRIPTION
All `spawn_task`, `spawn_critical_task`, `spawn_critical_blocking_task`, `spawn_blocking_task`, and `spawn_with_graceful_shutdown_signal` accept generic futures, so `Box::pin` at callsites just adds an unnecessary heap allocation. Replaced with direct futures or async closures.

Prompted by: DaniPopes