### PR TITLE
chore(tasks): include thread name in priority log messages

### DIFF
--- a/crates/tasks/src/utils.rs
+++ b/crates/tasks/src/utils.rs
@@ -8,14 +8,15 @@ pub use thread_priority::{self, *};
 /// falls back to a moderate bump via [`ThreadPriority::Crossplatform`] (~5 nice points
 /// on unix). Failures are logged at `debug` level.
 pub fn increase_thread_priority() {
+    let thread_name = std::thread::current().name().unwrap_or("unnamed").to_string();
     if let Err(err) = ThreadPriority::Max.set_for_current() {
-        tracing::debug!(?err, "failed to set max thread priority, trying moderate bump");
+        tracing::debug!(%thread_name, ?err, "failed to set max thread priority, trying moderate bump; grant CAP_SYS_NICE to the process to enable this");
         // Crossplatform value 62/99 ≈ nice -5 on unix.
         let fallback = ThreadPriority::Crossplatform(
             ThreadPriorityValue::try_from(62u8).expect("62 is within the valid 0..100 range"),
         );
         if let Err(err) = fallback.set_for_current() {
-            tracing::debug!(?err, "failed to set moderate thread priority");
+            tracing::debug!(%thread_name, ?err, "failed to set moderate thread priority");
         }
     }
 }


### PR DESCRIPTION
Logs the thread name and mentions `CAP_SYS_NICE` in the debug message so operators know which thread tried to bump priority and what capability to grant.

Co-Authored-By: DaniPopes <57450786+DaniPopes@users.noreply.github.com>

Prompted by: danipopes