### PR TITLE
refactor(engine): move prewarming terminate_execution into ctx with should_stop/stop methods

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -44,7 +44,7 @@ use reth_trie_sparse::{
 use std::{
     ops::Not,
     sync::{
-        atomic::{AtomicBool, AtomicUsize},
+        atomic::AtomicUsize,
         mpsc::{self, channel},
         Arc,
     },
@@ -489,17 +489,16 @@ where
         let executed_tx_index = Arc::new(AtomicUsize::new(0));
 
         // configure prewarming
-        let prewarm_ctx = PrewarmContext {
+        let prewarm_ctx = PrewarmContext::new(
             env,
-            evm_config: self.evm_config.clone(),
-            saved_cache: saved_cache.clone(),
-            provider: provider_builder,
-            metrics: PrewarmMetrics::default(),
-            terminate_execution: Arc::new(AtomicBool::new(false)),
-            executed_tx_index: Arc::clone(&executed_tx_index),
-            precompile_cache_disabled: self.precompile_cache_disabled,
-            precompile_cache_map: self.precompile_cache_map.clone(),
-        };
+            self.evm_config.clone(),
+            saved_cache.clone(),
+            provider_builder,
+            PrewarmMetrics::default(),
+            Arc::clone(&executed_tx_index),
+            self.precompile_cache_disabled,
+            self.precompile_cache_map.clone(),
+        );
 
         let (prewarm_task, to_prewarm_task) = PrewarmCacheTask::new(
             self.executor.clone(),

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -44,7 +44,7 @@ use reth_trie_sparse::{
 use std::{
     ops::Not,
     sync::{
-        atomic::AtomicUsize,
+        atomic::{AtomicBool, AtomicUsize},
         mpsc::{self, channel},
         Arc,
     },
@@ -489,16 +489,17 @@ where
         let executed_tx_index = Arc::new(AtomicUsize::new(0));
 
         // configure prewarming
-        let prewarm_ctx = PrewarmContext::new(
+        let prewarm_ctx = PrewarmContext {
             env,
-            self.evm_config.clone(),
-            saved_cache.clone(),
-            provider_builder,
-            PrewarmMetrics::default(),
-            Arc::clone(&executed_tx_index),
-            self.precompile_cache_disabled,
-            self.precompile_cache_map.clone(),
-        );
+            evm_config: self.evm_config.clone(),
+            saved_cache: saved_cache.clone(),
+            provider: provider_builder,
+            metrics: PrewarmMetrics::default(),
+            terminate_execution: Arc::new(AtomicBool::new(false)),
+            executed_tx_index: Arc::clone(&executed_tx_index),
+            precompile_cache_disabled: self.precompile_cache_disabled,
+            precompile_cache_map: self.precompile_cache_map.clone(),
+        };
 
         let (prewarm_task, to_prewarm_task) = PrewarmCacheTask::new(
             self.executor.clone(),

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -207,7 +207,7 @@ where
         Tx: ExecutableTxFor<Evm>,
     {
         WorkerPool::with_worker_mut(|worker| {
-            let Some((evm, metrics)) =
+            let Some(evm) =
                 worker.get_or_init::<PrewarmEvmState<Evm>>(|| ctx.evm_for_ctx()).as_mut()
             else {
                 return;
@@ -235,11 +235,11 @@ where
                         sender=%tx.signer(),
                         "Error when executing prewarm transaction",
                     );
-                    metrics.transaction_errors.increment(1);
+                    ctx.metrics.transaction_errors.increment(1);
                     return;
                 }
             };
-            metrics.execution_duration.record(start.elapsed());
+            ctx.metrics.execution_duration.record(start.elapsed());
 
             if ctx.should_stop() {
                 return;
@@ -247,13 +247,13 @@ where
 
             if index > 0 {
                 let (targets, storage_targets) = multiproof_targets_from_state(res.state);
-                metrics.prefetch_storage_targets.record(storage_targets as f64);
+                ctx.metrics.prefetch_storage_targets.record(storage_targets as f64);
                 if let Some(to_multi_proof) = to_multi_proof {
                     let _ = to_multi_proof.send(MultiProofMessage::PrefetchProofs(targets));
                 }
             }
 
-            metrics.total_runtime.record(start.elapsed());
+            ctx.metrics.total_runtime.record(start.elapsed());
         });
     }
 
@@ -520,7 +520,7 @@ where
 /// Per-thread EVM state initialised by [`PrewarmContext::evm_for_ctx`] and stored in
 /// [`WorkerPool`] workers via [`Worker::get_or_init`](reth_tasks::pool::Worker::get_or_init).
 type PrewarmEvmState<Evm> =
-    Option<(EvmFor<Evm, StateProviderDatabase<reth_provider::StateProviderBox>>, PrewarmMetrics)>;
+    Option<EvmFor<Evm, StateProviderDatabase<reth_provider::StateProviderBox>>>;
 
 impl<N, P, Evm> PrewarmContext<N, P, Evm>
 where
@@ -528,7 +528,7 @@ where
     P: BlockReader + StateProviderFactory + StateReader + Clone + 'static,
     Evm: ConfigureEvm<Primitives = N> + 'static,
 {
-    /// Creates a per-thread EVM, metrics handle, and termination flag for prewarming.
+    /// Creates a per-thread EVM for prewarming.
     #[instrument(level = "debug", target = "engine::tree::payload_processor::prewarm", skip_all)]
     fn evm_for_ctx(&self) -> PrewarmEvmState<Evm> {
         let mut state_provider = match self.provider.build() {
@@ -579,7 +579,7 @@ where
             });
         }
 
-        Some((evm, self.metrics.clone()))
+        Some(evm)
     }
 
     /// Returns `true` if prewarming should stop.

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -149,7 +149,7 @@ where
                 });
 
                 while let Ok((index, tx)) = pending.recv() {
-                    if ctx.terminate_execution.load(Ordering::Relaxed) {
+                    if ctx.should_stop() {
                         trace!(
                             target: "engine::tree::payload_processor::prewarm",
                             "Termination requested, stopping transaction distribution"
@@ -207,13 +207,13 @@ where
         Tx: ExecutableTxFor<Evm>,
     {
         WorkerPool::with_worker_mut(|worker| {
-            let Some((evm, metrics, terminate_execution)) =
+            let Some((evm, metrics)) =
                 worker.get_or_init::<PrewarmEvmState<Evm>>(|| ctx.evm_for_ctx()).as_mut()
             else {
                 return;
             };
 
-            if terminate_execution.load(Ordering::Relaxed) {
+            if ctx.should_stop() {
                 return;
             }
 
@@ -241,7 +241,7 @@ where
             };
             metrics.execution_duration.record(start.elapsed());
 
-            if terminate_execution.load(Ordering::Relaxed) {
+            if ctx.should_stop() {
                 return;
             }
 
@@ -358,7 +358,7 @@ where
             bal.par_iter().for_each_init(
                 || (ctx.clone(), None::<CachedStateProvider<reth_provider::StateProviderBox>>),
                 |(ctx, provider), account| {
-                    if ctx.terminate_execution.load(Ordering::Relaxed) {
+                    if ctx.should_stop() {
                         return;
                     }
                     ctx.prefetch_bal_account(provider, account);
@@ -452,7 +452,7 @@ where
                 PrewarmTaskEvent::TerminateTransactionExecution => {
                     // stop tx processing
                     debug!(target: "engine::tree::prewarm", "Terminating prewarm execution");
-                    self.ctx.terminate_execution.store(true, Ordering::Relaxed);
+                    self.ctx.stop();
                 }
                 PrewarmTaskEvent::Terminate { execution_outcome, valid_block_rx } => {
                     trace!(target: "engine::tree::payload_processor::prewarm", "Received termination signal");
@@ -506,7 +506,7 @@ where
     /// The metrics for the prewarm task.
     pub metrics: PrewarmMetrics,
     /// An atomic bool that tells prewarm tasks to not start any more execution.
-    pub terminate_execution: Arc<AtomicBool>,
+    terminate_execution: Arc<AtomicBool>,
     /// Shared counter tracking the next transaction index to be executed by the main execution
     /// loop. Prewarm workers skip transactions with `index < counter` since those have already
     /// been executed.
@@ -517,13 +517,40 @@ where
     pub precompile_cache_map: PrecompileCacheMap<SpecFor<Evm>>,
 }
 
+impl<N, P, Evm> PrewarmContext<N, P, Evm>
+where
+    N: NodePrimitives,
+    Evm: ConfigureEvm<Primitives = N>,
+{
+    /// Creates a new prewarm context.
+    pub fn new(
+        env: ExecutionEnv<Evm>,
+        evm_config: Evm,
+        saved_cache: Option<SavedCache>,
+        provider: StateProviderBuilder<N, P>,
+        metrics: PrewarmMetrics,
+        executed_tx_index: Arc<AtomicUsize>,
+        precompile_cache_disabled: bool,
+        precompile_cache_map: PrecompileCacheMap<SpecFor<Evm>>,
+    ) -> Self {
+        Self {
+            env,
+            evm_config,
+            saved_cache,
+            provider,
+            metrics,
+            terminate_execution: Arc::new(AtomicBool::new(false)),
+            executed_tx_index,
+            precompile_cache_disabled,
+            precompile_cache_map,
+        }
+    }
+}
+
 /// Per-thread EVM state initialised by [`PrewarmContext::evm_for_ctx`] and stored in
 /// [`WorkerPool`] workers via [`Worker::get_or_init`](reth_tasks::pool::Worker::get_or_init).
-type PrewarmEvmState<Evm> = Option<(
-    EvmFor<Evm, StateProviderDatabase<reth_provider::StateProviderBox>>,
-    PrewarmMetrics,
-    Arc<AtomicBool>,
-)>;
+type PrewarmEvmState<Evm> =
+    Option<(EvmFor<Evm, StateProviderDatabase<reth_provider::StateProviderBox>>, PrewarmMetrics)>;
 
 impl<N, P, Evm> PrewarmContext<N, P, Evm>
 where
@@ -582,7 +609,19 @@ where
             });
         }
 
-        Some((evm, self.metrics.clone(), self.terminate_execution.clone()))
+        Some((evm, self.metrics.clone()))
+    }
+
+    /// Returns `true` if prewarming should stop.
+    #[inline]
+    pub fn should_stop(&self) -> bool {
+        self.terminate_execution.load(Ordering::Relaxed)
+    }
+
+    /// Signals all prewarm tasks to stop execution.
+    #[inline]
+    pub fn stop(&self) {
+        self.terminate_execution.store(true, Ordering::Relaxed);
     }
 
     /// Prefetches a single account and all its storage slots from the BAL into the cache.

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -506,7 +506,7 @@ where
     /// The metrics for the prewarm task.
     pub metrics: PrewarmMetrics,
     /// An atomic bool that tells prewarm tasks to not start any more execution.
-    terminate_execution: Arc<AtomicBool>,
+    pub terminate_execution: Arc<AtomicBool>,
     /// Shared counter tracking the next transaction index to be executed by the main execution
     /// loop. Prewarm workers skip transactions with `index < counter` since those have already
     /// been executed.
@@ -515,36 +515,6 @@ where
     pub precompile_cache_disabled: bool,
     /// The precompile cache map.
     pub precompile_cache_map: PrecompileCacheMap<SpecFor<Evm>>,
-}
-
-impl<N, P, Evm> PrewarmContext<N, P, Evm>
-where
-    N: NodePrimitives,
-    Evm: ConfigureEvm<Primitives = N>,
-{
-    /// Creates a new prewarm context.
-    pub fn new(
-        env: ExecutionEnv<Evm>,
-        evm_config: Evm,
-        saved_cache: Option<SavedCache>,
-        provider: StateProviderBuilder<N, P>,
-        metrics: PrewarmMetrics,
-        executed_tx_index: Arc<AtomicUsize>,
-        precompile_cache_disabled: bool,
-        precompile_cache_map: PrecompileCacheMap<SpecFor<Evm>>,
-    ) -> Self {
-        Self {
-            env,
-            evm_config,
-            saved_cache,
-            provider,
-            metrics,
-            terminate_execution: Arc::new(AtomicBool::new(false)),
-            executed_tx_index,
-            precompile_cache_disabled,
-            precompile_cache_map,
-        }
-    }
 }
 
 /// Per-thread EVM state initialised by [`PrewarmContext::evm_for_ctx`] and stored in


### PR DESCRIPTION
Makes `terminate_execution` private on `PrewarmContext` and replaces all manual `AtomicBool` loads/stores with `ctx.should_stop()` / `ctx.stop()`. Also removes the `Arc<AtomicBool>` from the per-thread `PrewarmEvmState` tuple since workers now go through `ctx` directly.

Prompted by: DaniPopes