### PR TITLE
feat(trie): add metrics for sparse trie cache retained memory

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -50,7 +50,7 @@ use std::{
     },
     time::Duration,
 };
-use tracing::{debug, debug_span, info, instrument, warn, Span};
+use tracing::{debug, debug_span, instrument, warn, Span};
 
 pub mod bal;
 pub mod multiproof;
@@ -653,20 +653,12 @@ where
                 trie_metrics
                     .into_trie_for_reuse_duration_histogram
                     .record(start.elapsed().as_secs_f64());
-                let retained_bytes = trie.memory_size();
-                let retained_tries = trie.retained_storage_tries_count();
                 trie_metrics
                     .sparse_trie_retained_memory_bytes
-                    .set(retained_bytes as f64);
+                    .set(trie.memory_size() as f64);
                 trie_metrics
                     .sparse_trie_retained_storage_tries
-                    .set(retained_tries as f64);
-                info!(
-                    target: "engine::tree::payload_processor",
-                    retained_bytes,
-                    retained_tries,
-                    "Preserved sparse trie cache"
-                );
+                    .set(trie.retained_storage_tries_count() as f64);
                 guard.store(PreservedSparseTrie::anchored(trie, result.state_root));
                 deferred
             } else {

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -50,7 +50,7 @@ use std::{
     },
     time::Duration,
 };
-use tracing::{debug, debug_span, instrument, warn, Span};
+use tracing::{debug, debug_span, info, instrument, warn, Span};
 
 pub mod bal;
 pub mod multiproof;
@@ -653,12 +653,20 @@ where
                 trie_metrics
                     .into_trie_for_reuse_duration_histogram
                     .record(start.elapsed().as_secs_f64());
+                let retained_bytes = trie.memory_size();
+                let retained_tries = trie.retained_storage_tries_count();
                 trie_metrics
                     .sparse_trie_retained_memory_bytes
-                    .set(trie.memory_size() as f64);
+                    .set(retained_bytes as f64);
                 trie_metrics
                     .sparse_trie_retained_storage_tries
-                    .set(trie.retained_storage_tries_count() as f64);
+                    .set(retained_tries as f64);
+                info!(
+                    target: "engine::tree::payload_processor",
+                    retained_bytes,
+                    retained_tries,
+                    "Preserved sparse trie cache"
+                );
                 guard.store(PreservedSparseTrie::anchored(trie, result.state_root));
                 deferred
             } else {

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -653,6 +653,12 @@ where
                 trie_metrics
                     .into_trie_for_reuse_duration_histogram
                     .record(start.elapsed().as_secs_f64());
+                trie_metrics
+                    .sparse_trie_retained_memory_bytes
+                    .set(trie.memory_size() as f64);
+                trie_metrics
+                    .sparse_trie_retained_storage_tries
+                    .set(trie.retained_storage_tries_count() as f64);
                 guard.store(PreservedSparseTrie::anchored(trie, result.state_root));
                 deferred
             } else {

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -190,6 +190,11 @@ pub(crate) struct MultiProofTaskMetrics {
     pub into_trie_for_reuse_duration_histogram: Histogram,
     /// Time spent waiting for preserved sparse trie cache to become available.
     pub sparse_trie_cache_wait_duration_histogram: Histogram,
+
+    /// Retained memory of the preserved sparse trie cache in bytes.
+    pub sparse_trie_retained_memory_bytes: Gauge,
+    /// Number of storage tries retained in the preserved sparse trie cache.
+    pub sparse_trie_retained_storage_tries: Gauge,
 }
 
 /// Dispatches work items as a single unit or in chunks based on target size and worker

--- a/crates/trie/sparse/src/parallel.rs
+++ b/crates/trie/sparse/src/parallel.rs
@@ -1153,6 +1153,10 @@ impl SparseTrie for ParallelSparseTrie {
         upper_count + lower_count
     }
 
+    fn memory_size(&self) -> usize {
+        self.memory_size()
+    }
+
     fn prune(&mut self, max_depth: usize) -> usize {
         #[cfg(feature = "trie-debug")]
         self.debug_recorder.reset();

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -826,35 +826,31 @@ where
     pub fn memory_size(&self) -> usize {
         let mut size = core::mem::size_of::<Self>();
 
-        // Account trie
         size += match &self.state {
-            RevealableSparseTrie::Revealed(trie) => trie.memory_size(),
-            RevealableSparseTrie::Blind(Some(trie)) => trie.memory_size(),
+            RevealableSparseTrie::Revealed(t) | RevealableSparseTrie::Blind(Some(t)) => {
+                t.memory_size()
+            }
             RevealableSparseTrie::Blind(None) => 0,
         };
 
-        // Active storage tries
         for trie in self.storage.tries.values() {
             size += match trie {
-                RevealableSparseTrie::Revealed(t) => t.memory_size(),
-                RevealableSparseTrie::Blind(Some(t)) => t.memory_size(),
+                RevealableSparseTrie::Revealed(t) | RevealableSparseTrie::Blind(Some(t)) => {
+                    t.memory_size()
+                }
                 RevealableSparseTrie::Blind(None) => 0,
             };
         }
-
-        // Cleared storage tries retained for allocation reuse
         for trie in &self.storage.cleared_tries {
             size += match trie {
-                RevealableSparseTrie::Revealed(t) => t.memory_size(),
-                RevealableSparseTrie::Blind(Some(t)) => t.memory_size(),
+                RevealableSparseTrie::Revealed(t) | RevealableSparseTrie::Blind(Some(t)) => {
+                    t.memory_size()
+                }
                 RevealableSparseTrie::Blind(None) => 0,
             };
         }
 
-        // Revealed account paths
         size += self.revealed_account_paths.capacity() * core::mem::size_of::<Nibbles>();
-
-        // Revealed storage paths
         for paths in self.storage.revealed_paths.values() {
             size += paths.capacity() * core::mem::size_of::<Nibbles>();
         }

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -819,6 +819,54 @@ where
         self.account_rlp_buf.clear();
     }
 
+    /// Returns a heuristic for the total in-memory size of this state trie in bytes.
+    ///
+    /// This aggregates the memory usage of the account trie, all revealed storage tries
+    /// (including cleared ones retained for allocation reuse), and auxiliary data structures.
+    pub fn memory_size(&self) -> usize {
+        let mut size = core::mem::size_of::<Self>();
+
+        // Account trie
+        size += match &self.state {
+            RevealableSparseTrie::Revealed(trie) => trie.memory_size(),
+            RevealableSparseTrie::Blind(Some(trie)) => trie.memory_size(),
+            RevealableSparseTrie::Blind(None) => 0,
+        };
+
+        // Active storage tries
+        for trie in self.storage.tries.values() {
+            size += match trie {
+                RevealableSparseTrie::Revealed(t) => t.memory_size(),
+                RevealableSparseTrie::Blind(Some(t)) => t.memory_size(),
+                RevealableSparseTrie::Blind(None) => 0,
+            };
+        }
+
+        // Cleared storage tries retained for allocation reuse
+        for trie in &self.storage.cleared_tries {
+            size += match trie {
+                RevealableSparseTrie::Revealed(t) => t.memory_size(),
+                RevealableSparseTrie::Blind(Some(t)) => t.memory_size(),
+                RevealableSparseTrie::Blind(None) => 0,
+            };
+        }
+
+        // Revealed account paths
+        size += self.revealed_account_paths.capacity() * core::mem::size_of::<Nibbles>();
+
+        // Revealed storage paths
+        for paths in self.storage.revealed_paths.values() {
+            size += paths.capacity() * core::mem::size_of::<Nibbles>();
+        }
+
+        size
+    }
+
+    /// Returns the number of storage tries currently retained (active + cleared).
+    pub fn retained_storage_tries_count(&self) -> usize {
+        self.storage.tries.len() + self.storage.cleared_tries.len()
+    }
+
     /// Shrinks the capacity of the sparse trie to the given node and value sizes.
     ///
     /// This helps reduce memory usage when the trie has excess capacity.

--- a/crates/trie/sparse/src/traits.rs
+++ b/crates/trie/sparse/src/traits.rs
@@ -288,6 +288,12 @@ pub trait SparseTrie: Sized + Debug + Send + Sync {
     /// during pruning. Larger values indicate larger tries that are more valuable to preserve.
     fn size_hint(&self) -> usize;
 
+    /// Returns a heuristic for the in-memory size of this trie in bytes.
+    ///
+    /// This is an approximation that accounts for the trie's nodes, values,
+    /// and auxiliary data structures.
+    fn memory_size(&self) -> usize;
+
     /// Replaces nodes beyond `max_depth` with hash stubs and removes their descendants.
     ///
     /// Depth counts nodes traversed (not nibbles), so extension nodes count as 1 depth


### PR DESCRIPTION
## Summary

Add metrics to measure the retained memory of the sparse trie cache after preservation.

## Changes

- Added `memory_size()` to the `SparseTrie` trait (`crates/trie/sparse/src/traits.rs`)
- Wired `ParallelSparseTrie::memory_size()` into the trait impl (`crates/trie/sparse/src/parallel.rs`)
- Added `memory_size()` and `retained_storage_tries_count()` to `SparseStateTrie` (`crates/trie/sparse/src/state.rs`)
- Added two gauge metrics under `tree.root` scope (`crates/engine/tree/src/tree/payload_processor/multiproof.rs`):
  - `sparse_trie_retained_memory_bytes` — total bytes retained by the preserved trie
  - `sparse_trie_retained_storage_tries` — number of storage tries retained
- Recorded both gauges after `into_trie_for_reuse` (`crates/engine/tree/src/tree/payload_processor/mod.rs`)

## Testing

`cargo check -p reth-trie-sparse --features metrics` and `cargo check -p reth-engine-tree` pass.

Co-Authored-By: Sergei Shulepov <2205845+pepyakin@users.noreply.github.com>

Prompted by: pep