### PR TITLE
fix(node): Graceful engine shutdown on node drop

### DIFF
--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -293,114 +293,113 @@ impl EngineNodeLauncher {
         let startup_sync_state_idle = ctx.node_config().debug.startup_sync_state_idle;
 
         info!(target: "reth::cli", "Starting consensus engine");
-        ctx.task_executor().spawn_critical_with_shutdown_signal(
-            "consensus engine",
-            move |on_shutdown| async move {
-                if let Some(initial_target) = initial_target {
-                    debug!(target: "reth::cli", %initial_target,  "start backfill sync");
-                    // network_handle's sync state is already initialized at Syncing
-                    orchestrator.start_backfill_sync(initial_target);
-                } else if startup_sync_state_idle {
-                    network_handle.update_sync_state(SyncState::Idle);
-                }
+        let consensus_engine = move |on_shutdown| async move {
+            if let Some(initial_target) = initial_target {
+                debug!(target: "reth::cli", %initial_target,  "start backfill sync");
+                // network_handle's sync state is already initialized at Syncing
+                orchestrator.start_backfill_sync(initial_target);
+            } else if startup_sync_state_idle {
+                network_handle.update_sync_state(SyncState::Idle);
+            }
 
-                let mut res = Ok(());
-                let mut shutdown_rx = shutdown_rx.fuse();
-                let mut on_shutdown = on_shutdown;
+            let mut res = Ok(());
+            let mut shutdown_rx = shutdown_rx.fuse();
+            let mut on_shutdown = on_shutdown;
 
-                // advance the chain and await payloads built locally to add into the engine api
-                // tree handler to prevent re-execution if that block is received as payload from
-                // the CL
-                loop {
-                    tokio::select! {
-                        event = orchestrator.next() => {
-                            let Some(event) = event else { break };
-                            debug!(target: "reth::cli", "Event: {event}");
-                            match event {
-                                ChainEvent::BackfillSyncFinished => {
-                                    if terminate_after_backfill {
-                                        debug!(target: "reth::cli", "Terminating after initial backfill");
-                                        break
-                                    }
-                                    if startup_sync_state_idle {
-                                        network_handle.update_sync_state(SyncState::Idle);
-                                    }
-                                }
-                                ChainEvent::BackfillSyncStarted => {
-                                    network_handle.update_sync_state(SyncState::Syncing);
-                                }
-                                ChainEvent::FatalError => {
-                                    error!(target: "reth::cli", "Fatal error in consensus engine");
-                                    res = Err(eyre::eyre!("Fatal error in consensus engine"));
+            // advance the chain and await payloads built locally to add into the engine api
+            // tree handler to prevent re-execution if that block is received as payload from
+            // the CL
+            loop {
+                tokio::select! {
+                    event = orchestrator.next() => {
+                        let Some(event) = event else { break };
+                        debug!(target: "reth::cli", "Event: {event}");
+                        match event {
+                            ChainEvent::BackfillSyncFinished => {
+                                if terminate_after_backfill {
+                                    debug!(target: "reth::cli", "Terminating after initial backfill");
                                     break
                                 }
-                                ChainEvent::Handler(ev) => {
-                                    if let Some(head) = ev.canonical_header() {
-                                        // Once we're progressing via live sync, we can consider the node is not syncing anymore
-                                        network_handle.update_sync_state(SyncState::Idle);
-                                        let head_block = Head {
-                                            number: head.number(),
-                                            hash: head.hash(),
-                                            difficulty: head.difficulty(),
-                                            timestamp: head.timestamp(),
-                                            total_difficulty: chainspec.final_paris_total_difficulty()
-                                                .filter(|_| chainspec.is_paris_active_at_block(head.number()))
-                                                .unwrap_or_default(),
-                                        };
-                                        network_handle.update_status(head_block);
+                                if startup_sync_state_idle {
+                                    network_handle.update_sync_state(SyncState::Idle);
+                                }
+                            }
+                            ChainEvent::BackfillSyncStarted => {
+                                network_handle.update_sync_state(SyncState::Syncing);
+                            }
+                            ChainEvent::FatalError => {
+                                error!(target: "reth::cli", "Fatal error in consensus engine");
+                                res = Err(eyre::eyre!("Fatal error in consensus engine"));
+                                break
+                            }
+                            ChainEvent::Handler(ev) => {
+                                if let Some(head) = ev.canonical_header() {
+                                    // Once we're progressing via live sync, we can consider the node is not syncing anymore
+                                    network_handle.update_sync_state(SyncState::Idle);
+                                    let head_block = Head {
+                                        number: head.number(),
+                                        hash: head.hash(),
+                                        difficulty: head.difficulty(),
+                                        timestamp: head.timestamp(),
+                                        total_difficulty: chainspec.final_paris_total_difficulty()
+                                            .filter(|_| chainspec.is_paris_active_at_block(head.number()))
+                                            .unwrap_or_default(),
+                                    };
+                                    network_handle.update_status(head_block);
 
-                                        let updated = BlockRangeUpdate {
-                                            earliest: provider.earliest_block_number().unwrap_or_default(),
-                                            latest: head.number(),
-                                            latest_hash: head.hash(),
-                                        };
-                                        network_handle.update_block_range(updated);
-                                    }
-                                    event_sender.notify(ev);
+                                    let updated = BlockRangeUpdate {
+                                        earliest: provider.earliest_block_number().unwrap_or_default(),
+                                        latest: head.number(),
+                                        latest_hash: head.hash(),
+                                    };
+                                    network_handle.update_block_range(updated);
                                 }
+                                event_sender.notify(ev);
                             }
-                        }
-                        payload = built_payloads.select_next_some(), if !built_payloads.is_terminated() => {
-                            if let Some(executed_block) = payload.executed_block() {
-                                debug!(target: "reth::cli", block=?executed_block.recovered_block.num_hash(),  "inserting built payload");
-                                orchestrator.handler_mut().handler_mut().on_event(EngineApiRequest::InsertExecutedBlock(executed_block.into_executed_payload()).into());
-                            }
-                        }
-                        shutdown_req = &mut shutdown_rx => {
-                            // Always send Terminate regardless of whether the shutdown handle was
-                            // explicitly invoked (Ok) or dropped without calling shutdown (Err).
-                            let done_tx = match shutdown_req {
-                                Ok(req) => {
-                                    debug!(target: "reth::cli", "received engine shutdown request");
-                                    req.done_tx
-                                }
-                                Err(_) => {
-                                    debug!(target: "reth::cli", "engine shutdown handle dropped, terminating engine");
-                                    let (tx, _) = oneshot::channel();
-                                    tx
-                                }
-                            };
-                            orchestrator.handler_mut().handler_mut().on_event(
-                                FromOrchestrator::Terminate { tx: done_tx }.into()
-                            );
-                        }
-                        _ = &mut on_shutdown => {
-                            // Shutdown signal received.
-                            // Send Terminate so the engine OS thread can exit cleanly before we
-                            // drop the orchestrator.
-                            debug!(target: "reth::cli", "shutdown signal received, terminating engine");
-                            let (done_tx, _) = oneshot::channel();
-                            orchestrator.handler_mut().handler_mut().on_event(
-                                FromOrchestrator::Terminate { tx: done_tx }.into()
-                            );
-                            break;
                         }
                     }
+                    payload = built_payloads.select_next_some(), if !built_payloads.is_terminated() => {
+                        if let Some(executed_block) = payload.executed_block() {
+                            debug!(target: "reth::cli", block=?executed_block.recovered_block.num_hash(),  "inserting built payload");
+                            orchestrator.handler_mut().handler_mut().on_event(EngineApiRequest::InsertExecutedBlock(executed_block.into_executed_payload()).into());
+                        }
+                    }
+                    shutdown_req = &mut shutdown_rx => {
+                        // Always send Terminate regardless of whether the shutdown handle was
+                        // explicitly invoked (Ok) or dropped without calling shutdown (Err).
+                        let done_tx = match shutdown_req {
+                            Ok(req) => {
+                                debug!(target: "reth::cli", "received engine shutdown request");
+                                req.done_tx
+                            }
+                            Err(_) => {
+                                debug!(target: "reth::cli", "engine shutdown handle dropped, terminating engine");
+                                let (tx, _) = oneshot::channel();
+                                tx
+                            }
+                        };
+                        orchestrator.handler_mut().handler_mut().on_event(
+                            FromOrchestrator::Terminate { tx: done_tx }.into()
+                        );
+                    }
+                    _ = &mut on_shutdown => {
+                        // Shutdown signal received.
+                        // Send Terminate so the engine OS thread can exit cleanly before we
+                        // drop the orchestrator.
+                        debug!(target: "reth::cli", "shutdown signal received, terminating engine");
+                        let (done_tx, _) = oneshot::channel();
+                        orchestrator.handler_mut().handler_mut().on_event(
+                            FromOrchestrator::Terminate { tx: done_tx }.into()
+                        );
+                        break;
+                    }
                 }
+            }
 
-                let _ = exit.send(res);
-            },
-        );
+            let _ = exit.send(res);
+        };
+        ctx.task_executor()
+            .spawn_critical_with_shutdown_signal("consensus engine", consensus_engine);
 
         let engine_events_for_ethstats = engine_events.new_listener();
 

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -293,90 +293,114 @@ impl EngineNodeLauncher {
         let startup_sync_state_idle = ctx.node_config().debug.startup_sync_state_idle;
 
         info!(target: "reth::cli", "Starting consensus engine");
-        let consensus_engine = async move {
-            if let Some(initial_target) = initial_target {
-                debug!(target: "reth::cli", %initial_target,  "start backfill sync");
-                // network_handle's sync state is already initialized at Syncing
-                orchestrator.start_backfill_sync(initial_target);
-            } else if startup_sync_state_idle {
-                network_handle.update_sync_state(SyncState::Idle);
-            }
+        ctx.task_executor().spawn_critical_with_shutdown_signal(
+            "consensus engine",
+            move |on_shutdown| async move {
+                if let Some(initial_target) = initial_target {
+                    debug!(target: "reth::cli", %initial_target,  "start backfill sync");
+                    // network_handle's sync state is already initialized at Syncing
+                    orchestrator.start_backfill_sync(initial_target);
+                } else if startup_sync_state_idle {
+                    network_handle.update_sync_state(SyncState::Idle);
+                }
 
-            let mut res = Ok(());
-            let mut shutdown_rx = shutdown_rx.fuse();
+                let mut res = Ok(());
+                let mut shutdown_rx = shutdown_rx.fuse();
+                let mut on_shutdown = on_shutdown;
 
-            // advance the chain and await payloads built locally to add into the engine api
-            // tree handler to prevent re-execution if that block is received as payload from
-            // the CL
-            loop {
-                tokio::select! {
-                    event = orchestrator.next() => {
-                        let Some(event) = event else { break };
-                        debug!(target: "reth::cli", "Event: {event}");
-                        match event {
-                            ChainEvent::BackfillSyncFinished => {
-                                if terminate_after_backfill {
-                                    debug!(target: "reth::cli", "Terminating after initial backfill");
+                // advance the chain and await payloads built locally to add into the engine api
+                // tree handler to prevent re-execution if that block is received as payload from
+                // the CL
+                loop {
+                    tokio::select! {
+                        event = orchestrator.next() => {
+                            let Some(event) = event else { break };
+                            debug!(target: "reth::cli", "Event: {event}");
+                            match event {
+                                ChainEvent::BackfillSyncFinished => {
+                                    if terminate_after_backfill {
+                                        debug!(target: "reth::cli", "Terminating after initial backfill");
+                                        break
+                                    }
+                                    if startup_sync_state_idle {
+                                        network_handle.update_sync_state(SyncState::Idle);
+                                    }
+                                }
+                                ChainEvent::BackfillSyncStarted => {
+                                    network_handle.update_sync_state(SyncState::Syncing);
+                                }
+                                ChainEvent::FatalError => {
+                                    error!(target: "reth::cli", "Fatal error in consensus engine");
+                                    res = Err(eyre::eyre!("Fatal error in consensus engine"));
                                     break
                                 }
-                                if startup_sync_state_idle {
-                                    network_handle.update_sync_state(SyncState::Idle);
-                                }
-                            }
-                            ChainEvent::BackfillSyncStarted => {
-                                network_handle.update_sync_state(SyncState::Syncing);
-                            }
-                            ChainEvent::FatalError => {
-                                error!(target: "reth::cli", "Fatal error in consensus engine");
-                                res = Err(eyre::eyre!("Fatal error in consensus engine"));
-                                break
-                            }
-                            ChainEvent::Handler(ev) => {
-                                if let Some(head) = ev.canonical_header() {
-                                    // Once we're progressing via live sync, we can consider the node is not syncing anymore
-                                    network_handle.update_sync_state(SyncState::Idle);
-                                    let head_block = Head {
-                                        number: head.number(),
-                                        hash: head.hash(),
-                                        difficulty: head.difficulty(),
-                                        timestamp: head.timestamp(),
-                                        total_difficulty: chainspec.final_paris_total_difficulty()
-                                            .filter(|_| chainspec.is_paris_active_at_block(head.number()))
-                                            .unwrap_or_default(),
-                                    };
-                                    network_handle.update_status(head_block);
+                                ChainEvent::Handler(ev) => {
+                                    if let Some(head) = ev.canonical_header() {
+                                        // Once we're progressing via live sync, we can consider the node is not syncing anymore
+                                        network_handle.update_sync_state(SyncState::Idle);
+                                        let head_block = Head {
+                                            number: head.number(),
+                                            hash: head.hash(),
+                                            difficulty: head.difficulty(),
+                                            timestamp: head.timestamp(),
+                                            total_difficulty: chainspec.final_paris_total_difficulty()
+                                                .filter(|_| chainspec.is_paris_active_at_block(head.number()))
+                                                .unwrap_or_default(),
+                                        };
+                                        network_handle.update_status(head_block);
 
-                                    let updated = BlockRangeUpdate {
-                                        earliest: provider.earliest_block_number().unwrap_or_default(),
-                                        latest: head.number(),
-                                        latest_hash: head.hash(),
-                                    };
-                                    network_handle.update_block_range(updated);
+                                        let updated = BlockRangeUpdate {
+                                            earliest: provider.earliest_block_number().unwrap_or_default(),
+                                            latest: head.number(),
+                                            latest_hash: head.hash(),
+                                        };
+                                        network_handle.update_block_range(updated);
+                                    }
+                                    event_sender.notify(ev);
                                 }
-                                event_sender.notify(ev);
                             }
                         }
-                    }
-                    payload = built_payloads.select_next_some(), if !built_payloads.is_terminated() => {
-                        if let Some(executed_block) = payload.executed_block() {
-                            debug!(target: "reth::cli", block=?executed_block.recovered_block.num_hash(),  "inserting built payload");
-                            orchestrator.handler_mut().handler_mut().on_event(EngineApiRequest::InsertExecutedBlock(executed_block.into_executed_payload()).into());
+                        payload = built_payloads.select_next_some(), if !built_payloads.is_terminated() => {
+                            if let Some(executed_block) = payload.executed_block() {
+                                debug!(target: "reth::cli", block=?executed_block.recovered_block.num_hash(),  "inserting built payload");
+                                orchestrator.handler_mut().handler_mut().on_event(EngineApiRequest::InsertExecutedBlock(executed_block.into_executed_payload()).into());
+                            }
                         }
-                    }
-                    shutdown_req = &mut shutdown_rx => {
-                        if let Ok(req) = shutdown_req {
-                            debug!(target: "reth::cli", "received engine shutdown request");
+                        shutdown_req = &mut shutdown_rx => {
+                            // Always send Terminate regardless of whether the shutdown handle was
+                            // explicitly invoked (Ok) or dropped without calling shutdown (Err).
+                            let done_tx = match shutdown_req {
+                                Ok(req) => {
+                                    debug!(target: "reth::cli", "received engine shutdown request");
+                                    req.done_tx
+                                }
+                                Err(_) => {
+                                    debug!(target: "reth::cli", "engine shutdown handle dropped, terminating engine");
+                                    let (tx, _) = oneshot::channel();
+                                    tx
+                                }
+                            };
                             orchestrator.handler_mut().handler_mut().on_event(
-                                FromOrchestrator::Terminate { tx: req.done_tx }.into()
+                                FromOrchestrator::Terminate { tx: done_tx }.into()
                             );
+                        }
+                        _ = &mut on_shutdown => {
+                            // Shutdown signal received.
+                            // Send Terminate so the engine OS thread can exit cleanly before we
+                            // drop the orchestrator.
+                            debug!(target: "reth::cli", "shutdown signal received, terminating engine");
+                            let (done_tx, _) = oneshot::channel();
+                            orchestrator.handler_mut().handler_mut().on_event(
+                                FromOrchestrator::Terminate { tx: done_tx }.into()
+                            );
+                            break;
                         }
                     }
                 }
-            }
 
-            let _ = exit.send(res);
-        };
-        ctx.task_executor().spawn_critical_task("consensus engine", consensus_engine);
+                let _ = exit.send(res);
+            },
+        );
 
         let engine_events_for_ethstats = engine_events.new_listener();
 

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -293,7 +293,7 @@ impl EngineNodeLauncher {
         let startup_sync_state_idle = ctx.node_config().debug.startup_sync_state_idle;
 
         info!(target: "reth::cli", "Starting consensus engine");
-        let consensus_engine = move |on_shutdown| async move {
+        let consensus_engine = move |mut on_graceful_shutdown| async move {
             if let Some(initial_target) = initial_target {
                 debug!(target: "reth::cli", %initial_target,  "start backfill sync");
                 // network_handle's sync state is already initialized at Syncing
@@ -304,7 +304,6 @@ impl EngineNodeLauncher {
 
             let mut res = Ok(());
             let mut shutdown_rx = shutdown_rx.fuse();
-            let mut on_shutdown = on_shutdown;
 
             // advance the chain and await payloads built locally to add into the engine api
             // tree handler to prevent re-execution if that block is received as payload from
@@ -365,32 +364,23 @@ impl EngineNodeLauncher {
                         }
                     }
                     shutdown_req = &mut shutdown_rx => {
-                        // Always send Terminate regardless of whether the shutdown handle was
-                        // explicitly invoked (Ok) or dropped without calling shutdown (Err).
-                        let done_tx = match shutdown_req {
-                            Ok(req) => {
-                                debug!(target: "reth::cli", "received engine shutdown request");
-                                req.done_tx
-                            }
-                            Err(_) => {
-                                debug!(target: "reth::cli", "engine shutdown handle dropped, terminating engine");
-                                let (tx, _) = oneshot::channel();
-                                tx
-                            }
-                        };
-                        orchestrator.handler_mut().handler_mut().on_event(
-                            FromOrchestrator::Terminate { tx: done_tx }.into()
-                        );
+                        if let Ok(req) = shutdown_req {
+                            debug!(target: "reth::cli", "received engine shutdown request");
+                            orchestrator.handler_mut().handler_mut().on_event(
+                                FromOrchestrator::Terminate { tx: req.done_tx }.into()
+                            );
+                        }
                     }
-                    _ = &mut on_shutdown => {
+                    _ = &mut on_graceful_shutdown => {
                         // Shutdown signal received.
                         // Send Terminate so the engine OS thread can exit cleanly before we
                         // drop the orchestrator.
                         debug!(target: "reth::cli", "shutdown signal received, terminating engine");
-                        let (done_tx, _) = oneshot::channel();
+                        let (done_tx, done_rx) = oneshot::channel();
                         orchestrator.handler_mut().handler_mut().on_event(
                             FromOrchestrator::Terminate { tx: done_tx }.into()
                         );
+                        let _ = done_rx.await;
                         break;
                     }
                 }


### PR DESCRIPTION
When dropping in-process node with `NodeHandle` instance, the node do not correctly shutdown the engine and leaves behind a few os threads (`EngineApiTreeHandler`, `PersistenceService`, all rayon thread pool from `RuntimeInner`). 
This cause approximately 13-15 os threads leaked per instance.

### Issue

`EngineApiTreeHandler::spawn_new` places the engine on an os thread that runs a blocking `crossbeam_channel::recv()` loop. The only non-error exit path is when receiving `FromOrchestrator::Terminate` through the `to_tree` sender held inside orchestrator in `on_engine_message`.

https://github.com/paradigmxyz/reth/blob/01f3e58229027c14156e0420641eacf8009ddd92/crates/engine/tree/src/tree/mod.rs#L443-L481

https://github.com/paradigmxyz/reth/blob/01f3e58229027c14156e0420641eacf8009ddd92/crates/engine/tree/src/tree/mod.rs#L1438-L1444

On Terminate, the engine thread returns from run() and drops the `PersistenceHandle` and drops its outgoing sender, which makes orchestrator.next() to return None and break the consensus engine loop.

https://github.com/paradigmxyz/reth/blob/01f3e58229027c14156e0420641eacf8009ddd92/crates/node/builder/src/launch/engine.rs#L307-L313

When directly calling drop(node), `FullNode.add_ons_handle.engine_shutdown` is dropped without calling shutdown(). EngineShutdown wraps a `oneshot::Sender` so the channel closes and shutdown_rx inside the consensus engine task fires with `Err(RecvError)`. 
However the engine silently discards this Err by only handling Ok cases in shutdown handling:

https://github.com/paradigmxyz/reth/blob/01f3e58229027c14156e0420641eacf8009ddd92/crates/node/builder/src/launch/engine.rs#L365-L372

No Terminate is ever sent. The engine thread stays blocked in recv in wait_for_event(). Because the engine thread owns PersistenceHandle, the persistence thread stays blocked too.

The consensus engine task is now also stuck because orchestrator.next() never returns None as the engine thread never drops its outgoing sender. orchestrator stays alive and its backfill sync task as well; `PipelineSync::pipeline_task_spawner`  clone Runtime with Arc<RuntimeInner>.

https://github.com/paradigmxyz/reth/blob/01f3e58229027c14156e0420641eacf8009ddd92/crates/node/builder/src/launch/engine.rs#L234

Arc<RuntimeInner> is unable to reach ref count of zero so the six rayon ThreadPool are never dropped, so roughly 12 rayon threads + WorkerMap thread are never joined.

Lastly, spawn_critical_task wraps the future in an outer select(on_shutdown, fut). If the shutdown signal fires before the consensus engine task is polled, this outer select cancels the entire future in place dropping orchestrator without ever queuing Terminate. The engine thread is then orphaned: the to_tree sender is gone, the thread's own self-referential incoming_tx keeps the channel open so it never sees a disconnect either.

### Fix

This pr try to fix this with changes in EngineNodeLauncher:
- use spawn_critical_with_shutdown_signal with on_shutdown directly, giving the consensus engine full control over its shutdown sequence. Terminate is always queued before orchestrator is dropped.
- always send Terminate when shutdown_rx resolves (the channel delivers Terminate to engine thread regardless of whether the sender is later dropped).
- handle the shutdown signal inside the loop to handle the case where the shutdown signal fires before engine_shutdown is explicitly dropped.

This should ensure shutdown sequence:
- drop(node)
  - engine_shutdown dropped -> shutdown_rx fires Err
  - Terminate queued in crossbeam channel
  - engine OS thread receives Terminate -> run() returns
     - PersistenceHandle dropped -> persistence thread exits
     - outgoing sender dropped -> orchestrator.next() returns None
  - consensus engine loop breaks -> task exits normally
  - orchestrator dropped -> PipelineSync::pipeline_task_spawner (Runtime clone) freed
  - Arc<RuntimeInner> refcount -> 0 -> rayon pools dropped -> threads joined