### PR TITLE
chore(alloy-evm): upgrade to 0.28.1 to fix debug_TraceCall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c766c49df3a611b3a4dab6a3b92a27ad5a16f742db9e1204ccf9ba14651ce5d1"
+checksum = "8d432029684c0239fcf8ddcfd3c61b1887210867548edf5b53a3288772b02478"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -454,7 +454,7 @@ alloy-sol-types = { version = "1.5.6", default-features = false }
 alloy-chains = { version = "0.2.5", default-features = false }
 alloy-eip2124 = { version = "0.2.0", default-features = false }
 alloy-eip7928 = { version = "0.3.0", default-features = false }
-alloy-evm = { version = "0.28.0", default-features = false }
+alloy-evm = { version = "0.28.1", default-features = false }
 alloy-rlp = { version = "0.3.13", default-features = false, features = ["core-net"] }
 alloy-trie = { version = "0.9.4", default-features = false }
 


### PR DESCRIPTION
chore(alloy-evm): upgrade to 0.28.1 to fix debug_TraceCall

https://github.com/paradigmxyz/reth/issues/22683