### PR TITLE
refactor(tasks): centralize channel imports behind reth-tasks

### DIFF
--- a/.github/scripts/check_wasm.sh
+++ b/.github/scripts/check_wasm.sh
@@ -68,8 +68,17 @@ exclude_crates=(
   reth-static-file # tokio
   reth-transaction-pool # c-kzg
   reth-payload-util # reth-transaction-pool
+  reth-trie # reth-tasks
+  reth-trie-db # reth-trie
   reth-trie-parallel # tokio
   reth-trie-sparse-parallel # rayon
+  reth-chain-state # reth-trie
+  reth-engine-primitives # reth-chain-state
+  reth-ethereum-engine-primitives # reth-engine-primitives
+  reth-exex-types # reth-chain-state
+  reth-node-types # reth-engine-primitives
+  reth-payload-builder-primitives # reth-node-types
+  reth-payload-primitives # reth-node-types
   reth-testing-utils
   reth-era-downloader # tokio
   reth-era-utils # tokio

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8319,7 +8319,6 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "assert_matches",
- "crossbeam-channel",
  "derive_more",
  "eyre",
  "fixed-cache",
@@ -8465,6 +8464,7 @@ dependencies = [
  "reth-provider",
  "reth-stages-types",
  "reth-storage-api",
+ "reth-tasks",
  "tempfile",
  "tokio",
  "tokio-util",
@@ -8754,6 +8754,7 @@ dependencies = [
  "reth-execution-types",
  "reth-primitives-traits",
  "reth-storage-errors",
+ "reth-tasks",
  "reth-testing-utils",
  "revm",
  "secp256k1 0.30.0",
@@ -10210,6 +10211,7 @@ dependencies = [
  "reth-stages-types",
  "reth-static-file-types",
  "reth-storage-errors",
+ "reth-tasks",
  "reth-testing-utils",
  "reth-tokio-util",
  "tempfile",
@@ -10306,6 +10308,7 @@ dependencies = [
 name = "reth-tasks"
 version = "1.11.1"
 dependencies = [
+ "crossbeam-channel",
  "crossbeam-utils",
  "dashmap",
  "futures-util",
@@ -10456,6 +10459,7 @@ dependencies = [
  "reth-primitives-traits",
  "reth-stages-types",
  "reth-storage-errors",
+ "reth-tasks",
  "reth-tracing",
  "reth-trie-common",
  "reth-trie-sparse",
@@ -10534,7 +10538,6 @@ version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "crossbeam-channel",
  "derive_more",
  "itertools 0.14.0",
  "metrics",

--- a/crates/cli/commands/src/init_state/without_evm.rs
+++ b/crates/cli/commands/src/init_state/without_evm.rs
@@ -109,7 +109,7 @@ where
     N: NodePrimitives,
     F: Fn(BlockNumber) -> N::BlockHeader + Send + Sync + 'static,
 {
-    let (tx, rx) = std::sync::mpsc::channel();
+    let (tx, rx) = reth_tasks::channel::unbounded();
 
     // Spawn jobs for incrementing the block end range of transactions, receipts, and senders.
     for segment in [

--- a/crates/cli/runner/src/lib.rs
+++ b/crates/cli/runner/src/lib.rs
@@ -10,8 +10,8 @@
 
 //! Entrypoint for running commands.
 
-use reth_tasks::{PanickedTaskError, TaskExecutor};
-use std::{future::Future, pin::pin, sync::mpsc, time::Duration};
+use reth_tasks::{channel, PanickedTaskError, TaskExecutor};
+use std::{future::Future, pin::pin, time::Duration};
 use tokio::task::JoinHandle;
 use tracing::{debug, error, info};
 
@@ -291,7 +291,7 @@ const DEFAULT_RUNTIME_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 /// Dropping the runtime on the current thread could block due to tokio pool teardown.
 /// Instead, we drop it on a separate thread and optionally wait for completion.
 fn runtime_shutdown(rt: reth_tasks::Runtime, wait: bool) {
-    let (tx, rx) = mpsc::channel();
+    let (tx, rx) = channel::unbounded();
     std::thread::Builder::new()
         .name("rt-shutdown".to_string())
         .spawn(move || {

--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -65,7 +65,6 @@ rayon.workspace = true
 tracing.workspace = true
 derive_more.workspace = true
 parking_lot.workspace = true
-crossbeam-channel.workspace = true
 
 # optional deps for test-utils
 reth-prune-types = { workspace = true, optional = true }
@@ -100,7 +99,6 @@ revm-state.workspace = true
 assert_matches.workspace = true
 eyre.workspace = true
 serde_json.workspace = true
-crossbeam-channel.workspace = true
 proptest.workspace = true
 rand.workspace = true
 rand_08.workspace = true

--- a/crates/engine/tree/src/engine.rs
+++ b/crates/engine/tree/src/engine.rs
@@ -6,13 +6,13 @@ use crate::{
     download::{BlockDownloader, DownloadAction, DownloadOutcome},
 };
 use alloy_primitives::{map::B256Set, B256};
-use crossbeam_channel::Sender;
 use futures::{Stream, StreamExt};
 use reth_chain_state::ExecutedBlock;
 use reth_engine_primitives::{BeaconEngineMessage, ConsensusEngineEvent};
 use reth_ethereum_primitives::EthPrimitives;
 use reth_payload_primitives::PayloadTypes;
 use reth_primitives_traits::{Block, NodePrimitives, SealedBlock};
+use reth_tasks::channel::Sender;
 use std::{
     fmt::Display,
     task::{ready, Context, Poll},

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -1,6 +1,5 @@
 use crate::metrics::PersistenceMetrics;
 use alloy_eips::BlockNumHash;
-use crossbeam_channel::Sender as CrossbeamSender;
 use reth_chain_state::ExecutedBlock;
 use reth_errors::ProviderError;
 use reth_ethereum_primitives::EthPrimitives;
@@ -11,14 +10,11 @@ use reth_provider::{
 };
 use reth_prune::{PrunerError, PrunerWithFactory};
 use reth_stages_api::{MetricEvent, MetricEventsSender};
-use reth_tasks::spawn_os_thread;
-use std::{
-    sync::{
-        mpsc::{Receiver, SendError, Sender},
-        Arc,
-    },
-    thread::JoinHandle,
+use reth_tasks::{
+    channel::{self, Receiver, SendError, Sender},
+    spawn_os_thread,
 };
+use std::{sync::Arc, thread::JoinHandle};
 use thiserror::Error;
 use tracing::{debug, error, instrument};
 
@@ -202,13 +198,13 @@ pub enum PersistenceAction<N: NodePrimitives = EthPrimitives> {
     ///
     /// First, header, transaction, and receipt-related data should be written to static files.
     /// Then the execution history-related data will be written to the database.
-    SaveBlocks(Vec<ExecutedBlock<N>>, CrossbeamSender<Option<BlockNumHash>>),
+    SaveBlocks(Vec<ExecutedBlock<N>>, Sender<Option<BlockNumHash>>),
 
     /// Removes block data above the given block number from the database.
     ///
     /// This will first update checkpoints from the database, then remove actual block data from
     /// static files.
-    RemoveBlocksAbove(u64, CrossbeamSender<Option<BlockNumHash>>),
+    RemoveBlocksAbove(u64, Sender<Option<BlockNumHash>>),
 
     /// Update the persisted finalized block on disk
     SaveFinalizedBlock(u64),
@@ -250,7 +246,7 @@ impl<T: NodePrimitives> PersistenceHandle<T> {
         N: ProviderNodeTypes,
     {
         // create the initial channels
-        let (db_service_tx, db_service_rx) = std::sync::mpsc::channel();
+        let (db_service_tx, db_service_rx) = channel::unbounded();
 
         // spawn the persistence service
         let db_service =
@@ -287,7 +283,7 @@ impl<T: NodePrimitives> PersistenceHandle<T> {
     pub fn save_blocks(
         &self,
         blocks: Vec<ExecutedBlock<T>>,
-        tx: CrossbeamSender<Option<BlockNumHash>>,
+        tx: Sender<Option<BlockNumHash>>,
     ) -> Result<(), SendError<PersistenceAction<T>>> {
         self.send_action(PersistenceAction::SaveBlocks(blocks, tx))
     }
@@ -322,7 +318,7 @@ impl<T: NodePrimitives> PersistenceHandle<T> {
     pub fn remove_blocks_above(
         &self,
         block_num: u64,
-        tx: CrossbeamSender<Option<BlockNumHash>>,
+        tx: Sender<Option<BlockNumHash>>,
     ) -> Result<(), SendError<PersistenceAction<T>>> {
         self.send_action(PersistenceAction::RemoveBlocksAbove(block_num, tx))
     }
@@ -378,7 +374,7 @@ mod tests {
         let handle = default_persistence_handle();
 
         let blocks = vec![];
-        let (tx, rx) = crossbeam_channel::bounded(1);
+        let (tx, rx) = channel::bounded(1);
 
         handle.save_blocks(blocks, tx).unwrap();
 
@@ -397,7 +393,7 @@ mod tests {
         let block_hash = executed.recovered_block().hash();
 
         let blocks = vec![executed];
-        let (tx, rx) = crossbeam_channel::bounded(1);
+        let (tx, rx) = channel::bounded(1);
 
         handle.save_blocks(blocks, tx).unwrap();
 
@@ -417,7 +413,7 @@ mod tests {
         let mut test_block_builder = TestBlockBuilder::eth();
         let blocks = test_block_builder.get_executed_blocks(0..5).collect::<Vec<_>>();
         let last_hash = blocks.last().unwrap().recovered_block().hash();
-        let (tx, rx) = crossbeam_channel::bounded(1);
+        let (tx, rx) = channel::bounded(1);
 
         handle.save_blocks(blocks, tx).unwrap();
         let BlockNumHash { hash: actual_hash, number: _ } = rx.recv().unwrap().unwrap();
@@ -434,7 +430,7 @@ mod tests {
         for range in ranges {
             let blocks = test_block_builder.get_executed_blocks(range).collect::<Vec<_>>();
             let last_hash = blocks.last().unwrap().recovered_block().hash();
-            let (tx, rx) = crossbeam_channel::bounded(1);
+            let (tx, rx) = channel::bounded(1);
 
             handle.save_blocks(blocks, tx).unwrap();
 

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -374,7 +374,7 @@ mod tests {
         let handle = default_persistence_handle();
 
         let blocks = vec![];
-        let (tx, rx) = channel::bounded(1);
+        let (tx, rx) = channel::oneshot();
 
         handle.save_blocks(blocks, tx).unwrap();
 
@@ -393,7 +393,7 @@ mod tests {
         let block_hash = executed.recovered_block().hash();
 
         let blocks = vec![executed];
-        let (tx, rx) = channel::bounded(1);
+        let (tx, rx) = channel::oneshot();
 
         handle.save_blocks(blocks, tx).unwrap();
 
@@ -413,7 +413,7 @@ mod tests {
         let mut test_block_builder = TestBlockBuilder::eth();
         let blocks = test_block_builder.get_executed_blocks(0..5).collect::<Vec<_>>();
         let last_hash = blocks.last().unwrap().recovered_block().hash();
-        let (tx, rx) = channel::bounded(1);
+        let (tx, rx) = channel::oneshot();
 
         handle.save_blocks(blocks, tx).unwrap();
         let BlockNumHash { hash: actual_hash, number: _ } = rx.recv().unwrap().unwrap();
@@ -430,7 +430,7 @@ mod tests {
         for range in ranges {
             let blocks = test_block_builder.get_executed_blocks(range).collect::<Vec<_>>();
             let last_hash = blocks.last().unwrap().recovered_block().hash();
-            let (tx, rx) = channel::bounded(1);
+            let (tx, rx) = channel::oneshot();
 
             handle.save_blocks(blocks, tx).unwrap();
 

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -44,7 +44,7 @@ use revm::interpreter::debug_unreachable;
 use state::TreeState;
 use std::{fmt::Debug, ops, sync::Arc, time::Duration};
 
-use crossbeam_channel::{Receiver, Sender};
+use reth_tasks::channel::{self, Receiver, Sender};
 use tokio::sync::{
     mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
     oneshot,
@@ -343,7 +343,7 @@ where
         changeset_cache: ChangesetCache,
         use_hashed_state: bool,
     ) -> Self {
-        let (incoming_tx, incoming) = crossbeam_channel::unbounded();
+        let (incoming_tx, incoming) = channel::unbounded();
 
         Self {
             provider,
@@ -492,7 +492,7 @@ where
         if let Some((persistence_rx, start_time, action)) = maybe_persistence {
             // Biased select prioritizes persistence completion to update in memory state and
             // unblock further writes
-            crossbeam_channel::select_biased! {
+            reth_tasks::channel::select_biased! {
                 recv(persistence_rx) -> result => {
                     // Don't put it back - consumed (oneshot-like behavior)
                     match result {
@@ -1253,7 +1253,7 @@ where
         debug!(target: "engine::tree", ?new_tip_num, last_persisted_block_number=?self.persistence_state.last_persisted_block.number, "Removing blocks using persistence task");
         if new_tip_num < self.persistence_state.last_persisted_block.number {
             debug!(target: "engine::tree", ?new_tip_num, "Starting remove blocks job");
-            let (tx, rx) = crossbeam_channel::bounded(1);
+            let (tx, rx) = channel::bounded(1);
             let _ = self.persistence.remove_blocks_above(new_tip_num, tx);
             self.persistence_state.start_remove(new_tip_num, rx);
         }
@@ -1275,7 +1275,7 @@ where
             .expect("Checked non-empty persisting blocks");
 
         debug!(target: "engine::tree", count=blocks_to_persist.len(), blocks = ?blocks_to_persist.iter().map(|block| block.recovered_block().num_hash()).collect::<Vec<_>>(), "Persisting blocks");
-        let (tx, rx) = crossbeam_channel::bounded(1);
+        let (tx, rx) = channel::bounded(1);
         let _ = self.persistence.save_blocks(blocks_to_persist, tx);
 
         self.persistence_state.start_save(highest_num_hash, rx);
@@ -1348,14 +1348,12 @@ where
                 self.on_persistence_complete(result, start_time)?;
                 Ok(true)
             }
-            Err(crossbeam_channel::TryRecvError::Empty) => {
+            Err(channel::TryRecvError::Empty) => {
                 // Not ready yet, put it back
                 self.persistence_state.rx = Some((rx, start_time, action));
                 Ok(false)
             }
-            Err(crossbeam_channel::TryRecvError::Disconnected) => {
-                Err(AdvancePersistenceError::ChannelClosed)
-            }
+            Err(channel::TryRecvError::Disconnected) => Err(AdvancePersistenceError::ChannelClosed),
         }
     }
 
@@ -1568,8 +1566,7 @@ where
                                 let persistence_rx = if let Some((rx, start_time, _action)) =
                                     pending_persistence
                                 {
-                                    let (persistence_tx, persistence_rx) =
-                                        std::sync::mpsc::channel();
+                                    let (persistence_tx, persistence_rx) = channel::unbounded();
                                     tokio::task::spawn_blocking(move || {
                                         let start = Instant::now();
                                         let result =

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1260,7 +1260,7 @@ where
         debug!(target: "engine::tree", ?new_tip_num, last_persisted_block_number=?self.persistence_state.last_persisted_block.number, "Removing blocks using persistence task");
         if new_tip_num < self.persistence_state.last_persisted_block.number {
             debug!(target: "engine::tree", ?new_tip_num, "Starting remove blocks job");
-            let (tx, rx) = channel::bounded(1);
+            let (tx, rx) = channel::oneshot();
             let _ = self.persistence.remove_blocks_above(new_tip_num, tx);
             self.persistence_state.start_remove(new_tip_num, rx);
         }
@@ -1282,7 +1282,7 @@ where
             .expect("Checked non-empty persisting blocks");
 
         debug!(target: "engine::tree", count=blocks_to_persist.len(), blocks = ?blocks_to_persist.iter().map(|block| block.recovered_block().num_hash()).collect::<Vec<_>>(), "Persisting blocks");
-        let (tx, rx) = channel::bounded(1);
+        let (tx, rx) = channel::oneshot();
         let _ = self.persistence.save_blocks(blocks_to_persist, tx);
 
         self.persistence_state.start_save(highest_num_hash, rx);

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -14,7 +14,6 @@ use alloy_eip7928::BlockAccessList;
 use alloy_eips::{eip1898::BlockWithParent, eip4895::Withdrawal};
 use alloy_evm::block::StateChangeSource;
 use alloy_primitives::B256;
-use crossbeam_channel::{Receiver as CrossbeamReceiver, Sender as CrossbeamSender};
 use metrics::{Counter, Histogram};
 use multiproof::*;
 use parking_lot::RwLock;
@@ -32,7 +31,11 @@ use reth_provider::{
     BlockExecutionOutput, BlockReader, DatabaseProviderROFactory, StateProviderFactory, StateReader,
 };
 use reth_revm::{db::BundleState, state::EvmState};
-use reth_tasks::{utils::increase_thread_priority, ForEachOrdered, Runtime};
+use reth_tasks::{
+    channel::{self, Receiver, Sender},
+    utils::increase_thread_priority,
+    ForEachOrdered, Runtime,
+};
 use reth_trie::{hashed_cursor::HashedCursorFactory, trie_cursor::TrieCursorFactory};
 use reth_trie_parallel::{
     proof_task::{ProofTaskCtx, ProofWorkerHandle},
@@ -45,7 +48,6 @@ use std::{
     ops::Not,
     sync::{
         atomic::{AtomicBool, AtomicUsize},
-        mpsc::{self, channel},
         Arc,
     },
     time::Duration,
@@ -189,8 +191,8 @@ where
         let sparse_trie = self.sparse_state_trie.clone();
 
         // Use channels and spawn_blocking instead of std::thread::spawn
-        let (execution_tx, execution_rx) = std::sync::mpsc::channel();
-        let (sparse_trie_tx, sparse_trie_rx) = std::sync::mpsc::channel();
+        let (execution_tx, execution_rx) = channel::unbounded();
+        let (sparse_trie_tx, sparse_trie_rx) = channel::unbounded();
 
         self.executor.spawn_blocking(move || {
             let _ = execution_tx.send(execution_cache.wait_for_availability());
@@ -348,13 +350,13 @@ where
             + Sync
             + 'static,
     {
-        let (to_multi_proof, from_multi_proof) = crossbeam_channel::unbounded();
+        let (to_multi_proof, from_multi_proof) = channel::unbounded();
 
         let task_ctx = ProofTaskCtx::new(multiproof_provider_factory);
         let halve_workers = env.transaction_count <= Self::SMALL_BLOCK_PROOF_WORKER_TX_THRESHOLD;
         let proof_handle = ProofWorkerHandle::new(&self.executor, task_ctx, halve_workers);
 
-        let (state_root_tx, state_root_rx) = channel();
+        let (state_root_tx, state_root_rx) = channel::unbounded();
 
         self.spawn_sparse_trie_task(
             proof_handle,
@@ -401,11 +403,11 @@ where
         transactions: I,
         transaction_count: usize,
     ) -> (
-        mpsc::Receiver<(usize, WithTxEnv<TxEnvFor<Evm>, I::Recovered>)>,
-        mpsc::Receiver<Result<WithTxEnv<TxEnvFor<Evm>, I::Recovered>, I::Error>>,
+        Receiver<(usize, WithTxEnv<TxEnvFor<Evm>, I::Recovered>)>,
+        Receiver<Result<WithTxEnv<TxEnvFor<Evm>, I::Recovered>, I::Error>>,
     ) {
-        let (prewarm_tx, prewarm_rx) = mpsc::sync_channel(transaction_count);
-        let (execute_tx, execute_rx) = mpsc::sync_channel(transaction_count);
+        let (prewarm_tx, prewarm_rx) = channel::bounded(transaction_count);
+        let (execute_tx, execute_rx) = channel::bounded(transaction_count);
 
         if transaction_count == 0 {
             // Empty block — nothing to do.
@@ -473,9 +475,9 @@ where
     fn spawn_caching_with<P>(
         &self,
         env: ExecutionEnv<Evm>,
-        transactions: mpsc::Receiver<(usize, impl ExecutableTxFor<Evm> + Clone + Send + 'static)>,
+        transactions: Receiver<(usize, impl ExecutableTxFor<Evm> + Clone + Send + 'static)>,
         provider_builder: StateProviderBuilder<N, P>,
-        to_multi_proof: Option<CrossbeamSender<MultiProofMessage>>,
+        to_multi_proof: Option<Sender<MultiProofMessage>>,
         bal: Option<Arc<BlockAccessList>>,
     ) -> CacheTaskHandle<N::Receipt>
     where
@@ -551,8 +553,8 @@ where
     fn spawn_sparse_trie_task(
         &self,
         proof_worker_handle: ProofWorkerHandle,
-        state_root_tx: mpsc::Sender<Result<StateRootComputeOutcome, ParallelStateRootError>>,
-        from_multi_proof: CrossbeamReceiver<MultiProofMessage>,
+        state_root_tx: Sender<Result<StateRootComputeOutcome, ParallelStateRootError>>,
+        from_multi_proof: Receiver<MultiProofMessage>,
         parent_state_root: B256,
         chunk_size: usize,
     ) {
@@ -728,8 +730,8 @@ where
 fn convert_serial<RawTx, Tx, TxEnv, InnerTx, Recovered, Err, C>(
     iter: impl Iterator<Item = RawTx>,
     convert: &C,
-    prewarm_tx: &mpsc::SyncSender<(usize, WithTxEnv<TxEnv, Recovered>)>,
-    execute_tx: &mpsc::SyncSender<Result<WithTxEnv<TxEnv, Recovered>, Err>>,
+    prewarm_tx: &Sender<(usize, WithTxEnv<TxEnv, Recovered>)>,
+    execute_tx: &Sender<Result<WithTxEnv<TxEnv, Recovered>, Err>>,
 ) where
     Tx: ExecutableTxParts<TxEnv, InnerTx, Recovered = Recovered>,
     TxEnv: Clone,
@@ -759,16 +761,16 @@ fn convert_serial<RawTx, Tx, TxEnv, InnerTx, Recovered, Err, C>(
 #[derive(Debug)]
 pub struct StateRootHandle {
     /// Channel for evm state updates to the multiproof pipeline.
-    to_multi_proof: CrossbeamSender<MultiProofMessage>,
+    to_multi_proof: Sender<MultiProofMessage>,
     /// Receiver for the computed state root.
-    state_root_rx: Option<mpsc::Receiver<Result<StateRootComputeOutcome, ParallelStateRootError>>>,
+    state_root_rx: Option<Receiver<Result<StateRootComputeOutcome, ParallelStateRootError>>>,
 }
 
 impl StateRootHandle {
     /// Creates a new state root handle.
     pub const fn new(
-        to_multi_proof: CrossbeamSender<MultiProofMessage>,
-        state_root_rx: mpsc::Receiver<Result<StateRootComputeOutcome, ParallelStateRootError>>,
+        to_multi_proof: Sender<MultiProofMessage>,
+        state_root_rx: Receiver<Result<StateRootComputeOutcome, ParallelStateRootError>>,
     ) -> Self {
         Self { to_multi_proof, state_root_rx: Some(state_root_rx) }
     }
@@ -805,7 +807,7 @@ impl StateRootHandle {
     /// If called more than once.
     pub const fn take_state_root_rx(
         &mut self,
-    ) -> mpsc::Receiver<Result<StateRootComputeOutcome, ParallelStateRootError>> {
+    ) -> Receiver<Result<StateRootComputeOutcome, ParallelStateRootError>> {
         self.state_root_rx.take().expect("state_root already taken")
     }
 }
@@ -821,7 +823,7 @@ pub struct PayloadHandle<Tx, Err, R> {
     // must include the receiver of the state root wired to the sparse trie
     prewarm_handle: CacheTaskHandle<R>,
     /// Stream of block transactions
-    transactions: mpsc::Receiver<Result<Tx, Err>>,
+    transactions: Receiver<Result<Tx, Err>>,
     /// Span for tracing
     _span: Span,
 }
@@ -850,7 +852,7 @@ impl<Tx, Err, R: Send + Sync + 'static> PayloadHandle<Tx, Err, R> {
     /// If payload processing was started without background tasks.
     pub const fn take_state_root_rx(
         &mut self,
-    ) -> mpsc::Receiver<Result<StateRootComputeOutcome, ParallelStateRootError>> {
+    ) -> Receiver<Result<StateRootComputeOutcome, ParallelStateRootError>> {
         self.state_root_handle.as_mut().expect("state_root_handle is None").take_state_root_rx()
     }
 
@@ -896,7 +898,7 @@ impl<Tx, Err, R: Send + Sync + 'static> PayloadHandle<Tx, Err, R> {
     pub fn terminate_caching(
         &mut self,
         execution_outcome: Option<Arc<BlockExecutionOutput<R>>>,
-    ) -> Option<mpsc::Sender<()>> {
+    ) -> Option<Sender<()>> {
         self.prewarm_handle.terminate_caching(execution_outcome)
     }
 
@@ -915,7 +917,7 @@ pub struct CacheTaskHandle<R> {
     /// The shared cache the task operates with.
     saved_cache: Option<SavedCache>,
     /// Channel to the spawned prewarm task if any
-    to_prewarm_task: Option<std::sync::mpsc::Sender<PrewarmTaskEvent<R>>>,
+    to_prewarm_task: Option<Sender<PrewarmTaskEvent<R>>>,
     /// Shared counter tracking the next transaction index to be executed by the main execution
     /// loop. Prewarm workers skip transactions below this index.
     executed_tx_index: Arc<AtomicUsize>,
@@ -939,9 +941,9 @@ impl<R: Send + Sync + 'static> CacheTaskHandle<R> {
     pub fn terminate_caching(
         &mut self,
         execution_outcome: Option<Arc<BlockExecutionOutput<R>>>,
-    ) -> Option<mpsc::Sender<()>> {
+    ) -> Option<Sender<()>> {
         if let Some(tx) = self.to_prewarm_task.take() {
-            let (valid_block_tx, valid_block_rx) = mpsc::channel();
+            let (valid_block_tx, valid_block_rx) = channel::unbounded();
             let event = PrewarmTaskEvent::Terminate { execution_outcome, valid_block_rx };
             let _ = tx.send(event);
 
@@ -958,7 +960,7 @@ impl<R> Drop for CacheTaskHandle<R> {
         if let Some(tx) = self.to_prewarm_task.take() {
             let _ = tx.send(PrewarmTaskEvent::Terminate {
                 execution_outcome: None,
-                valid_block_rx: mpsc::channel().1,
+                valid_block_rx: channel::unbounded().1,
             });
         }
     }

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -2,11 +2,11 @@
 
 use alloy_evm::block::StateChangeSource;
 use alloy_primitives::{keccak256, B256};
-use crossbeam_channel::Sender as CrossbeamSender;
 use derive_more::derive::Deref;
 use metrics::{Gauge, Histogram};
 use reth_metrics::Metrics;
 use reth_revm::state::EvmState;
+use reth_tasks::channel::Sender;
 use reth_trie::{HashedPostState, HashedStorage};
 use reth_trie_common::MultiProofTargetsV2;
 use std::sync::Arc;
@@ -77,11 +77,11 @@ pub enum MultiProofMessage {
 /// This should trigger once the block has been executed (after) the last state update has been
 /// sent. This triggers the exit condition of the multi proof task.
 #[derive(Deref, Debug)]
-pub struct StateHookSender(CrossbeamSender<MultiProofMessage>);
+pub struct StateHookSender(Sender<MultiProofMessage>);
 
 impl StateHookSender {
     /// Creates a new [`StateHookSender`] wrapping the given channel sender.
-    pub const fn new(inner: CrossbeamSender<MultiProofMessage>) -> Self {
+    pub const fn new(inner: Sender<MultiProofMessage>) -> Self {
         Self(inner)
     }
 }

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -21,7 +21,6 @@ use alloy_consensus::transaction::TxHashRef;
 use alloy_eip7928::BlockAccessList;
 use alloy_eips::eip4895::Withdrawal;
 use alloy_primitives::{keccak256, StorageKey, B256};
-use crossbeam_channel::Sender as CrossbeamSender;
 use metrics::{Counter, Gauge, Histogram};
 use rayon::prelude::*;
 use reth_evm::{execute::ExecutableTxFor, ConfigureEvm, Evm, EvmFor, RecoveredTx, SpecFor};
@@ -32,11 +31,14 @@ use reth_provider::{
     StateReader,
 };
 use reth_revm::{database::StateProviderDatabase, state::EvmState};
-use reth_tasks::{pool::WorkerPool, Runtime};
+use reth_tasks::{
+    channel::{self, Receiver, Sender},
+    pool::WorkerPool,
+    Runtime,
+};
 use reth_trie_common::{MultiProofTargetsV2, ProofV2Target};
 use std::sync::{
     atomic::{AtomicBool, AtomicUsize, Ordering},
-    mpsc::{self, channel, Receiver, Sender},
     Arc,
 };
 use tracing::{debug, debug_span, instrument, trace, warn, Span};
@@ -70,7 +72,7 @@ where
     /// Context provided to execution tasks
     ctx: PrewarmContext<N, P, Evm>,
     /// Sender to emit evm state outcome messages, if any.
-    to_multi_proof: Option<CrossbeamSender<MultiProofMessage>>,
+    to_multi_proof: Option<Sender<MultiProofMessage>>,
     /// Receiver for events produced by tx execution
     actions_rx: Receiver<PrewarmTaskEvent<N::Receipt>>,
     /// Parent span for tracing
@@ -88,9 +90,9 @@ where
         executor: Runtime,
         execution_cache: PayloadExecutionCache,
         ctx: PrewarmContext<N, P, Evm>,
-        to_multi_proof: Option<CrossbeamSender<MultiProofMessage>>,
+        to_multi_proof: Option<Sender<MultiProofMessage>>,
     ) -> (Self, Sender<PrewarmTaskEvent<N::Receipt>>) {
-        let (actions_tx, actions_rx) = channel();
+        let (actions_tx, actions_rx) = channel::unbounded();
 
         trace!(
             target: "engine::tree::payload_processor::prewarm",
@@ -120,9 +122,9 @@ where
     /// their EVM state on first access via [`get_or_init`](reth_tasks::pool::Worker::get_or_init).
     fn spawn_txs_prewarm<Tx>(
         &self,
-        pending: mpsc::Receiver<(usize, Tx)>,
+        pending: Receiver<(usize, Tx)>,
         actions_tx: Sender<PrewarmTaskEvent<N::Receipt>>,
-        to_multi_proof: Option<CrossbeamSender<MultiProofMessage>>,
+        to_multi_proof: Option<Sender<MultiProofMessage>>,
     ) where
         Tx: ExecutableTxFor<Evm> + Send + 'static,
     {
@@ -202,7 +204,7 @@ where
         ctx: &PrewarmContext<N, P, Evm>,
         index: usize,
         tx: Tx,
-        to_multi_proof: Option<&CrossbeamSender<MultiProofMessage>>,
+        to_multi_proof: Option<&Sender<MultiProofMessage>>,
     ) where
         Tx: ExecutableTxFor<Evm>,
     {
@@ -272,7 +274,7 @@ where
     fn save_cache(
         self,
         execution_outcome: Arc<BlockExecutionOutput<N::Receipt>>,
-        valid_block_rx: mpsc::Receiver<()>,
+        valid_block_rx: Receiver<()>,
     ) {
         let start = Instant::now();
 
@@ -709,7 +711,7 @@ pub enum PrewarmTaskEvent<R> {
         ///
         /// Cache saving is racing the state root validation. We optimistically construct the
         /// updated cache but only save it once we know the block is valid.
-        valid_block_rx: mpsc::Receiver<()>,
+        valid_block_rx: Receiver<()>,
     },
     /// Finished executing all transactions
     FinishedTxExecution {

--- a/crates/engine/tree/src/tree/payload_processor/receipt_root_task.rs
+++ b/crates/engine/tree/src/tree/payload_processor/receipt_root_task.rs
@@ -8,8 +8,8 @@
 
 use alloy_eips::Encodable2718;
 use alloy_primitives::{Bloom, B256};
-use crossbeam_channel::Receiver;
 use reth_primitives_traits::Receipt;
+use reth_tasks::channel::Receiver;
 use reth_trie_common::ordered_root::OrderedTrieRootEncodedBuilder;
 use tokio::sync::oneshot;
 use tracing::debug_span;
@@ -124,8 +124,8 @@ mod tests {
     use super::*;
     use alloy_consensus::{proofs::calculate_receipt_root, TxReceipt};
     use alloy_primitives::{b256, hex, Address, Bytes, Log};
-    use crossbeam_channel::bounded;
     use reth_ethereum_primitives::{Receipt, TxType};
+    use reth_tasks::channel::bounded;
 
     #[tokio::test]
     async fn test_receipt_root_task_empty() {

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -11,10 +11,12 @@ use crate::tree::{
 };
 use alloy_primitives::B256;
 use alloy_rlp::{Decodable, Encodable};
-use crossbeam_channel::{Receiver as CrossbeamReceiver, Sender as CrossbeamSender};
 use rayon::iter::ParallelIterator;
 use reth_primitives_traits::{Account, FastInstant as Instant, ParallelBridgeBuffered};
-use reth_tasks::Runtime;
+use reth_tasks::{
+    channel::{self, Receiver, Sender},
+    Runtime,
+};
 use reth_trie::{
     updates::TrieUpdates, DecodedMultiProofV2, HashedPostState, TrieAccount, EMPTY_ROOT_HASH,
     TRIE_ACCOUNT_RLP_MAX_SIZE,
@@ -41,11 +43,11 @@ const MAX_PENDING_UPDATES: usize = 100;
 /// Sparse trie task implementation that uses in-memory sparse trie data to schedule proof fetching.
 pub(super) struct SparseTrieCacheTask<A = ParallelSparseTrie, S = ParallelSparseTrie> {
     /// Sender for proof results.
-    proof_result_tx: CrossbeamSender<ProofResultMessage>,
+    proof_result_tx: Sender<ProofResultMessage>,
     /// Receiver for proof results directly from workers.
-    proof_result_rx: CrossbeamReceiver<ProofResultMessage>,
+    proof_result_rx: Receiver<ProofResultMessage>,
     /// Receives updates from execution and prewarming.
-    updates: CrossbeamReceiver<SparseTrieTaskMessage>,
+    updates: Receiver<SparseTrieTaskMessage>,
     /// `SparseStateTrie` used for computing the state root.
     trie: SparseStateTrie<A, S>,
     /// Handle to the proof worker pools (storage and account).
@@ -110,14 +112,14 @@ where
     /// Creates a new sparse trie, pre-populating with an existing [`SparseStateTrie`].
     pub(super) fn new_with_trie(
         executor: &Runtime,
-        updates: CrossbeamReceiver<MultiProofMessage>,
+        updates: Receiver<MultiProofMessage>,
         proof_worker_handle: ProofWorkerHandle,
         metrics: MultiProofTaskMetrics,
         trie: SparseStateTrie<A, S>,
         chunk_size: usize,
     ) -> Self {
-        let (proof_result_tx, proof_result_rx) = crossbeam_channel::unbounded();
-        let (hashed_state_tx, hashed_state_rx) = crossbeam_channel::unbounded();
+        let (proof_result_tx, proof_result_rx) = channel::unbounded();
+        let (hashed_state_tx, hashed_state_rx) = channel::unbounded();
 
         let parent_span = tracing::Span::current();
         executor.spawn_blocking_named("trie-hashing", move || {
@@ -151,8 +153,8 @@ where
     /// Runs the hashing task that drains updates from the channel and converts them to
     /// `HashedPostState` in parallel.
     fn run_hashing_task(
-        updates: CrossbeamReceiver<MultiProofMessage>,
-        hashed_state_tx: CrossbeamSender<SparseTrieTaskMessage>,
+        updates: Receiver<MultiProofMessage>,
+        hashed_state_tx: Sender<SparseTrieTaskMessage>,
     ) {
         while let Ok(message) = updates.recv() {
             let msg = match message {
@@ -239,7 +241,7 @@ where
 
         loop {
             let mut t = Instant::now();
-            crossbeam_channel::select_biased! {
+            reth_tasks::channel::select_biased! {
                 recv(self.updates) -> message => {
                     self.metrics
                         .sparse_trie_channel_wait_duration_histogram
@@ -778,8 +780,8 @@ mod tests {
 
     #[test]
     fn test_run_hashing_task_hashed_state_update_forwards() {
-        let (updates_tx, updates_rx) = crossbeam_channel::unbounded();
-        let (hashed_state_tx, hashed_state_rx) = crossbeam_channel::unbounded();
+        let (updates_tx, updates_rx) = channel::unbounded();
+        let (hashed_state_tx, hashed_state_rx) = channel::unbounded();
 
         let address = keccak256(Address::random());
         let slot = keccak256(U256::from(42).to_be_bytes::<32>());

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -43,6 +43,7 @@ use reth_provider::{
     StateProviderFactory, StateReader, StorageChangeSetReader, StorageSettingsCache,
 };
 use reth_revm::db::{states::bundle_state::BundleRetention, State};
+use reth_tasks::channel::RecvTimeoutError;
 use reth_trie::{updates::TrieUpdates, HashedPostState, StateRoot};
 use reth_trie_db::ChangesetCache;
 use reth_trie_parallel::root::{ParallelStateRoot, ParallelStateRootError};
@@ -52,7 +53,6 @@ use std::{
     panic::{self, AssertUnwindSafe},
     sync::{
         atomic::{AtomicUsize, Ordering},
-        mpsc::RecvTimeoutError,
         Arc,
     },
 };
@@ -862,7 +862,7 @@ where
         // Spawn background task to compute receipt root and logs bloom incrementally.
         // Unbounded channel is used since tx count bounds capacity anyway (max ~30k txs per block).
         let receipts_len = input.transaction_count();
-        let (receipt_tx, receipt_rx) = crossbeam_channel::unbounded();
+        let (receipt_tx, receipt_rx) = reth_tasks::channel::unbounded();
         let (result_tx, result_rx) = tokio::sync::oneshot::channel();
         let task_handle = ReceiptRootTaskHandle::new(receipt_rx, result_tx);
         self.payload_processor
@@ -922,7 +922,7 @@ where
         mut executor: E,
         transaction_count: usize,
         transactions: impl Iterator<Item = Result<Tx, Err>>,
-        receipt_tx: &crossbeam_channel::Sender<IndexedReceipt<N::Receipt>>,
+        receipt_tx: &reth_tasks::channel::Sender<IndexedReceipt<N::Receipt>>,
         executed_tx_index: &AtomicUsize,
     ) -> Result<(E, Vec<Address>), BlockExecutionError>
     where
@@ -1084,7 +1084,7 @@ where
                 self.metrics.block_validation.state_root_task_timeout_total.increment(1);
 
                 let (seq_tx, seq_rx) =
-                    std::sync::mpsc::channel::<ProviderResult<(B256, TrieUpdates)>>();
+                    reth_tasks::channel::unbounded::<ProviderResult<(B256, TrieUpdates)>>();
 
                 let seq_overlay = overlay_factory;
                 let seq_hashed_state = hashed_state.clone();

--- a/crates/engine/tree/src/tree/persistence_state.rs
+++ b/crates/engine/tree/src/tree/persistence_state.rs
@@ -22,8 +22,8 @@
 
 use alloy_eips::BlockNumHash;
 use alloy_primitives::B256;
-use crossbeam_channel::Receiver as CrossbeamReceiver;
 use reth_primitives_traits::FastInstant as Instant;
+use reth_tasks::channel::Receiver;
 use tracing::trace;
 
 /// The state of the persistence task.
@@ -35,8 +35,7 @@ pub struct PersistenceState {
     pub(crate) last_persisted_block: BlockNumHash,
     /// Receiver end of channel where the result of the persistence task will be
     /// sent when done. A None value means there's no persistence task in progress.
-    pub(crate) rx:
-        Option<(CrossbeamReceiver<Option<BlockNumHash>>, Instant, CurrentPersistenceAction)>,
+    pub(crate) rx: Option<(Receiver<Option<BlockNumHash>>, Instant, CurrentPersistenceAction)>,
 }
 
 impl PersistenceState {
@@ -47,21 +46,13 @@ impl PersistenceState {
     }
 
     /// Sets the state for a block removal operation.
-    pub(crate) fn start_remove(
-        &mut self,
-        new_tip_num: u64,
-        rx: CrossbeamReceiver<Option<BlockNumHash>>,
-    ) {
+    pub(crate) fn start_remove(&mut self, new_tip_num: u64, rx: Receiver<Option<BlockNumHash>>) {
         self.rx =
             Some((rx, Instant::now(), CurrentPersistenceAction::RemovingBlocks { new_tip_num }));
     }
 
     /// Sets the state for a block save operation.
-    pub(crate) fn start_save(
-        &mut self,
-        highest: BlockNumHash,
-        rx: CrossbeamReceiver<Option<BlockNumHash>>,
-    ) {
+    pub(crate) fn start_save(&mut self, highest: BlockNumHash, rx: Receiver<Option<BlockNumHash>>) {
         self.rx = Some((rx, Instant::now(), CurrentPersistenceAction::SavingBlocks { highest }));
     }
 

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -408,7 +408,7 @@ impl ValidatorTestHarness {
     /// Configure `PersistenceState` for specific persistence scenarios
     fn start_persistence_operation(&mut self, action: CurrentPersistenceAction) {
         // Create a dummy receiver for testing - it will never receive a value
-        let (_tx, rx) = channel::bounded(1);
+        let (_tx, rx) = channel::oneshot();
 
         match action {
             CurrentPersistenceAction::SavingBlocks { highest } => {

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -28,15 +28,11 @@ use reth_ethereum_primitives::{Block, EthPrimitives};
 use reth_evm_ethereum::MockEvmConfig;
 use reth_primitives_traits::Block as _;
 use reth_provider::test_utils::MockEthProvider;
-use reth_tasks::spawn_os_thread;
-use std::{
-    collections::BTreeMap,
-    str::FromStr,
-    sync::{
-        mpsc::{Receiver, Sender},
-        Arc,
-    },
+use reth_tasks::{
+    channel::{self, Receiver, Sender},
+    spawn_os_thread,
 };
+use std::{collections::BTreeMap, str::FromStr, sync::Arc};
 use tokio::sync::oneshot;
 
 /// Mock engine validator for tests
@@ -99,10 +95,9 @@ struct TestChannel<T> {
 impl<T: Send + 'static> TestChannel<T> {
     /// Creates a new test channel
     fn spawn_channel() -> (Sender<T>, Receiver<T>, TestChannelHandle) {
-        use std::sync::mpsc::channel;
-        let (original_tx, original_rx) = channel();
-        let (wrapped_tx, wrapped_rx) = channel();
-        let (release_tx, release_rx) = channel();
+        let (original_tx, original_rx) = channel::unbounded();
+        let (wrapped_tx, wrapped_rx) = channel::unbounded();
+        let (release_tx, release_rx) = channel::unbounded();
         let handle = TestChannelHandle::new(release_tx);
         let test_channel = Self { release: release_rx, tx: wrapped_tx, rx: original_rx };
         // spawn the task that listens and releases stuff
@@ -146,9 +141,7 @@ struct TestHarness {
         BasicEngineValidator<MockEthProvider, MockEvmConfig, MockEngineValidator>,
         MockEvmConfig,
     >,
-    to_tree_tx: crossbeam_channel::Sender<
-        FromEngine<EngineApiRequest<EthEngineTypes, EthPrimitives>, Block>,
-    >,
+    to_tree_tx: channel::Sender<FromEngine<EngineApiRequest<EthEngineTypes, EthPrimitives>, Block>>,
     from_tree_rx: UnboundedReceiver<EngineApiEvent>,
     blocks: Vec<ExecutedBlock>,
     action_rx: Receiver<PersistenceAction>,
@@ -158,8 +151,7 @@ struct TestHarness {
 
 impl TestHarness {
     fn new(chain_spec: Arc<ChainSpec>) -> Self {
-        use std::sync::mpsc::channel;
-        let (action_tx, action_rx) = channel();
+        let (action_tx, action_rx) = channel::unbounded();
         Self::with_persistence_channel(chain_spec, action_tx, action_rx)
     }
 
@@ -415,7 +407,7 @@ impl ValidatorTestHarness {
     /// Configure `PersistenceState` for specific persistence scenarios
     fn start_persistence_operation(&mut self, action: CurrentPersistenceAction) {
         // Create a dummy receiver for testing - it will never receive a value
-        let (_tx, rx) = crossbeam_channel::bounded(1);
+        let (_tx, rx) = channel::bounded(1);
 
         match action {
             CurrentPersistenceAction::SavingBlocks { highest } => {

--- a/crates/era-utils/Cargo.toml
+++ b/crates/era-utils/Cargo.toml
@@ -17,6 +17,7 @@ alloy-primitives.workspace = true
 # reth
 reth-db-api.workspace = true
 reth-era.workspace = true
+reth-tasks.workspace = true
 reth-era-downloader.workspace = true
 reth-etl.workspace = true
 reth-fs-util.workspace = true

--- a/crates/era-utils/src/history.rs
+++ b/crates/era-utils/src/history.rs
@@ -31,6 +31,7 @@ use reth_storage_api::{
     errors::ProviderResult, DBProvider, DatabaseProviderFactory, NodePrimitivesProvider,
     StageCheckpointWriter,
 };
+use reth_tasks::channel;
 use std::{
     collections::Bound,
     error::Error,
@@ -38,7 +39,6 @@ use std::{
     io::{Read, Seek},
     iter::Map,
     ops::RangeBounds,
-    sync::mpsc,
 };
 use tracing::info;
 
@@ -66,7 +66,7 @@ where
             + StageCheckpointWriter,
     > + StaticFileProviderFactory<Primitives = <<PF as DatabaseProviderFactory>::ProviderRW as NodePrimitivesProvider>::Primitives>,
 {
-    let (tx, rx) = mpsc::channel();
+    let (tx, rx) = channel::unbounded();
 
     // Handle IO-bound async download in a background tokio task
     tokio::spawn(async move {

--- a/crates/ethereum/evm/Cargo.toml
+++ b/crates/ethereum/evm/Cargo.toml
@@ -29,6 +29,7 @@ alloy-consensus.workspace = true
 alloy-rpc-types-engine.workspace = true
 
 [dev-dependencies]
+reth-tasks.workspace = true
 reth-testing-utils.workspace = true
 reth-evm = { workspace = true, features = ["test-utils"] }
 secp256k1.workspace = true
@@ -59,4 +60,5 @@ test-utils = [
     "reth-ethereum-primitives/test-utils",
     "reth-evm/test-utils",
     "reth-primitives-traits/test-utils",
+    "reth-tasks/test-utils",
 ]

--- a/crates/ethereum/evm/tests/execute.rs
+++ b/crates/ethereum/evm/tests/execute.rs
@@ -21,6 +21,7 @@ use reth_execution_types::BlockExecutionResult;
 use reth_primitives_traits::{
     crypto::secp256k1::public_key_to_address, Block as _, RecoveredBlock,
 };
+use reth_tasks::channel;
 use reth_testing_utils::generators::{self, sign_tx_with_key_pair};
 use revm::{
     database::{CacheDB, EmptyDB, TransitionState},
@@ -28,7 +29,7 @@ use revm::{
     state::{AccountInfo, Bytecode, EvmState},
     Database,
 };
-use std::sync::{mpsc, Arc};
+use std::sync::Arc;
 
 fn create_database_with_beacon_root_contract() -> CacheDB<EmptyDB> {
     let mut db = CacheDB::new(Default::default());
@@ -807,7 +808,7 @@ fn test_balance_increment_not_duplicated() {
     let provider = EthEvmConfig::new(chain_spec);
     let executor = provider.batch_executor(db);
 
-    let (tx, rx) = mpsc::channel();
+    let (tx, rx) = channel::unbounded();
     let tx_clone = tx.clone();
 
     let _output = executor

--- a/crates/stages/stages/src/stages/hashing_account.rs
+++ b/crates/stages/stages/src/stages/hashing_account.rs
@@ -17,10 +17,10 @@ use reth_stages_api::{
     StageError, StageId, UnwindInput, UnwindOutput,
 };
 use reth_storage_errors::provider::ProviderResult;
+use reth_tasks::channel;
 use std::{
     fmt::Debug,
     ops::{Range, RangeInclusive},
-    sync::mpsc::{self, Receiver},
 };
 use tracing::*;
 
@@ -184,7 +184,7 @@ where
             for chunk in &accounts_cursor.walk(None)?.chunks(WORKER_CHUNK_SIZE) {
                 // An _unordered_ channel to receive results from a rayon job
                 let chunk = chunk.collect::<Result<Vec<_>, _>>()?;
-                let (tx, rx) = mpsc::sync_channel(chunk.len());
+                let (tx, rx) = channel::bounded(chunk.len());
                 channels.push(rx);
                 // Spawn the hashing task onto the global rayon pool
                 rayon::spawn(move || {
@@ -273,7 +273,7 @@ where
 
 /// Flushes channels hashes to ETL collector.
 fn collect(
-    channels: &mut Vec<Receiver<(RawKey<B256>, RawValue<Account>)>>,
+    channels: &mut Vec<channel::Receiver<(RawKey<B256>, RawValue<Account>)>>,
     collector: &mut Collector<RawKey<B256>, RawValue<Account>>,
 ) -> Result<(), StageError> {
     for channel in channels.iter_mut() {

--- a/crates/stages/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/stages/src/stages/hashing_storage.rs
@@ -17,10 +17,8 @@ use reth_stages_api::{
 };
 use reth_storage_api::StorageSettingsCache;
 use reth_storage_errors::provider::ProviderResult;
-use std::{
-    fmt::Debug,
-    sync::mpsc::{self, Receiver},
-};
+use reth_tasks::channel;
+use std::fmt::Debug;
 use tracing::*;
 
 /// Maximum number of channels that can exist in memory.
@@ -111,7 +109,7 @@ where
             for chunk in &storage_cursor.walk(None)?.chunks(WORKER_CHUNK_SIZE) {
                 // An _unordered_ channel to receive results from a rayon job
                 let chunk = chunk.collect::<Result<Vec<_>, _>>()?;
-                let (tx, rx) = mpsc::sync_channel(chunk.len());
+                let (tx, rx) = channel::bounded(chunk.len());
                 channels.push(rx);
                 // Spawn the hashing task onto the global rayon pool
                 rayon::spawn(move || {
@@ -210,7 +208,7 @@ where
 
 /// Flushes channels hashes to ETL collector.
 fn collect(
-    channels: &mut Vec<Receiver<(Vec<u8>, CompactU256)>>,
+    channels: &mut Vec<channel::Receiver<(Vec<u8>, CompactU256)>>,
     collector: &mut Collector<Vec<u8>, CompactU256>,
 ) -> Result<(), StageError> {
     for channel in channels.iter_mut() {

--- a/crates/stages/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/stages/src/stages/sender_recovery.rs
@@ -23,7 +23,8 @@ use reth_stages_api::{
     StageId, UnwindInput, UnwindOutput,
 };
 use reth_static_file_types::StaticFileSegment;
-use std::{fmt::Debug, ops::Range, sync::mpsc};
+use reth_tasks::channel;
+use std::{fmt::Debug, ops::Range};
 use thiserror::Error;
 use tracing::*;
 
@@ -36,7 +37,7 @@ const BATCH_SIZE: usize = 100_000;
 const WORKER_CHUNK_SIZE: usize = 100;
 
 /// Type alias for a sender that transmits the result of sender recovery.
-type RecoveryResultSender = mpsc::SyncSender<Result<(u64, Address), Box<SenderRecoveryStageError>>>;
+type RecoveryResultSender = channel::Sender<Result<(u64, Address), Box<SenderRecoveryStageError>>>;
 
 /// The sender recovery stage iterates over existing transactions,
 /// recovers the transaction signer and stores them
@@ -226,7 +227,7 @@ fn recover_range<Provider, CURSOR>(
     tx_range: Range<TxNumber>,
     block_numbers: Vec<BlockNumber>,
     provider: &Provider,
-    tx_batch_sender: mpsc::Sender<Vec<(Range<u64>, RecoveryResultSender)>>,
+    tx_batch_sender: channel::Sender<Vec<(Range<u64>, RecoveryResultSender)>>,
     writer: &mut EitherWriter<'_, CURSOR, Provider::Primitives>,
 ) -> Result<(), StageError>
 where
@@ -247,7 +248,7 @@ where
         .step_by(WORKER_CHUNK_SIZE)
         .map(|start| {
             let range = start..std::cmp::min(start + WORKER_CHUNK_SIZE as u64, tx_range.end);
-            let (tx, rx) = mpsc::sync_channel((range.end - range.start) as usize);
+            let (tx, rx) = channel::bounded((range.end - range.start) as usize);
             // Range and channel sender will be sent to rayon worker
             ((range, tx), rx)
         })
@@ -328,13 +329,13 @@ where
 /// transactions in parallel using global rayon pool
 fn setup_range_recovery<Provider>(
     provider: &Provider,
-) -> mpsc::Sender<Vec<(Range<u64>, RecoveryResultSender)>>
+) -> channel::Sender<Vec<(Range<u64>, RecoveryResultSender)>>
 where
     Provider: DBProvider
         + HeaderProvider
         + StaticFileProviderFactory<Primitives: NodePrimitives<SignedTx: Value + SignedTransaction>>,
 {
-    let (tx_sender, tx_receiver) = mpsc::channel::<Vec<(Range<u64>, RecoveryResultSender)>>();
+    let (tx_sender, tx_receiver) = channel::unbounded::<Vec<(Range<u64>, RecoveryResultSender)>>();
     let static_file_provider = provider.static_file_provider();
 
     // We do not use `tokio::task::spawn_blocking` because, during a shutdown,

--- a/crates/static-file/static-file/Cargo.toml
+++ b/crates/static-file/static-file/Cargo.toml
@@ -32,6 +32,7 @@ parking_lot = { workspace = true, features = ["send_guard", "arc_lock"] }
 
 [dev-dependencies]
 reth-stages = { workspace = true, features = ["test-utils"] }
+reth-tasks.workspace = true
 reth-testing-utils.workspace = true
 
 assert_matches.workspace = true

--- a/crates/static-file/static-file/src/static_file_producer.rs
+++ b/crates/static-file/static-file/src/static_file_producer.rs
@@ -243,10 +243,11 @@ mod tests {
     use reth_prune_types::PruneModes;
     use reth_stages::test_utils::{StorageKind, TestStageDB};
     use reth_static_file_types::{HighestStaticFiles, StaticFileSegment};
+    use reth_tasks::channel::unbounded;
     use reth_testing_utils::generators::{
         self, random_block_range, random_receipt, BlockRangeParams,
     };
-    use std::{sync::mpsc::channel, time::Duration};
+    use std::time::Duration;
     use tempfile::TempDir;
 
     fn setup() -> (ProviderFactory<MockNodeTypesWithDB>, TempDir) {
@@ -334,7 +335,7 @@ mod tests {
 
         let static_file_producer = StaticFileProducer::new(provider_factory, PruneModes::default());
 
-        let (tx, rx) = channel();
+        let (tx, rx) = unbounded();
 
         for i in 0..5 {
             let producer = static_file_producer.clone();

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -275,7 +275,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
     pub fn watch_directory(&self) {
         let provider = self.clone();
         reth_tasks::spawn_os_thread("sf-watch", move || {
-            let (tx, rx) = std::sync::mpsc::channel();
+            let (tx, rx) = reth_tasks::channel::unbounded();
             let mut watcher = RecommendedWatcher::new(
                 move |res| tx.send(res).unwrap(),
                 notify::Config::default(),

--- a/crates/tasks/Cargo.toml
+++ b/crates/tasks/Cargo.toml
@@ -22,6 +22,7 @@ reth-metrics.workspace = true
 metrics.workspace = true
 
 # misc
+crossbeam-channel.workspace = true
 dashmap.workspace = true
 thread-priority.workspace = true
 tracing.workspace = true

--- a/crates/tasks/src/channel.rs
+++ b/crates/tasks/src/channel.rs
@@ -1,0 +1,11 @@
+//! Centralized channel type aliases backed by [`crossbeam_channel`].
+
+pub use crossbeam_channel::{
+    bounded, select, select_biased, unbounded, Receiver, RecvError, RecvTimeoutError, SendError,
+    Sender, TryRecvError, TrySendError,
+};
+
+/// Creates a bounded channel with capacity 1, usable as a oneshot.
+pub fn oneshot<T>() -> (Sender<T>, Receiver<T>) {
+    bounded(1)
+}

--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -30,6 +30,7 @@ use tokio::{
 };
 use tracing::debug;
 
+pub mod channel;
 pub mod lazy;
 pub mod metrics;
 pub mod runtime;

--- a/crates/trie/parallel/Cargo.toml
+++ b/crates/trie/parallel/Cargo.toml
@@ -33,7 +33,6 @@ thiserror.workspace = true
 derive_more.workspace = true
 rayon.workspace = true
 itertools.workspace = true
-crossbeam-channel.workspace = true
 
 # `metrics` feature
 reth-metrics = { workspace = true, optional = true }

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -36,12 +36,14 @@ use alloy_primitives::{
     map::{B256Map, B256Set},
     B256,
 };
-use crossbeam_channel::{unbounded, Receiver as CrossbeamReceiver, Sender as CrossbeamSender};
 use reth_execution_errors::{SparseTrieError, SparseTrieErrorKind, StateProofError};
 use reth_primitives_traits::{dashmap::DashMap, FastInstant as Instant};
 use reth_provider::{DatabaseProviderROFactory, ProviderError, ProviderResult};
 use reth_storage_errors::db::DatabaseError;
-use reth_tasks::Runtime;
+use reth_tasks::{
+    channel::{oneshot, unbounded, Receiver, Sender},
+    Runtime,
+};
 use reth_trie::{
     hashed_cursor::HashedCursorFactory,
     proof::{ProofBlindedAccountProvider, ProofBlindedStorageProvider},
@@ -56,7 +58,6 @@ use std::{
     rc::Rc,
     sync::{
         atomic::{AtomicUsize, Ordering},
-        mpsc::{channel, Receiver, Sender},
         Arc,
     },
     time::Duration,
@@ -94,9 +95,9 @@ type V2StorageProofCalculator<'a, Provider> = proof_v2::StorageProofCalculator<
 #[derive(Debug, Clone)]
 pub struct ProofWorkerHandle {
     /// Direct sender to storage worker pool
-    storage_work_tx: CrossbeamSender<StorageWorkerJob>,
+    storage_work_tx: Sender<StorageWorkerJob>,
     /// Direct sender to account worker pool
-    account_work_tx: CrossbeamSender<AccountWorkerJob>,
+    account_work_tx: Sender<AccountWorkerJob>,
     /// Counter tracking available storage workers. Workers decrement when starting work,
     /// increment when finishing. Used to determine whether to chunk multiproofs.
     storage_available_workers: Arc<AtomicUsize>,
@@ -299,7 +300,7 @@ impl ProofWorkerHandle {
     pub fn dispatch_storage_proof(
         &self,
         input: StorageProofInput,
-        proof_result_sender: CrossbeamSender<StorageProofResultMessage>,
+        proof_result_sender: Sender<StorageProofResultMessage>,
     ) -> Result<(), ProviderError> {
         let hashed_address = input.hashed_address;
         self.storage_work_tx
@@ -353,7 +354,7 @@ impl ProofWorkerHandle {
         account: B256,
         path: Nibbles,
     ) -> Result<Receiver<TrieNodeProviderResult>, ProviderError> {
-        let (tx, rx) = channel();
+        let (tx, rx) = oneshot();
         self.storage_work_tx
             .send(StorageWorkerJob::BlindedStorageNode { account, path, result_sender: tx })
             .map_err(|_| {
@@ -368,7 +369,7 @@ impl ProofWorkerHandle {
         &self,
         path: Nibbles,
     ) -> Result<Receiver<TrieNodeProviderResult>, ProviderError> {
-        let (tx, rx) = channel();
+        let (tx, rx) = oneshot();
         self.account_work_tx
             .send(AccountWorkerJob::BlindedAccountNode { path, result_sender: tx })
             .map_err(|_| {
@@ -521,7 +522,7 @@ impl TrieNodeProvider for ProofTaskTrieNodeProvider {
 /// `MultiProofTask`.
 ///
 /// Workers use this sender to deliver proof results directly to `MultiProofTask`.
-pub type ProofResultSender = CrossbeamSender<ProofResultMessage>;
+pub type ProofResultSender = Sender<ProofResultMessage>;
 
 /// Message containing a completed proof result with metadata for direct delivery to
 /// `MultiProofTask`.
@@ -596,7 +597,7 @@ pub(crate) enum StorageWorkerJob {
         /// Storage proof input parameters
         input: StorageProofInput,
         /// Context for sending the proof result.
-        proof_result_sender: CrossbeamSender<StorageProofResultMessage>,
+        proof_result_sender: Sender<StorageProofResultMessage>,
     },
     /// Blinded storage node retrieval request
     BlindedStorageNode {
@@ -617,7 +618,7 @@ struct StorageProofWorker<Factory> {
     /// Shared task context with database factory and prefix sets
     task_ctx: ProofTaskCtx<Factory>,
     /// Channel for receiving work
-    work_rx: CrossbeamReceiver<StorageWorkerJob>,
+    work_rx: Receiver<StorageWorkerJob>,
     /// Unique identifier for this worker (used for tracing)
     worker_id: usize,
     /// Counter tracking worker availability
@@ -639,7 +640,7 @@ where
     /// Creates a new storage proof worker.
     const fn new(
         task_ctx: ProofTaskCtx<Factory>,
-        work_rx: CrossbeamReceiver<StorageWorkerJob>,
+        work_rx: Receiver<StorageWorkerJob>,
         worker_id: usize,
         available_workers: Arc<AtomicUsize>,
         cached_storage_roots: Arc<DashMap<B256, B256>>,
@@ -764,7 +765,7 @@ where
             <Provider as HashedCursorFactory>::StorageCursor<'_>,
         >,
         input: StorageProofInput,
-        proof_result_sender: CrossbeamSender<StorageProofResultMessage>,
+        proof_result_sender: Sender<StorageProofResultMessage>,
         storage_proofs_processed: &mut u64,
     ) where
         Provider: TrieCursorFactory + HashedCursorFactory,
@@ -868,11 +869,11 @@ struct AccountProofWorker<Factory> {
     /// Shared task context with database factory and prefix sets
     task_ctx: ProofTaskCtx<Factory>,
     /// Channel for receiving work
-    work_rx: CrossbeamReceiver<AccountWorkerJob>,
+    work_rx: Receiver<AccountWorkerJob>,
     /// Unique identifier for this worker (used for tracing)
     worker_id: usize,
     /// Channel for dispatching storage proof work (for pre-dispatched target proofs)
-    storage_work_tx: CrossbeamSender<StorageWorkerJob>,
+    storage_work_tx: Sender<StorageWorkerJob>,
     /// Counter tracking worker availability
     available_workers: Arc<AtomicUsize>,
     /// Cached storage roots
@@ -893,9 +894,9 @@ where
     #[allow(clippy::too_many_arguments)]
     const fn new(
         task_ctx: ProofTaskCtx<Factory>,
-        work_rx: CrossbeamReceiver<AccountWorkerJob>,
+        work_rx: Receiver<AccountWorkerJob>,
         worker_id: usize,
-        storage_work_tx: CrossbeamSender<StorageWorkerJob>,
+        storage_work_tx: Sender<StorageWorkerJob>,
         available_workers: Arc<AtomicUsize>,
         cached_storage_roots: Arc<DashMap<B256, B256>>,
         #[cfg(feature = "metrics")] metrics: ProofTaskTrieMetrics,
@@ -1195,10 +1196,10 @@ where
 ///
 /// Propagates errors up if queuing fails. Receivers must be consumed by the caller.
 fn dispatch_v2_storage_proofs(
-    storage_work_tx: &CrossbeamSender<StorageWorkerJob>,
+    storage_work_tx: &Sender<StorageWorkerJob>,
     account_targets: &[ProofV2Target],
     mut storage_targets: B256Map<Vec<ProofV2Target>>,
-) -> Result<B256Map<CrossbeamReceiver<StorageProofResultMessage>>, ParallelStateRootError> {
+) -> Result<B256Map<Receiver<StorageProofResultMessage>>, ParallelStateRootError> {
     let mut storage_proof_receivers =
         B256Map::with_capacity_and_hasher(account_targets.len(), Default::default());
 
@@ -1224,7 +1225,7 @@ fn dispatch_v2_storage_proofs(
     // Dispatch all proofs for targeted storage slots
     for (hashed_address, targets) in sorted_storage_targets {
         // Create channel for receiving StorageProofResultMessage
-        let (result_tx, result_rx) = crossbeam_channel::unbounded();
+        let (result_tx, result_rx) = unbounded();
         let input = StorageProofInput::new(hashed_address, targets);
 
         storage_work_tx

--- a/crates/trie/parallel/src/root.rs
+++ b/crates/trie/parallel/src/root.rs
@@ -105,7 +105,7 @@ where
             #[cfg(feature = "metrics")]
             let metrics = self.metrics.storage_trie.clone();
 
-            let (tx, rx) = channel::bounded(1);
+            let (tx, rx) = channel::oneshot();
 
             // Spawn a blocking task to calculate account's storage root from database I/O
             drop(handle.spawn_blocking(move || {

--- a/crates/trie/parallel/src/root.rs
+++ b/crates/trie/parallel/src/root.rs
@@ -7,7 +7,7 @@ use itertools::Itertools;
 use reth_execution_errors::{SparseTrieError, StateProofError, StorageRootError};
 use reth_provider::{DatabaseProviderROFactory, ProviderError};
 use reth_storage_errors::db::DatabaseError;
-use reth_tasks::Runtime;
+use reth_tasks::{channel, Runtime};
 use reth_trie::{
     hashed_cursor::HashedCursorFactory,
     node_iter::{TrieElement, TrieNodeIter},
@@ -17,7 +17,7 @@ use reth_trie::{
     walker::TrieWalker,
     HashBuilder, Nibbles, StorageRoot, TRIE_ACCOUNT_RLP_MAX_SIZE,
 };
-use std::{collections::HashMap, sync::mpsc};
+use std::collections::HashMap;
 use thiserror::Error;
 use tracing::*;
 
@@ -105,7 +105,7 @@ where
             #[cfg(feature = "metrics")]
             let metrics = self.metrics.storage_trie.clone();
 
-            let (tx, rx) = mpsc::sync_channel(1);
+            let (tx, rx) = channel::bounded(1);
 
             // Spawn a blocking task to calculate account's storage root from database I/O
             drop(handle.spawn_blocking(move || {

--- a/crates/trie/parallel/src/value_encoder.rs
+++ b/crates/trie/parallel/src/value_encoder.rs
@@ -2,10 +2,10 @@ use crate::proof_task::StorageProofResultMessage;
 use alloy_primitives::{map::B256Map, B256};
 use alloy_rlp::Encodable;
 use core::cell::RefCell;
-use crossbeam_channel::Receiver as CrossbeamReceiver;
 use reth_execution_errors::trie::StateProofError;
 use reth_primitives_traits::{dashmap::DashMap, Account};
 use reth_storage_errors::db::DatabaseError;
+use reth_tasks::channel::Receiver;
 use reth_trie::{
     hashed_cursor::HashedStorageCursor,
     proof_v2::{DeferredValueEncoder, LeafValueEncoder, StorageProofCalculator},
@@ -56,8 +56,7 @@ pub(crate) enum AsyncAccountDeferredValueEncoder<TC, HC> {
         /// The receiver for the storage proof result. This is an `Option` so that `encode` can
         /// take ownership of the receiver, preventing the `Drop` impl from trying to receive on
         /// it again.
-        proof_result_rx:
-            Option<Result<CrossbeamReceiver<StorageProofResultMessage>, DatabaseError>>,
+        proof_result_rx: Option<Result<Receiver<StorageProofResultMessage>, DatabaseError>>,
         /// Shared storage proof results.
         storage_proof_results: Rc<RefCell<B256Map<Vec<ProofTrieNodeV2>>>>,
         /// Shared stats for tracking wait time and counts.
@@ -212,7 +211,7 @@ where
 /// multiple accounts.
 pub(crate) struct AsyncAccountValueEncoder<TC, HC> {
     /// Storage proof jobs which were dispatched ahead of time.
-    dispatched: B256Map<CrossbeamReceiver<StorageProofResultMessage>>,
+    dispatched: B256Map<Receiver<StorageProofResultMessage>>,
     /// Storage roots which have already been computed. This can be used only if a storage proof
     /// wasn't dispatched for an account, otherwise we must consume the proof result.
     cached_storage_roots: Arc<DashMap<B256, B256>>,
@@ -235,7 +234,7 @@ impl<TC, HC> AsyncAccountValueEncoder<TC, HC> {
     /// - `cached_storage_roots`: Shared cache of already-computed storage roots
     /// - `storage_calculator`: Shared storage proof calculator for synchronous computation
     pub(crate) fn new(
-        dispatched: B256Map<CrossbeamReceiver<StorageProofResultMessage>>,
+        dispatched: B256Map<Receiver<StorageProofResultMessage>>,
         cached_storage_roots: Arc<DashMap<B256, B256>>,
         storage_calculator: Rc<RefCell<StorageProofCalculator<TC, HC>>>,
     ) -> Self {

--- a/crates/trie/trie/Cargo.toml
+++ b/crates/trie/trie/Cargo.toml
@@ -19,6 +19,7 @@ reth-stages-types.workspace = true
 reth-storage-errors.workspace = true
 reth-trie-sparse.workspace = true
 reth-trie-common = { workspace = true, features = ["rayon"] }
+reth-tasks.workspace = true
 
 revm-database.workspace = true
 
@@ -92,6 +93,7 @@ test-utils = [
     "reth-trie-common/test-utils",
     "reth-trie-sparse/test-utils",
     "reth-stages-types/test-utils",
+    "reth-tasks/test-utils",
 ]
 serde-bincode-compat = [
     "alloy-consensus/serde-bincode-compat",

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -19,12 +19,12 @@ use reth_execution_errors::{
     SparseStateTrieErrorKind, SparseTrieError, SparseTrieErrorKind, StateProofError,
     TrieWitnessError,
 };
+use reth_tasks::channel;
 use reth_trie_common::{MultiProofTargets, Nibbles};
 use reth_trie_sparse::{
     provider::{RevealedNode, TrieNodeProvider, TrieNodeProviderFactory},
     SparseStateTrie,
 };
-use std::sync::mpsc;
 
 /// State transition witness for the trie.
 #[derive(Debug)]
@@ -146,7 +146,7 @@ where
             }
         }
 
-        let (tx, rx) = mpsc::channel();
+        let (tx, rx) = channel::unbounded();
         let blinded_provider_factory = WitnessTrieNodeProviderFactory::new(
             ProofTrieNodeProviderFactory::new(self.trie_cursor_factory, self.hashed_cursor_factory),
             tx,
@@ -239,11 +239,11 @@ struct WitnessTrieNodeProviderFactory<F> {
     /// Trie node provider factory.
     provider_factory: F,
     /// Sender for forwarding fetched trie node.
-    tx: mpsc::Sender<Bytes>,
+    tx: channel::Sender<Bytes>,
 }
 
 impl<F> WitnessTrieNodeProviderFactory<F> {
-    const fn new(provider_factory: F, tx: mpsc::Sender<Bytes>) -> Self {
+    const fn new(provider_factory: F, tx: channel::Sender<Bytes>) -> Self {
         Self { provider_factory, tx }
     }
 }
@@ -273,11 +273,11 @@ struct WitnessTrieNodeProvider<P> {
     /// Proof-based blinded.
     provider: P,
     /// Sender for forwarding fetched blinded node.
-    tx: mpsc::Sender<Bytes>,
+    tx: channel::Sender<Bytes>,
 }
 
 impl<P> WitnessTrieNodeProvider<P> {
-    const fn new(provider: P, tx: mpsc::Sender<Bytes>) -> Self {
+    const fn new(provider: P, tx: channel::Sender<Bytes>) -> Self {
         Self { provider, tx }
     }
 }


### PR DESCRIPTION
Adds a `reth_tasks::channel` module that re-exports `crossbeam-channel` types as the canonical channel implementation. Replaces all `std::sync::mpsc` and direct `crossbeam_channel` imports to go through `reth_tasks::channel`.

Mapping:
- `std::sync::mpsc::channel()` → `channel::unbounded()`
- `std::sync::mpsc::sync_channel(n)` → `channel::bounded(n)`
- `crossbeam_channel::{Sender, Receiver, ...}` → `reth_tasks::channel::{Sender, Receiver, ...}`

Prompted by: DaniPopes