### PR TITLE
feat(engine): add persistence backpressure threshold for newPayload

### DIFF
--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -9,6 +9,11 @@ pub const DEFAULT_PERSISTENCE_THRESHOLD: u64 = 2;
 /// How close to the canonical head we persist blocks.
 pub const DEFAULT_MEMORY_BLOCK_BUFFER_TARGET: u64 = 0;
 
+/// Default threshold for persistence backpressure. When the number of in-memory blocks
+/// exceeds this, newPayload processing is delayed until persistence catches up.
+/// `None` means backpressure is disabled.
+pub const DEFAULT_PERSISTENCE_BACKPRESSURE_THRESHOLD: Option<u64> = None;
+
 /// The size of proof targets chunk to spawn in one multiproof calculation.
 pub const DEFAULT_MULTIPROOF_TASK_CHUNK_SIZE: usize = 5;
 
@@ -77,6 +82,15 @@ pub struct TreeConfig {
     ///
     /// Note: this should be less than or equal to `persistence_threshold`.
     memory_block_buffer_target: u64,
+    /// Maximum number of canonical blocks to keep in memory before applying backpressure
+    /// to newPayload processing.
+    ///
+    /// When the number of in-memory blocks (canonical head minus last persisted block)
+    /// exceeds this threshold, newPayload processing will be delayed until persistence
+    /// catches up, forcing a persist if one isn't already in progress.
+    ///
+    /// `None` means backpressure is disabled (default).
+    persistence_backpressure_threshold: Option<u64>,
     /// Number of pending blocks that cannot be executed due to missing parent and
     /// are kept in cache.
     block_buffer_limit: u32,
@@ -147,6 +161,7 @@ impl Default for TreeConfig {
         Self {
             persistence_threshold: DEFAULT_PERSISTENCE_THRESHOLD,
             memory_block_buffer_target: DEFAULT_MEMORY_BLOCK_BUFFER_TARGET,
+            persistence_backpressure_threshold: DEFAULT_PERSISTENCE_BACKPRESSURE_THRESHOLD,
             block_buffer_limit: DEFAULT_BLOCK_BUFFER_LIMIT,
             max_invalid_header_cache_length: DEFAULT_MAX_INVALID_HEADER_CACHE_LENGTH,
             max_execute_block_batch_size: DEFAULT_MAX_EXECUTE_BLOCK_BATCH_SIZE,
@@ -178,6 +193,7 @@ impl TreeConfig {
     pub const fn new(
         persistence_threshold: u64,
         memory_block_buffer_target: u64,
+        persistence_backpressure_threshold: Option<u64>,
         block_buffer_limit: u32,
         max_invalid_header_cache_length: u32,
         max_execute_block_batch_size: usize,
@@ -202,6 +218,7 @@ impl TreeConfig {
         Self {
             persistence_threshold,
             memory_block_buffer_target,
+            persistence_backpressure_threshold,
             block_buffer_limit,
             max_invalid_header_cache_length,
             max_execute_block_batch_size,
@@ -234,6 +251,11 @@ impl TreeConfig {
     /// Return the memory block buffer target.
     pub const fn memory_block_buffer_target(&self) -> u64 {
         self.memory_block_buffer_target
+    }
+
+    /// Return the persistence backpressure threshold.
+    pub const fn persistence_backpressure_threshold(&self) -> Option<u64> {
+        self.persistence_backpressure_threshold
     }
 
     /// Return the block buffer limit.
@@ -341,6 +363,15 @@ impl TreeConfig {
         memory_block_buffer_target: u64,
     ) -> Self {
         self.memory_block_buffer_target = memory_block_buffer_target;
+        self
+    }
+
+    /// Setter for persistence backpressure threshold.
+    pub const fn with_persistence_backpressure_threshold(
+        mut self,
+        persistence_backpressure_threshold: Option<u64>,
+    ) -> Self {
+        self.persistence_backpressure_threshold = persistence_backpressure_threshold;
         self
     }
 

--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -181,6 +181,10 @@ pub struct EngineMetrics {
     pub(crate) failed_forkchoice_updated_response_deliveries: Counter,
     /// block insert duration
     pub(crate) block_insert_total_duration: Histogram,
+    /// The number of times newPayload processing was delayed due to persistence backpressure.
+    pub(crate) persistence_backpressure_count: Counter,
+    /// Duration of persistence backpressure waits.
+    pub(crate) persistence_backpressure_duration: Histogram,
 }
 
 /// Metrics for engine forkchoiceUpdated responses.

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1892,21 +1892,11 @@ where
 
     /// Returns the number of canonical blocks currently held in memory
     /// (i.e., not yet persisted to disk).
-    const fn num_in_memory_blocks(&self) -> u64 {
+    const fn canonical_in_memory_count(&self) -> u64 {
         self.state
             .tree_state
             .canonical_block_number()
             .saturating_sub(self.persistence_state.last_persisted_block.number)
-    }
-
-    /// Returns `true` if the number of in-memory blocks exceeds the configured
-    /// persistence backpressure threshold.
-    const fn exceeds_backpressure_threshold(&self) -> bool {
-        if let Some(threshold) = self.config.persistence_backpressure_threshold() {
-            self.num_in_memory_blocks() > threshold
-        } else {
-            false
-        }
     }
 
     /// Applies persistence backpressure by waiting for any in-progress persistence to complete
@@ -1915,16 +1905,19 @@ where
     /// This is called before processing `newPayload` to prevent unbounded in-memory block
     /// accumulation when persistence can't keep up.
     fn apply_persistence_backpressure(&mut self) -> Result<(), AdvancePersistenceError> {
-        if !self.exceeds_backpressure_threshold() {
+        let Some(threshold) = self.config.persistence_backpressure_threshold() else {
+            return Ok(());
+        };
+
+        if self.canonical_in_memory_count() <= threshold {
             return Ok(());
         }
 
         let start = Instant::now();
-        let in_memory = self.num_in_memory_blocks();
         debug!(
             target: "engine::tree",
-            in_memory_blocks = in_memory,
-            threshold = ?self.config.persistence_backpressure_threshold(),
+            in_memory_blocks = self.canonical_in_memory_count(),
+            threshold,
             "Persistence backpressure triggered, waiting for persistence"
         );
 
@@ -1945,7 +1938,7 @@ where
         debug!(
             target: "engine::tree",
             elapsed = ?wait_duration,
-            in_memory_blocks_after = self.num_in_memory_blocks(),
+            in_memory_blocks_after = self.canonical_in_memory_count(),
             "Persistence backpressure resolved"
         );
 
@@ -1961,9 +1954,7 @@ where
             return false
         }
 
-        let min_block = self.persistence_state.last_persisted_block.number;
-        self.state.tree_state.canonical_block_number().saturating_sub(min_block) >
-            self.config.persistence_threshold()
+        self.canonical_in_memory_count() > self.config.persistence_threshold()
     }
 
     /// Returns a batch of consecutive canonical blocks to persist in the range

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1529,38 +1529,37 @@ where
                                     let _ = tx.send(Err(BeaconOnNewPayloadError::Internal(
                                         Box::new(err),
                                     )));
-                                    return Ok(ops::ControlFlow::Continue(()));
+                                } else {
+                                    let start = Instant::now();
+                                    let gas_used = payload.gas_used();
+                                    let num_hash = payload.num_hash();
+                                    let mut output = self.on_new_payload(payload);
+                                    self.metrics.engine.new_payload.update_response_metrics(
+                                        start,
+                                        &mut self.metrics.engine.forkchoice_updated.latest_finish_at,
+                                        &output,
+                                        gas_used,
+                                    );
+
+                                    let maybe_event =
+                                        output.as_mut().ok().and_then(|out| out.event.take());
+
+                                    // emit response
+                                    if let Err(err) =
+                                        tx.send(output.map(|o| o.outcome).map_err(|e| {
+                                            BeaconOnNewPayloadError::Internal(Box::new(e))
+                                        }))
+                                    {
+                                        warn!(target: "engine::tree", payload=?num_hash, elapsed=?start.elapsed(), "Failed to deliver newPayload response, receiver dropped (request cancelled): {err:?}");
+                                        self.metrics
+                                            .engine
+                                            .failed_new_payload_response_deliveries
+                                            .increment(1);
+                                    }
+
+                                    // handle the event if any
+                                    self.on_maybe_tree_event(maybe_event)?;
                                 }
-
-                                let start = Instant::now();
-                                let gas_used = payload.gas_used();
-                                let num_hash = payload.num_hash();
-                                let mut output = self.on_new_payload(payload);
-                                self.metrics.engine.new_payload.update_response_metrics(
-                                    start,
-                                    &mut self.metrics.engine.forkchoice_updated.latest_finish_at,
-                                    &output,
-                                    gas_used,
-                                );
-
-                                let maybe_event =
-                                    output.as_mut().ok().and_then(|out| out.event.take());
-
-                                // emit response
-                                if let Err(err) =
-                                    tx.send(output.map(|o| o.outcome).map_err(|e| {
-                                        BeaconOnNewPayloadError::Internal(Box::new(e))
-                                    }))
-                                {
-                                    warn!(target: "engine::tree", payload=?num_hash, elapsed=?start.elapsed(), "Failed to deliver newPayload response, receiver dropped (request cancelled): {err:?}");
-                                    self.metrics
-                                        .engine
-                                        .failed_new_payload_response_deliveries
-                                        .increment(1);
-                                }
-
-                                // handle the event if any
-                                self.on_maybe_tree_event(maybe_event)?;
                             }
                             BeaconEngineMessage::RethNewPayload { payload, tx } => {
                                 // Before processing the new payload, we wait for persistence and

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1523,6 +1523,15 @@ where
                                 }
                             }
                             BeaconEngineMessage::NewPayload { payload, tx } => {
+                                // Apply backpressure if too many blocks are in memory
+                                if let Err(err) = self.apply_persistence_backpressure() {
+                                    error!(target: "engine::tree", %err, "Persistence backpressure failed");
+                                    let _ = tx.send(Err(BeaconOnNewPayloadError::Internal(
+                                        Box::new(err),
+                                    )));
+                                    return Ok(ops::ControlFlow::Continue(()));
+                                }
+
                                 let start = Instant::now();
                                 let gas_used = payload.gas_used();
                                 let num_hash = payload.num_hash();
@@ -1880,6 +1889,68 @@ where
         let _ = self.outgoing.send(event).inspect_err(
             |err| error!(target: "engine::tree", "Failed to send internal event: {err:?}"),
         );
+    }
+
+    /// Returns the number of canonical blocks currently held in memory
+    /// (i.e., not yet persisted to disk).
+    const fn num_in_memory_blocks(&self) -> u64 {
+        self.state
+            .tree_state
+            .canonical_block_number()
+            .saturating_sub(self.persistence_state.last_persisted_block.number)
+    }
+
+    /// Returns `true` if the number of in-memory blocks exceeds the configured
+    /// persistence backpressure threshold.
+    const fn exceeds_backpressure_threshold(&self) -> bool {
+        if let Some(threshold) = self.config.persistence_backpressure_threshold() {
+            self.num_in_memory_blocks() > threshold
+        } else {
+            false
+        }
+    }
+
+    /// Applies persistence backpressure by waiting for any in-progress persistence to complete
+    /// and triggering a new one if the in-memory block count still exceeds the threshold.
+    ///
+    /// This is called before processing `newPayload` to prevent unbounded in-memory block
+    /// accumulation when persistence can't keep up.
+    fn apply_persistence_backpressure(&mut self) -> Result<(), AdvancePersistenceError> {
+        if !self.exceeds_backpressure_threshold() {
+            return Ok(());
+        }
+
+        let start = Instant::now();
+        let in_memory = self.num_in_memory_blocks();
+        debug!(
+            target: "engine::tree",
+            in_memory_blocks = in_memory,
+            threshold = ?self.config.persistence_backpressure_threshold(),
+            "Persistence backpressure triggered, waiting for persistence"
+        );
+
+        // If persistence is not in progress, trigger it now
+        if !self.persistence_state.in_progress() {
+            self.advance_persistence()?;
+        }
+
+        // Wait for the in-progress persistence to complete (blocking)
+        if let Some((rx, persistence_start_time, _action)) = self.persistence_state.rx.take() {
+            let result = rx.recv().map_err(|_| AdvancePersistenceError::ChannelClosed)?;
+            self.on_persistence_complete(result, persistence_start_time)?;
+        }
+
+        let wait_duration = start.elapsed();
+        self.metrics.engine.persistence_backpressure_count.increment(1);
+        self.metrics.engine.persistence_backpressure_duration.record(wait_duration);
+        debug!(
+            target: "engine::tree",
+            elapsed = ?wait_duration,
+            in_memory_blocks_after = self.num_in_memory_blocks(),
+            "Persistence backpressure resolved"
+        );
+
+        Ok(())
     }
 
     /// Returns true if the canonical chain length minus the last persisted

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1536,7 +1536,11 @@ where
                                     let mut output = self.on_new_payload(payload);
                                     self.metrics.engine.new_payload.update_response_metrics(
                                         start,
-                                        &mut self.metrics.engine.forkchoice_updated.latest_finish_at,
+                                        &mut self
+                                            .metrics
+                                            .engine
+                                            .forkchoice_updated
+                                            .latest_finish_at,
                                         &output,
                                         gas_used,
                                     );
@@ -1562,92 +1566,107 @@ where
                                 }
                             }
                             BeaconEngineMessage::RethNewPayload { payload, tx } => {
-                                // Before processing the new payload, we wait for persistence and
-                                // cache updates to complete. We do it in parallel, spawning
-                                // persistence and cache update wait tasks with Tokio, so that we
-                                // can get an unbiased breakdown on how long did every step take.
-                                //
-                                // If we first wait for persistence, and only then for cache
-                                // updates, we will offset the cache update waits by the duration of
-                                // persistence, which is incorrect.
-                                debug!(target: "engine::tree", "Waiting for persistence and caches in parallel before processing reth_newPayload");
-
-                                let pending_persistence = self.persistence_state.rx.take();
-                                let persistence_rx = if let Some((rx, start_time, _action)) =
-                                    pending_persistence
-                                {
-                                    let (persistence_tx, persistence_rx) =
-                                        std::sync::mpsc::channel();
-                                    tokio::task::spawn_blocking(move || {
-                                        let start = Instant::now();
-                                        let result =
-                                            rx.recv().expect("persistence state channel closed");
-                                        let _ = persistence_tx.send((
-                                            result,
-                                            start_time,
-                                            start.elapsed(),
-                                        ));
-                                    });
-                                    Some(persistence_rx)
+                                // Apply backpressure if too many blocks are in memory
+                                if let Err(err) = self.apply_persistence_backpressure() {
+                                    error!(target: "engine::tree", %err, "Persistence backpressure failed");
+                                    let _ = tx.send(Err(BeaconOnNewPayloadError::Internal(
+                                        Box::new(err),
+                                    )));
                                 } else {
-                                    None
-                                };
+                                    // Before processing the new payload, we wait for persistence
+                                    // and cache updates to complete. We do it in parallel, spawning
+                                    // persistence and cache update wait tasks with Tokio, so that
+                                    // we can get an unbiased breakdown on how long did every step
+                                    // take.
+                                    //
+                                    // If we first wait for persistence, and only then for cache
+                                    // updates, we will offset the cache update waits by the
+                                    // duration of persistence, which is incorrect.
+                                    debug!(target: "engine::tree", "Waiting for persistence and caches in parallel before processing reth_newPayload");
 
-                                let cache_wait = self.payload_validator.wait_for_caches();
+                                    let pending_persistence = self.persistence_state.rx.take();
+                                    let persistence_rx = if let Some((rx, start_time, _action)) =
+                                        pending_persistence
+                                    {
+                                        let (persistence_tx, persistence_rx) =
+                                            std::sync::mpsc::channel();
+                                        tokio::task::spawn_blocking(move || {
+                                            let start = Instant::now();
+                                            let result = rx
+                                                .recv()
+                                                .expect("persistence state channel closed");
+                                            let _ = persistence_tx.send((
+                                                result,
+                                                start_time,
+                                                start.elapsed(),
+                                            ));
+                                        });
+                                        Some(persistence_rx)
+                                    } else {
+                                        None
+                                    };
 
-                                let persistence_wait = if let Some(persistence_rx) = persistence_rx
-                                {
-                                    let (result, start_time, wait_duration) = persistence_rx
-                                        .recv()
-                                        .expect("persistence result channel closed");
-                                    let _ = self.on_persistence_complete(result, start_time);
-                                    Some(wait_duration)
-                                } else {
-                                    None
-                                };
+                                    let cache_wait = self.payload_validator.wait_for_caches();
 
-                                debug!(
-                                    target: "engine::tree",
-                                    ?persistence_wait,
-                                    execution_cache_wait = ?cache_wait.execution_cache,
-                                    sparse_trie_wait = ?cache_wait.sparse_trie,
-                                    "Persistence finished and caches updated for reth_newPayload"
-                                );
+                                    let persistence_wait = if let Some(persistence_rx) =
+                                        persistence_rx
+                                    {
+                                        let (result, start_time, wait_duration) = persistence_rx
+                                            .recv()
+                                            .expect("persistence result channel closed");
+                                        let _ = self.on_persistence_complete(result, start_time);
+                                        Some(wait_duration)
+                                    } else {
+                                        None
+                                    };
 
-                                let start = Instant::now();
-                                let gas_used = payload.gas_used();
-                                let num_hash = payload.num_hash();
-                                let mut output = self.on_new_payload(payload);
-                                let latency = start.elapsed();
-                                self.metrics.engine.new_payload.update_response_metrics(
-                                    start,
-                                    &mut self.metrics.engine.forkchoice_updated.latest_finish_at,
-                                    &output,
-                                    gas_used,
-                                );
+                                    debug!(
+                                        target: "engine::tree",
+                                        ?persistence_wait,
+                                        execution_cache_wait = ?cache_wait.execution_cache,
+                                        sparse_trie_wait = ?cache_wait.sparse_trie,
+                                        "Persistence finished and caches updated for reth_newPayload"
+                                    );
 
-                                let maybe_event =
-                                    output.as_mut().ok().and_then(|out| out.event.take());
+                                    let start = Instant::now();
+                                    let gas_used = payload.gas_used();
+                                    let num_hash = payload.num_hash();
+                                    let mut output = self.on_new_payload(payload);
+                                    let latency = start.elapsed();
+                                    self.metrics.engine.new_payload.update_response_metrics(
+                                        start,
+                                        &mut self
+                                            .metrics
+                                            .engine
+                                            .forkchoice_updated
+                                            .latest_finish_at,
+                                        &output,
+                                        gas_used,
+                                    );
 
-                                let timings = NewPayloadTimings {
-                                    latency,
-                                    persistence_wait,
-                                    execution_cache_wait: cache_wait.execution_cache,
-                                    sparse_trie_wait: cache_wait.sparse_trie,
-                                };
-                                if let Err(err) =
-                                    tx.send(output.map(|o| (o.outcome, timings)).map_err(|e| {
-                                        BeaconOnNewPayloadError::Internal(Box::new(e))
-                                    }))
-                                {
-                                    error!(target: "engine::tree", payload=?num_hash, elapsed=?start.elapsed(), "Failed to send event: {err:?}");
-                                    self.metrics
-                                        .engine
-                                        .failed_new_payload_response_deliveries
-                                        .increment(1);
+                                    let maybe_event =
+                                        output.as_mut().ok().and_then(|out| out.event.take());
+
+                                    let timings = NewPayloadTimings {
+                                        latency,
+                                        persistence_wait,
+                                        execution_cache_wait: cache_wait.execution_cache,
+                                        sparse_trie_wait: cache_wait.sparse_trie,
+                                    };
+                                    if let Err(err) =
+                                        tx.send(output.map(|o| (o.outcome, timings)).map_err(|e| {
+                                            BeaconOnNewPayloadError::Internal(Box::new(e))
+                                        }))
+                                    {
+                                        error!(target: "engine::tree", payload=?num_hash, elapsed=?start.elapsed(), "Failed to send event: {err:?}");
+                                        self.metrics
+                                            .engine
+                                            .failed_new_payload_response_deliveries
+                                            .increment(1);
+                                    }
+
+                                    self.on_maybe_tree_event(maybe_event)?;
                                 }
-
-                                self.on_maybe_tree_event(maybe_event)?;
                             }
                         }
                     }
@@ -1899,11 +1918,13 @@ where
             .saturating_sub(self.persistence_state.last_persisted_block.number)
     }
 
-    /// Applies persistence backpressure by waiting for any in-progress persistence to complete
-    /// and triggering a new one if the in-memory block count still exceeds the threshold.
+    /// Applies persistence backpressure by blocking until all in-memory blocks are persisted
+    /// to disk.
     ///
-    /// This is called before processing `newPayload` to prevent unbounded in-memory block
-    /// accumulation when persistence can't keep up.
+    /// This is called before processing `newPayload` / `reth_newPayload` to prevent unbounded
+    /// in-memory block accumulation when block production outpaces persistence. When triggered,
+    /// it loops — waiting for any in-progress persistence, then persisting all remaining blocks
+    /// up to the canonical head — until the in-memory count drops below the threshold.
     fn apply_persistence_backpressure(&mut self) -> Result<(), AdvancePersistenceError> {
         let Some(threshold) = self.config.persistence_backpressure_threshold() else {
             return Ok(());
@@ -1921,15 +1942,20 @@ where
             "Persistence backpressure triggered, waiting for persistence"
         );
 
-        // If persistence is not in progress, trigger it now
-        if !self.persistence_state.in_progress() {
-            self.advance_persistence()?;
-        }
+        while self.canonical_in_memory_count() > threshold {
+            // Wait for any in-progress persistence to complete first
+            if let Some((rx, persistence_start_time, _action)) = self.persistence_state.rx.take() {
+                let result = rx.recv().map_err(|_| AdvancePersistenceError::ChannelClosed)?;
+                self.on_persistence_complete(result, persistence_start_time)?;
+                continue;
+            }
 
-        // Wait for the in-progress persistence to complete (blocking)
-        if let Some((rx, persistence_start_time, _action)) = self.persistence_state.rx.take() {
-            let result = rx.recv().map_err(|_| AdvancePersistenceError::ChannelClosed)?;
-            self.on_persistence_complete(result, persistence_start_time)?;
+            // No persistence in progress — persist all blocks up to the canonical head
+            let blocks_to_persist = self.get_canonical_blocks_to_persist(PersistTarget::Head)?;
+            if blocks_to_persist.is_empty() {
+                break;
+            }
+            self.persist_blocks(blocks_to_persist);
         }
 
         let wait_duration = start.elapsed();

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -505,6 +505,7 @@ mod tests {
         let args = EngineArgs {
             persistence_threshold: 100,
             memory_block_buffer_target: 50,
+            persistence_backpressure_threshold: Some(36),
             legacy_state_root_task_enabled: true,
             caching_and_prewarming_enabled: true,
             state_cache_disabled: true,
@@ -538,6 +539,8 @@ mod tests {
             "100",
             "--engine.memory-block-buffer-target",
             "50",
+            "--engine.persistence-backpressure-threshold",
+            "36",
             "--engine.legacy-state-root",
             "--engine.disable-state-cache",
             "--engine.disable-prewarming",

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -245,6 +245,15 @@ pub struct EngineArgs {
     #[arg(long = "engine.memory-block-buffer-target", default_value_t = DefaultEngineValues::get_global().memory_block_buffer_target)]
     pub memory_block_buffer_target: u64,
 
+    /// Configure the maximum number of in-memory blocks before applying backpressure to
+    /// newPayload processing by waiting for persistence to complete.
+    ///
+    /// When set, if the number of in-memory blocks exceeds this threshold, incoming newPayload
+    /// requests will be delayed until persistence catches up. This prevents unbounded memory
+    /// growth when block production outpaces persistence.
+    #[arg(long = "engine.persistence-backpressure-threshold")]
+    pub persistence_backpressure_threshold: Option<u64>,
+
     /// Enable legacy state root
     #[arg(long = "engine.legacy-state-root", default_value_t = DefaultEngineValues::get_global().legacy_state_root_task_enabled)]
     pub legacy_state_root_task_enabled: bool,
@@ -410,6 +419,7 @@ impl Default for EngineArgs {
         Self {
             persistence_threshold,
             memory_block_buffer_target,
+            persistence_backpressure_threshold: None,
             legacy_state_root_task_enabled,
             state_root_task_compare_updates,
             caching_and_prewarming_enabled: true,
@@ -447,6 +457,7 @@ impl EngineArgs {
         TreeConfig::default()
             .with_persistence_threshold(self.persistence_threshold)
             .with_memory_block_buffer_target(self.memory_block_buffer_target)
+            .with_persistence_backpressure_threshold(self.persistence_backpressure_threshold)
             .with_legacy_state_root(self.legacy_state_root_task_enabled)
             .without_state_cache(self.state_cache_disabled)
             .without_prewarming(self.prewarming_disabled)

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -927,6 +927,11 @@ Engine:
 
           [default: 0]
 
+      --engine.persistence-backpressure-threshold <PERSISTENCE_BACKPRESSURE_THRESHOLD>
+          Configure the maximum number of in-memory blocks before applying backpressure to newPayload processing by waiting for persistence to complete.
+
+          When set, if the number of in-memory blocks exceeds this threshold, incoming newPayload requests will be delayed until persistence catches up. This prevents unbounded memory growth when block production outpaces persistence.
+
       --engine.legacy-state-root
           Enable legacy state root
 


### PR DESCRIPTION
## Summary

Introduces a configurable threshold for in-memory blocks waiting to be persisted. When exceeded, `newPayload` processing is delayed until persistence catches up.

## Motivation

When block production outpaces disk persistence, in-memory block count can grow unboundedly. This adds a safety valve: once the in-memory block count exceeds the configured threshold, the engine blocks on incoming `newPayload` requests until persistence completes, preventing OOM scenarios.

## Changes

- `TreeConfig`: new `persistence_backpressure_threshold: Option<u64>` field (disabled by default)
- `EngineApiTreeHandler`: `apply_persistence_backpressure()` method that force-triggers persistence and blocks until complete when threshold is exceeded
- Called before processing `BeaconEngineMessage::NewPayload`
- CLI flag: `--engine.persistence-backpressure-threshold <N>`
- Metrics: `persistence_backpressure_count` and `persistence_backpressure_duration`

## Testing

`cargo check` and `cargo clippy` pass on affected crates. Disabled by default (`None`), so zero impact on existing behavior.

Prompted by: alexey