### PR TITLE
fix(codecs): return advanced buf from AlloyGenesisAccount and AlloyWithdrawal compact decoding

### DIFF
--- a/crates/storage/codecs/src/alloy/genesis_account.rs
+++ b/crates/storage/codecs/src/alloy/genesis_account.rs
@@ -92,7 +92,7 @@ impl Compact for AlloyGenesisAccount {
     }
 
     fn from_compact(buf: &[u8], len: usize) -> (Self, &[u8]) {
-        let (account, _) = GenesisAccount::from_compact(buf, len);
+        let (account, buf) = GenesisAccount::from_compact(buf, len);
         let alloy_account = Self {
             nonce: account.nonce,
             balance: account.balance,

--- a/crates/storage/codecs/src/alloy/withdrawal.rs
+++ b/crates/storage/codecs/src/alloy/withdrawal.rs
@@ -43,7 +43,7 @@ impl Compact for AlloyWithdrawal {
     }
 
     fn from_compact(buf: &[u8], len: usize) -> (Self, &[u8]) {
-        let (withdrawal, _) = Withdrawal::from_compact(buf, len);
+        let (withdrawal, buf) = Withdrawal::from_compact(buf, len);
         let alloy_withdrawal = Self {
             index: withdrawal.index,
             validator_index: withdrawal.validator_index,


### PR DESCRIPTION
`from_compact` on both types was discarding the advanced buffer and returning the original one, which violates the Compact trait contract. Not currently causing issues since neither type is nested inside another Compact struct, but would silently corrupt decoding if that ever changes.