### PR TITLE
fix(ipc): break out of service loop when response stream is closed

### DIFF
--- a/crates/rpc/ipc/src/server/mod.rs
+++ b/crates/rpc/ipc/src/server/mod.rs
@@ -532,9 +532,8 @@ async fn to_ipc_service<S, T>(
                break
             }
             item = rx_item.next() => {
-                if let Some(item) = item {
-                    conn.push_back(item.to_string());
-                }
+                let Some(item) = item else { break };
+                conn.push_back(item.to_string());
             }
             _ = &mut stopped => {
                 // shutdown


### PR DESCRIPTION
When the sender side of the response channel is dropped, `rx_item.next()` returns `None` immediately on every poll, causing the select loop to busy-spin. Break out of the loop on `None` instead of silently ignoring it.