### PR TITLE
perf(engine): use spawn_blocking_named instead of tokio::task::spawn_blocking

### DIFF
--- a/crates/engine/tree/src/launch.rs
+++ b/crates/engine/tree/src/launch.rs
@@ -64,6 +64,7 @@ pub fn build_engine_orchestrator<N, Client, S, V, C>(
     sync_metrics_tx: MetricEventsSender,
     evm_config: C,
     changeset_cache: ChangesetCache,
+    runtime: Runtime,
 ) -> ChainOrchestrator<
     EngineHandler<
         EngineApiRequestHandler<EngineApiRequest<N::Payload, N::Primitives>, N::Primitives>,
@@ -99,6 +100,7 @@ where
         evm_config,
         changeset_cache,
         use_hashed_state,
+        runtime.clone(),
     );
 
     let engine_handler = EngineApiRequestHandler::new(to_tree_tx, from_tree);

--- a/crates/engine/tree/src/launch.rs
+++ b/crates/engine/tree/src/launch.rs
@@ -100,7 +100,7 @@ where
         evm_config,
         changeset_cache,
         use_hashed_state,
-        runtime.clone(),
+        runtime,
     );
 
     let engine_handler = EngineApiRequestHandler::new(to_tree_tx, from_tree);

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1572,28 +1572,25 @@ where
                                 debug!(target: "engine::tree", "Waiting for persistence and caches in parallel before processing reth_newPayload");
 
                                 let pending_persistence = self.persistence_state.rx.take();
-                                let persistence_rx =
-                                    if let Some((rx, start_time, _action)) = pending_persistence {
-                                        let (persistence_tx, persistence_rx) =
-                                            std::sync::mpsc::channel();
-                                        self.runtime.spawn_blocking_named(
-                                            "wait-persistence",
-                                            move || {
-                                                let start = Instant::now();
-                                                let result = rx
-                                                    .recv()
-                                                    .expect("persistence state channel closed");
-                                                let _ = persistence_tx.send((
-                                                    result,
-                                                    start_time,
-                                                    start.elapsed(),
-                                                ));
-                                            },
-                                        );
-                                        Some(persistence_rx)
-                                    } else {
-                                        None
-                                    };
+                                let persistence_rx = if let Some((rx, start_time, _action)) =
+                                    pending_persistence
+                                {
+                                    let (persistence_tx, persistence_rx) =
+                                        std::sync::mpsc::channel();
+                                    self.runtime.spawn_blocking_named("wait-persist", move || {
+                                        let start = Instant::now();
+                                        let result =
+                                            rx.recv().expect("persistence state channel closed");
+                                        let _ = persistence_tx.send((
+                                            result,
+                                            start_time,
+                                            start.elapsed(),
+                                        ));
+                                    });
+                                    Some(persistence_rx)
+                                } else {
+                                    None
+                                };
 
                                 let cache_wait = self.payload_validator.wait_for_caches();
 

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -276,6 +276,8 @@ where
     /// Whether the node uses hashed state as canonical storage (v2 mode).
     /// Cached at construction to avoid threading `StorageSettingsCache` bounds everywhere.
     use_hashed_state: bool,
+    /// Task runtime for spawning blocking work on named, reusable threads.
+    runtime: reth_tasks::Runtime,
 }
 
 impl<N, P: Debug, T: PayloadTypes + Debug, V: Debug, C> std::fmt::Debug
@@ -302,6 +304,7 @@ where
             .field("evm_config", &self.evm_config)
             .field("changeset_cache", &self.changeset_cache)
             .field("use_hashed_state", &self.use_hashed_state)
+            .field("runtime", &self.runtime)
             .finish()
     }
 }
@@ -342,6 +345,7 @@ where
         evm_config: C,
         changeset_cache: ChangesetCache,
         use_hashed_state: bool,
+        runtime: reth_tasks::Runtime,
     ) -> Self {
         let (incoming_tx, incoming) = crossbeam_channel::unbounded();
 
@@ -364,6 +368,7 @@ where
             evm_config,
             changeset_cache,
             use_hashed_state,
+            runtime,
         }
     }
 
@@ -385,6 +390,7 @@ where
         evm_config: C,
         changeset_cache: ChangesetCache,
         use_hashed_state: bool,
+        runtime: reth_tasks::Runtime,
     ) -> (Sender<FromEngine<EngineApiRequest<T, N>, N::Block>>, UnboundedReceiver<EngineApiEvent<N>>)
     {
         let best_block_number = provider.best_block_number().unwrap_or(0);
@@ -418,6 +424,7 @@ where
             evm_config,
             changeset_cache,
             use_hashed_state,
+            runtime,
         );
         let incoming = task.incoming_tx.clone();
         spawn_os_thread("engine", || {
@@ -1411,7 +1418,7 @@ where
         // Spawn a background task to trigger computation so it's ready when the next payload
         // arrives.
         if let Some(overlay) = self.state.tree_state.prepare_canonical_overlay() {
-            tokio::task::spawn_blocking(move || {
+            self.runtime.spawn_blocking_named("prepare-overlay", move || {
                 let _ = overlay.get();
             });
         }
@@ -1565,25 +1572,28 @@ where
                                 debug!(target: "engine::tree", "Waiting for persistence and caches in parallel before processing reth_newPayload");
 
                                 let pending_persistence = self.persistence_state.rx.take();
-                                let persistence_rx = if let Some((rx, start_time, _action)) =
-                                    pending_persistence
-                                {
-                                    let (persistence_tx, persistence_rx) =
-                                        std::sync::mpsc::channel();
-                                    tokio::task::spawn_blocking(move || {
-                                        let start = Instant::now();
-                                        let result =
-                                            rx.recv().expect("persistence state channel closed");
-                                        let _ = persistence_tx.send((
-                                            result,
-                                            start_time,
-                                            start.elapsed(),
-                                        ));
-                                    });
-                                    Some(persistence_rx)
-                                } else {
-                                    None
-                                };
+                                let persistence_rx =
+                                    if let Some((rx, start_time, _action)) = pending_persistence {
+                                        let (persistence_tx, persistence_rx) =
+                                            std::sync::mpsc::channel();
+                                        self.runtime.spawn_blocking_named(
+                                            "wait-persistence",
+                                            move || {
+                                                let start = Instant::now();
+                                                let result = rx
+                                                    .recv()
+                                                    .expect("persistence state channel closed");
+                                                let _ = persistence_tx.send((
+                                                    result,
+                                                    start_time,
+                                                    start.elapsed(),
+                                                ));
+                                            },
+                                        );
+                                        Some(persistence_rx)
+                                    } else {
+                                        None
+                                    };
 
                                 let cache_wait = self.payload_validator.wait_for_caches();
 

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -222,6 +222,7 @@ impl TestHarness {
             evm_config,
             changeset_cache,
             provider.cached_storage_settings().use_hashed_state(),
+            reth_tasks::Runtime::test(),
         );
 
         let block_builder = TestBlockBuilder::default().with_chain_spec((*chain_spec).clone());

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -241,6 +241,7 @@ impl EngineNodeLauncher {
             ctx.sync_metrics_tx(),
             ctx.components().evm_config().clone(),
             changeset_cache,
+            ctx.task_executor().clone(),
         );
 
         info!(target: "reth::cli", "Consensus engine initialized");


### PR DESCRIPTION
Replaces `tokio::task::spawn_blocking` with `Runtime::spawn_blocking_named` in the engine tree hot paths (overlay preparation during persistence and persistence wait during `newPayload`).

Named threads are reused across calls, avoiding thread creation overhead on every invocation.

Prompted by: DaniPopes