### PR TITLE
feat(provider): add storage_range for paginated storage enumeration

### DIFF
--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -3,7 +3,7 @@ use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_genesis::ChainConfig;
 use alloy_json_rpc::RpcObject;
 use alloy_primitives::{Address, Bytes, B256, U64};
-use alloy_rpc_types_debug::ExecutionWitness;
+use alloy_rpc_types_debug::{ExecutionWitness, StorageRangeResult};
 use alloy_rpc_types_eth::{Bundle, StateContext};
 use alloy_rpc_types_trace::geth::{
     BlockTraceResult, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
@@ -394,7 +394,7 @@ pub trait DebugApi<TxReq: RpcObject> {
         contract_address: Address,
         key_start: B256,
         max_result: u64,
-    ) -> RpcResult<()>;
+    ) -> RpcResult<StorageRangeResult>;
 
     /// Returns the structured logs created during the execution of EVM against a block pulled
     /// from the pool of bad ones and returns them as a JSON object. For the second parameter see

--- a/crates/rpc/rpc-eth-api/src/helpers/fee.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/fee.rs
@@ -6,7 +6,7 @@ use alloy_consensus::BlockHeader;
 use alloy_eips::eip7840::BlobParams;
 use alloy_primitives::U256;
 use alloy_rpc_types_eth::{BlockNumberOrTag, FeeHistory};
-use futures::{Future, StreamExt};
+use futures::Future;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_primitives_traits::BlockBody;
 use reth_rpc_eth_types::{
@@ -199,22 +199,18 @@ pub trait EthFees:
                         .unwrap_or_else(BlobParams::cancun);
 
                     base_fee_per_blob_gas.push(header.blob_fee(blob_params).unwrap_or_default());
-                    blob_gas_used_ratio.push(checked_blob_gas_used_ratio(
-                        header.blob_gas_used().unwrap_or_default(),
-                        blob_params.max_blob_gas_per_block(),
-                    ));
-                }
+                    blob_gas_used_ratio.push(
+                        checked_blob_gas_used_ratio(
+                            header.blob_gas_used().unwrap_or_default(),
+                            blob_params.max_blob_gas_per_block(),
+                        )
+                    );
 
-                if let Some(percentiles) = reward_percentiles.as_ref().filter(|p| !p.is_empty()) {
-                    // Fetch blocks and receipts with bounded concurrency (4 in flight). Drive with `while let` so we process each result as it arrives.
-                    let mut stream =
-                        futures::stream::iter(headers.iter().map(|h| h.hash()).collect::<Vec<_>>())
-                            .map(|hash| self.cache().get_block_and_receipts(hash))
-                            .buffered(4);
-                    let mut header_iter = headers.iter();
-                    while let Some(result) = stream.next().await {
-                        let header = header_iter.next().expect("stream length equals headers");
-                        let (block, receipts) = result
+                    // Percentiles were specified, so we need to collect reward percentile info
+                    if let Some(percentiles) = &reward_percentiles {
+                        let (block, receipts) = self.cache()
+                            .get_block_and_receipts(header.hash())
+                            .await
                             .map_err(Self::Error::from_eth_err)?
                             .ok_or(EthApiError::InvalidBlockRange)?;
                         rewards.push(

--- a/crates/rpc/rpc-eth-api/src/helpers/fee.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/fee.rs
@@ -6,7 +6,7 @@ use alloy_consensus::BlockHeader;
 use alloy_eips::eip7840::BlobParams;
 use alloy_primitives::U256;
 use alloy_rpc_types_eth::{BlockNumberOrTag, FeeHistory};
-use futures::Future;
+use futures::{Future, StreamExt};
 use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_primitives_traits::BlockBody;
 use reth_rpc_eth_types::{
@@ -199,18 +199,22 @@ pub trait EthFees:
                         .unwrap_or_else(BlobParams::cancun);
 
                     base_fee_per_blob_gas.push(header.blob_fee(blob_params).unwrap_or_default());
-                    blob_gas_used_ratio.push(
-                        checked_blob_gas_used_ratio(
-                            header.blob_gas_used().unwrap_or_default(),
-                            blob_params.max_blob_gas_per_block(),
-                        )
-                    );
+                    blob_gas_used_ratio.push(checked_blob_gas_used_ratio(
+                        header.blob_gas_used().unwrap_or_default(),
+                        blob_params.max_blob_gas_per_block(),
+                    ));
+                }
 
-                    // Percentiles were specified, so we need to collect reward percentile info
-                    if let Some(percentiles) = &reward_percentiles {
-                        let (block, receipts) = self.cache()
-                            .get_block_and_receipts(header.hash())
-                            .await
+                if let Some(percentiles) = reward_percentiles.as_ref().filter(|p| !p.is_empty()) {
+                    // Fetch blocks and receipts with bounded concurrency (4 in flight). Drive with `while let` so we process each result as it arrives.
+                    let mut stream =
+                        futures::stream::iter(headers.iter().map(|h| h.hash()).collect::<Vec<_>>())
+                            .map(|hash| self.cache().get_block_and_receipts(hash))
+                            .buffered(4);
+                    let mut header_iter = headers.iter();
+                    while let Some(result) = stream.next().await {
+                        let header = header_iter.next().expect("stream length equals headers");
+                        let (block, receipts) = result
                             .map_err(Self::Error::from_eth_err)?
                             .ok_or(EthApiError::InvalidBlockRange)?;
                         rewards.push(

--- a/crates/rpc/rpc-eth-types/src/cache/db.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/db.rs
@@ -154,6 +154,15 @@ impl StateProvider for StateProviderTraitObjWrapper {
         self.0.storage(account, storage_key)
     }
 
+    fn storage_range_iter(
+        &self,
+        address: Address,
+        key_start: B256,
+        limit: usize,
+    ) -> reth_errors::ProviderResult<reth_storage_api::StorageRangeIter> {
+        self.0.storage_range_iter(address, key_start, limit)
+    }
+
     fn account_code(
         &self,
         addr: &Address,

--- a/crates/rpc/rpc-eth-types/src/cache/db.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/db.rs
@@ -154,13 +154,13 @@ impl StateProvider for StateProviderTraitObjWrapper {
         self.0.storage(account, storage_key)
     }
 
-    fn storage_range_iter(
+    fn storage_range(
         &self,
         address: Address,
         key_start: B256,
         limit: usize,
-    ) -> reth_errors::ProviderResult<reth_storage_api::StorageRangeIter> {
-        self.0.storage_range_iter(address, key_start, limit)
+    ) -> reth_errors::ProviderResult<Vec<(B256, reth_primitives_traits::StorageEntry)>> {
+        self.0.storage_range(address, key_start, limit)
     }
 
     fn account_code(

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -727,7 +727,7 @@ where
                 if !has_overlay {
                     // Fast path: provider result is authoritative, use it
                     // directly with limit + 1 to detect next_key.
-                    let iter = StateProvider::storage_range_iter(
+                    let entries = StateProvider::storage_range(
                         &db.database.0,
                         contract_address,
                         key_start,
@@ -737,8 +737,7 @@ where
 
                     let mut storage = BTreeMap::new();
                     let mut next_key = None;
-                    for entry in iter {
-                        let (hash, se) = entry.map_err(Eth::Error::from_eth_err)?;
+                    for (hash, se) in entries {
                         if storage.len() >= limit {
                             next_key = Some(hash);
                             break;
@@ -769,7 +768,7 @@ where
                 let overlay_size = overlay.map_or(0, |s| s.len());
                 let provider_limit = limit.saturating_add(overlay_size).saturating_add(1);
 
-                let base_iter = StateProvider::storage_range_iter(
+                let base_entries = StateProvider::storage_range(
                     &db.database.0,
                     contract_address,
                     key_start,
@@ -779,8 +778,7 @@ where
 
                 // Collect base entries keyed by plain slot for overlay merge
                 let mut merged: BTreeMap<B256, U256> = BTreeMap::new();
-                for entry in base_iter {
-                    let (_hash, se) = entry.map_err(Eth::Error::from_eth_err)?;
+                for (_hash, se) in base_entries {
                     merged.insert(se.key, se.value);
                 }
 

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -3,10 +3,10 @@ use alloy_eip7928::BlockAccessList;
 use alloy_eips::{eip2718::Encodable2718, BlockId, BlockNumberOrTag};
 use alloy_evm::{env::BlockEnvironment, Evm};
 use alloy_genesis::ChainConfig;
-use alloy_primitives::{hex::decode, uint, Address, Bytes, B256, U64};
+use alloy_primitives::{hex::decode, keccak256, uint, Address, Bytes, B256, U256, U64};
 use alloy_rlp::{Decodable, Encodable};
 use alloy_rpc_types::BlockTransactionsKind;
-use alloy_rpc_types_debug::ExecutionWitness;
+use alloy_rpc_types_debug::{ExecutionWitness, StorageRangeResult, StorageResult};
 use alloy_rpc_types_eth::{state::EvmOverrides, BlockError, Bundle, StateContext};
 use alloy_rpc_types_trace::geth::{
     BlockTraceResult, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
@@ -33,15 +33,18 @@ use reth_rpc_eth_types::EthApiError;
 use reth_rpc_server_types::{result::internal_rpc_err, ToRpcResult};
 use reth_storage_api::{
     BlockIdReader, BlockReaderIdExt, HashedPostStateProvider, HeaderProvider, ProviderBlock,
-    ReceiptProviderIdExt, StateProofProvider, StateProviderFactory, StateRootProvider,
-    TransactionVariant,
+    ReceiptProviderIdExt, StateProofProvider, StateProvider, StateProviderFactory,
+    StateRootProvider, TransactionVariant,
 };
 use reth_tasks::{pool::BlockingTaskGuard, Runtime};
 use reth_trie_common::{updates::TrieUpdates, HashedPostState};
 use revm::{database::states::bundle_state::BundleRetention, DatabaseCommit};
 use revm_inspectors::tracing::{DebugInspector, TransactionContext};
 use serde::{Deserialize, Serialize};
-use std::{collections::VecDeque, sync::Arc};
+use std::{
+    collections::{BTreeMap, VecDeque},
+    sync::Arc,
+};
 use tokio::sync::{AcquireError, OwnedSemaphorePermit};
 use tokio_stream::StreamExt;
 
@@ -665,6 +668,160 @@ where
             })
             .await
     }
+
+    /// Returns the contract storage for the given address at the block and transaction index.
+    ///
+    /// Replays all transactions up to the given index to build the intermediate state, then
+    /// enumerates storage slots keyed by their keccak hash.
+    pub async fn debug_storage_range_at(
+        &self,
+        block_hash: B256,
+        tx_idx: usize,
+        contract_address: Address,
+        key_start: B256,
+        max_result: u64,
+    ) -> Result<StorageRangeResult, Eth::Error> {
+        let block = self
+            .eth_api()
+            .recovered_block(block_hash.into())
+            .await?
+            .ok_or(EthApiError::HeaderNotFound(block_hash.into()))?;
+
+        if tx_idx > block.transaction_count() {
+            return Err(EthApiError::InvalidParams(format!(
+                "tx index {} out of range for block with {} transactions",
+                tx_idx,
+                block.transaction_count()
+            ))
+            .into())
+        }
+
+        let evm_env = self.eth_api().evm_env_for_header(block.sealed_block().sealed_header())?;
+        let parent_hash = block.parent_hash();
+
+        self.eth_api()
+            .spawn_with_state_at_block(parent_hash, move |eth_api, mut db| {
+                eth_api.apply_pre_execution_changes(&block, &mut db)?;
+
+                // Replay transactions before tx_idx to reach the desired intermediate state
+                let mut evm = eth_api.evm_config().evm_with_env(&mut db, evm_env);
+                for tx in block.transactions_recovered().take(tx_idx) {
+                    let tx_env = eth_api.evm_config().tx_env(tx);
+                    evm.transact_commit(tx_env).map_err(Eth::Error::from_evm_err)?;
+                }
+                drop(evm);
+
+                let limit = max_result as usize;
+
+                // Check whether replayed transactions modified this contract's
+                // storage. When there is no overlay we can push both key_start
+                // AND limit into the provider and consume its iterator directly
+                // — one pass, no re-hashing, no intermediate collections.
+                let has_overlay = db
+                    .cache
+                    .accounts
+                    .get(&contract_address)
+                    .and_then(|a| a.account.as_ref())
+                    .is_some_and(|a| !a.storage.is_empty());
+
+                if !has_overlay {
+                    // Fast path: provider result is authoritative, use it
+                    // directly with limit + 1 to detect next_key.
+                    let iter = StateProvider::storage_range_iter(
+                        &db.database.0,
+                        contract_address,
+                        key_start,
+                        limit + 1,
+                    )
+                    .map_err(Eth::Error::from_eth_err)?;
+
+                    let mut storage = BTreeMap::new();
+                    let mut next_key = None;
+                    for entry in iter {
+                        let (hash, se) = entry.map_err(Eth::Error::from_eth_err)?;
+                        if storage.len() >= limit {
+                            next_key = Some(hash);
+                            break;
+                        }
+                        storage.insert(
+                            hash,
+                            StorageResult {
+                                key: se.key,
+                                value: B256::from(se.value.to_be_bytes()),
+                            },
+                        );
+                    }
+
+                    return Ok(StorageRangeResult { storage: storage.into(), next_key });
+                }
+
+                // Slow path: overlay exists, so we fetch extra entries from
+                // the provider to compensate for slots the overlay may delete.
+                // The overlay can remove at most `overlay_size` base entries,
+                // so `limit + overlay_size` guarantees enough candidates.
+                let overlay = db
+                    .cache
+                    .accounts
+                    .get(&contract_address)
+                    .and_then(|a| a.account.as_ref())
+                    .map(|a| &a.storage);
+
+                let overlay_size = overlay.map_or(0, |s| s.len());
+                let provider_limit = limit.saturating_add(overlay_size).saturating_add(1);
+
+                let base_iter = StateProvider::storage_range_iter(
+                    &db.database.0,
+                    contract_address,
+                    key_start,
+                    provider_limit,
+                )
+                .map_err(Eth::Error::from_eth_err)?;
+
+                // Collect base entries keyed by plain slot for overlay merge
+                let mut merged: BTreeMap<B256, U256> = BTreeMap::new();
+                for entry in base_iter {
+                    let (_hash, se) = entry.map_err(Eth::Error::from_eth_err)?;
+                    merged.insert(se.key, se.value);
+                }
+
+                // Apply overlay — writes override base, zeroes delete
+                if let Some(overlay) = overlay {
+                    for (slot, value) in overlay {
+                        let key = B256::from(*slot);
+                        if value.is_zero() {
+                            merged.remove(&key);
+                        } else {
+                            merged.insert(key, *value);
+                        }
+                    }
+                }
+
+                // Hash, filter by key_start, sort, and paginate
+                let mut hashed: BTreeMap<B256, (B256, U256)> = BTreeMap::new();
+                for (slot, value) in &merged {
+                    let h = keccak256(slot);
+                    if h >= key_start {
+                        hashed.insert(h, (*slot, *value));
+                    }
+                }
+
+                let mut storage = BTreeMap::new();
+                let mut next_key = None;
+                for (hash, (slot, value)) in &hashed {
+                    if storage.len() >= limit {
+                        next_key = Some(*hash);
+                        break;
+                    }
+                    storage.insert(
+                        *hash,
+                        StorageResult { key: *slot, value: B256::from(value.to_be_bytes()) },
+                    );
+                }
+
+                Ok(StorageRangeResult { storage: storage.into(), next_key })
+            })
+            .await
+    }
 }
 
 #[async_trait]
@@ -1100,13 +1257,23 @@ where
 
     async fn debug_storage_range_at(
         &self,
-        _block_hash: B256,
-        _tx_idx: usize,
-        _contract_address: Address,
-        _key_start: B256,
-        _max_result: u64,
-    ) -> RpcResult<()> {
-        Ok(())
+        block_hash: B256,
+        tx_idx: usize,
+        contract_address: Address,
+        key_start: B256,
+        max_result: u64,
+    ) -> RpcResult<StorageRangeResult> {
+        let _permit = self.acquire_trace_permit().await;
+        Self::debug_storage_range_at(
+            self,
+            block_hash,
+            tx_idx,
+            contract_address,
+            key_start,
+            max_result,
+        )
+        .await
+        .map_err(Into::into)
     }
 
     async fn debug_trace_bad_block(

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -6,12 +6,13 @@ use alloy_eips::merge::EPOCH_SLOTS;
 use alloy_primitives::{Address, BlockNumber, Bytes, StorageKey, StorageValue, B256};
 use reth_db_api::{
     cursor::{DbCursorRO, DbDupCursorRO},
+    models::storage_sharded_key::StorageShardedKey,
     table::Table,
     tables,
     transaction::DbTx,
     BlockNumberList,
 };
-use reth_primitives_traits::{Account, Bytecode};
+use reth_primitives_traits::{Account, Bytecode, StorageEntry};
 use reth_storage_api::{
     BlockNumReader, BytecodeReader, DBProvider, NodePrimitivesProvider, StateProofProvider,
     StorageChangeSetReader, StorageRootProvider, StorageSettingsCache,
@@ -31,6 +32,7 @@ use reth_trie_db::{
     hashed_storage_from_reverts_with_provider, DatabaseProof, DatabaseStateRoot,
     DatabaseStorageProof, DatabaseStorageRoot,
 };
+use std::collections::{BTreeMap, BTreeSet};
 
 use std::fmt::Debug;
 
@@ -569,6 +571,76 @@ impl<
         storage_key: StorageKey,
     ) -> ProviderResult<Option<StorageValue>> {
         self.storage_by_lookup_key(address, storage_key)
+    }
+
+    fn storage_range_iter(
+        &self,
+        address: Address,
+        key_start: B256,
+        limit: usize,
+    ) -> ProviderResult<reth_storage_api::StorageRangeIter> {
+        if !self.lowest_available_blocks.is_storage_history_available(self.block_number) {
+            return Err(ProviderError::StateAtBlockPruned(self.block_number));
+        }
+
+        // Scan StoragesHistory to discover all unique plain slot keys for this address.
+        // The [address|key|block] key layout keeps all entries for one address contiguous.
+        let slots: BTreeSet<B256> = self.provider.with_rocksdb_tx(|_rocks_tx_ref| {
+            let mut slots = BTreeSet::new();
+
+            #[cfg(all(unix, feature = "rocksdb"))]
+            if let Some(rocks_tx) = _rocks_tx_ref {
+                let iter = rocks_tx.iter_from::<tables::StoragesHistory>(
+                    StorageShardedKey::new(address, B256::ZERO, 0),
+                )?;
+                for entry in iter {
+                    let (key, _) = entry?;
+                    if key.address != address {
+                        break;
+                    }
+                    slots.insert(key.sharded_key.key);
+                }
+                return Ok(slots);
+            }
+
+            // v1: MDBX cursor
+            let mut cursor = self.tx().cursor_read::<tables::StoragesHistory>()?;
+            let walker = cursor.walk_range(
+                StorageShardedKey::new(address, B256::ZERO, 0)..=
+                    StorageShardedKey::last(address, B256::repeat_byte(0xff)),
+            )?;
+            for entry in walker {
+                let (key, _) = entry?;
+                slots.insert(key.sharded_key.key);
+            }
+            Ok(slots)
+        })?;
+
+        // Phase 1 (CPU only): hash each slot, filter by key_start, sort, and
+        // truncate to `limit` so that only the needed slots proceed to the
+        // expensive history lookup in phase 2.
+        let mut candidates: BTreeMap<B256, B256> = BTreeMap::new();
+        for slot in &slots {
+            let hashed = alloy_primitives::keccak256(slot);
+            if hashed >= key_start {
+                candidates.insert(hashed, *slot);
+            }
+        }
+        // Phase 2 (bounded I/O): iterate candidates in hash order, look up
+        // historical values, and stop once we have `limit` non-zero entries.
+        let mut result: BTreeMap<B256, StorageEntry> = BTreeMap::new();
+        for (hashed, slot) in candidates {
+            if let Some(value) = self.storage_by_lookup_key(address, slot)? &&
+                value != StorageValue::ZERO
+            {
+                result.insert(hashed, StorageEntry::new(slot, value));
+                if result.len() == limit {
+                    break;
+                }
+            }
+        }
+
+        Ok(reth_storage_api::StorageRangeIter::new(result.into_iter().map(Ok)))
     }
 }
 

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -574,18 +574,16 @@ impl<
         self.storage_by_lookup_key(address, storage_key)
     }
 
-    fn storage_range_iter(
+    fn storage_range(
         &self,
         address: Address,
         key_start: B256,
         limit: usize,
-    ) -> ProviderResult<reth_storage_api::StorageRangeIter> {
+    ) -> ProviderResult<Vec<(B256, StorageEntry)>> {
         if !self.lowest_available_blocks.is_storage_history_available(self.block_number) {
             return Err(ProviderError::StateAtBlockPruned(self.block_number));
         }
 
-        // Scan StoragesHistory to discover all unique plain slot keys for this address.
-        // The [address|key|block] key layout keeps all entries for one address contiguous.
         let slots: BTreeSet<B256> = self.provider.with_rocksdb_tx(|_rocks_tx_ref| {
             let mut slots = BTreeSet::new();
 
@@ -604,7 +602,6 @@ impl<
                 return Ok(slots);
             }
 
-            // v1: MDBX cursor
             let mut cursor = self.tx().cursor_read::<tables::StoragesHistory>()?;
             let walker = cursor.walk_range(
                 StorageShardedKey::new(address, B256::ZERO, 0)..=
@@ -617,9 +614,6 @@ impl<
             Ok(slots)
         })?;
 
-        // Phase 1 (CPU only): hash each slot, filter by key_start, sort, and
-        // truncate to `limit` so that only the needed slots proceed to the
-        // expensive history lookup in phase 2.
         let mut candidates: BTreeMap<B256, B256> = BTreeMap::new();
         for slot in &slots {
             let hashed = alloy_primitives::keccak256(slot);
@@ -627,21 +621,20 @@ impl<
                 candidates.insert(hashed, *slot);
             }
         }
-        // Phase 2 (bounded I/O): iterate candidates in hash order, look up
-        // historical values, and stop once we have `limit` non-zero entries.
-        let mut result: BTreeMap<B256, StorageEntry> = BTreeMap::new();
+
+        let mut result: Vec<(B256, StorageEntry)> = Vec::new();
         for (hashed, slot) in candidates {
             if let Some(value) = self.storage_by_lookup_key(address, slot)? &&
                 value != StorageValue::ZERO
             {
-                result.insert(hashed, StorageEntry::new(slot, value));
+                result.push((hashed, StorageEntry::new(slot, value)));
                 if result.len() == limit {
                     break;
                 }
             }
         }
 
-        Ok(reth_storage_api::StorageRangeIter::new(result.into_iter().map(Ok)))
+        Ok(result)
     }
 }
 

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -32,9 +32,10 @@ use reth_trie_db::{
     hashed_storage_from_reverts_with_provider, DatabaseProof, DatabaseStateRoot,
     DatabaseStorageProof, DatabaseStorageRoot,
 };
-use std::collections::{BTreeMap, BTreeSet};
-
-use std::fmt::Debug;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt::Debug,
+};
 
 type DbStateRoot<'a, TX, A> = StateRoot<
     reth_trie_db::DatabaseTrieCursorFactory<&'a TX, A>,

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -625,7 +625,7 @@ impl<
         let mut result: Vec<(B256, StorageEntry)> = Vec::new();
         for (hashed, slot) in candidates {
             if let Some(value) = self.storage_by_lookup_key(address, slot)? &&
-                value != StorageValue::ZERO
+                !value.is_zero()
             {
                 result.push((hashed, StorageEntry::new(slot, value)));
                 if result.len() == limit {

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -275,20 +275,18 @@ impl<Provider: DBProvider + BlockHashReader + StorageSettingsCache> StateProvide
         }
     }
 
-    fn storage_range_iter(
+    fn storage_range(
         &self,
         address: Address,
         key_start: B256,
         limit: usize,
-    ) -> ProviderResult<reth_storage_api::StorageRangeIter> {
+    ) -> ProviderResult<Vec<(B256, StorageEntry)>> {
         if self.0.cached_storage_settings().use_hashed_state() {
-            return Ok(reth_storage_api::StorageRangeIter::empty());
+            return Ok(Vec::new());
         }
 
         let mut cursor = self.tx().cursor_dup_read::<tables::PlainStorageState>()?;
         let mut result: BTreeMap<B256, StorageEntry> = BTreeMap::new();
-        // Track the highest hash so we can evict entries beyond `limit`
-        // without rebuilding the entire map.
         let mut cutoff: Option<B256> = None;
         let walker = cursor.walk_dup(Some(address), None)?;
         for entry in walker {
@@ -300,8 +298,6 @@ impl<Provider: DBProvider + BlockHashReader + StorageSettingsCache> StateProvide
             if hashed < key_start {
                 continue;
             }
-            // Skip entries beyond the current cutoff — they can't make it
-            // into the top `limit` entries.
             if let Some(c) = cutoff &&
                 hashed >= c
             {
@@ -309,8 +305,6 @@ impl<Provider: DBProvider + BlockHashReader + StorageSettingsCache> StateProvide
             }
             result.insert(hashed, storage_entry);
             if result.len() > limit {
-                // Remove the largest entry and update the cutoff so future
-                // entries beyond this point are skipped entirely.
                 cutoff = result.keys().next_back().copied();
                 if let Some(c) = cutoff {
                     result.remove(&c);
@@ -318,7 +312,7 @@ impl<Provider: DBProvider + BlockHashReader + StorageSettingsCache> StateProvide
             }
         }
 
-        Ok(reth_storage_api::StorageRangeIter::new(result.into_iter().map(Ok)))
+        Ok(result.into_iter().collect())
     }
 }
 

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -3,7 +3,7 @@ use crate::{
 };
 use alloy_primitives::{Address, BlockNumber, Bytes, StorageKey, StorageValue, B256};
 use reth_db_api::{cursor::DbDupCursorRO, tables, transaction::DbTx};
-use reth_primitives_traits::{Account, Bytecode};
+use reth_primitives_traits::{Account, Bytecode, StorageEntry};
 use reth_storage_api::{
     BytecodeReader, DBProvider, StateProofProvider, StorageRootProvider, StorageSettingsCache,
 };
@@ -18,6 +18,7 @@ use reth_trie::{
     StateRoot, StorageMultiProof, StorageRoot, TrieInput, TrieInputSorted,
 };
 use reth_trie_db::{DatabaseProof, DatabaseStateRoot, DatabaseStorageProof, DatabaseStorageRoot};
+use std::collections::BTreeMap;
 
 type DbStateRoot<'a, TX, A> = StateRoot<
     reth_trie_db::DatabaseTrieCursorFactory<&'a TX, A>,
@@ -272,6 +273,45 @@ impl<Provider: DBProvider + BlockHashReader + StorageSettingsCache> StateProvide
             }
             Ok(None)
         }
+    }
+
+    fn storage_range_iter(
+        &self,
+        address: Address,
+        key_start: B256,
+        limit: usize,
+    ) -> ProviderResult<reth_storage_api::StorageRangeIter> {
+        if self.0.cached_storage_settings().use_hashed_state() {
+            // v2: HashedStorages only stores the hashed slot, so the original
+            // plain slot is unrecoverable. This path is unreachable in practice
+            // since debug_storageRangeAt uses the historical provider via
+            // spawn_with_state_at_block.
+            return Ok(reth_storage_api::StorageRangeIter::empty());
+        }
+
+        // v1: walk the PlainStorageState dup cursor for the address.
+        // We must hash every slot (keccak is unpredictable) but truncate to
+        // `limit` entries so the caller only pays for the requested page.
+        let mut cursor = self.tx().cursor_dup_read::<tables::PlainStorageState>()?;
+        let mut result: BTreeMap<B256, StorageEntry> = BTreeMap::new();
+        let walker = cursor.walk_dup(Some(address), None)?;
+        for entry in walker {
+            let (_, storage_entry) = entry?;
+            if storage_entry.value == StorageValue::ZERO {
+                continue;
+            }
+            let hashed = alloy_primitives::keccak256(storage_entry.key);
+            if hashed < key_start {
+                continue;
+            }
+            result.insert(hashed, storage_entry);
+        }
+
+        if result.len() > limit {
+            result = result.into_iter().take(limit).collect();
+        }
+
+        Ok(reth_storage_api::StorageRangeIter::new(result.into_iter().map(Ok)))
     }
 }
 

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -282,18 +282,14 @@ impl<Provider: DBProvider + BlockHashReader + StorageSettingsCache> StateProvide
         limit: usize,
     ) -> ProviderResult<reth_storage_api::StorageRangeIter> {
         if self.0.cached_storage_settings().use_hashed_state() {
-            // v2: HashedStorages only stores the hashed slot, so the original
-            // plain slot is unrecoverable. This path is unreachable in practice
-            // since debug_storageRangeAt uses the historical provider via
-            // spawn_with_state_at_block.
             return Ok(reth_storage_api::StorageRangeIter::empty());
         }
 
-        // v1: walk the PlainStorageState dup cursor for the address.
-        // We must hash every slot (keccak is unpredictable) but truncate to
-        // `limit` entries so the caller only pays for the requested page.
         let mut cursor = self.tx().cursor_dup_read::<tables::PlainStorageState>()?;
         let mut result: BTreeMap<B256, StorageEntry> = BTreeMap::new();
+        // Track the highest hash so we can evict entries beyond `limit`
+        // without rebuilding the entire map.
+        let mut cutoff: Option<B256> = None;
         let walker = cursor.walk_dup(Some(address), None)?;
         for entry in walker {
             let (_, storage_entry) = entry?;
@@ -304,11 +300,22 @@ impl<Provider: DBProvider + BlockHashReader + StorageSettingsCache> StateProvide
             if hashed < key_start {
                 continue;
             }
+            // Skip entries beyond the current cutoff — they can't make it
+            // into the top `limit` entries.
+            if let Some(c) = cutoff &&
+                hashed >= c
+            {
+                continue;
+            }
             result.insert(hashed, storage_entry);
-        }
-
-        if result.len() > limit {
-            result = result.into_iter().take(limit).collect();
+            if result.len() > limit {
+                // Remove the largest entry and update the cutoff so future
+                // entries beyond this point are skipped entirely.
+                cutoff = result.keys().next_back().copied();
+                if let Some(c) = cutoff {
+                    result.remove(&c);
+                }
+            }
         }
 
         Ok(reth_storage_api::StorageRangeIter::new(result.into_iter().map(Ok)))

--- a/crates/storage/storage-api/src/macros.rs
+++ b/crates/storage/storage-api/src/macros.rs
@@ -41,7 +41,7 @@ macro_rules! delegate_provider_impls {
             }
             StateProvider $(where [$($generics)*])? {
                 fn storage(&self, account: alloy_primitives::Address, storage_key: alloy_primitives::StorageKey) -> reth_storage_api::errors::provider::ProviderResult<Option<alloy_primitives::StorageValue>>;
-                fn storage_range_iter(&self, address: alloy_primitives::Address, key_start: alloy_primitives::B256, limit: usize) -> reth_storage_api::errors::provider::ProviderResult<reth_storage_api::StorageRangeIter>;
+                fn storage_range(&self, address: alloy_primitives::Address, key_start: alloy_primitives::B256, limit: usize) -> reth_storage_api::errors::provider::ProviderResult<Vec<(alloy_primitives::B256, reth_primitives_traits::StorageEntry)>>;
             }
             BytecodeReader $(where [$($generics)*])? {
                 fn bytecode_by_hash(&self, code_hash: &alloy_primitives::B256) -> reth_storage_api::errors::provider::ProviderResult<Option<reth_primitives_traits::Bytecode>>;

--- a/crates/storage/storage-api/src/macros.rs
+++ b/crates/storage/storage-api/src/macros.rs
@@ -41,6 +41,7 @@ macro_rules! delegate_provider_impls {
             }
             StateProvider $(where [$($generics)*])? {
                 fn storage(&self, account: alloy_primitives::Address, storage_key: alloy_primitives::StorageKey) -> reth_storage_api::errors::provider::ProviderResult<Option<alloy_primitives::StorageValue>>;
+                fn storage_range_iter(&self, address: alloy_primitives::Address, key_start: alloy_primitives::B256, limit: usize) -> reth_storage_api::errors::provider::ProviderResult<reth_storage_api::StorageRangeIter>;
             }
             BytecodeReader $(where [$($generics)*])? {
                 fn bytecode_by_hash(&self, code_hash: &alloy_primitives::B256) -> reth_storage_api::errors::provider::ProviderResult<Option<reth_primitives_traits::Bytecode>>;

--- a/crates/storage/storage-api/src/state.rs
+++ b/crates/storage/storage-api/src/state.rs
@@ -2,7 +2,7 @@ use super::{
     AccountReader, BlockHashReader, BlockIdReader, StateProofProvider, StateRootProvider,
     StorageRootProvider,
 };
-use alloc::boxed::Box;
+use alloc::{boxed::Box, vec::Vec};
 use alloy_consensus::constants::KECCAK_EMPTY;
 use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_primitives::{Address, BlockHash, BlockNumber, StorageKey, StorageValue, B256, U256};
@@ -29,43 +29,6 @@ pub trait StateReader: Send {
 /// Type alias of boxed [`StateProvider`].
 pub type StateProviderBox = Box<dyn StateProvider + Send + 'static>;
 
-/// Iterator over storage entries for [`StateProvider::storage_range_iter`].
-///
-/// Wraps a boxed, type-erased iterator that yields `(hashed_slot, StorageEntry)` pairs
-/// sorted by `hashed_slot`. The `B256` key is `keccak256(plain_slot)` and the
-/// [`StorageEntry`] contains the original plain slot key and its value.
-pub struct StorageRangeIter {
-    inner: Box<dyn Iterator<Item = ProviderResult<(B256, StorageEntry)>> + Send + 'static>,
-}
-
-impl StorageRangeIter {
-    /// Creates a new iterator from any compatible iterator.
-    pub fn new(
-        iter: impl Iterator<Item = ProviderResult<(B256, StorageEntry)>> + Send + 'static,
-    ) -> Self {
-        Self { inner: Box::new(iter) }
-    }
-
-    /// Creates an empty iterator that yields no items.
-    pub fn empty() -> Self {
-        Self { inner: Box::new(core::iter::empty()) }
-    }
-}
-
-impl Iterator for StorageRangeIter {
-    type Item = ProviderResult<(B256, StorageEntry)>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.inner.next()
-    }
-}
-
-impl core::fmt::Debug for StorageRangeIter {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("StorageRangeIter").finish_non_exhaustive()
-    }
-}
-
 /// An abstraction for a type that provides state data.
 #[auto_impl(&, Arc, Box)]
 pub trait StateProvider:
@@ -84,19 +47,19 @@ pub trait StateProvider:
         storage_key: StorageKey,
     ) -> ProviderResult<Option<StorageValue>>;
 
-    /// Returns an iterator over storage entries for `address` whose hashed slot
-    /// is greater than or equal to `key_start`, ordered by hashed slot.
+    /// Returns storage entries for `address` whose hashed slot is greater than
+    /// or equal to `key_start`, ordered by hashed slot, up to `limit` entries.
     ///
-    /// Each yielded item is `(keccak256(slot), StorageEntry)` where
-    /// [`StorageEntry`] contains both the plain slot key and its value.
-    /// Zero-valued slots are excluded.
-    fn storage_range_iter(
+    /// Each entry is `(keccak256(slot), StorageEntry)` where [`StorageEntry`]
+    /// contains both the plain slot key and its value. Zero-valued slots are
+    /// excluded.
+    fn storage_range(
         &self,
         _address: Address,
         _key_start: B256,
         _limit: usize,
-    ) -> ProviderResult<StorageRangeIter> {
-        Ok(StorageRangeIter::empty())
+    ) -> ProviderResult<Vec<(B256, StorageEntry)>> {
+        Ok(Vec::new())
     }
 
     /// Get account code by its address.

--- a/crates/storage/storage-api/src/state.rs
+++ b/crates/storage/storage-api/src/state.rs
@@ -8,7 +8,7 @@ use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_primitives::{Address, BlockHash, BlockNumber, StorageKey, StorageValue, B256, U256};
 use auto_impl::auto_impl;
 use reth_execution_types::ExecutionOutcome;
-use reth_primitives_traits::Bytecode;
+use reth_primitives_traits::{Bytecode, StorageEntry};
 use reth_storage_errors::provider::ProviderResult;
 use reth_trie_common::HashedPostState;
 use revm_database::BundleState;
@@ -29,6 +29,43 @@ pub trait StateReader: Send {
 /// Type alias of boxed [`StateProvider`].
 pub type StateProviderBox = Box<dyn StateProvider + Send + 'static>;
 
+/// Iterator over storage entries for [`StateProvider::storage_range_iter`].
+///
+/// Wraps a boxed, type-erased iterator that yields `(hashed_slot, StorageEntry)` pairs
+/// sorted by `hashed_slot`. The `B256` key is `keccak256(plain_slot)` and the
+/// [`StorageEntry`] contains the original plain slot key and its value.
+pub struct StorageRangeIter {
+    inner: Box<dyn Iterator<Item = ProviderResult<(B256, StorageEntry)>> + Send + 'static>,
+}
+
+impl StorageRangeIter {
+    /// Creates a new iterator from any compatible iterator.
+    pub fn new(
+        iter: impl Iterator<Item = ProviderResult<(B256, StorageEntry)>> + Send + 'static,
+    ) -> Self {
+        Self { inner: Box::new(iter) }
+    }
+
+    /// Creates an empty iterator that yields no items.
+    pub fn empty() -> Self {
+        Self { inner: Box::new(core::iter::empty()) }
+    }
+}
+
+impl Iterator for StorageRangeIter {
+    type Item = ProviderResult<(B256, StorageEntry)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+}
+
+impl core::fmt::Debug for StorageRangeIter {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("StorageRangeIter").finish_non_exhaustive()
+    }
+}
+
 /// An abstraction for a type that provides state data.
 #[auto_impl(&, Arc, Box)]
 pub trait StateProvider:
@@ -46,6 +83,21 @@ pub trait StateProvider:
         account: Address,
         storage_key: StorageKey,
     ) -> ProviderResult<Option<StorageValue>>;
+
+    /// Returns an iterator over storage entries for `address` whose hashed slot
+    /// is greater than or equal to `key_start`, ordered by hashed slot.
+    ///
+    /// Each yielded item is `(keccak256(slot), StorageEntry)` where
+    /// [`StorageEntry`] contains both the plain slot key and its value.
+    /// Zero-valued slots are excluded.
+    fn storage_range_iter(
+        &self,
+        _address: Address,
+        _key_start: B256,
+        _limit: usize,
+    ) -> ProviderResult<StorageRangeIter> {
+        Ok(StorageRangeIter::empty())
+    }
 
     /// Get account code by its address.
     ///


### PR DESCRIPTION
Adds `StateProvider::storage_range(address, key_start, limit) -> Vec<(B256, StorageEntry)>` to support efficient paginated storage enumeration, and wires it into `debug_storageRangeAt`.

The historical impl scans `StoragesHistory` to discover slots, then bounds expensive `storage_by_lookup_key` calls to the `limit` candidates. The latest impl uses a cutoff trick on a BTreeMap to cap memory.

Ref #22655