### PR TITLE
perf(trie): wait for pending changeset computation instead of DB fallback

### DIFF
--- a/.changelog/icy-tigers-buzz.md
+++ b/.changelog/icy-tigers-buzz.md
@@ -1,0 +1,6 @@
+---
+reth-trie-db: minor
+reth-engine-tree: minor
+---
+
+Added `PendingChangeset` and `PendingChangesetGuard` to `ChangesetCache` so concurrent readers wait for an in-progress computation instead of falling back to the expensive DB-based path. The guard automatically cancels the pending entry on drop (e.g. task panic), ensuring waiters always make progress.

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -43,7 +43,7 @@ use reth_provider::{
     StateProviderFactory, StateReader, StorageChangeSetReader, StorageSettingsCache,
 };
 use reth_revm::db::{states::bundle_state::BundleRetention, State};
-use reth_trie::{updates::TrieUpdates, HashedPostState, StateRoot};
+use reth_trie::{trie_cursor::TrieCursorFactory, updates::TrieUpdates, HashedPostState, StateRoot};
 use reth_trie_db::ChangesetCache;
 use reth_trie_parallel::root::{ParallelStateRoot, ParallelStateRootError};
 use revm_primitives::Address;
@@ -740,13 +740,20 @@ where
             let _ = valid_block_tx.send(());
         }
 
+        // Create the overlay provider NOW, while we're on the engine loop thread and trie changeset
+        // eviction cannot race with us. If we deferred this to the background task, persistence
+        // could advance and evict changeset cache entries between factory creation and the task
+        // actually running, causing expensive DB fallback computations when building the overlay.
+        let changeset_provider =
+            ensure_ok_post_block!(overlay_factory.database_provider_ro(), block);
+
         Ok(self.spawn_deferred_trie_task(
             block,
             output,
             &ctx,
             hashed_state,
             trie_output,
-            overlay_factory,
+            changeset_provider,
         ))
     }
 
@@ -1535,7 +1542,7 @@ where
         ctx: &TreeCtx<'_, N>,
         hashed_state: LazyHashedPostState,
         trie_output: Arc<TrieUpdates>,
-        overlay_factory: OverlayStateProviderFactory<P>,
+        changeset_provider: impl TrieCursorFactory + Send + 'static,
     ) -> ExecutedBlock<N> {
         // Capture parent hash and ancestor overlays for deferred trie input construction.
         let (anchor_hash, overlay_blocks) = ctx
@@ -1569,24 +1576,6 @@ where
         // this computation to finish rather than falling back to the expensive DB path.
         // The guard ensures the pending entry is cancelled if the task panics.
         let pending_changeset_guard = self.changeset_cache.register_pending(block_hash);
-
-        // Create the overlay provider NOW, while we're on the engine loop thread and
-        // eviction cannot race with us. If we deferred this to the background task,
-        // persistence could advance and evict changeset cache entries between factory
-        // creation and the task actually running, causing expensive DB fallback
-        // computations when building the overlay.
-        let changeset_provider = match overlay_factory.database_provider_ro() {
-            Ok(provider) => Some(provider),
-            Err(err) => {
-                warn!(
-                    target: "engine::tree::payload_validator",
-                    ?block_number,
-                    %err,
-                    "Failed to create overlay provider for deferred changeset computation"
-                );
-                None
-            }
-        };
 
         // Spawn background task to compute trie data. Calling `wait_cloned` will compute from
         // the stored inputs and cache the result, so subsequent calls return immediately.
@@ -1626,12 +1615,11 @@ where
                 // eviction that can happen between task spawn and execution.
                 let changeset_start = Instant::now();
 
-                let changeset_result = changeset_provider.as_ref().map(|provider| {
-                    reth_trie::changesets::compute_trie_changesets(provider, &computed.trie_updates)
-                });
-
-                match changeset_result {
-                    Some(Ok(changesets)) => {
+                match reth_trie::changesets::compute_trie_changesets(
+                    &changeset_provider,
+                    &computed.trie_updates,
+                ) {
+                    Ok(changesets) => {
                         debug!(
                             target: "engine::tree::changeset",
                             ?block_number,
@@ -1641,16 +1629,13 @@ where
 
                         pending_changeset_guard.resolve(block_number, Arc::new(changesets));
                     }
-                    Some(Err(e)) => {
+                    Err(e) => {
                         warn!(
                             target: "engine::tree::changeset",
                             ?block_number,
                             ?e,
                             "Failed to compute changesets in deferred trie task"
                         );
-                    }
-                    None => {
-                        // Provider creation failed; already logged at spawn time
                     }
                 }
             }));

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1564,19 +1564,15 @@ where
         // Capture block info and cache handle for changeset computation
         let block_hash = block.hash();
         let block_number = block.number();
-        let changeset_cache = self.changeset_cache.clone();
 
         // Register a pending changeset entry so that concurrent readers will wait for
         // this computation to finish rather than falling back to the expensive DB path.
         // The guard ensures the pending entry is cancelled if the task panics.
-        let pending_guard = changeset_cache.register_pending(block_hash);
+        let pending_changeset_guard = self.changeset_cache.register_pending(block_hash);
 
         // Spawn background task to compute trie data. Calling `wait_cloned` will compute from
         // the stored inputs and cache the result, so subsequent calls return immediately.
         let compute_trie_input_task = move || {
-            // Move the guard into the task so it's dropped (and cancelled) on panic.
-            let _pending_guard = pending_guard;
-
             let _span = debug_span!(
                 target: "engine::tree::payload_validator",
                 "compute_trie_input_task",
@@ -1629,7 +1625,7 @@ where
                             "Computed and caching changesets"
                         );
 
-                        changeset_cache.insert(block_hash, block_number, Arc::new(changesets));
+                        pending_changeset_guard.resolve(block_number, Arc::new(changesets));
                     }
                     Err(e) => {
                         warn!(

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1575,7 +1575,18 @@ where
         // persistence could advance and evict changeset cache entries between factory
         // creation and the task actually running, causing expensive DB fallback
         // computations when building the overlay.
-        let changeset_provider = overlay_factory.database_provider_ro().ok();
+        let changeset_provider = match overlay_factory.database_provider_ro() {
+            Ok(provider) => Some(provider),
+            Err(err) => {
+                warn!(
+                    target: "engine::tree::payload_validator",
+                    ?block_number,
+                    %err,
+                    "Failed to create overlay provider for deferred changeset computation"
+                );
+                None
+            }
+        };
 
         // Spawn background task to compute trie data. Calling `wait_cloned` will compute from
         // the stored inputs and cache the result, so subsequent calls return immediately.
@@ -1615,23 +1626,12 @@ where
                 // eviction that can happen between task spawn and execution.
                 let changeset_start = Instant::now();
 
-                let changeset_result = changeset_provider
-                    .as_ref()
-                    .ok_or_else(|| {
-                        ProviderError::other(std::io::Error::other(
-                            "overlay provider was not created during validation",
-                        ))
-                    })
-                    .and_then(|provider| {
-                        reth_trie::changesets::compute_trie_changesets(
-                            provider,
-                            &computed.trie_updates,
-                        )
-                        .map_err(ProviderError::Database)
-                    });
+                let changeset_result = changeset_provider.as_ref().map(|provider| {
+                    reth_trie::changesets::compute_trie_changesets(provider, &computed.trie_updates)
+                });
 
                 match changeset_result {
-                    Ok(changesets) => {
+                    Some(Ok(changesets)) => {
                         debug!(
                             target: "engine::tree::changeset",
                             ?block_number,
@@ -1641,13 +1641,16 @@ where
 
                         pending_changeset_guard.resolve(block_number, Arc::new(changesets));
                     }
-                    Err(e) => {
+                    Some(Err(e)) => {
                         warn!(
                             target: "engine::tree::changeset",
                             ?block_number,
                             ?e,
                             "Failed to compute changesets in deferred trie task"
                         );
+                    }
+                    None => {
+                        // Provider creation failed; already logged at spawn time
                     }
                 }
             }));

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1566,9 +1566,17 @@ where
         let block_number = block.number();
         let changeset_cache = self.changeset_cache.clone();
 
+        // Register a pending changeset entry so that concurrent readers will wait for
+        // this computation to finish rather than falling back to the expensive DB path.
+        // The guard ensures the pending entry is cancelled if the task panics.
+        let pending_guard = changeset_cache.register_pending(block_hash);
+
         // Spawn background task to compute trie data. Calling `wait_cloned` will compute from
         // the stored inputs and cache the result, so subsequent calls return immediately.
         let compute_trie_input_task = move || {
+            // Move the guard into the task so it's dropped (and cancelled) on panic.
+            let _pending_guard = pending_guard;
+
             let _span = debug_span!(
                 target: "engine::tree::payload_validator",
                 "compute_trie_input_task",

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1570,6 +1570,13 @@ where
         // The guard ensures the pending entry is cancelled if the task panics.
         let pending_changeset_guard = self.changeset_cache.register_pending(block_hash);
 
+        // Create the overlay provider NOW, while we're on the engine loop thread and
+        // eviction cannot race with us. If we deferred this to the background task,
+        // persistence could advance and evict changeset cache entries between factory
+        // creation and the task actually running, causing expensive DB fallback
+        // computations when building the overlay.
+        let changeset_provider = overlay_factory.database_provider_ro().ok();
+
         // Spawn background task to compute trie data. Calling `wait_cloned` will compute from
         // the stored inputs and cache the result, so subsequent calls return immediately.
         let compute_trie_input_task = move || {
@@ -1603,14 +1610,21 @@ where
                         .record(anchored.trie_input.state.total_len() as f64);
                 }
 
-                // Compute and cache changesets using the computed trie_updates
+                // Compute and cache changesets using the computed trie_updates.
+                // Use the pre-created provider to avoid races with changeset cache
+                // eviction that can happen between task spawn and execution.
                 let changeset_start = Instant::now();
 
-                // Get a provider from the overlay factory for trie cursor access
-                let changeset_result =
-                    overlay_factory.database_provider_ro().and_then(|provider| {
+                let changeset_result = changeset_provider
+                    .as_ref()
+                    .ok_or_else(|| {
+                        ProviderError::other(std::io::Error::other(
+                            "overlay provider was not created during validation",
+                        ))
+                    })
+                    .and_then(|provider| {
                         reth_trie::changesets::compute_trie_changesets(
-                            &provider,
+                            provider,
                             &computed.trie_updates,
                         )
                         .map_err(ProviderError::Database)

--- a/crates/trie/db/src/changesets.rs
+++ b/crates/trie/db/src/changesets.rs
@@ -11,7 +11,7 @@ use crate::{
     DatabaseHashedCursorFactory, DatabaseStateRoot, DatabaseTrieCursorFactory, TrieTableAdapter,
 };
 use alloy_primitives::{map::B256Map, BlockNumber, B256};
-use parking_lot::{Condvar, Mutex, RwLock};
+use parking_lot::RwLock;
 use reth_primitives_traits::FastInstant as Instant;
 use reth_storage_api::{
     BlockNumReader, ChangeSetReader, DBProvider, StageCheckpointReader, StorageChangeSetReader,
@@ -24,8 +24,13 @@ use reth_trie::{
     TrieInputSorted,
 };
 use reth_trie_common::updates::{StorageTrieUpdatesSorted, TrieUpdatesSorted};
-use std::{collections::BTreeMap, fmt, ops::RangeInclusive, sync::Arc};
-use tracing::debug;
+use std::{
+    collections::BTreeMap,
+    fmt,
+    ops::RangeInclusive,
+    sync::{Arc, OnceLock},
+};
+use tracing::{debug, debug_span};
 
 #[cfg(feature = "metrics")]
 use reth_metrics::{
@@ -303,46 +308,38 @@ where
 /// finishes, it waits on this entry instead of falling back to the expensive
 /// DB-based computation.
 struct PendingChangeset {
-    /// `None` while pending, `Some(Some(..))` when resolved with data,
-    /// `Some(None)` when cancelled (e.g. due to panic).
-    result: Mutex<Option<Option<Arc<TrieUpdatesSorted>>>>,
-    ready: Condvar,
+    /// `None` when cancelled (e.g. due to panic), `Some(..)` when resolved with data.
+    result: OnceLock<Option<Arc<TrieUpdatesSorted>>>,
 }
 
 impl PendingChangeset {
     const fn new() -> Self {
-        Self { result: Mutex::new(None), ready: Condvar::new() }
+        Self { result: OnceLock::new() }
     }
 
     /// Blocks until the computation finishes. Returns `Some` if resolved with data,
     /// `None` if the computation was cancelled.
     fn wait(&self) -> Option<Arc<TrieUpdatesSorted>> {
-        let mut result = self.result.lock();
-        while result.is_none() {
-            self.ready.wait(&mut result);
-        }
-        result.as_ref().expect("checked above").clone()
+        let _span =
+            debug_span!(target: "trie::changeset_cache", "waiting_for_pending_changeset").entered();
+        self.result.wait().clone()
     }
 
     /// Resolves the pending computation with the given result, waking all waiters.
     fn resolve(&self, changesets: Arc<TrieUpdatesSorted>) {
-        let mut result = self.result.lock();
-        *result = Some(Some(changesets));
-        self.ready.notify_all();
+        let _ = self.result.set(Some(changesets));
     }
 
     /// Cancels the pending computation, waking all waiters so they fall through
     /// to the DB fallback.
     fn cancel(&self) {
-        let mut result = self.result.lock();
-        *result = Some(None);
-        self.ready.notify_all();
+        let _ = self.result.set(None);
     }
 }
 
 impl fmt::Debug for PendingChangeset {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let is_resolved = self.result.lock().is_some();
+        let is_resolved = self.result.get().is_some();
         f.debug_struct("PendingChangeset").field("resolved", &is_resolved).finish()
     }
 }
@@ -392,7 +389,7 @@ impl ChangesetCache {
     /// * `block_hash` - Hash of the block
     /// * `block_number` - Block number for tracking and eviction
     /// * `changesets` - Trie changesets to cache
-    pub fn insert(&self, block_hash: B256, block_number: u64, changesets: Arc<TrieUpdatesSorted>) {
+    fn insert(&self, block_hash: B256, block_number: u64, changesets: Arc<TrieUpdatesSorted>) {
         let pending = {
             let mut cache = self.inner.write();
             cache.insert(block_hash, block_number, Arc::clone(&changesets));
@@ -418,8 +415,9 @@ impl ChangesetCache {
     /// waiters fall through to the DB fallback.
     pub fn register_pending(&self, block_hash: B256) -> PendingChangesetGuard {
         let pending = Arc::new(PendingChangeset::new());
-        self.inner.write().pending.insert(block_hash, Arc::clone(&pending));
-        PendingChangesetGuard { cache: self.clone(), block_hash, pending }
+        let prev = self.inner.write().pending.insert(block_hash, Arc::clone(&pending));
+        debug_assert!(prev.is_none(), "duplicate pending changeset for {block_hash:?}");
+        PendingChangesetGuard { cache: self.clone(), block_hash, pending: Some(pending) }
     }
 
     /// Evicts changesets for blocks below the given block number.
@@ -668,14 +666,26 @@ impl ChangesetCache {
 
 /// Guard for a pending changeset computation.
 ///
-/// Returned by [`ChangesetCache::register_pending`]. If dropped without the pending entry
-/// being resolved (e.g. via [`ChangesetCache::insert`]), the pending entry is automatically
-/// removed so waiters fall through to the DB fallback.
-#[must_use = "the guard must be kept alive until the changeset is inserted into the cache"]
+/// Returned by [`ChangesetCache::register_pending`]. Must be resolved via [`Self::resolve`]
+/// to insert the computed changesets into the cache and wake waiting threads.
+///
+/// If dropped without resolving (e.g. due to a panic), the pending entry is automatically
+/// cancelled so waiters fall through to the DB fallback.
+#[must_use = "call .resolve() to insert changesets into the cache"]
 pub struct PendingChangesetGuard {
     cache: ChangesetCache,
     block_hash: B256,
-    pending: Arc<PendingChangeset>,
+    /// `None` after [`Self::resolve`] has been called.
+    pending: Option<Arc<PendingChangeset>>,
+}
+
+impl PendingChangesetGuard {
+    /// Resolves the pending computation by inserting the changesets into the cache
+    /// and waking all waiting threads.
+    pub fn resolve(mut self, block_number: u64, changesets: Arc<TrieUpdatesSorted>) {
+        self.cache.insert(self.block_hash, block_number, changesets);
+        self.pending = None;
+    }
 }
 
 impl fmt::Debug for PendingChangesetGuard {
@@ -686,13 +696,14 @@ impl fmt::Debug for PendingChangesetGuard {
 
 impl Drop for PendingChangesetGuard {
     fn drop(&mut self) {
-        // If `insert()` was already called for this block hash, the pending entry has been
-        // removed from the map and resolved — this is a no-op.
-        // If not (e.g. the deferred task panicked), cancel the pending entry so waiters
-        // don't block forever and can fall through to the DB computation.
+        let Some(pending) = self.pending.take() else {
+            // Guard was resolved successfully already, no-op
+            return
+        };
+
         let removed = self.cache.inner.write().pending.remove(&self.block_hash);
         if let Some(removed) = removed {
-            if Arc::ptr_eq(&removed, &self.pending) {
+            if Arc::ptr_eq(&removed, &pending) {
                 debug!(
                     target: "trie::changeset_cache",
                     block_hash = ?self.block_hash,

--- a/crates/trie/db/src/changesets.rs
+++ b/crates/trie/db/src/changesets.rs
@@ -11,7 +11,7 @@ use crate::{
     DatabaseHashedCursorFactory, DatabaseStateRoot, DatabaseTrieCursorFactory, TrieTableAdapter,
 };
 use alloy_primitives::{map::B256Map, BlockNumber, B256};
-use parking_lot::RwLock;
+use parking_lot::{Condvar, Mutex, RwLock};
 use reth_primitives_traits::FastInstant as Instant;
 use reth_storage_api::{
     BlockNumReader, ChangeSetReader, DBProvider, StageCheckpointReader, StorageChangeSetReader,
@@ -24,7 +24,7 @@ use reth_trie::{
     TrieInputSorted,
 };
 use reth_trie_common::updates::{StorageTrieUpdatesSorted, TrieUpdatesSorted};
-use std::{collections::BTreeMap, ops::RangeInclusive, sync::Arc};
+use std::{collections::BTreeMap, fmt, ops::RangeInclusive, sync::Arc};
 use tracing::debug;
 
 #[cfg(feature = "metrics")]
@@ -296,6 +296,57 @@ where
     Ok(TrieUpdatesSorted::new(account_nodes, storage_tries))
 }
 
+/// A pending changeset computation that other threads can wait on.
+///
+/// When a deferred trie task starts computing changesets for a block, it registers
+/// a pending entry. If another thread needs the same changeset before the computation
+/// finishes, it waits on this entry instead of falling back to the expensive
+/// DB-based computation.
+struct PendingChangeset {
+    /// `None` while pending, `Some(Some(..))` when resolved with data,
+    /// `Some(None)` when cancelled (e.g. due to panic).
+    result: Mutex<Option<Option<Arc<TrieUpdatesSorted>>>>,
+    ready: Condvar,
+}
+
+impl PendingChangeset {
+    const fn new() -> Self {
+        Self { result: Mutex::new(None), ready: Condvar::new() }
+    }
+
+    /// Blocks until the computation finishes. Returns `Some` if resolved with data,
+    /// `None` if the computation was cancelled.
+    fn wait(&self) -> Option<Arc<TrieUpdatesSorted>> {
+        let mut result = self.result.lock();
+        while result.is_none() {
+            self.ready.wait(&mut result);
+        }
+        result.as_ref().expect("checked above").clone()
+    }
+
+    /// Resolves the pending computation with the given result, waking all waiters.
+    fn resolve(&self, changesets: Arc<TrieUpdatesSorted>) {
+        let mut result = self.result.lock();
+        *result = Some(Some(changesets));
+        self.ready.notify_all();
+    }
+
+    /// Cancels the pending computation, waking all waiters so they fall through
+    /// to the DB fallback.
+    fn cancel(&self) {
+        let mut result = self.result.lock();
+        *result = Some(None);
+        self.ready.notify_all();
+    }
+}
+
+impl fmt::Debug for PendingChangeset {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let is_resolved = self.result.lock().is_some();
+        f.debug_struct("PendingChangeset").field("resolved", &is_resolved).finish()
+    }
+}
+
 /// Thread-safe changeset cache.
 ///
 /// This type wraps a shared, mutable reference to the cache inner.
@@ -330,6 +381,9 @@ impl ChangesetCache {
 
     /// Inserts changesets for a block into the cache.
     ///
+    /// Also resolves any pending computation for this block hash, waking threads
+    /// that are waiting for the result.
+    ///
     /// This method does not perform any eviction. Eviction must be explicitly
     /// triggered by calling `evict()`.
     ///
@@ -339,7 +393,33 @@ impl ChangesetCache {
     /// * `block_number` - Block number for tracking and eviction
     /// * `changesets` - Trie changesets to cache
     pub fn insert(&self, block_hash: B256, block_number: u64, changesets: Arc<TrieUpdatesSorted>) {
-        self.inner.write().insert(block_hash, block_number, changesets)
+        let pending = {
+            let mut cache = self.inner.write();
+            cache.insert(block_hash, block_number, Arc::clone(&changesets));
+            cache.pending.remove(&block_hash)
+        };
+
+        // Resolve pending entry outside the write lock to avoid holding it
+        // while waiters wake up.
+        if let Some(pending) = pending {
+            pending.resolve(changesets);
+        }
+    }
+
+    /// Registers a pending changeset computation for the given block hash.
+    ///
+    /// Call this before starting changeset computation so that concurrent
+    /// readers can wait for the result instead of falling back to the expensive
+    /// DB-based computation.
+    ///
+    /// The returned [`PendingChangesetGuard`] must be used to resolve or cancel
+    /// the pending entry. If dropped without resolving (e.g. due to a panic),
+    /// the pending entry is automatically removed from the cache so that
+    /// waiters fall through to the DB fallback.
+    pub fn register_pending(&self, block_hash: B256) -> PendingChangesetGuard {
+        let pending = Arc::new(PendingChangeset::new());
+        self.inner.write().pending.insert(block_hash, Arc::clone(&pending));
+        PendingChangesetGuard { cache: self.clone(), block_hash, pending }
     }
 
     /// Evicts changesets for blocks below the given block number.
@@ -357,8 +437,10 @@ impl ChangesetCache {
 
     /// Gets changesets from cache, or computes them on-the-fly if missing.
     ///
-    /// This is the primary API for retrieving changesets. On cache miss,
-    /// it computes changesets from the database state and populates the cache.
+    /// This is the primary API for retrieving changesets. It checks three sources in order:
+    /// 1. **Cache hit** — returns immediately
+    /// 2. **Pending computation** — blocks until the deferred trie task finishes
+    /// 3. **DB fallback** — computes from database state (expensive)
     ///
     /// # Arguments
     ///
@@ -368,7 +450,7 @@ impl ChangesetCache {
     ///
     /// # Returns
     ///
-    /// Changesets for the block, either from cache or computed on-the-fly
+    /// Changesets for the block, either from cache, a pending computation, or computed on-the-fly
     pub fn get_or_compute<P>(
         &self,
         block_hash: B256,
@@ -383,8 +465,8 @@ impl ChangesetCache {
             + BlockNumReader
             + StorageSettingsCache,
     {
-        // Try cache first (with read lock)
-        {
+        // Try cache first, and if missing, check for a pending computation.
+        let pending = {
             let cache = self.inner.read();
             if let Some(changesets) = cache.get(&block_hash) {
                 debug!(
@@ -395,9 +477,41 @@ impl ChangesetCache {
                 );
                 return Ok(changesets);
             }
+            cache.pending.get(&block_hash).cloned()
+        };
+
+        // If there's a pending computation, wait for it instead of computing from DB.
+        if let Some(pending) = pending {
+            debug!(
+                target: "trie::changeset_cache",
+                ?block_hash,
+                block_number,
+                "Changeset cache MISS but pending computation found, waiting"
+            );
+
+            let start = Instant::now();
+
+            if let Some(changesets) = pending.wait() {
+                debug!(
+                    target: "trie::changeset_cache",
+                    ?block_hash,
+                    block_number,
+                    elapsed = ?start.elapsed(),
+                    "Pending changeset resolved"
+                );
+                return Ok(changesets);
+            }
+
+            debug!(
+                target: "trie::changeset_cache",
+                ?block_hash,
+                block_number,
+                elapsed = ?start.elapsed(),
+                "Pending changeset was cancelled, falling through to DB computation"
+            );
         }
 
-        // Cache miss - compute from database
+        // No cache hit and no pending computation - compute from database
         debug!(
             target: "trie::changeset_cache",
             ?block_hash,
@@ -423,10 +537,7 @@ impl ChangesetCache {
         );
 
         // Store in cache (with write lock)
-        {
-            let mut cache = self.inner.write();
-            cache.insert(block_hash, block_number, Arc::clone(&changesets));
-        }
+        self.insert(block_hash, block_number, Arc::clone(&changesets));
 
         debug!(
             target: "trie::changeset_cache",
@@ -555,6 +666,47 @@ impl ChangesetCache {
     }
 }
 
+/// Guard for a pending changeset computation.
+///
+/// Returned by [`ChangesetCache::register_pending`]. If dropped without the pending entry
+/// being resolved (e.g. via [`ChangesetCache::insert`]), the pending entry is automatically
+/// removed so waiters fall through to the DB fallback.
+#[must_use = "the guard must be kept alive until the changeset is inserted into the cache"]
+pub struct PendingChangesetGuard {
+    cache: ChangesetCache,
+    block_hash: B256,
+    pending: Arc<PendingChangeset>,
+}
+
+impl fmt::Debug for PendingChangesetGuard {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PendingChangesetGuard").field("block_hash", &self.block_hash).finish()
+    }
+}
+
+impl Drop for PendingChangesetGuard {
+    fn drop(&mut self) {
+        // If `insert()` was already called for this block hash, the pending entry has been
+        // removed from the map and resolved — this is a no-op.
+        // If not (e.g. the deferred task panicked), cancel the pending entry so waiters
+        // don't block forever and can fall through to the DB computation.
+        let removed = self.cache.inner.write().pending.remove(&self.block_hash);
+        if let Some(removed) = removed {
+            if Arc::ptr_eq(&removed, &self.pending) {
+                debug!(
+                    target: "trie::changeset_cache",
+                    block_hash = ?self.block_hash,
+                    "Pending changeset dropped without resolution, cancelling"
+                );
+                removed.cancel();
+            } else {
+                // Put it back — it belongs to a different registration.
+                self.cache.inner.write().pending.insert(self.block_hash, removed);
+            }
+        }
+    }
+}
+
 /// In-memory cache for trie changesets with explicit eviction policy.
 ///
 /// Holds changesets for blocks that have been validated but not yet persisted.
@@ -582,6 +734,10 @@ struct ChangesetCacheInner {
 
     /// Block number to hashes mapping for eviction
     block_numbers: BTreeMap<u64, Vec<B256>>,
+
+    /// Pending changeset computations: block hash -> pending entry.
+    /// Threads waiting on a pending entry will block until it's resolved.
+    pending: B256Map<Arc<PendingChangeset>>,
 
     /// Metrics for monitoring cache behavior
     #[cfg(feature = "metrics")]
@@ -624,6 +780,7 @@ impl ChangesetCacheInner {
         Self {
             entries: B256Map::default(),
             block_numbers: BTreeMap::new(),
+            pending: B256Map::default(),
             #[cfg(feature = "metrics")]
             metrics: Default::default(),
         }

--- a/crates/trie/db/src/changesets.rs
+++ b/crates/trie/db/src/changesets.rs
@@ -30,7 +30,7 @@ use std::{
     ops::RangeInclusive,
     sync::{Arc, OnceLock},
 };
-use tracing::{debug, debug_span};
+use tracing::{debug, debug_span, warn};
 
 #[cfg(feature = "metrics")]
 use reth_metrics::{
@@ -510,11 +510,11 @@ impl ChangesetCache {
         }
 
         // No cache hit and no pending computation - compute from database
-        debug!(
+        warn!(
             target: "trie::changeset_cache",
             ?block_hash,
             block_number,
-            "Changeset cache MISS, computing from database"
+            "Changeset cache MISS, falling back to DB-based computation"
         );
 
         let start = Instant::now();


### PR DESCRIPTION
When the deferred trie task is computing changesets for a block, concurrent readers now block-wait for that computation to finish instead of falling back to the expensive DB-based state root computation (which triggers the legacy `StorageRoot::calculate` path ~1.7M times for 100 blocks).

## Changes

- Add `PendingChangeset` (Mutex+Condvar) to `ChangesetCache` so in-flight computations are visible to concurrent readers
- `register_pending()` called before spawning the deferred trie task, returns a guard
- `get_or_compute()` checks for pending entries before falling back to DB
- `insert()` resolves the pending entry and wakes all waiters
- `PendingChangesetGuard` cancels on drop (panic safety) so waiters don't block forever


## Secondary Change

The provider used by the deferred trie task to compute trie changesets for a block is now passed in from the engine task. This prevents a second race-condition where persistence could run prior to the trie changesets for a block being computed, resulting in the changesets for parent blocks being evicted, and thus the deferred trie task needing to calculate changesets also for parent blocks, which takes forever and locks up the node.

## Testing

Existing tests pass. DB fallback is preserved for when no pending computation exists.

Prompted by: brian