### PR TITLE
perf(engine): skip redundant db fetch in prepare_invalid_response

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2103,19 +2103,14 @@ where
     /// Prepares the invalid payload response for the given hash, checking the
     /// database for the parent hash and populating the payload status with the latest valid hash
     /// according to the engine api spec.
-    fn prepare_invalid_response(&mut self, mut parent_hash: B256) -> ProviderResult<PayloadStatus> {
-        let parent_header = self.sealed_header_by_hash(parent_hash)?;
-
-        // Edge case: the `latestValid` field is the zero hash if the parent block is the terminal
-        // PoW block, which we need to identify by looking at the parent's block difficulty
-        if parent_header.as_ref().is_some_and(|p| !p.difficulty().is_zero()) {
-            parent_hash = B256::ZERO;
-        }
-
-        let valid_parent_hash = if parent_header.is_some() && !parent_hash.is_zero() {
-            Some(parent_hash)
-        } else {
-            self.latest_valid_hash_for_invalid_payload(parent_hash)?
+    fn prepare_invalid_response(&mut self, parent_hash: B256) -> ProviderResult<PayloadStatus> {
+        let valid_parent_hash = match self.sealed_header_by_hash(parent_hash)? {
+            // Edge case: the `latestValid` field is the zero hash if the parent block is the
+            // terminal PoW block, which we need to identify by looking at the parent's block
+            // difficulty
+            Some(parent) if !parent.difficulty().is_zero() => Some(B256::ZERO),
+            Some(_) => Some(parent_hash),
+            None => self.latest_valid_hash_for_invalid_payload(parent_hash)?,
         };
 
         Ok(PayloadStatus::from_status(PayloadStatusEnum::Invalid {

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2104,15 +2104,20 @@ where
     /// database for the parent hash and populating the payload status with the latest valid hash
     /// according to the engine api spec.
     fn prepare_invalid_response(&mut self, mut parent_hash: B256) -> ProviderResult<PayloadStatus> {
+        let parent_header = self.sealed_header_by_hash(parent_hash)?;
+
         // Edge case: the `latestValid` field is the zero hash if the parent block is the terminal
         // PoW block, which we need to identify by looking at the parent's block difficulty
-        if let Some(parent) = self.sealed_header_by_hash(parent_hash)? &&
-            !parent.difficulty().is_zero()
-        {
+        if parent_header.as_ref().is_some_and(|p| !p.difficulty().is_zero()) {
             parent_hash = B256::ZERO;
         }
 
-        let valid_parent_hash = self.latest_valid_hash_for_invalid_payload(parent_hash)?;
+        let valid_parent_hash = if parent_header.is_some() && !parent_hash.is_zero() {
+            Some(parent_hash)
+        } else {
+            self.latest_valid_hash_for_invalid_payload(parent_hash)?
+        };
+
         Ok(PayloadStatus::from_status(PayloadStatusEnum::Invalid {
             validation_error: PayloadValidationError::LinksToRejectedPayload.to_string(),
         })

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -352,9 +352,7 @@ where
             .into())
         }
 
-        // The block is already in hand; derive the EVM env from its header directly
-        // rather than fetching it from the database again.
-        let evm_env = self.eth_api().evm_env_for_header(block.sealed_block().sealed_header())?;
+        let (evm_env, _) = self.eth_api().evm_env_at(block.hash().into()).await?;
 
         // execute after the parent block, replaying `tx_index` transactions
         let state_at = block.parent_hash();

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -352,7 +352,9 @@ where
             .into())
         }
 
-        let (evm_env, _) = self.eth_api().evm_env_at(block.hash().into()).await?;
+        // The block is already in hand; derive the EVM env from its header directly
+        // rather than fetching it from the database again.
+        let evm_env = self.eth_api().evm_env_for_header(block.sealed_block().sealed_header())?;
 
         // execute after the parent block, replaying `tx_index` transactions
         let state_at = block.parent_hash();


### PR DESCRIPTION
Simplifies `prepare_invalid_response` by using a `match` on `sealed_header_by_hash` to directly determine the `latest_valid_hash` — avoids a redundant call to `latest_valid_hash_for_invalid_payload` when the parent header is already known.