### PR TITLE
Use `MockTransactionRatio::new()` method in tests

### DIFF
--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -1612,12 +1612,7 @@ impl MockTransactionDistribution {
         // now we can check and modify the distribution, preserving potentially uneven ratios
         // between transaction types
         if first_tx.is_eip4844() {
-            modified_distribution.transaction_ratio = MockTransactionRatio {
-                legacy_pct: 0,
-                access_list_pct: 0,
-                dynamic_fee_pct: 0,
-                blob_pct: 100,
-            };
+            modified_distribution.transaction_ratio = MockTransactionRatio::new(0, 0, 0, 100);
 
             // finally generate the transaction set
             NonConflictingSetOutcome::BlobsOnly(modified_distribution.tx_set(

--- a/crates/transaction-pool/src/test_utils/pool.rs
+++ b/crates/transaction-pool/src/test_utils/pool.rs
@@ -397,12 +397,7 @@ mod tests {
 
     #[test]
     fn test_on_chain_nonce_scenario() {
-        let transaction_ratio = MockTransactionRatio {
-            legacy_pct: 30,
-            dynamic_fee_pct: 70,
-            access_list_pct: 0,
-            blob_pct: 0,
-        };
+        let transaction_ratio = MockTransactionRatio::new(30, 0, 70, 0);
 
         let base_fee = 10u128;
         let fee_ranges = MockFeeRange {
@@ -434,12 +429,7 @@ mod tests {
 
     #[test]
     fn test_higher_nonce_scenario() {
-        let transaction_ratio = MockTransactionRatio {
-            legacy_pct: 30,
-            dynamic_fee_pct: 70,
-            access_list_pct: 0,
-            blob_pct: 0,
-        };
+        let transaction_ratio = MockTransactionRatio::new(30, 0, 70, 0);
 
         let base_fee = 10u128;
         let fee_ranges = MockFeeRange {
@@ -471,12 +461,7 @@ mod tests {
 
     #[test]
     fn test_below_base_fee_scenario() {
-        let transaction_ratio = MockTransactionRatio {
-            legacy_pct: 30,
-            dynamic_fee_pct: 70,
-            access_list_pct: 0,
-            blob_pct: 0,
-        };
+        let transaction_ratio = MockTransactionRatio::new(30, 0, 70, 0);
 
         let base_fee = 10u128;
         let fee_ranges = MockFeeRange {
@@ -510,12 +495,7 @@ mod tests {
 
     #[test]
     fn test_fill_nonce_gap_scenario() {
-        let transaction_ratio = MockTransactionRatio {
-            legacy_pct: 30,
-            dynamic_fee_pct: 70,
-            access_list_pct: 0,
-            blob_pct: 0,
-        };
+        let transaction_ratio = MockTransactionRatio::new(30, 0, 70, 0);
 
         let base_fee = 10u128;
         let fee_ranges = MockFeeRange {
@@ -563,12 +543,7 @@ mod tests {
 
     #[test]
     fn test_random_scenarios() {
-        let transaction_ratio = MockTransactionRatio {
-            legacy_pct: 30,
-            dynamic_fee_pct: 70,
-            access_list_pct: 0,
-            blob_pct: 0,
-        };
+        let transaction_ratio = MockTransactionRatio::new(30, 0, 70, 0);
 
         let base_fee = 10u128;
         let fee_ranges = MockFeeRange {

--- a/crates/transaction-pool/tests/it/evict.rs
+++ b/crates/transaction-pool/tests/it/evict.rs
@@ -45,12 +45,7 @@ async fn only_blobs_eviction() {
     let size_range = 10..1100;
 
     // create mock tx distribution, 100% blobs
-    let tx_ratio = MockTransactionRatio {
-        legacy_pct: 0,
-        dynamic_fee_pct: 0,
-        blob_pct: 100,
-        access_list_pct: 0,
-    };
+    let tx_ratio = MockTransactionRatio::new(0, 0, 0, 100);
 
     // Vary the amount of senders
     let senders = [1, 10, 100, total_txs];
@@ -162,12 +157,7 @@ async fn mixed_eviction() {
     let size_range = 10..1100;
 
     // Adjust the ratios to include a mix of transaction types
-    let tx_ratio = MockTransactionRatio {
-        legacy_pct: 25,
-        dynamic_fee_pct: 25,
-        blob_pct: 25,
-        access_list_pct: 25,
-    };
+    let tx_ratio = MockTransactionRatio::new(25, 25, 25, 25);
 
     let senders = [1, 5, 10];
     for sender_amt in &senders {
@@ -269,12 +259,7 @@ async fn nonce_gaps_eviction() {
     let size_range = 10..1100;
 
     // Adjust the ratios to include a mix of transaction types
-    let tx_ratio = MockTransactionRatio {
-        legacy_pct: 25,
-        dynamic_fee_pct: 25,
-        blob_pct: 25,
-        access_list_pct: 25,
-    };
+    let tx_ratio = MockTransactionRatio::new(25, 25, 25, 25);
 
     let senders = [1, 5, 10];
     for sender_amt in &senders {


### PR DESCRIPTION
This PR ensures that tests in `transaction-pool` use `MockTransactionRatio::new(...)` instead of manually specifying each field. This ensures the internal values always sum to zero (matching type invariants).